### PR TITLE
chore: publish to crates.io as part of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,14 @@ jobs:
             podup-windows-x86_64.exe \
             > SHA256SUMS
 
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --allow-dirty
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Add `cargo publish --locked` step to the `release` job, before creating the GitHub Release
- Uses `CARGO_REGISTRY_TOKEN` secret (now configured in repo)
- Installs stable Rust toolchain on the ubuntu runner first

Future releases will automatically publish to crates.io on every `v*` tag.