### PR TITLE
chore: release v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+podup (0.16.0) unstable; urgency=medium
+
+  * Ship a signed Debian package (podup_<version>_amd64.deb) as a release asset,
+    built on Debian sid and listed in the release SHA256SUMS.
+  * "podup update" now refuses to self-replace a binary installed by dpkg/apt
+    and redirects to the package manager, so an in-place update cannot desync
+    the package's record of the file.
+  * Add a cargo-fuzz harness (developer tooling) for the compose parser,
+    substitution, numeric parsers, dotenv, and the libpod stream framer.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 12:07:11 -0500
+
 podup (0.15.1) unstable; urgency=medium
 
   * Reject non-finite, negative, and out-of-range CPU and duration values in the

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.15.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.16.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Release prep for v0.16.0: bumps Cargo.toml/Cargo.lock, adds the Debian changelog entry, and syncs the man page version string.

Minor bump — additive `podup::update` API (`managing_package_manager`, `package_managed_error`).

Includes (already on develop): signed .deb release asset + `podup update` package-manager guard (#228); cargo-fuzz harness (#226).