### PR TITLE
release: v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+podup (0.10.0) unstable; urgency=medium
+
+  * Resolve relative bind-mount sources against the project directory and
+    expand a leading ~ instead of passing them to Podman raw.
+  * Mount named volumes under their actual created name ({project}_{name},
+    a custom name:, or the external name). NOTE: projects whose data was
+    written to an unprefixed volume by an earlier podup must migrate it.
+  * Resolve bare environment keys from podup's environment instead of
+    dropping them.
+  * Probe the compose-spec file precedence list (compose.yaml etc.) when
+    no compose file is given.
+  * Fall back to Containerfile when no Dockerfile is present.
+  * Always recreate services that have a build section on up.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 14:30:00 -0500
+
 podup (0.9.0) unstable; urgency=medium
 
   * up now recreates only services whose configuration changed, using a

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -125,7 +125,17 @@ impl Engine {
 		let (secret_files, secret_specs) = self.resolve_build_secrets(build, file)?;
 
 		let inline = build.dockerfile_inline().map(|s| s.to_string());
-		let df = build.dockerfile().unwrap_or("Dockerfile").to_string();
+		// Honour an explicit dockerfile; otherwise prefer Dockerfile but fall back
+		// to Podman's native Containerfile when only the latter is present.
+		let df = match build.dockerfile() {
+			Some(name) => name.to_string(),
+			None if !context_path.join("Dockerfile").is_file()
+				&& context_path.join("Containerfile").is_file() =>
+			{
+				"Containerfile".to_string()
+			}
+			None => "Dockerfile".to_string(),
+		};
 		let ctx = context_path.clone();
 		let (tar_bytes, dockerfile_name) =
 			tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String)> {

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -49,19 +49,36 @@ impl Engine {
 		}
 
 		// --- Environment ---
+		// A bare `KEY` (no `=`) is a passthrough: its value comes from podup's
+		// own environment, matching docker-compose. Drop it only when unset.
 		let env: HashMap<String, String> = build_env(service, &self.base_dir)?
 			.into_iter()
-			.filter_map(|s| {
-				let idx = s.find('=')?;
-				Some((s[..idx].to_string(), s[idx + 1..].to_string()))
+			.filter_map(|s| match s.find('=') {
+				Some(idx) => Some((s[..idx].to_string(), s[idx + 1..].to_string())),
+				None => std::env::var(&s).ok().map(|v| (s, v)),
 			})
 			.collect();
 
 		// --- Secrets and configs become bind mounts ---
 		let secret_binds = self.build_secret_binds(service, file)?;
 		let config_binds = self.build_config_binds(service, file)?;
-		let (mounts, named_volumes) =
+		let (mut mounts, mut named_volumes) =
 			build_mounts_all(service, &self.base_dir, &secret_binds, &config_binds);
+		// Resolve relative bind sources against the project base directory (and
+		// expand a leading `~`) so they don't depend on Podman's working
+		// directory; absolute paths (incl. staged secrets/configs) are untouched.
+		for m in &mut mounts {
+			if m.mount_type == "bind" {
+				if let Some(src) = m.source.take() {
+					m.source = Some(resolve_bind_source(&src, &self.base_dir));
+				}
+			}
+		}
+		// Map each named-volume reference to the actual volume name created by
+		// create_volumes (project-prefixed, custom `name:`, or external).
+		for nv in &mut named_volumes {
+			nv.name = self.resolved_volume_name(&nv.name, file);
+		}
 
 		// --- Port mappings ---
 		let parsed_ports = ports::parse_ports(&service.ports)?;
@@ -246,6 +263,57 @@ impl Engine {
 
 		Ok(())
 	}
+
+	/// Resolve a service's named-volume reference to the actual volume name
+	/// that `create_volumes` produced: a custom `name:`, the raw name for an
+	/// external volume, or the `{project}_{name}` form. References not declared
+	/// in the top-level `volumes:` map (anonymous/implicit) are left unchanged.
+	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> String {
+		resolve_volume_name(reference, &self.project, file)
+	}
+}
+
+/// Resolve a named-volume reference to the volume name `create_volumes`
+/// produced: a custom `name:`, the raw name for an external volume, or the
+/// `{project}_{name}` form. References not declared in the top-level `volumes:`
+/// map (anonymous/implicit) are returned unchanged.
+fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> String {
+	match file.volumes.get(reference) {
+		Some(cfg) => {
+			if let Some(name) = cfg.as_ref().and_then(|c| c.name.as_deref()) {
+				name.to_string()
+			} else if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
+				reference.to_string()
+			} else {
+				format!("{project}_{reference}")
+			}
+		}
+		None => reference.to_string(),
+	}
+}
+
+/// Resolve a bind-mount source path: expand a leading `~`, then make a relative
+/// path absolute against the project base directory. Absolute paths (including
+/// staged secret/config files) are returned unchanged.
+fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
+	if src.is_empty() {
+		return src.to_string();
+	}
+	let expanded = if let Some(rest) = src.strip_prefix("~/") {
+		match std::env::var("HOME") {
+			Ok(home) => format!("{home}/{rest}"),
+			Err(_) => src.to_string(),
+		}
+	} else if src == "~" {
+		std::env::var("HOME").unwrap_or_else(|_| src.to_string())
+	} else {
+		src.to_string()
+	};
+	if Path::new(&expanded).is_absolute() {
+		expanded
+	} else {
+		base_dir.join(&expanded).to_string_lossy().into_owned()
+	}
 }
 
 /// Stable content hash of a service definition, stored as the
@@ -276,8 +344,35 @@ fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-	use super::config_hash;
+	use super::{config_hash, resolve_volume_name};
 	use crate::parse_str;
+
+	#[test]
+	#[cfg(unix)]
+	fn bind_source_resolution() {
+		use super::resolve_bind_source;
+		use std::path::Path;
+		let base = Path::new("/srv/app");
+		assert_eq!(resolve_bind_source("/abs/path", base), "/abs/path");
+		assert_eq!(resolve_bind_source("./data", base), "/srv/app/./data");
+		assert_eq!(resolve_bind_source("data", base), "/srv/app/data");
+		std::env::set_var("HOME", "/home/u");
+		assert_eq!(resolve_bind_source("~/x", base), "/home/u/x");
+		assert_eq!(resolve_bind_source("~", base), "/home/u");
+	}
+
+	#[test]
+	fn volume_name_resolution() {
+		let f = parse_str(
+			"services:\n  s:\n    image: x\nvolumes:\n  data:\n  ext:\n    external: true\n  custom:\n    name: my-vol\n",
+		)
+		.unwrap();
+		assert_eq!(resolve_volume_name("data", "proj", &f), "proj_data");
+		assert_eq!(resolve_volume_name("ext", "proj", &f), "ext");
+		assert_eq!(resolve_volume_name("custom", "proj", &f), "my-vol");
+		// Not declared in top-level volumes -> left as-is.
+		assert_eq!(resolve_volume_name("anon", "proj", &f), "anon");
+	}
 
 	#[test]
 	fn config_hash_is_stable_and_sensitive() {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -188,7 +188,12 @@ impl Engine {
 							self.ensure_started(&container_name).await;
 							continue;
 						}
-						if existing_hash.get(&container_name) == Some(&new_hash) {
+						// Services with a build section are rebuilt on every up, so
+						// their container must be recreated to pick up the fresh
+						// image even when the compose config is unchanged.
+						if service.build.is_none()
+							&& existing_hash.get(&container_name) == Some(&new_hash)
+						{
 							info!("{container_name} is up to date — skipping recreate");
 							self.ensure_started(&container_name).await;
 							continue;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -13,14 +13,12 @@ use tracing_subscriber::EnvFilter;
 	about = "docker-compose translator for Podman"
 )]
 struct Cli {
-	/// Path to the compose file. May also be set via `COMPOSE_FILE`.
-	#[arg(
-		short,
-		long,
-		env = "COMPOSE_FILE",
-		default_value = "docker-compose.yml"
-	)]
-	file: PathBuf,
+	/// Path to the compose file. May also be set via `COMPOSE_FILE`. When
+	/// unset, the compose-spec precedence list is probed in the current
+	/// directory (compose.yaml, compose.yml, docker-compose.yaml,
+	/// docker-compose.yml).
+	#[arg(short, long, env = "COMPOSE_FILE")]
+	file: Option<PathBuf>,
 
 	/// Project name (used as a prefix for container names).
 	/// May also be set via `COMPOSE_PROJECT_NAME`.
@@ -290,6 +288,30 @@ fn write_quadlet(
 	Ok(())
 }
 
+/// Compose-spec file-name precedence, highest first.
+const COMPOSE_FILE_CANDIDATES: [&str; 4] = [
+	"compose.yaml",
+	"compose.yml",
+	"docker-compose.yaml",
+	"docker-compose.yml",
+];
+
+/// Resolve which compose file to load. An explicit `--file`/`COMPOSE_FILE`
+/// wins; otherwise probe the compose-spec precedence list in the current
+/// directory, falling back to `docker-compose.yml` so a missing-file error
+/// names a sensible path.
+fn resolve_compose_file(explicit: Option<PathBuf>) -> PathBuf {
+	if let Some(path) = explicit {
+		return path;
+	}
+	for candidate in COMPOSE_FILE_CANDIDATES {
+		if Path::new(candidate).is_file() {
+			return PathBuf::from(candidate);
+		}
+	}
+	PathBuf::from("docker-compose.yml")
+}
+
 /// Resolve the base directory for relative-path resolution. An explicit
 /// `--project-directory` wins; otherwise it is the directory containing the
 /// compose file (compose-spec default), or the current directory when the
@@ -336,7 +358,8 @@ async fn run() -> podup::Result<()> {
 			.map_err(|e| podup::ComposeError::Update(format!("update task failed: {e}")))?;
 	}
 
-	let file = podup::parse_file(&cli.file)?;
+	let compose_path = resolve_compose_file(cli.file.clone());
+	let file = podup::parse_file(&compose_path)?;
 
 	if matches!(cli.command, Commands::Config) {
 		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
@@ -354,7 +377,7 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
-	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &cli.file);
+	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_path);
 	let engine = podup::Engine::with_base_dir(client, cli.project, base_dir);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
@@ -456,8 +479,28 @@ async fn run() -> podup::Result<()> {
 
 #[cfg(test)]
 mod tests {
-	use super::resolve_base_dir;
+	use super::{resolve_base_dir, resolve_compose_file};
 	use std::path::{Path, PathBuf};
+
+	#[test]
+	fn explicit_compose_file_wins() {
+		let p = resolve_compose_file(Some(PathBuf::from("custom.yml")));
+		assert_eq!(p, PathBuf::from("custom.yml"));
+	}
+
+	#[test]
+	fn missing_compose_file_falls_back_to_default_name() {
+		// In a directory with no candidate files, the default name is returned
+		// so the resulting error names a sensible path.
+		let dir = std::env::temp_dir().join(format!("podup-cf-{}", std::process::id()));
+		std::fs::create_dir_all(&dir).unwrap();
+		let prev = std::env::current_dir().unwrap();
+		std::env::set_current_dir(&dir).unwrap();
+		let p = resolve_compose_file(None);
+		std::env::set_current_dir(prev).unwrap();
+		let _ = std::fs::remove_dir_all(&dir);
+		assert_eq!(p, PathBuf::from("docker-compose.yml"));
+	}
 
 	#[test]
 	fn project_directory_override_wins() {


### PR DESCRIPTION
## v0.10.0 — compose-spec correctness

Fixes from a full audit of the compose spec against our parser/engine (#163): env passthrough keys, compose-file precedence discovery, Containerfile fallback, relative bind-path resolution, named-volume project-prefixing, and build-service recreate.

### ⚠️ Breaking (behavioural)
Named volumes now mount under their project-prefixed name (matching docker-compose). A project whose data was written to an unprefixed volume by an earlier podup must migrate it to `<project>_<name>`.

Remaining parity gaps tracked in #164. Tag `v0.10.0` triggers the published release + crates.io.