### PR TITLE
fix: compose-spec parity — run ports, env_file precedence, external resources, config-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.11.0) unstable; urgency=medium
+
+  * run no longer publishes the service's declared ports by default; pass
+    --service-ports to opt in, matching compose semantics.
+  * env_file: when a key is defined in multiple files, the last file now
+    wins (later entries override earlier ones).
+  * External volumes and networks that do not exist now fail with an error
+    instead of being silently skipped; external networks resolve to their
+    literal name rather than a project-prefixed one.
+  * config-hash is now computed from a key-sorted canonical form, so
+    services with map-typed fields no longer recreate spuriously on up.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
+
 podup (0.10.0) unstable; urgency=medium
 
   * Resolve relative bind-mount sources against the project directory and

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -322,7 +322,12 @@ fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
 /// and the container must be recreated, or is unchanged and can be left as is.
 pub(crate) fn config_hash(service: &Service) -> String {
 	use sha2::{Digest, Sha256};
-	let serialized = serde_json::to_vec(service).unwrap_or_default();
+	// Canonicalise through `serde_json::Value` first: object keys are emitted in
+	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
+	// between runs and flap the hash into a spurious recreate.
+	let serialized = serde_json::to_value(service)
+		.and_then(|v| serde_json::to_vec(&v))
+		.unwrap_or_default();
 	Sha256::digest(&serialized)
 		.iter()
 		.map(|b| format!("{b:02x}"))
@@ -385,5 +390,24 @@ mod tests {
 		assert_eq!(ha, hb, "same config produces the same hash");
 		assert_ne!(ha, hc, "a changed image produces a different hash");
 		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
+	}
+
+	#[test]
+	fn config_hash_stable_despite_map_field_order() {
+		// `storage_opt` is a HashMap; canonical serialisation must sort its keys
+		// so the hash does not flap and trigger a spurious recreate on `up`.
+		let a = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      size: \"10G\"\n      foo: bar\n      baz: qux\n",
+		)
+		.unwrap();
+		let b = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      baz: qux\n      size: \"10G\"\n      foo: bar\n",
+		)
+		.unwrap();
+		assert_eq!(
+			config_hash(&a.services["web"]),
+			config_hash(&b.services["web"]),
+			"hash must be independent of storage_opt key order",
+		);
 	}
 }

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -251,6 +251,7 @@ impl Engine {
 			detach,
 			env_overrides,
 			name_override,
+			service_ports,
 		} = opts;
 		let service = file
 			.services
@@ -276,6 +277,12 @@ impl Engine {
 			run_service.environment = crate::compose::types::EnvVars::List(env_list);
 		}
 		run_service.restart = None;
+		// Compose `run` does not publish the service's ports unless
+		// `--service-ports` is given; otherwise a one-off run would collide
+		// with the long-running service's host-port bindings.
+		if !service_ports {
+			run_service.ports.clear();
+		}
 		// Force non-TTY so Podman uses multiplexed log framing that
 		// parse_multiplexed can decode. TTY mode sends raw bytes without
 		// the 8-byte header, which would produce garbled output.

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -28,6 +28,9 @@ pub struct RunOptions {
 	pub env_overrides: Vec<String>,
 	/// Override the generated container name.
 	pub name_override: Option<String>,
+	/// Publish the service's declared `ports:` (compose `run --service-ports`).
+	/// When false, `run` leaves ports unpublished to avoid host-port collisions.
+	pub service_ports: bool,
 }
 
 impl Engine {

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -23,6 +23,12 @@ impl Engine {
 
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
+				let external_name = config
+					.as_ref()
+					.and_then(|c| c.name.as_deref())
+					.unwrap_or(name);
+				self.ensure_external_exists("network", "networks", external_name)
+					.await?;
 				continue;
 			}
 
@@ -160,12 +166,18 @@ pub(super) fn resolve_network_mode(
 
 /// Resolve the actual network name on the host for a compose network key.
 pub(super) fn resolve_network_name(network: &str, file: &ComposeFile, project: &str) -> String {
-	file.networks
-		.get(network)
-		.and_then(|c| c.as_ref())
-		.and_then(|c| c.name.as_deref())
-		.map(|s| s.to_string())
-		.unwrap_or_else(|| format!("{project}_{network}"))
+	match file.networks.get(network).and_then(|c| c.as_ref()) {
+		Some(cfg) => {
+			if let Some(name) = cfg.name.as_deref() {
+				name.to_string()
+			} else if cfg.external.unwrap_or(false) {
+				network.to_string()
+			} else {
+				format!("{project}_{network}")
+			}
+		}
+		None => format!("{project}_{network}"),
+	}
 }
 
 fn build_subnets(ipam: &IpamConfig) -> Vec<Subnet> {
@@ -215,6 +227,17 @@ mod tests {
 			resolve_network_name("mynet", &file, "proj"),
 			"custom-net-name"
 		);
+	}
+
+	#[test]
+	fn resolve_network_name_external_uses_key_not_prefix() {
+		let cfg = NetworkConfig {
+			external: Some(true),
+			..Default::default()
+		};
+		let mut file = empty_file();
+		file.networks.insert("shared".to_string(), Some(cfg));
+		assert_eq!(resolve_network_name("shared", &file, "proj"), "shared");
 	}
 
 	#[test]

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -14,7 +14,7 @@ use crate::compose::types::{
 };
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::volume::VolumeCreateOptions;
-use crate::libpod::API_PREFIX;
+use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::{staging, Engine};
 
@@ -23,6 +23,12 @@ impl Engine {
 		for (name, config) in &file.volumes {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
+				let external_name = config
+					.as_ref()
+					.and_then(|c| c.name.as_deref())
+					.unwrap_or(name);
+				self.ensure_external_exists("volume", "volumes", external_name)
+					.await?;
 				continue;
 			}
 
@@ -69,6 +75,27 @@ impl Engine {
 			}
 		}
 		Ok(())
+	}
+
+	/// Verify an `external: true` volume/network already exists on the host.
+	///
+	/// The compose spec requires podup to error when an external resource is
+	/// declared but absent, rather than silently skipping it and letting
+	/// containers fail later with an opaque mount/attach error.
+	pub(super) async fn ensure_external_exists(
+		&self,
+		kind: &str,
+		api_segment: &str,
+		name: &str,
+	) -> Result<()> {
+		let path = format!("{API_PREFIX}/{api_segment}/{}/json", urlencoded(name));
+		match self.client.get_json::<serde_json::Value>(&path).await {
+			Ok(_) => Ok(()),
+			Err(ref e) if e.is_status(404) => Err(ComposeError::ExternalNotFound(format!(
+				"external {kind} \"{name}\" does not exist; create it before running"
+			))),
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
 	}
 
 	pub(super) fn build_secret_binds(

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -12,7 +12,7 @@ use crate::error::{ComposeError, Result};
 /// Load all `env_file` paths relative to `base_dir`.
 ///
 /// Returns a merged map.  If the same key appears in multiple files, the
-/// first file wins (earlier entries in the list have higher priority).
+/// last file wins (later entries in the list override earlier ones).
 /// `env_file:` never overrides service-level `environment:`.
 ///
 /// Returns [`ComposeError::FileNotFound`] when an env file does not exist.
@@ -76,7 +76,7 @@ pub fn load_env_file_entries(
 				continue;
 			}
 
-			result.entry(key).or_insert(value);
+			result.insert(key, value);
 		}
 	}
 
@@ -144,7 +144,7 @@ mod tests {
 	}
 
 	#[test]
-	fn first_file_wins_on_duplicate_key() {
+	fn last_file_wins_on_duplicate_key() {
 		let dir = tempfile::tempdir().unwrap();
 		std::fs::write(dir.path().join("a.env"), "FOO=first\n").unwrap();
 		std::fs::write(dir.path().join("b.env"), "FOO=second\n").unwrap();
@@ -153,7 +153,7 @@ mod tests {
 			EnvFileEntry::Path("b.env".into()),
 		];
 		let m = load_env_file_entries(&entries, dir.path()).unwrap();
-		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("first"));
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("second"));
 	}
 
 	#[test]

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -25,6 +25,7 @@ pub enum ComposeError {
 	Unsupported(String),
 	RunExited(i64),
 	Update(String),
+	ExternalNotFound(String),
 }
 
 impl fmt::Display for ComposeError {
@@ -49,6 +50,7 @@ impl fmt::Display for ComposeError {
 			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
 			Self::Update(s) => write!(f, "update error: {s}"),
+			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
 		}
 	}
 }
@@ -141,6 +143,10 @@ mod tests {
 				ComposeError::RunExited(1),
 			),
 			("update error: u", ComposeError::Update("u".into())),
+			(
+				"external resource not found: external volume \"v\" does not exist",
+				ComposeError::ExternalNotFound("external volume \"v\" does not exist".into()),
+			),
 		];
 		for (expected_prefix, err) in cases {
 			let msg = err.to_string();

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -140,6 +140,9 @@ enum Commands {
 		/// Override the container name.
 		#[arg(long)]
 		name: Option<String>,
+		/// Publish the service's declared ports (off by default).
+		#[arg(long)]
+		service_ports: bool,
 		/// Command (and arguments) to run.
 		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
 		cmd: Vec<String>,
@@ -437,6 +440,7 @@ async fn run() -> podup::Result<()> {
 			detach,
 			env_overrides,
 			name,
+			service_ports,
 			cmd,
 		} => {
 			engine
@@ -449,6 +453,7 @@ async fn run() -> podup::Result<()> {
 						detach,
 						env_overrides,
 						name_override: name,
+						service_ports,
 					},
 				)
 				.await?

--- a/tests/engine_integration/group_a3.rs
+++ b/tests/engine_integration/group_a3.rs
@@ -274,22 +274,25 @@ async fn config_long_form_ref() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn external_volume_skipped_on_up() {
+async fn external_volume_missing_errors_on_up() {
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,
 	};
 	let proj = proj("exv");
 	let engine = Engine::new(client, proj.clone());
-	// The external volume is declared but not mounted by the service,
-	// so create_volumes() hits the `continue` branch without creating it.
+	// An external volume that does not exist must surface an error rather than
+	// being silently skipped (compose spec requires the resource to exist).
 	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\nvolumes:\n  extdata:\n    external: true\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\nvolumes:\n  extdata-does-not-exist:\n    external: true\n",
 	)
 	.unwrap();
 
-	engine.up(&file).await.unwrap();
-	engine.down(&file).await.unwrap();
+	let result = engine.up(&file).await;
+	assert!(
+		matches!(result, Err(podup::ComposeError::ExternalNotFound(_))),
+		"expected ExternalNotFound, got {result:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -48,6 +48,7 @@ async fn engine_run_command_succeeds() {
 				detach: false,
 				env_overrides: vec![],
 				name_override: None,
+				service_ports: false,
 			},
 		)
 		.await;
@@ -74,6 +75,7 @@ async fn engine_run_nonzero_exit_returns_run_exited() {
 				detach: false,
 				env_overrides: vec![],
 				name_override: None,
+				service_ports: false,
 			},
 		)
 		.await;

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -35,7 +35,7 @@ fn string_or_list_many() {
 }
 
 #[test]
-fn first_file_wins_for_duplicate_keys() {
+fn last_file_wins_for_duplicate_keys() {
 	let dir = tempfile::tempdir().unwrap();
 
 	let mut a = std::fs::File::create(dir.path().join("a.env")).unwrap();
@@ -45,7 +45,7 @@ fn first_file_wins_for_duplicate_keys() {
 	writeln!(b, "KEY=from_b").unwrap();
 
 	let map = load_env_files(&["a.env".to_string(), "b.env".to_string()], dir.path()).unwrap();
-	assert_eq!(map["KEY"], "from_a");
+	assert_eq!(map["KEY"], "from_b");
 }
 
 #[test]


### PR DESCRIPTION
## What

Resolves the HIGH-severity compose-spec parity gaps from the audit (part of #164), plus the config-hash determinism fix.

### `run` no longer publishes service ports by default
Per the compose spec, `run` does not publish a service's declared `ports:` unless `--service-ports` is given. Previously every `run` cloned the full service spec including `ports`, risking a host-port collision with the long-running service. Added a `--service-ports` flag (`RunOptions.service_ports`); ports are cleared otherwise.

### `env_file` duplicate-key precedence is now last-wins
When the same key appears in multiple `env_file:` entries, later files override earlier ones (was first-wins via `or_insert`). Service-level `environment:` still overrides `env_file` values — that path is unchanged.

### External volumes/networks must exist
A declared `external: true` volume or network that does not exist now errors (new `ComposeError::ExternalNotFound`) instead of being silently skipped, which used to defer the failure to an opaque mount/attach error. External networks now also resolve to their literal name (or `name:`) rather than a project-prefixed name, mirroring how external volumes already resolved.

### config-hash determinism
`config_hash` now serialises through a key-sorted canonical form, so a service with map-typed fields (`storage_opt: HashMap`) no longer yields a flapping hash and a spurious recreate on every `up`.

## Tests
- `last_file_wins_on_duplicate_key` (flipped)
- `resolve_network_name_external_uses_key_not_prefix`
- `config_hash_stable_despite_map_field_order`
- `ExternalNotFound` Display coverage
- integration `RunOptions` updated for the new field

423 lib tests pass; clippy clean; fmt applied.
