### PR TITLE
ci: auto-close pull requests from non-collaborators

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -1,0 +1,36 @@
+name: pr-guard
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  collaborators-only:
+    name: collaborators-only
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Close pull requests from non-collaborators
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASSOC: ${{ github.event.pull_request.author_association }}
+          LOGIN: ${{ github.event.pull_request.user.login }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$LOGIN" = "dependabot[bot]" ]; then
+            echo "Dependabot is allowed."
+            exit 0
+          fi
+          case "$ASSOC" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "Author is a collaborator."
+              ;;
+            *)
+              gh pr comment "$PR" --repo "$REPO" --body "Thanks for your interest. This project does not accept unsolicited pull requests — contributions are invitation-only (see CONTRIBUTING.md). If you found a bug, please open an issue instead: we genuinely appreciate bug reports."
+              gh pr close "$PR" --repo "$REPO"
+              ;;
+          esac


### PR DESCRIPTION
Contributions are invitation-only. This workflow closes PRs from authors who are not collaborators, with a comment redirecting them to open an issue instead. Issues stay open to everyone for bug reports. Dependabot is exempt. Runs on `pull_request_target` without checking out untrusted code.