### PR TITLE
release: v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.3.0)"
+        required: true
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Verify tag matches crate version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Tag must equal Cargo.toml version
+        env:
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          CRATE_VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "$VERSION" != "$CRATE_VERSION" ]; then
+            echo "::error::Tag ${TAG} does not match Cargo.toml version ${CRATE_VERSION}."
+            exit 1
+          fi
+          echo "Releasing version ${VERSION}."
+
+  build:
+    name: Build ${{ matrix.arch }}
+    needs: verify
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq musl-tools
+          rustup target add ${{ matrix.target }}
+
+      - name: Build static binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Stage artifact
+        run: cp "target/${{ matrix.target }}/release/podup" "podup-linux-${{ matrix.arch }}"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: podup-linux-${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: podup-${{ matrix.arch }}
+          path: podup-linux-${{ matrix.arch }}
+          retention-days: 1
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: sha256sum podup-linux-x86_64 podup-linux-arm64 > SHA256SUMS
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --generate-notes \
+            --verify-tag \
+            podup-linux-x86_64 \
+            podup-linux-arm64 \
+            SHA256SUMS \
+            install.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,30 +747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
-name = "lynx-compose"
-version = "0.2.0"
-dependencies = [
- "anyhow",
- "bollard",
- "bytes",
- "clap",
- "flate2",
- "futures",
- "indexmap",
- "libc",
- "notify",
- "serde",
- "tar",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "walkdir",
- "yaml_serde",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +865,30 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "podup"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "bollard",
+ "bytes",
+ "clap",
+ "flate2",
+ "futures",
+ "indexmap",
+ "libc",
+ "notify",
+ "serde",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "walkdir",
+ "yaml_serde",
+]
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "lynx-compose"
+name = "podup"
 version = "0.2.0"
 edition = "2021"
 
 [[bin]]
-name = "lynx-compose"
+name = "podup"
 path = "internal/main.rs"
 
 [lib]
-name = "lynx_compose"
+name = "podup"
 path = "internal/lib.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# podman-compose
+# podup
 
-`lynx-compose` — docker-compose translator and runner for rootless Podman,
+`podup` — docker-compose translator and runner for rootless Podman,
 built in Rust.
 
 It parses `docker-compose.yml` files and drives rootless Podman to create the
 equivalent containers, networks and volumes. Used by the
-[Lynx panel](https://github.com/Glyndor/panel) through the
+[Glyndor panel](https://github.com/Glyndor/panel) through the
 [panel-agent](https://github.com/Glyndor/panel-agent), and usable standalone
-as a CLI and as a library (`lynx_compose`).
+as a CLI and as a library (`podup`).
 
 ## Build
 
@@ -19,7 +19,7 @@ cargo test
 ## Usage
 
 ```bash
-lynx-compose up -f docker-compose.yml
+podup up -f docker-compose.yml
 ```
 
 ## Contributing & security

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# podup installer — downloads a release binary, verifies it and installs it.
+#
+# Usage:
+#   curl -fsSL https://github.com/Glyndor/podup/releases/latest/download/install.sh | bash
+#
+# Environment:
+#   PODUP_VERSION      Release tag to install (e.g. v0.3.0). Default: latest.
+#   PODUP_INSTALL_DIR  Installation directory. Default: /usr/local/bin.
+
+set -euo pipefail
+
+REPO="Glyndor/podup"
+INSTALL_DIR="${PODUP_INSTALL_DIR:-/usr/local/bin}"
+VERSION="${PODUP_VERSION:-latest}"
+
+log_info()  { printf '\033[1;34m[info]\033[0m %s\n' "$1"; }
+log_ok()    { printf '\033[1;32m[ ok ]\033[0m %s\n' "$1"; }
+log_error() { printf '\033[1;31m[fail]\033[0m %s\n' "$1" >&2; }
+
+fail() {
+	log_error "$1"
+	exit 1
+}
+
+# --- Platform detection ------------------------------------------------------
+
+OS="$(uname -s)"
+[[ "$OS" == "Linux" ]] || fail "Unsupported OS: $OS (podup supports Linux only)"
+
+case "$(uname -m)" in
+	x86_64)          ARCH="x86_64" ;;
+	aarch64 | arm64) ARCH="arm64" ;;
+	*)               fail "Unsupported architecture: $(uname -m) (supported: x86_64, arm64)" ;;
+esac
+
+ARTIFACT="podup-linux-${ARCH}"
+
+# --- Download ----------------------------------------------------------------
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+
+if [[ "$VERSION" == "latest" ]]; then
+	BASE_URL="https://github.com/${REPO}/releases/latest/download"
+else
+	BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+log_info "Downloading ${ARTIFACT} (${VERSION}) ..."
+curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/${ARTIFACT}" \
+	"${BASE_URL}/${ARTIFACT}" || fail "Download failed: ${BASE_URL}/${ARTIFACT}"
+curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS" \
+	"${BASE_URL}/SHA256SUMS" || fail "Download failed: ${BASE_URL}/SHA256SUMS"
+
+# --- Verify ------------------------------------------------------------------
+
+log_info "Verifying SHA-256 checksum ..."
+(cd "$TMP_DIR" && grep " ${ARTIFACT}\$" SHA256SUMS | sha256sum -c --quiet -) \
+	|| fail "Checksum verification failed for ${ARTIFACT}"
+log_ok "Checksum verified"
+
+# Verify the build provenance attestation when the GitHub CLI is available.
+# This proves the binary was built by this repository's release workflow.
+if command -v gh >/dev/null 2>&1; then
+	log_info "Verifying artifact attestation ..."
+	gh attestation verify "${TMP_DIR}/${ARTIFACT}" --repo "$REPO" >/dev/null \
+		|| fail "Attestation verification failed for ${ARTIFACT}"
+	log_ok "Attestation verified"
+else
+	log_info "GitHub CLI not found — skipping attestation verification (checksum already verified)"
+fi
+
+# --- Install -----------------------------------------------------------------
+
+INSTALL_CMD=(install -m 0755 "${TMP_DIR}/${ARTIFACT}" "${INSTALL_DIR}/podup")
+
+if [[ -w "$INSTALL_DIR" ]]; then
+	"${INSTALL_CMD[@]}"
+elif command -v sudo >/dev/null 2>&1; then
+	log_info "Installing to ${INSTALL_DIR} (requires sudo) ..."
+	sudo "${INSTALL_CMD[@]}"
+else
+	fail "Cannot write to ${INSTALL_DIR} and sudo is not available. Set PODUP_INSTALL_DIR to a writable directory."
+fi
+
+log_ok "podup installed: $("${INSTALL_DIR}/podup" --version)"

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -88,8 +88,8 @@ impl Engine {
         for (k, v) in service.annotations.to_map() {
             labels.insert(format!("annotation.{k}"), v);
         }
-        labels.insert("lynx.compose.project".to_string(), self.project.clone());
-        labels.insert("lynx.compose.service".to_string(), service_name.to_string());
+        labels.insert("podup.project".to_string(), self.project.clone());
+        labels.insert("podup.service".to_string(), service_name.to_string());
 
         let ulimits: Vec<ResourcesUlimits> = service
             .ulimits

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -232,7 +232,7 @@ impl Engine {
     }
 
     pub async fn ps(&self, _file: &ComposeFile) -> Result<()> {
-        let label = format!("lynx.compose.project={}", self.project);
+        let label = format!("podup.project={}", self.project);
         let mut filters: HashMap<String, Vec<String>> = HashMap::new();
         filters.insert("label".to_string(), vec![label]);
 
@@ -427,7 +427,7 @@ impl Engine {
 
     /// Remove containers that belong to this project but are no longer in the compose file.
     pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
-        let label = format!("lynx.compose.project={}", self.project);
+        let label = format!("podup.project={}", self.project);
         let mut filters: HashMap<String, Vec<String>> = HashMap::new();
         filters.insert("label".to_string(), vec![label]);
 

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -41,7 +41,7 @@ impl Engine {
                 .as_ref()
                 .map(|c| c.labels.to_map())
                 .unwrap_or_default();
-            labels.insert("lynx.compose.project".to_string(), self.project.clone());
+            labels.insert("podup.project".to_string(), self.project.clone());
 
             let driver_opts: HashMap<String, String> = config
                 .as_ref()

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -41,7 +41,7 @@ impl Engine {
                 .as_ref()
                 .map(|c| c.labels.to_map())
                 .unwrap_or_default();
-            labels.insert("lynx.compose.project".to_string(), self.project.clone());
+            labels.insert("podup.project".to_string(), self.project.clone());
 
             let driver = config
                 .as_ref()
@@ -425,7 +425,7 @@ impl Engine {
         }
 
         let dir = std::env::temp_dir()
-            .join(format!("lynx-compose-{}", self.project))
+            .join(format!("podup-{}", self.project))
             .join(kind);
 
         // Create dir with 0o700 so only the owning user can list/enter it.
@@ -476,7 +476,7 @@ impl Engine {
 
     /// Remove the per-project temp directory created by `materialize_inline`.
     pub(super) fn cleanup_temp_dir(&self) {
-        let dir = std::env::temp_dir().join(format!("lynx-compose-{}", self.project));
+        let dir = std::env::temp_dir().join(format!("podup-{}", self.project));
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -1,11 +1,11 @@
-//! Error types for the lynx-compose library.
+//! Error types for the podup library.
 //!
 //! All fallible operations return [`Result<T>`], which is an alias for
 //! `std::result::Result<T, ComposeError>`.
 
 use thiserror::Error;
 
-/// All errors produced by lynx-compose.
+/// All errors produced by podup.
 #[derive(Debug, Error)]
 pub enum ComposeError {
     #[error("failed to parse compose file: {0}")]

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -1,4 +1,4 @@
-//! `lynx-compose` — docker-compose → Podman translator library.
+//! `podup` — docker-compose → Podman translator library.
 //!
 //! Provides parsing, variable substitution, topological ordering, and an
 //! async engine that drives container lifecycle via Podman's Docker-compatible

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -1,4 +1,4 @@
-//! `lynx-compose` — docker-compose to Podman translator CLI.
+//! `podup` — docker-compose to Podman translator CLI.
 
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -6,7 +6,7 @@ use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(
-    name = "lynx-compose",
+    name = "podup",
     version,
     about = "docker-compose translator for Podman"
 )]
@@ -16,7 +16,7 @@ struct Cli {
     file: PathBuf,
 
     /// Project name (used as a prefix for container names).
-    #[arg(short, long, default_value = "lynx")]
+    #[arg(short, long, default_value = "podup")]
     project: String,
 
     /// Podman socket path (overrides auto-detection and PODMAN_SOCKET env).
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
-    let file = lynx_compose::parse_file(&cli.file)?;
+    let file = podup::parse_file(&cli.file)?;
 
     // The `config` command does not need a Podman connection.
     if matches!(cli.command, Commands::Config) {
@@ -106,13 +106,13 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let docker = lynx_compose::podman::connect(cli.socket.as_deref())?;
+    let docker = podup::podman::connect(cli.socket.as_deref())?;
     let base_dir = cli
         .file
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or_default();
-    let engine = lynx_compose::Engine::with_base_dir(docker, cli.project, base_dir);
+    let engine = podup::Engine::with_base_dir(docker, cli.project, base_dir);
 
     match cli.command {
         Commands::Up {

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -1,5 +1,5 @@
-use lynx_compose::env_file::load_env_files;
-use lynx_compose::ComposeError;
+use podup::env_file::load_env_files;
+use podup::ComposeError;
 use std::io::Write;
 
 #[test]
@@ -20,7 +20,7 @@ fn basic_key_value() {
 
 #[test]
 fn string_or_list_single() {
-    use lynx_compose::compose::types::StringOrList;
+    use podup::compose::types::StringOrList;
     assert_eq!(
         StringOrList::Single("file.env".to_string()).to_list(),
         vec!["file.env"]
@@ -29,7 +29,7 @@ fn string_or_list_single() {
 
 #[test]
 fn string_or_list_many() {
-    use lynx_compose::compose::types::StringOrList;
+    use podup::compose::types::StringOrList;
     let sol = StringOrList::List(vec!["a.env".to_string(), "b.env".to_string()]);
     assert_eq!(sol.to_list().len(), 2);
 }

--- a/tests/env_file/merge.rs
+++ b/tests/env_file/merge.rs
@@ -1,4 +1,4 @@
-use lynx_compose::env_file::merge_env;
+use podup::env_file::merge_env;
 use std::collections::HashMap;
 
 #[test]

--- a/tests/parse/anchors.rs
+++ b/tests/parse/anchors.rs
@@ -1,5 +1,5 @@
-use lynx_compose::parse_file;
-use lynx_compose::parse_str;
+use podup::parse_file;
+use podup::parse_str;
 use std::io::Write;
 
 #[test]

--- a/tests/parse/basic.rs
+++ b/tests/parse/basic.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::*;
-use lynx_compose::parse_str;
+use podup::compose::types::*;
+use podup::parse_str;
 
 #[test]
 fn minimal() {

--- a/tests/parse/coverage.rs
+++ b/tests/parse/coverage.rs
@@ -1,6 +1,6 @@
 /// Parse tests for features present in the type system but not previously covered.
-use lynx_compose::compose::types::*;
-use lynx_compose::parse_str;
+use podup::compose::types::*;
+use podup::parse_str;
 
 // ---------------------------------------------------------------------------
 // blkio_config

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -1,4 +1,4 @@
-use lynx_compose::{parse_file, parse_str};
+use podup::{parse_file, parse_str};
 use std::io::Write;
 
 #[test]

--- a/tests/parse/fields.rs
+++ b/tests/parse/fields.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::*;
-use lynx_compose::parse_str;
+use podup::compose::types::*;
+use podup::parse_str;
 
 #[test]
 fn sysctls_as_list() {

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -1,4 +1,4 @@
-use lynx_compose::parse_file;
+use podup::parse_file;
 use std::io::Write;
 
 #[test]

--- a/tests/parse/order.rs
+++ b/tests/parse/order.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::ServiceCondition;
-use lynx_compose::{parse_str, resolve_order};
+use podup::compose::types::ServiceCondition;
+use podup::{parse_str, resolve_order};
 
 #[test]
 fn no_deps() {

--- a/tests/ports/conversion.rs
+++ b/tests/ports/conversion.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::PortMapping;
-use lynx_compose::ports::{parse_ports, to_bollard};
+use podup::compose::types::PortMapping;
+use podup::ports::{parse_ports, to_bollard};
 
 fn short(s: &str) -> PortMapping {
     PortMapping::Short(s.to_string())

--- a/tests/ports/formats.rs
+++ b/tests/ports/formats.rs
@@ -1,5 +1,5 @@
-use lynx_compose::compose::types::PortMapping;
-use lynx_compose::ports::parse_ports;
+use podup::compose::types::PortMapping;
+use podup::ports::parse_ports;
 
 fn short(s: &str) -> PortMapping {
     PortMapping::Short(s.to_string())
@@ -95,8 +95,8 @@ fn range_at_limit_accepted() {
 
 #[test]
 fn long_form_invalid_published_string_rejected() {
-    use lynx_compose::compose::types::StringOrU16;
-    let mapping = lynx_compose::compose::types::PortMapping::Long {
+    use podup::compose::types::StringOrU16;
+    let mapping = podup::compose::types::PortMapping::Long {
         target: 80,
         published: Some(StringOrU16::String("invalid".to_string())),
         protocol: None,

--- a/tests/size.rs
+++ b/tests/size.rs
@@ -1,6 +1,6 @@
 //! Tests for the memory / cpu / duration parser helpers.
 
-use lynx_compose::size::{parse_cpus, parse_duration_nanos, parse_duration_secs, parse_memory};
+use podup::size::{parse_cpus, parse_duration_nanos, parse_duration_secs, parse_memory};
 
 #[test]
 fn memory_bytes() {

--- a/tests/substitute/dotenv.rs
+++ b/tests/substitute/dotenv.rs
@@ -1,4 +1,4 @@
-use lynx_compose::substitute::{build_vars, load_dotenv};
+use podup::substitute::{build_vars, load_dotenv};
 use std::io::Write;
 
 #[test]
@@ -38,11 +38,11 @@ fn process_env_takes_precedence() {
 fn build_vars_includes_dotenv() {
     let dir = tempfile::tempdir().unwrap();
     let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
-    writeln!(f, "LYNX_TEST_DOTENV_KEY=from_file").unwrap();
+    writeln!(f, "PODUP_TEST_DOTENV_KEY=from_file").unwrap();
 
     let vars = build_vars(dir.path());
     assert_eq!(
-        vars.get("LYNX_TEST_DOTENV_KEY").map(|s| s.as_str()),
+        vars.get("PODUP_TEST_DOTENV_KEY").map(|s| s.as_str()),
         Some("from_file")
     );
 }

--- a/tests/substitute/modifiers.rs
+++ b/tests/substitute/modifiers.rs
@@ -1,5 +1,5 @@
-use lynx_compose::substitute::substitute;
-use lynx_compose::ComposeError;
+use podup::substitute::substitute;
+use podup::ComposeError;
 use std::collections::HashMap;
 
 fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {


### PR DESCRIPTION
First release under the **podup** name.

## Breaking

- Crate, binary and library renamed `lynx-compose`/`lynx_compose` → `podup` (#15, #16). Container labels are now `podup.project`/`podup.service`, the default project name is `podup` and the volume staging prefix is `podup-<project>` — containers created by pre-rename versions are not matched by the new labels and must be brought down with the old binary or recreated.

## Features

- `install.sh` installer with mandatory SHA-256 verification and optional attestation verification (#18, #19)

## CI

- Release workflow building attested static musl binaries for x86_64 and arm64 (#17, #20)

## Chores

- Version bumped to 0.3.0 (#21)

After merge: tag `v0.3.0` on `main`; the release workflow publishes binaries, `SHA256SUMS` and `install.sh`. panel-agent's dependency pin then moves to the release ref.