### PR TITLE
release: v0.12.0 (arm64 Windows cross-build fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,11 @@ jobs:
             runner: windows-latest
             target: x86_64-pc-windows-msvc
             bin: podup.exe
+          # Cross-compiled from the x64 Windows runner: the aarch64 toolchain
+          # is added with rustup, and the signing step's Python wheels are only
+          # published for x64 Windows (no native arm64 wheel exists).
           - asset: podup-windows-arm64.exe
-            runner: windows-11-arm
+            runner: windows-latest
             target: aarch64-pc-windows-msvc
             bin: podup.exe
 


### PR DESCRIPTION
Re-promotes develop to main so the v0.12.0 tag includes the arm64 Windows cross-build fix (#188). The prior v0.12.0 release run failed building podup-windows-arm64.exe; this builds it on the x64 runner. No version change — v0.12.0 was never published (the publish step was skipped), so the tag is re-pointed at this commit.