### PR TITLE
ci: add asset-name contract and Debian package build checks

### DIFF
--- a/.github/scripts/check-asset-names.py
+++ b/.github/scripts/check-asset-names.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Assert install.sh and release.yml agree on release asset names.
+
+Releases are immutable: once a tag is published its asset names can never
+change. install.sh downloads `podup-${OS}-${ARCH}` for the platform it runs
+on, and release.yml publishes a fixed list of assets. If the two drift, the
+installer breaks for users and the only remedy is a brand-new patch release.
+
+This check derives every asset name install.sh can request from its platform
+case arms and asserts each one is published by release.yml. It runs in CI so
+the drift is caught on the pull request, before any tag exists.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = ROOT / "install.sh"
+RELEASE_YML = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def installer_requestable() -> set[str]:
+	"""Asset names install.sh can ask for: podup-<os>-<arch> over all arms."""
+	text = INSTALL_SH.read_text()
+	template = re.search(r'ARTIFACT="([^"]+)"', text)
+	if not template or template.group(1) != "podup-${OS}-${ARCH}":
+		sys.exit(
+			"check-asset-names: install.sh ARTIFACT template changed; "
+			"update this check to match."
+		)
+	oses = set(re.findall(r'OS="([a-z0-9_]+)"', text))
+	arches = set(re.findall(r'ARCH="([a-z0-9_]+)"', text))
+	if not oses or not arches:
+		sys.exit("check-asset-names: could not parse OS/ARCH arms from install.sh.")
+	return {f"podup-{os}-{arch}" for os in oses for arch in arches}
+
+
+def release_published() -> set[str]:
+	"""Asset names declared in the release.yml build matrix."""
+	text = RELEASE_YML.read_text()
+	assets = set(re.findall(r"^\s*-?\s*asset:\s*(\S+)\s*$", text, re.MULTILINE))
+	if not assets:
+		sys.exit("check-asset-names: could not parse asset names from release.yml.")
+	return assets
+
+
+def main() -> None:
+	requestable = installer_requestable()
+	published = release_published()
+	missing = sorted(requestable - published)
+	if missing:
+		lines = "\n".join(f"  - {name}" for name in missing)
+		sys.exit(
+			"check-asset-names: install.sh can request assets that release.yml "
+			f"does not publish:\n{lines}\n"
+			f"published: {sorted(published)}"
+		)
+	print(
+		f"OK: all {len(requestable)} installer-requestable assets are published "
+		f"by release.yml."
+	)
+
+
+if __name__ == "__main__":
+	main()

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -1,0 +1,33 @@
+name: Asset name contract
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "install.sh"
+      - ".github/workflows/release.yml"
+      - ".github/scripts/check-asset-names.py"
+      - ".github/workflows/asset-contract.yml"
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "install.sh"
+      - ".github/workflows/release.yml"
+      - ".github/scripts/check-asset-names.py"
+      - ".github/workflows/asset-contract.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: install.sh ↔ release.yml asset names
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify asset names are in sync
+        run: python3 .github/scripts/check-asset-names.py

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -1,0 +1,64 @@
+name: Debian package
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "debian/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "internal/**"
+      - ".github/workflows/debian-build.yml"
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "debian/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "internal/**"
+      - ".github/workflows/debian-build.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: dpkg-buildpackage
+    runs-on: ubuntu-latest
+    # The package requires rustc >= 1.86 (idna -> icu chain), which Debian
+    # trixie (1.85) cannot satisfy; sid ships a new enough toolchain.
+    container: debian:sid
+    steps:
+      - name: Install build tooling
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            build-essential \
+            dpkg-dev \
+            debhelper \
+            cargo \
+            rustc
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Confirm build dependencies are satisfiable
+        run: dpkg-checkbuilddeps
+
+      - name: Build the package
+        run: dpkg-buildpackage -us -uc -b
+
+      - name: Confirm the .deb was produced
+        run: |
+          deb=$(ls ../podup_*.deb 2>/dev/null | head -n1)
+          if [ -z "$deb" ]; then
+            echo "::error::no .deb artifact was produced"
+            exit 1
+          fi
+          echo "Built $deb"
+          dpkg-deb --contents "$deb"

--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,9 @@ endif
 	dh $@
 
 override_dh_auto_build:
+ifneq ($(wildcard vendor/),)
 	$(if $(wildcard .cargo/config.toml),,$(MAKE) -f debian/rules debian/cargo-config)
+endif
 	cargo build --release --locked $(CARGO_FLAGS)
 
 override_dh_auto_test:


### PR DESCRIPTION
## What
Two CI hardening checks, both podup-local:

1. **Asset-name contract** (Refs #144) — derives every `podup-<os>-<arch>` asset install.sh can request from its platform case arms and asserts release.yml publishes each one. Guards against installer breakage, which on an immutable release can only be fixed by a new patch.
2. **Debian package build** (Refs #146) — runs `dpkg-buildpackage -us -uc -b` in a `debian:sid` container (trixie's rustc 1.85 cannot satisfy the >= 1.86 build dependency) and asserts a .deb is produced.

## Notes
Both workflows are path-filtered, so they are intentionally NOT added as required status checks (a path-filtered required check would sit pending forever on unrelated PRs).

## Test plan
- `python3 .github/scripts/check-asset-names.py` → OK, all 4 installer-requestable assets published.
- Both workflow files validated as YAML.

Refs #144, #146