### PR TITLE
fix: forward long-form volume subpath to the mount

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,8 @@ podup (0.11.0) unstable; urgency=medium
   * Parse env files and .env with dotenv rules: strip surrounding quotes,
     honour escape sequences in double-quoted values, drop inline comments
     on unquoted values, and support multi-line quoted values.
+  * Forward a long-form volume's subpath so only the named sub-directory of
+    the volume is mounted instead of dropping the option.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/engine/volume_mounts.rs
+++ b/internal/engine/volume_mounts.rs
@@ -99,6 +99,7 @@ pub(crate) fn build_mounts_all(
 						name: source.clone().unwrap_or_default(),
 						dest: target.clone(),
 						options: opts,
+						sub_path: volume.as_ref().and_then(|v| v.subpath.clone()),
 					});
 				}
 				VolumeType::Npipe => {
@@ -182,6 +183,7 @@ fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> 
 				name: src.to_string(),
 				dest: dst.to_string(),
 				options: opts,
+				sub_path: None,
 			}),
 		))
 	}
@@ -333,6 +335,26 @@ mod tests {
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].name, "myvolume");
 		assert!(named[0].options.contains(&"nocopy".to_string()));
+	}
+
+	#[test]
+	fn long_form_volume_subpath_forwarded() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Volume,
+			source: Some("myvolume".into()),
+			target: "/data".into(),
+			read_only: None,
+			bind: None,
+			volume: Some(VolumeOptions {
+				subpath: Some("nested/dir".into()),
+				..Default::default()
+			}),
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		assert_eq!(named.len(), 1);
+		assert_eq!(named[0].sub_path.as_deref(), Some("nested/dir"));
 	}
 
 	#[test]

--- a/internal/libpod/types/container/spec.rs
+++ b/internal/libpod/types/container/spec.rs
@@ -302,6 +302,10 @@ pub struct NamedVolume {
 
 	#[serde(rename = "Options", skip_serializing_if = "Vec::is_empty", default)]
 	pub options: Vec<String>,
+
+	/// Mount only this sub-directory of the volume (compose `volume.subpath`).
+	#[serde(rename = "SubPath", skip_serializing_if = "Option::is_none", default)]
+	pub sub_path: Option<String>,
 }
 
 /// Linux OCI resource limits for SpecGenerator.


### PR DESCRIPTION
## What

Closes part of #164 (volume `subpath` gap).

A long-form volume's `volume.subpath` was parsed into `VolumeOptions` but never forwarded, so Podman mounted the whole volume instead of the requested sub-directory. Adds a `SubPath` field to the libpod `NamedVolume` spec and sets it from the volume options.

## Tests
- `long_form_volume_subpath_forwarded` unit test
- 439 lib tests pass; clippy clean; fmt applied. No public API change.