### PR TITLE
feat: support macOS via podman machine socket detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,6 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@c2cf3d74719451a7a11fa8e5fae3f4a3c4e37fe6 # main
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@bc62ab8f95465df2b2f6f23775305f10a44e1502 # main
+    with:
+      extra-test-os: '["macos-latest"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "Releasing version ${VERSION}."
 
   build:
-    name: Build ${{ matrix.arch }}
+    name: Build ${{ matrix.asset }}
     needs: verify
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -48,29 +48,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: x86_64
+          - asset: podup-linux-x86_64
             runner: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          - arch: arm64
+          - asset: podup-linux-arm64
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
+          - asset: podup-darwin-arm64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+          - asset: podup-darwin-x86_64
+            runner: macos-latest
+            target: x86_64-apple-darwin
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
-      - name: Install musl toolchain
+      - name: Install build target
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq musl-tools
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq musl-tools
+          fi
           rustup target add ${{ matrix.target }}
 
-      - name: Build static binary
+      - name: Build binary
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Stage artifact
-        run: cp "target/${{ matrix.target }}/release/podup" "podup-linux-${{ matrix.arch }}"
+        run: cp "target/${{ matrix.target }}/release/podup" "${{ matrix.asset }}"
 
       - name: Sign binary
         env:
@@ -83,21 +91,21 @@ jobs:
             echo "::error::RELEASE_SIGN_KEY secret is not configured; refusing to release unsigned binaries."
             exit 1
           fi
-          pip install --quiet cryptography==48.0.0
-          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "podup-linux-${{ matrix.arch }}"
+          python3 -m pip install --quiet cryptography==48.0.0
+          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "${{ matrix.asset }}"
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: podup-linux-${{ matrix.arch }}
+          subject-path: ${{ matrix.asset }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: podup-${{ matrix.arch }}
+          name: ${{ matrix.asset }}
           path: |
-            podup-linux-${{ matrix.arch }}
-            podup-linux-${{ matrix.arch }}.sig
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sig
           retention-days: 1
           if-no-files-found: error
 
@@ -118,7 +126,13 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: sha256sum podup-linux-x86_64 podup-linux-arm64 > SHA256SUMS
+        run: |
+          sha256sum \
+            podup-linux-x86_64 \
+            podup-linux-arm64 \
+            podup-darwin-arm64 \
+            podup-darwin-x86_64 \
+            > SHA256SUMS
 
       - name: Create GitHub Release
         env:
@@ -132,5 +146,9 @@ jobs:
             podup-linux-x86_64.sig \
             podup-linux-arm64 \
             podup-linux-arm64.sig \
+            podup-darwin-arm64 \
+            podup-darwin-arm64.sig \
+            podup-darwin-x86_64 \
+            podup-darwin-x86_64.sig \
             SHA256SUMS \
             install.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ flowchart LR
 - 📄 **Compose-spec parsing** — YAML anchors, `extends`, `include`, profiles, `env_file`, variable substitution with modifiers
 - 🔁 **Dependency-aware** — `depends_on` ordering with healthcheck conditions
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
-- 📦 **Single static binary** — musl-linked, no runtime dependencies
+- 📦 **Single binary** — statically musl-linked on Linux, no runtime dependencies
 - 🦀 **Library too** — embed the parser and engine in your own Rust project
 
 ## 📥 Install
@@ -31,8 +31,9 @@ flowchart LR
 curl -fsSL https://github.com/Glyndor/podup/releases/latest/download/install.sh | bash
 ```
 
-Binaries for Linux x86_64 and arm64, SHA-256 verified, with build provenance
-attestations. Or build from source:
+Binaries for Linux and macOS (x86_64 and arm64), SHA-256 verified, with build
+provenance attestations. On macOS, podup talks to the `podman machine` VM
+through its host-side socket. Or build from source:
 
 ```bash
 cargo build --release

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,11 @@ fail() {
 
 # --- Platform detection ------------------------------------------------------
 
-OS="$(uname -s)"
-[[ "$OS" == "Linux" ]] || fail "Unsupported OS: $OS (podup supports Linux only)"
+case "$(uname -s)" in
+	Linux)  OS="linux" ;;
+	Darwin) OS="darwin" ;;
+	*)      fail "Unsupported OS: $(uname -s) (supported: Linux, macOS)" ;;
+esac
 
 case "$(uname -m)" in
 	x86_64)          ARCH="x86_64" ;;
@@ -35,12 +38,20 @@ case "$(uname -m)" in
 	*)               fail "Unsupported architecture: $(uname -m) (supported: x86_64, arm64)" ;;
 esac
 
-ARTIFACT="podup-linux-${ARCH}"
+ARTIFACT="podup-${OS}-${ARCH}"
 
 # --- Download ----------------------------------------------------------------
 
 command -v curl >/dev/null 2>&1 || fail "curl is required"
-command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+
+# macOS ships shasum instead of sha256sum.
+if command -v sha256sum >/dev/null 2>&1; then
+	SHA256_CMD=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+	SHA256_CMD=(shasum -a 256)
+else
+	fail "sha256sum or shasum is required"
+fi
 
 if [[ "$VERSION" == "latest" ]]; then
 	BASE_URL="https://github.com/${REPO}/releases/latest/download"
@@ -60,7 +71,7 @@ curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS" \
 # --- Verify ------------------------------------------------------------------
 
 log_info "Verifying SHA-256 checksum ..."
-(cd "$TMP_DIR" && grep " ${ARTIFACT}\$" SHA256SUMS | sha256sum -c --quiet -) \
+(cd "$TMP_DIR" && grep " ${ARTIFACT}\$" SHA256SUMS | "${SHA256_CMD[@]}" -c --quiet -) \
 	|| fail "Checksum verification failed for ${ARTIFACT}"
 log_ok "Checksum verified"
 

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -2,29 +2,24 @@
 
 use crate::error::Result;
 use bollard::Docker;
+use std::path::Path;
 
-const DEFAULT_PODMAN_SOCKET: &str = "/run/podman/podman.sock";
+const ROOT_SOCKET: &str = "/run/podman/podman.sock";
 
 /// Connect to Podman's Docker-compatible socket.
 ///
 /// Priority:
 /// 1. `socket_path` if provided.
-/// 2. `/run/podman/podman.sock` when running as root.
-/// 3. `/run/user/<uid>/podman/podman.sock` for non-root users.
+/// 2. The first existing platform default — on Linux the rootful or
+///    per-user runtime socket, on macOS the host-side socket exposed by
+///    `podman machine`.
+/// 3. The conventional path for this platform, so a failed connection
+///    reports the location podup expected.
 pub fn connect(socket_path: Option<&str>) -> Result<Docker> {
     let default_path = default_socket_path();
     let path = socket_path.unwrap_or(&default_path);
     let client = Docker::connect_with_unix(path, 120, bollard::API_DEFAULT_VERSION)?;
     Ok(client)
-}
-
-fn default_socket_path() -> String {
-    let uid = unsafe { libc::getuid() };
-    if uid == 0 {
-        DEFAULT_PODMAN_SOCKET.to_string()
-    } else {
-        format!("/run/user/{uid}/podman/podman.sock")
-    }
 }
 
 /// Connect using `PODMAN_SOCKET` or `DOCKER_HOST` environment variables.
@@ -35,4 +30,161 @@ pub fn connect_from_env() -> Result<Docker> {
 
     let path = socket.as_deref().and_then(|s| s.strip_prefix("unix://"));
     connect(path)
+}
+
+fn default_socket_path() -> String {
+    let candidates = candidate_socket_paths();
+    first_existing(&candidates)
+        .or_else(machine_socket_path)
+        .or_else(|| candidates.into_iter().next())
+        .unwrap_or_else(|| ROOT_SOCKET.to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn candidate_socket_paths() -> Vec<String> {
+    let uid = unsafe { libc::getuid() };
+    runtime_candidates(uid, std::env::var("XDG_RUNTIME_DIR").ok().as_deref())
+}
+
+#[cfg(target_os = "macos")]
+fn candidate_socket_paths() -> Vec<String> {
+    match std::env::var("HOME") {
+        Ok(home) => machine_candidates(&home),
+        Err(_) => vec![ROOT_SOCKET.to_string()],
+    }
+}
+
+/// Socket candidates for Linux and other unix hosts: the rootful socket
+/// for uid 0, otherwise the user's runtime directory (preferring
+/// `XDG_RUNTIME_DIR` when set).
+#[cfg(any(not(target_os = "macos"), test))]
+fn runtime_candidates(uid: u32, xdg_runtime_dir: Option<&str>) -> Vec<String> {
+    if uid == 0 {
+        return vec![ROOT_SOCKET.to_string()];
+    }
+    let mut candidates = Vec::new();
+    if let Some(dir) = xdg_runtime_dir {
+        if !dir.is_empty() {
+            candidates.push(format!("{dir}/podman/podman.sock"));
+        }
+    }
+    let run_user = format!("/run/user/{uid}/podman/podman.sock");
+    if !candidates.contains(&run_user) {
+        candidates.push(run_user);
+    }
+    candidates
+}
+
+/// Socket candidates on macOS: the host-side sockets `podman machine`
+/// creates, newest layout first.
+#[cfg(any(target_os = "macos", test))]
+fn machine_candidates(home: &str) -> Vec<String> {
+    let machine_dir = format!("{home}/.local/share/containers/podman/machine");
+    vec![
+        format!("{machine_dir}/podman.sock"),
+        format!("{machine_dir}/qemu/podman.sock"),
+        format!("{machine_dir}/podman-machine-default/podman.sock"),
+    ]
+}
+
+/// Ask `podman machine inspect` for the host-side socket path. Only used
+/// on macOS, where the VM provider decides where the API socket lives.
+#[cfg(target_os = "macos")]
+fn machine_socket_path() -> Option<String> {
+    let output = std::process::Command::new("podman")
+        .args([
+            "machine",
+            "inspect",
+            "--format",
+            "{{ .ConnectionInfo.PodmanSocket.Path }}",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!path.is_empty() && Path::new(&path).exists()).then_some(path)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn machine_socket_path() -> Option<String> {
+    None
+}
+
+fn first_existing(candidates: &[String]) -> Option<String> {
+    candidates.iter().find(|p| Path::new(p).exists()).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_existing_picks_first_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let hit = dir.path().join("podman.sock");
+        std::fs::write(&hit, b"").unwrap();
+        let candidates = vec![
+            dir.path().join("missing.sock").display().to_string(),
+            hit.display().to_string(),
+            dir.path().join("later.sock").display().to_string(),
+        ];
+        assert_eq!(first_existing(&candidates), Some(hit.display().to_string()));
+    }
+
+    #[test]
+    fn first_existing_none_when_no_candidate_exists() {
+        let candidates = vec!["/nonexistent/podup-test/podman.sock".to_string()];
+        assert_eq!(first_existing(&candidates), None);
+    }
+
+    #[test]
+    fn runtime_candidates_root_uses_system_socket() {
+        let candidates = runtime_candidates(0, Some("/run/user/0"));
+        assert_eq!(candidates, vec![ROOT_SOCKET.to_string()]);
+    }
+
+    #[test]
+    fn runtime_candidates_prefers_xdg_runtime_dir() {
+        let candidates = runtime_candidates(1000, Some("/custom/runtime"));
+        assert_eq!(
+            candidates,
+            vec![
+                "/custom/runtime/podman/podman.sock".to_string(),
+                "/run/user/1000/podman/podman.sock".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_candidates_dedupes_default_runtime_dir() {
+        let candidates = runtime_candidates(1000, Some("/run/user/1000"));
+        assert_eq!(
+            candidates,
+            vec!["/run/user/1000/podman/podman.sock".to_string()]
+        );
+    }
+
+    #[test]
+    fn runtime_candidates_ignores_empty_runtime_dir() {
+        let candidates = runtime_candidates(1000, Some(""));
+        assert_eq!(
+            candidates,
+            vec!["/run/user/1000/podman/podman.sock".to_string()]
+        );
+    }
+
+    #[test]
+    fn machine_candidates_cover_known_layouts() {
+        let machine_dir = "/Users/dev/.local/share/containers/podman/machine";
+        assert_eq!(
+            machine_candidates("/Users/dev"),
+            vec![
+                format!("{machine_dir}/podman.sock"),
+                format!("{machine_dir}/qemu/podman.sock"),
+                format!("{machine_dir}/podman-machine-default/podman.sock"),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Closes #43

## What

- **Socket resolution per platform** (`internal/podman/mod.rs`): auto-detection now probes a candidate list and picks the first socket that exists. Linux keeps the rootful (`/run/podman/podman.sock`) and per-user runtime paths, now honoring `XDG_RUNTIME_DIR`; macOS probes the host-side sockets `podman machine` creates (stable layout, qemu, per-machine) and falls back to `podman machine inspect --format '{{ .ConnectionInfo.PodmanSocket.Path }}'` when no known layout matches. Explicit `--socket` / `PODMAN_SOCKET` / `DOCKER_HOST` still win.
- **Release**: `aarch64-apple-darwin` and `x86_64-apple-darwin` join the build matrix (both on `macos-latest`; x86_64 cross-compiled). New assets `podup-darwin-arm64` / `podup-darwin-x86_64` with `.sig` and attestations. Linux asset names unchanged — darwin assets are additions to the `install.sh` naming contract.
- **install.sh**: Darwin detection, `shasum -a 256` fallback (macOS ships no `sha256sum`).
- **README**: install section mentions macOS.

The staging code in `internal/engine/volume.rs` is already macOS-correct: it is plain unix (`geteuid`, `chown`, mode 0700) and `XDG_RUNTIME_DIR` being unset on macOS lands on the verified `temp_dir()/podup-<euid>` fallback.

CI on `macos-latest` lands separately: Glyndor/.github#23 adds an `extra-test-os` input to the reusable workflow; the pin bump follows once that reaches `main`.

## Test plan

- `cargo test --workspace` — 222 tests green, including new unit tests for candidate ordering, XDG preference/dedupe and first-existing selection
- `cargo clippy --all-targets --all-features` — clean
- `cargo check --target aarch64-apple-darwin --all-targets` and `--target x86_64-apple-darwin --all-targets` — the whole crate, tests included, compiles for both darwin targets
- `bash -n install.sh` — syntax OK; `lint-shell` workflow shellchecks it in CI
- Real `podman machine` smoke test on macOS hardware pending (no Apple machine in the VM matrix) — tracked before tagging the next release