### PR TITLE
ci: enable MSRV, package, semver and doc checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@49b960ef2b033f8219e98b5314a5429c3d514a48 # main
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@2de584f368690524992185b30e23f342c19aab23 # main
     with:
       extra-test-os: '["macos-latest", "windows-latest"]'
       podman: true
       coverage-threshold: 90
+      msrv: "1.86"
+      package-check: true
+      semver-check: true
+      doc-warnings: true

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -3,7 +3,7 @@
 //! Flow: resolve the latest release tag, compare against the compiled-in
 //! version, and (unless `--check`) download the platform binary plus the signed
 //! `SHA256SUMS` manifest. The manifest's Ed25519 signature is verified against
-//! the public key embedded in this binary ([`verify::RELEASE_PUBKEY`]); only
+//! the public key embedded in this binary (`verify::RELEASE_PUBKEY`); only
 //! then is the binary's digest checked against the manifest and the running
 //! executable atomically replaced. Every step fails closed — a missing key,
 //! bad signature, or checksum mismatch aborts before anything is written.


### PR DESCRIPTION
Bumps the reusable rust-ci pin to the release that adds the new opt-in jobs and turns them on:
- **msrv: "1.86"** — verifies the declared MSRV builds (#143).
- **package-check** — `cargo publish --dry-run` on PRs (#145).
- **semver-check** — `cargo-semver-checks` vs the last release (#147).
- **doc-warnings** — `cargo doc -D warnings` (#148).

Also fixes the one issue doc-warnings surfaced: a public doc comment in the update module linked to the private `verify::RELEASE_PUBKEY`.

## Test plan
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` clean locally.

Closes #143, #145, #147, #148