### PR TITLE
feat: global --env-file flag for interpolation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -21,6 +21,8 @@ podup (0.11.0) unstable; urgency=medium
   * Resolve relative paths (build context, env_file, bind mounts, secret and
     config files) of services pulled in via include or an external extends
     against the imported file's directory instead of the project directory.
+  * Add a global --env-file flag to load extra env files into the variable
+    map used for interpolation.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -17,9 +17,17 @@ use types::ComposeFile;
 /// Parse a compose file from disk, applying variable substitution and
 /// resolving `extends:` / `include:` directives.
 pub fn parse_file(path: &Path) -> Result<ComposeFile> {
+	parse_file_with_env_files(path, &[])
+}
+
+/// Like [`parse_file`], additionally loading `env_files` (the global
+/// `--env-file` flag) into the variable map used for interpolation. These take
+/// effect for the top-level file and any included files; the process
+/// environment and a project `.env` still take precedence.
+pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<ComposeFile> {
 	let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 	let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
-	let mut file = parse_file_inner(&abs, &dir)?;
+	let mut file = parse_file_inner_with_env(&abs, &dir, env_files)?;
 
 	let includes = std::mem::take(&mut file.include);
 	for inc in includes {
@@ -56,7 +64,9 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 					.map(|p| p.to_path_buf())
 					.unwrap_or_else(|| dir.clone())
 			});
-			let mut included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
+			let mut combined_env_files = env_files.to_vec();
+			combined_env_files.extend(extra_env_files.iter().cloned());
+			let mut included = parse_file_inner_with_env(&inc_path, &inc_dir, &combined_env_files)?;
 			anchor::anchor_compose_file(&mut included, &inc_dir);
 			include::merge_compose_file(&mut file, included);
 		}

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -17,7 +17,7 @@ pub mod size;
 pub mod substitute;
 pub mod update;
 
-pub use compose::{parse_file, parse_str, parse_str_raw, resolve_order};
+pub use compose::{parse_file, parse_file_with_env_files, parse_str, parse_str_raw, resolve_order};
 pub use engine::{Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -39,6 +39,12 @@ struct Cli {
 	#[arg(long, global = true)]
 	project_directory: Option<PathBuf>,
 
+	/// Additional env file(s) loaded into the variable map used for
+	/// interpolation. May be given multiple times; later files win. The
+	/// process environment and a project `.env` still take precedence.
+	#[arg(long = "env-file", global = true)]
+	env_file: Vec<String>,
+
 	#[command(subcommand)]
 	command: Commands,
 }
@@ -362,7 +368,7 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_path = resolve_compose_file(cli.file.clone());
-	let file = podup::parse_file(&compose_path)?;
+	let file = podup::parse_file_with_env_files(&compose_path, &cli.env_file)?;
 
 	if matches!(cli.command, Commands::Config) {
 		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -105,3 +105,19 @@ services:
 		Some("alpine:override")
 	);
 }
+
+#[test]
+fn global_env_file_feeds_interpolation() {
+	let dir = tempfile::tempdir().unwrap();
+
+	let env_path = dir.path().join("prod.env");
+	let mut e = std::fs::File::create(&env_path).unwrap();
+	writeln!(e, "IMG=nginx:1.27").unwrap();
+
+	let main_path = dir.path().join("docker-compose.yml");
+	let mut m = std::fs::File::create(&main_path).unwrap();
+	writeln!(m, "services:\n  web:\n    image: ${{IMG}}").unwrap();
+
+	let file = podup::parse_file_with_env_files(&main_path, &["prod.env".to_string()]).unwrap();
+	assert_eq!(file.services["web"].image.as_deref(), Some("nginx:1.27"));
+}


### PR DESCRIPTION
## What

Part of #164 (CLI parity, gap 11). Adds Compose's global `--env-file` for variable interpolation; podup previously only consulted a project `.env`.

- New repeatable global `--env-file` flag.
- New public `parse_file_with_env_files(path, &[String])` that threads the files into the substitution variable map for the top-level file and any `include:`d files. `parse_file` delegates to it with no extra files.
- Precedence unchanged: process environment and a project `.env` still win over `--env-file` values; among `--env-file` entries later files win.

## Tests
- `global_env_file_feeds_interpolation`: `image: ${IMG}` resolves from a passed env file.

All tests pass; clippy clean; fmt applied. Additive public API (new function), no breaking change.
