### PR TITLE
fix: skip attestation verification when gh lacks the attestation subcommand

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,15 +64,16 @@ log_info "Verifying SHA-256 checksum ..."
 	|| fail "Checksum verification failed for ${ARTIFACT}"
 log_ok "Checksum verified"
 
-# Verify the build provenance attestation when the GitHub CLI is available.
-# This proves the binary was built by this repository's release workflow.
-if command -v gh >/dev/null 2>&1; then
+# Verify the build provenance attestation when the GitHub CLI supports it
+# (gh >= 2.49). This proves the binary was built by this repository's release
+# workflow. When the subcommand actually runs and fails, abort.
+if command -v gh >/dev/null 2>&1 && gh attestation --help >/dev/null 2>&1; then
 	log_info "Verifying artifact attestation ..."
 	gh attestation verify "${TMP_DIR}/${ARTIFACT}" --repo "$REPO" >/dev/null \
 		|| fail "Attestation verification failed for ${ARTIFACT}"
 	log_ok "Attestation verified"
 else
-	log_info "GitHub CLI not found — skipping attestation verification (checksum already verified)"
+	log_info "GitHub CLI with attestation support not found — skipping attestation verification (checksum already verified)"
 fi
 
 # --- Install -----------------------------------------------------------------


### PR DESCRIPTION
Closes #24

`install.sh` gated the attestation step on `gh` existing, not on it supporting `attestation` (added in gh 2.49). On hosts with an older gh the install aborted after the mandatory SHA-256 verification had already passed.

The gate now also requires `gh attestation --help` to succeed. When the subcommand actually runs and verification fails, the install still aborts (fail closed).

## Test plan

- End-to-end against the published v0.3.0 release on a host whose gh lacks `attestation`: download → checksum verified → attestation step skipped with a notice → `podup 0.3.0` installed.
- `bash -n` clean.