### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "podup"
-version = "0.5.8"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.5.8"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+podup (0.6.0) unstable; urgency=medium
+
+  * Honor COMPOSE_PROJECT_NAME and COMPOSE_FILE environment variables.
+  * Forward build.secrets into the build context; support build.cache_to and
+    build.additional_contexts; warn that build.ssh has no libpod REST mapping.
+  * Support .dockerignore negation (!pattern) and ** recursive globs.
+  * Prevent zip-slip when copying files from a container to the host.
+  * Surface a failed container wait in `run` instead of reporting exit 0.
+  * Serialize mutating commands with a per-project advisory lock.
+  * Split oversized modules, add .editorconfig, document the libpod API prefix.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 08:50:00 -0500
+
+podup (0.5.8) unstable; urgency=low
+
+  * Add mac_address per-network fallback and Swarm-only deploy warnings.
+  * Add Docker migration and deploy documentation.
+  * Reject setuid/setgid/sticky bits in secret/config mode.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Wed, 10 Jun 2026 22:00:00 -0500
+
 podup (0.5.7) unstable; urgency=low
 
   * Add /// doc comments on all public types and engine methods.


### PR DESCRIPTION
Bump crate version to 0.6.0 for the compose-fidelity / security / standards release (PR #137 features). Updates Cargo.lock and debian/changelog (backfills the missing 0.5.8 entry).