### PR TITLE
feat: support Windows hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
   rust:
     uses: Glyndor/.github/.github/workflows/rust-ci.yml@bc62ab8f95465df2b2f6f23775305f10a44e1502 # main
     with:
-      extra-test-os: '["macos-latest"]'
+      extra-test-os: '["macos-latest", "windows-latest"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,27 @@ jobs:
           - asset: podup-linux-x86_64
             runner: ubuntu-latest
             target: x86_64-unknown-linux-musl
+            bin: podup
           - asset: podup-linux-arm64
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
+            bin: podup
           - asset: podup-darwin-arm64
             runner: macos-latest
             target: aarch64-apple-darwin
+            bin: podup
           - asset: podup-darwin-x86_64
             runner: macos-latest
             target: x86_64-apple-darwin
+            bin: podup
+          - asset: podup-windows-x86_64.exe
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            bin: podup.exe
+
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -78,7 +90,7 @@ jobs:
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Stage artifact
-        run: cp "target/${{ matrix.target }}/release/podup" "${{ matrix.asset }}"
+        run: cp "target/${{ matrix.target }}/release/${{ matrix.bin }}" "${{ matrix.asset }}"
 
       - name: Sign binary
         env:
@@ -132,6 +144,7 @@ jobs:
             podup-linux-arm64 \
             podup-darwin-arm64 \
             podup-darwin-x86_64 \
+            podup-windows-x86_64.exe \
             > SHA256SUMS
 
       - name: Create GitHub Release
@@ -150,5 +163,7 @@ jobs:
             podup-darwin-arm64.sig \
             podup-darwin-x86_64 \
             podup-darwin-x86_64.sig \
+            podup-windows-x86_64.exe \
+            podup-windows-x86_64.exe.sig \
             SHA256SUMS \
             install.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,14 @@ bollard = "0.21"
 clap = { version = "4", features = ["derive", "env"] }
 indexmap = { version = "2", features = ["serde"] }
 futures = "0.3"
-libc = "0.2"
 tar = "0.4"
 flate2 = "1.0"
 bytes = "1"
 walkdir = "2"
 notify = "8"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ flowchart LR
 curl -fsSL https://github.com/Glyndor/podup/releases/latest/download/install.sh | bash
 ```
 
-Binaries for Linux and macOS (x86_64 and arm64), SHA-256 verified, with build
-provenance attestations. On macOS, podup talks to the `podman machine` VM
-through its host-side socket. Or build from source:
+Binaries for Linux and macOS (x86_64 and arm64) plus Windows (x86_64),
+SHA-256 verified, with build provenance attestations. On macOS and Windows,
+podup talks to the `podman machine` VM through its host-side socket or named
+pipe. Windows users download `podup-windows-x86_64.exe` from the
+[releases page](https://github.com/Glyndor/podup/releases) directly. Or build
+from source:
 
 ```bash
 cargo build --release

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -7,6 +7,7 @@ mod container;
 mod health;
 mod network;
 mod profiles;
+mod staging;
 mod volume;
 mod watch;
 

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -1,0 +1,361 @@
+//! Private staging of inline secret/config content.
+//!
+//! Inline `content:`/`environment:` secrets and configs are written to a
+//! per-user, per-project staging directory before being bind-mounted into
+//! containers. The base directory must never be usable by another local
+//! user. On unix it is created 0700 under `$XDG_RUNTIME_DIR` (fallback:
+//! `temp_dir()/podup-<euid>`) and verified — real directory, owned by the
+//! current user, no group/other bits — failing closed on anything else.
+//! On Windows the base lives under the per-user temp directory, whose
+//! default ACLs already restrict access to the owning user; only the
+//! non-symlink directory check applies.
+
+use crate::error::{ComposeError, Result};
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::path::Path;
+
+/// Whether `name` is safe to use as a single path component and container
+/// name prefix: non-empty, bounded, ASCII alphanumeric plus `-`/`_`/`.`,
+/// not starting with a dot (rejects `.`, `..` and hidden directories).
+pub(super) fn is_safe_project_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && !name.starts_with('.')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+/// Per-user staging base for inline secret/config content.
+///
+/// Prefers `$XDG_RUNTIME_DIR/podup` (per-user and 0700 by contract); falls
+/// back to `temp_dir()/podup-<euid>`. The base sits in a world-writable
+/// parent in the fallback case, so after creation it is verified to be a
+/// real directory (not a symlink), owned by the current user, with no
+/// group/other permission bits. Anything else aborts (fail closed) instead
+/// of writing secret material under — or later deleting — a path another
+/// local user may control.
+#[cfg(unix)]
+pub(super) fn staging_base() -> Result<PathBuf> {
+    // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+
+    let base = match std::env::var_os("XDG_RUNTIME_DIR") {
+        Some(dir) if Path::new(&dir).is_absolute() => PathBuf::from(dir).join("podup"),
+        _ => std::env::temp_dir().join(format!("podup-{euid}")),
+    };
+
+    ensure_private_dir(&base, euid)?;
+    Ok(base)
+}
+
+/// Per-user staging base on Windows: `%TEMP%\podup`.
+///
+/// Unlike `/tmp` on unix, the Windows temp directory resolves under the
+/// user profile and its default ACLs grant access to the owning user only,
+/// so no ownership or permission-bit verification applies — just the
+/// non-symlink directory check.
+#[cfg(windows)]
+pub(super) fn staging_base() -> Result<PathBuf> {
+    let base = std::env::temp_dir().join("podup");
+    std::fs::create_dir_all(&base).map_err(ComposeError::Io)?;
+    let meta = std::fs::symlink_metadata(&base).map_err(ComposeError::Io)?;
+    if !meta.is_dir() || meta.file_type().is_symlink() {
+        return Err(ComposeError::Unsupported(format!(
+            "staging directory {} is not a private directory owned by the \
+             current user — refusing to use it",
+            base.display()
+        )));
+    }
+    Ok(base)
+}
+
+/// Create `dir` (recursively) accessible only to the current user.
+#[cfg(unix)]
+pub(super) fn create_private_subdir(dir: &Path) -> Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    // Create dir with 0o700 so only the owning user can list/enter it.
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+        .map_err(ComposeError::Io)
+}
+
+/// Create `dir` (recursively); the staging base already restricts access
+/// to the current user via inherited ACLs.
+#[cfg(windows)]
+pub(super) fn create_private_subdir(dir: &std::path::Path) -> Result<()> {
+    std::fs::create_dir_all(dir).map_err(ComposeError::Io)
+}
+
+/// Create `path` readable only by the current user and write `content`.
+#[cfg(unix)]
+pub(super) fn write_private_file(path: &Path, content: &[u8]) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    // Create file with 0o600 atomically — no world-readable window before chmod.
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(ComposeError::Io)?;
+    file.write_all(content).map_err(ComposeError::Io)
+}
+
+/// Create `path` and write `content`; access is restricted by the ACLs
+/// inherited from the per-user staging directory.
+#[cfg(windows)]
+pub(super) fn write_private_file(path: &std::path::Path, content: &[u8]) -> Result<()> {
+    std::fs::write(path, content).map_err(ComposeError::Io)
+}
+
+/// Apply a compose `mode:` value (octal unix permissions) to `path`.
+#[cfg(unix)]
+pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(ComposeError::Io)
+}
+
+/// Unix permission modes have no Windows equivalent — warn and continue.
+#[cfg(windows)]
+pub(super) fn apply_mode(path: &std::path::Path, mode: u32) -> Result<()> {
+    tracing::warn!(
+        "ignoring mode {mode:#o} for {}: unix permissions do not apply on this platform",
+        path.display()
+    );
+    Ok(())
+}
+
+/// Best-effort chown — succeeds in rootful Podman, no-op in rootless.
+#[cfg(unix)]
+pub(super) fn apply_owner(path: &Path, uid: Option<&str>, gid: Option<&str>) {
+    let uid_val: libc::uid_t = uid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
+    let gid_val: libc::gid_t = gid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
+    if uid_val != u32::MAX || gid_val != u32::MAX {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+        if let Ok(p) = CString::new(path.as_os_str().as_bytes()) {
+            let rc = unsafe { libc::chown(p.as_ptr(), uid_val, gid_val) };
+            if rc != 0 {
+                tracing::warn!(
+                    "chown failed for {}: {}",
+                    path.display(),
+                    std::io::Error::last_os_error()
+                );
+            }
+        }
+    }
+}
+
+/// Unix ownership has no Windows equivalent — warn and continue.
+#[cfg(windows)]
+pub(super) fn apply_owner(path: &std::path::Path, uid: Option<&str>, gid: Option<&str>) {
+    if uid.is_some() || gid.is_some() {
+        tracing::warn!(
+            "ignoring uid/gid for {}: unix ownership does not apply on this platform",
+            path.display()
+        );
+    }
+}
+
+/// Create `dir` (0700) if needed and require it to be a private directory.
+///
+/// `DirBuilder` does not reset permissions on a pre-existing directory, so
+/// a leftover directory we own whose bits drifted is self-healed with a
+/// chmod first — only if it is a real directory (never chmod through a
+/// symlink; in the worst race the chmod tightens something we own to 0700).
+/// `verify_private_dir` then rejects anything not ours (fail closed).
+#[cfg(unix)]
+fn ensure_private_dir(dir: &Path, euid: u32) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+        .map_err(ComposeError::Io)?;
+
+    let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
+    if meta.is_dir() {
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(ComposeError::Io)?;
+    }
+
+    verify_private_dir(dir, euid)
+}
+
+/// Verify that `dir` is a non-symlink directory owned by `euid` with no
+/// group/other permission bits.
+#[cfg(unix)]
+fn verify_private_dir(dir: &Path, euid: u32) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
+    if !meta.is_dir() || meta.uid() != euid || meta.mode() & 0o077 != 0 {
+        return Err(ComposeError::Unsupported(format!(
+            "staging directory {} is not a private directory owned by the \
+             current user — refusing to use it",
+            dir.display()
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod name_tests {
+    use super::is_safe_project_name;
+
+    #[test]
+    fn safe_project_names_accepted() {
+        for name in ["web", "my-app", "my_app", "app.v2", "A1"] {
+            assert!(is_safe_project_name(name), "{name:?} must be accepted");
+        }
+    }
+
+    #[test]
+    fn unsafe_project_names_rejected() {
+        let long = "a".repeat(129);
+        for name in [
+            "",
+            ".",
+            "..",
+            ".hidden",
+            "a/b",
+            "../x",
+            "a b",
+            "a\0b",
+            long.as_str(),
+        ] {
+            assert!(!is_safe_project_name(name), "{name:?} must be rejected");
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod staging_tests {
+    use super::verify_private_dir;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn private_dir_accepted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("chmod");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(dir.path(), euid).is_ok());
+    }
+
+    #[test]
+    fn group_accessible_dir_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
+            .expect("chmod");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(dir.path(), euid).is_err());
+    }
+
+    #[test]
+    fn foreign_owner_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("chmod");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let other = unsafe { libc::geteuid() } + 1;
+        assert!(verify_private_dir(dir.path(), other).is_err());
+    }
+
+    #[test]
+    fn symlink_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("real");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).expect("mkdir");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(&link, euid).is_err());
+    }
+
+    #[test]
+    fn regular_file_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("file");
+        std::fs::write(&file, b"x").expect("write");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(verify_private_dir(&file, euid).is_err());
+    }
+}
+
+#[cfg(all(test, unix))]
+mod ensure_dir_tests {
+    use super::ensure_private_dir;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    #[test]
+    fn creates_fresh_private_dir() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let dir = root.path().join("base");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        ensure_private_dir(&dir, euid).expect("fresh dir");
+        let meta = std::fs::metadata(&dir).expect("metadata");
+        assert_eq!(meta.mode() & 0o777, 0o700);
+    }
+
+    #[test]
+    fn heals_drifted_permissions_on_owned_dir() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let dir = root.path().join("base");
+        std::fs::create_dir(&dir).expect("mkdir");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        ensure_private_dir(&dir, euid).expect("healed dir");
+        let meta = std::fs::metadata(&dir).expect("metadata");
+        assert_eq!(meta.mode() & 0o777, 0o700);
+    }
+
+    #[test]
+    fn symlinked_dir_is_rejected_not_healed() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let target = root.path().join("real");
+        let link = root.path().join("link");
+        std::fs::create_dir(&target).expect("mkdir");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        assert!(ensure_private_dir(&link, euid).is_err());
+        // Target permissions stay untouched — no chmod through the link.
+        let meta = std::fs::metadata(&target).expect("metadata");
+        assert_eq!(meta.mode() & 0o777, 0o755);
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_staging_tests {
+    use super::staging_base;
+
+    #[test]
+    fn staging_base_is_a_directory() {
+        let base = staging_base().expect("staging base");
+        assert!(base.is_dir());
+        assert!(base.ends_with("podup"));
+    }
+}

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -22,7 +22,7 @@ use crate::compose::types::{
 };
 use crate::error::{ComposeError, Result};
 
-use super::Engine;
+use super::{staging, Engine};
 
 impl Engine {
     pub(super) async fn create_volumes(&self, file: &ComposeFile) -> Result<()> {
@@ -411,9 +411,6 @@ impl Engine {
         uid: Option<&str>,
         gid: Option<&str>,
     ) -> Result<std::path::PathBuf> {
-        use std::io::Write;
-        use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
-
         // Reject names that could escape the temp dir (path traversal).
         if std::path::Path::new(name)
             .components()
@@ -425,49 +422,15 @@ impl Engine {
         }
 
         let dir = self.staging_dir()?.join(kind);
-
-        // Create dir with 0o700 so only the owning user can list/enter it.
-        std::fs::DirBuilder::new()
-            .recursive(true)
-            .mode(0o700)
-            .create(&dir)
-            .map_err(ComposeError::Io)?;
+        staging::create_private_subdir(&dir)?;
 
         let path = dir.join(name);
-
-        // Create file with 0o600 atomically — no world-readable window before chmod.
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&path)
-            .map_err(ComposeError::Io)?;
-        file.write_all(content).map_err(ComposeError::Io)?;
-        drop(file);
+        staging::write_private_file(&path, content)?;
 
         if let Some(m) = mode {
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(m))
-                .map_err(ComposeError::Io)?;
+            staging::apply_mode(&path, m)?;
         }
-
-        // Best-effort chown — succeeds in rootful Podman, no-op in rootless.
-        let uid_val: libc::uid_t = uid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
-        let gid_val: libc::gid_t = gid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
-        if uid_val != u32::MAX || gid_val != u32::MAX {
-            use std::ffi::CString;
-            use std::os::unix::ffi::OsStrExt;
-            if let Ok(p) = CString::new(path.as_os_str().as_bytes()) {
-                let rc = unsafe { libc::chown(p.as_ptr(), uid_val, gid_val) };
-                if rc != 0 {
-                    tracing::warn!(
-                        "chown failed for {}: {}",
-                        path.display(),
-                        std::io::Error::last_os_error()
-                    );
-                }
-            }
-        }
+        staging::apply_owner(&path, uid, gid);
 
         Ok(path)
     }
@@ -484,90 +447,15 @@ impl Engine {
     /// The project name is validated first so it can never traverse out of
     /// the base — this same path is later passed to `remove_dir_all`.
     fn staging_dir(&self) -> Result<std::path::PathBuf> {
-        if !is_safe_project_name(&self.project) {
+        if !staging::is_safe_project_name(&self.project) {
             return Err(ComposeError::Unsupported(format!(
                 "project name must be ASCII alphanumeric/dash/underscore/dot \
                  and must not start with a dot: {}",
                 self.project
             )));
         }
-        Ok(staging_base()?.join(&self.project))
+        Ok(staging::staging_base()?.join(&self.project))
     }
-}
-
-/// Whether `name` is safe to use as a single path component and container
-/// name prefix: non-empty, bounded, ASCII alphanumeric plus `-`/`_`/`.`,
-/// not starting with a dot (rejects `.`, `..` and hidden directories).
-fn is_safe_project_name(name: &str) -> bool {
-    !name.is_empty()
-        && name.len() <= 128
-        && !name.starts_with('.')
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
-}
-
-/// Per-user staging base for inline secret/config content.
-///
-/// Prefers `$XDG_RUNTIME_DIR/podup` (per-user and 0700 by contract); falls
-/// back to `temp_dir()/podup-<euid>`. The base sits in a world-writable
-/// parent in the fallback case, so after creation it is verified to be a
-/// real directory (not a symlink), owned by the current user, with no
-/// group/other permission bits. Anything else aborts (fail closed) instead
-/// of writing secret material under — or later deleting — a path another
-/// local user may control.
-fn staging_base() -> Result<std::path::PathBuf> {
-    // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-    let euid = unsafe { libc::geteuid() };
-
-    let base = match std::env::var_os("XDG_RUNTIME_DIR") {
-        Some(dir) if Path::new(&dir).is_absolute() => std::path::PathBuf::from(dir).join("podup"),
-        _ => std::env::temp_dir().join(format!("podup-{euid}")),
-    };
-
-    ensure_private_dir(&base, euid)?;
-    Ok(base)
-}
-
-/// Create `dir` (0700) if needed and require it to be a private directory.
-///
-/// `DirBuilder` does not reset permissions on a pre-existing directory, so
-/// a leftover directory we own whose bits drifted is self-healed with a
-/// chmod first — only if it is a real directory (never chmod through a
-/// symlink; in the worst race the chmod tightens something we own to 0700).
-/// `verify_private_dir` then rejects anything not ours (fail closed).
-fn ensure_private_dir(dir: &Path, euid: u32) -> Result<()> {
-    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
-
-    std::fs::DirBuilder::new()
-        .recursive(true)
-        .mode(0o700)
-        .create(dir)
-        .map_err(ComposeError::Io)?;
-
-    let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
-    if meta.is_dir() {
-        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
-            .map_err(ComposeError::Io)?;
-    }
-
-    verify_private_dir(dir, euid)
-}
-
-/// Verify that `dir` is a non-symlink directory owned by `euid` with no
-/// group/other permission bits.
-fn verify_private_dir(dir: &Path, euid: u32) -> Result<()> {
-    use std::os::unix::fs::MetadataExt;
-
-    let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
-    if !meta.is_dir() || meta.uid() != euid || meta.mode() & 0o077 != 0 {
-        return Err(ComposeError::Unsupported(format!(
-            "staging directory {} is not a private directory owned by the \
-             current user — refusing to use it",
-            dir.display()
-        )));
-    }
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -665,135 +553,5 @@ mod tests {
         }]);
         let binds = build_binds(&svc, Path::new("/base"));
         assert!(binds.is_empty());
-    }
-}
-
-#[cfg(test)]
-mod staging_tests {
-    use super::{is_safe_project_name, verify_private_dir};
-    use std::os::unix::fs::PermissionsExt;
-
-    #[test]
-    fn safe_project_names_accepted() {
-        for name in ["web", "my-app", "my_app", "app.v2", "A1"] {
-            assert!(is_safe_project_name(name), "{name:?} must be accepted");
-        }
-    }
-
-    #[test]
-    fn unsafe_project_names_rejected() {
-        let long = "a".repeat(129);
-        for name in [
-            "",
-            ".",
-            "..",
-            ".hidden",
-            "a/b",
-            "../x",
-            "a b",
-            "a\0b",
-            long.as_str(),
-        ] {
-            assert!(!is_safe_project_name(name), "{name:?} must be rejected");
-        }
-    }
-
-    #[test]
-    fn private_dir_accepted() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
-            .expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(dir.path(), euid).is_ok());
-    }
-
-    #[test]
-    fn group_accessible_dir_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
-            .expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(dir.path(), euid).is_err());
-    }
-
-    #[test]
-    fn foreign_owner_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
-            .expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let other = unsafe { libc::geteuid() } + 1;
-        assert!(verify_private_dir(dir.path(), other).is_err());
-    }
-
-    #[test]
-    fn symlink_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let target = dir.path().join("real");
-        let link = dir.path().join("link");
-        std::fs::create_dir(&target).expect("mkdir");
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).expect("chmod");
-        std::os::unix::fs::symlink(&target, &link).expect("symlink");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(&link, euid).is_err());
-    }
-
-    #[test]
-    fn regular_file_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let file = dir.path().join("file");
-        std::fs::write(&file, b"x").expect("write");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(&file, euid).is_err());
-    }
-}
-
-#[cfg(test)]
-mod ensure_dir_tests {
-    use super::ensure_private_dir;
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
-
-    #[test]
-    fn creates_fresh_private_dir() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let dir = root.path().join("base");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        ensure_private_dir(&dir, euid).expect("fresh dir");
-        let meta = std::fs::metadata(&dir).expect("metadata");
-        assert_eq!(meta.mode() & 0o777, 0o700);
-    }
-
-    #[test]
-    fn heals_drifted_permissions_on_owned_dir() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let dir = root.path().join("base");
-        std::fs::create_dir(&dir).expect("mkdir");
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        ensure_private_dir(&dir, euid).expect("healed dir");
-        let meta = std::fs::metadata(&dir).expect("metadata");
-        assert_eq!(meta.mode() & 0o777, 0o700);
-    }
-
-    #[test]
-    fn symlinked_dir_is_rejected_not_healed() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let target = root.path().join("real");
-        let link = root.path().join("link");
-        std::fs::create_dir(&target).expect("mkdir");
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        std::os::unix::fs::symlink(&target, &link).expect("symlink");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(ensure_private_dir(&link, euid).is_err());
-        // Target permissions stay untouched — no chmod through the link.
-        let meta = std::fs::metadata(&target).expect("metadata");
-        assert_eq!(meta.mode() & 0o777, 0o755);
     }
 }

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -2,23 +2,32 @@
 
 use crate::error::Result;
 use bollard::Docker;
+#[cfg(any(not(windows), test))]
 use std::path::Path;
 
+#[cfg(any(not(windows), test))]
 const ROOT_SOCKET: &str = "/run/podman/podman.sock";
 
-/// Connect to Podman's Docker-compatible socket.
+/// Named pipe `podman machine` exposes on Windows for its default machine.
+#[cfg(windows)]
+const DEFAULT_PIPE: &str = "//./pipe/podman-machine-default";
+
+/// Connect to Podman's Docker-compatible API.
 ///
 /// Priority:
 /// 1. `socket_path` if provided.
 /// 2. The first existing platform default — on Linux the rootful or
 ///    per-user runtime socket, on macOS the host-side socket exposed by
-///    `podman machine`.
+///    `podman machine`, on Windows the `podman machine` named pipe.
 /// 3. The conventional path for this platform, so a failed connection
 ///    reports the location podup expected.
 pub fn connect(socket_path: Option<&str>) -> Result<Docker> {
     let default_path = default_socket_path();
     let path = socket_path.unwrap_or(&default_path);
+    #[cfg(not(windows))]
     let client = Docker::connect_with_unix(path, 120, bollard::API_DEFAULT_VERSION)?;
+    #[cfg(windows)]
+    let client = Docker::connect_with_named_pipe(path, 120, bollard::API_DEFAULT_VERSION)?;
     Ok(client)
 }
 
@@ -28,10 +37,14 @@ pub fn connect_from_env() -> Result<Docker> {
         .or_else(|_| std::env::var("DOCKER_HOST"))
         .ok();
 
-    let path = socket.as_deref().and_then(|s| s.strip_prefix("unix://"));
+    let path = socket.as_deref().and_then(|s| {
+        s.strip_prefix("unix://")
+            .or_else(|| s.strip_prefix("npipe://"))
+    });
     connect(path)
 }
 
+#[cfg(not(windows))]
 fn default_socket_path() -> String {
     let candidates = candidate_socket_paths();
     first_existing(&candidates)
@@ -40,7 +53,14 @@ fn default_socket_path() -> String {
         .unwrap_or_else(|| ROOT_SOCKET.to_string())
 }
 
-#[cfg(not(target_os = "macos"))]
+/// Windows: named pipes are not probeable through `Path::exists`, so ask
+/// `podman machine inspect` and fall back to the default machine's pipe.
+#[cfg(windows)]
+fn default_socket_path() -> String {
+    machine_socket_path().unwrap_or_else(|| DEFAULT_PIPE.to_string())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn candidate_socket_paths() -> Vec<String> {
     let uid = unsafe { libc::getuid() };
     runtime_candidates(uid, std::env::var("XDG_RUNTIME_DIR").ok().as_deref())
@@ -57,7 +77,7 @@ fn candidate_socket_paths() -> Vec<String> {
 /// Socket candidates for Linux and other unix hosts: the rootful socket
 /// for uid 0, otherwise the user's runtime directory (preferring
 /// `XDG_RUNTIME_DIR` when set).
-#[cfg(any(not(target_os = "macos"), test))]
+#[cfg(any(all(unix, not(target_os = "macos")), test))]
 fn runtime_candidates(uid: u32, xdg_runtime_dir: Option<&str>) -> Vec<String> {
     if uid == 0 {
         return vec![ROOT_SOCKET.to_string()];
@@ -107,11 +127,33 @@ fn machine_socket_path() -> Option<String> {
     (!path.is_empty() && Path::new(&path).exists()).then_some(path)
 }
 
-#[cfg(not(target_os = "macos"))]
+/// Ask `podman machine inspect` for the named pipe of the default machine.
+/// The pipe path is reported by the machine config; `Path::exists` cannot
+/// probe named pipes, so the value is used as-is.
+#[cfg(windows)]
+fn machine_socket_path() -> Option<String> {
+    let output = std::process::Command::new("podman")
+        .args([
+            "machine",
+            "inspect",
+            "--format",
+            "{{ .ConnectionInfo.PodmanPipe.Path }}",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!path.is_empty() && path != "<nil>").then_some(path)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn machine_socket_path() -> Option<String> {
     None
 }
 
+#[cfg(any(not(windows), test))]
 fn first_existing(candidates: &[String]) -> Option<String> {
     candidates.iter().find(|p| Path::new(p).exists()).cloned()
 }


### PR DESCRIPTION
Closes #44

Completes cross-platform support (Linux + macOS landed in #46): podup now builds, tests and releases for Windows.

## What

- **Named pipe connection** (`internal/podman/mod.rs`): on Windows podup connects through `Docker::connect_with_named_pipe`, resolving the pipe via `podman machine inspect --format '{{ .ConnectionInfo.PodmanPipe.Path }}'` and falling back to the default machine's `//./pipe/podman-machine-default`. `DOCKER_HOST`/`PODMAN_SOCKET` values with an `npipe://` prefix are honored.
- **Staging extracted to `engine::staging`** (new module, also shrinks the 799-line `volume.rs` per the file-size standard): all platform-specific filesystem behavior for inline secret/config materialisation now lives in one place.
  - unix: byte-for-byte the previous behavior — verified 0700 `XDG_RUNTIME_DIR` base, atomic 0600 file creation, mode/chown application, fail-closed ownership checks. Tests moved along.
  - Windows: stages under `%TEMP%\podup` (per-user ACLs by default, unlike world-writable `/tmp`; symlink/non-dir still rejected) and warns when compose `mode:`/`uid:`/`gid:` fields cannot apply.
- **libc** becomes a `[target.'cfg(unix)'.dependencies]` entry.
- **CI**: `windows-latest` joins `extra-test-os`.
- **Release**: `podup-windows-x86_64.exe` (+`.sig`, attestation, checksum) joins the matrix; build steps standardized on bash across runners. `install.sh` stays unix-only — the README points Windows users at the release asset.

## Test plan

- `cargo test --workspace` — 264 tests green on Linux
- `cargo clippy --all-targets --all-features` clean on `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-gnu` and `aarch64-apple-darwin`
- `cargo check --target x86_64-pc-windows-gnu --all-targets` — whole crate, tests included
- The `Test (windows-latest)` and `Test (macos-latest)` CI jobs on this PR run the suite on real runners
- Real `podman machine` smoke test on Windows hardware pending — tracked with the macOS smoke test before tagging the next release