### PR TITLE
fix: publish crate before downloading artifacts to avoid packaging binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,14 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
@@ -169,11 +177,3 @@ jobs:
             podup-windows-x86_64.exe.sig \
             SHA256SUMS \
             install.sh
-
-      - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --allow-dirty


### PR DESCRIPTION
## Summary

The `release` job downloads the 5 signed binaries into the working directory before `cargo publish`, which inflates the package from ~75 KiB to 11.2 MiB compressed (over crates.io's 10 MiB limit) because `--allow-dirty` made cargo include untracked binary files.

Fix: move `Install Rust toolchain` + `Publish to crates.io` steps to before `download-artifact`, so the working directory is clean when cargo packages. Dropped `--allow-dirty` (no longer needed with a clean checkout).