### PR TITLE
fix: honor image-inherited healthcheck for service_healthy

### DIFF
--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -15,6 +15,12 @@ impl Engine {
 	/// Poll a container until its health status is `healthy` or timeout.
 	///
 	/// Uses `healthcheck.retries` (default 30) with a 2 s interval between probes.
+	///
+	/// The wait is driven by the container's *effective* healthcheck reported by
+	/// the runtime, so healthchecks inherited from the image count too — not just
+	/// those declared in compose. If the container has no effective healthcheck at
+	/// all (none in the image or compose), it can never report `healthy`, so the
+	/// wait short-circuits as satisfied rather than blocking until timeout.
 	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
 		let retries = service
 			.healthcheck
@@ -38,12 +44,20 @@ impl Engine {
 					continue;
 				}
 			};
-			if let Some(state) = info.state {
-				if let Some(health) = state.health {
+			if let Some(state) = &info.state {
+				if let Some(health) = &state.health {
 					if health.status.as_deref() == Some("healthy") {
 						return Ok(());
 					}
 				}
+			}
+			// No `healthy` status yet. If the container has no effective
+			// healthcheck, it never will — treat the dependency as satisfied.
+			if !info.config.map(|c| c.has_healthcheck()).unwrap_or(false) {
+				tracing::debug!(
+					"{container_name} has no effective healthcheck; treating service_healthy as satisfied"
+				);
+				return Ok(());
 			}
 			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 		}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -130,17 +130,21 @@ impl Engine {
 					match condition {
 						ServiceCondition::ServiceStarted => {}
 						ServiceCondition::ServiceHealthy => {
-							if dep_service
+							// Wait unless the healthcheck is explicitly disabled in
+							// compose. With no compose healthcheck we still wait:
+							// `wait_healthy` consults the container's effective
+							// healthcheck, so image-inherited ones are honored and
+							// the wait short-circuits when none exists.
+							let disabled = dep_service
 								.healthcheck
 								.as_ref()
-								.map(|h| !h.is_disabled())
-								.unwrap_or(false)
-							{
-								self.wait_healthy(&dep_container, dep_service).await?;
-							} else {
+								.is_some_and(|h| h.is_disabled());
+							if disabled {
 								tracing::debug!(
-									"{dep} requested service_healthy but has no healthcheck — skipping wait"
+									"{dep} healthcheck disabled — skipping service_healthy wait"
 								);
+							} else {
+								self.wait_healthy(&dep_container, dep_service).await?;
 							}
 						}
 						ServiceCondition::ServiceCompletedSuccessfully => {

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -49,8 +49,36 @@ pub struct ContainerInspect {
 	#[serde(rename = "State")]
 	pub state: Option<ContainerState>,
 
+	#[serde(rename = "Config")]
+	pub config: Option<ContainerConfig>,
+
 	#[serde(rename = "NetworkSettings")]
 	pub network_settings: Option<NetworkSettings>,
+}
+
+/// Container config sub-object from inspect.
+#[derive(Deserialize, Default)]
+pub struct ContainerConfig {
+	#[serde(rename = "Healthcheck")]
+	pub healthcheck: Option<HealthConfig>,
+}
+
+impl ContainerConfig {
+	/// Whether the container has an effective healthcheck that can report a
+	/// `healthy` status. Covers healthchecks inherited from the image as well
+	/// as those declared in compose. A `["NONE"]` test means it was disabled.
+	pub fn has_healthcheck(&self) -> bool {
+		self.healthcheck
+			.as_ref()
+			.is_some_and(|h| h.test.first().is_some_and(|first| first != "NONE"))
+	}
+}
+
+/// Effective healthcheck config baked into the container (image or compose).
+#[derive(Deserialize, Default)]
+pub struct HealthConfig {
+	#[serde(rename = "Test", default, deserialize_with = "null_default")]
+	pub test: Vec<String>,
 }
 
 /// Container state sub-object.
@@ -162,7 +190,38 @@ mod tests {
 		let json = r#"{}"#;
 		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
 		assert!(ci.state.is_none());
+		assert!(ci.config.is_none());
 		assert!(ci.network_settings.is_none());
+	}
+
+	#[test]
+	fn has_healthcheck_true_for_image_inherited() {
+		let json = r#"{
+			"Config": { "Healthcheck": { "Test": ["CMD-SHELL", "curl -f http://localhost || exit 1"] } }
+		}"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(ci.config.unwrap().has_healthcheck());
+	}
+
+	#[test]
+	fn has_healthcheck_false_when_disabled_with_none() {
+		let json = r#"{ "Config": { "Healthcheck": { "Test": ["NONE"] } } }"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(!ci.config.unwrap().has_healthcheck());
+	}
+
+	#[test]
+	fn has_healthcheck_false_when_absent() {
+		let json = r#"{ "Config": {} }"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(!ci.config.unwrap().has_healthcheck());
+	}
+
+	#[test]
+	fn has_healthcheck_false_when_test_null() {
+		let json = r#"{ "Config": { "Healthcheck": { "Test": null } } }"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(!ci.config.unwrap().has_healthcheck());
 	}
 
 	#[test]

--- a/tests/engine_integration/group_a4.rs
+++ b/tests/engine_integration/group_a4.rs
@@ -332,3 +332,33 @@ async fn target_services_duplicate_entry() {
 		.unwrap();
 	engine.down(&file).await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// service_healthy honors a healthcheck baked into the image, even when the
+// compose service declares none (health.rs / lifecycle.rs gate). The db image
+// carries its own HEALTHCHECK; web depends on it with condition: service_healthy
+// and no compose healthcheck. `up` must wait for the inherited check to report
+// healthy and then succeed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn service_healthy_image_inherited_healthcheck() {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
+		let client = match podman().await {
+			Some(d) => d,
+			None => return,
+		};
+		let dir = tempfile::tempdir().unwrap();
+		let proj = proj("ihc");
+		let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+		let image_tag = format!("podup-test-ihc-{}:latest", std::process::id());
+		let yaml = format!(
+			"services:\n  db:\n    build:\n      context: .\n      dockerfile_inline: |\n        FROM alpine:latest\n        HEALTHCHECK --interval=1s --timeout=2s --retries=3 CMD true\n    image: {image_tag}\n    command: [\"sleep\", \"infinity\"]\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    depends_on:\n      db:\n        condition: service_healthy\n"
+		);
+		let file = parse_str(&yaml).unwrap();
+
+		engine.up(&file).await.unwrap();
+		engine.down(&file).await.unwrap();
+	});
+}


### PR DESCRIPTION
## Summary

Found during the compose-spec edge-case sweep (#152): a `depends_on` condition of `service_healthy` only waited when the dependency declared a `healthcheck` **in compose**. If the healthcheck was inherited from the image, the wait was skipped and the dependent service started immediately — violating the compose spec.

## Fix

Drive the wait from the container's **effective** healthcheck reported by the runtime (`Config.Healthcheck`), which covers both image- and compose-defined checks:

- `wait_healthy` now short-circuits as satisfied only when the container has *no* effective healthcheck (`Healthcheck` absent or `Test: ["NONE"]`), instead of blocking until timeout.
- The startup gate calls `wait_healthy` whenever `service_healthy` is requested and the compose healthcheck is not explicitly disabled.

Behavior matrix:

| dependency healthcheck | before | after |
|---|---|---|
| declared in compose | wait | wait (unchanged) |
| inherited from image | **skipped (bug)** | wait |
| disabled (`disable: true` / `["NONE"]`) | skip | skip (unchanged) |
| none anywhere | skip | short-circuit (no hang) |

## Tests

- Unit tests for `ContainerConfig::has_healthcheck` detection (image-inherited, `["NONE"]`, absent, null `Test`).
- Integration regression `service_healthy_image_inherited_healthcheck`: an image with a baked `HEALTHCHECK` + a dependent declaring `service_healthy` and no compose healthcheck; `up` must wait then succeed.
- Full suite green (93 integration tests against podman, incl. `wait_healthy_times_out`).
