### PR TITLE
chore: release v0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+podup (0.15.1) unstable; urgency=medium
+
+  * Reject non-finite, negative, and out-of-range CPU and duration values in the
+    numeric parsers instead of silently saturating the integer cast.
+  * URL-encode the daemon-returned exec id in the libpod exec-start path.
+  * Cap the size of compose, include, extends, and env files read into memory
+    (16 MiB) so an oversized or hostile file fails closed.
+  * Bound libpod response bodies (64 MiB), stream-reassembly buffers (256 MiB),
+    and socket connect time (30s) against a rogue or unresponsive daemon.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 11:02:20 -0500
+
 podup (0.15.0) unstable; urgency=medium
 
   * Security: validate the project name at the CLI boundary, rejecting unsafe

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.15.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.15.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Release prep for v0.15.1: bumps Cargo.toml/Cargo.lock, adds the Debian changelog entry, and syncs the man page version string.

Patch bump — no public API change (semver-checks green on #222).

Includes (already on develop, from #222): numeric-parse guards, exec_id URL encoding, file-size cap, and libpod response/stream/connect bounds.