### PR TITLE
chore: release v0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+podup (0.14.1) unstable; urgency=medium
+
+  * Security: "podup config" no longer prints inline secret and config
+    "content:" values; they are replaced with "<redacted>" before rendering,
+    so secret material is never written to stdout.
+  * Security: verify release digests in constant time instead of a
+    short-circuiting case-insensitive comparison.
+  * Use tab indentation in the release signing script and double-quoted YAML
+    in the CI caller, matching the project style standard.
+  * Test coverage for every Quadlet unmapped-field warning.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 08:19:11 -0500
+
 podup (0.14.0) unstable; urgency=medium
 
   * Surface diagnostics by default: forward-compatibility warnings about unknown

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.13.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.14.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Release prep for v0.14.1. Bumps Cargo.toml/Cargo.lock, adds the Debian changelog entry and syncs the man page version string.

Includes (already on develop):
- security: redact inline secret content in `config` output + constant-time digest comparison (#212)
- ci: tab indentation in sign.py + double-quoted YAML caller (#213)
- test: cover all Quadlet unmapped-field warnings (#214)