### PR TITLE
deps: feature-gate notify behind optional watch feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,14 @@ tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"
 walkdir = "2"
-notify = "8"
+notify = { version = "8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [features]
+default = ["watch"]
+watch = ["notify"]
 test-helpers = []
 
 [dev-dependencies]

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -16,6 +16,7 @@ mod query;
 mod staging;
 mod volume;
 mod volume_mounts;
+#[cfg(feature = "watch")]
 mod watch;
 
 use std::path::PathBuf;
@@ -134,5 +135,12 @@ impl Engine {
 		} else {
 			(1..=replicas).map(|i| format!("{base}-{i}")).collect()
 		}
+	}
+
+	#[cfg(not(feature = "watch"))]
+	pub async fn watch(&self, _file: &crate::compose::types::ComposeFile) -> Result<()> {
+		Err(crate::error::ComposeError::Unsupported(
+			"watch requires the 'watch' feature".into(),
+		))
 	}
 }


### PR DESCRIPTION
Make `notify` an optional dep, enabled by default via a new `watch` feature. `engine/watch.rs` is now compiled only when `watch` is active. A stub `Engine::watch()` returning `ComposeError::Unsupported` is provided when the feature is off, keeping main.rs unchanged.

Debian packaging can strip ~10 notify-related crates with `--no-default-features`.

Closes #110

## Test plan
- [x] `cargo build` + `cargo test` clean (default features)
- [x] `cargo build --no-default-features` + `cargo test --no-default-features` clean