### PR TITLE
fix: restrict GITHUB_TOKEN permissions in guard workflow

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions: {}
+
 jobs:
   develop-only:
     name: develop-only


### PR DESCRIPTION
Adds an empty `permissions` block so the workflow runs with no token permissions at all. Flagged by CodeQL (actions/missing-workflow-permissions).