### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+podup (0.4.0) unstable; urgency=medium
+
+  * Resolve the Podman socket per platform; macOS and Windows hosts are
+    now supported via the podman machine socket and named pipe.
+  * Extract inline secret/config staging into a per-platform module.
+  * Add crates.io package metadata.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 05 Jun 2026 19:00:00 -0500
+
 podup (0.3.2) unstable; urgency=medium
 
   * Harden inline secret staging directory against tmp squatting.

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -31,8 +31,10 @@ single file: `/usr/bin/podup`.
    maintainer's identity.
 3. **Sponsorship** — upload through a Debian Developer (the Rust team's
    `team+rust@tracker.debian.org` is the natural reviewer for a Rust tool).
-4. **crates.io publication** — the name `podup` is verified available;
-   `debcargo` consumes crates.io releases, so publishing there first
+4. **crates.io publication** — the name `podup` is verified available and
+   the crate metadata is in place (`cargo package` verifies clean), so
+   publication is a single `cargo publish` with the owner's registry
+   token. `debcargo` consumes crates.io releases, so publishing first
    simplifies everything.
 5. **Stability promise** — official packages imply SemVer discipline and a
    `1.0.0` once the CLI surface is settled.


### PR DESCRIPTION
Part of #48

Release prep for v0.4.0:

- `Cargo.toml`/`Cargo.lock` → 0.4.0
- `debian/changelog` 0.4.0 entry (required in every release PR)
- `docs/debian-packaging.md`: crates.io metadata is in place; publication is one `cargo publish` away

## Test plan

- `cargo check` — clean, lockfile consistent