### PR TITLE
ci: add release workflow with attested binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.3.0)"
+        required: true
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Verify tag matches crate version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Tag must equal Cargo.toml version
+        env:
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          CRATE_VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "$VERSION" != "$CRATE_VERSION" ]; then
+            echo "::error::Tag ${TAG} does not match Cargo.toml version ${CRATE_VERSION}."
+            exit 1
+          fi
+          echo "Releasing version ${VERSION}."
+
+  build:
+    name: Build ${{ matrix.arch }}
+    needs: verify
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq musl-tools
+          rustup target add ${{ matrix.target }}
+
+      - name: Build static binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Stage artifact
+        run: cp "target/${{ matrix.target }}/release/podup" "podup-linux-${{ matrix.arch }}"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: podup-linux-${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: podup-${{ matrix.arch }}
+          path: podup-linux-${{ matrix.arch }}
+          retention-days: 1
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: sha256sum podup-linux-x86_64 podup-linux-arm64 > SHA256SUMS
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --generate-notes \
+            --verify-tag \
+            podup-linux-x86_64 \
+            podup-linux-arm64 \
+            SHA256SUMS \
+            install.sh


### PR DESCRIPTION
Closes #17

Adds `.github/workflows/release.yml`, podup's release pipeline:

- Triggers on `v*` tag push, with a `workflow_dispatch` fallback taking the tag as input
- **verify** — fails the release if the tag does not match `Cargo.toml`'s version (fail closed; releases are immutable, a mismatch must never publish)
- **build** — static musl binaries for `x86_64` (`ubuntu-latest`) and `arm64` (`ubuntu-24.04-arm`, native runner — no cross-compilation toolchain), built with `--locked`; each binary gets a build provenance attestation via `actions/attest-build-provenance`
- **release** — generates `SHA256SUMS` and publishes the GitHub Release with generated notes, both binaries, the checksums file and `install.sh` (#19 defines the artifact naming contract this follows: `podup-linux-<arch>`)

Policy compliance: GitHub-owned actions only, all SHA-pinned; top-level `permissions: {}` with per-job grants (`id-token`/`attestations` only on build, `contents: write` only on publish).

## Test plan

- YAML validated; action SHAs resolved from the actions' latest releases (checkout v6.0.3, upload-artifact v7.0.1, download-artifact v8.0.1, attest-build-provenance v4.1.0).
- Static musl release build verified locally: `cargo build --release --target x86_64-unknown-linux-musl` produces a `static-pie` stripped binary.
- Full pipeline will be exercised by the first tag (`v0.3.0`); `workflow_dispatch` provides the retry path without moving the tag.