### PR TITLE
test: cover self-update package-manager guard and substitution parser

### DIFF
--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -154,3 +154,190 @@ pub(super) fn resolve_modifier(
 		},
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn peekable(s: &str) -> std::iter::Peekable<std::str::Chars<'_>> {
+		s.chars().peekable()
+	}
+
+	fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+		pairs
+			.iter()
+			.map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+			.collect()
+	}
+
+	// --- char predicates ---
+
+	#[test]
+	fn var_start_and_char_classes() {
+		assert!(is_var_start('_'));
+		assert!(is_var_start('a'));
+		assert!(!is_var_start('1'));
+		assert!(!is_var_start('-'));
+		assert!(is_var_char('9'));
+		assert!(!is_var_char('-'));
+	}
+
+	// --- collect_var_name ---
+
+	#[test]
+	fn collect_var_name_stops_at_non_var_char() {
+		let mut it = peekable("NAME-rest");
+		assert_eq!(collect_var_name(&mut it), "NAME");
+		// The `-` and everything after it is left unconsumed.
+		assert_eq!(it.collect::<String>(), "-rest");
+	}
+
+	// --- parse_braced_var: bare + every modifier form ---
+
+	#[test]
+	fn parse_bare_var_consumes_closing_brace() {
+		let mut it = peekable("FOO}tail");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::None));
+		assert_eq!(it.collect::<String>(), "tail");
+	}
+
+	#[test]
+	fn parse_unterminated_var_is_none_modifier() {
+		let mut it = peekable("FOO");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::None));
+	}
+
+	#[test]
+	fn parse_each_modifier_form() {
+		type Check = fn(&Modifier) -> bool;
+		let cases: &[(&str, Check)] = &[
+			(
+				"V:-d}",
+				|m| matches!(m, Modifier::DefaultIfUnsetOrEmpty(s) if s == "d"),
+			),
+			(
+				"V-d}",
+				|m| matches!(m, Modifier::DefaultIfUnset(s) if s == "d"),
+			),
+			(
+				"V:+a}",
+				|m| matches!(m, Modifier::AltIfSetAndNonEmpty(s) if s == "a"),
+			),
+			("V+a}", |m| matches!(m, Modifier::AltIfSet(s) if s == "a")),
+			(
+				"V:?e}",
+				|m| matches!(m, Modifier::ErrorIfUnsetOrEmpty(s) if s == "e"),
+			),
+			(
+				"V?e}",
+				|m| matches!(m, Modifier::ErrorIfUnset(s) if s == "e"),
+			),
+		];
+		for (input, check) in cases {
+			let mut it = peekable(input);
+			let (name, modifier) = parse_braced_var(&mut it).unwrap();
+			assert_eq!(name, "V", "input {input}");
+			assert!(check(&modifier), "modifier mismatch for {input}");
+		}
+	}
+
+	#[test]
+	fn parse_colon_without_known_op_defaults_to_default_if_unset_or_empty() {
+		let mut it = peekable("V:x}");
+		let (_, modifier) = parse_braced_var(&mut it).unwrap();
+		assert!(matches!(modifier, Modifier::DefaultIfUnsetOrEmpty(s) if s == "x"));
+	}
+
+	// --- resolve_modifier ---
+
+	#[test]
+	fn resolve_none_uses_value_or_empty() {
+		let v = vars(&[("A", "1")]);
+		assert_eq!(
+			resolve_modifier("A".into(), Modifier::None, &v).unwrap(),
+			"1"
+		);
+		assert_eq!(
+			resolve_modifier("MISSING".into(), Modifier::None, &v).unwrap(),
+			""
+		);
+	}
+
+	#[test]
+	fn resolve_default_if_unset_or_empty() {
+		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
+		let m = || Modifier::DefaultIfUnsetOrEmpty("def".into());
+		assert_eq!(resolve_modifier("EMPTY".into(), m(), &v).unwrap(), "def");
+		assert_eq!(resolve_modifier("MISSING".into(), m(), &v).unwrap(), "def");
+		assert_eq!(resolve_modifier("SET".into(), m(), &v).unwrap(), "x");
+	}
+
+	#[test]
+	fn resolve_default_if_unset_keeps_empty_value() {
+		let v = vars(&[("EMPTY", "")]);
+		assert_eq!(
+			resolve_modifier("EMPTY".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			""
+		);
+		assert_eq!(
+			resolve_modifier("MISSING".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			"def"
+		);
+	}
+
+	#[test]
+	fn resolve_alt_forms() {
+		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
+		assert_eq!(
+			resolve_modifier("SET".into(), Modifier::AltIfSetAndNonEmpty("a".into()), &v).unwrap(),
+			"a"
+		);
+		assert_eq!(
+			resolve_modifier(
+				"EMPTY".into(),
+				Modifier::AltIfSetAndNonEmpty("a".into()),
+				&v
+			)
+			.unwrap(),
+			""
+		);
+		assert_eq!(
+			resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			"a"
+		);
+		assert_eq!(
+			resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			""
+		);
+	}
+
+	#[test]
+	fn resolve_error_forms() {
+		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
+		assert!(resolve_modifier(
+			"EMPTY".into(),
+			Modifier::ErrorIfUnsetOrEmpty("e".into()),
+			&v
+		)
+		.is_err());
+		assert_eq!(
+			resolve_modifier("SET".into(), Modifier::ErrorIfUnsetOrEmpty("e".into()), &v).unwrap(),
+			"x"
+		);
+		assert!(
+			resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v).is_err()
+		);
+		assert_eq!(
+			resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v).unwrap(),
+			""
+		);
+	}
+}

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -46,6 +46,17 @@ pub fn run_with(
 	current: &str,
 	opts: UpdateOptions,
 ) -> crate::Result<()> {
+	run_with_guard(source, current, opts, install::managing_package_manager())
+}
+
+/// [`run_with`] with the package-manager guard injected, so the refusal branch
+/// can be exercised without a dpkg-managed binary on the test host.
+fn run_with_guard(
+	source: &dyn ReleaseSource,
+	current: &str,
+	opts: UpdateOptions,
+	managed_by: Option<&str>,
+) -> crate::Result<()> {
 	let current_v = verify::parse_version(current)?;
 	let latest_tag = source.latest_version()?;
 	let latest_v = verify::parse_version(&latest_tag)?;
@@ -67,7 +78,7 @@ pub fn run_with(
 
 	// Refuse to self-replace a package-manager-managed binary (even with
 	// --force): overwriting it would desync the package manager's records.
-	if let Some(pm) = install::managing_package_manager() {
+	if let Some(pm) = managed_by {
 		return Err(install::package_managed_error(pm));
 	}
 
@@ -196,6 +207,48 @@ mod tests {
 		let err = run_with(&src, "0.6.0", UpdateOptions::default()).unwrap_err();
 		assert!(matches!(err, ComposeError::Update(_)));
 		assert!(src.fetched.borrow().contains(&"SHA256SUMS.sig".to_string()));
+	}
+
+	#[test]
+	fn package_managed_binary_refuses_and_does_not_download() {
+		// A newer release is available and --force is set, so the flow reaches the
+		// package-manager guard. With a manager owning the binary it must refuse
+		// before fetching anything.
+		let src = MockSource {
+			latest: "v9.9.9".into(),
+			assets: HashMap::new(),
+			fetched: RefCell::new(Vec::new()),
+		};
+		let opts = UpdateOptions {
+			check_only: false,
+			force: true,
+		};
+		let err = run_with_guard(&src, "0.6.0", opts, Some("apt")).unwrap_err();
+		match err {
+			ComposeError::Update(msg) => assert!(msg.contains("apt")),
+			other => panic!("expected Update error, got {other:?}"),
+		}
+		assert!(
+			src.fetched.borrow().is_empty(),
+			"a package-managed binary must not download an update"
+		);
+	}
+
+	#[test]
+	fn check_only_returns_before_package_manager_guard() {
+		// --check must short-circuit even when a package manager owns the binary,
+		// so `podup update --check` never errors on a deb install.
+		let src = MockSource {
+			latest: "v9.9.9".into(),
+			assets: HashMap::new(),
+			fetched: RefCell::new(Vec::new()),
+		};
+		let opts = UpdateOptions {
+			check_only: true,
+			force: false,
+		};
+		run_with_guard(&src, "0.6.0", opts, Some("apt")).unwrap();
+		assert!(src.fetched.borrow().is_empty());
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
Closes two unit-test gaps from the standalone test-health review.

- **Self-update guard** — `run_with` now delegates to `run_with_guard(.., managed_by)`; the real `managing_package_manager()` is injected in production and a fixed value in tests. New tests cover the refuse-and-don't-download branch (the v0.16.0 dpkg protection) and the `--check` short-circuit ahead of it.
- **`substitute/parse.rs`** — new `#[cfg(test)]` module covering char predicates, `collect_var_name`, all six `${…}` modifier forms, and every `resolve_modifier` branch including the error forms.

No production behaviour change beyond the extracted seam. Lib suite 512 → 520, clippy `--all-targets` clean.

Closes #233