### PR TITLE
release: v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+podup (0.12.0) unstable; urgency=medium
+
+  * Derive the project name from the compose-spec precedence when -p and
+    COMPOSE_PROJECT_NAME are unset: the top-level name: field, then the
+    sanitized basename of the project directory, instead of the fixed
+    podup literal. NOTE: this changes the default volume/network/container
+    name prefix for projects that relied on the podup default; set -p podup
+    to keep the previous names.
+  * Wait on service_healthy when a container's healthcheck is inherited from
+    its image (HEALTHCHECK in the Containerfile), not only when one is
+    declared in the compose file; services with no healthcheck no longer
+    stall the dependency wait.
+  * Update sha2 to 0.11.0.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 12 Jun 2026 10:00:00 -0500
+
 podup (0.11.0) unstable; urgency=medium
 
   * run no longer publishes the service's declared ports by default; pass
@@ -33,17 +49,6 @@ podup (0.11.0) unstable; urgency=medium
     service name as the alias); external_links are still passed through as-is.
   * Accept multiple compose files (repeated -f or a COMPOSE_FILE list) and
     merge them in order, with later files overriding earlier ones.
-  * Derive the project name from the compose-spec precedence when -p and
-    COMPOSE_PROJECT_NAME are unset: the top-level name: field, then the
-    sanitized basename of the project directory, instead of the fixed
-    podup literal. NOTE: this changes the default volume/network/container
-    name prefix for projects that relied on the podup default; set -p podup
-    to keep the previous names.
-  * Wait on service_healthy when a container's healthcheck is inherited from
-    its image (HEALTHCHECK in the Containerfile), not only when one is
-    declared in the compose file; services with no healthcheck no longer
-    stall the dependency wait.
-  * Update sha2 to 0.11.0.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 11 Jun 2026 15:45:00 -0500
 


### PR DESCRIPTION
Bumps the crate to 0.12.0 and adds the 0.12.0 changelog stanza for the changes merged after v0.11.0 was released:

- compose-spec project name resolution (#181)
- service_healthy image-inherited healthcheck fix (#179)
- sha2 0.11.0 (#178)

The 0.11.0 stanza is restored to its as-released contents (the three bullets above were mistakenly appended to it). Cargo.lock synced. The arm64-Windows prebuilt (#183) is a release-workflow change with no packaged-binary entry.

After this merges to develop, a release PR promotes it to main and tag v0.12.0 is pushed.