### PR TITLE
ci: add explicit permissions block to audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   audit:
     name: cargo audit


### PR DESCRIPTION
Adds `permissions: {}` to `audit.yml`. CodeQL flagged the missing block on PR #74.