### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Prepares the first release under the podup name.

The crate rename `lynx-compose` → `podup` (#16) is a breaking change — new library/crate name, renamed container labels and runtime defaults. On `0.x`, breaking bumps MINOR: `0.2.0` → `0.3.0`.

## Test plan

- `cargo build` clean with the updated `Cargo.lock`.
- The release workflow's verify job (#20) enforces that the `v0.3.0` tag matches this version.