### PR TITLE
feat: add up --no-deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -27,6 +27,8 @@ podup (0.11.0) unstable; urgency=medium
     instead of treating the URL as a local directory to tar.
   * Forward NVIDIA GPU reservations (deploy.resources.reservations.devices)
     to Podman as CDI devices instead of warning and ignoring them.
+  * Add up --no-deps to start the named services without their depends_on
+    dependencies.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -36,7 +36,7 @@ pub struct RunOptions {
 impl Engine {
 	/// Start all services defined in the compose file, creating containers that do not exist.
 	pub async fn up(&self, file: &ComposeFile) -> Result<()> {
-		self.up_with_options(file, false, &[], &[], false, false)
+		self.up_with_options(file, false, &[], &[], false, false, false)
 			.await
 	}
 
@@ -52,6 +52,7 @@ impl Engine {
 	}
 
 	/// Start services with explicit options. When `no_recreate` is true, running containers are left untouched. On partial failure, staging directories are cleaned up.
+	#[allow(clippy::too_many_arguments)]
 	pub async fn up_with_options(
 		&self,
 		file: &ComposeFile,
@@ -60,30 +61,13 @@ impl Engine {
 		target_services: &[String],
 		no_recreate: bool,
 		force_recreate: bool,
+		no_deps: bool,
 	) -> Result<()> {
 		let r: Result<()> = async {
 			let order = crate::compose::resolve_order(file)?;
 			let active = active_profiles_set(active_profiles);
 
-			let target_set: Option<HashSet<String>> = if target_services.is_empty() {
-				None
-			} else {
-				let mut set = HashSet::new();
-				let mut stack: Vec<String> = target_services.to_vec();
-				while let Some(name) = stack.pop() {
-					if !set.insert(name.clone()) {
-						continue;
-					}
-					if let Some(service) = file.services.get(&name) {
-						for dep in service.depends_on.service_names() {
-							if !set.contains(&dep) {
-								stack.push(dep);
-							}
-						}
-					}
-				}
-				Some(set)
-			};
+			let target_set = expand_targets(file, target_services, no_deps);
 
 			// Prefetch the project's containers once (instead of one API call per
 			// replica): which names already exist, and each one's config-hash
@@ -344,13 +328,45 @@ pub(super) fn filter_services(
 		.collect())
 }
 
+/// Resolve which services `up` should start given an explicit target list.
+///
+/// Returns `None` when no targets are given (start everything). Otherwise the
+/// set contains the targets plus, unless `no_deps` is set, their transitive
+/// `depends_on` services.
+fn expand_targets(
+	file: &ComposeFile,
+	target_services: &[String],
+	no_deps: bool,
+) -> Option<HashSet<String>> {
+	if target_services.is_empty() {
+		return None;
+	}
+	let mut set = HashSet::new();
+	let mut stack: Vec<String> = target_services.to_vec();
+	while let Some(name) = stack.pop() {
+		if !set.insert(name.clone()) {
+			continue;
+		}
+		if !no_deps {
+			if let Some(service) = file.services.get(&name) {
+				for dep in service.depends_on.service_names() {
+					if !set.contains(&dep) {
+						stack.push(dep);
+					}
+				}
+			}
+		}
+	}
+	Some(set)
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
-	use super::filter_services;
+	use super::{expand_targets, filter_services};
 	use crate::compose::types::{ComposeFile, Service};
 
 	fn file_with_services(names: &[&str]) -> ComposeFile {
@@ -394,5 +410,36 @@ mod tests {
 			err,
 			crate::error::ComposeError::ServiceNotFound(_)
 		));
+	}
+
+	// --- expand_targets ---
+
+	fn file_web_depends_db() -> ComposeFile {
+		crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn expand_targets_empty_is_none() {
+		let file = file_web_depends_db();
+		assert!(expand_targets(&file, &[], false).is_none());
+	}
+
+	#[test]
+	fn expand_targets_includes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], false).unwrap();
+		assert!(set.contains("web"));
+		assert!(set.contains("db"));
+	}
+
+	#[test]
+	fn expand_targets_no_deps_excludes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
+		assert!(set.contains("web"));
+		assert!(!set.contains("db"));
 	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -71,6 +71,9 @@ enum Commands {
 		/// Recreate containers even if their configuration is unchanged.
 		#[arg(long)]
 		force_recreate: bool,
+		/// Do not start linked services (depends_on) of the named services.
+		#[arg(long)]
+		no_deps: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]
@@ -407,6 +410,7 @@ async fn run() -> podup::Result<()> {
 			remove_orphans,
 			no_recreate,
 			force_recreate,
+			no_deps,
 			services,
 		} => {
 			if remove_orphans {
@@ -423,6 +427,7 @@ async fn run() -> podup::Result<()> {
 					&services,
 					no_recreate,
 					force_recreate,
+					no_deps,
 				)
 				.await?;
 			if watch {

--- a/tests/engine_integration/group_a1.rs
+++ b/tests/engine_integration/group_a1.rs
@@ -37,7 +37,7 @@ async fn up_no_recreate_skips_running() {
 	engine.up(&file).await.unwrap();
 	// Second up with no_recreate: already running → skip
 	engine
-		.up_with_options(&file, false, &[], &[], true, false)
+		.up_with_options(&file, false, &[], &[], true, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -58,7 +58,7 @@ async fn up_target_services_only() {
 
 	// Only start web (and its dep db)
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -348,7 +348,7 @@ async fn up_skips_recreate_when_config_unchanged() {
 	engine.up(&file).await.unwrap();
 	// force_recreate -> recreate even though config is unchanged.
 	engine
-		.up_with_options(&file, false, &[], &[], false, true)
+		.up_with_options(&file, false, &[], &[], false, true, false)
 		.await
 		.unwrap();
 	// Changed config -> hash differs -> recreate.

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -228,7 +228,7 @@ async fn profile_filtered_service_skipped() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &[], false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();

--- a/tests/engine_integration/group_a4.rs
+++ b/tests/engine_integration/group_a4.rs
@@ -49,7 +49,7 @@ fn active_profiles_via_env() {
 			.unwrap();
 			// Pass empty active_profiles slice so it falls back to COMPOSE_PROFILES env
 			engine
-				.up_with_options(&file, false, &[], &[], false, false)
+				.up_with_options(&file, false, &[], &[], false, false, false)
 				.await
 				.unwrap();
 			engine.down(&file).await.unwrap();
@@ -187,7 +187,7 @@ async fn target_services_skips_non_dep() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -210,7 +210,7 @@ async fn dep_on_profile_filtered_service() {
 
 	// No active profiles → db is skipped; web still runs but skips db's dep wait
 	engine
-		.up_with_options(&file, false, &[], &[], false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -293,7 +293,7 @@ async fn optional_dep_not_in_file() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -324,6 +324,7 @@ async fn target_services_duplicate_entry() {
 			false,
 			&[],
 			&["web".to_string(), "web".to_string()],
+			false,
 			false,
 			false,
 		)


### PR DESCRIPTION
## What

Part of #164 (gap 11). `up` always started the transitive `depends_on` services of any targeted service. Adds `up --no-deps` so only the named services are started.

- New `--no-deps` flag on `up`.
- Target-expansion logic extracted into a pure `expand_targets(file, targets, no_deps)` helper and unit-tested.

## Breaking
`Engine::up_with_options` gains a trailing `no_deps: bool` parameter (public library signature change). Part of the 0.11.0 cycle; panel-agent will pick it up at the next pin bump.

## Tests
- `expand_targets_empty_is_none`, `expand_targets_includes_dependencies`, `expand_targets_no_deps_excludes_dependencies`

All tests pass; clippy clean; fmt applied.
