### PR TITLE
fix: target all replicas in restart/logs/top; first replica in exec/port/attach

### DIFF
--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -288,46 +288,48 @@ impl Engine {
 
 		for name in &names {
 			let service = &file.services[name];
-			let container_name = self.container_name(name, service);
 
-			let _ = self
-				.docker
-				.stop_container(
-					&container_name,
-					Some(StopContainerOptions {
-						t: Some(grace_period_secs(service)),
-						..Default::default()
-					}),
-				)
-				.await;
+			for container_name in self.replica_names(name, service) {
+				let _ = self
+					.docker
+					.stop_container(
+						&container_name,
+						Some(StopContainerOptions {
+							t: Some(grace_period_secs(service)),
+							..Default::default()
+						}),
+					)
+					.await;
 
-			self.docker
-				.start_container(&container_name, None::<StartContainerOptions>)
-				.await?;
+				self.docker
+					.start_container(&container_name, None::<StartContainerOptions>)
+					.await?;
 
-			info!("restarted {container_name}");
+				info!("restarted {container_name}");
+			}
 
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
-					let dep_container = self.container_name(dep_name, dep_service);
-					let _ = self
-						.docker
-						.stop_container(
-							&dep_container,
-							Some(StopContainerOptions {
-								t: Some(grace_period_secs(dep_service)),
-								..Default::default()
-							}),
-						)
-						.await;
-					if let Err(e) = self
-						.docker
-						.start_container(&dep_container, None::<StartContainerOptions>)
-						.await
-					{
-						tracing::warn!("cascade restart of {dep_name} failed: {e}");
-					} else {
-						info!("cascade-restarted {dep_container} (depends_on.restart)");
+					for dep_container in self.replica_names(dep_name, dep_service) {
+						let _ = self
+							.docker
+							.stop_container(
+								&dep_container,
+								Some(StopContainerOptions {
+									t: Some(grace_period_secs(dep_service)),
+									..Default::default()
+								}),
+							)
+							.await;
+						if let Err(e) = self
+							.docker
+							.start_container(&dep_container, None::<StartContainerOptions>)
+							.await
+						{
+							tracing::warn!("cascade restart of {dep_name} failed: {e}");
+						} else {
+							info!("cascade-restarted {dep_container} (depends_on.restart)");
+						}
 					}
 				}
 			}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -137,6 +137,16 @@ impl Engine {
 		}
 	}
 
+	/// Name of the first (or only) replica — for commands that target one container.
+	pub(super) fn first_replica_name(&self, service_name: &str, service: &Service) -> String {
+		let replicas = service
+			.scale
+			.or(service.deploy.as_ref().and_then(|d| d.replicas))
+			.unwrap_or(1) as usize;
+		let base = self.container_name(service_name, service);
+		if replicas == 1 { base } else { format!("{base}-1") }
+	}
+
 	#[cfg(not(feature = "watch"))]
 	pub async fn watch(&self, _file: &crate::compose::types::ComposeFile) -> Result<()> {
 		Err(crate::error::ComposeError::Unsupported(

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -144,7 +144,11 @@ impl Engine {
 			.or(service.deploy.as_ref().and_then(|d| d.replicas))
 			.unwrap_or(1) as usize;
 		let base = self.container_name(service_name, service);
-		if replicas == 1 { base } else { format!("{base}-1") }
+		if replicas == 1 {
+			base
+		} else {
+			format!("{base}-1")
+		}
 	}
 
 	#[cfg(not(feature = "watch"))]

--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -70,11 +70,11 @@ impl Engine {
 				.services
 				.get(svc)
 				.ok_or_else(|| ComposeError::ServiceNotFound(svc.into()))?;
-			vec![self.container_name(svc, service)]
+			self.replica_names(svc, service)
 		} else {
 			file.services
 				.iter()
-				.map(|(n, s)| self.container_name(n, s))
+				.flat_map(|(n, s)| self.replica_names(n, s))
 				.collect()
 		};
 
@@ -115,7 +115,7 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.container_name(service_name, service);
+		let container_name = self.first_replica_name(service_name, service);
 
 		let exec_id = self
 			.docker
@@ -234,20 +234,21 @@ impl Engine {
 
 		for name in &names {
 			let service = &file.services[name];
-			let container_name = self.container_name(name, service);
-			match self.docker.top_processes(&container_name, None).await {
-				Ok(result) => {
-					println!("{container_name}");
-					if let Some(titles) = &result.titles {
-						println!("{}", titles.join("\t"));
-					}
-					if let Some(processes) = &result.processes {
-						for row in processes {
-							println!("{}", row.join("\t"));
+			for container_name in self.replica_names(name, service) {
+				match self.docker.top_processes(&container_name, None).await {
+					Ok(result) => {
+						println!("{container_name}");
+						if let Some(titles) = &result.titles {
+							println!("{}", titles.join("\t"));
+						}
+						if let Some(processes) = &result.processes {
+							for row in processes {
+								println!("{}", row.join("\t"));
+							}
 						}
 					}
+					Err(e) => tracing::warn!("top {container_name}: {e}"),
 				}
-				Err(e) => tracing::warn!("top {container_name}: {e}"),
 			}
 		}
 		Ok(())
@@ -267,7 +268,7 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.container_name(service_name, service);
+		let container_name = self.first_replica_name(service_name, service);
 
 		let info = self
 			.docker
@@ -333,7 +334,16 @@ impl Engine {
 			.services
 			.iter()
 			.filter(|(_, s)| s.attach.unwrap_or(true))
-			.map(|(name, s)| (name.clone(), self.container_name(name, s)))
+			.flat_map(|(name, s)| {
+				let proj_prefix = format!("{}-", self.project);
+				self.replica_names(name, s).into_iter().map(move |cname| {
+					let display = cname
+						.strip_prefix(proj_prefix.as_str())
+						.map(|s| s.to_string())
+						.unwrap_or_else(|| cname.clone());
+					(display, cname)
+				})
+			})
 			.collect();
 
 		if attached.is_empty() {

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -1825,6 +1825,105 @@ async fn engine_cp_to_container_uploads_file() {
 }
 
 // ---------------------------------------------------------------------------
+// Replicas: restart, logs, top, exec, port target correct containers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn restart_scaled_service_all_replicas() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("rsr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// Both replicas must be reachable for restart to succeed.
+	engine.restart(&file, Some("worker")).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn logs_scaled_service_all_replicas() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("lsr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo hello && sleep infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// logs for a named service with replicas: should stream from all without error.
+	engine.logs(&file, Some("worker"), false).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn top_scaled_service_all_replicas() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("tsr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine.top(&file, &[]).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn exec_scaled_service_targets_first_replica() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("esr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine
+		.exec(&file, "worker", vec!["echo".to_string(), "ok".to_string()])
+		.await
+		.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn port_scaled_service_targets_first_replica() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("psr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:18090:80\"\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine.port(&file, "worker", 80, "tcp").await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // CLI binary (covers main.rs)
 // ---------------------------------------------------------------------------
 

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -1914,7 +1914,7 @@ async fn port_scaled_service_targets_first_replica() {
 	let proj = proj("psr");
 	let engine = Engine::new(docker, proj.clone());
 	let file = parse_str(
-		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:18090:80\"\n    deploy:\n      replicas: 2\n",
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"80\"\n    deploy:\n      replicas: 2\n",
 	)
 	.unwrap();
 


### PR DESCRIPTION
## Summary

- `restart()` now stops and starts every replica (`replica_names()`) instead of only the base container name
- `logs()` streams from all replicas for both named-service and all-services paths
- `top()` iterates all replicas and prints each process table
- `exec()` and `port()` target `{proj}-{svc}-1` (first replica) when `scale > 1` — consistent with compose-spec expectation for single-container commands
- `attach_logs()` fan-out expanded to all replicas; log prefix shows `web-1`, `web-2`, etc. for scaled services
- Adds `first_replica_name()` helper to `Engine` for exec/port/attach callers
- Integration tests added: `restart_scaled_service_all_replicas`, `logs_scaled_service_all_replicas`, `top_scaled_service_all_replicas`, `exec_scaled_service_targets_first_replica`, `port_scaled_service_targets_first_replica`

## Test plan

- [ ] `cargo test --lib` passes (existing 133 tests)
- [ ] New integration tests compile clean (`cargo check --tests`)
- [ ] `cargo clippy` clean