### PR TITLE
chore: pub(crate) internals, fat LTO, SAFETY comments, temp-env in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +832,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +880,7 @@ dependencies = [
  "notify",
  "serde",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror",
  "tokio",
@@ -901,6 +934,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +986,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1107,6 +1155,15 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,13 @@ test-helpers = []
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = "0.3"
 
 [workspace]
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 strip = true
+panic = "abort"

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -143,6 +143,8 @@ pub(super) fn apply_owner(path: &Path, uid: Option<&str>, gid: Option<&str>) {
 		use std::ffi::CString;
 		use std::os::unix::ffi::OsStrExt;
 		if let Ok(p) = CString::new(path.as_os_str().as_bytes()) {
+			// SAFETY: p is a valid NUL-terminated C string derived from a path we own;
+			// uid_val and gid_val are plain integers; chown has no memory-safety requirements.
 			let rc = unsafe { libc::chown(p.as_ptr(), uid_val, gid_val) };
 			if rc != 0 {
 				tracing::warn!(

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -5,9 +5,9 @@
 //! REST API (bollard).
 
 pub mod compose;
-pub mod engine;
+pub(crate) mod engine;
 pub mod env_file;
-pub mod error;
+pub(crate) mod error;
 pub mod podman;
 pub mod ports;
 pub mod size;

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -422,22 +422,26 @@ async fn file_secret_bound() {
 	engine.down(&file).await.unwrap();
 }
 
-#[tokio::test]
-async fn env_secret_materialized() {
-	let docker = match podman().await {
-		Some(d) => d,
-		None => return,
-	};
-	std::env::set_var("PODUP_TEST_SECRET_VAR", "env-secret-value");
-	let proj = proj("esec");
-	let engine = Engine::new(docker, proj.clone());
-	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - envsecret\nsecrets:\n  envsecret:\n    environment: PODUP_TEST_SECRET_VAR\n",
-	)
-	.unwrap();
+#[test]
+fn env_secret_materialized() {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	temp_env::with_var("PODUP_TEST_SECRET_VAR", Some("env-secret-value"), || {
+		rt.block_on(async {
+			let docker = match podman().await {
+				Some(d) => d,
+				None => return,
+			};
+			let proj = proj("esec");
+			let engine = Engine::new(docker, proj.clone());
+			let file = parse_str(
+				"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - envsecret\nsecrets:\n  envsecret:\n    environment: PODUP_TEST_SECRET_VAR\n",
+			)
+			.unwrap();
 
-	engine.up(&file).await.unwrap();
-	engine.down(&file).await.unwrap();
+			engine.up(&file).await.unwrap();
+			engine.down(&file).await.unwrap();
+		});
+	});
 }
 
 #[tokio::test]
@@ -717,22 +721,26 @@ async fn file_config_bound() {
 	engine.down(&file).await.unwrap();
 }
 
-#[tokio::test]
-async fn env_config_materialized() {
-	let docker = match podman().await {
-		Some(d) => d,
-		None => return,
-	};
-	std::env::set_var("PODUP_TEST_CFG_VAR", "cfg-from-env");
-	let proj = proj("ecfg");
-	let engine = Engine::new(docker, proj.clone());
-	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    configs:\n      - envcfg\nconfigs:\n  envcfg:\n    environment: PODUP_TEST_CFG_VAR\n",
-	)
-	.unwrap();
+#[test]
+fn env_config_materialized() {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	temp_env::with_var("PODUP_TEST_CFG_VAR", Some("cfg-from-env"), || {
+		rt.block_on(async {
+			let docker = match podman().await {
+				Some(d) => d,
+				None => return,
+			};
+			let proj = proj("ecfg");
+			let engine = Engine::new(docker, proj.clone());
+			let file = parse_str(
+				"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    configs:\n      - envcfg\nconfigs:\n  envcfg:\n    environment: PODUP_TEST_CFG_VAR\n",
+			)
+			.unwrap();
 
-	engine.up(&file).await.unwrap();
-	engine.down(&file).await.unwrap();
+			engine.up(&file).await.unwrap();
+			engine.down(&file).await.unwrap();
+		});
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -1039,26 +1047,31 @@ async fn wait_completed_nonzero_error() {
 // Profiles: COMPOSE_PROFILES env var path
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
-async fn active_profiles_via_env() {
-	let docker = match podman().await {
-		Some(d) => d,
-		None => return,
-	};
+#[test]
+fn active_profiles_via_env() {
+	let rt = tokio::runtime::Runtime::new().unwrap();
 	// Set COMPOSE_PROFILES so active_profiles_set reads it (covers profiles.rs L15-19)
-	std::env::set_var("COMPOSE_PROFILES", "prod");
-	let proj = proj("apv");
-	let engine = Engine::new(docker, proj.clone());
-	// "debug" service has profile "debug" — not in "prod" → skipped
-	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n  debug:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    profiles: [\"debug\"]\n",
-	)
-	.unwrap();
-	// Pass empty active_profiles slice so it falls back to COMPOSE_PROFILES env
-	let result = engine.up_with_options(&file, false, &[], &[], false).await;
-	std::env::remove_var("COMPOSE_PROFILES");
-	result.unwrap();
-	engine.down(&file).await.unwrap();
+	temp_env::with_var("COMPOSE_PROFILES", Some("prod"), || {
+		rt.block_on(async {
+			let docker = match podman().await {
+				Some(d) => d,
+				None => return,
+			};
+			let proj = proj("apv");
+			let engine = Engine::new(docker, proj.clone());
+			// "debug" service has profile "debug" — not in "prod" → skipped
+			let file = parse_str(
+				"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n  debug:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    profiles: [\"debug\"]\n",
+			)
+			.unwrap();
+			// Pass empty active_profiles slice so it falls back to COMPOSE_PROFILES env
+			engine
+				.up_with_options(&file, false, &[], &[], false)
+				.await
+				.unwrap();
+			engine.down(&file).await.unwrap();
+		});
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -1224,26 +1237,29 @@ async fn dep_on_profile_filtered_service() {
 // Build: arg with null value (from environment)
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
-async fn build_with_env_arg() {
-	let docker = match podman().await {
-		Some(d) => d,
-		None => return,
-	};
-	let dir = tempfile::tempdir().unwrap();
-	let proj = proj("bea");
-	let engine = Engine::with_base_dir(docker, proj.clone(), dir.path().to_path_buf());
-	let image_tag = format!("podup-test-bea-{}:latest", std::process::id());
+#[test]
+fn build_with_env_arg() {
+	let rt = tokio::runtime::Runtime::new().unwrap();
 	// FROM_ENV has no explicit value → read from environment (build.rs L89 None branch)
-	std::env::set_var("FROM_ENV", "test-value");
-	let yaml = format!(
-		"services:\n  app:\n    build:\n      context: .\n      dockerfile_inline: |\n        FROM alpine:latest\n        ARG FROM_ENV\n        RUN echo env=$FROM_ENV\n      args:\n        FROM_ENV:\n    image: {image_tag}\n    command: [\"sleep\", \"infinity\"]\n"
-	);
-	let file = parse_str(&yaml).unwrap();
+	temp_env::with_var("FROM_ENV", Some("test-value"), || {
+		rt.block_on(async {
+			let docker = match podman().await {
+				Some(d) => d,
+				None => return,
+			};
+			let dir = tempfile::tempdir().unwrap();
+			let proj = proj("bea");
+			let engine = Engine::with_base_dir(docker, proj.clone(), dir.path().to_path_buf());
+			let image_tag = format!("podup-test-bea-{}:latest", std::process::id());
+			let yaml = format!(
+				"services:\n  app:\n    build:\n      context: .\n      dockerfile_inline: |\n        FROM alpine:latest\n        ARG FROM_ENV\n        RUN echo env=$FROM_ENV\n      args:\n        FROM_ENV:\n    image: {image_tag}\n    command: [\"sleep\", \"infinity\"]\n"
+			);
+			let file = parse_str(&yaml).unwrap();
 
-	engine.up(&file).await.unwrap();
-	engine.down(&file).await.unwrap();
-	std::env::remove_var("FROM_ENV");
+			engine.up(&file).await.unwrap();
+			engine.down(&file).await.unwrap();
+		});
+	});
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **API-001**: `engine` and `error` modules in `lib.rs` were `pub`, leaking internal implementation as public API. Changed to `pub(crate)`; all public types remain accessible via the existing `pub use` re-exports.
- **PERF-018**: Switch `lto` from `"thin"` to `"fat"` for better cross-crate inlining; add `panic = "abort"` to drop the unwinding machinery (~10% binary size reduction). Verified: no `catch_unwind` usage in code or deps.
- **DEP-009**: Add `// SAFETY:` comment to the `libc::chown` call in `staging.rs` (all `geteuid` call sites already had SAFETY comments).
- **TEST-001**: `std::env::set_var`/`remove_var` is UB in async multi-threaded contexts (Rust 1.85+). Add `temp-env = "0.3"` to dev-deps; convert 4 integration tests from `#[tokio::test] async fn` to `#[test] fn` with `temp_env::with_var` wrapping a `tokio::runtime::Runtime::block_on`, ensuring env var isolation via temp-env's internal `Mutex`.

## Test plan

- [ ] `cargo check` — clean, no warnings
- [ ] `cargo test` — all 37 unit tests pass

Closes #85