### PR TITLE
chore: attribute copyright to Glyndor

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 podman-compose
-Copyright 2026 Jaro-c
+Copyright 2026 Glyndor


### PR DESCRIPTION
Copyright in NOTICE (and README attribution where present) now names the Glyndor organization instead of an individual.