### PR TITLE
refactor: replace futures umbrella with futures-util + futures-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,27 +369,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -397,29 +382,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -433,13 +395,8 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -928,7 +885,8 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "flate2",
- "futures",
+ "futures-core",
+ "futures-util",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
 indexmap = { version = "2", features = ["serde"] }
-futures = { version = "0.3", default-features = false, features = ["async-await", "std"] }
+futures-core = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,7 +8,7 @@
 mod context;
 
 use bytes::Bytes;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use tracing::{debug, info, warn};
 
 use crate::compose::types::{BuildConfig, Service};

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,6 +1,6 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use tracing::info;
 
 use crate::compose::types::ComposeFile;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -23,7 +23,7 @@ mod watch;
 
 use std::path::PathBuf;
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 use crate::compose::types::{LifecycleHook, Service};
 use crate::error::{ComposeError, Result};

--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -1,6 +1,6 @@
 //! Query and observation commands: ps, logs, exec, pull, remove_orphans, attach_logs, top, port, images.
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
@@ -119,7 +119,7 @@ impl Engine {
 					}
 				})
 				.collect();
-			futures::future::join_all(futs).await;
+			futures_util::future::join_all(futs).await;
 		} else {
 			for (container_name, is_tty) in targets {
 				let path = format!(
@@ -231,7 +231,7 @@ impl Engine {
 			.map(|s| self.pull_image(s))
 			.collect();
 
-		let results = futures::future::join_all(futs).await;
+		let results = futures_util::future::join_all(futs).await;
 		for r in results {
 			r?;
 		}
@@ -462,14 +462,14 @@ impl Engine {
 			use tokio::signal::unix::{signal, SignalKind};
 			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
 			tokio::select! {
-				_ = futures::future::join_all(streams) => {}
+				_ = futures_util::future::join_all(streams) => {}
 				_ = tokio::signal::ctrl_c() => {}
 				_ = sigterm.recv() => {}
 			}
 		}
 		#[cfg(not(unix))]
 		tokio::select! {
-			_ = futures::future::join_all(streams) => {}
+			_ = futures_util::future::join_all(streams) => {}
 			_ = tokio::signal::ctrl_c() => {}
 		}
 

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use crate::libpod::types::exec::{ExecCreateConfig, ExecCreateResponse, ExecStartConfig};
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 use bytes::Bytes;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -5,7 +5,7 @@
 //! Stream type 1 = stdout, 2 = stderr.
 
 use bytes::Bytes;
-use futures::Stream;
+use futures_core::Stream;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use std::pin::Pin;
@@ -62,7 +62,7 @@ pub(crate) fn take_json_line(buf: &mut Vec<u8>) -> Option<Vec<u8>> {
 /// Emits [`LogOutput`] items as frames arrive. The returned stream ends when
 /// the response body is fully consumed.
 pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
-	Box::pin(futures::stream::try_unfold(
+	Box::pin(futures_util::stream::try_unfold(
 		(body, Vec::<u8>::new()),
 		|(mut body, mut buf)| async move {
 			loop {
@@ -96,21 +96,24 @@ pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
 /// Used for TTY containers where Podman sends raw bytes without 8-byte frame
 /// headers. All bytes are treated as stdout since TTY merges the streams.
 pub fn parse_raw(body: Incoming) -> BoxStream<LogOutput> {
-	Box::pin(futures::stream::try_unfold(body, |mut body| async move {
-		loop {
-			match body.frame().await {
-				Some(Ok(frame)) => {
-					if let Ok(data) = frame.into_data() {
-						if !data.is_empty() {
-							return Ok(Some((LogOutput::StdOut { message: data }, body)));
+	Box::pin(futures_util::stream::try_unfold(
+		body,
+		|mut body| async move {
+			loop {
+				match body.frame().await {
+					Some(Ok(frame)) => {
+						if let Ok(data) = frame.into_data() {
+							if !data.is_empty() {
+								return Ok(Some((LogOutput::StdOut { message: data }, body)));
+							}
 						}
 					}
+					Some(Err(e)) => return Err(PodmanError::from(e)),
+					None => return Ok(None),
 				}
-				Some(Err(e)) => return Err(PodmanError::from(e)),
-				None => return Ok(None),
 			}
-		}
-	}))
+		},
+	))
 }
 
 /// Parse a newline-delimited JSON stream (used for image pull and build output).
@@ -120,7 +123,7 @@ pub fn parse_raw(body: Incoming) -> BoxStream<LogOutput> {
 pub fn parse_json_lines<T: serde::de::DeserializeOwned + Send + 'static>(
 	body: Incoming,
 ) -> BoxStream<T> {
-	Box::pin(futures::stream::try_unfold(
+	Box::pin(futures_util::stream::try_unfold(
 		(body, Vec::<u8>::new()),
 		|(mut body, mut buf)| async move {
 			loop {


### PR DESCRIPTION
The engine only used `StreamExt`, `future::join_all`, `stream::try_unfold` and the `Stream` trait — all available from `futures-util` and `futures-core`. The umbrella `futures` crate also pulled `futures-io`, `futures-sink`, `futures-executor` and `futures-macro` for no benefit. Depending on the two sub-crates directly removes the umbrella and those extras.

## Test plan
- `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo test --lib` → 409 passed; `cargo tree` confirms the `futures` umbrella crate is gone.

Closes #150