### PR TITLE
feat: merge multiple compose files (-f / COMPOSE_FILE list)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -31,6 +31,8 @@ podup (0.11.0) unstable; urgency=medium
     dependencies.
   * Resolve service links to the linked service's container name (keeping the
     service name as the alias); external_links are still passed through as-is.
+  * Accept multiple compose files (repeated -f or a COMPOSE_FILE list) and
+    merge them in order, with later files overriding earlier ones.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -9,7 +9,7 @@ use super::super::types::{
 	DependsOn, EnvFile, EnvVars, Labels, Service, ServiceNetworks, StringOrList, Sysctls,
 };
 
-pub(super) fn merge_service(base: Service, override_svc: Service) -> Service {
+pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) -> Service {
 	fn opt<T>(o: Option<T>, b: Option<T>) -> Option<T> {
 		o.or(b)
 	}

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -17,7 +17,7 @@ use super::parse_file_inner;
 use super::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
-use merge::merge_service;
+pub(in crate::compose) use merge::merge_service;
 
 const MAX_EXTENDS_DEPTH: usize = 16;
 

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -8,7 +8,7 @@ mod extends;
 mod include;
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{ComposeError, Result};
 use crate::substitute;
@@ -74,6 +74,51 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 
 	extends::resolve_all_extends(&mut file, &dir)?;
 	Ok(file)
+}
+
+/// Parse and merge multiple compose files (the `-f`/`COMPOSE_FILE` list).
+///
+/// Files are merged left to right: a later file overrides an earlier one,
+/// service by service (per-field, like `extends`), with top-level
+/// volumes/networks/secrets/configs replaced on key conflicts. Relative paths
+/// resolve against the first file's directory, matching the compose project
+/// directory. `env_files` feed interpolation for every file.
+pub fn parse_files_with_env_files(paths: &[PathBuf], env_files: &[String]) -> Result<ComposeFile> {
+	let mut iter = paths.iter();
+	let first = iter
+		.next()
+		.ok_or_else(|| ComposeError::FileNotFound("no compose file given".to_string()))?;
+	let mut merged = parse_file_with_env_files(first, env_files)?;
+	for path in iter {
+		let other = parse_file_with_env_files(path, env_files)?;
+		merge_override(&mut merged, other);
+	}
+	Ok(merged)
+}
+
+/// Merge `other` into `target` with `other` winning (compose `-f` override
+/// semantics): services are merged field-by-field, other top-level maps replace
+/// on key conflict.
+fn merge_override(target: &mut ComposeFile, other: ComposeFile) {
+	for (name, svc) in other.services {
+		if let Some(base) = target.services.get_mut(&name) {
+			*base = extends::merge_service(std::mem::take(base), svc);
+		} else {
+			target.services.insert(name, svc);
+		}
+	}
+	for (k, v) in other.volumes {
+		target.volumes.insert(k, v);
+	}
+	for (k, v) in other.networks {
+		target.networks.insert(k, v);
+	}
+	for (k, v) in other.secrets {
+		target.secrets.insert(k, v);
+	}
+	for (k, v) in other.configs {
+		target.configs.insert(k, v);
+	}
 }
 
 /// Parse a compose YAML string (no file I/O).

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -17,7 +17,10 @@ pub mod size;
 pub mod substitute;
 pub mod update;
 
-pub use compose::{parse_file, parse_file_with_env_files, parse_str, parse_str_raw, resolve_order};
+pub use compose::{
+	parse_file, parse_file_with_env_files, parse_files_with_env_files, parse_str, parse_str_raw,
+	resolve_order,
+};
 pub use engine::{Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -17,8 +17,8 @@ struct Cli {
 	/// unset, the compose-spec precedence list is probed in the current
 	/// directory (compose.yaml, compose.yml, docker-compose.yaml,
 	/// docker-compose.yml).
-	#[arg(short, long, env = "COMPOSE_FILE")]
-	file: Option<PathBuf>,
+	#[arg(short, long)]
+	file: Vec<PathBuf>,
 
 	/// Project name (used as a prefix for container names).
 	/// May also be set via `COMPOSE_PROJECT_NAME`.
@@ -308,20 +308,27 @@ const COMPOSE_FILE_CANDIDATES: [&str; 4] = [
 	"docker-compose.yml",
 ];
 
-/// Resolve which compose file to load. An explicit `--file`/`COMPOSE_FILE`
-/// wins; otherwise probe the compose-spec precedence list in the current
-/// directory, falling back to `docker-compose.yml` so a missing-file error
-/// names a sensible path.
-fn resolve_compose_file(explicit: Option<PathBuf>) -> PathBuf {
-	if let Some(path) = explicit {
-		return path;
+/// Resolve which compose file(s) to load. Explicit `--file` flags win; then the
+/// `COMPOSE_FILE` environment variable (a path-separator-delimited list);
+/// otherwise probe the compose-spec precedence list in the current directory,
+/// falling back to `docker-compose.yml` so a missing-file error names a
+/// sensible path. Multiple files are merged in order, later overriding earlier.
+fn resolve_compose_files(explicit: &[PathBuf]) -> Vec<PathBuf> {
+	if !explicit.is_empty() {
+		return explicit.to_vec();
+	}
+	if let Ok(env) = std::env::var("COMPOSE_FILE") {
+		if !env.is_empty() {
+			let sep = if cfg!(windows) { ';' } else { ':' };
+			return env.split(sep).map(PathBuf::from).collect();
+		}
 	}
 	for candidate in COMPOSE_FILE_CANDIDATES {
 		if Path::new(candidate).is_file() {
-			return PathBuf::from(candidate);
+			return vec![PathBuf::from(candidate)];
 		}
 	}
-	PathBuf::from("docker-compose.yml")
+	vec![PathBuf::from("docker-compose.yml")]
 }
 
 /// Resolve the base directory for relative-path resolution. An explicit
@@ -370,8 +377,8 @@ async fn run() -> podup::Result<()> {
 			.map_err(|e| podup::ComposeError::Update(format!("update task failed: {e}")))?;
 	}
 
-	let compose_path = resolve_compose_file(cli.file.clone());
-	let file = podup::parse_file_with_env_files(&compose_path, &cli.env_file)?;
+	let compose_files = resolve_compose_files(&cli.file);
+	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
 
 	if matches!(cli.command, Commands::Config) {
 		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
@@ -389,7 +396,7 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
-	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_path);
+	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
 	let engine = podup::Engine::with_base_dir(client, cli.project, base_dir);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
@@ -495,13 +502,19 @@ async fn run() -> podup::Result<()> {
 
 #[cfg(test)]
 mod tests {
-	use super::{resolve_base_dir, resolve_compose_file};
+	use super::{resolve_base_dir, resolve_compose_files};
 	use std::path::{Path, PathBuf};
 
 	#[test]
-	fn explicit_compose_file_wins() {
-		let p = resolve_compose_file(Some(PathBuf::from("custom.yml")));
-		assert_eq!(p, PathBuf::from("custom.yml"));
+	fn explicit_compose_files_win() {
+		let p = resolve_compose_files(&[PathBuf::from("custom.yml")]);
+		assert_eq!(p, vec![PathBuf::from("custom.yml")]);
+	}
+
+	#[test]
+	fn multiple_explicit_compose_files_preserved() {
+		let p = resolve_compose_files(&[PathBuf::from("a.yml"), PathBuf::from("b.yml")]);
+		assert_eq!(p, vec![PathBuf::from("a.yml"), PathBuf::from("b.yml")]);
 	}
 
 	#[test]
@@ -512,10 +525,16 @@ mod tests {
 		std::fs::create_dir_all(&dir).unwrap();
 		let prev = std::env::current_dir().unwrap();
 		std::env::set_current_dir(&dir).unwrap();
-		let p = resolve_compose_file(None);
+		// Guard against a COMPOSE_FILE set in the test environment.
+		let had_env = std::env::var_os("COMPOSE_FILE");
+		std::env::remove_var("COMPOSE_FILE");
+		let p = resolve_compose_files(&[]);
+		if let Some(v) = had_env {
+			std::env::set_var("COMPOSE_FILE", v);
+		}
 		std::env::set_current_dir(prev).unwrap();
 		let _ = std::fs::remove_dir_all(&dir);
-		assert_eq!(p, PathBuf::from("docker-compose.yml"));
+		assert_eq!(p, vec![PathBuf::from("docker-compose.yml")]);
 	}
 
 	#[test]

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -121,3 +121,33 @@ fn global_env_file_feeds_interpolation() {
 	let file = podup::parse_file_with_env_files(&main_path, &["prod.env".to_string()]).unwrap();
 	assert_eq!(file.services["web"].image.as_deref(), Some("nginx:1.27"));
 }
+
+#[test]
+fn multiple_files_merge_with_override() {
+	let dir = tempfile::tempdir().unwrap();
+
+	let base = dir.path().join("base.yml");
+	let mut b = std::fs::File::create(&base).unwrap();
+	writeln!(
+		b,
+		"services:\n  web:\n    image: nginx:1.0\n    environment:\n      A: \"1\"\n"
+	)
+	.unwrap();
+
+	let over = dir.path().join("override.yml");
+	let mut o = std::fs::File::create(&over).unwrap();
+	writeln!(
+		o,
+		"services:\n  web:\n    image: nginx:2.0\n    environment:\n      B: \"2\"\n  db:\n    image: postgres:16\n"
+	)
+	.unwrap();
+
+	let file = podup::parse_files_with_env_files(&[base, over], &[]).unwrap();
+
+	// Later file overrides the image and adds a service; environment keys merge.
+	assert_eq!(file.services["web"].image.as_deref(), Some("nginx:2.0"));
+	assert!(file.services.contains_key("db"));
+	let env = file.services["web"].environment.to_map();
+	assert!(env.contains_key("A"));
+	assert!(env.contains_key("B"));
+}


### PR DESCRIPTION
## What

Completes #164 gap 11 (multi-file support). podup loaded a single compose file; now it accepts and merges several.

- Repeated `-f`/`--file` flags, or a `COMPOSE_FILE` environment variable holding a path-separator-delimited list (`:` on Unix, `;` on Windows).
- Files are merged left to right, later overriding earlier: services merge field by field (reusing the `extends` merge logic), top-level volumes/networks/secrets/configs replace on key conflict.
- Relative paths resolve against the first file's directory (the project directory).
- New public `parse_files_with_env_files(paths, env_files)` performs the parse-and-merge; `--env-file` still applies to every file.

## Tests
- `multiple_files_merge_with_override` (image override, added service, merged environment)
- `multiple_explicit_compose_files_preserved`, updated resolver tests

All tests pass; clippy clean; fmt applied. Additive public API (new function); the `--file` flag now repeatable.
