### PR TITLE
fix: derive project name from compose name and directory basename

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -33,6 +33,12 @@ podup (0.11.0) unstable; urgency=medium
     service name as the alias); external_links are still passed through as-is.
   * Accept multiple compose files (repeated -f or a COMPOSE_FILE list) and
     merge them in order, with later files overriding earlier ones.
+  * Derive the project name from the compose-spec precedence when -p and
+    COMPOSE_PROJECT_NAME are unset: the top-level name: field, then the
+    sanitized basename of the project directory, instead of the fixed
+    podup literal. NOTE: this changes the default volume/network/container
+    name prefix for projects that relied on the podup default; set -p podup
+    to keep the previous names.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -20,10 +20,12 @@ struct Cli {
 	#[arg(short, long)]
 	file: Vec<PathBuf>,
 
-	/// Project name (used as a prefix for container names).
-	/// May also be set via `COMPOSE_PROJECT_NAME`.
-	#[arg(short, long, env = "COMPOSE_PROJECT_NAME", default_value = "podup")]
-	project: String,
+	/// Project name (used as a prefix for container names). May also be set via
+	/// `COMPOSE_PROJECT_NAME`. When unset, the compose-spec precedence applies:
+	/// the top-level `name:` field, then the sanitized basename of the project
+	/// directory.
+	#[arg(short, long, env = "COMPOSE_PROJECT_NAME")]
+	project: Option<String>,
 
 	/// Podman socket path (overrides auto-detection and PODMAN_SOCKET env).
 	#[arg(long, env = "PODMAN_SOCKET")]
@@ -341,6 +343,55 @@ fn resolve_base_dir(project_directory: Option<&Path>, file: &Path) -> PathBuf {
 		.unwrap_or_else(|| file.parent().map(Path::to_path_buf).unwrap_or_default())
 }
 
+/// Resolve the project name following the compose-spec precedence: an explicit
+/// `-p` / `COMPOSE_PROJECT_NAME` value, then the top-level `name:` field, then
+/// the sanitized basename of the project directory. Explicit values are taken
+/// verbatim; only the directory basename is sanitized.
+fn resolve_project_name(
+	explicit: Option<String>,
+	compose_name: Option<&str>,
+	base_dir: &Path,
+) -> String {
+	if let Some(name) = explicit {
+		return name;
+	}
+	if let Some(name) = compose_name {
+		return name.to_string();
+	}
+	// An empty base dir means a bare compose filename in the current directory;
+	// canonicalize `.` so the basename comes from the working directory.
+	let probe = if base_dir.as_os_str().is_empty() {
+		Path::new(".")
+	} else {
+		base_dir
+	};
+	let basename = probe
+		.canonicalize()
+		.unwrap_or_else(|_| probe.to_path_buf())
+		.file_name()
+		.map(|n| n.to_string_lossy().into_owned())
+		.unwrap_or_default();
+	sanitize_project_name(&basename)
+}
+
+/// Normalize a raw directory name into a valid compose project name: lowercase,
+/// keep only `[a-z0-9_-]`, then strip any leading `_`/`-`. Falls back to the
+/// `podup` literal when nothing valid remains, so the project name is never
+/// empty.
+fn sanitize_project_name(raw: &str) -> String {
+	let kept: String = raw
+		.to_lowercase()
+		.chars()
+		.filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '_' || *c == '-')
+		.collect();
+	let trimmed = kept.trim_start_matches(['_', '-']);
+	if trimmed.is_empty() {
+		"podup".to_string()
+	} else {
+		trimmed.to_string()
+	}
+}
+
 #[tokio::main]
 async fn main() {
 	match run().await {
@@ -386,18 +437,20 @@ async fn run() -> podup::Result<()> {
 		return Ok(());
 	}
 
+	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+	let project = resolve_project_name(cli.project, file.name.as_deref(), &base_dir);
+
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.
 	if let Commands::Generate {
 		kind: GenerateCommands::Quadlet { output },
 	} = &cli.command
 	{
-		return write_quadlet(&file, &cli.project, output.as_deref());
+		return write_quadlet(&file, &project, output.as_deref());
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
-	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
-	let engine = podup::Engine::with_base_dir(client, cli.project, base_dir);
+	let engine = podup::Engine::with_base_dir(client, project, base_dir);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,
@@ -502,7 +555,9 @@ async fn run() -> podup::Result<()> {
 
 #[cfg(test)]
 mod tests {
-	use super::{resolve_base_dir, resolve_compose_files};
+	use super::{
+		resolve_base_dir, resolve_compose_files, resolve_project_name, sanitize_project_name,
+	};
 	use std::path::{Path, PathBuf};
 
 	#[test]
@@ -556,5 +611,58 @@ mod tests {
 	fn bare_filename_resolves_to_current_dir() {
 		let base = resolve_base_dir(None, Path::new("docker-compose.yml"));
 		assert_eq!(base, PathBuf::from(""));
+	}
+
+	#[test]
+	fn explicit_project_name_wins() {
+		let name = resolve_project_name(
+			Some("explicit".to_string()),
+			Some("from-compose"),
+			Path::new("/srv/myapp"),
+		);
+		assert_eq!(name, "explicit");
+	}
+
+	#[test]
+	fn compose_name_used_when_no_explicit() {
+		let name = resolve_project_name(None, Some("from-compose"), Path::new("/srv/myapp"));
+		assert_eq!(name, "from-compose");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn falls_back_to_directory_basename() {
+		let dir = std::env::temp_dir().join(format!("podup-pn-{}", std::process::id()));
+		std::fs::create_dir_all(&dir).unwrap();
+		let name = resolve_project_name(None, None, &dir);
+		let _ = std::fs::remove_dir_all(&dir);
+		// The basename is sanitized; the temp dir name is already lowercase
+		// alphanumeric with hyphens, so it survives unchanged.
+		assert_eq!(
+			name,
+			dir.file_name().unwrap().to_string_lossy().to_lowercase()
+		);
+	}
+
+	#[test]
+	fn sanitize_lowercases_and_drops_invalid_chars() {
+		assert_eq!(sanitize_project_name("My App!"), "myapp");
+	}
+
+	#[test]
+	fn sanitize_keeps_underscore_and_hyphen() {
+		assert_eq!(sanitize_project_name("web_service-1"), "web_service-1");
+	}
+
+	#[test]
+	fn sanitize_strips_leading_separators() {
+		assert_eq!(sanitize_project_name("__leading"), "leading");
+		assert_eq!(sanitize_project_name("--dash"), "dash");
+	}
+
+	#[test]
+	fn sanitize_empty_result_falls_back_to_podup() {
+		assert_eq!(sanitize_project_name("!!!"), "podup");
+		assert_eq!(sanitize_project_name(""), "podup");
 	}
 }


### PR DESCRIPTION
## Summary

Closes #180.

The project name resolution stopped at the hardcoded `podup` literal once `-p` and `COMPOSE_PROJECT_NAME` were unset, skipping the rest of the Compose-spec precedence. Now resolved post-parse as:

```
-p / --project-name || COMPOSE_PROJECT_NAME || compose name: || sanitize(basename(project_dir))
```

A new `sanitize_project_name` helper lowercases, keeps `[a-z0-9_-]`, strips leading `_`/`-`, and falls back to `podup` when nothing valid remains, so the project name is never empty.

## Why

- Restores drop-in migration from docker-compose: volumes, networks and containers are prefixed with the project name (`{project}_` / `{project}-`), so deriving it from `name:` / the directory basename makes existing `{dir}_db` volumes visible again.
- Stops every project run without `-p` from colliding on the shared `podup` prefix.

## Behavioural change

Projects that relied on the fixed `podup` default now get a name derived from `name:` or the directory basename. Set `-p podup` to keep the old names. Documented in the changelog stanza.

## Tests

7 new unit tests covering the precedence order and the sanitizer (lowercasing, invalid-char drop, leading-separator strip, empty fallback). Full suite green; clippy `-D warnings` and `rustfmt --check` clean.

## API

Library API unchanged (`Engine::with_base_dir` still takes `String`) — this is a CLI/behavioural change only, no semver bump.