### PR TITLE
chore: update Cargo.lock for v0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "bollard",
  "bytes",


### PR DESCRIPTION
Cargo.lock was not updated when bumping Cargo.toml version; cargo build --locked failed.