### PR TITLE
fix: harden inline secret staging directory against tmp squatting

### DIFF
--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -424,9 +424,7 @@ impl Engine {
             )));
         }
 
-        let dir = std::env::temp_dir()
-            .join(format!("podup-{}", self.project))
-            .join(kind);
+        let dir = self.staging_dir()?.join(kind);
 
         // Create dir with 0o700 so only the owning user can list/enter it.
         std::fs::DirBuilder::new()
@@ -476,9 +474,83 @@ impl Engine {
 
     /// Remove the per-project temp directory created by `materialize_inline`.
     pub(super) fn cleanup_temp_dir(&self) {
-        let dir = std::env::temp_dir().join(format!("podup-{}", self.project));
-        let _ = std::fs::remove_dir_all(dir);
+        if let Ok(dir) = self.staging_dir() {
+            let _ = std::fs::remove_dir_all(dir);
+        }
     }
+
+    /// Per-project staging directory under a verified per-user base.
+    ///
+    /// The project name is validated first so it can never traverse out of
+    /// the base — this same path is later passed to `remove_dir_all`.
+    fn staging_dir(&self) -> Result<std::path::PathBuf> {
+        if !is_safe_project_name(&self.project) {
+            return Err(ComposeError::Unsupported(format!(
+                "project name must be ASCII alphanumeric/dash/underscore/dot \
+                 and must not start with a dot: {}",
+                self.project
+            )));
+        }
+        Ok(staging_base()?.join(&self.project))
+    }
+}
+
+/// Whether `name` is safe to use as a single path component and container
+/// name prefix: non-empty, bounded, ASCII alphanumeric plus `-`/`_`/`.`,
+/// not starting with a dot (rejects `.`, `..` and hidden directories).
+fn is_safe_project_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && !name.starts_with('.')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+/// Per-user staging base for inline secret/config content.
+///
+/// Prefers `$XDG_RUNTIME_DIR/podup` (per-user and 0700 by contract); falls
+/// back to `temp_dir()/podup-<euid>`. The base sits in a world-writable
+/// parent in the fallback case, so after creation it is verified to be a
+/// real directory (not a symlink), owned by the current user, with no
+/// group/other permission bits. Anything else aborts (fail closed) instead
+/// of writing secret material under — or later deleting — a path another
+/// local user may control.
+fn staging_base() -> Result<std::path::PathBuf> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+
+    let base = match std::env::var_os("XDG_RUNTIME_DIR") {
+        Some(dir) if Path::new(&dir).is_absolute() => std::path::PathBuf::from(dir).join("podup"),
+        _ => std::env::temp_dir().join(format!("podup-{euid}")),
+    };
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(&base)
+        .map_err(ComposeError::Io)?;
+
+    verify_private_dir(&base, euid)?;
+    Ok(base)
+}
+
+/// Verify that `dir` is a non-symlink directory owned by `euid` with no
+/// group/other permission bits.
+fn verify_private_dir(dir: &Path, euid: u32) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
+    if !meta.is_dir() || meta.uid() != euid || meta.mode() & 0o077 != 0 {
+        return Err(ComposeError::Unsupported(format!(
+            "staging directory {} is not a private directory owned by the \
+             current user — refusing to use it",
+            dir.display()
+        )));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -576,5 +648,89 @@ mod tests {
         }]);
         let binds = build_binds(&svc, Path::new("/base"));
         assert!(binds.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod staging_tests {
+    use super::{is_safe_project_name, verify_private_dir};
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn safe_project_names_accepted() {
+        for name in ["web", "my-app", "my_app", "app.v2", "A1"] {
+            assert!(is_safe_project_name(name), "{name:?} must be accepted");
+        }
+    }
+
+    #[test]
+    fn unsafe_project_names_rejected() {
+        let long = "a".repeat(129);
+        for name in [
+            "",
+            ".",
+            "..",
+            ".hidden",
+            "a/b",
+            "../x",
+            "a b",
+            "a\0b",
+            long.as_str(),
+        ] {
+            assert!(!is_safe_project_name(name), "{name:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn private_dir_accepted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("chmod");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(dir.path(), euid).is_ok());
+    }
+
+    #[test]
+    fn group_accessible_dir_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
+            .expect("chmod");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(dir.path(), euid).is_err());
+    }
+
+    #[test]
+    fn foreign_owner_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("chmod");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let other = unsafe { libc::geteuid() } + 1;
+        assert!(verify_private_dir(dir.path(), other).is_err());
+    }
+
+    #[test]
+    fn symlink_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("real");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).expect("mkdir");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(&link, euid).is_err());
+    }
+
+    #[test]
+    fn regular_file_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("file");
+        std::fs::write(&file, b"x").expect("write");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(&file, euid).is_err());
     }
 }


### PR DESCRIPTION
Closes #33

Inline secret/config content was materialized under the predictable `/tmp/podup-<project>` and `down` ran `remove_dir_all` on that same path. Two problems on a multi-user host:

- `/tmp` is world-writable and the name is predictable: another local user can pre-create the directory, and the recursive `DirBuilder::create` accepted it without checking owner or mode — secret material written under an attacker-controlled parent, plus a deletion path the attacker chose.
- The project name was never validated, so `-p 'a/../../<anything>'` traversed out of `/tmp` — including in the `remove_dir_all` call.

Now:

- Staging base is `$XDG_RUNTIME_DIR/podup` (per-user, 0700 by contract) with a `temp_dir()/podup-<euid>` fallback
- After creation the base must be a non-symlink directory, owned by the current euid, mode 0700 — anything else aborts (fail closed)
- Project names must be ASCII alphanumeric/`-`/`_`/`.`, not dot-leading, ≤128 chars — rejects `.`, `..` and any path separator before the name reaches the filesystem
- `cleanup_temp_dir` goes through the same validated path builder

`unsafe` is limited to `libc::geteuid()` with a soundness comment (no arguments, no memory access).

## Test plan

- Unit tests: project-name accept/reject sets; private-dir verification against 0700 dir (ok), group-accessible dir, foreign owner, symlink and regular file (all rejected). 254 tests pass, clippy clean.
- Live against rootless Podman: inline `environment:` secret staged under `$XDG_RUNTIME_DIR/podup/<project>` (0700), container receives it, `down` removes the staging dir; `-p 'a/../escape'` is rejected before any filesystem access.