### PR TITLE
fix: exclude tests/ from crate package; publish GH release before crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,14 +149,6 @@ jobs:
             podup-windows-x86_64.exe \
             > SHA256SUMS
 
-      - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --allow-dirty
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -177,3 +169,11 @@ jobs:
             podup-windows-x86_64.exe.sig \
             SHA256SUMS \
             install.sh
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --allow-dirty

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Glyndor/podup"
 readme = "README.md"
 keywords = ["podman", "compose", "containers", "docker-compose", "rootless"]
 categories = ["command-line-utilities", "virtualization"]
-exclude = ["/.github", "/debian", "/docs", "/install.sh"]
+exclude = ["/.github", "/debian", "/docs", "/install.sh", "/tests"]
 
 [[bin]]
 name = "podup"


### PR DESCRIPTION
## Summary

- Add `/tests` to `Cargo.toml` exclude list — integration tests pushed the crate package to 11.2 MiB compressed, over crates.io's 10 MiB limit. Package drops from 77 files to 47.
- Move "Create GitHub Release" before "Publish to crates.io" in `release.yml` — GitHub Release (binaries for users) now always succeeds if builds pass, regardless of transient crates.io failures.

Fixes the v0.5.0 release workflow failure (HTTP 413 on first run, 503 on retry).