### PR TITLE
release: v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,16 +80,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -144,12 +175,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -175,6 +313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +327,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -199,6 +349,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fsevent-sys"
@@ -283,6 +442,27 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -393,10 +573,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -485,6 +768,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -610,10 +899,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "podup"
@@ -621,6 +926,7 @@ version = "0.6.0"
 dependencies = [
  "bytes",
  "clap",
+ "ed25519-dalek",
  "flate2",
  "futures",
  "http-body-util",
@@ -632,12 +938,23 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "tar",
  "temp-env",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -675,6 +992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +1027,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +1060,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -797,6 +1181,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +1201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +1214,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -844,10 +1254,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -858,6 +1290,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -886,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -899,6 +1342,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -981,6 +1434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,10 +1458,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1082,6 +1586,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,11 +1620,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1116,20 +1647,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1139,9 +1692,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1151,9 +1716,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1163,15 +1740,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1271,6 +1866,95 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,12 @@ tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"
 notify = { version = "8", optional = true }
+# Self-update: HTTPS fetch of signed release assets and verification.
+# ureq (rustls + webpki roots) keeps static musl builds self-contained; the
+# Ed25519 signature pinned to an embedded key is the real trust anchor, not TLS.
+ureq = { version = "2", default-features = false, features = ["tls"] }
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ from source:
 cargo build --release
 ```
 
+### Updating
+
+```bash
+podup update            # download and install the latest signed release
+podup update --check    # report whether a newer release exists, install nothing
+```
+
+`podup update` replaces the running binary in place, but only after verifying
+the release's Ed25519 signature against the public key embedded in your build
+and matching its SHA-256 checksum. It fails closed: a bad signature, missing
+key, or checksum mismatch aborts before the installed binary is touched. See
+[docs/self-update.md](docs/self-update.md) for the trust model. Installing into
+a system directory (e.g. `/usr/local/bin`) needs elevation — re-run with `sudo`.
+
 ## 🚀 Quick start
 
 ```bash

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -1,0 +1,90 @@
+# Self-update security model
+
+`podup update` replaces the running binary with the latest release. The design
+goal is that **the update source is impossible to tamper with**: no attacker —
+even one who controls the network or the download host — can make `podup`
+install a modified binary.
+
+## Trust anchor
+
+The trust anchor is **not** the download domain, DNS, or TLS. It is an **Ed25519
+public key compiled into the binary** (`internal/update/verify.rs`,
+`RELEASE_PUBKEY`). The matching private key exists only as the
+`RELEASE_SIGN_KEY` GitHub Actions secret and signs every release in CI
+(`.github/workflows/release.yml`).
+
+Because the public key is baked into a binary that is itself signed and carries
+a GitHub build-provenance attestation, an attacker cannot swap the key without
+invalidating the binary that contains it. TLS only protects transport; it is not
+relied on for integrity.
+
+## Verification flow
+
+`podup update` performs, in order, failing closed at the first problem:
+
+1. Resolve the latest release tag from the GitHub API and compare it with the
+   compiled-in version (`env!("CARGO_PKG_VERSION")`). Nothing is downloaded if
+   the current build is already newest (unless `--force`).
+2. Download the platform binary, `SHA256SUMS`, and `SHA256SUMS.sig` over HTTPS
+   (rustls + webpki roots; HTTPS-only URLs).
+3. **Verify the Ed25519 signature** of `SHA256SUMS` against the embedded public
+   key. A missing/placeholder key, malformed signature, or bad signature aborts
+   here — nothing is written.
+4. Look up the binary's expected SHA-256 in the now-trusted `SHA256SUMS` and
+   verify the downloaded bytes match.
+5. Atomically replace the running executable (write a sibling temp file, fsync,
+   preserve mode, then `rename`). On Windows the in-use `.exe` is renamed aside
+   first and cleaned up on the next run.
+
+Any failure exits with code `2` and leaves the installed binary untouched.
+
+## install.sh
+
+The one-line installer applies the same fail-closed policy. It requires **at
+least one** strong proof to succeed — the Ed25519 signature (when `python3` +
+`cryptography` and a configured public key are present) **or** the GitHub
+build-provenance attestation (`gh attestation verify`). If neither verifier is
+available it refuses to install. `PODUP_INSECURE_SKIP_VERIFY=1` is the explicit,
+documented opt-out (checksum only) for constrained environments.
+
+## The embedded public key
+
+The release public key is embedded in two places, both holding the same key
+(base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`):
+
+- `internal/update/verify.rs` — `RELEASE_PUBKEY` (raw 32 bytes).
+- `install.sh` — `PODUP_RELEASE_PUBKEY_B64` default (base64, unpadded).
+
+It is verified against the genuine published `SHA256SUMS.sig` by the
+`embedded_key_verifies_real_release` regression test, so an accidental or
+malicious edit to the constant fails CI. If the key is ever zeroed, both the
+binary and the installer fail closed and install nothing. The same key signs
+`podup`, `panel`, and `panel-agent` releases (shared `RELEASE_SIGN_KEY`).
+
+### Deriving the public key from the signing secret
+
+To re-derive or rotate it, run locally with the `RELEASE_SIGN_KEY` value (the
+raw 32-byte Ed25519 seed, base64). **Never commit or share the private seed** —
+only its public half:
+
+```bash
+python3 -c '
+import base64, sys
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+seed = base64.b64decode(sys.argv[1] + "==")
+pub = Ed25519PrivateKey.from_private_bytes(seed).public_key()
+raw = pub.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+print("install.sh base64 :", base64.b64encode(raw).decode().rstrip("="))
+print("verify.rs bytes   :", ", ".join(str(b) for b in raw))
+' "$RELEASE_SIGN_KEY"
+```
+
+Paste the base64 form into `install.sh` and the byte array into `RELEASE_PUBKEY`.
+
+### Key rotation
+
+Rotating the signing key requires shipping a new binary that embeds the new
+public key *before* the first release signed with the new private key — older
+binaries verify only against the key they were built with. Plan a release that
+updates the embedded key, then switch the CI secret on the following release.

--- a/install.sh
+++ b/install.sh
@@ -74,10 +74,21 @@ curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS.sig" \
 
 # --- Verify ------------------------------------------------------------------
 
+# Checksum alone is not a trust anchor: a tampered release can ship a matching
+# SHA256SUMS. The binary is trusted only after at least one cryptographic proof
+# tied to the release key or the repository's build identity succeeds — the
+# Ed25519 signature over SHA256SUMS, or the GitHub build-provenance attestation.
+# If neither verifier can run, the install fails closed. Set
+# PODUP_INSECURE_SKIP_VERIFY=1 to explicitly opt out (checksum only).
+
+# Baked-in base64 (unpadded) raw Ed25519 public key (32 bytes) matching the
+# release signing key (RELEASE_SIGN_KEY). Verified against the genuine published
+# SHA256SUMS.sig. Override for a fork via the PODUP_RELEASE_PUBKEY_B64 env var.
+PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y}"
+
+verified=0
+
 log_info "Verifying SHA256SUMS signature ..."
-# Base64-encoded raw Ed25519 public key (32 bytes) matching RELEASE_SIGN_KEY.
-# Set PODUP_RELEASE_PUBKEY_B64 to override (e.g. for testing a fork).
-PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-}"
 if [[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]; then
 	if command -v python3 >/dev/null 2>&1 && python3 -c "from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey" 2>/dev/null; then
 		if python3 - "${TMP_DIR}/SHA256SUMS.sig" "${TMP_DIR}/SHA256SUMS" "$PODUP_RELEASE_PUBKEY_B64" <<'PYEOF'
@@ -94,32 +105,44 @@ except InvalidSignature:
 PYEOF
 		then
 			log_ok "SHA256SUMS signature verified"
+			verified=1
 		else
 			fail "SHA256SUMS signature verification failed — release may be tampered"
 		fi
 	else
-		log_info "python3+cryptography not available — skipping SHA256SUMS signature verification"
+		log_info "python3+cryptography not available — cannot check Ed25519 signature"
 	fi
 else
-	log_info "PODUP_RELEASE_PUBKEY_B64 not set — skipping SHA256SUMS signature verification"
+	log_info "no release public key configured — skipping Ed25519 signature check"
+fi
+
+# Build-provenance attestation: proves the binary was produced by this repo's
+# release workflow (GitHub OIDC). Strong even without the release public key.
+if command -v gh >/dev/null 2>&1 && gh attestation --help >/dev/null 2>&1; then
+	log_info "Verifying artifact attestation ..."
+	gh attestation verify "${TMP_DIR}/${ARTIFACT}" --repo "$REPO" >/dev/null \
+		|| fail "Attestation verification failed for ${ARTIFACT}"
+	log_ok "Attestation verified"
+	verified=1
+else
+	log_info "GitHub CLI with attestation support not found — cannot check attestation"
+fi
+
+# Fail closed unless a strong proof succeeded or the user explicitly opts out.
+if [[ "$verified" -ne 1 ]]; then
+	if [[ "${PODUP_INSECURE_SKIP_VERIFY:-0}" == "1" ]]; then
+		log_info "PODUP_INSECURE_SKIP_VERIFY=1 — proceeding with checksum verification only"
+	else
+		fail "No signature or attestation verifier available. Install 'gh' (>= 2.49) \
+or python3 with the 'cryptography' package, set PODUP_RELEASE_PUBKEY_B64, or re-run \
+with PODUP_INSECURE_SKIP_VERIFY=1 to accept checksum-only verification."
+	fi
 fi
 
 log_info "Verifying SHA-256 checksum ..."
 (cd "$TMP_DIR" && grep " ${ARTIFACT}\$" SHA256SUMS | "${SHA256_CMD[@]}" -c --quiet -) \
 	|| fail "Checksum verification failed for ${ARTIFACT}"
 log_ok "Checksum verified"
-
-# Verify the build provenance attestation when the GitHub CLI supports it
-# (gh >= 2.49). This proves the binary was built by this repository's release
-# workflow. When the subcommand actually runs and fails, abort.
-if command -v gh >/dev/null 2>&1 && gh attestation --help >/dev/null 2>&1; then
-	log_info "Verifying artifact attestation ..."
-	gh attestation verify "${TMP_DIR}/${ARTIFACT}" --repo "$REPO" >/dev/null \
-		|| fail "Attestation verification failed for ${ARTIFACT}"
-	log_ok "Attestation verified"
-else
-	log_info "GitHub CLI with attestation support not found — skipping attestation verification (checksum already verified)"
-fi
 
 # --- Install -----------------------------------------------------------------
 

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -24,6 +24,7 @@ pub enum ComposeError {
 	Watch(String),
 	Unsupported(String),
 	RunExited(i64),
+	Update(String),
 }
 
 impl fmt::Display for ComposeError {
@@ -47,6 +48,7 @@ impl fmt::Display for ComposeError {
 			Self::Watch(s) => write!(f, "watch error: {s}"),
 			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
+			Self::Update(s) => write!(f, "update error: {s}"),
 		}
 	}
 }
@@ -138,6 +140,7 @@ mod tests {
 				"run container exited with code 1",
 				ComposeError::RunExited(1),
 			),
+			("update error: u", ComposeError::Update("u".into())),
 		];
 		for (expected_prefix, err) in cases {
 			let msg = err.to_string();

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -13,6 +13,7 @@ pub mod podman;
 pub mod ports;
 pub mod size;
 pub mod substitute;
+pub mod update;
 
 pub use compose::{parse_file, parse_str, parse_str_raw, resolve_order};
 pub use engine::{Engine, ProjectLock, RunOptions};

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -193,6 +193,21 @@ enum Commands {
 	Config,
 	/// Watch for file changes and sync/rebuild/restart as configured by develop.watch.
 	Watch,
+	/// Update podup to the latest signed release.
+	///
+	/// Downloads the release binary for this platform and replaces the running
+	/// executable, but only after verifying the release's Ed25519 signature
+	/// against the public key embedded in this build and matching its SHA-256
+	/// checksum. Verification fails closed: a missing key, bad signature, or
+	/// checksum mismatch aborts without touching the installed binary.
+	Update {
+		/// Report whether a newer release exists without installing it.
+		#[arg(long)]
+		check: bool,
+		/// Reinstall even if the latest release is not newer than this build.
+		#[arg(long)]
+		force: bool,
+	},
 }
 
 /// Whether a command creates, destroys, or changes the state of containers and
@@ -219,6 +234,10 @@ async fn main() {
 	match run().await {
 		Ok(()) => {}
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
+		Err(e @ podup::ComposeError::Update(_)) => {
+			eprintln!("error: {e}");
+			process::exit(podup::update::exit_code(&e));
+		}
 		Err(e) => {
 			eprintln!("error: {e}");
 			process::exit(1);
@@ -232,6 +251,19 @@ async fn run() -> podup::Result<()> {
 		.init();
 
 	let cli = Cli::parse();
+
+	// `update` operates on the binary itself, not a compose project, so it runs
+	// before any compose file is parsed or Podman is contacted. The network and
+	// filesystem work is blocking; keep it off the async path entirely.
+	if let Commands::Update { check, force } = cli.command {
+		let opts = podup::update::UpdateOptions {
+			check_only: check,
+			force,
+		};
+		return tokio::task::spawn_blocking(move || podup::update::run(opts))
+			.await
+			.map_err(|e| podup::ComposeError::Update(format!("update task failed: {e}")))?;
+	}
 
 	let file = podup::parse_file(&cli.file)?;
 
@@ -331,6 +363,7 @@ async fn run() -> podup::Result<()> {
 		Commands::Restart { service } => engine.restart(&file, service.as_deref()).await?,
 		Commands::Config => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
+		Commands::Update { .. } => unreachable!("handled before compose parsing"),
 	}
 
 	Ok(())

--- a/internal/update/github.rs
+++ b/internal/update/github.rs
@@ -1,0 +1,131 @@
+//! GitHub release source for self-update.
+//!
+//! Talks to GitHub over HTTPS only (rustls + webpki roots via `ureq`). TLS
+//! guards transport, but the downloaded bytes are trusted only after the
+//! Ed25519 signature check in [`super::verify`] — a compromised endpoint cannot
+//! produce a binary that passes that check.
+
+use std::io::Read;
+
+use crate::ComposeError;
+
+use super::ReleaseSource;
+
+/// `owner/repo` slug of the canonical release repository.
+pub const REPO: &str = "Glyndor/podup";
+
+/// Hard cap on any single downloaded asset (defensive against a hostile or
+/// broken endpoint streaming unbounded data into memory).
+const MAX_ASSET_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Fetches release metadata and assets from GitHub.
+pub struct GitHubSource {
+	repo: String,
+	agent: ureq::Agent,
+}
+
+impl GitHubSource {
+	/// Source for the given `owner/repo`.
+	pub fn new(repo: impl Into<String>) -> Self {
+		let agent = ureq::AgentBuilder::new()
+			.timeout(std::time::Duration::from_secs(60))
+			.user_agent(concat!("podup/", env!("CARGO_PKG_VERSION")))
+			.build();
+		Self {
+			repo: repo.into(),
+			agent,
+		}
+	}
+}
+
+impl Default for GitHubSource {
+	fn default() -> Self {
+		Self::new(REPO)
+	}
+}
+
+/// Read at most `MAX_ASSET_BYTES` from `reader`, erroring if the stream exceeds
+/// the cap rather than truncating silently.
+fn read_capped(mut reader: impl Read) -> crate::Result<Vec<u8>> {
+	let mut buf = Vec::new();
+	let read = reader
+		.by_ref()
+		.take(MAX_ASSET_BYTES + 1)
+		.read_to_end(&mut buf)
+		.map_err(ComposeError::Io)?;
+	if read as u64 > MAX_ASSET_BYTES {
+		return Err(ComposeError::Update(
+			"release asset exceeds the maximum allowed size".to_string(),
+		));
+	}
+	Ok(buf)
+}
+
+impl ReleaseSource for GitHubSource {
+	fn latest_version(&self) -> crate::Result<String> {
+		let url = format!("https://api.github.com/repos/{}/releases/latest", self.repo);
+		let body = self
+			.agent
+			.get(&url)
+			.set("Accept", "application/vnd.github+json")
+			.call()
+			.map_err(|e| ComposeError::Update(format!("cannot reach GitHub releases API: {e}")))?
+			.into_string()
+			.map_err(|e| ComposeError::Update(format!("failed reading release metadata: {e}")))?;
+
+		#[derive(serde::Deserialize)]
+		struct Latest {
+			tag_name: String,
+		}
+		let latest: Latest = serde_json::from_str(&body)
+			.map_err(|e| ComposeError::Update(format!("malformed release metadata: {e}")))?;
+		Ok(latest.tag_name)
+	}
+
+	fn fetch(&self, asset: &str) -> crate::Result<Vec<u8>> {
+		// Pinned to the latest release; `ureq` follows GitHub's redirect to the
+		// asset host. Always HTTPS — the URL is a compile-time constant scheme.
+		let url = format!(
+			"https://github.com/{}/releases/latest/download/{asset}",
+			self.repo
+		);
+		let resp = self
+			.agent
+			.get(&url)
+			.call()
+			.map_err(|e| ComposeError::Update(format!("download failed for {asset}: {e}")))?;
+		read_capped(resp.into_reader())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn read_capped_accepts_small() {
+		let data = b"hello world".to_vec();
+		let got = read_capped(&data[..]).unwrap();
+		assert_eq!(got, data);
+	}
+
+	#[test]
+	fn read_capped_rejects_oversize() {
+		struct Endless;
+		impl Read for Endless {
+			fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+				for b in buf.iter_mut() {
+					*b = 0;
+				}
+				Ok(buf.len())
+			}
+		}
+		assert!(read_capped(Endless).is_err());
+	}
+
+	#[test]
+	fn default_uses_canonical_repo() {
+		let src = GitHubSource::default();
+		assert_eq!(src.repo, REPO);
+	}
+}

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -1,0 +1,215 @@
+//! Atomic, in-place replacement of the running binary.
+//!
+//! The verified new bytes are written to a temporary file in the *same*
+//! directory as the target (so the final swap is a same-filesystem rename, which
+//! is atomic) and then moved into place. On Unix the running binary's inode can
+//! be replaced directly. On Windows a running `.exe` cannot be overwritten, so
+//! the current file is renamed aside (`.old`) first and cleaned up on the next
+//! run.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::ComposeError;
+
+/// The release asset name for the platform this binary was built for. Mirrors
+/// the `release.yml` build matrix exactly.
+pub fn platform_asset() -> Option<&'static str> {
+	match (std::env::consts::OS, std::env::consts::ARCH) {
+		("linux", "x86_64") => Some("podup-linux-x86_64"),
+		("linux", "aarch64") => Some("podup-linux-arm64"),
+		("macos", "aarch64") => Some("podup-darwin-arm64"),
+		("macos", "x86_64") => Some("podup-darwin-x86_64"),
+		("windows", "x86_64") => Some("podup-windows-x86_64.exe"),
+		_ => None,
+	}
+}
+
+/// Resolve the asset for the current platform or fail with a clear message.
+pub fn require_platform_asset() -> crate::Result<&'static str> {
+	platform_asset().ok_or_else(|| {
+		ComposeError::Update(format!(
+			"self-update is not supported on {}/{}; reinstall manually from \
+			 https://github.com/Glyndor/podup/releases",
+			std::env::consts::OS,
+			std::env::consts::ARCH
+		))
+	})
+}
+
+/// Replace the currently running executable with `new_bytes`. Returns the path
+/// that was updated. The caller MUST have verified `new_bytes` first.
+pub fn install_binary(new_bytes: &[u8]) -> crate::Result<PathBuf> {
+	let exe = std::env::current_exe()
+		.map_err(|e| ComposeError::Update(format!("cannot locate current executable: {e}")))?;
+	// Resolve symlinks so we replace the real file, not a symlink pointing at it.
+	let target = std::fs::canonicalize(&exe).unwrap_or(exe);
+	install_at(&target, new_bytes)?;
+	Ok(target)
+}
+
+/// Write `new_bytes` to a sibling temp file and atomically move it onto
+/// `target`, preserving the target's permissions. Factored out of
+/// [`install_binary`] so the swap is testable against an arbitrary path.
+pub fn install_at(target: &Path, new_bytes: &[u8]) -> crate::Result<()> {
+	let dir = target.parent().ok_or_else(|| {
+		ComposeError::Update(format!(
+			"target {} has no parent directory",
+			target.display()
+		))
+	})?;
+
+	let file_name = target
+		.file_name()
+		.map(|n| n.to_string_lossy().into_owned())
+		.unwrap_or_else(|| "podup".to_string());
+	let tmp = dir.join(format!(".{file_name}.update-{}", std::process::id()));
+
+	write_temp(&tmp, new_bytes, target).inspect_err(|_| {
+		let _ = std::fs::remove_file(&tmp);
+	})?;
+
+	if let Err(e) = swap_into_place(&tmp, target) {
+		let _ = std::fs::remove_file(&tmp);
+		return Err(e);
+	}
+	Ok(())
+}
+
+/// Write the new bytes to `tmp`, copy `target`'s permission bits (default 0755
+/// on Unix when the target does not yet exist), and flush to disk.
+fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> {
+	let mut f = std::fs::File::create(tmp).map_err(|e| {
+		ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
+	})?;
+	f.write_all(new_bytes).map_err(ComposeError::Io)?;
+	f.flush().map_err(ComposeError::Io)?;
+
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+		let mode = std::fs::metadata(target)
+			.map(|m| m.permissions().mode())
+			.unwrap_or(0o755);
+		std::fs::set_permissions(tmp, std::fs::Permissions::from_mode(mode))
+			.map_err(ComposeError::Io)?;
+	}
+	#[cfg(not(unix))]
+	{
+		let _ = target; // permissions are inherited on non-Unix.
+	}
+
+	f.sync_all().map_err(ComposeError::Io)?;
+	Ok(())
+}
+
+/// Atomically move `tmp` onto `target`. Unix replaces the inode directly;
+/// Windows renames the in-use file aside first.
+#[cfg(not(windows))]
+fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
+	std::fs::rename(tmp, target).map_err(|e| rename_error(e, target))
+}
+
+#[cfg(windows)]
+fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
+	// A running .exe cannot be overwritten, but it can be renamed. Move it aside,
+	// put the new binary in place, then best-effort delete the old one (it may
+	// still be locked while running — the next run cleans it up).
+	let backup = target.with_extension("old");
+	let _ = std::fs::remove_file(&backup);
+	if target.exists() {
+		std::fs::rename(target, &backup).map_err(|e| rename_error(e, target))?;
+	}
+	if let Err(e) = std::fs::rename(tmp, target) {
+		// Roll back so the user is not left without a binary.
+		let _ = std::fs::rename(&backup, target);
+		return Err(rename_error(e, target));
+	}
+	let _ = std::fs::remove_file(&backup);
+	Ok(())
+}
+
+/// Turn a rename failure into an actionable error, calling out the common
+/// permission case (system install dirs need elevation).
+fn rename_error(e: std::io::Error, target: &Path) -> ComposeError {
+	if e.kind() == std::io::ErrorKind::PermissionDenied {
+		ComposeError::Update(format!(
+			"permission denied writing {}; re-run with elevated privileges \
+			 (e.g. sudo) or set a writable install location",
+			target.display()
+		))
+	} else {
+		ComposeError::Update(format!(
+			"failed to install update to {}: {e}",
+			target.display()
+		))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn platform_asset_matches_known_targets() {
+		// Whatever host runs the tests, the asset (if any) must be one of the
+		// release matrix names.
+		if let Some(asset) = platform_asset() {
+			assert!(asset.starts_with("podup-"));
+		}
+	}
+
+	#[test]
+	fn install_at_replaces_contents() {
+		let dir = tempfile::tempdir().unwrap();
+		let target = dir.path().join("podup");
+		std::fs::write(&target, b"old version").unwrap();
+
+		install_at(&target, b"new version").unwrap();
+		assert_eq!(std::fs::read(&target).unwrap(), b"new version");
+	}
+
+	#[test]
+	fn install_at_creates_when_absent() {
+		let dir = tempfile::tempdir().unwrap();
+		let target = dir.path().join("podup");
+		install_at(&target, b"fresh").unwrap();
+		assert_eq!(std::fs::read(&target).unwrap(), b"fresh");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn install_at_preserves_executable_mode() {
+		use std::os::unix::fs::PermissionsExt;
+		let dir = tempfile::tempdir().unwrap();
+		let target = dir.path().join("podup");
+		std::fs::write(&target, b"old").unwrap();
+		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+		install_at(&target, b"new").unwrap();
+		let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+		assert_eq!(mode & 0o777, 0o755);
+	}
+
+	#[test]
+	fn install_at_leaves_no_temp_files() {
+		let dir = tempfile::tempdir().unwrap();
+		let target = dir.path().join("podup");
+		install_at(&target, b"data").unwrap();
+		let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+			.unwrap()
+			.filter_map(|e| e.ok())
+			.filter(|e| e.file_name().to_string_lossy().contains("update-"))
+			.collect();
+		assert!(leftovers.is_empty(), "temp file left behind");
+	}
+
+	#[test]
+	fn require_platform_asset_is_consistent() {
+		match (platform_asset(), require_platform_asset()) {
+			(Some(a), Ok(b)) => assert_eq!(a, b),
+			(None, Err(_)) => {}
+			_ => panic!("platform_asset and require_platform_asset disagree"),
+		}
+	}
+}

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -1,0 +1,199 @@
+//! Secure self-update for the `podup` binary.
+//!
+//! Flow: resolve the latest release tag, compare against the compiled-in
+//! version, and (unless `--check`) download the platform binary plus the signed
+//! `SHA256SUMS` manifest. The manifest's Ed25519 signature is verified against
+//! the public key embedded in this binary ([`verify::RELEASE_PUBKEY`]); only
+//! then is the binary's digest checked against the manifest and the running
+//! executable atomically replaced. Every step fails closed — a missing key,
+//! bad signature, or checksum mismatch aborts before anything is written.
+
+mod github;
+mod install;
+mod verify;
+
+pub use github::{GitHubSource, REPO};
+
+use crate::ComposeError;
+
+/// Options controlling an update run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UpdateOptions {
+	/// Report whether a newer release exists without installing it.
+	pub check_only: bool,
+	/// Reinstall even if the latest release is not newer than the current build.
+	pub force: bool,
+}
+
+/// A source of release metadata and assets. Abstracted so the verification and
+/// install flow can be exercised without network access.
+pub trait ReleaseSource {
+	/// Latest published release tag (e.g. `v0.6.0`).
+	fn latest_version(&self) -> crate::Result<String>;
+	/// Raw bytes of a named release asset.
+	fn fetch(&self, asset: &str) -> crate::Result<Vec<u8>>;
+}
+
+/// Run an update against GitHub for the version compiled into this binary.
+pub fn run(opts: UpdateOptions) -> crate::Result<()> {
+	let source = GitHubSource::default();
+	run_with(&source, env!("CARGO_PKG_VERSION"), opts)
+}
+
+/// Core update flow against an arbitrary [`ReleaseSource`] and current version.
+pub fn run_with(
+	source: &dyn ReleaseSource,
+	current: &str,
+	opts: UpdateOptions,
+) -> crate::Result<()> {
+	let current_v = verify::parse_version(current)?;
+	let latest_tag = source.latest_version()?;
+	let latest_v = verify::parse_version(&latest_tag)?;
+
+	if latest_v <= current_v && !opts.force {
+		println!("podup is up to date (v{current})");
+		return Ok(());
+	}
+
+	if latest_v > current_v {
+		println!("update available: v{current} -> {latest_tag}");
+	} else {
+		println!("reinstalling {latest_tag} (--force)");
+	}
+	if opts.check_only {
+		println!("run `podup update` to install it");
+		return Ok(());
+	}
+
+	let asset = install::require_platform_asset()?;
+	println!("downloading {asset} ({latest_tag}) ...");
+	let binary = source.fetch(asset)?;
+	let sha256sums = source.fetch("SHA256SUMS")?;
+	let signature = source.fetch("SHA256SUMS.sig")?;
+
+	// Security gate: signed manifest first, then the binary's digest against it.
+	verify::verify_signature(&sha256sums, &signature)?;
+	let expected = verify::expected_digest(&sha256sums, asset)?;
+	verify::verify_digest(&binary, &expected)?;
+	println!("signature and checksum verified");
+
+	let path = install::install_binary(&binary)?;
+	println!("updated to {latest_tag}: {}", path.display());
+	Ok(())
+}
+
+/// Map an update failure onto a stable process exit code (`2`), distinct from a
+/// run-container exit, so scripts can branch on "update failed".
+pub fn exit_code(_err: &ComposeError) -> i32 {
+	2
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::cell::RefCell;
+	use std::collections::HashMap;
+
+	/// In-memory release source signed with a throwaway key, so the full flow
+	/// (version gate, signature, checksum, install) runs without network or the
+	/// placeholder pubkey guard.
+	struct MockSource {
+		latest: String,
+		assets: HashMap<String, Vec<u8>>,
+		fetched: RefCell<Vec<String>>,
+	}
+
+	impl ReleaseSource for MockSource {
+		fn latest_version(&self) -> crate::Result<String> {
+			Ok(self.latest.clone())
+		}
+		fn fetch(&self, asset: &str) -> crate::Result<Vec<u8>> {
+			self.fetched.borrow_mut().push(asset.to_string());
+			self.assets
+				.get(asset)
+				.cloned()
+				.ok_or_else(|| ComposeError::Update(format!("missing asset {asset}")))
+		}
+	}
+
+	#[test]
+	fn up_to_date_skips_download() {
+		let src = MockSource {
+			latest: "v0.6.0".into(),
+			assets: HashMap::new(),
+			fetched: RefCell::new(Vec::new()),
+		};
+		run_with(&src, "0.6.0", UpdateOptions::default()).unwrap();
+		assert!(
+			src.fetched.borrow().is_empty(),
+			"must not fetch when current"
+		);
+	}
+
+	#[test]
+	fn newer_release_check_only_does_not_install() {
+		let src = MockSource {
+			latest: "v0.7.0".into(),
+			assets: HashMap::new(),
+			fetched: RefCell::new(Vec::new()),
+		};
+		let opts = UpdateOptions {
+			check_only: true,
+			force: false,
+		};
+		run_with(&src, "0.6.0", opts).unwrap();
+		assert!(
+			src.fetched.borrow().is_empty(),
+			"check-only must not download"
+		);
+	}
+
+	#[test]
+	fn bad_version_from_source_errors() {
+		let src = MockSource {
+			latest: "not-a-version".into(),
+			assets: HashMap::new(),
+			fetched: RefCell::new(Vec::new()),
+		};
+		assert!(run_with(&src, "0.6.0", UpdateOptions::default()).is_err());
+	}
+
+	#[test]
+	fn newer_release_with_real_install_path() {
+		// Only meaningful where the host maps to a known release asset.
+		let Some(asset) = install::platform_asset() else {
+			return;
+		};
+
+		use ed25519_dalek::{Signer, SigningKey};
+		let sk = SigningKey::from_bytes(&[42u8; 32]);
+
+		let binary = b"the new podup binary".to_vec();
+		let digest = verify::sha256_hex(&binary);
+		let sums = format!("{digest}  {asset}\n");
+		let sig = sk.sign(sums.as_bytes()).to_bytes().to_vec();
+
+		let mut assets = HashMap::new();
+		assets.insert(asset.to_string(), binary.clone());
+		assets.insert("SHA256SUMS".to_string(), sums.into_bytes());
+		assets.insert("SHA256SUMS.sig".to_string(), sig);
+
+		let src = MockSource {
+			latest: "v9.9.9".into(),
+			assets,
+			fetched: RefCell::new(Vec::new()),
+		};
+
+		// The manifest is internally consistent but signed with a throwaway key,
+		// not the embedded release key — verification must fail closed, proving
+		// the gate rejects anything not signed by the real key.
+		let err = run_with(&src, "0.6.0", UpdateOptions::default()).unwrap_err();
+		assert!(matches!(err, ComposeError::Update(_)));
+		assert!(src.fetched.borrow().contains(&"SHA256SUMS.sig".to_string()));
+	}
+
+	#[test]
+	fn exit_code_is_two() {
+		assert_eq!(exit_code(&ComposeError::Update("x".into())), 2);
+	}
+}

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -1,0 +1,341 @@
+//! Verification primitives for self-update — the security core.
+//!
+//! Trust anchor is the Ed25519 public key embedded in this binary
+//! ([`RELEASE_PUBKEY`]), not the download domain or TLS. A release is accepted
+//! only if `SHA256SUMS` carries a valid signature from the matching private key
+//! (held in CI as `RELEASE_SIGN_KEY`) and the downloaded binary's SHA-256 digest
+//! appears in that signed manifest. Every check fails closed.
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use crate::ComposeError;
+
+/// Raw 32-byte Ed25519 public key matching the Glyndor release signing key
+/// (`RELEASE_SIGN_KEY`, base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`).
+/// The key is public by design — its integrity comes from being baked into the
+/// signed, build-provenance-attested binary, so an attacker cannot swap it
+/// without invalidating the binary itself.
+///
+/// Verified against the genuine published `SHA256SUMS.sig` (see
+/// `embedded_key_verifies_real_release`). [`release_pubkey`] still fails closed
+/// if this is ever zeroed, so a misbuild can never trust an unverifiable release.
+pub const RELEASE_PUBKEY: [u8; 32] = [
+	0, 248, 126, 146, 30, 181, 116, 151, 147, 208, 124, 198, 248, 164, 23, 16, 188, 195, 140, 174,
+	28, 114, 250, 152, 244, 175, 133, 166, 211, 153, 223, 230,
+];
+
+/// A parsed `MAJOR.MINOR.PATCH` version, ordered for comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+	pub major: u64,
+	pub minor: u64,
+	pub patch: u64,
+}
+
+/// Parse a `vX.Y.Z` or `X.Y.Z` version string. Anything else is rejected so a
+/// malformed tag can never be mistaken for "newer".
+pub fn parse_version(s: &str) -> crate::Result<Version> {
+	let trimmed = s.trim();
+	let core = trimmed.strip_prefix('v').unwrap_or(trimmed);
+	let mut parts = core.split('.');
+	let mut next = |what: &str| -> crate::Result<u64> {
+		parts
+			.next()
+			.and_then(|p| p.parse::<u64>().ok())
+			.ok_or_else(|| ComposeError::Update(format!("invalid version '{s}': bad {what}")))
+	};
+	let major = next("major")?;
+	let minor = next("minor")?;
+	let patch = next("patch")?;
+	if parts.next().is_some() {
+		return Err(ComposeError::Update(format!(
+			"invalid version '{s}': too many components"
+		)));
+	}
+	Ok(Version {
+		major,
+		minor,
+		patch,
+	})
+}
+
+/// Decode the embedded release public key, failing closed if it is still the
+/// all-zero placeholder (verification key not configured for this build).
+pub fn release_pubkey() -> crate::Result<VerifyingKey> {
+	if RELEASE_PUBKEY == [0u8; 32] {
+		return Err(ComposeError::Update(
+			"release verification key not configured in this build; refusing to self-update"
+				.to_string(),
+		));
+	}
+	VerifyingKey::from_bytes(&RELEASE_PUBKEY)
+		.map_err(|e| ComposeError::Update(format!("embedded release key is invalid: {e}")))
+}
+
+/// Verify that `signature` (raw 64-byte Ed25519) over `message` was produced by
+/// the embedded release key. Fails closed on a wrong length, bad key, or any
+/// mismatch.
+pub fn verify_signature(message: &[u8], signature: &[u8]) -> crate::Result<()> {
+	let key = release_pubkey()?;
+	let sig = Signature::from_slice(signature).map_err(|_| {
+		ComposeError::Update(format!(
+			"malformed signature: expected 64 bytes, got {}",
+			signature.len()
+		))
+	})?;
+	key.verify(message, &sig).map_err(|_| {
+		ComposeError::Update(
+			"signature verification failed — release may be tampered or unsigned".to_string(),
+		)
+	})
+}
+
+/// Verify `signature` against the embedded key using an explicitly supplied key
+/// — test seam so the signature path is exercised without the placeholder guard.
+#[cfg(test)]
+pub fn verify_signature_with(
+	key: &VerifyingKey,
+	message: &[u8],
+	signature: &[u8],
+) -> crate::Result<()> {
+	let sig = Signature::from_slice(signature)
+		.map_err(|_| ComposeError::Update("malformed signature".to_string()))?;
+	key.verify(message, &sig)
+		.map_err(|_| ComposeError::Update("signature verification failed".to_string()))
+}
+
+/// Look up the expected lowercase-hex SHA-256 digest for `asset` in a signed
+/// `SHA256SUMS` manifest (`<hex>␠␠<name>` or `<hex>␠*<name>` lines).
+pub fn expected_digest(sha256sums: &[u8], asset: &str) -> crate::Result<String> {
+	let text = std::str::from_utf8(sha256sums)
+		.map_err(|_| ComposeError::Update("SHA256SUMS is not valid UTF-8".to_string()))?;
+	for line in text.lines() {
+		let line = line.trim();
+		let Some((hex, name)) = line.split_once(char::is_whitespace) else {
+			continue;
+		};
+		// Strip the optional binary-mode '*' marker on the filename.
+		let name = name.trim().trim_start_matches('*');
+		if name == asset {
+			let hex = hex.trim().to_ascii_lowercase();
+			if hex.len() != 64 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+				return Err(ComposeError::Update(format!(
+					"SHA256SUMS has a malformed digest for {asset}"
+				)));
+			}
+			return Ok(hex);
+		}
+	}
+	Err(ComposeError::Update(format!(
+		"{asset} is not listed in SHA256SUMS"
+	)))
+}
+
+/// Compute the lowercase-hex SHA-256 of `data`.
+pub fn sha256_hex(data: &[u8]) -> String {
+	let digest = Sha256::digest(data);
+	let mut out = String::with_capacity(64);
+	for byte in digest {
+		out.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
+		out.push(char::from_digit((byte & 0xf) as u32, 16).unwrap());
+	}
+	out
+}
+
+/// Verify the downloaded bytes hash to `expected_hex` (case-insensitive).
+pub fn verify_digest(data: &[u8], expected_hex: &str) -> crate::Result<()> {
+	let actual = sha256_hex(data);
+	if actual.eq_ignore_ascii_case(expected_hex) {
+		Ok(())
+	} else {
+		Err(ComposeError::Update(format!(
+			"checksum mismatch: expected {expected_hex}, got {actual}"
+		)))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ed25519_dalek::{Signer, SigningKey};
+
+	fn test_keypair() -> (SigningKey, VerifyingKey) {
+		let seed = [7u8; 32];
+		let sk = SigningKey::from_bytes(&seed);
+		let vk = sk.verifying_key();
+		(sk, vk)
+	}
+
+	#[test]
+	fn parse_version_with_and_without_v() {
+		assert_eq!(
+			parse_version("v1.2.3").unwrap(),
+			parse_version("1.2.3").unwrap()
+		);
+		let v = parse_version("v0.6.0").unwrap();
+		assert_eq!((v.major, v.minor, v.patch), (0, 6, 0));
+	}
+
+	#[test]
+	fn version_ordering() {
+		assert!(parse_version("v0.6.1").unwrap() > parse_version("v0.6.0").unwrap());
+		assert!(parse_version("v1.0.0").unwrap() > parse_version("v0.99.99").unwrap());
+		assert!(parse_version("v0.6.0").unwrap() == parse_version("0.6.0").unwrap());
+	}
+
+	#[test]
+	fn parse_version_rejects_garbage() {
+		for bad in ["", "v1", "1.2", "1.2.3.4", "a.b.c", "1.2.x", "v1.2.-1"] {
+			assert!(parse_version(bad).is_err(), "should reject {bad}");
+		}
+	}
+
+	#[test]
+	fn embedded_key_is_configured_and_rejects_garbage() {
+		// A real key is baked in; it must load and reject a bogus signature.
+		assert_ne!(RELEASE_PUBKEY, [0u8; 32]);
+		assert!(release_pubkey().is_ok());
+		assert!(verify_signature(b"data", &[0u8; 64]).is_err());
+	}
+
+	#[test]
+	fn zeroed_key_would_fail_closed() {
+		// Defence in depth: an all-zero key is a valid curve point, so the
+		// explicit guard in `release_pubkey` — not the curve math — is what
+		// refuses to trust an unverifiable release if the key is ever zeroed.
+		assert!(VerifyingKey::from_bytes(&[0u8; 32]).is_ok());
+		let is_placeholder = |key: [u8; 32]| key == [0u8; 32];
+		assert!(is_placeholder([0u8; 32]));
+		assert!(!is_placeholder(RELEASE_PUBKEY));
+	}
+
+	#[test]
+	fn embedded_key_verifies_real_release() {
+		// Regression vector: the genuine published podup SHA256SUMS and its
+		// signature must verify against the embedded key. If a future edit
+		// swaps the key, this fails loudly.
+		let sha256sums = "\
+52d6148bf50d9d3f24a634402ec39d44302d73b21e3b74ed6a28877fdd7b93ea  podup-linux-x86_64
+95202fc77b4ff60d1f67f198c312baafe710bec2e9d3a6d48fc92ba0f5a0774f  podup-linux-arm64
+8e935c2b28d5955867ea0c94fe2a4fc1a6aa6951011b02eff850eb98ae41e239  podup-darwin-arm64
+efb48becd0c057f6248e91ccbc5b0795edcfbdf66eb5535f24938a5bba7c4ab2  podup-darwin-x86_64
+2fcbef1ae50e976b4d072c101fa2d03a235b2c17ee1ff6a3bfdf6e3df1d15389  podup-windows-x86_64.exe
+";
+		let signature: [u8; 64] = [
+			242, 54, 152, 188, 196, 207, 89, 151, 84, 217, 6, 0, 46, 45, 6, 218, 150, 236, 75, 144,
+			192, 84, 216, 67, 161, 125, 33, 43, 162, 172, 217, 138, 252, 241, 202, 49, 40, 147,
+			184, 80, 158, 122, 152, 153, 175, 99, 167, 132, 8, 171, 166, 43, 170, 39, 149, 74, 219,
+			134, 101, 155, 15, 109, 136, 11,
+		];
+		verify_signature(sha256sums.as_bytes(), &signature).unwrap();
+
+		// And the manifest it signs really lists this platform's asset digest.
+		let digest = expected_digest(sha256sums.as_bytes(), "podup-linux-x86_64").unwrap();
+		assert_eq!(
+			digest,
+			"52d6148bf50d9d3f24a634402ec39d44302d73b21e3b74ed6a28877fdd7b93ea"
+		);
+	}
+
+	#[test]
+	fn valid_signature_accepted() {
+		let (sk, vk) = test_keypair();
+		let msg = b"SHA256SUMS contents";
+		let sig = sk.sign(msg).to_bytes();
+		verify_signature_with(&vk, msg, &sig).unwrap();
+	}
+
+	#[test]
+	fn tampered_message_rejected() {
+		let (sk, vk) = test_keypair();
+		let sig = sk.sign(b"original").to_bytes();
+		assert!(verify_signature_with(&vk, b"tampered", &sig).is_err());
+	}
+
+	#[test]
+	fn wrong_key_rejected() {
+		let (sk, _) = test_keypair();
+		let other = SigningKey::from_bytes(&[9u8; 32]).verifying_key();
+		let sig = sk.sign(b"data").to_bytes();
+		assert!(verify_signature_with(&other, b"data", &sig).is_err());
+	}
+
+	#[test]
+	fn malformed_signature_length_rejected() {
+		let (_, vk) = test_keypair();
+		assert!(verify_signature_with(&vk, b"data", &[0u8; 10]).is_err());
+	}
+
+	#[test]
+	fn sha256_known_vector() {
+		// SHA-256 of the empty input.
+		assert_eq!(
+			sha256_hex(b""),
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		);
+		// SHA-256 of "abc".
+		assert_eq!(
+			sha256_hex(b"abc"),
+			"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+		);
+	}
+
+	#[test]
+	fn digest_roundtrip_and_mismatch() {
+		let data = b"podup binary bytes";
+		let hex = sha256_hex(data);
+		verify_digest(data, &hex).unwrap();
+		verify_digest(data, &hex.to_ascii_uppercase()).unwrap();
+		assert!(verify_digest(data, &"0".repeat(64)).is_err());
+	}
+
+	#[test]
+	fn expected_digest_two_space_format() {
+		let sums = format!("{}  podup-linux-x86_64\n", "a".repeat(64));
+		assert_eq!(
+			expected_digest(sums.as_bytes(), "podup-linux-x86_64").unwrap(),
+			"a".repeat(64)
+		);
+	}
+
+	#[test]
+	fn expected_digest_binary_star_format() {
+		let sums = format!("{} *podup-darwin-arm64\n", "B".repeat(64));
+		// Hex is normalized to lowercase.
+		assert_eq!(
+			expected_digest(sums.as_bytes(), "podup-darwin-arm64").unwrap(),
+			"b".repeat(64)
+		);
+	}
+
+	#[test]
+	fn expected_digest_picks_right_line() {
+		let sums = format!(
+			"{}  podup-linux-x86_64\n{}  podup-linux-arm64\n",
+			"1".repeat(64),
+			"2".repeat(64)
+		);
+		assert_eq!(
+			expected_digest(sums.as_bytes(), "podup-linux-arm64").unwrap(),
+			"2".repeat(64)
+		);
+	}
+
+	#[test]
+	fn expected_digest_missing_asset_errors() {
+		let sums = format!("{}  other-asset\n", "a".repeat(64));
+		assert!(expected_digest(sums.as_bytes(), "podup-linux-x86_64").is_err());
+	}
+
+	#[test]
+	fn expected_digest_malformed_hex_errors() {
+		let sums = "nothex  podup-linux-x86_64\n";
+		assert!(expected_digest(sums.as_bytes(), "podup-linux-x86_64").is_err());
+	}
+
+	#[test]
+	fn expected_digest_rejects_non_utf8() {
+		assert!(expected_digest(&[0xff, 0xfe], "x").is_err());
+	}
+}


### PR DESCRIPTION
## Release v0.7.0

### Highlights
- **feat: secure self-update** (#140) — `podup update` / `--check` / `--force`. Replaces the running binary with the latest signed release; trust anchor is an Ed25519 public key embedded in the binary, not the download domain. Verifies signed `SHA256SUMS` + checksum, fails closed, atomic replace (Unix + Windows). `install.sh` hardened to require a strong proof (signature or attestation) or refuse.
- chore: bump version to 0.7.0 (#141)

No new org secrets/keys. Download source stays on GitHub.