### PR TITLE
chore: finalize the 0.13.0 changelog for release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-podup (0.13.0) UNRELEASED; urgency=medium
+podup (0.13.0) unstable; urgency=medium
 
   * Harden the Quadlet export against hostile compose input: reject path
     traversal in generated unit file names and strip control characters from
@@ -13,6 +13,14 @@ podup (0.13.0) UNRELEASED; urgency=medium
     icu dependency chain that required 1.86 was removed, so Debian trixie can
     now build the package.
   * Ship a podup(1) man page and a command-reference doc.
+  * Report every unsupported or unknown compose field at parse time instead of
+    dropping it silently, including unknown keys inside service sub-objects and
+    top-level network and volume definitions, so a typo or a newer Docker or
+    Podman field is surfaced rather than ignored.
+  * Accept the mapping form of extra_hosts and the device-object list form of
+    gpus.
+  * Create the watch sync target directory when it is missing, matching the
+    behaviour of docker compose watch.
 
  -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 12 Jun 2026 16:00:00 -0500
 


### PR DESCRIPTION
Mark the debian/changelog 0.13.0 entry `unstable` and add the compose-spec-coverage bullets. Last step before the v0.13.0 release PR (develop -> main).