### PR TITLE
ci: lint install.sh with shellcheck

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -6,12 +6,14 @@ on:
       - develop
     paths:
       - "**.sh"
+      - ".github/workflows/lint-shell.yml"
   pull_request:
     branches:
       - main
       - develop
     paths:
       - "**.sh"
+      - ".github/workflows/lint-shell.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -1,0 +1,30 @@
+name: Lint shell scripts
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "**.sh"
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "**.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Syntax check
+        run: bash -n install.sh
+
+      - name: Run shellcheck
+        run: shellcheck --severity=style install.sh


### PR DESCRIPTION
Closes #30

Adds `lint-shell.yml`: `bash -n` + `shellcheck --severity=style` on `install.sh`, on PRs and on `develop` pushes touching `*.sh`. shellcheck is preinstalled on the ubuntu runners — no downloads, GitHub-owned actions only, SHA-pinned, `contents: read`.

## Test plan

- YAML validated.
- The PR itself touches a `.sh`-adjacent workflow only; the job runs on this PR via the `pull_request` trigger and must pass on `install.sh` as shipped.