### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,9 +904,8 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
- "anyhow",
  "bollard",
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+podup (0.5.0) unstable; urgency=medium
+
+  * Add run, pause, unpause, cp, top, port, images commands for full
+    docker-compose parity (21 commands total).
+  * Add stop, start, kill, build, rm commands and up --build flag.
+  * Remove anyhow dependency; propagate run exit codes via process::exit.
+  * Derive container image tag from service name when only build: is set.
+  * Debian offline build support: vendor/ directory detected in rules.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 01:15:00 -0500
+
 podup (0.4.0) unstable; urgency=medium
 
   * Resolve the Podman socket per platform; macOS and Windows hosts are


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version to 0.5.0
- Add `debian/changelog` entry for 0.5.0 release

## Release notes

- Full docker-compose parity: run, pause, unpause, cp, top, port, images (21 commands total)
- stop, start, kill, build, rm commands and `up --build` flag
- Remove anyhow dependency; propagate run exit codes via `process::exit`
- Derive container image tag from service name when only `build:` is set
- Debian offline build support via `vendor/` directory detection in `debian/rules`