### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+podup (0.8.0) unstable; urgency=medium
+
+  * Add --project-directory to override the base path for relative-path
+    resolution (env_file, build context, bind mounts, config/secret sources).
+  * Add `podup generate quadlet` to export systemd Quadlet units
+    (.container/.network/.volume) so systemd can own the container lifecycle.
+  * Reduce the dependency surface: drop the futures umbrella crate in favour
+    of futures-util and futures-core.
+  * Fix dpkg-buildpackage for non-vendored builds (override_dh_auto_build no
+    longer invokes a vendored-only cargo-config target).
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 12:10:00 -0500
+
+podup (0.7.0) unstable; urgency=medium
+
+  * Secure self-update: `podup update` downloads signed release assets and
+    verifies the Ed25519 signature and SHA-256 checksum, failing closed.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Wed, 11 Jun 2026 09:00:00 -0500
+
 podup (0.6.0) unstable; urgency=medium
 
   * Honor COMPOSE_PROJECT_NAME and COMPOSE_FILE environment variables.


### PR DESCRIPTION
Prepares the 0.8.0 release: bumps Cargo.toml/lock, backfills the missing 0.7.0 changelog entry, and adds the 0.8.0 entry (--project-directory, quadlet exporter, futures dependency reduction, non-vendored dpkg-buildpackage fix).