### PR TITLE
perf: prefetch running containers, spawn_blocking for I/O, stage cleanup

### DIFF
--- a/internal/engine/build.rs
+++ b/internal/engine/build.rs
@@ -119,10 +119,9 @@ impl Engine {
 			} else {
 				let ctx = context_path.clone();
 				let df_s = df.to_string();
-				let bytes =
-					tokio::task::spawn_blocking(move || build_context_tar(&ctx, &df_s))
-						.await
-						.map_err(|e| ComposeError::Build(e.to_string()))??;
+				let bytes = tokio::task::spawn_blocking(move || build_context_tar(&ctx, &df_s))
+					.await
+					.map_err(|e| ComposeError::Build(e.to_string()))??;
 				(bytes, df.to_string())
 			}
 		};

--- a/internal/engine/build.rs
+++ b/internal/engine/build.rs
@@ -98,14 +98,32 @@ impl Engine {
 
 		info!("building {tag} from {}", context_path.display());
 
+		// PERF-004: walkdir + file I/O are blocking; run off the tokio thread pool.
 		let (tar_bytes, dockerfile_name) = if let Some(inline) = build.dockerfile_inline() {
-			build_context_tar_with_inline(&context_path, inline)?
+			let ctx = context_path.clone();
+			let inline_s = inline.to_string();
+			tokio::task::spawn_blocking(move || build_context_tar_with_inline(&ctx, &inline_s))
+				.await
+				.map_err(|e| ComposeError::Build(e.to_string()))??
 		} else {
 			let df = build.dockerfile().unwrap_or("Dockerfile");
 			if let Some(target) = build.target() {
-				build_context_tar_with_target(&context_path, df, target)?
+				let ctx = context_path.clone();
+				let df_s = df.to_string();
+				let tgt_s = target.to_string();
+				tokio::task::spawn_blocking(move || {
+					build_context_tar_with_target(&ctx, &df_s, &tgt_s)
+				})
+				.await
+				.map_err(|e| ComposeError::Build(e.to_string()))??
 			} else {
-				(build_context_tar(&context_path, df)?, df.to_string())
+				let ctx = context_path.clone();
+				let df_s = df.to_string();
+				let bytes =
+					tokio::task::spawn_blocking(move || build_context_tar(&ctx, &df_s))
+						.await
+						.map_err(|e| ComposeError::Build(e.to_string()))??;
+				(bytes, df.to_string())
 			}
 		};
 

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -75,9 +75,14 @@ impl Engine {
 			std::env::current_dir().map_err(ComposeError::Io)?
 		};
 
-		let cursor = std::io::Cursor::new(tar_bytes);
-		let mut archive = tar::Archive::new(cursor);
-		archive.unpack(&dst_path).map_err(ComposeError::Io)?;
+		// PERF-005: tar extraction is blocking I/O.
+		tokio::task::spawn_blocking(move || {
+			let cursor = std::io::Cursor::new(tar_bytes);
+			let mut archive = tar::Archive::new(cursor);
+			archive.unpack(&dst_path).map_err(ComposeError::Io)
+		})
+		.await
+		.map_err(|e| ComposeError::Build(e.to_string()))??;
 
 		Ok(())
 	}
@@ -95,7 +100,11 @@ impl Engine {
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container_name = self.container_name(service_name, service);
 
-		let tar_bytes = pack_path(src)?;
+		// PERF-005: tar creation is blocking I/O.
+		let src_buf = src.to_path_buf();
+		let tar_bytes = tokio::task::spawn_blocking(move || pack_path(&src_buf))
+			.await
+			.map_err(|e| ComposeError::Build(e.to_string()))??;
 
 		self.docker
 			.upload_to_container(

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -1,9 +1,11 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
+use std::collections::{HashMap, HashSet};
+
 use bollard::container::LogOutput;
 use bollard::query_parameters::{
-	KillContainerOptions, LogsOptions, RemoveContainerOptions, StartContainerOptions,
-	StopContainerOptions, WaitContainerOptions,
+	KillContainerOptions, ListContainersOptions, LogsOptions, RemoveContainerOptions,
+	StartContainerOptions, StopContainerOptions, WaitContainerOptions,
 };
 use futures::StreamExt;
 use tracing::info;
@@ -41,113 +43,144 @@ impl Engine {
 		target_services: &[String],
 		no_recreate: bool,
 	) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let active = active_profiles_set(active_profiles);
+		let r: Result<()> = async {
+			let order = crate::compose::resolve_order(file)?;
+			let active = active_profiles_set(active_profiles);
 
-		let target_set: Option<std::collections::HashSet<String>> = if target_services.is_empty() {
-			None
-		} else {
-			let mut set = std::collections::HashSet::new();
-			let mut stack: Vec<String> = target_services.to_vec();
-			while let Some(name) = stack.pop() {
-				if !set.insert(name.clone()) {
-					continue;
-				}
-				if let Some(service) = file.services.get(&name) {
-					for dep in service.depends_on.service_names() {
-						if !set.contains(&dep) {
-							stack.push(dep);
+			let target_set: Option<HashSet<String>> = if target_services.is_empty() {
+				None
+			} else {
+				let mut set = HashSet::new();
+				let mut stack: Vec<String> = target_services.to_vec();
+				while let Some(name) = stack.pop() {
+					if !set.insert(name.clone()) {
+						continue;
+					}
+					if let Some(service) = file.services.get(&name) {
+						for dep in service.depends_on.service_names() {
+							if !set.contains(&dep) {
+								stack.push(dep);
+							}
 						}
 					}
 				}
-			}
-			Some(set)
-		};
+				Some(set)
+			};
 
-		self.create_networks(file).await?;
-		self.create_volumes(file).await?;
+			// PERF-003: prefetch running containers once instead of one API call per replica.
+			let running: HashSet<String> = if no_recreate {
+				let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+				filters.insert(
+					"label".to_string(),
+					vec![format!("podup.project={}", self.project)],
+				);
+				self.docker
+					.list_containers(Some(ListContainersOptions {
+						all: false,
+						filters: Some(filters),
+						..Default::default()
+					}))
+					.await?
+					.into_iter()
+					.flat_map(|c| c.names.unwrap_or_default())
+					.map(|n| n.trim_start_matches('/').to_string())
+					.collect()
+			} else {
+				HashSet::new()
+			};
 
-		for name in &order {
-			if let Some(ref set) = target_set {
-				if !set.contains(name) {
+			self.create_networks(file).await?;
+			self.create_volumes(file).await?;
+
+			for name in &order {
+				if let Some(ref set) = target_set {
+					if !set.contains(name) {
+						continue;
+					}
+				}
+				let service = &file.services[name];
+
+				if !service_in_profiles(service, &active) {
+					tracing::debug!("skipping {name}: no active profile match");
 					continue;
 				}
-			}
-			let service = &file.services[name];
 
-			if !service_in_profiles(service, &active) {
-				tracing::debug!("skipping {name}: no active profile match");
-				continue;
-			}
+				for dep in service.depends_on.service_names() {
+					let condition = service.depends_on.condition_for(&dep);
+					let dep_service = match file.services.get(&dep) {
+						Some(s) => s,
+						None => continue,
+					};
+					if !service_in_profiles(dep_service, &active) {
+						continue;
+					}
+					let dep_container = self.container_name(&dep, dep_service);
 
-			for dep in service.depends_on.service_names() {
-				let condition = service.depends_on.condition_for(&dep);
-				let dep_service = match file.services.get(&dep) {
-					Some(s) => s,
-					None => continue,
-				};
-				if !service_in_profiles(dep_service, &active) {
-					continue;
-				}
-				let dep_container = self.container_name(&dep, dep_service);
-
-				match condition {
-					ServiceCondition::ServiceStarted => {}
-					ServiceCondition::ServiceHealthy => {
-						if dep_service
-							.healthcheck
-							.as_ref()
-							.map(|h| !h.is_disabled())
-							.unwrap_or(false)
-						{
-							self.wait_healthy(&dep_container, dep_service).await?;
-						} else {
-							tracing::debug!(
-								"{dep} requested service_healthy but has no healthcheck — skipping wait"
-							);
+					match condition {
+						ServiceCondition::ServiceStarted => {}
+						ServiceCondition::ServiceHealthy => {
+							if dep_service
+								.healthcheck
+								.as_ref()
+								.map(|h| !h.is_disabled())
+								.unwrap_or(false)
+							{
+								self.wait_healthy(&dep_container, dep_service).await?;
+							} else {
+								tracing::debug!(
+									"{dep} requested service_healthy but has no healthcheck — skipping wait"
+								);
+							}
+						}
+						ServiceCondition::ServiceCompletedSuccessfully => {
+							self.wait_completed(&dep_container).await?;
 						}
 					}
-					ServiceCondition::ServiceCompletedSuccessfully => {
-						self.wait_completed(&dep_container).await?;
+				}
+
+				let policy = service.pull_policy.as_deref().unwrap_or("missing");
+				match (service.build.is_some(), policy) {
+					(true, _) => self.build_service(name, service).await?,
+					(false, "never") => {}
+					(false, _) => self.pull_image(service).await?,
+				}
+
+				let replicas = service
+					.scale
+					.or(service.deploy.as_ref().and_then(|d| d.replicas))
+					.unwrap_or(1) as usize;
+
+				for i in 1..=replicas {
+					let container_name = if replicas == 1 {
+						self.container_name(name, service)
+					} else {
+						format!("{}-{i}", self.container_name(name, service))
+					};
+					if no_recreate && running.contains(&container_name) {
+						info!("{container_name} already running — skipping recreate");
+						continue;
+					}
+					self.create_and_start(&container_name, name, service, file)
+						.await?;
+					self.connect_extra_networks(&container_name, service, file)
+						.await?;
+					info!("started {container_name}");
+
+					for hook in &service.post_start {
+						self.run_lifecycle_hook(&container_name, hook).await?;
 					}
 				}
 			}
 
-			let policy = service.pull_policy.as_deref().unwrap_or("missing");
-			match (service.build.is_some(), policy) {
-				(true, _) => self.build_service(name, service).await?,
-				(false, "never") => {}
-				(false, _) => self.pull_image(service).await?,
-			}
-
-			let replicas = service
-				.scale
-				.or(service.deploy.as_ref().and_then(|d| d.replicas))
-				.unwrap_or(1) as usize;
-
-			for i in 1..=replicas {
-				let container_name = if replicas == 1 {
-					self.container_name(name, service)
-				} else {
-					format!("{}-{i}", self.container_name(name, service))
-				};
-				if no_recreate && self.is_container_running(&container_name).await {
-					info!("{container_name} already running — skipping recreate");
-					continue;
-				}
-				self.create_and_start(&container_name, name, service, file)
-					.await?;
-				self.connect_extra_networks(&container_name, service, file)
-					.await?;
-				info!("started {container_name}");
-
-				for hook in &service.post_start {
-					self.run_lifecycle_hook(&container_name, hook).await?;
-				}
-			}
+			Ok(())
 		}
-
-		Ok(())
+		.await;
+		// STAGE-001: clean up staging dir on partial failure so inline secret/config
+		// files are not left behind when up errors mid-way.
+		if r.is_err() {
+			self.cleanup_temp_dir();
+		}
+		r
 	}
 
 	pub async fn down(&self, file: &ComposeFile) -> Result<()> {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -116,7 +116,6 @@ impl Engine {
 		Ok(())
 	}
 
-
 	pub(super) fn container_name(&self, service_name: &str, service: &Service) -> String {
 		service
 			.container_name

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -18,12 +18,10 @@ mod volume;
 mod volume_mounts;
 mod watch;
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use bollard::container::LogOutput;
 use bollard::exec::{CreateExecOptions, StartExecResults};
-use bollard::query_parameters::ListContainersOptions;
 use bollard::Docker;
 use futures::StreamExt;
 
@@ -118,21 +116,6 @@ impl Engine {
 		Ok(())
 	}
 
-	pub(super) async fn is_container_running(&self, container_name: &str) -> bool {
-		// list_containers (not inspect_container) avoids Bollard deserialization
-		// failures when Podman returns "stopped" state.
-		let mut filters = HashMap::new();
-		filters.insert("name".to_string(), vec![container_name.to_string()]);
-		self.docker
-			.list_containers(Some(ListContainersOptions {
-				all: false,
-				filters: Some(filters),
-				..Default::default()
-			}))
-			.await
-			.map(|v| !v.is_empty())
-			.unwrap_or(false)
-	}
 
 	pub(super) fn container_name(&self, service_name: &str, service: &Service) -> String {
 		service


### PR DESCRIPTION
## Summary

- **PERF-003**: `up_with_options` called `is_container_running` per container replica — each was a separate `list_containers` round-trip. Replaced with a single prefetch of all running project containers into a `HashSet`; in-loop checks become O(1) hash lookups. Removes the now-dead `is_container_running` helper.
- **PERF-004**: `build_context_tar*` functions ran `walkdir` + file reads on the tokio executor thread. Wrapped all three variants (`build_context_tar`, `build_context_tar_with_inline`, `build_context_tar_with_target`) in `tokio::task::spawn_blocking`.
- **PERF-005**: `pack_path` (tar creation) and `tar::Archive::unpack` (tar extraction) ran blocking I/O on the tokio thread. Wrapped both in `spawn_blocking`.
- **STAGE-001**: `up_with_options` never called `cleanup_temp_dir` on failure, leaving inline secret/config staging files behind. Wrapped the up body in an async block and call `cleanup_temp_dir` before propagating any error.

## Test plan

- [ ] `cargo check` — clean, no warnings
- [ ] `cargo test` — all tests pass

Closes #84