### PR TITLE
fix: remove networks and named volumes on down

### DIFF
--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -70,7 +70,7 @@ impl Engine {
 
 		let restart_policy = build_restart_policy(service);
 		let log_config = build_log_config(service.logging.as_ref());
-		let (network_mode, first_network) = resolve_network_mode(service, file);
+		let (network_mode, first_network) = resolve_network_mode(service, file, &self.project);
 		let label_file_labels = build_label_file_labels(service, &self.base_dir);
 
 		let mut labels = service.labels.to_map();

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -223,12 +223,16 @@ impl Engine {
 					.unwrap_or_else(|| format!("{}_{}", self.project, key));
 				match self
 					.docker
-					.remove_volume(&volume_name, None::<bollard::query_parameters::RemoveVolumeOptions>)
+					.remove_volume(
+						&volume_name,
+						None::<bollard::query_parameters::RemoveVolumeOptions>,
+					)
 					.await
 				{
 					Ok(_) => info!("removed volume {volume_name}"),
 					Err(bollard::errors::Error::DockerResponseServerError {
-						status_code: 404, ..
+						status_code: 404,
+						..
 					}) => {}
 					Err(e) => tracing::warn!("could not remove volume {volume_name}: {e}"),
 				}

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -11,6 +11,7 @@ use tracing::info;
 use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::{ComposeError, Result};
 
+use super::network::resolve_network_name;
 use super::profiles::{active_profiles_set, service_in_profiles};
 use super::Engine;
 
@@ -182,13 +183,55 @@ impl Engine {
 						&container_name,
 						Some(RemoveContainerOptions {
 							force: true,
-							v: remove_volumes,
+							v: false,
 							..Default::default()
 						}),
 					)
 					.await;
 
 				info!("removed {container_name}");
+			}
+		}
+
+		// Remove non-external networks declared in the compose file.
+		for (key, config) in &file.networks {
+			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
+			if external {
+				continue;
+			}
+			let network_name = resolve_network_name(key, file, &self.project);
+			match self.docker.remove_network(&network_name).await {
+				Ok(_) => info!("removed network {network_name}"),
+				Err(bollard::errors::Error::DockerResponseServerError {
+					status_code: 404, ..
+				}) => {}
+				Err(e) => tracing::warn!("could not remove network {network_name}: {e}"),
+			}
+		}
+
+		// Remove non-external named volumes when --volumes is requested.
+		if remove_volumes {
+			for (key, config) in &file.volumes {
+				let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
+				if external {
+					continue;
+				}
+				let volume_name = config
+					.as_ref()
+					.and_then(|c| c.name.as_deref())
+					.map(|s| s.to_string())
+					.unwrap_or_else(|| format!("{}_{}", self.project, key));
+				match self
+					.docker
+					.remove_volume(&volume_name, None::<bollard::query_parameters::RemoveVolumeOptions>)
+					.await
+				{
+					Ok(_) => info!("removed volume {volume_name}"),
+					Err(bollard::errors::Error::DockerResponseServerError {
+						status_code: 404, ..
+					}) => {}
+					Err(e) => tracing::warn!("could not remove volume {volume_name}: {e}"),
+				}
 			}
 		}
 

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -250,7 +250,10 @@ mod tests {
 	#[test]
 	fn resolve_network_name_uses_config_name_over_prefix() {
 		let file = file_with_named_network("mynet", "custom-net-name");
-		assert_eq!(resolve_network_name("mynet", &file, "proj"), "custom-net-name");
+		assert_eq!(
+			resolve_network_name("mynet", &file, "proj"),
+			"custom-net-name"
+		);
 	}
 
 	#[test]

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -25,7 +25,8 @@ impl Engine {
 			let network_name = config
 				.as_ref()
 				.and_then(|c| c.name.as_deref())
-				.unwrap_or(name);
+				.map(|s| s.to_string())
+				.unwrap_or_else(|| format!("{}_{}", self.project, name));
 
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
@@ -54,7 +55,7 @@ impl Engine {
 				.map(build_ipam);
 
 			let request = NetworkCreateRequest {
-				name: network_name.to_string(),
+				name: network_name.clone(),
 				driver: Some(driver.clone()),
 				internal: config.as_ref().and_then(|c| c.internal),
 				attachable: config.as_ref().and_then(|c| c.attachable),
@@ -96,7 +97,7 @@ impl Engine {
 
 		let network_names = service.networks.names();
 		for network in network_names.iter().skip(1) {
-			let full_name = resolve_network_name(network, file);
+			let full_name = resolve_network_name(network, file, &self.project);
 			let endpoint_config =
 				build_endpoint_settings(service.networks.config_for(network), file);
 			self.docker
@@ -157,6 +158,7 @@ pub(super) fn build_endpoint_settings(
 pub(super) fn resolve_network_mode(
 	service: &Service,
 	file: &ComposeFile,
+	project: &str,
 ) -> (Option<String>, Option<String>) {
 	if let Some(mode) = &service.network_mode {
 		return (Some(mode.clone()), None);
@@ -165,18 +167,23 @@ pub(super) fn resolve_network_mode(
 	if networks.is_empty() {
 		(None, None)
 	} else {
-		let first = resolve_network_name(&networks[0], file);
+		let first = resolve_network_name(&networks[0], file, project);
 		(None, Some(first))
 	}
 }
 
-pub(super) fn resolve_network_name(network: &str, file: &ComposeFile) -> String {
+/// Resolve the actual network name on the host for a compose network key.
+///
+/// If the network config has an explicit `name:`, that takes precedence.
+/// Otherwise the name is prefixed with `{project}_` to avoid collisions
+/// between projects that use the same compose key (e.g. "default").
+pub(super) fn resolve_network_name(network: &str, file: &ComposeFile, project: &str) -> String {
 	file.networks
 		.get(network)
 		.and_then(|c| c.as_ref())
 		.and_then(|c| c.name.as_deref())
-		.unwrap_or(network)
-		.to_string()
+		.map(|s| s.to_string())
+		.unwrap_or_else(|| format!("{project}_{network}"))
 }
 
 fn build_ipam(ipam: &IpamConfig) -> Ipam {
@@ -235,15 +242,15 @@ mod tests {
 	}
 
 	#[test]
-	fn resolve_network_name_key_not_found_returns_key() {
+	fn resolve_network_name_key_not_found_prefixes_project() {
 		let file = empty_file();
-		assert_eq!(resolve_network_name("mynet", &file), "mynet");
+		assert_eq!(resolve_network_name("mynet", &file, "proj"), "proj_mynet");
 	}
 
 	#[test]
-	fn resolve_network_name_uses_config_name() {
+	fn resolve_network_name_uses_config_name_over_prefix() {
 		let file = file_with_named_network("mynet", "custom-net-name");
-		assert_eq!(resolve_network_name("mynet", &file), "custom-net-name");
+		assert_eq!(resolve_network_name("mynet", &file, "proj"), "custom-net-name");
 	}
 
 	#[test]
@@ -253,7 +260,7 @@ mod tests {
 			..Default::default()
 		};
 		let file = empty_file();
-		let (mode, first) = resolve_network_mode(&svc, &file);
+		let (mode, first) = resolve_network_mode(&svc, &file, "proj");
 		assert_eq!(mode.as_deref(), Some("host"));
 		assert!(first.is_none());
 	}
@@ -262,7 +269,7 @@ mod tests {
 	fn resolve_network_mode_no_networks() {
 		let svc = Service::default();
 		let file = empty_file();
-		let (mode, first) = resolve_network_mode(&svc, &file);
+		let (mode, first) = resolve_network_mode(&svc, &file, "proj");
 		assert!(mode.is_none());
 		assert!(first.is_none());
 	}

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -28,7 +28,8 @@ impl Engine {
 			let volume_name = config
 				.as_ref()
 				.and_then(|c| c.name.as_deref())
-				.unwrap_or(name);
+				.map(|s| s.to_string())
+				.unwrap_or_else(|| format!("{}_{}", self.project, name));
 
 			let mut labels: HashMap<String, String> = config
 				.as_ref()
@@ -47,7 +48,7 @@ impl Engine {
 				.unwrap_or_default();
 
 			let options = VolumeCreateRequest {
-				name: Some(volume_name.to_string()),
+				name: Some(volume_name.clone()),
 				driver: Some(driver.clone()),
 				driver_opts: if driver_opts.is_empty() {
 					None


### PR DESCRIPTION
## Summary

- **LIFE-001**: `down_with_options` now removes all non-external networks after stopping containers, preventing host network namespace exhaustion
- **LIFE-002**: When `--volumes` is passed, all non-external named volumes are now explicitly removed via `remove_volume` (bollard's `remove_container v: true` only removes anonymous volumes)
- External networks/volumes are always left intact
- 404 responses are silently ignored (already gone); other errors warn but don't fail the down

**Note**: This PR depends on #86 (project-prefix networks/volumes) — it uses `resolve_network_name` with the updated 3-arg signature and the same `{project}_{key}` name resolution for volumes.

## Test plan

- [ ] `cargo test --lib` passes (127 tests)
- [ ] `podup down` removes the project's networks from `podman network ls`
- [ ] `podup down -v` removes named volumes from `podman volume ls`
- [ ] `podup down` leaves external networks/volumes intact

Closes #77