### PR TITLE
feat: ship signed .deb release asset and guard update against package-managed installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,57 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  build-deb:
+    name: Build Debian package
+    needs: verify
+    runs-on: ubuntu-latest
+    container: debian:sid
+    permissions:
+      contents: read
+    steps:
+      - name: Install build tooling
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            build-essential \
+            dpkg-dev \
+            debhelper \
+            cargo \
+            rustc
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Build the package
+        run: |
+          dpkg-checkbuilddeps
+          dpkg-buildpackage -us -uc -b
+
+      - name: Stage the .deb into the workspace
+        run: |
+          deb=$(ls ../podup_*_amd64.deb 2>/dev/null | head -n1)
+          if [ -z "$deb" ]; then
+            echo "::error::no .deb artifact was produced"
+            exit 1
+          fi
+          cp "$deb" "$(basename "$deb")"
+          echo "Staged $(basename "$deb")"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: podup-deb
+          path: podup_*_amd64.deb
+          retention-days: 1
+          if-no-files-found: error
+
   release:
     name: Publish release
-    needs: build
+    needs: [build, build-deb]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -158,6 +206,16 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Resolve Debian package name
+        run: |
+          deb=$(ls podup_*_amd64.deb 2>/dev/null | head -n1)
+          if [ -z "$deb" ]; then
+            echo "::error::Debian package artifact missing"
+            exit 1
+          fi
+          echo "DEB=$deb" >> "$GITHUB_ENV"
+          echo "Releasing Debian package $deb"
+
       - name: Generate checksums
         run: |
           sha256sum \
@@ -167,9 +225,10 @@ jobs:
             podup-darwin-x86_64 \
             podup-windows-x86_64.exe \
             podup-windows-arm64.exe \
+            "$DEB" \
             > SHA256SUMS
 
-      - name: Sign SHA256SUMS
+      - name: Sign SHA256SUMS and the Debian package
         env:
           RELEASE_SIGN_KEY: ${{ secrets.RELEASE_SIGN_KEY }}
           PYTHONUTF8: "1"
@@ -181,6 +240,7 @@ jobs:
           fi
           python3 -m pip install --quiet --require-hashes -r .github/scripts/sign-requirements.txt
           python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" SHA256SUMS
+          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "$DEB"
 
       - name: Create GitHub Release
         env:
@@ -202,13 +262,15 @@ jobs:
             podup-windows-x86_64.exe.sig \
             podup-windows-arm64.exe \
             podup-windows-arm64.exe.sig \
+            "$DEB" \
+            "$DEB.sig" \
             SHA256SUMS \
             SHA256SUMS.sig \
             install.sh \
             install.ps1
 
       - name: Remove release artifacts
-        run: rm -f podup-* SHA256SUMS SHA256SUMS.sig
+        run: rm -f podup-* podup_* SHA256SUMS SHA256SUMS.sig
 
       - name: Publish to crates.io
         env:

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -14,6 +14,20 @@ Requires `debhelper`, `cargo` and `rustc >= 1.85` (the crate's declared
 `rust-version`). The package installs `/usr/bin/podup` and the `podup(1)` man
 page.
 
+## Prebuilt .deb from releases
+
+Each tagged release attaches a signed `podup_<version>_amd64.deb` (with its
+`.sig`, and an entry in the release `SHA256SUMS`) built on Debian sid. Install
+it directly:
+
+```bash
+sudo apt install ./podup_<version>_amd64.deb
+```
+
+`podup update` refuses to self-replace a binary installed this way — it would
+desync dpkg's record of the file — and points back to the package manager;
+upgrade with `apt` instead.
+
 > **Debian compatibility note:** the MSRV is 1.85, which Debian trixie ships, so
 > trixie and sid can both build the package. (Earlier releases needed 1.86 via
 > an `idna`/`icu` dependency chain that has since been removed.)

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -44,6 +44,42 @@ pub fn require_platform_asset() -> crate::Result<&'static str> {
 	})
 }
 
+/// Name of the system package manager that owns the running binary, if any.
+///
+/// Self-update replaces the executable in place, which would corrupt a package
+/// manager's record of the installed file. When the running binary is tracked
+/// by such a manager the caller refuses and redirects the user to it.
+///
+/// Only `dpkg`/`apt` is detected, on Linux. cargo-install layouts
+/// (`~/.cargo/bin`, `/usr/local/bin`) are not owned by `dpkg` and update
+/// normally. A missing `dpkg-query`, or a path no package owns, returns `None`.
+#[cfg(target_os = "linux")]
+pub fn managing_package_manager() -> Option<&'static str> {
+	let exe = std::env::current_exe().ok()?;
+	let path = std::fs::canonicalize(&exe).unwrap_or(exe);
+	let output = std::process::Command::new("dpkg-query")
+		.arg("-S")
+		.arg(&path)
+		.output()
+		.ok()?;
+	output.status.success().then_some("apt")
+}
+
+/// Non-Linux platforms have no supported package-manager-managed install yet.
+#[cfg(not(target_os = "linux"))]
+pub fn managing_package_manager() -> Option<&'static str> {
+	None
+}
+
+/// Error returned when the running binary is managed by package manager `pm`.
+pub fn package_managed_error(pm: &str) -> ComposeError {
+	ComposeError::Update(format!(
+		"this podup was installed by {pm}; update it with your package manager \
+		 (e.g. `apt upgrade podup`) rather than `podup update`, which would break \
+		 the package's record of the file"
+	))
+}
+
 /// Replace the currently running executable with `new_bytes`. Returns the path
 /// that was updated. The caller MUST have verified `new_bytes` first.
 pub fn install_binary(new_bytes: &[u8]) -> crate::Result<PathBuf> {
@@ -240,5 +276,24 @@ mod tests {
 			(None, Err(_)) => {}
 			_ => panic!("platform_asset and require_platform_asset disagree"),
 		}
+	}
+
+	#[test]
+	fn package_managed_error_names_the_manager() {
+		let e = package_managed_error("apt");
+		match e {
+			ComposeError::Update(msg) => {
+				assert!(msg.contains("apt"));
+				assert!(msg.contains("podup update"));
+			}
+			_ => panic!("expected an Update error"),
+		}
+	}
+
+	#[test]
+	fn test_binary_is_not_package_managed() {
+		// The test runner binary lives under target/, which no package owns, so
+		// detection must not false-positive and block updates for normal builds.
+		assert_eq!(managing_package_manager(), None);
 	}
 }

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -65,6 +65,12 @@ pub fn run_with(
 		return Ok(());
 	}
 
+	// Refuse to self-replace a package-manager-managed binary (even with
+	// --force): overwriting it would desync the package manager's records.
+	if let Some(pm) = install::managing_package_manager() {
+		return Err(install::package_managed_error(pm));
+	}
+
 	let asset = install::require_platform_asset()?;
 	println!("downloading {asset} ({latest_tag}) ...");
 	let binary = source.fetch(asset)?;


### PR DESCRIPTION
## Summary

- **build-deb release job** — builds `podup_<version>_amd64.deb` on Debian sid, signs it with the release Ed25519 key, adds it to `SHA256SUMS`, and attaches it (+ `.sig`) to the GitHub release. Mirrors the proven `debian-build.yml` build steps.
- **`podup update` package-manager guard** — refuses to self-replace a dpkg-owned binary (`dpkg-query -S`, Linux only), redirecting to `apt`; cargo/curl installs and `--check` are unaffected.

## Test plan

- `cargo build --all-targets`, `clippy -D warnings`, `fmt --check` — clean
- `cargo test` — all pass, incl. new `package_managed_error_names_the_manager` and `test_binary_is_not_package_managed`
- Release-workflow YAML validated; the `.deb` build path is exercised by the existing Debian-package PR check. Note: the release-attach steps only run on a tag.

Minor bump (additive `podup::update` API). Closes #227