### PR TITLE
refactor: rename crate and binary from lynx-compose to podup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,30 +747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
-name = "lynx-compose"
-version = "0.2.0"
-dependencies = [
- "anyhow",
- "bollard",
- "bytes",
- "clap",
- "flate2",
- "futures",
- "indexmap",
- "libc",
- "notify",
- "serde",
- "tar",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "walkdir",
- "yaml_serde",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +865,30 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "podup"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "bollard",
+ "bytes",
+ "clap",
+ "flate2",
+ "futures",
+ "indexmap",
+ "libc",
+ "notify",
+ "serde",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "walkdir",
+ "yaml_serde",
+]
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "lynx-compose"
+name = "podup"
 version = "0.2.0"
 edition = "2021"
 
 [[bin]]
-name = "lynx-compose"
+name = "podup"
 path = "internal/main.rs"
 
 [lib]
-name = "lynx_compose"
+name = "podup"
 path = "internal/lib.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# podman-compose
+# podup
 
-`lynx-compose` — docker-compose translator and runner for rootless Podman,
+`podup` — docker-compose translator and runner for rootless Podman,
 built in Rust.
 
 It parses `docker-compose.yml` files and drives rootless Podman to create the
 equivalent containers, networks and volumes. Used by the
-[Lynx panel](https://github.com/Glyndor/panel) through the
+[Glyndor panel](https://github.com/Glyndor/panel) through the
 [panel-agent](https://github.com/Glyndor/panel-agent), and usable standalone
-as a CLI and as a library (`lynx_compose`).
+as a CLI and as a library (`podup`).
 
 ## Build
 
@@ -19,7 +19,7 @@ cargo test
 ## Usage
 
 ```bash
-lynx-compose up -f docker-compose.yml
+podup up -f docker-compose.yml
 ```
 
 ## Contributing & security

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -88,8 +88,8 @@ impl Engine {
         for (k, v) in service.annotations.to_map() {
             labels.insert(format!("annotation.{k}"), v);
         }
-        labels.insert("lynx.compose.project".to_string(), self.project.clone());
-        labels.insert("lynx.compose.service".to_string(), service_name.to_string());
+        labels.insert("podup.project".to_string(), self.project.clone());
+        labels.insert("podup.service".to_string(), service_name.to_string());
 
         let ulimits: Vec<ResourcesUlimits> = service
             .ulimits

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -232,7 +232,7 @@ impl Engine {
     }
 
     pub async fn ps(&self, _file: &ComposeFile) -> Result<()> {
-        let label = format!("lynx.compose.project={}", self.project);
+        let label = format!("podup.project={}", self.project);
         let mut filters: HashMap<String, Vec<String>> = HashMap::new();
         filters.insert("label".to_string(), vec![label]);
 
@@ -427,7 +427,7 @@ impl Engine {
 
     /// Remove containers that belong to this project but are no longer in the compose file.
     pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
-        let label = format!("lynx.compose.project={}", self.project);
+        let label = format!("podup.project={}", self.project);
         let mut filters: HashMap<String, Vec<String>> = HashMap::new();
         filters.insert("label".to_string(), vec![label]);
 

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -41,7 +41,7 @@ impl Engine {
                 .as_ref()
                 .map(|c| c.labels.to_map())
                 .unwrap_or_default();
-            labels.insert("lynx.compose.project".to_string(), self.project.clone());
+            labels.insert("podup.project".to_string(), self.project.clone());
 
             let driver_opts: HashMap<String, String> = config
                 .as_ref()

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -41,7 +41,7 @@ impl Engine {
                 .as_ref()
                 .map(|c| c.labels.to_map())
                 .unwrap_or_default();
-            labels.insert("lynx.compose.project".to_string(), self.project.clone());
+            labels.insert("podup.project".to_string(), self.project.clone());
 
             let driver = config
                 .as_ref()
@@ -425,7 +425,7 @@ impl Engine {
         }
 
         let dir = std::env::temp_dir()
-            .join(format!("lynx-compose-{}", self.project))
+            .join(format!("podup-{}", self.project))
             .join(kind);
 
         // Create dir with 0o700 so only the owning user can list/enter it.
@@ -476,7 +476,7 @@ impl Engine {
 
     /// Remove the per-project temp directory created by `materialize_inline`.
     pub(super) fn cleanup_temp_dir(&self) {
-        let dir = std::env::temp_dir().join(format!("lynx-compose-{}", self.project));
+        let dir = std::env::temp_dir().join(format!("podup-{}", self.project));
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -1,11 +1,11 @@
-//! Error types for the lynx-compose library.
+//! Error types for the podup library.
 //!
 //! All fallible operations return [`Result<T>`], which is an alias for
 //! `std::result::Result<T, ComposeError>`.
 
 use thiserror::Error;
 
-/// All errors produced by lynx-compose.
+/// All errors produced by podup.
 #[derive(Debug, Error)]
 pub enum ComposeError {
     #[error("failed to parse compose file: {0}")]

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -1,4 +1,4 @@
-//! `lynx-compose` — docker-compose → Podman translator library.
+//! `podup` — docker-compose → Podman translator library.
 //!
 //! Provides parsing, variable substitution, topological ordering, and an
 //! async engine that drives container lifecycle via Podman's Docker-compatible

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -16,7 +16,7 @@ struct Cli {
     file: PathBuf,
 
     /// Project name (used as a prefix for container names).
-    #[arg(short, long, default_value = "lynx")]
+    #[arg(short, long, default_value = "podup")]
     project: String,
 
     /// Podman socket path (overrides auto-detection and PODMAN_SOCKET env).

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -1,4 +1,4 @@
-//! `lynx-compose` — docker-compose to Podman translator CLI.
+//! `podup` — docker-compose to Podman translator CLI.
 
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -6,7 +6,7 @@ use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(
-    name = "lynx-compose",
+    name = "podup",
     version,
     about = "docker-compose translator for Podman"
 )]
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
-    let file = lynx_compose::parse_file(&cli.file)?;
+    let file = podup::parse_file(&cli.file)?;
 
     // The `config` command does not need a Podman connection.
     if matches!(cli.command, Commands::Config) {
@@ -106,13 +106,13 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let docker = lynx_compose::podman::connect(cli.socket.as_deref())?;
+    let docker = podup::podman::connect(cli.socket.as_deref())?;
     let base_dir = cli
         .file
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or_default();
-    let engine = lynx_compose::Engine::with_base_dir(docker, cli.project, base_dir);
+    let engine = podup::Engine::with_base_dir(docker, cli.project, base_dir);
 
     match cli.command {
         Commands::Up {

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -1,5 +1,5 @@
-use lynx_compose::env_file::load_env_files;
-use lynx_compose::ComposeError;
+use podup::env_file::load_env_files;
+use podup::ComposeError;
 use std::io::Write;
 
 #[test]
@@ -20,7 +20,7 @@ fn basic_key_value() {
 
 #[test]
 fn string_or_list_single() {
-    use lynx_compose::compose::types::StringOrList;
+    use podup::compose::types::StringOrList;
     assert_eq!(
         StringOrList::Single("file.env".to_string()).to_list(),
         vec!["file.env"]
@@ -29,7 +29,7 @@ fn string_or_list_single() {
 
 #[test]
 fn string_or_list_many() {
-    use lynx_compose::compose::types::StringOrList;
+    use podup::compose::types::StringOrList;
     let sol = StringOrList::List(vec!["a.env".to_string(), "b.env".to_string()]);
     assert_eq!(sol.to_list().len(), 2);
 }

--- a/tests/env_file/merge.rs
+++ b/tests/env_file/merge.rs
@@ -1,4 +1,4 @@
-use lynx_compose::env_file::merge_env;
+use podup::env_file::merge_env;
 use std::collections::HashMap;
 
 #[test]

--- a/tests/parse/anchors.rs
+++ b/tests/parse/anchors.rs
@@ -1,5 +1,5 @@
-use lynx_compose::parse_file;
-use lynx_compose::parse_str;
+use podup::parse_file;
+use podup::parse_str;
 use std::io::Write;
 
 #[test]

--- a/tests/parse/basic.rs
+++ b/tests/parse/basic.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::*;
-use lynx_compose::parse_str;
+use podup::compose::types::*;
+use podup::parse_str;
 
 #[test]
 fn minimal() {

--- a/tests/parse/coverage.rs
+++ b/tests/parse/coverage.rs
@@ -1,6 +1,6 @@
 /// Parse tests for features present in the type system but not previously covered.
-use lynx_compose::compose::types::*;
-use lynx_compose::parse_str;
+use podup::compose::types::*;
+use podup::parse_str;
 
 // ---------------------------------------------------------------------------
 // blkio_config

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -1,4 +1,4 @@
-use lynx_compose::{parse_file, parse_str};
+use podup::{parse_file, parse_str};
 use std::io::Write;
 
 #[test]

--- a/tests/parse/fields.rs
+++ b/tests/parse/fields.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::*;
-use lynx_compose::parse_str;
+use podup::compose::types::*;
+use podup::parse_str;
 
 #[test]
 fn sysctls_as_list() {

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -1,4 +1,4 @@
-use lynx_compose::parse_file;
+use podup::parse_file;
 use std::io::Write;
 
 #[test]

--- a/tests/parse/order.rs
+++ b/tests/parse/order.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::ServiceCondition;
-use lynx_compose::{parse_str, resolve_order};
+use podup::compose::types::ServiceCondition;
+use podup::{parse_str, resolve_order};
 
 #[test]
 fn no_deps() {

--- a/tests/ports/conversion.rs
+++ b/tests/ports/conversion.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::PortMapping;
-use lynx_compose::ports::{parse_ports, to_bollard};
+use podup::compose::types::PortMapping;
+use podup::ports::{parse_ports, to_bollard};
 
 fn short(s: &str) -> PortMapping {
     PortMapping::Short(s.to_string())

--- a/tests/ports/formats.rs
+++ b/tests/ports/formats.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::PortMapping;
-use lynx_compose::ports::parse_ports;
+use podup::compose::types::PortMapping;
+use podup::ports::parse_ports;
 
 fn short(s: &str) -> PortMapping {
     PortMapping::Short(s.to_string())
@@ -95,8 +95,8 @@ fn range_at_limit_accepted() {
 
 #[test]
 fn long_form_invalid_published_string_rejected() {
-    use lynx_compose::compose::types::StringOrU16;
-    let mapping = lynx_compose::compose::types::PortMapping::Long {
+    use podup::compose::types::StringOrU16;
+    let mapping = podup::compose::types::PortMapping::Long {
         target: 80,
         published: Some(StringOrU16::String("invalid".to_string())),
         protocol: None,

--- a/tests/size.rs
+++ b/tests/size.rs
@@ -1,6 +1,6 @@
 //! Tests for the memory / cpu / duration parser helpers.
 
-use lynx_compose::size::{parse_cpus, parse_duration_nanos, parse_duration_secs, parse_memory};
+use podup::size::{parse_cpus, parse_duration_nanos, parse_duration_secs, parse_memory};
 
 #[test]
 fn memory_bytes() {

--- a/tests/substitute/dotenv.rs
+++ b/tests/substitute/dotenv.rs
@@ -1,4 +1,4 @@
-use lynx_compose::substitute::{build_vars, load_dotenv};
+use podup::substitute::{build_vars, load_dotenv};
 use std::io::Write;
 
 #[test]

--- a/tests/substitute/dotenv.rs
+++ b/tests/substitute/dotenv.rs
@@ -38,11 +38,11 @@ fn process_env_takes_precedence() {
 fn build_vars_includes_dotenv() {
     let dir = tempfile::tempdir().unwrap();
     let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
-    writeln!(f, "LYNX_TEST_DOTENV_KEY=from_file").unwrap();
+    writeln!(f, "PODUP_TEST_DOTENV_KEY=from_file").unwrap();
 
     let vars = build_vars(dir.path());
     assert_eq!(
-        vars.get("LYNX_TEST_DOTENV_KEY").map(|s| s.as_str()),
+        vars.get("PODUP_TEST_DOTENV_KEY").map(|s| s.as_str()),
         Some("from_file")
     );
 }

--- a/tests/substitute/modifiers.rs
+++ b/tests/substitute/modifiers.rs
@@ -1,5 +1,5 @@
-use lynx_compose::substitute::substitute;
-use lynx_compose::ComposeError;
+use podup::substitute::substitute;
+use podup::ComposeError;
 use std::collections::HashMap;
 
 fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {


### PR DESCRIPTION
Closes #15

Renames every `lynx` identifier to the product name `podup`:

- Crate, binary target and library renamed `lynx-compose`/`lynx_compose` → `podup` in `Cargo.toml`, with all imports and doc comments updated.
- Container labels renamed `lynx.compose.project`/`lynx.compose.service` → `podup.project`/`podup.service`, default project name `lynx` → `podup`, volume staging directory prefix `lynx-compose-<project>` → `podup-<project>`.
- README updated to the podup name and the Glyndor panel branding.

**Breaking:** the library crate name changes (panel-agent's git dependency must move to `podup`, matching PR in panel-agent) and containers created by previous versions are not matched by the new labels — they must be brought down with the old binary or recreated.

## Test plan

- `cargo test` — 220 tests pass.
- `cargo fmt --check` and `cargo clippy --all-targets` clean.
- Runtime behavior against a live Podman socket is unchanged apart from the label/default renames; no engine logic touched.