### PR TITLE
chore: bump version to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+podup (0.5.3) unstable; urgency=low
+
+  * Use glyndor.net/install/podup as canonical install URL in README and
+    install.sh.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 03:00:00 -0500
+
 podup (0.5.2) unstable; urgency=low
 
   * Narrow tokio feature set from "full" to only required features


### PR DESCRIPTION
Bump to publish updated install.sh (canonical glyndor.net/install/podup URL) as release asset.