### PR TITLE
release: v0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,10 @@ jobs:
             runner: windows-latest
             target: x86_64-pc-windows-msvc
             bin: podup.exe
+          - asset: podup-windows-arm64.exe
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            bin: podup.exe
 
     defaults:
       run:
@@ -159,6 +163,7 @@ jobs:
             podup-darwin-arm64 \
             podup-darwin-x86_64 \
             podup-windows-x86_64.exe \
+            podup-windows-arm64.exe \
             > SHA256SUMS
 
       - name: Sign SHA256SUMS
@@ -192,6 +197,8 @@ jobs:
             podup-darwin-x86_64.sig \
             podup-windows-x86_64.exe \
             podup-windows-x86_64.exe.sig \
+            podup-windows-arm64.exe \
+            podup-windows-arm64.exe.sig \
             SHA256SUMS \
             SHA256SUMS.sig \
             install.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,10 +190,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -209,15 +233,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -241,7 +274,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -251,8 +284,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -285,7 +329,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -494,6 +538,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -896,7 +949,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "temp-env",
  "tempfile",
@@ -1145,8 +1198,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ notify = { version = "8", optional = true }
 # Ed25519 signature pinned to an embedded key is the real trust anchor, not TLS.
 ureq = { version = "2", default-features = false, features = ["tls"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
-sha2 = "0.10"
+sha2 = "0.11"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/debian/changelog
+++ b/debian/changelog
@@ -39,6 +39,11 @@ podup (0.11.0) unstable; urgency=medium
     podup literal. NOTE: this changes the default volume/network/container
     name prefix for projects that relied on the podup default; set -p podup
     to keep the previous names.
+  * Wait on service_healthy when a container's healthcheck is inherited from
+    its image (HEALTHCHECK in the Containerfile), not only when one is
+    declared in the compose file; services with no healthcheck no longer
+    stall the dependency wait.
+  * Update sha2 to 0.11.0.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -33,6 +33,12 @@ podup (0.11.0) unstable; urgency=medium
     service name as the alias); external_links are still passed through as-is.
   * Accept multiple compose files (repeated -f or a COMPOSE_FILE list) and
     merge them in order, with later files overriding earlier ones.
+  * Derive the project name from the compose-spec precedence when -p and
+    COMPOSE_PROJECT_NAME are unset: the top-level name: field, then the
+    sanitized basename of the project directory, instead of the fixed
+    podup literal. NOTE: this changes the default volume/network/container
+    name prefix for projects that relied on the podup default; set -p podup
+    to keep the previous names.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -15,6 +15,12 @@ impl Engine {
 	/// Poll a container until its health status is `healthy` or timeout.
 	///
 	/// Uses `healthcheck.retries` (default 30) with a 2 s interval between probes.
+	///
+	/// The wait is driven by the container's *effective* healthcheck reported by
+	/// the runtime, so healthchecks inherited from the image count too — not just
+	/// those declared in compose. If the container has no effective healthcheck at
+	/// all (none in the image or compose), it can never report `healthy`, so the
+	/// wait short-circuits as satisfied rather than blocking until timeout.
 	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
 		let retries = service
 			.healthcheck
@@ -38,12 +44,20 @@ impl Engine {
 					continue;
 				}
 			};
-			if let Some(state) = info.state {
-				if let Some(health) = state.health {
+			if let Some(state) = &info.state {
+				if let Some(health) = &state.health {
 					if health.status.as_deref() == Some("healthy") {
 						return Ok(());
 					}
 				}
+			}
+			// No `healthy` status yet. If the container has no effective
+			// healthcheck, it never will — treat the dependency as satisfied.
+			if !info.config.map(|c| c.has_healthcheck()).unwrap_or(false) {
+				tracing::debug!(
+					"{container_name} has no effective healthcheck; treating service_healthy as satisfied"
+				);
+				return Ok(());
 			}
 			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 		}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -130,17 +130,21 @@ impl Engine {
 					match condition {
 						ServiceCondition::ServiceStarted => {}
 						ServiceCondition::ServiceHealthy => {
-							if dep_service
+							// Wait unless the healthcheck is explicitly disabled in
+							// compose. With no compose healthcheck we still wait:
+							// `wait_healthy` consults the container's effective
+							// healthcheck, so image-inherited ones are honored and
+							// the wait short-circuits when none exists.
+							let disabled = dep_service
 								.healthcheck
 								.as_ref()
-								.map(|h| !h.is_disabled())
-								.unwrap_or(false)
-							{
-								self.wait_healthy(&dep_container, dep_service).await?;
-							} else {
+								.is_some_and(|h| h.is_disabled());
+							if disabled {
 								tracing::debug!(
-									"{dep} requested service_healthy but has no healthcheck — skipping wait"
+									"{dep} healthcheck disabled — skipping service_healthy wait"
 								);
+							} else {
+								self.wait_healthy(&dep_container, dep_service).await?;
 							}
 						}
 						ServiceCondition::ServiceCompletedSuccessfully => {

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -49,8 +49,36 @@ pub struct ContainerInspect {
 	#[serde(rename = "State")]
 	pub state: Option<ContainerState>,
 
+	#[serde(rename = "Config")]
+	pub config: Option<ContainerConfig>,
+
 	#[serde(rename = "NetworkSettings")]
 	pub network_settings: Option<NetworkSettings>,
+}
+
+/// Container config sub-object from inspect.
+#[derive(Deserialize, Default)]
+pub struct ContainerConfig {
+	#[serde(rename = "Healthcheck")]
+	pub healthcheck: Option<HealthConfig>,
+}
+
+impl ContainerConfig {
+	/// Whether the container has an effective healthcheck that can report a
+	/// `healthy` status. Covers healthchecks inherited from the image as well
+	/// as those declared in compose. A `["NONE"]` test means it was disabled.
+	pub fn has_healthcheck(&self) -> bool {
+		self.healthcheck
+			.as_ref()
+			.is_some_and(|h| h.test.first().is_some_and(|first| first != "NONE"))
+	}
+}
+
+/// Effective healthcheck config baked into the container (image or compose).
+#[derive(Deserialize, Default)]
+pub struct HealthConfig {
+	#[serde(rename = "Test", default, deserialize_with = "null_default")]
+	pub test: Vec<String>,
 }
 
 /// Container state sub-object.
@@ -162,7 +190,38 @@ mod tests {
 		let json = r#"{}"#;
 		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
 		assert!(ci.state.is_none());
+		assert!(ci.config.is_none());
 		assert!(ci.network_settings.is_none());
+	}
+
+	#[test]
+	fn has_healthcheck_true_for_image_inherited() {
+		let json = r#"{
+			"Config": { "Healthcheck": { "Test": ["CMD-SHELL", "curl -f http://localhost || exit 1"] } }
+		}"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(ci.config.unwrap().has_healthcheck());
+	}
+
+	#[test]
+	fn has_healthcheck_false_when_disabled_with_none() {
+		let json = r#"{ "Config": { "Healthcheck": { "Test": ["NONE"] } } }"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(!ci.config.unwrap().has_healthcheck());
+	}
+
+	#[test]
+	fn has_healthcheck_false_when_absent() {
+		let json = r#"{ "Config": {} }"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(!ci.config.unwrap().has_healthcheck());
+	}
+
+	#[test]
+	fn has_healthcheck_false_when_test_null() {
+		let json = r#"{ "Config": { "Healthcheck": { "Test": null } } }"#;
+		let ci: ContainerInspect = serde_json::from_str(json).unwrap();
+		assert!(!ci.config.unwrap().has_healthcheck());
 	}
 
 	#[test]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -20,10 +20,12 @@ struct Cli {
 	#[arg(short, long)]
 	file: Vec<PathBuf>,
 
-	/// Project name (used as a prefix for container names).
-	/// May also be set via `COMPOSE_PROJECT_NAME`.
-	#[arg(short, long, env = "COMPOSE_PROJECT_NAME", default_value = "podup")]
-	project: String,
+	/// Project name (used as a prefix for container names). May also be set via
+	/// `COMPOSE_PROJECT_NAME`. When unset, the compose-spec precedence applies:
+	/// the top-level `name:` field, then the sanitized basename of the project
+	/// directory.
+	#[arg(short, long, env = "COMPOSE_PROJECT_NAME")]
+	project: Option<String>,
 
 	/// Podman socket path (overrides auto-detection and PODMAN_SOCKET env).
 	#[arg(long, env = "PODMAN_SOCKET")]
@@ -341,6 +343,55 @@ fn resolve_base_dir(project_directory: Option<&Path>, file: &Path) -> PathBuf {
 		.unwrap_or_else(|| file.parent().map(Path::to_path_buf).unwrap_or_default())
 }
 
+/// Resolve the project name following the compose-spec precedence: an explicit
+/// `-p` / `COMPOSE_PROJECT_NAME` value, then the top-level `name:` field, then
+/// the sanitized basename of the project directory. Explicit values are taken
+/// verbatim; only the directory basename is sanitized.
+fn resolve_project_name(
+	explicit: Option<String>,
+	compose_name: Option<&str>,
+	base_dir: &Path,
+) -> String {
+	if let Some(name) = explicit {
+		return name;
+	}
+	if let Some(name) = compose_name {
+		return name.to_string();
+	}
+	// An empty base dir means a bare compose filename in the current directory;
+	// canonicalize `.` so the basename comes from the working directory.
+	let probe = if base_dir.as_os_str().is_empty() {
+		Path::new(".")
+	} else {
+		base_dir
+	};
+	let basename = probe
+		.canonicalize()
+		.unwrap_or_else(|_| probe.to_path_buf())
+		.file_name()
+		.map(|n| n.to_string_lossy().into_owned())
+		.unwrap_or_default();
+	sanitize_project_name(&basename)
+}
+
+/// Normalize a raw directory name into a valid compose project name: lowercase,
+/// keep only `[a-z0-9_-]`, then strip any leading `_`/`-`. Falls back to the
+/// `podup` literal when nothing valid remains, so the project name is never
+/// empty.
+fn sanitize_project_name(raw: &str) -> String {
+	let kept: String = raw
+		.to_lowercase()
+		.chars()
+		.filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '_' || *c == '-')
+		.collect();
+	let trimmed = kept.trim_start_matches(['_', '-']);
+	if trimmed.is_empty() {
+		"podup".to_string()
+	} else {
+		trimmed.to_string()
+	}
+}
+
 #[tokio::main]
 async fn main() {
 	match run().await {
@@ -386,18 +437,20 @@ async fn run() -> podup::Result<()> {
 		return Ok(());
 	}
 
+	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+	let project = resolve_project_name(cli.project, file.name.as_deref(), &base_dir);
+
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.
 	if let Commands::Generate {
 		kind: GenerateCommands::Quadlet { output },
 	} = &cli.command
 	{
-		return write_quadlet(&file, &cli.project, output.as_deref());
+		return write_quadlet(&file, &project, output.as_deref());
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
-	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
-	let engine = podup::Engine::with_base_dir(client, cli.project, base_dir);
+	let engine = podup::Engine::with_base_dir(client, project, base_dir);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,
@@ -502,7 +555,9 @@ async fn run() -> podup::Result<()> {
 
 #[cfg(test)]
 mod tests {
-	use super::{resolve_base_dir, resolve_compose_files};
+	use super::{
+		resolve_base_dir, resolve_compose_files, resolve_project_name, sanitize_project_name,
+	};
 	use std::path::{Path, PathBuf};
 
 	#[test]
@@ -556,5 +611,58 @@ mod tests {
 	fn bare_filename_resolves_to_current_dir() {
 		let base = resolve_base_dir(None, Path::new("docker-compose.yml"));
 		assert_eq!(base, PathBuf::from(""));
+	}
+
+	#[test]
+	fn explicit_project_name_wins() {
+		let name = resolve_project_name(
+			Some("explicit".to_string()),
+			Some("from-compose"),
+			Path::new("/srv/myapp"),
+		);
+		assert_eq!(name, "explicit");
+	}
+
+	#[test]
+	fn compose_name_used_when_no_explicit() {
+		let name = resolve_project_name(None, Some("from-compose"), Path::new("/srv/myapp"));
+		assert_eq!(name, "from-compose");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn falls_back_to_directory_basename() {
+		let dir = std::env::temp_dir().join(format!("podup-pn-{}", std::process::id()));
+		std::fs::create_dir_all(&dir).unwrap();
+		let name = resolve_project_name(None, None, &dir);
+		let _ = std::fs::remove_dir_all(&dir);
+		// The basename is sanitized; the temp dir name is already lowercase
+		// alphanumeric with hyphens, so it survives unchanged.
+		assert_eq!(
+			name,
+			dir.file_name().unwrap().to_string_lossy().to_lowercase()
+		);
+	}
+
+	#[test]
+	fn sanitize_lowercases_and_drops_invalid_chars() {
+		assert_eq!(sanitize_project_name("My App!"), "myapp");
+	}
+
+	#[test]
+	fn sanitize_keeps_underscore_and_hyphen() {
+		assert_eq!(sanitize_project_name("web_service-1"), "web_service-1");
+	}
+
+	#[test]
+	fn sanitize_strips_leading_separators() {
+		assert_eq!(sanitize_project_name("__leading"), "leading");
+		assert_eq!(sanitize_project_name("--dash"), "dash");
+	}
+
+	#[test]
+	fn sanitize_empty_result_falls_back_to_podup() {
+		assert_eq!(sanitize_project_name("!!!"), "podup");
+		assert_eq!(sanitize_project_name(""), "podup");
 	}
 }

--- a/tests/engine_integration/group_a4.rs
+++ b/tests/engine_integration/group_a4.rs
@@ -332,3 +332,33 @@ async fn target_services_duplicate_entry() {
 		.unwrap();
 	engine.down(&file).await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// service_healthy honors a healthcheck baked into the image, even when the
+// compose service declares none (health.rs / lifecycle.rs gate). The db image
+// carries its own HEALTHCHECK; web depends on it with condition: service_healthy
+// and no compose healthcheck. `up` must wait for the inherited check to report
+// healthy and then succeed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn service_healthy_image_inherited_healthcheck() {
+	let rt = tokio::runtime::Runtime::new().unwrap();
+	rt.block_on(async {
+		let client = match podman().await {
+			Some(d) => d,
+			None => return,
+		};
+		let dir = tempfile::tempdir().unwrap();
+		let proj = proj("ihc");
+		let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+		let image_tag = format!("podup-test-ihc-{}:latest", std::process::id());
+		let yaml = format!(
+			"services:\n  db:\n    build:\n      context: .\n      dockerfile_inline: |\n        FROM alpine:latest\n        HEALTHCHECK --interval=1s --timeout=2s --retries=3 CMD true\n    image: {image_tag}\n    command: [\"sleep\", \"infinity\"]\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    depends_on:\n      db:\n        condition: service_healthy\n"
+		);
+		let file = parse_str(&yaml).unwrap();
+
+		engine.up(&file).await.unwrap();
+		engine.down(&file).await.unwrap();
+	});
+}


### PR DESCRIPTION
## v0.11.0

Promotes develop to main for the v0.11.0 release. Highlights:

- Compose-spec parity batch (#164): run --service-ports, env_file last-wins, external vol/net must-exist, dotenv parser, volume subpath, IPAM forwarding, include/extends path anchoring, global --env-file, Git/URL build context, GPU CDI devices, multi-file -f merge.
- Project name now follows the compose-spec precedence (name: / directory basename) instead of a fixed literal.
- service_healthy honours image-inherited healthchecks.
- arm64 Windows prebuilt binary added to the release workflow.
- config-hash determinism fix; sha2 0.11.0.

Full list in debian/changelog. Cargo.toml at 0.11.0; tag v0.11.0 follows the merge.

Breaking (library): ComposeError::ExternalNotFound variant, RunOptions.service_ports field, up_with_options trailing no_deps arg — panel-agent pin bumps to v0.11.0 after release.