### PR TITLE
refactor: split oversized engine files and add unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,4 @@ jobs:
     uses: Glyndor/.github/.github/workflows/rust-ci.yml@bc62ab8f95465df2b2f6f23775305f10a44e1502 # main
     with:
       extra-test-os: '["macos-latest", "windows-latest"]'
+      coverage-threshold: 50

--- a/internal/compose/extends.rs
+++ b/internal/compose/extends.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 
 use super::parse_file_inner;
 use super::types::{
-    ComposeFile, DependsOn, EnvFile, EnvVars, Labels, Service, ServiceNetworks, StringOrList,
-    Sysctls,
+	ComposeFile, DependsOn, EnvFile, EnvVars, Labels, Service, ServiceNetworks, StringOrList,
+	Sysctls,
 };
 use crate::error::{ComposeError, Result};
 
@@ -26,23 +26,23 @@ use crate::error::{ComposeError, Result};
 ///
 /// Used by [`super::parse_str`] where there is no on-disk path.
 pub(super) fn resolve_extends_same_file(file: &mut ComposeFile) -> Result<()> {
-    let names: Vec<String> = file.services.keys().cloned().collect();
-    for name in names {
-        let mut visited: HashSet<String> = HashSet::new();
-        resolve_one_extends_in_memory(file, &name, &mut visited)?;
-    }
-    Ok(())
+	let names: Vec<String> = file.services.keys().cloned().collect();
+	for name in names {
+		let mut visited: HashSet<String> = HashSet::new();
+		resolve_one_extends_in_memory(file, &name, &mut visited)?;
+	}
+	Ok(())
 }
 
 /// Resolve `extends:` for every service in `file`, including chains across
 /// other compose files referenced by `extends.file`.
 pub(super) fn resolve_all_extends(file: &mut ComposeFile, base_dir: &Path) -> Result<()> {
-    let names: Vec<String> = file.services.keys().cloned().collect();
-    for name in names {
-        let mut visited: HashSet<String> = HashSet::new();
-        resolve_one_extends(file, &name, base_dir, &mut visited)?;
-    }
-    Ok(())
+	let names: Vec<String> = file.services.keys().cloned().collect();
+	for name in names {
+		let mut visited: HashSet<String> = HashSet::new();
+		resolve_one_extends(file, &name, base_dir, &mut visited)?;
+	}
+	Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -50,126 +50,126 @@ pub(super) fn resolve_all_extends(file: &mut ComposeFile, base_dir: &Path) -> Re
 // ---------------------------------------------------------------------------
 
 fn resolve_one_extends_in_memory(
-    file: &mut ComposeFile,
-    name: &str,
-    visited: &mut HashSet<String>,
+	file: &mut ComposeFile,
+	name: &str,
+	visited: &mut HashSet<String>,
 ) -> Result<()> {
-    if !visited.insert(name.to_string()) {
-        return Err(ComposeError::Extends(format!("circular extends at {name}")));
-    }
+	if !visited.insert(name.to_string()) {
+		return Err(ComposeError::Extends(format!("circular extends at {name}")));
+	}
 
-    let extends = match file.services.get(name).and_then(|s| s.extends.clone()) {
-        Some(e) => e,
-        None => return Ok(()),
-    };
+	let extends = match file.services.get(name).and_then(|s| s.extends.clone()) {
+		Some(e) => e,
+		None => return Ok(()),
+	};
 
-    if extends.file().is_some() {
-        return Err(ComposeError::Extends(format!(
-            "service '{name}' uses 'extends.file' but parser was given a string, not a path"
-        )));
-    }
+	if extends.file().is_some() {
+		return Err(ComposeError::Extends(format!(
+			"service '{name}' uses 'extends.file' but parser was given a string, not a path"
+		)));
+	}
 
-    let base_name = extends.service().to_string();
-    if base_name == name {
-        return Err(ComposeError::Extends(format!(
-            "service '{name}' extends itself"
-        )));
-    }
+	let base_name = extends.service().to_string();
+	if base_name == name {
+		return Err(ComposeError::Extends(format!(
+			"service '{name}' extends itself"
+		)));
+	}
 
-    if file.services.get(&base_name).is_none() {
-        return Err(ComposeError::Extends(format!(
-            "service '{name}' extends unknown service '{base_name}'"
-        )));
-    }
-    resolve_one_extends_in_memory(file, &base_name, visited)?;
+	if file.services.get(&base_name).is_none() {
+		return Err(ComposeError::Extends(format!(
+			"service '{name}' extends unknown service '{base_name}'"
+		)));
+	}
+	resolve_one_extends_in_memory(file, &base_name, visited)?;
 
-    let base = file
-        .services
-        .get(&base_name)
-        .cloned()
-        .ok_or_else(|| ComposeError::Extends(base_name.clone()))?;
+	let base = file
+		.services
+		.get(&base_name)
+		.cloned()
+		.ok_or_else(|| ComposeError::Extends(base_name.clone()))?;
 
-    if let Some(svc) = file.services.get_mut(name) {
-        let merged = merge_service(base, svc.clone());
-        *svc = merged;
-        svc.extends = None;
-    }
+	if let Some(svc) = file.services.get_mut(name) {
+		let merged = merge_service(base, svc.clone());
+		*svc = merged;
+		svc.extends = None;
+	}
 
-    Ok(())
+	Ok(())
 }
 
 fn resolve_one_extends(
-    file: &mut ComposeFile,
-    name: &str,
-    base_dir: &Path,
-    visited: &mut HashSet<String>,
+	file: &mut ComposeFile,
+	name: &str,
+	base_dir: &Path,
+	visited: &mut HashSet<String>,
 ) -> Result<()> {
-    if !visited.insert(name.to_string()) {
-        return Err(ComposeError::Extends(format!("circular extends at {name}")));
-    }
+	if !visited.insert(name.to_string()) {
+		return Err(ComposeError::Extends(format!("circular extends at {name}")));
+	}
 
-    let extends = match file.services.get(name).and_then(|s| s.extends.clone()) {
-        Some(e) => e,
-        None => return Ok(()),
-    };
+	let extends = match file.services.get(name).and_then(|s| s.extends.clone()) {
+		Some(e) => e,
+		None => return Ok(()),
+	};
 
-    let base_name = extends.service().to_string();
+	let base_name = extends.service().to_string();
 
-    let base_service = if let Some(file_path) = extends.file() {
-        let fp = std::path::Path::new(file_path);
-        if fp.is_absolute() {
-            return Err(ComposeError::Extends(format!(
-                "service '{name}' extends.file must be relative, got absolute path: {file_path}"
-            )));
-        }
-        if fp
-            .components()
-            .any(|c| c == std::path::Component::ParentDir)
-        {
-            return Err(ComposeError::Extends(format!(
-                "service '{name}' extends.file must not traverse parent directories: {file_path}"
-            )));
-        }
-        let abs = base_dir.join(file_path);
-        let abs = abs.canonicalize().unwrap_or(abs);
-        let dir = abs
-            .parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| base_dir.to_path_buf());
-        let mut other = parse_file_inner(&abs, &dir)?;
-        let mut nested_visited: HashSet<String> = HashSet::new();
-        resolve_one_extends(&mut other, &base_name, &dir, &mut nested_visited)?;
-        other.services.swap_remove(&base_name).ok_or_else(|| {
-            ComposeError::Extends(format!(
-                "service '{base_name}' not found in {}",
-                abs.display()
-            ))
-        })?
-    } else {
-        if base_name == name {
-            return Err(ComposeError::Extends(format!(
-                "service '{name}' extends itself"
-            )));
-        }
-        if !file.services.contains_key(&base_name) {
-            return Err(ComposeError::Extends(format!(
-                "service '{name}' extends unknown service '{base_name}'"
-            )));
-        }
-        resolve_one_extends(file, &base_name, base_dir, visited)?;
-        file.services
-            .get(&base_name)
-            .cloned()
-            .ok_or_else(|| ComposeError::Extends(base_name.clone()))?
-    };
+	let base_service = if let Some(file_path) = extends.file() {
+		let fp = std::path::Path::new(file_path);
+		if fp.is_absolute() {
+			return Err(ComposeError::Extends(format!(
+				"service '{name}' extends.file must be relative, got absolute path: {file_path}"
+			)));
+		}
+		if fp
+			.components()
+			.any(|c| c == std::path::Component::ParentDir)
+		{
+			return Err(ComposeError::Extends(format!(
+				"service '{name}' extends.file must not traverse parent directories: {file_path}"
+			)));
+		}
+		let abs = base_dir.join(file_path);
+		let abs = abs.canonicalize().unwrap_or(abs);
+		let dir = abs
+			.parent()
+			.map(|p| p.to_path_buf())
+			.unwrap_or_else(|| base_dir.to_path_buf());
+		let mut other = parse_file_inner(&abs, &dir)?;
+		let mut nested_visited: HashSet<String> = HashSet::new();
+		resolve_one_extends(&mut other, &base_name, &dir, &mut nested_visited)?;
+		other.services.swap_remove(&base_name).ok_or_else(|| {
+			ComposeError::Extends(format!(
+				"service '{base_name}' not found in {}",
+				abs.display()
+			))
+		})?
+	} else {
+		if base_name == name {
+			return Err(ComposeError::Extends(format!(
+				"service '{name}' extends itself"
+			)));
+		}
+		if !file.services.contains_key(&base_name) {
+			return Err(ComposeError::Extends(format!(
+				"service '{name}' extends unknown service '{base_name}'"
+			)));
+		}
+		resolve_one_extends(file, &base_name, base_dir, visited)?;
+		file.services
+			.get(&base_name)
+			.cloned()
+			.ok_or_else(|| ComposeError::Extends(base_name.clone()))?
+	};
 
-    if let Some(svc) = file.services.get_mut(name) {
-        let merged = merge_service(base_service, svc.clone());
-        *svc = merged;
-        svc.extends = None;
-    }
+	if let Some(svc) = file.services.get_mut(name) {
+		let merged = merge_service(base_service, svc.clone());
+		*svc = merged;
+		svc.extends = None;
+	}
 
-    Ok(())
+	Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -181,176 +181,176 @@ fn resolve_one_extends(
 /// `override_svc` wins for scalar fields it explicitly sets.
 /// `Vec` / `Map` collections are replaced when the override is non-empty.
 pub(super) fn merge_service(base: Service, override_svc: Service) -> Service {
-    fn opt<T>(o: Option<T>, b: Option<T>) -> Option<T> {
-        o.or(b)
-    }
+	fn opt<T>(o: Option<T>, b: Option<T>) -> Option<T> {
+		o.or(b)
+	}
 
-    fn merge_envvars(base: EnvVars, over: EnvVars) -> EnvVars {
-        if matches!(over, EnvVars::Empty) && !matches!(base, EnvVars::Empty) {
-            return base;
-        }
-        if matches!(base, EnvVars::Empty) {
-            return over;
-        }
-        let mut merged: indexmap::IndexMap<String, Option<serde_yaml::Value>> =
-            indexmap::IndexMap::new();
-        for (k, v) in base.to_map() {
-            merged.insert(k, v.map(serde_yaml::Value::String));
-        }
-        for (k, v) in over.to_map() {
-            merged.insert(k, v.map(serde_yaml::Value::String));
-        }
-        EnvVars::Map(merged)
-    }
+	fn merge_envvars(base: EnvVars, over: EnvVars) -> EnvVars {
+		if matches!(over, EnvVars::Empty) && !matches!(base, EnvVars::Empty) {
+			return base;
+		}
+		if matches!(base, EnvVars::Empty) {
+			return over;
+		}
+		let mut merged: indexmap::IndexMap<String, Option<serde_yaml::Value>> =
+			indexmap::IndexMap::new();
+		for (k, v) in base.to_map() {
+			merged.insert(k, v.map(serde_yaml::Value::String));
+		}
+		for (k, v) in over.to_map() {
+			merged.insert(k, v.map(serde_yaml::Value::String));
+		}
+		EnvVars::Map(merged)
+	}
 
-    fn merge_labels(base: Labels, over: Labels) -> Labels {
-        if base.is_empty() && over.is_empty() {
-            return Labels::Empty;
-        }
-        let mut map: indexmap::IndexMap<String, String> = indexmap::IndexMap::new();
-        for (k, v) in base.to_map() {
-            map.insert(k, v);
-        }
-        for (k, v) in over.to_map() {
-            map.insert(k, v);
-        }
-        Labels::Map(map)
-    }
+	fn merge_labels(base: Labels, over: Labels) -> Labels {
+		if base.is_empty() && over.is_empty() {
+			return Labels::Empty;
+		}
+		let mut map: indexmap::IndexMap<String, String> = indexmap::IndexMap::new();
+		for (k, v) in base.to_map() {
+			map.insert(k, v);
+		}
+		for (k, v) in over.to_map() {
+			map.insert(k, v);
+		}
+		Labels::Map(map)
+	}
 
-    fn merge_vec<T: Clone>(base: Vec<T>, over: Vec<T>) -> Vec<T> {
-        if over.is_empty() {
-            base
-        } else {
-            over
-        }
-    }
+	fn merge_vec<T: Clone>(base: Vec<T>, over: Vec<T>) -> Vec<T> {
+		if over.is_empty() {
+			base
+		} else {
+			over
+		}
+	}
 
-    fn merge_sol(base: StringOrList, over: StringOrList) -> StringOrList {
-        if over.is_empty() {
-            base
-        } else {
-            over
-        }
-    }
+	fn merge_sol(base: StringOrList, over: StringOrList) -> StringOrList {
+		if over.is_empty() {
+			base
+		} else {
+			over
+		}
+	}
 
-    fn merge_env_file(base: EnvFile, over: EnvFile) -> EnvFile {
-        if over.is_empty() {
-            base
-        } else {
-            over
-        }
-    }
+	fn merge_env_file(base: EnvFile, over: EnvFile) -> EnvFile {
+		if over.is_empty() {
+			base
+		} else {
+			over
+		}
+	}
 
-    Service {
-        image: opt(override_svc.image, base.image),
-        build: override_svc.build.or(base.build),
-        extends: override_svc.extends.or(base.extends),
-        command: override_svc.command.or(base.command),
-        entrypoint: override_svc.entrypoint.or(base.entrypoint),
-        ports: merge_vec(base.ports, override_svc.ports),
-        expose: merge_vec(base.expose, override_svc.expose),
-        environment: merge_envvars(base.environment, override_svc.environment),
-        env_file: merge_env_file(base.env_file, override_svc.env_file),
-        volumes: merge_vec(base.volumes, override_svc.volumes),
-        tmpfs: merge_sol(base.tmpfs, override_svc.tmpfs),
-        volumes_from: merge_vec(base.volumes_from, override_svc.volumes_from),
-        configs: merge_vec(base.configs, override_svc.configs),
-        secrets: merge_vec(base.secrets, override_svc.secrets),
-        networks: if matches!(override_svc.networks, ServiceNetworks::Empty) {
-            base.networks
-        } else {
-            override_svc.networks
-        },
-        hostname: override_svc.hostname.or(base.hostname),
-        domainname: override_svc.domainname.or(base.domainname),
-        mac_address: override_svc.mac_address.or(base.mac_address),
-        links: merge_vec(base.links, override_svc.links),
-        external_links: merge_vec(base.external_links, override_svc.external_links),
-        extra_hosts: merge_vec(base.extra_hosts, override_svc.extra_hosts),
-        dns: merge_sol(base.dns, override_svc.dns),
-        dns_search: merge_sol(base.dns_search, override_svc.dns_search),
-        dns_opt: merge_sol(base.dns_opt, override_svc.dns_opt),
-        network_mode: override_svc.network_mode.or(base.network_mode),
-        depends_on: if matches!(override_svc.depends_on, DependsOn::Empty) {
-            base.depends_on
-        } else {
-            override_svc.depends_on
-        },
-        healthcheck: override_svc.healthcheck.or(base.healthcheck),
-        restart: override_svc.restart.or(base.restart),
-        stop_signal: override_svc.stop_signal.or(base.stop_signal),
-        stop_grace_period: override_svc.stop_grace_period.or(base.stop_grace_period),
-        profiles: merge_vec(base.profiles, override_svc.profiles),
-        post_start: merge_vec(base.post_start, override_svc.post_start),
-        pre_stop: merge_vec(base.pre_stop, override_svc.pre_stop),
-        labels: merge_labels(base.labels, override_svc.labels),
-        annotations: merge_labels(base.annotations, override_svc.annotations),
-        container_name: override_svc.container_name.or(base.container_name),
-        user: override_svc.user.or(base.user),
-        working_dir: override_svc.working_dir.or(base.working_dir),
-        group_add: merge_vec(base.group_add, override_svc.group_add),
-        platform: override_svc.platform.or(base.platform),
-        cap_add: merge_vec(base.cap_add, override_svc.cap_add),
-        cap_drop: merge_vec(base.cap_drop, override_svc.cap_drop),
-        security_opt: merge_vec(base.security_opt, override_svc.security_opt),
-        read_only: override_svc.read_only.or(base.read_only),
-        privileged: override_svc.privileged.or(base.privileged),
-        init: override_svc.init.or(base.init),
-        tty: override_svc.tty.or(base.tty),
-        stdin_open: override_svc.stdin_open.or(base.stdin_open),
-        runtime: override_svc.runtime.or(base.runtime),
-        shm_size: override_svc.shm_size.or(base.shm_size),
-        userns_mode: override_svc.userns_mode.or(base.userns_mode),
-        pid: override_svc.pid.or(base.pid),
-        ipc: override_svc.ipc.or(base.ipc),
-        uts: override_svc.uts.or(base.uts),
-        cgroup_parent: override_svc.cgroup_parent.or(base.cgroup_parent),
-        cgroup: override_svc.cgroup.or(base.cgroup),
-        devices: merge_vec(base.devices, override_svc.devices),
-        device_cgroup_rules: merge_vec(base.device_cgroup_rules, override_svc.device_cgroup_rules),
-        storage_opt: {
-            let mut m = base.storage_opt;
-            for (k, v) in override_svc.storage_opt {
-                m.insert(k, v);
-            }
-            m
-        },
-        scale: override_svc.scale.or(base.scale),
-        cpu_shares: override_svc.cpu_shares.or(base.cpu_shares),
-        cpu_quota: override_svc.cpu_quota.or(base.cpu_quota),
-        cpu_period: override_svc.cpu_period.or(base.cpu_period),
-        cpuset: override_svc.cpuset.or(base.cpuset),
-        cpus: override_svc.cpus.or(base.cpus),
-        cpu_count: override_svc.cpu_count.or(base.cpu_count),
-        cpu_percent: override_svc.cpu_percent.or(base.cpu_percent),
-        cpu_rt_runtime: override_svc.cpu_rt_runtime.or(base.cpu_rt_runtime),
-        cpu_rt_period: override_svc.cpu_rt_period.or(base.cpu_rt_period),
-        mem_limit: override_svc.mem_limit.or(base.mem_limit),
-        memswap_limit: override_svc.memswap_limit.or(base.memswap_limit),
-        mem_reservation: override_svc.mem_reservation.or(base.mem_reservation),
-        mem_swappiness: override_svc.mem_swappiness.or(base.mem_swappiness),
-        pids_limit: override_svc.pids_limit.or(base.pids_limit),
-        oom_kill_disable: override_svc.oom_kill_disable.or(base.oom_kill_disable),
-        oom_score_adj: override_svc.oom_score_adj.or(base.oom_score_adj),
-        blkio_config: override_svc.blkio_config.or(base.blkio_config),
-        logging: override_svc.logging.or(base.logging),
-        sysctls: if matches!(override_svc.sysctls, Sysctls::Empty) {
-            base.sysctls
-        } else {
-            override_svc.sysctls
-        },
-        ulimits: {
-            let mut m = base.ulimits;
-            for (k, v) in override_svc.ulimits {
-                m.insert(k, v);
-            }
-            m
-        },
-        label_file: merge_sol(base.label_file, override_svc.label_file),
-        attach: override_svc.attach.or(base.attach),
-        pull_policy: override_svc.pull_policy.or(base.pull_policy),
-        deploy: override_svc.deploy.or(base.deploy),
-        develop: override_svc.develop.or(base.develop),
-        gpus: override_svc.gpus.or(base.gpus),
-    }
+	Service {
+		image: opt(override_svc.image, base.image),
+		build: override_svc.build.or(base.build),
+		extends: override_svc.extends.or(base.extends),
+		command: override_svc.command.or(base.command),
+		entrypoint: override_svc.entrypoint.or(base.entrypoint),
+		ports: merge_vec(base.ports, override_svc.ports),
+		expose: merge_vec(base.expose, override_svc.expose),
+		environment: merge_envvars(base.environment, override_svc.environment),
+		env_file: merge_env_file(base.env_file, override_svc.env_file),
+		volumes: merge_vec(base.volumes, override_svc.volumes),
+		tmpfs: merge_sol(base.tmpfs, override_svc.tmpfs),
+		volumes_from: merge_vec(base.volumes_from, override_svc.volumes_from),
+		configs: merge_vec(base.configs, override_svc.configs),
+		secrets: merge_vec(base.secrets, override_svc.secrets),
+		networks: if matches!(override_svc.networks, ServiceNetworks::Empty) {
+			base.networks
+		} else {
+			override_svc.networks
+		},
+		hostname: override_svc.hostname.or(base.hostname),
+		domainname: override_svc.domainname.or(base.domainname),
+		mac_address: override_svc.mac_address.or(base.mac_address),
+		links: merge_vec(base.links, override_svc.links),
+		external_links: merge_vec(base.external_links, override_svc.external_links),
+		extra_hosts: merge_vec(base.extra_hosts, override_svc.extra_hosts),
+		dns: merge_sol(base.dns, override_svc.dns),
+		dns_search: merge_sol(base.dns_search, override_svc.dns_search),
+		dns_opt: merge_sol(base.dns_opt, override_svc.dns_opt),
+		network_mode: override_svc.network_mode.or(base.network_mode),
+		depends_on: if matches!(override_svc.depends_on, DependsOn::Empty) {
+			base.depends_on
+		} else {
+			override_svc.depends_on
+		},
+		healthcheck: override_svc.healthcheck.or(base.healthcheck),
+		restart: override_svc.restart.or(base.restart),
+		stop_signal: override_svc.stop_signal.or(base.stop_signal),
+		stop_grace_period: override_svc.stop_grace_period.or(base.stop_grace_period),
+		profiles: merge_vec(base.profiles, override_svc.profiles),
+		post_start: merge_vec(base.post_start, override_svc.post_start),
+		pre_stop: merge_vec(base.pre_stop, override_svc.pre_stop),
+		labels: merge_labels(base.labels, override_svc.labels),
+		annotations: merge_labels(base.annotations, override_svc.annotations),
+		container_name: override_svc.container_name.or(base.container_name),
+		user: override_svc.user.or(base.user),
+		working_dir: override_svc.working_dir.or(base.working_dir),
+		group_add: merge_vec(base.group_add, override_svc.group_add),
+		platform: override_svc.platform.or(base.platform),
+		cap_add: merge_vec(base.cap_add, override_svc.cap_add),
+		cap_drop: merge_vec(base.cap_drop, override_svc.cap_drop),
+		security_opt: merge_vec(base.security_opt, override_svc.security_opt),
+		read_only: override_svc.read_only.or(base.read_only),
+		privileged: override_svc.privileged.or(base.privileged),
+		init: override_svc.init.or(base.init),
+		tty: override_svc.tty.or(base.tty),
+		stdin_open: override_svc.stdin_open.or(base.stdin_open),
+		runtime: override_svc.runtime.or(base.runtime),
+		shm_size: override_svc.shm_size.or(base.shm_size),
+		userns_mode: override_svc.userns_mode.or(base.userns_mode),
+		pid: override_svc.pid.or(base.pid),
+		ipc: override_svc.ipc.or(base.ipc),
+		uts: override_svc.uts.or(base.uts),
+		cgroup_parent: override_svc.cgroup_parent.or(base.cgroup_parent),
+		cgroup: override_svc.cgroup.or(base.cgroup),
+		devices: merge_vec(base.devices, override_svc.devices),
+		device_cgroup_rules: merge_vec(base.device_cgroup_rules, override_svc.device_cgroup_rules),
+		storage_opt: {
+			let mut m = base.storage_opt;
+			for (k, v) in override_svc.storage_opt {
+				m.insert(k, v);
+			}
+			m
+		},
+		scale: override_svc.scale.or(base.scale),
+		cpu_shares: override_svc.cpu_shares.or(base.cpu_shares),
+		cpu_quota: override_svc.cpu_quota.or(base.cpu_quota),
+		cpu_period: override_svc.cpu_period.or(base.cpu_period),
+		cpuset: override_svc.cpuset.or(base.cpuset),
+		cpus: override_svc.cpus.or(base.cpus),
+		cpu_count: override_svc.cpu_count.or(base.cpu_count),
+		cpu_percent: override_svc.cpu_percent.or(base.cpu_percent),
+		cpu_rt_runtime: override_svc.cpu_rt_runtime.or(base.cpu_rt_runtime),
+		cpu_rt_period: override_svc.cpu_rt_period.or(base.cpu_rt_period),
+		mem_limit: override_svc.mem_limit.or(base.mem_limit),
+		memswap_limit: override_svc.memswap_limit.or(base.memswap_limit),
+		mem_reservation: override_svc.mem_reservation.or(base.mem_reservation),
+		mem_swappiness: override_svc.mem_swappiness.or(base.mem_swappiness),
+		pids_limit: override_svc.pids_limit.or(base.pids_limit),
+		oom_kill_disable: override_svc.oom_kill_disable.or(base.oom_kill_disable),
+		oom_score_adj: override_svc.oom_score_adj.or(base.oom_score_adj),
+		blkio_config: override_svc.blkio_config.or(base.blkio_config),
+		logging: override_svc.logging.or(base.logging),
+		sysctls: if matches!(override_svc.sysctls, Sysctls::Empty) {
+			base.sysctls
+		} else {
+			override_svc.sysctls
+		},
+		ulimits: {
+			let mut m = base.ulimits;
+			for (k, v) in override_svc.ulimits {
+				m.insert(k, v);
+			}
+			m
+		},
+		label_file: merge_sol(base.label_file, override_svc.label_file),
+		attach: override_svc.attach.or(base.attach),
+		pull_policy: override_svc.pull_policy.or(base.pull_policy),
+		deploy: override_svc.deploy.or(base.deploy),
+		develop: override_svc.develop.or(base.develop),
+		gpus: override_svc.gpus.or(base.gpus),
+	}
 }

--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -11,19 +11,19 @@ use super::types::ComposeFile;
 /// Services / volumes / networks / secrets / configs from `other` are added;
 /// existing entries in `target` win on conflict (parent file overrides included content).
 pub(super) fn merge_compose_file(target: &mut ComposeFile, other: ComposeFile) {
-    for (k, v) in other.services {
-        target.services.entry(k).or_insert(v);
-    }
-    for (k, v) in other.volumes {
-        target.volumes.entry(k).or_insert(v);
-    }
-    for (k, v) in other.networks {
-        target.networks.entry(k).or_insert(v);
-    }
-    for (k, v) in other.secrets {
-        target.secrets.entry(k).or_insert(v);
-    }
-    for (k, v) in other.configs {
-        target.configs.entry(k).or_insert(v);
-    }
+	for (k, v) in other.services {
+		target.services.entry(k).or_insert(v);
+	}
+	for (k, v) in other.volumes {
+		target.volumes.entry(k).or_insert(v);
+	}
+	for (k, v) in other.networks {
+		target.networks.entry(k).or_insert(v);
+	}
+	for (k, v) in other.secrets {
+		target.secrets.entry(k).or_insert(v);
+	}
+	for (k, v) in other.configs {
+		target.configs.entry(k).or_insert(v);
+	}
 }

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -20,52 +20,52 @@ use types::ComposeFile;
 /// Parse a compose file from disk, applying variable substitution and
 /// resolving `extends:` / `include:` directives.
 pub fn parse_file(path: &Path) -> Result<ComposeFile> {
-    let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
-    let mut file = parse_file_inner(&abs, &dir)?;
+	let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+	let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
+	let mut file = parse_file_inner(&abs, &dir)?;
 
-    let includes = std::mem::take(&mut file.include);
-    for inc in includes {
-        let (extra_env_files, project_dir_override) = match &inc {
-            types::IncludeConfig::Long {
-                env_file,
-                project_directory,
-                ..
-            } => (
-                env_file.as_ref().map(|ef| ef.to_list()).unwrap_or_default(),
-                project_directory.as_ref().map(|pd| dir.join(pd)),
-            ),
-            _ => (vec![], None),
-        };
-        for rel in inc.paths() {
-            let rel_path = std::path::Path::new(&rel);
-            if rel_path.is_absolute() {
-                return Err(ComposeError::Include(format!(
-                    "include path must be relative, got absolute path: {rel}"
-                )));
-            }
-            if rel_path
-                .components()
-                .any(|c| c == std::path::Component::ParentDir)
-            {
-                return Err(ComposeError::Include(format!(
-                    "include path must not traverse parent directories: {rel}"
-                )));
-            }
-            let inc_path = dir.join(&rel);
-            let inc_dir = project_dir_override.clone().unwrap_or_else(|| {
-                inc_path
-                    .parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or_else(|| dir.clone())
-            });
-            let included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
-            include::merge_compose_file(&mut file, included);
-        }
-    }
+	let includes = std::mem::take(&mut file.include);
+	for inc in includes {
+		let (extra_env_files, project_dir_override) = match &inc {
+			types::IncludeConfig::Long {
+				env_file,
+				project_directory,
+				..
+			} => (
+				env_file.as_ref().map(|ef| ef.to_list()).unwrap_or_default(),
+				project_directory.as_ref().map(|pd| dir.join(pd)),
+			),
+			_ => (vec![], None),
+		};
+		for rel in inc.paths() {
+			let rel_path = std::path::Path::new(&rel);
+			if rel_path.is_absolute() {
+				return Err(ComposeError::Include(format!(
+					"include path must be relative, got absolute path: {rel}"
+				)));
+			}
+			if rel_path
+				.components()
+				.any(|c| c == std::path::Component::ParentDir)
+			{
+				return Err(ComposeError::Include(format!(
+					"include path must not traverse parent directories: {rel}"
+				)));
+			}
+			let inc_path = dir.join(&rel);
+			let inc_dir = project_dir_override.clone().unwrap_or_else(|| {
+				inc_path
+					.parent()
+					.map(|p| p.to_path_buf())
+					.unwrap_or_else(|| dir.clone())
+			});
+			let included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
+			include::merge_compose_file(&mut file, included);
+		}
+	}
 
-    extends::resolve_all_extends(&mut file, &dir)?;
-    Ok(file)
+	extends::resolve_all_extends(&mut file, &dir)?;
+	Ok(file)
 }
 
 /// Parse a compose YAML string (no file I/O).
@@ -74,17 +74,17 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 /// `extends: { file: ... }` and `include:` directives are not resolved —
 /// use [`parse_file`] for that.
 pub fn parse_str(content: &str) -> Result<ComposeFile> {
-    let vars = substitute::build_vars(Path::new("."));
-    let substituted = substitute::substitute(content, &vars)?;
-    let mut file = deserialize_with_merge(&substituted)?;
-    extends::resolve_extends_same_file(&mut file)?;
-    Ok(file)
+	let vars = substitute::build_vars(Path::new("."));
+	let substituted = substitute::substitute(content, &vars)?;
+	let mut file = deserialize_with_merge(&substituted)?;
+	extends::resolve_extends_same_file(&mut file)?;
+	Ok(file)
 }
 
 /// Parse raw (already-substituted) YAML into a `ComposeFile` without any
 /// post-processing.
 pub fn parse_str_raw(content: &str) -> Result<ComposeFile> {
-    deserialize_with_merge(content)
+	deserialize_with_merge(content)
 }
 
 /// Compute a topological start order for all services (Kahn's algorithm).
@@ -93,54 +93,54 @@ pub fn parse_str_raw(content: &str) -> Result<ComposeFile> {
 /// Errors on cycles ([`ComposeError::CircularDependency`]) or missing required
 /// dependencies ([`ComposeError::ServiceNotFound`]).
 pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
-    let services: Vec<&str> = file.services.keys().map(|s| s.as_str()).collect();
-    let mut in_degree: HashMap<&str, usize> = services.iter().map(|&s| (s, 0)).collect();
-    let mut graph: HashMap<&str, Vec<&str>> = services.iter().map(|&s| (s, vec![])).collect();
+	let services: Vec<&str> = file.services.keys().map(|s| s.as_str()).collect();
+	let mut in_degree: HashMap<&str, usize> = services.iter().map(|&s| (s, 0)).collect();
+	let mut graph: HashMap<&str, Vec<&str>> = services.iter().map(|&s| (s, vec![])).collect();
 
-    for (name, service) in &file.services {
-        for dep in service.depends_on.service_names() {
-            if !file.services.contains_key(&dep) {
-                if !service.depends_on.required_for(&dep) {
-                    continue;
-                }
-                return Err(ComposeError::ServiceNotFound(dep));
-            }
-            if let Some(neighbors) = graph.get_mut(dep.as_str()) {
-                neighbors.push(name.as_str());
-            }
-            if let Some(deg) = in_degree.get_mut(name.as_str()) {
-                *deg += 1;
-            }
-        }
-    }
+	for (name, service) in &file.services {
+		for dep in service.depends_on.service_names() {
+			if !file.services.contains_key(&dep) {
+				if !service.depends_on.required_for(&dep) {
+					continue;
+				}
+				return Err(ComposeError::ServiceNotFound(dep));
+			}
+			if let Some(neighbors) = graph.get_mut(dep.as_str()) {
+				neighbors.push(name.as_str());
+			}
+			if let Some(deg) = in_degree.get_mut(name.as_str()) {
+				*deg += 1;
+			}
+		}
+	}
 
-    let mut queue: std::collections::VecDeque<&str> = in_degree
-        .iter()
-        .filter(|(_, &deg)| deg == 0)
-        .map(|(&s, _)| s)
-        .collect();
+	let mut queue: std::collections::VecDeque<&str> = in_degree
+		.iter()
+		.filter(|(_, &deg)| deg == 0)
+		.map(|(&s, _)| s)
+		.collect();
 
-    let mut order = Vec::new();
-    while let Some(node) = queue.pop_front() {
-        order.push(node.to_string());
-        let neighbors: Vec<&str> = graph.get(node).map_or(&[][..], |v| v.as_slice()).to_vec();
-        for neighbor in neighbors {
-            if let Some(deg) = in_degree.get_mut(neighbor) {
-                *deg -= 1;
-                if *deg == 0 {
-                    queue.push_back(neighbor);
-                }
-            }
-        }
-    }
+	let mut order = Vec::new();
+	while let Some(node) = queue.pop_front() {
+		order.push(node.to_string());
+		let neighbors: Vec<&str> = graph.get(node).map_or(&[][..], |v| v.as_slice()).to_vec();
+		for neighbor in neighbors {
+			if let Some(deg) = in_degree.get_mut(neighbor) {
+				*deg -= 1;
+				if *deg == 0 {
+					queue.push_back(neighbor);
+				}
+			}
+		}
+	}
 
-    if order.len() != services.len() {
-        return Err(ComposeError::CircularDependency(
-            "cycle detected in depends_on".into(),
-        ));
-    }
+	if order.len() != services.len() {
+		return Err(ComposeError::CircularDependency(
+			"cycle detected in depends_on".into(),
+		));
+	}
 
-    Ok(order)
+	Ok(order)
 }
 
 // ---------------------------------------------------------------------------
@@ -148,30 +148,30 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 // ---------------------------------------------------------------------------
 
 pub(crate) fn parse_file_inner(path: &Path, dir: &Path) -> Result<ComposeFile> {
-    parse_file_inner_with_env(path, dir, &[])
+	parse_file_inner_with_env(path, dir, &[])
 }
 
 pub(crate) fn parse_file_inner_with_env(
-    path: &Path,
-    dir: &Path,
-    extra_env_files: &[String],
+	path: &Path,
+	dir: &Path,
+	extra_env_files: &[String],
 ) -> Result<ComposeFile> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|_| ComposeError::FileNotFound(path.display().to_string()))?;
-    let vars = if extra_env_files.is_empty() {
-        substitute::build_vars(dir)
-    } else {
-        substitute::build_vars_with_env_files(dir, extra_env_files)
-    };
-    let substituted = substitute::substitute(&content, &vars)?;
-    deserialize_with_merge(&substituted)
+	let content = std::fs::read_to_string(path)
+		.map_err(|_| ComposeError::FileNotFound(path.display().to_string()))?;
+	let vars = if extra_env_files.is_empty() {
+		substitute::build_vars(dir)
+	} else {
+		substitute::build_vars_with_env_files(dir, extra_env_files)
+	};
+	let substituted = substitute::substitute(&content, &vars)?;
+	deserialize_with_merge(&substituted)
 }
 
 fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
-    let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
-    apply_merge_keys(&mut value);
-    let file: ComposeFile = serde_yaml::from_value(value)?;
-    Ok(file)
+	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
+	apply_merge_keys(&mut value);
+	let file: ComposeFile = serde_yaml::from_value(value)?;
+	Ok(file)
 }
 
 /// Recursively resolve YAML merge keys (`<<: *anchor`) in a `Value` tree.
@@ -179,38 +179,38 @@ fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
 /// yaml_serde does not expose `apply_merge()` — this replaces it.
 /// Merge semantics: keys from the anchor fill in only where the child has no value.
 fn apply_merge_keys(value: &mut serde_yaml::Value) {
-    match value {
-        serde_yaml::Value::Mapping(mapping) => {
-            for v in mapping.values_mut() {
-                apply_merge_keys(v);
-            }
-            let merge_key = serde_yaml::Value::String("<<".to_string());
-            if let Some(merge_val) = mapping.remove(&merge_key) {
-                let bases: Vec<serde_yaml::Mapping> = match merge_val {
-                    serde_yaml::Value::Mapping(m) => vec![m],
-                    serde_yaml::Value::Sequence(seq) => seq
-                        .into_iter()
-                        .filter_map(|v| match v {
-                            serde_yaml::Value::Mapping(m) => Some(m),
-                            _ => None,
-                        })
-                        .collect(),
-                    _ => vec![],
-                };
-                for base in bases {
-                    for (k, v) in base {
-                        if !mapping.contains_key(&k) {
-                            mapping.insert(k, v);
-                        }
-                    }
-                }
-            }
-        }
-        serde_yaml::Value::Sequence(seq) => {
-            for v in seq.iter_mut() {
-                apply_merge_keys(v);
-            }
-        }
-        _ => {}
-    }
+	match value {
+		serde_yaml::Value::Mapping(mapping) => {
+			for v in mapping.values_mut() {
+				apply_merge_keys(v);
+			}
+			let merge_key = serde_yaml::Value::String("<<".to_string());
+			if let Some(merge_val) = mapping.remove(&merge_key) {
+				let bases: Vec<serde_yaml::Mapping> = match merge_val {
+					serde_yaml::Value::Mapping(m) => vec![m],
+					serde_yaml::Value::Sequence(seq) => seq
+						.into_iter()
+						.filter_map(|v| match v {
+							serde_yaml::Value::Mapping(m) => Some(m),
+							_ => None,
+						})
+						.collect(),
+					_ => vec![],
+				};
+				for base in bases {
+					for (k, v) in base {
+						if !mapping.contains_key(&k) {
+							mapping.insert(k, v);
+						}
+					}
+				}
+			}
+		}
+		serde_yaml::Value::Sequence(seq) => {
+			for v in seq.iter_mut() {
+				apply_merge_keys(v);
+			}
+		}
+		_ => {}
+	}
 }

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -17,23 +17,23 @@ use super::{EnvVars, Labels, StringOrList, UlimitConfig};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IncludeConfig {
-    Path(String),
-    Long {
-        path: StringOrList,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        env_file: Option<StringOrList>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        project_directory: Option<String>,
-    },
+	Path(String),
+	Long {
+		path: StringOrList,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		env_file: Option<StringOrList>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		project_directory: Option<String>,
+	},
 }
 
 impl IncludeConfig {
-    pub fn paths(&self) -> Vec<String> {
-        match self {
-            IncludeConfig::Path(p) => vec![p.clone()],
-            IncludeConfig::Long { path, .. } => path.to_list(),
-        }
-    }
+	pub fn paths(&self) -> Vec<String> {
+		match self {
+			IncludeConfig::Path(p) => vec![p.clone()],
+			IncludeConfig::Long { path, .. } => path.to_list(),
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -43,28 +43,28 @@ impl IncludeConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ExtendsConfig {
-    Service(String),
-    Long {
-        service: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        file: Option<String>,
-    },
+	Service(String),
+	Long {
+		service: String,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		file: Option<String>,
+	},
 }
 
 impl ExtendsConfig {
-    pub fn service(&self) -> &str {
-        match self {
-            ExtendsConfig::Service(s) => s,
-            ExtendsConfig::Long { service, .. } => service,
-        }
-    }
+	pub fn service(&self) -> &str {
+		match self {
+			ExtendsConfig::Service(s) => s,
+			ExtendsConfig::Long { service, .. } => service,
+		}
+	}
 
-    pub fn file(&self) -> Option<&str> {
-        match self {
-            ExtendsConfig::Service(_) => None,
-            ExtendsConfig::Long { file, .. } => file.as_deref(),
-        }
-    }
+	pub fn file(&self) -> Option<&str> {
+		match self {
+			ExtendsConfig::Service(_) => None,
+			ExtendsConfig::Long { file, .. } => file.as_deref(),
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -75,135 +75,135 @@ impl ExtendsConfig {
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum BuildConfig {
-    Context(String),
-    Config {
-        context: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        dockerfile: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        dockerfile_inline: Option<String>,
-        #[serde(default)]
-        args: EnvVars,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        target: Option<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        cache_from: Vec<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        cache_to: Vec<String>,
-        #[serde(default)]
-        labels: Labels,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        shm_size: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        network: Option<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        platforms: Vec<String>,
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-        additional_contexts: HashMap<String, String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        no_cache: Option<bool>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pull: Option<bool>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        extra_hosts: Vec<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        tags: Vec<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        privileged: Option<bool>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        ssh: Vec<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        secrets: Vec<String>,
-        #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-        ulimits: IndexMap<String, UlimitConfig>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        isolation: Option<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        entitlements: Vec<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        provenance: Option<serde_yaml::Value>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        sbom: Option<bool>,
-    },
+	Context(String),
+	Config {
+		context: String,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		dockerfile: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		dockerfile_inline: Option<String>,
+		#[serde(default)]
+		args: EnvVars,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		target: Option<String>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		cache_from: Vec<String>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		cache_to: Vec<String>,
+		#[serde(default)]
+		labels: Labels,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		shm_size: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		network: Option<String>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		platforms: Vec<String>,
+		#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+		additional_contexts: HashMap<String, String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		no_cache: Option<bool>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		pull: Option<bool>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		extra_hosts: Vec<String>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		tags: Vec<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		privileged: Option<bool>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		ssh: Vec<String>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		secrets: Vec<String>,
+		#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+		ulimits: IndexMap<String, UlimitConfig>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		isolation: Option<String>,
+		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		entitlements: Vec<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		provenance: Option<serde_yaml::Value>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		sbom: Option<bool>,
+	},
 }
 
 impl BuildConfig {
-    pub fn context(&self) -> &str {
-        match self {
-            BuildConfig::Context(ctx) => ctx,
-            BuildConfig::Config { context, .. } => context,
-        }
-    }
+	pub fn context(&self) -> &str {
+		match self {
+			BuildConfig::Context(ctx) => ctx,
+			BuildConfig::Config { context, .. } => context,
+		}
+	}
 
-    pub fn dockerfile(&self) -> Option<&str> {
-        match self {
-            BuildConfig::Context(_) => None,
-            BuildConfig::Config { dockerfile, .. } => dockerfile.as_deref(),
-        }
-    }
+	pub fn dockerfile(&self) -> Option<&str> {
+		match self {
+			BuildConfig::Context(_) => None,
+			BuildConfig::Config { dockerfile, .. } => dockerfile.as_deref(),
+		}
+	}
 
-    pub fn args(&self) -> EnvVars {
-        match self {
-            BuildConfig::Context(_) => EnvVars::Empty,
-            BuildConfig::Config { args, .. } => args.clone(),
-        }
-    }
+	pub fn args(&self) -> EnvVars {
+		match self {
+			BuildConfig::Context(_) => EnvVars::Empty,
+			BuildConfig::Config { args, .. } => args.clone(),
+		}
+	}
 
-    pub fn target(&self) -> Option<&str> {
-        match self {
-            BuildConfig::Context(_) => None,
-            BuildConfig::Config { target, .. } => target.as_deref(),
-        }
-    }
+	pub fn target(&self) -> Option<&str> {
+		match self {
+			BuildConfig::Context(_) => None,
+			BuildConfig::Config { target, .. } => target.as_deref(),
+		}
+	}
 
-    pub fn no_cache(&self) -> bool {
-        match self {
-            BuildConfig::Context(_) => false,
-            BuildConfig::Config { no_cache, .. } => no_cache.unwrap_or(false),
-        }
-    }
+	pub fn no_cache(&self) -> bool {
+		match self {
+			BuildConfig::Context(_) => false,
+			BuildConfig::Config { no_cache, .. } => no_cache.unwrap_or(false),
+		}
+	}
 
-    pub fn pull(&self) -> bool {
-        match self {
-            BuildConfig::Context(_) => false,
-            BuildConfig::Config { pull, .. } => pull.unwrap_or(false),
-        }
-    }
+	pub fn pull(&self) -> bool {
+		match self {
+			BuildConfig::Context(_) => false,
+			BuildConfig::Config { pull, .. } => pull.unwrap_or(false),
+		}
+	}
 
-    pub fn shm_size(&self) -> Option<&str> {
-        match self {
-            BuildConfig::Context(_) => None,
-            BuildConfig::Config { shm_size, .. } => shm_size.as_deref(),
-        }
-    }
+	pub fn shm_size(&self) -> Option<&str> {
+		match self {
+			BuildConfig::Context(_) => None,
+			BuildConfig::Config { shm_size, .. } => shm_size.as_deref(),
+		}
+	}
 
-    pub fn extra_hosts(&self) -> &[String] {
-        match self {
-            BuildConfig::Context(_) => &[],
-            BuildConfig::Config { extra_hosts, .. } => extra_hosts,
-        }
-    }
+	pub fn extra_hosts(&self) -> &[String] {
+		match self {
+			BuildConfig::Context(_) => &[],
+			BuildConfig::Config { extra_hosts, .. } => extra_hosts,
+		}
+	}
 
-    pub fn tags(&self) -> &[String] {
-        match self {
-            BuildConfig::Context(_) => &[],
-            BuildConfig::Config { tags, .. } => tags,
-        }
-    }
+	pub fn tags(&self) -> &[String] {
+		match self {
+			BuildConfig::Context(_) => &[],
+			BuildConfig::Config { tags, .. } => tags,
+		}
+	}
 
-    pub fn cache_from(&self) -> &[String] {
-        match self {
-            BuildConfig::Context(_) => &[],
-            BuildConfig::Config { cache_from, .. } => cache_from,
-        }
-    }
+	pub fn cache_from(&self) -> &[String] {
+		match self {
+			BuildConfig::Context(_) => &[],
+			BuildConfig::Config { cache_from, .. } => cache_from,
+		}
+	}
 
-    pub fn dockerfile_inline(&self) -> Option<&str> {
-        match self {
-            BuildConfig::Context(_) => None,
-            BuildConfig::Config {
-                dockerfile_inline, ..
-            } => dockerfile_inline.as_deref(),
-        }
-    }
+	pub fn dockerfile_inline(&self) -> Option<&str> {
+		match self {
+			BuildConfig::Context(_) => None,
+			BuildConfig::Config {
+				dockerfile_inline, ..
+			} => dockerfile_inline.as_deref(),
+		}
+	}
 }

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -17,24 +17,24 @@ use super::Labels;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub replicas: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resources: Option<ResourcesConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub restart_policy: Option<DeployRestartPolicy>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub update_config: Option<DeployUpdateConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rollback_config: Option<DeployUpdateConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub endpoint_mode: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<String>,
-    #[serde(default)]
-    pub labels: Labels,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub placement: Option<DeployPlacement>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub replicas: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub resources: Option<ResourcesConfig>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub restart_policy: Option<DeployRestartPolicy>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub update_config: Option<DeployUpdateConfig>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub rollback_config: Option<DeployUpdateConfig>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub endpoint_mode: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub mode: Option<String>,
+	#[serde(default)]
+	pub labels: Labels,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub placement: Option<DeployPlacement>,
 }
 
 // ---------------------------------------------------------------------------
@@ -43,22 +43,22 @@ pub struct DeployConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourcesConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub limits: Option<ResourceSpec>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reservations: Option<ResourceSpec>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub limits: Option<ResourceSpec>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub reservations: Option<ResourceSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourceSpec {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpus: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pids: Option<u64>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub devices: Vec<DeviceReservation>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpus: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub memory: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub pids: Option<u64>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub devices: Vec<DeviceReservation>,
 }
 
 // ---------------------------------------------------------------------------
@@ -68,33 +68,33 @@ pub struct ResourceSpec {
 /// `deploy.resources.reservations.devices` — generic device reservation.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeviceReservation {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub capabilities: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub count: Option<CountOrAll>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub device_ids: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub options: HashMap<String, String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub capabilities: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub count: Option<CountOrAll>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub device_ids: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub options: HashMap<String, String>,
 }
 
 /// `count: all` or `count: N`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CountOrAll {
-    Named(String),
-    N(i64),
+	Named(String),
+	N(i64),
 }
 
 impl CountOrAll {
-    pub fn to_i64(&self) -> i64 {
-        match self {
-            CountOrAll::Named(_) => -1,
-            CountOrAll::N(n) => *n,
-        }
-    }
+	pub fn to_i64(&self) -> i64 {
+		match self {
+			CountOrAll::Named(_) => -1,
+			CountOrAll::N(n) => *n,
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -103,38 +103,38 @@ impl CountOrAll {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployRestartPolicy {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub condition: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub delay: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_attempts: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub window: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub condition: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub delay: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub max_attempts: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub window: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployUpdateConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub parallelism: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub delay: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failure_action: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub monitor: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_failure_ratio: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub parallelism: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub delay: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub failure_action: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub monitor: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub max_failure_ratio: Option<f64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub order: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployPlacement {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub constraints: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub preferences: Vec<serde_yaml::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_replicas_per_node: Option<u32>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub constraints: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub preferences: Vec<serde_yaml::Value>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub max_replicas_per_node: Option<u32>,
 }

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DevelopConfig {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub watch: Vec<WatchRule>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub watch: Vec<WatchRule>,
 }
 
 // ---------------------------------------------------------------------------
@@ -23,18 +23,18 @@ pub struct DevelopConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchRule {
-    pub path: String,
-    pub action: WatchAction,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub target: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub ignore: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub include: Vec<String>,
-    #[serde(default)]
-    pub initial_sync: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub exec: Option<WatchExec>,
+	pub path: String,
+	pub action: WatchAction,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub target: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub ignore: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub include: Vec<String>,
+	#[serde(default)]
+	pub initial_sync: bool,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub exec: Option<WatchExec>,
 }
 
 // ---------------------------------------------------------------------------
@@ -43,28 +43,28 @@ pub struct WatchRule {
 
 #[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
 pub enum WatchAction {
-    #[default]
-    Sync,
-    Rebuild,
-    Restart,
-    SyncAndRestart,
-    SyncAndExec,
+	#[default]
+	Sync,
+	Rebuild,
+	Restart,
+	SyncAndRestart,
+	SyncAndExec,
 }
 
 impl<'de> Deserialize<'de> for WatchAction {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(d)?;
-        match s.as_str() {
-            "sync" => Ok(WatchAction::Sync),
-            "rebuild" => Ok(WatchAction::Rebuild),
-            "restart" => Ok(WatchAction::Restart),
-            "sync+restart" => Ok(WatchAction::SyncAndRestart),
-            "sync+exec" => Ok(WatchAction::SyncAndExec),
-            other => Err(serde::de::Error::custom(format!(
-                "unknown watch action: {other}"
-            ))),
-        }
-    }
+	fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+		let s = String::deserialize(d)?;
+		match s.as_str() {
+			"sync" => Ok(WatchAction::Sync),
+			"rebuild" => Ok(WatchAction::Rebuild),
+			"restart" => Ok(WatchAction::Restart),
+			"sync+restart" => Ok(WatchAction::SyncAndRestart),
+			"sync+exec" => Ok(WatchAction::SyncAndExec),
+			other => Err(serde::de::Error::custom(format!(
+				"unknown watch action: {other}"
+			))),
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -73,5 +73,5 @@ impl<'de> Deserialize<'de> for WatchAction {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchExec {
-    pub command: Vec<String>,
+	pub command: Vec<String>,
 }

--- a/internal/compose/types/env.rs
+++ b/internal/compose/types/env.rs
@@ -11,114 +11,114 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum EnvVars {
-    #[default]
-    Empty,
-    List(Vec<String>),
-    Map(IndexMap<String, Option<serde_yaml::Value>>),
+	#[default]
+	Empty,
+	List(Vec<String>),
+	Map(IndexMap<String, Option<serde_yaml::Value>>),
 }
 
 impl EnvVars {
-    pub fn to_map(&self) -> HashMap<String, Option<String>> {
-        match self {
-            EnvVars::Empty => HashMap::new(),
-            EnvVars::List(list) => list
-                .iter()
-                .filter_map(|s| {
-                    let mut parts = s.splitn(2, '=');
-                    let key = parts.next()?.to_string();
-                    let val = parts.next().map(|v| v.to_string());
-                    Some((key, val))
-                })
-                .collect(),
-            EnvVars::Map(map) => map
-                .iter()
-                .map(|(k, v)| {
-                    let val = v.as_ref().and_then(|v| match v {
-                        serde_yaml::Value::String(s) => Some(s.clone()),
-                        serde_yaml::Value::Number(n) => Some(n.to_string()),
-                        serde_yaml::Value::Bool(b) => Some(b.to_string()),
-                        serde_yaml::Value::Null => None,
-                        _ => None,
-                    });
-                    (k.clone(), val)
-                })
-                .collect(),
-        }
-    }
+	pub fn to_map(&self) -> HashMap<String, Option<String>> {
+		match self {
+			EnvVars::Empty => HashMap::new(),
+			EnvVars::List(list) => list
+				.iter()
+				.filter_map(|s| {
+					let mut parts = s.splitn(2, '=');
+					let key = parts.next()?.to_string();
+					let val = parts.next().map(|v| v.to_string());
+					Some((key, val))
+				})
+				.collect(),
+			EnvVars::Map(map) => map
+				.iter()
+				.map(|(k, v)| {
+					let val = v.as_ref().and_then(|v| match v {
+						serde_yaml::Value::String(s) => Some(s.clone()),
+						serde_yaml::Value::Number(n) => Some(n.to_string()),
+						serde_yaml::Value::Bool(b) => Some(b.to_string()),
+						serde_yaml::Value::Null => None,
+						_ => None,
+					});
+					(k.clone(), val)
+				})
+				.collect(),
+		}
+	}
 
-    pub fn is_empty(&self) -> bool {
-        match self {
-            EnvVars::Empty => true,
-            EnvVars::List(v) => v.is_empty(),
-            EnvVars::Map(m) => m.is_empty(),
-        }
-    }
+	pub fn is_empty(&self) -> bool {
+		match self {
+			EnvVars::Empty => true,
+			EnvVars::List(v) => v.is_empty(),
+			EnvVars::Map(m) => m.is_empty(),
+		}
+	}
 }
 
 /// One entry in an `env_file:` list — either a bare path or a long-form object.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum EnvFileEntry {
-    Path(String),
-    Config {
-        path: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        required: Option<bool>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        format: Option<String>,
-    },
+	Path(String),
+	Config {
+		path: String,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		required: Option<bool>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		format: Option<String>,
+	},
 }
 
 impl EnvFileEntry {
-    pub fn path(&self) -> &str {
-        match self {
-            EnvFileEntry::Path(p) => p,
-            EnvFileEntry::Config { path, .. } => path,
-        }
-    }
+	pub fn path(&self) -> &str {
+		match self {
+			EnvFileEntry::Path(p) => p,
+			EnvFileEntry::Config { path, .. } => path,
+		}
+	}
 
-    /// `true` by default — missing file is an error unless `required: false`.
-    pub fn required(&self) -> bool {
-        match self {
-            EnvFileEntry::Path(_) => true,
-            EnvFileEntry::Config { required, .. } => required.unwrap_or(true),
-        }
-    }
+	/// `true` by default — missing file is an error unless `required: false`.
+	pub fn required(&self) -> bool {
+		match self {
+			EnvFileEntry::Path(_) => true,
+			EnvFileEntry::Config { required, .. } => required.unwrap_or(true),
+		}
+	}
 }
 
 /// `env_file:` field — single path, list of paths, or list of long-form objects.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum EnvFile {
-    #[default]
-    Empty,
-    Single(EnvFileEntry),
-    List(Vec<EnvFileEntry>),
+	#[default]
+	Empty,
+	Single(EnvFileEntry),
+	List(Vec<EnvFileEntry>),
 }
 
 impl EnvFile {
-    pub fn to_entries(&self) -> Vec<EnvFileEntry> {
-        match self {
-            EnvFile::Empty => vec![],
-            EnvFile::Single(e) => vec![e.clone()],
-            EnvFile::List(v) => v.clone(),
-        }
-    }
+	pub fn to_entries(&self) -> Vec<EnvFileEntry> {
+		match self {
+			EnvFile::Empty => vec![],
+			EnvFile::Single(e) => vec![e.clone()],
+			EnvFile::List(v) => v.clone(),
+		}
+	}
 
-    /// Return just the paths (strips `required` / `format` info).
-    /// Kept for test compatibility; prefer `to_entries()` in engine code.
-    pub fn to_list(&self) -> Vec<String> {
-        self.to_entries()
-            .into_iter()
-            .map(|e| e.path().to_string())
-            .collect()
-    }
+	/// Return just the paths (strips `required` / `format` info).
+	/// Kept for test compatibility; prefer `to_entries()` in engine code.
+	pub fn to_list(&self) -> Vec<String> {
+		self.to_entries()
+			.into_iter()
+			.map(|e| e.path().to_string())
+			.collect()
+	}
 
-    pub fn is_empty(&self) -> bool {
-        match self {
-            EnvFile::Empty => true,
-            EnvFile::Single(_) => false,
-            EnvFile::List(v) => v.is_empty(),
-        }
-    }
+	pub fn is_empty(&self) -> bool {
+		match self {
+			EnvFile::Empty => true,
+			EnvFile::Single(_) => false,
+			EnvFile::List(v) => v.is_empty(),
+		}
+	}
 }

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -15,134 +15,134 @@ use super::primitives::Command;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum DependsOn {
-    #[default]
-    Empty,
-    List(Vec<String>),
-    Map(IndexMap<String, DependsOnCondition>),
+	#[default]
+	Empty,
+	List(Vec<String>),
+	Map(IndexMap<String, DependsOnCondition>),
 }
 
 impl DependsOn {
-    pub fn service_names(&self) -> Vec<String> {
-        match self {
-            DependsOn::Empty => vec![],
-            DependsOn::List(v) => v.clone(),
-            DependsOn::Map(m) => m.keys().cloned().collect(),
-        }
-    }
+	pub fn service_names(&self) -> Vec<String> {
+		match self {
+			DependsOn::Empty => vec![],
+			DependsOn::List(v) => v.clone(),
+			DependsOn::Map(m) => m.keys().cloned().collect(),
+		}
+	}
 
-    pub fn condition_for(&self, service: &str) -> ServiceCondition {
-        match self {
-            DependsOn::Map(m) => m
-                .get(service)
-                .map(|c| c.condition.clone())
-                .unwrap_or(ServiceCondition::ServiceStarted),
-            _ => ServiceCondition::ServiceStarted,
-        }
-    }
+	pub fn condition_for(&self, service: &str) -> ServiceCondition {
+		match self {
+			DependsOn::Map(m) => m
+				.get(service)
+				.map(|c| c.condition.clone())
+				.unwrap_or(ServiceCondition::ServiceStarted),
+			_ => ServiceCondition::ServiceStarted,
+		}
+	}
 
-    pub fn restart_for(&self, service: &str) -> bool {
-        match self {
-            DependsOn::Map(m) => m.get(service).and_then(|c| c.restart).unwrap_or(false),
-            _ => false,
-        }
-    }
+	pub fn restart_for(&self, service: &str) -> bool {
+		match self {
+			DependsOn::Map(m) => m.get(service).and_then(|c| c.restart).unwrap_or(false),
+			_ => false,
+		}
+	}
 
-    pub fn required_for(&self, service: &str) -> bool {
-        match self {
-            DependsOn::Map(m) => m.get(service).and_then(|c| c.required).unwrap_or(true),
-            _ => true,
-        }
-    }
+	pub fn required_for(&self, service: &str) -> bool {
+		match self {
+			DependsOn::Map(m) => m.get(service).and_then(|c| c.required).unwrap_or(true),
+			_ => true,
+		}
+	}
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DependsOnCondition {
-    pub condition: ServiceCondition,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub restart: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub required: Option<bool>,
+	pub condition: ServiceCondition,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub restart: Option<bool>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub required: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ServiceCondition {
-    #[default]
-    ServiceStarted,
-    ServiceHealthy,
-    ServiceCompletedSuccessfully,
+	#[default]
+	ServiceStarted,
+	ServiceHealthy,
+	ServiceCompletedSuccessfully,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct HealthCheck {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub test: Option<Command>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timeout: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub retries: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_period: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_interval: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub disable: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub test: Option<Command>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub interval: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub timeout: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub retries: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub start_period: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub start_interval: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub disable: Option<bool>,
 }
 
 impl HealthCheck {
-    pub fn is_disabled(&self) -> bool {
-        if self.disable.unwrap_or(false) {
-            return true;
-        }
-        matches!(&self.test, Some(Command::Exec(v)) if v.len() == 1 && v[0].eq_ignore_ascii_case("NONE"))
-    }
+	pub fn is_disabled(&self) -> bool {
+		if self.disable.unwrap_or(false) {
+			return true;
+		}
+		matches!(&self.test, Some(Command::Exec(v)) if v.len() == 1 && v[0].eq_ignore_ascii_case("NONE"))
+	}
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LifecycleHook {
-    pub command: Command,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub privileged: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub working_dir: Option<String>,
-    #[serde(default)]
-    pub environment: EnvVars,
+	pub command: Command,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub user: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub privileged: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub working_dir: Option<String>,
+	#[serde(default)]
+	pub environment: EnvVars,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum RestartPolicy {
-    No,
-    Always,
-    OnFailure { max_attempts: Option<u32> },
-    UnlessStopped,
+	No,
+	Always,
+	OnFailure { max_attempts: Option<u32> },
+	UnlessStopped,
 }
 
 impl<'de> Deserialize<'de> for RestartPolicy {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        match s.as_str() {
-            "no" => Ok(RestartPolicy::No),
-            "always" => Ok(RestartPolicy::Always),
-            "unless-stopped" => Ok(RestartPolicy::UnlessStopped),
-            "on-failure" => Ok(RestartPolicy::OnFailure { max_attempts: None }),
-            s if s.starts_with("on-failure:") => {
-                let n = s["on-failure:".len()..]
-                    .parse::<u32>()
-                    .map_err(serde::de::Error::custom)?;
-                Ok(RestartPolicy::OnFailure {
-                    max_attempts: Some(n),
-                })
-            }
-            other => Err(serde::de::Error::custom(format!(
-                "invalid restart policy: {other}"
-            ))),
-        }
-    }
+	fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		let s = String::deserialize(deserializer)?;
+		match s.as_str() {
+			"no" => Ok(RestartPolicy::No),
+			"always" => Ok(RestartPolicy::Always),
+			"unless-stopped" => Ok(RestartPolicy::UnlessStopped),
+			"on-failure" => Ok(RestartPolicy::OnFailure { max_attempts: None }),
+			s if s.starts_with("on-failure:") => {
+				let n = s["on-failure:".len()..]
+					.parse::<u32>()
+					.map_err(serde::de::Error::custom)?;
+				Ok(RestartPolicy::OnFailure {
+					max_attempts: Some(n),
+				})
+			}
+			other => Err(serde::de::Error::custom(format!(
+				"invalid restart policy: {other}"
+			))),
+		}
+	}
 }

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -34,46 +34,46 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct SecretConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub environment: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub driver_opts: HashMap<String, String>,
-    #[serde(default)]
-    pub labels: Labels,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub template_driver: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub file: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub external: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub content: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub environment: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub driver_opts: HashMap<String, String>,
+	#[serde(default)]
+	pub labels: Labels,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub template_driver: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ConfigConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub environment: Option<String>,
-    #[serde(default)]
-    pub labels: Labels,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub driver_opts: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub template_driver: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub file: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub external: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub content: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub environment: Option<String>,
+	#[serde(default)]
+	pub labels: Labels,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub driver_opts: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub template_driver: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -82,23 +82,23 @@ pub struct ConfigConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ComposeFile {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub include: Vec<IncludeConfig>,
-    #[serde(default)]
-    pub services: IndexMap<String, Service>,
-    #[serde(default)]
-    pub volumes: IndexMap<String, Option<VolumeConfig>>,
-    #[serde(default)]
-    pub networks: IndexMap<String, Option<NetworkConfig>>,
-    #[serde(default)]
-    pub secrets: IndexMap<String, SecretConfig>,
-    #[serde(default)]
-    pub configs: IndexMap<String, ConfigConfig>,
-    /// Top-level `x-*` extension fields — preserved and round-tripped via `config` subcommand.
-    #[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
-    pub extensions: IndexMap<String, serde_yaml::Value>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub version: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub include: Vec<IncludeConfig>,
+	#[serde(default)]
+	pub services: IndexMap<String, Service>,
+	#[serde(default)]
+	pub volumes: IndexMap<String, Option<VolumeConfig>>,
+	#[serde(default)]
+	pub networks: IndexMap<String, Option<NetworkConfig>>,
+	#[serde(default)]
+	pub secrets: IndexMap<String, SecretConfig>,
+	#[serde(default)]
+	pub configs: IndexMap<String, ConfigConfig>,
+	/// Top-level `x-*` extension fields — preserved and round-tripped via `config` subcommand.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub extensions: IndexMap<String, serde_yaml::Value>,
 }

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -17,27 +17,27 @@ use super::Labels;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum ServiceNetworks {
-    #[default]
-    Empty,
-    List(Vec<String>),
-    Map(IndexMap<String, Option<ServiceNetworkConfig>>),
+	#[default]
+	Empty,
+	List(Vec<String>),
+	Map(IndexMap<String, Option<ServiceNetworkConfig>>),
 }
 
 impl ServiceNetworks {
-    pub fn names(&self) -> Vec<String> {
-        match self {
-            ServiceNetworks::Empty => vec![],
-            ServiceNetworks::List(v) => v.clone(),
-            ServiceNetworks::Map(m) => m.keys().cloned().collect(),
-        }
-    }
+	pub fn names(&self) -> Vec<String> {
+		match self {
+			ServiceNetworks::Empty => vec![],
+			ServiceNetworks::List(v) => v.clone(),
+			ServiceNetworks::Map(m) => m.keys().cloned().collect(),
+		}
+	}
 
-    pub fn config_for(&self, name: &str) -> Option<&ServiceNetworkConfig> {
-        match self {
-            ServiceNetworks::Map(m) => m.get(name).and_then(|c| c.as_ref()),
-            _ => None,
-        }
-    }
+	pub fn config_for(&self, name: &str) -> Option<&ServiceNetworkConfig> {
+		match self {
+			ServiceNetworks::Map(m) => m.get(name).and_then(|c| c.as_ref()),
+			_ => None,
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -46,24 +46,24 @@ impl ServiceNetworks {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ServiceNetworkConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub aliases: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ipv4_address: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ipv6_address: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub link_local_ips: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub priority: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mac_address: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub driver_opts: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gw_priority: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub interface_name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub aliases: Option<Vec<String>>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub ipv4_address: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub ipv6_address: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub link_local_ips: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub priority: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub mac_address: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub driver_opts: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub gw_priority: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub interface_name: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -72,26 +72,26 @@ pub struct ServiceNetworkConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct NetworkConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub driver_opts: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub internal: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_ipv6: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_ipv4: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub attachable: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ipam: Option<IpamConfig>,
-    #[serde(default)]
-    pub labels: Labels,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub driver_opts: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub external: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub internal: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub enable_ipv6: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub enable_ipv4: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub attachable: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub ipam: Option<IpamConfig>,
+	#[serde(default)]
+	pub labels: Labels,
 }
 
 // ---------------------------------------------------------------------------
@@ -100,22 +100,22 @@ pub struct NetworkConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct IpamConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub config: Vec<IpamPool>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub options: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub config: Vec<IpamPool>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub options: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct IpamPool {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subnet: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gateway: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_range: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub aux_addresses: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub subnet: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub gateway: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub ip_range: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub aux_addresses: HashMap<String, String>,
 }

--- a/internal/compose/types/ports.rs
+++ b/internal/compose/types/ports.rs
@@ -13,17 +13,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringOrU16 {
-    String(String),
-    Number(u16),
+	String(String),
+	Number(u16),
 }
 
 impl StringOrU16 {
-    pub fn as_str_val(&self) -> String {
-        match self {
-            StringOrU16::String(s) => s.clone(),
-            StringOrU16::Number(n) => n.to_string(),
-        }
-    }
+	pub fn as_str_val(&self) -> String {
+		match self {
+			StringOrU16::String(s) => s.clone(),
+			StringOrU16::Number(n) => n.to_string(),
+		}
+	}
 }
 
 /// A single entry in a service's `ports:` list.
@@ -35,20 +35,20 @@ impl StringOrU16 {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PortMapping {
-    Short(String),
-    Long {
-        target: u16,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        published: Option<StringOrU16>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        protocol: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        host_ip: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        mode: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        app_protocol: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        name: Option<String>,
-    },
+	Short(String),
+	Long {
+		target: u16,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		published: Option<StringOrU16>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		protocol: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		host_ip: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		mode: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		app_protocol: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		name: Option<String>,
+	},
 }

--- a/internal/compose/types/primitives.rs
+++ b/internal/compose/types/primitives.rs
@@ -14,135 +14,135 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Command {
-    Shell(String),
-    Exec(Vec<String>),
+	Shell(String),
+	Exec(Vec<String>),
 }
 
 impl Command {
-    pub fn to_exec(&self) -> Vec<String> {
-        match self {
-            Command::Shell(s) => vec!["sh".into(), "-c".into(), s.clone()],
-            Command::Exec(v) => v.clone(),
-        }
-    }
+	pub fn to_exec(&self) -> Vec<String> {
+		match self {
+			Command::Shell(s) => vec!["sh".into(), "-c".into(), s.clone()],
+			Command::Exec(v) => v.clone(),
+		}
+	}
 
-    pub fn to_argv(&self) -> Vec<String> {
-        match self {
-            Command::Shell(s) => vec![s.clone()],
-            Command::Exec(v) => v.clone(),
-        }
-    }
+	pub fn to_argv(&self) -> Vec<String> {
+		match self {
+			Command::Shell(s) => vec![s.clone()],
+			Command::Exec(v) => v.clone(),
+		}
+	}
 }
 
 /// A field that accepts either a single string or a list of strings.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum StringOrList {
-    #[default]
-    Empty,
-    Single(String),
-    List(Vec<String>),
+	#[default]
+	Empty,
+	Single(String),
+	List(Vec<String>),
 }
 
 impl StringOrList {
-    pub fn to_list(&self) -> Vec<String> {
-        match self {
-            StringOrList::Empty => vec![],
-            StringOrList::Single(s) => vec![s.clone()],
-            StringOrList::List(v) => v.clone(),
-        }
-    }
+	pub fn to_list(&self) -> Vec<String> {
+		match self {
+			StringOrList::Empty => vec![],
+			StringOrList::Single(s) => vec![s.clone()],
+			StringOrList::List(v) => v.clone(),
+		}
+	}
 
-    pub fn is_empty(&self) -> bool {
-        match self {
-            StringOrList::Empty => true,
-            StringOrList::Single(s) => s.is_empty(),
-            StringOrList::List(v) => v.is_empty(),
-        }
-    }
+	pub fn is_empty(&self) -> bool {
+		match self {
+			StringOrList::Empty => true,
+			StringOrList::Single(s) => s.is_empty(),
+			StringOrList::List(v) => v.is_empty(),
+		}
+	}
 }
 
 /// Labels — list or map form.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum Labels {
-    #[default]
-    Empty,
-    List(Vec<String>),
-    Map(IndexMap<String, String>),
+	#[default]
+	Empty,
+	List(Vec<String>),
+	Map(IndexMap<String, String>),
 }
 
 impl Labels {
-    pub fn to_map(&self) -> HashMap<String, String> {
-        match self {
-            Labels::Empty => HashMap::new(),
-            Labels::List(list) => list
-                .iter()
-                .filter_map(|s| {
-                    let mut parts = s.splitn(2, '=');
-                    Some((
-                        parts.next()?.to_string(),
-                        parts.next().unwrap_or("").to_string(),
-                    ))
-                })
-                .collect(),
-            Labels::Map(m) => m.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-        }
-    }
+	pub fn to_map(&self) -> HashMap<String, String> {
+		match self {
+			Labels::Empty => HashMap::new(),
+			Labels::List(list) => list
+				.iter()
+				.filter_map(|s| {
+					let mut parts = s.splitn(2, '=');
+					Some((
+						parts.next()?.to_string(),
+						parts.next().unwrap_or("").to_string(),
+					))
+				})
+				.collect(),
+			Labels::Map(m) => m.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+		}
+	}
 
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Labels::Empty => true,
-            Labels::List(v) => v.is_empty(),
-            Labels::Map(m) => m.is_empty(),
-        }
-    }
+	pub fn is_empty(&self) -> bool {
+		match self {
+			Labels::Empty => true,
+			Labels::List(v) => v.is_empty(),
+			Labels::Map(m) => m.is_empty(),
+		}
+	}
 }
 
 /// `logging:` configuration — driver name and driver-specific options.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct LoggingConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub options: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub options: HashMap<String, String>,
 }
 
 /// Kernel parameters — list (`["net.ipv4.ip_forward=1"]`) or map form.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum Sysctls {
-    #[default]
-    Empty,
-    List(Vec<String>),
-    Map(IndexMap<String, serde_yaml::Value>),
+	#[default]
+	Empty,
+	List(Vec<String>),
+	Map(IndexMap<String, serde_yaml::Value>),
 }
 
 impl Sysctls {
-    pub fn to_map(&self) -> HashMap<String, String> {
-        match self {
-            Sysctls::Empty => HashMap::new(),
-            Sysctls::List(list) => list
-                .iter()
-                .filter_map(|s| {
-                    let mut parts = s.splitn(2, '=');
-                    let key = parts.next()?.to_string();
-                    let val = parts.next().unwrap_or("").to_string();
-                    Some((key, val))
-                })
-                .collect(),
-            Sysctls::Map(m) => m
-                .iter()
-                .map(|(k, v)| {
-                    let s = match v {
-                        serde_yaml::Value::String(s) => s.clone(),
-                        serde_yaml::Value::Number(n) => n.to_string(),
-                        serde_yaml::Value::Bool(b) => b.to_string(),
-                        _ => String::new(),
-                    };
-                    (k.clone(), s)
-                })
-                .collect(),
-        }
-    }
+	pub fn to_map(&self) -> HashMap<String, String> {
+		match self {
+			Sysctls::Empty => HashMap::new(),
+			Sysctls::List(list) => list
+				.iter()
+				.filter_map(|s| {
+					let mut parts = s.splitn(2, '=');
+					let key = parts.next()?.to_string();
+					let val = parts.next().unwrap_or("").to_string();
+					Some((key, val))
+				})
+				.collect(),
+			Sysctls::Map(m) => m
+				.iter()
+				.map(|(k, v)| {
+					let s = match v {
+						serde_yaml::Value::String(s) => s.clone(),
+						serde_yaml::Value::Number(n) => n.to_string(),
+						serde_yaml::Value::Bool(b) => b.to_string(),
+						_ => String::new(),
+					};
+					(k.clone(), s)
+				})
+				.collect(),
+		}
+	}
 }

--- a/internal/compose/types/resources.rs
+++ b/internal/compose/types/resources.rs
@@ -9,79 +9,79 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum UlimitConfig {
-    Single(i64),
-    Pair { soft: i64, hard: i64 },
+	Single(i64),
+	Pair { soft: i64, hard: i64 },
 }
 
 impl UlimitConfig {
-    pub fn soft(&self) -> i64 {
-        match self {
-            UlimitConfig::Single(n) => *n,
-            UlimitConfig::Pair { soft, .. } => *soft,
-        }
-    }
+	pub fn soft(&self) -> i64 {
+		match self {
+			UlimitConfig::Single(n) => *n,
+			UlimitConfig::Pair { soft, .. } => *soft,
+		}
+	}
 
-    pub fn hard(&self) -> i64 {
-        match self {
-            UlimitConfig::Single(n) => *n,
-            UlimitConfig::Pair { hard, .. } => *hard,
-        }
-    }
+	pub fn hard(&self) -> i64 {
+		match self {
+			UlimitConfig::Single(n) => *n,
+			UlimitConfig::Pair { hard, .. } => *hard,
+		}
+	}
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BlkioConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub weight: Option<u16>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub weight_device: Vec<BlkioWeightDevice>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub device_read_bps: Vec<BlkioRateDevice>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub device_write_bps: Vec<BlkioRateDevice>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub device_read_iops: Vec<BlkioRateDevice>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub device_write_iops: Vec<BlkioRateDevice>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub weight: Option<u16>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub weight_device: Vec<BlkioWeightDevice>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub device_read_bps: Vec<BlkioRateDevice>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub device_write_bps: Vec<BlkioRateDevice>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub device_read_iops: Vec<BlkioRateDevice>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub device_write_iops: Vec<BlkioRateDevice>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioWeightDevice {
-    pub path: String,
-    pub weight: u16,
+	pub path: String,
+	pub weight: u16,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioRateDevice {
-    pub path: String,
-    pub rate: serde_yaml::Value,
+	pub path: String,
+	pub rate: serde_yaml::Value,
 }
 
 impl BlkioRateDevice {
-    /// Return rate as bytes/second (or IOPS as a plain integer).
-    pub fn rate_value(&self) -> i64 {
-        match &self.rate {
-            serde_yaml::Value::Number(n) => n.as_i64().unwrap_or(0),
-            serde_yaml::Value::String(s) => crate::size::parse_memory(s).unwrap_or(0),
-            _ => 0,
-        }
-    }
+	/// Return rate as bytes/second (or IOPS as a plain integer).
+	pub fn rate_value(&self) -> i64 {
+		match &self.rate {
+			serde_yaml::Value::Number(n) => n.as_i64().unwrap_or(0),
+			serde_yaml::Value::String(s) => crate::size::parse_memory(s).unwrap_or(0),
+			_ => 0,
+		}
+	}
 }
 
 /// `gpus: all` or `gpus: 2` top-level service field.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GpuSpec {
-    Named(String),
-    Count(u32),
+	Named(String),
+	Count(u32),
 }
 
 impl GpuSpec {
-    /// -1 = all; positive = exact count.
-    pub fn to_count(&self) -> i64 {
-        match self {
-            GpuSpec::Named(_) => -1,
-            GpuSpec::Count(n) => *n as i64,
-        }
-    }
+	/// -1 = all; positive = exact count.
+	pub fn to_count(&self) -> i64 {
+		match self {
+			GpuSpec::Named(_) => -1,
+			GpuSpec::Count(n) => *n as i64,
+		}
+	}
 }

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -14,218 +14,218 @@ use super::develop::DevelopConfig;
 use super::network::ServiceNetworks;
 use super::volume::{ServiceConfigRef, ServiceSecretRef, VolumeMount};
 use super::{
-    BlkioConfig, Command, DependsOn, EnvFile, EnvVars, GpuSpec, HealthCheck, Labels, LifecycleHook,
-    LoggingConfig, PortMapping, RestartPolicy, StringOrList, Sysctls, UlimitConfig,
+	BlkioConfig, Command, DependsOn, EnvFile, EnvVars, GpuSpec, HealthCheck, Labels, LifecycleHook,
+	LoggingConfig, PortMapping, RestartPolicy, StringOrList, Sysctls, UlimitConfig,
 };
 
 /// A single service definition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Service {
-    // ---------------- core ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub image: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub build: Option<BuildConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extends: Option<ExtendsConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command: Option<Command>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entrypoint: Option<Command>,
+	// ---------------- core ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub image: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub build: Option<BuildConfig>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub extends: Option<ExtendsConfig>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub command: Option<Command>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub entrypoint: Option<Command>,
 
-    // ---------------- ports / network ----------------
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub ports: Vec<PortMapping>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub expose: Vec<String>,
+	// ---------------- ports / network ----------------
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub ports: Vec<PortMapping>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub expose: Vec<String>,
 
-    // ---------------- env / mounts ----------------
-    #[serde(default)]
-    pub environment: EnvVars,
-    #[serde(default)]
-    pub env_file: EnvFile,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub volumes: Vec<VolumeMount>,
-    #[serde(default)]
-    pub tmpfs: StringOrList,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub volumes_from: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub configs: Vec<ServiceConfigRef>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub secrets: Vec<ServiceSecretRef>,
+	// ---------------- env / mounts ----------------
+	#[serde(default)]
+	pub environment: EnvVars,
+	#[serde(default)]
+	pub env_file: EnvFile,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub volumes: Vec<VolumeMount>,
+	#[serde(default)]
+	pub tmpfs: StringOrList,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub volumes_from: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub configs: Vec<ServiceConfigRef>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub secrets: Vec<ServiceSecretRef>,
 
-    // ---------------- networking ----------------
-    #[serde(default)]
-    pub networks: ServiceNetworks,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hostname: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub domainname: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mac_address: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub links: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub external_links: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub extra_hosts: Vec<String>,
-    #[serde(default)]
-    pub dns: StringOrList,
-    #[serde(default)]
-    pub dns_search: StringOrList,
-    #[serde(default)]
-    pub dns_opt: StringOrList,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub network_mode: Option<String>,
+	// ---------------- networking ----------------
+	#[serde(default)]
+	pub networks: ServiceNetworks,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub hostname: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub domainname: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub mac_address: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub links: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub external_links: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub extra_hosts: Vec<String>,
+	#[serde(default)]
+	pub dns: StringOrList,
+	#[serde(default)]
+	pub dns_search: StringOrList,
+	#[serde(default)]
+	pub dns_opt: StringOrList,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub network_mode: Option<String>,
 
-    // ---------------- ordering / health ----------------
-    #[serde(default)]
-    pub depends_on: DependsOn,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub healthcheck: Option<HealthCheck>,
+	// ---------------- ordering / health ----------------
+	#[serde(default)]
+	pub depends_on: DependsOn,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub healthcheck: Option<HealthCheck>,
 
-    // ---------------- lifecycle / restart ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub restart: Option<RestartPolicy>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop_signal: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop_grace_period: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub profiles: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub post_start: Vec<LifecycleHook>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub pre_stop: Vec<LifecycleHook>,
+	// ---------------- lifecycle / restart ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub restart: Option<RestartPolicy>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub stop_signal: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub stop_grace_period: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub profiles: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub post_start: Vec<LifecycleHook>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub pre_stop: Vec<LifecycleHook>,
 
-    // ---------------- identity / labels ----------------
-    #[serde(default)]
-    pub labels: Labels,
-    #[serde(default)]
-    pub annotations: Labels,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub container_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub working_dir: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub group_add: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub platform: Option<String>,
+	// ---------------- identity / labels ----------------
+	#[serde(default)]
+	pub labels: Labels,
+	#[serde(default)]
+	pub annotations: Labels,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub container_name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub user: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub working_dir: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub group_add: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub platform: Option<String>,
 
-    // ---------------- security / capabilities ----------------
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub cap_add: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub cap_drop: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub security_opt: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub read_only: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub privileged: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub init: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tty: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stdin_open: Option<bool>,
+	// ---------------- security / capabilities ----------------
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub cap_add: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub cap_drop: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub security_opt: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub read_only: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub privileged: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub init: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub tty: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub stdin_open: Option<bool>,
 
-    // ---------------- runtime / namespaces ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub runtime: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub shm_size: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub userns_mode: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pid: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ipc: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uts: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cgroup_parent: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cgroup: Option<String>,
+	// ---------------- runtime / namespaces ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub runtime: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub shm_size: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub userns_mode: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub pid: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub ipc: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub uts: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cgroup_parent: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cgroup: Option<String>,
 
-    // ---------------- devices / filesystem ----------------
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub devices: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub device_cgroup_rules: Vec<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub storage_opt: HashMap<String, String>,
+	// ---------------- devices / filesystem ----------------
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub devices: Vec<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub device_cgroup_rules: Vec<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub storage_opt: HashMap<String, String>,
 
-    // ---------------- resources / limits (top-level) ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scale: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_shares: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_quota: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_period: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpuset: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpus: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_count: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_percent: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_rt_runtime: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_rt_period: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mem_limit: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub memswap_limit: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mem_reservation: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mem_swappiness: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pids_limit: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub oom_kill_disable: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub oom_score_adj: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub blkio_config: Option<BlkioConfig>,
+	// ---------------- resources / limits (top-level) ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub scale: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpu_shares: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpu_quota: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpu_period: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpuset: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpus: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpu_count: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpu_percent: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpu_rt_runtime: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cpu_rt_period: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub mem_limit: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub memswap_limit: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub mem_reservation: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub mem_swappiness: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub pids_limit: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub oom_kill_disable: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub oom_score_adj: Option<i64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub blkio_config: Option<BlkioConfig>,
 
-    // ---------------- logging / sysctl / ulimit ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub logging: Option<LoggingConfig>,
-    #[serde(default)]
-    pub sysctls: Sysctls,
-    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-    pub ulimits: IndexMap<String, UlimitConfig>,
+	// ---------------- logging / sysctl / ulimit ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub logging: Option<LoggingConfig>,
+	#[serde(default)]
+	pub sysctls: Sysctls,
+	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+	pub ulimits: IndexMap<String, UlimitConfig>,
 
-    // ---------------- labels / annotations ----------------
-    #[serde(default)]
-    pub label_file: StringOrList,
+	// ---------------- labels / annotations ----------------
+	#[serde(default)]
+	pub label_file: StringOrList,
 
-    // ---------------- attach / log collection ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub attach: Option<bool>,
+	// ---------------- attach / log collection ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub attach: Option<bool>,
 
-    // ---------------- pull policy ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pull_policy: Option<String>,
+	// ---------------- pull policy ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub pull_policy: Option<String>,
 
-    // ---------------- deploy ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deploy: Option<DeployConfig>,
+	// ---------------- deploy ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub deploy: Option<DeployConfig>,
 
-    // ---------------- develop (file-watch) ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub develop: Option<DevelopConfig>,
+	// ---------------- develop (file-watch) ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub develop: Option<DevelopConfig>,
 
-    // ---------------- gpu shorthand ----------------
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gpus: Option<GpuSpec>,
+	// ---------------- gpu shorthand ----------------
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub gpus: Option<GpuSpec>,
 }

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -17,11 +17,11 @@ use super::Labels;
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum VolumeType {
-    Volume,
-    Bind,
-    Tmpfs,
-    Npipe,
-    Cluster,
+	Volume,
+	Bind,
+	Tmpfs,
+	Npipe,
+	Cluster,
 }
 
 // ---------------------------------------------------------------------------
@@ -30,40 +30,40 @@ pub enum VolumeType {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BindOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub propagation: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub create_host_path: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub selinux: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub propagation: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub create_host_path: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub selinux: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VolumeOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub nocopy: Option<bool>,
-    #[serde(default)]
-    pub labels: Labels,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver_config: Option<DriverConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subpath: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub nocopy: Option<bool>,
+	#[serde(default)]
+	pub labels: Labels,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver_config: Option<DriverConfig>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub subpath: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DriverConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub options: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub options: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct TmpfsOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub size: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<u32>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub size: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub mode: Option<u32>,
 }
 
 // ---------------------------------------------------------------------------
@@ -74,40 +74,40 @@ pub struct TmpfsOptions {
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum VolumeMount {
-    Short(String),
-    Long {
-        #[serde(rename = "type")]
-        volume_type: VolumeType,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        source: Option<String>,
-        target: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        read_only: Option<bool>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        bind: Option<BindOptions>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        volume: Option<VolumeOptions>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        tmpfs: Option<TmpfsOptions>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        consistency: Option<String>,
-    },
+	Short(String),
+	Long {
+		#[serde(rename = "type")]
+		volume_type: VolumeType,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		source: Option<String>,
+		target: String,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		read_only: Option<bool>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		bind: Option<BindOptions>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		volume: Option<VolumeOptions>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		tmpfs: Option<TmpfsOptions>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		consistency: Option<String>,
+	},
 }
 
 impl VolumeMount {
-    pub fn target(&self) -> &str {
-        match self {
-            VolumeMount::Short(s) => {
-                let parts: Vec<&str> = s.splitn(3, ':').collect();
-                if parts.len() >= 2 {
-                    parts[1]
-                } else {
-                    parts[0]
-                }
-            }
-            VolumeMount::Long { target, .. } => target,
-        }
-    }
+	pub fn target(&self) -> &str {
+		match self {
+			VolumeMount::Short(s) => {
+				let parts: Vec<&str> = s.splitn(3, ':').collect();
+				if parts.len() >= 2 {
+					parts[1]
+				} else {
+					parts[0]
+				}
+			}
+			VolumeMount::Long { target, .. } => target,
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -116,16 +116,16 @@ impl VolumeMount {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VolumeConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub driver: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub driver_opts: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub labels: Labels,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub driver: Option<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub driver_opts: HashMap<String, String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub external: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(default)]
+	pub labels: Labels,
 }
 
 // ---------------------------------------------------------------------------
@@ -135,65 +135,65 @@ pub struct VolumeConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceConfigRef {
-    Short(String),
-    Long {
-        source: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        target: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        uid: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        gid: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        mode: Option<u32>,
-    },
+	Short(String),
+	Long {
+		source: String,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		target: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		uid: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		gid: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		mode: Option<u32>,
+	},
 }
 
 impl ServiceConfigRef {
-    pub fn source(&self) -> &str {
-        match self {
-            ServiceConfigRef::Short(s) => s,
-            ServiceConfigRef::Long { source, .. } => source,
-        }
-    }
+	pub fn source(&self) -> &str {
+		match self {
+			ServiceConfigRef::Short(s) => s,
+			ServiceConfigRef::Long { source, .. } => source,
+		}
+	}
 
-    pub fn target(&self) -> Option<&str> {
-        match self {
-            ServiceConfigRef::Short(_) => None,
-            ServiceConfigRef::Long { target, .. } => target.as_deref(),
-        }
-    }
+	pub fn target(&self) -> Option<&str> {
+		match self {
+			ServiceConfigRef::Short(_) => None,
+			ServiceConfigRef::Long { target, .. } => target.as_deref(),
+		}
+	}
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceSecretRef {
-    Short(String),
-    Long {
-        source: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        target: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        uid: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        gid: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        mode: Option<u32>,
-    },
+	Short(String),
+	Long {
+		source: String,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		target: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		uid: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		gid: Option<String>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		mode: Option<u32>,
+	},
 }
 
 impl ServiceSecretRef {
-    pub fn source(&self) -> &str {
-        match self {
-            ServiceSecretRef::Short(s) => s,
-            ServiceSecretRef::Long { source, .. } => source,
-        }
-    }
+	pub fn source(&self) -> &str {
+		match self {
+			ServiceSecretRef::Short(s) => s,
+			ServiceSecretRef::Long { source, .. } => source,
+		}
+	}
 
-    pub fn target(&self) -> Option<&str> {
-        match self {
-            ServiceSecretRef::Short(_) => None,
-            ServiceSecretRef::Long { target, .. } => target.as_deref(),
-        }
-    }
+	pub fn target(&self) -> Option<&str> {
+		match self {
+			ServiceSecretRef::Short(_) => None,
+			ServiceSecretRef::Long { target, .. } => target.as_deref(),
+		}
+	}
 }

--- a/internal/engine/build.rs
+++ b/internal/engine/build.rs
@@ -23,186 +23,186 @@ use crate::size;
 use super::Engine;
 
 impl Engine {
-    pub(super) async fn pull_image(&self, service: &Service) -> Result<()> {
-        let image = match &service.image {
-            Some(img) => img.clone(),
-            None => return Ok(()),
-        };
+	pub(super) async fn pull_image(&self, service: &Service) -> Result<()> {
+		let image = match &service.image {
+			Some(img) => img.clone(),
+			None => return Ok(()),
+		};
 
-        info!("pulling {image}");
+		info!("pulling {image}");
 
-        let mut stream = self.docker.create_image(
-            Some(CreateImageOptions {
-                from_image: Some(image.clone()),
-                platform: service.platform.clone().unwrap_or_default(),
-                ..Default::default()
-            }),
-            None,
-            None,
-        );
+		let mut stream = self.docker.create_image(
+			Some(CreateImageOptions {
+				from_image: Some(image.clone()),
+				platform: service.platform.clone().unwrap_or_default(),
+				..Default::default()
+			}),
+			None,
+			None,
+		);
 
-        while let Some(result) = stream.next().await {
-            match result {
-                Ok(info) => {
-                    if let Some(status) = info.status {
-                        debug!("{status}");
-                    }
-                }
-                Err(e) => warn!("pull warning: {e}"),
-            }
-        }
+		while let Some(result) = stream.next().await {
+			match result {
+				Ok(info) => {
+					if let Some(status) = info.status {
+						debug!("{status}");
+					}
+				}
+				Err(e) => warn!("pull warning: {e}"),
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    pub(super) async fn build_service(&self, service_name: &str, service: &Service) -> Result<()> {
-        let build = match &service.build {
-            Some(b) => b,
-            None => return Ok(()),
-        };
+	pub(super) async fn build_service(&self, service_name: &str, service: &Service) -> Result<()> {
+		let build = match &service.build {
+			Some(b) => b,
+			None => return Ok(()),
+		};
 
-        let context_path = self.base_dir.join(build.context());
-        let tag = service
-            .image
-            .clone()
-            .unwrap_or_else(|| format!("{}:latest", service_name));
+		let context_path = self.base_dir.join(build.context());
+		let tag = service
+			.image
+			.clone()
+			.unwrap_or_else(|| format!("{}:latest", service_name));
 
-        info!("building {tag} from {}", context_path.display());
+		info!("building {tag} from {}", context_path.display());
 
-        let (tar_bytes, dockerfile_name) = if let Some(inline) = build.dockerfile_inline() {
-            build_context_tar_with_inline(&context_path, inline)?
-        } else {
-            let df = build.dockerfile().unwrap_or("Dockerfile");
-            if let Some(target) = build.target() {
-                build_context_tar_with_target(&context_path, df, target)?
-            } else {
-                (build_context_tar(&context_path, df)?, df.to_string())
-            }
-        };
+		let (tar_bytes, dockerfile_name) = if let Some(inline) = build.dockerfile_inline() {
+			build_context_tar_with_inline(&context_path, inline)?
+		} else {
+			let df = build.dockerfile().unwrap_or("Dockerfile");
+			if let Some(target) = build.target() {
+				build_context_tar_with_target(&context_path, df, target)?
+			} else {
+				(build_context_tar(&context_path, df)?, df.to_string())
+			}
+		};
 
-        let arg_map = build.args().to_map();
-        let mut build_args: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
-        for (k, v) in arg_map {
-            let value = match v {
-                Some(val) => val,
-                None => std::env::var(&k).unwrap_or_default(),
-            };
-            build_args.insert(k, value);
-        }
+		let arg_map = build.args().to_map();
+		let mut build_args: std::collections::HashMap<String, String> =
+			std::collections::HashMap::new();
+		for (k, v) in arg_map {
+			let value = match v {
+				Some(val) => val,
+				None => std::env::var(&k).unwrap_or_default(),
+			};
+			build_args.insert(k, value);
+		}
 
-        let mut labels: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
-        if let BuildConfig::Config { labels: l, .. } = build {
-            labels.extend(l.to_map());
-        }
+		let mut labels: std::collections::HashMap<String, String> =
+			std::collections::HashMap::new();
+		if let BuildConfig::Config { labels: l, .. } = build {
+			labels.extend(l.to_map());
+		}
 
-        let network_owned = if let BuildConfig::Config {
-            network: Some(n), ..
-        } = build
-        {
-            n.clone()
-        } else {
-            String::new()
-        };
-        let platform_owned = if let BuildConfig::Config { platforms, .. } = build {
-            platforms.first().cloned().unwrap_or_default()
-        } else {
-            String::new()
-        };
-        let shmsize = build
-            .shm_size()
-            .and_then(size::parse_memory)
-            .map(|s| s as u64)
-            .unwrap_or(0);
-        let extrahosts = build.extra_hosts().join(",");
+		let network_owned = if let BuildConfig::Config {
+			network: Some(n), ..
+		} = build
+		{
+			n.clone()
+		} else {
+			String::new()
+		};
+		let platform_owned = if let BuildConfig::Config { platforms, .. } = build {
+			platforms.first().cloned().unwrap_or_default()
+		} else {
+			String::new()
+		};
+		let shmsize = build
+			.shm_size()
+			.and_then(size::parse_memory)
+			.map(|s| s as u64)
+			.unwrap_or(0);
+		let extrahosts = build.extra_hosts().join(",");
 
-        let options = BuildImageOptions {
-            dockerfile: dockerfile_name,
-            t: Some(tag.clone()),
-            rm: true,
-            nocache: build.no_cache(),
-            pull: if build.pull() {
-                Some("1".to_string())
-            } else {
-                None
-            },
-            buildargs: if build_args.is_empty() {
-                None
-            } else {
-                Some(build_args)
-            },
-            labels: if labels.is_empty() {
-                None
-            } else {
-                Some(labels)
-            },
-            networkmode: if network_owned.is_empty() {
-                None
-            } else {
-                Some(network_owned)
-            },
-            platform: platform_owned,
-            shmsize: if shmsize > 0 {
-                Some(shmsize as i32)
-            } else {
-                None
-            },
-            extrahosts: if extrahosts.is_empty() {
-                None
-            } else {
-                Some(extrahosts)
-            },
-            cachefrom: if build.cache_from().is_empty() {
-                None
-            } else {
-                Some(build.cache_from().to_vec())
-            },
-            ..Default::default()
-        };
+		let options = BuildImageOptions {
+			dockerfile: dockerfile_name,
+			t: Some(tag.clone()),
+			rm: true,
+			nocache: build.no_cache(),
+			pull: if build.pull() {
+				Some("1".to_string())
+			} else {
+				None
+			},
+			buildargs: if build_args.is_empty() {
+				None
+			} else {
+				Some(build_args)
+			},
+			labels: if labels.is_empty() {
+				None
+			} else {
+				Some(labels)
+			},
+			networkmode: if network_owned.is_empty() {
+				None
+			} else {
+				Some(network_owned)
+			},
+			platform: platform_owned,
+			shmsize: if shmsize > 0 {
+				Some(shmsize as i32)
+			} else {
+				None
+			},
+			extrahosts: if extrahosts.is_empty() {
+				None
+			} else {
+				Some(extrahosts)
+			},
+			cachefrom: if build.cache_from().is_empty() {
+				None
+			} else {
+				Some(build.cache_from().to_vec())
+			},
+			..Default::default()
+		};
 
-        let body = Bytes::from(tar_bytes);
-        let mut stream = self
-            .docker
-            .build_image(options, None, Some(body_full(body)));
+		let body = Bytes::from(tar_bytes);
+		let mut stream = self
+			.docker
+			.build_image(options, None, Some(body_full(body)));
 
-        while let Some(result) = stream.next().await {
-            match result {
-                Ok(info) => {
-                    if let Some(stream_msg) = info.stream {
-                        print!("{stream_msg}");
-                    }
-                    if let Some(err) = info.error_detail.and_then(|e| e.message) {
-                        return Err(ComposeError::Build(err));
-                    }
-                }
-                Err(e) => return Err(ComposeError::Podman(e)),
-            }
-        }
+		while let Some(result) = stream.next().await {
+			match result {
+				Ok(info) => {
+					if let Some(stream_msg) = info.stream {
+						print!("{stream_msg}");
+					}
+					if let Some(err) = info.error_detail.and_then(|e| e.message) {
+						return Err(ComposeError::Build(err));
+					}
+				}
+				Err(e) => return Err(ComposeError::Podman(e)),
+			}
+		}
 
-        // Apply additional tags.
-        for extra_tag in build.tags() {
-            let (repo, tag_str) = extra_tag
-                .rsplit_once(':')
-                .map(|(r, t)| (r.to_string(), t.to_string()))
-                .unwrap_or_else(|| (extra_tag.clone(), "latest".to_string()));
-            if let Err(e) = self
-                .docker
-                .tag_image(
-                    &tag,
-                    Some(TagImageOptions {
-                        repo: Some(repo),
-                        tag: Some(tag_str),
-                    }),
-                )
-                .await
-            {
-                warn!("failed to apply extra tag {extra_tag}: {e}");
-            }
-        }
+		// Apply additional tags.
+		for extra_tag in build.tags() {
+			let (repo, tag_str) = extra_tag
+				.rsplit_once(':')
+				.map(|(r, t)| (r.to_string(), t.to_string()))
+				.unwrap_or_else(|| (extra_tag.clone(), "latest".to_string()));
+			if let Err(e) = self
+				.docker
+				.tag_image(
+					&tag,
+					Some(TagImageOptions {
+						repo: Some(repo),
+						tag: Some(tag_str),
+					}),
+				)
+				.await
+			{
+				warn!("failed to apply extra tag {extra_tag}: {e}");
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -211,90 +211,90 @@ impl Engine {
 
 /// Write inline Dockerfile content into the context tar as `.dockerfile-inline`.
 fn build_context_tar_with_inline(context: &Path, inline: &str) -> Result<(Vec<u8>, String)> {
-    let inline_name = ".dockerfile-inline";
-    let ignore_patterns = read_dockerignore(context);
+	let inline_name = ".dockerfile-inline";
+	let ignore_patterns = read_dockerignore(context);
 
-    let encoder = GzEncoder::new(Vec::new(), Compression::default());
-    let mut tar = tar::Builder::new(encoder);
+	let encoder = GzEncoder::new(Vec::new(), Compression::default());
+	let mut tar = tar::Builder::new(encoder);
 
-    // Inline Dockerfile first.
-    let mut header = tar::Header::new_gnu();
-    header.set_size(inline.len() as u64);
-    header.set_mode(0o644);
-    header.set_cksum();
-    tar.append_data(&mut header, inline_name, inline.as_bytes())
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
+	// Inline Dockerfile first.
+	let mut header = tar::Header::new_gnu();
+	header.set_size(inline.len() as u64);
+	header.set_mode(0o644);
+	header.set_cksum();
+	tar.append_data(&mut header, inline_name, inline.as_bytes())
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-    for entry in WalkDir::new(context).follow_links(false) {
-        let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-        let abs = entry.path();
-        let rel = abs
-            .strip_prefix(context)
-            .map_err(|_| ComposeError::Build("path strip error".into()))?;
-        if rel.as_os_str().is_empty() {
-            continue;
-        }
-        let rel_str = rel.to_string_lossy();
-        if is_ignored(&rel_str, &ignore_patterns) {
-            continue;
-        }
-        if abs.is_dir() {
-            tar.append_dir(rel, abs)
-                .map_err(|e| ComposeError::Build(e.to_string()))?;
-        } else {
-            tar.append_path_with_name(abs, rel)
-                .map_err(|e| ComposeError::Build(e.to_string()))?;
-        }
-    }
+	for entry in WalkDir::new(context).follow_links(false) {
+		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
+		let abs = entry.path();
+		let rel = abs
+			.strip_prefix(context)
+			.map_err(|_| ComposeError::Build("path strip error".into()))?;
+		if rel.as_os_str().is_empty() {
+			continue;
+		}
+		let rel_str = rel.to_string_lossy();
+		if is_ignored(&rel_str, &ignore_patterns) {
+			continue;
+		}
+		if abs.is_dir() {
+			tar.append_dir(rel, abs)
+				.map_err(|e| ComposeError::Build(e.to_string()))?;
+		} else {
+			tar.append_path_with_name(abs, rel)
+				.map_err(|e| ComposeError::Build(e.to_string()))?;
+		}
+	}
 
-    let gz = tar
-        .into_inner()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
-    let bytes = gz
-        .finish()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
-    Ok((bytes, inline_name.to_string()))
+	let gz = tar
+		.into_inner()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	let bytes = gz
+		.finish()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	Ok((bytes, inline_name.to_string()))
 }
 
 pub(crate) fn build_context_tar(context: &Path, _dockerfile: &str) -> Result<Vec<u8>> {
-    let ignore_patterns = read_dockerignore(context);
+	let ignore_patterns = read_dockerignore(context);
 
-    let encoder = GzEncoder::new(Vec::new(), Compression::default());
-    let mut tar = tar::Builder::new(encoder);
+	let encoder = GzEncoder::new(Vec::new(), Compression::default());
+	let mut tar = tar::Builder::new(encoder);
 
-    for entry in WalkDir::new(context).follow_links(false) {
-        let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-        let abs = entry.path();
-        let rel = abs
-            .strip_prefix(context)
-            .map_err(|_| ComposeError::Build("path strip error".into()))?;
+	for entry in WalkDir::new(context).follow_links(false) {
+		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
+		let abs = entry.path();
+		let rel = abs
+			.strip_prefix(context)
+			.map_err(|_| ComposeError::Build("path strip error".into()))?;
 
-        if rel.as_os_str().is_empty() {
-            continue;
-        }
+		if rel.as_os_str().is_empty() {
+			continue;
+		}
 
-        let rel_str = rel.to_string_lossy();
-        if is_ignored(&rel_str, &ignore_patterns) {
-            continue;
-        }
+		let rel_str = rel.to_string_lossy();
+		if is_ignored(&rel_str, &ignore_patterns) {
+			continue;
+		}
 
-        if abs.is_dir() {
-            tar.append_dir(rel, abs)
-                .map_err(|e| ComposeError::Build(e.to_string()))?;
-        } else {
-            tar.append_path_with_name(abs, rel)
-                .map_err(|e| ComposeError::Build(e.to_string()))?;
-        }
-    }
+		if abs.is_dir() {
+			tar.append_dir(rel, abs)
+				.map_err(|e| ComposeError::Build(e.to_string()))?;
+		} else {
+			tar.append_path_with_name(abs, rel)
+				.map_err(|e| ComposeError::Build(e.to_string()))?;
+		}
+	}
 
-    let gz = tar
-        .into_inner()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
-    let bytes = gz
-        .finish()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
+	let gz = tar
+		.into_inner()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	let bytes = gz
+		.finish()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-    Ok(bytes)
+	Ok(bytes)
 }
 
 /// Build a context tar with the Dockerfile truncated to stages up to `target`.
@@ -302,60 +302,60 @@ pub(crate) fn build_context_tar(context: &Path, _dockerfile: &str) -> Result<Vec
 /// Achieves the same result as `docker build --target=<target>` without requiring
 /// bollard API support for the target parameter.
 fn build_context_tar_with_target(
-    context: &Path,
-    dockerfile: &str,
-    target: &str,
+	context: &Path,
+	dockerfile: &str,
+	target: &str,
 ) -> Result<(Vec<u8>, String)> {
-    let df_path = context.join(dockerfile);
-    let df_content = std::fs::read_to_string(&df_path).map_err(ComposeError::Io)?;
-    let truncated = truncate_dockerfile_to_target(&df_content, target);
+	let df_path = context.join(dockerfile);
+	let df_content = std::fs::read_to_string(&df_path).map_err(ComposeError::Io)?;
+	let truncated = truncate_dockerfile_to_target(&df_content, target);
 
-    let ignore_patterns = read_dockerignore(context);
-    let encoder = GzEncoder::new(Vec::new(), Compression::default());
-    let mut tar = tar::Builder::new(encoder);
+	let ignore_patterns = read_dockerignore(context);
+	let encoder = GzEncoder::new(Vec::new(), Compression::default());
+	let mut tar = tar::Builder::new(encoder);
 
-    // Write truncated Dockerfile first.
-    let df_bytes = truncated.as_bytes();
-    let mut header = tar::Header::new_gnu();
-    header.set_size(df_bytes.len() as u64);
-    header.set_mode(0o644);
-    header.set_cksum();
-    tar.append_data(&mut header, dockerfile, df_bytes)
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
+	// Write truncated Dockerfile first.
+	let df_bytes = truncated.as_bytes();
+	let mut header = tar::Header::new_gnu();
+	header.set_size(df_bytes.len() as u64);
+	header.set_mode(0o644);
+	header.set_cksum();
+	tar.append_data(&mut header, dockerfile, df_bytes)
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-    // Add context, skipping the original Dockerfile (already wrote truncated version).
-    for entry in WalkDir::new(context).follow_links(false) {
-        let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-        let abs = entry.path();
-        let rel = abs
-            .strip_prefix(context)
-            .map_err(|_| ComposeError::Build("path strip error".into()))?;
-        if rel.as_os_str().is_empty() {
-            continue;
-        }
-        let rel_str = rel.to_string_lossy();
-        if is_ignored(&rel_str, &ignore_patterns) {
-            continue;
-        }
-        if rel_str == dockerfile {
-            continue; // Replaced by truncated version above.
-        }
-        if abs.is_dir() {
-            tar.append_dir(rel, abs)
-                .map_err(|e| ComposeError::Build(e.to_string()))?;
-        } else {
-            tar.append_path_with_name(abs, rel)
-                .map_err(|e| ComposeError::Build(e.to_string()))?;
-        }
-    }
+	// Add context, skipping the original Dockerfile (already wrote truncated version).
+	for entry in WalkDir::new(context).follow_links(false) {
+		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
+		let abs = entry.path();
+		let rel = abs
+			.strip_prefix(context)
+			.map_err(|_| ComposeError::Build("path strip error".into()))?;
+		if rel.as_os_str().is_empty() {
+			continue;
+		}
+		let rel_str = rel.to_string_lossy();
+		if is_ignored(&rel_str, &ignore_patterns) {
+			continue;
+		}
+		if rel_str == dockerfile {
+			continue; // Replaced by truncated version above.
+		}
+		if abs.is_dir() {
+			tar.append_dir(rel, abs)
+				.map_err(|e| ComposeError::Build(e.to_string()))?;
+		} else {
+			tar.append_path_with_name(abs, rel)
+				.map_err(|e| ComposeError::Build(e.to_string()))?;
+		}
+	}
 
-    let gz = tar
-        .into_inner()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
-    let bytes = gz
-        .finish()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
-    Ok((bytes, dockerfile.to_string()))
+	let gz = tar
+		.into_inner()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	let bytes = gz
+		.finish()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	Ok((bytes, dockerfile.to_string()))
 }
 
 /// Truncate a Dockerfile to only include stages up to and including `target`.
@@ -363,66 +363,66 @@ fn build_context_tar_with_target(
 /// Stages after `target` are dropped, making the target stage the effective
 /// final output — equivalent to `docker build --target=<target>`.
 pub(crate) fn truncate_dockerfile_to_target(content: &str, target: &str) -> String {
-    let target_lower = target.to_lowercase();
-    let mut lines: Vec<&str> = Vec::new();
-    let mut found_target = false;
+	let target_lower = target.to_lowercase();
+	let mut lines: Vec<&str> = Vec::new();
+	let mut found_target = false;
 
-    for line in content.lines() {
-        let trimmed = line.trim().to_ascii_lowercase();
+	for line in content.lines() {
+		let trimmed = line.trim().to_ascii_lowercase();
 
-        if trimmed.starts_with("from ") {
-            if found_target {
-                // First FROM after our target stage — stop here.
-                break;
-            }
-            lines.push(line);
-            if let Some(as_idx) = trimmed.find(" as ") {
-                let stage = trimmed[as_idx + 4..].trim().to_string();
-                if stage == target_lower {
-                    found_target = true;
-                }
-            }
-        } else {
-            lines.push(line);
-        }
-    }
+		if trimmed.starts_with("from ") {
+			if found_target {
+				// First FROM after our target stage — stop here.
+				break;
+			}
+			lines.push(line);
+			if let Some(as_idx) = trimmed.find(" as ") {
+				let stage = trimmed[as_idx + 4..].trim().to_string();
+				if stage == target_lower {
+					found_target = true;
+				}
+			}
+		} else {
+			lines.push(line);
+		}
+	}
 
-    if !found_target {
-        tracing::warn!(
+	if !found_target {
+		tracing::warn!(
             "build.target '{target}' not found as a named stage in Dockerfile — using full Dockerfile"
         );
-        return content.to_string();
-    }
+		return content.to_string();
+	}
 
-    lines.join("\n")
+	lines.join("\n")
 }
 
 fn read_dockerignore(context: &Path) -> Vec<String> {
-    let path = context.join(".dockerignore");
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    content
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty() && !l.starts_with('#'))
-        .collect()
+	let path = context.join(".dockerignore");
+	let Ok(content) = std::fs::read_to_string(path) else {
+		return Vec::new();
+	};
+	content
+		.lines()
+		.map(|l| l.trim().to_string())
+		.filter(|l| !l.is_empty() && !l.starts_with('#'))
+		.collect()
 }
 
 fn is_ignored(path: &str, patterns: &[String]) -> bool {
-    for pattern in patterns {
-        if pattern.ends_with('/') {
-            if path.starts_with(pattern.as_str()) {
-                return true;
-            }
-        } else if path == pattern.as_str()
-            || (path.starts_with(pattern.as_str())
-                && path.as_bytes().get(pattern.len()) == Some(&b'/'))
-        {
-            return true;
-        }
-    }
-    false
+	for pattern in patterns {
+		if pattern.ends_with('/') {
+			if path.starts_with(pattern.as_str()) {
+				return true;
+			}
+		} else if path == pattern.as_str()
+			|| (path.starts_with(pattern.as_str())
+				&& path.as_bytes().get(pattern.len()) == Some(&b'/'))
+		{
+			return true;
+		}
+	}
+	false
 }
 
 // ---------------------------------------------------------------------------
@@ -431,37 +431,37 @@ fn is_ignored(path: &str, patterns: &[String]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_dockerfile_to_target;
+	use super::truncate_dockerfile_to_target;
 
-    #[test]
-    fn truncate_drops_stages_after_target() {
-        let df = "FROM base AS builder\nRUN build\nFROM builder AS production\nRUN run\nFROM production AS final\nRUN finalize\n";
-        let result = truncate_dockerfile_to_target(df, "production");
-        assert!(result.contains("FROM base AS builder"));
-        assert!(result.contains("FROM builder AS production"));
-        assert!(!result.contains("FROM production AS final"));
-    }
+	#[test]
+	fn truncate_drops_stages_after_target() {
+		let df = "FROM base AS builder\nRUN build\nFROM builder AS production\nRUN run\nFROM production AS final\nRUN finalize\n";
+		let result = truncate_dockerfile_to_target(df, "production");
+		assert!(result.contains("FROM base AS builder"));
+		assert!(result.contains("FROM builder AS production"));
+		assert!(!result.contains("FROM production AS final"));
+	}
 
-    #[test]
-    fn truncate_unknown_target_returns_full() {
-        let df = "FROM alpine\nRUN echo hi\n";
-        let result = truncate_dockerfile_to_target(df, "nonexistent");
-        assert_eq!(result, df);
-    }
+	#[test]
+	fn truncate_unknown_target_returns_full() {
+		let df = "FROM alpine\nRUN echo hi\n";
+		let result = truncate_dockerfile_to_target(df, "nonexistent");
+		assert_eq!(result, df);
+	}
 
-    #[test]
-    fn truncate_case_insensitive_target() {
-        let df = "FROM base AS Builder\nRUN step\nFROM Builder AS Next\nRUN other\n";
-        let result = truncate_dockerfile_to_target(df, "builder");
-        assert!(result.contains("AS Builder"));
-        assert!(!result.contains("AS Next"));
-    }
+	#[test]
+	fn truncate_case_insensitive_target() {
+		let df = "FROM base AS Builder\nRUN step\nFROM Builder AS Next\nRUN other\n";
+		let result = truncate_dockerfile_to_target(df, "builder");
+		assert!(result.contains("AS Builder"));
+		assert!(!result.contains("AS Next"));
+	}
 
-    #[test]
-    fn truncate_single_stage_target() {
-        let df = "FROM alpine AS app\nRUN echo done\n";
-        let result = truncate_dockerfile_to_target(df, "app");
-        assert!(result.contains("FROM alpine AS app"));
-        assert!(result.contains("echo done"));
-    }
+	#[test]
+	fn truncate_single_stage_target() {
+		let df = "FROM alpine AS app\nRUN echo done\n";
+		let result = truncate_dockerfile_to_target(df, "app");
+		assert!(result.contains("FROM alpine AS app"));
+		assert!(result.contains("echo done"));
+	}
 }

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -133,14 +133,22 @@ impl Engine {
 
 		let host_config = HostConfig {
 			binds: opt_vec(all_binds),
-			mounts: if mounts.is_empty() { None } else { Some(mounts) },
+			mounts: if mounts.is_empty() {
+				None
+			} else {
+				Some(mounts)
+			},
 			network_mode: network_mode.clone(),
 			restart_policy,
 			port_bindings: opt_map(port_bindings),
 			cap_add: opt_vec(service.cap_add.clone()),
 			cap_drop: opt_vec(service.cap_drop.clone()),
 			sysctls: opt_map(sysctls),
-			ulimits: if ulimits.is_empty() { None } else { Some(ulimits) },
+			ulimits: if ulimits.is_empty() {
+				None
+			} else {
+				Some(ulimits)
+			},
 			extra_hosts: opt_vec(extra_hosts),
 			dns: opt_vec(dns),
 			dns_search: opt_vec(dns_search),
@@ -187,7 +195,11 @@ impl Engine {
 			blkio_device_write_bps: blkio.as_ref().and_then(|b| b.device_write_bps.clone()),
 			blkio_device_read_iops: blkio.as_ref().and_then(|b| b.device_read_iops.clone()),
 			blkio_device_write_iops: blkio.as_ref().and_then(|b| b.device_write_iops.clone()),
-			device_requests: if device_requests.is_empty() { None } else { Some(device_requests) },
+			device_requests: if device_requests.is_empty() {
+				None
+			} else {
+				Some(device_requests)
+			},
 			annotations: opt_map(service.annotations.to_map()),
 			..Default::default()
 		};

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -1,703 +1,274 @@
-//! Container creation, configuration, and lifecycle management.
-//!
-//! [`Engine::create_and_start`] is the main entry point: it assembles the full
-//! bollard `Config` from a [`Service`] definition (env vars, mounts, ports,
-//! resource limits, networking) and starts the container. Helper functions
-//! (`build_env`, `build_mounts`, `resolve_resources`, etc.) each own one
-//! slice of the config to keep the mapping manageable.
+//! Container creation and start: assembles bollard `Config` from a [`Service`]
+//! and starts the container. Config-building helpers live in [`super::container_config`].
 
 use std::collections::HashMap;
 use std::path::Path;
 
-use bollard::models::{
-    ContainerCreateBody, DeviceMapping, DeviceRequest, HealthConfig, HostConfig,
-    HostConfigLogConfig, NetworkingConfig, ResourcesBlkioWeightDevice, ResourcesUlimits,
-    RestartPolicy as BollardRestart, RestartPolicyNameEnum, ThrottleDevice,
-};
+use bollard::models::{ContainerCreateBody, HostConfig, NetworkingConfig};
 use bollard::query_parameters::{
-    CreateContainerOptions, RemoveContainerOptions, StartContainerOptions,
+	CreateContainerOptions, RemoveContainerOptions, StartContainerOptions,
 };
-use tracing::warn;
 
-use crate::compose::types::{
-    Command as ComposeCommand, ComposeFile, HealthCheck, LoggingConfig,
-    RestartPolicy as ComposeRestart, Service, VolumeMount, VolumeType,
-};
+use crate::compose::types::{ComposeFile, Service, VolumeMount, VolumeType};
 use crate::error::{ComposeError, Result};
 use crate::{env_file, ports, size};
 
+use super::container_config::{
+	build_healthcheck, build_log_config, build_restart_policy, build_ulimits, resolve_resources,
+};
+use super::container_misc::{
+	build_blkio_config, build_device_requests, build_label_file_labels, opt_map, opt_vec,
+	parse_device, tmpfs_options_to_string,
+};
 use super::network::{build_endpoint_settings, resolve_network_mode};
-use super::volume::{build_binds, build_mounts};
+use super::volume_mounts::{build_binds, build_mounts};
 use super::Engine;
 
 impl Engine {
-    pub(super) async fn create_and_start(
-        &self,
-        container_name: &str,
-        service_name: &str,
-        service: &Service,
-        file: &ComposeFile,
-    ) -> Result<()> {
-        let image = service
-            .image
-            .as_deref()
-            .ok_or_else(|| ComposeError::NoImageOrBuild(service_name.into()))?;
+	pub(super) async fn create_and_start(
+		&self,
+		container_name: &str,
+		service_name: &str,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<()> {
+		let image = service
+			.image
+			.as_deref()
+			.ok_or_else(|| ComposeError::NoImageOrBuild(service_name.into()))?;
 
-        let env = build_env(service, &self.base_dir)?;
+		let env = build_env(service, &self.base_dir)?;
 
-        let binds = build_binds(service, &self.base_dir);
-        let secret_binds = self.build_secret_binds(service, file)?;
-        let config_binds = self.build_config_binds(service, file)?;
-        let all_binds: Vec<String> = binds
-            .into_iter()
-            .chain(secret_binds)
-            .chain(config_binds)
-            .collect();
+		let binds = build_binds(service, &self.base_dir);
+		let secret_binds = self.build_secret_binds(service, file)?;
+		let config_binds = self.build_config_binds(service, file)?;
+		let all_binds: Vec<String> = binds
+			.into_iter()
+			.chain(secret_binds)
+			.chain(config_binds)
+			.collect();
 
-        let parsed_ports = ports::parse_ports(&service.ports)?;
-        let (port_bindings, exposed_ports_map) = ports::to_bollard(&parsed_ports);
+		let parsed_ports = ports::parse_ports(&service.ports)?;
+		let (port_bindings, exposed_ports_map) = ports::to_bollard(&parsed_ports);
 
-        let mut exposed_port_keys: Vec<String> = exposed_ports_map.into_keys().collect();
-        for raw in &service.expose {
-            let key = if raw.contains('/') {
-                raw.clone()
-            } else {
-                format!("{raw}/tcp")
-            };
-            if !exposed_port_keys.contains(&key) {
-                exposed_port_keys.push(key);
-            }
-        }
+		let mut exposed_port_keys: Vec<String> = exposed_ports_map.into_keys().collect();
+		for raw in &service.expose {
+			let key = if raw.contains('/') {
+				raw.clone()
+			} else {
+				format!("{raw}/tcp")
+			};
+			if !exposed_port_keys.contains(&key) {
+				exposed_port_keys.push(key);
+			}
+		}
 
-        let restart_policy = build_restart_policy(service);
-        let log_config = build_log_config(service.logging.as_ref());
-        let (network_mode, first_network) = resolve_network_mode(service, file);
-        let label_file_labels = build_label_file_labels(service, &self.base_dir);
+		let restart_policy = build_restart_policy(service);
+		let log_config = build_log_config(service.logging.as_ref());
+		let (network_mode, first_network) = resolve_network_mode(service, file);
+		let label_file_labels = build_label_file_labels(service, &self.base_dir);
 
-        let mut labels = service.labels.to_map();
-        // Merge label_file labels (lower priority than inline labels).
-        for (k, v) in label_file_labels {
-            labels.entry(k).or_insert(v);
-        }
-        // Merge deploy.labels (lower priority than service.labels).
-        if let Some(deploy) = &service.deploy {
-            for (k, v) in deploy.labels.to_map() {
-                labels.entry(k).or_insert(v);
-            }
-        }
-        for (k, v) in service.annotations.to_map() {
-            labels.insert(format!("annotation.{k}"), v);
-        }
-        labels.insert("podup.project".to_string(), self.project.clone());
-        labels.insert("podup.service".to_string(), service_name.to_string());
+		let mut labels = service.labels.to_map();
+		for (k, v) in label_file_labels {
+			labels.entry(k).or_insert(v);
+		}
+		if let Some(deploy) = &service.deploy {
+			for (k, v) in deploy.labels.to_map() {
+				labels.entry(k).or_insert(v);
+			}
+		}
+		for (k, v) in service.annotations.to_map() {
+			labels.insert(format!("annotation.{k}"), v);
+		}
+		labels.insert("podup.project".to_string(), self.project.clone());
+		labels.insert("podup.service".to_string(), service_name.to_string());
 
-        let ulimits: Vec<ResourcesUlimits> = service
-            .ulimits
-            .iter()
-            .map(|(name, cfg)| ResourcesUlimits {
-                name: Some(name.clone()),
-                soft: Some(cfg.soft()),
-                hard: Some(cfg.hard()),
-            })
-            .collect();
+		let ulimits = build_ulimits(service);
+		let sysctls: HashMap<String, String> = service.sysctls.to_map();
+		let extra_hosts: Vec<String> = service.extra_hosts.clone();
+		let dns = service.dns.to_list();
+		let dns_search = service.dns_search.to_list();
+		let dns_opt = service.dns_opt.to_list();
 
-        let sysctls: HashMap<String, String> = service.sysctls.to_map();
-        let extra_hosts: Vec<String> = service.extra_hosts.clone();
-        let dns = service.dns.to_list();
-        let dns_search = service.dns_search.to_list();
-        let dns_opt = service.dns_opt.to_list();
+		let devices: Vec<bollard::models::DeviceMapping> = service
+			.devices
+			.iter()
+			.map(|s| parse_device(s.as_str()))
+			.collect();
 
-        let devices: Vec<DeviceMapping> = service
-            .devices
-            .iter()
-            .map(|s| parse_device(s.as_str()))
-            .collect();
+		let device_requests = build_device_requests(service);
 
-        let device_requests = build_device_requests(service);
+		let tmpfs_list = service.tmpfs.to_list();
+		let mut tmpfs_map: HashMap<String, String> =
+			tmpfs_list.into_iter().map(|p| (p, String::new())).collect();
+		for v in &service.volumes {
+			if let VolumeMount::Long {
+				volume_type: VolumeType::Tmpfs,
+				target,
+				tmpfs,
+				..
+			} = v
+			{
+				let opts = tmpfs_options_to_string(tmpfs.as_ref());
+				tmpfs_map.insert(target.clone(), opts);
+			}
+		}
 
-        let tmpfs_list = service.tmpfs.to_list();
-        let mut tmpfs_map: HashMap<String, String> =
-            tmpfs_list.into_iter().map(|p| (p, String::new())).collect();
-        for v in &service.volumes {
-            if let VolumeMount::Long {
-                volume_type: VolumeType::Tmpfs,
-                target,
-                tmpfs,
-                ..
-            } = v
-            {
-                let opts = tmpfs_options_to_string(tmpfs.as_ref());
-                tmpfs_map.insert(target.clone(), opts);
-            }
-        }
+		let (
+			mem_limit,
+			mem_reservation,
+			memswap,
+			nano_cpus,
+			cpu_quota_eff,
+			cpu_period_eff,
+			pids_limit,
+		) = resolve_resources(service);
 
-        let (
-            mem_limit,
-            mem_reservation,
-            memswap,
-            nano_cpus,
-            cpu_quota_eff,
-            cpu_period_eff,
-            pids_limit,
-        ) = resolve_resources(service);
+		let blkio = build_blkio_config(service);
 
-        let blkio = build_blkio_config(service);
+		let mut all_links: Vec<String> = service.links.clone();
+		all_links.extend_from_slice(&service.external_links);
 
-        let mut all_links: Vec<String> = service.links.clone();
-        all_links.extend_from_slice(&service.external_links);
+		let mounts = build_mounts(service);
 
-        let mounts = build_mounts(service);
+		let host_config = HostConfig {
+			binds: opt_vec(all_binds),
+			mounts: if mounts.is_empty() { None } else { Some(mounts) },
+			network_mode: network_mode.clone(),
+			restart_policy,
+			port_bindings: opt_map(port_bindings),
+			cap_add: opt_vec(service.cap_add.clone()),
+			cap_drop: opt_vec(service.cap_drop.clone()),
+			sysctls: opt_map(sysctls),
+			ulimits: if ulimits.is_empty() { None } else { Some(ulimits) },
+			extra_hosts: opt_vec(extra_hosts),
+			dns: opt_vec(dns),
+			dns_search: opt_vec(dns_search),
+			dns_options: opt_vec(dns_opt),
+			init: service.init,
+			privileged: service.privileged,
+			log_config,
+			pid_mode: service.pid.clone(),
+			ipc_mode: service.ipc.clone(),
+			uts_mode: service.uts.clone(),
+			cgroup_parent: service.cgroup_parent.clone(),
+			cgroupns_mode: service.cgroup.as_deref().and_then(|v| v.parse().ok()),
+			shm_size: service.shm_size.as_deref().and_then(size::parse_memory),
+			userns_mode: service.userns_mode.clone(),
+			security_opt: opt_vec(service.security_opt.clone()),
+			readonly_rootfs: service.read_only,
+			devices: opt_vec(devices),
+			device_cgroup_rules: opt_vec(service.device_cgroup_rules.clone()),
+			tmpfs: opt_map(tmpfs_map),
+			volumes_from: opt_vec(service.volumes_from.clone()),
+			links: opt_vec(all_links),
+			runtime: service.runtime.clone(),
+			memory: mem_limit,
+			memory_reservation: mem_reservation,
+			memory_swap: memswap,
+			memory_swappiness: service.mem_swappiness,
+			nano_cpus,
+			cpu_shares: service.cpu_shares.map(|s| s as i64),
+			cpu_quota: cpu_quota_eff,
+			cpu_period: cpu_period_eff,
+			cpuset_cpus: service.cpuset.clone(),
+			pids_limit,
+			cpu_count: service.cpu_count,
+			cpu_percent: service.cpu_percent,
+			cpu_realtime_period: service.cpu_rt_period,
+			cpu_realtime_runtime: service.cpu_rt_runtime,
+			oom_kill_disable: service.oom_kill_disable,
+			oom_score_adj: service.oom_score_adj,
+			storage_opt: opt_map(service.storage_opt.clone()),
+			group_add: opt_vec(service.group_add.clone()),
+			blkio_weight: blkio.as_ref().and_then(|b| b.weight),
+			blkio_weight_device: blkio.as_ref().and_then(|b| b.weight_device.clone()),
+			blkio_device_read_bps: blkio.as_ref().and_then(|b| b.device_read_bps.clone()),
+			blkio_device_write_bps: blkio.as_ref().and_then(|b| b.device_write_bps.clone()),
+			blkio_device_read_iops: blkio.as_ref().and_then(|b| b.device_read_iops.clone()),
+			blkio_device_write_iops: blkio.as_ref().and_then(|b| b.device_write_iops.clone()),
+			device_requests: if device_requests.is_empty() { None } else { Some(device_requests) },
+			annotations: opt_map(service.annotations.to_map()),
+			..Default::default()
+		};
 
-        let host_config = HostConfig {
-            binds: opt_vec(all_binds),
-            mounts: if mounts.is_empty() {
-                None
-            } else {
-                Some(mounts)
-            },
-            network_mode: network_mode.clone(),
-            restart_policy,
-            port_bindings: opt_map(port_bindings),
-            cap_add: opt_vec(service.cap_add.clone()),
-            cap_drop: opt_vec(service.cap_drop.clone()),
-            sysctls: opt_map(sysctls),
-            ulimits: if ulimits.is_empty() {
-                None
-            } else {
-                Some(ulimits)
-            },
-            extra_hosts: opt_vec(extra_hosts),
-            dns: opt_vec(dns),
-            dns_search: opt_vec(dns_search),
-            dns_options: opt_vec(dns_opt),
-            init: service.init,
-            privileged: service.privileged,
-            log_config,
-            pid_mode: service.pid.clone(),
-            ipc_mode: service.ipc.clone(),
-            uts_mode: service.uts.clone(),
-            cgroup_parent: service.cgroup_parent.clone(),
-            cgroupns_mode: service.cgroup.as_deref().and_then(|v| v.parse().ok()),
-            shm_size: service.shm_size.as_deref().and_then(size::parse_memory),
-            userns_mode: service.userns_mode.clone(),
-            security_opt: opt_vec(service.security_opt.clone()),
-            readonly_rootfs: service.read_only,
-            devices: opt_vec(devices),
-            device_cgroup_rules: opt_vec(service.device_cgroup_rules.clone()),
-            tmpfs: opt_map(tmpfs_map),
-            volumes_from: opt_vec(service.volumes_from.clone()),
-            links: opt_vec(all_links),
-            runtime: service.runtime.clone(),
-            memory: mem_limit,
-            memory_reservation: mem_reservation,
-            memory_swap: memswap,
-            memory_swappiness: service.mem_swappiness,
-            nano_cpus,
-            cpu_shares: service.cpu_shares.map(|s| s as i64),
-            cpu_quota: cpu_quota_eff,
-            cpu_period: cpu_period_eff,
-            cpuset_cpus: service.cpuset.clone(),
-            pids_limit,
-            cpu_count: service.cpu_count,
-            cpu_percent: service.cpu_percent,
-            cpu_realtime_period: service.cpu_rt_period,
-            cpu_realtime_runtime: service.cpu_rt_runtime,
-            oom_kill_disable: service.oom_kill_disable,
-            oom_score_adj: service.oom_score_adj,
-            storage_opt: opt_map(service.storage_opt.clone()),
-            group_add: opt_vec(service.group_add.clone()),
-            blkio_weight: blkio.as_ref().and_then(|b| b.weight),
-            blkio_weight_device: blkio.as_ref().and_then(|b| b.weight_device.clone()),
-            blkio_device_read_bps: blkio.as_ref().and_then(|b| b.device_read_bps.clone()),
-            blkio_device_write_bps: blkio.as_ref().and_then(|b| b.device_write_bps.clone()),
-            blkio_device_read_iops: blkio.as_ref().and_then(|b| b.device_read_iops.clone()),
-            blkio_device_write_iops: blkio.as_ref().and_then(|b| b.device_write_iops.clone()),
-            device_requests: if device_requests.is_empty() {
-                None
-            } else {
-                Some(device_requests)
-            },
-            annotations: opt_map(service.annotations.to_map()),
-            ..Default::default()
-        };
+		let cmd = service.command.as_ref().map(|c| c.to_exec());
+		let entrypoint = service.entrypoint.as_ref().map(|c| c.to_exec());
 
-        let cmd = service.command.as_ref().map(|c| c.to_exec());
-        let entrypoint = service.entrypoint.as_ref().map(|c| c.to_exec());
+		let networking_config = first_network.as_ref().map(|net| {
+			let mut endpoints = HashMap::new();
+			let svc_net_cfg = service.networks.config_for(net);
+			endpoints.insert(net.clone(), build_endpoint_settings(svc_net_cfg, file));
+			NetworkingConfig {
+				endpoints_config: Some(endpoints),
+			}
+		});
 
-        let networking_config = first_network.as_ref().map(|net| {
-            let mut endpoints = HashMap::new();
-            let svc_net_cfg = service.networks.config_for(net);
-            endpoints.insert(net.clone(), build_endpoint_settings(svc_net_cfg, file));
-            NetworkingConfig {
-                endpoints_config: Some(endpoints),
-            }
-        });
+		let healthcheck = service.healthcheck.as_ref().map(build_healthcheck);
 
-        let healthcheck = service.healthcheck.as_ref().map(build_healthcheck);
+		let config = ContainerCreateBody {
+			image: Some(image.to_string()),
+			env: opt_vec(env),
+			cmd,
+			entrypoint,
+			host_config: Some(host_config),
+			labels: opt_map(labels),
+			exposed_ports: opt_vec(exposed_port_keys),
+			tty: service.tty,
+			open_stdin: service.stdin_open,
+			user: service.user.clone(),
+			working_dir: service.working_dir.clone(),
+			stop_signal: service.stop_signal.clone(),
+			stop_timeout: service
+				.stop_grace_period
+				.as_deref()
+				.and_then(size::parse_duration_secs)
+				.map(|s| s as i64),
+			hostname: service.hostname.clone(),
+			domainname: service.domainname.clone(),
+			networking_config,
+			healthcheck,
+			..Default::default()
+		};
 
-        let config = ContainerCreateBody {
-            image: Some(image.to_string()),
-            env: opt_vec(env),
-            cmd,
-            entrypoint,
-            host_config: Some(host_config),
-            labels: opt_map(labels),
-            exposed_ports: opt_vec(exposed_port_keys),
-            tty: service.tty,
-            open_stdin: service.stdin_open,
-            user: service.user.clone(),
-            working_dir: service.working_dir.clone(),
-            stop_signal: service.stop_signal.clone(),
-            stop_timeout: service
-                .stop_grace_period
-                .as_deref()
-                .and_then(size::parse_duration_secs)
-                .map(|s| s as i64),
-            hostname: service.hostname.clone(),
-            domainname: service.domainname.clone(),
-            networking_config,
-            healthcheck,
-            ..Default::default()
-        };
+		let _ = self
+			.docker
+			.remove_container(
+				container_name,
+				Some(RemoveContainerOptions {
+					force: true,
+					..Default::default()
+				}),
+			)
+			.await;
 
-        // Remove any pre-existing container with the same name.
-        let _ = self
-            .docker
-            .remove_container(
-                container_name,
-                Some(RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
-            )
-            .await;
+		self.docker
+			.create_container(
+				Some(CreateContainerOptions {
+					name: Some(container_name.to_string()),
+					platform: service.platform.clone().unwrap_or_default(),
+				}),
+				config,
+			)
+			.await?;
 
-        self.docker
-            .create_container(
-                Some(CreateContainerOptions {
-                    name: Some(container_name.to_string()),
-                    platform: service.platform.clone().unwrap_or_default(),
-                }),
-                config,
-            )
-            .await?;
+		self.docker
+			.start_container(container_name, None::<StartContainerOptions>)
+			.await?;
 
-        self.docker
-            .start_container(container_name, None::<StartContainerOptions>)
-            .await?;
-
-        Ok(())
-    }
+		Ok(())
+	}
 }
-
-// ---------------------------------------------------------------------------
-// Container config helpers
-// ---------------------------------------------------------------------------
 
 fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
-    let entries = service.env_file.to_entries();
-    let env_file_vars = if !entries.is_empty() {
-        env_file::load_env_file_entries(&entries, base_dir)?
-    } else {
-        HashMap::new()
-    };
-    Ok(env_file::merge_env(
-        service.environment.to_map(),
-        env_file_vars,
-    ))
-}
-
-pub(crate) fn build_restart_policy(service: &Service) -> Option<BollardRestart> {
-    if let Some(r) = &service.restart {
-        return Some(match r {
-            ComposeRestart::No => BollardRestart {
-                name: Some(RestartPolicyNameEnum::NO),
-                maximum_retry_count: None,
-            },
-            ComposeRestart::Always => BollardRestart {
-                name: Some(RestartPolicyNameEnum::ALWAYS),
-                maximum_retry_count: None,
-            },
-            ComposeRestart::OnFailure { max_attempts } => BollardRestart {
-                name: Some(RestartPolicyNameEnum::ON_FAILURE),
-                maximum_retry_count: max_attempts.map(|n| n as i64),
-            },
-            ComposeRestart::UnlessStopped => BollardRestart {
-                name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),
-                maximum_retry_count: None,
-            },
-        });
-    }
-    // Fall back to deploy.restart_policy when service.restart is absent.
-    // delay/window are Swarm-specific and have no container API equivalent.
-    if let Some(drp) = service
-        .deploy
-        .as_ref()
-        .and_then(|d| d.restart_policy.as_ref())
-    {
-        let name = match drp.condition.as_deref().unwrap_or("any") {
-            "none" => RestartPolicyNameEnum::NO,
-            "on-failure" => RestartPolicyNameEnum::ON_FAILURE,
-            _ => RestartPolicyNameEnum::UNLESS_STOPPED,
-        };
-        return Some(BollardRestart {
-            name: Some(name),
-            maximum_retry_count: drp.max_attempts.map(|n| n as i64),
-        });
-    }
-    None
-}
-
-fn build_log_config(logging: Option<&LoggingConfig>) -> Option<HostConfigLogConfig> {
-    logging.map(|l| HostConfigLogConfig {
-        typ: l.driver.clone(),
-        config: if l.options.is_empty() {
-            None
-        } else {
-            Some(l.options.clone())
-        },
-    })
-}
-
-fn build_healthcheck(hc: &HealthCheck) -> HealthConfig {
-    if hc.is_disabled() {
-        return HealthConfig {
-            test: Some(vec!["NONE".to_string()]),
-            ..Default::default()
-        };
-    }
-    let test = hc.test.as_ref().map(|cmd| match cmd {
-        ComposeCommand::Shell(s) => vec!["CMD-SHELL".to_string(), s.clone()],
-        ComposeCommand::Exec(v) => v.clone(),
-    });
-    HealthConfig {
-        test,
-        interval: hc.interval.as_deref().and_then(size::parse_duration_nanos),
-        timeout: hc.timeout.as_deref().and_then(size::parse_duration_nanos),
-        retries: hc.retries.map(|r| r as i64),
-        start_period: hc
-            .start_period
-            .as_deref()
-            .and_then(size::parse_duration_nanos),
-        start_interval: hc
-            .start_interval
-            .as_deref()
-            .and_then(size::parse_duration_nanos),
-    }
-}
-
-#[allow(clippy::type_complexity)]
-fn resolve_resources(
-    service: &Service,
-) -> (
-    Option<i64>,
-    Option<i64>,
-    Option<i64>,
-    Option<i64>,
-    Option<i64>,
-    Option<i64>,
-    Option<i64>,
-) {
-    let mut memory = service.mem_limit.as_deref().and_then(size::parse_memory);
-    let mut mem_reservation = service
-        .mem_reservation
-        .as_deref()
-        .and_then(size::parse_memory);
-    let memswap = service
-        .memswap_limit
-        .as_deref()
-        .and_then(size::parse_memory);
-    let mut nano_cpus = service.cpus.as_deref().and_then(size::parse_cpus);
-    let cpu_quota = service.cpu_quota;
-    let cpu_period = service.cpu_period.map(|p| p as i64);
-    let mut pids_limit = service.pids_limit;
-
-    if let Some(deploy) = &service.deploy {
-        if let Some(res) = &deploy.resources {
-            if let Some(limits) = &res.limits {
-                if memory.is_none() {
-                    memory = limits.memory.as_deref().and_then(size::parse_memory);
-                }
-                if nano_cpus.is_none() {
-                    nano_cpus = limits.cpus.as_deref().and_then(size::parse_cpus);
-                }
-                if pids_limit.is_none() {
-                    pids_limit = limits.pids.map(|p| p as i64);
-                }
-            }
-            if let Some(reserv) = &res.reservations {
-                if mem_reservation.is_none() {
-                    mem_reservation = reserv.memory.as_deref().and_then(size::parse_memory);
-                }
-            }
-        }
-    }
-
-    (
-        memory,
-        mem_reservation,
-        memswap,
-        nano_cpus,
-        cpu_quota,
-        cpu_period,
-        pids_limit,
-    )
-}
-
-pub(crate) fn parse_device(s: &str) -> DeviceMapping {
-    let parts: Vec<&str> = s.splitn(3, ':').collect();
-    let host = parts.first().copied().unwrap_or("").to_string();
-    let cont = parts
-        .get(1)
-        .copied()
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| host.clone());
-    let perm = parts.get(2).copied().unwrap_or("rwm").to_string();
-    DeviceMapping {
-        path_on_host: Some(host),
-        path_in_container: Some(cont),
-        cgroup_permissions: Some(perm),
-    }
-}
-
-pub(crate) fn tmpfs_options_to_string(
-    opts: Option<&crate::compose::types::TmpfsOptions>,
-) -> String {
-    let opts = match opts {
-        Some(o) => o,
-        None => return String::new(),
-    };
-    let mut parts: Vec<String> = Vec::new();
-    if let Some(size) = opts.size {
-        parts.push(format!("size={size}"));
-    }
-    if let Some(mode) = opts.mode {
-        parts.push(format!("mode={mode:o}"));
-    }
-    parts.join(",")
-}
-
-pub(crate) fn opt_vec<T>(v: Vec<T>) -> Option<Vec<T>> {
-    if v.is_empty() {
-        None
-    } else {
-        Some(v)
-    }
-}
-
-pub(crate) fn opt_map<K, V>(m: HashMap<K, V>) -> Option<HashMap<K, V>> {
-    if m.is_empty() {
-        None
-    } else {
-        Some(m)
-    }
-}
-
-fn build_label_file_labels(service: &Service, base_dir: &Path) -> HashMap<String, String> {
-    let mut labels = HashMap::new();
-    for path in service.label_file.to_list() {
-        let full = if std::path::Path::new(&path).is_absolute() {
-            std::path::PathBuf::from(&path)
-        } else {
-            base_dir.join(&path)
-        };
-        let Ok(content) = std::fs::read_to_string(&full) else {
-            warn!("label_file: cannot read {}", full.display());
-            continue;
-        };
-        for line in content.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
-            let mut parts = trimmed.splitn(2, '=');
-            let key = parts.next().unwrap_or("").trim().to_string();
-            let val = parts.next().unwrap_or("").to_string();
-            if !key.is_empty() {
-                labels.insert(key, val);
-            }
-        }
-    }
-    labels
-}
-
-struct BlkioHostConfig {
-    weight: Option<u16>,
-    weight_device: Option<Vec<ResourcesBlkioWeightDevice>>,
-    device_read_bps: Option<Vec<ThrottleDevice>>,
-    device_write_bps: Option<Vec<ThrottleDevice>>,
-    device_read_iops: Option<Vec<ThrottleDevice>>,
-    device_write_iops: Option<Vec<ThrottleDevice>>,
-}
-
-fn build_device_requests(service: &Service) -> Vec<DeviceRequest> {
-    use crate::compose::types::CountOrAll;
-
-    let mut requests: Vec<DeviceRequest> = Vec::new();
-
-    // Top-level `gpus:` shorthand.
-    if let Some(gpus) = &service.gpus {
-        requests.push(DeviceRequest {
-            driver: Some("".into()),
-            count: Some(gpus.to_count()),
-            device_ids: None,
-            capabilities: Some(vec![vec!["gpu".into()]]),
-            options: None,
-        });
-    }
-
-    // `deploy.resources.reservations.devices`.
-    if let Some(deploy) = &service.deploy {
-        if let Some(resources) = &deploy.resources {
-            if let Some(reservations) = &resources.reservations {
-                for dev in &reservations.devices {
-                    if dev.capabilities.is_empty() {
-                        continue;
-                    }
-
-                    let count = if !dev.device_ids.is_empty() {
-                        None
-                    } else {
-                        Some(
-                            dev.count
-                                .as_ref()
-                                .map(|c: &CountOrAll| c.to_i64())
-                                .unwrap_or(-1),
-                        )
-                    };
-
-                    let device_ids = if dev.device_ids.is_empty() {
-                        None
-                    } else {
-                        Some(dev.device_ids.clone())
-                    };
-
-                    requests.push(DeviceRequest {
-                        driver: dev.driver.clone().or(Some("".into())),
-                        count,
-                        device_ids,
-                        capabilities: Some(vec![dev.capabilities.clone()]),
-                        options: if dev.options.is_empty() {
-                            None
-                        } else {
-                            Some(dev.options.clone())
-                        },
-                    });
-                }
-            }
-        }
-    }
-
-    requests
-}
-
-fn build_blkio_config(service: &Service) -> Option<BlkioHostConfig> {
-    use crate::compose::types::BlkioConfig;
-    let cfg: &BlkioConfig = service.blkio_config.as_ref()?;
-
-    let weight_device = if cfg.weight_device.is_empty() {
-        None
-    } else {
-        Some(
-            cfg.weight_device
-                .iter()
-                .map(|d| ResourcesBlkioWeightDevice {
-                    path: Some(d.path.clone()),
-                    weight: Some(d.weight as usize),
-                })
-                .collect(),
-        )
-    };
-
-    let to_throttle = |devs: &[crate::compose::types::BlkioRateDevice]| {
-        if devs.is_empty() {
-            None
-        } else {
-            Some(
-                devs.iter()
-                    .map(|d| ThrottleDevice {
-                        path: Some(d.path.clone()),
-                        rate: Some(d.rate_value()),
-                    })
-                    .collect(),
-            )
-        }
-    };
-
-    Some(BlkioHostConfig {
-        weight: cfg.weight,
-        weight_device,
-        device_read_bps: to_throttle(&cfg.device_read_bps),
-        device_write_bps: to_throttle(&cfg.device_write_bps),
-        device_read_iops: to_throttle(&cfg.device_read_iops),
-        device_write_iops: to_throttle(&cfg.device_write_iops),
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Unit tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::{parse_device, tmpfs_options_to_string};
-    use crate::compose::types::TmpfsOptions;
-
-    #[test]
-    fn parse_device_host_container_perm() {
-        let d = parse_device("/dev/sda:/dev/xvda:rwm");
-        assert_eq!(d.path_on_host.as_deref(), Some("/dev/sda"));
-        assert_eq!(d.path_in_container.as_deref(), Some("/dev/xvda"));
-        assert_eq!(d.cgroup_permissions.as_deref(), Some("rwm"));
-    }
-
-    #[test]
-    fn parse_device_default_perm() {
-        let d = parse_device("/dev/null:/dev/null");
-        assert_eq!(d.cgroup_permissions.as_deref(), Some("rwm"));
-    }
-
-    #[test]
-    fn parse_device_same_path_both_sides() {
-        let d = parse_device("/dev/dri");
-        assert_eq!(d.path_on_host.as_deref(), Some("/dev/dri"));
-        assert_eq!(d.path_in_container.as_deref(), Some("/dev/dri"));
-    }
-
-    #[test]
-    fn tmpfs_options_empty() {
-        let s = tmpfs_options_to_string(None);
-        assert!(s.is_empty());
-    }
-
-    #[test]
-    fn tmpfs_options_size_only() {
-        let opts = TmpfsOptions {
-            size: Some(67108864),
-            mode: None,
-        };
-        let s = tmpfs_options_to_string(Some(&opts));
-        assert_eq!(s, "size=67108864");
-    }
-
-    #[test]
-    fn tmpfs_options_mode_only() {
-        let opts = TmpfsOptions {
-            size: None,
-            mode: Some(0o1755),
-        };
-        let s = tmpfs_options_to_string(Some(&opts));
-        assert_eq!(s, "mode=1755");
-    }
-
-    #[test]
-    fn tmpfs_options_size_and_mode() {
-        let opts = TmpfsOptions {
-            size: Some(1024),
-            mode: Some(0o755),
-        };
-        let s = tmpfs_options_to_string(Some(&opts));
-        assert!(s.contains("size=1024"));
-        assert!(s.contains("mode=755"));
-    }
+	let entries = service.env_file.to_entries();
+	let env_file_vars = if !entries.is_empty() {
+		env_file::load_env_file_entries(&entries, base_dir)?
+	} else {
+		HashMap::new()
+	};
+	Ok(env_file::merge_env(
+		service.environment.to_map(),
+		env_file_vars,
+	))
 }

--- a/internal/engine/container_config.rs
+++ b/internal/engine/container_config.rs
@@ -1,0 +1,405 @@
+//! Pure configuration builders for container creation: restart policy, logging,
+//! healthcheck, resource limits, and ulimits.
+//!
+//! Device, blkio, tmpfs, and label-file helpers live in [`super::container_misc`].
+
+use bollard::models::{
+	HealthConfig, HostConfigLogConfig, ResourcesUlimits, RestartPolicy as BollardRestart,
+	RestartPolicyNameEnum,
+};
+
+use crate::compose::types::{
+	Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart, Service,
+};
+use crate::size;
+
+// ---------------------------------------------------------------------------
+// Restart policy
+// ---------------------------------------------------------------------------
+
+pub(super) fn build_restart_policy(service: &Service) -> Option<BollardRestart> {
+	if let Some(r) = &service.restart {
+		return Some(match r {
+			ComposeRestart::No => BollardRestart {
+				name: Some(RestartPolicyNameEnum::NO),
+				maximum_retry_count: None,
+			},
+			ComposeRestart::Always => BollardRestart {
+				name: Some(RestartPolicyNameEnum::ALWAYS),
+				maximum_retry_count: None,
+			},
+			ComposeRestart::OnFailure { max_attempts } => BollardRestart {
+				name: Some(RestartPolicyNameEnum::ON_FAILURE),
+				maximum_retry_count: max_attempts.map(|n| n as i64),
+			},
+			ComposeRestart::UnlessStopped => BollardRestart {
+				name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),
+				maximum_retry_count: None,
+			},
+		});
+	}
+	if let Some(drp) = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.restart_policy.as_ref())
+	{
+		let name = match drp.condition.as_deref().unwrap_or("any") {
+			"none" => RestartPolicyNameEnum::NO,
+			"on-failure" => RestartPolicyNameEnum::ON_FAILURE,
+			_ => RestartPolicyNameEnum::UNLESS_STOPPED,
+		};
+		return Some(BollardRestart {
+			name: Some(name),
+			maximum_retry_count: drp.max_attempts.map(|n| n as i64),
+		});
+	}
+	None
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+pub(super) fn build_log_config(logging: Option<&LoggingConfig>) -> Option<HostConfigLogConfig> {
+	logging.map(|l| HostConfigLogConfig {
+		typ: l.driver.clone(),
+		config: if l.options.is_empty() {
+			None
+		} else {
+			Some(l.options.clone())
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Healthcheck
+// ---------------------------------------------------------------------------
+
+pub(super) fn build_healthcheck(hc: &HealthCheck) -> HealthConfig {
+	if hc.is_disabled() {
+		return HealthConfig {
+			test: Some(vec!["NONE".to_string()]),
+			..Default::default()
+		};
+	}
+	let test = hc.test.as_ref().map(|cmd| match cmd {
+		ComposeCommand::Shell(s) => vec!["CMD-SHELL".to_string(), s.clone()],
+		ComposeCommand::Exec(v) => v.clone(),
+	});
+	HealthConfig {
+		test,
+		interval: hc.interval.as_deref().and_then(size::parse_duration_nanos),
+		timeout: hc.timeout.as_deref().and_then(size::parse_duration_nanos),
+		retries: hc.retries.map(|r| r as i64),
+		start_period: hc
+			.start_period
+			.as_deref()
+			.and_then(size::parse_duration_nanos),
+		start_interval: hc
+			.start_interval
+			.as_deref()
+			.and_then(size::parse_duration_nanos),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resource limits
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::type_complexity)]
+pub(super) fn resolve_resources(
+	service: &Service,
+) -> (
+	Option<i64>,
+	Option<i64>,
+	Option<i64>,
+	Option<i64>,
+	Option<i64>,
+	Option<i64>,
+	Option<i64>,
+) {
+	let mut memory = service.mem_limit.as_deref().and_then(size::parse_memory);
+	let mut mem_reservation = service
+		.mem_reservation
+		.as_deref()
+		.and_then(size::parse_memory);
+	let memswap = service
+		.memswap_limit
+		.as_deref()
+		.and_then(size::parse_memory);
+	let mut nano_cpus = service.cpus.as_deref().and_then(size::parse_cpus);
+	let cpu_quota = service.cpu_quota;
+	let cpu_period = service.cpu_period.map(|p| p as i64);
+	let mut pids_limit = service.pids_limit;
+
+	if let Some(deploy) = &service.deploy {
+		if let Some(res) = &deploy.resources {
+			if let Some(limits) = &res.limits {
+				if memory.is_none() {
+					memory = limits.memory.as_deref().and_then(size::parse_memory);
+				}
+				if nano_cpus.is_none() {
+					nano_cpus = limits.cpus.as_deref().and_then(size::parse_cpus);
+				}
+				if pids_limit.is_none() {
+					pids_limit = limits.pids.map(|p| p as i64);
+				}
+			}
+			if let Some(reserv) = &res.reservations {
+				if mem_reservation.is_none() {
+					mem_reservation = reserv.memory.as_deref().and_then(size::parse_memory);
+				}
+			}
+		}
+	}
+
+	(
+		memory,
+		mem_reservation,
+		memswap,
+		nano_cpus,
+		cpu_quota,
+		cpu_period,
+		pids_limit,
+	)
+}
+
+pub(super) fn build_ulimits(service: &Service) -> Vec<ResourcesUlimits> {
+	service
+		.ulimits
+		.iter()
+		.map(|(name, cfg)| ResourcesUlimits {
+			name: Some(name.clone()),
+			soft: Some(cfg.soft()),
+			hard: Some(cfg.hard()),
+		})
+		.collect()
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::{
+		Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart,
+		Service,
+	};
+
+	fn default_service() -> Service {
+		Service::default()
+	}
+
+	// --- restart policy ---
+
+	#[test]
+	fn restart_policy_no() {
+		let mut svc = default_service();
+		svc.restart = Some(ComposeRestart::No);
+		let p = build_restart_policy(&svc).unwrap();
+		assert_eq!(p.name, Some(RestartPolicyNameEnum::NO));
+		assert!(p.maximum_retry_count.is_none());
+	}
+
+	#[test]
+	fn restart_policy_always() {
+		let mut svc = default_service();
+		svc.restart = Some(ComposeRestart::Always);
+		let p = build_restart_policy(&svc).unwrap();
+		assert_eq!(p.name, Some(RestartPolicyNameEnum::ALWAYS));
+	}
+
+	#[test]
+	fn restart_policy_on_failure_with_retries() {
+		let mut svc = default_service();
+		svc.restart = Some(ComposeRestart::OnFailure { max_attempts: Some(3) });
+		let p = build_restart_policy(&svc).unwrap();
+		assert_eq!(p.name, Some(RestartPolicyNameEnum::ON_FAILURE));
+		assert_eq!(p.maximum_retry_count, Some(3));
+	}
+
+	#[test]
+	fn restart_policy_unless_stopped() {
+		let mut svc = default_service();
+		svc.restart = Some(ComposeRestart::UnlessStopped);
+		let p = build_restart_policy(&svc).unwrap();
+		assert_eq!(p.name, Some(RestartPolicyNameEnum::UNLESS_STOPPED));
+	}
+
+	#[test]
+	fn restart_policy_none_when_absent() {
+		assert!(build_restart_policy(&default_service()).is_none());
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_on_failure() {
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy {
+				condition: Some("on-failure".into()),
+				max_attempts: Some(5),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+		let p = build_restart_policy(&svc).unwrap();
+		assert_eq!(p.name, Some(RestartPolicyNameEnum::ON_FAILURE));
+		assert_eq!(p.maximum_retry_count, Some(5));
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_none_condition() {
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy {
+				condition: Some("none".into()),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+		let p = build_restart_policy(&svc).unwrap();
+		assert_eq!(p.name, Some(RestartPolicyNameEnum::NO));
+	}
+
+	// --- log config ---
+
+	#[test]
+	fn log_config_none_when_absent() {
+		assert!(build_log_config(None).is_none());
+	}
+
+	#[test]
+	fn log_config_driver_only() {
+		let logging = LoggingConfig {
+			driver: Some("json-file".into()),
+			options: Default::default(),
+		};
+		let cfg = build_log_config(Some(&logging)).unwrap();
+		assert_eq!(cfg.typ.as_deref(), Some("json-file"));
+		assert!(cfg.config.is_none());
+	}
+
+	#[test]
+	fn log_config_with_options() {
+		let mut opts = std::collections::HashMap::new();
+		opts.insert("max-size".into(), "10m".into());
+		let logging = LoggingConfig {
+			driver: Some("json-file".into()),
+			options: opts,
+		};
+		let cfg = build_log_config(Some(&logging)).unwrap();
+		assert_eq!(cfg.config.unwrap()["max-size"], "10m");
+	}
+
+	// --- healthcheck ---
+
+	#[test]
+	fn healthcheck_disabled() {
+		let hc = HealthCheck {
+			disable: Some(true),
+			..Default::default()
+		};
+		let cfg = build_healthcheck(&hc);
+		assert_eq!(cfg.test.unwrap(), vec!["NONE"]);
+	}
+
+	#[test]
+	fn healthcheck_shell_command() {
+		let hc = HealthCheck {
+			test: Some(ComposeCommand::Shell("curl -f http://localhost/health".into())),
+			interval: Some("30s".into()),
+			timeout: Some("10s".into()),
+			retries: Some(3),
+			..Default::default()
+		};
+		let cfg = build_healthcheck(&hc);
+		let test = cfg.test.unwrap();
+		assert_eq!(test[0], "CMD-SHELL");
+		assert!(test[1].contains("curl"));
+		assert_eq!(cfg.retries, Some(3));
+	}
+
+	#[test]
+	fn healthcheck_exec_command() {
+		let hc = HealthCheck {
+			test: Some(ComposeCommand::Exec(vec![
+				"curl".into(),
+				"-f".into(),
+				"http://localhost".into(),
+			])),
+			..Default::default()
+		};
+		let cfg = build_healthcheck(&hc);
+		let test = cfg.test.unwrap();
+		assert_eq!(test[0], "curl");
+	}
+
+	// --- resource resolution ---
+
+	#[test]
+	fn resolve_resources_empty_service() {
+		let (mem, mem_res, memswap, nano_cpus, cpu_quota, cpu_period, pids) =
+			resolve_resources(&default_service());
+		assert!(mem.is_none());
+		assert!(mem_res.is_none());
+		assert!(memswap.is_none());
+		assert!(nano_cpus.is_none());
+		assert!(cpu_quota.is_none());
+		assert!(cpu_period.is_none());
+		assert!(pids.is_none());
+	}
+
+	#[test]
+	fn resolve_resources_mem_limit() {
+		let mut svc = default_service();
+		svc.mem_limit = Some("512m".into());
+		let (mem, _, _, _, _, _, _) = resolve_resources(&svc);
+		assert_eq!(mem, Some(512 * 1024 * 1024));
+	}
+
+	#[test]
+	fn resolve_resources_deploy_overrides() {
+		use crate::compose::types::{DeployConfig, ResourceSpec, ResourcesConfig};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			resources: Some(ResourcesConfig {
+				limits: Some(ResourceSpec {
+					memory: Some("256m".into()),
+					..Default::default()
+				}),
+				reservations: None,
+			}),
+			..Default::default()
+		});
+		let (mem, _, _, _, _, _, _) = resolve_resources(&svc);
+		assert_eq!(mem, Some(256 * 1024 * 1024));
+	}
+
+	// --- ulimits ---
+
+	#[test]
+	fn build_ulimits_single_value() {
+		use crate::compose::types::UlimitConfig;
+		let mut svc = default_service();
+		svc.ulimits.insert("nofile".to_string(), UlimitConfig::Single(1024));
+		let ul = build_ulimits(&svc);
+		assert_eq!(ul.len(), 1);
+		assert_eq!(ul[0].name.as_deref(), Some("nofile"));
+		assert_eq!(ul[0].soft, Some(1024));
+		assert_eq!(ul[0].hard, Some(1024));
+	}
+
+	#[test]
+	fn build_ulimits_pair() {
+		use crate::compose::types::UlimitConfig;
+		let mut svc = default_service();
+		svc.ulimits.insert("nofile".to_string(), UlimitConfig::Pair { soft: 512, hard: 2048 });
+		let ul = build_ulimits(&svc);
+		assert_eq!(ul[0].soft, Some(512));
+		assert_eq!(ul[0].hard, Some(2048));
+	}
+}

--- a/internal/engine/container_config.rs
+++ b/internal/engine/container_config.rs
@@ -214,7 +214,9 @@ mod tests {
 	#[test]
 	fn restart_policy_on_failure_with_retries() {
 		let mut svc = default_service();
-		svc.restart = Some(ComposeRestart::OnFailure { max_attempts: Some(3) });
+		svc.restart = Some(ComposeRestart::OnFailure {
+			max_attempts: Some(3),
+		});
 		let p = build_restart_policy(&svc).unwrap();
 		assert_eq!(p.name, Some(RestartPolicyNameEnum::ON_FAILURE));
 		assert_eq!(p.maximum_retry_count, Some(3));
@@ -310,7 +312,9 @@ mod tests {
 	#[test]
 	fn healthcheck_shell_command() {
 		let hc = HealthCheck {
-			test: Some(ComposeCommand::Shell("curl -f http://localhost/health".into())),
+			test: Some(ComposeCommand::Shell(
+				"curl -f http://localhost/health".into(),
+			)),
 			interval: Some("30s".into()),
 			timeout: Some("10s".into()),
 			retries: Some(3),
@@ -385,7 +389,8 @@ mod tests {
 	fn build_ulimits_single_value() {
 		use crate::compose::types::UlimitConfig;
 		let mut svc = default_service();
-		svc.ulimits.insert("nofile".to_string(), UlimitConfig::Single(1024));
+		svc.ulimits
+			.insert("nofile".to_string(), UlimitConfig::Single(1024));
 		let ul = build_ulimits(&svc);
 		assert_eq!(ul.len(), 1);
 		assert_eq!(ul[0].name.as_deref(), Some("nofile"));
@@ -397,7 +402,13 @@ mod tests {
 	fn build_ulimits_pair() {
 		use crate::compose::types::UlimitConfig;
 		let mut svc = default_service();
-		svc.ulimits.insert("nofile".to_string(), UlimitConfig::Pair { soft: 512, hard: 2048 });
+		svc.ulimits.insert(
+			"nofile".to_string(),
+			UlimitConfig::Pair {
+				soft: 512,
+				hard: 2048,
+			},
+		);
 		let ul = build_ulimits(&svc);
 		assert_eq!(ul[0].soft, Some(512));
 		assert_eq!(ul[0].hard, Some(2048));

--- a/internal/engine/container_misc.rs
+++ b/internal/engine/container_misc.rs
@@ -357,7 +357,10 @@ mod tests {
 	#[test]
 	fn build_device_requests_gpus_count() {
 		use crate::compose::types::GpuSpec;
-		let svc = Service { gpus: Some(GpuSpec::Count(2)), ..Default::default() };
+		let svc = Service {
+			gpus: Some(GpuSpec::Count(2)),
+			..Default::default()
+		};
 		let reqs = build_device_requests(&svc);
 		assert_eq!(reqs.len(), 1);
 		assert_eq!(reqs[0].count, Some(2));
@@ -368,7 +371,10 @@ mod tests {
 	#[test]
 	fn build_device_requests_gpus_all() {
 		use crate::compose::types::GpuSpec;
-		let svc = Service { gpus: Some(GpuSpec::Named("all".into())), ..Default::default() };
+		let svc = Service {
+			gpus: Some(GpuSpec::Named("all".into())),
+			..Default::default()
+		};
 		let reqs = build_device_requests(&svc);
 		assert_eq!(reqs.len(), 1);
 		assert_eq!(reqs[0].count, Some(-1));
@@ -376,7 +382,9 @@ mod tests {
 
 	#[test]
 	fn build_device_requests_no_capabilities_skipped() {
-		use crate::compose::types::{DeployConfig, DeviceReservation, ResourceSpec, ResourcesConfig};
+		use crate::compose::types::{
+			DeployConfig, DeviceReservation, ResourceSpec, ResourcesConfig,
+		};
 		let svc = Service {
 			deploy: Some(DeployConfig {
 				resources: Some(ResourcesConfig {
@@ -398,7 +406,9 @@ mod tests {
 
 	#[test]
 	fn build_device_requests_deploy_device_with_ids() {
-		use crate::compose::types::{DeployConfig, DeviceReservation, ResourceSpec, ResourcesConfig};
+		use crate::compose::types::{
+			DeployConfig, DeviceReservation, ResourceSpec, ResourcesConfig,
+		};
 		let svc = Service {
 			deploy: Some(DeployConfig {
 				resources: Some(ResourcesConfig {
@@ -419,7 +429,10 @@ mod tests {
 		let reqs = build_device_requests(&svc);
 		assert_eq!(reqs.len(), 1);
 		assert!(reqs[0].count.is_none());
-		assert_eq!(reqs[0].device_ids.as_ref().unwrap(), &vec!["GPU-abc".to_string()]);
+		assert_eq!(
+			reqs[0].device_ids.as_ref().unwrap(),
+			&vec!["GPU-abc".to_string()]
+		);
 	}
 
 	#[test]
@@ -427,7 +440,10 @@ mod tests {
 		use crate::compose::types::{BlkioConfig, BlkioWeightDevice};
 		let mut svc = default_service();
 		svc.blkio_config = Some(BlkioConfig {
-			weight_device: vec![BlkioWeightDevice { path: "/dev/sda".into(), weight: 300 }],
+			weight_device: vec![BlkioWeightDevice {
+				path: "/dev/sda".into(),
+				weight: 300,
+			}],
 			..Default::default()
 		});
 		let blkio = build_blkio_config(&svc).unwrap();

--- a/internal/engine/container_misc.rs
+++ b/internal/engine/container_misc.rs
@@ -1,0 +1,331 @@
+//! Device, blkio, tmpfs, label-file, and small utility helpers for container creation.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use bollard::models::{
+	DeviceRequest, ResourcesBlkioWeightDevice, ThrottleDevice,
+};
+use tracing::warn;
+
+use crate::compose::types::{BlkioConfig, CountOrAll, Service};
+
+// ---------------------------------------------------------------------------
+// Device helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn parse_device(s: &str) -> bollard::models::DeviceMapping {
+	let parts: Vec<&str> = s.splitn(3, ':').collect();
+	let host = parts.first().copied().unwrap_or("").to_string();
+	let cont = parts
+		.get(1)
+		.copied()
+		.map(|c| c.to_string())
+		.unwrap_or_else(|| host.clone());
+	let perm = parts.get(2).copied().unwrap_or("rwm").to_string();
+	bollard::models::DeviceMapping {
+		path_on_host: Some(host),
+		path_in_container: Some(cont),
+		cgroup_permissions: Some(perm),
+	}
+}
+
+pub(super) fn build_device_requests(service: &Service) -> Vec<DeviceRequest> {
+	let mut requests: Vec<DeviceRequest> = Vec::new();
+
+	if let Some(gpus) = &service.gpus {
+		requests.push(DeviceRequest {
+			driver: Some("".into()),
+			count: Some(gpus.to_count()),
+			device_ids: None,
+			capabilities: Some(vec![vec!["gpu".into()]]),
+			options: None,
+		});
+	}
+
+	if let Some(deploy) = &service.deploy {
+		if let Some(resources) = &deploy.resources {
+			if let Some(reservations) = &resources.reservations {
+				for dev in &reservations.devices {
+					if dev.capabilities.is_empty() {
+						continue;
+					}
+
+					let count = if !dev.device_ids.is_empty() {
+						None
+					} else {
+						Some(
+							dev.count
+								.as_ref()
+								.map(|c: &CountOrAll| c.to_i64())
+								.unwrap_or(-1),
+						)
+					};
+
+					let device_ids = if dev.device_ids.is_empty() {
+						None
+					} else {
+						Some(dev.device_ids.clone())
+					};
+
+					requests.push(DeviceRequest {
+						driver: dev.driver.clone().or(Some("".into())),
+						count,
+						device_ids,
+						capabilities: Some(vec![dev.capabilities.clone()]),
+						options: if dev.options.is_empty() {
+							None
+						} else {
+							Some(dev.options.clone())
+						},
+					});
+				}
+			}
+		}
+	}
+
+	requests
+}
+
+// ---------------------------------------------------------------------------
+// Blkio
+// ---------------------------------------------------------------------------
+
+pub(super) struct BlkioHostConfig {
+	pub(super) weight: Option<u16>,
+	pub(super) weight_device: Option<Vec<ResourcesBlkioWeightDevice>>,
+	pub(super) device_read_bps: Option<Vec<ThrottleDevice>>,
+	pub(super) device_write_bps: Option<Vec<ThrottleDevice>>,
+	pub(super) device_read_iops: Option<Vec<ThrottleDevice>>,
+	pub(super) device_write_iops: Option<Vec<ThrottleDevice>>,
+}
+
+pub(super) fn build_blkio_config(service: &Service) -> Option<BlkioHostConfig> {
+	let cfg: &BlkioConfig = service.blkio_config.as_ref()?;
+
+	let weight_device = if cfg.weight_device.is_empty() {
+		None
+	} else {
+		Some(
+			cfg.weight_device
+				.iter()
+				.map(|d| ResourcesBlkioWeightDevice {
+					path: Some(d.path.clone()),
+					weight: Some(d.weight as usize),
+				})
+				.collect(),
+		)
+	};
+
+	let to_throttle = |devs: &[crate::compose::types::BlkioRateDevice]| {
+		if devs.is_empty() {
+			None
+		} else {
+			Some(
+				devs.iter()
+					.map(|d| ThrottleDevice {
+						path: Some(d.path.clone()),
+						rate: Some(d.rate_value()),
+					})
+					.collect(),
+			)
+		}
+	};
+
+	Some(BlkioHostConfig {
+		weight: cfg.weight,
+		weight_device,
+		device_read_bps: to_throttle(&cfg.device_read_bps),
+		device_write_bps: to_throttle(&cfg.device_write_bps),
+		device_read_iops: to_throttle(&cfg.device_read_iops),
+		device_write_iops: to_throttle(&cfg.device_write_iops),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Tmpfs / label helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn tmpfs_options_to_string(
+	opts: Option<&crate::compose::types::TmpfsOptions>,
+) -> String {
+	let opts = match opts {
+		Some(o) => o,
+		None => return String::new(),
+	};
+	let mut parts: Vec<String> = Vec::new();
+	if let Some(size) = opts.size {
+		parts.push(format!("size={size}"));
+	}
+	if let Some(mode) = opts.mode {
+		parts.push(format!("mode={mode:o}"));
+	}
+	parts.join(",")
+}
+
+pub(super) fn build_label_file_labels(service: &Service, base_dir: &Path) -> HashMap<String, String> {
+	let mut labels = HashMap::new();
+	for path in service.label_file.to_list() {
+		let full = if std::path::Path::new(&path).is_absolute() {
+			std::path::PathBuf::from(&path)
+		} else {
+			base_dir.join(&path)
+		};
+		let Ok(content) = std::fs::read_to_string(&full) else {
+			warn!("label_file: cannot read {}", full.display());
+			continue;
+		};
+		for line in content.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() || trimmed.starts_with('#') {
+				continue;
+			}
+			let mut parts = trimmed.splitn(2, '=');
+			let key = parts.next().unwrap_or("").trim().to_string();
+			let val = parts.next().unwrap_or("").to_string();
+			if !key.is_empty() {
+				labels.insert(key, val);
+			}
+		}
+	}
+	labels
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+pub(crate) fn opt_vec<T>(v: Vec<T>) -> Option<Vec<T>> {
+	if v.is_empty() { None } else { Some(v) }
+}
+
+pub(crate) fn opt_map<K, V>(m: HashMap<K, V>) -> Option<HashMap<K, V>> {
+	if m.is_empty() { None } else { Some(m) }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::{Service, TmpfsOptions};
+
+	fn default_service() -> Service {
+		Service::default()
+	}
+
+	// --- device parsing ---
+
+	#[test]
+	fn parse_device_host_container_perm() {
+		let d = parse_device("/dev/sda:/dev/xvda:rwm");
+		assert_eq!(d.path_on_host.as_deref(), Some("/dev/sda"));
+		assert_eq!(d.path_in_container.as_deref(), Some("/dev/xvda"));
+		assert_eq!(d.cgroup_permissions.as_deref(), Some("rwm"));
+	}
+
+	#[test]
+	fn parse_device_default_perm() {
+		let d = parse_device("/dev/null:/dev/null");
+		assert_eq!(d.cgroup_permissions.as_deref(), Some("rwm"));
+	}
+
+	#[test]
+	fn parse_device_same_path_both_sides() {
+		let d = parse_device("/dev/dri");
+		assert_eq!(d.path_on_host.as_deref(), Some("/dev/dri"));
+		assert_eq!(d.path_in_container.as_deref(), Some("/dev/dri"));
+	}
+
+	// --- tmpfs ---
+
+	#[test]
+	fn tmpfs_options_empty() {
+		assert!(tmpfs_options_to_string(None).is_empty());
+	}
+
+	#[test]
+	fn tmpfs_options_size_only() {
+		let opts = TmpfsOptions { size: Some(67108864), mode: None };
+		assert_eq!(tmpfs_options_to_string(Some(&opts)), "size=67108864");
+	}
+
+	#[test]
+	fn tmpfs_options_mode_only() {
+		let opts = TmpfsOptions { size: None, mode: Some(0o1755) };
+		assert_eq!(tmpfs_options_to_string(Some(&opts)), "mode=1755");
+	}
+
+	#[test]
+	fn tmpfs_options_size_and_mode() {
+		let opts = TmpfsOptions { size: Some(1024), mode: Some(0o755) };
+		let s = tmpfs_options_to_string(Some(&opts));
+		assert!(s.contains("size=1024"));
+		assert!(s.contains("mode=755"));
+	}
+
+	// --- blkio ---
+
+	#[test]
+	fn build_blkio_config_empty_no_blkio() {
+		assert!(build_blkio_config(&default_service()).is_none());
+	}
+
+	#[test]
+	fn build_blkio_config_weight_only() {
+		use crate::compose::types::BlkioConfig;
+		let mut svc = default_service();
+		svc.blkio_config = Some(BlkioConfig {
+			weight: Some(500),
+			..Default::default()
+		});
+		let blkio = build_blkio_config(&svc).unwrap();
+		assert_eq!(blkio.weight, Some(500));
+		assert!(blkio.weight_device.is_none());
+		assert!(blkio.device_read_bps.is_none());
+	}
+
+	#[test]
+	fn build_blkio_config_with_rate_device() {
+		use crate::compose::types::{BlkioConfig, BlkioRateDevice};
+		let mut svc = default_service();
+		svc.blkio_config = Some(BlkioConfig {
+			device_read_bps: vec![BlkioRateDevice {
+				path: "/dev/sda".into(),
+				rate: serde_yaml::Value::Number(serde_yaml::Number::from(1048576u64)),
+			}],
+			..Default::default()
+		});
+		let blkio = build_blkio_config(&svc).unwrap();
+		let devs = blkio.device_read_bps.unwrap();
+		assert_eq!(devs.len(), 1);
+		assert_eq!(devs[0].path.as_deref(), Some("/dev/sda"));
+		assert_eq!(devs[0].rate, Some(1048576));
+	}
+
+	// --- opt_vec / opt_map ---
+
+	#[test]
+	fn opt_vec_empty() {
+		assert!(opt_vec::<String>(vec![]).is_none());
+	}
+
+	#[test]
+	fn opt_vec_nonempty() {
+		assert!(opt_vec(vec!["x"]).is_some());
+	}
+
+	#[test]
+	fn opt_map_empty() {
+		assert!(opt_map::<String, String>(Default::default()).is_none());
+	}
+
+	#[test]
+	fn opt_map_nonempty() {
+		let mut m = HashMap::new();
+		m.insert("k".to_string(), "v".to_string());
+		assert!(opt_map(m).is_some());
+	}
+}

--- a/internal/engine/container_misc.rs
+++ b/internal/engine/container_misc.rs
@@ -346,4 +346,94 @@ mod tests {
 		m.insert("k".to_string(), "v".to_string());
 		assert!(opt_map(m).is_some());
 	}
+
+	// --- build_device_requests ---
+
+	#[test]
+	fn build_device_requests_empty() {
+		assert!(build_device_requests(&default_service()).is_empty());
+	}
+
+	#[test]
+	fn build_device_requests_gpus_count() {
+		use crate::compose::types::GpuSpec;
+		let svc = Service { gpus: Some(GpuSpec::Count(2)), ..Default::default() };
+		let reqs = build_device_requests(&svc);
+		assert_eq!(reqs.len(), 1);
+		assert_eq!(reqs[0].count, Some(2));
+		let caps = reqs[0].capabilities.as_ref().unwrap();
+		assert_eq!(caps[0], vec!["gpu".to_string()]);
+	}
+
+	#[test]
+	fn build_device_requests_gpus_all() {
+		use crate::compose::types::GpuSpec;
+		let svc = Service { gpus: Some(GpuSpec::Named("all".into())), ..Default::default() };
+		let reqs = build_device_requests(&svc);
+		assert_eq!(reqs.len(), 1);
+		assert_eq!(reqs[0].count, Some(-1));
+	}
+
+	#[test]
+	fn build_device_requests_no_capabilities_skipped() {
+		use crate::compose::types::{DeployConfig, DeviceReservation, ResourceSpec, ResourcesConfig};
+		let svc = Service {
+			deploy: Some(DeployConfig {
+				resources: Some(ResourcesConfig {
+					reservations: Some(ResourceSpec {
+						devices: vec![DeviceReservation {
+							capabilities: vec![],
+							..Default::default()
+						}],
+						..Default::default()
+					}),
+					..Default::default()
+				}),
+				..Default::default()
+			}),
+			..Default::default()
+		};
+		assert!(build_device_requests(&svc).is_empty());
+	}
+
+	#[test]
+	fn build_device_requests_deploy_device_with_ids() {
+		use crate::compose::types::{DeployConfig, DeviceReservation, ResourceSpec, ResourcesConfig};
+		let svc = Service {
+			deploy: Some(DeployConfig {
+				resources: Some(ResourcesConfig {
+					reservations: Some(ResourceSpec {
+						devices: vec![DeviceReservation {
+							capabilities: vec!["gpu".into()],
+							device_ids: vec!["GPU-abc".into()],
+							..Default::default()
+						}],
+						..Default::default()
+					}),
+					..Default::default()
+				}),
+				..Default::default()
+			}),
+			..Default::default()
+		};
+		let reqs = build_device_requests(&svc);
+		assert_eq!(reqs.len(), 1);
+		assert!(reqs[0].count.is_none());
+		assert_eq!(reqs[0].device_ids.as_ref().unwrap(), &vec!["GPU-abc".to_string()]);
+	}
+
+	#[test]
+	fn build_blkio_config_with_weight_device() {
+		use crate::compose::types::{BlkioConfig, BlkioWeightDevice};
+		let mut svc = default_service();
+		svc.blkio_config = Some(BlkioConfig {
+			weight_device: vec![BlkioWeightDevice { path: "/dev/sda".into(), weight: 300 }],
+			..Default::default()
+		});
+		let blkio = build_blkio_config(&svc).unwrap();
+		let devs = blkio.weight_device.unwrap();
+		assert_eq!(devs.len(), 1);
+		assert_eq!(devs[0].path.as_deref(), Some("/dev/sda"));
+		assert_eq!(devs[0].weight, Some(300));
+	}
 }

--- a/internal/engine/container_misc.rs
+++ b/internal/engine/container_misc.rs
@@ -3,9 +3,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use bollard::models::{
-	DeviceRequest, ResourcesBlkioWeightDevice, ThrottleDevice,
-};
+use bollard::models::{DeviceRequest, ResourcesBlkioWeightDevice, ThrottleDevice};
 use tracing::warn;
 
 use crate::compose::types::{BlkioConfig, CountOrAll, Service};
@@ -163,7 +161,10 @@ pub(crate) fn tmpfs_options_to_string(
 	parts.join(",")
 }
 
-pub(super) fn build_label_file_labels(service: &Service, base_dir: &Path) -> HashMap<String, String> {
+pub(super) fn build_label_file_labels(
+	service: &Service,
+	base_dir: &Path,
+) -> HashMap<String, String> {
 	let mut labels = HashMap::new();
 	for path in service.label_file.to_list() {
 		let full = if std::path::Path::new(&path).is_absolute() {
@@ -196,11 +197,19 @@ pub(super) fn build_label_file_labels(service: &Service, base_dir: &Path) -> Has
 // ---------------------------------------------------------------------------
 
 pub(crate) fn opt_vec<T>(v: Vec<T>) -> Option<Vec<T>> {
-	if v.is_empty() { None } else { Some(v) }
+	if v.is_empty() {
+		None
+	} else {
+		Some(v)
+	}
 }
 
 pub(crate) fn opt_map<K, V>(m: HashMap<K, V>) -> Option<HashMap<K, V>> {
-	if m.is_empty() { None } else { Some(m) }
+	if m.is_empty() {
+		None
+	} else {
+		Some(m)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -248,19 +257,28 @@ mod tests {
 
 	#[test]
 	fn tmpfs_options_size_only() {
-		let opts = TmpfsOptions { size: Some(67108864), mode: None };
+		let opts = TmpfsOptions {
+			size: Some(67108864),
+			mode: None,
+		};
 		assert_eq!(tmpfs_options_to_string(Some(&opts)), "size=67108864");
 	}
 
 	#[test]
 	fn tmpfs_options_mode_only() {
-		let opts = TmpfsOptions { size: None, mode: Some(0o1755) };
+		let opts = TmpfsOptions {
+			size: None,
+			mode: Some(0o1755),
+		};
 		assert_eq!(tmpfs_options_to_string(Some(&opts)), "mode=1755");
 	}
 
 	#[test]
 	fn tmpfs_options_size_and_mode() {
-		let opts = TmpfsOptions { size: Some(1024), mode: Some(0o755) };
+		let opts = TmpfsOptions {
+			size: Some(1024),
+			mode: Some(0o755),
+		};
 		let s = tmpfs_options_to_string(Some(&opts));
 		assert!(s.contains("size=1024"));
 		assert!(s.contains("mode=755"));

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -11,69 +11,69 @@ use crate::error::{ComposeError, Result};
 use super::Engine;
 
 impl Engine {
-    /// Poll a container until its health status is `healthy` or timeout.
-    ///
-    /// Uses `healthcheck.retries` (default 30) with a 2 s interval between probes.
-    pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
-        use bollard::models::HealthStatusEnum;
+	/// Poll a container until its health status is `healthy` or timeout.
+	///
+	/// Uses `healthcheck.retries` (default 30) with a 2 s interval between probes.
+	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
+		use bollard::models::HealthStatusEnum;
 
-        let retries = service
-            .healthcheck
-            .as_ref()
-            .and_then(|h| h.retries)
-            .unwrap_or(30);
+		let retries = service
+			.healthcheck
+			.as_ref()
+			.and_then(|h| h.retries)
+			.unwrap_or(30);
 
-        for _ in 0..retries {
-            let info = match self.docker.inspect_container(container_name, None).await {
-                Ok(i) => i,
-                Err(e) => {
-                    // Podman uses "stopped" for exited containers; Bollard can't
-                    // deserialize it. Treat any inspect error as "not healthy yet".
-                    tracing::debug!("inspect_container error (will retry): {e}");
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    continue;
-                }
-            };
-            if let Some(state) = info.state {
-                if let Some(health) = state.health {
-                    if health.status == Some(HealthStatusEnum::HEALTHY) {
-                        return Ok(());
-                    }
-                }
-            }
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        }
+		for _ in 0..retries {
+			let info = match self.docker.inspect_container(container_name, None).await {
+				Ok(i) => i,
+				Err(e) => {
+					// Podman uses "stopped" for exited containers; Bollard can't
+					// deserialize it. Treat any inspect error as "not healthy yet".
+					tracing::debug!("inspect_container error (will retry): {e}");
+					tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+					continue;
+				}
+			};
+			if let Some(state) = info.state {
+				if let Some(health) = state.health {
+					if health.status == Some(HealthStatusEnum::HEALTHY) {
+						return Ok(());
+					}
+				}
+			}
+			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+		}
 
-        Err(ComposeError::HealthCheckTimeout(container_name.into()))
-    }
+		Err(ComposeError::HealthCheckTimeout(container_name.into()))
+	}
 
-    /// Poll a container until it exits with status 0.
-    ///
-    /// Tries for up to 600 seconds (1 s interval). Errors if the container
-    /// exits with a non-zero code or if the deadline is exceeded.
-    pub(super) async fn wait_completed(&self, container_name: &str) -> Result<()> {
-        for _ in 0..600 {
-            let info = match self.docker.inspect_container(container_name, None).await {
-                Ok(i) => i,
-                Err(e) => {
-                    tracing::debug!("inspect_container error (will retry): {e}");
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    continue;
-                }
-            };
-            if let Some(state) = info.state {
-                let status = state.status.map(|s| format!("{s:?}").to_lowercase());
-                if status.as_deref() == Some("exited") {
-                    if state.exit_code.unwrap_or(-1) == 0 {
-                        return Ok(());
-                    }
-                    return Err(ComposeError::HealthCheckTimeout(format!(
-                        "{container_name} exited with non-zero status"
-                    )));
-                }
-            }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-        Err(ComposeError::HealthCheckTimeout(container_name.into()))
-    }
+	/// Poll a container until it exits with status 0.
+	///
+	/// Tries for up to 600 seconds (1 s interval). Errors if the container
+	/// exits with a non-zero code or if the deadline is exceeded.
+	pub(super) async fn wait_completed(&self, container_name: &str) -> Result<()> {
+		for _ in 0..600 {
+			let info = match self.docker.inspect_container(container_name, None).await {
+				Ok(i) => i,
+				Err(e) => {
+					tracing::debug!("inspect_container error (will retry): {e}");
+					tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+					continue;
+				}
+			};
+			if let Some(state) = info.state {
+				let status = state.status.map(|s| format!("{s:?}").to_lowercase());
+				if status.as_deref() == Some("exited") {
+					if state.exit_code.unwrap_or(-1) == 0 {
+						return Ok(());
+					}
+					return Err(ComposeError::HealthCheckTimeout(format!(
+						"{container_name} exited with non-zero status"
+					)));
+				}
+			}
+			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+		}
+		Err(ComposeError::HealthCheckTimeout(container_name.into()))
+	}
 }

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -1,0 +1,239 @@
+//! Service lifecycle commands: up, down, restart.
+
+use bollard::query_parameters::{RemoveContainerOptions, StartContainerOptions, StopContainerOptions};
+use tracing::info;
+
+use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::error::{ComposeError, Result};
+
+use super::profiles::{active_profiles_set, service_in_profiles};
+use super::Engine;
+
+impl Engine {
+	pub async fn up(&self, file: &ComposeFile) -> Result<()> {
+		self.up_with_options(file, false, &[], &[], false).await
+	}
+
+	pub async fn up_with_options(
+		&self,
+		file: &ComposeFile,
+		_detach: bool,
+		active_profiles: &[String],
+		target_services: &[String],
+		no_recreate: bool,
+	) -> Result<()> {
+		let order = crate::compose::resolve_order(file)?;
+		let active = active_profiles_set(active_profiles);
+
+		let target_set: Option<std::collections::HashSet<String>> = if target_services.is_empty() {
+			None
+		} else {
+			let mut set = std::collections::HashSet::new();
+			let mut stack: Vec<String> = target_services.to_vec();
+			while let Some(name) = stack.pop() {
+				if !set.insert(name.clone()) {
+					continue;
+				}
+				if let Some(service) = file.services.get(&name) {
+					for dep in service.depends_on.service_names() {
+						if !set.contains(&dep) {
+							stack.push(dep);
+						}
+					}
+				}
+			}
+			Some(set)
+		};
+
+		self.create_networks(file).await?;
+		self.create_volumes(file).await?;
+
+		for name in &order {
+			if let Some(ref set) = target_set {
+				if !set.contains(name) {
+					continue;
+				}
+			}
+			let service = &file.services[name];
+
+			if !service_in_profiles(service, &active) {
+				tracing::debug!("skipping {name}: no active profile match");
+				continue;
+			}
+
+			for dep in service.depends_on.service_names() {
+				let condition = service.depends_on.condition_for(&dep);
+				let dep_service = match file.services.get(&dep) {
+					Some(s) => s,
+					None => continue,
+				};
+				if !service_in_profiles(dep_service, &active) {
+					continue;
+				}
+				let dep_container = self.container_name(&dep, dep_service);
+
+				match condition {
+					ServiceCondition::ServiceStarted => {}
+					ServiceCondition::ServiceHealthy => {
+						if dep_service
+							.healthcheck
+							.as_ref()
+							.map(|h| !h.is_disabled())
+							.unwrap_or(false)
+						{
+							self.wait_healthy(&dep_container, dep_service).await?;
+						} else {
+							tracing::debug!(
+								"{dep} requested service_healthy but has no healthcheck — skipping wait"
+							);
+						}
+					}
+					ServiceCondition::ServiceCompletedSuccessfully => {
+						self.wait_completed(&dep_container).await?;
+					}
+				}
+			}
+
+			let policy = service.pull_policy.as_deref().unwrap_or("missing");
+			match (service.build.is_some(), policy) {
+				(true, _) => self.build_service(name, service).await?,
+				(false, "never") => {}
+				(false, _) => self.pull_image(service).await?,
+			}
+
+			let replicas = service
+				.scale
+				.or(service.deploy.as_ref().and_then(|d| d.replicas))
+				.unwrap_or(1) as usize;
+
+			for i in 1..=replicas {
+				let container_name = if replicas == 1 {
+					self.container_name(name, service)
+				} else {
+					format!("{}-{i}", self.container_name(name, service))
+				};
+				if no_recreate && self.is_container_running(&container_name).await {
+					info!("{container_name} already running — skipping recreate");
+					continue;
+				}
+				self.create_and_start(&container_name, name, service, file)
+					.await?;
+				self.connect_extra_networks(&container_name, service, file)
+					.await?;
+				info!("started {container_name}");
+
+				for hook in &service.post_start {
+					self.run_lifecycle_hook(&container_name, hook).await?;
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	pub async fn down(&self, file: &ComposeFile) -> Result<()> {
+		self.down_with_options(file, false).await
+	}
+
+	pub async fn down_with_options(&self, file: &ComposeFile, remove_volumes: bool) -> Result<()> {
+		let mut order = crate::compose::resolve_order(file)?;
+		order.reverse();
+
+		for name in &order {
+			let service = &file.services[name];
+			for container_name in self.replica_names(name, service) {
+				for hook in &service.pre_stop {
+					let _ = self.run_lifecycle_hook(&container_name, hook).await;
+				}
+
+				let _ = self
+					.docker
+					.stop_container(
+						&container_name,
+						Some(StopContainerOptions {
+							t: Some(10),
+							..Default::default()
+						}),
+					)
+					.await;
+
+				let _ = self
+					.docker
+					.remove_container(
+						&container_name,
+						Some(RemoveContainerOptions {
+							force: true,
+							v: remove_volumes,
+							..Default::default()
+						}),
+					)
+					.await;
+
+				info!("removed {container_name}");
+			}
+		}
+
+		self.cleanup_temp_dir();
+		Ok(())
+	}
+
+	pub async fn restart(&self, file: &ComposeFile, service_name: Option<&str>) -> Result<()> {
+		let names: Vec<String> = if let Some(svc) = service_name {
+			if !file.services.contains_key(svc) {
+				return Err(ComposeError::ServiceNotFound(svc.into()));
+			}
+			vec![svc.to_string()]
+		} else {
+			file.services.keys().cloned().collect()
+		};
+
+		for name in &names {
+			let service = &file.services[name];
+			let container_name = self.container_name(name, service);
+
+			let _ = self
+				.docker
+				.stop_container(
+					&container_name,
+					Some(StopContainerOptions {
+						t: Some(10),
+						..Default::default()
+					}),
+				)
+				.await;
+
+			self.docker
+				.start_container(&container_name, None::<StartContainerOptions>)
+				.await?;
+
+			info!("restarted {container_name}");
+
+			for (dep_name, dep_service) in &file.services {
+				if dep_service.depends_on.restart_for(name) {
+					let dep_container = self.container_name(dep_name, dep_service);
+					let _ = self
+						.docker
+						.stop_container(
+							&dep_container,
+							Some(StopContainerOptions {
+								t: Some(10),
+								..Default::default()
+							}),
+						)
+						.await;
+					if let Err(e) = self
+						.docker
+						.start_container(&dep_container, None::<StartContainerOptions>)
+						.await
+					{
+						tracing::warn!("cascade restart of {dep_name} failed: {e}");
+					} else {
+						info!("cascade-restarted {dep_container} (depends_on.restart)");
+					}
+				}
+			}
+		}
+
+		Ok(())
+	}
+}

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -1,6 +1,8 @@
 //! Service lifecycle commands: up, down, restart.
 
-use bollard::query_parameters::{RemoveContainerOptions, StartContainerOptions, StopContainerOptions};
+use bollard::query_parameters::{
+	RemoveContainerOptions, StartContainerOptions, StopContainerOptions,
+};
 use tracing::info;
 
 use crate::compose::types::{ComposeFile, ServiceCondition};

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -4,11 +4,16 @@
 
 mod build;
 mod container;
+mod container_config;
+mod container_misc;
 mod health;
+mod lifecycle;
 mod network;
 mod profiles;
+mod query;
 mod staging;
 mod volume;
+mod volume_mounts;
 mod watch;
 
 use std::collections::HashMap;
@@ -16,630 +21,134 @@ use std::path::PathBuf;
 
 use bollard::container::LogOutput;
 use bollard::exec::{CreateExecOptions, StartExecResults};
-use bollard::query_parameters::{
-    ListContainersOptions, LogsOptions, RemoveContainerOptions, StartContainerOptions,
-    StopContainerOptions,
-};
+use bollard::query_parameters::ListContainersOptions;
 use bollard::Docker;
 use futures::StreamExt;
-use tracing::info;
 
-use crate::compose::types::{ComposeFile, LifecycleHook, Service, ServiceCondition};
-use crate::error::{ComposeError, Result};
-
-use profiles::{active_profiles_set, service_in_profiles};
+use crate::compose::types::{LifecycleHook, Service};
+use crate::error::Result;
 
 // ---------------------------------------------------------------------------
 // Engine
 // ---------------------------------------------------------------------------
 
 pub struct Engine {
-    docker: Docker,
-    project: String,
-    base_dir: PathBuf,
+	pub(super) docker: Docker,
+	pub(super) project: String,
+	pub(super) base_dir: PathBuf,
 }
 
 impl Engine {
-    pub fn new(docker: Docker, project: String) -> Self {
-        Self {
-            docker,
-            project,
-            base_dir: std::env::current_dir().unwrap_or_default(),
-        }
-    }
+	pub fn new(docker: Docker, project: String) -> Self {
+		Self {
+			docker,
+			project,
+			base_dir: std::env::current_dir().unwrap_or_default(),
+		}
+	}
 
-    pub fn with_base_dir(docker: Docker, project: String, base_dir: PathBuf) -> Self {
-        Self {
-            docker,
-            project,
-            base_dir,
-        }
-    }
+	pub fn with_base_dir(docker: Docker, project: String, base_dir: PathBuf) -> Self {
+		Self {
+			docker,
+			project,
+			base_dir,
+		}
+	}
 
-    // -----------------------------------------------------------------------
-    // Public commands
-    // -----------------------------------------------------------------------
+	// -----------------------------------------------------------------------
+	// Internal helpers shared across engine submodules
+	// -----------------------------------------------------------------------
 
-    pub async fn up(&self, file: &ComposeFile) -> Result<()> {
-        self.up_with_options(file, false, &[], &[], false).await
-    }
+	pub(super) async fn run_lifecycle_hook(
+		&self,
+		container_name: &str,
+		hook: &LifecycleHook,
+	) -> Result<()> {
+		let cmd = hook.command.to_exec();
+		let env: Option<Vec<String>> = {
+			let m = hook.environment.to_map();
+			if m.is_empty() {
+				None
+			} else {
+				Some(
+					m.into_iter()
+						.filter_map(|(k, v)| v.map(|v| format!("{k}={v}")))
+						.collect(),
+				)
+			}
+		};
 
-    pub async fn up_with_options(
-        &self,
-        file: &ComposeFile,
-        _detach: bool,
-        active_profiles: &[String],
-        target_services: &[String],
-        no_recreate: bool,
-    ) -> Result<()> {
-        let order = crate::compose::resolve_order(file)?;
-        let active = active_profiles_set(active_profiles);
+		let exec_id = self
+			.docker
+			.create_exec(
+				container_name,
+				CreateExecOptions::<String> {
+					cmd: Some(cmd),
+					user: hook.user.clone(),
+					privileged: hook.privileged,
+					working_dir: hook.working_dir.clone(),
+					env,
+					attach_stdout: Some(true),
+					attach_stderr: Some(true),
+					..Default::default()
+				},
+			)
+			.await?
+			.id;
 
-        // When target_services is non-empty, restrict the start set to those
-        // services plus their transitive dependencies.
-        let target_set: Option<std::collections::HashSet<String>> = if target_services.is_empty() {
-            None
-        } else {
-            let mut set = std::collections::HashSet::new();
-            let mut stack: Vec<String> = target_services.to_vec();
-            while let Some(name) = stack.pop() {
-                if !set.insert(name.clone()) {
-                    continue;
-                }
-                if let Some(service) = file.services.get(&name) {
-                    for dep in service.depends_on.service_names() {
-                        if !set.contains(&dep) {
-                            stack.push(dep);
-                        }
-                    }
-                }
-            }
-            Some(set)
-        };
+		match self.docker.start_exec(&exec_id, None).await? {
+			StartExecResults::Attached { mut output, .. } => {
+				while let Some(msg) = output.next().await {
+					match msg? {
+						LogOutput::StdOut { message } => {
+							print!("{}", String::from_utf8_lossy(&message));
+						}
+						LogOutput::StdErr { message } => {
+							eprint!("{}", String::from_utf8_lossy(&message));
+						}
+						_ => {}
+					}
+				}
+			}
+			StartExecResults::Detached => {}
+		}
 
-        self.create_networks(file).await?;
-        self.create_volumes(file).await?;
+		Ok(())
+	}
 
-        for name in &order {
-            if let Some(ref set) = target_set {
-                if !set.contains(name) {
-                    continue;
-                }
-            }
-            let service = &file.services[name];
+	pub(super) async fn is_container_running(&self, container_name: &str) -> bool {
+		// list_containers (not inspect_container) avoids Bollard deserialization
+		// failures when Podman returns "stopped" state.
+		let mut filters = HashMap::new();
+		filters.insert("name".to_string(), vec![container_name.to_string()]);
+		self.docker
+			.list_containers(Some(ListContainersOptions {
+				all: false,
+				filters: Some(filters),
+				..Default::default()
+			}))
+			.await
+			.map(|v| !v.is_empty())
+			.unwrap_or(false)
+	}
 
-            if !service_in_profiles(service, &active) {
-                tracing::debug!("skipping {name}: no active profile match");
-                continue;
-            }
+	pub(super) fn container_name(&self, service_name: &str, service: &Service) -> String {
+		service
+			.container_name
+			.clone()
+			.unwrap_or_else(|| format!("{}-{}", self.project, service_name))
+	}
 
-            for dep in service.depends_on.service_names() {
-                let condition = service.depends_on.condition_for(&dep);
-                let dep_service = match file.services.get(&dep) {
-                    Some(s) => s,
-                    None => continue,
-                };
-                if !service_in_profiles(dep_service, &active) {
-                    continue;
-                }
-                let dep_container = self.container_name(&dep, dep_service);
-
-                match condition {
-                    ServiceCondition::ServiceStarted => {}
-                    ServiceCondition::ServiceHealthy => {
-                        if dep_service
-                            .healthcheck
-                            .as_ref()
-                            .map(|h| !h.is_disabled())
-                            .unwrap_or(false)
-                        {
-                            self.wait_healthy(&dep_container, dep_service).await?;
-                        } else {
-                            tracing::debug!(
-                                "{dep} requested service_healthy but has no healthcheck — skipping wait"
-                            );
-                        }
-                    }
-                    ServiceCondition::ServiceCompletedSuccessfully => {
-                        self.wait_completed(&dep_container).await?;
-                    }
-                }
-            }
-
-            let policy = service.pull_policy.as_deref().unwrap_or("missing");
-            match (service.build.is_some(), policy) {
-                (true, _) => self.build_service(name, service).await?,
-                (false, "never") => {}
-                (false, "always") => self.pull_image(service).await?,
-                (false, _) => self.pull_image(service).await?,
-            }
-
-            let replicas = service
-                .scale
-                .or(service.deploy.as_ref().and_then(|d| d.replicas))
-                .unwrap_or(1) as usize;
-
-            for i in 1..=replicas {
-                let container_name = if replicas == 1 {
-                    self.container_name(name, service)
-                } else {
-                    format!("{}-{i}", self.container_name(name, service))
-                };
-                if no_recreate && self.is_container_running(&container_name).await {
-                    info!("{container_name} already running — skipping recreate");
-                    continue;
-                }
-                self.create_and_start(&container_name, name, service, file)
-                    .await?;
-                self.connect_extra_networks(&container_name, service, file)
-                    .await?;
-                info!("started {container_name}");
-
-                // Execute post_start lifecycle hooks.
-                for hook in &service.post_start {
-                    self.run_lifecycle_hook(&container_name, hook).await?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    pub async fn down(&self, file: &ComposeFile) -> Result<()> {
-        self.down_with_options(file, false).await
-    }
-
-    pub async fn down_with_options(&self, file: &ComposeFile, remove_volumes: bool) -> Result<()> {
-        let mut order = crate::compose::resolve_order(file)?;
-        order.reverse();
-
-        for name in &order {
-            let service = &file.services[name];
-            for container_name in self.replica_names(name, service) {
-                // Execute pre_stop lifecycle hooks before stopping.
-                for hook in &service.pre_stop {
-                    let _ = self.run_lifecycle_hook(&container_name, hook).await;
-                }
-
-                let _ = self
-                    .docker
-                    .stop_container(
-                        &container_name,
-                        Some(StopContainerOptions {
-                            t: Some(10),
-                            ..Default::default()
-                        }),
-                    )
-                    .await;
-
-                let _ = self
-                    .docker
-                    .remove_container(
-                        &container_name,
-                        Some(RemoveContainerOptions {
-                            force: true,
-                            v: remove_volumes,
-                            ..Default::default()
-                        }),
-                    )
-                    .await;
-
-                info!("removed {container_name}");
-            }
-        }
-
-        self.cleanup_temp_dir();
-        Ok(())
-    }
-
-    pub async fn ps(&self, _file: &ComposeFile) -> Result<()> {
-        let label = format!("podup.project={}", self.project);
-        let mut filters: HashMap<String, Vec<String>> = HashMap::new();
-        filters.insert("label".to_string(), vec![label]);
-
-        let containers = self
-            .docker
-            .list_containers(Some(ListContainersOptions {
-                all: true,
-                filters: Some(filters),
-                ..Default::default()
-            }))
-            .await?;
-
-        println!("{:<40} {:<30} {:<20}", "NAME", "IMAGE", "STATUS");
-        for c in containers {
-            let names = c
-                .names
-                .unwrap_or_default()
-                .join(", ")
-                .trim_start_matches('/')
-                .to_string();
-            let image = c.image.unwrap_or_default();
-            let status = c.status.unwrap_or_default();
-            let ports = c
-                .ports
-                .unwrap_or_default()
-                .iter()
-                .map(|p| {
-                    format!(
-                        "{}:{}->{}",
-                        p.ip.as_deref().unwrap_or(""),
-                        p.public_port.unwrap_or(0),
-                        p.private_port
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            println!("{names:<40} {image:<30} {status:<20} {ports}");
-        }
-
-        Ok(())
-    }
-
-    pub async fn logs(
-        &self,
-        file: &ComposeFile,
-        service_name: Option<&str>,
-        follow: bool,
-    ) -> Result<()> {
-        let targets: Vec<String> = if let Some(svc) = service_name {
-            let service = file
-                .services
-                .get(svc)
-                .ok_or_else(|| ComposeError::ServiceNotFound(svc.into()))?;
-            vec![self.container_name(svc, service)]
-        } else {
-            file.services
-                .iter()
-                .map(|(n, s)| self.container_name(n, s))
-                .collect()
-        };
-
-        for container_name in targets {
-            let mut stream = self.docker.logs(
-                &container_name,
-                Some(LogsOptions {
-                    stdout: true,
-                    stderr: true,
-                    follow,
-                    ..Default::default()
-                }),
-            );
-
-            while let Some(msg) = stream.next().await {
-                match msg? {
-                    LogOutput::StdOut { message } => {
-                        print!("{}", String::from_utf8_lossy(&message));
-                    }
-                    LogOutput::StdErr { message } => {
-                        eprint!("{}", String::from_utf8_lossy(&message));
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    pub async fn exec(
-        &self,
-        file: &ComposeFile,
-        service_name: &str,
-        cmd: Vec<String>,
-    ) -> Result<()> {
-        let service = file
-            .services
-            .get(service_name)
-            .ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-        let container_name = self.container_name(service_name, service);
-
-        let exec_id = self
-            .docker
-            .create_exec(
-                &container_name,
-                CreateExecOptions::<String> {
-                    cmd: Some(cmd),
-                    attach_stdout: Some(true),
-                    attach_stderr: Some(true),
-                    attach_stdin: Some(true),
-                    tty: Some(true),
-                    ..Default::default()
-                },
-            )
-            .await?
-            .id;
-
-        match self.docker.start_exec(&exec_id, None).await? {
-            StartExecResults::Attached { mut output, .. } => {
-                while let Some(msg) = output.next().await {
-                    match msg? {
-                        LogOutput::StdOut { message } => {
-                            print!("{}", String::from_utf8_lossy(&message));
-                        }
-                        LogOutput::StdErr { message } => {
-                            eprint!("{}", String::from_utf8_lossy(&message));
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            StartExecResults::Detached => {}
-        }
-
-        Ok(())
-    }
-
-    /// Stream logs from all attached services until Ctrl+C.
-    ///
-    /// Services with `attach: false` are excluded. Respects the compose spec:
-    /// when not detaching, all attached services have their output forwarded.
-    pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
-        use bollard::query_parameters::LogsOptions;
-        use futures::StreamExt;
-
-        let attached: Vec<(String, String)> = file
-            .services
-            .iter()
-            .filter(|(_, s)| s.attach.unwrap_or(true))
-            .map(|(name, s)| (name.clone(), self.container_name(name, s)))
-            .collect();
-
-        if attached.is_empty() {
-            return Ok(());
-        }
-
-        let streams: Vec<_> = attached
-            .iter()
-            .map(|(name, cname)| {
-                let prefix = name.clone();
-                let mut stream = self.docker.logs(
-                    cname,
-                    Some(LogsOptions {
-                        stdout: true,
-                        stderr: true,
-                        follow: true,
-                        ..Default::default()
-                    }),
-                );
-                async move {
-                    while let Some(msg) = stream.next().await {
-                        match msg {
-                            Ok(LogOutput::StdOut { message }) => {
-                                print!("{prefix} | {}", String::from_utf8_lossy(&message));
-                            }
-                            Ok(LogOutput::StdErr { message }) => {
-                                eprint!("{prefix} | {}", String::from_utf8_lossy(&message));
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            })
-            .collect();
-
-        tokio::select! {
-            _ = futures::future::join_all(streams) => {}
-            _ = tokio::signal::ctrl_c() => {}
-        }
-
-        Ok(())
-    }
-
-    /// Remove containers that belong to this project but are no longer in the compose file.
-    pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
-        let label = format!("podup.project={}", self.project);
-        let mut filters: HashMap<String, Vec<String>> = HashMap::new();
-        filters.insert("label".to_string(), vec![label]);
-
-        let running = self
-            .docker
-            .list_containers(Some(ListContainersOptions {
-                all: true,
-                filters: Some(filters),
-                ..Default::default()
-            }))
-            .await?;
-
-        let known: std::collections::HashSet<String> = file
-            .services
-            .iter()
-            .flat_map(|(n, s)| self.replica_names(n, s))
-            .collect();
-
-        for c in running {
-            let names = c.names.unwrap_or_default();
-            for raw in &names {
-                let name = raw.trim_start_matches('/');
-                if !known.contains(name) {
-                    tracing::info!("removing orphan container {name}");
-                    let _ = self
-                        .docker
-                        .remove_container(
-                            name,
-                            Some(RemoveContainerOptions {
-                                force: true,
-                                ..Default::default()
-                            }),
-                        )
-                        .await;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
-        let futs: Vec<_> = file
-            .services
-            .values()
-            .filter(|s| s.image.is_some())
-            .map(|s| self.pull_image(s))
-            .collect();
-
-        let results = futures::future::join_all(futs).await;
-        for r in results {
-            r?;
-        }
-        Ok(())
-    }
-
-    pub async fn restart(&self, file: &ComposeFile, service_name: Option<&str>) -> Result<()> {
-        let names: Vec<String> = if let Some(svc) = service_name {
-            if !file.services.contains_key(svc) {
-                return Err(ComposeError::ServiceNotFound(svc.into()));
-            }
-            vec![svc.to_string()]
-        } else {
-            file.services.keys().cloned().collect()
-        };
-
-        for name in &names {
-            let service = &file.services[name];
-            let container_name = self.container_name(name, service);
-
-            let _ = self
-                .docker
-                .stop_container(
-                    &container_name,
-                    Some(StopContainerOptions {
-                        t: Some(10),
-                        ..Default::default()
-                    }),
-                )
-                .await;
-
-            self.docker
-                .start_container(&container_name, None::<StartContainerOptions>)
-                .await?;
-
-            info!("restarted {container_name}");
-
-            // Cascade restart to dependents with depends_on.restart: true.
-            for (dep_name, dep_service) in &file.services {
-                if dep_service.depends_on.restart_for(name) {
-                    let dep_container = self.container_name(dep_name, dep_service);
-                    let _ = self
-                        .docker
-                        .stop_container(
-                            &dep_container,
-                            Some(StopContainerOptions {
-                                t: Some(10),
-                                ..Default::default()
-                            }),
-                        )
-                        .await;
-                    if let Err(e) = self
-                        .docker
-                        .start_container(&dep_container, None::<StartContainerOptions>)
-                        .await
-                    {
-                        tracing::warn!("cascade restart of {dep_name} failed: {e}");
-                    } else {
-                        info!("cascade-restarted {dep_container} (depends_on.restart)");
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    // -----------------------------------------------------------------------
-    // Internal
-    // -----------------------------------------------------------------------
-
-    async fn run_lifecycle_hook(&self, container_name: &str, hook: &LifecycleHook) -> Result<()> {
-        use bollard::exec::{CreateExecOptions, StartExecResults};
-
-        let cmd = hook.command.to_exec();
-        let env: Option<Vec<String>> = {
-            let m = hook.environment.to_map();
-            if m.is_empty() {
-                None
-            } else {
-                Some(
-                    m.into_iter()
-                        .filter_map(|(k, v)| v.map(|v| format!("{k}={v}")))
-                        .collect(),
-                )
-            }
-        };
-
-        let exec_id = self
-            .docker
-            .create_exec(
-                container_name,
-                CreateExecOptions::<String> {
-                    cmd: Some(cmd),
-                    user: hook.user.clone(),
-                    privileged: hook.privileged,
-                    working_dir: hook.working_dir.clone(),
-                    env,
-                    attach_stdout: Some(true),
-                    attach_stderr: Some(true),
-                    ..Default::default()
-                },
-            )
-            .await?
-            .id;
-
-        match self.docker.start_exec(&exec_id, None).await? {
-            StartExecResults::Attached { mut output, .. } => {
-                use bollard::container::LogOutput;
-                use futures::StreamExt;
-                while let Some(msg) = output.next().await {
-                    match msg? {
-                        LogOutput::StdOut { message } => {
-                            print!("{}", String::from_utf8_lossy(&message));
-                        }
-                        LogOutput::StdErr { message } => {
-                            eprint!("{}", String::from_utf8_lossy(&message));
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            StartExecResults::Detached => {}
-        }
-
-        Ok(())
-    }
-
-    async fn is_container_running(&self, container_name: &str) -> bool {
-        // Use list_containers (not inspect_container) to avoid Bollard
-        // deserialization failures when Podman returns "stopped" state.
-        let mut filters = HashMap::new();
-        filters.insert("name".to_string(), vec![container_name.to_string()]);
-        self.docker
-            .list_containers(Some(ListContainersOptions {
-                all: false,
-                filters: Some(filters),
-                ..Default::default()
-            }))
-            .await
-            .map(|v| !v.is_empty())
-            .unwrap_or(false)
-    }
-
-    fn container_name(&self, service_name: &str, service: &Service) -> String {
-        service
-            .container_name
-            .clone()
-            .unwrap_or_else(|| format!("{}-{}", self.project, service_name))
-    }
-
-    /// Return one container name per replica (indexed when scale > 1).
-    fn replica_names(&self, service_name: &str, service: &Service) -> Vec<String> {
-        let replicas = service
-            .scale
-            .or(service.deploy.as_ref().and_then(|d| d.replicas))
-            .unwrap_or(1) as usize;
-        let base = self.container_name(service_name, service);
-        if replicas == 1 {
-            vec![base]
-        } else {
-            (1..=replicas).map(|i| format!("{base}-{i}")).collect()
-        }
-    }
+	pub(super) fn replica_names(&self, service_name: &str, service: &Service) -> Vec<String> {
+		let replicas = service
+			.scale
+			.or(service.deploy.as_ref().and_then(|d| d.replicas))
+			.unwrap_or(1) as usize;
+		let base = self.container_name(service_name, service);
+		if replicas == 1 {
+			vec![base]
+		} else {
+			(1..=replicas).map(|i| format!("{base}-{i}")).collect()
+		}
+	}
 }

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -225,7 +225,10 @@ mod tests {
 	}
 
 	fn file_with_named_network(key: &str, name: &str) -> ComposeFile {
-		let cfg = NetworkConfig { name: Some(name.to_string()), ..Default::default() };
+		let cfg = NetworkConfig {
+			name: Some(name.to_string()),
+			..Default::default()
+		};
 		let mut file = empty_file();
 		file.networks.insert(key.to_string(), Some(cfg));
 		file
@@ -245,7 +248,10 @@ mod tests {
 
 	#[test]
 	fn resolve_network_mode_explicit_mode() {
-		let svc = Service { network_mode: Some("host".to_string()), ..Default::default() };
+		let svc = Service {
+			network_mode: Some("host".to_string()),
+			..Default::default()
+		};
 		let file = empty_file();
 		let (mode, first) = resolve_network_mode(&svc, &file);
 		assert_eq!(mode.as_deref(), Some("host"));
@@ -311,7 +317,10 @@ mod tests {
 	#[test]
 	fn build_ipam_with_driver_and_options() {
 		use crate::compose::types::IpamConfig;
-		let mut ipam = IpamConfig { driver: Some("default".into()), ..Default::default() };
+		let mut ipam = IpamConfig {
+			driver: Some("default".into()),
+			..Default::default()
+		};
 		ipam.options.insert("route_metric".into(), "100".into());
 		let result = build_ipam(&ipam);
 		assert_eq!(result.driver.as_deref(), Some("default"));
@@ -327,7 +336,10 @@ mod tests {
 			ip_range: Some("192.168.0.128/25".into()),
 			aux_addresses: Default::default(),
 		};
-		let ipam = IpamConfig { config: vec![pool], ..Default::default() };
+		let ipam = IpamConfig {
+			config: vec![pool],
+			..Default::default()
+		};
 		let result = build_ipam(&ipam);
 		let cfg = result.config.unwrap();
 		assert_eq!(cfg.len(), 1);
@@ -341,8 +353,12 @@ mod tests {
 	fn build_ipam_with_aux_addresses() {
 		use crate::compose::types::{IpamConfig, IpamPool};
 		let mut pool = IpamPool::default();
-		pool.aux_addresses.insert("router".into(), "192.168.0.254".into());
-		let ipam = IpamConfig { config: vec![pool], ..Default::default() };
+		pool.aux_addresses
+			.insert("router".into(), "192.168.0.254".into());
+		let ipam = IpamConfig {
+			config: vec![pool],
+			..Default::default()
+		};
 		let result = build_ipam(&ipam);
 		let cfg = result.config.unwrap();
 		let aux = cfg[0].auxiliary_addresses.as_ref().unwrap();

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -9,8 +9,8 @@
 use std::collections::HashMap;
 
 use bollard::models::{
-    EndpointIpamConfig, EndpointSettings, Ipam, IpamConfig as BollardIpamConfig,
-    NetworkConnectRequest, NetworkCreateRequest,
+	EndpointIpamConfig, EndpointSettings, Ipam, IpamConfig as BollardIpamConfig,
+	NetworkConnectRequest, NetworkCreateRequest,
 };
 use tracing::{debug, info};
 
@@ -20,99 +20,99 @@ use crate::error::{ComposeError, Result};
 use super::Engine;
 
 impl Engine {
-    pub(super) async fn create_networks(&self, file: &ComposeFile) -> Result<()> {
-        for (name, config) in &file.networks {
-            let network_name = config
-                .as_ref()
-                .and_then(|c| c.name.as_deref())
-                .unwrap_or(name);
+	pub(super) async fn create_networks(&self, file: &ComposeFile) -> Result<()> {
+		for (name, config) in &file.networks {
+			let network_name = config
+				.as_ref()
+				.and_then(|c| c.name.as_deref())
+				.unwrap_or(name);
 
-            let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
-            if external {
-                continue;
-            }
+			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
+			if external {
+				continue;
+			}
 
-            let driver = config
-                .as_ref()
-                .and_then(|c| c.driver.clone())
-                .unwrap_or_else(|| "bridge".into());
+			let driver = config
+				.as_ref()
+				.and_then(|c| c.driver.clone())
+				.unwrap_or_else(|| "bridge".into());
 
-            let mut labels: HashMap<String, String> = config
-                .as_ref()
-                .map(|c| c.labels.to_map())
-                .unwrap_or_default();
-            labels.insert("podup.project".to_string(), self.project.clone());
+			let mut labels: HashMap<String, String> = config
+				.as_ref()
+				.map(|c| c.labels.to_map())
+				.unwrap_or_default();
+			labels.insert("podup.project".to_string(), self.project.clone());
 
-            let driver_opts: HashMap<String, String> = config
-                .as_ref()
-                .map(|c| c.driver_opts.clone())
-                .unwrap_or_default();
+			let driver_opts: HashMap<String, String> = config
+				.as_ref()
+				.map(|c| c.driver_opts.clone())
+				.unwrap_or_default();
 
-            let ipam = config
-                .as_ref()
-                .and_then(|c| c.ipam.as_ref())
-                .map(build_ipam);
+			let ipam = config
+				.as_ref()
+				.and_then(|c| c.ipam.as_ref())
+				.map(build_ipam);
 
-            let request = NetworkCreateRequest {
-                name: network_name.to_string(),
-                driver: Some(driver.clone()),
-                internal: config.as_ref().and_then(|c| c.internal),
-                attachable: config.as_ref().and_then(|c| c.attachable),
-                enable_ipv6: config.as_ref().and_then(|c| c.enable_ipv6),
-                options: if driver_opts.is_empty() {
-                    None
-                } else {
-                    Some(driver_opts)
-                },
-                labels: if labels.is_empty() {
-                    None
-                } else {
-                    Some(labels)
-                },
-                ipam,
-                ..Default::default()
-            };
+			let request = NetworkCreateRequest {
+				name: network_name.to_string(),
+				driver: Some(driver.clone()),
+				internal: config.as_ref().and_then(|c| c.internal),
+				attachable: config.as_ref().and_then(|c| c.attachable),
+				enable_ipv6: config.as_ref().and_then(|c| c.enable_ipv6),
+				options: if driver_opts.is_empty() {
+					None
+				} else {
+					Some(driver_opts)
+				},
+				labels: if labels.is_empty() {
+					None
+				} else {
+					Some(labels)
+				},
+				ipam,
+				..Default::default()
+			};
 
-            match self.docker.create_network(request).await {
-                Ok(_) => info!("created network {network_name}"),
-                Err(bollard::errors::Error::DockerResponseServerError {
-                    status_code: 409, ..
-                }) => {}
-                Err(e) => return Err(ComposeError::Podman(e)),
-            }
-        }
-        Ok(())
-    }
+			match self.docker.create_network(request).await {
+				Ok(_) => info!("created network {network_name}"),
+				Err(bollard::errors::Error::DockerResponseServerError {
+					status_code: 409, ..
+				}) => {}
+				Err(e) => return Err(ComposeError::Podman(e)),
+			}
+		}
+		Ok(())
+	}
 
-    pub(super) async fn connect_extra_networks(
-        &self,
-        container_name: &str,
-        service: &Service,
-        file: &ComposeFile,
-    ) -> Result<()> {
-        if service.network_mode.is_some() {
-            return Ok(());
-        }
+	pub(super) async fn connect_extra_networks(
+		&self,
+		container_name: &str,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<()> {
+		if service.network_mode.is_some() {
+			return Ok(());
+		}
 
-        let network_names = service.networks.names();
-        for network in network_names.iter().skip(1) {
-            let full_name = resolve_network_name(network, file);
-            let endpoint_config =
-                build_endpoint_settings(service.networks.config_for(network), file);
-            self.docker
-                .connect_network(
-                    &full_name,
-                    NetworkConnectRequest {
-                        container: container_name.to_string(),
-                        endpoint_config: Some(endpoint_config),
-                    },
-                )
-                .await?;
-            debug!("connected {container_name} to network {full_name}");
-        }
+		let network_names = service.networks.names();
+		for network in network_names.iter().skip(1) {
+			let full_name = resolve_network_name(network, file);
+			let endpoint_config =
+				build_endpoint_settings(service.networks.config_for(network), file);
+			self.docker
+				.connect_network(
+					&full_name,
+					NetworkConnectRequest {
+						container: container_name.to_string(),
+						endpoint_config: Some(endpoint_config),
+					},
+				)
+				.await?;
+			debug!("connected {container_name} to network {full_name}");
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -120,63 +120,63 @@ impl Engine {
 // ---------------------------------------------------------------------------
 
 pub(super) fn build_endpoint_settings(
-    cfg: Option<&ServiceNetworkConfig>,
-    _file: &ComposeFile,
+	cfg: Option<&ServiceNetworkConfig>,
+	_file: &ComposeFile,
 ) -> EndpointSettings {
-    let mut settings = EndpointSettings::default();
-    if let Some(c) = cfg {
-        if let Some(aliases) = &c.aliases {
-            settings.aliases = Some(aliases.clone());
-        }
-        if c.ipv4_address.is_some() || c.ipv6_address.is_some() || !c.link_local_ips.is_empty() {
-            settings.ipam_config = Some(EndpointIpamConfig {
-                ipv4_address: c.ipv4_address.clone(),
-                ipv6_address: c.ipv6_address.clone(),
-                link_local_ips: if c.link_local_ips.is_empty() {
-                    None
-                } else {
-                    Some(c.link_local_ips.clone())
-                },
-            });
-        }
-        if c.mac_address.is_some() {
-            settings.mac_address = c.mac_address.clone();
-        }
-        if let Some(prio) = c.priority {
-            let mut m = HashMap::new();
-            m.insert("priority".to_string(), prio.to_string());
-            settings.driver_opts = Some(m);
-        }
-    }
-    settings
+	let mut settings = EndpointSettings::default();
+	if let Some(c) = cfg {
+		if let Some(aliases) = &c.aliases {
+			settings.aliases = Some(aliases.clone());
+		}
+		if c.ipv4_address.is_some() || c.ipv6_address.is_some() || !c.link_local_ips.is_empty() {
+			settings.ipam_config = Some(EndpointIpamConfig {
+				ipv4_address: c.ipv4_address.clone(),
+				ipv6_address: c.ipv6_address.clone(),
+				link_local_ips: if c.link_local_ips.is_empty() {
+					None
+				} else {
+					Some(c.link_local_ips.clone())
+				},
+			});
+		}
+		if c.mac_address.is_some() {
+			settings.mac_address = c.mac_address.clone();
+		}
+		if let Some(prio) = c.priority {
+			let mut m = HashMap::new();
+			m.insert("priority".to_string(), prio.to_string());
+			settings.driver_opts = Some(m);
+		}
+	}
+	settings
 }
 
 /// Determine `network_mode` and the first named network for `NetworkingConfig`.
 ///
 /// Returns `(Option<network_mode>, Option<first_network_name>)`.
 pub(super) fn resolve_network_mode(
-    service: &Service,
-    file: &ComposeFile,
+	service: &Service,
+	file: &ComposeFile,
 ) -> (Option<String>, Option<String>) {
-    if let Some(mode) = &service.network_mode {
-        return (Some(mode.clone()), None);
-    }
-    let networks = service.networks.names();
-    if networks.is_empty() {
-        (None, None)
-    } else {
-        let first = resolve_network_name(&networks[0], file);
-        (None, Some(first))
-    }
+	if let Some(mode) = &service.network_mode {
+		return (Some(mode.clone()), None);
+	}
+	let networks = service.networks.names();
+	if networks.is_empty() {
+		(None, None)
+	} else {
+		let first = resolve_network_name(&networks[0], file);
+		(None, Some(first))
+	}
 }
 
 pub(super) fn resolve_network_name(network: &str, file: &ComposeFile) -> String {
-    file.networks
-        .get(network)
-        .and_then(|c| c.as_ref())
-        .and_then(|c| c.name.as_deref())
-        .unwrap_or(network)
-        .to_string()
+	file.networks
+		.get(network)
+		.and_then(|c| c.as_ref())
+		.and_then(|c| c.name.as_deref())
+		.unwrap_or(network)
+		.to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -270,33 +270,33 @@ mod tests {
 }
 
 fn build_ipam(ipam: &IpamConfig) -> Ipam {
-    let config = if ipam.config.is_empty() {
-        None
-    } else {
-        Some(
-            ipam.config
-                .iter()
-                .map(|pool| BollardIpamConfig {
-                    subnet: pool.subnet.clone(),
-                    gateway: pool.gateway.clone(),
-                    ip_range: pool.ip_range.clone(),
-                    auxiliary_addresses: if pool.aux_addresses.is_empty() {
-                        None
-                    } else {
-                        Some(pool.aux_addresses.clone())
-                    },
-                })
-                .collect(),
-        )
-    };
+	let config = if ipam.config.is_empty() {
+		None
+	} else {
+		Some(
+			ipam.config
+				.iter()
+				.map(|pool| BollardIpamConfig {
+					subnet: pool.subnet.clone(),
+					gateway: pool.gateway.clone(),
+					ip_range: pool.ip_range.clone(),
+					auxiliary_addresses: if pool.aux_addresses.is_empty() {
+						None
+					} else {
+						Some(pool.aux_addresses.clone())
+					},
+				})
+				.collect(),
+		)
+	};
 
-    Ipam {
-        driver: ipam.driver.clone(),
-        config,
-        options: if ipam.options.is_empty() {
-            None
-        } else {
-            Some(ipam.options.clone())
-        },
-    }
+	Ipam {
+		driver: ipam.driver.clone(),
+		config,
+		options: if ipam.options.is_empty() {
+			None
+		} else {
+			Some(ipam.options.clone())
+		},
+	}
 }

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -179,6 +179,38 @@ pub(super) fn resolve_network_name(network: &str, file: &ComposeFile) -> String 
 		.to_string()
 }
 
+fn build_ipam(ipam: &IpamConfig) -> Ipam {
+	let config = if ipam.config.is_empty() {
+		None
+	} else {
+		Some(
+			ipam.config
+				.iter()
+				.map(|pool| BollardIpamConfig {
+					subnet: pool.subnet.clone(),
+					gateway: pool.gateway.clone(),
+					ip_range: pool.ip_range.clone(),
+					auxiliary_addresses: if pool.aux_addresses.is_empty() {
+						None
+					} else {
+						Some(pool.aux_addresses.clone())
+					},
+				})
+				.collect(),
+		)
+	};
+
+	Ipam {
+		driver: ipam.driver.clone(),
+		config,
+		options: if ipam.options.is_empty() {
+			None
+		} else {
+			Some(ipam.options.clone())
+		},
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
@@ -187,15 +219,13 @@ pub(super) fn resolve_network_name(network: &str, file: &ComposeFile) -> String 
 mod tests {
 	use super::*;
 	use crate::compose::types::{ComposeFile, NetworkConfig, Service};
-	use indexmap::IndexMap;
 
 	fn empty_file() -> ComposeFile {
 		ComposeFile::default()
 	}
 
 	fn file_with_named_network(key: &str, name: &str) -> ComposeFile {
-		let mut cfg = NetworkConfig::default();
-		cfg.name = Some(name.to_string());
+		let cfg = NetworkConfig { name: Some(name.to_string()), ..Default::default() };
 		let mut file = empty_file();
 		file.networks.insert(key.to_string(), Some(cfg));
 		file
@@ -215,8 +245,7 @@ mod tests {
 
 	#[test]
 	fn resolve_network_mode_explicit_mode() {
-		let mut svc = Service::default();
-		svc.network_mode = Some("host".to_string());
+		let svc = Service { network_mode: Some("host".to_string()), ..Default::default() };
 		let file = empty_file();
 		let (mode, first) = resolve_network_mode(&svc, &file);
 		assert_eq!(mode.as_deref(), Some("host"));
@@ -267,36 +296,56 @@ mod tests {
 		let ipam = settings.ipam_config.unwrap();
 		assert_eq!(ipam.ipv4_address.as_deref(), Some("10.0.0.5"));
 	}
-}
 
-fn build_ipam(ipam: &IpamConfig) -> Ipam {
-	let config = if ipam.config.is_empty() {
-		None
-	} else {
-		Some(
-			ipam.config
-				.iter()
-				.map(|pool| BollardIpamConfig {
-					subnet: pool.subnet.clone(),
-					gateway: pool.gateway.clone(),
-					ip_range: pool.ip_range.clone(),
-					auxiliary_addresses: if pool.aux_addresses.is_empty() {
-						None
-					} else {
-						Some(pool.aux_addresses.clone())
-					},
-				})
-				.collect(),
-		)
-	};
+	// --- build_ipam ---
 
-	Ipam {
-		driver: ipam.driver.clone(),
-		config,
-		options: if ipam.options.is_empty() {
-			None
-		} else {
-			Some(ipam.options.clone())
-		},
+	#[test]
+	fn build_ipam_defaults_empty() {
+		use crate::compose::types::IpamConfig;
+		let result = build_ipam(&IpamConfig::default());
+		assert!(result.config.is_none());
+		assert!(result.options.is_none());
+		assert!(result.driver.is_none());
+	}
+
+	#[test]
+	fn build_ipam_with_driver_and_options() {
+		use crate::compose::types::IpamConfig;
+		let mut ipam = IpamConfig { driver: Some("default".into()), ..Default::default() };
+		ipam.options.insert("route_metric".into(), "100".into());
+		let result = build_ipam(&ipam);
+		assert_eq!(result.driver.as_deref(), Some("default"));
+		assert!(result.options.is_some());
+	}
+
+	#[test]
+	fn build_ipam_with_subnet_pool() {
+		use crate::compose::types::{IpamConfig, IpamPool};
+		let pool = IpamPool {
+			subnet: Some("192.168.0.0/24".into()),
+			gateway: Some("192.168.0.1".into()),
+			ip_range: Some("192.168.0.128/25".into()),
+			aux_addresses: Default::default(),
+		};
+		let ipam = IpamConfig { config: vec![pool], ..Default::default() };
+		let result = build_ipam(&ipam);
+		let cfg = result.config.unwrap();
+		assert_eq!(cfg.len(), 1);
+		assert_eq!(cfg[0].subnet.as_deref(), Some("192.168.0.0/24"));
+		assert_eq!(cfg[0].gateway.as_deref(), Some("192.168.0.1"));
+		assert_eq!(cfg[0].ip_range.as_deref(), Some("192.168.0.128/25"));
+		assert!(cfg[0].auxiliary_addresses.is_none());
+	}
+
+	#[test]
+	fn build_ipam_with_aux_addresses() {
+		use crate::compose::types::{IpamConfig, IpamPool};
+		let mut pool = IpamPool::default();
+		pool.aux_addresses.insert("router".into(), "192.168.0.254".into());
+		let ipam = IpamConfig { config: vec![pool], ..Default::default() };
+		let result = build_ipam(&ipam);
+		let cfg = result.config.unwrap();
+		let aux = cfg[0].auxiliary_addresses.as_ref().unwrap();
+		assert_eq!(aux.get("router").map(|s| s.as_str()), Some("192.168.0.254"));
 	}
 }

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -179,6 +179,96 @@ pub(super) fn resolve_network_name(network: &str, file: &ComposeFile) -> String 
         .to_string()
 }
 
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::{ComposeFile, NetworkConfig, Service};
+	use indexmap::IndexMap;
+
+	fn empty_file() -> ComposeFile {
+		ComposeFile::default()
+	}
+
+	fn file_with_named_network(key: &str, name: &str) -> ComposeFile {
+		let mut cfg = NetworkConfig::default();
+		cfg.name = Some(name.to_string());
+		let mut file = empty_file();
+		file.networks.insert(key.to_string(), Some(cfg));
+		file
+	}
+
+	#[test]
+	fn resolve_network_name_key_not_found_returns_key() {
+		let file = empty_file();
+		assert_eq!(resolve_network_name("mynet", &file), "mynet");
+	}
+
+	#[test]
+	fn resolve_network_name_uses_config_name() {
+		let file = file_with_named_network("mynet", "custom-net-name");
+		assert_eq!(resolve_network_name("mynet", &file), "custom-net-name");
+	}
+
+	#[test]
+	fn resolve_network_mode_explicit_mode() {
+		let mut svc = Service::default();
+		svc.network_mode = Some("host".to_string());
+		let file = empty_file();
+		let (mode, first) = resolve_network_mode(&svc, &file);
+		assert_eq!(mode.as_deref(), Some("host"));
+		assert!(first.is_none());
+	}
+
+	#[test]
+	fn resolve_network_mode_no_networks() {
+		let svc = Service::default();
+		let file = empty_file();
+		let (mode, first) = resolve_network_mode(&svc, &file);
+		assert!(mode.is_none());
+		assert!(first.is_none());
+	}
+
+	#[test]
+	fn build_endpoint_settings_no_config() {
+		let file = empty_file();
+		let settings = build_endpoint_settings(None, &file);
+		assert!(settings.aliases.is_none());
+		assert!(settings.ipam_config.is_none());
+	}
+
+	#[test]
+	fn build_endpoint_settings_with_aliases() {
+		use crate::compose::types::ServiceNetworkConfig;
+		let cfg = ServiceNetworkConfig {
+			aliases: Some(vec!["web".to_string(), "api".to_string()]),
+			..Default::default()
+		};
+		let file = empty_file();
+		let settings = build_endpoint_settings(Some(&cfg), &file);
+		assert_eq!(
+			settings.aliases.as_ref().unwrap(),
+			&vec!["web".to_string(), "api".to_string()]
+		);
+	}
+
+	#[test]
+	fn build_endpoint_settings_with_ipv4() {
+		use crate::compose::types::ServiceNetworkConfig;
+		let cfg = ServiceNetworkConfig {
+			ipv4_address: Some("10.0.0.5".to_string()),
+			..Default::default()
+		};
+		let file = empty_file();
+		let settings = build_endpoint_settings(Some(&cfg), &file);
+		let ipam = settings.ipam_config.unwrap();
+		assert_eq!(ipam.ipv4_address.as_deref(), Some("10.0.0.5"));
+	}
+}
+
 fn build_ipam(ipam: &IpamConfig) -> Ipam {
     let config = if ipam.config.is_empty() {
         None

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -63,24 +63,24 @@ mod tests {
 
 	#[test]
 	fn service_profile_matches_active() {
-		let mut svc = Service::default();
-		svc.profiles = vec!["debug".to_string()];
+		let svc = Service { profiles: vec!["debug".to_string()], ..Default::default() };
 		let active: HashSet<String> = ["debug".to_string()].into();
 		assert!(service_in_profiles(&svc, &active));
 	}
 
 	#[test]
 	fn service_profile_does_not_match() {
-		let mut svc = Service::default();
-		svc.profiles = vec!["debug".to_string()];
+		let svc = Service { profiles: vec!["debug".to_string()], ..Default::default() };
 		let active: HashSet<String> = ["prod".to_string()].into();
 		assert!(!service_in_profiles(&svc, &active));
 	}
 
 	#[test]
 	fn service_any_profile_match_sufficient() {
-		let mut svc = Service::default();
-		svc.profiles = vec!["debug".to_string(), "prod".to_string()];
+		let svc = Service {
+			profiles: vec!["debug".to_string(), "prod".to_string()],
+			..Default::default()
+		};
 		let active: HashSet<String> = ["prod".to_string()].into();
 		assert!(service_in_profiles(&svc, &active));
 	}

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -63,14 +63,20 @@ mod tests {
 
 	#[test]
 	fn service_profile_matches_active() {
-		let svc = Service { profiles: vec!["debug".to_string()], ..Default::default() };
+		let svc = Service {
+			profiles: vec!["debug".to_string()],
+			..Default::default()
+		};
 		let active: HashSet<String> = ["debug".to_string()].into();
 		assert!(service_in_profiles(&svc, &active));
 	}
 
 	#[test]
 	fn service_profile_does_not_match() {
-		let svc = Service { profiles: vec!["debug".to_string()], ..Default::default() };
+		let svc = Service {
+			profiles: vec!["debug".to_string()],
+			..Default::default()
+		};
 		let active: HashSet<String> = ["prod".to_string()].into();
 		assert!(!service_in_profiles(&svc, &active));
 	}

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -24,8 +24,64 @@ pub(super) fn active_profiles_set(active: &[String]) -> HashSet<String> {
 ///
 /// Services with no profiles always start.
 pub(super) fn service_in_profiles(service: &Service, active: &HashSet<String>) -> bool {
-    if service.profiles.is_empty() {
-        return true;
-    }
-    service.profiles.iter().any(|p| active.contains(p))
+	if service.profiles.is_empty() {
+		return true;
+	}
+	service.profiles.iter().any(|p| active.contains(p))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::Service;
+
+	#[test]
+	fn explicit_profiles_ignores_env() {
+		let set = active_profiles_set(&["prod".to_string()]);
+		assert!(set.contains("prod"));
+		assert_eq!(set.len(), 1);
+	}
+
+	#[test]
+	fn empty_slice_with_no_env_returns_empty() {
+		// Ensure COMPOSE_PROFILES is unset for this test.
+		unsafe { std::env::remove_var("COMPOSE_PROFILES") };
+		let set = active_profiles_set(&[]);
+		assert!(set.is_empty());
+	}
+
+	#[test]
+	fn service_with_no_profiles_always_runs() {
+		let svc = Service::default();
+		let active: HashSet<String> = HashSet::new();
+		assert!(service_in_profiles(&svc, &active));
+	}
+
+	#[test]
+	fn service_profile_matches_active() {
+		let mut svc = Service::default();
+		svc.profiles = vec!["debug".to_string()];
+		let active: HashSet<String> = ["debug".to_string()].into();
+		assert!(service_in_profiles(&svc, &active));
+	}
+
+	#[test]
+	fn service_profile_does_not_match() {
+		let mut svc = Service::default();
+		svc.profiles = vec!["debug".to_string()];
+		let active: HashSet<String> = ["prod".to_string()].into();
+		assert!(!service_in_profiles(&svc, &active));
+	}
+
+	#[test]
+	fn service_any_profile_match_sufficient() {
+		let mut svc = Service::default();
+		svc.profiles = vec!["debug".to_string(), "prod".to_string()];
+		let active: HashSet<String> = ["prod".to_string()].into();
+		assert!(service_in_profiles(&svc, &active));
+	}
 }

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -6,18 +6,18 @@ use crate::compose::types::Service;
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.
 pub(super) fn active_profiles_set(active: &[String]) -> HashSet<String> {
-    if !active.is_empty() {
-        return active.iter().cloned().collect();
-    }
-    std::env::var("COMPOSE_PROFILES")
-        .ok()
-        .map(|s| {
-            s.split(',')
-                .map(|p| p.trim().to_string())
-                .filter(|p| !p.is_empty())
-                .collect()
-        })
-        .unwrap_or_default()
+	if !active.is_empty() {
+		return active.iter().cloned().collect();
+	}
+	std::env::var("COMPOSE_PROFILES")
+		.ok()
+		.map(|s| {
+			s.split(',')
+				.map(|p| p.trim().to_string())
+				.filter(|p| !p.is_empty())
+				.collect()
+		})
+		.unwrap_or_default()
 }
 
 /// True if the service should be started given the active profile set.

--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -1,0 +1,262 @@
+//! Query and observation commands: ps, logs, exec, pull, remove_orphans, attach_logs.
+
+use std::collections::HashMap;
+
+use bollard::container::LogOutput;
+use bollard::exec::{CreateExecOptions, StartExecResults};
+use bollard::query_parameters::{ListContainersOptions, LogsOptions, RemoveContainerOptions};
+use futures::StreamExt;
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+
+use super::Engine;
+
+impl Engine {
+	pub async fn ps(&self, _file: &ComposeFile) -> Result<()> {
+		let label = format!("podup.project={}", self.project);
+		let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+		filters.insert("label".to_string(), vec![label]);
+
+		let containers = self
+			.docker
+			.list_containers(Some(ListContainersOptions {
+				all: true,
+				filters: Some(filters),
+				..Default::default()
+			}))
+			.await?;
+
+		println!("{:<40} {:<30} {:<20}", "NAME", "IMAGE", "STATUS");
+		for c in containers {
+			let names = c
+				.names
+				.unwrap_or_default()
+				.join(", ")
+				.trim_start_matches('/')
+				.to_string();
+			let image = c.image.unwrap_or_default();
+			let status = c.status.unwrap_or_default();
+			let ports = c
+				.ports
+				.unwrap_or_default()
+				.iter()
+				.map(|p| {
+					format!(
+						"{}:{}->{}",
+						p.ip.as_deref().unwrap_or(""),
+						p.public_port.unwrap_or(0),
+						p.private_port
+					)
+				})
+				.collect::<Vec<_>>()
+				.join(", ");
+			println!("{names:<40} {image:<30} {status:<20} {ports}");
+		}
+
+		Ok(())
+	}
+
+	pub async fn logs(
+		&self,
+		file: &ComposeFile,
+		service_name: Option<&str>,
+		follow: bool,
+	) -> Result<()> {
+		let targets: Vec<String> = if let Some(svc) = service_name {
+			let service = file
+				.services
+				.get(svc)
+				.ok_or_else(|| ComposeError::ServiceNotFound(svc.into()))?;
+			vec![self.container_name(svc, service)]
+		} else {
+			file.services
+				.iter()
+				.map(|(n, s)| self.container_name(n, s))
+				.collect()
+		};
+
+		for container_name in targets {
+			let mut stream = self.docker.logs(
+				&container_name,
+				Some(LogsOptions {
+					stdout: true,
+					stderr: true,
+					follow,
+					..Default::default()
+				}),
+			);
+
+			while let Some(msg) = stream.next().await {
+				match msg? {
+					LogOutput::StdOut { message } => {
+						print!("{}", String::from_utf8_lossy(&message));
+					}
+					LogOutput::StdErr { message } => {
+						eprint!("{}", String::from_utf8_lossy(&message));
+					}
+					_ => {}
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	pub async fn exec(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		cmd: Vec<String>,
+	) -> Result<()> {
+		let service = file
+			.services
+			.get(service_name)
+			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
+		let container_name = self.container_name(service_name, service);
+
+		let exec_id = self
+			.docker
+			.create_exec(
+				&container_name,
+				CreateExecOptions::<String> {
+					cmd: Some(cmd),
+					attach_stdout: Some(true),
+					attach_stderr: Some(true),
+					attach_stdin: Some(true),
+					tty: Some(true),
+					..Default::default()
+				},
+			)
+			.await?
+			.id;
+
+		match self.docker.start_exec(&exec_id, None).await? {
+			StartExecResults::Attached { mut output, .. } => {
+				while let Some(msg) = output.next().await {
+					match msg? {
+						LogOutput::StdOut { message } => {
+							print!("{}", String::from_utf8_lossy(&message));
+						}
+						LogOutput::StdErr { message } => {
+							eprint!("{}", String::from_utf8_lossy(&message));
+						}
+						_ => {}
+					}
+				}
+			}
+			StartExecResults::Detached => {}
+		}
+
+		Ok(())
+	}
+
+	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
+		let futs: Vec<_> = file
+			.services
+			.values()
+			.filter(|s| s.image.is_some())
+			.map(|s| self.pull_image(s))
+			.collect();
+
+		let results = futures::future::join_all(futs).await;
+		for r in results {
+			r?;
+		}
+		Ok(())
+	}
+
+	pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
+		let label = format!("podup.project={}", self.project);
+		let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+		filters.insert("label".to_string(), vec![label]);
+
+		let running = self
+			.docker
+			.list_containers(Some(ListContainersOptions {
+				all: true,
+				filters: Some(filters),
+				..Default::default()
+			}))
+			.await?;
+
+		let known: std::collections::HashSet<String> = file
+			.services
+			.iter()
+			.flat_map(|(n, s)| self.replica_names(n, s))
+			.collect();
+
+		for c in running {
+			let names = c.names.unwrap_or_default();
+			for raw in &names {
+				let name = raw.trim_start_matches('/');
+				if !known.contains(name) {
+					tracing::info!("removing orphan container {name}");
+					let _ = self
+						.docker
+						.remove_container(
+							name,
+							Some(RemoveContainerOptions {
+								force: true,
+								..Default::default()
+							}),
+						)
+						.await;
+				}
+			}
+		}
+		Ok(())
+	}
+
+	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
+		use bollard::query_parameters::LogsOptions;
+		use futures::StreamExt;
+
+		let attached: Vec<(String, String)> = file
+			.services
+			.iter()
+			.filter(|(_, s)| s.attach.unwrap_or(true))
+			.map(|(name, s)| (name.clone(), self.container_name(name, s)))
+			.collect();
+
+		if attached.is_empty() {
+			return Ok(());
+		}
+
+		let streams: Vec<_> = attached
+			.iter()
+			.map(|(name, cname)| {
+				let prefix = name.clone();
+				let mut stream = self.docker.logs(
+					cname,
+					Some(LogsOptions {
+						stdout: true,
+						stderr: true,
+						follow: true,
+						..Default::default()
+					}),
+				);
+				async move {
+					while let Some(msg) = stream.next().await {
+						match msg {
+							Ok(LogOutput::StdOut { message }) => {
+								print!("{prefix} | {}", String::from_utf8_lossy(&message));
+							}
+							Ok(LogOutput::StdErr { message }) => {
+								eprint!("{prefix} | {}", String::from_utf8_lossy(&message));
+							}
+							_ => {}
+						}
+					}
+				}
+			})
+			.collect();
+
+		tokio::select! {
+			_ = futures::future::join_all(streams) => {}
+			_ = tokio::signal::ctrl_c() => {}
+		}
+
+		Ok(())
+	}
+}

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -20,12 +20,12 @@ use std::path::Path;
 /// name prefix: non-empty, bounded, ASCII alphanumeric plus `-`/`_`/`.`,
 /// not starting with a dot (rejects `.`, `..` and hidden directories).
 pub(super) fn is_safe_project_name(name: &str) -> bool {
-    !name.is_empty()
-        && name.len() <= 128
-        && !name.starts_with('.')
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+	!name.is_empty()
+		&& name.len() <= 128
+		&& !name.starts_with('.')
+		&& name
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
 }
 
 /// Per-user staging base for inline secret/config content.
@@ -39,16 +39,16 @@ pub(super) fn is_safe_project_name(name: &str) -> bool {
 /// local user may control.
 #[cfg(unix)]
 pub(super) fn staging_base() -> Result<PathBuf> {
-    // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-    let euid = unsafe { libc::geteuid() };
+	// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+	let euid = unsafe { libc::geteuid() };
 
-    let base = match std::env::var_os("XDG_RUNTIME_DIR") {
-        Some(dir) if Path::new(&dir).is_absolute() => PathBuf::from(dir).join("podup"),
-        _ => std::env::temp_dir().join(format!("podup-{euid}")),
-    };
+	let base = match std::env::var_os("XDG_RUNTIME_DIR") {
+		Some(dir) if Path::new(&dir).is_absolute() => PathBuf::from(dir).join("podup"),
+		_ => std::env::temp_dir().join(format!("podup-{euid}")),
+	};
 
-    ensure_private_dir(&base, euid)?;
-    Ok(base)
+	ensure_private_dir(&base, euid)?;
+	Ok(base)
 }
 
 /// Per-user staging base on Windows: `%TEMP%\podup`.
@@ -59,111 +59,111 @@ pub(super) fn staging_base() -> Result<PathBuf> {
 /// non-symlink directory check.
 #[cfg(windows)]
 pub(super) fn staging_base() -> Result<PathBuf> {
-    let base = std::env::temp_dir().join("podup");
-    std::fs::create_dir_all(&base).map_err(ComposeError::Io)?;
-    let meta = std::fs::symlink_metadata(&base).map_err(ComposeError::Io)?;
-    if !meta.is_dir() || meta.file_type().is_symlink() {
-        return Err(ComposeError::Unsupported(format!(
-            "staging directory {} is not a private directory owned by the \
+	let base = std::env::temp_dir().join("podup");
+	std::fs::create_dir_all(&base).map_err(ComposeError::Io)?;
+	let meta = std::fs::symlink_metadata(&base).map_err(ComposeError::Io)?;
+	if !meta.is_dir() || meta.file_type().is_symlink() {
+		return Err(ComposeError::Unsupported(format!(
+			"staging directory {} is not a private directory owned by the \
              current user — refusing to use it",
-            base.display()
-        )));
-    }
-    Ok(base)
+			base.display()
+		)));
+	}
+	Ok(base)
 }
 
 /// Create `dir` (recursively) accessible only to the current user.
 #[cfg(unix)]
 pub(super) fn create_private_subdir(dir: &Path) -> Result<()> {
-    use std::os::unix::fs::DirBuilderExt;
+	use std::os::unix::fs::DirBuilderExt;
 
-    // Create dir with 0o700 so only the owning user can list/enter it.
-    std::fs::DirBuilder::new()
-        .recursive(true)
-        .mode(0o700)
-        .create(dir)
-        .map_err(ComposeError::Io)
+	// Create dir with 0o700 so only the owning user can list/enter it.
+	std::fs::DirBuilder::new()
+		.recursive(true)
+		.mode(0o700)
+		.create(dir)
+		.map_err(ComposeError::Io)
 }
 
 /// Create `dir` (recursively); the staging base already restricts access
 /// to the current user via inherited ACLs.
 #[cfg(windows)]
 pub(super) fn create_private_subdir(dir: &std::path::Path) -> Result<()> {
-    std::fs::create_dir_all(dir).map_err(ComposeError::Io)
+	std::fs::create_dir_all(dir).map_err(ComposeError::Io)
 }
 
 /// Create `path` readable only by the current user and write `content`.
 #[cfg(unix)]
 pub(super) fn write_private_file(path: &Path, content: &[u8]) -> Result<()> {
-    use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
+	use std::io::Write;
+	use std::os::unix::fs::OpenOptionsExt;
 
-    // Create file with 0o600 atomically — no world-readable window before chmod.
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(path)
-        .map_err(ComposeError::Io)?;
-    file.write_all(content).map_err(ComposeError::Io)
+	// Create file with 0o600 atomically — no world-readable window before chmod.
+	let mut file = std::fs::OpenOptions::new()
+		.write(true)
+		.create(true)
+		.truncate(true)
+		.mode(0o600)
+		.open(path)
+		.map_err(ComposeError::Io)?;
+	file.write_all(content).map_err(ComposeError::Io)
 }
 
 /// Create `path` and write `content`; access is restricted by the ACLs
 /// inherited from the per-user staging directory.
 #[cfg(windows)]
 pub(super) fn write_private_file(path: &std::path::Path, content: &[u8]) -> Result<()> {
-    std::fs::write(path, content).map_err(ComposeError::Io)
+	std::fs::write(path, content).map_err(ComposeError::Io)
 }
 
 /// Apply a compose `mode:` value (octal unix permissions) to `path`.
 #[cfg(unix)]
 pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
+	use std::os::unix::fs::PermissionsExt;
 
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(ComposeError::Io)
+	std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(ComposeError::Io)
 }
 
 /// Unix permission modes have no Windows equivalent — warn and continue.
 #[cfg(windows)]
 pub(super) fn apply_mode(path: &std::path::Path, mode: u32) -> Result<()> {
-    tracing::warn!(
-        "ignoring mode {mode:#o} for {}: unix permissions do not apply on this platform",
-        path.display()
-    );
-    Ok(())
+	tracing::warn!(
+		"ignoring mode {mode:#o} for {}: unix permissions do not apply on this platform",
+		path.display()
+	);
+	Ok(())
 }
 
 /// Best-effort chown — succeeds in rootful Podman, no-op in rootless.
 #[cfg(unix)]
 pub(super) fn apply_owner(path: &Path, uid: Option<&str>, gid: Option<&str>) {
-    let uid_val: libc::uid_t = uid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
-    let gid_val: libc::gid_t = gid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
-    if uid_val != u32::MAX || gid_val != u32::MAX {
-        use std::ffi::CString;
-        use std::os::unix::ffi::OsStrExt;
-        if let Ok(p) = CString::new(path.as_os_str().as_bytes()) {
-            let rc = unsafe { libc::chown(p.as_ptr(), uid_val, gid_val) };
-            if rc != 0 {
-                tracing::warn!(
-                    "chown failed for {}: {}",
-                    path.display(),
-                    std::io::Error::last_os_error()
-                );
-            }
-        }
-    }
+	let uid_val: libc::uid_t = uid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
+	let gid_val: libc::gid_t = gid.and_then(|s| s.parse().ok()).unwrap_or(u32::MAX);
+	if uid_val != u32::MAX || gid_val != u32::MAX {
+		use std::ffi::CString;
+		use std::os::unix::ffi::OsStrExt;
+		if let Ok(p) = CString::new(path.as_os_str().as_bytes()) {
+			let rc = unsafe { libc::chown(p.as_ptr(), uid_val, gid_val) };
+			if rc != 0 {
+				tracing::warn!(
+					"chown failed for {}: {}",
+					path.display(),
+					std::io::Error::last_os_error()
+				);
+			}
+		}
+	}
 }
 
 /// Unix ownership has no Windows equivalent — warn and continue.
 #[cfg(windows)]
 pub(super) fn apply_owner(path: &std::path::Path, uid: Option<&str>, gid: Option<&str>) {
-    if uid.is_some() || gid.is_some() {
-        tracing::warn!(
-            "ignoring uid/gid for {}: unix ownership does not apply on this platform",
-            path.display()
-        );
-    }
+	if uid.is_some() || gid.is_some() {
+		tracing::warn!(
+			"ignoring uid/gid for {}: unix ownership does not apply on this platform",
+			path.display()
+		);
+	}
 }
 
 /// Create `dir` (0700) if needed and require it to be a private directory.
@@ -175,38 +175,38 @@ pub(super) fn apply_owner(path: &std::path::Path, uid: Option<&str>, gid: Option
 /// `verify_private_dir` then rejects anything not ours (fail closed).
 #[cfg(unix)]
 fn ensure_private_dir(dir: &Path, euid: u32) -> Result<()> {
-    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+	use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
 
-    std::fs::DirBuilder::new()
-        .recursive(true)
-        .mode(0o700)
-        .create(dir)
-        .map_err(ComposeError::Io)?;
+	std::fs::DirBuilder::new()
+		.recursive(true)
+		.mode(0o700)
+		.create(dir)
+		.map_err(ComposeError::Io)?;
 
-    let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
-    if meta.is_dir() {
-        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
-            .map_err(ComposeError::Io)?;
-    }
+	let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
+	if meta.is_dir() {
+		std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+			.map_err(ComposeError::Io)?;
+	}
 
-    verify_private_dir(dir, euid)
+	verify_private_dir(dir, euid)
 }
 
 /// Verify that `dir` is a non-symlink directory owned by `euid` with no
 /// group/other permission bits.
 #[cfg(unix)]
 fn verify_private_dir(dir: &Path, euid: u32) -> Result<()> {
-    use std::os::unix::fs::MetadataExt;
+	use std::os::unix::fs::MetadataExt;
 
-    let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
-    if !meta.is_dir() || meta.uid() != euid || meta.mode() & 0o077 != 0 {
-        return Err(ComposeError::Unsupported(format!(
-            "staging directory {} is not a private directory owned by the \
+	let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
+	if !meta.is_dir() || meta.uid() != euid || meta.mode() & 0o077 != 0 {
+		return Err(ComposeError::Unsupported(format!(
+			"staging directory {} is not a private directory owned by the \
              current user — refusing to use it",
-            dir.display()
-        )));
-    }
-    Ok(())
+			dir.display()
+		)));
+	}
+	Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -215,147 +215,147 @@ fn verify_private_dir(dir: &Path, euid: u32) -> Result<()> {
 
 #[cfg(test)]
 mod name_tests {
-    use super::is_safe_project_name;
+	use super::is_safe_project_name;
 
-    #[test]
-    fn safe_project_names_accepted() {
-        for name in ["web", "my-app", "my_app", "app.v2", "A1"] {
-            assert!(is_safe_project_name(name), "{name:?} must be accepted");
-        }
-    }
+	#[test]
+	fn safe_project_names_accepted() {
+		for name in ["web", "my-app", "my_app", "app.v2", "A1"] {
+			assert!(is_safe_project_name(name), "{name:?} must be accepted");
+		}
+	}
 
-    #[test]
-    fn unsafe_project_names_rejected() {
-        let long = "a".repeat(129);
-        for name in [
-            "",
-            ".",
-            "..",
-            ".hidden",
-            "a/b",
-            "../x",
-            "a b",
-            "a\0b",
-            long.as_str(),
-        ] {
-            assert!(!is_safe_project_name(name), "{name:?} must be rejected");
-        }
-    }
+	#[test]
+	fn unsafe_project_names_rejected() {
+		let long = "a".repeat(129);
+		for name in [
+			"",
+			".",
+			"..",
+			".hidden",
+			"a/b",
+			"../x",
+			"a b",
+			"a\0b",
+			long.as_str(),
+		] {
+			assert!(!is_safe_project_name(name), "{name:?} must be rejected");
+		}
+	}
 }
 
 #[cfg(all(test, unix))]
 mod staging_tests {
-    use super::verify_private_dir;
-    use std::os::unix::fs::PermissionsExt;
+	use super::verify_private_dir;
+	use std::os::unix::fs::PermissionsExt;
 
-    #[test]
-    fn private_dir_accepted() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
-            .expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(dir.path(), euid).is_ok());
-    }
+	#[test]
+	fn private_dir_accepted() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+			.expect("chmod");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let euid = unsafe { libc::geteuid() };
+		assert!(verify_private_dir(dir.path(), euid).is_ok());
+	}
 
-    #[test]
-    fn group_accessible_dir_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
-            .expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(dir.path(), euid).is_err());
-    }
+	#[test]
+	fn group_accessible_dir_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750))
+			.expect("chmod");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let euid = unsafe { libc::geteuid() };
+		assert!(verify_private_dir(dir.path(), euid).is_err());
+	}
 
-    #[test]
-    fn foreign_owner_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
-            .expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let other = unsafe { libc::geteuid() } + 1;
-        assert!(verify_private_dir(dir.path(), other).is_err());
-    }
+	#[test]
+	fn foreign_owner_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+			.expect("chmod");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let other = unsafe { libc::geteuid() } + 1;
+		assert!(verify_private_dir(dir.path(), other).is_err());
+	}
 
-    #[test]
-    fn symlink_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let target = dir.path().join("real");
-        let link = dir.path().join("link");
-        std::fs::create_dir(&target).expect("mkdir");
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).expect("chmod");
-        std::os::unix::fs::symlink(&target, &link).expect("symlink");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(&link, euid).is_err());
-    }
+	#[test]
+	fn symlink_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let target = dir.path().join("real");
+		let link = dir.path().join("link");
+		std::fs::create_dir(&target).expect("mkdir");
+		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+		std::os::unix::fs::symlink(&target, &link).expect("symlink");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let euid = unsafe { libc::geteuid() };
+		assert!(verify_private_dir(&link, euid).is_err());
+	}
 
-    #[test]
-    fn regular_file_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let file = dir.path().join("file");
-        std::fs::write(&file, b"x").expect("write");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(verify_private_dir(&file, euid).is_err());
-    }
+	#[test]
+	fn regular_file_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let file = dir.path().join("file");
+		std::fs::write(&file, b"x").expect("write");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let euid = unsafe { libc::geteuid() };
+		assert!(verify_private_dir(&file, euid).is_err());
+	}
 }
 
 #[cfg(all(test, unix))]
 mod ensure_dir_tests {
-    use super::ensure_private_dir;
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+	use super::ensure_private_dir;
+	use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
-    #[test]
-    fn creates_fresh_private_dir() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let dir = root.path().join("base");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        ensure_private_dir(&dir, euid).expect("fresh dir");
-        let meta = std::fs::metadata(&dir).expect("metadata");
-        assert_eq!(meta.mode() & 0o777, 0o700);
-    }
+	#[test]
+	fn creates_fresh_private_dir() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let dir = root.path().join("base");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let euid = unsafe { libc::geteuid() };
+		ensure_private_dir(&dir, euid).expect("fresh dir");
+		let meta = std::fs::metadata(&dir).expect("metadata");
+		assert_eq!(meta.mode() & 0o777, 0o700);
+	}
 
-    #[test]
-    fn heals_drifted_permissions_on_owned_dir() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let dir = root.path().join("base");
-        std::fs::create_dir(&dir).expect("mkdir");
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        ensure_private_dir(&dir, euid).expect("healed dir");
-        let meta = std::fs::metadata(&dir).expect("metadata");
-        assert_eq!(meta.mode() & 0o777, 0o700);
-    }
+	#[test]
+	fn heals_drifted_permissions_on_owned_dir() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let dir = root.path().join("base");
+		std::fs::create_dir(&dir).expect("mkdir");
+		std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let euid = unsafe { libc::geteuid() };
+		ensure_private_dir(&dir, euid).expect("healed dir");
+		let meta = std::fs::metadata(&dir).expect("metadata");
+		assert_eq!(meta.mode() & 0o777, 0o700);
+	}
 
-    #[test]
-    fn symlinked_dir_is_rejected_not_healed() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let target = root.path().join("real");
-        let link = root.path().join("link");
-        std::fs::create_dir(&target).expect("mkdir");
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        std::os::unix::fs::symlink(&target, &link).expect("symlink");
-        // SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        assert!(ensure_private_dir(&link, euid).is_err());
-        // Target permissions stay untouched — no chmod through the link.
-        let meta = std::fs::metadata(&target).expect("metadata");
-        assert_eq!(meta.mode() & 0o777, 0o755);
-    }
+	#[test]
+	fn symlinked_dir_is_rejected_not_healed() {
+		let root = tempfile::tempdir().expect("tempdir");
+		let target = root.path().join("real");
+		let link = root.path().join("link");
+		std::fs::create_dir(&target).expect("mkdir");
+		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+		std::os::unix::fs::symlink(&target, &link).expect("symlink");
+		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
+		let euid = unsafe { libc::geteuid() };
+		assert!(ensure_private_dir(&link, euid).is_err());
+		// Target permissions stay untouched — no chmod through the link.
+		let meta = std::fs::metadata(&target).expect("metadata");
+		assert_eq!(meta.mode() & 0o777, 0o755);
+	}
 }
 
 #[cfg(all(test, windows))]
 mod windows_staging_tests {
-    use super::staging_base;
+	use super::staging_base;
 
-    #[test]
-    fn staging_base_is_a_directory() {
-        let base = staging_base().expect("staging base");
-        assert!(base.is_dir());
-        assert!(base.ends_with("podup"));
-    }
+	#[test]
+	fn staging_base_is_a_directory() {
+		let base = staging_base().expect("staging base");
+		assert!(base.is_dir());
+		assert!(base.ends_with("podup"));
+	}
 }

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -1,557 +1,272 @@
-//! Volume and secret/config mount helpers.
+//! Volume creation and secret/config materialisation.
 //!
 //! [`Engine::create_volumes`] pre-creates named volumes before containers start.
-//! [`build_binds`] and [`build_mounts`] convert `volumes:` entries to bollard's
-//! bind-string and Mount-API formats respectively (tmpfs and volumes with
-//! subpath/labels require the Mount API; simple bind/volume mounts use strings).
 //! [`Engine::build_secret_binds`] and [`Engine::build_config_binds`] materialise
-//! inline secrets/configs to a restricted temp directory and return bind strings.
+//! inline secrets/configs to a restricted temp directory. Bind-string and
+//! Mount-API helpers live in [`super::volume_mounts`].
 
 use std::collections::HashMap;
-use std::path::Path;
 
-use bollard::models::{
-    Mount, MountBindOptions, MountTmpfsOptions, MountType, MountVolumeOptions,
-    MountVolumeOptionsDriverConfig, VolumeCreateRequest,
-};
+use bollard::models::VolumeCreateRequest;
 use tracing::info;
 
 use crate::compose::types::{
-    BindOptions, ComposeFile, ConfigConfig, SecretConfig, Service, ServiceConfigRef,
-    ServiceSecretRef, VolumeMount, VolumeOptions, VolumeType,
+	ComposeFile, ConfigConfig, SecretConfig, Service, ServiceConfigRef, ServiceSecretRef,
 };
 use crate::error::{ComposeError, Result};
 
 use super::{staging, Engine};
 
 impl Engine {
-    pub(super) async fn create_volumes(&self, file: &ComposeFile) -> Result<()> {
-        for (name, config) in &file.volumes {
-            let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
-            if external {
-                continue;
-            }
+	pub(super) async fn create_volumes(&self, file: &ComposeFile) -> Result<()> {
+		for (name, config) in &file.volumes {
+			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
+			if external {
+				continue;
+			}
 
-            let volume_name = config
-                .as_ref()
-                .and_then(|c| c.name.as_deref())
-                .unwrap_or(name);
+			let volume_name = config
+				.as_ref()
+				.and_then(|c| c.name.as_deref())
+				.unwrap_or(name);
 
-            let mut labels: HashMap<String, String> = config
-                .as_ref()
-                .map(|c| c.labels.to_map())
-                .unwrap_or_default();
-            labels.insert("podup.project".to_string(), self.project.clone());
+			let mut labels: HashMap<String, String> = config
+				.as_ref()
+				.map(|c| c.labels.to_map())
+				.unwrap_or_default();
+			labels.insert("podup.project".to_string(), self.project.clone());
 
-            let driver = config
-                .as_ref()
-                .and_then(|c| c.driver.clone())
-                .unwrap_or_else(|| "local".into());
+			let driver = config
+				.as_ref()
+				.and_then(|c| c.driver.clone())
+				.unwrap_or_else(|| "local".into());
 
-            let driver_opts: HashMap<String, String> = config
-                .as_ref()
-                .map(|c| c.driver_opts.clone())
-                .unwrap_or_default();
+			let driver_opts: HashMap<String, String> = config
+				.as_ref()
+				.map(|c| c.driver_opts.clone())
+				.unwrap_or_default();
 
-            let options = VolumeCreateRequest {
-                name: Some(volume_name.to_string()),
-                driver: Some(driver.clone()),
-                driver_opts: if driver_opts.is_empty() {
-                    None
-                } else {
-                    Some(driver_opts)
-                },
-                labels: if labels.is_empty() {
-                    None
-                } else {
-                    Some(labels)
-                },
-                ..Default::default()
-            };
+			let options = VolumeCreateRequest {
+				name: Some(volume_name.to_string()),
+				driver: Some(driver.clone()),
+				driver_opts: if driver_opts.is_empty() {
+					None
+				} else {
+					Some(driver_opts)
+				},
+				labels: if labels.is_empty() {
+					None
+				} else {
+					Some(labels)
+				},
+				..Default::default()
+			};
 
-            match self.docker.create_volume(options).await {
-                Ok(_) => info!("created volume {volume_name}"),
-                Err(bollard::errors::Error::DockerResponseServerError {
-                    status_code: 409, ..
-                }) => {}
-                Err(e) => return Err(ComposeError::Podman(e)),
-            }
-        }
-        Ok(())
-    }
-}
+			match self.docker.create_volume(options).await {
+				Ok(_) => info!("created volume {volume_name}"),
+				Err(bollard::errors::Error::DockerResponseServerError {
+					status_code: 409, ..
+				}) => {}
+				Err(e) => return Err(ComposeError::Podman(e)),
+			}
+		}
+		Ok(())
+	}
 
-// ---------------------------------------------------------------------------
-// Free helpers (pub(super) for container.rs)
-// ---------------------------------------------------------------------------
+	pub(super) fn build_secret_binds(
+		&self,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<Vec<String>> {
+		let mut binds = Vec::new();
+		for secret_ref in &service.secrets {
+			let (name, target_override, ref_mode, ref_uid, ref_gid) = match secret_ref {
+				ServiceSecretRef::Short(s) => (s.clone(), None, None, None, None),
+				ServiceSecretRef::Long {
+					source,
+					target,
+					mode,
+					uid,
+					gid,
+				} => (
+					source.clone(),
+					target.clone(),
+					*mode,
+					uid.clone(),
+					gid.clone(),
+				),
+			};
+			if let Some(config) = file.secrets.get(&name) {
+				let target = target_override.unwrap_or_else(|| format!("/run/secrets/{name}"));
+				match config {
+					SecretConfig {
+						file: Some(host_path),
+						..
+					} => {
+						binds.push(format!("{host_path}:{target}:ro"));
+					}
+					SecretConfig {
+						content: Some(content),
+						..
+					} => {
+						let path = self.materialize_inline_full(
+							"secrets",
+							&name,
+							content.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					SecretConfig {
+						environment: Some(env_var),
+						..
+					} => {
+						let value = std::env::var(env_var).unwrap_or_default();
+						let path = self.materialize_inline_full(
+							"secrets",
+							&name,
+							value.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					SecretConfig {
+						external: Some(true),
+						..
+					} => {
+						tracing::debug!("external secret {name} — relying on runtime injection");
+					}
+					_ => {}
+				}
+			}
+		}
+		Ok(binds)
+	}
 
-pub(crate) fn build_binds(service: &Service, base_dir: &Path) -> Vec<String> {
-    let mut out = Vec::new();
-    for v in &service.volumes {
-        match v {
-            VolumeMount::Short(s) => out.push(s.clone()),
-            VolumeMount::Long {
-                volume_type,
-                source,
-                target,
-                read_only,
-                bind,
-                volume,
-                ..
-            } => {
-                if matches!(volume_type, VolumeType::Tmpfs) {
-                    continue;
-                }
-                // Volumes with subpath/labels/driver_config go through the Mount API.
-                if needs_mount_api(volume) {
-                    continue;
-                }
-                let src = source.as_deref().unwrap_or("");
+	pub(super) fn build_config_binds(
+		&self,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<Vec<String>> {
+		let mut binds = Vec::new();
+		for config_ref in &service.configs {
+			let (name, target_override, ref_mode, ref_uid, ref_gid) = match config_ref {
+				ServiceConfigRef::Short(s) => (s.clone(), None, None, None, None),
+				ServiceConfigRef::Long {
+					source,
+					target,
+					mode,
+					uid,
+					gid,
+				} => (
+					source.clone(),
+					target.clone(),
+					*mode,
+					uid.clone(),
+					gid.clone(),
+				),
+			};
+			if let Some(cfg) = file.configs.get(&name) {
+				let target = target_override.unwrap_or_else(|| format!("/{name}"));
+				match cfg {
+					ConfigConfig {
+						file: Some(host_path),
+						..
+					} => {
+						binds.push(format!("{host_path}:{target}:ro"));
+					}
+					ConfigConfig {
+						content: Some(content),
+						..
+					} => {
+						let path = self.materialize_inline_full(
+							"configs",
+							&name,
+							content.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					ConfigConfig {
+						environment: Some(env_var),
+						..
+					} => {
+						let value = std::env::var(env_var).unwrap_or_default();
+						let path = self.materialize_inline_full(
+							"configs",
+							&name,
+							value.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					ConfigConfig {
+						external: Some(true),
+						..
+					} => {
+						tracing::debug!("external config {name} — relying on runtime injection");
+					}
+					_ => {}
+				}
+			}
+		}
+		Ok(binds)
+	}
 
-                if matches!(volume_type, VolumeType::Bind) {
-                    if let Some(b) = bind {
-                        if b.create_host_path.unwrap_or(false) && !src.is_empty() {
-                            let abs = if Path::new(src).is_absolute() {
-                                std::path::PathBuf::from(src)
-                            } else {
-                                base_dir.join(src)
-                            };
-                            if let Err(e) = std::fs::create_dir_all(&abs) {
-                                tracing::warn!(
-                                    "create_host_path: failed to create {}: {e}",
-                                    abs.display()
-                                );
-                            }
-                        }
-                    }
-                }
+	fn materialize_inline_full(
+		&self,
+		kind: &str,
+		name: &str,
+		content: &[u8],
+		mode: Option<u32>,
+		uid: Option<&str>,
+		gid: Option<&str>,
+	) -> Result<std::path::PathBuf> {
+		if std::path::Path::new(name)
+			.components()
+			.any(|c| !matches!(c, std::path::Component::Normal(_)))
+		{
+			return Err(ComposeError::Unsupported(format!(
+				"{kind} name must not contain path separators or '..': {name}"
+			)));
+		}
 
-                let mut opts: Vec<String> = Vec::new();
-                if read_only.unwrap_or(false) {
-                    opts.push("ro".into());
-                } else {
-                    opts.push("rw".into());
-                }
-                if let Some(b) = bind {
-                    extend_bind_opts(&mut opts, b);
-                }
-                if let Some(vol) = volume {
-                    extend_volume_opts(&mut opts, vol);
-                }
-                out.push(format!("{src}:{target}:{}", opts.join(",")));
-            }
-        }
-    }
-    out
-}
+		let dir = self.staging_dir()?.join(kind);
+		staging::create_private_subdir(&dir)?;
 
-fn needs_mount_api(volume: &Option<VolumeOptions>) -> bool {
-    volume
-        .as_ref()
-        .is_some_and(|v| v.subpath.is_some() || !v.labels.is_empty() || v.driver_config.is_some())
-}
+		let path = dir.join(name);
+		staging::write_private_file(&path, content)?;
 
-pub(crate) fn build_mounts(service: &Service) -> Vec<Mount> {
-    let mut out = Vec::new();
-    for v in &service.volumes {
-        if let VolumeMount::Long {
-            volume_type,
-            source,
-            target,
-            read_only,
-            bind,
-            volume,
-            tmpfs,
-            consistency,
-        } = v
-        {
-            if matches!(volume_type, VolumeType::Tmpfs) {
-                // Tmpfs via Mount API.
-                let tmpfs_options = tmpfs.as_ref().map(|t| MountTmpfsOptions {
-                    size_bytes: t.size.map(|s| s as i64),
-                    mode: t.mode.map(|m| m as i64),
-                    options: None,
-                });
-                out.push(Mount {
-                    target: Some(target.clone()),
-                    source: source.clone(),
-                    typ: Some(MountType::TMPFS),
-                    read_only: *read_only,
-                    consistency: consistency.clone(),
-                    tmpfs_options,
-                    ..Default::default()
-                });
-                continue;
-            }
-            if !needs_mount_api(volume) {
-                continue;
-            }
-            let mount_type = match volume_type {
-                VolumeType::Bind => MountType::BIND,
-                VolumeType::Volume => MountType::VOLUME,
-                VolumeType::Npipe => MountType::NPIPE,
-                VolumeType::Cluster => MountType::CLUSTER,
-                VolumeType::Tmpfs => unreachable!(),
-            };
-            let bind_options = bind.as_ref().map(|b| MountBindOptions {
-                propagation: b.propagation.as_deref().and_then(|p| p.parse().ok()),
-                ..Default::default()
-            });
-            let volume_options = volume.as_ref().map(|v| {
-                let labels = if v.labels.is_empty() {
-                    None
-                } else {
-                    Some(v.labels.to_map())
-                };
-                let driver_config =
-                    v.driver_config
-                        .as_ref()
-                        .map(|dc| MountVolumeOptionsDriverConfig {
-                            name: dc.name.clone(),
-                            options: if dc.options.is_empty() {
-                                None
-                            } else {
-                                Some(dc.options.clone())
-                            },
-                        });
-                MountVolumeOptions {
-                    no_copy: v.nocopy,
-                    labels,
-                    driver_config,
-                    subpath: v.subpath.clone(),
-                }
-            });
-            out.push(Mount {
-                target: Some(target.clone()),
-                source: source.clone(),
-                typ: Some(mount_type),
-                read_only: *read_only,
-                consistency: consistency.clone(),
-                bind_options,
-                volume_options,
-                ..Default::default()
-            });
-        }
-    }
-    out
-}
+		if let Some(m) = mode {
+			staging::apply_mode(&path, m)?;
+		}
+		staging::apply_owner(&path, uid, gid);
 
-fn extend_bind_opts(opts: &mut Vec<String>, b: &BindOptions) {
-    if let Some(p) = &b.propagation {
-        opts.push(p.clone());
-    }
-    if let Some(s) = &b.selinux {
-        opts.push(s.clone());
-    }
-}
+		Ok(path)
+	}
 
-fn extend_volume_opts(opts: &mut Vec<String>, v: &VolumeOptions) {
-    if v.nocopy.unwrap_or(false) {
-        opts.push("nocopy".into());
-    }
-}
+	pub(super) fn cleanup_temp_dir(&self) {
+		if let Ok(dir) = self.staging_dir() {
+			let _ = std::fs::remove_dir_all(dir);
+		}
+	}
 
-impl Engine {
-    pub(super) fn build_secret_binds(
-        &self,
-        service: &Service,
-        file: &ComposeFile,
-    ) -> Result<Vec<String>> {
-        let mut binds = Vec::new();
-        for secret_ref in &service.secrets {
-            let (name, target_override, ref_mode, ref_uid, ref_gid) = match secret_ref {
-                ServiceSecretRef::Short(s) => (s.clone(), None, None, None, None),
-                ServiceSecretRef::Long {
-                    source,
-                    target,
-                    mode,
-                    uid,
-                    gid,
-                } => (
-                    source.clone(),
-                    target.clone(),
-                    *mode,
-                    uid.clone(),
-                    gid.clone(),
-                ),
-            };
-            if let Some(config) = file.secrets.get(&name) {
-                let target = target_override.unwrap_or_else(|| format!("/run/secrets/{name}"));
-                match config {
-                    SecretConfig {
-                        file: Some(host_path),
-                        ..
-                    } => {
-                        binds.push(format!("{host_path}:{target}:ro"));
-                    }
-                    SecretConfig {
-                        content: Some(content),
-                        ..
-                    } => {
-                        let path = self.materialize_inline_full(
-                            "secrets",
-                            &name,
-                            content.as_bytes(),
-                            ref_mode,
-                            ref_uid.as_deref(),
-                            ref_gid.as_deref(),
-                        )?;
-                        binds.push(format!("{}:{target}:ro", path.display()));
-                    }
-                    SecretConfig {
-                        environment: Some(env_var),
-                        ..
-                    } => {
-                        let value = std::env::var(env_var).unwrap_or_default();
-                        let path = self.materialize_inline_full(
-                            "secrets",
-                            &name,
-                            value.as_bytes(),
-                            ref_mode,
-                            ref_uid.as_deref(),
-                            ref_gid.as_deref(),
-                        )?;
-                        binds.push(format!("{}:{target}:ro", path.display()));
-                    }
-                    SecretConfig {
-                        external: Some(true),
-                        ..
-                    } => {
-                        tracing::debug!("external secret {name} — relying on runtime injection");
-                    }
-                    _ => {}
-                }
-            }
-        }
-        Ok(binds)
-    }
-
-    pub(super) fn build_config_binds(
-        &self,
-        service: &Service,
-        file: &ComposeFile,
-    ) -> Result<Vec<String>> {
-        let mut binds = Vec::new();
-        for config_ref in &service.configs {
-            let (name, target_override, ref_mode, ref_uid, ref_gid) = match config_ref {
-                ServiceConfigRef::Short(s) => (s.clone(), None, None, None, None),
-                ServiceConfigRef::Long {
-                    source,
-                    target,
-                    mode,
-                    uid,
-                    gid,
-                } => (
-                    source.clone(),
-                    target.clone(),
-                    *mode,
-                    uid.clone(),
-                    gid.clone(),
-                ),
-            };
-            if let Some(cfg) = file.configs.get(&name) {
-                let target = target_override.unwrap_or_else(|| format!("/{name}"));
-                match cfg {
-                    ConfigConfig {
-                        file: Some(host_path),
-                        ..
-                    } => {
-                        binds.push(format!("{host_path}:{target}:ro"));
-                    }
-                    ConfigConfig {
-                        content: Some(content),
-                        ..
-                    } => {
-                        let path = self.materialize_inline_full(
-                            "configs",
-                            &name,
-                            content.as_bytes(),
-                            ref_mode,
-                            ref_uid.as_deref(),
-                            ref_gid.as_deref(),
-                        )?;
-                        binds.push(format!("{}:{target}:ro", path.display()));
-                    }
-                    ConfigConfig {
-                        environment: Some(env_var),
-                        ..
-                    } => {
-                        let value = std::env::var(env_var).unwrap_or_default();
-                        let path = self.materialize_inline_full(
-                            "configs",
-                            &name,
-                            value.as_bytes(),
-                            ref_mode,
-                            ref_uid.as_deref(),
-                            ref_gid.as_deref(),
-                        )?;
-                        binds.push(format!("{}:{target}:ro", path.display()));
-                    }
-                    ConfigConfig {
-                        external: Some(true),
-                        ..
-                    } => {
-                        tracing::debug!("external config {name} — relying on runtime injection");
-                    }
-                    _ => {}
-                }
-            }
-        }
-        Ok(binds)
-    }
-
-    /// Write `content` to a per-project temp file and return its path.
-    ///
-    fn materialize_inline_full(
-        &self,
-        kind: &str,
-        name: &str,
-        content: &[u8],
-        mode: Option<u32>,
-        uid: Option<&str>,
-        gid: Option<&str>,
-    ) -> Result<std::path::PathBuf> {
-        // Reject names that could escape the temp dir (path traversal).
-        if std::path::Path::new(name)
-            .components()
-            .any(|c| !matches!(c, std::path::Component::Normal(_)))
-        {
-            return Err(ComposeError::Unsupported(format!(
-                "{kind} name must not contain path separators or '..': {name}"
-            )));
-        }
-
-        let dir = self.staging_dir()?.join(kind);
-        staging::create_private_subdir(&dir)?;
-
-        let path = dir.join(name);
-        staging::write_private_file(&path, content)?;
-
-        if let Some(m) = mode {
-            staging::apply_mode(&path, m)?;
-        }
-        staging::apply_owner(&path, uid, gid);
-
-        Ok(path)
-    }
-
-    /// Remove the per-project temp directory created by `materialize_inline`.
-    pub(super) fn cleanup_temp_dir(&self) {
-        if let Ok(dir) = self.staging_dir() {
-            let _ = std::fs::remove_dir_all(dir);
-        }
-    }
-
-    /// Per-project staging directory under a verified per-user base.
-    ///
-    /// The project name is validated first so it can never traverse out of
-    /// the base — this same path is later passed to `remove_dir_all`.
-    fn staging_dir(&self) -> Result<std::path::PathBuf> {
-        if !staging::is_safe_project_name(&self.project) {
-            return Err(ComposeError::Unsupported(format!(
-                "project name must be ASCII alphanumeric/dash/underscore/dot \
-                 and must not start with a dot: {}",
-                self.project
-            )));
-        }
-        Ok(staging::staging_base()?.join(&self.project))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Unit tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::build_binds;
-    use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
-    use std::path::Path;
-
-    fn svc_with_volumes(vols: Vec<VolumeMount>) -> Service {
-        Service {
-            volumes: vols,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn short_form_passthrough() {
-        let svc = svc_with_volumes(vec![VolumeMount::Short("./data:/app/data".into())]);
-        let binds = build_binds(&svc, Path::new("/base"));
-        assert_eq!(binds, vec!["./data:/app/data"]);
-    }
-
-    #[test]
-    fn long_form_bind_read_only() {
-        let svc = svc_with_volumes(vec![VolumeMount::Long {
-            volume_type: VolumeType::Bind,
-            source: Some("/host/path".into()),
-            target: "/container/path".into(),
-            read_only: Some(true),
-            bind: None,
-            volume: None,
-            tmpfs: None,
-            consistency: None,
-        }]);
-        let binds = build_binds(&svc, Path::new("/base"));
-        assert_eq!(binds.len(), 1);
-        assert!(binds[0].contains("ro"));
-        assert!(binds[0].contains("/host/path:/container/path"));
-    }
-
-    #[test]
-    fn long_form_bind_with_propagation() {
-        let svc = svc_with_volumes(vec![VolumeMount::Long {
-            volume_type: VolumeType::Bind,
-            source: Some("/host".into()),
-            target: "/cont".into(),
-            read_only: Some(false),
-            bind: Some(BindOptions {
-                propagation: Some("rshared".into()),
-                create_host_path: None,
-                selinux: None,
-            }),
-            volume: None,
-            tmpfs: None,
-            consistency: None,
-        }]);
-        let binds = build_binds(&svc, Path::new("/base"));
-        assert!(binds[0].contains("rshared"));
-    }
-
-    #[test]
-    fn long_form_volume_nocopy() {
-        let svc = svc_with_volumes(vec![VolumeMount::Long {
-            volume_type: VolumeType::Volume,
-            source: Some("myvolume".into()),
-            target: "/data".into(),
-            read_only: None,
-            bind: None,
-            volume: Some(VolumeOptions {
-                nocopy: Some(true),
-                ..Default::default()
-            }),
-            tmpfs: None,
-            consistency: None,
-        }]);
-        let binds = build_binds(&svc, Path::new("/base"));
-        assert!(binds[0].contains("nocopy"));
-    }
-
-    #[test]
-    fn tmpfs_type_excluded_from_binds() {
-        let svc = svc_with_volumes(vec![VolumeMount::Long {
-            volume_type: VolumeType::Tmpfs,
-            source: None,
-            target: "/run".into(),
-            read_only: None,
-            bind: None,
-            volume: None,
-            tmpfs: None,
-            consistency: None,
-        }]);
-        let binds = build_binds(&svc, Path::new("/base"));
-        assert!(binds.is_empty());
-    }
+	fn staging_dir(&self) -> Result<std::path::PathBuf> {
+		if !staging::is_safe_project_name(&self.project) {
+			return Err(ComposeError::Unsupported(format!(
+				"project name must be ASCII alphanumeric/dash/underscore/dot \
+				 and must not start with a dot: {}",
+				self.project
+			)));
+		}
+		Ok(staging::staging_base()?.join(&self.project))
+	}
 }

--- a/internal/engine/volume_mounts.rs
+++ b/internal/engine/volume_mounts.rs
@@ -1,0 +1,314 @@
+//! Volume bind-string and Mount-API helpers.
+//!
+//! [`build_binds`] converts `volumes:` entries to bollard bind strings.
+//! [`build_mounts`] converts entries that require the Mount API (tmpfs,
+//! volumes with subpath/labels/driver_config).
+
+use std::path::Path;
+
+use bollard::models::{
+	Mount, MountBindOptions, MountTmpfsOptions, MountType, MountVolumeOptions,
+	MountVolumeOptionsDriverConfig,
+};
+
+use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
+
+pub(crate) fn build_binds(service: &Service, base_dir: &Path) -> Vec<String> {
+	let mut out = Vec::new();
+	for v in &service.volumes {
+		match v {
+			VolumeMount::Short(s) => out.push(s.clone()),
+			VolumeMount::Long {
+				volume_type,
+				source,
+				target,
+				read_only,
+				bind,
+				volume,
+				..
+			} => {
+				if matches!(volume_type, VolumeType::Tmpfs) {
+					continue;
+				}
+				if needs_mount_api(volume) {
+					continue;
+				}
+				let src = source.as_deref().unwrap_or("");
+
+				if matches!(volume_type, VolumeType::Bind) {
+					if let Some(b) = bind {
+						if b.create_host_path.unwrap_or(false) && !src.is_empty() {
+							let abs = if Path::new(src).is_absolute() {
+								std::path::PathBuf::from(src)
+							} else {
+								base_dir.join(src)
+							};
+							if let Err(e) = std::fs::create_dir_all(&abs) {
+								tracing::warn!(
+									"create_host_path: failed to create {}: {e}",
+									abs.display()
+								);
+							}
+						}
+					}
+				}
+
+				let mut opts: Vec<String> = Vec::new();
+				if read_only.unwrap_or(false) {
+					opts.push("ro".into());
+				} else {
+					opts.push("rw".into());
+				}
+				if let Some(b) = bind {
+					extend_bind_opts(&mut opts, b);
+				}
+				if let Some(vol) = volume {
+					extend_volume_opts(&mut opts, vol);
+				}
+				out.push(format!("{src}:{target}:{}", opts.join(",")));
+			}
+		}
+	}
+	out
+}
+
+fn needs_mount_api(volume: &Option<VolumeOptions>) -> bool {
+	volume
+		.as_ref()
+		.is_some_and(|v| v.subpath.is_some() || !v.labels.is_empty() || v.driver_config.is_some())
+}
+
+pub(crate) fn build_mounts(service: &Service) -> Vec<Mount> {
+	let mut out = Vec::new();
+	for v in &service.volumes {
+		if let VolumeMount::Long {
+			volume_type,
+			source,
+			target,
+			read_only,
+			bind,
+			volume,
+			tmpfs,
+			consistency,
+		} = v
+		{
+			if matches!(volume_type, VolumeType::Tmpfs) {
+				let tmpfs_options = tmpfs.as_ref().map(|t| MountTmpfsOptions {
+					size_bytes: t.size.map(|s| s as i64),
+					mode: t.mode.map(|m| m as i64),
+					options: None,
+				});
+				out.push(Mount {
+					target: Some(target.clone()),
+					source: source.clone(),
+					typ: Some(MountType::TMPFS),
+					read_only: *read_only,
+					consistency: consistency.clone(),
+					tmpfs_options,
+					..Default::default()
+				});
+				continue;
+			}
+			if !needs_mount_api(volume) {
+				continue;
+			}
+			let mount_type = match volume_type {
+				VolumeType::Bind => MountType::BIND,
+				VolumeType::Volume => MountType::VOLUME,
+				VolumeType::Npipe => MountType::NPIPE,
+				VolumeType::Cluster => MountType::CLUSTER,
+				VolumeType::Tmpfs => unreachable!(),
+			};
+			let bind_options = bind.as_ref().map(|b| MountBindOptions {
+				propagation: b.propagation.as_deref().and_then(|p| p.parse().ok()),
+				..Default::default()
+			});
+			let volume_options = volume.as_ref().map(|v| {
+				let labels = if v.labels.is_empty() {
+					None
+				} else {
+					Some(v.labels.to_map())
+				};
+				let driver_config =
+					v.driver_config
+						.as_ref()
+						.map(|dc| MountVolumeOptionsDriverConfig {
+							name: dc.name.clone(),
+							options: if dc.options.is_empty() {
+								None
+							} else {
+								Some(dc.options.clone())
+							},
+						});
+				MountVolumeOptions {
+					no_copy: v.nocopy,
+					labels,
+					driver_config,
+					subpath: v.subpath.clone(),
+				}
+			});
+			out.push(Mount {
+				target: Some(target.clone()),
+				source: source.clone(),
+				typ: Some(mount_type),
+				read_only: *read_only,
+				consistency: consistency.clone(),
+				bind_options,
+				volume_options,
+				..Default::default()
+			});
+		}
+	}
+	out
+}
+
+fn extend_bind_opts(opts: &mut Vec<String>, b: &BindOptions) {
+	if let Some(p) = &b.propagation {
+		opts.push(p.clone());
+	}
+	if let Some(s) = &b.selinux {
+		opts.push(s.clone());
+	}
+}
+
+fn extend_volume_opts(opts: &mut Vec<String>, v: &VolumeOptions) {
+	if v.nocopy.unwrap_or(false) {
+		opts.push("nocopy".into());
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::{build_binds, build_mounts};
+	use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
+	use std::path::Path;
+
+	fn svc_with_volumes(vols: Vec<VolumeMount>) -> Service {
+		Service {
+			volumes: vols,
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn short_form_passthrough() {
+		let svc = svc_with_volumes(vec![VolumeMount::Short("./data:/app/data".into())]);
+		let binds = build_binds(&svc, Path::new("/base"));
+		assert_eq!(binds, vec!["./data:/app/data"]);
+	}
+
+	#[test]
+	fn long_form_bind_read_only() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Bind,
+			source: Some("/host/path".into()),
+			target: "/container/path".into(),
+			read_only: Some(true),
+			bind: None,
+			volume: None,
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let binds = build_binds(&svc, Path::new("/base"));
+		assert_eq!(binds.len(), 1);
+		assert!(binds[0].contains("ro"));
+		assert!(binds[0].contains("/host/path:/container/path"));
+	}
+
+	#[test]
+	fn long_form_bind_with_propagation() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Bind,
+			source: Some("/host".into()),
+			target: "/cont".into(),
+			read_only: Some(false),
+			bind: Some(BindOptions {
+				propagation: Some("rshared".into()),
+				create_host_path: None,
+				selinux: None,
+			}),
+			volume: None,
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let binds = build_binds(&svc, Path::new("/base"));
+		assert!(binds[0].contains("rshared"));
+	}
+
+	#[test]
+	fn long_form_volume_nocopy() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Volume,
+			source: Some("myvolume".into()),
+			target: "/data".into(),
+			read_only: None,
+			bind: None,
+			volume: Some(VolumeOptions {
+				nocopy: Some(true),
+				..Default::default()
+			}),
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let binds = build_binds(&svc, Path::new("/base"));
+		assert!(binds[0].contains("nocopy"));
+	}
+
+	#[test]
+	fn tmpfs_type_excluded_from_binds() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Tmpfs,
+			source: None,
+			target: "/run".into(),
+			read_only: None,
+			bind: None,
+			volume: None,
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let binds = build_binds(&svc, Path::new("/base"));
+		assert!(binds.is_empty());
+	}
+
+	#[test]
+	fn build_mounts_tmpfs_long_form() {
+		use crate::compose::types::TmpfsOptions;
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Tmpfs,
+			source: None,
+			target: "/tmp/cache".into(),
+			read_only: None,
+			bind: None,
+			volume: None,
+			tmpfs: Some(TmpfsOptions { size: Some(65536), mode: Some(0o700) }),
+			consistency: None,
+		}]);
+		let mounts = build_mounts(&svc);
+		assert_eq!(mounts.len(), 1);
+		let m = &mounts[0];
+		assert_eq!(m.target.as_deref(), Some("/tmp/cache"));
+		let opts = m.tmpfs_options.as_ref().unwrap();
+		assert_eq!(opts.size_bytes, Some(65536));
+		assert_eq!(opts.mode, Some(0o700));
+	}
+
+	#[test]
+	fn build_mounts_non_tmpfs_skipped_without_mount_api() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Bind,
+			source: Some("/host".into()),
+			target: "/cont".into(),
+			read_only: None,
+			bind: None,
+			volume: None,
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let mounts = build_mounts(&svc);
+		assert!(mounts.is_empty(), "plain bind goes through bind string, not Mount API");
+	}
+}

--- a/internal/engine/volume_mounts.rs
+++ b/internal/engine/volume_mounts.rs
@@ -284,7 +284,10 @@ mod tests {
 			read_only: None,
 			bind: None,
 			volume: None,
-			tmpfs: Some(TmpfsOptions { size: Some(65536), mode: Some(0o700) }),
+			tmpfs: Some(TmpfsOptions {
+				size: Some(65536),
+				mode: Some(0o700),
+			}),
 			consistency: None,
 		}]);
 		let mounts = build_mounts(&svc);
@@ -309,6 +312,9 @@ mod tests {
 			consistency: None,
 		}]);
 		let mounts = build_mounts(&svc);
-		assert!(mounts.is_empty(), "plain bind goes through bind string, not Mount API");
+		assert!(
+			mounts.is_empty(),
+			"plain bind goes through bind string, not Mount API"
+		);
 	}
 }

--- a/internal/engine/watch.rs
+++ b/internal/engine/watch.rs
@@ -16,7 +16,7 @@ use bollard::body_full;
 use bollard::container::LogOutput;
 use bollard::exec::{CreateExecOptions, StartExecResults};
 use bollard::query_parameters::{
-    StartContainerOptions, StopContainerOptions, UploadToContainerOptions,
+	StartContainerOptions, StopContainerOptions, UploadToContainerOptions,
 };
 use bytes::Bytes;
 use flate2::write::GzEncoder;
@@ -37,10 +37,10 @@ use super::Engine;
 
 /// Pre-resolved watch rule: service identity + rule + absolute host path for fast matching.
 struct RuleEntry {
-    service_name: String,
-    container_name: String,
-    rule: WatchRule,
-    abs_path: PathBuf,
+	service_name: String,
+	container_name: String,
+	rule: WatchRule,
+	abs_path: PathBuf,
 }
 
 // ---------------------------------------------------------------------------
@@ -48,253 +48,253 @@ struct RuleEntry {
 // ---------------------------------------------------------------------------
 
 impl Engine {
-    pub async fn watch(&self, file: &ComposeFile) -> Result<()> {
-        let mut rule_entries: Vec<RuleEntry> = Vec::new();
+	pub async fn watch(&self, file: &ComposeFile) -> Result<()> {
+		let mut rule_entries: Vec<RuleEntry> = Vec::new();
 
-        for (name, service) in &file.services {
-            if let Some(dev) = &service.develop {
-                for rule in &dev.watch {
-                    let abs = self.base_dir.join(&rule.path);
-                    rule_entries.push(RuleEntry {
-                        service_name: name.clone(),
-                        container_name: self.container_name(name, service),
-                        rule: rule.clone(),
-                        abs_path: abs,
-                    });
-                }
-            }
-        }
+		for (name, service) in &file.services {
+			if let Some(dev) = &service.develop {
+				for rule in &dev.watch {
+					let abs = self.base_dir.join(&rule.path);
+					rule_entries.push(RuleEntry {
+						service_name: name.clone(),
+						container_name: self.container_name(name, service),
+						rule: rule.clone(),
+						abs_path: abs,
+					});
+				}
+			}
+		}
 
-        if rule_entries.is_empty() {
-            info!("no develop.watch rules found");
-            return Ok(());
-        }
+		if rule_entries.is_empty() {
+			info!("no develop.watch rules found");
+			return Ok(());
+		}
 
-        // Initial sync.
-        for entry in &rule_entries {
-            if entry.rule.initial_sync {
-                if let Some(target) = &entry.rule.target {
-                    info!("initial sync {} -> {target}", entry.abs_path.display());
-                    if let Err(e) = self
-                        .sync_to_container(&entry.container_name, &entry.abs_path, target)
-                        .await
-                    {
-                        warn!("initial sync failed: {e}");
-                    }
-                }
-            }
-        }
+		// Initial sync.
+		for entry in &rule_entries {
+			if entry.rule.initial_sync {
+				if let Some(target) = &entry.rule.target {
+					info!("initial sync {} -> {target}", entry.abs_path.display());
+					if let Err(e) = self
+						.sync_to_container(&entry.container_name, &entry.abs_path, target)
+						.await
+					{
+						warn!("initial sync failed: {e}");
+					}
+				}
+			}
+		}
 
-        // Notify watcher with tokio channel bridge.
-        let (tx, mut rx) = mpsc::unbounded_channel::<notify::Result<notify::Event>>();
-        let mut watcher = RecommendedWatcher::new(
-            move |res| {
-                let _ = tx.send(res);
-            },
-            notify::Config::default(),
-        )
-        .map_err(|e| ComposeError::Watch(e.to_string()))?;
+		// Notify watcher with tokio channel bridge.
+		let (tx, mut rx) = mpsc::unbounded_channel::<notify::Result<notify::Event>>();
+		let mut watcher = RecommendedWatcher::new(
+			move |res| {
+				let _ = tx.send(res);
+			},
+			notify::Config::default(),
+		)
+		.map_err(|e| ComposeError::Watch(e.to_string()))?;
 
-        for entry in &rule_entries {
-            if entry.abs_path.exists() {
-                watcher
-                    .watch(&entry.abs_path, RecursiveMode::Recursive)
-                    .map_err(|e| ComposeError::Watch(e.to_string()))?;
-            } else {
-                warn!("watch path not found: {}", entry.abs_path.display());
-            }
-        }
+		for entry in &rule_entries {
+			if entry.abs_path.exists() {
+				watcher
+					.watch(&entry.abs_path, RecursiveMode::Recursive)
+					.map_err(|e| ComposeError::Watch(e.to_string()))?;
+			} else {
+				warn!("watch path not found: {}", entry.abs_path.display());
+			}
+		}
 
-        info!("watching {} rule(s) — Ctrl+C to stop", rule_entries.len());
+		info!("watching {} rule(s) — Ctrl+C to stop", rule_entries.len());
 
-        let debounce = Duration::from_millis(100);
+		let debounce = Duration::from_millis(100);
 
-        loop {
-            let event = tokio::select! {
-                ev = rx.recv() => match ev {
-                    Some(Ok(e)) => e,
-                    Some(Err(e)) => { warn!("notify error: {e}"); continue; }
-                    None => break,
-                },
-                _ = tokio::signal::ctrl_c() => break,
-            };
+		loop {
+			let event = tokio::select! {
+				ev = rx.recv() => match ev {
+					Some(Ok(e)) => e,
+					Some(Err(e)) => { warn!("notify error: {e}"); continue; }
+					None => break,
+				},
+				_ = tokio::signal::ctrl_c() => break,
+			};
 
-            // Drain events within debounce window.
-            let mut paths = event.paths;
-            let deadline = tokio::time::Instant::now() + debounce;
-            while let Ok(Some(Ok(e))) = tokio::time::timeout_at(deadline, rx.recv()).await {
-                paths.extend(e.paths);
-            }
+			// Drain events within debounce window.
+			let mut paths = event.paths;
+			let deadline = tokio::time::Instant::now() + debounce;
+			while let Ok(Some(Ok(e))) = tokio::time::timeout_at(deadline, rx.recv()).await {
+				paths.extend(e.paths);
+			}
 
-            // Dispatch each changed path.
-            'outer: for path in &paths {
-                for entry in &rule_entries {
-                    if !path.starts_with(&entry.abs_path) {
-                        continue;
-                    }
+			// Dispatch each changed path.
+			'outer: for path in &paths {
+				for entry in &rule_entries {
+					if !path.starts_with(&entry.abs_path) {
+						continue;
+					}
 
-                    let rel = path.strip_prefix(&self.base_dir).unwrap_or(path.as_path());
-                    let rel_str = rel.to_string_lossy();
+					let rel = path.strip_prefix(&self.base_dir).unwrap_or(path.as_path());
+					let rel_str = rel.to_string_lossy();
 
-                    if is_ignored(&rel_str, &entry.rule.ignore) {
-                        continue;
-                    }
-                    if !entry.rule.include.is_empty() && !is_included(&rel_str, &entry.rule.include)
-                    {
-                        continue;
-                    }
+					if is_ignored(&rel_str, &entry.rule.ignore) {
+						continue;
+					}
+					if !entry.rule.include.is_empty() && !is_included(&rel_str, &entry.rule.include)
+					{
+						continue;
+					}
 
-                    debug!("dispatch {:?} for {}", entry.rule.action, path.display());
+					debug!("dispatch {:?} for {}", entry.rule.action, path.display());
 
-                    if let Err(e) = self.dispatch_action(file, path, entry).await {
-                        warn!("watch action failed: {e}");
-                    }
+					if let Err(e) = self.dispatch_action(file, path, entry).await {
+						warn!("watch action failed: {e}");
+					}
 
-                    continue 'outer;
-                }
-            }
-        }
+					continue 'outer;
+				}
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    async fn dispatch_action(
-        &self,
-        file: &ComposeFile,
-        path: &Path,
-        entry: &RuleEntry,
-    ) -> Result<()> {
-        match &entry.rule.action {
-            WatchAction::Sync => {
-                if let Some(target) = &entry.rule.target {
-                    self.sync_to_container(&entry.container_name, path, target)
-                        .await?;
-                }
-            }
-            WatchAction::Rebuild => {
-                self.watch_rebuild(file, &entry.service_name).await?;
-            }
-            WatchAction::Restart => {
-                self.watch_restart(&entry.container_name).await?;
-            }
-            WatchAction::SyncAndRestart => {
-                if let Some(target) = &entry.rule.target {
-                    self.sync_to_container(&entry.container_name, path, target)
-                        .await?;
-                }
-                self.watch_restart(&entry.container_name).await?;
-            }
-            WatchAction::SyncAndExec => {
-                if let Some(target) = &entry.rule.target {
-                    self.sync_to_container(&entry.container_name, path, target)
-                        .await?;
-                }
-                if let Some(exec) = &entry.rule.exec {
-                    self.watch_exec(&entry.container_name, exec.command.clone())
-                        .await?;
-                }
-            }
-        }
-        Ok(())
-    }
+	async fn dispatch_action(
+		&self,
+		file: &ComposeFile,
+		path: &Path,
+		entry: &RuleEntry,
+	) -> Result<()> {
+		match &entry.rule.action {
+			WatchAction::Sync => {
+				if let Some(target) = &entry.rule.target {
+					self.sync_to_container(&entry.container_name, path, target)
+						.await?;
+				}
+			}
+			WatchAction::Rebuild => {
+				self.watch_rebuild(file, &entry.service_name).await?;
+			}
+			WatchAction::Restart => {
+				self.watch_restart(&entry.container_name).await?;
+			}
+			WatchAction::SyncAndRestart => {
+				if let Some(target) = &entry.rule.target {
+					self.sync_to_container(&entry.container_name, path, target)
+						.await?;
+				}
+				self.watch_restart(&entry.container_name).await?;
+			}
+			WatchAction::SyncAndExec => {
+				if let Some(target) = &entry.rule.target {
+					self.sync_to_container(&entry.container_name, path, target)
+						.await?;
+				}
+				if let Some(exec) = &entry.rule.exec {
+					self.watch_exec(&entry.container_name, exec.command.clone())
+						.await?;
+				}
+			}
+		}
+		Ok(())
+	}
 
-    // -----------------------------------------------------------------------
-    // Action helpers
-    // -----------------------------------------------------------------------
+	// -----------------------------------------------------------------------
+	// Action helpers
+	// -----------------------------------------------------------------------
 
-    async fn sync_to_container(&self, container: &str, src: &Path, target: &str) -> Result<()> {
-        let tar_bytes = build_sync_tar(src)?;
+	async fn sync_to_container(&self, container: &str, src: &Path, target: &str) -> Result<()> {
+		let tar_bytes = build_sync_tar(src)?;
 
-        let dest_dir = if target.ends_with('/') {
-            target.to_string()
-        } else {
-            Path::new(target)
-                .parent()
-                .map(|p| p.to_string_lossy().into_owned())
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| "/".to_string())
-        };
+		let dest_dir = if target.ends_with('/') {
+			target.to_string()
+		} else {
+			Path::new(target)
+				.parent()
+				.map(|p| p.to_string_lossy().into_owned())
+				.filter(|s| !s.is_empty())
+				.unwrap_or_else(|| "/".to_string())
+		};
 
-        self.docker
-            .upload_to_container(
-                container,
-                Some(UploadToContainerOptions {
-                    path: dest_dir,
-                    no_overwrite_dir_non_dir: None,
-                    copy_uidgid: None,
-                }),
-                body_full(Bytes::from(tar_bytes)),
-            )
-            .await
-            .map_err(ComposeError::Podman)?;
+		self.docker
+			.upload_to_container(
+				container,
+				Some(UploadToContainerOptions {
+					path: dest_dir,
+					no_overwrite_dir_non_dir: None,
+					copy_uidgid: None,
+				}),
+				body_full(Bytes::from(tar_bytes)),
+			)
+			.await
+			.map_err(ComposeError::Podman)?;
 
-        info!("synced {} -> {target}", src.display());
-        Ok(())
-    }
+		info!("synced {} -> {target}", src.display());
+		Ok(())
+	}
 
-    async fn watch_rebuild(&self, file: &ComposeFile, service_name: &str) -> Result<()> {
-        let service = match file.services.get(service_name) {
-            Some(s) => s,
-            None => return Ok(()),
-        };
-        info!("rebuilding {service_name}");
-        self.build_service(service_name, service).await?;
-        let container_name = self.container_name(service_name, service);
-        self.create_and_start(&container_name, service_name, service, file)
-            .await
-    }
+	async fn watch_rebuild(&self, file: &ComposeFile, service_name: &str) -> Result<()> {
+		let service = match file.services.get(service_name) {
+			Some(s) => s,
+			None => return Ok(()),
+		};
+		info!("rebuilding {service_name}");
+		self.build_service(service_name, service).await?;
+		let container_name = self.container_name(service_name, service);
+		self.create_and_start(&container_name, service_name, service, file)
+			.await
+	}
 
-    async fn watch_restart(&self, container_name: &str) -> Result<()> {
-        info!("restarting {container_name}");
-        let _ = self
-            .docker
-            .stop_container(
-                container_name,
-                Some(StopContainerOptions {
-                    t: Some(5),
-                    ..Default::default()
-                }),
-            )
-            .await;
-        self.docker
-            .start_container(container_name, None::<StartContainerOptions>)
-            .await?;
-        Ok(())
-    }
+	async fn watch_restart(&self, container_name: &str) -> Result<()> {
+		info!("restarting {container_name}");
+		let _ = self
+			.docker
+			.stop_container(
+				container_name,
+				Some(StopContainerOptions {
+					t: Some(5),
+					..Default::default()
+				}),
+			)
+			.await;
+		self.docker
+			.start_container(container_name, None::<StartContainerOptions>)
+			.await?;
+		Ok(())
+	}
 
-    async fn watch_exec(&self, container_name: &str, cmd: Vec<String>) -> Result<()> {
-        let exec_id = self
-            .docker
-            .create_exec(
-                container_name,
-                CreateExecOptions::<String> {
-                    cmd: Some(cmd),
-                    attach_stdout: Some(true),
-                    attach_stderr: Some(true),
-                    ..Default::default()
-                },
-            )
-            .await?
-            .id;
+	async fn watch_exec(&self, container_name: &str, cmd: Vec<String>) -> Result<()> {
+		let exec_id = self
+			.docker
+			.create_exec(
+				container_name,
+				CreateExecOptions::<String> {
+					cmd: Some(cmd),
+					attach_stdout: Some(true),
+					attach_stderr: Some(true),
+					..Default::default()
+				},
+			)
+			.await?
+			.id;
 
-        match self.docker.start_exec(&exec_id, None).await? {
-            StartExecResults::Attached { mut output, .. } => {
-                while let Some(msg) = output.next().await {
-                    match msg? {
-                        LogOutput::StdOut { message } => {
-                            print!("{}", String::from_utf8_lossy(&message));
-                        }
-                        LogOutput::StdErr { message } => {
-                            eprint!("{}", String::from_utf8_lossy(&message));
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            StartExecResults::Detached => {}
-        }
-        Ok(())
-    }
+		match self.docker.start_exec(&exec_id, None).await? {
+			StartExecResults::Attached { mut output, .. } => {
+				while let Some(msg) = output.next().await {
+					match msg? {
+						LogOutput::StdOut { message } => {
+							print!("{}", String::from_utf8_lossy(&message));
+						}
+						LogOutput::StdErr { message } => {
+							eprint!("{}", String::from_utf8_lossy(&message));
+						}
+						_ => {}
+					}
+				}
+			}
+			StartExecResults::Detached => {}
+		}
+		Ok(())
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -302,39 +302,39 @@ impl Engine {
 // ---------------------------------------------------------------------------
 
 fn build_sync_tar(src: &Path) -> Result<Vec<u8>> {
-    let encoder = GzEncoder::new(Vec::new(), Compression::default());
-    let mut tar = tar::Builder::new(encoder);
+	let encoder = GzEncoder::new(Vec::new(), Compression::default());
+	let mut tar = tar::Builder::new(encoder);
 
-    if src.is_dir() {
-        for entry in walkdir::WalkDir::new(src).follow_links(false) {
-            let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-            let abs = entry.path();
-            let rel = abs
-                .strip_prefix(src)
-                .map_err(|_| ComposeError::Build("path strip".into()))?;
-            if rel.as_os_str().is_empty() {
-                continue;
-            }
-            if abs.is_dir() {
-                tar.append_dir(rel, abs)
-                    .map_err(|e| ComposeError::Build(e.to_string()))?;
-            } else {
-                tar.append_path_with_name(abs, rel)
-                    .map_err(|e| ComposeError::Build(e.to_string()))?;
-            }
-        }
-    } else if let Some(name) = src.file_name() {
-        tar.append_path_with_name(src, name)
-            .map_err(|e| ComposeError::Build(e.to_string()))?;
-    }
+	if src.is_dir() {
+		for entry in walkdir::WalkDir::new(src).follow_links(false) {
+			let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
+			let abs = entry.path();
+			let rel = abs
+				.strip_prefix(src)
+				.map_err(|_| ComposeError::Build("path strip".into()))?;
+			if rel.as_os_str().is_empty() {
+				continue;
+			}
+			if abs.is_dir() {
+				tar.append_dir(rel, abs)
+					.map_err(|e| ComposeError::Build(e.to_string()))?;
+			} else {
+				tar.append_path_with_name(abs, rel)
+					.map_err(|e| ComposeError::Build(e.to_string()))?;
+			}
+		}
+	} else if let Some(name) = src.file_name() {
+		tar.append_path_with_name(src, name)
+			.map_err(|e| ComposeError::Build(e.to_string()))?;
+	}
 
-    let gz = tar
-        .into_inner()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
-    let bytes = gz
-        .finish()
-        .map_err(|e| ComposeError::Build(e.to_string()))?;
-    Ok(bytes)
+	let gz = tar
+		.into_inner()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	let bytes = gz
+		.finish()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	Ok(bytes)
 }
 
 // ---------------------------------------------------------------------------
@@ -342,38 +342,38 @@ fn build_sync_tar(src: &Path) -> Result<Vec<u8>> {
 // ---------------------------------------------------------------------------
 
 fn is_ignored(path: &str, patterns: &[String]) -> bool {
-    for pat in patterns {
-        if pat.ends_with('/') {
-            if path.starts_with(pat.as_str()) {
-                return true;
-            }
-        } else if path == pat.as_str()
-            || (path.starts_with(pat.as_str()) && path.as_bytes().get(pat.len()) == Some(&b'/'))
-        {
-            return true;
-        }
-    }
-    false
+	for pat in patterns {
+		if pat.ends_with('/') {
+			if path.starts_with(pat.as_str()) {
+				return true;
+			}
+		} else if path == pat.as_str()
+			|| (path.starts_with(pat.as_str()) && path.as_bytes().get(pat.len()) == Some(&b'/'))
+		{
+			return true;
+		}
+	}
+	false
 }
 
 fn is_included(path: &str, patterns: &[String]) -> bool {
-    for pat in patterns {
-        if pat.starts_with("*.") {
-            let ext = &pat[1..];
-            if path.ends_with(ext) {
-                return true;
-            }
-        } else if pat.ends_with('/') {
-            if path.starts_with(pat.as_str()) {
-                return true;
-            }
-        } else if path == pat.as_str()
-            || (path.len() > pat.len() + 1
-                && path.as_bytes()[path.len() - pat.len() - 1] == b'/'
-                && path.ends_with(pat.as_str()))
-        {
-            return true;
-        }
-    }
-    false
+	for pat in patterns {
+		if pat.starts_with("*.") {
+			let ext = &pat[1..];
+			if path.ends_with(ext) {
+				return true;
+			}
+		} else if pat.ends_with('/') {
+			if path.starts_with(pat.as_str()) {
+				return true;
+			}
+		} else if path == pat.as_str()
+			|| (path.len() > pat.len() + 1
+				&& path.as_bytes()[path.len() - pat.len() - 1] == b'/'
+				&& path.ends_with(pat.as_str()))
+		{
+			return true;
+		}
+	}
+	false
 }

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -17,90 +17,90 @@ use crate::error::{ComposeError, Result};
 ///
 /// Returns [`ComposeError::FileNotFound`] when an env file does not exist.
 pub fn load_env_files(paths: &[String], base_dir: &Path) -> Result<HashMap<String, String>> {
-    let entries: Vec<EnvFileEntry> = paths
-        .iter()
-        .map(|p| EnvFileEntry::Path(p.clone()))
-        .collect();
-    load_env_file_entries(&entries, base_dir)
+	let entries: Vec<EnvFileEntry> = paths
+		.iter()
+		.map(|p| EnvFileEntry::Path(p.clone()))
+		.collect();
+	load_env_file_entries(&entries, base_dir)
 }
 
 /// Load env_file entries supporting both short and long-form (with `required` and `format`).
 ///
 /// When `required: false`, a missing file is silently skipped instead of returning an error.
 pub fn load_env_file_entries(
-    entries: &[EnvFileEntry],
-    base_dir: &Path,
+	entries: &[EnvFileEntry],
+	base_dir: &Path,
 ) -> Result<HashMap<String, String>> {
-    let mut result: HashMap<String, String> = HashMap::new();
+	let mut result: HashMap<String, String> = HashMap::new();
 
-    for entry in entries {
-        if let EnvFileEntry::Config {
-            format: Some(fmt), ..
-        } = entry
-        {
-            if fmt != "dotenv" {
-                return Err(ComposeError::Unsupported(format!(
-                    "env_file format '{fmt}' not supported (only 'dotenv')"
-                )));
-            }
-        }
+	for entry in entries {
+		if let EnvFileEntry::Config {
+			format: Some(fmt), ..
+		} = entry
+		{
+			if fmt != "dotenv" {
+				return Err(ComposeError::Unsupported(format!(
+					"env_file format '{fmt}' not supported (only 'dotenv')"
+				)));
+			}
+		}
 
-        let abs = base_dir.join(entry.path());
-        let content = match std::fs::read_to_string(&abs) {
-            Ok(c) => c,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                if entry.required() {
-                    return Err(ComposeError::FileNotFound(abs.display().to_string()));
-                } else {
-                    continue;
-                }
-            }
-            Err(e) => return Err(ComposeError::Io(e)),
-        };
+		let abs = base_dir.join(entry.path());
+		let content = match std::fs::read_to_string(&abs) {
+			Ok(c) => c,
+			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+				if entry.required() {
+					return Err(ComposeError::FileNotFound(abs.display().to_string()));
+				} else {
+					continue;
+				}
+			}
+			Err(e) => return Err(ComposeError::Io(e)),
+		};
 
-        for line in content.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
+		for line in content.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() || trimmed.starts_with('#') {
+				continue;
+			}
 
-            let (key, value) = if let Some(eq) = trimmed.find('=') {
-                let k = trimmed[..eq].trim().to_string();
-                let v = trimmed[eq + 1..].to_string();
-                (k, v)
-            } else {
-                (trimmed.to_string(), String::new())
-            };
+			let (key, value) = if let Some(eq) = trimmed.find('=') {
+				let k = trimmed[..eq].trim().to_string();
+				let v = trimmed[eq + 1..].to_string();
+				(k, v)
+			} else {
+				(trimmed.to_string(), String::new())
+			};
 
-            if key.is_empty() {
-                continue;
-            }
+			if key.is_empty() {
+				continue;
+			}
 
-            result.entry(key).or_insert(value);
-        }
-    }
+			result.entry(key).or_insert(value);
+		}
+	}
 
-    Ok(result)
+	Ok(result)
 }
 
 /// Merge env_file values with service environment.
 ///
 /// `service_env` takes precedence: only keys not already in `service_env` are added.
 pub fn merge_env(
-    service_env: HashMap<String, Option<String>>,
-    env_file_vars: HashMap<String, String>,
+	service_env: HashMap<String, Option<String>>,
+	env_file_vars: HashMap<String, String>,
 ) -> Vec<String> {
-    // Start with service env (higher priority), fill gaps from env_file.
-    let mut merged = service_env;
-    for (k, v) in env_file_vars {
-        merged.entry(k).or_insert(Some(v));
-    }
+	// Start with service env (higher priority), fill gaps from env_file.
+	let mut merged = service_env;
+	for (k, v) in env_file_vars {
+		merged.entry(k).or_insert(Some(v));
+	}
 
-    merged
-        .into_iter()
-        .map(|(k, v)| match v {
-            Some(val) => format!("{k}={val}"),
-            None => k,
-        })
-        .collect()
+	merged
+		.into_iter()
+		.map(|(k, v)| match v {
+			Some(val) => format!("{k}={val}"),
+			None => k,
+		})
+		.collect()
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -8,50 +8,50 @@ use thiserror::Error;
 /// All errors produced by podup.
 #[derive(Debug, Error)]
 pub enum ComposeError {
-    #[error("failed to parse compose file: {0}")]
-    Parse(#[from] serde_yaml::Error),
+	#[error("failed to parse compose file: {0}")]
+	Parse(#[from] serde_yaml::Error),
 
-    #[error("compose file not found: {0}")]
-    FileNotFound(String),
+	#[error("compose file not found: {0}")]
+	FileNotFound(String),
 
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
+	#[error("io error: {0}")]
+	Io(#[from] std::io::Error),
 
-    #[error("podman error: {0}")]
-    Podman(#[from] bollard::errors::Error),
+	#[error("podman error: {0}")]
+	Podman(#[from] bollard::errors::Error),
 
-    #[error("service '{0}' not found")]
-    ServiceNotFound(String),
+	#[error("service '{0}' not found")]
+	ServiceNotFound(String),
 
-    #[error("circular dependency detected: {0}")]
-    CircularDependency(String),
+	#[error("circular dependency detected: {0}")]
+	CircularDependency(String),
 
-    #[error("service '{0}' has no image or build config")]
-    NoImageOrBuild(String),
+	#[error("service '{0}' has no image or build config")]
+	NoImageOrBuild(String),
 
-    #[error("required variable '{var}' is not set: {msg}")]
-    RequiredVarNotSet { var: String, msg: String },
+	#[error("required variable '{var}' is not set: {msg}")]
+	RequiredVarNotSet { var: String, msg: String },
 
-    #[error("health check timeout for container '{0}'")]
-    HealthCheckTimeout(String),
+	#[error("health check timeout for container '{0}'")]
+	HealthCheckTimeout(String),
 
-    #[error("invalid port mapping: {0}")]
-    InvalidPort(String),
+	#[error("invalid port mapping: {0}")]
+	InvalidPort(String),
 
-    #[error("build error: {0}")]
-    Build(String),
+	#[error("build error: {0}")]
+	Build(String),
 
-    #[error("extends error: {0}")]
-    Extends(String),
+	#[error("extends error: {0}")]
+	Extends(String),
 
-    #[error("include error: {0}")]
-    Include(String),
+	#[error("include error: {0}")]
+	Include(String),
 
-    #[error("watch error: {0}")]
-    Watch(String),
+	#[error("watch error: {0}")]
+	Watch(String),
 
-    #[error("unsupported feature: {0}")]
-    Unsupported(String),
+	#[error("unsupported feature: {0}")]
+	Unsupported(String),
 }
 
 pub type Result<T> = std::result::Result<T, ComposeError>;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -6,145 +6,145 @@ use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(
-    name = "podup",
-    version,
-    about = "docker-compose translator for Podman"
+	name = "podup",
+	version,
+	about = "docker-compose translator for Podman"
 )]
 struct Cli {
-    /// Path to the compose file.
-    #[arg(short, long, default_value = "docker-compose.yml")]
-    file: PathBuf,
+	/// Path to the compose file.
+	#[arg(short, long, default_value = "docker-compose.yml")]
+	file: PathBuf,
 
-    /// Project name (used as a prefix for container names).
-    #[arg(short, long, default_value = "podup")]
-    project: String,
+	/// Project name (used as a prefix for container names).
+	#[arg(short, long, default_value = "podup")]
+	project: String,
 
-    /// Podman socket path (overrides auto-detection and PODMAN_SOCKET env).
-    #[arg(long, env = "PODMAN_SOCKET")]
-    socket: Option<String>,
+	/// Podman socket path (overrides auto-detection and PODMAN_SOCKET env).
+	#[arg(long, env = "PODMAN_SOCKET")]
+	socket: Option<String>,
 
-    /// Active profiles (comma-separated).  May also be set via `COMPOSE_PROFILES`.
-    #[arg(long, value_delimiter = ',', global = true)]
-    profile: Vec<String>,
+	/// Active profiles (comma-separated).  May also be set via `COMPOSE_PROFILES`.
+	#[arg(long, value_delimiter = ',', global = true)]
+	profile: Vec<String>,
 
-    #[command(subcommand)]
-    command: Commands,
+	#[command(subcommand)]
+	command: Commands,
 }
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Create and start all services.
-    Up {
-        /// Run containers in the background.
-        #[arg(short, long)]
-        detach: bool,
-        /// Watch for file changes and sync/rebuild/restart per develop.watch rules.
-        #[arg(short, long)]
-        watch: bool,
-        /// Remove containers for services not defined in the compose file.
-        #[arg(long)]
-        remove_orphans: bool,
-        /// Do not recreate containers that are already running.
-        #[arg(long)]
-        no_recreate: bool,
-        /// Bring up only these services (and their transitive depends_on).
-        /// If omitted, brings up every service in the compose file.
-        #[arg(trailing_var_arg = true)]
-        services: Vec<String>,
-    },
-    /// Stop and remove containers.
-    Down {
-        /// Also remove named volumes declared in the compose file.
-        #[arg(short = 'v', long)]
-        volumes: bool,
-    },
-    /// List containers.
-    Ps,
-    /// View output from containers.
-    Logs {
-        /// Only show logs for this service.
-        service: Option<String>,
-        /// Follow log output.
-        #[arg(short, long)]
-        follow: bool,
-    },
-    /// Execute a command in a running service container.
-    Exec {
-        /// Service name.
-        service: String,
-        /// Command (and arguments) to execute.
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        cmd: Vec<String>,
-    },
-    /// Pull images for all services.
-    Pull,
-    /// Restart services.
-    Restart {
-        /// Only restart this service.
-        service: Option<String>,
-    },
-    /// Print the resolved compose file (after substitution / extends / include).
-    Config,
-    /// Watch for file changes and sync/rebuild/restart as configured by develop.watch.
-    Watch,
+	/// Create and start all services.
+	Up {
+		/// Run containers in the background.
+		#[arg(short, long)]
+		detach: bool,
+		/// Watch for file changes and sync/rebuild/restart per develop.watch rules.
+		#[arg(short, long)]
+		watch: bool,
+		/// Remove containers for services not defined in the compose file.
+		#[arg(long)]
+		remove_orphans: bool,
+		/// Do not recreate containers that are already running.
+		#[arg(long)]
+		no_recreate: bool,
+		/// Bring up only these services (and their transitive depends_on).
+		/// If omitted, brings up every service in the compose file.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
+	/// Stop and remove containers.
+	Down {
+		/// Also remove named volumes declared in the compose file.
+		#[arg(short = 'v', long)]
+		volumes: bool,
+	},
+	/// List containers.
+	Ps,
+	/// View output from containers.
+	Logs {
+		/// Only show logs for this service.
+		service: Option<String>,
+		/// Follow log output.
+		#[arg(short, long)]
+		follow: bool,
+	},
+	/// Execute a command in a running service container.
+	Exec {
+		/// Service name.
+		service: String,
+		/// Command (and arguments) to execute.
+		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+		cmd: Vec<String>,
+	},
+	/// Pull images for all services.
+	Pull,
+	/// Restart services.
+	Restart {
+		/// Only restart this service.
+		service: Option<String>,
+	},
+	/// Print the resolved compose file (after substitution / extends / include).
+	Config,
+	/// Watch for file changes and sync/rebuild/restart as configured by develop.watch.
+	Watch,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+	tracing_subscriber::fmt()
+		.with_env_filter(EnvFilter::from_default_env())
+		.init();
 
-    let cli = Cli::parse();
+	let cli = Cli::parse();
 
-    let file = podup::parse_file(&cli.file)?;
+	let file = podup::parse_file(&cli.file)?;
 
-    // The `config` command does not need a Podman connection.
-    if matches!(cli.command, Commands::Config) {
-        let yaml = serde_yaml::to_string(&file)?;
-        println!("{yaml}");
-        return Ok(());
-    }
+	// The `config` command does not need a Podman connection.
+	if matches!(cli.command, Commands::Config) {
+		let yaml = serde_yaml::to_string(&file)?;
+		println!("{yaml}");
+		return Ok(());
+	}
 
-    let docker = podup::podman::connect(cli.socket.as_deref())?;
-    let base_dir = cli
-        .file
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_default();
-    let engine = podup::Engine::with_base_dir(docker, cli.project, base_dir);
+	let docker = podup::podman::connect(cli.socket.as_deref())?;
+	let base_dir = cli
+		.file
+		.parent()
+		.map(|p| p.to_path_buf())
+		.unwrap_or_default();
+	let engine = podup::Engine::with_base_dir(docker, cli.project, base_dir);
 
-    match cli.command {
-        Commands::Up {
-            detach,
-            watch,
-            remove_orphans,
-            no_recreate,
-            services,
-        } => {
-            if remove_orphans {
-                engine.remove_orphans(&file).await?;
-            }
-            engine
-                .up_with_options(&file, detach, &cli.profile, &services, no_recreate)
-                .await?;
-            if watch {
-                engine.watch(&file).await?;
-            } else if !detach {
-                engine.attach_logs(&file).await?;
-            }
-        }
-        Commands::Down { volumes } => engine.down_with_options(&file, volumes).await?,
-        Commands::Ps => engine.ps(&file).await?,
-        Commands::Logs { service, follow } => {
-            engine.logs(&file, service.as_deref(), follow).await?
-        }
-        Commands::Exec { service, cmd } => engine.exec(&file, &service, cmd).await?,
-        Commands::Pull => engine.pull(&file).await?,
-        Commands::Restart { service } => engine.restart(&file, service.as_deref()).await?,
-        Commands::Config => unreachable!("handled above"),
-        Commands::Watch => engine.watch(&file).await?,
-    }
+	match cli.command {
+		Commands::Up {
+			detach,
+			watch,
+			remove_orphans,
+			no_recreate,
+			services,
+		} => {
+			if remove_orphans {
+				engine.remove_orphans(&file).await?;
+			}
+			engine
+				.up_with_options(&file, detach, &cli.profile, &services, no_recreate)
+				.await?;
+			if watch {
+				engine.watch(&file).await?;
+			} else if !detach {
+				engine.attach_logs(&file).await?;
+			}
+		}
+		Commands::Down { volumes } => engine.down_with_options(&file, volumes).await?,
+		Commands::Ps => engine.ps(&file).await?,
+		Commands::Logs { service, follow } => {
+			engine.logs(&file, service.as_deref(), follow).await?
+		}
+		Commands::Exec { service, cmd } => engine.exec(&file, &service, cmd).await?,
+		Commands::Pull => engine.pull(&file).await?,
+		Commands::Restart { service } => engine.restart(&file, service.as_deref()).await?,
+		Commands::Config => unreachable!("handled above"),
+		Commands::Watch => engine.watch(&file).await?,
+	}
 
-    Ok(())
+	Ok(())
 }

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -22,56 +22,56 @@ const DEFAULT_PIPE: &str = "//./pipe/podman-machine-default";
 /// 3. The conventional path for this platform, so a failed connection
 ///    reports the location podup expected.
 pub fn connect(socket_path: Option<&str>) -> Result<Docker> {
-    let default_path = default_socket_path();
-    let path = socket_path.unwrap_or(&default_path);
-    #[cfg(not(windows))]
-    let client = Docker::connect_with_unix(path, 120, bollard::API_DEFAULT_VERSION)?;
-    #[cfg(windows)]
-    let client = Docker::connect_with_named_pipe(path, 120, bollard::API_DEFAULT_VERSION)?;
-    Ok(client)
+	let default_path = default_socket_path();
+	let path = socket_path.unwrap_or(&default_path);
+	#[cfg(not(windows))]
+	let client = Docker::connect_with_unix(path, 120, bollard::API_DEFAULT_VERSION)?;
+	#[cfg(windows)]
+	let client = Docker::connect_with_named_pipe(path, 120, bollard::API_DEFAULT_VERSION)?;
+	Ok(client)
 }
 
 /// Connect using `PODMAN_SOCKET` or `DOCKER_HOST` environment variables.
 pub fn connect_from_env() -> Result<Docker> {
-    let socket = std::env::var("PODMAN_SOCKET")
-        .or_else(|_| std::env::var("DOCKER_HOST"))
-        .ok();
+	let socket = std::env::var("PODMAN_SOCKET")
+		.or_else(|_| std::env::var("DOCKER_HOST"))
+		.ok();
 
-    let path = socket.as_deref().and_then(|s| {
-        s.strip_prefix("unix://")
-            .or_else(|| s.strip_prefix("npipe://"))
-    });
-    connect(path)
+	let path = socket.as_deref().and_then(|s| {
+		s.strip_prefix("unix://")
+			.or_else(|| s.strip_prefix("npipe://"))
+	});
+	connect(path)
 }
 
 #[cfg(not(windows))]
 fn default_socket_path() -> String {
-    let candidates = candidate_socket_paths();
-    first_existing(&candidates)
-        .or_else(machine_socket_path)
-        .or_else(|| candidates.into_iter().next())
-        .unwrap_or_else(|| ROOT_SOCKET.to_string())
+	let candidates = candidate_socket_paths();
+	first_existing(&candidates)
+		.or_else(machine_socket_path)
+		.or_else(|| candidates.into_iter().next())
+		.unwrap_or_else(|| ROOT_SOCKET.to_string())
 }
 
 /// Windows: named pipes are not probeable through `Path::exists`, so ask
 /// `podman machine inspect` and fall back to the default machine's pipe.
 #[cfg(windows)]
 fn default_socket_path() -> String {
-    machine_socket_path().unwrap_or_else(|| DEFAULT_PIPE.to_string())
+	machine_socket_path().unwrap_or_else(|| DEFAULT_PIPE.to_string())
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn candidate_socket_paths() -> Vec<String> {
-    let uid = unsafe { libc::getuid() };
-    runtime_candidates(uid, std::env::var("XDG_RUNTIME_DIR").ok().as_deref())
+	let uid = unsafe { libc::getuid() };
+	runtime_candidates(uid, std::env::var("XDG_RUNTIME_DIR").ok().as_deref())
 }
 
 #[cfg(target_os = "macos")]
 fn candidate_socket_paths() -> Vec<String> {
-    match std::env::var("HOME") {
-        Ok(home) => machine_candidates(&home),
-        Err(_) => vec![ROOT_SOCKET.to_string()],
-    }
+	match std::env::var("HOME") {
+		Ok(home) => machine_candidates(&home),
+		Err(_) => vec![ROOT_SOCKET.to_string()],
+	}
 }
 
 /// Socket candidates for Linux and other unix hosts: the rootful socket
@@ -79,52 +79,52 @@ fn candidate_socket_paths() -> Vec<String> {
 /// `XDG_RUNTIME_DIR` when set).
 #[cfg(any(all(unix, not(target_os = "macos")), test))]
 fn runtime_candidates(uid: u32, xdg_runtime_dir: Option<&str>) -> Vec<String> {
-    if uid == 0 {
-        return vec![ROOT_SOCKET.to_string()];
-    }
-    let mut candidates = Vec::new();
-    if let Some(dir) = xdg_runtime_dir {
-        if !dir.is_empty() {
-            candidates.push(format!("{dir}/podman/podman.sock"));
-        }
-    }
-    let run_user = format!("/run/user/{uid}/podman/podman.sock");
-    if !candidates.contains(&run_user) {
-        candidates.push(run_user);
-    }
-    candidates
+	if uid == 0 {
+		return vec![ROOT_SOCKET.to_string()];
+	}
+	let mut candidates = Vec::new();
+	if let Some(dir) = xdg_runtime_dir {
+		if !dir.is_empty() {
+			candidates.push(format!("{dir}/podman/podman.sock"));
+		}
+	}
+	let run_user = format!("/run/user/{uid}/podman/podman.sock");
+	if !candidates.contains(&run_user) {
+		candidates.push(run_user);
+	}
+	candidates
 }
 
 /// Socket candidates on macOS: the host-side sockets `podman machine`
 /// creates, newest layout first.
 #[cfg(any(target_os = "macos", test))]
 fn machine_candidates(home: &str) -> Vec<String> {
-    let machine_dir = format!("{home}/.local/share/containers/podman/machine");
-    vec![
-        format!("{machine_dir}/podman.sock"),
-        format!("{machine_dir}/qemu/podman.sock"),
-        format!("{machine_dir}/podman-machine-default/podman.sock"),
-    ]
+	let machine_dir = format!("{home}/.local/share/containers/podman/machine");
+	vec![
+		format!("{machine_dir}/podman.sock"),
+		format!("{machine_dir}/qemu/podman.sock"),
+		format!("{machine_dir}/podman-machine-default/podman.sock"),
+	]
 }
 
 /// Ask `podman machine inspect` for the host-side socket path. Only used
 /// on macOS, where the VM provider decides where the API socket lives.
 #[cfg(target_os = "macos")]
 fn machine_socket_path() -> Option<String> {
-    let output = std::process::Command::new("podman")
-        .args([
-            "machine",
-            "inspect",
-            "--format",
-            "{{ .ConnectionInfo.PodmanSocket.Path }}",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    (!path.is_empty() && Path::new(&path).exists()).then_some(path)
+	let output = std::process::Command::new("podman")
+		.args([
+			"machine",
+			"inspect",
+			"--format",
+			"{{ .ConnectionInfo.PodmanSocket.Path }}",
+		])
+		.output()
+		.ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
+	(!path.is_empty() && Path::new(&path).exists()).then_some(path)
 }
 
 /// Ask `podman machine inspect` for the named pipe of the default machine.
@@ -132,101 +132,101 @@ fn machine_socket_path() -> Option<String> {
 /// probe named pipes, so the value is used as-is.
 #[cfg(windows)]
 fn machine_socket_path() -> Option<String> {
-    let output = std::process::Command::new("podman")
-        .args([
-            "machine",
-            "inspect",
-            "--format",
-            "{{ .ConnectionInfo.PodmanPipe.Path }}",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    (!path.is_empty() && path != "<nil>").then_some(path)
+	let output = std::process::Command::new("podman")
+		.args([
+			"machine",
+			"inspect",
+			"--format",
+			"{{ .ConnectionInfo.PodmanPipe.Path }}",
+		])
+		.output()
+		.ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
+	(!path.is_empty() && path != "<nil>").then_some(path)
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn machine_socket_path() -> Option<String> {
-    None
+	None
 }
 
 #[cfg(any(not(windows), test))]
 fn first_existing(candidates: &[String]) -> Option<String> {
-    candidates.iter().find(|p| Path::new(p).exists()).cloned()
+	candidates.iter().find(|p| Path::new(p).exists()).cloned()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn first_existing_picks_first_match() {
-        let dir = tempfile::tempdir().unwrap();
-        let hit = dir.path().join("podman.sock");
-        std::fs::write(&hit, b"").unwrap();
-        let candidates = vec![
-            dir.path().join("missing.sock").display().to_string(),
-            hit.display().to_string(),
-            dir.path().join("later.sock").display().to_string(),
-        ];
-        assert_eq!(first_existing(&candidates), Some(hit.display().to_string()));
-    }
+	#[test]
+	fn first_existing_picks_first_match() {
+		let dir = tempfile::tempdir().unwrap();
+		let hit = dir.path().join("podman.sock");
+		std::fs::write(&hit, b"").unwrap();
+		let candidates = vec![
+			dir.path().join("missing.sock").display().to_string(),
+			hit.display().to_string(),
+			dir.path().join("later.sock").display().to_string(),
+		];
+		assert_eq!(first_existing(&candidates), Some(hit.display().to_string()));
+	}
 
-    #[test]
-    fn first_existing_none_when_no_candidate_exists() {
-        let candidates = vec!["/nonexistent/podup-test/podman.sock".to_string()];
-        assert_eq!(first_existing(&candidates), None);
-    }
+	#[test]
+	fn first_existing_none_when_no_candidate_exists() {
+		let candidates = vec!["/nonexistent/podup-test/podman.sock".to_string()];
+		assert_eq!(first_existing(&candidates), None);
+	}
 
-    #[test]
-    fn runtime_candidates_root_uses_system_socket() {
-        let candidates = runtime_candidates(0, Some("/run/user/0"));
-        assert_eq!(candidates, vec![ROOT_SOCKET.to_string()]);
-    }
+	#[test]
+	fn runtime_candidates_root_uses_system_socket() {
+		let candidates = runtime_candidates(0, Some("/run/user/0"));
+		assert_eq!(candidates, vec![ROOT_SOCKET.to_string()]);
+	}
 
-    #[test]
-    fn runtime_candidates_prefers_xdg_runtime_dir() {
-        let candidates = runtime_candidates(1000, Some("/custom/runtime"));
-        assert_eq!(
-            candidates,
-            vec![
-                "/custom/runtime/podman/podman.sock".to_string(),
-                "/run/user/1000/podman/podman.sock".to_string(),
-            ]
-        );
-    }
+	#[test]
+	fn runtime_candidates_prefers_xdg_runtime_dir() {
+		let candidates = runtime_candidates(1000, Some("/custom/runtime"));
+		assert_eq!(
+			candidates,
+			vec![
+				"/custom/runtime/podman/podman.sock".to_string(),
+				"/run/user/1000/podman/podman.sock".to_string(),
+			]
+		);
+	}
 
-    #[test]
-    fn runtime_candidates_dedupes_default_runtime_dir() {
-        let candidates = runtime_candidates(1000, Some("/run/user/1000"));
-        assert_eq!(
-            candidates,
-            vec!["/run/user/1000/podman/podman.sock".to_string()]
-        );
-    }
+	#[test]
+	fn runtime_candidates_dedupes_default_runtime_dir() {
+		let candidates = runtime_candidates(1000, Some("/run/user/1000"));
+		assert_eq!(
+			candidates,
+			vec!["/run/user/1000/podman/podman.sock".to_string()]
+		);
+	}
 
-    #[test]
-    fn runtime_candidates_ignores_empty_runtime_dir() {
-        let candidates = runtime_candidates(1000, Some(""));
-        assert_eq!(
-            candidates,
-            vec!["/run/user/1000/podman/podman.sock".to_string()]
-        );
-    }
+	#[test]
+	fn runtime_candidates_ignores_empty_runtime_dir() {
+		let candidates = runtime_candidates(1000, Some(""));
+		assert_eq!(
+			candidates,
+			vec!["/run/user/1000/podman/podman.sock".to_string()]
+		);
+	}
 
-    #[test]
-    fn machine_candidates_cover_known_layouts() {
-        let machine_dir = "/Users/dev/.local/share/containers/podman/machine";
-        assert_eq!(
-            machine_candidates("/Users/dev"),
-            vec![
-                format!("{machine_dir}/podman.sock"),
-                format!("{machine_dir}/qemu/podman.sock"),
-                format!("{machine_dir}/podman-machine-default/podman.sock"),
-            ]
-        );
-    }
+	#[test]
+	fn machine_candidates_cover_known_layouts() {
+		let machine_dir = "/Users/dev/.local/share/containers/podman/machine";
+		assert_eq!(
+			machine_candidates("/Users/dev"),
+			vec![
+				format!("{machine_dir}/podman.sock"),
+				format!("{machine_dir}/qemu/podman.sock"),
+				format!("{machine_dir}/podman-machine-default/podman.sock"),
+			]
+		);
+	}
 }

--- a/internal/ports.rs
+++ b/internal/ports.rs
@@ -12,23 +12,23 @@ use crate::error::{ComposeError, Result};
 /// A parsed, normalized port binding.
 #[derive(Debug, Clone)]
 pub struct ParsedPort {
-    /// Container port number.
-    pub container_port: u16,
-    /// Protocol (`tcp`, `udp`, `sctp`).
-    pub protocol: String,
-    /// Host IP (may be empty to mean all interfaces).
-    pub host_ip: String,
-    /// Host port (`None` means random / ephemeral; `Some(0)` means runtime-assigned).
-    pub host_port: Option<u16>,
+	/// Container port number.
+	pub container_port: u16,
+	/// Protocol (`tcp`, `udp`, `sctp`).
+	pub protocol: String,
+	/// Host IP (may be empty to mean all interfaces).
+	pub host_ip: String,
+	/// Host port (`None` means random / ephemeral; `Some(0)` means runtime-assigned).
+	pub host_port: Option<u16>,
 }
 
 /// Parse all port mappings in a service, expanding ranges.
 pub fn parse_ports(ports: &[PortMapping]) -> Result<Vec<ParsedPort>> {
-    let mut result = Vec::new();
-    for mapping in ports {
-        result.extend(parse_one(mapping)?);
-    }
-    Ok(result)
+	let mut result = Vec::new();
+	for mapping in ports {
+		result.extend(parse_one(mapping)?);
+	}
+	Ok(result)
 }
 
 /// Convert parsed ports into bollard's `PortBindings` and `ExposedPorts` maps.
@@ -37,40 +37,40 @@ pub fn parse_ports(ports: &[PortMapping]) -> Result<Vec<ParsedPort>> {
 /// host_port string per the Docker API convention for "auto-assign".
 #[allow(clippy::type_complexity)]
 pub fn to_bollard(
-    ports: &[ParsedPort],
+	ports: &[ParsedPort],
 ) -> (
-    HashMap<String, Option<Vec<PortBinding>>>,
-    HashMap<String, HashMap<(), ()>>,
+	HashMap<String, Option<Vec<PortBinding>>>,
+	HashMap<String, HashMap<(), ()>>,
 ) {
-    let mut port_bindings: HashMap<String, Option<Vec<PortBinding>>> = HashMap::new();
-    let mut exposed_ports: HashMap<String, HashMap<(), ()>> = HashMap::new();
+	let mut port_bindings: HashMap<String, Option<Vec<PortBinding>>> = HashMap::new();
+	let mut exposed_ports: HashMap<String, HashMap<(), ()>> = HashMap::new();
 
-    for p in ports {
-        let key = format!("{}/{}", p.container_port, p.protocol);
-        let host_ip = if p.host_ip.is_empty() {
-            "0.0.0.0".to_string()
-        } else {
-            p.host_ip.clone()
-        };
-        let host_port = match p.host_port {
-            Some(0) => Some(String::new()),
-            Some(n) => Some(n.to_string()),
-            None => None,
-        };
-        let binding = PortBinding {
-            host_ip: Some(host_ip),
-            host_port,
-        };
-        let bindings = port_bindings
-            .entry(key.clone())
-            .or_insert_with(|| Some(Vec::new()));
-        if let Some(v) = bindings {
-            v.push(binding);
-        }
-        exposed_ports.entry(key).or_default();
-    }
+	for p in ports {
+		let key = format!("{}/{}", p.container_port, p.protocol);
+		let host_ip = if p.host_ip.is_empty() {
+			"0.0.0.0".to_string()
+		} else {
+			p.host_ip.clone()
+		};
+		let host_port = match p.host_port {
+			Some(0) => Some(String::new()),
+			Some(n) => Some(n.to_string()),
+			None => None,
+		};
+		let binding = PortBinding {
+			host_ip: Some(host_ip),
+			host_port,
+		};
+		let bindings = port_bindings
+			.entry(key.clone())
+			.or_insert_with(|| Some(Vec::new()));
+		if let Some(v) = bindings {
+			v.push(binding);
+		}
+		exposed_ports.entry(key).or_default();
+	}
 
-    (port_bindings, exposed_ports)
+	(port_bindings, exposed_ports)
 }
 
 // ---------------------------------------------------------------------------
@@ -78,34 +78,34 @@ pub fn to_bollard(
 // ---------------------------------------------------------------------------
 
 fn parse_one(mapping: &PortMapping) -> Result<Vec<ParsedPort>> {
-    match mapping {
-        PortMapping::Short(s) => parse_short(s),
-        PortMapping::Long {
-            target,
-            published,
-            protocol,
-            host_ip,
-            ..
-        } => {
-            let proto = protocol.clone().unwrap_or_else(|| "tcp".into());
-            let hip = host_ip.clone().unwrap_or_default();
-            let host_port = published
-                .as_ref()
-                .map(|p| match p {
-                    StringOrU16::Number(n) => Ok(*n),
-                    StringOrU16::String(s) => s.parse::<u16>().map_err(|_| {
-                        ComposeError::InvalidPort(format!("invalid published port: {s}"))
-                    }),
-                })
-                .transpose()?;
-            Ok(vec![ParsedPort {
-                container_port: *target,
-                protocol: proto,
-                host_ip: hip,
-                host_port,
-            }])
-        }
-    }
+	match mapping {
+		PortMapping::Short(s) => parse_short(s),
+		PortMapping::Long {
+			target,
+			published,
+			protocol,
+			host_ip,
+			..
+		} => {
+			let proto = protocol.clone().unwrap_or_else(|| "tcp".into());
+			let hip = host_ip.clone().unwrap_or_default();
+			let host_port = published
+				.as_ref()
+				.map(|p| match p {
+					StringOrU16::Number(n) => Ok(*n),
+					StringOrU16::String(s) => s.parse::<u16>().map_err(|_| {
+						ComposeError::InvalidPort(format!("invalid published port: {s}"))
+					}),
+				})
+				.transpose()?;
+			Ok(vec![ParsedPort {
+				container_port: *target,
+				protocol: proto,
+				host_ip: hip,
+				host_port,
+			}])
+		}
+	}
 }
 
 /// Parse a short-form port string.
@@ -119,141 +119,141 @@ fn parse_one(mapping: &PortMapping) -> Result<Vec<ParsedPort>> {
 /// - `ip:host:container/proto`
 /// - `host_start-host_end:container_start-container_end`
 fn parse_short(s: &str) -> Result<Vec<ParsedPort>> {
-    // Split off protocol suffix.
-    let (rest, proto) = if let Some(idx) = s.rfind('/') {
-        (&s[..idx], s[idx + 1..].to_string())
-    } else {
-        (s, "tcp".to_string())
-    };
+	// Split off protocol suffix.
+	let (rest, proto) = if let Some(idx) = s.rfind('/') {
+		(&s[..idx], s[idx + 1..].to_string())
+	} else {
+		(s, "tcp".to_string())
+	};
 
-    // IPv6 form: `[::1]:host:container` or `[::1]:container`.
-    if let Some(rest) = rest.strip_prefix('[') {
-        let close = rest
-            .find(']')
-            .ok_or_else(|| ComposeError::InvalidPort(format!("unclosed `[` in {s}")))?;
-        let ip = &rest[..close];
-        let after = &rest[close + 1..];
-        let after = after.strip_prefix(':').unwrap_or(after);
-        return parse_with_ip(ip, after, &proto, s);
-    }
+	// IPv6 form: `[::1]:host:container` or `[::1]:container`.
+	if let Some(rest) = rest.strip_prefix('[') {
+		let close = rest
+			.find(']')
+			.ok_or_else(|| ComposeError::InvalidPort(format!("unclosed `[` in {s}")))?;
+		let ip = &rest[..close];
+		let after = &rest[close + 1..];
+		let after = after.strip_prefix(':').unwrap_or(after);
+		return parse_with_ip(ip, after, &proto, s);
+	}
 
-    // Count colons to determine format.
-    let colon_count = rest.chars().filter(|&c| c == ':').count();
+	// Count colons to determine format.
+	let colon_count = rest.chars().filter(|&c| c == ':').count();
 
-    match colon_count {
-        0 => {
-            // Just container port (possibly a range).
-            let ports = expand_port_range(rest)?;
-            Ok(ports
-                .into_iter()
-                .map(|cp| ParsedPort {
-                    container_port: cp,
-                    protocol: proto.clone(),
-                    host_ip: String::new(),
-                    host_port: None,
-                })
-                .collect())
-        }
-        1 => {
-            let (left, right) = split_last_colon(rest);
-            let host_ports = expand_port_range(left)?;
-            let container_ports = expand_port_range(right)?;
-            if host_ports.len() != container_ports.len() && host_ports.len() != 1 {
-                return Err(ComposeError::InvalidPort(format!(
-                    "port range mismatch: {s}"
-                )));
-            }
-            Ok(host_ports
-                .into_iter()
-                .zip(container_ports)
-                .map(|(hp, cp)| ParsedPort {
-                    container_port: cp,
-                    protocol: proto.clone(),
-                    host_ip: String::new(),
-                    host_port: Some(hp),
-                })
-                .collect())
-        }
-        _ => {
-            let parts: Vec<&str> = rest.splitn(3, ':').collect();
-            if parts.len() < 3 {
-                return Err(ComposeError::InvalidPort(format!("invalid port spec: {s}")));
-            }
-            parse_with_ip(parts[0], &format!("{}:{}", parts[1], parts[2]), &proto, s)
-        }
-    }
+	match colon_count {
+		0 => {
+			// Just container port (possibly a range).
+			let ports = expand_port_range(rest)?;
+			Ok(ports
+				.into_iter()
+				.map(|cp| ParsedPort {
+					container_port: cp,
+					protocol: proto.clone(),
+					host_ip: String::new(),
+					host_port: None,
+				})
+				.collect())
+		}
+		1 => {
+			let (left, right) = split_last_colon(rest);
+			let host_ports = expand_port_range(left)?;
+			let container_ports = expand_port_range(right)?;
+			if host_ports.len() != container_ports.len() && host_ports.len() != 1 {
+				return Err(ComposeError::InvalidPort(format!(
+					"port range mismatch: {s}"
+				)));
+			}
+			Ok(host_ports
+				.into_iter()
+				.zip(container_ports)
+				.map(|(hp, cp)| ParsedPort {
+					container_port: cp,
+					protocol: proto.clone(),
+					host_ip: String::new(),
+					host_port: Some(hp),
+				})
+				.collect())
+		}
+		_ => {
+			let parts: Vec<&str> = rest.splitn(3, ':').collect();
+			if parts.len() < 3 {
+				return Err(ComposeError::InvalidPort(format!("invalid port spec: {s}")));
+			}
+			parse_with_ip(parts[0], &format!("{}:{}", parts[1], parts[2]), &proto, s)
+		}
+	}
 }
 
 /// Parse the `host[:container]` portion when an explicit IP prefix is present.
 fn parse_with_ip(ip: &str, after: &str, proto: &str, full: &str) -> Result<Vec<ParsedPort>> {
-    if let Some((left, right)) = after.split_once(':') {
-        let host_ports = expand_port_range(left)?;
-        let container_ports = expand_port_range(right)?;
-        if host_ports.len() != container_ports.len() && host_ports.len() != 1 {
-            return Err(ComposeError::InvalidPort(format!(
-                "port range mismatch: {full}"
-            )));
-        }
-        Ok(host_ports
-            .into_iter()
-            .zip(container_ports)
-            .map(|(hp, cp)| ParsedPort {
-                container_port: cp,
-                protocol: proto.to_string(),
-                host_ip: ip.to_string(),
-                host_port: Some(hp),
-            })
-            .collect())
-    } else {
-        let cp: u16 = after
-            .parse()
-            .map_err(|_| ComposeError::InvalidPort(format!("bad port: {full}")))?;
-        Ok(vec![ParsedPort {
-            container_port: cp,
-            protocol: proto.to_string(),
-            host_ip: ip.to_string(),
-            host_port: None,
-        }])
-    }
+	if let Some((left, right)) = after.split_once(':') {
+		let host_ports = expand_port_range(left)?;
+		let container_ports = expand_port_range(right)?;
+		if host_ports.len() != container_ports.len() && host_ports.len() != 1 {
+			return Err(ComposeError::InvalidPort(format!(
+				"port range mismatch: {full}"
+			)));
+		}
+		Ok(host_ports
+			.into_iter()
+			.zip(container_ports)
+			.map(|(hp, cp)| ParsedPort {
+				container_port: cp,
+				protocol: proto.to_string(),
+				host_ip: ip.to_string(),
+				host_port: Some(hp),
+			})
+			.collect())
+	} else {
+		let cp: u16 = after
+			.parse()
+			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {full}")))?;
+		Ok(vec![ParsedPort {
+			container_port: cp,
+			protocol: proto.to_string(),
+			host_ip: ip.to_string(),
+			host_port: None,
+		}])
+	}
 }
 
 /// Split at the LAST colon (to avoid splitting IPv6 addresses incorrectly).
 fn split_last_colon(s: &str) -> (&str, &str) {
-    if let Some(idx) = s.rfind(':') {
-        (&s[..idx], &s[idx + 1..])
-    } else {
-        ("", s)
-    }
+	if let Some(idx) = s.rfind(':') {
+		(&s[..idx], &s[idx + 1..])
+	} else {
+		("", s)
+	}
 }
 
 const MAX_PORT_RANGE: usize = 1024;
 
 /// Expand `start-end` or a single port string.
 fn expand_port_range(s: &str) -> Result<Vec<u16>> {
-    let s = s.trim();
-    if let Some(idx) = s.find('-') {
-        let start: u16 = s[..idx]
-            .parse()
-            .map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
-        let end: u16 = s[idx + 1..]
-            .parse()
-            .map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
-        if start > end {
-            return Err(ComposeError::InvalidPort(format!(
-                "start > end in range: {s}"
-            )));
-        }
-        let count = (end as usize) - (start as usize) + 1;
-        if count > MAX_PORT_RANGE {
-            return Err(ComposeError::InvalidPort(format!(
-                "port range too large ({count} ports, max {MAX_PORT_RANGE}): {s}"
-            )));
-        }
-        Ok((start..=end).collect())
-    } else {
-        let p: u16 = s
-            .parse()
-            .map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
-        Ok(vec![p])
-    }
+	let s = s.trim();
+	if let Some(idx) = s.find('-') {
+		let start: u16 = s[..idx]
+			.parse()
+			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
+		let end: u16 = s[idx + 1..]
+			.parse()
+			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
+		if start > end {
+			return Err(ComposeError::InvalidPort(format!(
+				"start > end in range: {s}"
+			)));
+		}
+		let count = (end as usize) - (start as usize) + 1;
+		if count > MAX_PORT_RANGE {
+			return Err(ComposeError::InvalidPort(format!(
+				"port range too large ({count} ports, max {MAX_PORT_RANGE}): {s}"
+			)));
+		}
+		Ok((start..=end).collect())
+	} else {
+		let p: u16 = s
+			.parse()
+			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
+		Ok(vec![p])
+	}
 }

--- a/internal/size.rs
+++ b/internal/size.rs
@@ -7,48 +7,48 @@
 /// `g`/`gb`, `t`/`tb`.  Returns `None` for unparseable values, and `Some(-1)`
 /// for the special string `"-1"` (commonly used to disable swap limits).
 pub fn parse_memory(s: &str) -> Option<i64> {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    if trimmed == "-1" {
-        return Some(-1);
-    }
+	let trimmed = s.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	if trimmed == "-1" {
+		return Some(-1);
+	}
 
-    // Find where the numeric portion ends.
-    let split_at = trimmed
-        .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
-        .unwrap_or(trimmed.len());
+	// Find where the numeric portion ends.
+	let split_at = trimmed
+		.find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+		.unwrap_or(trimmed.len());
 
-    let (num_part, suffix) = trimmed.split_at(split_at);
-    let num_part = num_part.trim();
-    let suffix = suffix.trim().to_ascii_lowercase();
+	let (num_part, suffix) = trimmed.split_at(split_at);
+	let num_part = num_part.trim();
+	let suffix = suffix.trim().to_ascii_lowercase();
 
-    let num: f64 = num_part.parse().ok()?;
-    if num < 0.0 {
-        return None;
-    }
+	let num: f64 = num_part.parse().ok()?;
+	if num < 0.0 {
+		return None;
+	}
 
-    let multiplier: u64 = match suffix.as_str() {
-        "" | "b" => 1,
-        "k" | "kb" => 1024,
-        "m" | "mb" => 1024 * 1024,
-        "g" | "gb" => 1024 * 1024 * 1024,
-        "t" | "tb" => 1024_u64 * 1024 * 1024 * 1024,
-        _ => return None,
-    };
+	let multiplier: u64 = match suffix.as_str() {
+		"" | "b" => 1,
+		"k" | "kb" => 1024,
+		"m" | "mb" => 1024 * 1024,
+		"g" | "gb" => 1024 * 1024 * 1024,
+		"t" | "tb" => 1024_u64 * 1024 * 1024 * 1024,
+		_ => return None,
+	};
 
-    let bytes = num * multiplier as f64;
-    if bytes > i64::MAX as f64 {
-        return None;
-    }
-    Some(bytes as i64)
+	let bytes = num * multiplier as f64;
+	if bytes > i64::MAX as f64 {
+		return None;
+	}
+	Some(bytes as i64)
 }
 
 /// Parse a CPU count string like `"0.5"`, `"1"`, `"2.5"` into nano-CPUs
 /// (1 CPU = 1_000_000_000 nano-CPUs).
 pub fn parse_cpus(s: &str) -> Option<i64> {
-    s.trim().parse::<f64>().ok().map(|f| (f * 1e9) as i64)
+	s.trim().parse::<f64>().ok().map(|f| (f * 1e9) as i64)
 }
 
 /// Parse a duration like `5s`, `200ms`, `1m`, `1h` into seconds (rounded down).
@@ -56,46 +56,46 @@ pub fn parse_cpus(s: &str) -> Option<i64> {
 /// This is a best-effort parser used when the engine needs an integer
 /// seconds value (e.g. Docker API `start_period`).
 pub fn parse_duration_secs(s: &str) -> Option<u64> {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    let split_at = trimmed
-        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
-        .unwrap_or(trimmed.len());
-    let (num_part, suffix) = trimmed.split_at(split_at);
-    let num: f64 = num_part.parse().ok()?;
-    let secs = match suffix.trim() {
-        "" | "s" => num,
-        "ms" => num / 1000.0,
-        "us" | "µs" => num / 1_000_000.0,
-        "ns" => num / 1_000_000_000.0,
-        "m" => num * 60.0,
-        "h" => num * 3600.0,
-        _ => return None,
-    };
-    Some(secs as u64)
+	let trimmed = s.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	let split_at = trimmed
+		.find(|c: char| !(c.is_ascii_digit() || c == '.'))
+		.unwrap_or(trimmed.len());
+	let (num_part, suffix) = trimmed.split_at(split_at);
+	let num: f64 = num_part.parse().ok()?;
+	let secs = match suffix.trim() {
+		"" | "s" => num,
+		"ms" => num / 1000.0,
+		"us" | "µs" => num / 1_000_000.0,
+		"ns" => num / 1_000_000_000.0,
+		"m" => num * 60.0,
+		"h" => num * 3600.0,
+		_ => return None,
+	};
+	Some(secs as u64)
 }
 
 /// Parse a duration into nanoseconds (used by Docker healthcheck APIs).
 pub fn parse_duration_nanos(s: &str) -> Option<i64> {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    let split_at = trimmed
-        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
-        .unwrap_or(trimmed.len());
-    let (num_part, suffix) = trimmed.split_at(split_at);
-    let num: f64 = num_part.parse().ok()?;
-    let nanos = match suffix.trim() {
-        "" | "s" => num * 1e9,
-        "ms" => num * 1e6,
-        "us" | "µs" => num * 1e3,
-        "ns" => num,
-        "m" => num * 60.0 * 1e9,
-        "h" => num * 3600.0 * 1e9,
-        _ => return None,
-    };
-    Some(nanos as i64)
+	let trimmed = s.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	let split_at = trimmed
+		.find(|c: char| !(c.is_ascii_digit() || c == '.'))
+		.unwrap_or(trimmed.len());
+	let (num_part, suffix) = trimmed.split_at(split_at);
+	let num: f64 = num_part.parse().ok()?;
+	let nanos = match suffix.trim() {
+		"" | "s" => num * 1e9,
+		"ms" => num * 1e6,
+		"us" | "µs" => num * 1e3,
+		"ns" => num,
+		"m" => num * 60.0 * 1e9,
+		"h" => num * 3600.0 * 1e9,
+		_ => return None,
+	};
+	Some(nanos as i64)
 }

--- a/internal/substitute.rs
+++ b/internal/substitute.rs
@@ -17,46 +17,46 @@ use crate::error::{ComposeError, Result};
 /// `vars` should contain both the process environment and the `.env` file
 /// entries (process environment takes precedence).
 pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String> {
-    let mut out = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
+	let mut out = String::with_capacity(input.len());
+	let mut chars = input.chars().peekable();
 
-    while let Some(ch) = chars.next() {
-        if ch != '$' {
-            out.push(ch);
-            continue;
-        }
+	while let Some(ch) = chars.next() {
+		if ch != '$' {
+			out.push(ch);
+			continue;
+		}
 
-        match chars.peek() {
-            None => {
-                // Trailing bare `$` — keep as-is.
-                out.push('$');
-            }
-            Some('$') => {
-                // `$$` → literal `$`
-                chars.next();
-                out.push('$');
-            }
-            Some('{') => {
-                // Consume `{`
-                chars.next();
-                let (var, modifier) = parse_braced_var(&mut chars)?;
-                let value = resolve_modifier(var, modifier, vars)?;
-                out.push_str(&value);
-            }
-            Some(c) if is_var_start(*c) => {
-                // Bare `$VAR`
-                let var = collect_var_name(&mut chars);
-                let value = vars.get(&var).cloned().unwrap_or_default();
-                out.push_str(&value);
-            }
-            Some(_) => {
-                // Not a variable — keep the `$`
-                out.push('$');
-            }
-        }
-    }
+		match chars.peek() {
+			None => {
+				// Trailing bare `$` — keep as-is.
+				out.push('$');
+			}
+			Some('$') => {
+				// `$$` → literal `$`
+				chars.next();
+				out.push('$');
+			}
+			Some('{') => {
+				// Consume `{`
+				chars.next();
+				let (var, modifier) = parse_braced_var(&mut chars)?;
+				let value = resolve_modifier(var, modifier, vars)?;
+				out.push_str(&value);
+			}
+			Some(c) if is_var_start(*c) => {
+				// Bare `$VAR`
+				let var = collect_var_name(&mut chars);
+				let value = vars.get(&var).cloned().unwrap_or_default();
+				out.push_str(&value);
+			}
+			Some(_) => {
+				// Not a variable — keep the `$`
+				out.push('$');
+			}
+		}
+	}
 
-    Ok(out)
+	Ok(out)
 }
 
 /// Load a `.env` file from `dir`.
@@ -68,83 +68,83 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String>
 /// - Process environment variables take precedence: if a key already exists in
 ///   the current process env it will *not* be overridden by the `.env` file.
 pub fn load_dotenv(dir: &Path) -> HashMap<String, String> {
-    let path = dir.join(".env");
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return HashMap::new();
-    };
+	let path = dir.join(".env");
+	let Ok(content) = std::fs::read_to_string(&path) else {
+		return HashMap::new();
+	};
 
-    let mut map = HashMap::new();
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        let (key, value) = if let Some(eq) = trimmed.find('=') {
-            let k = trimmed[..eq].trim().to_string();
-            let v = trimmed[eq + 1..].to_string();
-            (k, v)
-        } else {
-            (trimmed.to_string(), String::new())
-        };
+	let mut map = HashMap::new();
+	for line in content.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() || trimmed.starts_with('#') {
+			continue;
+		}
+		let (key, value) = if let Some(eq) = trimmed.find('=') {
+			let k = trimmed[..eq].trim().to_string();
+			let v = trimmed[eq + 1..].to_string();
+			(k, v)
+		} else {
+			(trimmed.to_string(), String::new())
+		};
 
-        if key.is_empty() {
-            continue;
-        }
+		if key.is_empty() {
+			continue;
+		}
 
-        // Process env takes precedence.
-        if std::env::var(&key).is_ok() {
-            continue;
-        }
+		// Process env takes precedence.
+		if std::env::var(&key).is_ok() {
+			continue;
+		}
 
-        map.insert(key, value);
-    }
+		map.insert(key, value);
+	}
 
-    map
+	map
 }
 
 /// Build the full variable map: process env + dotenv (process env wins).
 pub fn build_vars(dir: &Path) -> HashMap<String, String> {
-    let mut vars: HashMap<String, String> = std::env::vars().collect();
-    // Merge dotenv; only insert keys not already present.
-    for (k, v) in load_dotenv(dir) {
-        vars.entry(k).or_insert(v);
-    }
-    vars
+	let mut vars: HashMap<String, String> = std::env::vars().collect();
+	// Merge dotenv; only insert keys not already present.
+	for (k, v) in load_dotenv(dir) {
+		vars.entry(k).or_insert(v);
+	}
+	vars
 }
 
 /// Build vars additionally loading explicit env files (process env + dotenv + extra files).
 ///
 /// Extra files are loaded after dotenv; process env still wins for all keys.
 pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String, String> {
-    let mut vars = build_vars(dir);
-    for path in extra {
-        let abs = if std::path::Path::new(path).is_absolute() {
-            std::path::PathBuf::from(path)
-        } else {
-            dir.join(path)
-        };
-        let Ok(content) = std::fs::read_to_string(&abs) else {
-            continue;
-        };
-        for line in content.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
-            let (key, value) = if let Some(eq) = trimmed.find('=') {
-                (
-                    trimmed[..eq].trim().to_string(),
-                    trimmed[eq + 1..].to_string(),
-                )
-            } else {
-                (trimmed.to_string(), String::new())
-            };
-            if !key.is_empty() {
-                vars.entry(key).or_insert(value);
-            }
-        }
-    }
-    vars
+	let mut vars = build_vars(dir);
+	for path in extra {
+		let abs = if std::path::Path::new(path).is_absolute() {
+			std::path::PathBuf::from(path)
+		} else {
+			dir.join(path)
+		};
+		let Ok(content) = std::fs::read_to_string(&abs) else {
+			continue;
+		};
+		for line in content.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() || trimmed.starts_with('#') {
+				continue;
+			}
+			let (key, value) = if let Some(eq) = trimmed.find('=') {
+				(
+					trimmed[..eq].trim().to_string(),
+					trimmed[eq + 1..].to_string(),
+				)
+			} else {
+				(trimmed.to_string(), String::new())
+			};
+			if !key.is_empty() {
+				vars.entry(key).or_insert(value);
+			}
+		}
+	}
+	vars
 }
 
 // ---------------------------------------------------------------------------
@@ -152,168 +152,168 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 // ---------------------------------------------------------------------------
 
 fn is_var_start(c: char) -> bool {
-    c.is_alphabetic() || c == '_'
+	c.is_alphabetic() || c == '_'
 }
 
 fn is_var_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_'
+	c.is_alphanumeric() || c == '_'
 }
 
 /// Collect a bare variable name (alphanumeric + `_`).
 fn collect_var_name(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
-    let mut name = String::new();
-    while let Some(&c) = chars.peek() {
-        if is_var_char(c) {
-            name.push(c);
-            chars.next();
-        } else {
-            break;
-        }
-    }
-    name
+	let mut name = String::new();
+	while let Some(&c) = chars.peek() {
+		if is_var_char(c) {
+			name.push(c);
+			chars.next();
+		} else {
+			break;
+		}
+	}
+	name
 }
 
 #[derive(Debug)]
 enum Modifier {
-    None,
-    /// `${VAR:-default}` — use default if unset or empty
-    DefaultIfUnsetOrEmpty(String),
-    /// `${VAR-default}` — use default if unset (empty value is OK)
-    DefaultIfUnset(String),
-    /// `${VAR:+value}` — use value if set and non-empty
-    AltIfSetAndNonEmpty(String),
-    /// `${VAR+value}` — use value if set (even if empty)
-    AltIfSet(String),
-    /// `${VAR:?error}` — error if unset or empty
-    ErrorIfUnsetOrEmpty(String),
-    /// `${VAR?error}` — error if unset
-    ErrorIfUnset(String),
+	None,
+	/// `${VAR:-default}` — use default if unset or empty
+	DefaultIfUnsetOrEmpty(String),
+	/// `${VAR-default}` — use default if unset (empty value is OK)
+	DefaultIfUnset(String),
+	/// `${VAR:+value}` — use value if set and non-empty
+	AltIfSetAndNonEmpty(String),
+	/// `${VAR+value}` — use value if set (even if empty)
+	AltIfSet(String),
+	/// `${VAR:?error}` — error if unset or empty
+	ErrorIfUnsetOrEmpty(String),
+	/// `${VAR?error}` — error if unset
+	ErrorIfUnset(String),
 }
 
 /// Parse the content inside `${…}`.  The opening `{` has already been consumed.
 ///
 /// Returns `(variable_name, Modifier)`.
 fn parse_braced_var(
-    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+	chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
 ) -> Result<(String, Modifier)> {
-    let mut name = String::new();
+	let mut name = String::new();
 
-    // Read until we hit `}`, `:`, `+`, `-`, `?`, or end-of-input.
-    loop {
-        match chars.peek() {
-            None => {
-                // Unclosed brace — treat as literal.
-                return Ok((name, Modifier::None));
-            }
-            Some('}') => {
-                chars.next();
-                return Ok((name, Modifier::None));
-            }
-            Some(':') => {
-                chars.next();
-                // Peek at what follows `:`.
-                let modifier = match chars.peek() {
-                    Some('-') => {
-                        chars.next();
-                        Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
-                    }
-                    Some('+') => {
-                        chars.next();
-                        Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
-                    }
-                    Some('?') => {
-                        chars.next();
-                        Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
-                    }
-                    _ => {
-                        // `${VAR:` with unknown char — collect default anyway.
-                        Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
-                    }
-                };
-                return Ok((name, modifier));
-            }
-            Some('-') => {
-                chars.next();
-                return Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))));
-            }
-            Some('+') => {
-                chars.next();
-                return Ok((name, Modifier::AltIfSet(collect_until_close(chars))));
-            }
-            Some('?') => {
-                chars.next();
-                return Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))));
-            }
-            Some(&c) => {
-                name.push(c);
-                chars.next();
-            }
-        }
-    }
+	// Read until we hit `}`, `:`, `+`, `-`, `?`, or end-of-input.
+	loop {
+		match chars.peek() {
+			None => {
+				// Unclosed brace — treat as literal.
+				return Ok((name, Modifier::None));
+			}
+			Some('}') => {
+				chars.next();
+				return Ok((name, Modifier::None));
+			}
+			Some(':') => {
+				chars.next();
+				// Peek at what follows `:`.
+				let modifier = match chars.peek() {
+					Some('-') => {
+						chars.next();
+						Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
+					}
+					Some('+') => {
+						chars.next();
+						Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
+					}
+					Some('?') => {
+						chars.next();
+						Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
+					}
+					_ => {
+						// `${VAR:` with unknown char — collect default anyway.
+						Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
+					}
+				};
+				return Ok((name, modifier));
+			}
+			Some('-') => {
+				chars.next();
+				return Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))));
+			}
+			Some('+') => {
+				chars.next();
+				return Ok((name, Modifier::AltIfSet(collect_until_close(chars))));
+			}
+			Some('?') => {
+				chars.next();
+				return Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))));
+			}
+			Some(&c) => {
+				name.push(c);
+				chars.next();
+			}
+		}
+	}
 }
 
 /// Collect everything until `}` (exclusive), consuming the `}`.
 fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
-    let mut buf = String::new();
-    for c in chars.by_ref() {
-        if c == '}' {
-            break;
-        }
-        buf.push(c);
-    }
-    buf
+	let mut buf = String::new();
+	for c in chars.by_ref() {
+		if c == '}' {
+			break;
+		}
+		buf.push(c);
+	}
+	buf
 }
 
 fn resolve_modifier(
-    var: String,
-    modifier: Modifier,
-    vars: &HashMap<String, String>,
+	var: String,
+	modifier: Modifier,
+	vars: &HashMap<String, String>,
 ) -> Result<String> {
-    let value = vars.get(&var);
+	let value = vars.get(&var);
 
-    match modifier {
-        Modifier::None => Ok(value.cloned().unwrap_or_default()),
+	match modifier {
+		Modifier::None => Ok(value.cloned().unwrap_or_default()),
 
-        Modifier::DefaultIfUnsetOrEmpty(default) => {
-            // Use default when unset OR empty.
-            match value {
-                Some(v) if !v.is_empty() => Ok(v.clone()),
-                _ => Ok(default),
-            }
-        }
+		Modifier::DefaultIfUnsetOrEmpty(default) => {
+			// Use default when unset OR empty.
+			match value {
+				Some(v) if !v.is_empty() => Ok(v.clone()),
+				_ => Ok(default),
+			}
+		}
 
-        Modifier::DefaultIfUnset(default) => {
-            // Use default only when unset.
-            match value {
-                Some(v) => Ok(v.clone()),
-                None => Ok(default),
-            }
-        }
+		Modifier::DefaultIfUnset(default) => {
+			// Use default only when unset.
+			match value {
+				Some(v) => Ok(v.clone()),
+				None => Ok(default),
+			}
+		}
 
-        Modifier::AltIfSetAndNonEmpty(alt) => {
-            // Use alt when set and non-empty; else empty.
-            match value {
-                Some(v) if !v.is_empty() => Ok(alt),
-                _ => Ok(String::new()),
-            }
-        }
+		Modifier::AltIfSetAndNonEmpty(alt) => {
+			// Use alt when set and non-empty; else empty.
+			match value {
+				Some(v) if !v.is_empty() => Ok(alt),
+				_ => Ok(String::new()),
+			}
+		}
 
-        Modifier::AltIfSet(alt) => {
-            // Use alt when set (even if empty); else empty.
-            match value {
-                Some(_) => Ok(alt),
-                None => Ok(String::new()),
-            }
-        }
+		Modifier::AltIfSet(alt) => {
+			// Use alt when set (even if empty); else empty.
+			match value {
+				Some(_) => Ok(alt),
+				None => Ok(String::new()),
+			}
+		}
 
-        Modifier::ErrorIfUnsetOrEmpty(msg) => match value {
-            Some(v) if !v.is_empty() => Ok(v.clone()),
-            _ => Err(ComposeError::RequiredVarNotSet { var, msg }),
-        },
+		Modifier::ErrorIfUnsetOrEmpty(msg) => match value {
+			Some(v) if !v.is_empty() => Ok(v.clone()),
+			_ => Err(ComposeError::RequiredVarNotSet { var, msg }),
+		},
 
-        Modifier::ErrorIfUnset(msg) => match value {
-            Some(v) => Ok(v.clone()),
-            None => Err(ComposeError::RequiredVarNotSet { var, msg }),
-        },
-    }
+		Modifier::ErrorIfUnset(msg) => match value {
+			Some(v) => Ok(v.clone()),
+			None => Err(ComposeError::RequiredVarNotSet { var, msg }),
+		},
+	}
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+hard_tabs = true
+tab_spaces = 4
+edition = "2021"

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -4,74 +4,74 @@ use std::io::Write;
 
 #[test]
 fn basic_key_value() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut f = std::fs::File::create(dir.path().join("app.env")).unwrap();
-    writeln!(f, "# comment").unwrap();
-    writeln!(f).unwrap();
-    writeln!(f, "DB_HOST=localhost").unwrap();
-    writeln!(f, "PORT=5432").unwrap();
-    writeln!(f, "NOVALUE").unwrap();
+	let dir = tempfile::tempdir().unwrap();
+	let mut f = std::fs::File::create(dir.path().join("app.env")).unwrap();
+	writeln!(f, "# comment").unwrap();
+	writeln!(f).unwrap();
+	writeln!(f, "DB_HOST=localhost").unwrap();
+	writeln!(f, "PORT=5432").unwrap();
+	writeln!(f, "NOVALUE").unwrap();
 
-    let map = load_env_files(&["app.env".to_string()], dir.path()).unwrap();
-    assert_eq!(map["DB_HOST"], "localhost");
-    assert_eq!(map["PORT"], "5432");
-    assert_eq!(map["NOVALUE"], "");
+	let map = load_env_files(&["app.env".to_string()], dir.path()).unwrap();
+	assert_eq!(map["DB_HOST"], "localhost");
+	assert_eq!(map["PORT"], "5432");
+	assert_eq!(map["NOVALUE"], "");
 }
 
 #[test]
 fn string_or_list_single() {
-    use podup::compose::types::StringOrList;
-    assert_eq!(
-        StringOrList::Single("file.env".to_string()).to_list(),
-        vec!["file.env"]
-    );
+	use podup::compose::types::StringOrList;
+	assert_eq!(
+		StringOrList::Single("file.env".to_string()).to_list(),
+		vec!["file.env"]
+	);
 }
 
 #[test]
 fn string_or_list_many() {
-    use podup::compose::types::StringOrList;
-    let sol = StringOrList::List(vec!["a.env".to_string(), "b.env".to_string()]);
-    assert_eq!(sol.to_list().len(), 2);
+	use podup::compose::types::StringOrList;
+	let sol = StringOrList::List(vec!["a.env".to_string(), "b.env".to_string()]);
+	assert_eq!(sol.to_list().len(), 2);
 }
 
 #[test]
 fn first_file_wins_for_duplicate_keys() {
-    let dir = tempfile::tempdir().unwrap();
+	let dir = tempfile::tempdir().unwrap();
 
-    let mut a = std::fs::File::create(dir.path().join("a.env")).unwrap();
-    writeln!(a, "KEY=from_a").unwrap();
+	let mut a = std::fs::File::create(dir.path().join("a.env")).unwrap();
+	writeln!(a, "KEY=from_a").unwrap();
 
-    let mut b = std::fs::File::create(dir.path().join("b.env")).unwrap();
-    writeln!(b, "KEY=from_b").unwrap();
+	let mut b = std::fs::File::create(dir.path().join("b.env")).unwrap();
+	writeln!(b, "KEY=from_b").unwrap();
 
-    let map = load_env_files(&["a.env".to_string(), "b.env".to_string()], dir.path()).unwrap();
-    assert_eq!(map["KEY"], "from_a");
+	let map = load_env_files(&["a.env".to_string(), "b.env".to_string()], dir.path()).unwrap();
+	assert_eq!(map["KEY"], "from_a");
 }
 
 #[test]
 fn quoted_values_preserved_as_is() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut f = std::fs::File::create(dir.path().join("q.env")).unwrap();
-    writeln!(f, r#"KEY="value with spaces""#).unwrap();
+	let dir = tempfile::tempdir().unwrap();
+	let mut f = std::fs::File::create(dir.path().join("q.env")).unwrap();
+	writeln!(f, r#"KEY="value with spaces""#).unwrap();
 
-    let map = load_env_files(&["q.env".to_string()], dir.path()).unwrap();
-    // Per compose-spec, quotes are preserved literally.
-    assert_eq!(map["KEY"], "\"value with spaces\"");
+	let map = load_env_files(&["q.env".to_string()], dir.path()).unwrap();
+	// Per compose-spec, quotes are preserved literally.
+	assert_eq!(map["KEY"], "\"value with spaces\"");
 }
 
 #[test]
 fn value_with_equals_sign() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut f = std::fs::File::create(dir.path().join("eq.env")).unwrap();
-    writeln!(f, "KEY=val=ue=more").unwrap();
+	let dir = tempfile::tempdir().unwrap();
+	let mut f = std::fs::File::create(dir.path().join("eq.env")).unwrap();
+	writeln!(f, "KEY=val=ue=more").unwrap();
 
-    let map = load_env_files(&["eq.env".to_string()], dir.path()).unwrap();
-    assert_eq!(map["KEY"], "val=ue=more");
+	let map = load_env_files(&["eq.env".to_string()], dir.path()).unwrap();
+	assert_eq!(map["KEY"], "val=ue=more");
 }
 
 #[test]
 fn missing_env_file_errors() {
-    let dir = tempfile::tempdir().unwrap();
-    let result = load_env_files(&["does_not_exist.env".to_string()], dir.path());
-    assert!(matches!(result, Err(ComposeError::FileNotFound(_))));
+	let dir = tempfile::tempdir().unwrap();
+	let result = load_env_files(&["does_not_exist.env".to_string()], dir.path());
+	assert!(matches!(result, Err(ComposeError::FileNotFound(_))));
 }

--- a/tests/env_file/merge.rs
+++ b/tests/env_file/merge.rs
@@ -3,32 +3,32 @@ use std::collections::HashMap;
 
 #[test]
 fn service_env_wins_over_env_file() {
-    let mut service_env = HashMap::new();
-    service_env.insert("KEY".to_string(), Some("from-service".to_string()));
+	let mut service_env = HashMap::new();
+	service_env.insert("KEY".to_string(), Some("from-service".to_string()));
 
-    let mut env_file_vars = HashMap::new();
-    env_file_vars.insert("KEY".to_string(), "from-file".to_string());
-    env_file_vars.insert("EXTRA".to_string(), "extra".to_string());
+	let mut env_file_vars = HashMap::new();
+	env_file_vars.insert("KEY".to_string(), "from-file".to_string());
+	env_file_vars.insert("EXTRA".to_string(), "extra".to_string());
 
-    let merged = merge_env(service_env, env_file_vars);
-    let map: HashMap<_, _> = merged
-        .iter()
-        .filter_map(|s| {
-            let mut it = s.splitn(2, '=');
-            Some((it.next()?.to_string(), it.next()?.to_string()))
-        })
-        .collect();
+	let merged = merge_env(service_env, env_file_vars);
+	let map: HashMap<_, _> = merged
+		.iter()
+		.filter_map(|s| {
+			let mut it = s.splitn(2, '=');
+			Some((it.next()?.to_string(), it.next()?.to_string()))
+		})
+		.collect();
 
-    assert_eq!(map["KEY"], "from-service");
-    assert_eq!(map["EXTRA"], "extra");
+	assert_eq!(map["KEY"], "from-service");
+	assert_eq!(map["EXTRA"], "extra");
 }
 
 #[test]
 fn env_file_only_key_included() {
-    let service_env = HashMap::new();
-    let mut env_file_vars = HashMap::new();
-    env_file_vars.insert("FROM_FILE".to_string(), "yes".to_string());
+	let service_env = HashMap::new();
+	let mut env_file_vars = HashMap::new();
+	env_file_vars.insert("FROM_FILE".to_string(), "yes".to_string());
 
-    let merged = merge_env(service_env, env_file_vars);
-    assert!(merged.iter().any(|s| s.starts_with("FROM_FILE=")));
+	let merged = merge_env(service_env, env_file_vars);
+	assert!(merged.iter().any(|s| s.starts_with("FROM_FILE=")));
 }

--- a/tests/parse/anchors.rs
+++ b/tests/parse/anchors.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 
 #[test]
 fn yaml_anchor_and_alias() {
-    let yaml = r#"
+	let yaml = r#"
 x-common: &common
   image: alpine
   restart: always
@@ -18,26 +18,26 @@ services:
     <<: *common
     image: node:20
 "#;
-    let file = parse_str(yaml).unwrap();
+	let file = parse_str(yaml).unwrap();
 
-    // web inherits image and environment from anchor.
-    assert_eq!(file.services["web"].image.as_deref(), Some("alpine"));
-    assert!(file.services["web"]
-        .environment
-        .to_map()
-        .contains_key("LOG_LEVEL"));
+	// web inherits image and environment from anchor.
+	assert_eq!(file.services["web"].image.as_deref(), Some("alpine"));
+	assert!(file.services["web"]
+		.environment
+		.to_map()
+		.contains_key("LOG_LEVEL"));
 
-    // api overrides image, keeps environment.
-    assert_eq!(file.services["api"].image.as_deref(), Some("node:20"));
-    assert!(file.services["api"]
-        .environment
-        .to_map()
-        .contains_key("LOG_LEVEL"));
+	// api overrides image, keeps environment.
+	assert_eq!(file.services["api"].image.as_deref(), Some("node:20"));
+	assert!(file.services["api"]
+		.environment
+		.to_map()
+		.contains_key("LOG_LEVEL"));
 }
 
 #[test]
 fn yaml_anchor_passthrough_for_environment() {
-    let yaml = r#"
+	let yaml = r#"
 x-env: &env
   NODE_ENV: production
   PORT: "3000"
@@ -47,21 +47,21 @@ services:
     image: node
     environment: *env
 "#;
-    let file = parse_str(yaml).unwrap();
-    let env = file.services["app"].environment.to_map();
-    assert_eq!(
-        env.get("NODE_ENV").and_then(|v| v.clone()).as_deref(),
-        Some("production")
-    );
-    assert_eq!(
-        env.get("PORT").and_then(|v| v.clone()).as_deref(),
-        Some("3000")
-    );
+	let file = parse_str(yaml).unwrap();
+	let env = file.services["app"].environment.to_map();
+	assert_eq!(
+		env.get("NODE_ENV").and_then(|v| v.clone()).as_deref(),
+		Some("production")
+	);
+	assert_eq!(
+		env.get("PORT").and_then(|v| v.clone()).as_deref(),
+		Some("3000")
+	);
 }
 
 #[test]
 fn yaml_merge_key_sequence_of_anchors() {
-    let yaml = r#"
+	let yaml = r#"
 x-a: &a
   restart: always
 x-b: &b
@@ -73,64 +73,64 @@ services:
     image: alpine
     <<: [*a, *b]
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(
-        file.services["app"]
-            .restart
-            .as_ref()
-            .map(|r| format!("{r:?}")),
-        Some("Always".to_string())
-    );
-    assert!(file.services["app"]
-        .environment
-        .to_map()
-        .contains_key("FROM_B"));
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.services["app"]
+			.restart
+			.as_ref()
+			.map(|r| format!("{r:?}")),
+		Some("Always".to_string())
+	);
+	assert!(file.services["app"]
+		.environment
+		.to_map()
+		.contains_key("FROM_B"));
 }
 
 #[test]
 fn include_absolute_path_rejected() {
-    let dir = tempfile::tempdir().unwrap();
-    let main = dir.path().join("docker-compose.yml");
-    writeln!(
-        std::fs::File::create(&main).unwrap(),
-        "include:\n  - /etc/passwd\nservices:\n  app:\n    image: alpine"
-    )
-    .unwrap();
-    assert!(parse_file(&main).is_err());
+	let dir = tempfile::tempdir().unwrap();
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		"include:\n  - /etc/passwd\nservices:\n  app:\n    image: alpine"
+	)
+	.unwrap();
+	assert!(parse_file(&main).is_err());
 }
 
 #[test]
 fn include_parent_traversal_rejected() {
-    let dir = tempfile::tempdir().unwrap();
-    let main = dir.path().join("docker-compose.yml");
-    writeln!(
-        std::fs::File::create(&main).unwrap(),
-        "include:\n  - ../../secret.yml\nservices:\n  app:\n    image: alpine"
-    )
-    .unwrap();
-    assert!(parse_file(&main).is_err());
+	let dir = tempfile::tempdir().unwrap();
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		"include:\n  - ../../secret.yml\nservices:\n  app:\n    image: alpine"
+	)
+	.unwrap();
+	assert!(parse_file(&main).is_err());
 }
 
 #[test]
 fn extends_file_absolute_path_rejected() {
-    let dir = tempfile::tempdir().unwrap();
-    let main = dir.path().join("docker-compose.yml");
-    writeln!(
-        std::fs::File::create(&main).unwrap(),
-        "services:\n  app:\n    extends:\n      service: base\n      file: /etc/shadow"
-    )
-    .unwrap();
-    assert!(parse_file(&main).is_err());
+	let dir = tempfile::tempdir().unwrap();
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		"services:\n  app:\n    extends:\n      service: base\n      file: /etc/shadow"
+	)
+	.unwrap();
+	assert!(parse_file(&main).is_err());
 }
 
 #[test]
 fn extends_file_parent_traversal_rejected() {
-    let dir = tempfile::tempdir().unwrap();
-    let main = dir.path().join("docker-compose.yml");
-    writeln!(
-        std::fs::File::create(&main).unwrap(),
-        "services:\n  app:\n    extends:\n      service: base\n      file: ../../other.yml"
-    )
-    .unwrap();
-    assert!(parse_file(&main).is_err());
+	let dir = tempfile::tempdir().unwrap();
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		"services:\n  app:\n    extends:\n      service: base\n      file: ../../other.yml"
+	)
+	.unwrap();
+	assert!(parse_file(&main).is_err());
 }

--- a/tests/parse/basic.rs
+++ b/tests/parse/basic.rs
@@ -3,24 +3,24 @@ use podup::parse_str;
 
 #[test]
 fn minimal() {
-    let file = parse_str("services:\n  web:\n    image: nginx:alpine").unwrap();
-    assert!(file.services.contains_key("web"));
-    assert_eq!(file.services["web"].image.as_deref(), Some("nginx:alpine"));
+	let file = parse_str("services:\n  web:\n    image: nginx:alpine").unwrap();
+	assert!(file.services.contains_key("web"));
+	assert_eq!(file.services["web"].image.as_deref(), Some("nginx:alpine"));
 }
 
 #[test]
 fn empty_services() {
-    assert!(parse_str("services: {}").unwrap().services.is_empty());
+	assert!(parse_str("services: {}").unwrap().services.is_empty());
 }
 
 #[test]
 fn invalid_yaml() {
-    assert!(parse_str("services: [invalid: yaml: here").is_err());
+	assert!(parse_str("services: [invalid: yaml: here").is_err());
 }
 
 #[test]
 fn env_as_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: node:20
@@ -29,17 +29,17 @@ services:
       - PORT=3000
       - SECRET
 "#;
-    let env = parse_str(yaml).unwrap().services["app"]
-        .environment
-        .to_map();
-    assert_eq!(env["NODE_ENV"].as_deref(), Some("production"));
-    assert_eq!(env["PORT"].as_deref(), Some("3000"));
-    assert!(env.contains_key("SECRET"));
+	let env = parse_str(yaml).unwrap().services["app"]
+		.environment
+		.to_map();
+	assert_eq!(env["NODE_ENV"].as_deref(), Some("production"));
+	assert_eq!(env["PORT"].as_deref(), Some("3000"));
+	assert!(env.contains_key("SECRET"));
 }
 
 #[test]
 fn env_as_map() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: node:20
@@ -47,94 +47,94 @@ services:
       NODE_ENV: production
       PORT: 3000
 "#;
-    let env = parse_str(yaml).unwrap().services["app"]
-        .environment
-        .to_map();
-    assert_eq!(env["NODE_ENV"].as_deref(), Some("production"));
-    assert_eq!(env["PORT"].as_deref(), Some("3000"));
+	let env = parse_str(yaml).unwrap().services["app"]
+		.environment
+		.to_map();
+	assert_eq!(env["NODE_ENV"].as_deref(), Some("production"));
+	assert_eq!(env["PORT"].as_deref(), Some("3000"));
 }
 
 #[test]
 fn command_shell() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: node:20
     command: "node server.js --port 3000"
 "#;
-    let exec = parse_str(yaml).unwrap().services["app"]
-        .command
-        .as_ref()
-        .unwrap()
-        .to_exec();
-    assert_eq!(exec[0], "sh");
-    assert_eq!(exec[1], "-c");
+	let exec = parse_str(yaml).unwrap().services["app"]
+		.command
+		.as_ref()
+		.unwrap()
+		.to_exec();
+	assert_eq!(exec[0], "sh");
+	assert_eq!(exec[1], "-c");
 }
 
 #[test]
 fn command_exec() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: node:20
     command: ["node", "server.js"]
 "#;
-    let exec = parse_str(yaml).unwrap().services["app"]
-        .command
-        .as_ref()
-        .unwrap()
-        .to_exec();
-    assert_eq!(exec, vec!["node", "server.js"]);
+	let exec = parse_str(yaml).unwrap().services["app"]
+		.command
+		.as_ref()
+		.unwrap()
+		.to_exec();
+	assert_eq!(exec, vec!["node", "server.js"]);
 }
 
 #[test]
 fn entrypoint_shell() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     entrypoint: "/usr/local/bin/init.sh --foo"
 "#;
-    let ep = parse_str(yaml).unwrap().services["app"]
-        .entrypoint
-        .as_ref()
-        .unwrap()
-        .to_exec();
-    assert_eq!(ep[0], "sh");
-    assert_eq!(ep[1], "-c");
-    assert!(ep[2].contains("init.sh"));
+	let ep = parse_str(yaml).unwrap().services["app"]
+		.entrypoint
+		.as_ref()
+		.unwrap()
+		.to_exec();
+	assert_eq!(ep[0], "sh");
+	assert_eq!(ep[1], "-c");
+	assert!(ep[2].contains("init.sh"));
 }
 
 #[test]
 fn entrypoint_exec() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     entrypoint: ["/bin/init", "--foo"]
 "#;
-    let ep = parse_str(yaml).unwrap().services["app"]
-        .entrypoint
-        .as_ref()
-        .unwrap()
-        .to_exec();
-    assert_eq!(ep, vec!["/bin/init", "--foo"]);
+	let ep = parse_str(yaml).unwrap().services["app"]
+		.entrypoint
+		.as_ref()
+		.unwrap()
+		.to_exec();
+	assert_eq!(ep, vec!["/bin/init", "--foo"]);
 }
 
 #[test]
 fn ports_short() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   web:
     image: nginx
     ports: ["80:80", "443:443"]
 "#;
-    assert_eq!(parse_str(yaml).unwrap().services["web"].ports.len(), 2);
+	assert_eq!(parse_str(yaml).unwrap().services["web"].ports.len(), 2);
 }
 
 #[test]
 fn volumes_short() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   db:
     image: postgres:17
@@ -144,14 +144,14 @@ services:
 volumes:
   pgdata:
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["db"].volumes.len(), 2);
-    assert!(file.volumes.contains_key("pgdata"));
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["db"].volumes.len(), 2);
+	assert!(file.volumes.contains_key("pgdata"));
 }
 
 #[test]
 fn networks_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   web:
     image: nginx
@@ -160,14 +160,14 @@ networks:
   frontend:
     driver: bridge
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert!(file.networks.contains_key("frontend"));
-    assert_eq!(file.services["web"].networks.names(), vec!["frontend"]);
+	let file = parse_str(yaml).unwrap();
+	assert!(file.networks.contains_key("frontend"));
+	assert_eq!(file.services["web"].networks.names(), vec!["frontend"]);
 }
 
 #[test]
 fn healthcheck() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   db:
     image: postgres:17
@@ -177,17 +177,17 @@ services:
       timeout: 3s
       retries: 10
 "#;
-    let hc = parse_str(yaml).unwrap().services["db"]
-        .healthcheck
-        .as_ref()
-        .unwrap()
-        .retries;
-    assert_eq!(hc, Some(10));
+	let hc = parse_str(yaml).unwrap().services["db"]
+		.healthcheck
+		.as_ref()
+		.unwrap()
+		.retries;
+	assert_eq!(hc, Some(10));
 }
 
 #[test]
 fn depends_on_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: node:20
@@ -197,16 +197,16 @@ services:
   redis:
     image: redis:8
 "#;
-    let deps = parse_str(yaml).unwrap().services["app"]
-        .depends_on
-        .service_names();
-    assert!(deps.contains(&"db".to_string()));
-    assert!(deps.contains(&"redis".to_string()));
+	let deps = parse_str(yaml).unwrap().services["app"]
+		.depends_on
+		.service_names();
+	assert!(deps.contains(&"db".to_string()));
+	assert!(deps.contains(&"redis".to_string()));
 }
 
 #[test]
 fn depends_on_map_with_condition() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: node:20
@@ -216,74 +216,74 @@ services:
   db:
     image: postgres:17
 "#;
-    let file = parse_str(yaml).unwrap();
-    let condition = file.services["app"].depends_on.condition_for("db");
-    assert!(matches!(condition, ServiceCondition::ServiceHealthy));
+	let file = parse_str(yaml).unwrap();
+	let condition = file.services["app"].depends_on.condition_for("db");
+	assert!(matches!(condition, ServiceCondition::ServiceHealthy));
 }
 
 #[test]
 fn secrets_top_level() {
-    let yaml = r#"
+	let yaml = r#"
 secrets:
   db_password:
     file: ./secrets/db_password.txt
   jwt_secret:
     external: true
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(
-        file.secrets["db_password"].file.as_deref(),
-        Some("./secrets/db_password.txt")
-    );
-    assert_eq!(file.secrets["jwt_secret"].external, Some(true));
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.secrets["db_password"].file.as_deref(),
+		Some("./secrets/db_password.txt")
+	);
+	assert_eq!(file.secrets["jwt_secret"].external, Some(true));
 }
 
 #[test]
 fn hostname_and_domainname() {
-    let yaml =
-        "services:\n  app:\n    image: alpine\n    hostname: web1\n    domainname: example.com\n";
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].hostname.as_deref(), Some("web1"));
-    assert_eq!(
-        file.services["app"].domainname.as_deref(),
-        Some("example.com")
-    );
+	let yaml =
+		"services:\n  app:\n    image: alpine\n    hostname: web1\n    domainname: example.com\n";
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].hostname.as_deref(), Some("web1"));
+	assert_eq!(
+		file.services["app"].domainname.as_deref(),
+		Some("example.com")
+	);
 }
 
 #[test]
 fn mac_address() {
-    let yaml = "services:\n  app:\n    image: alpine\n    mac_address: 02:42:ac:11:00:01\n";
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(
-        file.services["app"].mac_address.as_deref(),
-        Some("02:42:ac:11:00:01")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    mac_address: 02:42:ac:11:00:01\n";
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.services["app"].mac_address.as_deref(),
+		Some("02:42:ac:11:00:01")
+	);
 }
 
 #[test]
 fn read_only_root() {
-    let yaml = "services:\n  app:\n    image: alpine\n    read_only: true\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].read_only,
-        Some(true)
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    read_only: true\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].read_only,
+		Some(true)
+	);
 }
 
 #[test]
 fn expose_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     expose: ["80", "443"]
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].expose, vec!["80", "443"]);
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].expose, vec!["80", "443"]);
 }
 
 #[test]
 fn volumes_from_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -291,22 +291,22 @@ services:
       - service:ro
       - container:mycontainer
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].volumes_from.len(), 2);
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].volumes_from.len(), 2);
 }
 
 #[test]
 fn tmpfs_as_string() {
-    let yaml = "services:\n  app:\n    image: alpine\n    tmpfs: /run\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].tmpfs.to_list(),
-        vec!["/run"]
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    tmpfs: /run\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].tmpfs.to_list(),
+		vec!["/run"]
+	);
 }
 
 #[test]
 fn tmpfs_as_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -314,18 +314,18 @@ services:
       - /run
       - /tmp
 "#;
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .tmpfs
-            .to_list()
-            .len(),
-        2
-    );
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.tmpfs
+			.to_list()
+			.len(),
+		2
+	);
 }
 
 #[test]
 fn security_opt_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -333,14 +333,14 @@ services:
       - "no-new-privileges:true"
       - "label=disable"
 "#;
-    let so = &parse_str(yaml).unwrap().services["app"].security_opt;
-    assert_eq!(so.len(), 2);
-    assert!(so.iter().any(|s| s.contains("no-new-privileges")));
+	let so = &parse_str(yaml).unwrap().services["app"].security_opt;
+	assert_eq!(so.len(), 2);
+	assert!(so.iter().any(|s| s.contains("no-new-privileges")));
 }
 
 #[test]
 fn devices_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -348,57 +348,57 @@ services:
       - "/dev/sda:/dev/xvda:rwm"
       - "/dev/null:/dev/null"
 "#;
-    assert_eq!(parse_str(yaml).unwrap().services["app"].devices.len(), 2);
+	assert_eq!(parse_str(yaml).unwrap().services["app"].devices.len(), 2);
 }
 
 #[test]
 fn group_add_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     group_add: [audio, video, "1000"]
 "#;
-    let g = &parse_str(yaml).unwrap().services["app"].group_add;
-    assert_eq!(g.len(), 3);
-    assert!(g.contains(&"audio".to_string()));
+	let g = &parse_str(yaml).unwrap().services["app"].group_add;
+	assert_eq!(g.len(), 3);
+	assert!(g.contains(&"audio".to_string()));
 }
 
 #[test]
 fn userns_mode() {
-    let yaml =
-        "services:\n  app:\n    image: alpine\n    userns_mode: \"keep-id:uid=1000,gid=1000\"\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .userns_mode
-            .as_deref(),
-        Some("keep-id:uid=1000,gid=1000")
-    );
+	let yaml =
+		"services:\n  app:\n    image: alpine\n    userns_mode: \"keep-id:uid=1000,gid=1000\"\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.userns_mode
+			.as_deref(),
+		Some("keep-id:uid=1000,gid=1000")
+	);
 }
 
 #[test]
 fn shm_size() {
-    let yaml = "services:\n  app:\n    image: alpine\n    shm_size: 128m\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].shm_size.as_deref(),
-        Some("128m")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    shm_size: 128m\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].shm_size.as_deref(),
+		Some("128m")
+	);
 }
 
 #[test]
 fn cgroup_parent_field() {
-    let yaml = "services:\n  app:\n    image: alpine\n    cgroup_parent: my-cgroup\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .cgroup_parent
-            .as_deref(),
-        Some("my-cgroup")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    cgroup_parent: my-cgroup\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.cgroup_parent
+			.as_deref(),
+		Some("my-cgroup")
+	);
 }
 
 #[test]
 fn cpu_fields() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -406,8 +406,8 @@ services:
     cpuset: "0-1"
     mem_limit: 256m
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    assert_eq!(svc.cpu_shares, Some(512));
-    assert_eq!(svc.cpuset.as_deref(), Some("0-1"));
-    assert_eq!(svc.mem_limit.as_deref(), Some("256m"));
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	assert_eq!(svc.cpu_shares, Some(512));
+	assert_eq!(svc.cpuset.as_deref(), Some("0-1"));
+	assert_eq!(svc.mem_limit.as_deref(), Some("256m"));
 }

--- a/tests/parse/coverage.rs
+++ b/tests/parse/coverage.rs
@@ -8,21 +8,21 @@ use podup::parse_str;
 
 #[test]
 fn blkio_weight() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     blkio_config:
       weight: 300
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let bc = svc.blkio_config.as_ref().unwrap();
-    assert_eq!(bc.weight, Some(300));
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let bc = svc.blkio_config.as_ref().unwrap();
+	assert_eq!(bc.weight, Some(300));
 }
 
 #[test]
 fn blkio_weight_device() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -31,16 +31,16 @@ services:
         - path: /dev/sda
           weight: 400
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let bc = svc.blkio_config.as_ref().unwrap();
-    assert_eq!(bc.weight_device.len(), 1);
-    assert_eq!(bc.weight_device[0].path, "/dev/sda");
-    assert_eq!(bc.weight_device[0].weight, 400);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let bc = svc.blkio_config.as_ref().unwrap();
+	assert_eq!(bc.weight_device.len(), 1);
+	assert_eq!(bc.weight_device[0].path, "/dev/sda");
+	assert_eq!(bc.weight_device[0].weight, 400);
 }
 
 #[test]
 fn blkio_device_read_bps() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -52,16 +52,16 @@ services:
         - path: /dev/sda
           rate: "1024k"
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let bc = svc.blkio_config.as_ref().unwrap();
-    assert_eq!(bc.device_read_bps.len(), 1);
-    assert_eq!(bc.device_read_bps[0].path, "/dev/sda");
-    assert_eq!(bc.device_write_bps.len(), 1);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let bc = svc.blkio_config.as_ref().unwrap();
+	assert_eq!(bc.device_read_bps.len(), 1);
+	assert_eq!(bc.device_read_bps[0].path, "/dev/sda");
+	assert_eq!(bc.device_write_bps.len(), 1);
 }
 
 #[test]
 fn blkio_device_read_write_iops() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -73,12 +73,12 @@ services:
         - path: /dev/sda
           rate: 200
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let bc = svc.blkio_config.as_ref().unwrap();
-    assert_eq!(bc.device_read_iops.len(), 1);
-    assert_eq!(bc.device_write_iops.len(), 1);
-    assert_eq!(bc.device_read_iops[0].rate_value(), 100);
-    assert_eq!(bc.device_write_iops[0].rate_value(), 200);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let bc = svc.blkio_config.as_ref().unwrap();
+	assert_eq!(bc.device_read_iops.len(), 1);
+	assert_eq!(bc.device_write_iops.len(), 1);
+	assert_eq!(bc.device_read_iops[0].rate_value(), 100);
+	assert_eq!(bc.device_write_iops[0].rate_value(), 200);
 }
 
 // ---------------------------------------------------------------------------
@@ -87,28 +87,28 @@ services:
 
 #[test]
 fn gpus_all() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     gpus: all
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let gpus = svc.gpus.as_ref().unwrap();
-    assert_eq!(gpus.to_count(), -1);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let gpus = svc.gpus.as_ref().unwrap();
+	assert_eq!(gpus.to_count(), -1);
 }
 
 #[test]
 fn gpus_count() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     gpus: 2
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let gpus = svc.gpus.as_ref().unwrap();
-    assert_eq!(gpus.to_count(), 2);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let gpus = svc.gpus.as_ref().unwrap();
+	assert_eq!(gpus.to_count(), 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -117,7 +117,7 @@ services:
 
 #[test]
 fn deploy_gpu_device_reservation() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -131,19 +131,19 @@ services:
               count: all
               device_ids: ["GPU-0", "GPU-1"]
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let deploy = svc.deploy.as_ref().unwrap();
-    let devs = &deploy
-        .resources
-        .as_ref()
-        .unwrap()
-        .reservations
-        .as_ref()
-        .unwrap()
-        .devices;
-    assert_eq!(devs.len(), 2);
-    assert!(devs[0].capabilities.contains(&"gpu".to_string()));
-    assert_eq!(devs[1].device_ids.len(), 2);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let deploy = svc.deploy.as_ref().unwrap();
+	let devs = &deploy
+		.resources
+		.as_ref()
+		.unwrap()
+		.reservations
+		.as_ref()
+		.unwrap()
+		.devices;
+	assert_eq!(devs.len(), 2);
+	assert!(devs[0].capabilities.contains(&"gpu".to_string()));
+	assert_eq!(devs[1].device_ids.len(), 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -152,7 +152,7 @@ services:
 
 #[test]
 fn develop_watch_sync() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -164,19 +164,19 @@ services:
           ignore:
             - node_modules
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let dev = svc.develop.as_ref().unwrap();
-    assert_eq!(dev.watch.len(), 1);
-    let rule = &dev.watch[0];
-    assert_eq!(rule.path, "./src");
-    assert_eq!(rule.action, WatchAction::Sync);
-    assert_eq!(rule.target.as_deref(), Some("/app/src"));
-    assert_eq!(rule.ignore.len(), 1);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let dev = svc.develop.as_ref().unwrap();
+	assert_eq!(dev.watch.len(), 1);
+	let rule = &dev.watch[0];
+	assert_eq!(rule.path, "./src");
+	assert_eq!(rule.action, WatchAction::Sync);
+	assert_eq!(rule.target.as_deref(), Some("/app/src"));
+	assert_eq!(rule.ignore.len(), 1);
 }
 
 #[test]
 fn develop_watch_rebuild() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -185,14 +185,14 @@ services:
         - path: ./Dockerfile
           action: rebuild
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    let rule = &svc.develop.as_ref().unwrap().watch[0];
-    assert_eq!(rule.action, WatchAction::Rebuild);
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	let rule = &svc.develop.as_ref().unwrap().watch[0];
+	assert_eq!(rule.action, WatchAction::Rebuild);
 }
 
 #[test]
 fn develop_watch_sync_restart() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -203,10 +203,10 @@ services:
           target: /etc/app
           initial_sync: true
 "#;
-    let file = parse_str(yaml).unwrap();
-    let rule = &file.services["app"].develop.as_ref().unwrap().watch[0];
-    assert_eq!(rule.action, WatchAction::SyncAndRestart);
-    assert!(rule.initial_sync);
+	let file = parse_str(yaml).unwrap();
+	let rule = &file.services["app"].develop.as_ref().unwrap().watch[0];
+	assert_eq!(rule.action, WatchAction::SyncAndRestart);
+	assert!(rule.initial_sync);
 }
 
 // ---------------------------------------------------------------------------
@@ -215,23 +215,23 @@ services:
 
 #[test]
 fn post_start_exec_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     post_start:
       - command: ["/scripts/init.sh", "--quiet"]
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    assert_eq!(svc.post_start.len(), 1);
-    let cmd = svc.post_start[0].command.to_exec();
-    assert_eq!(cmd[0], "/scripts/init.sh");
-    assert_eq!(cmd[1], "--quiet");
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	assert_eq!(svc.post_start.len(), 1);
+	let cmd = svc.post_start[0].command.to_exec();
+	assert_eq!(cmd[0], "/scripts/init.sh");
+	assert_eq!(cmd[1], "--quiet");
 }
 
 #[test]
 fn pre_stop_with_env_and_user() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -243,15 +243,15 @@ services:
         environment:
           CLEANUP: "true"
 "#;
-    let hook = &parse_str(yaml).unwrap().services["app"].pre_stop[0];
-    assert_eq!(hook.user.as_deref(), Some("1000"));
-    assert_eq!(hook.privileged, Some(false));
-    assert_eq!(hook.working_dir.as_deref(), Some("/app"));
-    let env = hook.environment.to_map();
-    assert_eq!(
-        env.get("CLEANUP").and_then(|v| v.clone()).as_deref(),
-        Some("true")
-    );
+	let hook = &parse_str(yaml).unwrap().services["app"].pre_stop[0];
+	assert_eq!(hook.user.as_deref(), Some("1000"));
+	assert_eq!(hook.privileged, Some(false));
+	assert_eq!(hook.working_dir.as_deref(), Some("/app"));
+	let env = hook.environment.to_map();
+	assert_eq!(
+		env.get("CLEANUP").and_then(|v| v.clone()).as_deref(),
+		Some("true")
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -260,7 +260,7 @@ services:
 
 #[test]
 fn env_file_long_form_with_required() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -270,19 +270,19 @@ services:
       - path: .env.local
         required: true
 "#;
-    let entries = parse_str(yaml).unwrap().services["app"]
-        .env_file
-        .to_entries();
-    assert_eq!(entries.len(), 2);
-    assert_eq!(entries[0].path(), ".env.prod");
-    assert!(!entries[0].required());
-    assert_eq!(entries[1].path(), ".env.local");
-    assert!(entries[1].required());
+	let entries = parse_str(yaml).unwrap().services["app"]
+		.env_file
+		.to_entries();
+	assert_eq!(entries.len(), 2);
+	assert_eq!(entries[0].path(), ".env.prod");
+	assert!(!entries[0].required());
+	assert_eq!(entries[1].path(), ".env.local");
+	assert!(entries[1].required());
 }
 
 #[test]
 fn env_file_long_form_with_format() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -290,16 +290,16 @@ services:
       - path: .env
         format: dotenv
 "#;
-    let entries = parse_str(yaml).unwrap().services["app"]
-        .env_file
-        .to_entries();
-    assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].path(), ".env");
+	let entries = parse_str(yaml).unwrap().services["app"]
+		.env_file
+		.to_entries();
+	assert_eq!(entries.len(), 1);
+	assert_eq!(entries[0].path(), ".env");
 }
 
 #[test]
 fn env_file_mixed_short_and_long() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -308,12 +308,12 @@ services:
       - path: .env.local
         required: false
 "#;
-    let entries = parse_str(yaml).unwrap().services["app"]
-        .env_file
-        .to_entries();
-    assert_eq!(entries.len(), 2);
-    assert!(entries[0].required()); // short form defaults to required
-    assert!(!entries[1].required());
+	let entries = parse_str(yaml).unwrap().services["app"]
+		.env_file
+		.to_entries();
+	assert_eq!(entries.len(), 2);
+	assert!(entries[0].required()); // short form defaults to required
+	assert!(!entries[1].required());
 }
 
 // ---------------------------------------------------------------------------
@@ -322,35 +322,35 @@ services:
 
 #[test]
 fn secret_content_inline() {
-    let yaml = r#"
+	let yaml = r#"
 secrets:
   db_password:
     content: "s3cr3t_password"
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(
-        file.secrets["db_password"].content.as_deref(),
-        Some("s3cr3t_password")
-    );
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.secrets["db_password"].content.as_deref(),
+		Some("s3cr3t_password")
+	);
 }
 
 #[test]
 fn secret_from_environment() {
-    let yaml = r#"
+	let yaml = r#"
 secrets:
   api_key:
     environment: MY_API_KEY
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(
-        file.secrets["api_key"].environment.as_deref(),
-        Some("MY_API_KEY")
-    );
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.secrets["api_key"].environment.as_deref(),
+		Some("MY_API_KEY")
+	);
 }
 
 #[test]
 fn secret_with_driver_and_labels() {
-    let yaml = r#"
+	let yaml = r#"
 secrets:
   db_pass:
     driver: vault
@@ -359,18 +359,18 @@ secrets:
     labels:
       team: backend
 "#;
-    let s = &parse_str(yaml).unwrap().secrets["db_pass"];
-    assert_eq!(s.driver.as_deref(), Some("vault"));
-    assert_eq!(
-        s.driver_opts.get("path").map(|s| s.as_str()),
-        Some("secret/db")
-    );
-    assert!(!s.labels.to_map().is_empty());
+	let s = &parse_str(yaml).unwrap().secrets["db_pass"];
+	assert_eq!(s.driver.as_deref(), Some("vault"));
+	assert_eq!(
+		s.driver_opts.get("path").map(|s| s.as_str()),
+		Some("secret/db")
+	);
+	assert!(!s.labels.to_map().is_empty());
 }
 
 #[test]
 fn secret_long_form_uid_gid_mode() {
-    let yaml = r#"
+	let yaml = r#"
 secrets:
   app_cert:
     file: ./cert.pem
@@ -384,18 +384,18 @@ services:
         gid: "1000"
         mode: 256
 "#;
-    let file = parse_str(yaml).unwrap();
-    let sref = &file.services["app"].secrets[0];
-    assert_eq!(sref.source(), "app_cert");
-    assert_eq!(sref.target(), Some("/run/secrets/cert.pem"));
-    match sref {
-        ServiceSecretRef::Long { uid, gid, mode, .. } => {
-            assert_eq!(uid.as_deref(), Some("1000"));
-            assert_eq!(gid.as_deref(), Some("1000"));
-            assert_eq!(*mode, Some(256));
-        }
-        _ => panic!("expected long-form secret ref"),
-    }
+	let file = parse_str(yaml).unwrap();
+	let sref = &file.services["app"].secrets[0];
+	assert_eq!(sref.source(), "app_cert");
+	assert_eq!(sref.target(), Some("/run/secrets/cert.pem"));
+	match sref {
+		ServiceSecretRef::Long { uid, gid, mode, .. } => {
+			assert_eq!(uid.as_deref(), Some("1000"));
+			assert_eq!(gid.as_deref(), Some("1000"));
+			assert_eq!(*mode, Some(256));
+		}
+		_ => panic!("expected long-form secret ref"),
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -404,37 +404,37 @@ services:
 
 #[test]
 fn config_content_multiline() {
-    let yaml = r#"
+	let yaml = r#"
 configs:
   app_conf:
     content: |
       [server]
       port = 8080
 "#;
-    let content = parse_str(yaml).unwrap().configs["app_conf"]
-        .content
-        .clone()
-        .unwrap();
-    assert!(content.contains("port = 8080"));
+	let content = parse_str(yaml).unwrap().configs["app_conf"]
+		.content
+		.clone()
+		.unwrap();
+	assert!(content.contains("port = 8080"));
 }
 
 #[test]
 fn config_from_environment() {
-    let yaml = r#"
+	let yaml = r#"
 configs:
   token:
     environment: AUTH_TOKEN
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(
-        file.configs["token"].environment.as_deref(),
-        Some("AUTH_TOKEN")
-    );
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.configs["token"].environment.as_deref(),
+		Some("AUTH_TOKEN")
+	);
 }
 
 #[test]
 fn config_long_form_uid_gid_mode() {
-    let yaml = r#"
+	let yaml = r#"
 configs:
   app_cfg:
     file: ./app.conf
@@ -448,18 +448,18 @@ services:
         gid: "500"
         mode: 292
 "#;
-    let file = parse_str(yaml).unwrap();
-    let cref = &file.services["app"].configs[0];
-    assert_eq!(cref.source(), "app_cfg");
-    assert_eq!(cref.target(), Some("/etc/app.conf"));
-    match cref {
-        ServiceConfigRef::Long { uid, gid, mode, .. } => {
-            assert_eq!(uid.as_deref(), Some("500"));
-            assert_eq!(gid.as_deref(), Some("500"));
-            assert_eq!(*mode, Some(292));
-        }
-        _ => panic!("expected long-form config ref"),
-    }
+	let file = parse_str(yaml).unwrap();
+	let cref = &file.services["app"].configs[0];
+	assert_eq!(cref.source(), "app_cfg");
+	assert_eq!(cref.target(), Some("/etc/app.conf"));
+	match cref {
+		ServiceConfigRef::Long { uid, gid, mode, .. } => {
+			assert_eq!(uid.as_deref(), Some("500"));
+			assert_eq!(gid.as_deref(), Some("500"));
+			assert_eq!(*mode, Some(292));
+		}
+		_ => panic!("expected long-form config ref"),
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -468,7 +468,7 @@ services:
 
 #[test]
 fn network_ipam_subnet_gateway() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   backend:
     driver: bridge
@@ -479,22 +479,22 @@ networks:
           gateway: 192.168.90.1
           ip_range: 192.168.90.128/25
 "#;
-    let file = parse_str(yaml).unwrap();
-    let net = file.networks["backend"].as_ref().unwrap();
-    let ipam = net.ipam.as_ref().unwrap();
-    assert_eq!(ipam.driver.as_deref(), Some("default"));
-    assert_eq!(ipam.config.len(), 1);
-    assert_eq!(ipam.config[0].subnet.as_deref(), Some("192.168.90.0/24"));
-    assert_eq!(ipam.config[0].gateway.as_deref(), Some("192.168.90.1"));
-    assert_eq!(
-        ipam.config[0].ip_range.as_deref(),
-        Some("192.168.90.128/25")
-    );
+	let file = parse_str(yaml).unwrap();
+	let net = file.networks["backend"].as_ref().unwrap();
+	let ipam = net.ipam.as_ref().unwrap();
+	assert_eq!(ipam.driver.as_deref(), Some("default"));
+	assert_eq!(ipam.config.len(), 1);
+	assert_eq!(ipam.config[0].subnet.as_deref(), Some("192.168.90.0/24"));
+	assert_eq!(ipam.config[0].gateway.as_deref(), Some("192.168.90.1"));
+	assert_eq!(
+		ipam.config[0].ip_range.as_deref(),
+		Some("192.168.90.128/25")
+	);
 }
 
 #[test]
 fn network_ipam_aux_addresses() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   mynet:
     ipam:
@@ -503,13 +503,13 @@ networks:
           aux_addresses:
             host1: 172.16.238.5
 "#;
-    let file = parse_str(yaml).unwrap();
-    let net = file.networks["mynet"].as_ref().unwrap();
-    let pool = &net.ipam.as_ref().unwrap().config[0];
-    assert_eq!(
-        pool.aux_addresses.get("host1").map(|s| s.as_str()),
-        Some("172.16.238.5")
-    );
+	let file = parse_str(yaml).unwrap();
+	let net = file.networks["mynet"].as_ref().unwrap();
+	let pool = &net.ipam.as_ref().unwrap().config[0];
+	assert_eq!(
+		pool.aux_addresses.get("host1").map(|s| s.as_str()),
+		Some("172.16.238.5")
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -518,11 +518,11 @@ networks:
 
 #[test]
 fn pids_limit_service_field() {
-    let yaml = "services:\n  app:\n    image: alpine\n    pids_limit: 256\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].pids_limit,
-        Some(256)
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    pids_limit: 256\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].pids_limit,
+		Some(256)
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -531,7 +531,7 @@ fn pids_limit_service_field() {
 
 #[test]
 fn deploy_restart_policy() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -542,21 +542,21 @@ services:
         max_attempts: 3
         window: 120s
 "#;
-    let file = parse_str(yaml).unwrap();
-    let rp = file.services["app"]
-        .deploy
-        .as_ref()
-        .unwrap()
-        .restart_policy
-        .as_ref()
-        .unwrap();
-    assert_eq!(rp.condition.as_deref(), Some("on-failure"));
-    assert_eq!(rp.max_attempts, Some(3));
+	let file = parse_str(yaml).unwrap();
+	let rp = file.services["app"]
+		.deploy
+		.as_ref()
+		.unwrap()
+		.restart_policy
+		.as_ref()
+		.unwrap();
+	assert_eq!(rp.condition.as_deref(), Some("on-failure"));
+	assert_eq!(rp.max_attempts, Some(3));
 }
 
 #[test]
 fn deploy_update_config() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -567,21 +567,21 @@ services:
         failure_action: rollback
         order: start-first
 "#;
-    let file = parse_str(yaml).unwrap();
-    let uc = file.services["app"]
-        .deploy
-        .as_ref()
-        .unwrap()
-        .update_config
-        .as_ref()
-        .unwrap();
-    assert_eq!(uc.parallelism, Some(2));
-    assert_eq!(uc.failure_action.as_deref(), Some("rollback"));
+	let file = parse_str(yaml).unwrap();
+	let uc = file.services["app"]
+		.deploy
+		.as_ref()
+		.unwrap()
+		.update_config
+		.as_ref()
+		.unwrap();
+	assert_eq!(uc.parallelism, Some(2));
+	assert_eq!(uc.failure_action.as_deref(), Some("rollback"));
 }
 
 #[test]
 fn deploy_rollback_config() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -590,20 +590,20 @@ services:
         parallelism: 1
         delay: 5s
 "#;
-    let file = parse_str(yaml).unwrap();
-    let rc = file.services["app"]
-        .deploy
-        .as_ref()
-        .unwrap()
-        .rollback_config
-        .as_ref()
-        .unwrap();
-    assert_eq!(rc.parallelism, Some(1));
+	let file = parse_str(yaml).unwrap();
+	let rc = file.services["app"]
+		.deploy
+		.as_ref()
+		.unwrap()
+		.rollback_config
+		.as_ref()
+		.unwrap();
+	assert_eq!(rc.parallelism, Some(1));
 }
 
 #[test]
 fn deploy_placement_constraints() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -614,21 +614,21 @@ services:
           - "node.labels.datacenter==east"
         max_replicas_per_node: 3
 "#;
-    let file = parse_str(yaml).unwrap();
-    let pl = file.services["app"]
-        .deploy
-        .as_ref()
-        .unwrap()
-        .placement
-        .as_ref()
-        .unwrap();
-    assert_eq!(pl.constraints.len(), 2);
-    assert_eq!(pl.max_replicas_per_node, Some(3));
+	let file = parse_str(yaml).unwrap();
+	let pl = file.services["app"]
+		.deploy
+		.as_ref()
+		.unwrap()
+		.placement
+		.as_ref()
+		.unwrap();
+	assert_eq!(pl.constraints.len(), 2);
+	assert_eq!(pl.max_replicas_per_node, Some(3));
 }
 
 #[test]
 fn deploy_mode_and_endpoint_mode() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -636,10 +636,10 @@ services:
       mode: replicated
       endpoint_mode: vip
 "#;
-    let file = parse_str(yaml).unwrap();
-    let deploy = file.services["app"].deploy.as_ref().unwrap();
-    assert_eq!(deploy.mode.as_deref(), Some("replicated"));
-    assert_eq!(deploy.endpoint_mode.as_deref(), Some("vip"));
+	let file = parse_str(yaml).unwrap();
+	let deploy = file.services["app"].deploy.as_ref().unwrap();
+	assert_eq!(deploy.mode.as_deref(), Some("replicated"));
+	assert_eq!(deploy.endpoint_mode.as_deref(), Some("vip"));
 }
 
 // ---------------------------------------------------------------------------
@@ -649,7 +649,7 @@ services:
 
 #[test]
 fn build_no_cache_and_pull() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -657,15 +657,15 @@ services:
       no_cache: true
       pull: true
 "#;
-    let file = parse_str(yaml).unwrap();
-    let build = file.services["app"].build.as_ref().unwrap();
-    assert!(build.no_cache());
-    assert!(build.pull());
+	let file = parse_str(yaml).unwrap();
+	let build = file.services["app"].build.as_ref().unwrap();
+	assert!(build.no_cache());
+	assert!(build.pull());
 }
 
 #[test]
 fn build_tags() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -674,34 +674,34 @@ services:
         - myregistry.io/myapp:v1.2.3
         - myregistry.io/myapp:latest
 "#;
-    let file = parse_str(yaml).unwrap();
-    let build = file.services["app"].build.as_ref().unwrap();
-    assert_eq!(build.tags().len(), 2);
-    assert!(build.tags()[0].contains("v1.2.3"));
+	let file = parse_str(yaml).unwrap();
+	let build = file.services["app"].build.as_ref().unwrap();
+	assert_eq!(build.tags().len(), 2);
+	assert!(build.tags()[0].contains("v1.2.3"));
 }
 
 #[test]
 fn build_privileged() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
       context: .
       privileged: true
 "#;
-    match parse_str(yaml).unwrap().services["app"]
-        .build
-        .as_ref()
-        .unwrap()
-    {
-        BuildConfig::Config { privileged, .. } => assert_eq!(*privileged, Some(true)),
-        _ => panic!("expected long-form build"),
-    }
+	match parse_str(yaml).unwrap().services["app"]
+		.build
+		.as_ref()
+		.unwrap()
+	{
+		BuildConfig::Config { privileged, .. } => assert_eq!(*privileged, Some(true)),
+		_ => panic!("expected long-form build"),
+	}
 }
 
 #[test]
 fn build_extra_hosts() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -709,14 +709,14 @@ services:
       extra_hosts:
         - "somehost:162.242.195.82"
 "#;
-    let file = parse_str(yaml).unwrap();
-    let build = file.services["app"].build.as_ref().unwrap();
-    assert_eq!(build.extra_hosts().len(), 1);
+	let file = parse_str(yaml).unwrap();
+	let build = file.services["app"].build.as_ref().unwrap();
+	assert_eq!(build.extra_hosts().len(), 1);
 }
 
 #[test]
 fn build_additional_contexts() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -724,27 +724,27 @@ services:
       additional_contexts:
         mylib: /path/to/mylib
 "#;
-    match parse_str(yaml).unwrap().services["app"]
-        .build
-        .as_ref()
-        .unwrap()
-    {
-        BuildConfig::Config {
-            additional_contexts,
-            ..
-        } => {
-            assert_eq!(
-                additional_contexts.get("mylib").map(|s| s.as_str()),
-                Some("/path/to/mylib")
-            );
-        }
-        _ => panic!("expected long-form build"),
-    }
+	match parse_str(yaml).unwrap().services["app"]
+		.build
+		.as_ref()
+		.unwrap()
+	{
+		BuildConfig::Config {
+			additional_contexts,
+			..
+		} => {
+			assert_eq!(
+				additional_contexts.get("mylib").map(|s| s.as_str()),
+				Some("/path/to/mylib")
+			);
+		}
+		_ => panic!("expected long-form build"),
+	}
 }
 
 #[test]
 fn build_dockerfile_inline() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -753,15 +753,15 @@ services:
         FROM alpine
         RUN echo hello
 "#;
-    let file = parse_str(yaml).unwrap();
-    let build = file.services["app"].build.as_ref().unwrap();
-    let inline = build.dockerfile_inline().unwrap();
-    assert!(inline.contains("FROM alpine"));
+	let file = parse_str(yaml).unwrap();
+	let build = file.services["app"].build.as_ref().unwrap();
+	let inline = build.dockerfile_inline().unwrap();
+	assert!(inline.contains("FROM alpine"));
 }
 
 #[test]
 fn build_ssh_and_secrets() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -771,18 +771,18 @@ services:
       secrets:
         - server-certificate
 "#;
-    match parse_str(yaml).unwrap().services["app"]
-        .build
-        .as_ref()
-        .unwrap()
-    {
-        BuildConfig::Config { ssh, secrets, .. } => {
-            assert_eq!(ssh.len(), 1);
-            assert_eq!(secrets.len(), 1);
-            assert_eq!(secrets[0], "server-certificate");
-        }
-        _ => panic!("expected long-form build"),
-    }
+	match parse_str(yaml).unwrap().services["app"]
+		.build
+		.as_ref()
+		.unwrap()
+	{
+		BuildConfig::Config { ssh, secrets, .. } => {
+			assert_eq!(ssh.len(), 1);
+			assert_eq!(secrets.len(), 1);
+			assert_eq!(secrets[0], "server-certificate");
+		}
+		_ => panic!("expected long-form build"),
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -792,7 +792,7 @@ services:
 
 #[test]
 fn network_service_gw_priority() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   frontend:
 services:
@@ -802,17 +802,17 @@ services:
       frontend:
         gw_priority: 100
 "#;
-    let file = parse_str(yaml).unwrap();
-    let cfg = file.services["app"]
-        .networks
-        .config_for("frontend")
-        .unwrap();
-    assert_eq!(cfg.gw_priority, Some(100));
+	let file = parse_str(yaml).unwrap();
+	let cfg = file.services["app"]
+		.networks
+		.config_for("frontend")
+		.unwrap();
+	assert_eq!(cfg.gw_priority, Some(100));
 }
 
 #[test]
 fn network_service_mac_address() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   net:
 services:
@@ -822,14 +822,14 @@ services:
       net:
         mac_address: "02:42:ac:11:00:02"
 "#;
-    let file = parse_str(yaml).unwrap();
-    let cfg = file.services["app"].networks.config_for("net").unwrap();
-    assert_eq!(cfg.mac_address.as_deref(), Some("02:42:ac:11:00:02"));
+	let file = parse_str(yaml).unwrap();
+	let cfg = file.services["app"].networks.config_for("net").unwrap();
+	assert_eq!(cfg.mac_address.as_deref(), Some("02:42:ac:11:00:02"));
 }
 
 #[test]
 fn network_service_link_local_ips() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   net:
 services:
@@ -840,15 +840,15 @@ services:
         link_local_ips:
           - 169.254.8.1
 "#;
-    let file = parse_str(yaml).unwrap();
-    let cfg = file.services["app"].networks.config_for("net").unwrap();
-    assert_eq!(cfg.link_local_ips.len(), 1);
-    assert_eq!(cfg.link_local_ips[0], "169.254.8.1");
+	let file = parse_str(yaml).unwrap();
+	let cfg = file.services["app"].networks.config_for("net").unwrap();
+	assert_eq!(cfg.link_local_ips.len(), 1);
+	assert_eq!(cfg.link_local_ips[0], "169.254.8.1");
 }
 
 #[test]
 fn network_service_interface_name() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   net:
 services:
@@ -858,9 +858,9 @@ services:
       net:
         interface_name: eth0
 "#;
-    let file = parse_str(yaml).unwrap();
-    let cfg = file.services["app"].networks.config_for("net").unwrap();
-    assert_eq!(cfg.interface_name.as_deref(), Some("eth0"));
+	let file = parse_str(yaml).unwrap();
+	let cfg = file.services["app"].networks.config_for("net").unwrap();
+	assert_eq!(cfg.interface_name.as_deref(), Some("eth0"));
 }
 
 // ---------------------------------------------------------------------------
@@ -869,7 +869,7 @@ services:
 
 #[test]
 fn volume_consistency() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -879,18 +879,18 @@ services:
         target: /data
         consistency: cached
 "#;
-    let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
-    match v {
-        VolumeMount::Long { consistency, .. } => {
-            assert_eq!(consistency.as_deref(), Some("cached"));
-        }
-        _ => panic!("expected long-form volume"),
-    }
+	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
+	match v {
+		VolumeMount::Long { consistency, .. } => {
+			assert_eq!(consistency.as_deref(), Some("cached"));
+		}
+		_ => panic!("expected long-form volume"),
+	}
 }
 
 #[test]
 fn volume_options_driver_config() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -905,25 +905,25 @@ services:
             options:
               addr: "nfs.example.com"
 "#;
-    let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
-    match v {
-        VolumeMount::Long {
-            volume: Some(vo), ..
-        } => {
-            let dc = vo.driver_config.as_ref().unwrap();
-            assert_eq!(dc.name.as_deref(), Some("nfs"));
-            assert_eq!(
-                dc.options.get("addr").map(|s| s.as_str()),
-                Some("nfs.example.com")
-            );
-        }
-        _ => panic!("expected long-form volume with options"),
-    }
+	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
+	match v {
+		VolumeMount::Long {
+			volume: Some(vo), ..
+		} => {
+			let dc = vo.driver_config.as_ref().unwrap();
+			assert_eq!(dc.name.as_deref(), Some("nfs"));
+			assert_eq!(
+				dc.options.get("addr").map(|s| s.as_str()),
+				Some("nfs.example.com")
+			);
+		}
+		_ => panic!("expected long-form volume with options"),
+	}
 }
 
 #[test]
 fn volume_options_subpath() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -934,20 +934,20 @@ services:
         volume:
           subpath: subdir/nested
 "#;
-    let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
-    match v {
-        VolumeMount::Long {
-            volume: Some(vo), ..
-        } => {
-            assert_eq!(vo.subpath.as_deref(), Some("subdir/nested"));
-        }
-        _ => panic!("expected long-form volume"),
-    }
+	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
+	match v {
+		VolumeMount::Long {
+			volume: Some(vo), ..
+		} => {
+			assert_eq!(vo.subpath.as_deref(), Some("subdir/nested"));
+		}
+		_ => panic!("expected long-form volume"),
+	}
 }
 
 #[test]
 fn volume_options_labels() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -959,16 +959,16 @@ services:
           labels:
             backup: daily
 "#;
-    let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
-    match v {
-        VolumeMount::Long {
-            volume: Some(vo), ..
-        } => {
-            let labels = vo.labels.to_map();
-            assert_eq!(labels.get("backup").map(|s| s.as_str()), Some("daily"));
-        }
-        _ => panic!("expected long-form volume"),
-    }
+	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
+	match v {
+		VolumeMount::Long {
+			volume: Some(vo), ..
+		} => {
+			let labels = vo.labels.to_map();
+			assert_eq!(labels.get("backup").map(|s| s.as_str()), Some("daily"));
+		}
+		_ => panic!("expected long-form volume"),
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -977,30 +977,30 @@ services:
 
 #[test]
 fn cpu_count_and_percent() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     cpu_count: 4
     cpu_percent: 75
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    assert_eq!(svc.cpu_count, Some(4));
-    assert_eq!(svc.cpu_percent, Some(75));
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	assert_eq!(svc.cpu_count, Some(4));
+	assert_eq!(svc.cpu_percent, Some(75));
 }
 
 #[test]
 fn cpu_rt_runtime_and_period() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     cpu_rt_runtime: 950000
     cpu_rt_period: 1000000
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    assert_eq!(svc.cpu_rt_runtime, Some(950000));
-    assert_eq!(svc.cpu_rt_period, Some(1000000));
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	assert_eq!(svc.cpu_rt_runtime, Some(950000));
+	assert_eq!(svc.cpu_rt_period, Some(1000000));
 }
 
 // ---------------------------------------------------------------------------
@@ -1009,16 +1009,16 @@ services:
 
 #[test]
 fn label_file_single() {
-    let yaml = "services:\n  app:\n    image: alpine\n    label_file: ./labels.properties\n";
-    let list = parse_str(yaml).unwrap().services["app"]
-        .label_file
-        .to_list();
-    assert_eq!(list, vec!["./labels.properties"]);
+	let yaml = "services:\n  app:\n    image: alpine\n    label_file: ./labels.properties\n";
+	let list = parse_str(yaml).unwrap().services["app"]
+		.label_file
+		.to_list();
+	assert_eq!(list, vec!["./labels.properties"]);
 }
 
 #[test]
 fn label_file_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -1026,16 +1026,16 @@ services:
       - ./labels.properties
       - ./extra.labels
 "#;
-    let list = parse_str(yaml).unwrap().services["app"]
-        .label_file
-        .to_list();
-    assert_eq!(list.len(), 2);
+	let list = parse_str(yaml).unwrap().services["app"]
+		.label_file
+		.to_list();
+	assert_eq!(list.len(), 2);
 }
 
 #[test]
 fn attach_field() {
-    let yaml = "services:\n  app:\n    image: alpine\n    attach: false\n";
-    assert_eq!(parse_str(yaml).unwrap().services["app"].attach, Some(false));
+	let yaml = "services:\n  app:\n    image: alpine\n    attach: false\n";
+	assert_eq!(parse_str(yaml).unwrap().services["app"].attach, Some(false));
 }
 
 // ---------------------------------------------------------------------------
@@ -1044,20 +1044,20 @@ fn attach_field() {
 
 #[test]
 fn uts_host() {
-    let yaml = "services:\n  app:\n    image: alpine\n    uts: host\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].uts.as_deref(),
-        Some("host")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    uts: host\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].uts.as_deref(),
+		Some("host")
+	);
 }
 
 #[test]
 fn cgroup_field() {
-    let yaml = "services:\n  app:\n    image: alpine\n    cgroup: host\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].cgroup.as_deref(),
-        Some("host")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    cgroup: host\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].cgroup.as_deref(),
+		Some("host")
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -1066,26 +1066,26 @@ fn cgroup_field() {
 
 #[test]
 fn build_isolation() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
       context: .
       isolation: hyperv
 "#;
-    match parse_str(yaml).unwrap().services["app"]
-        .build
-        .as_ref()
-        .unwrap()
-    {
-        BuildConfig::Config { isolation, .. } => assert_eq!(isolation.as_deref(), Some("hyperv")),
-        _ => panic!("expected long-form build"),
-    }
+	match parse_str(yaml).unwrap().services["app"]
+		.build
+		.as_ref()
+		.unwrap()
+	{
+		BuildConfig::Config { isolation, .. } => assert_eq!(isolation.as_deref(), Some("hyperv")),
+		_ => panic!("expected long-form build"),
+	}
 }
 
 #[test]
 fn build_entitlements() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -1094,36 +1094,36 @@ services:
         - network.host
         - security.insecure
 "#;
-    match parse_str(yaml).unwrap().services["app"]
-        .build
-        .as_ref()
-        .unwrap()
-    {
-        BuildConfig::Config { entitlements, .. } => {
-            assert_eq!(entitlements.len(), 2);
-            assert!(entitlements.contains(&"network.host".to_string()));
-        }
-        _ => panic!("expected long-form build"),
-    }
+	match parse_str(yaml).unwrap().services["app"]
+		.build
+		.as_ref()
+		.unwrap()
+	{
+		BuildConfig::Config { entitlements, .. } => {
+			assert_eq!(entitlements.len(), 2);
+			assert!(entitlements.contains(&"network.host".to_string()));
+		}
+		_ => panic!("expected long-form build"),
+	}
 }
 
 #[test]
 fn build_sbom() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
       context: .
       sbom: true
 "#;
-    match parse_str(yaml).unwrap().services["app"]
-        .build
-        .as_ref()
-        .unwrap()
-    {
-        BuildConfig::Config { sbom, .. } => assert_eq!(*sbom, Some(true)),
-        _ => panic!("expected long-form build"),
-    }
+	match parse_str(yaml).unwrap().services["app"]
+		.build
+		.as_ref()
+		.unwrap()
+	{
+		BuildConfig::Config { sbom, .. } => assert_eq!(*sbom, Some(true)),
+		_ => panic!("expected long-form build"),
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1132,7 +1132,7 @@ services:
 
 #[test]
 fn network_ipam_options() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   mynet:
     ipam:
@@ -1140,15 +1140,15 @@ networks:
       options:
         foo: bar
 "#;
-    let file = parse_str(yaml).unwrap();
-    let ipam = file.networks["mynet"]
-        .as_ref()
-        .unwrap()
-        .ipam
-        .as_ref()
-        .unwrap();
-    assert_eq!(ipam.driver.as_deref(), Some("custom"));
-    assert_eq!(ipam.options.get("foo").map(|s| s.as_str()), Some("bar"));
+	let file = parse_str(yaml).unwrap();
+	let ipam = file.networks["mynet"]
+		.as_ref()
+		.unwrap()
+		.ipam
+		.as_ref()
+		.unwrap();
+	assert_eq!(ipam.driver.as_deref(), Some("custom"));
+	assert_eq!(ipam.options.get("foo").map(|s| s.as_str()), Some("bar"));
 }
 
 // ---------------------------------------------------------------------------
@@ -1157,7 +1157,7 @@ networks:
 
 #[test]
 fn deploy_labels_as_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -1166,18 +1166,18 @@ services:
         - "com.example.description=API service"
         - "com.example.tier=backend"
 "#;
-    let file = parse_str(yaml).unwrap();
-    let deploy = file.services["app"].deploy.as_ref().unwrap();
-    let labels = deploy.labels.to_map();
-    assert_eq!(
-        labels.get("com.example.description").map(|s| s.as_str()),
-        Some("API service")
-    );
+	let file = parse_str(yaml).unwrap();
+	let deploy = file.services["app"].deploy.as_ref().unwrap();
+	let labels = deploy.labels.to_map();
+	assert_eq!(
+		labels.get("com.example.description").map(|s| s.as_str()),
+		Some("API service")
+	);
 }
 
 #[test]
 fn deploy_labels_as_map() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -1185,10 +1185,10 @@ services:
       labels:
         app.version: "1.0"
 "#;
-    let file = parse_str(yaml).unwrap();
-    let deploy = file.services["app"].deploy.as_ref().unwrap();
-    let labels = deploy.labels.to_map();
-    assert_eq!(labels.get("app.version").map(|s| s.as_str()), Some("1.0"));
+	let file = parse_str(yaml).unwrap();
+	let deploy = file.services["app"].deploy.as_ref().unwrap();
+	let labels = deploy.labels.to_map();
+	assert_eq!(labels.get("app.version").map(|s| s.as_str()), Some("1.0"));
 }
 
 // ---------------------------------------------------------------------------
@@ -1197,7 +1197,7 @@ services:
 
 #[test]
 fn dns_search_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -1205,10 +1205,10 @@ services:
       - example.com
       - internal.local
 "#;
-    let list = parse_str(yaml).unwrap().services["app"]
-        .dns_search
-        .to_list();
-    assert!(list.contains(&"example.com".to_string()));
+	let list = parse_str(yaml).unwrap().services["app"]
+		.dns_search
+		.to_list();
+	assert!(list.contains(&"example.com".to_string()));
 }
 
 // ---------------------------------------------------------------------------
@@ -1217,7 +1217,7 @@ services:
 
 #[test]
 fn device_cgroup_rules() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -1225,7 +1225,7 @@ services:
       - "c 1:3 mr"
       - "b 7:* rmw"
 "#;
-    let rules = &parse_str(yaml).unwrap().services["app"].device_cgroup_rules;
-    assert_eq!(rules.len(), 2);
-    assert!(rules[0].contains("c 1:3"));
+	let rules = &parse_str(yaml).unwrap().services["app"].device_cgroup_rules;
+	assert_eq!(rules.len(), 2);
+	assert!(rules[0].contains("c 1:3"));
 }

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 #[test]
 fn extends_same_file() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   base:
     image: alpine
@@ -12,13 +12,13 @@ services:
   app:
     extends: base
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
 }
 
 #[test]
 fn extends_merges_environment() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   base:
     image: alpine
@@ -32,26 +32,26 @@ services:
       LOG: debug
       EXTRA: ok
 "#;
-    let file = parse_str(yaml).unwrap();
-    let env = file.services["app"].environment.to_map();
-    // Override wins for LOG, base value preserved for KEEP, override-only EXTRA present.
-    assert_eq!(
-        env.get("LOG").and_then(|v| v.clone()).as_deref(),
-        Some("debug")
-    );
-    assert_eq!(
-        env.get("KEEP").and_then(|v| v.clone()).as_deref(),
-        Some("yes")
-    );
-    assert_eq!(
-        env.get("EXTRA").and_then(|v| v.clone()).as_deref(),
-        Some("ok")
-    );
+	let file = parse_str(yaml).unwrap();
+	let env = file.services["app"].environment.to_map();
+	// Override wins for LOG, base value preserved for KEEP, override-only EXTRA present.
+	assert_eq!(
+		env.get("LOG").and_then(|v| v.clone()).as_deref(),
+		Some("debug")
+	);
+	assert_eq!(
+		env.get("KEEP").and_then(|v| v.clone()).as_deref(),
+		Some("yes")
+	);
+	assert_eq!(
+		env.get("EXTRA").and_then(|v| v.clone()).as_deref(),
+		Some("ok")
+	);
 }
 
 #[test]
 fn extends_override_image_wins() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   base:
     image: alpine
@@ -59,13 +59,13 @@ services:
     extends: base
     image: nginx:alpine
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].image.as_deref(), Some("nginx:alpine"));
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].image.as_deref(), Some("nginx:alpine"));
 }
 
 #[test]
 fn extends_chains_through_multiple_levels() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   grand:
     image: alpine
@@ -80,17 +80,17 @@ services:
     environment:
       C: 3
 "#;
-    let file = parse_str(yaml).unwrap();
-    let env = file.services["child"].environment.to_map();
-    assert!(env.contains_key("A"));
-    assert!(env.contains_key("B"));
-    assert!(env.contains_key("C"));
-    assert_eq!(file.services["child"].image.as_deref(), Some("alpine"));
+	let file = parse_str(yaml).unwrap();
+	let env = file.services["child"].environment.to_map();
+	assert!(env.contains_key("A"));
+	assert!(env.contains_key("B"));
+	assert!(env.contains_key("C"));
+	assert_eq!(file.services["child"].image.as_deref(), Some("alpine"));
 }
 
 #[test]
 fn extends_circular_errors() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   a:
     image: alpine
@@ -99,53 +99,53 @@ services:
     image: alpine
     extends: a
 "#;
-    assert!(parse_str(yaml).is_err());
+	assert!(parse_str(yaml).is_err());
 }
 
 #[test]
 fn extends_self_errors() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   a:
     image: alpine
     extends: a
 "#;
-    assert!(parse_str(yaml).is_err());
+	assert!(parse_str(yaml).is_err());
 }
 
 #[test]
 fn extends_unknown_service_errors() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   a:
     image: alpine
     extends: missing
 "#;
-    assert!(parse_str(yaml).is_err());
+	assert!(parse_str(yaml).is_err());
 }
 
 #[test]
 fn extends_with_external_file() {
-    let dir = tempfile::tempdir().unwrap();
-    let common_path = dir.path().join("common.yml");
-    let mut f = std::fs::File::create(&common_path).unwrap();
-    writeln!(
-        f,
-        r#"
+	let dir = tempfile::tempdir().unwrap();
+	let common_path = dir.path().join("common.yml");
+	let mut f = std::fs::File::create(&common_path).unwrap();
+	writeln!(
+		f,
+		r#"
 services:
   base:
     image: alpine
     environment:
       FROM_BASE: yes
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let main_path = dir.path().join("docker-compose.yml");
-    let mut m = std::fs::File::create(&main_path).unwrap();
-    writeln!(
-        m,
-        r#"
+	let main_path = dir.path().join("docker-compose.yml");
+	let mut m = std::fs::File::create(&main_path).unwrap();
+	writeln!(
+		m,
+		r#"
 services:
   app:
     extends:
@@ -154,12 +154,12 @@ services:
     environment:
       FROM_APP: yes
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let file = parse_file(&main_path).unwrap();
-    assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
-    let env = file.services["app"].environment.to_map();
-    assert!(env.contains_key("FROM_BASE"));
-    assert!(env.contains_key("FROM_APP"));
+	let file = parse_file(&main_path).unwrap();
+	assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
+	let env = file.services["app"].environment.to_map();
+	assert!(env.contains_key("FROM_BASE"));
+	assert!(env.contains_key("FROM_APP"));
 }

--- a/tests/parse/fields.rs
+++ b/tests/parse/fields.rs
@@ -3,7 +3,7 @@ use podup::parse_str;
 
 #[test]
 fn sysctls_as_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -11,61 +11,61 @@ services:
       - net.core.somaxconn=1024
       - net.ipv4.ip_forward=1
 "#;
-    let sc = parse_str(yaml).unwrap().services["app"].sysctls.to_map();
-    assert_eq!(
-        sc.get("net.core.somaxconn").map(|s| s.as_str()),
-        Some("1024")
-    );
-    assert_eq!(sc.get("net.ipv4.ip_forward").map(|s| s.as_str()), Some("1"));
+	let sc = parse_str(yaml).unwrap().services["app"].sysctls.to_map();
+	assert_eq!(
+		sc.get("net.core.somaxconn").map(|s| s.as_str()),
+		Some("1024")
+	);
+	assert_eq!(sc.get("net.ipv4.ip_forward").map(|s| s.as_str()), Some("1"));
 }
 
 #[test]
 fn sysctls_as_map() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     sysctls:
       net.core.somaxconn: "1024"
 "#;
-    let sc = parse_str(yaml).unwrap().services["app"].sysctls.to_map();
-    assert_eq!(
-        sc.get("net.core.somaxconn").map(|s| s.as_str()),
-        Some("1024")
-    );
+	let sc = parse_str(yaml).unwrap().services["app"].sysctls.to_map();
+	assert_eq!(
+		sc.get("net.core.somaxconn").map(|s| s.as_str()),
+		Some("1024")
+	);
 }
 
 #[test]
 fn sysctls_as_map_with_int() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     sysctls:
       net.ipv4.ip_forward: 1
 "#;
-    let sc = parse_str(yaml).unwrap().services["app"].sysctls.to_map();
-    assert_eq!(sc.get("net.ipv4.ip_forward").map(|s| s.as_str()), Some("1"));
+	let sc = parse_str(yaml).unwrap().services["app"].sysctls.to_map();
+	assert_eq!(sc.get("net.ipv4.ip_forward").map(|s| s.as_str()), Some("1"));
 }
 
 #[test]
 fn ulimits_as_number() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     ulimits:
       nofile: 1024
 "#;
-    let ul = parse_str(yaml).unwrap();
-    let ul = &ul.services["app"].ulimits["nofile"];
-    assert_eq!(ul.soft(), 1024);
-    assert_eq!(ul.hard(), 1024);
+	let ul = parse_str(yaml).unwrap();
+	let ul = &ul.services["app"].ulimits["nofile"];
+	assert_eq!(ul.soft(), 1024);
+	assert_eq!(ul.hard(), 1024);
 }
 
 #[test]
 fn ulimits_as_object() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -74,15 +74,15 @@ services:
         soft: 1024
         hard: 65536
 "#;
-    let file = parse_str(yaml).unwrap();
-    let ul = &file.services["app"].ulimits["nofile"];
-    assert_eq!(ul.soft(), 1024);
-    assert_eq!(ul.hard(), 65536);
+	let file = parse_str(yaml).unwrap();
+	let ul = &file.services["app"].ulimits["nofile"];
+	assert_eq!(ul.soft(), 1024);
+	assert_eq!(ul.hard(), 65536);
 }
 
 #[test]
 fn logging_config() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -92,18 +92,18 @@ services:
         max-size: 10m
         max-file: "3"
 "#;
-    let file = parse_str(yaml).unwrap();
-    let logging = file.services["app"].logging.as_ref().unwrap();
-    assert_eq!(logging.driver.as_deref(), Some("json-file"));
-    assert_eq!(
-        logging.options.get("max-size").map(|s| s.as_str()),
-        Some("10m")
-    );
+	let file = parse_str(yaml).unwrap();
+	let logging = file.services["app"].logging.as_ref().unwrap();
+	assert_eq!(logging.driver.as_deref(), Some("json-file"));
+	assert_eq!(
+		logging.options.get("max-size").map(|s| s.as_str()),
+		Some("10m")
+	);
 }
 
 #[test]
 fn deploy_config() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -114,36 +114,36 @@ services:
           cpus: "0.5"
           memory: 128M
 "#;
-    let file = parse_str(yaml).unwrap();
-    let deploy = file.services["app"].deploy.as_ref().unwrap();
-    assert_eq!(deploy.replicas, Some(3));
-    let limits = deploy.resources.as_ref().unwrap().limits.as_ref().unwrap();
-    assert_eq!(limits.cpus.as_deref(), Some("0.5"));
-    assert_eq!(limits.memory.as_deref(), Some("128M"));
+	let file = parse_str(yaml).unwrap();
+	let deploy = file.services["app"].deploy.as_ref().unwrap();
+	assert_eq!(deploy.replicas, Some(3));
+	let limits = deploy.resources.as_ref().unwrap().limits.as_ref().unwrap();
+	assert_eq!(limits.cpus.as_deref(), Some("0.5"));
+	assert_eq!(limits.memory.as_deref(), Some("128M"));
 }
 
 #[test]
 fn network_mode_host() {
-    let yaml = "services:\n  app:\n    image: alpine\n    network_mode: host\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .network_mode
-            .as_deref(),
-        Some("host")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    network_mode: host\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.network_mode
+			.as_deref(),
+		Some("host")
+	);
 }
 
 #[test]
 fn profiles() {
-    let yaml = "services:\n  debug:\n    image: alpine\n    profiles: [debug, dev]\n";
-    let profiles = &parse_str(yaml).unwrap().services["debug"].profiles;
-    assert!(profiles.contains(&"debug".to_string()));
-    assert!(profiles.contains(&"dev".to_string()));
+	let yaml = "services:\n  debug:\n    image: alpine\n    profiles: [debug, dev]\n";
+	let profiles = &parse_str(yaml).unwrap().services["debug"].profiles;
+	assert!(profiles.contains(&"debug".to_string()));
+	assert!(profiles.contains(&"dev".to_string()));
 }
 
 #[test]
 fn secrets_on_service() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -154,87 +154,87 @@ secrets:
   ext_secret:
     external: true
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].secrets.len(), 2);
-    assert_eq!(file.services["app"].secrets[0].source(), "my_secret");
-    assert_eq!(
-        file.secrets["my_secret"].file.as_deref(),
-        Some("./secret.txt")
-    );
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].secrets.len(), 2);
+	assert_eq!(file.services["app"].secrets[0].source(), "my_secret");
+	assert_eq!(
+		file.secrets["my_secret"].file.as_deref(),
+		Some("./secret.txt")
+	);
 }
 
 #[test]
 fn env_file_string() {
-    let yaml = "services:\n  app:\n    image: alpine\n    env_file: .env\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].env_file.to_list(),
-        vec![".env"]
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    env_file: .env\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].env_file.to_list(),
+		vec![".env"]
+	);
 }
 
 #[test]
 fn env_file_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     env_file: [.env, .env.local]
 "#;
-    let list = parse_str(yaml).unwrap().services["app"].env_file.to_list();
-    assert_eq!(list.len(), 2);
-    assert!(list.contains(&".env.local".to_string()));
+	let list = parse_str(yaml).unwrap().services["app"].env_file.to_list();
+	assert_eq!(list.len(), 2);
+	assert!(list.contains(&".env.local".to_string()));
 }
 
 #[test]
 fn restart_policies() {
-    for policy in &["no", "always", "on-failure", "unless-stopped"] {
-        let yaml = format!("services:\n  app:\n    image: alpine\n    restart: {policy}\n");
-        assert!(parse_str(&yaml).unwrap().services["app"].restart.is_some());
-    }
+	for policy in &["no", "always", "on-failure", "unless-stopped"] {
+		let yaml = format!("services:\n  app:\n    image: alpine\n    restart: {policy}\n");
+		assert!(parse_str(&yaml).unwrap().services["app"].restart.is_some());
+	}
 }
 
 #[test]
 fn restart_on_failure_with_count() {
-    let yaml = "services:\n  app:\n    image: alpine\n    restart: on-failure:5\n";
-    let r = parse_str(yaml).unwrap().services["app"]
-        .restart
-        .clone()
-        .unwrap();
-    match r {
-        RestartPolicy::OnFailure { max_attempts } => assert_eq!(max_attempts, Some(5)),
-        other => panic!("expected OnFailure, got {other:?}"),
-    }
+	let yaml = "services:\n  app:\n    image: alpine\n    restart: on-failure:5\n";
+	let r = parse_str(yaml).unwrap().services["app"]
+		.restart
+		.clone()
+		.unwrap();
+	match r {
+		RestartPolicy::OnFailure { max_attempts } => assert_eq!(max_attempts, Some(5)),
+		other => panic!("expected OnFailure, got {other:?}"),
+	}
 }
 
 #[test]
 fn labels_as_list() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     labels:
       - "com.example.env=prod"
 "#;
-    let labels = parse_str(yaml).unwrap().services["app"].labels.to_map();
-    assert_eq!(
-        labels.get("com.example.env").map(|s| s.as_str()),
-        Some("prod")
-    );
+	let labels = parse_str(yaml).unwrap().services["app"].labels.to_map();
+	assert_eq!(
+		labels.get("com.example.env").map(|s| s.as_str()),
+		Some("prod")
+	);
 }
 
 #[test]
 fn labels_as_map() {
-    let yaml = "services:\n  app:\n    image: alpine\n    labels:\n      com.example.env: prod\n";
-    let labels = parse_str(yaml).unwrap().services["app"].labels.to_map();
-    assert_eq!(
-        labels.get("com.example.env").map(|s| s.as_str()),
-        Some("prod")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    labels:\n      com.example.env: prod\n";
+	let labels = parse_str(yaml).unwrap().services["app"].labels.to_map();
+	assert_eq!(
+		labels.get("com.example.env").map(|s| s.as_str()),
+		Some("prod")
+	);
 }
 
 #[test]
 fn extra_hosts() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -242,62 +242,62 @@ services:
       - "somehost:162.242.195.82"
       - "otherhost:50.31.209.229"
 "#;
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"].extra_hosts.len(),
-        2
-    );
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"].extra_hosts.len(),
+		2
+	);
 }
 
 #[test]
 fn tty_and_stdin_open() {
-    let yaml = "services:\n  app:\n    image: alpine\n    tty: true\n    stdin_open: true\n";
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].tty, Some(true));
-    assert_eq!(file.services["app"].stdin_open, Some(true));
+	let yaml = "services:\n  app:\n    image: alpine\n    tty: true\n    stdin_open: true\n";
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].tty, Some(true));
+	assert_eq!(file.services["app"].stdin_open, Some(true));
 }
 
 #[test]
 fn privileged_and_init() {
-    let yaml = "services:\n  app:\n    image: alpine\n    privileged: true\n    init: true\n";
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].privileged, Some(true));
-    assert_eq!(file.services["app"].init, Some(true));
+	let yaml = "services:\n  app:\n    image: alpine\n    privileged: true\n    init: true\n";
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].privileged, Some(true));
+	assert_eq!(file.services["app"].init, Some(true));
 }
 
 #[test]
 fn stop_signal() {
-    let yaml = "services:\n  app:\n    image: alpine\n    stop_signal: SIGTERM\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .stop_signal
-            .as_deref(),
-        Some("SIGTERM")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    stop_signal: SIGTERM\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.stop_signal
+			.as_deref(),
+		Some("SIGTERM")
+	);
 }
 
 #[test]
 fn dns() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     dns: [8.8.8.8, 8.8.4.4]
 "#;
-    assert!(parse_str(yaml).unwrap().services["app"]
-        .dns
-        .to_list()
-        .contains(&"8.8.8.8".to_string()));
+	assert!(parse_str(yaml).unwrap().services["app"]
+		.dns
+		.to_list()
+		.contains(&"8.8.8.8".to_string()));
 }
 
 #[test]
 fn cap_add_and_drop() {
-    let yaml =
-        "services:\n  app:\n    image: alpine\n    cap_add: [NET_ADMIN]\n    cap_drop: [ALL]\n";
-    let file = parse_str(yaml).unwrap();
-    assert!(file.services["app"]
-        .cap_add
-        .contains(&"NET_ADMIN".to_string()));
-    assert!(file.services["app"].cap_drop.contains(&"ALL".to_string()));
+	let yaml =
+		"services:\n  app:\n    image: alpine\n    cap_add: [NET_ADMIN]\n    cap_drop: [ALL]\n";
+	let file = parse_str(yaml).unwrap();
+	assert!(file.services["app"]
+		.cap_add
+		.contains(&"NET_ADMIN".to_string()));
+	assert!(file.services["app"].cap_drop.contains(&"ALL".to_string()));
 }
 
 // ---------------------------------------------------------------------------
@@ -307,7 +307,7 @@ fn cap_add_and_drop() {
 
 #[test]
 fn extends_short_form() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   base:
     image: alpine
@@ -316,19 +316,19 @@ services:
   app:
     extends: base
 "#;
-    let file = parse_str(yaml).unwrap();
-    let app = &file.services["app"];
-    assert_eq!(app.image.as_deref(), Some("alpine"));
-    let env = app.environment.to_map();
-    assert_eq!(
-        env.get("LOG").and_then(|v| v.clone()).as_deref(),
-        Some("info")
-    );
+	let file = parse_str(yaml).unwrap();
+	let app = &file.services["app"];
+	assert_eq!(app.image.as_deref(), Some("alpine"));
+	let env = app.environment.to_map();
+	assert_eq!(
+		env.get("LOG").and_then(|v| v.clone()).as_deref(),
+		Some("info")
+	);
 }
 
 #[test]
 fn extends_long_form_no_file() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   base:
     image: alpine
@@ -336,14 +336,14 @@ services:
     extends:
       service: base
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
 }
 
 #[test]
 fn extends_with_file_field_parses() {
-    // Just verify that extends with file is parsed (resolution requires parse_file).
-    let yaml = r#"
+	// Just verify that extends with file is parsed (resolution requires parse_file).
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -351,18 +351,18 @@ services:
       service: base
       file: ./common.yml
 "#;
-    // parse_str does not resolve external files; the field should still parse,
-    // but extends must remain unresolved (we expect an error from parse_str).
-    let res = parse_str(yaml);
-    assert!(
-        res.is_err(),
-        "parse_str should reject extends.file references"
-    );
+	// parse_str does not resolve external files; the field should still parse,
+	// but extends must remain unresolved (we expect an error from parse_str).
+	let res = parse_str(yaml);
+	assert!(
+		res.is_err(),
+		"parse_str should reject extends.file references"
+	);
 }
 
 #[test]
 fn configs_top_level() {
-    let yaml = r#"
+	let yaml = r#"
 configs:
   app_cfg:
     file: ./app.conf
@@ -377,52 +377,52 @@ services:
         target: /etc/inline.conf
         mode: 420
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert!(file.configs.contains_key("app_cfg"));
-    assert_eq!(file.configs["app_cfg"].file.as_deref(), Some("./app.conf"));
-    assert_eq!(
-        file.configs["inline_cfg"].content.as_deref(),
-        Some("hello world")
-    );
-    assert_eq!(file.services["app"].configs.len(), 2);
-    assert_eq!(file.services["app"].configs[0].source(), "app_cfg");
-    assert_eq!(
-        file.services["app"].configs[1].target(),
-        Some("/etc/inline.conf")
-    );
+	let file = parse_str(yaml).unwrap();
+	assert!(file.configs.contains_key("app_cfg"));
+	assert_eq!(file.configs["app_cfg"].file.as_deref(), Some("./app.conf"));
+	assert_eq!(
+		file.configs["inline_cfg"].content.as_deref(),
+		Some("hello world")
+	);
+	assert_eq!(file.services["app"].configs.len(), 2);
+	assert_eq!(file.services["app"].configs[0].source(), "app_cfg");
+	assert_eq!(
+		file.services["app"].configs[1].target(),
+		Some("/etc/inline.conf")
+	);
 }
 
 #[test]
 fn annotations_as_list_and_map() {
-    let yaml_list = r#"
+	let yaml_list = r#"
 services:
   a:
     image: alpine
     annotations:
       - "io.k8s.example=foo"
 "#;
-    let yaml_map = r#"
+	let yaml_map = r#"
 services:
   a:
     image: alpine
     annotations:
       io.k8s.example: foo
 "#;
-    for yaml in &[yaml_list, yaml_map] {
-        let m = parse_str(yaml).unwrap().services["a"].annotations.to_map();
-        assert_eq!(m.get("io.k8s.example").map(|s| s.as_str()), Some("foo"));
-    }
+	for yaml in &[yaml_list, yaml_map] {
+		let m = parse_str(yaml).unwrap().services["a"].annotations.to_map();
+		assert_eq!(m.get("io.k8s.example").map(|s| s.as_str()), Some("foo"));
+	}
 }
 
 #[test]
 fn scale_field() {
-    let yaml = "services:\n  app:\n    image: alpine\n    scale: 3\n";
-    assert_eq!(parse_str(yaml).unwrap().services["app"].scale, Some(3));
+	let yaml = "services:\n  app:\n    image: alpine\n    scale: 3\n";
+	assert_eq!(parse_str(yaml).unwrap().services["app"].scale, Some(3));
 }
 
 #[test]
 fn volume_long_form_bind_propagation() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -435,21 +435,21 @@ services:
           create_host_path: true
           selinux: z
 "#;
-    let file = parse_str(yaml).unwrap();
-    let v = &file.services["app"].volumes[0];
-    match v {
-        VolumeMount::Long { bind: Some(b), .. } => {
-            assert_eq!(b.propagation.as_deref(), Some("rshared"));
-            assert_eq!(b.create_host_path, Some(true));
-            assert_eq!(b.selinux.as_deref(), Some("z"));
-        }
-        _ => panic!("expected long-form bind mount"),
-    }
+	let file = parse_str(yaml).unwrap();
+	let v = &file.services["app"].volumes[0];
+	match v {
+		VolumeMount::Long { bind: Some(b), .. } => {
+			assert_eq!(b.propagation.as_deref(), Some("rshared"));
+			assert_eq!(b.create_host_path, Some(true));
+			assert_eq!(b.selinux.as_deref(), Some("z"));
+		}
+		_ => panic!("expected long-form bind mount"),
+	}
 }
 
 #[test]
 fn volume_long_form_tmpfs_size_mode() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -460,19 +460,19 @@ services:
           size: 67108864
           mode: 1023
 "#;
-    let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
-    match v {
-        VolumeMount::Long { tmpfs: Some(t), .. } => {
-            assert_eq!(t.size, Some(67108864));
-            assert_eq!(t.mode, Some(1023));
-        }
-        _ => panic!("expected tmpfs mount"),
-    }
+	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
+	match v {
+		VolumeMount::Long { tmpfs: Some(t), .. } => {
+			assert_eq!(t.size, Some(67108864));
+			assert_eq!(t.mode, Some(1023));
+		}
+		_ => panic!("expected tmpfs mount"),
+	}
 }
 
 #[test]
 fn volume_long_form_volume_nocopy() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -483,18 +483,18 @@ services:
         volume:
           nocopy: true
 "#;
-    let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
-    match v {
-        VolumeMount::Long {
-            volume: Some(vo), ..
-        } => assert_eq!(vo.nocopy, Some(true)),
-        _ => panic!("expected long-form volume mount"),
-    }
+	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
+	match v {
+		VolumeMount::Long {
+			volume: Some(vo), ..
+		} => assert_eq!(vo.nocopy, Some(true)),
+		_ => panic!("expected long-form volume mount"),
+	}
 }
 
 #[test]
 fn build_cache_from() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -502,48 +502,48 @@ services:
       cache_from:
         - registry/example:latest
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    match svc.build.as_ref().unwrap() {
-        BuildConfig::Config { cache_from, .. } => assert_eq!(cache_from.len(), 1),
-        _ => panic!("expected long-form build"),
-    }
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	match svc.build.as_ref().unwrap() {
+		BuildConfig::Config { cache_from, .. } => assert_eq!(cache_from.len(), 1),
+		_ => panic!("expected long-form build"),
+	}
 }
 
 #[test]
 fn build_shm_size() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
       context: .
       shm_size: 128m
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    match svc.build.as_ref().unwrap() {
-        BuildConfig::Config { shm_size, .. } => assert_eq!(shm_size.as_deref(), Some("128m")),
-        _ => panic!(""),
-    }
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	match svc.build.as_ref().unwrap() {
+		BuildConfig::Config { shm_size, .. } => assert_eq!(shm_size.as_deref(), Some("128m")),
+		_ => panic!(""),
+	}
 }
 
 #[test]
 fn build_network() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
       context: .
       network: host
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    match svc.build.as_ref().unwrap() {
-        BuildConfig::Config { network, .. } => assert_eq!(network.as_deref(), Some("host")),
-        _ => panic!(""),
-    }
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	match svc.build.as_ref().unwrap() {
+		BuildConfig::Config { network, .. } => assert_eq!(network.as_deref(), Some("host")),
+		_ => panic!(""),
+	}
 }
 
 #[test]
 fn build_platforms() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     build:
@@ -552,16 +552,16 @@ services:
         - linux/amd64
         - linux/arm64
 "#;
-    let svc = &parse_str(yaml).unwrap().services["app"];
-    match svc.build.as_ref().unwrap() {
-        BuildConfig::Config { platforms, .. } => assert_eq!(platforms.len(), 2),
-        _ => panic!(""),
-    }
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	match svc.build.as_ref().unwrap() {
+		BuildConfig::Config { platforms, .. } => assert_eq!(platforms.len(), 2),
+		_ => panic!(""),
+	}
 }
 
 #[test]
 fn network_per_service_map_form() {
-    let yaml = r#"
+	let yaml = r#"
 networks:
   frontend:
   backend:
@@ -575,56 +575,56 @@ services:
         ipv6_address: 2001:db8::10
       backend: ~
 "#;
-    let file = parse_str(yaml).unwrap();
-    let names = file.services["app"].networks.names();
-    assert!(names.contains(&"frontend".to_string()));
-    assert!(names.contains(&"backend".to_string()));
-    let cfg = file.services["app"]
-        .networks
-        .config_for("frontend")
-        .expect("frontend cfg");
-    assert_eq!(cfg.aliases.as_ref().unwrap().len(), 2);
-    assert_eq!(cfg.ipv4_address.as_deref(), Some("172.16.238.10"));
-    assert_eq!(cfg.ipv6_address.as_deref(), Some("2001:db8::10"));
+	let file = parse_str(yaml).unwrap();
+	let names = file.services["app"].networks.names();
+	assert!(names.contains(&"frontend".to_string()));
+	assert!(names.contains(&"backend".to_string()));
+	let cfg = file.services["app"]
+		.networks
+		.config_for("frontend")
+		.expect("frontend cfg");
+	assert_eq!(cfg.aliases.as_ref().unwrap().len(), 2);
+	assert_eq!(cfg.ipv4_address.as_deref(), Some("172.16.238.10"));
+	assert_eq!(cfg.ipv6_address.as_deref(), Some("2001:db8::10"));
 }
 
 #[test]
 fn healthcheck_disable_via_test_none() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     healthcheck:
       test: ["NONE"]
 "#;
-    let hc = parse_str(yaml).unwrap().services["app"]
-        .healthcheck
-        .as_ref()
-        .unwrap()
-        .clone();
-    assert!(hc.is_disabled());
+	let hc = parse_str(yaml).unwrap().services["app"]
+		.healthcheck
+		.as_ref()
+		.unwrap()
+		.clone();
+	assert!(hc.is_disabled());
 }
 
 #[test]
 fn healthcheck_disable_explicit() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
     healthcheck:
       disable: true
 "#;
-    let hc = parse_str(yaml).unwrap().services["app"]
-        .healthcheck
-        .as_ref()
-        .unwrap()
-        .clone();
-    assert!(hc.is_disabled());
+	let hc = parse_str(yaml).unwrap().services["app"]
+		.healthcheck
+		.as_ref()
+		.unwrap()
+		.clone();
+	assert!(hc.is_disabled());
 }
 
 #[test]
 fn healthcheck_start_interval() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -632,44 +632,44 @@ services:
       test: ["CMD", "true"]
       start_interval: 1s
 "#;
-    let hc = parse_str(yaml).unwrap().services["app"]
-        .healthcheck
-        .as_ref()
-        .unwrap()
-        .clone();
-    assert_eq!(hc.start_interval.as_deref(), Some("1s"));
+	let hc = parse_str(yaml).unwrap().services["app"]
+		.healthcheck
+		.as_ref()
+		.unwrap()
+		.clone();
+	assert_eq!(hc.start_interval.as_deref(), Some("1s"));
 }
 
 #[test]
 fn network_mode_slirp4netns() {
-    let yaml = "services:\n  app:\n    image: alpine\n    network_mode: slirp4netns\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .network_mode
-            .as_deref(),
-        Some("slirp4netns")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    network_mode: slirp4netns\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.network_mode
+			.as_deref(),
+		Some("slirp4netns")
+	);
 }
 
 #[test]
 fn network_mode_pasta() {
-    let yaml = "services:\n  app:\n    image: alpine\n    network_mode: pasta\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .network_mode
-            .as_deref(),
-        Some("pasta")
-    );
+	let yaml = "services:\n  app:\n    image: alpine\n    network_mode: pasta\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.network_mode
+			.as_deref(),
+		Some("pasta")
+	);
 }
 
 #[test]
 fn network_mode_ns_path() {
-    let yaml =
-        "services:\n  app:\n    image: alpine\n    network_mode: \"ns:/run/netns/mynamespace\"\n";
-    assert_eq!(
-        parse_str(yaml).unwrap().services["app"]
-            .network_mode
-            .as_deref(),
-        Some("ns:/run/netns/mynamespace")
-    );
+	let yaml =
+		"services:\n  app:\n    image: alpine\n    network_mode: \"ns:/run/netns/mynamespace\"\n";
+	assert_eq!(
+		parse_str(yaml).unwrap().services["app"]
+			.network_mode
+			.as_deref(),
+		Some("ns:/run/netns/mynamespace")
+	);
 }

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -3,23 +3,23 @@ use std::io::Write;
 
 #[test]
 fn include_string_form_merges_services() {
-    let dir = tempfile::tempdir().unwrap();
+	let dir = tempfile::tempdir().unwrap();
 
-    let included = dir.path().join("services.yml");
-    writeln!(
-        std::fs::File::create(&included).unwrap(),
-        r#"
+	let included = dir.path().join("services.yml");
+	writeln!(
+		std::fs::File::create(&included).unwrap(),
+		r#"
 services:
   helper:
     image: alpine
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let main = dir.path().join("docker-compose.yml");
-    writeln!(
-        std::fs::File::create(&main).unwrap(),
-        r#"
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		r#"
 include:
   - ./services.yml
 
@@ -27,33 +27,33 @@ services:
   app:
     image: nginx
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let file = parse_file(&main).unwrap();
-    assert!(file.services.contains_key("app"));
-    assert!(file.services.contains_key("helper"));
+	let file = parse_file(&main).unwrap();
+	assert!(file.services.contains_key("app"));
+	assert!(file.services.contains_key("helper"));
 }
 
 #[test]
 fn include_long_form_parses() {
-    let dir = tempfile::tempdir().unwrap();
+	let dir = tempfile::tempdir().unwrap();
 
-    let inc = dir.path().join("inc.yml");
-    writeln!(
-        std::fs::File::create(&inc).unwrap(),
-        r#"
+	let inc = dir.path().join("inc.yml");
+	writeln!(
+		std::fs::File::create(&inc).unwrap(),
+		r#"
 services:
   inc_svc:
     image: alpine
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let main = dir.path().join("docker-compose.yml");
-    writeln!(
-        std::fs::File::create(&main).unwrap(),
-        r#"
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		r#"
 include:
   - path: ./inc.yml
 
@@ -61,33 +61,33 @@ services:
   main_svc:
     image: alpine
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let file = parse_file(&main).unwrap();
-    assert!(file.services.contains_key("inc_svc"));
-    assert!(file.services.contains_key("main_svc"));
+	let file = parse_file(&main).unwrap();
+	assert!(file.services.contains_key("inc_svc"));
+	assert!(file.services.contains_key("main_svc"));
 }
 
 #[test]
 fn parent_overrides_included_service() {
-    let dir = tempfile::tempdir().unwrap();
+	let dir = tempfile::tempdir().unwrap();
 
-    let inc = dir.path().join("inc.yml");
-    writeln!(
-        std::fs::File::create(&inc).unwrap(),
-        r#"
+	let inc = dir.path().join("inc.yml");
+	writeln!(
+		std::fs::File::create(&inc).unwrap(),
+		r#"
 services:
   shared:
     image: alpine:included
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let main = dir.path().join("docker-compose.yml");
-    writeln!(
-        std::fs::File::create(&main).unwrap(),
-        r#"
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		r#"
 include:
   - ./inc.yml
 
@@ -95,13 +95,13 @@ services:
   shared:
     image: alpine:override
 "#
-    )
-    .unwrap();
+	)
+	.unwrap();
 
-    let file = parse_file(&main).unwrap();
-    // Parent file definition wins.
-    assert_eq!(
-        file.services["shared"].image.as_deref(),
-        Some("alpine:override")
-    );
+	let file = parse_file(&main).unwrap();
+	// Parent file definition wins.
+	assert_eq!(
+		file.services["shared"].image.as_deref(),
+		Some("alpine:override")
+	);
 }

--- a/tests/parse/order.rs
+++ b/tests/parse/order.rs
@@ -3,14 +3,14 @@ use podup::{parse_str, resolve_order};
 
 #[test]
 fn no_deps() {
-    let yaml =
-        "services:\n  a:\n    image: alpine\n  b:\n    image: alpine\n  c:\n    image: alpine\n";
-    assert_eq!(resolve_order(&parse_str(yaml).unwrap()).unwrap().len(), 3);
+	let yaml =
+		"services:\n  a:\n    image: alpine\n  b:\n    image: alpine\n  c:\n    image: alpine\n";
+	assert_eq!(resolve_order(&parse_str(yaml).unwrap()).unwrap().len(), 3);
 }
 
 #[test]
 fn linear_chain() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   c:
     image: alpine
@@ -21,15 +21,15 @@ services:
   a:
     image: alpine
 "#;
-    let order = resolve_order(&parse_str(yaml).unwrap()).unwrap();
-    let pos = |s: &str| order.iter().position(|x| x == s).unwrap();
-    assert!(pos("a") < pos("b"));
-    assert!(pos("b") < pos("c"));
+	let order = resolve_order(&parse_str(yaml).unwrap()).unwrap();
+	let pos = |s: &str| order.iter().position(|x| x == s).unwrap();
+	assert!(pos("a") < pos("b"));
+	assert!(pos("b") < pos("c"));
 }
 
 #[test]
 fn diamond() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -43,17 +43,17 @@ services:
   db:
     image: alpine
 "#;
-    let order = resolve_order(&parse_str(yaml).unwrap()).unwrap();
-    let pos = |s: &str| order.iter().position(|x| x == s).unwrap();
-    assert!(pos("db") < pos("api"));
-    assert!(pos("db") < pos("worker"));
-    assert!(pos("api") < pos("app"));
-    assert!(pos("worker") < pos("app"));
+	let order = resolve_order(&parse_str(yaml).unwrap()).unwrap();
+	let pos = |s: &str| order.iter().position(|x| x == s).unwrap();
+	assert!(pos("db") < pos("api"));
+	assert!(pos("db") < pos("worker"));
+	assert!(pos("api") < pos("app"));
+	assert!(pos("worker") < pos("app"));
 }
 
 #[test]
 fn circular_dependency_error() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   a:
     image: alpine
@@ -62,18 +62,18 @@ services:
     image: alpine
     depends_on: [a]
 "#;
-    assert!(resolve_order(&parse_str(yaml).unwrap()).is_err());
+	assert!(resolve_order(&parse_str(yaml).unwrap()).is_err());
 }
 
 #[test]
 fn missing_dependency_error() {
-    let yaml = "services:\n  a:\n    image: alpine\n    depends_on: [nonexistent]\n";
-    assert!(resolve_order(&parse_str(yaml).unwrap()).is_err());
+	let yaml = "services:\n  a:\n    image: alpine\n    depends_on: [nonexistent]\n";
+	assert!(resolve_order(&parse_str(yaml).unwrap()).is_err());
 }
 
 #[test]
 fn service_completed_successfully_parses() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -83,14 +83,14 @@ services:
   seed:
     image: alpine
 "#;
-    let file = parse_str(yaml).unwrap();
-    let cond = file.services["app"].depends_on.condition_for("seed");
-    assert_eq!(cond, ServiceCondition::ServiceCompletedSuccessfully);
+	let file = parse_str(yaml).unwrap();
+	let cond = file.services["app"].depends_on.condition_for("seed");
+	assert_eq!(cond, ServiceCondition::ServiceCompletedSuccessfully);
 }
 
 #[test]
 fn depends_on_with_required_false_skipped() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   app:
     image: alpine
@@ -99,10 +99,10 @@ services:
         condition: service_started
         required: false
 "#;
-    // Without `required: false` this would fail; with it, the missing dep is ignored.
-    let file = parse_str(yaml).unwrap();
-    let order = resolve_order(&file);
-    assert!(order.is_ok());
+	// Without `required: false` this would fail; with it, the missing dep is ignored.
+	let file = parse_str(yaml).unwrap();
+	let order = resolve_order(&file);
+	assert!(order.is_ok());
 }
 
 // ---------------------------------------------------------------------------
@@ -112,7 +112,7 @@ services:
 
 #[test]
 fn services_with_profiles_are_listed() {
-    let yaml = r#"
+	let yaml = r#"
 services:
   always:
     image: alpine
@@ -123,10 +123,10 @@ services:
     image: alpine
     profiles: [monitoring, full]
 "#;
-    let file = parse_str(yaml).unwrap();
-    assert!(file.services["always"].profiles.is_empty());
-    assert_eq!(file.services["debug"].profiles, vec!["debug"]);
-    assert!(file.services["monitoring"]
-        .profiles
-        .contains(&"full".to_string()));
+	let file = parse_str(yaml).unwrap();
+	assert!(file.services["always"].profiles.is_empty());
+	assert_eq!(file.services["debug"].profiles, vec!["debug"]);
+	assert!(file.services["monitoring"]
+		.profiles
+		.contains(&"full".to_string()));
 }

--- a/tests/ports/conversion.rs
+++ b/tests/ports/conversion.rs
@@ -2,31 +2,31 @@ use podup::compose::types::PortMapping;
 use podup::ports::{parse_ports, to_bollard};
 
 fn short(s: &str) -> PortMapping {
-    PortMapping::Short(s.to_string())
+	PortMapping::Short(s.to_string())
 }
 
 #[test]
 fn bollard_keys_and_bindings() {
-    let ports = parse_ports(&[short("8080:80")]).unwrap();
-    let (bindings, exposed) = to_bollard(&ports);
-    assert!(bindings.contains_key("80/tcp"));
-    assert!(exposed.contains_key("80/tcp"));
-    let b = bindings["80/tcp"].as_ref().unwrap();
-    assert_eq!(b[0].host_port.as_deref(), Some("8080"));
-    assert_eq!(b[0].host_ip.as_deref(), Some("0.0.0.0"));
+	let ports = parse_ports(&[short("8080:80")]).unwrap();
+	let (bindings, exposed) = to_bollard(&ports);
+	assert!(bindings.contains_key("80/tcp"));
+	assert!(exposed.contains_key("80/tcp"));
+	let b = bindings["80/tcp"].as_ref().unwrap();
+	assert_eq!(b[0].host_port.as_deref(), Some("8080"));
+	assert_eq!(b[0].host_ip.as_deref(), Some("0.0.0.0"));
 }
 
 #[test]
 fn bollard_udp_key() {
-    let ports = parse_ports(&[short("514:514/udp")]).unwrap();
-    let (bindings, _) = to_bollard(&ports);
-    assert!(bindings.contains_key("514/udp"));
+	let ports = parse_ports(&[short("514:514/udp")]).unwrap();
+	let (bindings, _) = to_bollard(&ports);
+	assert!(bindings.contains_key("514/udp"));
 }
 
 #[test]
 fn bollard_range_produces_multiple_keys() {
-    let ports = parse_ports(&[short("8000-8001:8000-8001")]).unwrap();
-    let (bindings, _) = to_bollard(&ports);
-    assert!(bindings.contains_key("8000/tcp"));
-    assert!(bindings.contains_key("8001/tcp"));
+	let ports = parse_ports(&[short("8000-8001:8000-8001")]).unwrap();
+	let (bindings, _) = to_bollard(&ports);
+	assert!(bindings.contains_key("8000/tcp"));
+	assert!(bindings.contains_key("8001/tcp"));
 }

--- a/tests/ports/formats.rs
+++ b/tests/ports/formats.rs
@@ -2,108 +2,108 @@ use podup::compose::types::PortMapping;
 use podup::ports::parse_ports;
 
 fn short(s: &str) -> PortMapping {
-    PortMapping::Short(s.to_string())
+	PortMapping::Short(s.to_string())
 }
 
 #[test]
 fn container_only() {
-    let ports = parse_ports(&[short("80")]).unwrap();
-    assert_eq!(ports[0].container_port, 80);
-    assert_eq!(ports[0].protocol, "tcp");
-    assert!(ports[0].host_port.is_none());
+	let ports = parse_ports(&[short("80")]).unwrap();
+	assert_eq!(ports[0].container_port, 80);
+	assert_eq!(ports[0].protocol, "tcp");
+	assert!(ports[0].host_port.is_none());
 }
 
 #[test]
 fn host_colon_container() {
-    let ports = parse_ports(&[short("8080:80")]).unwrap();
-    assert_eq!(ports[0].container_port, 80);
-    assert_eq!(ports[0].host_port, Some(8080));
+	let ports = parse_ports(&[short("8080:80")]).unwrap();
+	assert_eq!(ports[0].container_port, 80);
+	assert_eq!(ports[0].host_port, Some(8080));
 }
 
 #[test]
 fn ip_host_container() {
-    let ports = parse_ports(&[short("127.0.0.1:8080:80")]).unwrap();
-    assert_eq!(ports[0].container_port, 80);
-    assert_eq!(ports[0].host_port, Some(8080));
-    assert_eq!(ports[0].host_ip, "127.0.0.1");
+	let ports = parse_ports(&[short("127.0.0.1:8080:80")]).unwrap();
+	assert_eq!(ports[0].container_port, 80);
+	assert_eq!(ports[0].host_port, Some(8080));
+	assert_eq!(ports[0].host_ip, "127.0.0.1");
 }
 
 #[test]
 fn udp_protocol() {
-    assert_eq!(
-        parse_ports(&[short("514:514/udp")]).unwrap()[0].protocol,
-        "udp"
-    );
+	assert_eq!(
+		parse_ports(&[short("514:514/udp")]).unwrap()[0].protocol,
+		"udp"
+	);
 }
 
 #[test]
 fn container_only_udp() {
-    let ports = parse_ports(&[short("53/udp")]).unwrap();
-    assert_eq!(ports[0].container_port, 53);
-    assert_eq!(ports[0].protocol, "udp");
-    assert!(ports[0].host_port.is_none());
+	let ports = parse_ports(&[short("53/udp")]).unwrap();
+	assert_eq!(ports[0].container_port, 53);
+	assert_eq!(ports[0].protocol, "udp");
+	assert!(ports[0].host_port.is_none());
 }
 
 #[test]
 fn range_expansion() {
-    let ports = parse_ports(&[short("8000-8002:8000-8002")]).unwrap();
-    assert_eq!(ports.len(), 3);
-    assert_eq!(ports[0].container_port, 8000);
-    assert_eq!(ports[1].container_port, 8001);
-    assert_eq!(ports[2].container_port, 8002);
+	let ports = parse_ports(&[short("8000-8002:8000-8002")]).unwrap();
+	assert_eq!(ports.len(), 3);
+	assert_eq!(ports[0].container_port, 8000);
+	assert_eq!(ports[1].container_port, 8001);
+	assert_eq!(ports[2].container_port, 8002);
 }
 
 #[test]
 fn ipv6_host_ip() {
-    let ports = parse_ports(&[short("[::1]:8080:80")]).unwrap();
-    assert_eq!(ports[0].host_ip, "::1");
-    assert_eq!(ports[0].host_port, Some(8080));
-    assert_eq!(ports[0].container_port, 80);
+	let ports = parse_ports(&[short("[::1]:8080:80")]).unwrap();
+	assert_eq!(ports[0].host_ip, "::1");
+	assert_eq!(ports[0].host_port, Some(8080));
+	assert_eq!(ports[0].container_port, 80);
 }
 
 #[test]
 fn random_host_port_via_zero() {
-    let ports = parse_ports(&[short("0:80")]).unwrap();
-    assert_eq!(ports[0].container_port, 80);
-    assert_eq!(ports[0].host_port, Some(0));
+	let ports = parse_ports(&[short("0:80")]).unwrap();
+	assert_eq!(ports[0].container_port, 80);
+	assert_eq!(ports[0].host_port, Some(0));
 }
 
 #[test]
 fn sctp_protocol() {
-    let ports = parse_ports(&[short("80:80/sctp")]).unwrap();
-    assert_eq!(ports[0].protocol, "sctp");
+	let ports = parse_ports(&[short("80:80/sctp")]).unwrap();
+	assert_eq!(ports[0].protocol, "sctp");
 }
 
 #[test]
 fn range_with_udp() {
-    let ports = parse_ports(&[short("5000-5010:5000-5010/udp")]).unwrap();
-    assert_eq!(ports.len(), 11);
-    assert!(ports.iter().all(|p| p.protocol == "udp"));
+	let ports = parse_ports(&[short("5000-5010:5000-5010/udp")]).unwrap();
+	assert_eq!(ports.len(), 11);
+	assert!(ports.iter().all(|p| p.protocol == "udp"));
 }
 
 #[test]
 fn range_too_large_rejected() {
-    assert!(parse_ports(&[short("1-1025")]).is_err());
-    assert!(parse_ports(&[short("1-65535")]).is_err());
+	assert!(parse_ports(&[short("1-1025")]).is_err());
+	assert!(parse_ports(&[short("1-65535")]).is_err());
 }
 
 #[test]
 fn range_at_limit_accepted() {
-    let ports = parse_ports(&[short("1-1024")]).unwrap();
-    assert_eq!(ports.len(), 1024);
+	let ports = parse_ports(&[short("1-1024")]).unwrap();
+	assert_eq!(ports.len(), 1024);
 }
 
 #[test]
 fn long_form_invalid_published_string_rejected() {
-    use podup::compose::types::StringOrU16;
-    let mapping = podup::compose::types::PortMapping::Long {
-        target: 80,
-        published: Some(StringOrU16::String("invalid".to_string())),
-        protocol: None,
-        host_ip: None,
-        mode: None,
-        app_protocol: None,
-        name: None,
-    };
-    assert!(parse_ports(&[mapping]).is_err());
+	use podup::compose::types::StringOrU16;
+	let mapping = podup::compose::types::PortMapping::Long {
+		target: 80,
+		published: Some(StringOrU16::String("invalid".to_string())),
+		protocol: None,
+		host_ip: None,
+		mode: None,
+		app_protocol: None,
+		name: None,
+	};
+	assert!(parse_ports(&[mapping]).is_err());
 }

--- a/tests/size.rs
+++ b/tests/size.rs
@@ -4,72 +4,72 @@ use podup::size::{parse_cpus, parse_duration_nanos, parse_duration_secs, parse_m
 
 #[test]
 fn memory_bytes() {
-    assert_eq!(parse_memory("1024"), Some(1024));
-    assert_eq!(parse_memory("1024b"), Some(1024));
-    assert_eq!(parse_memory("1024B"), Some(1024));
+	assert_eq!(parse_memory("1024"), Some(1024));
+	assert_eq!(parse_memory("1024b"), Some(1024));
+	assert_eq!(parse_memory("1024B"), Some(1024));
 }
 
 #[test]
 fn memory_kilobytes() {
-    assert_eq!(parse_memory("1k"), Some(1024));
-    assert_eq!(parse_memory("1K"), Some(1024));
-    assert_eq!(parse_memory("2KB"), Some(2 * 1024));
+	assert_eq!(parse_memory("1k"), Some(1024));
+	assert_eq!(parse_memory("1K"), Some(1024));
+	assert_eq!(parse_memory("2KB"), Some(2 * 1024));
 }
 
 #[test]
 fn memory_megabytes() {
-    assert_eq!(parse_memory("128m"), Some(128 * 1024 * 1024));
-    assert_eq!(parse_memory("128M"), Some(128 * 1024 * 1024));
-    assert_eq!(parse_memory("128MB"), Some(128 * 1024 * 1024));
+	assert_eq!(parse_memory("128m"), Some(128 * 1024 * 1024));
+	assert_eq!(parse_memory("128M"), Some(128 * 1024 * 1024));
+	assert_eq!(parse_memory("128MB"), Some(128 * 1024 * 1024));
 }
 
 #[test]
 fn memory_gigabytes() {
-    assert_eq!(parse_memory("1g"), Some(1024 * 1024 * 1024));
-    assert_eq!(parse_memory("1G"), Some(1024 * 1024 * 1024));
+	assert_eq!(parse_memory("1g"), Some(1024 * 1024 * 1024));
+	assert_eq!(parse_memory("1G"), Some(1024 * 1024 * 1024));
 }
 
 #[test]
 fn memory_terabytes() {
-    assert_eq!(parse_memory("1t"), Some(1024_i64 * 1024 * 1024 * 1024));
+	assert_eq!(parse_memory("1t"), Some(1024_i64 * 1024 * 1024 * 1024));
 }
 
 #[test]
 fn memory_negative_one() {
-    assert_eq!(parse_memory("-1"), Some(-1));
+	assert_eq!(parse_memory("-1"), Some(-1));
 }
 
 #[test]
 fn memory_invalid() {
-    assert!(parse_memory("xyz").is_none());
-    assert!(parse_memory("12xb").is_none());
+	assert!(parse_memory("xyz").is_none());
+	assert!(parse_memory("12xb").is_none());
 }
 
 #[test]
 fn memory_overflow_returns_none() {
-    // Values that overflow i64::MAX must return None, not wrap around.
-    assert!(parse_memory("99999999t").is_none());
-    assert!(parse_memory("9999999999g").is_none());
+	// Values that overflow i64::MAX must return None, not wrap around.
+	assert!(parse_memory("99999999t").is_none());
+	assert!(parse_memory("9999999999g").is_none());
 }
 
 #[test]
 fn cpus_fractional() {
-    assert_eq!(parse_cpus("0.5"), Some(500_000_000));
-    assert_eq!(parse_cpus("1"), Some(1_000_000_000));
-    assert_eq!(parse_cpus("2.5"), Some(2_500_000_000));
+	assert_eq!(parse_cpus("0.5"), Some(500_000_000));
+	assert_eq!(parse_cpus("1"), Some(1_000_000_000));
+	assert_eq!(parse_cpus("2.5"), Some(2_500_000_000));
 }
 
 #[test]
 fn duration_seconds() {
-    assert_eq!(parse_duration_secs("5"), Some(5));
-    assert_eq!(parse_duration_secs("5s"), Some(5));
-    assert_eq!(parse_duration_secs("1m"), Some(60));
-    assert_eq!(parse_duration_secs("1h"), Some(3600));
+	assert_eq!(parse_duration_secs("5"), Some(5));
+	assert_eq!(parse_duration_secs("5s"), Some(5));
+	assert_eq!(parse_duration_secs("1m"), Some(60));
+	assert_eq!(parse_duration_secs("1h"), Some(3600));
 }
 
 #[test]
 fn duration_nanos() {
-    assert_eq!(parse_duration_nanos("1s"), Some(1_000_000_000));
-    assert_eq!(parse_duration_nanos("1ms"), Some(1_000_000));
-    assert_eq!(parse_duration_nanos("500ms"), Some(500_000_000));
+	assert_eq!(parse_duration_nanos("1s"), Some(1_000_000_000));
+	assert_eq!(parse_duration_nanos("1ms"), Some(1_000_000));
+	assert_eq!(parse_duration_nanos("500ms"), Some(500_000_000));
 }

--- a/tests/substitute/dotenv.rs
+++ b/tests/substitute/dotenv.rs
@@ -3,46 +3,46 @@ use std::io::Write;
 
 #[test]
 fn basic_key_value() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
-    writeln!(f, "# comment").unwrap();
-    writeln!(f).unwrap();
-    writeln!(f, "KEY=value").unwrap();
-    writeln!(f, "EMPTY=").unwrap();
-    writeln!(f, "NOVALUE").unwrap();
+	let dir = tempfile::tempdir().unwrap();
+	let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
+	writeln!(f, "# comment").unwrap();
+	writeln!(f).unwrap();
+	writeln!(f, "KEY=value").unwrap();
+	writeln!(f, "EMPTY=").unwrap();
+	writeln!(f, "NOVALUE").unwrap();
 
-    let map = load_dotenv(dir.path());
-    assert_eq!(map.get("KEY").map(|s| s.as_str()), Some("value"));
-    assert_eq!(map.get("EMPTY").map(|s| s.as_str()), Some(""));
-    assert_eq!(map.get("NOVALUE").map(|s| s.as_str()), Some(""));
-    assert!(!map.contains_key("# comment"));
+	let map = load_dotenv(dir.path());
+	assert_eq!(map.get("KEY").map(|s| s.as_str()), Some("value"));
+	assert_eq!(map.get("EMPTY").map(|s| s.as_str()), Some(""));
+	assert_eq!(map.get("NOVALUE").map(|s| s.as_str()), Some(""));
+	assert!(!map.contains_key("# comment"));
 }
 
 #[test]
 fn missing_file_returns_empty() {
-    let dir = tempfile::tempdir().unwrap();
-    assert!(load_dotenv(dir.path()).is_empty());
+	let dir = tempfile::tempdir().unwrap();
+	assert!(load_dotenv(dir.path()).is_empty());
 }
 
 #[test]
 fn process_env_takes_precedence() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
-    writeln!(f, "PATH=/should/not/override").unwrap();
+	let dir = tempfile::tempdir().unwrap();
+	let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
+	writeln!(f, "PATH=/should/not/override").unwrap();
 
-    let map = load_dotenv(dir.path());
-    assert!(!map.contains_key("PATH"));
+	let map = load_dotenv(dir.path());
+	assert!(!map.contains_key("PATH"));
 }
 
 #[test]
 fn build_vars_includes_dotenv() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
-    writeln!(f, "PODUP_TEST_DOTENV_KEY=from_file").unwrap();
+	let dir = tempfile::tempdir().unwrap();
+	let mut f = std::fs::File::create(dir.path().join(".env")).unwrap();
+	writeln!(f, "PODUP_TEST_DOTENV_KEY=from_file").unwrap();
 
-    let vars = build_vars(dir.path());
-    assert_eq!(
-        vars.get("PODUP_TEST_DOTENV_KEY").map(|s| s.as_str()),
-        Some("from_file")
-    );
+	let vars = build_vars(dir.path());
+	assert_eq!(
+		vars.get("PODUP_TEST_DOTENV_KEY").map(|s| s.as_str()),
+		Some("from_file")
+	);
 }

--- a/tests/substitute/modifiers.rs
+++ b/tests/substitute/modifiers.rs
@@ -3,167 +3,167 @@ use podup::ComposeError;
 use std::collections::HashMap;
 
 fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-    pairs
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-        .collect()
+	pairs
+		.iter()
+		.map(|(k, v)| (k.to_string(), v.to_string()))
+		.collect()
 }
 
 #[test]
 fn bare_dollar_sign() {
-    assert_eq!(substitute("cost: $5", &vars(&[])).unwrap(), "cost: $5");
+	assert_eq!(substitute("cost: $5", &vars(&[])).unwrap(), "cost: $5");
 }
 
 #[test]
 fn double_dollar_escape() {
-    assert_eq!(
-        substitute("$$VAR", &vars(&[("VAR", "hello")])).unwrap(),
-        "$VAR"
-    );
+	assert_eq!(
+		substitute("$$VAR", &vars(&[("VAR", "hello")])).unwrap(),
+		"$VAR"
+	);
 }
 
 #[test]
 fn bare_var_set() {
-    assert_eq!(
-        substitute("$FOO bar", &vars(&[("FOO", "hello")])).unwrap(),
-        "hello bar"
-    );
+	assert_eq!(
+		substitute("$FOO bar", &vars(&[("FOO", "hello")])).unwrap(),
+		"hello bar"
+	);
 }
 
 #[test]
 fn bare_var_unset() {
-    assert_eq!(substitute("$MISSING", &vars(&[])).unwrap(), "");
+	assert_eq!(substitute("$MISSING", &vars(&[])).unwrap(), "");
 }
 
 #[test]
 fn braced_var_set() {
-    assert_eq!(
-        substitute("${FOO}", &vars(&[("FOO", "world")])).unwrap(),
-        "world"
-    );
+	assert_eq!(
+		substitute("${FOO}", &vars(&[("FOO", "world")])).unwrap(),
+		"world"
+	);
 }
 
 #[test]
 fn braced_var_unset() {
-    assert_eq!(substitute("${MISSING}", &vars(&[])).unwrap(), "");
+	assert_eq!(substitute("${MISSING}", &vars(&[])).unwrap(), "");
 }
 
 #[test]
 fn default_if_unset_or_empty_nonempty() {
-    assert_eq!(
-        substitute("${FOO:-def}", &vars(&[("FOO", "bar")])).unwrap(),
-        "bar"
-    );
+	assert_eq!(
+		substitute("${FOO:-def}", &vars(&[("FOO", "bar")])).unwrap(),
+		"bar"
+	);
 }
 
 #[test]
 fn default_if_unset_or_empty_empty() {
-    assert_eq!(
-        substitute("${FOO:-def}", &vars(&[("FOO", "")])).unwrap(),
-        "def"
-    );
+	assert_eq!(
+		substitute("${FOO:-def}", &vars(&[("FOO", "")])).unwrap(),
+		"def"
+	);
 }
 
 #[test]
 fn default_if_unset_or_empty_unset() {
-    assert_eq!(substitute("${FOO:-def}", &vars(&[])).unwrap(), "def");
+	assert_eq!(substitute("${FOO:-def}", &vars(&[])).unwrap(), "def");
 }
 
 #[test]
 fn default_if_unset_set_empty() {
-    assert_eq!(substitute("${FOO-def}", &vars(&[("FOO", "")])).unwrap(), "");
+	assert_eq!(substitute("${FOO-def}", &vars(&[("FOO", "")])).unwrap(), "");
 }
 
 #[test]
 fn default_if_unset_unset() {
-    assert_eq!(substitute("${FOO-def}", &vars(&[])).unwrap(), "def");
+	assert_eq!(substitute("${FOO-def}", &vars(&[])).unwrap(), "def");
 }
 
 #[test]
 fn default_if_unset_set_nonempty() {
-    assert_eq!(
-        substitute("${FOO-def}", &vars(&[("FOO", "bar")])).unwrap(),
-        "bar"
-    );
+	assert_eq!(
+		substitute("${FOO-def}", &vars(&[("FOO", "bar")])).unwrap(),
+		"bar"
+	);
 }
 
 #[test]
 fn alt_if_set_and_nonempty() {
-    assert_eq!(
-        substitute("${FOO:+alt}", &vars(&[("FOO", "bar")])).unwrap(),
-        "alt"
-    );
+	assert_eq!(
+		substitute("${FOO:+alt}", &vars(&[("FOO", "bar")])).unwrap(),
+		"alt"
+	);
 }
 
 #[test]
 fn alt_if_set_empty_value() {
-    assert_eq!(
-        substitute("${FOO:+alt}", &vars(&[("FOO", "")])).unwrap(),
-        ""
-    );
+	assert_eq!(
+		substitute("${FOO:+alt}", &vars(&[("FOO", "")])).unwrap(),
+		""
+	);
 }
 
 #[test]
 fn alt_if_set_unset() {
-    assert_eq!(substitute("${FOO:+alt}", &vars(&[])).unwrap(), "");
+	assert_eq!(substitute("${FOO:+alt}", &vars(&[])).unwrap(), "");
 }
 
 #[test]
 fn alt_if_set_counts_empty() {
-    assert_eq!(
-        substitute("${FOO+alt}", &vars(&[("FOO", "")])).unwrap(),
-        "alt"
-    );
+	assert_eq!(
+		substitute("${FOO+alt}", &vars(&[("FOO", "")])).unwrap(),
+		"alt"
+	);
 }
 
 #[test]
 fn alt_if_set_unset_returns_empty() {
-    assert_eq!(substitute("${FOO+alt}", &vars(&[])).unwrap(), "");
+	assert_eq!(substitute("${FOO+alt}", &vars(&[])).unwrap(), "");
 }
 
 #[test]
 fn error_if_unset_or_empty_nonempty() {
-    assert_eq!(
-        substitute("${FOO:?err}", &vars(&[("FOO", "bar")])).unwrap(),
-        "bar"
-    );
+	assert_eq!(
+		substitute("${FOO:?err}", &vars(&[("FOO", "bar")])).unwrap(),
+		"bar"
+	);
 }
 
 #[test]
 fn error_if_unset_or_empty_unset() {
-    let result = substitute("${FOO:?err msg}", &vars(&[]));
-    assert!(
-        matches!(result, Err(ComposeError::RequiredVarNotSet { ref var, ref msg }) if var == "FOO" && msg == "err msg")
-    );
+	let result = substitute("${FOO:?err msg}", &vars(&[]));
+	assert!(
+		matches!(result, Err(ComposeError::RequiredVarNotSet { ref var, ref msg }) if var == "FOO" && msg == "err msg")
+	);
 }
 
 #[test]
 fn error_if_unset_or_empty_empty() {
-    assert!(substitute("${FOO:?err msg}", &vars(&[("FOO", "")])).is_err());
+	assert!(substitute("${FOO:?err msg}", &vars(&[("FOO", "")])).is_err());
 }
 
 #[test]
 fn error_if_unset_set_empty_ok() {
-    assert_eq!(substitute("${FOO?err}", &vars(&[("FOO", "")])).unwrap(), "");
+	assert_eq!(substitute("${FOO?err}", &vars(&[("FOO", "")])).unwrap(), "");
 }
 
 #[test]
 fn error_if_unset_unset() {
-    assert!(substitute("${FOO?err}", &vars(&[])).is_err());
+	assert!(substitute("${FOO?err}", &vars(&[])).is_err());
 }
 
 #[test]
 fn chained() {
-    let v = vars(&[("A", "hello"), ("B", "world")]);
-    assert_eq!(substitute("$A ${B}", &v).unwrap(), "hello world");
+	let v = vars(&[("A", "hello"), ("B", "world")]);
+	assert_eq!(substitute("$A ${B}", &v).unwrap(), "hello world");
 }
 
 #[test]
 fn yaml_default_in_string() {
-    assert_eq!(
-        substitute("image: myapp:${TAG:-latest}", &vars(&[])).unwrap(),
-        "image: myapp:latest"
-    );
+	assert_eq!(
+		substitute("image: myapp:${TAG:-latest}", &vars(&[])).unwrap(),
+		"image: myapp:latest"
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -172,68 +172,68 @@ fn yaml_default_in_string() {
 
 #[test]
 fn substitution_in_image_name() {
-    let v = vars(&[("VERSION", "1.2.3")]);
-    assert_eq!(
-        substitute("image: myapp:${VERSION:-dev}", &v).unwrap(),
-        "image: myapp:1.2.3"
-    );
+	let v = vars(&[("VERSION", "1.2.3")]);
+	assert_eq!(
+		substitute("image: myapp:${VERSION:-dev}", &v).unwrap(),
+		"image: myapp:1.2.3"
+	);
 }
 
 #[test]
 fn substitution_in_volume_path() {
-    let v = vars(&[]);
-    assert_eq!(
-        substitute("- ${DATA_DIR:-./data}:/app/data", &v).unwrap(),
-        "- ./data:/app/data"
-    );
+	let v = vars(&[]);
+	assert_eq!(
+		substitute("- ${DATA_DIR:-./data}:/app/data", &v).unwrap(),
+		"- ./data:/app/data"
+	);
 }
 
 #[test]
 fn substitution_in_port() {
-    let v = vars(&[]);
-    assert_eq!(
-        substitute("- \"${HOST_PORT:-8080}:80\"", &v).unwrap(),
-        "- \"8080:80\""
-    );
+	let v = vars(&[]);
+	assert_eq!(
+		substitute("- \"${HOST_PORT:-8080}:80\"", &v).unwrap(),
+		"- \"8080:80\""
+	);
 }
 
 #[test]
 fn empty_vs_unset_for_colon_dash() {
-    // :- treats both unset and empty as "use default"
-    assert_eq!(substitute("${V:-def}", &vars(&[])).unwrap(), "def");
-    assert_eq!(substitute("${V:-def}", &vars(&[("V", "")])).unwrap(), "def");
+	// :- treats both unset and empty as "use default"
+	assert_eq!(substitute("${V:-def}", &vars(&[])).unwrap(), "def");
+	assert_eq!(substitute("${V:-def}", &vars(&[("V", "")])).unwrap(), "def");
 }
 
 #[test]
 fn empty_vs_unset_for_dash() {
-    // - treats empty as "use the empty string" — different from :-
-    assert_eq!(substitute("${V-def}", &vars(&[])).unwrap(), "def");
-    assert_eq!(substitute("${V-def}", &vars(&[("V", "")])).unwrap(), "");
+	// - treats empty as "use the empty string" — different from :-
+	assert_eq!(substitute("${V-def}", &vars(&[])).unwrap(), "def");
+	assert_eq!(substitute("${V-def}", &vars(&[("V", "")])).unwrap(), "");
 }
 
 #[test]
 fn special_chars_in_default_with_spaces() {
-    assert_eq!(
-        substitute("${V:-hello world}", &vars(&[])).unwrap(),
-        "hello world"
-    );
+	assert_eq!(
+		substitute("${V:-hello world}", &vars(&[])).unwrap(),
+		"hello world"
+	);
 }
 
 #[test]
 fn special_chars_in_default_with_url() {
-    assert_eq!(
-        substitute("${V:-http://example.com}", &vars(&[])).unwrap(),
-        "http://example.com"
-    );
+	assert_eq!(
+		substitute("${V:-http://example.com}", &vars(&[])).unwrap(),
+		"http://example.com"
+	);
 }
 
 #[test]
 fn nested_like_two_subs_in_one_string() {
-    let v = vars(&[("V1", "hello"), ("V2", "world")]);
-    assert_eq!(substitute("${V1}_${V2}", &v).unwrap(), "hello_world");
+	let v = vars(&[("V1", "hello"), ("V2", "world")]);
+	assert_eq!(substitute("${V1}_${V2}", &v).unwrap(), "hello_world");
 }
 
 #[test]
 fn trailing_dollar_preserved() {
-    assert_eq!(substitute("price: $", &vars(&[])).unwrap(), "price: $");
+	assert_eq!(substitute("price: $", &vars(&[])).unwrap(), "price: $");
 }


### PR DESCRIPTION
## Summary

- Split three engine files that exceeded the 500-line hard limit into focused modules
- Added unit tests for all pure (non-Podman) helper functions, raising coverage from 41% → 50%
- Enabled the `coverage-threshold: 50` CI gate (was disabled — defaulted to 0)

## File splits

| Before | Lines | After | Lines |
|---|---|---|---|
| `engine/mod.rs` | 645 | `engine/mod.rs` | 154 |
| | | `engine/lifecycle.rs` (up/down/restart) | 239 |
| | | `engine/query.rs` (ps/logs/exec/pull/orphans/attach) | 262 |
| `engine/container.rs` | 703 | `engine/container.rs` | 274 |
| | | `engine/container_config.rs` (restart/log/health/resources) | 405 |
| | | `engine/container_misc.rs` (device/blkio/tmpfs/label_file/opt_vec) | 331 |
| `engine/volume.rs` | 557 | `engine/volume.rs` | 272 |
| | | `engine/volume_mounts.rs` (build_binds/build_mounts) | 314 |

## Coverage

All pure helper functions now have unit tests:
- `engine/profiles.rs`: 91%
- `engine/container_config.rs`: 76%
- `engine/container_misc.rs`: 67%
- `engine/volume_mounts.rs`: 78%
- `engine/network.rs`: 51%

The Podman-calling engine methods (lifecycle, query, container, volume, watch, build)
remain at 0% — they require a running Podman daemon. Integration tests are tracked
in #51. The coverage gate at 50% blocks regression on the testable portion.

## Test plan

- `cargo test` — all 304 tests pass
- `cargo llvm-cov --summary-only` — 50.16% total, 50% gate passes
- Builds clean on dev machine (`cargo build`)

Closes #51 (partial — gate enabled; integration tests remain)