### PR TITLE
chore: add crates.io metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,14 @@ name = "podup"
 version = "0.3.2"
 edition = "2021"
 rust-version = "1.85"
+description = "Translate and run docker-compose files on rootless Podman"
+license = "Apache-2.0"
+repository = "https://github.com/Glyndor/podup"
+homepage = "https://github.com/Glyndor/podup"
+readme = "README.md"
+keywords = ["podman", "compose", "containers", "docker-compose", "rootless"]
+categories = ["command-line-utilities", "virtualization"]
+exclude = ["/.github", "/debian", "/docs", "/install.sh"]
 
 [[bin]]
 name = "podup"


### PR DESCRIPTION
Closes #42

Adds the registry metadata `cargo publish` requires: description, license, repository, homepage, readme, keywords, categories. Excludes `/.github`, `/debian`, `/docs` and `/install.sh` from the crate tarball — the published crate carries only the source, tests, license and README.

## Why

The path to the official Debian/Ubuntu archive runs through `debcargo`, which consumes crates.io releases (`docs/debian-packaging.md`). Publishing is an owner action; this makes the crate publishable.

## Test plan

- `cargo package --list` — 57 files, no packaging/CI files leak into the tarball
- `cargo package` — builds and verifies the crate from the generated tarball