### PR TITLE
fix: correct MSRV to 1.86; update README commands and library version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "podup"
 version = "0.5.5"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"
 license = "Apache-2.0"
 repository = "https://github.com/Glyndor/podup"

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ flowchart LR
 
 ## ✨ Features
 
-- 🚀 **Drop-in workflow** — `up`, `down`, `ps`, `logs`, `exec`, `pull`, `restart`, `config`
+- 🚀 **Drop-in workflow** — `up`, `down`, `start`, `stop`, `ps`, `logs`, `exec`, `run`, `cp`, `build`, `pull`, `restart`, `rm`, `kill`, `pause`, `unpause`, `top`, `port`, `images`, `config`, `watch`
 - 🔒 **Rootless by design** — drives rootless Podman over its Docker-compatible API
 - 📄 **Compose-spec parsing** — YAML anchors, `extends`, `include`, profiles, `env_file`, variable substitution with modifiers
-- 🔁 **Dependency-aware** — `depends_on` ordering with healthcheck conditions
+- 🔁 **Dependency-aware** — `depends_on` ordering with `service_started`, `service_healthy`, and `service_completed_successfully` conditions
+- 🔢 **Replicas** — `scale:` and `deploy.replicas` with named replica containers
+- 🔐 **Secrets & configs** — inline content, file, and environment sources staged securely
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
 - 📦 **Single binary** — statically musl-linked on Linux, no runtime dependencies
 - 🦀 **Library too** — embed the parser and engine in your own Rust project
@@ -78,7 +80,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.3.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.5.5" }
 ```
 
 ## Contributing & security

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: podup
 Section: utils
 Priority: optional
 Maintainer: Glyndor <75870284+Jaro-c@users.noreply.github.com>
-Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.85)
+Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.86)
 Standards-Version: 4.7.0
 Homepage: https://github.com/Glyndor/podup
 Vcs-Git: https://github.com/Glyndor/podup.git
@@ -16,10 +16,12 @@ Recommends: podman (>= 4.0)
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides
- the familiar compose workflow (up, down, ps, logs, exec, pull,
- restart, config, watch) as a single binary with no daemon and no
- Python runtime.
+ the full compose workflow (up, down, start, stop, ps, logs, exec, run,
+ cp, build, pull, restart, rm, kill, pause, unpause, top, port, images,
+ config, watch) as a single static binary with no daemon and no Python
+ runtime.
  .
  It supports compose-spec parsing including YAML anchors, extends,
  include, profiles, env_file and variable substitution, with
- dependency-aware startup ordering and healthcheck conditions.
+ dependency-aware startup ordering, healthcheck conditions, secrets and
+ configs, replica scaling, and file-watch mode.

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -10,9 +10,13 @@ page tracks what that gives us and what the official archive still requires.
 dpkg-buildpackage -us -uc -b
 ```
 
-Requires `debhelper`, `cargo` and `rustc >= 1.85` (the crate's declared
-`rust-version`, kept compatible with Debian stable). The package installs a
-single file: `/usr/bin/podup`.
+Requires `debhelper`, `cargo` and `rustc >= 1.86` (the crate's declared
+`rust-version`, driven by the `idna_adapter ≥ 1.2` transitive dependency through
+bollard → url → idna). The package installs a single file: `/usr/bin/podup`.
+
+> **Debian compatibility note:** Debian trixie ships rustc 1.85; MSRV 1.86
+> requires Debian sid or a backported toolchain. Track
+> https://packages.debian.org/rustc for the trixie toolchain version.
 
 ## What the skeleton covers
 


### PR DESCRIPTION
## Summary

- `rust-version` in `Cargo.toml` corrected from `1.85` to `1.86` — `idna_adapter 1.2.2` (via bollard → url → idna) requires 1.86; no older version exists on crates.io
- `debian/control` `Build-Depends` updated to `rustc (>= 1.86)` and description updated to list the full command set
- `docs/debian-packaging.md` updated with correct MSRV and a Debian trixie compat note (trixie ships 1.85, requires sid or backported toolchain)
- `README.md` feature list now enumerates all 20+ commands, adds Replicas and Secrets & configs bullets, and bumps library dependency example from `v0.3.0` to `v0.5.5`

## Test plan

- [ ] `dpkg-buildpackage -us -uc -b` succeeds on a host with rustc 1.86+
- [ ] `cargo package --no-verify` clean (exclude list unchanged)