### PR TITLE
fix: resolve include/external-extends paths against the imported file's directory

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -18,6 +18,9 @@ podup (0.11.0) unstable; urgency=medium
     per-pool ip_range (as a lease range), and a per-network interface_name.
     Unsupported aux_addresses and gw_priority are warned about rather than
     silently dropped.
+  * Resolve relative paths (build context, env_file, bind mounts, secret and
+    config files) of services pulled in via include or an external extends
+    against the imported file's directory instead of the project directory.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/compose/anchor.rs
+++ b/internal/compose/anchor.rs
@@ -1,0 +1,228 @@
+//! Anchor relative paths of externally-imported content to their source dir.
+//!
+//! A service pulled in via `include:` or an external `extends: { file: ... }`
+//! carries paths (build context, env_file, bind-mount sources, secret/config
+//! files) that the compose spec resolves relative to the directory of the file
+//! that defined them — not the top-level project directory. The engine resolves
+//! every relative path against a single project base directory, so before such
+//! content is merged we rewrite its relative paths to absolute paths anchored at
+//! the imported file's directory. Absolute paths then pass through the engine's
+//! base-directory resolution unchanged.
+
+use std::path::Path;
+
+use super::types::{
+	BuildConfig, ComposeFile, EnvFile, EnvFileEntry, Service, VolumeMount, VolumeType,
+};
+
+/// Anchor every path-bearing field of an imported compose file to `dir`.
+pub(super) fn anchor_compose_file(file: &mut ComposeFile, dir: &Path) {
+	for svc in file.services.values_mut() {
+		anchor_service(svc, dir);
+	}
+	for secret in file.secrets.values_mut() {
+		if let Some(f) = secret.file.as_deref().and_then(|f| anchor_fs(f, dir)) {
+			secret.file = Some(f);
+		}
+	}
+	for config in file.configs.values_mut() {
+		if let Some(f) = config.file.as_deref().and_then(|f| anchor_fs(f, dir)) {
+			config.file = Some(f);
+		}
+	}
+}
+
+/// Anchor the path-bearing fields of a single service to `dir`.
+pub(super) fn anchor_service(svc: &mut Service, dir: &Path) {
+	if let Some(build) = svc.build.as_mut() {
+		match build {
+			BuildConfig::Context(c) => {
+				if let Some(a) = anchor_context(c, dir) {
+					*c = a;
+				}
+			}
+			BuildConfig::Config { context, .. } => {
+				if let Some(a) = anchor_context(context, dir) {
+					*context = a;
+				}
+			}
+		}
+	}
+
+	match &mut svc.env_file {
+		EnvFile::Empty => {}
+		EnvFile::Single(e) => anchor_env_entry(e, dir),
+		EnvFile::List(list) => {
+			for e in list.iter_mut() {
+				anchor_env_entry(e, dir);
+			}
+		}
+	}
+
+	for v in svc.volumes.iter_mut() {
+		match v {
+			VolumeMount::Short(s) => {
+				if let Some(a) = anchor_short_volume(s, dir) {
+					*s = a;
+				}
+			}
+			VolumeMount::Long {
+				volume_type: VolumeType::Bind,
+				source: Some(src),
+				..
+			} => {
+				if let Some(a) = anchor_bind(src, dir) {
+					*src = a;
+				}
+			}
+			VolumeMount::Long { .. } => {}
+		}
+	}
+}
+
+/// A path is anchorable when it is relative and not a `~` home reference
+/// (home expansion happens later, against the user's home, not the file dir).
+fn anchor_fs(path: &str, dir: &Path) -> Option<String> {
+	if path.is_empty() || path.starts_with('~') || Path::new(path).is_absolute() {
+		return None;
+	}
+	Some(dir.join(path).to_string_lossy().into_owned())
+}
+
+/// Build contexts may be Git/URL references, which must not be anchored.
+fn anchor_context(context: &str, dir: &Path) -> Option<String> {
+	if context.contains("://") || context.starts_with("git@") {
+		return None;
+	}
+	anchor_fs(context, dir)
+}
+
+/// Only explicit relative bind sources (`./x`, `../x`) are anchored; named
+/// volumes, absolute paths, and `~` references are left untouched.
+fn anchor_bind(src: &str, dir: &Path) -> Option<String> {
+	src.starts_with('.')
+		.then(|| dir.join(src).to_string_lossy().into_owned())
+}
+
+fn anchor_short_volume(s: &str, dir: &Path) -> Option<String> {
+	let parts: Vec<&str> = s.splitn(3, ':').collect();
+	let src = parts.first()?;
+	if !src.starts_with('.') {
+		return None;
+	}
+	let mut rebuilt = dir.join(src).to_string_lossy().into_owned();
+	for part in &parts[1..] {
+		rebuilt.push(':');
+		rebuilt.push_str(part);
+	}
+	Some(rebuilt)
+}
+
+fn anchor_env_entry(entry: &mut EnvFileEntry, dir: &Path) {
+	match entry {
+		EnvFileEntry::Path(p) => {
+			if let Some(a) = anchor_fs(p, dir) {
+				*p = a;
+			}
+		}
+		EnvFileEntry::Config { path, .. } => {
+			if let Some(a) = anchor_fs(path, dir) {
+				*path = a;
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::Service;
+	use std::path::Path;
+
+	fn dir() -> &'static Path {
+		Path::new("/proj/sub")
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn anchors_relative_build_context() {
+		let mut svc = Service {
+			build: Some(BuildConfig::Context("./app".into())),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		match svc.build.unwrap() {
+			BuildConfig::Context(c) => assert_eq!(c, "/proj/sub/./app"),
+			_ => panic!("expected context"),
+		}
+	}
+
+	#[test]
+	fn leaves_url_build_context() {
+		let mut svc = Service {
+			build: Some(BuildConfig::Context("https://github.com/x/y.git".into())),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		match svc.build.unwrap() {
+			BuildConfig::Context(c) => assert_eq!(c, "https://github.com/x/y.git"),
+			_ => panic!("expected context"),
+		}
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn anchors_env_file_list() {
+		let mut svc = Service {
+			env_file: EnvFile::List(vec![
+				EnvFileEntry::Path("./a.env".into()),
+				EnvFileEntry::Path("/abs/b.env".into()),
+			]),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		let EnvFile::List(list) = &svc.env_file else {
+			panic!("expected list");
+		};
+		assert_eq!(list[0].path(), "/proj/sub/./a.env");
+		assert_eq!(list[1].path(), "/abs/b.env");
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn anchors_relative_short_bind_only() {
+		let mut svc = Service {
+			volumes: vec![
+				VolumeMount::Short("./data:/data:ro".into()),
+				VolumeMount::Short("named:/v".into()),
+				VolumeMount::Short("/abs:/a".into()),
+			],
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		let got: Vec<_> = svc
+			.volumes
+			.iter()
+			.map(|v| match v {
+				VolumeMount::Short(s) => s.clone(),
+				_ => unreachable!(),
+			})
+			.collect();
+		assert_eq!(got[0], "/proj/sub/./data:/data:ro");
+		assert_eq!(got[1], "named:/v");
+		assert_eq!(got[2], "/abs:/a");
+	}
+
+	#[test]
+	fn leaves_tilde_paths() {
+		let mut svc = Service {
+			env_file: EnvFile::Single(EnvFileEntry::Path("~/x.env".into())),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		let EnvFile::Single(e) = &svc.env_file else {
+			panic!("expected single");
+		};
+		assert_eq!(e.path(), "~/x.env");
+	}
+}

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -137,12 +137,16 @@ fn resolve_one_extends(
 		let mut other = parse_file_inner(&abs, &dir)?;
 		let mut nested_visited: HashSet<String> = HashSet::new();
 		resolve_one_extends(&mut other, &base_name, &dir, &mut nested_visited, depth + 1)?;
-		other.services.swap_remove(&base_name).ok_or_else(|| {
+		let mut base = other.services.swap_remove(&base_name).ok_or_else(|| {
 			ComposeError::Extends(format!(
 				"service '{base_name}' not found in {}",
 				abs.display()
 			))
-		})?
+		})?;
+		// The base service's relative paths are relative to the external file's
+		// directory; anchor them before merging into the current file's service.
+		super::anchor::anchor_service(&mut base, &dir);
+		base
 	} else {
 		if base_name == name {
 			return Err(ComposeError::Extends(format!(

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod types;
 
+mod anchor;
 mod extends;
 mod include;
 
@@ -55,7 +56,8 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 					.map(|p| p.to_path_buf())
 					.unwrap_or_else(|| dir.clone())
 			});
-			let included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
+			let mut included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
+			anchor::anchor_compose_file(&mut included, &inc_dir);
 			include::merge_compose_file(&mut file, included);
 		}
 	}

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -175,6 +175,68 @@ services:
 }
 
 #[test]
+fn extends_external_file_anchors_relative_paths() {
+	let dir = tempfile::tempdir().unwrap();
+	let sub = dir.path().join("svc");
+	std::fs::create_dir(&sub).unwrap();
+
+	let common_path = sub.join("common.yml");
+	let mut f = std::fs::File::create(&common_path).unwrap();
+	writeln!(
+		f,
+		r#"
+services:
+  base:
+    image: alpine
+    env_file:
+      - ./base.env
+    volumes:
+      - ./data:/data
+"#
+	)
+	.unwrap();
+
+	let main_path = dir.path().join("docker-compose.yml");
+	let mut m = std::fs::File::create(&main_path).unwrap();
+	writeln!(
+		m,
+		r#"
+services:
+  app:
+    extends:
+      service: base
+      file: ./svc/common.yml
+"#
+	)
+	.unwrap();
+
+	let file = parse_file(&main_path).unwrap();
+	let app = &file.services["app"];
+
+	// The base service's relative env_file/volume paths must be anchored to the
+	// external file's directory, not the top-level project directory.
+	let entries = app.env_file.to_entries();
+	let env_path = std::path::Path::new(entries[0].path());
+	assert!(
+		env_path.is_absolute(),
+		"env_file not anchored: {env_path:?}"
+	);
+	assert!(
+		env_path.ends_with("svc/base.env"),
+		"wrong dir: {env_path:?}"
+	);
+
+	let vol = match &app.volumes[0] {
+		podup::compose::types::VolumeMount::Short(s) => s.clone(),
+		other => panic!("expected short volume, got {other:?}"),
+	};
+	assert!(
+		vol.contains("svc") && vol.ends_with(":/data"),
+		"volume bind not anchored: {vol}"
+	);
+}
+
+#[test]
 fn extends_chain_within_depth_limit() {
 	// 16 services = 15 hops — must succeed.
 	let yaml = make_chain_yaml(15);


### PR DESCRIPTION
## What

Closes the last MEDIUM compose-spec parity gap from #164 (cross-file relative path resolution).

A service brought in via `include:` or an external `extends: { file: ... }` carries relative paths — build context, `env_file`, bind-mount sources, secret/config `file:` — that the compose spec resolves against **the directory of the file that defined the service**, not the top-level project directory. podup resolves every relative path against one project base directory, so imported services pointed at the wrong location.

### Fix
A new `compose::anchor` module rewrites the relative paths of imported content to absolute paths anchored at the imported file's directory, before merging. Absolute paths then pass through the engine's existing base-directory resolution unchanged. Applied at both import points:
- `include:` — the whole included file is anchored to its directory.
- external `extends` — the base service is anchored to the external file's directory.

Left untouched: Git/URL build contexts (`://`, `git@`), named volumes, absolute paths, and `~` home references (home expansion happens later).

## Tests
- 5 unit tests on the anchor helpers (build context, URL passthrough, env_file list, relative-bind-only, `~` passthrough)
- end-to-end `extends_external_file_anchors_relative_paths`: an external extends with relative `env_file`/`volumes` resolves to the external file's dir

450 lib tests pass; clippy clean; fmt applied. No public API change.
