### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Patch release carrying the installer fix (#25) and the expanded README (#26). No library or CLI changes.

## Test plan

- `cargo build` clean with the updated `Cargo.lock`; the release verify job enforces the `v0.3.1` tag matches.