### PR TITLE
deps: remove thiserror, use manual Error impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,6 @@ dependencies = [
  "tar",
  "temp-env",
  "tempfile",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "internal/lib.rs"
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
-thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -3,58 +3,81 @@
 //! All fallible operations return [`Result<T>`], which is an alias for
 //! `std::result::Result<T, ComposeError>`.
 
-use thiserror::Error;
+use std::fmt;
 
 /// All errors produced by podup.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum ComposeError {
-	#[error("failed to parse compose file: {0}")]
-	Parse(#[from] serde_yaml::Error),
-
-	#[error("compose file not found: {0}")]
+	Parse(serde_yaml::Error),
 	FileNotFound(String),
-
-	#[error("io error: {0}")]
-	Io(#[from] std::io::Error),
-
-	#[error("podman error: {0}")]
-	Podman(#[from] bollard::errors::Error),
-
-	#[error("service '{0}' not found")]
+	Io(std::io::Error),
+	Podman(bollard::errors::Error),
 	ServiceNotFound(String),
-
-	#[error("circular dependency detected: {0}")]
 	CircularDependency(String),
-
-	#[error("service '{0}' has no image or build config")]
 	NoImageOrBuild(String),
-
-	#[error("required variable '{var}' is not set: {msg}")]
 	RequiredVarNotSet { var: String, msg: String },
-
-	#[error("health check timeout for container '{0}'")]
 	HealthCheckTimeout(String),
-
-	#[error("invalid port mapping: {0}")]
 	InvalidPort(String),
-
-	#[error("build error: {0}")]
 	Build(String),
-
-	#[error("extends error: {0}")]
 	Extends(String),
-
-	#[error("include error: {0}")]
 	Include(String),
-
-	#[error("watch error: {0}")]
 	Watch(String),
-
-	#[error("unsupported feature: {0}")]
 	Unsupported(String),
-
-	#[error("run container exited with code {0}")]
 	RunExited(i64),
+}
+
+impl fmt::Display for ComposeError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Parse(e) => write!(f, "failed to parse compose file: {e}"),
+			Self::FileNotFound(s) => write!(f, "compose file not found: {s}"),
+			Self::Io(e) => write!(f, "io error: {e}"),
+			Self::Podman(e) => write!(f, "podman error: {e}"),
+			Self::ServiceNotFound(s) => write!(f, "service '{s}' not found"),
+			Self::CircularDependency(s) => write!(f, "circular dependency detected: {s}"),
+			Self::NoImageOrBuild(s) => write!(f, "service '{s}' has no image or build config"),
+			Self::RequiredVarNotSet { var, msg } => {
+				write!(f, "required variable '{var}' is not set: {msg}")
+			}
+			Self::HealthCheckTimeout(s) => write!(f, "health check timeout for container '{s}'"),
+			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),
+			Self::Build(s) => write!(f, "build error: {s}"),
+			Self::Extends(s) => write!(f, "extends error: {s}"),
+			Self::Include(s) => write!(f, "include error: {s}"),
+			Self::Watch(s) => write!(f, "watch error: {s}"),
+			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
+			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
+		}
+	}
+}
+
+impl std::error::Error for ComposeError {
+	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+		match self {
+			Self::Parse(e) => Some(e),
+			Self::Io(e) => Some(e),
+			Self::Podman(e) => Some(e),
+			_ => None,
+		}
+	}
+}
+
+impl From<serde_yaml::Error> for ComposeError {
+	fn from(e: serde_yaml::Error) -> Self {
+		Self::Parse(e)
+	}
+}
+
+impl From<std::io::Error> for ComposeError {
+	fn from(e: std::io::Error) -> Self {
+		Self::Io(e)
+	}
+}
+
+impl From<bollard::errors::Error> for ComposeError {
+	fn from(e: bollard::errors::Error) -> Self {
+		Self::Podman(e)
+	}
 }
 
 pub type Result<T> = std::result::Result<T, ComposeError>;

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -97,10 +97,7 @@ mod tests {
 				"compose file not found: f",
 				ComposeError::FileNotFound("f".into()),
 			),
-			(
-				"io error:",
-				ComposeError::Io(std::io::Error::other("x")),
-			),
+			("io error:", ComposeError::Io(std::io::Error::other("x"))),
 			(
 				"service 's' not found",
 				ComposeError::ServiceNotFound("s".into()),

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -81,3 +81,93 @@ impl From<bollard::errors::Error> for ComposeError {
 }
 
 pub type Result<T> = std::result::Result<T, ComposeError>;
+
+#[cfg(test)]
+mod tests {
+	use super::ComposeError;
+
+	#[test]
+	fn display_covers_all_variants() {
+		let cases: &[(&str, ComposeError)] = &[
+			(
+				"failed to parse compose file:",
+				ComposeError::Parse(serde_yaml::from_str::<serde_yaml::Value>(":\0").unwrap_err()),
+			),
+			(
+				"compose file not found: f",
+				ComposeError::FileNotFound("f".into()),
+			),
+			(
+				"io error:",
+				ComposeError::Io(std::io::Error::other("x")),
+			),
+			(
+				"service 's' not found",
+				ComposeError::ServiceNotFound("s".into()),
+			),
+			(
+				"circular dependency detected: c",
+				ComposeError::CircularDependency("c".into()),
+			),
+			(
+				"service 'svc' has no image or build config",
+				ComposeError::NoImageOrBuild("svc".into()),
+			),
+			(
+				"required variable 'V' is not set: reason",
+				ComposeError::RequiredVarNotSet {
+					var: "V".into(),
+					msg: "reason".into(),
+				},
+			),
+			(
+				"health check timeout for container 'c'",
+				ComposeError::HealthCheckTimeout("c".into()),
+			),
+			(
+				"invalid port mapping: p",
+				ComposeError::InvalidPort("p".into()),
+			),
+			("build error: b", ComposeError::Build("b".into())),
+			("extends error: e", ComposeError::Extends("e".into())),
+			("include error: i", ComposeError::Include("i".into())),
+			("watch error: w", ComposeError::Watch("w".into())),
+			(
+				"unsupported feature: u",
+				ComposeError::Unsupported("u".into()),
+			),
+			(
+				"run container exited with code 1",
+				ComposeError::RunExited(1),
+			),
+		];
+		for (expected_prefix, err) in cases {
+			let msg = err.to_string();
+			assert!(
+				msg.starts_with(expected_prefix),
+				"Display for {:?}: got {msg:?}, expected prefix {expected_prefix:?}",
+				std::mem::discriminant(err),
+			);
+		}
+	}
+
+	#[test]
+	fn source_provided_for_wrapped_variants() {
+		use std::error::Error;
+		let io = ComposeError::Io(std::io::Error::other("x"));
+		assert!(io.source().is_some());
+		let svc = ComposeError::ServiceNotFound("s".into());
+		assert!(svc.source().is_none());
+	}
+
+	#[test]
+	fn from_impls_convert_correctly() {
+		let io_err = std::io::Error::other("x");
+		let e: ComposeError = io_err.into();
+		assert!(matches!(e, ComposeError::Io(_)));
+
+		let yaml_err = serde_yaml::from_str::<serde_yaml::Value>(":\0").unwrap_err();
+		let e: ComposeError = yaml_err.into();
+		assert!(matches!(e, ComposeError::Parse(_)));
+	}
+}


### PR DESCRIPTION
Replace `thiserror` proc-macro with hand-written `Display` and `Error` impls for all `ComposeError` variants. Explicit `From` impls replace the `#[from]` attributes. No behavior change.

Closes #108

## Test plan
- [x] `cargo build` clean
- [x] All 450 tests pass (`cargo test`)