### PR TITLE
ci: sign release binaries with the shared release key

### DIFF
--- a/.github/scripts/sign.py
+++ b/.github/scripts/sign.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Sign a file with an Ed25519 private key (raw 32-byte seed, base64-encoded).
+
+Usage:
+  sign.py <base64-private-key> <input-file> [<output-sig-file>]
+
+If output-sig-file is omitted, writes to <input-file>.sig.
+The key must be the raw 32-byte Ed25519 seed in standard base64.
+"""
+import base64
+import sys
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+
+    key_b64 = sys.argv[1]
+    input_file = sys.argv[2]
+    sig_file = sys.argv[3] if len(sys.argv) > 3 else input_file + ".sig"
+
+    key_bytes = base64.b64decode(key_b64 + "==")
+    private_key = Ed25519PrivateKey.from_private_bytes(key_bytes)
+
+    with open(input_file, "rb") as f:
+        data = f.read()
+
+    sig = private_key.sign(data)
+
+    with open(sig_file, "wb") as f:
+        f.write(sig)
+
+    print(f"signed {input_file} ({len(data):,} bytes) → {sig_file} ({len(sig)} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,20 @@ jobs:
       - name: Stage artifact
         run: cp "target/${{ matrix.target }}/release/podup" "podup-linux-${{ matrix.arch }}"
 
+      - name: Sign binary
+        env:
+          RELEASE_SIGN_KEY: ${{ secrets.RELEASE_SIGN_KEY }}
+        run: |
+          # The panel installer/updater verifies this Ed25519 signature; a
+          # release without it cannot be consumed. Fail closed when the key
+          # is absent instead of publishing unsigned binaries.
+          if [ -z "$RELEASE_SIGN_KEY" ]; then
+            echo "::error::RELEASE_SIGN_KEY secret is not configured; refusing to release unsigned binaries."
+            exit 1
+          fi
+          pip install --quiet cryptography
+          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "podup-linux-${{ matrix.arch }}"
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
@@ -81,7 +95,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: podup-${{ matrix.arch }}
-          path: podup-linux-${{ matrix.arch }}
+          path: |
+            podup-linux-${{ matrix.arch }}
+            podup-linux-${{ matrix.arch }}.sig
           retention-days: 1
           if-no-files-found: error
 
@@ -113,6 +129,8 @@ jobs:
             --generate-notes \
             --verify-tag \
             podup-linux-x86_64 \
+            podup-linux-x86_64.sig \
             podup-linux-arm64 \
+            podup-linux-arm64.sig \
             SHA256SUMS \
             install.sh


### PR DESCRIPTION
Refs #29

The panel installer/updater (Glyndor/panel#94) expects each `podup-linux-<arch>` release asset to carry a detached Ed25519 `.sig` produced by the org's shared release key, like panel-agent's releases.

- `.github/scripts/sign.py` — same script as in `panel` (raw Ed25519 seed from `RELEASE_SIGN_KEY`, detached `.sig`)
- `release.yml` signs each binary right after staging and publishes the `.sig` files next to the binaries
- **Fail closed:** when `RELEASE_SIGN_KEY` is not configured, the build job errors instead of publishing unsigned binaries — after this merges, the next tag will not release until the secret is added to this repository (owner action, tracked in #29)

`SHA256SUMS` keeps covering the binaries only; signature integrity is proven by the Ed25519 verification itself.

## Test plan

- YAML validated; `sign.py` parses and is byte-identical to panel's.
- The signing path can only be exercised by a real tagged run once the secret exists; #29 stays open until a signed patch release ships.