### PR TITLE
chore: merge develop into main (auto cargo publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,14 @@ jobs:
             podup-windows-x86_64.exe \
             > SHA256SUMS
 
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --allow-dirty
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- #55 chore: add `cargo publish` step to release workflow — publishes to crates.io automatically on every `v*` tag using `CARGO_REGISTRY_TOKEN`