### PR TITLE
chore: bump version to 0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"


### PR DESCRIPTION
Bump version from 0.5.7 → 0.5.8.

## Changes in this release

- fix: warn and honor deprecated top-level `mac_address` on service (#128)
- fix: warn on Swarm-only `deploy:` fields that have no effect on Podman (#129)
- docs: add Docker-to-Podman migration guide (#130)
- docs: correct `DeployConfig` doc comment (#131)
- security: reject setuid/setgid/sticky bits in secret/config file modes (#133)
- test: 319 unit tests, 65% local line coverage (90%+ in CI with Podman integration)

## Labels