### PR TITLE
docs: list the healthcheck fix and sha2 bump in the 0.11.0 changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -39,6 +39,11 @@ podup (0.11.0) unstable; urgency=medium
     podup literal. NOTE: this changes the default volume/network/container
     name prefix for projects that relied on the podup default; set -p podup
     to keep the previous names.
+  * Wait on service_healthy when a container's healthcheck is inherited from
+    its image (HEALTHCHECK in the Containerfile), not only when one is
+    declared in the compose file; services with no healthcheck no longer
+    stall the dependency wait.
+  * Update sha2 to 0.11.0.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 


### PR DESCRIPTION
## Summary

The unreleased 0.11.0 changelog stanza was missing two changes already merged to develop:

- the `service_healthy` fix for image-inherited healthchecks (#179);
- the `sha2` 0.11.0 update (#178).

This adds both bullets so the changelog matches the release contents before the v0.11.0 release PR is cut. No code change.