### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.85"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
-podup (0.3.1) unstable; urgency=medium
+podup (0.3.2) unstable; urgency=medium
 
+  * Harden inline secret staging directory against tmp squatting.
+  * Sign release binaries with the shared release key.
   * Initial Debian packaging.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 05 Jun 2026 17:15:00 -0500


### PR DESCRIPTION
Prepares the first signed release. Carries the staging-directory hardening (#34), release signing (#32), shell lint (#31), Debian packaging (#36) and the MSRV/lockfile work since v0.3.1. `debian/changelog` bumped alongside per the packaging convention.

Note: tagging `v0.3.2` stays blocked on #29 (`RELEASE_SIGN_KEY` secret) — the release workflow now fails closed without it.

## Test plan

- `cargo build` clean with the updated lock; the release verify job enforces tag↔version match at tag time.