### PR TITLE
chore: bump version to 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (0.5.6) unstable; urgency=medium
+
+  * Fix restart, logs, top to target all replicas in scaled services.
+  * Fix exec and port to target first replica in scaled services.
+  * Fix attach_logs stream labels for replica containers.
+  * Correct declared MSRV from 1.85 to 1.86 (idna_adapter 1.2.2 requirement).
+  * Update README to list all commands and bump library version example.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 20:00:00 -0500
+
 podup (0.5.5) unstable; urgency=low
 
   * Migrate yaml_serde to serde_yaml_ng (actively maintained successor).


### PR DESCRIPTION
Bump version to 0.5.6. Releases the replica scale fixes and MSRV/docs corrections from PRs #118 and #119.

## Changes in this release

- **fix:** `restart`, `logs`, `top` now target all replicas in scaled services
- **fix:** `exec` and `port` target the first replica (`{proj}-{svc}-1`) when `scale > 1`
- **fix:** `attach_logs` stream labels show `web-1`, `web-2`, etc. for scaled services
- **fix:** declared MSRV corrected from 1.85 to 1.86 (`idna_adapter 1.2.2` via bollard → url → idna)
- **docs:** README lists all 20+ commands; library version example bumped to v0.5.5
- **debian:** `Build-Depends` updated to `rustc (>= 1.86)`; description lists full command set