### PR TITLE
release: v0.15.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo install cargo-audit --version "^0.22" --locked
 
       - name: Run cargo audit
         run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.15.0) unstable; urgency=medium
+
+  * Security: validate the project name at the CLI boundary, rejecting unsafe
+    "--project"/"COMPOSE_PROJECT_NAME" values and compose "name:" fields before
+    any filesystem path is built from them (including the "generate quadlet"
+    path, which never locks or stages).
+  * Security: reject any execute bit in secret and config file "mode:" values; a
+    data file is never code.
+  * Deny "unsafe_code" crate-wide, opting back in only on the libc FFI modules so
+    a new unsafe block elsewhere fails the build.
+  * Pin cargo-audit in the security-audit workflow for reproducible runs.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 10:00:07 -0500
+
 podup (0.14.1) unstable; urgency=medium
 
   * Security: "podup config" no longer prints inline secret and config

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.14.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.15.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/engine/container_fields.rs
+++ b/internal/engine/container_fields.rs
@@ -1,6 +1,10 @@
 //! Container-spec field builders: device mappings, block-I/O throttling,
 //! label-file labels, and Swarm-only deploy-field warnings.
 
+// libc FFI (stat, for device major/minor) is needed here; each block carries a
+// soundness comment.
+#![allow(unsafe_code)]
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -7,6 +7,9 @@
 //! serializes them with a `flock(2)` advisory lock on a per-user, per-project
 //! lock file; the lock is released when the returned guard is dropped.
 
+// libc FFI (flock) is needed here; each block carries a soundness comment.
+#![allow(unsafe_code)]
+
 use crate::error::{ComposeError, Result};
 
 use super::Engine;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -16,6 +16,7 @@ mod network;
 mod profiles;
 mod query;
 mod staging;
+pub use staging::is_safe_project_name;
 mod volume;
 mod volume_mounts;
 #[cfg(feature = "watch")]

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -48,12 +48,14 @@ mod tests {
 
 	#[test]
 	fn empty_slice_with_no_env_returns_empty() {
-		// Ensure COMPOSE_PROFILES is unset for this test.
-		// SAFETY: single-threaded test with no other thread reading the
-		// environment concurrently, so removing the var cannot race.
-		unsafe { std::env::remove_var("COMPOSE_PROFILES") };
-		let set = active_profiles_set(&[]);
-		assert!(set.is_empty());
+		// Scope COMPOSE_PROFILES to "unset" race-free: `temp-env` serializes
+		// the mutation and restores the prior value, avoiding the data race
+		// that a bare `std::env::remove_var` carries under the parallel test
+		// runner.
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			let set = active_profiles_set(&[]);
+			assert!(set.is_empty());
+		});
 	}
 
 	#[test]

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -10,6 +10,10 @@
 //! default ACLs already restrict access to the owning user; only the
 //! non-symlink directory check applies.
 
+// libc FFI (geteuid/chown) is needed here; each block carries a soundness
+// comment. Opt back into `unsafe` for this module only.
+#![allow(unsafe_code)]
+
 use crate::error::{ComposeError, Result};
 use std::path::PathBuf;
 
@@ -19,7 +23,7 @@ use std::path::Path;
 /// Whether `name` is safe to use as a single path component and container
 /// name prefix: non-empty, bounded, ASCII alphanumeric plus `-`/`_`/`.`,
 /// not starting with a dot (rejects `.`, `..` and hidden directories).
-pub(super) fn is_safe_project_name(name: &str) -> bool {
+pub fn is_safe_project_name(name: &str) -> bool {
 	!name.is_empty()
 		&& name.len() <= 128
 		&& !name.starts_with('.')
@@ -120,6 +124,8 @@ pub(super) fn write_private_file(path: &std::path::Path, content: &[u8]) -> Resu
 /// Rejects:
 /// - group-readable (`g+r`, 0o040) or world-readable (`o+r`, 0o004) bits — a
 ///   secret or config file must never be readable by other users.
+/// - any execute bit (`0o111`) — a secret/config file holds data, never code,
+///   so the execute bit has no legitimate use and is rejected unconditionally.
 /// - setuid (0o4000), setgid (0o2000), or sticky (0o1000) bits — these have no
 ///   legitimate use on a secret/config data file and are either a
 ///   misconfiguration or an attack attempt; reject unconditionally.
@@ -131,6 +137,13 @@ pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
 		return Err(ComposeError::Unsupported(format!(
 			"mode {mode:#o} for {} grants group- or world-read access to a secret/config file; \
 			 use a mode with no g+r or o+r bits (e.g. 0o400 or 0o600)",
+			path.display()
+		)));
+	}
+	if mode & 0o111 != 0 {
+		return Err(ComposeError::Unsupported(format!(
+			"mode {mode:#o} for {} sets an execute bit on a secret/config file; \
+			 only plain owner read/write bits are permitted (e.g. 0o400 or 0o600)",
 			path.display()
 		)));
 	}
@@ -381,7 +394,19 @@ mod apply_mode_tests {
 		std::fs::write(&file, b"value").expect("write");
 		assert!(apply_mode(&file, 0o400).is_ok());
 		assert!(apply_mode(&file, 0o600).is_ok());
-		assert!(apply_mode(&file, 0o700).is_ok());
+		assert!(apply_mode(&file, 0o200).is_ok());
+	}
+
+	#[test]
+	fn executable_mode_rejected() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let file = dir.path().join("secret");
+		std::fs::write(&file, b"value").expect("write");
+		// A secret/config file holds data, never code — the execute bit is
+		// rejected even when only the owner-execute bit is set.
+		assert!(apply_mode(&file, 0o100).is_err());
+		assert!(apply_mode(&file, 0o700).is_err());
+		assert!(apply_mode(&file, 0o500).is_err());
 	}
 
 	#[test]

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -4,6 +4,11 @@
 //! async engine that drives container lifecycle via Podman's native libpod
 //! REST API over a Unix socket or Windows named pipe.
 
+// `unsafe` is denied crate-wide; the few modules that need libc FFI opt back in
+// locally with `#![allow(unsafe_code)]` and a soundness comment per block, so a
+// new `unsafe` block elsewhere fails the build.
+#![deny(unsafe_code)]
+
 pub mod compose;
 pub(crate) mod dotenv;
 pub(crate) mod engine;
@@ -21,6 +26,6 @@ pub use compose::{
 	parse_file, parse_file_with_env_files, parse_files_with_env_files, parse_str, parse_str_raw,
 	resolve_levels, resolve_order,
 };
-pub use engine::{Engine, ProjectLock, RunOptions};
+pub use engine::{is_safe_project_name, Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -1,5 +1,8 @@
 //! `podup` — docker-compose to Podman translator CLI.
 
+// The binary carries no `unsafe`; deny it so any future addition is caught.
+#![deny(unsafe_code)]
+
 use std::path::Path;
 use std::process;
 
@@ -214,6 +217,18 @@ async fn run() -> podup::Result<()> {
 
 	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
 	let project = resolve_project_name(cli.project, file.name.as_deref(), &base_dir);
+
+	// Validate the resolved project name at the trust boundary, before it reaches
+	// any code path that builds a filesystem path from it (staging, lock files,
+	// quadlet generation). Explicit `-p`/`COMPOSE_PROJECT_NAME` values and the
+	// compose `name:` field are otherwise taken verbatim; rejecting an unsafe
+	// name here fails closed regardless of which command runs next.
+	if !podup::is_safe_project_name(&project) {
+		return Err(podup::ComposeError::Unsupported(format!(
+			"project name {project:?} is not a safe path component: use only ASCII \
+			 letters, digits, '-', '_', '.', not starting with '.', max 128 chars"
+		)));
+	}
 
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -1,5 +1,8 @@
 //! Podman socket connection helpers.
 
+// libc FFI (getuid) is needed here; the block carries a soundness comment.
+#![allow(unsafe_code)]
+
 use crate::error::Result;
 use crate::libpod::Client;
 #[cfg(any(not(windows), test))]

--- a/internal/resolve.rs
+++ b/internal/resolve.rs
@@ -119,13 +119,9 @@ mod tests {
 		std::fs::create_dir_all(&dir).unwrap();
 		let prev = std::env::current_dir().unwrap();
 		std::env::set_current_dir(&dir).unwrap();
-		// Guard against a COMPOSE_FILE set in the test environment.
-		let had_env = std::env::var_os("COMPOSE_FILE");
-		std::env::remove_var("COMPOSE_FILE");
-		let p = resolve_compose_files(&[]);
-		if let Some(v) = had_env {
-			std::env::set_var("COMPOSE_FILE", v);
-		}
+		// Scope COMPOSE_FILE to "unset" race-free so a value set in the test
+		// environment cannot leak in and `temp-env` restores it afterwards.
+		let p = temp_env::with_var_unset("COMPOSE_FILE", || resolve_compose_files(&[]));
 		std::env::set_current_dir(prev).unwrap();
 		let _ = std::fs::remove_dir_all(&dir);
 		assert_eq!(p, vec![PathBuf::from("docker-compose.yml")]);

--- a/tests/project_name_safety.rs
+++ b/tests/project_name_safety.rs
@@ -1,0 +1,79 @@
+//! Boundary guard: the CLI must reject an unsafe project name before it reaches
+//! any code path that builds a filesystem path from it.
+//!
+//! `--project` / `COMPOSE_PROJECT_NAME` and the compose `name:` field are taken
+//! verbatim, so a traversal value like `../evil` must be rejected up front —
+//! including on the `generate quadlet` path, which neither locks nor stages and
+//! would otherwise never consult `is_safe_project_name`.
+
+use std::fs;
+use std::process::Command;
+
+/// Write a minimal valid compose file into a fresh temp dir and return the dir.
+fn compose_dir() -> tempfile::TempDir {
+	let dir = tempfile::tempdir().expect("tempdir");
+	fs::write(
+		dir.path().join("docker-compose.yml"),
+		"services:\n  web:\n    image: alpine\n",
+	)
+	.expect("write compose");
+	dir
+}
+
+fn podup() -> Command {
+	Command::new(env!("CARGO_BIN_EXE_podup"))
+}
+
+#[test]
+fn rejects_traversal_project_name() {
+	let dir = compose_dir();
+	let out = podup()
+		.current_dir(dir.path())
+		.args(["-p", "../evil", "generate", "quadlet"])
+		.output()
+		.expect("run podup");
+
+	assert!(
+		!out.status.success(),
+		"unsafe project name must fail; stdout: {}",
+		String::from_utf8_lossy(&out.stdout)
+	);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("not a safe path component"),
+		"error must name the boundary check; got: {stderr}"
+	);
+}
+
+#[test]
+fn rejects_project_name_from_env() {
+	let dir = compose_dir();
+	let out = podup()
+		.current_dir(dir.path())
+		.env("COMPOSE_PROJECT_NAME", "../../etc")
+		.args(["generate", "quadlet"])
+		.output()
+		.expect("run podup");
+
+	assert!(
+		!out.status.success(),
+		"unsafe COMPOSE_PROJECT_NAME must fail"
+	);
+	assert!(String::from_utf8_lossy(&out.stderr).contains("not a safe path component"));
+}
+
+#[test]
+fn accepts_safe_project_name() {
+	let dir = compose_dir();
+	let out = podup()
+		.current_dir(dir.path())
+		.args(["-p", "my-app", "generate", "quadlet"])
+		.output()
+		.expect("run podup");
+
+	assert!(
+		out.status.success(),
+		"a safe project name must be accepted; stderr: {}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+}


### PR DESCRIPTION
## v0.15.0 — security hardening release

Security-audit (OWASP ASVS L3) hardening from #217/#218.

- Validate the project name at the CLI trust boundary (rejects unsafe `--project`/`COMPOSE_PROJECT_NAME` and compose `name:` before any path is built, incl. `generate quadlet`).
- Reject execute bits in secret/config file `mode:` values.
- `#![deny(unsafe_code)]` crate-wide with scoped libc-FFI allows.
- `temp-env` in tests; pinned `cargo-audit` in the audit workflow.

Minor bump for the new additive public API `podup::is_safe_project_name`.

All checks green on the prep PR (#219): tests (incl. new `project_name_safety` + `executable_mode_rejected`), clippy `-D warnings`, fmt, Coverage (90%), MSRV 1.85, Semver, macOS/Windows, dpkg-buildpackage.