### PR TITLE
fix: supply chain hardening — sign SHA256SUMS, validate version inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
+      - name: Validate tag format
+        env:
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag '${TAG}' does not match required format v<major>.<minor>.<patch>."
+            exit 1
+          fi
+
       - name: Tag must equal Cargo.toml version
         env:
           TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
@@ -157,6 +166,19 @@ jobs:
             podup-windows-x86_64.exe \
             > SHA256SUMS
 
+      - name: Sign SHA256SUMS
+        env:
+          RELEASE_SIGN_KEY: ${{ secrets.RELEASE_SIGN_KEY }}
+          PYTHONUTF8: "1"
+          PIP_BREAK_SYSTEM_PACKAGES: "1"
+        run: |
+          if [ -z "$RELEASE_SIGN_KEY" ]; then
+            echo "::error::RELEASE_SIGN_KEY secret is not configured; refusing to release unsigned checksums."
+            exit 1
+          fi
+          python3 -m pip install --quiet cryptography==48.0.0
+          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" SHA256SUMS
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -176,4 +198,5 @@ jobs:
             podup-windows-x86_64.exe \
             podup-windows-x86_64.exe.sig \
             SHA256SUMS \
+            SHA256SUMS.sig \
             install.sh

--- a/install.sh
+++ b/install.sh
@@ -55,8 +55,10 @@ fi
 
 if [[ "$VERSION" == "latest" ]]; then
 	BASE_URL="https://github.com/${REPO}/releases/latest/download"
-else
+elif [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+else
+	fail "PODUP_VERSION must be 'latest' or a semver tag like v1.2.3, got: ${VERSION}"
 fi
 
 TMP_DIR="$(mktemp -d)"
@@ -67,8 +69,40 @@ curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/${ARTIFACT}" \
 	"${BASE_URL}/${ARTIFACT}" || fail "Download failed: ${BASE_URL}/${ARTIFACT}"
 curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS" \
 	"${BASE_URL}/SHA256SUMS" || fail "Download failed: ${BASE_URL}/SHA256SUMS"
+curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS.sig" \
+	"${BASE_URL}/SHA256SUMS.sig" || fail "Download failed: ${BASE_URL}/SHA256SUMS.sig"
 
 # --- Verify ------------------------------------------------------------------
+
+log_info "Verifying SHA256SUMS signature ..."
+# Base64-encoded raw Ed25519 public key (32 bytes) matching RELEASE_SIGN_KEY.
+# Set PODUP_RELEASE_PUBKEY_B64 to override (e.g. for testing a fork).
+PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-}"
+if [[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]; then
+	if command -v python3 >/dev/null 2>&1 && python3 -c "from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey" 2>/dev/null; then
+		if python3 - "${TMP_DIR}/SHA256SUMS.sig" "${TMP_DIR}/SHA256SUMS" "$PODUP_RELEASE_PUBKEY_B64" <<'PYEOF'
+import base64, sys
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+sig_file, data_file, pubkey_b64 = sys.argv[1], sys.argv[2], sys.argv[3]
+key = Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "=="))
+try:
+    key.verify(open(sig_file, "rb").read(), open(data_file, "rb").read())
+    sys.exit(0)
+except InvalidSignature:
+    sys.exit(1)
+PYEOF
+		then
+			log_ok "SHA256SUMS signature verified"
+		else
+			fail "SHA256SUMS signature verification failed — release may be tampered"
+		fi
+	else
+		log_info "python3+cryptography not available — skipping SHA256SUMS signature verification"
+	fi
+else
+	log_info "PODUP_RELEASE_PUBKEY_B64 not set — skipping SHA256SUMS signature verification"
+fi
 
 log_info "Verifying SHA-256 checksum ..."
 (cd "$TMP_DIR" && grep " ${ARTIFACT}\$" SHA256SUMS | "${SHA256_CMD[@]}" -c --quiet -) \


### PR DESCRIPTION
## Summary

- **SC-004** — SHA256SUMS is now signed with the Ed25519 release key after checksum generation; `SHA256SUMS.sig` is uploaded alongside the release assets. `install.sh` downloads `SHA256SUMS.sig` and verifies it when python3+cryptography is available and `PODUP_RELEASE_PUBKEY_B64` is set (soft-skips with an info message otherwise, consistent with the existing attestation check)
- **SC-006** — `install.sh` validates `PODUP_VERSION` against `^v[0-9]+\.[0-9]+\.[0-9]+$` or `latest` before constructing the download URL, preventing path injection via that variable
- **SC-007** — A new "Validate tag format" step in the `verify` job checks the tag matches `v<major>.<minor>.<patch>` before the version/Cargo.toml comparison, rejecting malformed `workflow_dispatch` inputs early

Closes #81

## Test plan

- [ ] `bash -n install.sh` passes (syntax check)
- [ ] `PODUP_VERSION=../../etc/passwd bash install.sh` → "must be 'latest' or a semver tag" error
- [ ] `PODUP_VERSION=v1.2.3 bash install.sh` → proceeds to download
- [ ] Release workflow `workflow_dispatch` with tag `not-a-version` → fails in verify job
- [ ] Release workflow with valid tag → proceeds normally