### PR TITLE
release: promote develop to main

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -1,0 +1,20 @@
+name: guard
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  develop-only:
+    name: develop-only
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require develop as source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::Pull requests into main must come from develop (got $HEAD_REF)."
+            exit 1
+          fi
+          echo "Source branch is develop."


### PR DESCRIPTION
Brings the `guard` workflow to `main` so it can run on incoming pull requests. First release using the new merge policy (merge commit), which keeps `main` and `develop` history synchronized.