### PR TITLE
release: v0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "podup"
 version = "0.5.5"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"
 license = "Apache-2.0"
 repository = "https://github.com/Glyndor/podup"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ flowchart LR
 
 ## ✨ Features
 
-- 🚀 **Drop-in workflow** — `up`, `down`, `ps`, `logs`, `exec`, `pull`, `restart`, `config`
+- 🚀 **Drop-in workflow** — `up`, `down`, `start`, `stop`, `ps`, `logs`, `exec`, `run`, `cp`, `build`, `pull`, `restart`, `rm`, `kill`, `pause`, `unpause`, `top`, `port`, `images`, `config`, `watch`
 - 🔒 **Rootless by design** — drives rootless Podman over its Docker-compatible API
 - 📄 **Compose-spec parsing** — YAML anchors, `extends`, `include`, profiles, `env_file`, variable substitution with modifiers
-- 🔁 **Dependency-aware** — `depends_on` ordering with healthcheck conditions
+- 🔁 **Dependency-aware** — `depends_on` ordering with `service_started`, `service_healthy`, and `service_completed_successfully` conditions
+- 🔢 **Replicas** — `scale:` and `deploy.replicas` with named replica containers
+- 🔐 **Secrets & configs** — inline content, file, and environment sources staged securely
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
 - 📦 **Single binary** — statically musl-linked on Linux, no runtime dependencies
 - 🦀 **Library too** — embed the parser and engine in your own Rust project
@@ -78,7 +80,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.3.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.5.5" }
 ```
 
 ## Contributing & security

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (0.5.6) unstable; urgency=medium
+
+  * Fix restart, logs, top to target all replicas in scaled services.
+  * Fix exec and port to target first replica in scaled services.
+  * Fix attach_logs stream labels for replica containers.
+  * Correct declared MSRV from 1.85 to 1.86 (idna_adapter 1.2.2 requirement).
+  * Update README to list all commands and bump library version example.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 20:00:00 -0500
+
 podup (0.5.5) unstable; urgency=low
 
   * Migrate yaml_serde to serde_yaml_ng (actively maintained successor).

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: podup
 Section: utils
 Priority: optional
 Maintainer: Glyndor <75870284+Jaro-c@users.noreply.github.com>
-Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.85)
+Build-Depends: debhelper-compat (= 13), cargo, rustc (>= 1.86)
 Standards-Version: 4.7.0
 Homepage: https://github.com/Glyndor/podup
 Vcs-Git: https://github.com/Glyndor/podup.git
@@ -16,10 +16,12 @@ Recommends: podman (>= 4.0)
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides
- the familiar compose workflow (up, down, ps, logs, exec, pull,
- restart, config, watch) as a single binary with no daemon and no
- Python runtime.
+ the full compose workflow (up, down, start, stop, ps, logs, exec, run,
+ cp, build, pull, restart, rm, kill, pause, unpause, top, port, images,
+ config, watch) as a single static binary with no daemon and no Python
+ runtime.
  .
  It supports compose-spec parsing including YAML anchors, extends,
  include, profiles, env_file and variable substitution, with
- dependency-aware startup ordering and healthcheck conditions.
+ dependency-aware startup ordering, healthcheck conditions, secrets and
+ configs, replica scaling, and file-watch mode.

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -10,9 +10,13 @@ page tracks what that gives us and what the official archive still requires.
 dpkg-buildpackage -us -uc -b
 ```
 
-Requires `debhelper`, `cargo` and `rustc >= 1.85` (the crate's declared
-`rust-version`, kept compatible with Debian stable). The package installs a
-single file: `/usr/bin/podup`.
+Requires `debhelper`, `cargo` and `rustc >= 1.86` (the crate's declared
+`rust-version`, driven by the `idna_adapter ≥ 1.2` transitive dependency through
+bollard → url → idna). The package installs a single file: `/usr/bin/podup`.
+
+> **Debian compatibility note:** Debian trixie ships rustc 1.85; MSRV 1.86
+> requires Debian sid or a backported toolchain. Track
+> https://packages.debian.org/rustc for the trixie toolchain version.
 
 ## What the skeleton covers
 

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -288,46 +288,48 @@ impl Engine {
 
 		for name in &names {
 			let service = &file.services[name];
-			let container_name = self.container_name(name, service);
 
-			let _ = self
-				.docker
-				.stop_container(
-					&container_name,
-					Some(StopContainerOptions {
-						t: Some(grace_period_secs(service)),
-						..Default::default()
-					}),
-				)
-				.await;
+			for container_name in self.replica_names(name, service) {
+				let _ = self
+					.docker
+					.stop_container(
+						&container_name,
+						Some(StopContainerOptions {
+							t: Some(grace_period_secs(service)),
+							..Default::default()
+						}),
+					)
+					.await;
 
-			self.docker
-				.start_container(&container_name, None::<StartContainerOptions>)
-				.await?;
+				self.docker
+					.start_container(&container_name, None::<StartContainerOptions>)
+					.await?;
 
-			info!("restarted {container_name}");
+				info!("restarted {container_name}");
+			}
 
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
-					let dep_container = self.container_name(dep_name, dep_service);
-					let _ = self
-						.docker
-						.stop_container(
-							&dep_container,
-							Some(StopContainerOptions {
-								t: Some(grace_period_secs(dep_service)),
-								..Default::default()
-							}),
-						)
-						.await;
-					if let Err(e) = self
-						.docker
-						.start_container(&dep_container, None::<StartContainerOptions>)
-						.await
-					{
-						tracing::warn!("cascade restart of {dep_name} failed: {e}");
-					} else {
-						info!("cascade-restarted {dep_container} (depends_on.restart)");
+					for dep_container in self.replica_names(dep_name, dep_service) {
+						let _ = self
+							.docker
+							.stop_container(
+								&dep_container,
+								Some(StopContainerOptions {
+									t: Some(grace_period_secs(dep_service)),
+									..Default::default()
+								}),
+							)
+							.await;
+						if let Err(e) = self
+							.docker
+							.start_container(&dep_container, None::<StartContainerOptions>)
+							.await
+						{
+							tracing::warn!("cascade restart of {dep_name} failed: {e}");
+						} else {
+							info!("cascade-restarted {dep_container} (depends_on.restart)");
+						}
 					}
 				}
 			}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -137,6 +137,20 @@ impl Engine {
 		}
 	}
 
+	/// Name of the first (or only) replica — for commands that target one container.
+	pub(super) fn first_replica_name(&self, service_name: &str, service: &Service) -> String {
+		let replicas = service
+			.scale
+			.or(service.deploy.as_ref().and_then(|d| d.replicas))
+			.unwrap_or(1) as usize;
+		let base = self.container_name(service_name, service);
+		if replicas == 1 {
+			base
+		} else {
+			format!("{base}-1")
+		}
+	}
+
 	#[cfg(not(feature = "watch"))]
 	pub async fn watch(&self, _file: &crate::compose::types::ComposeFile) -> Result<()> {
 		Err(crate::error::ComposeError::Unsupported(

--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -70,11 +70,11 @@ impl Engine {
 				.services
 				.get(svc)
 				.ok_or_else(|| ComposeError::ServiceNotFound(svc.into()))?;
-			vec![self.container_name(svc, service)]
+			self.replica_names(svc, service)
 		} else {
 			file.services
 				.iter()
-				.map(|(n, s)| self.container_name(n, s))
+				.flat_map(|(n, s)| self.replica_names(n, s))
 				.collect()
 		};
 
@@ -115,7 +115,7 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.container_name(service_name, service);
+		let container_name = self.first_replica_name(service_name, service);
 
 		let exec_id = self
 			.docker
@@ -234,20 +234,21 @@ impl Engine {
 
 		for name in &names {
 			let service = &file.services[name];
-			let container_name = self.container_name(name, service);
-			match self.docker.top_processes(&container_name, None).await {
-				Ok(result) => {
-					println!("{container_name}");
-					if let Some(titles) = &result.titles {
-						println!("{}", titles.join("\t"));
-					}
-					if let Some(processes) = &result.processes {
-						for row in processes {
-							println!("{}", row.join("\t"));
+			for container_name in self.replica_names(name, service) {
+				match self.docker.top_processes(&container_name, None).await {
+					Ok(result) => {
+						println!("{container_name}");
+						if let Some(titles) = &result.titles {
+							println!("{}", titles.join("\t"));
+						}
+						if let Some(processes) = &result.processes {
+							for row in processes {
+								println!("{}", row.join("\t"));
+							}
 						}
 					}
+					Err(e) => tracing::warn!("top {container_name}: {e}"),
 				}
-				Err(e) => tracing::warn!("top {container_name}: {e}"),
 			}
 		}
 		Ok(())
@@ -267,7 +268,7 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.container_name(service_name, service);
+		let container_name = self.first_replica_name(service_name, service);
 
 		let info = self
 			.docker
@@ -333,7 +334,16 @@ impl Engine {
 			.services
 			.iter()
 			.filter(|(_, s)| s.attach.unwrap_or(true))
-			.map(|(name, s)| (name.clone(), self.container_name(name, s)))
+			.flat_map(|(name, s)| {
+				let proj_prefix = format!("{}-", self.project);
+				self.replica_names(name, s).into_iter().map(move |cname| {
+					let display = cname
+						.strip_prefix(proj_prefix.as_str())
+						.map(|s| s.to_string())
+						.unwrap_or_else(|| cname.clone());
+					(display, cname)
+				})
+			})
 			.collect();
 
 		if attached.is_empty() {

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -1825,6 +1825,105 @@ async fn engine_cp_to_container_uploads_file() {
 }
 
 // ---------------------------------------------------------------------------
+// Replicas: restart, logs, top, exec, port target correct containers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn restart_scaled_service_all_replicas() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("rsr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// Both replicas must be reachable for restart to succeed.
+	engine.restart(&file, Some("worker")).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn logs_scaled_service_all_replicas() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("lsr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo hello && sleep infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// logs for a named service with replicas: should stream from all without error.
+	engine.logs(&file, Some("worker"), false).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn top_scaled_service_all_replicas() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("tsr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine.top(&file, &[]).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn exec_scaled_service_targets_first_replica() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("esr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine
+		.exec(&file, "worker", vec!["echo".to_string(), "ok".to_string()])
+		.await
+		.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn port_scaled_service_targets_first_replica() {
+	let docker = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("psr");
+	let engine = Engine::new(docker, proj.clone());
+	let file = parse_str(
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"80\"\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine.port(&file, "worker", 80, "tcp").await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // CLI binary (covers main.rs)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Release v0.5.6.

## Changes

- **fix:** `restart`, `logs`, `top` now target all replicas in scaled services (#118)
- **fix:** `exec` and `port` target the first replica when `scale > 1` (#118)
- **fix:** `attach_logs` stream labels show `web-1`, `web-2`, etc. for scaled services (#118)
- **fix:** declared MSRV corrected from 1.85 to 1.86 (`idna_adapter 1.2.2` via bollard → url → idna) (#119)
- **docs:** README lists all 20+ commands; library version example updated (#119)
- **debian:** `Build-Depends` updated to `rustc (>= 1.86)`; command list in description updated (#119)