### PR TITLE
release: v0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bollard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ async fn main() -> podup::Result<()> {
 podup = { git = "https://github.com/Glyndor/podup", tag = "v0.5.5" }
 ```
 
+## 📖 Docs
+
+- [Migrating from Docker Compose](docs/docker-migration.md) — compatibility guide, rootless differences, deprecated fields
+- [Debian packaging](docs/debian-packaging.md) — building and distributing a `.deb`
+
 ## Contributing & security
 
 See the org-wide [contributing guide](https://github.com/Glyndor/.github/blob/main/CONTRIBUTING.md).

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -1,0 +1,145 @@
+# Migrating from Docker Compose to podup
+
+This guide covers what to expect when you switch a `docker-compose.yml` from
+Docker to podup on rootless Podman.  The short answer is: **most files work
+without any changes**.  Read on for the full picture.
+
+## What works out of the box
+
+Every core Compose spec key is supported:
+
+| Category | Keys |
+|---|---|
+| Images / build | `image`, `build` (context, dockerfile, args, target, cache_from, cache_to, secrets, labels, network) |
+| Execution | `command`, `entrypoint`, `working_dir`, `user`, `platform`, `tty`, `stdin_open` |
+| Environment | `environment`, `env_file` (dotenv format), variable substitution (`${VAR:-default}`) |
+| Networking | `ports`, `expose`, `networks`, `network_mode`, `hostname`, `domainname`, `dns`, `dns_search`, `extra_hosts` |
+| Volumes | `volumes` (bind, named, tmpfs, npipe), `tmpfs`, `volumes_from` |
+| Secrets / configs | `secrets`, `configs` (file, inline content, environment source) |
+| Dependencies | `depends_on` (with `condition:` — `service_started`, `service_healthy`, `service_completed_successfully`) |
+| Health checks | `healthcheck` (test, interval, timeout, retries, start_period, disable) |
+| Lifecycle hooks | `post_start`, `pre_stop` |
+| Restart policies | `restart`, `deploy.restart_policy` |
+| Replicas / scale | `deploy.replicas`, `scale:` |
+| Resource limits | `deploy.resources`, `mem_limit`, `cpus`, `cpu_shares`, `cpu_quota`, `pids_limit`, `ulimits`, `blkio_config` |
+| Devices | `devices`, `device_cgroup_rules`, `deploy.resources.reservations.devices` (GPU) |
+| Security | `cap_add`, `cap_drop`, `security_opt`, `read_only`, `privileged`, `userns_mode` |
+| Namespaces | `pid`, `ipc`, `uts`, `cgroup`, `shm_size` |
+| Metadata | `labels`, `annotations`, `container_name`, `profiles` |
+| Logging | `logging` (driver + options) |
+| Compose features | `extends`, `include`, YAML anchors, x-extensions, `develop.watch` |
+
+## Rootless Podman differences
+
+These are Podman behaviours, not podup limitations.  They apply equally to any
+Podman-based tool.
+
+### Privileged ports (< 1024)
+
+Rootless containers cannot bind host ports below 1024 unless the kernel allows
+it:
+
+```bash
+# Allow a single port (temporary, requires root once):
+sudo sysctl net.ipv4.ip_unprivileged_port_start=80
+
+# Or map through a higher port in your compose file:
+ports:
+  - "8080:80"
+```
+
+### UID/GID mapping
+
+Containers run as your host user's UID inside a user namespace.  If a container
+image writes files with UID 0 (root inside the container), those files appear
+owned by your user on the host.  Bind-mount permissions reflect your host
+user's access.
+
+### Volume SELinux labels
+
+On SELinux-enforcing systems, bind mounts require relabeling.  Append `:z`
+(shared) or `:Z` (private) to the volume spec:
+
+```yaml
+volumes:
+  - ./data:/app/data:Z
+```
+
+### `network_mode: host`
+
+Attaches the container to your user's network namespace, not a privileged host
+namespace.  Traffic is still limited to your user's capabilities.
+
+### `network_mode: none`
+
+Supported.  The container gets a loopback interface only.
+
+## Deprecated fields (honored with a warning)
+
+### `mac_address:` at the service level
+
+The Compose spec deprecated the top-level `mac_address` field in favour of
+per-network configuration.  podup still honours it (for backward compatibility)
+and applies it to the primary network, but logs a deprecation warning.
+
+**Migration:** move it under `networks:`:
+
+```yaml
+# before
+services:
+  web:
+    mac_address: "02:42:ac:11:00:02"
+
+# after
+services:
+  web:
+    networks:
+      default:
+        mac_address: "02:42:ac:11:00:02"
+```
+
+## Swarm-only fields (accepted, no effect)
+
+These fields are part of the Compose spec for Docker Swarm deployments.  They
+are parsed without error so existing compose files validate cleanly, but they
+have no equivalent in single-host rootless Podman.  podup logs a warning for
+each one that is present.
+
+| Field | What it does in Swarm |
+|---|---|
+| `deploy.mode: global` | Run one replica per cluster node |
+| `deploy.placement` | Constrain which nodes a service runs on |
+| `deploy.update_config` | Rolling-update parallelism, delay, failure action |
+| `deploy.rollback_config` | Automatic rollback behaviour |
+| `deploy.endpoint_mode` | VIP vs DNS round-robin load balancing |
+
+If you see warnings for these fields, you can safely remove them from your
+compose file when targeting a single-host Podman deployment.
+
+## Not yet supported
+
+| Feature | Status |
+|---|---|
+| `env_file.format` values other than `dotenv` | Error is emitted; only the `dotenv` format is accepted |
+| Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
+
+## Enabling verbose output
+
+Run with `RUST_LOG=podup=debug` to see network creation, container lifecycle
+events, and deprecation warnings:
+
+```bash
+RUST_LOG=podup=warn podup up     # warnings only (default level)
+RUST_LOG=podup=info podup up     # info + warnings
+RUST_LOG=podup=debug podup up    # full trace
+```
+
+## Quick compatibility checklist
+
+Before running `podup up` on an existing compose file:
+
+- [ ] Remove or remap any host ports below 1024 if running fully rootless.
+- [ ] Add `:Z` to bind mounts on SELinux hosts if containers cannot write to them.
+- [ ] Check for `mac_address:` at the service level — move to `networks:` to silence the warning.
+- [ ] Check for Swarm-only `deploy.*` fields — they are harmless but can be cleaned up.
+- [ ] Verify `env_file` uses dotenv format (key=value lines, `#` comments).

--- a/internal/compose/extends.rs
+++ b/internal/compose/extends.rs
@@ -122,18 +122,9 @@ fn resolve_one_extends(
 	let base_name = extends.service().to_string();
 
 	let base_service = if let Some(file_path) = extends.file() {
-		let fp = std::path::Path::new(file_path);
-		if fp.is_absolute() {
+		if !is_safe_extends_path(file_path) {
 			return Err(ComposeError::Extends(format!(
-				"service '{name}' extends.file must be relative, got absolute path: {file_path}"
-			)));
-		}
-		if fp
-			.components()
-			.any(|c| c == std::path::Component::ParentDir)
-		{
-			return Err(ComposeError::Extends(format!(
-				"service '{name}' extends.file must not traverse parent directories: {file_path}"
+				"service '{name}' extends.file must be a relative path with no parent traversal: {file_path}"
 			)));
 		}
 		let abs = base_dir.join(file_path);
@@ -176,6 +167,28 @@ fn resolve_one_extends(
 	}
 
 	Ok(())
+}
+
+/// Security check: reject `extends.file` with absolute or parent-traversing paths.
+///
+/// Exposed for unit testing.
+pub(crate) fn is_safe_extends_path(path: &str) -> bool {
+	let fp = std::path::Path::new(path);
+	if fp.is_absolute() {
+		return false;
+	}
+	// On Windows, paths like "/etc/passwd" are not `is_absolute()` (no drive letter)
+	// but still escape the project directory via the root separator.
+	if fp.components().next() == Some(std::path::Component::RootDir) {
+		return false;
+	}
+	if fp
+		.components()
+		.any(|c| c == std::path::Component::ParentDir)
+	{
+		return false;
+	}
+	true
 }
 
 pub(super) fn merge_service(base: Service, override_svc: Service) -> Service {
@@ -350,5 +363,206 @@ pub(super) fn merge_service(base: Service, override_svc: Service) -> Service {
 		deploy: override_svc.deploy.or(base.deploy),
 		develop: override_svc.develop.or(base.develop),
 		gpus: override_svc.gpus.or(base.gpus),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::{ComposeFile, EnvVars, Labels, Service};
+	use indexmap::IndexMap;
+
+	fn svc(image: &str) -> Service {
+		Service {
+			image: Some(image.to_string()),
+			..Default::default()
+		}
+	}
+
+	// is_safe_extends_path
+
+	#[test]
+	fn safe_path_relative() {
+		assert!(is_safe_extends_path("other.yml"));
+	}
+
+	#[test]
+	fn safe_path_subdirectory() {
+		assert!(is_safe_extends_path("bases/db.yml"));
+	}
+
+	#[test]
+	fn unsafe_path_absolute() {
+		assert!(!is_safe_extends_path("/etc/compose.yml"));
+	}
+
+	#[test]
+	fn unsafe_path_parent_traversal() {
+		assert!(!is_safe_extends_path("../secret.yml"));
+	}
+
+	#[test]
+	fn unsafe_path_nested_traversal() {
+		assert!(!is_safe_extends_path("a/../../etc/passwd"));
+	}
+
+	// merge_service — scalar fields
+
+	#[test]
+	fn merge_override_image_wins() {
+		let base = svc("nginx:1.24");
+		let over = svc("nginx:1.25");
+		let merged = merge_service(base, over);
+		assert_eq!(merged.image.as_deref(), Some("nginx:1.25"));
+	}
+
+	#[test]
+	fn merge_base_image_used_when_override_missing() {
+		let base = svc("nginx:1.24");
+		let over = Service::default();
+		let merged = merge_service(base, over);
+		assert_eq!(merged.image.as_deref(), Some("nginx:1.24"));
+	}
+
+	// merge_service — env vars (override wins per key)
+
+	#[test]
+	fn merge_env_vars_override_wins_on_conflict() {
+		let mut base_map = IndexMap::new();
+		base_map.insert(
+			"PORT".to_string(),
+			Some(serde_yaml::Value::String("8080".into())),
+		);
+		let base = Service {
+			environment: EnvVars::Map(base_map),
+			..Default::default()
+		};
+
+		let mut over_map = IndexMap::new();
+		over_map.insert(
+			"PORT".to_string(),
+			Some(serde_yaml::Value::String("9090".into())),
+		);
+		let over = Service {
+			environment: EnvVars::Map(over_map),
+			..Default::default()
+		};
+
+		let merged = merge_service(base, over);
+		let env = merged.environment.to_map();
+		assert_eq!(env.get("PORT").and_then(|v| v.as_deref()), Some("9090"));
+	}
+
+	#[test]
+	fn merge_env_vars_base_key_preserved_when_not_overridden() {
+		let mut base_map = IndexMap::new();
+		base_map.insert(
+			"BASE_ONLY".to_string(),
+			Some(serde_yaml::Value::String("yes".into())),
+		);
+		let base = Service {
+			environment: EnvVars::Map(base_map),
+			..Default::default()
+		};
+		let over = Service::default();
+		let merged = merge_service(base, over);
+		let env = merged.environment.to_map();
+		assert_eq!(env.get("BASE_ONLY").and_then(|v| v.as_deref()), Some("yes"));
+	}
+
+	// merge_service — labels (merged, override wins on conflict)
+
+	#[test]
+	fn merge_labels_both_preserved() {
+		let mut base_im = IndexMap::new();
+		base_im.insert("team".to_string(), "infra".to_string());
+		let base = Service {
+			labels: Labels::Map(base_im),
+			..Default::default()
+		};
+
+		let mut over_im = IndexMap::new();
+		over_im.insert("env".to_string(), "prod".to_string());
+		let over = Service {
+			labels: Labels::Map(over_im),
+			..Default::default()
+		};
+
+		let merged = merge_service(base, over);
+		let lm = merged.labels.to_map();
+		assert_eq!(lm.get("team").map(|s| s.as_str()), Some("infra"));
+		assert_eq!(lm.get("env").map(|s| s.as_str()), Some("prod"));
+	}
+
+	// resolve_extends_same_file — cycle detection
+
+	#[test]
+	fn cycle_detection_returns_error() {
+		use crate::compose::types::ExtendsConfig;
+		let mut file = ComposeFile::default();
+		file.services.insert(
+			"a".to_string(),
+			Service {
+				extends: Some(ExtendsConfig::Service("b".to_string())),
+				..Default::default()
+			},
+		);
+		file.services.insert(
+			"b".to_string(),
+			Service {
+				extends: Some(ExtendsConfig::Service("a".to_string())),
+				..Default::default()
+			},
+		);
+		assert!(resolve_extends_same_file(&mut file).is_err());
+	}
+
+	#[test]
+	fn self_extends_returns_error() {
+		use crate::compose::types::ExtendsConfig;
+		let mut file = ComposeFile::default();
+		file.services.insert(
+			"web".to_string(),
+			Service {
+				extends: Some(ExtendsConfig::Service("web".to_string())),
+				..Default::default()
+			},
+		);
+		assert!(resolve_extends_same_file(&mut file).is_err());
+	}
+
+	#[test]
+	fn extends_unknown_service_returns_error() {
+		use crate::compose::types::ExtendsConfig;
+		let mut file = ComposeFile::default();
+		file.services.insert(
+			"web".to_string(),
+			Service {
+				extends: Some(ExtendsConfig::Service("nonexistent".to_string())),
+				..Default::default()
+			},
+		);
+		assert!(resolve_extends_same_file(&mut file).is_err());
+	}
+
+	#[test]
+	fn extends_inherits_image_from_base() {
+		use crate::compose::types::ExtendsConfig;
+		let mut file = ComposeFile::default();
+		file.services.insert("base".to_string(), svc("postgres:16"));
+		file.services.insert(
+			"db".to_string(),
+			Service {
+				extends: Some(ExtendsConfig::Service("base".to_string())),
+				..Default::default()
+			},
+		);
+		resolve_extends_same_file(&mut file).unwrap();
+		assert_eq!(file.services["db"].image.as_deref(), Some("postgres:16"));
+		assert!(file.services["db"].extends.is_none());
 	}
 }

--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -27,3 +27,76 @@ pub(super) fn merge_compose_file(target: &mut ComposeFile, other: ComposeFile) {
 		target.configs.entry(k).or_insert(v);
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::super::types::Service;
+	use super::*;
+
+	fn svc(image: &str) -> Service {
+		Service {
+			image: Some(image.to_string()),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn merge_adds_service_from_other() {
+		let mut target = ComposeFile::default();
+		let mut other = ComposeFile::default();
+		other.services.insert("db".to_string(), svc("postgres:16"));
+		merge_compose_file(&mut target, other);
+		assert!(target.services.contains_key("db"));
+	}
+
+	#[test]
+	fn merge_parent_wins_on_service_conflict() {
+		let mut target = ComposeFile::default();
+		target.services.insert("web".to_string(), svc("nginx:1.25"));
+		let mut other = ComposeFile::default();
+		other.services.insert("web".to_string(), svc("nginx:1.24"));
+		merge_compose_file(&mut target, other);
+		assert_eq!(target.services["web"].image.as_deref(), Some("nginx:1.25"));
+	}
+
+	#[test]
+	fn merge_adds_volume_from_other() {
+		let mut target = ComposeFile::default();
+		let mut other = ComposeFile::default();
+		other.volumes.insert("data".to_string(), None);
+		merge_compose_file(&mut target, other);
+		assert!(target.volumes.contains_key("data"));
+	}
+
+	#[test]
+	fn merge_parent_wins_on_volume_conflict() {
+		let mut target = ComposeFile::default();
+		target.volumes.insert("data".to_string(), None);
+		let mut other = ComposeFile::default();
+		other.volumes.insert("data".to_string(), None);
+		merge_compose_file(&mut target, other);
+		assert_eq!(target.volumes.len(), 1);
+	}
+
+	#[test]
+	fn merge_adds_network_from_other() {
+		let mut target = ComposeFile::default();
+		let mut other = ComposeFile::default();
+		other.networks.insert("backend".to_string(), None);
+		merge_compose_file(&mut target, other);
+		assert!(target.networks.contains_key("backend"));
+	}
+
+	#[test]
+	fn merge_empty_other_is_noop() {
+		let mut target = ComposeFile::default();
+		target.services.insert("web".to_string(), svc("nginx:1.25"));
+		let other = ComposeFile::default();
+		merge_compose_file(&mut target, other);
+		assert_eq!(target.services.len(), 1);
+	}
+}

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -206,3 +206,72 @@ fn apply_merge_keys(value: &mut serde_yaml::Value) {
 		_ => {}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// parse_str_raw
+
+	#[test]
+	fn parse_str_raw_minimal_service() {
+		let yaml = "services:\n  web:\n    image: nginx\n";
+		let file = parse_str_raw(yaml).unwrap();
+		assert!(file.services.contains_key("web"));
+		assert_eq!(file.services["web"].image.as_deref(), Some("nginx"));
+	}
+
+	#[test]
+	fn parse_str_raw_invalid_yaml_is_error() {
+		assert!(parse_str_raw(": : :").is_err());
+	}
+
+	// resolve_order
+
+	#[test]
+	fn resolve_order_no_deps_arbitrary_order() {
+		let yaml = "services:\n  a:\n    image: x\n  b:\n    image: y\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let order = resolve_order(&file).unwrap();
+		assert_eq!(order.len(), 2);
+		assert!(order.contains(&"a".to_string()));
+		assert!(order.contains(&"b".to_string()));
+	}
+
+	#[test]
+	fn resolve_order_dep_before_dependent() {
+		let yaml = "services:\n  web:\n    image: nginx\n    depends_on: [db]\n  db:\n    image: postgres\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let order = resolve_order(&file).unwrap();
+		let db_pos = order.iter().position(|s| s == "db").unwrap();
+		let web_pos = order.iter().position(|s| s == "web").unwrap();
+		assert!(db_pos < web_pos, "db must start before web");
+	}
+
+	#[test]
+	fn resolve_order_cycle_is_error() {
+		let yaml = "services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n";
+		let file = parse_str_raw(yaml).unwrap();
+		assert!(resolve_order(&file).is_err());
+	}
+
+	#[test]
+	fn resolve_order_missing_required_dep_is_error() {
+		let yaml = "services:\n  web:\n    image: nginx\n    depends_on: [db]\n";
+		let file = parse_str_raw(yaml).unwrap();
+		assert!(resolve_order(&file).is_err());
+	}
+
+	// YAML merge keys (<<)
+
+	#[test]
+	fn yaml_merge_key_fills_missing_fields() {
+		let yaml = "x-defaults: &defaults\n  image: nginx\n  restart: always\nservices:\n  web:\n    <<: *defaults\n    ports: ['80:80']\n";
+		let file = parse_str_raw(yaml).unwrap();
+		assert_eq!(file.services["web"].image.as_deref(), Some("nginx"));
+	}
+}

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -198,3 +198,94 @@ impl BuildConfig {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// IncludeConfig::paths
+
+	#[test]
+	fn include_config_path_returns_single() {
+		let c = IncludeConfig::Path("base.yml".into());
+		assert_eq!(c.paths(), vec!["base.yml"]);
+	}
+
+	#[test]
+	fn include_config_long_returns_list() {
+		let c = IncludeConfig::Long {
+			path: super::super::StringOrList::List(vec!["a.yml".into(), "b.yml".into()]),
+			env_file: None,
+			project_directory: None,
+		};
+		assert_eq!(c.paths(), vec!["a.yml", "b.yml"]);
+	}
+
+	// ExtendsConfig
+
+	#[test]
+	fn extends_service_short_form() {
+		let e = ExtendsConfig::Service("base".into());
+		assert_eq!(e.service(), "base");
+		assert!(e.file().is_none());
+	}
+
+	#[test]
+	fn extends_config_long_form() {
+		let e = ExtendsConfig::Long {
+			service: "base".into(),
+			file: Some("base.yml".into()),
+		};
+		assert_eq!(e.service(), "base");
+		assert_eq!(e.file(), Some("base.yml"));
+	}
+
+	// BuildConfig accessor methods
+
+	#[test]
+	fn build_config_context_string() {
+		let b = BuildConfig::Context("./app".into());
+		assert_eq!(b.context(), "./app");
+		assert!(b.dockerfile().is_none());
+		assert!(!b.no_cache());
+		assert!(!b.pull());
+	}
+
+	#[test]
+	fn build_config_long_form_context() {
+		let b = BuildConfig::Config {
+			context: "./app".into(),
+			dockerfile: Some("Dockerfile.prod".into()),
+			dockerfile_inline: None,
+			args: EnvVars::Empty,
+			target: Some("release".into()),
+			cache_from: vec![],
+			cache_to: vec![],
+			labels: Labels::Empty,
+			shm_size: None,
+			network: None,
+			platforms: vec![],
+			additional_contexts: Default::default(),
+			no_cache: Some(true),
+			pull: None,
+			extra_hosts: vec![],
+			tags: vec![],
+			privileged: None,
+			ssh: vec![],
+			secrets: vec![],
+			ulimits: Default::default(),
+			isolation: None,
+			entitlements: vec![],
+			provenance: None,
+			sbom: None,
+		};
+		assert_eq!(b.context(), "./app");
+		assert_eq!(b.dockerfile(), Some("Dockerfile.prod"));
+		assert_eq!(b.target(), Some("release"));
+		assert!(b.no_cache());
+	}
+}

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -11,7 +11,13 @@ use serde::{Deserialize, Serialize};
 
 use super::Labels;
 
-/// `deploy:` service key — resource limits, replica count, restart and update policies.
+/// `deploy:` service key — resource limits, replica count, restart policies, and labels.
+///
+/// The engine uses `replicas`, `resources`, `restart_policy`, and `labels`.
+/// Fields inherited from Docker Swarm (`mode`, `placement`, `update_config`,
+/// `rollback_config`, `endpoint_mode`) are parsed so existing compose files
+/// are accepted without error, but they have no effect on single-host Podman
+/// and emit a warning at runtime.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -63,3 +63,47 @@ impl<'de> Deserialize<'de> for WatchAction {
 pub struct WatchExec {
 	pub command: Vec<String>,
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn watch_action_sync() {
+		let a: WatchAction = serde_yaml::from_str("\"sync\"").unwrap();
+		assert_eq!(a, WatchAction::Sync);
+	}
+
+	#[test]
+	fn watch_action_rebuild() {
+		let a: WatchAction = serde_yaml::from_str("\"rebuild\"").unwrap();
+		assert_eq!(a, WatchAction::Rebuild);
+	}
+
+	#[test]
+	fn watch_action_restart() {
+		let a: WatchAction = serde_yaml::from_str("\"restart\"").unwrap();
+		assert_eq!(a, WatchAction::Restart);
+	}
+
+	#[test]
+	fn watch_action_sync_and_restart() {
+		let a: WatchAction = serde_yaml::from_str("\"sync+restart\"").unwrap();
+		assert_eq!(a, WatchAction::SyncAndRestart);
+	}
+
+	#[test]
+	fn watch_action_sync_and_exec() {
+		let a: WatchAction = serde_yaml::from_str("\"sync+exec\"").unwrap();
+		assert_eq!(a, WatchAction::SyncAndExec);
+	}
+
+	#[test]
+	fn watch_action_unknown_is_error() {
+		assert!(serde_yaml::from_str::<WatchAction>("\"deploy\"").is_err());
+	}
+}

--- a/internal/compose/types/env.rs
+++ b/internal/compose/types/env.rs
@@ -121,3 +121,119 @@ impl EnvFile {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use indexmap::IndexMap;
+
+	// EnvVars::to_map
+
+	#[test]
+	fn env_vars_empty_to_map() {
+		assert!(EnvVars::Empty.to_map().is_empty());
+	}
+
+	#[test]
+	fn env_vars_list_key_equals_value() {
+		let e = EnvVars::List(vec!["FOO=bar".into(), "BAZ=qux".into()]);
+		let m = e.to_map();
+		assert_eq!(m.get("FOO"), Some(&Some("bar".to_string())));
+		assert_eq!(m.get("BAZ"), Some(&Some("qux".to_string())));
+	}
+
+	#[test]
+	fn env_vars_list_key_only_has_none_value() {
+		let e = EnvVars::List(vec!["HOST_VAR".into()]);
+		let m = e.to_map();
+		assert_eq!(m.get("HOST_VAR"), Some(&None));
+	}
+
+	#[test]
+	fn env_vars_map_string_value() {
+		let mut im = IndexMap::new();
+		im.insert(
+			"PORT".to_string(),
+			Some(serde_yaml::Value::Number(8080.into())),
+		);
+		let m = EnvVars::Map(im).to_map();
+		assert_eq!(m.get("PORT"), Some(&Some("8080".to_string())));
+	}
+
+	#[test]
+	fn env_vars_map_null_value_is_none() {
+		let mut im = IndexMap::new();
+		im.insert("X".to_string(), Some(serde_yaml::Value::Null));
+		let m = EnvVars::Map(im).to_map();
+		assert_eq!(m.get("X"), Some(&None));
+	}
+
+	#[test]
+	fn env_vars_is_empty_variants() {
+		assert!(EnvVars::Empty.is_empty());
+		assert!(EnvVars::List(vec![]).is_empty());
+		assert!(!EnvVars::List(vec!["X=1".into()]).is_empty());
+	}
+
+	// EnvFileEntry
+
+	#[test]
+	fn env_file_entry_path_required_true() {
+		let e = EnvFileEntry::Path(".env".into());
+		assert_eq!(e.path(), ".env");
+		assert!(e.required());
+	}
+
+	#[test]
+	fn env_file_entry_config_not_required() {
+		let e = EnvFileEntry::Config {
+			path: ".env.optional".into(),
+			required: Some(false),
+			format: None,
+		};
+		assert!(!e.required());
+	}
+
+	#[test]
+	fn env_file_entry_config_missing_required_defaults_true() {
+		let e = EnvFileEntry::Config {
+			path: ".env".into(),
+			required: None,
+			format: None,
+		};
+		assert!(e.required());
+	}
+
+	// EnvFile::to_entries / is_empty
+
+	#[test]
+	fn env_file_empty_to_entries() {
+		assert!(EnvFile::Empty.to_entries().is_empty());
+	}
+
+	#[test]
+	fn env_file_single_to_entries() {
+		let e = EnvFile::Single(EnvFileEntry::Path(".env".into()));
+		assert_eq!(e.to_entries().len(), 1);
+	}
+
+	#[test]
+	fn env_file_list_to_list_returns_paths() {
+		let e = EnvFile::List(vec![
+			EnvFileEntry::Path(".env".into()),
+			EnvFileEntry::Path(".env.local".into()),
+		]);
+		assert_eq!(e.to_list(), vec![".env", ".env.local"]);
+	}
+
+	#[test]
+	fn env_file_is_empty_variants() {
+		assert!(EnvFile::Empty.is_empty());
+		assert!(EnvFile::List(vec![]).is_empty());
+		assert!(!EnvFile::Single(EnvFileEntry::Path(".env".into())).is_empty());
+	}
+}

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -152,3 +152,164 @@ impl<'de> Deserialize<'de> for RestartPolicy {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use indexmap::IndexMap;
+
+	// DependsOn::service_names
+
+	#[test]
+	fn depends_on_empty_has_no_names() {
+		assert!(DependsOn::Empty.service_names().is_empty());
+	}
+
+	#[test]
+	fn depends_on_list_returns_names() {
+		let d = DependsOn::List(vec!["db".into(), "cache".into()]);
+		assert_eq!(d.service_names(), vec!["db", "cache"]);
+	}
+
+	#[test]
+	fn depends_on_map_returns_keys() {
+		let mut m = IndexMap::new();
+		m.insert(
+			"db".to_string(),
+			DependsOnCondition {
+				condition: ServiceCondition::ServiceHealthy,
+				restart: None,
+				required: None,
+			},
+		);
+		assert_eq!(DependsOn::Map(m).service_names(), vec!["db"]);
+	}
+
+	// DependsOn::condition_for
+
+	#[test]
+	fn condition_for_empty_defaults_to_started() {
+		assert_eq!(
+			DependsOn::Empty.condition_for("db"),
+			ServiceCondition::ServiceStarted
+		);
+	}
+
+	#[test]
+	fn condition_for_map_returns_explicit() {
+		let mut m = IndexMap::new();
+		m.insert(
+			"db".to_string(),
+			DependsOnCondition {
+				condition: ServiceCondition::ServiceHealthy,
+				restart: None,
+				required: None,
+			},
+		);
+		assert_eq!(
+			DependsOn::Map(m).condition_for("db"),
+			ServiceCondition::ServiceHealthy
+		);
+	}
+
+	// DependsOn::restart_for / required_for
+
+	#[test]
+	fn restart_for_list_is_false() {
+		assert!(!DependsOn::List(vec!["db".into()]).restart_for("db"));
+	}
+
+	#[test]
+	fn required_for_list_defaults_true() {
+		assert!(DependsOn::List(vec!["db".into()]).required_for("db"));
+	}
+
+	#[test]
+	fn required_for_map_explicit_false() {
+		let mut m = IndexMap::new();
+		m.insert(
+			"db".to_string(),
+			DependsOnCondition {
+				condition: ServiceCondition::ServiceStarted,
+				restart: None,
+				required: Some(false),
+			},
+		);
+		assert!(!DependsOn::Map(m).required_for("db"));
+	}
+
+	// HealthCheck::is_disabled
+
+	#[test]
+	fn healthcheck_disable_true() {
+		let hc = HealthCheck {
+			disable: Some(true),
+			..Default::default()
+		};
+		assert!(hc.is_disabled());
+	}
+
+	#[test]
+	fn healthcheck_test_none_exec_disables() {
+		let hc = HealthCheck {
+			test: Some(Command::Exec(vec!["NONE".to_string()])),
+			..Default::default()
+		};
+		assert!(hc.is_disabled());
+	}
+
+	#[test]
+	fn healthcheck_real_test_not_disabled() {
+		let hc = HealthCheck {
+			test: Some(Command::Shell("curl -f http://localhost/".into())),
+			..Default::default()
+		};
+		assert!(!hc.is_disabled());
+	}
+
+	// RestartPolicy deserialization
+
+	#[test]
+	fn restart_policy_no() {
+		let p: RestartPolicy = serde_yaml::from_str("\"no\"").unwrap();
+		assert_eq!(p, RestartPolicy::No);
+	}
+
+	#[test]
+	fn restart_policy_always() {
+		let p: RestartPolicy = serde_yaml::from_str("\"always\"").unwrap();
+		assert_eq!(p, RestartPolicy::Always);
+	}
+
+	#[test]
+	fn restart_policy_unless_stopped() {
+		let p: RestartPolicy = serde_yaml::from_str("\"unless-stopped\"").unwrap();
+		assert_eq!(p, RestartPolicy::UnlessStopped);
+	}
+
+	#[test]
+	fn restart_policy_on_failure_bare() {
+		let p: RestartPolicy = serde_yaml::from_str("\"on-failure\"").unwrap();
+		assert_eq!(p, RestartPolicy::OnFailure { max_attempts: None });
+	}
+
+	#[test]
+	fn restart_policy_on_failure_with_count() {
+		let p: RestartPolicy = serde_yaml::from_str("\"on-failure:3\"").unwrap();
+		assert_eq!(
+			p,
+			RestartPolicy::OnFailure {
+				max_attempts: Some(3)
+			}
+		);
+	}
+
+	#[test]
+	fn restart_policy_invalid_is_error() {
+		assert!(serde_yaml::from_str::<RestartPolicy>("\"bogus\"").is_err());
+	}
+}

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -108,3 +108,68 @@ pub struct IpamPool {
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub aux_addresses: HashMap<String, String>,
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use indexmap::IndexMap;
+
+	// ServiceNetworks::names
+
+	#[test]
+	fn service_networks_empty_has_no_names() {
+		assert!(ServiceNetworks::Empty.names().is_empty());
+	}
+
+	#[test]
+	fn service_networks_list_returns_names() {
+		let n = ServiceNetworks::List(vec!["front".into(), "back".into()]);
+		assert_eq!(n.names(), vec!["front", "back"]);
+	}
+
+	#[test]
+	fn service_networks_map_returns_keys() {
+		let mut m = IndexMap::new();
+		m.insert("front".to_string(), None);
+		assert_eq!(ServiceNetworks::Map(m).names(), vec!["front"]);
+	}
+
+	// ServiceNetworks::config_for
+
+	#[test]
+	fn config_for_list_returns_none() {
+		let n = ServiceNetworks::List(vec!["front".into()]);
+		assert!(n.config_for("front").is_none());
+	}
+
+	#[test]
+	fn config_for_map_with_none_config_returns_none() {
+		let mut m = IndexMap::new();
+		m.insert("front".to_string(), None::<ServiceNetworkConfig>);
+		assert!(ServiceNetworks::Map(m).config_for("front").is_none());
+	}
+
+	#[test]
+	fn config_for_map_with_config_returns_it() {
+		let cfg = ServiceNetworkConfig {
+			ipv4_address: Some("10.0.0.2".into()),
+			..Default::default()
+		};
+		let mut m = IndexMap::new();
+		m.insert("front".to_string(), Some(cfg));
+		let nets = ServiceNetworks::Map(m);
+		let result = nets.config_for("front");
+		assert_eq!(result.unwrap().ipv4_address.as_deref(), Some("10.0.0.2"));
+	}
+
+	#[test]
+	fn config_for_missing_key_returns_none() {
+		let mut m = IndexMap::new();
+		m.insert("front".to_string(), None::<ServiceNetworkConfig>);
+		assert!(ServiceNetworks::Map(m).config_for("back").is_none());
+	}
+}

--- a/internal/compose/types/primitives.rs
+++ b/internal/compose/types/primitives.rs
@@ -146,3 +146,136 @@ impl Sysctls {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use indexmap::IndexMap;
+
+	// Command
+
+	#[test]
+	fn command_shell_to_exec_wraps_in_sh() {
+		let cmd = Command::Shell("echo hi".into());
+		assert_eq!(cmd.to_exec(), vec!["sh", "-c", "echo hi"]);
+	}
+
+	#[test]
+	fn command_exec_to_exec_passthrough() {
+		let cmd = Command::Exec(vec!["ls".into(), "-la".into()]);
+		assert_eq!(cmd.to_exec(), vec!["ls", "-la"]);
+	}
+
+	#[test]
+	fn command_shell_to_argv_returns_shell_string() {
+		let cmd = Command::Shell("echo hi".into());
+		assert_eq!(cmd.to_argv(), vec!["echo hi"]);
+	}
+
+	#[test]
+	fn command_exec_to_argv_passthrough() {
+		let cmd = Command::Exec(vec!["ls".into()]);
+		assert_eq!(cmd.to_argv(), vec!["ls"]);
+	}
+
+	// StringOrList
+
+	#[test]
+	fn string_or_list_empty_to_list() {
+		assert!(StringOrList::Empty.to_list().is_empty());
+	}
+
+	#[test]
+	fn string_or_list_single_to_list() {
+		assert_eq!(StringOrList::Single("a".into()).to_list(), vec!["a"]);
+	}
+
+	#[test]
+	fn string_or_list_list_to_list() {
+		let s = StringOrList::List(vec!["a".into(), "b".into()]);
+		assert_eq!(s.to_list(), vec!["a", "b"]);
+	}
+
+	#[test]
+	fn string_or_list_empty_is_empty() {
+		assert!(StringOrList::Empty.is_empty());
+	}
+
+	#[test]
+	fn string_or_list_single_empty_string_is_empty() {
+		assert!(StringOrList::Single(String::new()).is_empty());
+	}
+
+	#[test]
+	fn string_or_list_nonempty_single_not_empty() {
+		assert!(!StringOrList::Single("x".into()).is_empty());
+	}
+
+	// Labels
+
+	#[test]
+	fn labels_empty_to_map() {
+		assert!(Labels::Empty.to_map().is_empty());
+	}
+
+	#[test]
+	fn labels_list_parses_key_equals_value() {
+		let l = Labels::List(vec!["env=prod".into(), "team=infra".into()]);
+		let m = l.to_map();
+		assert_eq!(m.get("env").map(|s| s.as_str()), Some("prod"));
+		assert_eq!(m.get("team").map(|s| s.as_str()), Some("infra"));
+	}
+
+	#[test]
+	fn labels_list_key_only_has_empty_value() {
+		let l = Labels::List(vec!["bare".into()]);
+		let m = l.to_map();
+		assert_eq!(m.get("bare").map(|s| s.as_str()), Some(""));
+	}
+
+	#[test]
+	fn labels_map_to_map() {
+		let mut im = IndexMap::new();
+		im.insert("k".to_string(), "v".to_string());
+		let m = Labels::Map(im).to_map();
+		assert_eq!(m.get("k").map(|s| s.as_str()), Some("v"));
+	}
+
+	#[test]
+	fn labels_is_empty_variants() {
+		assert!(Labels::Empty.is_empty());
+		assert!(Labels::List(vec![]).is_empty());
+		let mut im = IndexMap::new();
+		im.insert("x".to_string(), "y".to_string());
+		assert!(!Labels::Map(im).is_empty());
+	}
+
+	// Sysctls
+
+	#[test]
+	fn sysctls_empty_to_map() {
+		assert!(Sysctls::Empty.to_map().is_empty());
+	}
+
+	#[test]
+	fn sysctls_list_parses() {
+		let s = Sysctls::List(vec!["net.ipv4.ip_forward=1".into()]);
+		let m = s.to_map();
+		assert_eq!(m.get("net.ipv4.ip_forward").map(|s| s.as_str()), Some("1"));
+	}
+
+	#[test]
+	fn sysctls_map_string_value() {
+		let mut im = IndexMap::new();
+		im.insert(
+			"net.core.somaxconn".to_string(),
+			serde_yaml::Value::Number(128.into()),
+		);
+		let m = Sysctls::Map(im).to_map();
+		assert_eq!(m.get("net.core.somaxconn").map(|s| s.as_str()), Some("128"));
+	}
+}

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -186,3 +186,103 @@ impl ServiceSecretRef {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// VolumeMount::target
+
+	#[test]
+	fn volume_mount_short_two_parts_returns_second() {
+		let m = VolumeMount::Short("./data:/app/data".to_string());
+		assert_eq!(m.target(), "/app/data");
+	}
+
+	#[test]
+	fn volume_mount_short_three_parts_returns_second() {
+		let m = VolumeMount::Short("./data:/app/data:ro".to_string());
+		assert_eq!(m.target(), "/app/data");
+	}
+
+	#[test]
+	fn volume_mount_short_no_colon_returns_whole_string() {
+		let m = VolumeMount::Short("/app/data".to_string());
+		assert_eq!(m.target(), "/app/data");
+	}
+
+	#[test]
+	fn volume_mount_long_returns_target_field() {
+		let m = VolumeMount::Long {
+			volume_type: VolumeType::Bind,
+			source: Some("/host/path".to_string()),
+			target: "/container/path".to_string(),
+			read_only: None,
+			bind: None,
+			volume: None,
+			tmpfs: None,
+			consistency: None,
+		};
+		assert_eq!(m.target(), "/container/path");
+	}
+
+	// ServiceConfigRef
+
+	#[test]
+	fn config_ref_short_source() {
+		let r = ServiceConfigRef::Short("my-config".to_string());
+		assert_eq!(r.source(), "my-config");
+		assert!(r.target().is_none());
+	}
+
+	#[test]
+	fn config_ref_long_source_and_target() {
+		let r = ServiceConfigRef::Long {
+			source: "my-config".to_string(),
+			target: Some("/run/configs/my-config".to_string()),
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		assert_eq!(r.source(), "my-config");
+		assert_eq!(r.target(), Some("/run/configs/my-config"));
+	}
+
+	#[test]
+	fn config_ref_long_no_target() {
+		let r = ServiceConfigRef::Long {
+			source: "my-config".to_string(),
+			target: None,
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		assert!(r.target().is_none());
+	}
+
+	// ServiceSecretRef
+
+	#[test]
+	fn secret_ref_short_source() {
+		let r = ServiceSecretRef::Short("my-secret".to_string());
+		assert_eq!(r.source(), "my-secret");
+		assert!(r.target().is_none());
+	}
+
+	#[test]
+	fn secret_ref_long_source_and_target() {
+		let r = ServiceSecretRef::Long {
+			source: "my-secret".to_string(),
+			target: Some("/run/secrets/my-secret".to_string()),
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		assert_eq!(r.source(), "my-secret");
+		assert_eq!(r.target(), Some("/run/secrets/my-secret"));
+	}
+}

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -212,10 +212,20 @@ impl Engine {
 		let cmd = service.command.as_ref().map(|c| c.to_exec());
 		let entrypoint = service.entrypoint.as_ref().map(|c| c.to_exec());
 
+		if service.mac_address.is_some() {
+			tracing::warn!(
+				"service \"{service_name}\": top-level mac_address is deprecated; \
+				move it to networks.<network>.mac_address"
+			);
+		}
+
 		let networking_config = first_network.as_ref().map(|net| {
 			let mut endpoints = HashMap::new();
 			let svc_net_cfg = service.networks.config_for(net);
-			endpoints.insert(net.clone(), build_endpoint_settings(svc_net_cfg, file));
+			endpoints.insert(
+				net.clone(),
+				build_endpoint_settings(svc_net_cfg, file, service.mac_address.as_deref()),
+			);
 			NetworkingConfig {
 				endpoints_config: Some(endpoints),
 			}

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -18,7 +18,7 @@ use super::container_config::{
 };
 use super::container_misc::{
 	build_blkio_config, build_device_requests, build_label_file_labels, opt_map, opt_vec,
-	parse_device, tmpfs_options_to_string,
+	parse_device, tmpfs_options_to_string, warn_swarm_only_deploy,
 };
 use super::network::{build_endpoint_settings, resolve_network_mode};
 use super::volume_mounts::{build_binds, build_mounts};
@@ -41,6 +41,8 @@ impl Engine {
 		} else {
 			return Err(ComposeError::NoImageOrBuild(service_name.into()));
 		};
+
+		warn_swarm_only_deploy(service_name, service);
 
 		let env = build_env(service, &self.base_dir)?;
 

--- a/internal/engine/container_misc.rs
+++ b/internal/engine/container_misc.rs
@@ -193,6 +193,52 @@ pub(super) fn build_label_file_labels(
 }
 
 // ---------------------------------------------------------------------------
+// Swarm-only deploy field diagnostics
+// ---------------------------------------------------------------------------
+
+/// Emit a warning for each `deploy:` sub-field that has no effect on
+/// single-host rootless Podman.  These are Docker Swarm concepts
+/// (`mode: global`, placement constraints, rolling-update config, etc.)
+/// that are silently accepted by the parser so compose files can be
+/// validated without error, but they have no Podman equivalent.
+pub(super) fn warn_swarm_only_deploy(service_name: &str, service: &Service) {
+	let Some(deploy) = &service.deploy else {
+		return;
+	};
+
+	if let Some(mode) = &deploy.mode {
+		warn!(
+			"service \"{service_name}\": deploy.mode=\"{mode}\" is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if deploy.placement.is_some() {
+		warn!(
+			"service \"{service_name}\": deploy.placement is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if deploy.update_config.is_some() {
+		warn!(
+			"service \"{service_name}\": deploy.update_config is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if deploy.rollback_config.is_some() {
+		warn!(
+			"service \"{service_name}\": deploy.rollback_config is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+	if let Some(mode) = &deploy.endpoint_mode {
+		warn!(
+			"service \"{service_name}\": deploy.endpoint_mode=\"{mode}\" is a Docker Swarm field \
+			and has no effect on single-host Podman"
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
 
@@ -451,5 +497,45 @@ mod tests {
 		assert_eq!(devs.len(), 1);
 		assert_eq!(devs[0].path.as_deref(), Some("/dev/sda"));
 		assert_eq!(devs[0].weight, Some(300));
+	}
+
+	// --- warn_swarm_only_deploy ---
+
+	#[test]
+	fn warn_swarm_only_deploy_no_deploy_is_noop() {
+		let svc = default_service();
+		warn_swarm_only_deploy("web", &svc);
+	}
+
+	#[test]
+	fn warn_swarm_only_deploy_no_swarm_fields_is_noop() {
+		use crate::compose::types::DeployConfig;
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			replicas: Some(2),
+			..Default::default()
+		});
+		warn_swarm_only_deploy("web", &svc);
+	}
+
+	#[test]
+	fn warn_swarm_only_deploy_all_swarm_fields_no_panic() {
+		use crate::compose::types::{DeployConfig, DeployPlacement, DeployUpdateConfig};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			mode: Some("global".to_string()),
+			placement: Some(DeployPlacement {
+				constraints: vec!["node.role == manager".to_string()],
+				..Default::default()
+			}),
+			update_config: Some(DeployUpdateConfig {
+				parallelism: Some(1),
+				..Default::default()
+			}),
+			rollback_config: Some(DeployUpdateConfig::default()),
+			endpoint_mode: Some("dnsrr".to_string()),
+			..Default::default()
+		});
+		warn_swarm_only_deploy("web", &svc);
 	}
 }

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -195,4 +195,48 @@ mod tests {
 		assert_eq!(parse_endpoint(":path"), None);
 		assert_eq!(parse_endpoint("svc:"), None);
 	}
+
+	#[test]
+	fn parse_windows_drive_letter_forward_slash() {
+		assert_eq!(parse_endpoint("C:/Users/foo"), None);
+	}
+
+	#[test]
+	fn parse_service_with_relative_path() {
+		assert_eq!(
+			parse_endpoint("web:data/file.txt"),
+			Some(("web", "data/file.txt"))
+		);
+	}
+
+	#[test]
+	fn parse_service_name_with_dots() {
+		assert_eq!(
+			parse_endpoint("my.service:/app/config"),
+			Some(("my.service", "/app/config"))
+		);
+	}
+
+	#[test]
+	fn pack_path_single_file() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let file = dir.path().join("data.txt");
+		std::fs::write(&file, b"hello").expect("write");
+		let result = super::pack_path(&file);
+		assert!(result.is_ok());
+		let bytes = result.unwrap();
+		assert!(!bytes.is_empty());
+	}
+
+	#[test]
+	fn pack_path_directory() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let subdir = dir.path().join("mydir");
+		std::fs::create_dir(&subdir).expect("mkdir");
+		std::fs::write(subdir.join("a.txt"), b"aaa").expect("write");
+		std::fs::write(subdir.join("b.txt"), b"bbb").expect("write");
+		let result = super::pack_path(&subdir);
+		assert!(result.is_ok());
+		assert!(!result.unwrap().is_empty());
+	}
 }

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -99,7 +99,7 @@ impl Engine {
 		for network in network_names.iter().skip(1) {
 			let full_name = resolve_network_name(network, file, &self.project);
 			let endpoint_config =
-				build_endpoint_settings(service.networks.config_for(network), file);
+				build_endpoint_settings(service.networks.config_for(network), file, None);
 			self.docker
 				.connect_network(
 					&full_name,
@@ -123,6 +123,7 @@ impl Engine {
 pub(super) fn build_endpoint_settings(
 	cfg: Option<&ServiceNetworkConfig>,
 	_file: &ComposeFile,
+	fallback_mac: Option<&str>,
 ) -> EndpointSettings {
 	let mut settings = EndpointSettings::default();
 	if let Some(c) = cfg {
@@ -140,14 +141,17 @@ pub(super) fn build_endpoint_settings(
 				},
 			});
 		}
-		if c.mac_address.is_some() {
-			settings.mac_address = c.mac_address.clone();
+		let mac = c.mac_address.as_deref().or(fallback_mac);
+		if mac.is_some() {
+			settings.mac_address = mac.map(|s| s.to_string());
 		}
 		if let Some(prio) = c.priority {
 			let mut m = HashMap::new();
 			m.insert("priority".to_string(), prio.to_string());
 			settings.driver_opts = Some(m);
 		}
+	} else if fallback_mac.is_some() {
+		settings.mac_address = fallback_mac.map(|s| s.to_string());
 	}
 	settings
 }
@@ -277,7 +281,7 @@ mod tests {
 	#[test]
 	fn build_endpoint_settings_no_config() {
 		let file = empty_file();
-		let settings = build_endpoint_settings(None, &file);
+		let settings = build_endpoint_settings(None, &file, None);
 		assert!(settings.aliases.is_none());
 		assert!(settings.ipam_config.is_none());
 	}
@@ -290,7 +294,7 @@ mod tests {
 			..Default::default()
 		};
 		let file = empty_file();
-		let settings = build_endpoint_settings(Some(&cfg), &file);
+		let settings = build_endpoint_settings(Some(&cfg), &file, None);
 		assert_eq!(
 			settings.aliases.as_ref().unwrap(),
 			&vec!["web".to_string(), "api".to_string()]
@@ -305,7 +309,7 @@ mod tests {
 			..Default::default()
 		};
 		let file = empty_file();
-		let settings = build_endpoint_settings(Some(&cfg), &file);
+		let settings = build_endpoint_settings(Some(&cfg), &file, None);
 		let ipam = settings.ipam_config.unwrap();
 		assert_eq!(ipam.ipv4_address.as_deref(), Some("10.0.0.5"));
 	}
@@ -370,5 +374,35 @@ mod tests {
 		let cfg = result.config.unwrap();
 		let aux = cfg[0].auxiliary_addresses.as_ref().unwrap();
 		assert_eq!(aux.get("router").map(|s| s.as_str()), Some("192.168.0.254"));
+	}
+
+	// --- build_endpoint_settings: fallback_mac ---
+
+	#[test]
+	fn fallback_mac_applied_when_no_config() {
+		let file = empty_file();
+		let settings = build_endpoint_settings(None, &file, Some("02:42:ac:11:00:02"));
+		assert_eq!(settings.mac_address.as_deref(), Some("02:42:ac:11:00:02"));
+	}
+
+	#[test]
+	fn fallback_mac_applied_when_config_has_no_mac() {
+		use crate::compose::types::ServiceNetworkConfig;
+		let cfg = ServiceNetworkConfig::default();
+		let file = empty_file();
+		let settings = build_endpoint_settings(Some(&cfg), &file, Some("02:42:ac:11:00:03"));
+		assert_eq!(settings.mac_address.as_deref(), Some("02:42:ac:11:00:03"));
+	}
+
+	#[test]
+	fn per_network_mac_takes_precedence_over_fallback() {
+		use crate::compose::types::ServiceNetworkConfig;
+		let cfg = ServiceNetworkConfig {
+			mac_address: Some("aa:bb:cc:dd:ee:ff".to_string()),
+			..Default::default()
+		};
+		let file = empty_file();
+		let settings = build_endpoint_settings(Some(&cfg), &file, Some("02:42:ac:11:00:03"));
+		assert_eq!(settings.mac_address.as_deref(), Some("aa:bb:cc:dd:ee:ff"));
 	}
 }

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -117,8 +117,12 @@ pub(super) fn write_private_file(path: &std::path::Path, content: &[u8]) -> Resu
 
 /// Apply a compose `mode:` value (octal unix permissions) to `path`.
 ///
-/// Rejects any mode with world-readable (`o+r`) or group-readable (`g+r`) bits
-/// set — a secret or config file must never be readable by other users.
+/// Rejects:
+/// - group-readable (`g+r`, 0o040) or world-readable (`o+r`, 0o004) bits — a
+///   secret or config file must never be readable by other users.
+/// - setuid (0o4000), setgid (0o2000), or sticky (0o1000) bits — these have no
+///   legitimate use on a secret/config data file and are either a
+///   misconfiguration or an attack attempt; reject unconditionally.
 #[cfg(unix)]
 pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
 	use std::os::unix::fs::PermissionsExt;
@@ -127,6 +131,13 @@ pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
 		return Err(ComposeError::Unsupported(format!(
 			"mode {mode:#o} for {} grants group- or world-read access to a secret/config file; \
 			 use a mode with no g+r or o+r bits (e.g. 0o400 or 0o600)",
+			path.display()
+		)));
+	}
+	if mode & (0o4000 | 0o2000 | 0o1000) != 0 {
+		return Err(ComposeError::Unsupported(format!(
+			"mode {mode:#o} for {} sets setuid, setgid, or sticky bits on a secret/config file; \
+			 only plain owner read/write bits are permitted (e.g. 0o400 or 0o600)",
 			path.display()
 		)));
 	}
@@ -390,6 +401,33 @@ mod apply_mode_tests {
 		assert!(apply_mode(&file, 0o604).is_err());
 		assert!(apply_mode(&file, 0o777).is_err());
 		assert!(apply_mode(&file, 0o444).is_err());
+	}
+
+	#[test]
+	fn setuid_mode_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let file = dir.path().join("secret");
+		std::fs::write(&file, b"value").expect("write");
+		assert!(apply_mode(&file, 0o4400).is_err());
+		assert!(apply_mode(&file, 0o4000).is_err());
+	}
+
+	#[test]
+	fn setgid_mode_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let file = dir.path().join("secret");
+		std::fs::write(&file, b"value").expect("write");
+		assert!(apply_mode(&file, 0o2400).is_err());
+		assert!(apply_mode(&file, 0o2000).is_err());
+	}
+
+	#[test]
+	fn sticky_mode_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let file = dir.path().join("secret");
+		std::fs::write(&file, b"value").expect("write");
+		assert!(apply_mode(&file, 0o1400).is_err());
+		assert!(apply_mode(&file, 0o1000).is_err());
 	}
 }
 

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -103,3 +103,119 @@ pub fn merge_env(
 		})
 		.collect()
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::EnvFileEntry;
+
+	// load_env_file_entries
+
+	#[test]
+	fn loads_key_value_pairs() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "FOO=bar\nBAZ=qux\n").unwrap();
+		let entries = vec![EnvFileEntry::Path(".env".into())];
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("bar"));
+		assert_eq!(m.get("BAZ").map(|s| s.as_str()), Some("qux"));
+	}
+
+	#[test]
+	fn skips_comments_and_blank_lines() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "# comment\n\nFOO=bar\n").unwrap();
+		let entries = vec![EnvFileEntry::Path(".env".into())];
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert_eq!(m.len(), 1);
+	}
+
+	#[test]
+	fn key_without_equals_has_empty_value() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "BARE\n").unwrap();
+		let entries = vec![EnvFileEntry::Path(".env".into())];
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert_eq!(m.get("BARE").map(|s| s.as_str()), Some(""));
+	}
+
+	#[test]
+	fn first_file_wins_on_duplicate_key() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), "FOO=first\n").unwrap();
+		std::fs::write(dir.path().join("b.env"), "FOO=second\n").unwrap();
+		let entries = vec![
+			EnvFileEntry::Path("a.env".into()),
+			EnvFileEntry::Path("b.env".into()),
+		];
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("first"));
+	}
+
+	#[test]
+	fn missing_required_file_returns_error() {
+		let dir = tempfile::tempdir().unwrap();
+		let entries = vec![EnvFileEntry::Path("nonexistent.env".into())];
+		assert!(load_env_file_entries(&entries, dir.path()).is_err());
+	}
+
+	#[test]
+	fn missing_optional_file_skipped() {
+		let dir = tempfile::tempdir().unwrap();
+		let entries = vec![EnvFileEntry::Config {
+			path: "nonexistent.env".into(),
+			required: Some(false),
+			format: None,
+		}];
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert!(m.is_empty());
+	}
+
+	#[test]
+	fn unsupported_format_returns_error() {
+		let dir = tempfile::tempdir().unwrap();
+		let entries = vec![EnvFileEntry::Config {
+			path: ".env".into(),
+			required: Some(false),
+			format: Some("json".into()),
+		}];
+		assert!(load_env_file_entries(&entries, dir.path()).is_err());
+	}
+
+	// merge_env
+
+	#[test]
+	fn service_env_wins_over_file_env() {
+		let service_env: HashMap<String, Option<String>> =
+			[("FOO".to_string(), Some("from-service".to_string()))].into();
+		let file_env: HashMap<String, String> =
+			[("FOO".to_string(), "from-file".to_string())].into();
+		let result = merge_env(service_env, file_env);
+		let foo_entry = result
+			.iter()
+			.find(|s| s.starts_with("FOO="))
+			.unwrap()
+			.clone();
+		assert_eq!(foo_entry, "FOO=from-service");
+	}
+
+	#[test]
+	fn file_env_fills_missing_keys() {
+		let service_env: HashMap<String, Option<String>> = HashMap::new();
+		let file_env: HashMap<String, String> = [("BAR".to_string(), "baz".to_string())].into();
+		let result = merge_env(service_env, file_env);
+		assert!(result.iter().any(|s| s == "BAR=baz"));
+	}
+
+	#[test]
+	fn key_only_env_var_has_no_equals() {
+		let service_env: HashMap<String, Option<String>> =
+			[("PASSTHROUGH".to_string(), None)].into();
+		let result = merge_env(service_env, HashMap::new());
+		assert!(result.iter().any(|s| s == "PASSTHROUGH"));
+	}
+}

--- a/internal/ports.rs
+++ b/internal/ports.rs
@@ -249,7 +249,7 @@ fn expand_single_host_port(
 	}
 }
 
-const MAX_PORT_RANGE: usize = 1024;
+pub(crate) const MAX_PORT_RANGE: usize = 1024;
 
 /// Expand `start-end` or a single port string.
 fn expand_port_range(s: &str) -> Result<Vec<u16>> {
@@ -278,5 +278,182 @@ fn expand_port_range(s: &str) -> Result<Vec<u16>> {
 			.parse()
 			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
 		Ok(vec![p])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::{PortMapping, StringOrU16};
+
+	fn short(s: &str) -> PortMapping {
+		PortMapping::Short(s.to_string())
+	}
+
+	fn parse_one_short(s: &str) -> Vec<ParsedPort> {
+		parse_ports(&[short(s)]).unwrap()
+	}
+
+	// Container port only
+
+	#[test]
+	fn container_port_only() {
+		let ports = parse_one_short("80");
+		assert_eq!(ports.len(), 1);
+		assert_eq!(ports[0].container_port, 80);
+		assert_eq!(ports[0].protocol, "tcp");
+		assert_eq!(ports[0].host_ip, "");
+		assert!(ports[0].host_port.is_none());
+	}
+
+	#[test]
+	fn container_port_with_explicit_protocol() {
+		let ports = parse_one_short("53/udp");
+		assert_eq!(ports[0].container_port, 53);
+		assert_eq!(ports[0].protocol, "udp");
+	}
+
+	// host:container
+
+	#[test]
+	fn host_colon_container() {
+		let ports = parse_one_short("8080:80");
+		assert_eq!(ports[0].container_port, 80);
+		assert_eq!(ports[0].host_port, Some(8080));
+		assert_eq!(ports[0].host_ip, "");
+	}
+
+	// ip:host:container
+
+	#[test]
+	fn ip_host_container() {
+		let ports = parse_one_short("127.0.0.1:8080:80");
+		assert_eq!(ports[0].container_port, 80);
+		assert_eq!(ports[0].host_port, Some(8080));
+		assert_eq!(ports[0].host_ip, "127.0.0.1");
+	}
+
+	#[test]
+	fn ipv6_bracketed() {
+		let ports = parse_one_short("[::1]:8080:80");
+		assert_eq!(ports[0].container_port, 80);
+		assert_eq!(ports[0].host_port, Some(8080));
+		assert_eq!(ports[0].host_ip, "::1");
+	}
+
+	// Range expansion
+
+	#[test]
+	fn container_port_range() {
+		let ports = parse_one_short("80-82");
+		assert_eq!(ports.len(), 3);
+		assert_eq!(ports[0].container_port, 80);
+		assert_eq!(ports[2].container_port, 82);
+	}
+
+	#[test]
+	fn host_range_to_container_range() {
+		let ports = parse_one_short("8080-8082:80-82");
+		assert_eq!(ports.len(), 3);
+		assert_eq!(ports[0].host_port, Some(8080));
+		assert_eq!(ports[0].container_port, 80);
+		assert_eq!(ports[2].host_port, Some(8082));
+		assert_eq!(ports[2].container_port, 82);
+	}
+
+	#[test]
+	fn single_host_expanded_for_container_range() {
+		let ports = parse_one_short("8080:80-82");
+		assert_eq!(ports.len(), 3);
+		assert_eq!(ports[0].host_port, Some(8080));
+		assert_eq!(ports[1].host_port, Some(8081));
+		assert_eq!(ports[2].host_port, Some(8082));
+	}
+
+	// Error cases
+
+	#[test]
+	fn range_start_greater_than_end_is_error() {
+		assert!(parse_ports(&[short("85-80")]).is_err());
+	}
+
+	#[test]
+	fn range_too_large_is_error() {
+		let big = format!("1-{}", MAX_PORT_RANGE + 1);
+		assert!(parse_ports(&[short(&big)]).is_err());
+	}
+
+	#[test]
+	fn invalid_port_string_is_error() {
+		assert!(parse_ports(&[short("abc")]).is_err());
+	}
+
+	#[test]
+	fn unclosed_ipv6_bracket_is_error() {
+		assert!(parse_ports(&[short("[::1:80")]).is_err());
+	}
+
+	// Long form
+
+	#[test]
+	fn long_form_with_published() {
+		let mapping = PortMapping::Long {
+			target: 80,
+			published: Some(StringOrU16::Number(8080)),
+			protocol: Some("tcp".to_string()),
+			host_ip: Some("0.0.0.0".to_string()),
+			mode: None,
+			app_protocol: None,
+			name: None,
+		};
+		let ports = parse_ports(&[mapping]).unwrap();
+		assert_eq!(ports[0].container_port, 80);
+		assert_eq!(ports[0].host_port, Some(8080));
+		assert_eq!(ports[0].host_ip, "0.0.0.0");
+	}
+
+	#[test]
+	fn long_form_no_published_defaults_to_none() {
+		let mapping = PortMapping::Long {
+			target: 80,
+			published: None,
+			protocol: None,
+			host_ip: None,
+			mode: None,
+			app_protocol: None,
+			name: None,
+		};
+		let ports = parse_ports(&[mapping]).unwrap();
+		assert!(ports[0].host_port.is_none());
+		assert_eq!(ports[0].protocol, "tcp");
+	}
+
+	// to_bollard
+
+	#[test]
+	fn to_bollard_produces_key_and_binding() {
+		let ports = parse_one_short("8080:80");
+		let (bindings, exposed) = to_bollard(&ports);
+		assert!(bindings.contains_key("80/tcp"));
+		assert!(exposed.contains_key("80/tcp"));
+		let b = bindings["80/tcp"].as_ref().unwrap();
+		assert_eq!(b[0].host_port.as_deref(), Some("8080"));
+	}
+
+	#[test]
+	fn to_bollard_port_zero_encodes_empty_string() {
+		let ports = vec![ParsedPort {
+			container_port: 80,
+			protocol: "tcp".to_string(),
+			host_ip: String::new(),
+			host_port: Some(0),
+		}];
+		let (bindings, _) = to_bollard(&ports);
+		let b = bindings["80/tcp"].as_ref().unwrap();
+		assert_eq!(b[0].host_port.as_deref(), Some(""));
 	}
 }

--- a/internal/size.rs
+++ b/internal/size.rs
@@ -99,3 +99,150 @@ pub fn parse_duration_nanos(s: &str) -> Option<i64> {
 	};
 	Some(nanos as i64)
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// parse_memory
+
+	#[test]
+	fn memory_bare_bytes() {
+		assert_eq!(parse_memory("1024"), Some(1024));
+	}
+
+	#[test]
+	fn memory_suffix_b() {
+		assert_eq!(parse_memory("512b"), Some(512));
+	}
+
+	#[test]
+	fn memory_suffix_k() {
+		assert_eq!(parse_memory("4k"), Some(4 * 1024));
+	}
+
+	#[test]
+	fn memory_suffix_kb() {
+		assert_eq!(parse_memory("4kb"), Some(4 * 1024));
+	}
+
+	#[test]
+	fn memory_suffix_m() {
+		assert_eq!(parse_memory("128m"), Some(128 * 1024 * 1024));
+	}
+
+	#[test]
+	fn memory_suffix_mb() {
+		assert_eq!(parse_memory("128mb"), Some(128 * 1024 * 1024));
+	}
+
+	#[test]
+	fn memory_suffix_g() {
+		assert_eq!(parse_memory("1g"), Some(1024 * 1024 * 1024));
+	}
+
+	#[test]
+	fn memory_suffix_uppercase() {
+		assert_eq!(parse_memory("64M"), Some(64 * 1024 * 1024));
+	}
+
+	#[test]
+	fn memory_minus_one_special() {
+		assert_eq!(parse_memory("-1"), Some(-1));
+	}
+
+	#[test]
+	fn memory_empty_is_none() {
+		assert_eq!(parse_memory(""), None);
+	}
+
+	#[test]
+	fn memory_invalid_is_none() {
+		assert_eq!(parse_memory("abc"), None);
+	}
+
+	#[test]
+	fn memory_unknown_suffix_is_none() {
+		assert_eq!(parse_memory("100x"), None);
+	}
+
+	// parse_cpus
+
+	#[test]
+	fn cpus_integer() {
+		assert_eq!(parse_cpus("2"), Some(2_000_000_000));
+	}
+
+	#[test]
+	fn cpus_fraction() {
+		assert_eq!(parse_cpus("0.5"), Some(500_000_000));
+	}
+
+	#[test]
+	fn cpus_empty_is_none() {
+		assert_eq!(parse_cpus(""), None);
+	}
+
+	// parse_duration_secs
+
+	#[test]
+	fn duration_secs_plain_s() {
+		assert_eq!(parse_duration_secs("30s"), Some(30));
+	}
+
+	#[test]
+	fn duration_secs_minutes() {
+		assert_eq!(parse_duration_secs("2m"), Some(120));
+	}
+
+	#[test]
+	fn duration_secs_hours() {
+		assert_eq!(parse_duration_secs("1h"), Some(3600));
+	}
+
+	#[test]
+	fn duration_secs_milliseconds_truncates() {
+		assert_eq!(parse_duration_secs("500ms"), Some(0));
+	}
+
+	#[test]
+	fn duration_secs_bare_number() {
+		assert_eq!(parse_duration_secs("10"), Some(10));
+	}
+
+	#[test]
+	fn duration_secs_empty_is_none() {
+		assert_eq!(parse_duration_secs(""), None);
+	}
+
+	#[test]
+	fn duration_secs_unknown_suffix_is_none() {
+		assert_eq!(parse_duration_secs("5d"), None);
+	}
+
+	// parse_duration_nanos
+
+	#[test]
+	fn duration_nanos_seconds() {
+		assert_eq!(parse_duration_nanos("1s"), Some(1_000_000_000));
+	}
+
+	#[test]
+	fn duration_nanos_milliseconds() {
+		assert_eq!(parse_duration_nanos("200ms"), Some(200_000_000));
+	}
+
+	#[test]
+	fn duration_nanos_minutes() {
+		assert_eq!(parse_duration_nanos("1m"), Some(60 * 1_000_000_000));
+	}
+
+	#[test]
+	fn duration_nanos_nanoseconds() {
+		assert_eq!(parse_duration_nanos("500ns"), Some(500));
+	}
+}

--- a/internal/substitute.rs
+++ b/internal/substitute.rs
@@ -290,3 +290,230 @@ fn resolve_modifier(
 		},
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+		pairs
+			.iter()
+			.map(|(k, v)| (k.to_string(), v.to_string()))
+			.collect()
+	}
+
+	// Plain passthrough
+
+	#[test]
+	fn plain_text_unchanged() {
+		assert_eq!(
+			substitute("hello world", &vars(&[])).unwrap(),
+			"hello world"
+		);
+	}
+
+	#[test]
+	fn dollar_at_end_emitted_literally() {
+		assert_eq!(substitute("price$", &vars(&[])).unwrap(), "price$");
+	}
+
+	#[test]
+	fn double_dollar_becomes_single() {
+		assert_eq!(substitute("$$", &vars(&[])).unwrap(), "$");
+	}
+
+	// $VAR (unbraced)
+
+	#[test]
+	fn unbraced_var_set_expands() {
+		assert_eq!(substitute("$FOO", &vars(&[("FOO", "bar")])).unwrap(), "bar");
+	}
+
+	#[test]
+	fn unbraced_var_unset_expands_to_empty() {
+		assert_eq!(substitute("$MISSING", &vars(&[])).unwrap(), "");
+	}
+
+	#[test]
+	fn unbraced_var_followed_by_non_ident() {
+		assert_eq!(substitute("$FOO!", &vars(&[("FOO", "x")])).unwrap(), "x!");
+	}
+
+	// ${VAR} (braced, no modifier)
+
+	#[test]
+	fn braced_var_set_expands() {
+		assert_eq!(
+			substitute("${FOO}", &vars(&[("FOO", "val")])).unwrap(),
+			"val"
+		);
+	}
+
+	#[test]
+	fn braced_var_unset_expands_to_empty() {
+		assert_eq!(substitute("${MISSING}", &vars(&[])).unwrap(), "");
+	}
+
+	// ${VAR:-default}
+
+	#[test]
+	fn default_if_unset_or_empty_when_unset() {
+		assert_eq!(
+			substitute("${X:-fallback}", &vars(&[])).unwrap(),
+			"fallback"
+		);
+	}
+
+	#[test]
+	fn default_if_unset_or_empty_when_empty() {
+		assert_eq!(
+			substitute("${X:-fallback}", &vars(&[("X", "")])).unwrap(),
+			"fallback"
+		);
+	}
+
+	#[test]
+	fn default_if_unset_or_empty_when_set() {
+		assert_eq!(
+			substitute("${X:-fallback}", &vars(&[("X", "real")])).unwrap(),
+			"real"
+		);
+	}
+
+	// ${VAR-default}
+
+	#[test]
+	fn default_if_unset_when_unset() {
+		assert_eq!(substitute("${X-fallback}", &vars(&[])).unwrap(), "fallback");
+	}
+
+	#[test]
+	fn default_if_unset_when_empty_keeps_empty() {
+		assert_eq!(
+			substitute("${X-fallback}", &vars(&[("X", "")])).unwrap(),
+			""
+		);
+	}
+
+	#[test]
+	fn default_if_unset_when_set() {
+		assert_eq!(
+			substitute("${X-fallback}", &vars(&[("X", "v")])).unwrap(),
+			"v"
+		);
+	}
+
+	// ${VAR:+alt}
+
+	#[test]
+	fn alt_if_set_and_nonempty_when_unset() {
+		assert_eq!(substitute("${X:+alt}", &vars(&[])).unwrap(), "");
+	}
+
+	#[test]
+	fn alt_if_set_and_nonempty_when_empty() {
+		assert_eq!(substitute("${X:+alt}", &vars(&[("X", "")])).unwrap(), "");
+	}
+
+	#[test]
+	fn alt_if_set_and_nonempty_when_set() {
+		assert_eq!(
+			substitute("${X:+alt}", &vars(&[("X", "v")])).unwrap(),
+			"alt"
+		);
+	}
+
+	// ${VAR+alt}
+
+	#[test]
+	fn alt_if_set_when_unset() {
+		assert_eq!(substitute("${X+alt}", &vars(&[])).unwrap(), "");
+	}
+
+	#[test]
+	fn alt_if_set_when_empty_returns_alt() {
+		assert_eq!(substitute("${X+alt}", &vars(&[("X", "")])).unwrap(), "alt");
+	}
+
+	// ${VAR:?msg}
+
+	#[test]
+	fn error_if_unset_or_empty_when_unset() {
+		assert!(substitute("${X:?required}", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn error_if_unset_or_empty_when_empty() {
+		assert!(substitute("${X:?required}", &vars(&[("X", "")])).is_err());
+	}
+
+	#[test]
+	fn error_if_unset_or_empty_when_set() {
+		assert_eq!(
+			substitute("${X:?required}", &vars(&[("X", "ok")])).unwrap(),
+			"ok"
+		);
+	}
+
+	// ${VAR?msg}
+
+	#[test]
+	fn error_if_unset_when_unset() {
+		assert!(substitute("${X?required}", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn error_if_unset_when_empty_returns_empty() {
+		assert_eq!(
+			substitute("${X?required}", &vars(&[("X", "")])).unwrap(),
+			""
+		);
+	}
+
+	// Multiple substitutions in one string
+
+	#[test]
+	fn multiple_vars_in_string() {
+		let v = vars(&[("A", "hello"), ("B", "world")]);
+		assert_eq!(substitute("$A ${B}!", &v).unwrap(), "hello world!");
+	}
+
+	// load_dotenv
+
+	#[test]
+	fn load_dotenv_parses_key_value() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "FOO=bar\nBAZ=qux\n").unwrap();
+		let map = load_dotenv(dir.path());
+		assert_eq!(map.get("FOO").map(|s| s.as_str()), Some("bar"));
+		assert_eq!(map.get("BAZ").map(|s| s.as_str()), Some("qux"));
+	}
+
+	#[test]
+	fn load_dotenv_skips_comments_and_blank_lines() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "# comment\n\nFOO=bar\n").unwrap();
+		let map = load_dotenv(dir.path());
+		assert_eq!(map.len(), 1);
+		assert_eq!(map["FOO"], "bar");
+	}
+
+	#[test]
+	fn load_dotenv_key_without_equals_is_empty() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "BARE_KEY\n").unwrap();
+		let map = load_dotenv(dir.path());
+		assert_eq!(map.get("BARE_KEY").map(|s| s.as_str()), Some(""));
+	}
+
+	#[test]
+	fn load_dotenv_missing_file_returns_empty() {
+		let dir = tempfile::tempdir().unwrap();
+		let map = load_dotenv(dir.path());
+		assert!(map.is_empty());
+	}
+}


### PR DESCRIPTION
Merge develop → main for v0.5.8 release.

## Included

- fix: warn and honor deprecated top-level `mac_address` on service (#128)
- fix: warn on Swarm-only `deploy:` fields that have no effect on Podman (#129)
- docs: add Docker-to-Podman migration guide (#130)
- docs: correct `DeployConfig` doc comment (#131)
- security: reject setuid/setgid/sticky bits in secret/config file modes (#133)
- chore: bump version to 0.5.8 (#134)

## Post-merge

Tag `v0.5.8` on main to trigger release workflow.