### PR TITLE
chore: bump version to 0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+podup (0.5.7) unstable; urgency=low
+
+  * Add /// doc comments on all public types and engine methods.
+  * Remove section-header noise comments and explains-what inline comments.
+  * Fix stale serde_yaml_ng reference in compose/mod.rs.
+  * Remove stale ticket prefixes from engine comments.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 21:00:00 -0500
+
 podup (0.5.6) unstable; urgency=medium
 
   * Fix restart, logs, top to target all replicas in scaled services.


### PR DESCRIPTION
Bump version to 0.5.7. Releases the code documentation audit from PR #122.