### PR TITLE
release: v0.14.1

### DIFF
--- a/.github/scripts/sign.py
+++ b/.github/scripts/sign.py
@@ -14,27 +14,27 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 def main() -> None:
-    if len(sys.argv) < 3:
-        print(__doc__, file=sys.stderr)
-        sys.exit(1)
+	if len(sys.argv) < 3:
+		print(__doc__, file=sys.stderr)
+		sys.exit(1)
 
-    key_b64 = sys.argv[1]
-    input_file = sys.argv[2]
-    sig_file = sys.argv[3] if len(sys.argv) > 3 else input_file + ".sig"
+	key_b64 = sys.argv[1]
+	input_file = sys.argv[2]
+	sig_file = sys.argv[3] if len(sys.argv) > 3 else input_file + ".sig"
 
-    key_bytes = base64.b64decode(key_b64 + "==")
-    private_key = Ed25519PrivateKey.from_private_bytes(key_bytes)
+	key_bytes = base64.b64decode(key_b64 + "==")
+	private_key = Ed25519PrivateKey.from_private_bytes(key_bytes)
 
-    with open(input_file, "rb") as f:
-        data = f.read()
+	with open(input_file, "rb") as f:
+		data = f.read()
 
-    sig = private_key.sign(data)
+	sig = private_key.sign(data)
 
-    with open(sig_file, "wb") as f:
-        f.write(sig)
+	with open(sig_file, "wb") as f:
+		f.write(sig)
 
-    print(f"signed {input_file} ({len(data):,} bytes) → {sig_file} ({len(sig)} bytes)")
+	print(f"signed {input_file} ({len(data):,} bytes) → {sig_file} ({len(sig)} bytes)")
 
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   rust:
     uses: Glyndor/.github/.github/workflows/rust-ci.yml@2de584f368690524992185b30e23f342c19aab23 # main
     with:
-      extra-test-os: '["macos-latest", "windows-latest"]'
+      extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       podman: true
       coverage-threshold: 90
       msrv: "1.85"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+podup (0.14.1) unstable; urgency=medium
+
+  * Security: "podup config" no longer prints inline secret and config
+    "content:" values; they are replaced with "<redacted>" before rendering,
+    so secret material is never written to stdout.
+  * Security: verify release digests in constant time instead of a
+    short-circuiting case-insensitive comparison.
+  * Use tab indentation in the release signing script and double-quoted YAML
+    in the CI caller, matching the project style standard.
+  * Test coverage for every Quadlet unmapped-field warning.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 08:19:11 -0500
+
 podup (0.14.0) unstable; urgency=medium
 
   * Surface diagnostics by default: forward-compatibility warnings about unknown

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.13.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.14.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -97,3 +97,86 @@ pub struct ComposeFile {
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub extensions: IndexMap<String, serde_yaml::Value>,
 }
+
+/// Placeholder substituted for inline secret/config `content:` values when the
+/// file is rendered for display.
+pub const REDACTED_PLACEHOLDER: &str = "<redacted>";
+
+impl ComposeFile {
+	/// Replace every inline `content:` value under `secrets:` and `configs:`
+	/// with [`REDACTED_PLACEHOLDER`], so rendering the file for display (the
+	/// `config` subcommand) never writes secret material to stdout. References
+	/// to a `file:` or `environment:` source are left untouched — they name a
+	/// source, they do not embed the value.
+	pub fn redact_inline_content(&mut self) {
+		for secret in self.secrets.values_mut() {
+			if secret.content.is_some() {
+				secret.content = Some(REDACTED_PLACEHOLDER.to_string());
+			}
+		}
+		for config in self.configs.values_mut() {
+			if config.content.is_some() {
+				config.content = Some(REDACTED_PLACEHOLDER.to_string());
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::parse_str;
+
+	#[test]
+	fn redacts_inline_secret_and_config_content() {
+		let yaml = r#"
+secrets:
+  inline_secret:
+    content: super-secret-value
+  file_secret:
+    file: ./token.txt
+configs:
+  inline_config:
+    content: embedded-config-body
+  env_config:
+    environment: CONFIG_FROM_ENV
+"#;
+		let mut file = parse_str(yaml).unwrap();
+		file.redact_inline_content();
+
+		assert_eq!(
+			file.secrets["inline_secret"].content.as_deref(),
+			Some("<redacted>")
+		);
+		// A `file:` source carries no embedded value, so nothing to redact.
+		assert!(file.secrets["file_secret"].content.is_none());
+		assert_eq!(
+			file.secrets["file_secret"].file.as_deref(),
+			Some("./token.txt")
+		);
+
+		assert_eq!(
+			file.configs["inline_config"].content.as_deref(),
+			Some("<redacted>")
+		);
+		// An `environment:` source names an env var; the value is not embedded.
+		assert!(file.configs["env_config"].content.is_none());
+		assert_eq!(
+			file.configs["env_config"].environment.as_deref(),
+			Some("CONFIG_FROM_ENV")
+		);
+	}
+
+	#[test]
+	fn rendered_config_never_contains_inline_secret_value() {
+		let yaml = r#"
+secrets:
+  db_password:
+    content: hunter2-do-not-leak
+"#;
+		let mut file = parse_str(yaml).unwrap();
+		file.redact_inline_content();
+		let rendered = serde_yaml::to_string(&file).unwrap();
+		assert!(!rendered.contains("hunter2-do-not-leak"));
+		assert!(rendered.contains("<redacted>"));
+	}
+}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -205,7 +205,9 @@ async fn run() -> podup::Result<()> {
 	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
 
 	if matches!(cli.command, Commands::Config) {
-		let yaml = serde_yaml::to_string(&file).map_err(podup::ComposeError::Parse)?;
+		let mut redacted = file.clone();
+		redacted.redact_inline_content();
+		let yaml = serde_yaml::to_string(&redacted).map_err(podup::ComposeError::Parse)?;
 		println!("{yaml}");
 		return Ok(());
 	}

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -52,3 +52,69 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 		);
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use crate::parse_str;
+	use crate::quadlet::generate;
+
+	#[test]
+	fn warns_for_every_unmapped_field() {
+		let yaml = r#"
+services:
+  everything:
+    image: app:1.0
+    build: .
+    scale: 3
+    privileged: true
+    network_mode: host
+    volumes_from:
+      - other
+    profiles:
+      - debug
+    healthcheck:
+      test: ["CMD", "true"]
+    secrets:
+      - my_secret
+    configs:
+      - my_config
+secrets:
+  my_secret:
+    file: ./s.txt
+configs:
+  my_config:
+    file: ./c.txt
+"#;
+		let file = parse_str(yaml).unwrap();
+		let warnings = generate(&file, "proj").warnings;
+		let joined = warnings.join("\n");
+
+		for field in [
+			"build",
+			"scale/replicas",
+			"healthcheck",
+			"secrets",
+			"configs",
+			"volumes_from",
+			"network_mode",
+			"profiles",
+			"privileged",
+		] {
+			assert!(
+				joined.contains(field),
+				"missing warning for {field}; got:\n{joined}"
+			);
+		}
+	}
+
+	#[test]
+	fn clean_service_warns_about_nothing() {
+		let yaml = r#"
+services:
+  web:
+    image: nginx:1.27
+"#;
+		let file = parse_str(yaml).unwrap();
+		assert!(generate(&file, "proj").warnings.is_empty());
+	}
+}

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -143,10 +143,29 @@ pub fn sha256_hex(data: &[u8]) -> String {
 	out
 }
 
+/// Compare two byte slices in constant time, returning `true` when equal.
+///
+/// The running time depends only on the length, not on where the first
+/// differing byte sits, so it leaks no information about a partial match.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+	if a.len() != b.len() {
+		return false;
+	}
+	let mut diff = 0u8;
+	for (x, y) in a.iter().zip(b.iter()) {
+		diff |= x ^ y;
+	}
+	diff == 0
+}
+
 /// Verify the downloaded bytes hash to `expected_hex` (case-insensitive).
+///
+/// The digest comparison runs in constant time so it cannot leak how many
+/// leading bytes matched.
 pub fn verify_digest(data: &[u8], expected_hex: &str) -> crate::Result<()> {
 	let actual = sha256_hex(data);
-	if actual.eq_ignore_ascii_case(expected_hex) {
+	let expected = expected_hex.to_ascii_lowercase();
+	if constant_time_eq(actual.as_bytes(), expected.as_bytes()) {
 		Ok(())
 	} else {
 		Err(ComposeError::Update(format!(
@@ -288,6 +307,16 @@ efb48becd0c057f6248e91ccbc5b0795edcfbdf66eb5535f24938a5bba7c4ab2  podup-darwin-x
 		verify_digest(data, &hex).unwrap();
 		verify_digest(data, &hex.to_ascii_uppercase()).unwrap();
 		assert!(verify_digest(data, &"0".repeat(64)).is_err());
+		// A length mismatch is rejected, not panicked on.
+		assert!(verify_digest(data, "deadbeef").is_err());
+	}
+
+	#[test]
+	fn constant_time_eq_matches_only_identical_slices() {
+		assert!(constant_time_eq(b"abc", b"abc"));
+		assert!(!constant_time_eq(b"abc", b"abd"));
+		assert!(!constant_time_eq(b"abc", b"ab"));
+		assert!(constant_time_eq(b"", b""));
 	}
 
 	#[test]


### PR DESCRIPTION
Release v0.14.1 — standards-compliance hardening from the audit.

## Security
- Redact inline secret/config `content:` in `podup config` output (#212, #209)
- Constant-time release digest comparison (#212, #209)

## CI / style
- Tab indentation in sign.py, double-quoted YAML caller (#213, #210)

## Tests
- Cover all Quadlet unmapped-field warnings (#214, #211)

No breaking changes. Patch release.