### PR TITLE
security: harden update temp-file perms and guard auxiliary file reads

### DIFF
--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -178,22 +178,7 @@ fn resolve_one_extends(
 ///
 /// Exposed for unit testing.
 pub(crate) fn is_safe_extends_path(path: &str) -> bool {
-	let fp = std::path::Path::new(path);
-	if fp.is_absolute() {
-		return false;
-	}
-	// On Windows, paths like "/etc/passwd" are not `is_absolute()` (no drive letter)
-	// but still escape the project directory via the root separator.
-	if fp.components().next() == Some(std::path::Component::RootDir) {
-		return false;
-	}
-	if fp
-		.components()
-		.any(|c| c == std::path::Component::ParentDir)
-	{
-		return false;
-	}
-	true
+	crate::fsutil::is_safe_relative_path(path)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -123,7 +123,7 @@ pub(super) fn map_additional_context(base_dir: &Path, value: &str) -> String {
 
 fn read_dockerignore(context: &Path) -> Vec<String> {
 	let path = context.join(".dockerignore");
-	let Ok(content) = std::fs::read_to_string(path) else {
+	let Ok(content) = crate::fsutil::read_to_string_capped(path) else {
 		return Vec::new();
 	};
 	content

--- a/internal/engine/container_fields.rs
+++ b/internal/engine/container_fields.rs
@@ -132,14 +132,17 @@ pub(super) fn build_label_file_labels(
 ) -> HashMap<String, String> {
 	let mut labels = HashMap::new();
 	for path in service.label_file.to_list() {
-		let full = if std::path::Path::new(&path).is_absolute() {
-			std::path::PathBuf::from(&path)
-		} else {
-			base_dir.join(&path)
-		};
-		let Ok(content) = std::fs::read_to_string(&full) else {
-			warn!("label_file: cannot read {}", full.display());
+		if !crate::fsutil::is_safe_relative_path(&path) {
+			warn!("label_file: refusing absolute or parent-escaping path {path}");
 			continue;
+		}
+		let full = base_dir.join(&path);
+		let content = match crate::fsutil::read_to_string_capped(&full) {
+			Ok(c) => c,
+			Err(e) => {
+				warn!("label_file: cannot read {}: {e}", full.display());
+				continue;
+			}
 		};
 		for line in content.lines() {
 			let trimmed = line.trim();

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -48,7 +48,13 @@ pub fn load_env_file_entries(
 			}
 		}
 
-		let abs = base_dir.join(entry.path());
+		let rel = entry.path();
+		if !crate::fsutil::is_safe_relative_path(rel) {
+			return Err(ComposeError::Unsupported(format!(
+				"env_file '{rel}' must be a path inside the project directory"
+			)));
+		}
+		let abs = base_dir.join(rel);
 		let content = match crate::fsutil::read_to_string_capped(&abs) {
 			Ok(c) => c,
 			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -170,6 +176,22 @@ mod tests {
 			format: Some("json".into()),
 		}];
 		assert!(load_env_file_entries(&entries, dir.path()).is_err());
+	}
+
+	#[test]
+	fn rejects_absolute_env_file_path() {
+		let dir = tempfile::tempdir().unwrap();
+		let entries = vec![EnvFileEntry::Path("/etc/passwd".into())];
+		let err = load_env_file_entries(&entries, dir.path()).unwrap_err();
+		assert!(matches!(err, ComposeError::Unsupported(_)));
+	}
+
+	#[test]
+	fn rejects_parent_escaping_env_file_path() {
+		let dir = tempfile::tempdir().unwrap();
+		let entries = vec![EnvFileEntry::Path("../outside.env".into())];
+		let err = load_env_file_entries(&entries, dir.path()).unwrap_err();
+		assert!(matches!(err, ComposeError::Unsupported(_)));
 	}
 
 	// merge_env

--- a/internal/fsutil.rs
+++ b/internal/fsutil.rs
@@ -1,7 +1,27 @@
 //! Filesystem helpers shared across parsing paths.
 
 use std::io;
-use std::path::Path;
+use std::path::{Component, Path};
+
+/// Reject a file reference that is absolute or escapes the project directory.
+///
+/// podup only reads files that live at or below the directory of the compose
+/// file being processed. A reference that is absolute, rooted (`/etc/passwd`,
+/// which is not `is_absolute()` on Windows but still escapes via the root
+/// separator), or contains a `..` component is refused so a compose file cannot
+/// turn podup into a confused deputy that reads arbitrary host paths. Shared by
+/// the `extends`, `env_file`, and `label_file` readers.
+pub(crate) fn is_safe_relative_path(path: impl AsRef<Path>) -> bool {
+	let fp = path.as_ref();
+	if fp.is_absolute() {
+		return false;
+	}
+	let mut comps = fp.components();
+	if comps.clone().next() == Some(Component::RootDir) {
+		return false;
+	}
+	!comps.any(|c| c == Component::ParentDir)
+}
 
 /// Upper bound on the size of any compose, include, extends, or env file podup
 /// will read into memory. Bounds memory use on an accidentally huge or hostile
@@ -33,7 +53,24 @@ fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
 
 #[cfg(test)]
 mod tests {
-	use super::read_to_string_capped_with;
+	use super::{is_safe_relative_path, read_to_string_capped_with};
+
+	#[test]
+	fn accepts_relative_subpaths() {
+		assert!(is_safe_relative_path("labels.env"));
+		assert!(is_safe_relative_path("config/labels.env"));
+	}
+
+	#[test]
+	fn rejects_absolute_paths() {
+		assert!(!is_safe_relative_path("/etc/passwd"));
+	}
+
+	#[test]
+	fn rejects_parent_traversal() {
+		assert!(!is_safe_relative_path("../secret.env"));
+		assert!(!is_safe_relative_path("a/../../etc/passwd"));
+	}
 
 	#[test]
 	fn reads_file_within_limit() {

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -122,6 +122,24 @@ pub fn install_at(target: &Path, new_bytes: &[u8]) -> crate::Result<()> {
 /// Write the new bytes to `tmp`, copy `target`'s permission bits (default 0755
 /// on Unix when the target does not yet exist), and flush to disk.
 fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> {
+	// Create the temp file private (0600) on Unix so the new binary's bytes are
+	// never world-readable in a shared directory (e.g. /usr/local/bin) during the
+	// window before the target's mode is applied. `File::create` honours the
+	// process umask and could otherwise leave a 0644 file readable by other users.
+	#[cfg(unix)]
+	let mut f = {
+		use std::os::unix::fs::OpenOptionsExt;
+		std::fs::OpenOptions::new()
+			.write(true)
+			.create(true)
+			.truncate(true)
+			.mode(0o600)
+			.open(tmp)
+			.map_err(|e| {
+				ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
+			})?
+	};
+	#[cfg(not(unix))]
 	let mut f = std::fs::File::create(tmp).map_err(|e| {
 		ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
 	})?;


### PR DESCRIPTION
## Summary
Standalone file-handling hardening across three trust boundaries.

- **install.rs** — self-update temp file now created `0600` then widened to the target mode (was `File::create`, umask-dependent, briefly world-readable in shared dirs).
- **fsutil** — new shared `is_safe_relative_path`; `is_safe_extends_path` delegates to it. Applied to `env_file` and `label_file`.
- **capped reads** — `label_file` and `.dockerignore` go through `read_to_string_capped`.

## Behaviour change
`env_file:` / `label_file:` with absolute or `..`-escaping paths are now refused, consistent with `extends`/`include`. Library public API signatures unchanged.

## Tests
`cargo build`, `cargo clippy --all-targets`, lib suite (512) and parse/substitute/secret/env_file suites all green. New unit tests for the guard and the `env_file` rejections.

Closes #231