### PR TITLE
fix: set PYTHONUTF8 and PIP_BREAK_SYSTEM_PACKAGES in release sign step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Sign binary
         env:
           RELEASE_SIGN_KEY: ${{ secrets.RELEASE_SIGN_KEY }}
+          PYTHONUTF8: "1"
+          PIP_BREAK_SYSTEM_PACKAGES: "1"
         run: |
           # The panel installer/updater verifies this Ed25519 signature; a
           # release without it cannot be consumed. Fail closed when the key


### PR DESCRIPTION
## Summary

- Add `PYTHONUTF8: "1"` env var to Sign binary step — fixes `UnicodeEncodeError` on Windows runners where pip notice messages contain arrow characters (→) incompatible with the default cp1252 encoding
- Add `PIP_BREAK_SYSTEM_PACKAGES: "1"` — fixes `externally-managed-environment` error on macOS runners enforcing PEP 668; no-op on systems without an `EXTERNALLY-MANAGED` marker (Windows, older Linux)

## Root cause

v0.4.0 release failed on macOS (both arches) and Windows in the Sign binary step. Linux builds succeeded. The failures are due to runner environment changes (newer macOS Python enforces PEP 668; newer pip prints Unicode notice messages that crash Windows' cp1252 console codec).

## Test plan

- [ ] After merge to develop then main: `gh workflow run release.yml --field tag=v0.4.0` to publish the v0.4.0 release assets