### PR TITLE
ci: use tabs in sign.py and double-quoted YAML in CI caller

### DIFF
--- a/.github/scripts/sign.py
+++ b/.github/scripts/sign.py
@@ -14,27 +14,27 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 def main() -> None:
-    if len(sys.argv) < 3:
-        print(__doc__, file=sys.stderr)
-        sys.exit(1)
+	if len(sys.argv) < 3:
+		print(__doc__, file=sys.stderr)
+		sys.exit(1)
 
-    key_b64 = sys.argv[1]
-    input_file = sys.argv[2]
-    sig_file = sys.argv[3] if len(sys.argv) > 3 else input_file + ".sig"
+	key_b64 = sys.argv[1]
+	input_file = sys.argv[2]
+	sig_file = sys.argv[3] if len(sys.argv) > 3 else input_file + ".sig"
 
-    key_bytes = base64.b64decode(key_b64 + "==")
-    private_key = Ed25519PrivateKey.from_private_bytes(key_bytes)
+	key_bytes = base64.b64decode(key_b64 + "==")
+	private_key = Ed25519PrivateKey.from_private_bytes(key_bytes)
 
-    with open(input_file, "rb") as f:
-        data = f.read()
+	with open(input_file, "rb") as f:
+		data = f.read()
 
-    sig = private_key.sign(data)
+	sig = private_key.sign(data)
 
-    with open(sig_file, "wb") as f:
-        f.write(sig)
+	with open(sig_file, "wb") as f:
+		f.write(sig)
 
-    print(f"signed {input_file} ({len(data):,} bytes) → {sig_file} ({len(sig)} bytes)")
+	print(f"signed {input_file} ({len(data):,} bytes) → {sig_file} ({len(sig)} bytes)")
 
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   rust:
     uses: Glyndor/.github/.github/workflows/rust-ci.yml@2de584f368690524992185b30e23f342c19aab23 # main
     with:
-      extra-test-os: '["macos-latest", "windows-latest"]'
+      extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       podman: true
       coverage-threshold: 90
       msrv: "1.85"


### PR DESCRIPTION
Style-standard drift in CI tooling: `sign.py` used four-space indentation (standard mandates tabs for Python) and `ci.yml` single-quoted the `extra-test-os` value (standard mandates double quotes when quoting YAML). No behavioural change.

Closes #210