### PR TITLE
release: v0.5.0 (fix crate package size)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,14 +149,6 @@ jobs:
             podup-windows-x86_64.exe \
             > SHA256SUMS
 
-      - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --allow-dirty
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -177,3 +169,11 @@ jobs:
             podup-windows-x86_64.exe.sig \
             SHA256SUMS \
             install.sh
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --allow-dirty

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Glyndor/podup"
 readme = "README.md"
 keywords = ["podman", "compose", "containers", "docker-compose", "rootless"]
 categories = ["command-line-utilities", "virtualization"]
-exclude = ["/.github", "/debian", "/docs", "/install.sh"]
+exclude = ["/.github", "/debian", "/docs", "/install.sh", "/tests"]
 
 [[bin]]
 name = "podup"


### PR DESCRIPTION
## Summary

Merge develop → main to include crate package and release workflow fixes for v0.5.0.

- Exclude `tests/` from published crate (77 → 47 files; package was 11.2 MiB compressed, over crates.io 10 MiB limit)
- Create GitHub Release before crates.io publish so binary release never blocks on transient registry failures

After this merges: delete and re-create tag `v0.5.0` on the new HEAD to re-trigger the release workflow.