### PR TITLE
chore: release v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.15.0) unstable; urgency=medium
+
+  * Security: validate the project name at the CLI boundary, rejecting unsafe
+    "--project"/"COMPOSE_PROJECT_NAME" values and compose "name:" fields before
+    any filesystem path is built from them (including the "generate quadlet"
+    path, which never locks or stages).
+  * Security: reject any execute bit in secret and config file "mode:" values; a
+    data file is never code.
+  * Deny "unsafe_code" crate-wide, opting back in only on the libc FFI modules so
+    a new unsafe block elsewhere fails the build.
+  * Pin cargo-audit in the security-audit workflow for reproducible runs.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 10:00:07 -0500
+
 podup (0.14.1) unstable; urgency=medium
 
   * Security: "podup config" no longer prints inline secret and config

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.14.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.15.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Release prep for v0.15.0: bumps Cargo.toml/Cargo.lock, adds the Debian changelog entry, and syncs the man page version string.

The minor bump reflects the new additive public API (`podup::is_safe_project_name`).

Includes (already on develop, from #218):
- Security: project-name validation at the CLI trust boundary
- Security: reject execute bits in secret/config file modes
- `#![deny(unsafe_code)]` crate-wide with scoped FFI allows
- `temp-env` in tests; pinned cargo-audit