### PR TITLE
release: v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -18,6 +18,9 @@ podup (0.11.0) unstable; urgency=medium
     per-pool ip_range (as a lease range), and a per-network interface_name.
     Unsupported aux_addresses and gw_priority are warned about rather than
     silently dropped.
+  * Resolve relative paths (build context, env_file, bind mounts, secret and
+    config files) of services pulled in via include or an external extends
+    against the imported file's directory instead of the project directory.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.11.0) unstable; urgency=medium
+
+  * run no longer publishes the service's declared ports by default; pass
+    --service-ports to opt in, matching compose semantics.
+  * env_file: when a key is defined in multiple files, the last file now
+    wins (later entries override earlier ones).
+  * External volumes and networks that do not exist now fail with an error
+    instead of being silently skipped; external networks resolve to their
+    literal name rather than a project-prefixed one.
+  * config-hash is now computed from a key-sorted canonical form, so
+    services with map-typed fields no longer recreate spuriously on up.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
+
 podup (0.10.0) unstable; urgency=medium
 
   * Resolve relative bind-mount sources against the project directory and

--- a/debian/changelog
+++ b/debian/changelog
@@ -29,6 +29,8 @@ podup (0.11.0) unstable; urgency=medium
     to Podman as CDI devices instead of warning and ignoring them.
   * Add up --no-deps to start the named services without their depends_on
     dependencies.
+  * Resolve service links to the linked service's container name (keeping the
+    service name as the alias); external_links are still passed through as-is.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -23,6 +23,8 @@ podup (0.11.0) unstable; urgency=medium
     against the imported file's directory instead of the project directory.
   * Add a global --env-file flag to load extra env files into the variable
     map used for interpolation.
+  * Build a Git/URL build context by having Podman clone it server-side
+    instead of treating the URL as a local directory to tar.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,8 @@ podup (0.11.0) unstable; urgency=medium
   * Parse env files and .env with dotenv rules: strip surrounding quotes,
     honour escape sequences in double-quoted values, drop inline comments
     on unquoted values, and support multi-line quoted values.
+  * Forward a long-form volume's subpath so only the named sub-directory of
+    the volume is mounted instead of dropping the option.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -21,6 +21,8 @@ podup (0.11.0) unstable; urgency=medium
   * Resolve relative paths (build context, env_file, bind mounts, secret and
     config files) of services pulled in via include or an external extends
     against the imported file's directory instead of the project directory.
+  * Add a global --env-file flag to load extra env files into the variable
+    map used for interpolation.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -31,6 +31,8 @@ podup (0.11.0) unstable; urgency=medium
     dependencies.
   * Resolve service links to the linked service's container name (keeping the
     service name as the alias); external_links are still passed through as-is.
+  * Accept multiple compose files (repeated -f or a COMPOSE_FILE list) and
+    merge them in order, with later files overriding earlier ones.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,9 @@ podup (0.11.0) unstable; urgency=medium
     literal name rather than a project-prefixed one.
   * config-hash is now computed from a key-sorted canonical form, so
     services with map-typed fields no longer recreate spuriously on up.
+  * Parse env files and .env with dotenv rules: strip surrounding quotes,
+    honour escape sequences in double-quoted values, drop inline comments
+    on unquoted values, and support multi-line quoted values.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -14,6 +14,10 @@ podup (0.11.0) unstable; urgency=medium
     on unquoted values, and support multi-line quoted values.
   * Forward a long-form volume's subpath so only the named sub-directory of
     the volume is mounted instead of dropping the option.
+  * Forward IPAM configuration to Podman: the ipam driver and options, the
+    per-pool ip_range (as a lease range), and a per-network interface_name.
+    Unsupported aux_addresses and gw_priority are warned about rather than
+    silently dropped.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -27,6 +27,8 @@ podup (0.11.0) unstable; urgency=medium
     instead of treating the URL as a local directory to tar.
   * Forward NVIDIA GPU reservations (deploy.resources.reservations.devices)
     to Podman as CDI devices instead of warning and ignoring them.
+  * Add up --no-deps to start the named services without their depends_on
+    dependencies.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -25,6 +25,8 @@ podup (0.11.0) unstable; urgency=medium
     map used for interpolation.
   * Build a Git/URL build context by having Podman clone it server-side
     instead of treating the URL as a local directory to tar.
+  * Forward NVIDIA GPU reservations (deploy.resources.reservations.devices)
+    to Podman as CDI devices instead of warning and ignoring them.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/compose/anchor.rs
+++ b/internal/compose/anchor.rs
@@ -1,0 +1,228 @@
+//! Anchor relative paths of externally-imported content to their source dir.
+//!
+//! A service pulled in via `include:` or an external `extends: { file: ... }`
+//! carries paths (build context, env_file, bind-mount sources, secret/config
+//! files) that the compose spec resolves relative to the directory of the file
+//! that defined them — not the top-level project directory. The engine resolves
+//! every relative path against a single project base directory, so before such
+//! content is merged we rewrite its relative paths to absolute paths anchored at
+//! the imported file's directory. Absolute paths then pass through the engine's
+//! base-directory resolution unchanged.
+
+use std::path::Path;
+
+use super::types::{
+	BuildConfig, ComposeFile, EnvFile, EnvFileEntry, Service, VolumeMount, VolumeType,
+};
+
+/// Anchor every path-bearing field of an imported compose file to `dir`.
+pub(super) fn anchor_compose_file(file: &mut ComposeFile, dir: &Path) {
+	for svc in file.services.values_mut() {
+		anchor_service(svc, dir);
+	}
+	for secret in file.secrets.values_mut() {
+		if let Some(f) = secret.file.as_deref().and_then(|f| anchor_fs(f, dir)) {
+			secret.file = Some(f);
+		}
+	}
+	for config in file.configs.values_mut() {
+		if let Some(f) = config.file.as_deref().and_then(|f| anchor_fs(f, dir)) {
+			config.file = Some(f);
+		}
+	}
+}
+
+/// Anchor the path-bearing fields of a single service to `dir`.
+pub(super) fn anchor_service(svc: &mut Service, dir: &Path) {
+	if let Some(build) = svc.build.as_mut() {
+		match build {
+			BuildConfig::Context(c) => {
+				if let Some(a) = anchor_context(c, dir) {
+					*c = a;
+				}
+			}
+			BuildConfig::Config { context, .. } => {
+				if let Some(a) = anchor_context(context, dir) {
+					*context = a;
+				}
+			}
+		}
+	}
+
+	match &mut svc.env_file {
+		EnvFile::Empty => {}
+		EnvFile::Single(e) => anchor_env_entry(e, dir),
+		EnvFile::List(list) => {
+			for e in list.iter_mut() {
+				anchor_env_entry(e, dir);
+			}
+		}
+	}
+
+	for v in svc.volumes.iter_mut() {
+		match v {
+			VolumeMount::Short(s) => {
+				if let Some(a) = anchor_short_volume(s, dir) {
+					*s = a;
+				}
+			}
+			VolumeMount::Long {
+				volume_type: VolumeType::Bind,
+				source: Some(src),
+				..
+			} => {
+				if let Some(a) = anchor_bind(src, dir) {
+					*src = a;
+				}
+			}
+			VolumeMount::Long { .. } => {}
+		}
+	}
+}
+
+/// A path is anchorable when it is relative and not a `~` home reference
+/// (home expansion happens later, against the user's home, not the file dir).
+fn anchor_fs(path: &str, dir: &Path) -> Option<String> {
+	if path.is_empty() || path.starts_with('~') || Path::new(path).is_absolute() {
+		return None;
+	}
+	Some(dir.join(path).to_string_lossy().into_owned())
+}
+
+/// Build contexts may be Git/URL references, which must not be anchored.
+fn anchor_context(context: &str, dir: &Path) -> Option<String> {
+	if context.contains("://") || context.starts_with("git@") {
+		return None;
+	}
+	anchor_fs(context, dir)
+}
+
+/// Only explicit relative bind sources (`./x`, `../x`) are anchored; named
+/// volumes, absolute paths, and `~` references are left untouched.
+fn anchor_bind(src: &str, dir: &Path) -> Option<String> {
+	src.starts_with('.')
+		.then(|| dir.join(src).to_string_lossy().into_owned())
+}
+
+fn anchor_short_volume(s: &str, dir: &Path) -> Option<String> {
+	let parts: Vec<&str> = s.splitn(3, ':').collect();
+	let src = parts.first()?;
+	if !src.starts_with('.') {
+		return None;
+	}
+	let mut rebuilt = dir.join(src).to_string_lossy().into_owned();
+	for part in &parts[1..] {
+		rebuilt.push(':');
+		rebuilt.push_str(part);
+	}
+	Some(rebuilt)
+}
+
+fn anchor_env_entry(entry: &mut EnvFileEntry, dir: &Path) {
+	match entry {
+		EnvFileEntry::Path(p) => {
+			if let Some(a) = anchor_fs(p, dir) {
+				*p = a;
+			}
+		}
+		EnvFileEntry::Config { path, .. } => {
+			if let Some(a) = anchor_fs(path, dir) {
+				*path = a;
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::types::Service;
+	use std::path::Path;
+
+	fn dir() -> &'static Path {
+		Path::new("/proj/sub")
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn anchors_relative_build_context() {
+		let mut svc = Service {
+			build: Some(BuildConfig::Context("./app".into())),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		match svc.build.unwrap() {
+			BuildConfig::Context(c) => assert_eq!(c, "/proj/sub/./app"),
+			_ => panic!("expected context"),
+		}
+	}
+
+	#[test]
+	fn leaves_url_build_context() {
+		let mut svc = Service {
+			build: Some(BuildConfig::Context("https://github.com/x/y.git".into())),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		match svc.build.unwrap() {
+			BuildConfig::Context(c) => assert_eq!(c, "https://github.com/x/y.git"),
+			_ => panic!("expected context"),
+		}
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn anchors_env_file_list() {
+		let mut svc = Service {
+			env_file: EnvFile::List(vec![
+				EnvFileEntry::Path("./a.env".into()),
+				EnvFileEntry::Path("/abs/b.env".into()),
+			]),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		let EnvFile::List(list) = &svc.env_file else {
+			panic!("expected list");
+		};
+		assert_eq!(list[0].path(), "/proj/sub/./a.env");
+		assert_eq!(list[1].path(), "/abs/b.env");
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn anchors_relative_short_bind_only() {
+		let mut svc = Service {
+			volumes: vec![
+				VolumeMount::Short("./data:/data:ro".into()),
+				VolumeMount::Short("named:/v".into()),
+				VolumeMount::Short("/abs:/a".into()),
+			],
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		let got: Vec<_> = svc
+			.volumes
+			.iter()
+			.map(|v| match v {
+				VolumeMount::Short(s) => s.clone(),
+				_ => unreachable!(),
+			})
+			.collect();
+		assert_eq!(got[0], "/proj/sub/./data:/data:ro");
+		assert_eq!(got[1], "named:/v");
+		assert_eq!(got[2], "/abs:/a");
+	}
+
+	#[test]
+	fn leaves_tilde_paths() {
+		let mut svc = Service {
+			env_file: EnvFile::Single(EnvFileEntry::Path("~/x.env".into())),
+			..Default::default()
+		};
+		anchor_service(&mut svc, dir());
+		let EnvFile::Single(e) = &svc.env_file else {
+			panic!("expected single");
+		};
+		assert_eq!(e.path(), "~/x.env");
+	}
+}

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -9,7 +9,7 @@ use super::super::types::{
 	DependsOn, EnvFile, EnvVars, Labels, Service, ServiceNetworks, StringOrList, Sysctls,
 };
 
-pub(super) fn merge_service(base: Service, override_svc: Service) -> Service {
+pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) -> Service {
 	fn opt<T>(o: Option<T>, b: Option<T>) -> Option<T> {
 		o.or(b)
 	}

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -137,12 +137,16 @@ fn resolve_one_extends(
 		let mut other = parse_file_inner(&abs, &dir)?;
 		let mut nested_visited: HashSet<String> = HashSet::new();
 		resolve_one_extends(&mut other, &base_name, &dir, &mut nested_visited, depth + 1)?;
-		other.services.swap_remove(&base_name).ok_or_else(|| {
+		let mut base = other.services.swap_remove(&base_name).ok_or_else(|| {
 			ComposeError::Extends(format!(
 				"service '{base_name}' not found in {}",
 				abs.display()
 			))
-		})?
+		})?;
+		// The base service's relative paths are relative to the external file's
+		// directory; anchor them before merging into the current file's service.
+		super::anchor::anchor_service(&mut base, &dir);
+		base
 	} else {
 		if base_name == name {
 			return Err(ComposeError::Extends(format!(

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -17,7 +17,7 @@ use super::parse_file_inner;
 use super::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
-use merge::merge_service;
+pub(in crate::compose) use merge::merge_service;
 
 const MAX_EXTENDS_DEPTH: usize = 16;
 

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -8,7 +8,7 @@ mod extends;
 mod include;
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{ComposeError, Result};
 use crate::substitute;
@@ -74,6 +74,51 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 
 	extends::resolve_all_extends(&mut file, &dir)?;
 	Ok(file)
+}
+
+/// Parse and merge multiple compose files (the `-f`/`COMPOSE_FILE` list).
+///
+/// Files are merged left to right: a later file overrides an earlier one,
+/// service by service (per-field, like `extends`), with top-level
+/// volumes/networks/secrets/configs replaced on key conflicts. Relative paths
+/// resolve against the first file's directory, matching the compose project
+/// directory. `env_files` feed interpolation for every file.
+pub fn parse_files_with_env_files(paths: &[PathBuf], env_files: &[String]) -> Result<ComposeFile> {
+	let mut iter = paths.iter();
+	let first = iter
+		.next()
+		.ok_or_else(|| ComposeError::FileNotFound("no compose file given".to_string()))?;
+	let mut merged = parse_file_with_env_files(first, env_files)?;
+	for path in iter {
+		let other = parse_file_with_env_files(path, env_files)?;
+		merge_override(&mut merged, other);
+	}
+	Ok(merged)
+}
+
+/// Merge `other` into `target` with `other` winning (compose `-f` override
+/// semantics): services are merged field-by-field, other top-level maps replace
+/// on key conflict.
+fn merge_override(target: &mut ComposeFile, other: ComposeFile) {
+	for (name, svc) in other.services {
+		if let Some(base) = target.services.get_mut(&name) {
+			*base = extends::merge_service(std::mem::take(base), svc);
+		} else {
+			target.services.insert(name, svc);
+		}
+	}
+	for (k, v) in other.volumes {
+		target.volumes.insert(k, v);
+	}
+	for (k, v) in other.networks {
+		target.networks.insert(k, v);
+	}
+	for (k, v) in other.secrets {
+		target.secrets.insert(k, v);
+	}
+	for (k, v) in other.configs {
+		target.configs.insert(k, v);
+	}
 }
 
 /// Parse a compose YAML string (no file I/O).

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -17,9 +17,17 @@ use types::ComposeFile;
 /// Parse a compose file from disk, applying variable substitution and
 /// resolving `extends:` / `include:` directives.
 pub fn parse_file(path: &Path) -> Result<ComposeFile> {
+	parse_file_with_env_files(path, &[])
+}
+
+/// Like [`parse_file`], additionally loading `env_files` (the global
+/// `--env-file` flag) into the variable map used for interpolation. These take
+/// effect for the top-level file and any included files; the process
+/// environment and a project `.env` still take precedence.
+pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<ComposeFile> {
 	let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 	let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
-	let mut file = parse_file_inner(&abs, &dir)?;
+	let mut file = parse_file_inner_with_env(&abs, &dir, env_files)?;
 
 	let includes = std::mem::take(&mut file.include);
 	for inc in includes {
@@ -56,7 +64,9 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 					.map(|p| p.to_path_buf())
 					.unwrap_or_else(|| dir.clone())
 			});
-			let mut included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
+			let mut combined_env_files = env_files.to_vec();
+			combined_env_files.extend(extra_env_files.iter().cloned());
+			let mut included = parse_file_inner_with_env(&inc_path, &inc_dir, &combined_env_files)?;
 			anchor::anchor_compose_file(&mut included, &inc_dir);
 			include::merge_compose_file(&mut file, included);
 		}

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod types;
 
+mod anchor;
 mod extends;
 mod include;
 
@@ -55,7 +56,8 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 					.map(|p| p.to_path_buf())
 					.unwrap_or_else(|| dir.clone())
 			});
-			let included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
+			let mut included = parse_file_inner_with_env(&inc_path, &inc_dir, &extra_env_files)?;
+			anchor::anchor_compose_file(&mut included, &inc_dir);
 			include::merge_compose_file(&mut file, included);
 		}
 	}

--- a/internal/dotenv.rs
+++ b/internal/dotenv.rs
@@ -1,0 +1,231 @@
+//! Minimal dotenv parser shared by `env_file` loading and `.env` interpolation.
+//!
+//! Implements the subset of compose-spec dotenv rules podup relies on:
+//! full-line comments, an optional `export` prefix, single- and double-quoted
+//! values (including values that span multiple lines), inline comments on
+//! unquoted values, and the standard double-quote escape sequences. Callers
+//! decide duplicate-key precedence by the order pairs are returned in.
+
+/// Parse dotenv `content` into ordered `(key, value)` pairs.
+///
+/// Pairs are returned in file order; a later duplicate key appears after an
+/// earlier one, leaving the precedence decision to the caller.
+pub fn parse(content: &str) -> Vec<(String, String)> {
+	let mut out = Vec::new();
+	let mut lines = content.lines();
+
+	while let Some(raw) = lines.next() {
+		let line = raw.trim_start();
+		if line.is_empty() || line.starts_with('#') {
+			continue;
+		}
+		let line = line
+			.strip_prefix("export ")
+			.map(str::trim_start)
+			.unwrap_or(line);
+
+		let Some(eq) = line.find('=') else {
+			let key = line.trim();
+			if !key.is_empty() {
+				out.push((key.to_string(), String::new()));
+			}
+			continue;
+		};
+
+		let key = line[..eq].trim();
+		if key.is_empty() {
+			continue;
+		}
+		let value = parse_value(line[eq + 1..].trim_start(), &mut lines);
+		out.push((key.to_string(), value));
+	}
+
+	out
+}
+
+/// Parse the value portion of an assignment, consuming continuation lines for
+/// a quoted value that does not close on the first line.
+fn parse_value(rest: &str, lines: &mut std::str::Lines) -> String {
+	match rest.chars().next() {
+		Some(quote @ ('"' | '\'')) => {
+			let body = &rest[quote.len_utf8()..];
+			if let Some(end) = find_closing(body, quote) {
+				return unescape(&body[..end], quote);
+			}
+			// Unterminated on this line: a multi-line quoted value.
+			let mut buf = String::from(body);
+			for next in lines.by_ref() {
+				buf.push('\n');
+				if let Some(end) = find_closing(next, quote) {
+					buf.push_str(&next[..end]);
+					return unescape(&buf, quote);
+				}
+				buf.push_str(next);
+			}
+			unescape(&buf, quote)
+		}
+		_ => strip_inline_comment(rest).trim_end().to_string(),
+	}
+}
+
+/// Byte index of the unescaped closing `quote` in `s`, if present.
+///
+/// Backslash escapes are honoured for double quotes only; single-quoted
+/// strings are literal and close at the first quote.
+fn find_closing(s: &str, quote: char) -> Option<usize> {
+	let bytes = s.as_bytes();
+	let q = quote as u8;
+	let mut i = 0;
+	while i < bytes.len() {
+		let c = bytes[i];
+		if quote == '"' && c == b'\\' {
+			i += 2;
+			continue;
+		}
+		if c == q {
+			return Some(i);
+		}
+		i += 1;
+	}
+	None
+}
+
+/// Expand escape sequences for double-quoted values; single-quoted values are
+/// returned verbatim.
+fn unescape(s: &str, quote: char) -> String {
+	if quote == '\'' {
+		return s.to_string();
+	}
+	let mut out = String::with_capacity(s.len());
+	let mut chars = s.chars();
+	while let Some(c) = chars.next() {
+		if c != '\\' {
+			out.push(c);
+			continue;
+		}
+		match chars.next() {
+			Some('n') => out.push('\n'),
+			Some('r') => out.push('\r'),
+			Some('t') => out.push('\t'),
+			Some('\\') => out.push('\\'),
+			Some('"') => out.push('"'),
+			Some('\'') => out.push('\''),
+			Some(other) => out.push(other),
+			None => out.push('\\'),
+		}
+	}
+	out
+}
+
+/// Trim an inline comment from an unquoted value: everything from the first
+/// `#` that is preceded by whitespace. A `#` with no preceding whitespace
+/// (e.g. directly after `=`) is part of the value.
+fn strip_inline_comment(s: &str) -> &str {
+	let bytes = s.as_bytes();
+	let mut i = 0;
+	while i < bytes.len() {
+		if bytes[i] == b'#' && i > 0 && bytes[i - 1].is_ascii_whitespace() {
+			return &s[..i];
+		}
+		i += 1;
+	}
+	s
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse;
+
+	fn map(content: &str) -> std::collections::HashMap<String, String> {
+		parse(content).into_iter().collect()
+	}
+
+	#[test]
+	fn plain_key_value() {
+		let m = map("FOO=bar\nBAZ=qux\n");
+		assert_eq!(m["FOO"], "bar");
+		assert_eq!(m["BAZ"], "qux");
+	}
+
+	#[test]
+	fn skips_blank_and_comment_lines() {
+		let m = map("# header\n\nFOO=bar\n   # indented comment\n");
+		assert_eq!(m.len(), 1);
+		assert_eq!(m["FOO"], "bar");
+	}
+
+	#[test]
+	fn strips_double_quotes() {
+		assert_eq!(map("FOO=\"bar\"\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn strips_single_quotes() {
+		assert_eq!(map("FOO='bar'\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn double_quoted_keeps_inner_hash() {
+		assert_eq!(map("FOO=\"a # b\"\n")["FOO"], "a # b");
+	}
+
+	#[test]
+	fn single_quoted_is_literal() {
+		assert_eq!(map("FOO='a\\nb'\n")["FOO"], "a\\nb");
+	}
+
+	#[test]
+	fn double_quoted_expands_escapes() {
+		assert_eq!(map("FOO=\"a\\nb\\tc\"\n")["FOO"], "a\nb\tc");
+	}
+
+	#[test]
+	fn unquoted_strips_inline_comment() {
+		assert_eq!(map("FOO=bar # trailing\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn unquoted_keeps_leading_hash_without_space() {
+		assert_eq!(map("FOO=#notacomment\n")["FOO"], "#notacomment");
+	}
+
+	#[test]
+	fn unquoted_keeps_internal_spaces() {
+		assert_eq!(map("FOO=a b c\n")["FOO"], "a b c");
+	}
+
+	#[test]
+	fn export_prefix_stripped() {
+		assert_eq!(map("export FOO=bar\n")["FOO"], "bar");
+	}
+
+	#[test]
+	fn bare_key_has_empty_value() {
+		assert_eq!(map("BARE\n")["BARE"], "");
+	}
+
+	#[test]
+	fn multiline_double_quoted_value() {
+		let m = map("FOO=\"line1\nline2\"\nBAR=baz\n");
+		assert_eq!(m["FOO"], "line1\nline2");
+		assert_eq!(m["BAR"], "baz");
+	}
+
+	#[test]
+	fn multiline_single_quoted_value() {
+		let m = map("FOO='line1\nline2'\n");
+		assert_eq!(m["FOO"], "line1\nline2");
+	}
+
+	#[test]
+	fn later_duplicate_returned_after_earlier() {
+		let pairs = parse("FOO=first\nFOO=second\n");
+		assert_eq!(
+			pairs,
+			vec![
+				("FOO".to_string(), "first".to_string()),
+				("FOO".to_string(), "second".to_string()),
+			]
+		);
+	}
+}

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -110,44 +110,63 @@ impl Engine {
 			None => return Ok(()),
 		};
 
-		let context_path = self.base_dir.join(build.context());
+		let context_str = build.context().to_string();
+		let remote_context = is_remote_context(&context_str);
 		let tag = service
 			.image
 			.clone()
 			.unwrap_or_else(|| format!("{}:latest", service_name));
 
-		info!("building {tag} from {}", context_path.display());
-
-		// Resolve `build.secrets` to in-tar files before building the context:
-		// each secret value is shipped inside the build-context tar and referenced
-		// by a relative `src=` path, which is the form the libpod build endpoint
-		// expects (`env=`/host-path forms don't work reliably over the socket).
-		let (secret_files, secret_specs) = self.resolve_build_secrets(build, file)?;
-
-		let inline = build.dockerfile_inline().map(|s| s.to_string());
-		// Honour an explicit dockerfile; otherwise prefer Dockerfile but fall back
-		// to Podman's native Containerfile when only the latter is present.
-		let df = match build.dockerfile() {
-			Some(name) => name.to_string(),
-			None if !context_path.join("Dockerfile").is_file()
-				&& context_path.join("Containerfile").is_file() =>
-			{
-				"Containerfile".to_string()
+		// A Git/URL context is cloned server-side by Podman via the `remote`
+		// query parameter — there is no local directory to tar. Tar-only features
+		// (inline Dockerfile, in-tar build secrets) do not apply.
+		let (tar_bytes, dockerfile_name, secret_specs) = if remote_context {
+			info!("building {tag} from remote context {context_str}");
+			if build.dockerfile_inline().is_some() {
+				warn!("build.dockerfile_inline is ignored for a remote build context");
 			}
-			None => "Dockerfile".to_string(),
-		};
-		let ctx = context_path.clone();
-		let (tar_bytes, dockerfile_name) =
-			tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String)> {
-				if let Some(inline_s) = inline {
-					build_context_tar_with_inline(&ctx, &inline_s, &secret_files)
-				} else {
-					let bytes = build_context_tar(&ctx, &df, &secret_files)?;
-					Ok((bytes, df))
+			if !build.secrets().is_empty() {
+				warn!("build.secrets are ignored for a remote build context");
+			}
+			let df = build.dockerfile().unwrap_or("Dockerfile").to_string();
+			(Vec::new(), df, Vec::new())
+		} else {
+			let context_path = self.base_dir.join(&context_str);
+			info!("building {tag} from {}", context_path.display());
+
+			// Resolve `build.secrets` to in-tar files before building the context:
+			// each secret value is shipped inside the build-context tar and
+			// referenced by a relative `src=` path, which is the form the libpod
+			// build endpoint expects (`env=`/host-path forms don't work reliably
+			// over the socket).
+			let (secret_files, secret_specs) = self.resolve_build_secrets(build, file)?;
+
+			let inline = build.dockerfile_inline().map(|s| s.to_string());
+			// Honour an explicit dockerfile; otherwise prefer Dockerfile but fall
+			// back to Podman's native Containerfile when only the latter is present.
+			let df = match build.dockerfile() {
+				Some(name) => name.to_string(),
+				None if !context_path.join("Dockerfile").is_file()
+					&& context_path.join("Containerfile").is_file() =>
+				{
+					"Containerfile".to_string()
 				}
-			})
-			.await
-			.map_err(|e| ComposeError::Build(e.to_string()))??;
+				None => "Dockerfile".to_string(),
+			};
+			let ctx = context_path.clone();
+			let (bytes, name) =
+				tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String)> {
+					if let Some(inline_s) = inline {
+						build_context_tar_with_inline(&ctx, &inline_s, &secret_files)
+					} else {
+						let bytes = build_context_tar(&ctx, &df, &secret_files)?;
+						Ok((bytes, df))
+					}
+				})
+				.await
+				.map_err(|e| ComposeError::Build(e.to_string()))??;
+			(bytes, name, secret_specs)
+		};
 
 		let arg_map = build.args().to_map();
 		let mut build_args: std::collections::HashMap<String, String> =
@@ -257,6 +276,10 @@ impl Engine {
 			);
 		}
 
+		if remote_context {
+			qs.push_str(&format!("&remote={}", urlencoded(&context_str)));
+		}
+
 		let path = format!("{API_PREFIX}/build?{qs}");
 		let body_bytes = Bytes::from(tar_bytes);
 		let resp = self
@@ -353,9 +376,15 @@ impl Engine {
 	}
 }
 
+/// A build context is remote when it is a URL or Git reference that Podman
+/// clones server-side, rather than a local directory to tar and upload.
+fn is_remote_context(context: &str) -> bool {
+	context.contains("://") || context.starts_with("git@")
+}
+
 #[cfg(test)]
 mod tests {
-	use super::Engine;
+	use super::{is_remote_context, Engine};
 	use crate::libpod::Client;
 
 	fn engine(base: std::path::PathBuf) -> Engine {
@@ -400,6 +429,16 @@ mod tests {
 		let (files, specs) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
 		assert!(files.is_empty());
 		assert!(specs.is_empty());
+	}
+
+	#[test]
+	fn remote_context_detection() {
+		assert!(is_remote_context("https://github.com/user/repo.git"));
+		assert!(is_remote_context("git://example.com/repo.git"));
+		assert!(is_remote_context("git@github.com:user/repo.git"));
+		assert!(!is_remote_context("."));
+		assert!(!is_remote_context("./build"));
+		assert!(!is_remote_context("/abs/path"));
 	}
 
 	#[test]

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -12,7 +12,8 @@ use crate::libpod::API_PREFIX;
 use crate::{env_file, ports, size};
 
 use super::container_config::{
-	build_healthcheck, build_log_config, build_resource_limits, build_restart_policy, build_ulimits,
+	build_healthcheck, build_log_config, build_resource_limits, build_restart_policy,
+	build_ulimits, cdi_devices,
 };
 use super::container_misc::{
 	build_blkio_config, build_label_file_labels, parse_device, warn_swarm_only_deploy,
@@ -227,6 +228,7 @@ impl Engine {
 			restart_policy,
 			restart_tries,
 			devices,
+			cdi_devices: cdi_devices(service),
 			device_cgroup_rule: service.device_cgroup_rules.clone(),
 			groups: service.group_add.clone(),
 			oom_score_adj: service.oom_score_adj,

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -161,8 +161,7 @@ impl Engine {
 			.unwrap_or((None, None));
 
 		// --- Links ---
-		let mut links: Vec<String> = service.links.clone();
-		links.extend_from_slice(&service.external_links);
+		let links = resolve_links(service, file, &self.project);
 
 		// --- SHM size ---
 		let shm_size = service.shm_size.as_deref().and_then(size::parse_memory);
@@ -318,6 +317,35 @@ fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
 	}
 }
 
+/// Resolve a service's `links` to concrete container references.
+///
+/// A compose `links:` entry names a sibling service; it is rewritten to that
+/// service's container name with the service name kept as the network alias
+/// (`{container}:{alias}`), so the linked container is reachable by the compose
+/// service name. `external_links` reference containers outside the project and
+/// are passed through verbatim.
+fn resolve_links(service: &Service, file: &ComposeFile, project: &str) -> Vec<String> {
+	let mut links: Vec<String> = service
+		.links
+		.iter()
+		.map(|link| {
+			let (target, alias) = link.split_once(':').unwrap_or((link, link));
+			let container = file
+				.services
+				.get(target)
+				.map(|svc| {
+					svc.container_name
+						.clone()
+						.unwrap_or_else(|| format!("{project}-{target}"))
+				})
+				.unwrap_or_else(|| target.to_string());
+			format!("{container}:{alias}")
+		})
+		.collect();
+	links.extend(service.external_links.iter().cloned());
+	links
+}
+
 /// Stable content hash of a service definition, stored as the
 /// `podup.config-hash` label. On `up`, comparing this against the label on an
 /// existing container tells podup whether the service configuration changed
@@ -351,8 +379,30 @@ fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-	use super::{config_hash, resolve_volume_name};
+	use super::{config_hash, resolve_links, resolve_volume_name};
 	use crate::parse_str;
+
+	#[test]
+	fn links_resolve_to_container_names_external_links_verbatim() {
+		let file = parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    links:\n      - db\n      - db:primary\n    external_links:\n      - legacy_db:db\n",
+		)
+		.unwrap();
+		let links = resolve_links(&file.services["web"], &file, "proj");
+		assert!(links.contains(&"proj-db:db".to_string()));
+		assert!(links.contains(&"proj-db:primary".to_string()));
+		assert!(links.contains(&"legacy_db:db".to_string()));
+	}
+
+	#[test]
+	fn links_honour_custom_container_name() {
+		let file = parse_str(
+			"services:\n  db:\n    image: x\n    container_name: my-db\n  web:\n    image: x\n    links:\n      - db\n",
+		)
+		.unwrap();
+		let links = resolve_links(&file.services["web"], &file, "proj");
+		assert_eq!(links, vec!["my-db:db".to_string()]);
+	}
 
 	#[test]
 	#[cfg(unix)]

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -322,7 +322,12 @@ fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
 /// and the container must be recreated, or is unchanged and can be left as is.
 pub(crate) fn config_hash(service: &Service) -> String {
 	use sha2::{Digest, Sha256};
-	let serialized = serde_json::to_vec(service).unwrap_or_default();
+	// Canonicalise through `serde_json::Value` first: object keys are emitted in
+	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
+	// between runs and flap the hash into a spurious recreate.
+	let serialized = serde_json::to_value(service)
+		.and_then(|v| serde_json::to_vec(&v))
+		.unwrap_or_default();
 	Sha256::digest(&serialized)
 		.iter()
 		.map(|b| format!("{b:02x}"))
@@ -385,5 +390,24 @@ mod tests {
 		assert_eq!(ha, hb, "same config produces the same hash");
 		assert_ne!(ha, hc, "a changed image produces a different hash");
 		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
+	}
+
+	#[test]
+	fn config_hash_stable_despite_map_field_order() {
+		// `storage_opt` is a HashMap; canonical serialisation must sort its keys
+		// so the hash does not flap and trigger a spurious recreate on `up`.
+		let a = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      size: \"10G\"\n      foo: bar\n      baz: qux\n",
+		)
+		.unwrap();
+		let b = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      baz: qux\n      size: \"10G\"\n      foo: bar\n",
+		)
+		.unwrap();
+		assert_eq!(
+			config_hash(&a.services["web"]),
+			config_hash(&b.services["web"]),
+			"hash must be independent of storage_opt key order",
+		);
 	}
 }

--- a/internal/engine/container_config.rs
+++ b/internal/engine/container_config.rs
@@ -121,12 +121,8 @@ pub(super) fn build_resource_limits(service: &Service) -> Option<LinuxResources>
 				if mem_reservation.is_none() {
 					mem_reservation = reserv.memory.as_deref().and_then(size::parse_memory);
 				}
-				if !reserv.devices.is_empty() {
-					tracing::warn!(
-						"deploy.resources.reservations.devices is not yet supported \
-						— GPU/device reservations will be ignored"
-					);
-				}
+				// GPU/device reservations are forwarded separately as CDI
+				// devices; see [`cdi_devices`].
 			}
 		}
 	}
@@ -205,6 +201,58 @@ pub(super) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 			hard: cfg.hard() as u64,
 		})
 		.collect()
+}
+
+/// Map `deploy.resources.reservations.devices` GPU reservations to Podman CDI
+/// device names (e.g. `nvidia.com/gpu=all`).
+///
+/// Only NVIDIA GPU reservations are translated — the common case Podman exposes
+/// through CDI. Reservations for other drivers or capabilities are warned about
+/// and skipped, since there is no portable mapping for them.
+pub(super) fn cdi_devices(service: &Service) -> Vec<String> {
+	let mut out = Vec::new();
+
+	let Some(reservations) = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.resources.as_ref())
+		.and_then(|r| r.reservations.as_ref())
+	else {
+		return out;
+	};
+
+	for dev in &reservations.devices {
+		let is_gpu = dev.capabilities.iter().any(|c| c == "gpu" || c == "nvidia");
+		let driver = dev.driver.as_deref().unwrap_or("nvidia");
+		if !is_gpu || (driver != "nvidia" && !driver.is_empty()) {
+			tracing::warn!(
+				"device reservation (driver {:?}, capabilities {:?}) is not supported and is ignored",
+				dev.driver,
+				dev.capabilities
+			);
+			continue;
+		}
+
+		if !dev.device_ids.is_empty() {
+			for id in &dev.device_ids {
+				out.push(format!("nvidia.com/gpu={id}"));
+			}
+			continue;
+		}
+
+		match dev.count.as_ref().map(|c| c.to_i64()) {
+			// `count: all` (-1) or unspecified → request every GPU.
+			Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
+			Some(n) if n > 0 => {
+				for i in 0..n {
+					out.push(format!("nvidia.com/gpu={i}"));
+				}
+			}
+			Some(_) => {}
+		}
+	}
+
+	out
 }
 
 // ---------------------------------------------------------------------------
@@ -447,5 +495,49 @@ mod tests {
 		let ul = build_ulimits(&svc);
 		assert_eq!(ul[0].soft, 512);
 		assert_eq!(ul[0].hard, 2048);
+	}
+
+	// --- cdi devices ---
+
+	fn cdi_for(yaml: &str) -> Vec<String> {
+		let file = crate::parse_str(yaml).unwrap();
+		cdi_devices(&file.services["app"])
+	}
+
+	#[test]
+	fn cdi_gpu_count_all() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              count: all\n",
+		);
+		assert_eq!(got, vec!["nvidia.com/gpu=all"]);
+	}
+
+	#[test]
+	fn cdi_gpu_count_n_enumerates() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              count: 2\n",
+		);
+		assert_eq!(got, vec!["nvidia.com/gpu=0", "nvidia.com/gpu=1"]);
+	}
+
+	#[test]
+	fn cdi_gpu_device_ids() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              device_ids: [\"GPU-abc\", \"1\"]\n",
+		);
+		assert_eq!(got, vec!["nvidia.com/gpu=GPU-abc", "nvidia.com/gpu=1"]);
+	}
+
+	#[test]
+	fn cdi_non_gpu_skipped() {
+		let got = cdi_for(
+			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [tpu]\n              driver: google\n",
+		);
+		assert!(got.is_empty());
+	}
+
+	#[test]
+	fn cdi_absent_without_deploy() {
+		assert!(cdi_devices(&default_service()).is_empty());
 	}
 }

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -251,6 +251,7 @@ impl Engine {
 			detach,
 			env_overrides,
 			name_override,
+			service_ports,
 		} = opts;
 		let service = file
 			.services
@@ -276,6 +277,12 @@ impl Engine {
 			run_service.environment = crate::compose::types::EnvVars::List(env_list);
 		}
 		run_service.restart = None;
+		// Compose `run` does not publish the service's ports unless
+		// `--service-ports` is given; otherwise a one-off run would collide
+		// with the long-running service's host-port bindings.
+		if !service_ports {
+			run_service.ports.clear();
+		}
 		// Force non-TTY so Podman uses multiplexed log framing that
 		// parse_multiplexed can decode. TTY mode sends raw bytes without
 		// the 8-byte header, which would produce garbled output.

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -28,6 +28,9 @@ pub struct RunOptions {
 	pub env_overrides: Vec<String>,
 	/// Override the generated container name.
 	pub name_override: Option<String>,
+	/// Publish the service's declared `ports:` (compose `run --service-ports`).
+	/// When false, `run` leaves ports unpublished to avoid host-port collisions.
+	pub service_ports: bool,
 }
 
 impl Engine {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -36,7 +36,7 @@ pub struct RunOptions {
 impl Engine {
 	/// Start all services defined in the compose file, creating containers that do not exist.
 	pub async fn up(&self, file: &ComposeFile) -> Result<()> {
-		self.up_with_options(file, false, &[], &[], false, false)
+		self.up_with_options(file, false, &[], &[], false, false, false)
 			.await
 	}
 
@@ -52,6 +52,7 @@ impl Engine {
 	}
 
 	/// Start services with explicit options. When `no_recreate` is true, running containers are left untouched. On partial failure, staging directories are cleaned up.
+	#[allow(clippy::too_many_arguments)]
 	pub async fn up_with_options(
 		&self,
 		file: &ComposeFile,
@@ -60,30 +61,13 @@ impl Engine {
 		target_services: &[String],
 		no_recreate: bool,
 		force_recreate: bool,
+		no_deps: bool,
 	) -> Result<()> {
 		let r: Result<()> = async {
 			let order = crate::compose::resolve_order(file)?;
 			let active = active_profiles_set(active_profiles);
 
-			let target_set: Option<HashSet<String>> = if target_services.is_empty() {
-				None
-			} else {
-				let mut set = HashSet::new();
-				let mut stack: Vec<String> = target_services.to_vec();
-				while let Some(name) = stack.pop() {
-					if !set.insert(name.clone()) {
-						continue;
-					}
-					if let Some(service) = file.services.get(&name) {
-						for dep in service.depends_on.service_names() {
-							if !set.contains(&dep) {
-								stack.push(dep);
-							}
-						}
-					}
-				}
-				Some(set)
-			};
+			let target_set = expand_targets(file, target_services, no_deps);
 
 			// Prefetch the project's containers once (instead of one API call per
 			// replica): which names already exist, and each one's config-hash
@@ -344,13 +328,45 @@ pub(super) fn filter_services(
 		.collect())
 }
 
+/// Resolve which services `up` should start given an explicit target list.
+///
+/// Returns `None` when no targets are given (start everything). Otherwise the
+/// set contains the targets plus, unless `no_deps` is set, their transitive
+/// `depends_on` services.
+fn expand_targets(
+	file: &ComposeFile,
+	target_services: &[String],
+	no_deps: bool,
+) -> Option<HashSet<String>> {
+	if target_services.is_empty() {
+		return None;
+	}
+	let mut set = HashSet::new();
+	let mut stack: Vec<String> = target_services.to_vec();
+	while let Some(name) = stack.pop() {
+		if !set.insert(name.clone()) {
+			continue;
+		}
+		if !no_deps {
+			if let Some(service) = file.services.get(&name) {
+				for dep in service.depends_on.service_names() {
+					if !set.contains(&dep) {
+						stack.push(dep);
+					}
+				}
+			}
+		}
+	}
+	Some(set)
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
-	use super::filter_services;
+	use super::{expand_targets, filter_services};
 	use crate::compose::types::{ComposeFile, Service};
 
 	fn file_with_services(names: &[&str]) -> ComposeFile {
@@ -394,5 +410,36 @@ mod tests {
 			err,
 			crate::error::ComposeError::ServiceNotFound(_)
 		));
+	}
+
+	// --- expand_targets ---
+
+	fn file_web_depends_db() -> ComposeFile {
+		crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn expand_targets_empty_is_none() {
+		let file = file_web_depends_db();
+		assert!(expand_targets(&file, &[], false).is_none());
+	}
+
+	#[test]
+	fn expand_targets_includes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], false).unwrap();
+		assert!(set.contains("web"));
+		assert!(set.contains("db"));
+	}
+
+	#[test]
+	fn expand_targets_no_deps_excludes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
+		assert!(set.contains("web"));
+		assert!(!set.contains("db"));
 	}
 }

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -7,7 +7,7 @@ use tracing::info;
 use crate::compose::types::{ComposeFile, IpamConfig, Service, ServiceNetworkConfig};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::{Namespace, PerNetworkOptions};
-use crate::libpod::types::network::{NetworkCreateRequest, Subnet};
+use crate::libpod::types::network::{LeaseRange, NetworkCreateRequest, Subnet};
 use crate::libpod::API_PREFIX;
 
 use super::Engine;
@@ -48,11 +48,9 @@ impl Engine {
 				.map(|c| c.driver_opts.clone())
 				.unwrap_or_default();
 
-			let subnets = config
-				.as_ref()
-				.and_then(|c| c.ipam.as_ref())
-				.map(build_subnets)
-				.unwrap_or_default();
+			let ipam = config.as_ref().and_then(|c| c.ipam.as_ref());
+			let subnets = ipam.map(build_subnets).unwrap_or_default();
+			let ipam_options = ipam.map(build_ipam_options).unwrap_or_default();
 
 			let request = NetworkCreateRequest {
 				name: network_name.clone(),
@@ -62,6 +60,7 @@ impl Engine {
 				ipv6_enabled: config.as_ref().and_then(|c| c.enable_ipv6),
 				dns_enabled: Some(true),
 				options: driver_opts,
+				ipam_options,
 				labels,
 				subnets,
 			};
@@ -112,6 +111,12 @@ pub(super) fn build_per_network_options(
 			let mut driver_opts = HashMap::new();
 			driver_opts.insert("priority".to_string(), prio.to_string());
 			opts.driver_opts = Some(driver_opts);
+		}
+		if let Some(iface) = &c.interface_name {
+			opts.interface_name = Some(iface.clone());
+		}
+		if c.gw_priority.is_some() {
+			tracing::debug!("network gw_priority is not supported by Podman and is ignored");
 		}
 	} else if let Some(mac) = fallback_mac {
 		opts.static_mac = Some(mac.to_string());
@@ -183,12 +188,79 @@ pub(super) fn resolve_network_name(network: &str, file: &ComposeFile, project: &
 fn build_subnets(ipam: &IpamConfig) -> Vec<Subnet> {
 	ipam.config
 		.iter()
-		.map(|pool| Subnet {
-			subnet: pool.subnet.clone(),
-			gateway: pool.gateway.clone(),
-			lease_range: None,
+		.map(|pool| {
+			if !pool.aux_addresses.is_empty() {
+				tracing::warn!(
+					"ipam aux_addresses are not supported by Podman and will be ignored"
+				);
+			}
+			Subnet {
+				subnet: pool.subnet.clone(),
+				gateway: pool.gateway.clone(),
+				lease_range: pool.ip_range.as_deref().and_then(lease_range_from_cidr),
+			}
 		})
 		.collect()
+}
+
+/// Translate `ipam.driver` and `ipam.options` into Podman's `ipam_options` map.
+fn build_ipam_options(ipam: &IpamConfig) -> HashMap<String, String> {
+	let mut opts = ipam.options.clone();
+	if let Some(driver) = &ipam.driver {
+		opts.insert("driver".to_string(), driver.clone());
+	}
+	opts
+}
+
+/// Convert a compose `ip_range` CIDR into a Podman lease range (the usable
+/// host range of the CIDR). Returns `None` for an unparseable CIDR.
+fn lease_range_from_cidr(cidr: &str) -> Option<LeaseRange> {
+	use std::net::{Ipv4Addr, Ipv6Addr};
+
+	let (addr, prefix) = cidr.split_once('/')?;
+	let prefix: u8 = prefix.parse().ok()?;
+
+	if let Ok(v4) = addr.parse::<Ipv4Addr>() {
+		if prefix > 32 {
+			return None;
+		}
+		let mask = if prefix == 0 {
+			0
+		} else {
+			u32::MAX << (32 - prefix)
+		};
+		let base = u32::from(v4) & mask;
+		let last = base | !mask;
+		// Reserve network and broadcast addresses for non-point-to-point ranges.
+		let (start, end) = if prefix >= 31 {
+			(base, last)
+		} else {
+			(base + 1, last - 1)
+		};
+		return Some(LeaseRange {
+			start_ip: Some(Ipv4Addr::from(start).to_string()),
+			end_ip: Some(Ipv4Addr::from(end).to_string()),
+		});
+	}
+
+	if let Ok(v6) = addr.parse::<Ipv6Addr>() {
+		if prefix > 128 {
+			return None;
+		}
+		let mask = if prefix == 0 {
+			0
+		} else {
+			u128::MAX << (128 - prefix)
+		};
+		let base = u128::from(v6) & mask;
+		let last = base | !mask;
+		return Some(LeaseRange {
+			start_ip: Some(Ipv6Addr::from(base).to_string()),
+			end_ip: Some(Ipv6Addr::from(last).to_string()),
+		});
+	}
+
+	None
 }
 
 // ---------------------------------------------------------------------------
@@ -295,6 +367,57 @@ mod tests {
 	fn fallback_mac_applied_when_no_config() {
 		let opts = build_per_network_options(None, Some("02:42:ac:11:00:02"));
 		assert_eq!(opts.static_mac.as_deref(), Some("02:42:ac:11:00:02"));
+	}
+
+	#[test]
+	fn lease_range_ipv4_reserves_network_and_broadcast() {
+		let lr = lease_range_from_cidr("172.28.5.0/24").unwrap();
+		assert_eq!(lr.start_ip.as_deref(), Some("172.28.5.1"));
+		assert_eq!(lr.end_ip.as_deref(), Some("172.28.5.254"));
+	}
+
+	#[test]
+	fn lease_range_ipv4_slash31_uses_both_addresses() {
+		let lr = lease_range_from_cidr("10.0.0.0/31").unwrap();
+		assert_eq!(lr.start_ip.as_deref(), Some("10.0.0.0"));
+		assert_eq!(lr.end_ip.as_deref(), Some("10.0.0.1"));
+	}
+
+	#[test]
+	fn lease_range_ipv6_full_span() {
+		let lr = lease_range_from_cidr("2001:db8::/120").unwrap();
+		assert_eq!(lr.start_ip.as_deref(), Some("2001:db8::"));
+		assert_eq!(lr.end_ip.as_deref(), Some("2001:db8::ff"));
+	}
+
+	#[test]
+	fn lease_range_invalid_cidr_is_none() {
+		assert!(lease_range_from_cidr("not-a-cidr").is_none());
+		assert!(lease_range_from_cidr("10.0.0.0/40").is_none());
+	}
+
+	#[test]
+	fn ipam_options_include_driver_and_options() {
+		use crate::compose::types::IpamConfig;
+		let ipam = IpamConfig {
+			driver: Some("host-local".into()),
+			options: [("foo".to_string(), "bar".to_string())].into(),
+			..Default::default()
+		};
+		let opts = build_ipam_options(&ipam);
+		assert_eq!(opts.get("driver").map(String::as_str), Some("host-local"));
+		assert_eq!(opts.get("foo").map(String::as_str), Some("bar"));
+	}
+
+	#[test]
+	fn per_network_interface_name_forwarded() {
+		use crate::compose::types::ServiceNetworkConfig;
+		let cfg = ServiceNetworkConfig {
+			interface_name: Some("eth1".into()),
+			..Default::default()
+		};
+		let opts = build_per_network_options(Some(&cfg), None);
+		assert_eq!(opts.interface_name.as_deref(), Some("eth1"));
 	}
 
 	#[test]

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -23,6 +23,12 @@ impl Engine {
 
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
+				let external_name = config
+					.as_ref()
+					.and_then(|c| c.name.as_deref())
+					.unwrap_or(name);
+				self.ensure_external_exists("network", "networks", external_name)
+					.await?;
 				continue;
 			}
 
@@ -160,12 +166,18 @@ pub(super) fn resolve_network_mode(
 
 /// Resolve the actual network name on the host for a compose network key.
 pub(super) fn resolve_network_name(network: &str, file: &ComposeFile, project: &str) -> String {
-	file.networks
-		.get(network)
-		.and_then(|c| c.as_ref())
-		.and_then(|c| c.name.as_deref())
-		.map(|s| s.to_string())
-		.unwrap_or_else(|| format!("{project}_{network}"))
+	match file.networks.get(network).and_then(|c| c.as_ref()) {
+		Some(cfg) => {
+			if let Some(name) = cfg.name.as_deref() {
+				name.to_string()
+			} else if cfg.external.unwrap_or(false) {
+				network.to_string()
+			} else {
+				format!("{project}_{network}")
+			}
+		}
+		None => format!("{project}_{network}"),
+	}
 }
 
 fn build_subnets(ipam: &IpamConfig) -> Vec<Subnet> {
@@ -215,6 +227,17 @@ mod tests {
 			resolve_network_name("mynet", &file, "proj"),
 			"custom-net-name"
 		);
+	}
+
+	#[test]
+	fn resolve_network_name_external_uses_key_not_prefix() {
+		let cfg = NetworkConfig {
+			external: Some(true),
+			..Default::default()
+		};
+		let mut file = empty_file();
+		file.networks.insert("shared".to_string(), Some(cfg));
+		assert_eq!(resolve_network_name("shared", &file, "proj"), "shared");
 	}
 
 	#[test]

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -14,7 +14,7 @@ use crate::compose::types::{
 };
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::volume::VolumeCreateOptions;
-use crate::libpod::API_PREFIX;
+use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::{staging, Engine};
 
@@ -23,6 +23,12 @@ impl Engine {
 		for (name, config) in &file.volumes {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
+				let external_name = config
+					.as_ref()
+					.and_then(|c| c.name.as_deref())
+					.unwrap_or(name);
+				self.ensure_external_exists("volume", "volumes", external_name)
+					.await?;
 				continue;
 			}
 
@@ -69,6 +75,27 @@ impl Engine {
 			}
 		}
 		Ok(())
+	}
+
+	/// Verify an `external: true` volume/network already exists on the host.
+	///
+	/// The compose spec requires podup to error when an external resource is
+	/// declared but absent, rather than silently skipping it and letting
+	/// containers fail later with an opaque mount/attach error.
+	pub(super) async fn ensure_external_exists(
+		&self,
+		kind: &str,
+		api_segment: &str,
+		name: &str,
+	) -> Result<()> {
+		let path = format!("{API_PREFIX}/{api_segment}/{}/json", urlencoded(name));
+		match self.client.get_json::<serde_json::Value>(&path).await {
+			Ok(_) => Ok(()),
+			Err(ref e) if e.is_status(404) => Err(ComposeError::ExternalNotFound(format!(
+				"external {kind} \"{name}\" does not exist; create it before running"
+			))),
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
 	}
 
 	pub(super) fn build_secret_binds(

--- a/internal/engine/volume_mounts.rs
+++ b/internal/engine/volume_mounts.rs
@@ -99,6 +99,7 @@ pub(crate) fn build_mounts_all(
 						name: source.clone().unwrap_or_default(),
 						dest: target.clone(),
 						options: opts,
+						sub_path: volume.as_ref().and_then(|v| v.subpath.clone()),
 					});
 				}
 				VolumeType::Npipe => {
@@ -182,6 +183,7 @@ fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> 
 				name: src.to_string(),
 				dest: dst.to_string(),
 				options: opts,
+				sub_path: None,
 			}),
 		))
 	}
@@ -333,6 +335,26 @@ mod tests {
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].name, "myvolume");
 		assert!(named[0].options.contains(&"nocopy".to_string()));
+	}
+
+	#[test]
+	fn long_form_volume_subpath_forwarded() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Volume,
+			source: Some("myvolume".into()),
+			target: "/data".into(),
+			read_only: None,
+			bind: None,
+			volume: Some(VolumeOptions {
+				subpath: Some("nested/dir".into()),
+				..Default::default()
+			}),
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		assert_eq!(named.len(), 1);
+		assert_eq!(named[0].sub_path.as_deref(), Some("nested/dir"));
 	}
 
 	#[test]

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -15,6 +15,9 @@ use crate::error::{ComposeError, Result};
 /// last file wins (later entries in the list override earlier ones).
 /// `env_file:` never overrides service-level `environment:`.
 ///
+/// Each file is parsed with dotenv rules (quote stripping, escapes, inline
+/// comments, multi-line quoted values).
+///
 /// Returns [`ComposeError::FileNotFound`] when an env file does not exist.
 pub fn load_env_files(paths: &[String], base_dir: &Path) -> Result<HashMap<String, String>> {
 	let entries: Vec<EnvFileEntry> = paths
@@ -58,24 +61,7 @@ pub fn load_env_file_entries(
 			Err(e) => return Err(ComposeError::Io(e)),
 		};
 
-		for line in content.lines() {
-			let trimmed = line.trim();
-			if trimmed.is_empty() || trimmed.starts_with('#') {
-				continue;
-			}
-
-			let (key, value) = if let Some(eq) = trimmed.find('=') {
-				let k = trimmed[..eq].trim().to_string();
-				let v = trimmed[eq + 1..].to_string();
-				(k, v)
-			} else {
-				(trimmed.to_string(), String::new())
-			};
-
-			if key.is_empty() {
-				continue;
-			}
-
+		for (key, value) in crate::dotenv::parse(&content) {
 			result.insert(key, value);
 		}
 	}

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -12,7 +12,7 @@ use crate::error::{ComposeError, Result};
 /// Load all `env_file` paths relative to `base_dir`.
 ///
 /// Returns a merged map.  If the same key appears in multiple files, the
-/// first file wins (earlier entries in the list have higher priority).
+/// last file wins (later entries in the list override earlier ones).
 /// `env_file:` never overrides service-level `environment:`.
 ///
 /// Returns [`ComposeError::FileNotFound`] when an env file does not exist.
@@ -76,7 +76,7 @@ pub fn load_env_file_entries(
 				continue;
 			}
 
-			result.entry(key).or_insert(value);
+			result.insert(key, value);
 		}
 	}
 
@@ -144,7 +144,7 @@ mod tests {
 	}
 
 	#[test]
-	fn first_file_wins_on_duplicate_key() {
+	fn last_file_wins_on_duplicate_key() {
 		let dir = tempfile::tempdir().unwrap();
 		std::fs::write(dir.path().join("a.env"), "FOO=first\n").unwrap();
 		std::fs::write(dir.path().join("b.env"), "FOO=second\n").unwrap();
@@ -153,7 +153,7 @@ mod tests {
 			EnvFileEntry::Path("b.env".into()),
 		];
 		let m = load_env_file_entries(&entries, dir.path()).unwrap();
-		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("first"));
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("second"));
 	}
 
 	#[test]

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -25,6 +25,7 @@ pub enum ComposeError {
 	Unsupported(String),
 	RunExited(i64),
 	Update(String),
+	ExternalNotFound(String),
 }
 
 impl fmt::Display for ComposeError {
@@ -49,6 +50,7 @@ impl fmt::Display for ComposeError {
 			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
 			Self::Update(s) => write!(f, "update error: {s}"),
+			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
 		}
 	}
 }
@@ -141,6 +143,10 @@ mod tests {
 				ComposeError::RunExited(1),
 			),
 			("update error: u", ComposeError::Update("u".into())),
+			(
+				"external resource not found: external volume \"v\" does not exist",
+				ComposeError::ExternalNotFound("external volume \"v\" does not exist".into()),
+			),
 		];
 		for (expected_prefix, err) in cases {
 			let msg = err.to_string();

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -17,7 +17,10 @@ pub mod size;
 pub mod substitute;
 pub mod update;
 
-pub use compose::{parse_file, parse_file_with_env_files, parse_str, parse_str_raw, resolve_order};
+pub use compose::{
+	parse_file, parse_file_with_env_files, parse_files_with_env_files, parse_str, parse_str_raw,
+	resolve_order,
+};
 pub use engine::{Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -17,7 +17,7 @@ pub mod size;
 pub mod substitute;
 pub mod update;
 
-pub use compose::{parse_file, parse_str, parse_str_raw, resolve_order};
+pub use compose::{parse_file, parse_file_with_env_files, parse_str, parse_str_raw, resolve_order};
 pub use engine::{Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -5,6 +5,7 @@
 //! REST API over a Unix socket or Windows named pipe.
 
 pub mod compose;
+pub(crate) mod dotenv;
 pub(crate) mod engine;
 pub mod env_file;
 pub(crate) mod error;

--- a/internal/libpod/types/container/spec.rs
+++ b/internal/libpod/types/container/spec.rs
@@ -160,6 +160,10 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub devices: Vec<LinuxDevice>,
 
+	/// CDI device names (e.g. `nvidia.com/gpu=all`) for GPU/accelerator access.
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	pub cdi_devices: Vec<String>,
+
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub device_cgroup_rule: Vec<String>,
 

--- a/internal/libpod/types/container/spec.rs
+++ b/internal/libpod/types/container/spec.rs
@@ -302,6 +302,10 @@ pub struct NamedVolume {
 
 	#[serde(rename = "Options", skip_serializing_if = "Vec::is_empty", default)]
 	pub options: Vec<String>,
+
+	/// Mount only this sub-directory of the volume (compose `volume.subpath`).
+	#[serde(rename = "SubPath", skip_serializing_if = "Option::is_none", default)]
+	pub sub_path: Option<String>,
 }
 
 /// Linux OCI resource limits for SpecGenerator.

--- a/internal/libpod/types/network.rs
+++ b/internal/libpod/types/network.rs
@@ -30,6 +30,9 @@ pub struct NetworkCreateRequest {
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub options: HashMap<String, String>,
 
+	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
+	pub ipam_options: HashMap<String, String>,
+
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub subnets: Vec<Subnet>,
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -140,6 +140,9 @@ enum Commands {
 		/// Override the container name.
 		#[arg(long)]
 		name: Option<String>,
+		/// Publish the service's declared ports (off by default).
+		#[arg(long)]
+		service_ports: bool,
 		/// Command (and arguments) to run.
 		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
 		cmd: Vec<String>,
@@ -437,6 +440,7 @@ async fn run() -> podup::Result<()> {
 			detach,
 			env_overrides,
 			name,
+			service_ports,
 			cmd,
 		} => {
 			engine
@@ -449,6 +453,7 @@ async fn run() -> podup::Result<()> {
 						detach,
 						env_overrides,
 						name_override: name,
+						service_ports,
 					},
 				)
 				.await?

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -39,6 +39,12 @@ struct Cli {
 	#[arg(long, global = true)]
 	project_directory: Option<PathBuf>,
 
+	/// Additional env file(s) loaded into the variable map used for
+	/// interpolation. May be given multiple times; later files win. The
+	/// process environment and a project `.env` still take precedence.
+	#[arg(long = "env-file", global = true)]
+	env_file: Vec<String>,
+
 	#[command(subcommand)]
 	command: Commands,
 }
@@ -362,7 +368,7 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_path = resolve_compose_file(cli.file.clone());
-	let file = podup::parse_file(&compose_path)?;
+	let file = podup::parse_file_with_env_files(&compose_path, &cli.env_file)?;
 
 	if matches!(cli.command, Commands::Config) {
 		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -17,8 +17,8 @@ struct Cli {
 	/// unset, the compose-spec precedence list is probed in the current
 	/// directory (compose.yaml, compose.yml, docker-compose.yaml,
 	/// docker-compose.yml).
-	#[arg(short, long, env = "COMPOSE_FILE")]
-	file: Option<PathBuf>,
+	#[arg(short, long)]
+	file: Vec<PathBuf>,
 
 	/// Project name (used as a prefix for container names).
 	/// May also be set via `COMPOSE_PROJECT_NAME`.
@@ -308,20 +308,27 @@ const COMPOSE_FILE_CANDIDATES: [&str; 4] = [
 	"docker-compose.yml",
 ];
 
-/// Resolve which compose file to load. An explicit `--file`/`COMPOSE_FILE`
-/// wins; otherwise probe the compose-spec precedence list in the current
-/// directory, falling back to `docker-compose.yml` so a missing-file error
-/// names a sensible path.
-fn resolve_compose_file(explicit: Option<PathBuf>) -> PathBuf {
-	if let Some(path) = explicit {
-		return path;
+/// Resolve which compose file(s) to load. Explicit `--file` flags win; then the
+/// `COMPOSE_FILE` environment variable (a path-separator-delimited list);
+/// otherwise probe the compose-spec precedence list in the current directory,
+/// falling back to `docker-compose.yml` so a missing-file error names a
+/// sensible path. Multiple files are merged in order, later overriding earlier.
+fn resolve_compose_files(explicit: &[PathBuf]) -> Vec<PathBuf> {
+	if !explicit.is_empty() {
+		return explicit.to_vec();
+	}
+	if let Ok(env) = std::env::var("COMPOSE_FILE") {
+		if !env.is_empty() {
+			let sep = if cfg!(windows) { ';' } else { ':' };
+			return env.split(sep).map(PathBuf::from).collect();
+		}
 	}
 	for candidate in COMPOSE_FILE_CANDIDATES {
 		if Path::new(candidate).is_file() {
-			return PathBuf::from(candidate);
+			return vec![PathBuf::from(candidate)];
 		}
 	}
-	PathBuf::from("docker-compose.yml")
+	vec![PathBuf::from("docker-compose.yml")]
 }
 
 /// Resolve the base directory for relative-path resolution. An explicit
@@ -370,8 +377,8 @@ async fn run() -> podup::Result<()> {
 			.map_err(|e| podup::ComposeError::Update(format!("update task failed: {e}")))?;
 	}
 
-	let compose_path = resolve_compose_file(cli.file.clone());
-	let file = podup::parse_file_with_env_files(&compose_path, &cli.env_file)?;
+	let compose_files = resolve_compose_files(&cli.file);
+	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
 
 	if matches!(cli.command, Commands::Config) {
 		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
@@ -389,7 +396,7 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
-	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_path);
+	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
 	let engine = podup::Engine::with_base_dir(client, cli.project, base_dir);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
@@ -495,13 +502,19 @@ async fn run() -> podup::Result<()> {
 
 #[cfg(test)]
 mod tests {
-	use super::{resolve_base_dir, resolve_compose_file};
+	use super::{resolve_base_dir, resolve_compose_files};
 	use std::path::{Path, PathBuf};
 
 	#[test]
-	fn explicit_compose_file_wins() {
-		let p = resolve_compose_file(Some(PathBuf::from("custom.yml")));
-		assert_eq!(p, PathBuf::from("custom.yml"));
+	fn explicit_compose_files_win() {
+		let p = resolve_compose_files(&[PathBuf::from("custom.yml")]);
+		assert_eq!(p, vec![PathBuf::from("custom.yml")]);
+	}
+
+	#[test]
+	fn multiple_explicit_compose_files_preserved() {
+		let p = resolve_compose_files(&[PathBuf::from("a.yml"), PathBuf::from("b.yml")]);
+		assert_eq!(p, vec![PathBuf::from("a.yml"), PathBuf::from("b.yml")]);
 	}
 
 	#[test]
@@ -512,10 +525,16 @@ mod tests {
 		std::fs::create_dir_all(&dir).unwrap();
 		let prev = std::env::current_dir().unwrap();
 		std::env::set_current_dir(&dir).unwrap();
-		let p = resolve_compose_file(None);
+		// Guard against a COMPOSE_FILE set in the test environment.
+		let had_env = std::env::var_os("COMPOSE_FILE");
+		std::env::remove_var("COMPOSE_FILE");
+		let p = resolve_compose_files(&[]);
+		if let Some(v) = had_env {
+			std::env::set_var("COMPOSE_FILE", v);
+		}
 		std::env::set_current_dir(prev).unwrap();
 		let _ = std::fs::remove_dir_all(&dir);
-		assert_eq!(p, PathBuf::from("docker-compose.yml"));
+		assert_eq!(p, vec![PathBuf::from("docker-compose.yml")]);
 	}
 
 	#[test]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -71,6 +71,9 @@ enum Commands {
 		/// Recreate containers even if their configuration is unchanged.
 		#[arg(long)]
 		force_recreate: bool,
+		/// Do not start linked services (depends_on) of the named services.
+		#[arg(long)]
+		no_deps: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]
@@ -407,6 +410,7 @@ async fn run() -> podup::Result<()> {
 			remove_orphans,
 			no_recreate,
 			force_recreate,
+			no_deps,
 			services,
 		} => {
 			if remove_orphans {
@@ -423,6 +427,7 @@ async fn run() -> podup::Result<()> {
 					&services,
 					no_recreate,
 					force_recreate,
+					no_deps,
 				)
 				.await?;
 			if watch {

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -62,7 +62,8 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String>
 ///
 /// - Lines starting with `#` are comments and are skipped.
 /// - Empty / whitespace-only lines are skipped.
-/// - `KEY=VALUE` sets KEY to VALUE (quotes are preserved as-is, matching compose-spec).
+/// - `KEY=VALUE` sets KEY to VALUE; surrounding quotes are stripped and
+///   dotenv escapes/inline comments are handled.
 /// - `KEY` without `=` sets KEY to empty string.
 /// - Process environment variables take precedence: if a key already exists in
 ///   the current process env it will *not* be overridden by the `.env` file.
@@ -73,27 +74,11 @@ pub fn load_dotenv(dir: &Path) -> HashMap<String, String> {
 	};
 
 	let mut map = HashMap::new();
-	for line in content.lines() {
-		let trimmed = line.trim();
-		if trimmed.is_empty() || trimmed.starts_with('#') {
-			continue;
-		}
-		let (key, value) = if let Some(eq) = trimmed.find('=') {
-			let k = trimmed[..eq].trim().to_string();
-			let v = strip_dotenv_quotes(trimmed[eq + 1..].trim());
-			(k, v.to_string())
-		} else {
-			(trimmed.to_string(), String::new())
-		};
-
-		if key.is_empty() {
-			continue;
-		}
-
+	for (key, value) in crate::dotenv::parse(&content) {
+		// Process environment variables take precedence over the `.env` file.
 		if std::env::var(&key).is_ok() {
 			continue;
 		}
-
 		map.insert(key, value);
 	}
 
@@ -123,38 +108,11 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 		let Ok(content) = std::fs::read_to_string(&abs) else {
 			continue;
 		};
-		for line in content.lines() {
-			let trimmed = line.trim();
-			if trimmed.is_empty() || trimmed.starts_with('#') {
-				continue;
-			}
-			let (key, value) = if let Some(eq) = trimmed.find('=') {
-				(
-					trimmed[..eq].trim().to_string(),
-					strip_dotenv_quotes(trimmed[eq + 1..].trim()).to_string(),
-				)
-			} else {
-				(trimmed.to_string(), String::new())
-			};
-			if !key.is_empty() {
-				vars.entry(key).or_insert(value);
-			}
+		for (key, value) in crate::dotenv::parse(&content) {
+			vars.entry(key).or_insert(value);
 		}
 	}
 	vars
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-fn strip_dotenv_quotes(s: &str) -> &str {
-	if s.len() >= 2
-		&& ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
-	{
-		return &s[1..s.len() - 1];
-	}
-	s
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/group_a1.rs
+++ b/tests/engine_integration/group_a1.rs
@@ -37,7 +37,7 @@ async fn up_no_recreate_skips_running() {
 	engine.up(&file).await.unwrap();
 	// Second up with no_recreate: already running → skip
 	engine
-		.up_with_options(&file, false, &[], &[], true, false)
+		.up_with_options(&file, false, &[], &[], true, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -58,7 +58,7 @@ async fn up_target_services_only() {
 
 	// Only start web (and its dep db)
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -348,7 +348,7 @@ async fn up_skips_recreate_when_config_unchanged() {
 	engine.up(&file).await.unwrap();
 	// force_recreate -> recreate even though config is unchanged.
 	engine
-		.up_with_options(&file, false, &[], &[], false, true)
+		.up_with_options(&file, false, &[], &[], false, true, false)
 		.await
 		.unwrap();
 	// Changed config -> hash differs -> recreate.

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -228,7 +228,7 @@ async fn profile_filtered_service_skipped() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &[], false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();

--- a/tests/engine_integration/group_a3.rs
+++ b/tests/engine_integration/group_a3.rs
@@ -274,22 +274,25 @@ async fn config_long_form_ref() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn external_volume_skipped_on_up() {
+async fn external_volume_missing_errors_on_up() {
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,
 	};
 	let proj = proj("exv");
 	let engine = Engine::new(client, proj.clone());
-	// The external volume is declared but not mounted by the service,
-	// so create_volumes() hits the `continue` branch without creating it.
+	// An external volume that does not exist must surface an error rather than
+	// being silently skipped (compose spec requires the resource to exist).
 	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\nvolumes:\n  extdata:\n    external: true\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\nvolumes:\n  extdata-does-not-exist:\n    external: true\n",
 	)
 	.unwrap();
 
-	engine.up(&file).await.unwrap();
-	engine.down(&file).await.unwrap();
+	let result = engine.up(&file).await;
+	assert!(
+		matches!(result, Err(podup::ComposeError::ExternalNotFound(_))),
+		"expected ExternalNotFound, got {result:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/group_a4.rs
+++ b/tests/engine_integration/group_a4.rs
@@ -49,7 +49,7 @@ fn active_profiles_via_env() {
 			.unwrap();
 			// Pass empty active_profiles slice so it falls back to COMPOSE_PROFILES env
 			engine
-				.up_with_options(&file, false, &[], &[], false, false)
+				.up_with_options(&file, false, &[], &[], false, false, false)
 				.await
 				.unwrap();
 			engine.down(&file).await.unwrap();
@@ -187,7 +187,7 @@ async fn target_services_skips_non_dep() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -210,7 +210,7 @@ async fn dep_on_profile_filtered_service() {
 
 	// No active profiles → db is skipped; web still runs but skips db's dep wait
 	engine
-		.up_with_options(&file, false, &[], &[], false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -293,7 +293,7 @@ async fn optional_dep_not_in_file() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false)
+		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -324,6 +324,7 @@ async fn target_services_duplicate_entry() {
 			false,
 			&[],
 			&["web".to_string(), "web".to_string()],
+			false,
 			false,
 			false,
 		)

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -48,6 +48,7 @@ async fn engine_run_command_succeeds() {
 				detach: false,
 				env_overrides: vec![],
 				name_override: None,
+				service_ports: false,
 			},
 		)
 		.await;
@@ -74,6 +75,7 @@ async fn engine_run_nonzero_exit_returns_run_exited() {
 				detach: false,
 				env_overrides: vec![],
 				name_override: None,
+				service_ports: false,
 			},
 		)
 		.await;

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -35,7 +35,7 @@ fn string_or_list_many() {
 }
 
 #[test]
-fn first_file_wins_for_duplicate_keys() {
+fn last_file_wins_for_duplicate_keys() {
 	let dir = tempfile::tempdir().unwrap();
 
 	let mut a = std::fs::File::create(dir.path().join("a.env")).unwrap();
@@ -45,7 +45,7 @@ fn first_file_wins_for_duplicate_keys() {
 	writeln!(b, "KEY=from_b").unwrap();
 
 	let map = load_env_files(&["a.env".to_string(), "b.env".to_string()], dir.path()).unwrap();
-	assert_eq!(map["KEY"], "from_a");
+	assert_eq!(map["KEY"], "from_b");
 }
 
 #[test]

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -49,14 +49,14 @@ fn last_file_wins_for_duplicate_keys() {
 }
 
 #[test]
-fn quoted_values_preserved_as_is() {
+fn surrounding_quotes_are_stripped() {
 	let dir = tempfile::tempdir().unwrap();
 	let mut f = std::fs::File::create(dir.path().join("q.env")).unwrap();
 	writeln!(f, r#"KEY="value with spaces""#).unwrap();
 
 	let map = load_env_files(&["q.env".to_string()], dir.path()).unwrap();
-	// Per compose-spec, quotes are preserved literally.
-	assert_eq!(map["KEY"], "\"value with spaces\"");
+	// Per compose-spec dotenv rules, surrounding quotes are stripped.
+	assert_eq!(map["KEY"], "value with spaces");
 }
 
 #[test]

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -175,6 +175,68 @@ services:
 }
 
 #[test]
+fn extends_external_file_anchors_relative_paths() {
+	let dir = tempfile::tempdir().unwrap();
+	let sub = dir.path().join("svc");
+	std::fs::create_dir(&sub).unwrap();
+
+	let common_path = sub.join("common.yml");
+	let mut f = std::fs::File::create(&common_path).unwrap();
+	writeln!(
+		f,
+		r#"
+services:
+  base:
+    image: alpine
+    env_file:
+      - ./base.env
+    volumes:
+      - ./data:/data
+"#
+	)
+	.unwrap();
+
+	let main_path = dir.path().join("docker-compose.yml");
+	let mut m = std::fs::File::create(&main_path).unwrap();
+	writeln!(
+		m,
+		r#"
+services:
+  app:
+    extends:
+      service: base
+      file: ./svc/common.yml
+"#
+	)
+	.unwrap();
+
+	let file = parse_file(&main_path).unwrap();
+	let app = &file.services["app"];
+
+	// The base service's relative env_file/volume paths must be anchored to the
+	// external file's directory, not the top-level project directory.
+	let entries = app.env_file.to_entries();
+	let env_path = std::path::Path::new(entries[0].path());
+	assert!(
+		env_path.is_absolute(),
+		"env_file not anchored: {env_path:?}"
+	);
+	assert!(
+		env_path.ends_with("svc/base.env"),
+		"wrong dir: {env_path:?}"
+	);
+
+	let vol = match &app.volumes[0] {
+		podup::compose::types::VolumeMount::Short(s) => s.clone(),
+		other => panic!("expected short volume, got {other:?}"),
+	};
+	assert!(
+		vol.contains("svc") && vol.ends_with(":/data"),
+		"volume bind not anchored: {vol}"
+	);
+}
+
+#[test]
 fn extends_chain_within_depth_limit() {
 	// 16 services = 15 hops — must succeed.
 	let yaml = make_chain_yaml(15);

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -105,3 +105,19 @@ services:
 		Some("alpine:override")
 	);
 }
+
+#[test]
+fn global_env_file_feeds_interpolation() {
+	let dir = tempfile::tempdir().unwrap();
+
+	let env_path = dir.path().join("prod.env");
+	let mut e = std::fs::File::create(&env_path).unwrap();
+	writeln!(e, "IMG=nginx:1.27").unwrap();
+
+	let main_path = dir.path().join("docker-compose.yml");
+	let mut m = std::fs::File::create(&main_path).unwrap();
+	writeln!(m, "services:\n  web:\n    image: ${{IMG}}").unwrap();
+
+	let file = podup::parse_file_with_env_files(&main_path, &["prod.env".to_string()]).unwrap();
+	assert_eq!(file.services["web"].image.as_deref(), Some("nginx:1.27"));
+}

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -121,3 +121,33 @@ fn global_env_file_feeds_interpolation() {
 	let file = podup::parse_file_with_env_files(&main_path, &["prod.env".to_string()]).unwrap();
 	assert_eq!(file.services["web"].image.as_deref(), Some("nginx:1.27"));
 }
+
+#[test]
+fn multiple_files_merge_with_override() {
+	let dir = tempfile::tempdir().unwrap();
+
+	let base = dir.path().join("base.yml");
+	let mut b = std::fs::File::create(&base).unwrap();
+	writeln!(
+		b,
+		"services:\n  web:\n    image: nginx:1.0\n    environment:\n      A: \"1\"\n"
+	)
+	.unwrap();
+
+	let over = dir.path().join("override.yml");
+	let mut o = std::fs::File::create(&over).unwrap();
+	writeln!(
+		o,
+		"services:\n  web:\n    image: nginx:2.0\n    environment:\n      B: \"2\"\n  db:\n    image: postgres:16\n"
+	)
+	.unwrap();
+
+	let file = podup::parse_files_with_env_files(&[base, over], &[]).unwrap();
+
+	// Later file overrides the image and adds a service; environment keys merge.
+	assert_eq!(file.services["web"].image.as_deref(), Some("nginx:2.0"));
+	assert!(file.services.contains_key("db"));
+	let env = file.services["web"].environment.to_map();
+	assert!(env.contains_key("A"));
+	assert!(env.contains_key("B"));
+}


### PR DESCRIPTION
## Release v0.11.0

Merges develop into main for the v0.11.0 release. After merge, tag `v0.11.0` to trigger the release workflow (binaries, signatures, attestations, crates.io publish).

### Changes since v0.10.0 — compose-spec parity batch (#164) + features
**Correctness fixes**
- `run` no longer publishes service ports by default; `--service-ports` opts in (#166)
- `env_file` duplicate keys are last-wins; `environment:` still wins overall (#166)
- external volumes/networks must exist, else error; external networks use their literal name (#166)
- config-hash is computed from a key-sorted canonical form (no spurious recreate) (#166)
- env files / `.env` parsed per dotenv rules: quotes, escapes, inline comments, multi-line (#167)
- volume `subpath` forwarded to the mount (#168)
- IPAM driver/options, `ip_range` (lease range), per-network `interface_name` forwarded (#169)
- include / external-`extends` relative paths resolve against the imported file's directory (#170)
- Git/URL `build.context` cloned server-side instead of tarred as a local dir (#172)
- GPU device reservations forwarded as CDI devices (#173)
- service `links` resolved to container names; `external_links` verbatim (#175)

**Features**
- global `--env-file` for interpolation (#171)
- `up --no-deps` (#174)
- multiple compose files via repeated `-f` / `COMPOSE_FILE` list, later-wins merge (#176)

### Breaking (library)
- `Engine::up_with_options` gains a trailing `no_deps: bool`
- `RunOptions` gains `service_ports`
- `ComposeError` gains `ExternalNotFound`

Covered by the 0.10.0 → 0.11.0 bump. panel-agent's pin should move to v0.11.0 (its call sites need updating).
