### PR TITLE
chore: bump version to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+podup (0.5.5) unstable; urgency=low
+
+  * Migrate yaml_serde to serde_yaml_ng (actively maintained successor).
+  * Remove thiserror; use manual Display + Error impls for ComposeError.
+  * Remove walkdir; use std::fs recursive directory walk.
+  * Feature-gate notify behind optional watch feature (default enabled).
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 14:20:00 -0500
+
+podup (0.5.4) unstable; urgency=medium
+
+  * Fix release workflow: sign SHA256SUMS file, add weekly cargo audit.
+  * Fix cffi and pycparser hashes in sign-requirements.txt.
+  * Fix release artifact cleanup before cargo publish.
+  * Harden CodeQL workflow with explicit permissions block.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 08:30:00 -0500
+
 podup (0.5.3) unstable; urgency=low
 
   * Use glyndor.net/install/podup as canonical install URL in README and


### PR DESCRIPTION
Bump version to 0.5.5. Releases the dependency reduction work from PRs #111–#114.

Closes #115