### PR TITLE
fix: parse env files per dotenv rules (quotes, comments, escapes, multi-line)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,9 @@ podup (0.11.0) unstable; urgency=medium
     literal name rather than a project-prefixed one.
   * config-hash is now computed from a key-sorted canonical form, so
     services with map-typed fields no longer recreate spuriously on up.
+  * Parse env files and .env with dotenv rules: strip surrounding quotes,
+    honour escape sequences in double-quoted values, drop inline comments
+    on unquoted values, and support multi-line quoted values.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/dotenv.rs
+++ b/internal/dotenv.rs
@@ -1,0 +1,231 @@
+//! Minimal dotenv parser shared by `env_file` loading and `.env` interpolation.
+//!
+//! Implements the subset of compose-spec dotenv rules podup relies on:
+//! full-line comments, an optional `export` prefix, single- and double-quoted
+//! values (including values that span multiple lines), inline comments on
+//! unquoted values, and the standard double-quote escape sequences. Callers
+//! decide duplicate-key precedence by the order pairs are returned in.
+
+/// Parse dotenv `content` into ordered `(key, value)` pairs.
+///
+/// Pairs are returned in file order; a later duplicate key appears after an
+/// earlier one, leaving the precedence decision to the caller.
+pub fn parse(content: &str) -> Vec<(String, String)> {
+	let mut out = Vec::new();
+	let mut lines = content.lines();
+
+	while let Some(raw) = lines.next() {
+		let line = raw.trim_start();
+		if line.is_empty() || line.starts_with('#') {
+			continue;
+		}
+		let line = line
+			.strip_prefix("export ")
+			.map(str::trim_start)
+			.unwrap_or(line);
+
+		let Some(eq) = line.find('=') else {
+			let key = line.trim();
+			if !key.is_empty() {
+				out.push((key.to_string(), String::new()));
+			}
+			continue;
+		};
+
+		let key = line[..eq].trim();
+		if key.is_empty() {
+			continue;
+		}
+		let value = parse_value(line[eq + 1..].trim_start(), &mut lines);
+		out.push((key.to_string(), value));
+	}
+
+	out
+}
+
+/// Parse the value portion of an assignment, consuming continuation lines for
+/// a quoted value that does not close on the first line.
+fn parse_value(rest: &str, lines: &mut std::str::Lines) -> String {
+	match rest.chars().next() {
+		Some(quote @ ('"' | '\'')) => {
+			let body = &rest[quote.len_utf8()..];
+			if let Some(end) = find_closing(body, quote) {
+				return unescape(&body[..end], quote);
+			}
+			// Unterminated on this line: a multi-line quoted value.
+			let mut buf = String::from(body);
+			for next in lines.by_ref() {
+				buf.push('\n');
+				if let Some(end) = find_closing(next, quote) {
+					buf.push_str(&next[..end]);
+					return unescape(&buf, quote);
+				}
+				buf.push_str(next);
+			}
+			unescape(&buf, quote)
+		}
+		_ => strip_inline_comment(rest).trim_end().to_string(),
+	}
+}
+
+/// Byte index of the unescaped closing `quote` in `s`, if present.
+///
+/// Backslash escapes are honoured for double quotes only; single-quoted
+/// strings are literal and close at the first quote.
+fn find_closing(s: &str, quote: char) -> Option<usize> {
+	let bytes = s.as_bytes();
+	let q = quote as u8;
+	let mut i = 0;
+	while i < bytes.len() {
+		let c = bytes[i];
+		if quote == '"' && c == b'\\' {
+			i += 2;
+			continue;
+		}
+		if c == q {
+			return Some(i);
+		}
+		i += 1;
+	}
+	None
+}
+
+/// Expand escape sequences for double-quoted values; single-quoted values are
+/// returned verbatim.
+fn unescape(s: &str, quote: char) -> String {
+	if quote == '\'' {
+		return s.to_string();
+	}
+	let mut out = String::with_capacity(s.len());
+	let mut chars = s.chars();
+	while let Some(c) = chars.next() {
+		if c != '\\' {
+			out.push(c);
+			continue;
+		}
+		match chars.next() {
+			Some('n') => out.push('\n'),
+			Some('r') => out.push('\r'),
+			Some('t') => out.push('\t'),
+			Some('\\') => out.push('\\'),
+			Some('"') => out.push('"'),
+			Some('\'') => out.push('\''),
+			Some(other) => out.push(other),
+			None => out.push('\\'),
+		}
+	}
+	out
+}
+
+/// Trim an inline comment from an unquoted value: everything from the first
+/// `#` that is preceded by whitespace. A `#` with no preceding whitespace
+/// (e.g. directly after `=`) is part of the value.
+fn strip_inline_comment(s: &str) -> &str {
+	let bytes = s.as_bytes();
+	let mut i = 0;
+	while i < bytes.len() {
+		if bytes[i] == b'#' && i > 0 && bytes[i - 1].is_ascii_whitespace() {
+			return &s[..i];
+		}
+		i += 1;
+	}
+	s
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse;
+
+	fn map(content: &str) -> std::collections::HashMap<String, String> {
+		parse(content).into_iter().collect()
+	}
+
+	#[test]
+	fn plain_key_value() {
+		let m = map("FOO=bar\nBAZ=qux\n");
+		assert_eq!(m["FOO"], "bar");
+		assert_eq!(m["BAZ"], "qux");
+	}
+
+	#[test]
+	fn skips_blank_and_comment_lines() {
+		let m = map("# header\n\nFOO=bar\n   # indented comment\n");
+		assert_eq!(m.len(), 1);
+		assert_eq!(m["FOO"], "bar");
+	}
+
+	#[test]
+	fn strips_double_quotes() {
+		assert_eq!(map("FOO=\"bar\"\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn strips_single_quotes() {
+		assert_eq!(map("FOO='bar'\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn double_quoted_keeps_inner_hash() {
+		assert_eq!(map("FOO=\"a # b\"\n")["FOO"], "a # b");
+	}
+
+	#[test]
+	fn single_quoted_is_literal() {
+		assert_eq!(map("FOO='a\\nb'\n")["FOO"], "a\\nb");
+	}
+
+	#[test]
+	fn double_quoted_expands_escapes() {
+		assert_eq!(map("FOO=\"a\\nb\\tc\"\n")["FOO"], "a\nb\tc");
+	}
+
+	#[test]
+	fn unquoted_strips_inline_comment() {
+		assert_eq!(map("FOO=bar # trailing\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn unquoted_keeps_leading_hash_without_space() {
+		assert_eq!(map("FOO=#notacomment\n")["FOO"], "#notacomment");
+	}
+
+	#[test]
+	fn unquoted_keeps_internal_spaces() {
+		assert_eq!(map("FOO=a b c\n")["FOO"], "a b c");
+	}
+
+	#[test]
+	fn export_prefix_stripped() {
+		assert_eq!(map("export FOO=bar\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn bare_key_has_empty_value() {
+		assert_eq!(map("BARE\n")["BARE"], "");
+	}
+
+	#[test]
+	fn multiline_double_quoted_value() {
+		let m = map("FOO=\"line1\nline2\"\nBAR=baz\n");
+		assert_eq!(m["FOO"], "line1\nline2");
+		assert_eq!(m["BAR"], "baz");
+	}
+
+	#[test]
+	fn multiline_single_quoted_value() {
+		let m = map("FOO='line1\nline2'\n");
+		assert_eq!(m["FOO"], "line1\nline2");
+	}
+
+	#[test]
+	fn later_duplicate_returned_after_earlier() {
+		let pairs = parse("FOO=first\nFOO=second\n");
+		assert_eq!(
+			pairs,
+			vec![
+				("FOO".to_string(), "first".to_string()),
+				("FOO".to_string(), "second".to_string()),
+			]
+		);
+	}
+}

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -15,6 +15,9 @@ use crate::error::{ComposeError, Result};
 /// last file wins (later entries in the list override earlier ones).
 /// `env_file:` never overrides service-level `environment:`.
 ///
+/// Each file is parsed with dotenv rules (quote stripping, escapes, inline
+/// comments, multi-line quoted values).
+///
 /// Returns [`ComposeError::FileNotFound`] when an env file does not exist.
 pub fn load_env_files(paths: &[String], base_dir: &Path) -> Result<HashMap<String, String>> {
 	let entries: Vec<EnvFileEntry> = paths
@@ -58,24 +61,7 @@ pub fn load_env_file_entries(
 			Err(e) => return Err(ComposeError::Io(e)),
 		};
 
-		for line in content.lines() {
-			let trimmed = line.trim();
-			if trimmed.is_empty() || trimmed.starts_with('#') {
-				continue;
-			}
-
-			let (key, value) = if let Some(eq) = trimmed.find('=') {
-				let k = trimmed[..eq].trim().to_string();
-				let v = trimmed[eq + 1..].to_string();
-				(k, v)
-			} else {
-				(trimmed.to_string(), String::new())
-			};
-
-			if key.is_empty() {
-				continue;
-			}
-
+		for (key, value) in crate::dotenv::parse(&content) {
 			result.insert(key, value);
 		}
 	}

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -5,6 +5,7 @@
 //! REST API over a Unix socket or Windows named pipe.
 
 pub mod compose;
+pub(crate) mod dotenv;
 pub(crate) mod engine;
 pub mod env_file;
 pub(crate) mod error;

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -62,7 +62,8 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String>
 ///
 /// - Lines starting with `#` are comments and are skipped.
 /// - Empty / whitespace-only lines are skipped.
-/// - `KEY=VALUE` sets KEY to VALUE (quotes are preserved as-is, matching compose-spec).
+/// - `KEY=VALUE` sets KEY to VALUE; surrounding quotes are stripped and
+///   dotenv escapes/inline comments are handled.
 /// - `KEY` without `=` sets KEY to empty string.
 /// - Process environment variables take precedence: if a key already exists in
 ///   the current process env it will *not* be overridden by the `.env` file.
@@ -73,27 +74,11 @@ pub fn load_dotenv(dir: &Path) -> HashMap<String, String> {
 	};
 
 	let mut map = HashMap::new();
-	for line in content.lines() {
-		let trimmed = line.trim();
-		if trimmed.is_empty() || trimmed.starts_with('#') {
-			continue;
-		}
-		let (key, value) = if let Some(eq) = trimmed.find('=') {
-			let k = trimmed[..eq].trim().to_string();
-			let v = strip_dotenv_quotes(trimmed[eq + 1..].trim());
-			(k, v.to_string())
-		} else {
-			(trimmed.to_string(), String::new())
-		};
-
-		if key.is_empty() {
-			continue;
-		}
-
+	for (key, value) in crate::dotenv::parse(&content) {
+		// Process environment variables take precedence over the `.env` file.
 		if std::env::var(&key).is_ok() {
 			continue;
 		}
-
 		map.insert(key, value);
 	}
 
@@ -123,38 +108,11 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 		let Ok(content) = std::fs::read_to_string(&abs) else {
 			continue;
 		};
-		for line in content.lines() {
-			let trimmed = line.trim();
-			if trimmed.is_empty() || trimmed.starts_with('#') {
-				continue;
-			}
-			let (key, value) = if let Some(eq) = trimmed.find('=') {
-				(
-					trimmed[..eq].trim().to_string(),
-					strip_dotenv_quotes(trimmed[eq + 1..].trim()).to_string(),
-				)
-			} else {
-				(trimmed.to_string(), String::new())
-			};
-			if !key.is_empty() {
-				vars.entry(key).or_insert(value);
-			}
+		for (key, value) in crate::dotenv::parse(&content) {
+			vars.entry(key).or_insert(value);
 		}
 	}
 	vars
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-fn strip_dotenv_quotes(s: &str) -> &str {
-	if s.len() >= 2
-		&& ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
-	{
-		return &s[1..s.len() - 1];
-	}
-	s
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -49,14 +49,14 @@ fn last_file_wins_for_duplicate_keys() {
 }
 
 #[test]
-fn quoted_values_preserved_as_is() {
+fn surrounding_quotes_are_stripped() {
 	let dir = tempfile::tempdir().unwrap();
 	let mut f = std::fs::File::create(dir.path().join("q.env")).unwrap();
 	writeln!(f, r#"KEY="value with spaces""#).unwrap();
 
 	let map = load_env_files(&["q.env".to_string()], dir.path()).unwrap();
-	// Per compose-spec, quotes are preserved literally.
-	assert_eq!(map["KEY"], "\"value with spaces\"");
+	// Per compose-spec dotenv rules, surrounding quotes are stripped.
+	assert_eq!(map["KEY"], "value with spaces");
 }
 
 #[test]


### PR DESCRIPTION
## What

Closes part of #164 (env_file quoting/comments gap). Routes both `env_file:` loading and `.env` interpolation through one shared dotenv parser.

Previously values were stored verbatim, so:
- `KEY="value"` yielded `"value"` (quotes leaked in)
- `KEY=val # note` yielded `val # note` (inline comment leaked in)
- `KEY="a\nb"` kept the literal backslash-n
- multi-line quoted values were mis-parsed line-by-line

### New `dotenv` parser
- strips a single layer of surrounding `'` or `"` quotes
- expands `\n \r \t \\ \"` in double-quoted values; single-quoted values stay literal
- drops inline comments on unquoted values (a `#` preceded by whitespace); a `#` with no preceding space stays in the value
- supports quoted values spanning multiple lines
- strips an optional leading `export `

The three former ad-hoc parsers (`env_file::load_env_file_entries`, `substitute::load_dotenv`, `substitute::build_vars_with_env_files`) now share this one implementation; duplicate-key precedence at each call site is unchanged.

## Tests
- 16 unit tests on the parser (quotes, escapes, inline comments, multi-line, export, bare key, duplicate order)
- updated the env_file integration test that asserted the old quote-preserving behaviour

438 lib tests pass; clippy clean; fmt applied. No public API change.
