### PR TITLE
release: v0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,12 +702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libyaml-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +861,7 @@ dependencies = [
  "libc",
  "notify",
  "serde",
+ "serde_yaml_ng",
  "tar",
  "temp-env",
  "tempfile",
@@ -875,7 +870,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
- "yaml_serde",
 ]
 
 [[package]]
@@ -1051,6 +1045,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1315,6 +1322,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -1636,19 +1649,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "yaml_serde"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
-dependencies = [
- "indexmap",
- "itoa",
- "libyaml-rs",
- "ryu",
- "serde",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,6 @@ dependencies = [
  "tar",
  "temp-env",
  "tempfile",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 bollard = "0.21"
 clap = { version = "4", features = ["derive", "env"] }
 indexmap = { version = "2", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,14 @@ tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"
 walkdir = "2"
-notify = "8"
+notify = { version = "8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [features]
+default = ["watch"]
+watch = ["notify"]
 test-helpers = []
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ futures = { version = "0.3", default-features = false, features = ["async-await"
 tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"
-walkdir = "2"
 notify = { version = "8", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "internal/lib.rs"
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
-thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+podup (0.5.5) unstable; urgency=low
+
+  * Migrate yaml_serde to serde_yaml_ng (actively maintained successor).
+  * Remove thiserror; use manual Display + Error impls for ComposeError.
+  * Remove walkdir; use std::fs recursive directory walk.
+  * Feature-gate notify behind optional watch feature (default enabled).
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 14:20:00 -0500
+
+podup (0.5.4) unstable; urgency=medium
+
+  * Fix release workflow: sign SHA256SUMS file, add weekly cargo audit.
+  * Fix cffi and pycparser hashes in sign-requirements.txt.
+  * Fix release artifact cleanup before cargo publish.
+  * Harden CodeQL workflow with explicit permissions block.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 08:30:00 -0500
+
 podup (0.5.3) unstable; urgency=low
 
   * Use glyndor.net/install/podup as canonical install URL in README and

--- a/internal/engine/build.rs
+++ b/internal/engine/build.rs
@@ -14,7 +14,6 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures::StreamExt;
 use tracing::{debug, info, warn};
-use walkdir::WalkDir;
 
 use crate::compose::types::{BuildConfig, Service};
 use crate::error::{ComposeError, Result};
@@ -98,7 +97,7 @@ impl Engine {
 
 		info!("building {tag} from {}", context_path.display());
 
-		// PERF-004: walkdir + file I/O are blocking; run off the tokio thread pool.
+		// PERF-004: directory walk + file I/O are blocking; run off the tokio thread pool.
 		let (tar_bytes, dockerfile_name) = if let Some(inline) = build.dockerfile_inline() {
 			let ctx = context_path.clone();
 			let inline_s = inline.to_string();
@@ -271,24 +270,19 @@ fn build_context_tar_with_inline(context: &Path, inline: &str) -> Result<(Vec<u8
 	tar.append_data(&mut header, inline_name, inline.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-	for entry in WalkDir::new(context).follow_links(false) {
-		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-		let abs = entry.path();
+	for abs in super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-		if rel.as_os_str().is_empty() {
-			continue;
-		}
 		let rel_str = rel.to_string_lossy();
 		if is_ignored(&rel_str, &ignore_patterns) {
 			continue;
 		}
 		if abs.is_dir() {
-			tar.append_dir(rel, abs)
+			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
-			tar.append_path_with_name(abs, rel)
+			tar.append_path_with_name(&abs, rel)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		}
 	}
@@ -308,27 +302,19 @@ pub(crate) fn build_context_tar(context: &Path, _dockerfile: &str) -> Result<Vec
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	for entry in WalkDir::new(context).follow_links(false) {
-		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-		let abs = entry.path();
+	for abs in super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-
-		if rel.as_os_str().is_empty() {
-			continue;
-		}
-
 		let rel_str = rel.to_string_lossy();
 		if is_ignored(&rel_str, &ignore_patterns) {
 			continue;
 		}
-
 		if abs.is_dir() {
-			tar.append_dir(rel, abs)
+			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
-			tar.append_path_with_name(abs, rel)
+			tar.append_path_with_name(&abs, rel)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		}
 	}
@@ -370,15 +356,10 @@ fn build_context_tar_with_target(
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
 	// Add context, skipping the original Dockerfile (already wrote truncated version).
-	for entry in WalkDir::new(context).follow_links(false) {
-		let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-		let abs = entry.path();
+	for abs in super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-		if rel.as_os_str().is_empty() {
-			continue;
-		}
 		let rel_str = rel.to_string_lossy();
 		if is_ignored(&rel_str, &ignore_patterns) {
 			continue;
@@ -387,10 +368,10 @@ fn build_context_tar_with_target(
 			continue; // Replaced by truncated version above.
 		}
 		if abs.is_dir() {
-			tar.append_dir(rel, abs)
+			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
-			tar.append_path_with_name(abs, rel)
+			tar.append_path_with_name(&abs, rel)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		}
 	}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -144,3 +144,29 @@ impl Engine {
 		))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+/// Recursively collect all file and directory paths under `root`, in pre-order.
+/// Symlinks are included as entries but are never followed into.
+fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
+	let mut out = Vec::new();
+	walk_collect(root, &mut out)?;
+	Ok(out)
+}
+
+fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
+	entries.sort_by_key(|e| e.file_name());
+	for entry in entries {
+		let path = entry.path();
+		let file_type = entry.file_type()?;
+		out.push(path.clone());
+		if file_type.is_dir() {
+			walk_collect(&path, out)?;
+		}
+	}
+	Ok(())
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -16,6 +16,7 @@ mod query;
 mod staging;
 mod volume;
 mod volume_mounts;
+#[cfg(feature = "watch")]
 mod watch;
 
 use std::path::PathBuf;
@@ -134,5 +135,12 @@ impl Engine {
 		} else {
 			(1..=replicas).map(|i| format!("{base}-{i}")).collect()
 		}
+	}
+
+	#[cfg(not(feature = "watch"))]
+	pub async fn watch(&self, _file: &crate::compose::types::ComposeFile) -> Result<()> {
+		Err(crate::error::ComposeError::Unsupported(
+			"watch requires the 'watch' feature".into(),
+		))
 	}
 }

--- a/internal/engine/watch.rs
+++ b/internal/engine/watch.rs
@@ -306,20 +306,15 @@ fn build_sync_tar(src: &Path) -> Result<Vec<u8>> {
 	let mut tar = tar::Builder::new(encoder);
 
 	if src.is_dir() {
-		for entry in walkdir::WalkDir::new(src).follow_links(false) {
-			let entry = entry.map_err(|e| ComposeError::Io(e.into()))?;
-			let abs = entry.path();
+		for abs in super::walk_dir(src).map_err(ComposeError::Io)? {
 			let rel = abs
 				.strip_prefix(src)
 				.map_err(|_| ComposeError::Build("path strip".into()))?;
-			if rel.as_os_str().is_empty() {
-				continue;
-			}
 			if abs.is_dir() {
-				tar.append_dir(rel, abs)
+				tar.append_dir(rel, &abs)
 					.map_err(|e| ComposeError::Build(e.to_string()))?;
 			} else {
-				tar.append_path_with_name(abs, rel)
+				tar.append_path_with_name(&abs, rel)
 					.map_err(|e| ComposeError::Build(e.to_string()))?;
 			}
 		}

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -3,58 +3,168 @@
 //! All fallible operations return [`Result<T>`], which is an alias for
 //! `std::result::Result<T, ComposeError>`.
 
-use thiserror::Error;
+use std::fmt;
 
 /// All errors produced by podup.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum ComposeError {
-	#[error("failed to parse compose file: {0}")]
-	Parse(#[from] serde_yaml::Error),
-
-	#[error("compose file not found: {0}")]
+	Parse(serde_yaml::Error),
 	FileNotFound(String),
-
-	#[error("io error: {0}")]
-	Io(#[from] std::io::Error),
-
-	#[error("podman error: {0}")]
-	Podman(#[from] bollard::errors::Error),
-
-	#[error("service '{0}' not found")]
+	Io(std::io::Error),
+	Podman(bollard::errors::Error),
 	ServiceNotFound(String),
-
-	#[error("circular dependency detected: {0}")]
 	CircularDependency(String),
-
-	#[error("service '{0}' has no image or build config")]
 	NoImageOrBuild(String),
-
-	#[error("required variable '{var}' is not set: {msg}")]
 	RequiredVarNotSet { var: String, msg: String },
-
-	#[error("health check timeout for container '{0}'")]
 	HealthCheckTimeout(String),
-
-	#[error("invalid port mapping: {0}")]
 	InvalidPort(String),
-
-	#[error("build error: {0}")]
 	Build(String),
-
-	#[error("extends error: {0}")]
 	Extends(String),
-
-	#[error("include error: {0}")]
 	Include(String),
-
-	#[error("watch error: {0}")]
 	Watch(String),
-
-	#[error("unsupported feature: {0}")]
 	Unsupported(String),
-
-	#[error("run container exited with code {0}")]
 	RunExited(i64),
 }
 
+impl fmt::Display for ComposeError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Parse(e) => write!(f, "failed to parse compose file: {e}"),
+			Self::FileNotFound(s) => write!(f, "compose file not found: {s}"),
+			Self::Io(e) => write!(f, "io error: {e}"),
+			Self::Podman(e) => write!(f, "podman error: {e}"),
+			Self::ServiceNotFound(s) => write!(f, "service '{s}' not found"),
+			Self::CircularDependency(s) => write!(f, "circular dependency detected: {s}"),
+			Self::NoImageOrBuild(s) => write!(f, "service '{s}' has no image or build config"),
+			Self::RequiredVarNotSet { var, msg } => {
+				write!(f, "required variable '{var}' is not set: {msg}")
+			}
+			Self::HealthCheckTimeout(s) => write!(f, "health check timeout for container '{s}'"),
+			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),
+			Self::Build(s) => write!(f, "build error: {s}"),
+			Self::Extends(s) => write!(f, "extends error: {s}"),
+			Self::Include(s) => write!(f, "include error: {s}"),
+			Self::Watch(s) => write!(f, "watch error: {s}"),
+			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
+			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
+		}
+	}
+}
+
+impl std::error::Error for ComposeError {
+	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+		match self {
+			Self::Parse(e) => Some(e),
+			Self::Io(e) => Some(e),
+			Self::Podman(e) => Some(e),
+			_ => None,
+		}
+	}
+}
+
+impl From<serde_yaml::Error> for ComposeError {
+	fn from(e: serde_yaml::Error) -> Self {
+		Self::Parse(e)
+	}
+}
+
+impl From<std::io::Error> for ComposeError {
+	fn from(e: std::io::Error) -> Self {
+		Self::Io(e)
+	}
+}
+
+impl From<bollard::errors::Error> for ComposeError {
+	fn from(e: bollard::errors::Error) -> Self {
+		Self::Podman(e)
+	}
+}
+
 pub type Result<T> = std::result::Result<T, ComposeError>;
+
+#[cfg(test)]
+mod tests {
+	use super::ComposeError;
+
+	#[test]
+	fn display_covers_all_variants() {
+		let cases: &[(&str, ComposeError)] = &[
+			(
+				"failed to parse compose file:",
+				ComposeError::Parse(serde_yaml::from_str::<serde_yaml::Value>(":\0").unwrap_err()),
+			),
+			(
+				"compose file not found: f",
+				ComposeError::FileNotFound("f".into()),
+			),
+			("io error:", ComposeError::Io(std::io::Error::other("x"))),
+			(
+				"service 's' not found",
+				ComposeError::ServiceNotFound("s".into()),
+			),
+			(
+				"circular dependency detected: c",
+				ComposeError::CircularDependency("c".into()),
+			),
+			(
+				"service 'svc' has no image or build config",
+				ComposeError::NoImageOrBuild("svc".into()),
+			),
+			(
+				"required variable 'V' is not set: reason",
+				ComposeError::RequiredVarNotSet {
+					var: "V".into(),
+					msg: "reason".into(),
+				},
+			),
+			(
+				"health check timeout for container 'c'",
+				ComposeError::HealthCheckTimeout("c".into()),
+			),
+			(
+				"invalid port mapping: p",
+				ComposeError::InvalidPort("p".into()),
+			),
+			("build error: b", ComposeError::Build("b".into())),
+			("extends error: e", ComposeError::Extends("e".into())),
+			("include error: i", ComposeError::Include("i".into())),
+			("watch error: w", ComposeError::Watch("w".into())),
+			(
+				"unsupported feature: u",
+				ComposeError::Unsupported("u".into()),
+			),
+			(
+				"run container exited with code 1",
+				ComposeError::RunExited(1),
+			),
+		];
+		for (expected_prefix, err) in cases {
+			let msg = err.to_string();
+			assert!(
+				msg.starts_with(expected_prefix),
+				"Display for {:?}: got {msg:?}, expected prefix {expected_prefix:?}",
+				std::mem::discriminant(err),
+			);
+		}
+	}
+
+	#[test]
+	fn source_provided_for_wrapped_variants() {
+		use std::error::Error;
+		let io = ComposeError::Io(std::io::Error::other("x"));
+		assert!(io.source().is_some());
+		let svc = ComposeError::ServiceNotFound("s".into());
+		assert!(svc.source().is_none());
+	}
+
+	#[test]
+	fn from_impls_convert_correctly() {
+		let io_err = std::io::Error::other("x");
+		let e: ComposeError = io_err.into();
+		assert!(matches!(e, ComposeError::Io(_)));
+
+		let yaml_err = serde_yaml::from_str::<serde_yaml::Value>(":\0").unwrap_err();
+		let e: ComposeError = yaml_err.into();
+		assert!(matches!(e, ComposeError::Parse(_)));
+	}
+}


### PR DESCRIPTION
Release v0.5.5 — dependency reduction.

## Changes

- **deps: migrate yaml_serde to serde_yaml_ng** (#111) — switch from unmaintained fork to actively maintained successor; API-identical drop-in
- **deps: feature-gate notify behind optional watch feature** (#114) — `notify` is now optional (default enabled); `--no-default-features` strips ~10 inotify-related crates for Debian/minimal builds
- **deps: remove thiserror** (#113) — manual `Display` + `Error` impls; removes proc-macro compile-time dependency
- **deps: remove walkdir** (#112) — 20-line `std::fs` recursive helper replaces all WalkDir call sites
- **chore: bump version to 0.5.5** (#116)