### PR TITLE
fix: stop containers on Ctrl-C and add SIGTERM handler

### DIFF
--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -362,6 +362,17 @@ impl Engine {
 			})
 			.collect();
 
+		#[cfg(unix)]
+		{
+			use tokio::signal::unix::{signal, SignalKind};
+			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+			tokio::select! {
+				_ = futures::future::join_all(streams) => {}
+				_ = tokio::signal::ctrl_c() => {}
+				_ = sigterm.recv() => {}
+			}
+		}
+		#[cfg(not(unix))]
 		tokio::select! {
 			_ = futures::future::join_all(streams) => {}
 			_ = tokio::signal::ctrl_c() => {}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -247,6 +247,7 @@ async fn run() -> podup::Result<()> {
 				engine.watch(&file).await?;
 			} else if !detach {
 				engine.attach_logs(&file).await?;
+				let _ = engine.stop(&file, &[]).await;
 			}
 		}
 		Commands::Down { volumes } => engine.down_with_options(&file, volumes).await?,


### PR DESCRIPTION
## Summary

- `attach_logs` now installs a SIGTERM handler (unix) alongside the existing SIGINT handler; either signal exits the select and returns to the caller
- `Up` command calls `engine.stop()` after `attach_logs` returns so Ctrl-C / SIGTERM triggers a clean container shutdown instead of leaving orphans running

Closes #79

## Test plan

- [ ] `cargo test` passes (444 tests)
- [ ] `podup up` then Ctrl-C → all containers stop cleanly (no orphans)
- [ ] `podup up` then `kill -TERM <pid>` → all containers stop cleanly