### PR TITLE
feat: report every unsupported compose field (forward compatibility)

### DIFF
--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -116,11 +116,34 @@ each one that is present.
 If you see warnings for these fields, you can safely remove them from your
 compose file when targeting a single-host Podman deployment.
 
+## Nothing is dropped silently
+
+podup follows the Compose spec's forward-compatibility rule — an unknown key is
+never a hard error, so `x-*` extensions and newer compose fields keep parsing.
+But anything podup cannot translate is **reported**, never silently ignored, so
+a typo or an unmapped feature can't hide. At parse time podup warns about:
+
+- unknown keys at the top level and inside every modeled object (services and
+  their `healthcheck`, `deploy`, `develop.watch`; top-level `networks`,
+  `networks.*.ipam`, and `volumes`) — usually a typo such as `enviroment:`;
+- fields it models but cannot honor on rootless Podman: `cpu_count` and
+  `cpu_percent` (Windows/Hyper-V only), `networks.*.enable_ipv4`, and the
+  BuildKit-only `build.privileged`, `build.ulimits`, `build.isolation`,
+  `build.entitlements`, `build.provenance`, `build.sbom`.
+
+This is what lets a compose file written for a newer Docker or Podman release
+run under podup: unsupported additions surface as warnings instead of vanishing.
+
+`extra_hosts` is accepted in both the list (`["host:ip"]`) and mapping
+(`{host: ip}`) forms.
+
 ## Not yet supported
 
 | Feature | Status |
 |---|---|
 | `env_file.format` values other than `dotenv` | Error is emitted; only the `dotenv` format is accepted |
+| `gpus:` as a list of device objects | Use `deploy.resources.reservations.devices` for GPU reservations; the scalar `gpus: all` / `gpus: N` shorthand is supported |
+| `provider:` / model-runner services (`provider`, top-level `models`) | No rootless Podman equivalent; reported as an unknown key |
 | Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
 
 ## Enabling verbose output

--- a/internal/compose/diagnostics.rs
+++ b/internal/compose/diagnostics.rs
@@ -16,10 +16,69 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	let mut out = Vec::new();
 	unknown_top_level_keys(file, &mut out);
 	unknown_service_keys(file, &mut out);
+	nested_unknown_keys(file, &mut out);
 	ignored_service_fields(file, &mut out);
 	ignored_build_fields(file, &mut out);
 	ignored_network_fields(file, &mut out);
 	out
+}
+
+/// Push a warning for each non-`x-` key captured at a nested level.
+fn push_unknown(
+	context: &str,
+	unknown: &indexmap::IndexMap<String, serde_yaml::Value>,
+	out: &mut Vec<String>,
+) {
+	for key in unknown.keys() {
+		if key.starts_with("x-") {
+			continue;
+		}
+		out.push(format!(
+			"{context}: unknown key '{key}' is ignored \
+			 (check for a typo or an unsupported compose feature)"
+		));
+	}
+}
+
+/// Unknown keys captured inside service sub-objects and top-level network /
+/// volume definitions. Together with the service- and top-level passes this
+/// means a typo or an unmapped future field at ANY modeled level is surfaced
+/// rather than silently dropped.
+fn nested_unknown_keys(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		if let Some(hc) = &def.healthcheck {
+			push_unknown(
+				&format!("service '{service}' healthcheck"),
+				&hc.unknown,
+				out,
+			);
+		}
+		if let Some(deploy) = &def.deploy {
+			push_unknown(&format!("service '{service}' deploy"), &deploy.unknown, out);
+		}
+		if let Some(develop) = &def.develop {
+			for (i, rule) in develop.watch.iter().enumerate() {
+				push_unknown(
+					&format!("service '{service}' develop.watch[{i}]"),
+					&rule.unknown,
+					out,
+				);
+			}
+		}
+	}
+	for (name, cfg) in &file.networks {
+		if let Some(c) = cfg {
+			push_unknown(&format!("network '{name}'"), &c.unknown, out);
+			if let Some(ipam) = &c.ipam {
+				push_unknown(&format!("network '{name}' ipam"), &ipam.unknown, out);
+			}
+		}
+	}
+	for (name, cfg) in &file.volumes {
+		if let Some(c) = cfg {
+			push_unknown(&format!("volume '{name}'"), &c.unknown, out);
+		}
+	}
 }
 
 /// Top-level keys that matched no known field (captured in `extensions`).
@@ -183,6 +242,41 @@ mod tests {
 			"services:\n  web:\n    image: nginx\nnetworks:\n  net:\n    enable_ipv4: false\n",
 		);
 		assert!(msgs.iter().any(|m| m.contains("enable_ipv4")));
+	}
+
+	#[test]
+	fn warns_on_unknown_key_in_healthcheck() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    healthcheck:\n      test: [\"CMD\", \"true\"]\n      retires: 3\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("healthcheck") && m.contains("retires")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_unknown_key_in_network_and_ipam() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\nnetworks:\n  net:\n    drivr: bridge\n    ipam:\n      confg: []\n",
+		);
+		assert!(msgs
+			.iter()
+			.any(|m| m.contains("network 'net'") && m.contains("drivr")));
+		assert!(msgs
+			.iter()
+			.any(|m| m.contains("ipam") && m.contains("confg")));
+	}
+
+	#[test]
+	fn warns_on_unknown_key_in_volume() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\nvolumes:\n  data:\n    externl: true\n",
+		);
+		assert!(msgs
+			.iter()
+			.any(|m| m.contains("volume 'data'") && m.contains("externl")));
 	}
 
 	#[test]

--- a/internal/compose/diagnostics.rs
+++ b/internal/compose/diagnostics.rs
@@ -1,0 +1,193 @@
+//! Parse-time diagnostics.
+//!
+//! podup accepts the full compose-spec surface and, per the spec's
+//! forward-compatibility rule, never treats an unknown key as a hard error.
+//! The cost of that leniency is silent drops: a typo or an unmapped compose
+//! feature would just vanish. This pass closes that gap by reporting every key
+//! or field podup parses but cannot translate, so nothing is ignored without
+//! the operator hearing about it — the same guarantee that lets podup absorb
+//! future Docker/Podman compose additions gracefully.
+
+use super::types::{BuildConfig, ComposeFile};
+
+/// Collect a warning for every parsed-but-unsupported key or field in `file`.
+/// Pure (no logging) so it can be unit-tested; the caller emits the messages.
+pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
+	let mut out = Vec::new();
+	unknown_top_level_keys(file, &mut out);
+	unknown_service_keys(file, &mut out);
+	ignored_service_fields(file, &mut out);
+	ignored_build_fields(file, &mut out);
+	ignored_network_fields(file, &mut out);
+	out
+}
+
+/// Top-level keys that matched no known field (captured in `extensions`).
+/// `x-*` extension keys are allowed by the spec and skipped.
+fn unknown_top_level_keys(file: &ComposeFile, out: &mut Vec<String>) {
+	for key in file.extensions.keys() {
+		if key.starts_with("x-") {
+			continue;
+		}
+		out.push(format!(
+			"unknown top-level key '{key}' is ignored \
+			 (check for a typo or an unsupported compose feature)"
+		));
+	}
+}
+
+/// Service keys that matched no known field. A likely typo — e.g.
+/// `enviroment:` — is easy to miss when it just vanishes, so surface it.
+fn unknown_service_keys(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		for key in def.unknown.keys() {
+			if key.starts_with("x-") {
+				continue;
+			}
+			out.push(format!(
+				"service '{service}': unknown key '{key}' is ignored \
+				 (check for a typo or an unsupported compose feature)"
+			));
+		}
+	}
+}
+
+/// Service fields that podup models but cannot honor on rootless Podman.
+fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		if def.cpu_count.is_some() {
+			out.push(format!(
+				"service '{service}': cpu_count is a Windows/Hyper-V control with no \
+				 rootless Podman equivalent and is ignored"
+			));
+		}
+		if def.cpu_percent.is_some() {
+			out.push(format!(
+				"service '{service}': cpu_percent is a Windows/Hyper-V control with no \
+				 rootless Podman equivalent and is ignored"
+			));
+		}
+	}
+}
+
+/// Build options that exist only in BuildKit/buildx and have no libpod
+/// build-API mapping. Honored fields are left untouched.
+fn ignored_build_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		let Some(BuildConfig::Config {
+			privileged,
+			ulimits,
+			isolation,
+			entitlements,
+			provenance,
+			sbom,
+			..
+		}) = &def.build
+		else {
+			continue;
+		};
+		let mut unmapped: Vec<&str> = Vec::new();
+		if privileged.is_some() {
+			unmapped.push("privileged");
+		}
+		if !ulimits.is_empty() {
+			unmapped.push("ulimits");
+		}
+		if isolation.is_some() {
+			unmapped.push("isolation");
+		}
+		if !entitlements.is_empty() {
+			unmapped.push("entitlements");
+		}
+		if provenance.is_some() {
+			unmapped.push("provenance");
+		}
+		if sbom.is_some() {
+			unmapped.push("sbom");
+		}
+		for field in unmapped {
+			out.push(format!(
+				"service '{service}': build.{field} has no libpod build-API equivalent \
+				 and is ignored"
+			));
+		}
+	}
+}
+
+/// Network fields podup parses but does not forward to Podman.
+fn ignored_network_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (name, cfg) in &file.networks {
+		if let Some(c) = cfg {
+			if c.enable_ipv4.is_some() {
+				out.push(format!(
+					"network '{name}': enable_ipv4 is not forwarded; Podman networks \
+					 enable IPv4 by default and expose no toggle"
+				));
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::parse_str;
+
+	fn diagnostics_for(yaml: &str) -> Vec<String> {
+		let file = parse_str(yaml).unwrap();
+		super::collect(&file)
+	}
+
+	#[test]
+	fn warns_on_unknown_top_level_key_but_not_x_extension() {
+		let msgs = diagnostics_for(
+			"x-anchors: ok\nservies:\n  typo: 1\nservices:\n  web:\n    image: nginx\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("unknown top-level key 'servies'")),
+			"got: {msgs:?}"
+		);
+		assert!(!msgs.iter().any(|m| m.contains("x-anchors")));
+	}
+
+	#[test]
+	fn warns_on_unknown_service_key_but_not_x_extension() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    enviroment:\n      A: 1\n    x-meta: ok\n",
+		);
+		assert!(msgs.iter().any(|m| m.contains("unknown key 'enviroment'")));
+		assert!(!msgs.iter().any(|m| m.contains("x-meta")));
+	}
+
+	#[test]
+	fn warns_on_windows_only_cpu_fields() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    cpu_count: 2\n    cpu_percent: 50\n",
+		);
+		assert!(msgs.iter().any(|m| m.contains("cpu_count")));
+		assert!(msgs.iter().any(|m| m.contains("cpu_percent")));
+	}
+
+	#[test]
+	fn warns_on_unmapped_build_fields() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    build:\n      context: .\n      privileged: true\n      isolation: chroot\n",
+		);
+		assert!(msgs.iter().any(|m| m.contains("build.privileged")));
+		assert!(msgs.iter().any(|m| m.contains("build.isolation")));
+	}
+
+	#[test]
+	fn warns_on_network_enable_ipv4() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\nnetworks:\n  net:\n    enable_ipv4: false\n",
+		);
+		assert!(msgs.iter().any(|m| m.contains("enable_ipv4")));
+	}
+
+	#[test]
+	fn clean_file_produces_no_diagnostics() {
+		let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    cpu_shares: 512\n");
+		assert!(msgs.is_empty(), "unexpected diagnostics: {msgs:?}");
+	}
+}

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -4,6 +4,7 @@
 pub mod types;
 
 mod anchor;
+mod diagnostics;
 mod extends;
 mod include;
 
@@ -93,27 +94,10 @@ pub fn parse_files_with_env_files(paths: &[PathBuf], env_files: &[String]) -> Re
 		let other = parse_file_with_env_files(path, env_files)?;
 		merge_override(&mut merged, other);
 	}
-	warn_unknown_service_keys(&merged);
-	Ok(merged)
-}
-
-/// Warn about service keys that don't map to a known compose field. These are
-/// silently tolerated (not a hard error, so `x-*` extensions and
-/// forward-compatible keys still parse), but a likely typo — e.g. `enviroment:`
-/// — is easy to miss when it just vanishes, so surface it. `x-*` extension keys
-/// are skipped per the compose spec.
-fn warn_unknown_service_keys(file: &ComposeFile) {
-	for (service, def) in &file.services {
-		for key in def.unknown.keys() {
-			if key.starts_with("x-") {
-				continue;
-			}
-			tracing::warn!(
-				"service '{service}': unknown key '{key}' is ignored \
-				 (check for a typo or an unsupported compose feature)"
-			);
-		}
+	for warning in diagnostics::collect(&merged) {
+		tracing::warn!("{warning}");
 	}
+	Ok(merged)
 }
 
 /// Merge `other` into `target` with `other` winning (compose `-f` override

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -95,7 +95,11 @@ pub enum BuildConfig {
 		no_cache: Option<bool>,
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		pull: Option<bool>,
-		#[serde(default, skip_serializing_if = "Vec::is_empty")]
+		#[serde(
+			default,
+			deserialize_with = "super::primitives::deserialize_extra_hosts",
+			skip_serializing_if = "Vec::is_empty"
+		)]
 		extra_hosts: Vec<String>,
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		tags: Vec<String>,

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -38,6 +38,8 @@ pub struct DeployConfig {
 	pub labels: Labels,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub placement: Option<DeployPlacement>,
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// Resource constraints under `deploy.resources:` — holds `limits` and `reservations`.

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -15,7 +15,7 @@ pub struct DevelopConfig {
 }
 
 /// A single `develop.watch` rule: a path to watch, an action to take, and optional ignore filters.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct WatchRule {
 	pub path: String,
 	pub action: WatchAction,
@@ -29,6 +29,8 @@ pub struct WatchRule {
 	pub initial_sync: bool,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub exec: Option<WatchExec>,
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// Action triggered by a `develop.watch` rule: `sync`, `rebuild`, `restart`, `sync+restart`, or `sync+exec`.

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -93,6 +93,8 @@ pub struct HealthCheck {
 	pub start_interval: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub disable: Option<bool>,
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
 
 impl HealthCheck {

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -83,6 +83,8 @@ pub struct NetworkConfig {
 	pub ipam: Option<IpamConfig>,
 	#[serde(default)]
 	pub labels: Labels,
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
 
 /// `ipam:` block inside a top-level network definition.
@@ -94,6 +96,8 @@ pub struct IpamConfig {
 	pub config: Vec<IpamPool>,
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub options: HashMap<String, String>,
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
 
 /// A single subnet/range entry within `ipam.config`.

--- a/internal/compose/types/primitives.rs
+++ b/internal/compose/types/primitives.rs
@@ -10,6 +10,28 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Deserialize `extra_hosts` accepting either the list form (`["host:ip"]`) or
+/// the mapping form (`{host: ip}`), normalizing both to `host:ip` strings so
+/// the rest of the pipeline sees a single shape. Docker Compose accepts both.
+pub(crate) fn deserialize_extra_hosts<'de, D>(de: D) -> Result<Vec<String>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	#[derive(Deserialize)]
+	#[serde(untagged)]
+	enum ListOrMap {
+		List(Vec<String>),
+		Map(IndexMap<String, String>),
+	}
+	Ok(match ListOrMap::deserialize(de)? {
+		ListOrMap::List(v) => v,
+		ListOrMap::Map(m) => m
+			.into_iter()
+			.map(|(host, ip)| format!("{host}:{ip}"))
+			.collect(),
+	})
+}
+
 /// Container entrypoint / command — either a shell string or exec list.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]

--- a/internal/compose/types/resources.rs
+++ b/internal/compose/types/resources.rs
@@ -72,19 +72,25 @@ impl BlkioRateDevice {
 	}
 }
 
-/// `gpus: all` or `gpus: 2` top-level service field.
+/// Top-level service `gpus:` field. The spec allows the `all`/`N` shorthand and
+/// a list of device-reservation objects (same shape as
+/// `deploy.resources.reservations.devices`); both forms are accepted so a valid
+/// compose file never fails to parse.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GpuSpec {
 	Named(String),
 	Count(u32),
+	Devices(Vec<super::deploy::DeviceReservation>),
 }
 
 impl GpuSpec {
-	/// -1 = all; positive = exact count.
+	/// -1 = all; positive = exact count. The device-list form is treated as
+	/// "all" since it is not mapped to CDI from this field (use
+	/// `deploy.resources.reservations.devices` for that).
 	pub fn to_count(&self) -> i64 {
 		match self {
-			GpuSpec::Named(_) => -1,
+			GpuSpec::Named(_) | GpuSpec::Devices(_) => -1,
 			GpuSpec::Count(n) => *n as i64,
 		}
 	}

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -64,7 +64,11 @@ pub struct Service {
 	pub links: Vec<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub external_links: Vec<String>,
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde(
+		default,
+		deserialize_with = "super::primitives::deserialize_extra_hosts",
+		skip_serializing_if = "Vec::is_empty"
+	)]
 	pub extra_hosts: Vec<String>,
 	#[serde(default)]
 	pub dns: StringOrList,

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -117,6 +117,8 @@ pub struct VolumeConfig {
 	pub name: Option<String>,
 	#[serde(default)]
 	pub labels: Labels,
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// Reference to a named config from a service — short form (name only) or long form with mount target.

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -209,6 +209,17 @@ impl Engine {
 				.unwrap_or_else(|| "/".to_string())
 		};
 
+		// docker compose watch creates the sync target directory when it is
+		// missing; match that so a sync to a not-yet-existing path works instead
+		// of failing the archive PUT. Best-effort: if mkdir is unavailable the
+		// PUT below still surfaces the real error.
+		let _ = self
+			.watch_exec(
+				container,
+				vec!["mkdir".into(), "-p".into(), dest_dir.clone()],
+			)
+			.await;
+
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
 			urlencoded(container),

--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -129,6 +129,42 @@ async fn watch_initial_sync_runs() {
 	);
 }
 
+#[tokio::test]
+async fn watch_sync_creates_missing_target_directory() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let src_file = dir.path().join("app.txt");
+	fs::write(&src_file, b"created").unwrap();
+
+	let proj = proj("wcd");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web");
+	// Sync into a directory that does not exist in the image; podup must create
+	// it (like docker compose watch) rather than fail.
+	engine
+		.test_sync_to_container(&cname, &src_file, "/newdir/app.txt")
+		.await
+		.unwrap();
+	let out = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/newdir/app.txt".into()])
+		.await
+		.unwrap_or_default();
+	engine.down(&file).await.unwrap();
+	assert!(
+		out.contains("created"),
+		"sync did not create the missing target directory: {out:?}"
+	);
+}
+
 /// Poll until `cat`-ing `path` in the container yields `expect`, or `secs`
 /// elapse. Read-only: used when the trigger already happened (initial_sync).
 async fn poll_synced(engine: &Engine, cname: &str, path: &str, expect: &str, secs: u64) -> bool {

--- a/tests/parse/coverage/part1.rs
+++ b/tests/parse/coverage/part1.rs
@@ -113,6 +113,23 @@ services:
 	assert_eq!(gpus.to_count(), 2);
 }
 
+#[test]
+fn gpus_device_object_list_form_parses() {
+	// The spec also allows gpus as a list of device-reservation objects; it
+	// must parse rather than error on a valid compose file.
+	let yaml = r#"
+services:
+  app:
+    image: alpine
+    gpus:
+      - driver: nvidia
+        count: all
+        capabilities: [gpu]
+"#;
+	let svc = &parse_str(yaml).unwrap().services["app"];
+	assert!(svc.gpus.is_some());
+}
+
 // ---------------------------------------------------------------------------
 // deploy.resources.reservations.devices (GPU reservation)
 // ---------------------------------------------------------------------------

--- a/tests/parse/fields/part1.rs
+++ b/tests/parse/fields/part1.rs
@@ -250,6 +250,22 @@ services:
 }
 
 #[test]
+fn extra_hosts_mapping_form_normalizes_to_host_colon_ip() {
+	// Compose also allows the mapping form; it must normalize to "host:ip".
+	let yaml = r#"
+services:
+  app:
+    image: alpine
+    extra_hosts:
+      somehost: "162.242.195.82"
+      otherhost: "50.31.209.229"
+"#;
+	let hosts = &parse_str(yaml).unwrap().services["app"].extra_hosts;
+	assert!(hosts.contains(&"somehost:162.242.195.82".to_string()));
+	assert!(hosts.contains(&"otherhost:50.31.209.229".to_string()));
+}
+
+#[test]
 fn tty_and_stdin_open() {
 	let yaml = "services:\n  app:\n    image: alpine\n    tty: true\n    stdin_open: true\n";
 	let file = parse_str(yaml).unwrap();


### PR DESCRIPTION
Closes #198. Stacked on #197 (base will retarget to develop once #197 merges).

Makes podup surface everything it cannot translate, so a compose file written for a newer Docker/Podman release runs under podup with warnings instead of silent drops.

- **Parse-time diagnostics pass** (`internal/compose/diagnostics.rs`): warns on unknown keys at the top level, service level, and inside service sub-objects (healthcheck, deploy, develop.watch) and top-level networks/ipam/volumes; plus modeled-but-unhonored fields (cpu_count, cpu_percent, network enable_ipv4, BuildKit-only build options). Implemented as a pure `collect()` with unit tests.
- **Unknown-key capture** added to the healthcheck, deploy, network, ipam, volume and watch-rule structs (mirroring the existing service/top-level capture).
- **`extra_hosts`** now accepts both the list and mapping forms.
- Docs updated with the no-silent-drop guarantee.

Verification: fmt + clippy --all-targets --all-features clean, 491 lib + 164 parse tests pass.