### PR TITLE
fix: warn on Swarm-only deploy fields that have no effect on Podman

### DIFF
--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -18,7 +18,7 @@ use super::container_config::{
 };
 use super::container_misc::{
 	build_blkio_config, build_device_requests, build_label_file_labels, opt_map, opt_vec,
-	parse_device, tmpfs_options_to_string,
+	parse_device, tmpfs_options_to_string, warn_swarm_only_deploy,
 };
 use super::network::{build_endpoint_settings, resolve_network_mode};
 use super::volume_mounts::{build_binds, build_mounts};
@@ -41,6 +41,8 @@ impl Engine {
 		} else {
 			return Err(ComposeError::NoImageOrBuild(service_name.into()));
 		};
+
+		warn_swarm_only_deploy(service_name, service);
 
 		let env = build_env(service, &self.base_dir)?;
 

--- a/internal/engine/container_misc.rs
+++ b/internal/engine/container_misc.rs
@@ -193,6 +193,52 @@ pub(super) fn build_label_file_labels(
 }
 
 // ---------------------------------------------------------------------------
+// Swarm-only deploy field diagnostics
+// ---------------------------------------------------------------------------
+
+/// Emit a warning for each `deploy:` sub-field that has no effect on
+/// single-host rootless Podman.  These are Docker Swarm concepts
+/// (`mode: global`, placement constraints, rolling-update config, etc.)
+/// that are silently accepted by the parser so compose files can be
+/// validated without error, but they have no Podman equivalent.
+pub(super) fn warn_swarm_only_deploy(service_name: &str, service: &Service) {
+	let Some(deploy) = &service.deploy else {
+		return;
+	};
+
+	if let Some(mode) = &deploy.mode {
+		warn!(
+			"service \"{service_name}\": deploy.mode=\"{mode}\" is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if deploy.placement.is_some() {
+		warn!(
+			"service \"{service_name}\": deploy.placement is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if deploy.update_config.is_some() {
+		warn!(
+			"service \"{service_name}\": deploy.update_config is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if deploy.rollback_config.is_some() {
+		warn!(
+			"service \"{service_name}\": deploy.rollback_config is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if let Some(mode) = &deploy.endpoint_mode {
+		warn!(
+			"service \"{service_name}\": deploy.endpoint_mode=\"{mode}\" is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
 
@@ -451,5 +497,45 @@ mod tests {
 		assert_eq!(devs.len(), 1);
 		assert_eq!(devs[0].path.as_deref(), Some("/dev/sda"));
 		assert_eq!(devs[0].weight, Some(300));
+	}
+
+	// --- warn_swarm_only_deploy ---
+
+	#[test]
+	fn warn_swarm_only_deploy_no_deploy_is_noop() {
+		let svc = default_service();
+		warn_swarm_only_deploy("web", &svc);
+	}
+
+	#[test]
+	fn warn_swarm_only_deploy_no_swarm_fields_is_noop() {
+		use crate::compose::types::DeployConfig;
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			replicas: Some(2),
+			..Default::default()
+		});
+		warn_swarm_only_deploy("web", &svc);
+	}
+
+	#[test]
+	fn warn_swarm_only_deploy_all_swarm_fields_no_panic() {
+		use crate::compose::types::{DeployConfig, DeployPlacement, DeployUpdateConfig};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			mode: Some("global".to_string()),
+			placement: Some(DeployPlacement {
+				constraints: vec!["node.role == manager".to_string()],
+				..Default::default()
+			}),
+			update_config: Some(DeployUpdateConfig {
+				parallelism: Some(1),
+				..Default::default()
+			}),
+			rollback_config: Some(DeployUpdateConfig::default()),
+			endpoint_mode: Some("dnsrr".to_string()),
+			..Default::default()
+		});
+		warn_swarm_only_deploy("web", &svc);
 	}
 }


### PR DESCRIPTION
## Summary

`deploy.mode`, `deploy.placement`, `deploy.update_config`, `deploy.rollback_config`, and `deploy.endpoint_mode` are Docker Swarm scheduling concepts. They were parsed but silently ignored — a user migrating a Swarm compose file got no indication that these fields had no effect.

- Added `warn_swarm_only_deploy()` in `container_misc`, called once per service at the start of `create_and_start`.
- Each Swarm-only field that is present emits a `tracing::warn!` naming the field and explaining it has no effect on single-host Podman.
- No behaviour change — warnings only; containers still start normally.

## Test plan

- [x] `cargo test` — 461 tests pass (136 unit + 325 integration)
- [x] `warn_swarm_only_deploy_no_deploy_is_noop` — no deploy block, no panic
- [x] `warn_swarm_only_deploy_no_swarm_fields_is_noop` — only supported fields, no panic
- [x] `warn_swarm_only_deploy_all_swarm_fields_no_panic` — all 5 Swarm fields set, warns without panic

Closes #126