### PR TITLE
docs: document RUST_LOG and exit status in man page and command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.14.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.16.0" }
 ```
 
 ## 📖 Docs

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -146,6 +146,23 @@ Default active profiles (see \fB\-\-profile\fR).
 .TP
 .B PODMAN_SOCKET
 Podman socket path (see \fB\-\-socket\fR).
+.TP
+.B RUST_LOG
+Log verbosity filter. With no value set, warnings and errors are shown; set
+e.g. \fBRUST_LOG=podup=info\fR or \fBRUST_LOG=podup=debug\fR for more detail.
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+A command failed (for example a parse error or a Podman error).
+.TP
+.B 2
+\fBupdate\fR failed to verify or install a release.
+.PP
+\fBrun\fR propagates the container's own exit code verbatim, so any other
+non-zero status comes from the container that was run.
 .SH FILES
 .TP
 .B docker-compose.yml

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -148,3 +148,26 @@ Forward-compatibility warnings about unknown or unsupported compose fields are
 shown by default; set `RUST_LOG=debug` for verbose tracing. An unexpected
 internal error prints a `podup: internal error:` notice with a bug-report link
 and a reminder to redact secrets before sharing logs.
+
+## Environment
+
+Every environment variable `podup` reads, in one place. Each compose variable
+has an equivalent flag (see [Global options](#global-options)); the flag wins
+when both are set.
+
+| Variable | Description |
+|---|---|
+| `COMPOSE_FILE` | Path-separator-delimited list of compose files (`--file`). |
+| `COMPOSE_PROJECT_NAME` | Default project name (`--project`). |
+| `COMPOSE_PROFILES` | Default active profiles (`--profile`). |
+| `PODMAN_SOCKET` | Podman socket path (`--socket`). |
+| `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
+
+## Exit status
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. |
+| `1` | A command failed (parse error, Podman error). |
+| `2` | `update` failed to verify or install a release. |
+| other | `run` propagates the container's own exit code verbatim. |


### PR DESCRIPTION
## Summary
- **`debian/podup.1`** — add `RUST_LOG` to `.SH ENVIRONMENT`; add `.SH EXIT STATUS` (0/1/2 + container code via `run`). Closes the `lintian`/Debian man-page coverage gap.
- **`docs/commands.md`** — new canonical **Environment** and **Exit status** tables.
- **`README.md`** — bump library snippet `tag` v0.14.0 → v0.16.0.

`PODUP_INSECURE_SKIP_VERIFY` is an `install.sh` variable (not read by the binary), so it stays in `docs/self-update.md`, not the binary man page.

Closes #235