### PR TITLE
feat: concurrent startup by dependency level + self-update/secret-path fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -181,5 +181,13 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		deploy: override_svc.deploy.or(base.deploy),
 		develop: override_svc.develop.or(base.develop),
 		gpus: override_svc.gpus.or(base.gpus),
+		unknown: {
+			// Keep unknown keys from both sides so a typo in either the base or
+			// the overriding service is still surfaced; the override wins on
+			// conflicting keys.
+			let mut u = base.unknown;
+			u.extend(override_svc.unknown);
+			u
+		},
 	}
 }

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -93,7 +93,27 @@ pub fn parse_files_with_env_files(paths: &[PathBuf], env_files: &[String]) -> Re
 		let other = parse_file_with_env_files(path, env_files)?;
 		merge_override(&mut merged, other);
 	}
+	warn_unknown_service_keys(&merged);
 	Ok(merged)
+}
+
+/// Warn about service keys that don't map to a known compose field. These are
+/// silently tolerated (not a hard error, so `x-*` extensions and
+/// forward-compatible keys still parse), but a likely typo — e.g. `enviroment:`
+/// — is easy to miss when it just vanishes, so surface it. `x-*` extension keys
+/// are skipped per the compose spec.
+fn warn_unknown_service_keys(file: &ComposeFile) {
+	for (service, def) in &file.services {
+		for key in def.unknown.keys() {
+			if key.starts_with("x-") {
+				continue;
+			}
+			tracing::warn!(
+				"service '{service}': unknown key '{key}' is ignored \
+				 (check for a typo or an unsupported compose feature)"
+			);
+		}
+	}
 }
 
 /// Merge `other` into `target` with `other` winning (compose `-f` override
@@ -194,6 +214,72 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 	}
 
 	Ok(order)
+}
+
+/// Group services into dependency levels (Kahn's algorithm, layered).
+///
+/// Each returned level contains services whose dependencies all live in earlier
+/// levels, so the services within one level have no `depends_on` relationship to
+/// each other and can be started concurrently. Levels are ordered
+/// dependencies-first; names within a level are sorted for deterministic
+/// dispatch. Errors on cycles or missing required dependencies, matching
+/// [`resolve_order`].
+pub fn resolve_levels(file: &ComposeFile) -> Result<Vec<Vec<String>>> {
+	let services: Vec<&str> = file.services.keys().map(|s| s.as_str()).collect();
+	let mut in_degree: HashMap<&str, usize> = services.iter().map(|&s| (s, 0)).collect();
+	let mut graph: HashMap<&str, Vec<&str>> = services.iter().map(|&s| (s, vec![])).collect();
+
+	for (name, service) in &file.services {
+		for dep in service.depends_on.service_names() {
+			if !file.services.contains_key(&dep) {
+				if !service.depends_on.required_for(&dep) {
+					continue;
+				}
+				return Err(ComposeError::ServiceNotFound(dep));
+			}
+			if let Some(neighbors) = graph.get_mut(dep.as_str()) {
+				neighbors.push(name.as_str());
+			}
+			if let Some(deg) = in_degree.get_mut(name.as_str()) {
+				*deg += 1;
+			}
+		}
+	}
+
+	let mut current: Vec<&str> = in_degree
+		.iter()
+		.filter(|(_, &deg)| deg == 0)
+		.map(|(&s, _)| s)
+		.collect();
+
+	let mut levels: Vec<Vec<String>> = Vec::new();
+	let mut processed = 0;
+	while !current.is_empty() {
+		current.sort_unstable();
+		let mut next: Vec<&str> = Vec::new();
+		for &node in &current {
+			processed += 1;
+			let neighbors: Vec<&str> = graph.get(node).map_or(&[][..], |v| v.as_slice()).to_vec();
+			for neighbor in neighbors {
+				if let Some(deg) = in_degree.get_mut(neighbor) {
+					*deg -= 1;
+					if *deg == 0 {
+						next.push(neighbor);
+					}
+				}
+			}
+		}
+		levels.push(current.iter().map(|s| s.to_string()).collect());
+		current = next;
+	}
+
+	if processed != services.len() {
+		return Err(ComposeError::CircularDependency(
+			"cycle detected in depends_on".into(),
+		));
+	}
+
+	Ok(levels)
 }
 
 pub(crate) fn parse_file_inner(path: &Path, dir: &Path) -> Result<ComposeFile> {
@@ -321,6 +407,52 @@ mod tests {
 		let yaml = "services:\n  web:\n    image: nginx\n    depends_on: [db]\n";
 		let file = parse_str_raw(yaml).unwrap();
 		assert!(resolve_order(&file).is_err());
+	}
+
+	// resolve_levels
+
+	#[test]
+	fn resolve_levels_groups_independent_services_together() {
+		let yaml = "services:\n  a:\n    image: x\n  b:\n    image: y\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let levels = resolve_levels(&file).unwrap();
+		// No deps → one level holding both, sorted for determinism.
+		assert_eq!(levels, vec![vec!["a".to_string(), "b".to_string()]]);
+	}
+
+	#[test]
+	fn resolve_levels_orders_dependencies_into_earlier_levels() {
+		let yaml = "services:\n  web:\n    image: nginx\n    depends_on: [db]\n  db:\n    image: postgres\n  cache:\n    image: redis\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let levels = resolve_levels(&file).unwrap();
+		// Level 0: db + cache (no deps); level 1: web (depends on db).
+		assert_eq!(levels[0], vec!["cache".to_string(), "db".to_string()]);
+		assert_eq!(levels[1], vec!["web".to_string()]);
+	}
+
+	#[test]
+	fn resolve_levels_cycle_is_error() {
+		let yaml = "services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n";
+		let file = parse_str_raw(yaml).unwrap();
+		assert!(resolve_levels(&file).is_err());
+	}
+
+	// unknown-key capture / warning
+
+	#[test]
+	fn unknown_service_key_is_captured_not_dropped() {
+		// A typo'd key lands in `unknown` instead of vanishing silently.
+		let yaml = "services:\n  web:\n    image: nginx\n    enviroment:\n      - A=1\n";
+		let file = parse_str_raw(yaml).unwrap();
+		assert!(file.services["web"].unknown.contains_key("enviroment"));
+		assert!(file.services["web"].environment.is_empty());
+	}
+
+	#[test]
+	fn known_service_keys_do_not_land_in_unknown() {
+		let yaml = "services:\n  web:\n    image: nginx\n    environment:\n      - A=1\n";
+		let file = parse_str_raw(yaml).unwrap();
+		assert!(file.services["web"].unknown.is_empty());
 	}
 
 	// YAML merge keys (<<)

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -210,4 +210,12 @@ pub struct Service {
 
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gpus: Option<GpuSpec>,
+
+	/// Keys present in the YAML that don't map to a known service field. Captured
+	/// (rather than silently dropped) so the parser can warn about likely typos
+	/// while still tolerating compose-spec `x-*` extensions and forward-compatible
+	/// keys. Not part of the container spec; round-tripped by the `config`
+	/// subcommand to preserve fidelity.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
 }

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -296,7 +296,7 @@ fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> St
 /// Resolve a bind-mount source path: expand a leading `~`, then make a relative
 /// path absolute against the project base directory. Absolute paths (including
 /// staged secret/config files) are returned unchanged.
-fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
+pub(super) fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
 	if src.is_empty() {
 		return src.to_string();
 	}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -64,7 +64,7 @@ impl Engine {
 		no_deps: bool,
 	) -> Result<()> {
 		let r: Result<()> = async {
-			let order = crate::compose::resolve_order(file)?;
+			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
 
 			let target_set = expand_targets(file, target_services, no_deps);
@@ -103,101 +103,25 @@ impl Engine {
 			self.create_networks(file).await?;
 			self.create_volumes(file).await?;
 
-			for name in &order {
-				if let Some(ref set) = target_set {
-					if !set.contains(name) {
-						continue;
-					}
-				}
-				let service = &file.services[name];
-
-				if !service_in_profiles(service, &active) {
-					tracing::debug!("skipping {name}: no active profile match");
-					continue;
-				}
-
-				for dep in service.depends_on.service_names() {
-					let condition = service.depends_on.condition_for(&dep);
-					let dep_service = match file.services.get(&dep) {
-						Some(s) => s,
-						None => continue,
-					};
-					if !service_in_profiles(dep_service, &active) {
-						continue;
-					}
-					let dep_container = self.container_name(&dep, dep_service);
-
-					match condition {
-						ServiceCondition::ServiceStarted => {}
-						ServiceCondition::ServiceHealthy => {
-							// Wait unless the healthcheck is explicitly disabled in
-							// compose. With no compose healthcheck we still wait:
-							// `wait_healthy` consults the container's effective
-							// healthcheck, so image-inherited ones are honored and
-							// the wait short-circuits when none exists.
-							let disabled = dep_service
-								.healthcheck
-								.as_ref()
-								.is_some_and(|h| h.is_disabled());
-							if disabled {
-								tracing::debug!(
-									"{dep} healthcheck disabled — skipping service_healthy wait"
-								);
-							} else {
-								self.wait_healthy(&dep_container, dep_service).await?;
-							}
-						}
-						ServiceCondition::ServiceCompletedSuccessfully => {
-							self.wait_completed(&dep_container).await?;
-						}
-					}
-				}
-
-				let policy = service.pull_policy.as_deref().unwrap_or("missing");
-				match (service.build.is_some(), policy) {
-					(true, _) => self.build_service(name, service, file).await?,
-					(false, "never") => {}
-					(false, _) => self.pull_image(service).await?,
-				}
-
-				let replicas = service
-					.scale
-					.or(service.deploy.as_ref().and_then(|d| d.replicas))
-					.unwrap_or(1) as usize;
-
-				let new_hash = config_hash(service);
-
-				for i in 1..=replicas {
-					let container_name = if replicas == 1 {
-						self.container_name(name, service)
-					} else {
-						format!("{}-{i}", self.container_name(name, service))
-					};
-					if !force_recreate {
-						if no_recreate && present.contains(&container_name) {
-							info!("{container_name} already exists — skipping recreate");
-							self.ensure_started(&container_name).await;
-							continue;
-						}
-						// Services with a build section are rebuilt on every up, so
-						// their container must be recreated to pick up the fresh
-						// image even when the compose config is unchanged.
-						if service.build.is_none()
-							&& existing_hash.get(&container_name) == Some(&new_hash)
-						{
-							info!("{container_name} is up to date — skipping recreate");
-							self.ensure_started(&container_name).await;
-							continue;
-						}
-					}
-					self.create_and_start(&container_name, name, service, file)
-						.await?;
-					info!("started {container_name}");
-
-					for hook in &service.post_start {
-						self.run_lifecycle_hook(&container_name, hook).await?;
-					}
-				}
+			// Start each dependency level in turn; services within a level have
+			// no `depends_on` relationship to each other (guaranteed by the
+			// layering), so they start concurrently. The barrier between levels
+			// preserves ordering and `service_healthy`/`service_completed`
+			// semantics: a level only begins once the previous one is up.
+			for level in &levels {
+				let started = level.iter().map(|name| {
+					self.up_one_service(
+						name,
+						file,
+						&active,
+						&target_set,
+						&present,
+						&existing_hash,
+						no_recreate,
+						force_recreate,
+					)
+				});
+				futures_util::future::try_join_all(started).await?;
 			}
 
 			Ok(())
@@ -209,6 +133,121 @@ impl Engine {
 			self.cleanup_temp_dir();
 		}
 		r
+	}
+
+	/// Bring up a single service: honor profile/target filters, wait on its
+	/// `depends_on` conditions, build or pull the image, and create/start each
+	/// replica (skipping containers that are unchanged unless `force_recreate`).
+	/// Used by [`Self::up_with_options`]; safe to run concurrently for services
+	/// in the same dependency level (the `Engine` holds no per-call mutable
+	/// state — the libpod client is connection-per-request).
+	#[allow(clippy::too_many_arguments)]
+	async fn up_one_service(
+		&self,
+		name: &str,
+		file: &ComposeFile,
+		active: &HashSet<String>,
+		target_set: &Option<HashSet<String>>,
+		present: &HashSet<String>,
+		existing_hash: &HashMap<String, String>,
+		no_recreate: bool,
+		force_recreate: bool,
+	) -> Result<()> {
+		if let Some(set) = target_set {
+			if !set.contains(name) {
+				return Ok(());
+			}
+		}
+		let service = &file.services[name];
+
+		if !service_in_profiles(service, active) {
+			tracing::debug!("skipping {name}: no active profile match");
+			return Ok(());
+		}
+
+		for dep in service.depends_on.service_names() {
+			let condition = service.depends_on.condition_for(&dep);
+			let dep_service = match file.services.get(&dep) {
+				Some(s) => s,
+				None => continue,
+			};
+			if !service_in_profiles(dep_service, active) {
+				continue;
+			}
+			let dep_container = self.container_name(&dep, dep_service);
+
+			match condition {
+				ServiceCondition::ServiceStarted => {}
+				ServiceCondition::ServiceHealthy => {
+					// Wait unless the healthcheck is explicitly disabled in
+					// compose. With no compose healthcheck we still wait:
+					// `wait_healthy` consults the container's effective
+					// healthcheck, so image-inherited ones are honored and
+					// the wait short-circuits when none exists.
+					let disabled = dep_service
+						.healthcheck
+						.as_ref()
+						.is_some_and(|h| h.is_disabled());
+					if disabled {
+						tracing::debug!(
+							"{dep} healthcheck disabled — skipping service_healthy wait"
+						);
+					} else {
+						self.wait_healthy(&dep_container, dep_service).await?;
+					}
+				}
+				ServiceCondition::ServiceCompletedSuccessfully => {
+					self.wait_completed(&dep_container).await?;
+				}
+			}
+		}
+
+		let policy = service.pull_policy.as_deref().unwrap_or("missing");
+		match (service.build.is_some(), policy) {
+			(true, _) => self.build_service(name, service, file).await?,
+			(false, "never") => {}
+			(false, _) => self.pull_image(service).await?,
+		}
+
+		let replicas = service
+			.scale
+			.or(service.deploy.as_ref().and_then(|d| d.replicas))
+			.unwrap_or(1) as usize;
+
+		let new_hash = config_hash(service);
+
+		for i in 1..=replicas {
+			let container_name = if replicas == 1 {
+				self.container_name(name, service)
+			} else {
+				format!("{}-{i}", self.container_name(name, service))
+			};
+			if !force_recreate {
+				if no_recreate && present.contains(&container_name) {
+					info!("{container_name} already exists — skipping recreate");
+					self.ensure_started(&container_name).await;
+					continue;
+				}
+				// Services with a build section are rebuilt on every up, so
+				// their container must be recreated to pick up the fresh
+				// image even when the compose config is unchanged.
+				if service.build.is_none() && existing_hash.get(&container_name) == Some(&new_hash)
+				{
+					info!("{container_name} is up to date — skipping recreate");
+					self.ensure_started(&container_name).await;
+					continue;
+				}
+			}
+			self.create_and_start(&container_name, name, service, file)
+				.await?;
+			info!("started {container_name}");
+
+			for hook in &service.post_start {
+				self.run_lifecycle_hook(&container_name, hook).await?;
+			}
+		}
+
+		Ok(())
 	}
 
 	/// Stop and remove all containers for the project. Does not remove volumes unless `remove_volumes` is set.

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -331,20 +331,25 @@ mod tests {
 	#[test]
 	fn secret_file_relative_path_is_anchored_to_base_dir() {
 		// A relative `file:` must resolve against the project dir, not the
-		// Podman service's cwd — same as a bind-mount source.
+		// Podman service's cwd — same as a bind-mount source. Build the expected
+		// path via `Path::join` so the separator is correct on every platform.
+		let base = PathBuf::from("/srv/project");
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: secret.txt\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let engine = engine_with_base("/srv/project");
+		let engine = engine_with_base(&base.to_string_lossy());
 		let binds = engine
 			.build_secret_binds(&file.services["web"], &file)
 			.unwrap();
-		assert_eq!(binds, vec!["/srv/project/secret.txt:/run/secrets/tok:ro"]);
+		let expected = format!("{}:/run/secrets/tok:ro", base.join("secret.txt").display());
+		assert_eq!(binds, vec![expected]);
 	}
 
+	#[cfg(unix)]
 	#[test]
 	fn config_file_absolute_path_is_passed_through() {
 		// Absolute paths are honored unchanged (compose allows mounting any host
-		// file, exactly as `volumes:` does).
+		// file, exactly as `volumes:` does). Uses a Unix-absolute path, so the
+		// assertion is gated to Unix.
 		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: /etc/app/cfg.yaml\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
 		let engine = engine_with_base("/srv/project");

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -128,7 +128,13 @@ impl Engine {
 						file: Some(host_path),
 						..
 					} => {
-						binds.push(format!("{host_path}:{target}:ro"));
+						// Resolve like a bind-mount source: a relative `file:` is
+						// anchored to the project dir (not the Podman service's cwd)
+						// and `~` is expanded — same handling as `volumes:`, which
+						// already mount arbitrary host paths.
+						let resolved =
+							super::container::resolve_bind_source(host_path, &self.base_dir);
+						binds.push(format!("{resolved}:{target}:ro"));
 					}
 					SecretConfig {
 						content: Some(content),
@@ -206,7 +212,11 @@ impl Engine {
 						file: Some(host_path),
 						..
 					} => {
-						binds.push(format!("{host_path}:{target}:ro"));
+						// Resolve like a bind-mount source: anchor a relative path to
+						// the project dir and expand `~`, matching `volumes:` handling.
+						let resolved =
+							super::container::resolve_bind_source(host_path, &self.base_dir);
+						binds.push(format!("{resolved}:{target}:ro"));
 					}
 					ConfigConfig {
 						content: Some(content),
@@ -301,5 +311,46 @@ impl Engine {
 			)));
 		}
 		Ok(staging::staging_base()?.join(&self.project))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::libpod::Client;
+	use std::path::PathBuf;
+
+	fn engine_with_base(base: &str) -> Engine {
+		Engine::with_base_dir(
+			Client::new("unused"),
+			"proj".to_string(),
+			PathBuf::from(base),
+		)
+	}
+
+	#[test]
+	fn secret_file_relative_path_is_anchored_to_base_dir() {
+		// A relative `file:` must resolve against the project dir, not the
+		// Podman service's cwd — same as a bind-mount source.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: secret.txt\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let engine = engine_with_base("/srv/project");
+		let binds = engine
+			.build_secret_binds(&file.services["web"], &file)
+			.unwrap();
+		assert_eq!(binds, vec!["/srv/project/secret.txt:/run/secrets/tok:ro"]);
+	}
+
+	#[test]
+	fn config_file_absolute_path_is_passed_through() {
+		// Absolute paths are honored unchanged (compose allows mounting any host
+		// file, exactly as `volumes:` does).
+		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: /etc/app/cfg.yaml\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let engine = engine_with_base("/srv/project");
+		let binds = engine
+			.build_config_binds(&file.services["web"], &file)
+			.unwrap();
+		assert_eq!(binds, vec!["/etc/app/cfg.yaml:/cfg:ro"]);
 	}
 }

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -19,7 +19,7 @@ pub mod update;
 
 pub use compose::{
 	parse_file, parse_file_with_env_files, parse_files_with_env_files, parse_str, parse_str_raw,
-	resolve_order,
+	resolve_levels, resolve_order,
 };
 pub use engine::{Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -15,12 +15,19 @@ use crate::ComposeError;
 /// The release asset name for the platform this binary was built for. Mirrors
 /// the `release.yml` build matrix exactly.
 pub fn platform_asset() -> Option<&'static str> {
-	match (std::env::consts::OS, std::env::consts::ARCH) {
+	asset_for(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+/// Map an OS/ARCH pair to its release asset name. Split out from
+/// [`platform_asset`] so the full matrix is testable without the host's values.
+fn asset_for(os: &str, arch: &str) -> Option<&'static str> {
+	match (os, arch) {
 		("linux", "x86_64") => Some("podup-linux-x86_64"),
 		("linux", "aarch64") => Some("podup-linux-arm64"),
 		("macos", "aarch64") => Some("podup-darwin-arm64"),
 		("macos", "x86_64") => Some("podup-darwin-x86_64"),
 		("windows", "x86_64") => Some("podup-windows-x86_64.exe"),
+		("windows", "aarch64") => Some("podup-windows-arm64.exe"),
 		_ => None,
 	}
 }
@@ -156,6 +163,28 @@ mod tests {
 		// release matrix names.
 		if let Some(asset) = platform_asset() {
 			assert!(asset.starts_with("podup-"));
+		}
+	}
+
+	#[test]
+	fn platform_asset_covers_every_release_target() {
+		// Pins the OS/ARCH → asset mapping to the full `release.yml` build
+		// matrix so a newly added prebuilt (or a dropped arm) is caught here
+		// instead of failing self-update silently in the field.
+		let expected = [
+			(("linux", "x86_64"), "podup-linux-x86_64"),
+			(("linux", "aarch64"), "podup-linux-arm64"),
+			(("macos", "aarch64"), "podup-darwin-arm64"),
+			(("macos", "x86_64"), "podup-darwin-x86_64"),
+			(("windows", "x86_64"), "podup-windows-x86_64.exe"),
+			(("windows", "aarch64"), "podup-windows-arm64.exe"),
+		];
+		for ((os, arch), asset) in expected {
+			assert_eq!(
+				asset_for(os, arch),
+				Some(asset),
+				"self-update mapping drifted for {os}/{arch}"
+			);
 		}
 	}
 


### PR DESCRIPTION
## Summary
Four changes from a compatibility/security/efficiency audit of the codebase.

### 1. Concurrent startup by dependency level (efficiency)
`up` started every service serially, even independent ones. New `resolve_levels` groups services into Kahn layers — within a level there are no `depends_on` relationships, so they start concurrently via `try_join_all`; a barrier between levels preserves ordering and `service_healthy`/`service_completed` waits. Safe because the libpod client is connection-per-request and `Engine` holds no per-call mutable state. Per-service logic extracted into `up_one_service`.

### 2. arm64-Windows self-update (bug)
`platform_asset()` had no `windows/aarch64` arm, so Windows-on-ARM users got "self-update is not supported" even though `podup-windows-arm64.exe` has shipped since v0.12.0. Added the mapping; split out `asset_for` and pinned the full release matrix in a test so the drift can't recur. Fixes the stale "mirrors release.yml exactly" comment.

### 3. secret/config `file:` path resolution (consistency + bug)
Secret/config `file:` host paths were forwarded to Podman raw, unlike `volumes:` which route through `resolve_bind_source`. Consequence: a relative `file:` resolved against the Podman service cwd (broken), not the project dir. Now routed through the same resolver — relative paths anchor to the project directory, `~` expands. Not a new attack surface (`volumes:` already mounts arbitrary host paths); just makes secrets consistent and fixes relative paths.

### 4. Warn on unknown service keys (footgun)
Unknown service keys were silently dropped (no `deny_unknown_fields`), so `enviroment:` just vanished. Now captured into a flattened map and warned about; `x-*` extensions are tolerated per spec and forward-compatible keys still parse (no hard error).

## Tests
820 pass (clippy + fmt clean). Added: `resolve_levels` layering/cycle, full self-update matrix, unknown-key capture, relative/absolute secret-config path resolution.

## Not done (needs your call, noted in handoff)
- `deny_unknown_fields` as a hard error (chose warn to avoid regressing x-/forward-compat files).
- Package-manager guard on `podup update` (relevant once .deb/PPA ships).