### PR TITLE
release: v0.8.0

### DIFF
--- a/.github/scripts/check-asset-names.py
+++ b/.github/scripts/check-asset-names.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Assert install.sh and release.yml agree on release asset names.
+
+Releases are immutable: once a tag is published its asset names can never
+change. install.sh downloads `podup-${OS}-${ARCH}` for the platform it runs
+on, and release.yml publishes a fixed list of assets. If the two drift, the
+installer breaks for users and the only remedy is a brand-new patch release.
+
+This check derives every asset name install.sh can request from its platform
+case arms and asserts each one is published by release.yml. It runs in CI so
+the drift is caught on the pull request, before any tag exists.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = ROOT / "install.sh"
+RELEASE_YML = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def installer_requestable() -> set[str]:
+	"""Asset names install.sh can ask for: podup-<os>-<arch> over all arms."""
+	text = INSTALL_SH.read_text()
+	template = re.search(r'ARTIFACT="([^"]+)"', text)
+	if not template or template.group(1) != "podup-${OS}-${ARCH}":
+		sys.exit(
+			"check-asset-names: install.sh ARTIFACT template changed; "
+			"update this check to match."
+		)
+	oses = set(re.findall(r'OS="([a-z0-9_]+)"', text))
+	arches = set(re.findall(r'ARCH="([a-z0-9_]+)"', text))
+	if not oses or not arches:
+		sys.exit("check-asset-names: could not parse OS/ARCH arms from install.sh.")
+	return {f"podup-{os}-{arch}" for os in oses for arch in arches}
+
+
+def release_published() -> set[str]:
+	"""Asset names declared in the release.yml build matrix."""
+	text = RELEASE_YML.read_text()
+	assets = set(re.findall(r"^\s*-?\s*asset:\s*(\S+)\s*$", text, re.MULTILINE))
+	if not assets:
+		sys.exit("check-asset-names: could not parse asset names from release.yml.")
+	return assets
+
+
+def main() -> None:
+	requestable = installer_requestable()
+	published = release_published()
+	missing = sorted(requestable - published)
+	if missing:
+		lines = "\n".join(f"  - {name}" for name in missing)
+		sys.exit(
+			"check-asset-names: install.sh can request assets that release.yml "
+			f"does not publish:\n{lines}\n"
+			f"published: {sorted(published)}"
+		)
+	print(
+		f"OK: all {len(requestable)} installer-requestable assets are published "
+		f"by release.yml."
+	)
+
+
+if __name__ == "__main__":
+	main()

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -1,0 +1,33 @@
+name: Asset name contract
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "install.sh"
+      - ".github/workflows/release.yml"
+      - ".github/scripts/check-asset-names.py"
+      - ".github/workflows/asset-contract.yml"
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "install.sh"
+      - ".github/workflows/release.yml"
+      - ".github/scripts/check-asset-names.py"
+      - ".github/workflows/asset-contract.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: install.sh ↔ release.yml asset names
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify asset names are in sync
+        run: python3 .github/scripts/check-asset-names.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@49b960ef2b033f8219e98b5314a5429c3d514a48 # main
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@2de584f368690524992185b30e23f342c19aab23 # main
     with:
       extra-test-os: '["macos-latest", "windows-latest"]'
       podman: true
       coverage-threshold: 90
+      msrv: "1.86"
+      package-check: true
+      semver-check: true
+      doc-warnings: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -1,0 +1,64 @@
+name: Debian package
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "debian/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "internal/**"
+      - ".github/workflows/debian-build.yml"
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "debian/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "internal/**"
+      - ".github/workflows/debian-build.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: dpkg-buildpackage
+    runs-on: ubuntu-latest
+    # The package requires rustc >= 1.86 (idna -> icu chain), which Debian
+    # trixie (1.85) cannot satisfy; sid ships a new enough toolchain.
+    container: debian:sid
+    steps:
+      - name: Install build tooling
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            build-essential \
+            dpkg-dev \
+            debhelper \
+            cargo \
+            rustc
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Confirm build dependencies are satisfiable
+        run: dpkg-checkbuilddeps
+
+      - name: Build the package
+        run: dpkg-buildpackage -us -uc -b
+
+      - name: Confirm the .deb was produced
+        run: |
+          deb=$(ls ../podup_*.deb 2>/dev/null | head -n1)
+          if [ -z "$deb" ]; then
+            echo "::error::no .deb artifact was produced"
+            exit 1
+          fi
+          echo "Built $deb"
+          dpkg-deb --contents "$deb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,27 +369,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -397,29 +382,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -433,13 +395,8 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -928,7 +885,8 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "flate2",
- "futures",
+ "futures-core",
+ "futures-util",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
 indexmap = { version = "2", features = ["serde"] }
-futures = { version = "0.3", default-features = false, features = ["async-await", "std"] }
+futures-core = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ podup -f stack.yml -p myapp up -d      # explicit file and project name
 podup ps                               # list project containers
 podup logs api --follow                # follow one service's logs
 podup down --volumes                   # tear down, removing named volumes
+podup generate quadlet -o ~/.config/containers/systemd  # emit systemd Quadlet units
 ```
 
 ## ⚖️ vs. alternatives

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+podup (0.8.0) unstable; urgency=medium
+
+  * Add --project-directory to override the base path for relative-path
+    resolution (env_file, build context, bind mounts, config/secret sources).
+  * Add `podup generate quadlet` to export systemd Quadlet units
+    (.container/.network/.volume) so systemd can own the container lifecycle.
+  * Reduce the dependency surface: drop the futures umbrella crate in favour
+    of futures-util and futures-core.
+  * Fix dpkg-buildpackage for non-vendored builds (override_dh_auto_build no
+    longer invokes a vendored-only cargo-config target).
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 12:10:00 -0500
+
+podup (0.7.0) unstable; urgency=medium
+
+  * Secure self-update: `podup update` downloads signed release assets and
+    verifies the Ed25519 signature and SHA-256 checksum, failing closed.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Wed, 11 Jun 2026 09:00:00 -0500
+
 podup (0.6.0) unstable; urgency=medium
 
   * Honor COMPOSE_PROJECT_NAME and COMPOSE_FILE environment variables.

--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,9 @@ endif
 	dh $@
 
 override_dh_auto_build:
+ifneq ($(wildcard vendor/),)
 	$(if $(wildcard .cargo/config.toml),,$(MAKE) -f debian/rules debian/cargo-config)
+endif
 	cargo build --release --locked $(CARGO_FLAGS)
 
 override_dh_auto_test:

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,7 +8,7 @@
 mod context;
 
 use bytes::Bytes;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use tracing::{debug, info, warn};
 
 use crate::compose::types::{BuildConfig, Service};

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,6 +1,6 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use tracing::info;
 
 use crate::compose::types::ComposeFile;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -23,7 +23,7 @@ mod watch;
 
 use std::path::PathBuf;
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 use crate::compose::types::{LifecycleHook, Service};
 use crate::error::{ComposeError, Result};

--- a/internal/engine/query.rs
+++ b/internal/engine/query.rs
@@ -1,6 +1,6 @@
 //! Query and observation commands: ps, logs, exec, pull, remove_orphans, attach_logs, top, port, images.
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
@@ -119,7 +119,7 @@ impl Engine {
 					}
 				})
 				.collect();
-			futures::future::join_all(futs).await;
+			futures_util::future::join_all(futs).await;
 		} else {
 			for (container_name, is_tty) in targets {
 				let path = format!(
@@ -231,7 +231,7 @@ impl Engine {
 			.map(|s| self.pull_image(s))
 			.collect();
 
-		let results = futures::future::join_all(futs).await;
+		let results = futures_util::future::join_all(futs).await;
 		for r in results {
 			r?;
 		}
@@ -462,14 +462,14 @@ impl Engine {
 			use tokio::signal::unix::{signal, SignalKind};
 			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
 			tokio::select! {
-				_ = futures::future::join_all(streams) => {}
+				_ = futures_util::future::join_all(streams) => {}
 				_ = tokio::signal::ctrl_c() => {}
 				_ = sigterm.recv() => {}
 			}
 		}
 		#[cfg(not(unix))]
 		tokio::select! {
-			_ = futures::future::join_all(streams) => {}
+			_ = futures_util::future::join_all(streams) => {}
 			_ = tokio::signal::ctrl_c() => {}
 		}
 

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use crate::libpod::types::exec::{ExecCreateConfig, ExecCreateResponse, ExecStartConfig};
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 use bytes::Bytes;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -11,6 +11,7 @@ pub(crate) mod error;
 pub(crate) mod libpod;
 pub mod podman;
 pub mod ports;
+pub mod quadlet;
 pub mod size;
 pub mod substitute;
 pub mod update;

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -5,7 +5,7 @@
 //! Stream type 1 = stdout, 2 = stderr.
 
 use bytes::Bytes;
-use futures::Stream;
+use futures_core::Stream;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use std::pin::Pin;
@@ -62,7 +62,7 @@ pub(crate) fn take_json_line(buf: &mut Vec<u8>) -> Option<Vec<u8>> {
 /// Emits [`LogOutput`] items as frames arrive. The returned stream ends when
 /// the response body is fully consumed.
 pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
-	Box::pin(futures::stream::try_unfold(
+	Box::pin(futures_util::stream::try_unfold(
 		(body, Vec::<u8>::new()),
 		|(mut body, mut buf)| async move {
 			loop {
@@ -96,21 +96,24 @@ pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
 /// Used for TTY containers where Podman sends raw bytes without 8-byte frame
 /// headers. All bytes are treated as stdout since TTY merges the streams.
 pub fn parse_raw(body: Incoming) -> BoxStream<LogOutput> {
-	Box::pin(futures::stream::try_unfold(body, |mut body| async move {
-		loop {
-			match body.frame().await {
-				Some(Ok(frame)) => {
-					if let Ok(data) = frame.into_data() {
-						if !data.is_empty() {
-							return Ok(Some((LogOutput::StdOut { message: data }, body)));
+	Box::pin(futures_util::stream::try_unfold(
+		body,
+		|mut body| async move {
+			loop {
+				match body.frame().await {
+					Some(Ok(frame)) => {
+						if let Ok(data) = frame.into_data() {
+							if !data.is_empty() {
+								return Ok(Some((LogOutput::StdOut { message: data }, body)));
+							}
 						}
 					}
+					Some(Err(e)) => return Err(PodmanError::from(e)),
+					None => return Ok(None),
 				}
-				Some(Err(e)) => return Err(PodmanError::from(e)),
-				None => return Ok(None),
 			}
-		}
-	}))
+		},
+	))
 }
 
 /// Parse a newline-delimited JSON stream (used for image pull and build output).
@@ -120,7 +123,7 @@ pub fn parse_raw(body: Incoming) -> BoxStream<LogOutput> {
 pub fn parse_json_lines<T: serde::de::DeserializeOwned + Send + 'static>(
 	body: Incoming,
 ) -> BoxStream<T> {
-	Box::pin(futures::stream::try_unfold(
+	Box::pin(futures_util::stream::try_unfold(
 		(body, Vec::<u8>::new()),
 		|(mut body, mut buf)| async move {
 			loop {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -1,6 +1,6 @@
 //! `podup` — docker-compose to Podman translator CLI.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::{Parser, Subcommand};
@@ -34,6 +34,12 @@ struct Cli {
 	/// Active profiles (comma-separated).  May also be set via `COMPOSE_PROFILES`.
 	#[arg(long, value_delimiter = ',', global = true)]
 	profile: Vec<String>,
+
+	/// Base directory for resolving relative paths (env_file, build context,
+	/// bind mounts, config/secret file sources). Defaults to the directory
+	/// containing the compose file.
+	#[arg(long, global = true)]
+	project_directory: Option<PathBuf>,
 
 	#[command(subcommand)]
 	command: Commands,
@@ -229,6 +235,16 @@ fn is_mutating(command: &Commands) -> bool {
 	)
 }
 
+/// Resolve the base directory for relative-path resolution. An explicit
+/// `--project-directory` wins; otherwise it is the directory containing the
+/// compose file (compose-spec default), or the current directory when the
+/// compose file has no parent component.
+fn resolve_base_dir(project_directory: Option<&Path>, file: &Path) -> PathBuf {
+	project_directory
+		.map(Path::to_path_buf)
+		.unwrap_or_else(|| file.parent().map(Path::to_path_buf).unwrap_or_default())
+}
+
 #[tokio::main]
 async fn main() {
 	match run().await {
@@ -274,11 +290,7 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
-	let base_dir = cli
-		.file
-		.parent()
-		.map(|p| p.to_path_buf())
-		.unwrap_or_default();
+	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &cli.file);
 	let engine = podup::Engine::with_base_dir(client, cli.project, base_dir);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
@@ -367,4 +379,31 @@ async fn run() -> podup::Result<()> {
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::resolve_base_dir;
+	use std::path::{Path, PathBuf};
+
+	#[test]
+	fn project_directory_override_wins() {
+		let base = resolve_base_dir(
+			Some(Path::new("/srv/app")),
+			Path::new("/etc/compose/docker-compose.yml"),
+		);
+		assert_eq!(base, PathBuf::from("/srv/app"));
+	}
+
+	#[test]
+	fn defaults_to_compose_file_parent() {
+		let base = resolve_base_dir(None, Path::new("/etc/compose/docker-compose.yml"));
+		assert_eq!(base, PathBuf::from("/etc/compose"));
+	}
+
+	#[test]
+	fn bare_filename_resolves_to_current_dir() {
+		let base = resolve_base_dir(None, Path::new("docker-compose.yml"));
+		assert_eq!(base, PathBuf::from(""));
+	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -197,6 +197,11 @@ enum Commands {
 	},
 	/// Print the resolved compose file (after substitution / extends / include).
 	Config,
+	/// Generate declarative artifacts from the compose file.
+	Generate {
+		#[command(subcommand)]
+		kind: GenerateCommands,
+	},
 	/// Watch for file changes and sync/rebuild/restart as configured by develop.watch.
 	Watch,
 	/// Update podup to the latest signed release.
@@ -213,6 +218,21 @@ enum Commands {
 		/// Reinstall even if the latest release is not newer than this build.
 		#[arg(long)]
 		force: bool,
+	},
+}
+
+#[derive(Subcommand)]
+enum GenerateCommands {
+	/// Translate the compose file into Podman Quadlet unit files.
+	///
+	/// Emits one `.container` per service plus `.network` and `.volume` units.
+	/// Without --output the units are printed to stdout; warnings about fields
+	/// with no Quadlet mapping go to stderr.
+	Quadlet {
+		/// Directory to write the unit files into (e.g.
+		/// ~/.config/containers/systemd). Prints to stdout when omitted.
+		#[arg(short, long)]
+		output: Option<PathBuf>,
 	},
 }
 
@@ -233,6 +253,38 @@ fn is_mutating(command: &Commands) -> bool {
 			| Commands::Run { .. }
 			| Commands::Restart { .. }
 	)
+}
+
+/// Generate Quadlet units from the compose file and either write them to a
+/// directory or print them to stdout. Warnings about unmapped fields go to
+/// stderr so stdout stays clean for piping.
+fn write_quadlet(
+	file: &podup::compose::types::ComposeFile,
+	project: &str,
+	output: Option<&Path>,
+) -> podup::Result<()> {
+	let result = podup::quadlet::generate(file, project);
+	for warning in &result.warnings {
+		eprintln!("warning: {warning}");
+	}
+	match output {
+		Some(dir) => {
+			std::fs::create_dir_all(dir)?;
+			for unit in &result.units {
+				let path = dir.join(&unit.filename);
+				std::fs::write(&path, &unit.contents)?;
+				println!("wrote {}", path.display());
+			}
+		}
+		None => {
+			for unit in &result.units {
+				println!("# {}", unit.filename);
+				print!("{}", unit.contents);
+				println!();
+			}
+		}
+	}
+	Ok(())
 }
 
 /// Resolve the base directory for relative-path resolution. An explicit
@@ -287,6 +339,15 @@ async fn run() -> podup::Result<()> {
 		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
 		println!("{yaml}");
 		return Ok(());
+	}
+
+	// `generate` produces declarative artifacts from the compose file alone; it
+	// neither contacts Podman nor mutates project state.
+	if let Commands::Generate {
+		kind: GenerateCommands::Quadlet { output },
+	} = &cli.command
+	{
+		return write_quadlet(&file, &cli.project, output.as_deref());
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
@@ -374,6 +435,7 @@ async fn run() -> podup::Result<()> {
 		Commands::Pull => engine.pull(&file).await?,
 		Commands::Restart { service } => engine.restart(&file, service.as_deref()).await?,
 		Commands::Config => unreachable!("handled above"),
+		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
 	}

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -1,0 +1,613 @@
+//! Translate a parsed compose file into Podman Quadlet unit files.
+//!
+//! Quadlet is Podman's systemd integration: declarative `.container`,
+//! `.network` and `.volume` units placed under
+//! `~/.config/containers/systemd/` that a systemd generator turns into
+//! services, so systemd owns the lifecycle (boot, restart, dependencies)
+//! instead of a long-running `podup` process.
+//!
+//! This is an additive export path, not a replacement for the runner. It
+//! maps the common compose fields and warns — loudly, never silently — for
+//! every field that is set but has no Quadlet equivalent yet, so generated
+//! units never quietly drop configuration.
+
+use std::collections::BTreeMap;
+
+use crate::compose::types::{
+	Command, ComposeFile, PortMapping, RestartPolicy, Service, VolumeMount,
+};
+use crate::ports::parse_ports;
+
+/// A single generated unit file: its name and full contents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuadletUnit {
+	/// File name, e.g. `web.container` or `db-data.volume`.
+	pub filename: String,
+	/// Full file contents, ending in a newline.
+	pub contents: String,
+}
+
+/// The result of a generation run: the units plus any warnings about set but
+/// unmapped fields.
+#[derive(Debug, Clone, Default)]
+pub struct QuadletOutput {
+	/// Generated unit files, in a deterministic order.
+	pub units: Vec<QuadletUnit>,
+	/// Human-readable warnings for compose fields with no Quadlet mapping.
+	pub warnings: Vec<String>,
+}
+
+/// Translate a compose file into Quadlet units for the given project name.
+///
+/// Emits one `.container` per service, one `.network` per declared network,
+/// and one `.volume` per declared named volume. Replica scaling, build
+/// services, and other fields without a Quadlet mapping are reported as
+/// warnings rather than silently dropped.
+pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
+	let mut out = QuadletOutput::default();
+
+	for (name, cfg) in &file.networks {
+		out.units.push(network_unit(name, project, cfg.is_some()));
+	}
+	for (name, cfg) in &file.volumes {
+		out.units.push(volume_unit(name, project, cfg.is_some()));
+	}
+
+	let declared_volumes: Vec<&str> = file.volumes.keys().map(String::as_str).collect();
+	for (name, service) in &file.services {
+		out.units.push(container_unit(
+			name,
+			service,
+			&declared_volumes,
+			&mut out.warnings,
+		));
+	}
+
+	out
+}
+
+fn network_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
+	let contents =
+		format!("[Network]\nNetworkName={project}_{name}\n\n[Install]\nWantedBy=default.target\n");
+	QuadletUnit {
+		filename: format!("{name}.network"),
+		contents,
+	}
+}
+
+fn volume_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
+	let contents =
+		format!("[Volume]\nVolumeName={project}_{name}\n\n[Install]\nWantedBy=default.target\n");
+	QuadletUnit {
+		filename: format!("{name}.volume"),
+		contents,
+	}
+}
+
+fn container_unit(
+	name: &str,
+	service: &Service,
+	declared_volumes: &[&str],
+	warnings: &mut Vec<String>,
+) -> QuadletUnit {
+	let mut unit = Section::new("Unit");
+	unit.add("Description", format!("{name} (podup)"));
+	for dep in service.depends_on.service_names() {
+		unit.add("After", format!("{dep}.service"));
+		if service.depends_on.required_for(&dep) {
+			unit.add("Requires", format!("{dep}.service"));
+		} else {
+			unit.add("Wants", format!("{dep}.service"));
+		}
+	}
+
+	let mut container = Section::new("Container");
+	container.add("ContainerName", name.to_string());
+	if let Some(image) = &service.image {
+		container.add("Image", image.clone());
+	}
+	if let Some(hostname) = &service.hostname {
+		container.add("HostName", hostname.clone());
+	}
+	if let Some(user) = &service.user {
+		container.add("User", user.clone());
+	}
+	if let Some(wd) = &service.working_dir {
+		container.add("WorkingDir", wd.clone());
+	}
+	if service.read_only == Some(true) {
+		container.add("ReadOnly", "true".to_string());
+	}
+	if service.init == Some(true) {
+		container.add("RunInit", "true".to_string());
+	}
+
+	match parse_ports(&service.ports) {
+		Ok(ports) => {
+			for p in ports {
+				container.add("PublishPort", render_publish_port(&p));
+			}
+		}
+		Err(_) => {
+			// Fall back to the raw short forms so nothing is dropped.
+			for port in &service.ports {
+				if let PortMapping::Short(s) = port {
+					container.add("PublishPort", s.clone());
+				}
+			}
+		}
+	}
+
+	for (key, val) in sorted_pairs(service.environment.to_map()) {
+		match val {
+			Some(v) => container.add("Environment", format!("{key}={v}")),
+			None => container.add("Environment", key),
+		}
+	}
+
+	for vol in &service.volumes {
+		container.add("Volume", render_volume(vol, declared_volumes));
+	}
+	for net in service.networks.names() {
+		container.add("Network", format!("{net}.network"));
+	}
+	for (key, val) in sorted_label_pairs(service.labels.to_map()) {
+		container.add("Label", format!("{key}={val}"));
+	}
+	for cap in &service.cap_add {
+		container.add("AddCapability", cap.clone());
+	}
+	for cap in &service.cap_drop {
+		container.add("DropCapability", cap.clone());
+	}
+	if let Some(entrypoint) = &service.entrypoint {
+		container.add("Entrypoint", render_command(entrypoint));
+	}
+	if let Some(command) = &service.command {
+		container.add("Exec", render_command(command));
+	}
+
+	let mut svc = Section::new("Service");
+	if let Some(restart) = &service.restart {
+		svc.add("Restart", render_restart(restart));
+	}
+
+	collect_warnings(name, service, warnings);
+
+	let mut contents = String::new();
+	contents.push_str(&unit.render());
+	contents.push('\n');
+	contents.push_str(&container.render());
+	if !svc.is_empty() {
+		contents.push('\n');
+		contents.push_str(&svc.render());
+	}
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
+
+	QuadletUnit {
+		filename: format!("{name}.container"),
+		contents,
+	}
+}
+
+/// Warn for fields that are set but have no Quadlet mapping, so the operator
+/// knows the generated unit is incomplete rather than discovering it at run
+/// time.
+fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec<String>) {
+	let mut warn = |field: &str, detail: &str| {
+		warnings.push(format!("{name}: {field} {detail}"));
+	};
+	if service.build.is_some() {
+		warn(
+			"build",
+			"has no Quadlet equivalent; build the image first and set `image`",
+		);
+	}
+	let replicas = service
+		.scale
+		.or(service.deploy.as_ref().and_then(|d| d.replicas));
+	if replicas.is_some_and(|r| r > 1) {
+		warn(
+			"scale/replicas",
+			"is ignored; Quadlet emits a single container per service",
+		);
+	}
+	if service.healthcheck.is_some() {
+		warn("healthcheck", "is not yet mapped to HealthCmd directives");
+	}
+	if !service.secrets.is_empty() {
+		warn(
+			"secrets",
+			"are not yet mapped to Quadlet Secret= directives",
+		);
+	}
+	if !service.configs.is_empty() {
+		warn("configs", "have no Quadlet equivalent and are skipped");
+	}
+	if !service.volumes_from.is_empty() {
+		warn("volumes_from", "has no Quadlet equivalent and is skipped");
+	}
+	if service.network_mode.is_some() {
+		warn("network_mode", "is not mapped; use networks instead");
+	}
+	if !service.profiles.is_empty() {
+		warn("profiles", "have no Quadlet equivalent and are ignored");
+	}
+	if service.privileged == Some(true) {
+		warn(
+			"privileged",
+			"is not mapped; add PodmanArgs manually if required",
+		);
+	}
+}
+
+fn render_publish_port(p: &crate::ports::ParsedPort) -> String {
+	let mut s = String::new();
+	if !p.host_ip.is_empty() {
+		s.push_str(&p.host_ip);
+		s.push(':');
+	}
+	// A host port of None/0 means "let Podman pick"; omit it so the published
+	// side is empty (PublishPort=<container>) and Podman assigns a port.
+	if let Some(host) = p.host_port.filter(|n| *n != 0) {
+		s.push_str(&host.to_string());
+		s.push(':');
+	}
+	s.push_str(&p.container_port.to_string());
+	if p.protocol != "tcp" {
+		s.push('/');
+		s.push_str(&p.protocol);
+	}
+	s
+}
+
+fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> String {
+	match vol {
+		VolumeMount::Short(s) => {
+			let parts: Vec<&str> = s.splitn(3, ':').collect();
+			if parts.len() >= 2 && declared_volumes.contains(&parts[0]) {
+				let mut out = format!("{}.volume:{}", parts[0], parts[1]);
+				if let Some(opts) = parts.get(2) {
+					out.push(':');
+					out.push_str(opts);
+				}
+				out
+			} else {
+				s.clone()
+			}
+		}
+		VolumeMount::Long {
+			source,
+			target,
+			read_only,
+			..
+		} => {
+			let src = source.clone().unwrap_or_default();
+			let src = if declared_volumes.contains(&src.as_str()) {
+				format!("{src}.volume")
+			} else {
+				src
+			};
+			let mut out = if src.is_empty() {
+				target.clone()
+			} else {
+				format!("{src}:{target}")
+			};
+			if *read_only == Some(true) {
+				out.push_str(":ro");
+			}
+			out
+		}
+	}
+}
+
+fn render_command(command: &Command) -> String {
+	match command {
+		Command::Shell(s) => s.clone(),
+		Command::Exec(parts) => parts.join(" "),
+	}
+}
+
+fn render_restart(restart: &RestartPolicy) -> String {
+	match restart {
+		RestartPolicy::No => "no".to_string(),
+		RestartPolicy::Always => "always".to_string(),
+		RestartPolicy::UnlessStopped => "always".to_string(),
+		RestartPolicy::OnFailure { .. } => "on-failure".to_string(),
+	}
+}
+
+fn sorted_pairs(
+	map: std::collections::HashMap<String, Option<String>>,
+) -> Vec<(String, Option<String>)> {
+	let sorted: BTreeMap<_, _> = map.into_iter().collect();
+	sorted.into_iter().collect()
+}
+
+fn sorted_label_pairs(map: std::collections::HashMap<String, String>) -> Vec<(String, String)> {
+	let sorted: BTreeMap<_, _> = map.into_iter().collect();
+	sorted.into_iter().collect()
+}
+
+/// A single `[Section]` accumulating `Key=Value` lines in insertion order.
+struct Section {
+	name: &'static str,
+	lines: Vec<String>,
+}
+
+impl Section {
+	fn new(name: &'static str) -> Self {
+		Section {
+			name,
+			lines: Vec::new(),
+		}
+	}
+
+	fn add(&mut self, key: &str, value: String) {
+		self.lines.push(format!("{key}={value}"));
+	}
+
+	fn is_empty(&self) -> bool {
+		self.lines.is_empty()
+	}
+
+	fn render(&self) -> String {
+		let mut s = format!("[{}]\n", self.name);
+		for line in &self.lines {
+			s.push_str(line);
+			s.push('\n');
+		}
+		s
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::parse_str;
+
+	fn unit_named<'a>(out: &'a QuadletOutput, filename: &str) -> &'a QuadletUnit {
+		out.units
+			.iter()
+			.find(|u| u.filename == filename)
+			.unwrap_or_else(|| panic!("no unit named {filename}"))
+	}
+
+	#[test]
+	fn generates_container_network_and_volume_units() {
+		let yaml = r#"
+services:
+  web:
+    image: nginx:1.27
+    container_name: web
+    ports:
+      - "8080:80"
+    environment:
+      B_KEY: two
+      A_KEY: one
+    volumes:
+      - data:/var/lib/data
+    networks:
+      - frontend
+    restart: unless-stopped
+    depends_on:
+      - db
+  db:
+    image: postgres:16
+volumes:
+  data:
+networks:
+  frontend:
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+
+		let web = unit_named(&out, "web.container");
+		assert!(web.contents.contains("Image=nginx:1.27"));
+		assert!(web.contents.contains("ContainerName=web"));
+		assert!(web.contents.contains("PublishPort=8080:80"));
+		// Environment is emitted in sorted key order for determinism.
+		let a = web.contents.find("Environment=A_KEY=one").unwrap();
+		let b = web.contents.find("Environment=B_KEY=two").unwrap();
+		assert!(a < b, "environment keys must be sorted");
+		// Declared named volume is tied to its .volume unit.
+		assert!(web.contents.contains("Volume=data.volume:/var/lib/data"));
+		assert!(web.contents.contains("Network=frontend.network"));
+		// unless-stopped maps to systemd Restart=always.
+		assert!(web.contents.contains("Restart=always"));
+		assert!(web.contents.contains("After=db.service"));
+		assert!(web.contents.contains("WantedBy=default.target"));
+
+		unit_named(&out, "db.container");
+		assert!(unit_named(&out, "data.volume")
+			.contents
+			.contains("VolumeName=proj_data"));
+		assert!(unit_named(&out, "frontend.network")
+			.contents
+			.contains("NetworkName=proj_frontend"));
+	}
+
+	#[test]
+	fn warns_about_unmapped_build_field() {
+		let yaml = r#"
+services:
+  app:
+    build: .
+    image: app:latest
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+		assert!(
+			out.warnings.iter().any(|w| w.contains("build")),
+			"a set build field must produce a warning"
+		);
+	}
+
+	#[test]
+	fn bind_path_volume_is_passed_through() {
+		let yaml = r#"
+services:
+  web:
+    image: nginx
+    volumes:
+      - ./html:/usr/share/nginx/html:ro
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+		let web = unit_named(&out, "web.container");
+		assert!(web
+			.contents
+			.contains("Volume=./html:/usr/share/nginx/html:ro"));
+	}
+
+	#[test]
+	fn maps_the_full_container_field_set() {
+		let yaml = r#"
+services:
+  app:
+    image: app:1.0
+    hostname: app-host
+    user: "1000:1000"
+    working_dir: /srv
+    read_only: true
+    init: true
+    entrypoint: ["/bin/sh", "-c"]
+    command: server --port 9000
+    labels:
+      z_team: core
+      a_tier: web
+    cap_add:
+      - NET_ADMIN
+    cap_drop:
+      - MKNOD
+    ports:
+      - target: 9000
+        published: 9000
+        protocol: udp
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+		let c = &unit_named(&out, "app.container").contents;
+		assert!(c.contains("HostName=app-host"));
+		assert!(c.contains("User=1000:1000"));
+		assert!(c.contains("WorkingDir=/srv"));
+		assert!(c.contains("ReadOnly=true"));
+		assert!(c.contains("RunInit=true"));
+		assert!(c.contains("Entrypoint=/bin/sh -c"));
+		assert!(c.contains("Exec=server --port 9000"));
+		assert!(c.contains("AddCapability=NET_ADMIN"));
+		assert!(c.contains("DropCapability=MKNOD"));
+		assert!(c.contains("PublishPort=9000:9000/udp"));
+		// Labels sorted by key.
+		let a = c.find("Label=a_tier=web").unwrap();
+		let z = c.find("Label=z_team=core").unwrap();
+		assert!(a < z, "labels must be sorted");
+	}
+
+	#[test]
+	fn long_form_volume_with_named_source_and_readonly() {
+		let yaml = r#"
+services:
+  db:
+    image: postgres
+    volumes:
+      - type: volume
+        source: pgdata
+        target: /var/lib/postgresql/data
+        read_only: true
+volumes:
+  pgdata:
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+		let c = &unit_named(&out, "db.container").contents;
+		assert!(c.contains("Volume=pgdata.volume:/var/lib/postgresql/data:ro"));
+	}
+
+	#[test]
+	fn restart_policies_map_to_systemd() {
+		let cases = [
+			("no", "Restart=no"),
+			("always", "Restart=always"),
+			("unless-stopped", "Restart=always"),
+			("on-failure", "Restart=on-failure"),
+		];
+		for (policy, expected) in cases {
+			let yaml = format!("services:\n  s:\n    image: x\n    restart: {policy}\n");
+			let file = parse_str(&yaml).unwrap();
+			let out = generate(&file, "p");
+			assert!(
+				unit_named(&out, "s.container").contents.contains(expected),
+				"{policy} -> {expected}"
+			);
+		}
+	}
+
+	#[test]
+	fn optional_dependency_uses_wants_not_requires() {
+		let yaml = r#"
+services:
+  web:
+    image: nginx
+    depends_on:
+      cache:
+        condition: service_started
+        required: false
+  cache:
+    image: redis
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+		let c = &unit_named(&out, "web.container").contents;
+		assert!(c.contains("After=cache.service"));
+		assert!(c.contains("Wants=cache.service"));
+		assert!(!c.contains("Requires=cache.service"));
+	}
+
+	#[test]
+	fn warns_for_every_unmapped_field() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    healthcheck:
+      test: ["CMD", "true"]
+    network_mode: host
+    privileged: true
+    profiles: [debug]
+    volumes_from:
+      - other
+    deploy:
+      replicas: 3
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let joined = out.warnings.join("\n");
+		for needle in [
+			"healthcheck",
+			"network_mode",
+			"privileged",
+			"profiles",
+			"volumes_from",
+			"scale/replicas",
+		] {
+			assert!(joined.contains(needle), "expected warning for {needle}");
+		}
+	}
+
+	#[test]
+	fn ephemeral_published_port_omits_host_side() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    ports:
+      - "80"
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(c.contains("PublishPort=80"));
+		assert!(!c.contains("PublishPort=:80"));
+	}
+}

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -3,7 +3,7 @@
 //! Flow: resolve the latest release tag, compare against the compiled-in
 //! version, and (unless `--check`) download the platform binary plus the signed
 //! `SHA256SUMS` manifest. The manifest's Ed25519 signature is verified against
-//! the public key embedded in this binary ([`verify::RELEASE_PUBKEY`]); only
+//! the public key embedded in this binary (`verify::RELEASE_PUBKEY`); only
 //! then is the binary's digest checked against the manifest and the running
 //! executable atomically replaced. Every step fails closed — a missing key,
 //! bad signature, or checksum mismatch aborts before anything is written.

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -1,0 +1,142 @@
+//! Golden tests for compose -> Quadlet translation. They pin the exact unit
+//! contents so any change to the mapping is reviewed deliberately.
+
+use std::fs;
+use std::process::Command;
+
+use podup::parse_str;
+use podup::quadlet::generate;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+fn unit<'a>(out: &'a podup::quadlet::QuadletOutput, name: &str) -> &'a str {
+	&out.units
+		.iter()
+		.find(|u| u.filename == name)
+		.unwrap_or_else(|| panic!("missing unit {name}"))
+		.contents
+}
+
+#[test]
+fn container_unit_matches_golden() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx:1.27
+    container_name: web
+    ports:
+      - "8080:80"
+    environment:
+      TZ: UTC
+    volumes:
+      - data:/var/lib/data
+    networks:
+      - frontend
+    restart: always
+    depends_on:
+      - db
+volumes:
+  data:
+networks:
+  frontend:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "proj");
+
+	let expected = "\
+[Unit]
+Description=web (podup)
+After=db.service
+Requires=db.service
+
+[Container]
+ContainerName=web
+Image=nginx:1.27
+PublishPort=8080:80
+Environment=TZ=UTC
+Volume=data.volume:/var/lib/data
+Network=frontend.network
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=default.target
+";
+	assert_eq!(unit(&out, "web.container"), expected);
+}
+
+#[test]
+fn network_and_volume_units_match_golden() {
+	let yaml = r#"
+services:
+  app:
+    image: alpine
+volumes:
+  cache:
+networks:
+  backend:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "myproj");
+
+	assert_eq!(
+		unit(&out, "cache.volume"),
+		"[Volume]\nVolumeName=myproj_cache\n\n[Install]\nWantedBy=default.target\n"
+	);
+	assert_eq!(
+		unit(&out, "backend.network"),
+		"[Network]\nNetworkName=myproj_backend\n\n[Install]\nWantedBy=default.target\n"
+	);
+}
+
+#[test]
+fn cli_writes_units_to_output_dir() {
+	let dir = std::env::temp_dir().join(format!("podup-quadlet-{}", std::process::id()));
+	let _ = fs::remove_dir_all(&dir);
+	let compose = dir.join("docker-compose.yml");
+	fs::create_dir_all(&dir).unwrap();
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: nginx\nvolumes:\n  data:\n",
+	)
+	.unwrap();
+	let out_dir = dir.join("units");
+
+	let status = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "generate", "quadlet", "-o"])
+		.arg(&out_dir)
+		.status()
+		.unwrap();
+	assert!(status.success());
+
+	let web = fs::read_to_string(out_dir.join("web.container")).unwrap();
+	assert!(web.contains("Image=nginx"));
+	assert!(fs::read_to_string(out_dir.join("data.volume"))
+		.unwrap()
+		.contains("VolumeName="));
+
+	let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn cli_prints_units_to_stdout() {
+	let dir = std::env::temp_dir().join(format!("podup-quadlet-stdout-{}", std::process::id()));
+	let _ = fs::remove_dir_all(&dir);
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("docker-compose.yml");
+	fs::write(&compose, "services:\n  web:\n    image: nginx\n").unwrap();
+
+	let output = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "generate", "quadlet"])
+		.output()
+		.unwrap();
+	assert!(output.status.success());
+	let stdout = String::from_utf8(output.stdout).unwrap();
+	assert!(stdout.contains("# web.container"));
+	assert!(stdout.contains("Image=nginx"));
+
+	let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## v0.8.0

### Features
- `--project-directory` to override the base path for relative-path resolution (#153).
- `podup generate quadlet` — export systemd Quadlet units so systemd can own the lifecycle (#151/#157).

### CI / build
- Reusable Rust CI gains opt-in MSRV, package-check, semver-check and doc-warnings jobs (#143/#145/#147/#148), enabled here.
- Asset-name contract check and Debian package build in CI (#144/#146); fixed `debian/rules` for non-vendored builds.

### Dependencies
- Dropped the `futures` umbrella crate in favour of `futures-util` + `futures-core` (#150).

### Chore
- Bumped to 0.8.0, backfilled the 0.7.0 changelog entry.

Merges develop into main. Tagging `v0.8.0` (which publishes the immutable release + crates.io) is left as the owner's manual step.