### PR TITLE
docs: use glyndor.net/install/podup as canonical install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ flowchart LR
 ## 📥 Install
 
 ```bash
-curl -fsSL https://github.com/Glyndor/podup/releases/latest/download/install.sh | bash
+curl -fsSL https://glyndor.net/install/podup | bash
 ```
 
 Binaries for Linux and macOS (x86_64 and arm64) plus Windows (x86_64),

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # podup installer — downloads a release binary, verifies it and installs it.
 #
 # Usage:
-#   curl -fsSL https://github.com/Glyndor/podup/releases/latest/download/install.sh | bash
+#   curl -fsSL https://glyndor.net/install/podup | bash
 #
 # Environment:
 #   PODUP_VERSION      Release tag to install (e.g. v0.3.0). Default: latest.


### PR DESCRIPTION
Update README and install.sh header to reference `https://glyndor.net/install/podup` instead of the raw GitHub releases URL.