### PR TITLE
fix: exec exit code, stop grace period, port range expansion

### DIFF
--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -8,7 +8,7 @@ use bollard::query_parameters::{
 use futures::StreamExt;
 use tracing::info;
 
-use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::compose::types::{ComposeFile, Service, ServiceCondition};
 use crate::error::{ComposeError, Result};
 
 use super::profiles::{active_profiles_set, service_in_profiles};
@@ -170,7 +170,7 @@ impl Engine {
 					.stop_container(
 						&container_name,
 						Some(StopContainerOptions {
-							t: Some(10),
+							t: Some(grace_period_secs(service)),
 							..Default::default()
 						}),
 					)
@@ -215,7 +215,7 @@ impl Engine {
 				.stop_container(
 					&container_name,
 					Some(StopContainerOptions {
-						t: Some(10),
+						t: Some(grace_period_secs(service)),
 						..Default::default()
 					}),
 				)
@@ -235,7 +235,7 @@ impl Engine {
 						.stop_container(
 							&dep_container,
 							Some(StopContainerOptions {
-								t: Some(10),
+								t: Some(grace_period_secs(dep_service)),
 								..Default::default()
 							}),
 						)
@@ -273,7 +273,7 @@ impl Engine {
 					.stop_container(
 						&container_name,
 						Some(StopContainerOptions {
-							t: Some(10),
+							t: Some(grace_period_secs(service)),
 							..Default::default()
 						}),
 					)
@@ -504,6 +504,15 @@ impl Engine {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn grace_period_secs(service: &Service) -> i32 {
+	service
+		.stop_grace_period
+		.as_deref()
+		.and_then(crate::size::parse_duration_secs)
+		.and_then(|s| i32::try_from(s).ok())
+		.unwrap_or(10)
+}
 
 /// Return the ordered service names filtered to `target_services`.
 ///

--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -150,6 +150,13 @@ impl Engine {
 			StartExecResults::Detached => {}
 		}
 
+		let inspect = self.docker.inspect_exec(&exec_id).await?;
+		if let Some(code) = inspect.exit_code {
+			if code != 0 {
+				return Err(ComposeError::RunExited(code));
+			}
+		}
+
 		Ok(())
 	}
 

--- a/internal/ports.rs
+++ b/internal/ports.rs
@@ -158,7 +158,8 @@ fn parse_short(s: &str) -> Result<Vec<ParsedPort>> {
 			let (left, right) = split_last_colon(rest);
 			let host_ports = expand_port_range(left)?;
 			let container_ports = expand_port_range(right)?;
-			if host_ports.len() != container_ports.len() && host_ports.len() != 1 {
+			let host_ports = expand_single_host_port(host_ports, container_ports.len(), s)?;
+			if host_ports.len() != container_ports.len() {
 				return Err(ComposeError::InvalidPort(format!(
 					"port range mismatch: {s}"
 				)));
@@ -189,7 +190,8 @@ fn parse_with_ip(ip: &str, after: &str, proto: &str, full: &str) -> Result<Vec<P
 	if let Some((left, right)) = after.split_once(':') {
 		let host_ports = expand_port_range(left)?;
 		let container_ports = expand_port_range(right)?;
-		if host_ports.len() != container_ports.len() && host_ports.len() != 1 {
+		let host_ports = expand_single_host_port(host_ports, container_ports.len(), full)?;
+		if host_ports.len() != container_ports.len() {
 			return Err(ComposeError::InvalidPort(format!(
 				"port range mismatch: {full}"
 			)));
@@ -223,6 +225,27 @@ fn split_last_colon(s: &str) -> (&str, &str) {
 		(&s[..idx], &s[idx + 1..])
 	} else {
 		("", s)
+	}
+}
+
+/// When `host_ports` contains exactly one port and `container_count > 1`, expand
+/// the host side to a range starting at `host_ports[0]` (docker-compose semantics
+/// for `8080:80-82` → 8080→80, 8081→81, 8082→82).
+fn expand_single_host_port(
+	host_ports: Vec<u16>,
+	container_count: usize,
+	spec: &str,
+) -> Result<Vec<u16>> {
+	if host_ports.len() == 1 && container_count > 1 {
+		let start = host_ports[0];
+		let end = start
+			.checked_add((container_count - 1) as u16)
+			.ok_or_else(|| {
+				ComposeError::InvalidPort(format!("host port range overflow: {spec}"))
+			})?;
+		Ok((start..=end).collect())
+	} else {
+		Ok(host_ports)
 	}
 }
 

--- a/tests/ports/formats.rs
+++ b/tests/ports/formats.rs
@@ -94,6 +94,19 @@ fn range_at_limit_accepted() {
 }
 
 #[test]
+fn single_host_port_expands_over_container_range() {
+	// Docker-compose semantics: 8080:80-82 → 8080→80, 8081→81, 8082→82
+	let ports = parse_ports(&[short("8080:80-82")]).unwrap();
+	assert_eq!(ports.len(), 3);
+	assert_eq!(ports[0].host_port, Some(8080));
+	assert_eq!(ports[0].container_port, 80);
+	assert_eq!(ports[1].host_port, Some(8081));
+	assert_eq!(ports[1].container_port, 81);
+	assert_eq!(ports[2].host_port, Some(8082));
+	assert_eq!(ports[2].container_port, 82);
+}
+
+#[test]
 fn long_form_invalid_published_string_rejected() {
 	use podup::compose::types::StringOrU16;
 	let mapping = podup::compose::types::PortMapping::Long {


### PR DESCRIPTION
## Summary

- **PORTS-001**: `parse_short` with single host port and container range (e.g. `8080:80-82`) produced only one mapping due to `zip` truncation. New `expand_single_host_port` helper expands the host side to a range, yielding all three expected mappings.
- **EXEC-001**: `exec` never inspected the process after output streaming finished — always returned `Ok(())`. Now calls `inspect_exec` and returns `Err(ComposeError::RunExited(code))` on non-zero exit.
- **LIFE-004**: All `stop_container` calls hardcoded `t: Some(10)`. Now reads `stop_grace_period` from the compose service via `parse_duration_secs`, with 10 s as fallback.

## Test plan

- [ ] `cargo test` — 17 port tests pass (up from 16), all 127 unit + 86 integration tests green
- [ ] New test `single_host_port_expands_over_container_range` verifies the PORTS-001 fix
- [ ] `cargo clippy` clean

Closes #82