### PR TITLE
release: v0.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"


### PR DESCRIPTION
Bump to v0.5.4. v0.5.3 tag was permanently blocked after a partial release run; all audit fixes included in this release.