### PR TITLE
release: v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,10 +759,11 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "clap",
+ "clap_complete",
  "ed25519-dalek",
  "flate2",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"
@@ -31,6 +31,7 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 indexmap = { version = "2", features = ["serde"] }
 futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.12.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.14.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+podup (0.14.0) unstable; urgency=medium
+
+  * Surface diagnostics by default: forward-compatibility warnings about unknown
+    or unsupported compose fields now print even with no RUST_LOG set, and all
+    warnings and errors go to stderr (keeping stdout a clean pipe for config and
+    generate output).
+  * Prefix all user-facing output with "podup:" and unify the warning format, so
+    the emitter is identifiable in journald and multi-tool logs.
+  * Install a panic hook that prints a "podup: internal error:" notice with a
+    bug-report link and a reminder to redact secrets before sharing logs, in
+    place of a raw Rust backtrace.
+  * Warn (without blocking) when generating Quadlet units on a non-Linux host,
+    since the systemd units will not run there.
+  * Add a "podup completions <shell>" subcommand (bash, zsh, fish, powershell,
+    elvish); the package installs the bash, zsh and fish scripts.
+  * Fix native-Windows path handling: expand "~" via USERPROFILE and join with
+    the platform separator, and classify a "C:\\..." drive-letter volume source
+    as a bind mount rather than a named volume.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 12 Jun 2026 18:00:00 -0500
+
 podup (0.13.0) unstable; urgency=medium
 
   * Harden the Quadlet export against hostile compose input: reject path

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -128,6 +128,11 @@ Update podup to the latest signed release. Verifies the release's Ed25519
 signature against the embedded public key and its SHA-256 checksum, failing
 closed. \fB\-\-check\fR only reports whether a newer release exists;
 \fB\-\-force\fR reinstalls even when not newer.
+.TP
+.B completions \fISHELL\fR
+Print a shell completion script to stdout for \fBbash\fR, \fBzsh\fR, \fBfish\fR,
+\fBpowershell\fR or \fBelvish\fR. The Debian package installs the bash, zsh and
+fish scripts automatically.
 .SH ENVIRONMENT
 .TP
 .B COMPOSE_FILE

--- a/debian/rules
+++ b/debian/rules
@@ -29,6 +29,14 @@ override_dh_auto_test:
 
 override_dh_auto_install:
 	install -D -m 0755 target/release/podup debian/podup/usr/bin/podup
+	# Shell completions, generated from the freshly built binary so they can
+	# never drift from the CLI definition.
+	install -d debian/podup/usr/share/bash-completion/completions
+	install -d debian/podup/usr/share/zsh/vendor-completions
+	install -d debian/podup/usr/share/fish/vendor_completions.d
+	target/release/podup completions bash > debian/podup/usr/share/bash-completion/completions/podup
+	target/release/podup completions zsh  > debian/podup/usr/share/zsh/vendor-completions/_podup
+	target/release/podup completions fish > debian/podup/usr/share/fish/vendor_completions.d/podup.fish
 
 override_dh_auto_clean:
 	cargo clean

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -101,6 +101,10 @@ print to stdout; warnings about fields with no Quadlet mapping go to stderr.
 podup generate quadlet -o ~/.config/containers/systemd
 ```
 
+Quadlet units are consumed by systemd, so they only run on Linux. Generating
+them on macOS or Windows is allowed (e.g. to deploy to a remote Linux host) but
+prints a `podup: warning:` to stderr noting the files will not run on the host.
+
 ## Watch
 
 ### `watch`
@@ -121,3 +125,26 @@ Replace the running binary with the latest signed release.
 Verification fails closed: a missing key, bad Ed25519 signature, or SHA-256
 mismatch aborts before the installed binary is touched. See
 [self-update.md](self-update.md) for the trust model.
+
+## Shell completions
+
+### `completions <SHELL>`
+Print a shell completion script to stdout for `bash`, `zsh`, `fish`,
+`powershell`, or `elvish`. The Debian package installs the bash/zsh/fish files
+automatically; otherwise source the output from your shell startup:
+
+```bash
+podup completions bash > ~/.local/share/bash-completion/completions/podup
+podup completions zsh  > "${fpath[1]}/_podup"
+podup completions fish > ~/.config/fish/completions/podup.fish
+```
+
+## Diagnostics
+
+podup writes warnings and errors to **stderr**, prefixed with `podup:` (so the
+emitter is identifiable in journald and multi-tool logs) while stdout stays a
+clean pipe (e.g. the YAML from `config`, the units from `generate quadlet`).
+Forward-compatibility warnings about unknown or unsupported compose fields are
+shown by default; set `RUST_LOG=debug` for verbose tracing. An unexpected
+internal error prints a `podup: internal error:` notice with a bug-report link
+and a reminder to redact secrets before sharing logs.

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 
 #[derive(Parser)]
 #[command(
@@ -231,6 +232,15 @@ pub(crate) enum Commands {
 		/// Reinstall even if the latest release is not newer than this build.
 		#[arg(long)]
 		force: bool,
+	},
+	/// Print a shell completion script to stdout.
+	///
+	/// Generates a completion script for the named shell from the CLI
+	/// definition. Source it from your shell's startup (or install the file the
+	/// Debian package ships) to get tab completion for podup commands and flags.
+	Completions {
+		/// Shell to generate completions for (bash, zsh, fish, powershell, elvish).
+		shell: Shell,
 	},
 }
 

--- a/internal/engine/container.rs
+++ b/internal/engine/container.rs
@@ -301,12 +301,17 @@ pub(super) fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
 		return src.to_string();
 	}
 	let expanded = if let Some(rest) = src.strip_prefix("~/") {
-		match std::env::var("HOME") {
-			Ok(home) => format!("{home}/{rest}"),
-			Err(_) => src.to_string(),
+		// Join with the platform separator rather than hardcoding `/`, and look
+		// up the home directory in a platform-correct way (USERPROFILE on
+		// native Windows, where HOME is usually unset).
+		match home_dir() {
+			Some(home) => home.join(rest).to_string_lossy().into_owned(),
+			None => src.to_string(),
 		}
 	} else if src == "~" {
-		std::env::var("HOME").unwrap_or_else(|_| src.to_string())
+		home_dir()
+			.map(|h| h.to_string_lossy().into_owned())
+			.unwrap_or_else(|| src.to_string())
 	} else {
 		src.to_string()
 	};
@@ -315,6 +320,16 @@ pub(super) fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
 	} else {
 		base_dir.join(&expanded).to_string_lossy().into_owned()
 	}
+}
+
+/// The current user's home directory. Prefers `HOME` (set on Unix and most
+/// shells), falling back to `USERPROFILE` for native Windows where `HOME` is
+/// usually absent. Empty values are treated as unset.
+fn home_dir() -> Option<std::path::PathBuf> {
+	std::env::var_os("HOME")
+		.or_else(|| std::env::var_os("USERPROFILE"))
+		.filter(|v| !v.is_empty())
+		.map(std::path::PathBuf::from)
 }
 
 /// Resolve a service's `links` to concrete container references.

--- a/internal/engine/volume_mounts.rs
+++ b/internal/engine/volume_mounts.rs
@@ -151,18 +151,13 @@ pub(crate) fn build_mounts_all(
 /// Returns `Some((mount, named))` where exactly one of the two is `Some`.
 /// Named volumes go to `SpecGenerator.volumes`; bind mounts go to `mounts`.
 fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> {
-	let parts: Vec<&str> = s.splitn(3, ':').collect();
-	let (src, dst, opts_str) = match parts.len() {
-		1 => (parts[0], parts[0], ""),
-		2 => (parts[0], parts[1], ""),
-		_ => (parts[0], parts[1], parts[2]),
-	};
+	let (src, dst, opts_str) = split_volume_spec(s);
 	let opts: Vec<String> = opts_str
 		.split(',')
 		.map(|o| o.trim().to_string())
 		.filter(|o| !o.is_empty())
 		.collect();
-	if src.starts_with('/') || src.starts_with('.') || src.starts_with('~') {
+	if is_bind_source(src) {
 		Some((
 			Some(Mount {
 				mount_type: "bind".into(),
@@ -186,6 +181,45 @@ fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> 
 				sub_path: None,
 			}),
 		))
+	}
+}
+
+/// Whether `s` begins with a Windows drive-letter prefix (e.g. `C:`), so the
+/// colon that follows is part of the path rather than a `src:dst` separator.
+fn has_windows_drive_prefix(s: &str) -> bool {
+	let b = s.as_bytes();
+	b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':'
+}
+
+/// Classify a short-form volume source. A leading `/`, `.` or `~` marks a host
+/// path bind; a Windows drive prefix (`C:\...`) does too. Anything else is a
+/// named volume.
+fn is_bind_source(src: &str) -> bool {
+	src.starts_with('/')
+		|| src.starts_with('.')
+		|| src.starts_with('~')
+		|| has_windows_drive_prefix(src)
+}
+
+/// Split a short-form volume spec into `(src, dst, opts)`. Colons separate the
+/// fields, except the colon in a leading Windows drive prefix, which belongs to
+/// the source path. The destination is always an in-container (Unix) path, so
+/// only the source can carry a drive letter.
+fn split_volume_spec(s: &str) -> (&str, &str, &str) {
+	let scan_from = if has_windows_drive_prefix(s) { 2 } else { 0 };
+	let seps: Vec<usize> = s
+		.bytes()
+		.enumerate()
+		.skip(scan_from)
+		.filter(|&(_, b)| b == b':')
+		.map(|(i, _)| i)
+		.take(2)
+		.collect();
+	match seps.as_slice() {
+		[] => (s, s, ""),
+		[a] => (&s[..*a], &s[a + 1..], ""),
+		[a, b] => (&s[..*a], &s[a + 1..*b], &s[b + 1..]),
+		_ => unreachable!("take(2) yields at most two separators"),
 	}
 }
 
@@ -245,9 +279,32 @@ fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOptions>) {
 
 #[cfg(test)]
 mod tests {
-	use super::build_mounts_all;
+	use super::{build_mounts_all, is_bind_source, split_volume_spec};
 	use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
 	use std::path::Path;
+
+	#[test]
+	fn windows_drive_source_is_a_bind_not_a_named_volume() {
+		// `C:\data:/in/container` — the drive colon must not be read as the
+		// src/dst separator, and the source must classify as a bind.
+		assert_eq!(
+			split_volume_spec(r"C:\data:/in/container"),
+			(r"C:\data", "/in/container", "")
+		);
+		assert!(is_bind_source(r"C:\data"));
+		assert!(is_bind_source("D:/forward/slash"));
+	}
+
+	#[test]
+	fn unix_volume_split_is_unchanged() {
+		assert_eq!(split_volume_spec("vol:/data"), ("vol", "/data", ""));
+		assert_eq!(split_volume_spec("./src:/dst:ro"), ("./src", "/dst", "ro"));
+		assert_eq!(split_volume_spec("named"), ("named", "named", ""));
+		assert!(!is_bind_source("named"));
+		assert!(is_bind_source("/abs"));
+		assert!(is_bind_source("./rel"));
+		assert!(is_bind_source("~/home"));
+	}
 
 	fn svc_with_volumes(vols: Vec<VolumeMount>) -> Service {
 		Service {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -3,7 +3,11 @@
 use std::path::Path;
 use std::process;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
 mod cli;
@@ -11,6 +15,52 @@ mod resolve;
 
 use cli::*;
 use resolve::*;
+
+/// Canonical project URL, reused for the bug-report hint on internal errors.
+const REPO_URL: &str = "https://github.com/Glyndor/podup";
+
+/// Event formatter that renders every diagnostic as `podup: <level>: <message>`
+/// on a single line, matching the prefix used by the CLI's own `eprintln!`
+/// warnings and errors. This unifies the compose forward-compat diagnostics
+/// (emitted via `tracing::warn!`) with the rest of podup's user-facing output.
+struct PodupFormat;
+
+impl<S, N> FormatEvent<S, N> for PodupFormat
+where
+	S: Subscriber + for<'a> LookupSpan<'a>,
+	N: for<'a> FormatFields<'a> + 'static,
+{
+	fn format_event(
+		&self,
+		ctx: &FmtContext<'_, S, N>,
+		mut writer: Writer<'_>,
+		event: &Event<'_>,
+	) -> std::fmt::Result {
+		write!(writer, "podup: {}: ", level_word(*event.metadata().level()))?;
+		ctx.field_format().format_fields(writer.by_ref(), event)?;
+		writeln!(writer)
+	}
+}
+
+/// Map a tracing level to the user-facing word used in `podup:` output.
+fn level_word(level: tracing::Level) -> &'static str {
+	match level {
+		tracing::Level::ERROR => "error",
+		tracing::Level::WARN => "warning",
+		tracing::Level::INFO => "info",
+		tracing::Level::DEBUG => "debug",
+		tracing::Level::TRACE => "trace",
+	}
+}
+
+/// Guidance printed after an internal error or panic: where to report it and a
+/// reminder to scrub secrets first. Kept off ordinary, user-correctable errors.
+fn internal_error_notice() -> String {
+	format!(
+		"podup: this looks like a bug; re-run with RUST_LOG=debug and report it at {REPO_URL}/issues\n\
+		 podup: redact secrets (passwords, tokens, resolved env values) from any logs before sharing"
+	)
+}
 
 /// Whether a command creates, destroys, or changes the state of containers and
 /// so must hold the exclusive project lock.
@@ -31,6 +81,19 @@ fn is_mutating(command: &Commands) -> bool {
 	)
 }
 
+/// Quadlet units are systemd unit files; they only run on Linux hosts (where
+/// systemd consumes them from `~/.config/containers/systemd/`). Generating them
+/// on macOS/Windows is legitimate (e.g. to deploy to a remote Linux host), so
+/// this returns an advisory string rather than blocking. `os` is
+/// [`std::env::consts::OS`]; the function is pure so every platform's branch is
+/// testable in a single run.
+fn quadlet_platform_advisory(os: &str) -> Option<String> {
+	(os != "linux").then(|| {
+		"quadlet units require systemd (Linux); generated files will not run on this host"
+			.to_string()
+	})
+}
+
 /// Generate Quadlet units from the compose file and either write them to a
 /// directory or print them to stdout. Warnings about unmapped fields go to
 /// stderr so stdout stays clean for piping.
@@ -40,8 +103,11 @@ fn write_quadlet(
 	output: Option<&Path>,
 ) -> podup::Result<()> {
 	let result = podup::quadlet::generate(file, project);
+	if let Some(advisory) = quadlet_platform_advisory(std::env::consts::OS) {
+		eprintln!("podup: warning: {advisory}");
+	}
 	for warning in &result.warnings {
-		eprintln!("warning: {warning}");
+		eprintln!("podup: warning: {warning}");
 	}
 	match output {
 		Some(dir) => {
@@ -77,26 +143,50 @@ fn write_quadlet(
 
 #[tokio::main]
 async fn main() {
+	// Replace the default panic output (a raw Rust backtrace) with a `podup:`
+	// internal-error notice that tells the user what to report and where, plus
+	// the reminder to redact secrets first.
+	std::panic::set_hook(Box::new(|info| {
+		eprintln!("podup: internal error: {info}");
+		eprintln!("{}", internal_error_notice());
+	}));
+
 	match run().await {
 		Ok(()) => {}
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
 		Err(e @ podup::ComposeError::Update(_)) => {
-			eprintln!("error: {e}");
+			eprintln!("podup: error: {e}");
 			process::exit(podup::update::exit_code(&e));
 		}
 		Err(e) => {
-			eprintln!("error: {e}");
+			eprintln!("podup: error: {e}");
 			process::exit(1);
 		}
 	}
 }
 
 async fn run() -> podup::Result<()> {
+	// Surface diagnostics by default: with no `RUST_LOG` set, show warnings (so
+	// the forward-compat "unknown field" notices are never silently dropped),
+	// and write them to stderr so a command's stdout stays a clean pipe.
 	tracing_subscriber::fmt()
-		.with_env_filter(EnvFilter::from_default_env())
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+		)
+		.with_writer(std::io::stderr)
+		.event_format(PodupFormat)
 		.init();
 
 	let cli = Cli::parse();
+
+	// `completions` derives entirely from the static CLI definition; it neither
+	// parses a compose file nor contacts Podman. Print to stdout for piping.
+	if let Commands::Completions { shell } = cli.command {
+		let mut cmd = Cli::command();
+		let name = cmd.get_name().to_string();
+		clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+		return Ok(());
+	}
 
 	// `update` operates on the binary itself, not a compose project, so it runs
 	// before any compose file is parsed or Podman is contacted. The network and
@@ -231,7 +321,43 @@ async fn run() -> podup::Result<()> {
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
+		Commands::Completions { .. } => unreachable!("handled before compose parsing"),
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn quadlet_advisory_only_on_non_linux() {
+		assert_eq!(quadlet_platform_advisory("linux"), None);
+		for os in ["macos", "windows", "freebsd"] {
+			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
+			assert!(msg.contains("systemd"), "advisory names the requirement");
+		}
+	}
+
+	#[test]
+	fn level_words_match_user_facing_terms() {
+		assert_eq!(level_word(tracing::Level::WARN), "warning");
+		assert_eq!(level_word(tracing::Level::ERROR), "error");
+	}
+
+	#[test]
+	fn internal_error_notice_reports_and_warns_on_secrets() {
+		let notice = internal_error_notice();
+		assert!(notice.contains(REPO_URL), "points at the issue tracker");
+		assert!(notice.contains("/issues"));
+		assert!(
+			notice.contains("redact"),
+			"reminds the user to scrub secrets"
+		);
+		assert!(
+			notice.contains("RUST_LOG=debug"),
+			"tells the user what to capture"
+		);
+	}
 }

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -1,0 +1,76 @@
+//! CLI-level checks for diagnostic surfacing: forward-compat warnings must be
+//! visible with no `RUST_LOG` set, must go to stderr, and must carry the
+//! `podup:` program prefix — while stdout stays a clean YAML pipe for `config`.
+
+use std::fs;
+use std::process::Command;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Write a compose file with an unsupported key into a fresh temp dir and
+/// return its path. The unknown key drives the forward-compat diagnostic.
+fn compose_with_unknown_key() -> std::path::PathBuf {
+	let dir = std::env::temp_dir().join(format!("podup-diag-{}", std::process::id()));
+	fs::create_dir_all(&dir).expect("create temp dir");
+	let path = dir.join("compose.yaml");
+	fs::write(
+		&path,
+		"services:\n  web:\n    image: nginx:1.27\n    bogus_field: oops\n",
+	)
+	.expect("write compose file");
+	path
+}
+
+#[test]
+fn config_warns_on_stderr_with_clean_stdout_and_no_rust_log() {
+	let file = compose_with_unknown_key();
+	let output = Command::new(bin())
+		.arg("-f")
+		.arg(&file)
+		.arg("config")
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup config");
+
+	assert!(output.status.success(), "config exits cleanly");
+
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	let stderr = String::from_utf8_lossy(&output.stderr);
+
+	// The diagnostic fires by default (no RUST_LOG) and lands on stderr with
+	// the unified `podup: warning:` prefix.
+	assert!(
+		stderr.contains("podup: warning:"),
+		"warning prefixed and on stderr; got stderr:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("bogus_field"),
+		"warning names the unknown key; got stderr:\n{stderr}"
+	);
+
+	// stdout is the resolved YAML only — no diagnostics interleaved.
+	assert!(stdout.contains("services:"), "stdout carries the YAML");
+	assert!(
+		!stdout.contains("warning"),
+		"stdout stays a clean pipe; got stdout:\n{stdout}"
+	);
+
+	let _ = fs::remove_dir_all(file.parent().unwrap());
+}
+
+#[test]
+fn completions_emit_a_script_to_stdout() {
+	let output = Command::new(bin())
+		.args(["completions", "bash"])
+		.output()
+		.expect("run podup completions bash");
+	assert!(output.status.success(), "completions exits cleanly");
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	assert!(
+		stdout.contains("_podup") || stdout.contains("complete"),
+		"emits a bash completion script; got:\n{}",
+		&stdout[..stdout.len().min(200)]
+	);
+}

--- a/tests/secret_safety.rs
+++ b/tests/secret_safety.rs
@@ -1,0 +1,80 @@
+//! Regression guard for the secret-safety rule: diagnostics and logs must print
+//! secret/config/env **names**, never their resolved **values**.
+//!
+//! The engine already complies (it logs `{name}`, stages bytes without logging
+//! them, and errors reference `/run/secrets/{name}` rather than contents). This
+//! test fails closed if a future change adds a logging or printing macro that
+//! interpolates a binding whose name marks it as a secret value, so a stray
+//! `debug!("{value}")` on the env/secret path cannot regress unnoticed.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Output macros that reach a user-visible channel (logs, stdout, stderr).
+const OUTPUT_MACROS: &[&str] = &[
+	"trace!",
+	"debug!",
+	"info!",
+	"warn!",
+	"error!",
+	"eprintln!",
+	"println!",
+	"eprint!",
+	"print!",
+];
+
+/// Interpolation fragments that name a resolved secret/env *value* rather than
+/// a key. A logging line containing one of these is almost certainly a leak.
+const BANNED_INTERPOLATIONS: &[&str] = &[
+	"{value}",
+	"{value:",
+	"{val}",
+	"{secret}",
+	"{password}",
+	"{passwd}",
+	"{token}",
+	"{contents}",
+	"{plaintext}",
+];
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+	for entry in fs::read_dir(dir).expect("read internal/ dir") {
+		let path = entry.expect("dir entry").path();
+		if path.is_dir() {
+			rust_sources(&path, out);
+		} else if path.extension().is_some_and(|e| e == "rs") {
+			out.push(path);
+		}
+	}
+}
+
+#[test]
+fn output_macros_never_interpolate_secret_values() {
+	let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("internal");
+	let mut files = Vec::new();
+	rust_sources(&root, &mut files);
+	assert!(!files.is_empty(), "found source files to scan");
+
+	let mut offenders = Vec::new();
+	for file in &files {
+		let text = fs::read_to_string(file).expect("read source");
+		for (lineno, line) in text.lines().enumerate() {
+			let is_output = OUTPUT_MACROS.iter().any(|m| line.contains(m));
+			if !is_output {
+				continue;
+			}
+			if let Some(bad) = BANNED_INTERPOLATIONS.iter().find(|b| line.contains(**b)) {
+				offenders.push(format!(
+					"{}:{}: interpolates {bad} into output",
+					file.display(),
+					lineno + 1
+				));
+			}
+		}
+	}
+	assert!(
+		offenders.is_empty(),
+		"output must log secret/env names, not values:\n{}",
+		offenders.join("\n")
+	);
+}


### PR DESCRIPTION
Release v0.14.0 — the remaining forward-work batch.

- #203 — diagnostics surfaced by default, on stderr, with a unified `podup:` prefix; panic hook with bug-report + redact guidance; secret-safety guard test.
- #204 — non-Linux quadlet generation warns (no block).
- #205 — `podup completions <shell>`; Debian package installs bash/zsh/fish.
- #206 — native-Windows bind-source (`~`/`USERPROFILE`, `Path::join`) and `C:\` volume-source classification.

No public API change (minor bump). All CI green on #207 incl. Windows, Semver, dpkg-buildpackage, Coverage.

Merge commit (not squash) per release branch flow. Tag `v0.14.0` follows on main to trigger the release pipeline.