### PR TITLE
chore: bump version to 0.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"


### PR DESCRIPTION
Bump from 0.5.3 to 0.5.4. v0.5.3 tag was permanently blocked by GitHub after a partial release run (binaries published but cargo publish failed); skipping to 0.5.4 for a clean release.