### PR TITLE
security: redact inline secret content in config output and use constant-time digest comparison

### DIFF
--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -97,3 +97,86 @@ pub struct ComposeFile {
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub extensions: IndexMap<String, serde_yaml::Value>,
 }
+
+/// Placeholder substituted for inline secret/config `content:` values when the
+/// file is rendered for display.
+pub const REDACTED_PLACEHOLDER: &str = "<redacted>";
+
+impl ComposeFile {
+	/// Replace every inline `content:` value under `secrets:` and `configs:`
+	/// with [`REDACTED_PLACEHOLDER`], so rendering the file for display (the
+	/// `config` subcommand) never writes secret material to stdout. References
+	/// to a `file:` or `environment:` source are left untouched — they name a
+	/// source, they do not embed the value.
+	pub fn redact_inline_content(&mut self) {
+		for secret in self.secrets.values_mut() {
+			if secret.content.is_some() {
+				secret.content = Some(REDACTED_PLACEHOLDER.to_string());
+			}
+		}
+		for config in self.configs.values_mut() {
+			if config.content.is_some() {
+				config.content = Some(REDACTED_PLACEHOLDER.to_string());
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::parse_str;
+
+	#[test]
+	fn redacts_inline_secret_and_config_content() {
+		let yaml = r#"
+secrets:
+  inline_secret:
+    content: super-secret-value
+  file_secret:
+    file: ./token.txt
+configs:
+  inline_config:
+    content: embedded-config-body
+  env_config:
+    environment: CONFIG_FROM_ENV
+"#;
+		let mut file = parse_str(yaml).unwrap();
+		file.redact_inline_content();
+
+		assert_eq!(
+			file.secrets["inline_secret"].content.as_deref(),
+			Some("<redacted>")
+		);
+		// A `file:` source carries no embedded value, so nothing to redact.
+		assert!(file.secrets["file_secret"].content.is_none());
+		assert_eq!(
+			file.secrets["file_secret"].file.as_deref(),
+			Some("./token.txt")
+		);
+
+		assert_eq!(
+			file.configs["inline_config"].content.as_deref(),
+			Some("<redacted>")
+		);
+		// An `environment:` source names an env var; the value is not embedded.
+		assert!(file.configs["env_config"].content.is_none());
+		assert_eq!(
+			file.configs["env_config"].environment.as_deref(),
+			Some("CONFIG_FROM_ENV")
+		);
+	}
+
+	#[test]
+	fn rendered_config_never_contains_inline_secret_value() {
+		let yaml = r#"
+secrets:
+  db_password:
+    content: hunter2-do-not-leak
+"#;
+		let mut file = parse_str(yaml).unwrap();
+		file.redact_inline_content();
+		let rendered = serde_yaml::to_string(&file).unwrap();
+		assert!(!rendered.contains("hunter2-do-not-leak"));
+		assert!(rendered.contains("<redacted>"));
+	}
+}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -205,7 +205,9 @@ async fn run() -> podup::Result<()> {
 	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
 
 	if matches!(cli.command, Commands::Config) {
-		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
+		let mut redacted = file.clone();
+		redacted.redact_inline_content();
+		let yaml = serde_yaml::to_string(&redacted).map_err(podup::ComposeError::Parse)?;
 		println!("{yaml}");
 		return Ok(());
 	}

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -143,10 +143,29 @@ pub fn sha256_hex(data: &[u8]) -> String {
 	out
 }
 
+/// Compare two byte slices in constant time, returning `true` when equal.
+///
+/// The running time depends only on the length, not on where the first
+/// differing byte sits, so it leaks no information about a partial match.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+	if a.len() != b.len() {
+		return false;
+	}
+	let mut diff = 0u8;
+	for (x, y) in a.iter().zip(b.iter()) {
+		diff |= x ^ y;
+	}
+	diff == 0
+}
+
 /// Verify the downloaded bytes hash to `expected_hex` (case-insensitive).
+///
+/// The digest comparison runs in constant time so it cannot leak how many
+/// leading bytes matched.
 pub fn verify_digest(data: &[u8], expected_hex: &str) -> crate::Result<()> {
 	let actual = sha256_hex(data);
-	if actual.eq_ignore_ascii_case(expected_hex) {
+	let expected = expected_hex.to_ascii_lowercase();
+	if constant_time_eq(actual.as_bytes(), expected.as_bytes()) {
 		Ok(())
 	} else {
 		Err(ComposeError::Update(format!(
@@ -288,6 +307,16 @@ efb48becd0c057f6248e91ccbc5b0795edcfbdf66eb5535f24938a5bba7c4ab2  podup-darwin-x
 		verify_digest(data, &hex).unwrap();
 		verify_digest(data, &hex.to_ascii_uppercase()).unwrap();
 		assert!(verify_digest(data, &"0".repeat(64)).is_err());
+		// A length mismatch is rejected, not panicked on.
+		assert!(verify_digest(data, "deadbeef").is_err());
+	}
+
+	#[test]
+	fn constant_time_eq_matches_only_identical_slices() {
+		assert!(constant_time_eq(b"abc", b"abc"));
+		assert!(!constant_time_eq(b"abc", b"abd"));
+		assert!(!constant_time_eq(b"abc", b"ab"));
+		assert!(constant_time_eq(b"", b""));
 	}
 
 	#[test]


### PR DESCRIPTION
Resolves two hardening gaps from the Glyndor standards audit.

- `podup config` no longer prints inline `secrets:`/`configs:` `content:` values; they are replaced with `<redacted>` before rendering (`file:`/`environment:` sources untouched).
- `verify_digest` now compares digests in constant time instead of `eq_ignore_ascii_case`.

Unit tests added for both. No new dependency.

Closes #209