### PR TITLE
ci: move cargo publish after release, add weekly cargo audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Security audit
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,11 +138,6 @@ jobs:
       - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal
 
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
@@ -177,3 +172,8 @@ jobs:
             podup-windows-x86_64.exe.sig \
             SHA256SUMS \
             install.sh
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked


### PR DESCRIPTION
## Summary

- **SC-009**: `cargo publish` previously ran before `actions/download-artifact` and `gh release create`. If the release creation failed (network blip, auth issue), the crate would already be live on crates.io without matching binaries. Moved `cargo publish` to be the final step, after all release assets are uploaded to GitHub.
- **SC-010**: Add `audit.yml` scheduled workflow running `cargo audit` every Monday at 06:00 UTC (plus manual dispatch). Alerts surface as GitHub Actions failures when CVEs are found in dependencies.

## Test plan

- [ ] Release workflow ordering looks correct in the YAML
- [ ] `audit.yml` syntax is valid YAML
- [ ] `cargo audit` runs cleanly in the current repo

Closes #78