### PR TITLE
feat: recreate only changed services on up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+podup (0.9.0) unstable; urgency=medium
+
+  * up now recreates only services whose configuration changed, using a
+    podup.config-hash label; unchanged containers are left in place.
+  * Add up --force-recreate to recreate containers unconditionally.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 13:30:00 -0500
+
 podup (0.8.0) unstable; urgency=medium
 
   * Add --project-directory to override the base path for relative-path

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -105,6 +105,7 @@ impl Engine {
 		}
 		labels.insert("podup.project".to_string(), self.project.clone());
 		labels.insert("podup.service".to_string(), service_name.to_string());
+		labels.insert("podup.config-hash".to_string(), config_hash(service));
 
 		// annotations
 		let annotations: HashMap<String, String> = service.annotations.to_map();
@@ -247,6 +248,19 @@ impl Engine {
 	}
 }
 
+/// Stable content hash of a service definition, stored as the
+/// `podup.config-hash` label. On `up`, comparing this against the label on an
+/// existing container tells podup whether the service configuration changed
+/// and the container must be recreated, or is unchanged and can be left as is.
+pub(crate) fn config_hash(service: &Service) -> String {
+	use sha2::{Digest, Sha256};
+	let serialized = serde_json::to_vec(service).unwrap_or_default();
+	Sha256::digest(&serialized)
+		.iter()
+		.map(|b| format!("{b:02x}"))
+		.collect()
+}
+
 fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
 	let entries = service.env_file.to_entries();
 	let env_file_vars = if !entries.is_empty() {
@@ -258,4 +272,23 @@ fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
 		service.environment.to_map(),
 		env_file_vars,
 	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::config_hash;
+	use crate::parse_str;
+
+	#[test]
+	fn config_hash_is_stable_and_sensitive() {
+		let a = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let b = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let c = parse_str("services:\n  web:\n    image: nginx:1.28\n").unwrap();
+		let ha = config_hash(&a.services["web"]);
+		let hb = config_hash(&b.services["web"]);
+		let hc = config_hash(&c.services["web"]);
+		assert_eq!(ha, hb, "same config produces the same hash");
+		assert_ne!(ha, hc, "a changed image produces a different hash");
+		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
+	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,13 +2,15 @@
 
 mod commands;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use tracing::info;
 
 use crate::compose::types::{ComposeFile, Service, ServiceCondition};
 use crate::error::{ComposeError, Result};
 use crate::libpod::API_PREFIX;
+
+use super::container::config_hash;
 
 use super::network::resolve_network_name;
 use super::profiles::{active_profiles_set, service_in_profiles};
@@ -31,7 +33,19 @@ pub struct RunOptions {
 impl Engine {
 	/// Start all services defined in the compose file, creating containers that do not exist.
 	pub async fn up(&self, file: &ComposeFile) -> Result<()> {
-		self.up_with_options(file, false, &[], &[], false).await
+		self.up_with_options(file, false, &[], &[], false, false)
+			.await
+	}
+
+	/// Start a container by name, ignoring an error from an already-running one.
+	/// Used when `up` leaves an unchanged container in place but wants to ensure
+	/// it is running.
+	async fn ensure_started(&self, container_name: &str) {
+		let path = format!(
+			"{API_PREFIX}/containers/{}/start",
+			crate::libpod::urlencoded(container_name)
+		);
+		let _ = self.client.post_empty_ok(&path).await;
 	}
 
 	/// Start services with explicit options. When `no_recreate` is true, running containers are left untouched. On partial failure, staging directories are cleaned up.
@@ -42,6 +56,7 @@ impl Engine {
 		active_profiles: &[String],
 		target_services: &[String],
 		no_recreate: bool,
+		force_recreate: bool,
 	) -> Result<()> {
 		let r: Result<()> = async {
 			let order = crate::compose::resolve_order(file)?;
@@ -67,26 +82,36 @@ impl Engine {
 				Some(set)
 			};
 
-			// prefetch running containers once instead of one API call per replica.
-			let running: HashSet<String> = if no_recreate {
+			// Prefetch the project's containers once (instead of one API call per
+			// replica): which names already exist, and each one's config-hash
+			// label so we can decide whether a container needs recreation.
+			let mut present: HashSet<String> = HashSet::new();
+			let mut existing_hash: HashMap<String, String> = HashMap::new();
+			if !force_recreate {
 				let filters = serde_json::json!({
 					"label": [format!("podup.project={}", self.project)],
 				});
 				let path = format!(
-					"{API_PREFIX}/containers/json?filters={}",
+					"{API_PREFIX}/containers/json?all=true&filters={}",
 					crate::libpod::urlencoded(&filters.to_string()),
 				);
-				self.client
+				let entries = self
+					.client
 					.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
 					.await
-					.map_err(crate::error::ComposeError::Podman)?
-					.into_iter()
-					.flat_map(|c| c.names)
-					.map(|n| n.trim_start_matches('/').to_string())
-					.collect()
-			} else {
-				HashSet::new()
-			};
+					.map_err(crate::error::ComposeError::Podman)?;
+				for entry in entries {
+					if let Some(hash) = entry.labels.get("podup.config-hash") {
+						for raw in &entry.names {
+							existing_hash
+								.insert(raw.trim_start_matches('/').to_string(), hash.clone());
+						}
+					}
+					for raw in entry.names {
+						present.insert(raw.trim_start_matches('/').to_string());
+					}
+				}
+			}
 
 			self.create_networks(file).await?;
 			self.create_volumes(file).await?;
@@ -149,15 +174,25 @@ impl Engine {
 					.or(service.deploy.as_ref().and_then(|d| d.replicas))
 					.unwrap_or(1) as usize;
 
+				let new_hash = config_hash(service);
+
 				for i in 1..=replicas {
 					let container_name = if replicas == 1 {
 						self.container_name(name, service)
 					} else {
 						format!("{}-{i}", self.container_name(name, service))
 					};
-					if no_recreate && running.contains(&container_name) {
-						info!("{container_name} already running — skipping recreate");
-						continue;
+					if !force_recreate {
+						if no_recreate && present.contains(&container_name) {
+							info!("{container_name} already exists — skipping recreate");
+							self.ensure_started(&container_name).await;
+							continue;
+						}
+						if existing_hash.get(&container_name) == Some(&new_hash) {
+							info!("{container_name} is up to date — skipping recreate");
+							self.ensure_started(&container_name).await;
+							continue;
+						}
 					}
 					self.create_and_start(&container_name, name, service, file)
 						.await?;

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -30,6 +30,9 @@ pub struct ContainerListEntry {
 
 	#[serde(rename = "Ports", default, deserialize_with = "null_default")]
 	pub ports: Vec<ContainerPort>,
+
+	#[serde(rename = "Labels", default, deserialize_with = "null_default")]
+	pub labels: HashMap<String, String>,
 }
 
 /// Port mapping entry in container list response.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -64,6 +64,9 @@ enum Commands {
 		/// Do not recreate containers that are already running.
 		#[arg(long)]
 		no_recreate: bool,
+		/// Recreate containers even if their configuration is unchanged.
+		#[arg(long)]
+		force_recreate: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]
@@ -371,6 +374,7 @@ async fn run() -> podup::Result<()> {
 			watch,
 			remove_orphans,
 			no_recreate,
+			force_recreate,
 			services,
 		} => {
 			if remove_orphans {
@@ -380,7 +384,14 @@ async fn run() -> podup::Result<()> {
 				engine.build_all(&file, &services).await?;
 			}
 			engine
-				.up_with_options(&file, detach, &cli.profile, &services, no_recreate)
+				.up_with_options(
+					&file,
+					detach,
+					&cli.profile,
+					&services,
+					no_recreate,
+					force_recreate,
+				)
 				.await?;
 			if watch {
 				engine.watch(&file).await?;

--- a/tests/engine_integration/group_a1.rs
+++ b/tests/engine_integration/group_a1.rs
@@ -37,7 +37,7 @@ async fn up_no_recreate_skips_running() {
 	engine.up(&file).await.unwrap();
 	// Second up with no_recreate: already running → skip
 	engine
-		.up_with_options(&file, false, &[], &[], true)
+		.up_with_options(&file, false, &[], &[], true, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -58,7 +58,7 @@ async fn up_target_services_only() {
 
 	// Only start web (and its dep db)
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -329,3 +329,33 @@ async fn attach_logs_empty_attach_returns() {
 }
 
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn up_skips_recreate_when_config_unchanged() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("rch");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// Same config again -> config-hash matches -> skip recreate + ensure started.
+	engine.up(&file).await.unwrap();
+	// force_recreate -> recreate even though config is unchanged.
+	engine
+		.up_with_options(&file, false, &[], &[], false, true)
+		.await
+		.unwrap();
+	// Changed config -> hash differs -> recreate.
+	let file2 = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"120\"]\n",
+	)
+	.unwrap();
+	engine.up(&file2).await.unwrap();
+	engine.down(&file2).await.unwrap();
+}

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -228,7 +228,7 @@ async fn profile_filtered_service_skipped() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &[], false)
+		.up_with_options(&file, false, &[], &[], false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();

--- a/tests/engine_integration/group_a4.rs
+++ b/tests/engine_integration/group_a4.rs
@@ -49,7 +49,7 @@ fn active_profiles_via_env() {
 			.unwrap();
 			// Pass empty active_profiles slice so it falls back to COMPOSE_PROFILES env
 			engine
-				.up_with_options(&file, false, &[], &[], false)
+				.up_with_options(&file, false, &[], &[], false, false)
 				.await
 				.unwrap();
 			engine.down(&file).await.unwrap();
@@ -187,7 +187,7 @@ async fn target_services_skips_non_dep() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -210,7 +210,7 @@ async fn dep_on_profile_filtered_service() {
 
 	// No active profiles → db is skipped; web still runs but skips db's dep wait
 	engine
-		.up_with_options(&file, false, &[], &[], false)
+		.up_with_options(&file, false, &[], &[], false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -293,7 +293,7 @@ async fn optional_dep_not_in_file() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -324,6 +324,7 @@ async fn target_services_duplicate_entry() {
 			false,
 			&[],
 			&["web".to_string(), "web".to_string()],
+			false,
 			false,
 		)
 		.await


### PR DESCRIPTION
## What
`up` previously recreated **every** container on each invocation. Now each container carries a `podup.config-hash` label (stable hash of the service definition); on `up`, a container whose hash matches the current config is left in place and just (re)started, and only services whose config changed are recreated. Adds `--force-recreate` to recreate unconditionally.

## Breaking
`Engine::up_with_options` gains a `force_recreate` parameter (callers must pass it; `Engine::up` is unchanged). The runtime recreate behaviour also changes. panel-agent will be bumped in a follow-up. Version bumped to 0.9.0 in this PR so cargo-semver-checks accepts the change.

## Tests
- Unit test for `config_hash` (stable + image-sensitive).
- Integration test exercising skip-unchanged, `--force-recreate`, and recreate-on-change (runs under Podman in CI).

Closes #160