### PR TITLE
release: v0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+podup (0.5.7) unstable; urgency=low
+
+  * Add /// doc comments on all public types and engine methods.
+  * Remove section-header noise comments and explains-what inline comments.
+  * Fix stale serde_yaml_ng reference in compose/mod.rs.
+  * Remove stale ticket prefixes from engine comments.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 10 Jun 2026 21:00:00 -0500
+
 podup (0.5.6) unstable; urgency=medium
 
   * Fix restart, logs, top to target all replicas in scaled services.

--- a/internal/compose/extends.rs
+++ b/internal/compose/extends.rs
@@ -18,10 +18,6 @@ use super::types::{
 };
 use crate::error::{ComposeError, Result};
 
-// ---------------------------------------------------------------------------
-// Public entry points
-// ---------------------------------------------------------------------------
-
 const MAX_EXTENDS_DEPTH: usize = 16;
 
 /// Resolve `extends:` only within the same file (no `file:` references).
@@ -46,10 +42,6 @@ pub(super) fn resolve_all_extends(file: &mut ComposeFile, base_dir: &Path) -> Re
 	}
 	Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Single-service resolution helpers
-// ---------------------------------------------------------------------------
 
 fn resolve_one_extends_in_memory(
 	file: &mut ComposeFile,
@@ -186,14 +178,6 @@ fn resolve_one_extends(
 	Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Service merge
-// ---------------------------------------------------------------------------
-
-/// Merge `override_svc` over `base`.
-///
-/// `override_svc` wins for scalar fields it explicitly sets.
-/// `Vec` / `Map` collections are replaced when the override is non-empty.
 pub(super) fn merge_service(base: Service, override_svc: Service) -> Service {
 	fn opt<T>(o: Option<T>, b: Option<T>) -> Option<T> {
 		o.or(b)

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -13,10 +13,6 @@ use crate::error::{ComposeError, Result};
 use crate::substitute;
 use types::ComposeFile;
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
 /// Parse a compose file from disk, applying variable substitution and
 /// resolving `extends:` / `include:` directives.
 pub fn parse_file(path: &Path) -> Result<ComposeFile> {
@@ -143,10 +139,6 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 	Ok(order)
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
 pub(crate) fn parse_file_inner(path: &Path, dir: &Path) -> Result<ComposeFile> {
 	parse_file_inner_with_env(path, dir, &[])
 }
@@ -176,7 +168,7 @@ fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
 
 /// Recursively resolve YAML merge keys (`<<: *anchor`) in a `Value` tree.
 ///
-/// yaml_serde does not expose `apply_merge()` — this replaces it.
+/// serde_yaml_ng does not expose `apply_merge()` — this replaces it.
 /// Merge semantics: keys from the anchor fill in only where the child has no value.
 fn apply_merge_keys(value: &mut serde_yaml::Value) {
 	match value {

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -10,10 +10,7 @@ use std::collections::HashMap;
 
 use super::{EnvVars, Labels, StringOrList, UlimitConfig};
 
-// ---------------------------------------------------------------------------
-// IncludeConfig
-// ---------------------------------------------------------------------------
-
+/// Compose `include:` directive — either a bare file path or a long-form block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IncludeConfig {
@@ -36,10 +33,7 @@ impl IncludeConfig {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// ExtendsConfig
-// ---------------------------------------------------------------------------
-
+/// Compose `extends:` directive — either a bare service name or a long-form `{service, file}` block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ExtendsConfig {
@@ -67,10 +61,7 @@ impl ExtendsConfig {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// BuildConfig
-// ---------------------------------------------------------------------------
-
+/// Compose `build:` directive — either a bare context path or a full build-config block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -11,10 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Labels;
 
-// ---------------------------------------------------------------------------
-// DeployConfig
-// ---------------------------------------------------------------------------
-
+/// `deploy:` service key — resource limits, replica count, restart and update policies.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -37,10 +34,7 @@ pub struct DeployConfig {
 	pub placement: Option<DeployPlacement>,
 }
 
-// ---------------------------------------------------------------------------
-// Resources
-// ---------------------------------------------------------------------------
-
+/// Resource constraints under `deploy.resources:` — holds `limits` and `reservations`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourcesConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -49,6 +43,7 @@ pub struct ResourcesConfig {
 	pub reservations: Option<ResourceSpec>,
 }
 
+/// A single resource specification: CPU shares, memory limit, pids limit, and device access.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourceSpec {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -97,10 +92,6 @@ impl CountOrAll {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Deploy policies
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
 	use super::CountOrAll;
@@ -116,6 +107,7 @@ mod tests {
 	}
 }
 
+/// Restart policy under `deploy.restart_policy:` — distinct from the service-level `restart:` string.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployRestartPolicy {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -128,6 +120,7 @@ pub struct DeployRestartPolicy {
 	pub window: Option<String>,
 }
 
+/// Update (and rollback) configuration — reused for both `deploy.update_config` and `deploy.rollback_config`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployUpdateConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -144,6 +137,7 @@ pub struct DeployUpdateConfig {
 	pub order: Option<String>,
 }
 
+/// Placement constraints and preferences controlling which nodes a service's containers may run on.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployPlacement {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -7,20 +7,14 @@
 
 use serde::{Deserialize, Serialize};
 
-// ---------------------------------------------------------------------------
-// DevelopConfig
-// ---------------------------------------------------------------------------
-
+/// `develop:` service key — holds file-watch rules for the `watch` command.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DevelopConfig {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub watch: Vec<WatchRule>,
 }
 
-// ---------------------------------------------------------------------------
-// WatchRule
-// ---------------------------------------------------------------------------
-
+/// A single `develop.watch` rule: a path to watch, an action to take, and optional ignore filters.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchRule {
 	pub path: String,
@@ -37,10 +31,7 @@ pub struct WatchRule {
 	pub exec: Option<WatchExec>,
 }
 
-// ---------------------------------------------------------------------------
-// WatchAction
-// ---------------------------------------------------------------------------
-
+/// Action triggered by a `develop.watch` rule: `sync`, `rebuild`, `restart`, `sync+restart`, or `sync+exec`.
 #[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
 pub enum WatchAction {
 	#[default]
@@ -67,10 +58,7 @@ impl<'de> Deserialize<'de> for WatchAction {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// WatchExec
-// ---------------------------------------------------------------------------
-
+/// Exec command run as part of a `sync+exec` watch action.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchExec {
 	pub command: Vec<String>,

--- a/internal/compose/types/env.rs
+++ b/internal/compose/types/env.rs
@@ -106,7 +106,6 @@ impl EnvFile {
 	}
 
 	/// Return just the paths (strips `required` / `format` info).
-	/// Kept for test compatibility; prefer `to_entries()` in engine code.
 	pub fn to_list(&self) -> Vec<String> {
 		self.to_entries()
 			.into_iter()

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::env::EnvVars;
 use super::primitives::Command;
 
+/// `depends_on:` value — absent, a bare list of service names, or a map of service name to condition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum DependsOn {
@@ -55,6 +56,7 @@ impl DependsOn {
 	}
 }
 
+/// Long-form per-dependency entry in `depends_on:` — holds the condition and restart flag.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DependsOnCondition {
 	pub condition: ServiceCondition,
@@ -64,6 +66,7 @@ pub struct DependsOnCondition {
 	pub required: Option<bool>,
 }
 
+/// Condition a dependency must satisfy before the dependent service starts.
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ServiceCondition {
@@ -73,6 +76,7 @@ pub enum ServiceCondition {
 	ServiceCompletedSuccessfully,
 }
 
+/// Inline `healthcheck:` block. `disable: true` overrides any inherited health check.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct HealthCheck {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -100,6 +104,7 @@ impl HealthCheck {
 	}
 }
 
+/// A single `post_start` or `pre_stop` lifecycle hook entry.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LifecycleHook {
 	pub command: Command,
@@ -113,6 +118,7 @@ pub struct LifecycleHook {
 	pub environment: EnvVars,
 }
 
+/// Service-level `restart:` policy — `no`, `always`, `unless-stopped`, or `on-failure` (with optional max-retries).
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum RestartPolicy {
 	No,

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -28,10 +28,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-// ---------------------------------------------------------------------------
-// Top-level secrets / configs
-// ---------------------------------------------------------------------------
-
+/// Top-level `secrets:` entry — defines a named secret available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct SecretConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -54,6 +51,7 @@ pub struct SecretConfig {
 	pub template_driver: Option<String>,
 }
 
+/// Top-level `configs:` entry — defines a named config available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ConfigConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -76,10 +74,7 @@ pub struct ConfigConfig {
 	pub template_driver: Option<String>,
 }
 
-// ---------------------------------------------------------------------------
-// ComposeFile (root)
-// ---------------------------------------------------------------------------
-
+/// Root deserialization target for a `docker-compose.yml` file.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ComposeFile {
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -10,10 +10,7 @@ use std::collections::HashMap;
 
 use super::Labels;
 
-// ---------------------------------------------------------------------------
-// ServiceNetworks
-// ---------------------------------------------------------------------------
-
+/// `networks:` value at service level — absent, a bare list of network names, or a detailed map.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum ServiceNetworks {
@@ -40,10 +37,7 @@ impl ServiceNetworks {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// ServiceNetworkConfig
-// ---------------------------------------------------------------------------
-
+/// Per-network attachment options: aliases, static IPv4/IPv6, link-local addresses, and priority.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ServiceNetworkConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -66,10 +60,7 @@ pub struct ServiceNetworkConfig {
 	pub interface_name: Option<String>,
 }
 
-// ---------------------------------------------------------------------------
-// Top-level NetworkConfig
-// ---------------------------------------------------------------------------
-
+/// Named network definition in the top-level `networks:` block.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct NetworkConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -94,10 +85,7 @@ pub struct NetworkConfig {
 	pub labels: Labels,
 }
 
-// ---------------------------------------------------------------------------
-// IPAM
-// ---------------------------------------------------------------------------
-
+/// `ipam:` block inside a top-level network definition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct IpamConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -108,6 +96,7 @@ pub struct IpamConfig {
 	pub options: HashMap<String, String>,
 }
 
+/// A single subnet/range entry within `ipam.config`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct IpamPool {
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/internal/compose/types/resources.rs
+++ b/internal/compose/types/resources.rs
@@ -6,6 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
+/// `ulimits:` entry — either a single integer (soft == hard) or an explicit `{soft, hard}` pair.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum UlimitConfig {
@@ -29,6 +30,7 @@ impl UlimitConfig {
 	}
 }
 
+/// `blkio_config:` service field — controls I/O weight and per-device rate limits.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BlkioConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -45,12 +47,14 @@ pub struct BlkioConfig {
 	pub device_write_iops: Vec<BlkioRateDevice>,
 }
 
+/// Per-device I/O weight entry under `blkio_config.weight_device`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioWeightDevice {
 	pub path: String,
 	pub weight: u16,
 }
 
+/// Per-device rate limit under `blkio_config` — used for both bps and iops limits.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioRateDevice {
 	pub path: String,

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -21,7 +21,6 @@ use super::{
 /// A single service definition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Service {
-	// ---------------- core ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -33,13 +32,11 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub entrypoint: Option<Command>,
 
-	// ---------------- ports / network ----------------
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ports: Vec<PortMapping>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub expose: Vec<String>,
 
-	// ---------------- env / mounts ----------------
 	#[serde(default)]
 	pub environment: EnvVars,
 	#[serde(default)]
@@ -55,7 +52,6 @@ pub struct Service {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub secrets: Vec<ServiceSecretRef>,
 
-	// ---------------- networking ----------------
 	#[serde(default)]
 	pub networks: ServiceNetworks,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -79,13 +75,11 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub network_mode: Option<String>,
 
-	// ---------------- ordering / health ----------------
 	#[serde(default)]
 	pub depends_on: DependsOn,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub healthcheck: Option<HealthCheck>,
 
-	// ---------------- lifecycle / restart ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart: Option<RestartPolicy>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -99,7 +93,6 @@ pub struct Service {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub pre_stop: Vec<LifecycleHook>,
 
-	// ---------------- identity / labels ----------------
 	#[serde(default)]
 	pub labels: Labels,
 	#[serde(default)]
@@ -115,7 +108,6 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub platform: Option<String>,
 
-	// ---------------- security / capabilities ----------------
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub cap_add: Vec<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -133,7 +125,6 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stdin_open: Option<bool>,
 
-	// ---------------- runtime / namespaces ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub runtime: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -151,7 +142,6 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup: Option<String>,
 
-	// ---------------- devices / filesystem ----------------
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub devices: Vec<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -159,7 +149,6 @@ pub struct Service {
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub storage_opt: HashMap<String, String>,
 
-	// ---------------- resources / limits (top-level) ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub scale: Option<u32>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -197,7 +186,6 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub blkio_config: Option<BlkioConfig>,
 
-	// ---------------- logging / sysctl / ulimit ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub logging: Option<LoggingConfig>,
 	#[serde(default)]
@@ -205,27 +193,21 @@ pub struct Service {
 	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 	pub ulimits: IndexMap<String, UlimitConfig>,
 
-	// ---------------- labels / annotations ----------------
 	#[serde(default)]
 	pub label_file: StringOrList,
 
-	// ---------------- attach / log collection ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attach: Option<bool>,
 
-	// ---------------- pull policy ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pull_policy: Option<String>,
 
-	// ---------------- deploy ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub deploy: Option<DeployConfig>,
 
-	// ---------------- develop (file-watch) ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub develop: Option<DevelopConfig>,
 
-	// ---------------- gpu shorthand ----------------
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gpus: Option<GpuSpec>,
 }

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -10,10 +10,7 @@ use std::collections::HashMap;
 
 use super::Labels;
 
-// ---------------------------------------------------------------------------
-// VolumeType
-// ---------------------------------------------------------------------------
-
+/// Volume mount type: `volume`, `bind`, `tmpfs`, `npipe`, or `cluster`.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum VolumeType {
@@ -24,10 +21,7 @@ pub enum VolumeType {
 	Cluster,
 }
 
-// ---------------------------------------------------------------------------
-// Mount options
-// ---------------------------------------------------------------------------
-
+/// Sub-options for a `bind`-type volume mount.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BindOptions {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -38,6 +32,7 @@ pub struct BindOptions {
 	pub selinux: Option<String>,
 }
 
+/// Sub-options for a `volume`-type mount — nocopy flag and optional driver config.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VolumeOptions {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -50,6 +45,7 @@ pub struct VolumeOptions {
 	pub subpath: Option<String>,
 }
 
+/// Driver name and key-value options nested under `VolumeOptions`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DriverConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -58,6 +54,7 @@ pub struct DriverConfig {
 	pub options: HashMap<String, String>,
 }
 
+/// Sub-options for a `tmpfs`-type mount — size and mode.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct TmpfsOptions {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -66,10 +63,7 @@ pub struct TmpfsOptions {
 	pub mode: Option<u32>,
 }
 
-// ---------------------------------------------------------------------------
-// VolumeMount
-// ---------------------------------------------------------------------------
-
+/// A volume mount entry — either a short-form string or a long-form typed block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
@@ -110,10 +104,7 @@ impl VolumeMount {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Top-level VolumeConfig
-// ---------------------------------------------------------------------------
-
+/// Named volume definition in the top-level `volumes:` block.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VolumeConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -128,10 +119,7 @@ pub struct VolumeConfig {
 	pub labels: Labels,
 }
 
-// ---------------------------------------------------------------------------
-// Service-level config / secret references
-// ---------------------------------------------------------------------------
-
+/// Reference to a named config from a service — short form (name only) or long form with mount target.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceConfigRef {
@@ -165,6 +153,7 @@ impl ServiceConfigRef {
 	}
 }
 
+/// Reference to a named secret from a service — short form (name only) or long form with mount target.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceSecretRef {

--- a/internal/engine/build.rs
+++ b/internal/engine/build.rs
@@ -97,7 +97,7 @@ impl Engine {
 
 		info!("building {tag} from {}", context_path.display());
 
-		// PERF-004: directory walk + file I/O are blocking; run off the tokio thread pool.
+		// directory walk + file I/O are blocking; run off the tokio thread pool.
 		let (tar_bytes, dockerfile_name) = if let Some(inline) = build.dockerfile_inline() {
 			let ctx = context_path.clone();
 			let inline_s = inline.to_string();
@@ -225,7 +225,6 @@ impl Engine {
 			}
 		}
 
-		// Apply additional tags.
 		for extra_tag in build.tags() {
 			let (repo, tag_str) = extra_tag
 				.rsplit_once(':')
@@ -262,7 +261,6 @@ fn build_context_tar_with_inline(context: &Path, inline: &str) -> Result<(Vec<u8
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	// Inline Dockerfile first.
 	let mut header = tar::Header::new_gnu();
 	header.set_size(inline.len() as u64);
 	header.set_mode(0o644);
@@ -346,7 +344,6 @@ fn build_context_tar_with_target(
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	// Write truncated Dockerfile first.
 	let df_bytes = truncated.as_bytes();
 	let mut header = tar::Header::new_gnu();
 	header.set_size(df_bytes.len() as u64);
@@ -355,7 +352,6 @@ fn build_context_tar_with_target(
 	tar.append_data(&mut header, dockerfile, df_bytes)
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-	// Add context, skipping the original Dockerfile (already wrote truncated version).
 	for abs in super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -75,7 +75,7 @@ impl Engine {
 			std::env::current_dir().map_err(ComposeError::Io)?
 		};
 
-		// PERF-005: tar extraction is blocking I/O.
+		// tar extraction is blocking I/O.
 		tokio::task::spawn_blocking(move || {
 			let cursor = std::io::Cursor::new(tar_bytes);
 			let mut archive = tar::Archive::new(cursor);
@@ -100,7 +100,7 @@ impl Engine {
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container_name = self.container_name(service_name, service);
 
-		// PERF-005: tar creation is blocking I/O.
+		// tar creation is blocking I/O.
 		let src_buf = src.to_path_buf();
 		let tar_bytes = tokio::task::spawn_blocking(move || pack_path(&src_buf))
 			.await

--- a/internal/engine/lifecycle.rs
+++ b/internal/engine/lifecycle.rs
@@ -32,10 +32,12 @@ pub struct RunOptions {
 }
 
 impl Engine {
+	/// Start all services defined in the compose file, creating containers that do not exist.
 	pub async fn up(&self, file: &ComposeFile) -> Result<()> {
 		self.up_with_options(file, false, &[], &[], false).await
 	}
 
+	/// Start services with explicit options. When `no_recreate` is true, running containers are left untouched. On partial failure, staging directories are cleaned up.
 	pub async fn up_with_options(
 		&self,
 		file: &ComposeFile,
@@ -68,7 +70,7 @@ impl Engine {
 				Some(set)
 			};
 
-			// PERF-003: prefetch running containers once instead of one API call per replica.
+			// prefetch running containers once instead of one API call per replica.
 			let running: HashSet<String> = if no_recreate {
 				let mut filters: HashMap<String, Vec<String>> = HashMap::new();
 				filters.insert(
@@ -176,7 +178,7 @@ impl Engine {
 			Ok(())
 		}
 		.await;
-		// STAGE-001: clean up staging dir on partial failure so inline secret/config
+		// clean up staging dir on partial failure so inline secret/config
 		// files are not left behind when up errors mid-way.
 		if r.is_err() {
 			self.cleanup_temp_dir();
@@ -184,10 +186,12 @@ impl Engine {
 		r
 	}
 
+	/// Stop and remove all containers for the project. Does not remove volumes unless `remove_volumes` is set.
 	pub async fn down(&self, file: &ComposeFile) -> Result<()> {
 		self.down_with_options(file, false).await
 	}
 
+	/// Stop and remove services in reverse dependency order. Optionally removes named volumes and orphaned containers.
 	pub async fn down_with_options(&self, file: &ComposeFile, remove_volumes: bool) -> Result<()> {
 		let mut order = crate::compose::resolve_order(file)?;
 		order.reverse();
@@ -226,7 +230,6 @@ impl Engine {
 			}
 		}
 
-		// Remove non-external networks declared in the compose file.
 		for (key, config) in &file.networks {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
@@ -242,7 +245,6 @@ impl Engine {
 			}
 		}
 
-		// Remove non-external named volumes when --volumes is requested.
 		if remove_volumes {
 			for (key, config) in &file.volumes {
 				let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
@@ -276,6 +278,7 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Restart the named service (or all services). Dependents with a `restart` condition in `depends_on` are also restarted.
 	pub async fn restart(&self, file: &ComposeFile, service_name: Option<&str>) -> Result<()> {
 		let names: Vec<String> = if let Some(svc) = service_name {
 			if !file.services.contains_key(svc) {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -33,6 +33,7 @@ use crate::error::Result;
 // Engine
 // ---------------------------------------------------------------------------
 
+/// Handle through which all Podman operations for a project are dispatched.
 pub struct Engine {
 	pub(super) docker: Docker,
 	pub(super) project: String,
@@ -40,6 +41,7 @@ pub struct Engine {
 }
 
 impl Engine {
+	/// Create an engine for `project_name` using the working directory as the base path for relative volume mounts.
 	pub fn new(docker: Docker, project: String) -> Self {
 		Self {
 			docker,
@@ -48,6 +50,7 @@ impl Engine {
 		}
 	}
 
+	/// Create an engine with an explicit base directory — use when the compose file is not in the working directory.
 	pub fn with_base_dir(docker: Docker, project: String, base_dir: PathBuf) -> Self {
 		Self {
 			docker,
@@ -55,10 +58,6 @@ impl Engine {
 			base_dir,
 		}
 	}
-
-	// -----------------------------------------------------------------------
-	// Internal helpers shared across engine submodules
-	// -----------------------------------------------------------------------
 
 	pub(super) async fn run_lifecycle_hook(
 		&self,
@@ -137,7 +136,6 @@ impl Engine {
 		}
 	}
 
-	/// Name of the first (or only) replica — for commands that target one container.
 	pub(super) fn first_replica_name(&self, service_name: &str, service: &Service) -> String {
 		let replicas = service
 			.scale
@@ -151,6 +149,7 @@ impl Engine {
 		}
 	}
 
+	/// Watch for file changes and apply the service's `develop.watch` rules. Returns an error when the `watch` feature is disabled.
 	#[cfg(not(feature = "watch"))]
 	pub async fn watch(&self, _file: &crate::compose::types::ComposeFile) -> Result<()> {
 		Err(crate::error::ComposeError::Unsupported(
@@ -163,8 +162,6 @@ impl Engine {
 // Filesystem helpers
 // ---------------------------------------------------------------------------
 
-/// Recursively collect all file and directory paths under `root`, in pre-order.
-/// Symlinks are included as entries but are never followed into.
 fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
 	let mut out = Vec::new();
 	walk_collect(root, &mut out)?;

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -117,7 +117,7 @@ impl Engine {
 }
 
 // ---------------------------------------------------------------------------
-// Free helpers (pub(super) so container.rs can call them)
+// Free helpers
 // ---------------------------------------------------------------------------
 
 pub(super) fn build_endpoint_settings(
@@ -152,9 +152,6 @@ pub(super) fn build_endpoint_settings(
 	settings
 }
 
-/// Determine `network_mode` and the first named network for `NetworkingConfig`.
-///
-/// Returns `(Option<network_mode>, Option<first_network_name>)`.
 pub(super) fn resolve_network_mode(
 	service: &Service,
 	file: &ComposeFile,

--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -15,6 +15,7 @@ use crate::error::{ComposeError, Result};
 use super::Engine;
 
 impl Engine {
+	/// List containers for this project: name, image, command, state, and port bindings.
 	pub async fn ps(&self, _file: &ComposeFile) -> Result<()> {
 		let label = format!("podup.project={}", self.project);
 		let mut filters: HashMap<String, Vec<String>> = HashMap::new();
@@ -59,6 +60,7 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Stream logs. When `service_name` is `None`, streams from all services. When `follow` is true, tails indefinitely.
 	pub async fn logs(
 		&self,
 		file: &ComposeFile,
@@ -105,6 +107,7 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Run a command in the first replica of the named service. Exits with the command's exit code.
 	pub async fn exec(
 		&self,
 		file: &ComposeFile,
@@ -160,6 +163,7 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Pull images for all services that declare an `image:` key, concurrently.
 	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
 		let futs: Vec<_> = file
 			.services
@@ -175,6 +179,7 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Remove containers labelled for this project that are not defined in the current compose file.
 	pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
 		let label = format!("podup.project={}", self.project);
 		let mut filters: HashMap<String, Vec<String>> = HashMap::new();
@@ -326,6 +331,7 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
 	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
 		use bollard::query_parameters::LogsOptions;
 		use futures::StreamExt;

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -77,7 +77,6 @@ pub(super) fn staging_base() -> Result<PathBuf> {
 pub(super) fn create_private_subdir(dir: &Path) -> Result<()> {
 	use std::os::unix::fs::DirBuilderExt;
 
-	// Create dir with 0o700 so only the owning user can list/enter it.
 	std::fs::DirBuilder::new()
 		.recursive(true)
 		.mode(0o700)
@@ -98,7 +97,7 @@ pub(super) fn write_private_file(path: &Path, content: &[u8]) -> Result<()> {
 	use std::io::Write;
 	use std::os::unix::fs::OpenOptionsExt;
 
-	// Create file with 0o600 atomically — no world-readable window before chmod.
+	// 0o600 on create avoids a world-readable window before any chmod.
 	let mut file = std::fs::OpenOptions::new()
 		.write(true)
 		.create(true)

--- a/internal/engine/watch.rs
+++ b/internal/engine/watch.rs
@@ -35,7 +35,6 @@ use super::Engine;
 // Rule tracking
 // ---------------------------------------------------------------------------
 
-/// Pre-resolved watch rule: service identity + rule + absolute host path for fast matching.
 struct RuleEntry {
 	service_name: String,
 	container_name: String,
@@ -48,6 +47,7 @@ struct RuleEntry {
 // ---------------------------------------------------------------------------
 
 impl Engine {
+	/// Set up filesystem watchers from `develop.watch` rules and dispatch sync/rebuild/restart/exec actions on file changes.
 	pub async fn watch(&self, file: &ComposeFile) -> Result<()> {
 		let mut rule_entries: Vec<RuleEntry> = Vec::new();
 
@@ -70,7 +70,6 @@ impl Engine {
 			return Ok(());
 		}
 
-		// Initial sync.
 		for entry in &rule_entries {
 			if entry.rule.initial_sync {
 				if let Some(target) = &entry.rule.target {
@@ -85,7 +84,6 @@ impl Engine {
 			}
 		}
 
-		// Notify watcher with tokio channel bridge.
 		let (tx, mut rx) = mpsc::unbounded_channel::<notify::Result<notify::Event>>();
 		let mut watcher = RecommendedWatcher::new(
 			move |res| {
@@ -119,14 +117,12 @@ impl Engine {
 				_ = tokio::signal::ctrl_c() => break,
 			};
 
-			// Drain events within debounce window.
 			let mut paths = event.paths;
 			let deadline = tokio::time::Instant::now() + debounce;
 			while let Ok(Some(Ok(e))) = tokio::time::timeout_at(deadline, rx.recv()).await {
 				paths.extend(e.paths);
 			}
 
-			// Dispatch each changed path.
 			'outer: for path in &paths {
 				for entry in &rule_entries {
 					if !path.starts_with(&entry.abs_path) {

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -90,7 +90,6 @@ pub fn merge_env(
 	service_env: HashMap<String, Option<String>>,
 	env_file_vars: HashMap<String, String>,
 ) -> Vec<String> {
-	// Start with service env (higher priority), fill gaps from env_file.
 	let mut merged = service_env;
 	for (k, v) in env_file_vars {
 		merged.entry(k).or_insert(Some(v));

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -80,6 +80,7 @@ impl From<bollard::errors::Error> for ComposeError {
 	}
 }
 
+/// Convenience alias for `std::result::Result<T, ComposeError>`.
 pub type Result<T> = std::result::Result<T, ComposeError>;
 
 #[cfg(test)]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -210,7 +210,6 @@ async fn run() -> podup::Result<()> {
 
 	let file = podup::parse_file(&cli.file)?;
 
-	// The `config` command does not need a Podman connection.
 	if matches!(cli.command, Commands::Config) {
 		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
 		println!("{yaml}");

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -31,7 +31,7 @@ pub fn connect(socket_path: Option<&str>) -> Result<Docker> {
 	Ok(client)
 }
 
-/// Connect using `PODMAN_SOCKET` or `DOCKER_HOST` environment variables.
+/// Strips the `unix://` or `npipe://` scheme prefix before passing the path to [`connect`].
 pub fn connect_from_env() -> Result<Docker> {
 	let socket = std::env::var("PODMAN_SOCKET")
 		.or_else(|_| std::env::var("DOCKER_HOST"))

--- a/internal/substitute.rs
+++ b/internal/substitute.rs
@@ -28,29 +28,24 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String>
 
 		match chars.peek() {
 			None => {
-				// Trailing bare `$` — keep as-is.
 				out.push('$');
 			}
 			Some('$') => {
-				// `$$` → literal `$`
 				chars.next();
 				out.push('$');
 			}
 			Some('{') => {
-				// Consume `{`
 				chars.next();
 				let (var, modifier) = parse_braced_var(&mut chars)?;
 				let value = resolve_modifier(var, modifier, vars)?;
 				out.push_str(&value);
 			}
 			Some(c) if is_var_start(*c) => {
-				// Bare `$VAR`
 				let var = collect_var_name(&mut chars);
 				let value = vars.get(&var).cloned().unwrap_or_default();
 				out.push_str(&value);
 			}
 			Some(_) => {
-				// Not a variable — keep the `$`
 				out.push('$');
 			}
 		}
@@ -91,7 +86,6 @@ pub fn load_dotenv(dir: &Path) -> HashMap<String, String> {
 			continue;
 		}
 
-		// Process env takes precedence.
 		if std::env::var(&key).is_ok() {
 			continue;
 		}
@@ -105,7 +99,6 @@ pub fn load_dotenv(dir: &Path) -> HashMap<String, String> {
 /// Build the full variable map: process env + dotenv (process env wins).
 pub fn build_vars(dir: &Path) -> HashMap<String, String> {
 	let mut vars: HashMap<String, String> = std::env::vars().collect();
-	// Merge dotenv; only insert keys not already present.
 	for (k, v) in load_dotenv(dir) {
 		vars.entry(k).or_insert(v);
 	}
@@ -159,7 +152,6 @@ fn is_var_char(c: char) -> bool {
 	c.is_alphanumeric() || c == '_'
 }
 
-/// Collect a bare variable name (alphanumeric + `_`).
 fn collect_var_name(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
 	let mut name = String::new();
 	while let Some(&c) = chars.peek() {
@@ -191,18 +183,14 @@ enum Modifier {
 }
 
 /// Parse the content inside `${…}`.  The opening `{` has already been consumed.
-///
-/// Returns `(variable_name, Modifier)`.
 fn parse_braced_var(
 	chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
 ) -> Result<(String, Modifier)> {
 	let mut name = String::new();
 
-	// Read until we hit `}`, `:`, `+`, `-`, `?`, or end-of-input.
 	loop {
 		match chars.peek() {
 			None => {
-				// Unclosed brace — treat as literal.
 				return Ok((name, Modifier::None));
 			}
 			Some('}') => {
@@ -225,10 +213,7 @@ fn parse_braced_var(
 						chars.next();
 						Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
 					}
-					_ => {
-						// `${VAR:` with unknown char — collect default anyway.
-						Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
-					}
+					_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)),
 				};
 				return Ok((name, modifier));
 			}
@@ -274,37 +259,25 @@ fn resolve_modifier(
 	match modifier {
 		Modifier::None => Ok(value.cloned().unwrap_or_default()),
 
-		Modifier::DefaultIfUnsetOrEmpty(default) => {
-			// Use default when unset OR empty.
-			match value {
-				Some(v) if !v.is_empty() => Ok(v.clone()),
-				_ => Ok(default),
-			}
-		}
+		Modifier::DefaultIfUnsetOrEmpty(default) => match value {
+			Some(v) if !v.is_empty() => Ok(v.clone()),
+			_ => Ok(default),
+		},
 
-		Modifier::DefaultIfUnset(default) => {
-			// Use default only when unset.
-			match value {
-				Some(v) => Ok(v.clone()),
-				None => Ok(default),
-			}
-		}
+		Modifier::DefaultIfUnset(default) => match value {
+			Some(v) => Ok(v.clone()),
+			None => Ok(default),
+		},
 
-		Modifier::AltIfSetAndNonEmpty(alt) => {
-			// Use alt when set and non-empty; else empty.
-			match value {
-				Some(v) if !v.is_empty() => Ok(alt),
-				_ => Ok(String::new()),
-			}
-		}
+		Modifier::AltIfSetAndNonEmpty(alt) => match value {
+			Some(v) if !v.is_empty() => Ok(alt),
+			_ => Ok(String::new()),
+		},
 
-		Modifier::AltIfSet(alt) => {
-			// Use alt when set (even if empty); else empty.
-			match value {
-				Some(_) => Ok(alt),
-				None => Ok(String::new()),
-			}
-		}
+		Modifier::AltIfSet(alt) => match value {
+			Some(_) => Ok(alt),
+			None => Ok(String::new()),
+		},
 
 		Modifier::ErrorIfUnsetOrEmpty(msg) => match value {
 			Some(v) if !v.is_empty() => Ok(v.clone()),


### PR DESCRIPTION
Release v0.5.7.

## Changes

- **docs:** add `///` doc comments on all public types in `compose/types/` and key engine methods (#122)
- **docs:** remove ~40 ASCII-box section-header comments and explains-what inline comments (#122)
- **fix:** stale `yaml_serde` reference corrected to `serde_yaml_ng` in `compose/mod.rs` (#122)
- **chore:** remove stale ticket prefixes `PERF-003`, `PERF-004`, `PERF-005`, `STAGE-001` from engine comments (#122)