### PR TITLE
feat: forward GPU device reservations as CDI devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -25,6 +25,8 @@ podup (0.11.0) unstable; urgency=medium
     map used for interpolation.
   * Build a Git/URL build context by having Podman clone it server-side
     instead of treating the URL as a local directory to tar.
+  * Forward NVIDIA GPU reservations (deploy.resources.reservations.devices)
+    to Podman as CDI devices instead of warning and ignoring them.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -12,7 +12,8 @@ use crate::libpod::API_PREFIX;
 use crate::{env_file, ports, size};
 
 use super::container_config::{
-	build_healthcheck, build_log_config, build_resource_limits, build_restart_policy, build_ulimits,
+	build_healthcheck, build_log_config, build_resource_limits, build_restart_policy,
+	build_ulimits, cdi_devices,
 };
 use super::container_misc::{
 	build_blkio_config, build_label_file_labels, parse_device, warn_swarm_only_deploy,
@@ -227,6 +228,7 @@ impl Engine {
 			restart_policy,
 			restart_tries,
 			devices,
+			cdi_devices: cdi_devices(service),
 			device_cgroup_rule: service.device_cgroup_rules.clone(),
 			groups: service.group_add.clone(),
 			oom_score_adj: service.oom_score_adj,

--- a/internal/engine/container_config.rs
+++ b/internal/engine/container_config.rs
@@ -121,12 +121,8 @@ pub(super) fn build_resource_limits(service: &Service) -> Option<LinuxResources>
 				if mem_reservation.is_none() {
 					mem_reservation = reserv.memory.as_deref().and_then(size::parse_memory);
 				}
-				if !reserv.devices.is_empty() {
-					tracing::warn!(
-						"deploy.resources.reservations.devices is not yet supported \
-						— GPU/device reservations will be ignored"
-					);
-				}
+				// GPU/device reservations are forwarded separately as CDI
+				// devices; see [`cdi_devices`].
 			}
 		}
 	}
@@ -205,6 +201,58 @@ pub(super) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 			hard: cfg.hard() as u64,
 		})
 		.collect()
+}
+
+/// Map `deploy.resources.reservations.devices` GPU reservations to Podman CDI
+/// device names (e.g. `nvidia.com/gpu=all`).
+///
+/// Only NVIDIA GPU reservations are translated — the common case Podman exposes
+/// through CDI. Reservations for other drivers or capabilities are warned about
+/// and skipped, since there is no portable mapping for them.
+pub(super) fn cdi_devices(service: &Service) -> Vec<String> {
+	let mut out = Vec::new();
+
+	let Some(reservations) = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.resources.as_ref())
+		.and_then(|r| r.reservations.as_ref())
+	else {
+		return out;
+	};
+
+	for dev in &reservations.devices {
+		let is_gpu = dev.capabilities.iter().any(|c| c == "gpu" || c == "nvidia");
+		let driver = dev.driver.as_deref().unwrap_or("nvidia");
+		if !is_gpu || (driver != "nvidia" && !driver.is_empty()) {
+			tracing::warn!(
+				"device reservation (driver {:?}, capabilities {:?}) is not supported and is ignored",
+				dev.driver,
+				dev.capabilities
+			);
+			continue;
+		}
+
+		if !dev.device_ids.is_empty() {
+			for id in &dev.device_ids {
+				out.push(format!("nvidia.com/gpu={id}"));
+			}
+			continue;
+		}
+
+		match dev.count.as_ref().map(|c| c.to_i64()) {
+			// `count: all` (-1) or unspecified → request every GPU.
+			Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
+			Some(n) if n > 0 => {
+				for i in 0..n {
+					out.push(format!("nvidia.com/gpu={i}"));
+				}
+			}
+			Some(_) => {}
+		}
+	}
+
+	out
 }
 
 // ---------------------------------------------------------------------------
@@ -447,5 +495,49 @@ mod tests {
 		let ul = build_ulimits(&svc);
 		assert_eq!(ul[0].soft, 512);
 		assert_eq!(ul[0].hard, 2048);
+	}
+
+	// --- cdi devices ---
+
+	fn cdi_for(yaml: &str) -> Vec<String> {
+		let file = crate::parse_str(yaml).unwrap();
+		cdi_devices(&file.services["app"])
+	}
+
+	#[test]
+	fn cdi_gpu_count_all() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              count: all\n",
+		);
+		assert_eq!(got, vec!["nvidia.com/gpu=all"]);
+	}
+
+	#[test]
+	fn cdi_gpu_count_n_enumerates() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              count: 2\n",
+		);
+		assert_eq!(got, vec!["nvidia.com/gpu=0", "nvidia.com/gpu=1"]);
+	}
+
+	#[test]
+	fn cdi_gpu_device_ids() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              device_ids: [\"GPU-abc\", \"1\"]\n",
+		);
+		assert_eq!(got, vec!["nvidia.com/gpu=GPU-abc", "nvidia.com/gpu=1"]);
+	}
+
+	#[test]
+	fn cdi_non_gpu_skipped() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [tpu]\n              driver: google\n",
+		);
+		assert!(got.is_empty());
+	}
+
+	#[test]
+	fn cdi_absent_without_deploy() {
+		assert!(cdi_devices(&default_service()).is_empty());
 	}
 }

--- a/internal/libpod/types/container/spec.rs
+++ b/internal/libpod/types/container/spec.rs
@@ -160,6 +160,10 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub devices: Vec<LinuxDevice>,
 
+	/// CDI device names (e.g. `nvidia.com/gpu=all`) for GPU/accelerator access.
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	pub cdi_devices: Vec<String>,
+
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub device_cgroup_rule: Vec<String>,
 


### PR DESCRIPTION
## What

Part of #164 (gap 10). `deploy.resources.reservations.devices` was parsed but only produced a "not yet supported" warning, so GPU workloads never received their accelerators.

Translate NVIDIA GPU reservations into Podman CDI device names and forward them through a new `cdi_devices` field on the `SpecGenerator`:
- `count: all` (or unspecified) → `nvidia.com/gpu=all`
- `count: N` → `nvidia.com/gpu=0` … `nvidia.com/gpu=N-1`
- `device_ids: [...]` → one `nvidia.com/gpu=<id>` per id

Reservations for other drivers/capabilities are warned about and skipped — there is no portable mapping for them.

## Tests
- `cdi_gpu_count_all`, `cdi_gpu_count_n_enumerates`, `cdi_gpu_device_ids`, `cdi_non_gpu_skipped`, `cdi_absent_without_deploy`

All tests pass; clippy clean; fmt applied. No public API change (the new spec field is crate-internal).
