### PR TITLE
feat: add install.sh installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# podup installer — downloads a release binary, verifies it and installs it.
+#
+# Usage:
+#   curl -fsSL https://github.com/Glyndor/podup/releases/latest/download/install.sh | bash
+#
+# Environment:
+#   PODUP_VERSION      Release tag to install (e.g. v0.3.0). Default: latest.
+#   PODUP_INSTALL_DIR  Installation directory. Default: /usr/local/bin.
+
+set -euo pipefail
+
+REPO="Glyndor/podup"
+INSTALL_DIR="${PODUP_INSTALL_DIR:-/usr/local/bin}"
+VERSION="${PODUP_VERSION:-latest}"
+
+log_info()  { printf '\033[1;34m[info]\033[0m %s\n' "$1"; }
+log_ok()    { printf '\033[1;32m[ ok ]\033[0m %s\n' "$1"; }
+log_error() { printf '\033[1;31m[fail]\033[0m %s\n' "$1" >&2; }
+
+fail() {
+	log_error "$1"
+	exit 1
+}
+
+# --- Platform detection ------------------------------------------------------
+
+OS="$(uname -s)"
+[[ "$OS" == "Linux" ]] || fail "Unsupported OS: $OS (podup supports Linux only)"
+
+case "$(uname -m)" in
+	x86_64)          ARCH="x86_64" ;;
+	aarch64 | arm64) ARCH="arm64" ;;
+	*)               fail "Unsupported architecture: $(uname -m) (supported: x86_64, arm64)" ;;
+esac
+
+ARTIFACT="podup-linux-${ARCH}"
+
+# --- Download ----------------------------------------------------------------
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+
+if [[ "$VERSION" == "latest" ]]; then
+	BASE_URL="https://github.com/${REPO}/releases/latest/download"
+else
+	BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+log_info "Downloading ${ARTIFACT} (${VERSION}) ..."
+curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/${ARTIFACT}" \
+	"${BASE_URL}/${ARTIFACT}" || fail "Download failed: ${BASE_URL}/${ARTIFACT}"
+curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS" \
+	"${BASE_URL}/SHA256SUMS" || fail "Download failed: ${BASE_URL}/SHA256SUMS"
+
+# --- Verify ------------------------------------------------------------------
+
+log_info "Verifying SHA-256 checksum ..."
+(cd "$TMP_DIR" && grep " ${ARTIFACT}\$" SHA256SUMS | sha256sum -c --quiet -) \
+	|| fail "Checksum verification failed for ${ARTIFACT}"
+log_ok "Checksum verified"
+
+# Verify the build provenance attestation when the GitHub CLI is available.
+# This proves the binary was built by this repository's release workflow.
+if command -v gh >/dev/null 2>&1; then
+	log_info "Verifying artifact attestation ..."
+	gh attestation verify "${TMP_DIR}/${ARTIFACT}" --repo "$REPO" >/dev/null \
+		|| fail "Attestation verification failed for ${ARTIFACT}"
+	log_ok "Attestation verified"
+else
+	log_info "GitHub CLI not found — skipping attestation verification (checksum already verified)"
+fi
+
+# --- Install -----------------------------------------------------------------
+
+INSTALL_CMD=(install -m 0755 "${TMP_DIR}/${ARTIFACT}" "${INSTALL_DIR}/podup")
+
+if [[ -w "$INSTALL_DIR" ]]; then
+	"${INSTALL_CMD[@]}"
+elif command -v sudo >/dev/null 2>&1; then
+	log_info "Installing to ${INSTALL_DIR} (requires sudo) ..."
+	sudo "${INSTALL_CMD[@]}"
+else
+	fail "Cannot write to ${INSTALL_DIR} and sudo is not available. Set PODUP_INSTALL_DIR to a writable directory."
+fi
+
+log_ok "podup installed: $("${INSTALL_DIR}/podup" --version)"


### PR DESCRIPTION
Closes #18

Adds `install.sh` at the repository root, to be shipped as a release asset and used as the documented one-liner install:

- Detects OS/arch (Linux x86_64 / arm64), fails clearly on anything else
- Downloads the requested release binary (`PODUP_VERSION`, default latest) over TLS 1.2+ with `--proto '=https'`
- **SHA-256 checksum verification is mandatory** against the released `SHA256SUMS`; install aborts on mismatch (fail closed)
- Additionally verifies the build provenance attestation when the GitHub CLI is present
- Installs to `/usr/local/bin/podup` (`PODUP_INSTALL_DIR` to override), using sudo only when the target is not writable
- Idempotent — re-running replaces the binary in place; touches nothing else

Artifact naming contract (consumed by the release workflow in #17): `podup-linux-x86_64`, `podup-linux-arm64`, `SHA256SUMS`.

## Test plan

- `bash -n` clean.
- Bogus version (`PODUP_VERSION=v9.9.9`) → clean 404 failure, exit 1, temp dir removed.
- Checksum verification fixture-tested for both match and corruption (fails closed).
- Full end-to-end run requires the first published release (#17); will be exercised when v0.3.0 ships.