### PR TITLE
feat: ship an arm64 Windows prebuilt binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,10 @@ jobs:
             runner: windows-latest
             target: x86_64-pc-windows-msvc
             bin: podup.exe
+          - asset: podup-windows-arm64.exe
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            bin: podup.exe
 
     defaults:
       run:
@@ -159,6 +163,7 @@ jobs:
             podup-darwin-arm64 \
             podup-darwin-x86_64 \
             podup-windows-x86_64.exe \
+            podup-windows-arm64.exe \
             > SHA256SUMS
 
       - name: Sign SHA256SUMS
@@ -192,6 +197,8 @@ jobs:
             podup-darwin-x86_64.sig \
             podup-windows-x86_64.exe \
             podup-windows-x86_64.exe.sig \
+            podup-windows-arm64.exe \
+            podup-windows-arm64.exe.sig \
             SHA256SUMS \
             SHA256SUMS.sig \
             install.sh


### PR DESCRIPTION
## Summary

Closes #182.

arm64 Windows (`aarch64-pc-windows-msvc`) was the only supported target without a prebuilt asset. This adds it to the release workflow:

- New build-matrix entry: asset `podup-windows-arm64.exe`, runner `windows-11-arm`, target `aarch64-pc-windows-msvc`, bin `podup.exe`.
- Added to the `SHA256SUMS` list and the `gh release create` asset list (binary + `.sig`).

The binary is signed and attested through the same steps as every other matrix target.

## No installer / contract impact

`install.sh` covers only Linux/macOS, so it is unchanged. The asset-contract check validates only installer-requestable assets, and still passes (`OK: all 4 installer-requestable assets are published`).

## Ships with

The next tagged release.