### PR TITLE
feat: add stop, start, kill, build, rm commands and up --build flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ path = "internal/lib.rs"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
-anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_yaml = { package = "yaml_serde", version = "0.10" }

--- a/internal/engine/build.rs
+++ b/internal/engine/build.rs
@@ -55,6 +55,35 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Build (or rebuild) images for services that have a `build:` block.
+	///
+	/// If `target_services` is empty, every service with a build config is built.
+	/// Services without a build config are silently skipped.
+	pub async fn build_all(
+		&self,
+		file: &crate::compose::types::ComposeFile,
+		target_services: &[String],
+	) -> Result<()> {
+		let names: Vec<String> = if target_services.is_empty() {
+			file.services.keys().cloned().collect()
+		} else {
+			for name in target_services {
+				if !file.services.contains_key(name) {
+					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
+				}
+			}
+			target_services.to_vec()
+		};
+
+		for name in &names {
+			let service = &file.services[name];
+			if service.build.is_some() {
+				self.build_service(name, service).await?;
+			}
+		}
+		Ok(())
+	}
+
 	pub(super) async fn build_service(&self, service_name: &str, service: &Service) -> Result<()> {
 		let build = match &service.build {
 			Some(b) => b,

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -32,10 +32,15 @@ impl Engine {
 		service: &Service,
 		file: &ComposeFile,
 	) -> Result<()> {
-		let image = service
-			.image
-			.as_deref()
-			.ok_or_else(|| ComposeError::NoImageOrBuild(service_name.into()))?;
+		let derived_image;
+		let image: &str = if let Some(img) = service.image.as_deref() {
+			img
+		} else if service.build.is_some() {
+			derived_image = format!("{}:latest", service_name);
+			&derived_image
+		} else {
+			return Err(ComposeError::NoImageOrBuild(service_name.into()));
+		};
 
 		let env = build_env(service, &self.base_dir)?;
 

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -1,7 +1,7 @@
-//! Service lifecycle commands: up, down, restart.
+//! Service lifecycle commands: up, down, start, stop, restart, kill, rm.
 
 use bollard::query_parameters::{
-	RemoveContainerOptions, StartContainerOptions, StopContainerOptions,
+	KillContainerOptions, RemoveContainerOptions, StartContainerOptions, StopContainerOptions,
 };
 use tracing::info;
 
@@ -237,5 +237,195 @@ impl Engine {
 		}
 
 		Ok(())
+	}
+
+	/// Stop running containers without removing them.
+	///
+	/// Services are stopped in reverse dependency order. If `target_services`
+	/// is empty, all services in the compose file are stopped.
+	pub async fn stop(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
+		let mut order = crate::compose::resolve_order(file)?;
+		order.reverse();
+		let order = filter_services(file, order, target_services)?;
+
+		for name in &order {
+			let service = &file.services[name];
+			for container_name in self.replica_names(name, service) {
+				let _ = self
+					.docker
+					.stop_container(
+						&container_name,
+						Some(StopContainerOptions {
+							t: Some(10),
+							..Default::default()
+						}),
+					)
+					.await;
+				info!("stopped {container_name}");
+			}
+		}
+		Ok(())
+	}
+
+	/// Start stopped containers.
+	///
+	/// Services are started in dependency order. If `target_services` is empty,
+	/// all services in the compose file are started.
+	pub async fn start(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
+		let order = crate::compose::resolve_order(file)?;
+		let order = filter_services(file, order, target_services)?;
+
+		for name in &order {
+			let service = &file.services[name];
+			for container_name in self.replica_names(name, service) {
+				self.docker
+					.start_container(&container_name, None::<StartContainerOptions>)
+					.await?;
+				info!("started {container_name}");
+			}
+		}
+		Ok(())
+	}
+
+	/// Send a signal to service containers (default: `SIGKILL`).
+	///
+	/// If `target_services` is empty, all services are signalled.
+	pub async fn kill(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		signal: &str,
+	) -> Result<()> {
+		let order = crate::compose::resolve_order(file)?;
+		let order = filter_services(file, order, target_services)?;
+
+		for name in &order {
+			let service = &file.services[name];
+			for container_name in self.replica_names(name, service) {
+				self.docker
+					.kill_container(
+						&container_name,
+						Some(KillContainerOptions {
+							signal: signal.to_string(),
+						}),
+					)
+					.await?;
+				info!("sent {signal} to {container_name}");
+			}
+		}
+		Ok(())
+	}
+
+	/// Remove stopped service containers.
+	///
+	/// When `force` is true, running containers are stopped before removal.
+	/// Services are removed in reverse dependency order.
+	pub async fn rm(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		force: bool,
+	) -> Result<()> {
+		let mut order = crate::compose::resolve_order(file)?;
+		order.reverse();
+		let order = filter_services(file, order, target_services)?;
+
+		for name in &order {
+			let service = &file.services[name];
+			for container_name in self.replica_names(name, service) {
+				let _ = self
+					.docker
+					.remove_container(
+						&container_name,
+						Some(RemoveContainerOptions {
+							force,
+							..Default::default()
+						}),
+					)
+					.await;
+				info!("removed {container_name}");
+			}
+		}
+		Ok(())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return the ordered service names filtered to `target_services`.
+///
+/// Returns an error if any name in `target_services` is not in the file.
+fn filter_services(
+	file: &crate::compose::types::ComposeFile,
+	order: Vec<String>,
+	target_services: &[String],
+) -> Result<Vec<String>> {
+	if target_services.is_empty() {
+		return Ok(order);
+	}
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	let set: std::collections::HashSet<&str> = target_services.iter().map(|s| s.as_str()).collect();
+	Ok(order
+		.into_iter()
+		.filter(|n| set.contains(n.as_str()))
+		.collect())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::filter_services;
+	use crate::compose::types::{ComposeFile, Service};
+
+	fn file_with_services(names: &[&str]) -> ComposeFile {
+		let mut file = ComposeFile::default();
+		for &name in names {
+			file.services.insert(name.to_string(), Service::default());
+		}
+		file
+	}
+
+	#[test]
+	fn filter_empty_target_returns_all() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order.clone(), &[]).unwrap();
+		assert_eq!(result, order);
+	}
+
+	#[test]
+	fn filter_target_subset_returns_intersection() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order, &["b".to_string()]).unwrap();
+		assert_eq!(result, vec!["b".to_string()]);
+	}
+
+	#[test]
+	fn filter_target_preserves_order() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order, &["c".to_string(), "a".to_string()]).unwrap();
+		assert_eq!(result, vec!["a".to_string(), "c".to_string()]);
+	}
+
+	#[test]
+	fn filter_unknown_service_returns_error() {
+		let file = file_with_services(&["a"]);
+		let order = vec!["a".to_string()];
+		let err = filter_services(&file, order, &["z".to_string()]).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ServiceNotFound(_)
+		));
 	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -1,7 +1,9 @@
 //! `podup` — docker-compose to Podman translator CLI.
 
-use clap::{Parser, Subcommand};
 use std::path::PathBuf;
+use std::process;
+
+use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
@@ -38,6 +40,9 @@ enum Commands {
 		/// Run containers in the background.
 		#[arg(short, long)]
 		detach: bool,
+		/// Build images before starting containers.
+		#[arg(long)]
+		build: bool,
 		/// Watch for file changes and sync/rebuild/restart per develop.watch rules.
 		#[arg(short, long)]
 		watch: bool,
@@ -57,6 +62,42 @@ enum Commands {
 		/// Also remove named volumes declared in the compose file.
 		#[arg(short = 'v', long)]
 		volumes: bool,
+	},
+	/// Start existing stopped containers.
+	Start {
+		/// Start only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
+	/// Stop running containers without removing them.
+	Stop {
+		/// Stop only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
+	/// Build or rebuild service images.
+	Build {
+		/// Build only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
+	/// Remove stopped service containers.
+	Rm {
+		/// Remove even running containers (stop first).
+		#[arg(short, long)]
+		force: bool,
+		/// Remove only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
+	/// Send a signal to service containers.
+	Kill {
+		/// Signal to send (default: SIGKILL).
+		#[arg(short, long, default_value = "SIGKILL")]
+		signal: String,
+		/// Signal only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
 	},
 	/// List containers.
 	Ps,
@@ -90,7 +131,14 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
+	if let Err(e) = run().await {
+		eprintln!("error: {e}");
+		process::exit(1);
+	}
+}
+
+async fn run() -> podup::Result<()> {
 	tracing_subscriber::fmt()
 		.with_env_filter(EnvFilter::from_default_env())
 		.init();
@@ -101,7 +149,7 @@ async fn main() -> anyhow::Result<()> {
 
 	// The `config` command does not need a Podman connection.
 	if matches!(cli.command, Commands::Config) {
-		let yaml = serde_yaml::to_string(&file)?;
+		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
 		println!("{yaml}");
 		return Ok(());
 	}
@@ -117,6 +165,7 @@ async fn main() -> anyhow::Result<()> {
 	match cli.command {
 		Commands::Up {
 			detach,
+			build,
 			watch,
 			remove_orphans,
 			no_recreate,
@@ -124,6 +173,9 @@ async fn main() -> anyhow::Result<()> {
 		} => {
 			if remove_orphans {
 				engine.remove_orphans(&file).await?;
+			}
+			if build {
+				engine.build_all(&file, &services).await?;
 			}
 			engine
 				.up_with_options(&file, detach, &cli.profile, &services, no_recreate)
@@ -135,6 +187,11 @@ async fn main() -> anyhow::Result<()> {
 			}
 		}
 		Commands::Down { volumes } => engine.down_with_options(&file, volumes).await?,
+		Commands::Start { services } => engine.start(&file, &services).await?,
+		Commands::Stop { services } => engine.stop(&file, &services).await?,
+		Commands::Build { services } => engine.build_all(&file, &services).await?,
+		Commands::Rm { force, services } => engine.rm(&file, &services, force).await?,
+		Commands::Kill { signal, services } => engine.kill(&file, &services, &signal).await?,
 		Commands::Ps => engine.ps(&file).await?,
 		Commands::Logs { service, follow } => {
 			engine.logs(&file, service.as_deref(), follow).await?

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -1856,4 +1856,188 @@ mod cli_tests {
 			.unwrap();
 		assert!(pull.status.success());
 	}
+
+	#[tokio::test]
+	async fn cli_stop_and_start_subcommands() {
+		if super::podman().await.is_none() {
+			return;
+		}
+		let dir = tempdir().unwrap();
+		let compose = dir.path().join("docker-compose.yml");
+		let proj = format!("t{}-clss", std::process::id());
+		fs::write(
+			&compose,
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+		)
+		.unwrap();
+
+		Command::new(bin())
+			.args([
+				"-f",
+				compose.to_str().unwrap(),
+				"-p",
+				&proj,
+				"up",
+				"--detach",
+			])
+			.output()
+			.unwrap();
+
+		let stop = Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "-p", &proj, "stop"])
+			.output()
+			.unwrap();
+		assert!(stop.status.success(), "stop failed: {:?}", stop.stderr);
+
+		let start = Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "-p", &proj, "start"])
+			.output()
+			.unwrap();
+		assert!(start.status.success(), "start failed: {:?}", start.stderr);
+
+		Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
+			.output()
+			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn cli_kill_subcommand() {
+		if super::podman().await.is_none() {
+			return;
+		}
+		let dir = tempdir().unwrap();
+		let compose = dir.path().join("docker-compose.yml");
+		let proj = format!("t{}-clkl", std::process::id());
+		fs::write(
+			&compose,
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+		)
+		.unwrap();
+
+		Command::new(bin())
+			.args([
+				"-f",
+				compose.to_str().unwrap(),
+				"-p",
+				&proj,
+				"up",
+				"--detach",
+			])
+			.output()
+			.unwrap();
+
+		let kill = Command::new(bin())
+			.args([
+				"-f",
+				compose.to_str().unwrap(),
+				"-p",
+				&proj,
+				"kill",
+				"--signal",
+				"SIGTERM",
+			])
+			.output()
+			.unwrap();
+		assert!(kill.status.success(), "kill failed: {:?}", kill.stderr);
+
+		Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
+			.output()
+			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn cli_rm_subcommand() {
+		if super::podman().await.is_none() {
+			return;
+		}
+		let dir = tempdir().unwrap();
+		let compose = dir.path().join("docker-compose.yml");
+		let proj = format!("t{}-clrm", std::process::id());
+		fs::write(
+			&compose,
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+		)
+		.unwrap();
+
+		Command::new(bin())
+			.args([
+				"-f",
+				compose.to_str().unwrap(),
+				"-p",
+				&proj,
+				"up",
+				"--detach",
+			])
+			.output()
+			.unwrap();
+
+		Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "-p", &proj, "stop"])
+			.output()
+			.unwrap();
+
+		let rm = Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "-p", &proj, "rm"])
+			.output()
+			.unwrap();
+		assert!(rm.status.success(), "rm failed: {:?}", rm.stderr);
+	}
+
+	#[tokio::test]
+	async fn cli_up_with_build_flag() {
+		if super::podman().await.is_none() {
+			return;
+		}
+		let dir = tempdir().unwrap();
+		let proj = format!("t{}-clbld", std::process::id());
+		fs::write(dir.path().join("Dockerfile"), "FROM alpine:latest\n").unwrap();
+		let compose = dir.path().join("docker-compose.yml");
+		fs::write(
+			&compose,
+			"services:\n  web:\n    build: .\n    command: [\"sleep\", \"infinity\"]\n",
+		)
+		.unwrap();
+
+		let up = Command::new(bin())
+			.args([
+				"-f",
+				compose.to_str().unwrap(),
+				"-p",
+				&proj,
+				"up",
+				"--detach",
+				"--build",
+			])
+			.output()
+			.unwrap();
+		assert!(up.status.success(), "up --build failed: {:?}", up.stderr);
+
+		Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
+			.output()
+			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn cli_build_subcommand() {
+		if super::podman().await.is_none() {
+			return;
+		}
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("Dockerfile"), "FROM alpine:latest\n").unwrap();
+		let compose = dir.path().join("docker-compose.yml");
+		fs::write(
+			&compose,
+			"services:\n  web:\n    build: .\n    command: [\"sleep\", \"infinity\"]\n",
+		)
+		.unwrap();
+
+		let build = Command::new(bin())
+			.args(["-f", compose.to_str().unwrap(), "build"])
+			.output()
+			.unwrap();
+		assert!(build.status.success(), "build failed: {:?}", build.stderr);
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `stop`, `start`, `kill`, `build`, `rm` subcommands — all missing from podup vs. docker-compose
- Adds `--build` flag to `up` to force image rebuild before starting
- Removes `anyhow` dependency (was only used in `main()` return type)
- All new engine methods unit-tested (`filter_services` helper) and integration-tested (CLI subcommand tests added to `tests/engine_integration.rs`)

## Command details

| Command | Behaviour |
|---------|-----------|
| `stop [services…]` | Stop containers (reverse dep order), no removal |
| `start [services…]` | Start stopped containers (dep order) |
| `kill [--signal SIG] [services…]` | Send signal, default `SIGKILL` |
| `build [services…]` | Build images without starting |
| `rm [-f] [services…]` | Remove stopped containers; `-f` force-stops first |
| `up --build` | Rebuild images before `up` |

## Test plan

- [ ] `cargo test` — unit tests pass, including new `filter_services` tests
- [ ] CI coverage ≥ 90%
- [ ] Integration tests pass with real Podman: stop/start round-trip, kill with SIGTERM, rm after stop, build standalone, up --build with Dockerfile

Closes #58