### PR TITLE
chore: ignore Python bytecode caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ fuzz/artifacts/
 
 # Build artifacts
 /target
+__pycache__/


### PR DESCRIPTION
Running `.github/scripts/sign.py` locally leaves a `__pycache__/` next to it; ignore it. Trivial housekeeping, no issue.