### PR TITLE
fix: remove artifacts before cargo publish; use requirements hashes for SHA256SUMS sign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
             echo "::error::RELEASE_SIGN_KEY secret is not configured; refusing to release unsigned checksums."
             exit 1
           fi
-          python3 -m pip install --quiet cryptography==48.0.0
+          python3 -m pip install --quiet --require-hashes -r .github/scripts/sign-requirements.txt
           python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" SHA256SUMS
 
       - name: Create GitHub Release
@@ -195,6 +195,9 @@ jobs:
             SHA256SUMS \
             SHA256SUMS.sig \
             install.sh
+
+      - name: Remove release artifacts
+        run: rm -f podup-* SHA256SUMS SHA256SUMS.sig
 
       - name: Publish to crates.io
         env:


### PR DESCRIPTION
Two release workflow fixes:\n1. **Remove release artifacts** step before `cargo publish` — downloaded binaries in workdir caused `cargo publish --locked` to fail with exit 101 (uncommitted changes).\n2. **Sign SHA256SUMS** now uses `--require-hashes -r sign-requirements.txt` (consistent with Sign binary step).