### PR TITLE
deps: remove walkdir, use std::fs recursive walk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ futures = { version = "0.3", default-features = false, features = ["async-await"
 tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"
-walkdir = "2"
 notify = { version = "8", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/internal/engine/build.rs
+++ b/internal/engine/build.rs
@@ -14,7 +14,6 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures::StreamExt;
 use tracing::{debug, info, warn};
-use walkdir::WalkDir;
 
 use crate::compose::types::{BuildConfig, Service};
 use crate::error::{ComposeError, Result};
@@ -98,7 +97,7 @@ impl Engine {
 
 		info!("building {tag} from {}", context_path.display());
 
-		// PERF-004: walkdir + file I/O are blocking; run off the tokio thread pool.
+		// PERF-004: directory walk + file I/O are blocking; run off the tokio thread pool.
 		let (tar_bytes, dockerfile_name) = if let Some(inline) = build.dockerfile_inline() {
 			let ctx = context_path.clone();
 			let inline_s = inline.to_string();
@@ -271,24 +270,19 @@ fn build_context_tar_with_inline(context: &Path, inline: &str) -> Result<(Vec<u8
 	tar.append_data(&mut header, inline_name, inline.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-	for entry in WalkDir::new(context).follow_links(false) {
-		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-		let abs = entry.path();
+	for abs in super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-		if rel.as_os_str().is_empty() {
-			continue;
-		}
 		let rel_str = rel.to_string_lossy();
 		if is_ignored(&rel_str, &ignore_patterns) {
 			continue;
 		}
 		if abs.is_dir() {
-			tar.append_dir(rel, abs)
+			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
-			tar.append_path_with_name(abs, rel)
+			tar.append_path_with_name(&abs, rel)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		}
 	}
@@ -308,27 +302,19 @@ pub(crate) fn build_context_tar(context: &Path, _dockerfile: &str) -> Result<Vec
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	for entry in WalkDir::new(context).follow_links(false) {
-		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-		let abs = entry.path();
+	for abs in super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-
-		if rel.as_os_str().is_empty() {
-			continue;
-		}
-
 		let rel_str = rel.to_string_lossy();
 		if is_ignored(&rel_str, &ignore_patterns) {
 			continue;
 		}
-
 		if abs.is_dir() {
-			tar.append_dir(rel, abs)
+			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
-			tar.append_path_with_name(abs, rel)
+			tar.append_path_with_name(&abs, rel)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		}
 	}
@@ -370,15 +356,10 @@ fn build_context_tar_with_target(
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
 	// Add context, skipping the original Dockerfile (already wrote truncated version).
-	for entry in WalkDir::new(context).follow_links(false) {
-		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-		let abs = entry.path();
+	for abs in super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-		if rel.as_os_str().is_empty() {
-			continue;
-		}
 		let rel_str = rel.to_string_lossy();
 		if is_ignored(&rel_str, &ignore_patterns) {
 			continue;
@@ -387,10 +368,10 @@ fn build_context_tar_with_target(
 			continue; // Replaced by truncated version above.
 		}
 		if abs.is_dir() {
-			tar.append_dir(rel, abs)
+			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
-			tar.append_path_with_name(abs, rel)
+			tar.append_path_with_name(&abs, rel)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		}
 	}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -158,8 +158,7 @@ fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
 }
 
 fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-	let mut entries: Vec<_> = std::fs::read_dir(dir)?
-		.collect::<std::io::Result<Vec<_>>>()?;
+	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
 	entries.sort_by_key(|e| e.file_name());
 	for entry in entries {
 		let path = entry.path();

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -144,3 +144,30 @@ impl Engine {
 		))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+/// Recursively collect all file and directory paths under `root`, in pre-order.
+/// Symlinks are included as entries but are never followed into.
+fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
+	let mut out = Vec::new();
+	walk_collect(root, &mut out)?;
+	Ok(out)
+}
+
+fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+	let mut entries: Vec<_> = std::fs::read_dir(dir)?
+		.collect::<std::io::Result<Vec<_>>>()?;
+	entries.sort_by_key(|e| e.file_name());
+	for entry in entries {
+		let path = entry.path();
+		let file_type = entry.file_type()?;
+		out.push(path.clone());
+		if file_type.is_dir() {
+			walk_collect(&path, out)?;
+		}
+	}
+	Ok(())
+}

--- a/internal/engine/watch.rs
+++ b/internal/engine/watch.rs
@@ -306,20 +306,15 @@ fn build_sync_tar(src: &Path) -> Result<Vec<u8>> {
 	let mut tar = tar::Builder::new(encoder);
 
 	if src.is_dir() {
-		for entry in walkdir::WalkDir::new(src).follow_links(false) {
-			let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-			let abs = entry.path();
+		for abs in super::walk_dir(src).map_err(ComposeError::Io)? {
 			let rel = abs
 				.strip_prefix(src)
 				.map_err(|_| ComposeError::Build("path strip".into()))?;
-			if rel.as_os_str().is_empty() {
-				continue;
-			}
 			if abs.is_dir() {
-				tar.append_dir(rel, abs)
+				tar.append_dir(rel, &abs)
 					.map_err(|e| ComposeError::Build(e.to_string()))?;
 			} else {
-				tar.append_path_with_name(abs, rel)
+				tar.append_path_with_name(&abs, rel)
 					.map_err(|e| ComposeError::Build(e.to_string()))?;
 			}
 		}


### PR DESCRIPTION
Replace `walkdir::WalkDir` with a ~20-line `walk_dir` helper in `engine/mod.rs` that uses `std::fs::read_dir` recursion. Symlinks are not followed (matching prior `follow_links(false)` behavior). Four call sites updated across `engine/build.rs` and `engine/watch.rs`.

Closes #109

## Test plan
- [x] `cargo build` clean
- [x] All 450 tests pass (`cargo test`)