### PR TITLE
release: v0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+podup (0.15.1) unstable; urgency=medium
+
+  * Reject non-finite, negative, and out-of-range CPU and duration values in the
+    numeric parsers instead of silently saturating the integer cast.
+  * URL-encode the daemon-returned exec id in the libpod exec-start path.
+  * Cap the size of compose, include, extends, and env files read into memory
+    (16 MiB) so an oversized or hostile file fails closed.
+  * Bound libpod response bodies (64 MiB), stream-reassembly buffers (256 MiB),
+    and socket connect time (30s) against a rogue or unresponsive daemon.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 11:02:20 -0500
+
 podup (0.15.0) unstable; urgency=medium
 
   * Security: validate the project name at the CLI boundary, rejecting unsafe

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.15.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.15.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -275,8 +275,13 @@ pub(crate) fn parse_file_inner_with_env(
 	dir: &Path,
 	extra_env_files: &[String],
 ) -> Result<ComposeFile> {
-	let content = std::fs::read_to_string(path)
-		.map_err(|_| ComposeError::FileNotFound(path.display().to_string()))?;
+	let content = crate::fsutil::read_to_string_capped(path).map_err(|e| {
+		if e.kind() == std::io::ErrorKind::NotFound {
+			ComposeError::FileNotFound(path.display().to_string())
+		} else {
+			ComposeError::Io(e)
+		}
+	})?;
 	let vars = if extra_env_files.is_empty() {
 		substitute::build_vars(dir)
 	} else {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -100,7 +100,10 @@ impl Engine {
 			detach: false,
 			tty: false,
 		};
-		let start_path = format!("{API_PREFIX}/exec/{exec_id}/start");
+		let start_path = format!(
+			"{API_PREFIX}/exec/{}/start",
+			crate::libpod::urlencoded(&exec_id)
+		);
 		let resp = self
 			.client
 			.post_json_stream(&start_path, &start_cfg)

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -49,7 +49,7 @@ pub fn load_env_file_entries(
 		}
 
 		let abs = base_dir.join(entry.path());
-		let content = match std::fs::read_to_string(&abs) {
+		let content = match crate::fsutil::read_to_string_capped(&abs) {
 			Ok(c) => c,
 			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
 				if entry.required() {

--- a/internal/fsutil.rs
+++ b/internal/fsutil.rs
@@ -1,0 +1,59 @@
+//! Filesystem helpers shared across parsing paths.
+
+use std::io;
+use std::path::Path;
+
+/// Upper bound on the size of any compose, include, extends, or env file podup
+/// will read into memory. Bounds memory use on an accidentally huge or hostile
+/// input before it reaches the substitution and YAML stages.
+pub(crate) const MAX_FILE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Read a file to a `String`, refusing inputs larger than [`MAX_FILE_BYTES`].
+///
+/// A drop-in replacement for [`std::fs::read_to_string`] that fails closed with
+/// an `InvalidData` error instead of allocating an unbounded buffer.
+pub(crate) fn read_to_string_capped(path: impl AsRef<Path>) -> io::Result<String> {
+	read_to_string_capped_with(path.as_ref(), MAX_FILE_BYTES)
+}
+
+fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
+	let meta = std::fs::metadata(path)?;
+	if meta.len() > max {
+		return Err(io::Error::new(
+			io::ErrorKind::InvalidData,
+			format!(
+				"{} is {} bytes, larger than the {max} byte limit",
+				path.display(),
+				meta.len()
+			),
+		));
+	}
+	std::fs::read_to_string(path)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::read_to_string_capped_with;
+
+	#[test]
+	fn reads_file_within_limit() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let f = dir.path().join("ok");
+		std::fs::write(&f, b"hello").expect("write");
+		assert_eq!(read_to_string_capped_with(&f, 16).unwrap(), "hello");
+	}
+
+	#[test]
+	fn rejects_file_over_limit() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let f = dir.path().join("big");
+		std::fs::write(&f, vec![b'x'; 32]).expect("write");
+		let err = read_to_string_capped_with(&f, 16).unwrap_err();
+		assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+	}
+
+	#[test]
+	fn missing_file_is_error() {
+		assert!(read_to_string_capped_with(std::path::Path::new("/no/such/file"), 16).is_err());
+	}
+}

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod dotenv;
 pub(crate) mod engine;
 pub mod env_file;
 pub(crate) mod error;
+pub(crate) mod fsutil;
 pub(crate) mod libpod;
 pub mod podman;
 pub mod ports;

--- a/internal/libpod/client.rs
+++ b/internal/libpod/client.rs
@@ -5,7 +5,7 @@
 //! API calls are sequential and infrequent.
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, Limited};
 use hyper::body::Incoming;
 use hyper::client::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
@@ -15,6 +15,15 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::error::PodmanError;
 
 type BoxBody = Full<Bytes>;
+
+/// Upper bound on a buffered (non-streaming) response body. Caps memory use
+/// when the daemon returns an oversized or runaway response.
+const MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+
+/// Ceiling on establishing the socket connection and HTTP handshake. Bounds the
+/// wait when the Podman socket is absent, busy, or unresponsive. This times the
+/// connect only — it does not limit the duration of a streaming response body.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Result alias for libpod client calls, fixing the error to [`PodmanError`].
 pub type Result<T> = std::result::Result<T, PodmanError>;
@@ -115,18 +124,29 @@ impl Client {
 
 	/// Send a request and return the raw response.
 	async fn send(&self, req: Request<BoxBody>) -> Result<Response<Incoming>> {
-		let mut sender = self.connect().await?;
+		let mut sender = tokio::time::timeout(CONNECT_TIMEOUT, self.connect())
+			.await
+			.map_err(|_| PodmanError::Api {
+				status: 0,
+				message: format!(
+					"timed out after {}s connecting to the Podman socket",
+					CONNECT_TIMEOUT.as_secs()
+				),
+			})??;
 		sender.send_request(req).await.map_err(PodmanError::Hyper)
 	}
 
-	/// Read the full response body into a `Vec<u8>`.
+	/// Read the full response body into a `Vec<u8>`, capped at
+	/// [`MAX_RESPONSE_BYTES`] so a rogue or runaway daemon cannot exhaust memory.
 	async fn read_body(resp: Response<Incoming>) -> Result<(StatusCode, Vec<u8>)> {
 		let status = resp.status();
-		let bytes = resp
-			.into_body()
+		let bytes = Limited::new(resp.into_body(), MAX_RESPONSE_BYTES)
 			.collect()
 			.await
-			.map_err(PodmanError::Hyper)?
+			.map_err(|e| PodmanError::Api {
+				status: 0,
+				message: format!("reading response body: {e}"),
+			})?
 			.to_bytes();
 		Ok((status, bytes.to_vec()))
 	}

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -22,6 +22,19 @@ pub enum LogOutput {
 /// Boxed stream alias used for parse_multiplexed and parse_json_lines return types.
 pub type BoxStream<T> = Pin<Box<dyn Stream<Item = Result<T, PodmanError>> + Send>>;
 
+/// Upper bound on the reassembly buffer for a single frame or JSON line. Bounds
+/// memory when the daemon advertises a huge frame size or never terminates a
+/// line, so a rogue or runaway daemon cannot exhaust memory.
+const MAX_STREAM_BUF: usize = 256 * 1024 * 1024;
+
+/// Error returned when the reassembly buffer exceeds [`MAX_STREAM_BUF`].
+fn stream_buf_overflow() -> PodmanError {
+	PodmanError::Api {
+		status: 0,
+		message: format!("stream chunk exceeds the {MAX_STREAM_BUF} byte limit"),
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Pure parsing helpers (also used by unit tests)
 // ---------------------------------------------------------------------------
@@ -81,6 +94,9 @@ pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
 					Some(Ok(frame)) => {
 						if let Ok(data) = frame.into_data() {
 							buf.extend_from_slice(&data);
+							if buf.len() > MAX_STREAM_BUF {
+								return Err(stream_buf_overflow());
+							}
 						}
 					}
 					Some(Err(e)) => return Err(PodmanError::from(e)),
@@ -139,6 +155,9 @@ pub fn parse_json_lines<T: serde::de::DeserializeOwned + Send + 'static>(
 					Some(Ok(frame)) => {
 						if let Ok(data) = frame.into_data() {
 							buf.extend_from_slice(&data);
+							if buf.len() > MAX_STREAM_BUF {
+								return Err(stream_buf_overflow());
+							}
 						}
 					}
 					Some(Err(e)) => return Err(PodmanError::from(e)),

--- a/internal/size.rs
+++ b/internal/size.rs
@@ -47,8 +47,15 @@ pub fn parse_memory(s: &str) -> Option<i64> {
 
 /// Parse a CPU count string like `"0.5"`, `"1"`, `"2.5"` into nano-CPUs
 /// (1 CPU = 1_000_000_000 nano-CPUs).
+///
+/// Returns `None` for non-finite (`NaN`/`inf`), negative, or out-of-`i64`-range
+/// values instead of silently saturating or wrapping the cast.
 pub fn parse_cpus(s: &str) -> Option<i64> {
-	s.trim().parse::<f64>().ok().map(|f| (f * 1e9) as i64)
+	let nanos = s.trim().parse::<f64>().ok()? * 1e9;
+	if !nanos.is_finite() || nanos < 0.0 || nanos > i64::MAX as f64 {
+		return None;
+	}
+	Some(nanos as i64)
 }
 
 /// Parse a duration like `5s`, `200ms`, `1m`, `1h` into seconds (rounded down).
@@ -97,6 +104,10 @@ pub fn parse_duration_nanos(s: &str) -> Option<i64> {
 		"h" => num * 3600.0 * 1e9,
 		_ => return None,
 	};
+	// Reject non-finite or out-of-range results rather than saturating the cast.
+	if !nanos.is_finite() || nanos < 0.0 || nanos > i64::MAX as f64 {
+		return None;
+	}
 	Some(nanos as i64)
 }
 
@@ -187,6 +198,18 @@ mod tests {
 		assert_eq!(parse_cpus(""), None);
 	}
 
+	#[test]
+	fn cpus_non_finite_is_none() {
+		assert_eq!(parse_cpus("nan"), None);
+		assert_eq!(parse_cpus("inf"), None);
+		assert_eq!(parse_cpus("1e300"), None);
+	}
+
+	#[test]
+	fn cpus_negative_is_none() {
+		assert_eq!(parse_cpus("-1"), None);
+	}
+
 	// parse_duration_secs
 
 	#[test]
@@ -244,5 +267,12 @@ mod tests {
 	#[test]
 	fn duration_nanos_nanoseconds() {
 		assert_eq!(parse_duration_nanos("500ns"), Some(500));
+	}
+
+	#[test]
+	fn duration_nanos_overflow_is_none() {
+		// A large finite value whose nanosecond product exceeds i64::MAX must
+		// return None rather than saturating to i64::MAX.
+		assert_eq!(parse_duration_nanos("99999999999h"), None);
 	}
 }

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -69,7 +69,7 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String>
 ///   the current process env it will *not* be overridden by the `.env` file.
 pub fn load_dotenv(dir: &Path) -> HashMap<String, String> {
 	let path = dir.join(".env");
-	let Ok(content) = std::fs::read_to_string(&path) else {
+	let Ok(content) = crate::fsutil::read_to_string_capped(&path) else {
 		return HashMap::new();
 	};
 
@@ -105,7 +105,7 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 		} else {
 			dir.join(path)
 		};
-		let Ok(content) = std::fs::read_to_string(&abs) else {
+		let Ok(content) = crate::fsutil::read_to_string_capped(&abs) else {
 			continue;
 		};
 		for (key, value) in crate::dotenv::parse(&content) {


### PR DESCRIPTION
## v0.15.1 — libpod/parser hardening

From the follow-up audit (#221/#222) of the two previously-unreviewed subsystems.

- Numeric-parse guards (reject non-finite/negative/overflow in cpu & duration parsers)
- URL-encode the daemon-returned exec id in the exec-start path
- 16 MiB cap on compose/include/extends/env file reads
- libpod: 64 MiB response cap, 256 MiB stream-buffer cap, 30s connect timeout

Patch bump, no public API change. All checks green on prep PR (#223).