### PR TITLE
ci: add cargo-deny supply-chain policy

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,3 +19,15 @@ jobs:
 
       - name: Run cargo audit
         run: cargo audit
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version "^0.19" --locked
+
+      - name: Run cargo deny
+        run: cargo deny check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Glyndor/podup"
 readme = "README.md"
 keywords = ["podman", "compose", "containers", "docker-compose", "rootless"]
 categories = ["command-line-utilities", "virtualization"]
-exclude = ["/.github", "/debian", "/docs", "/install.sh", "/tests"]
+exclude = ["/.github", "/debian", "/deny.toml", "/docs", "/install.sh", "/tests"]
 
 [[bin]]
 name = "podup"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,43 @@
+# cargo-deny configuration. Enforces the supply-chain policy locally and in CI:
+# audited advisories, a permissive-license allowlist, and a ban on wildcard
+# version requirements. Duplicate versions are reported (warn) rather than
+# denied: the only duplicates today come from the Windows target and the
+# dev-only tempfile tree, none of which reach the Linux production binary.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.9
+# Every license present in the dependency tree. A crate carrying anything not
+# listed here fails the check, forcing a deliberate review before it ships.
+allow = [
+	"Apache-2.0",
+	"Apache-2.0 WITH LLVM-exception",
+	"MIT",
+	"0BSD",
+	"BSD-1-Clause",
+	"BSD-3-Clause",
+	"BSL-1.0",
+	"ISC",
+	"Unicode-3.0",
+	"Unlicense",
+	"Zlib",
+	"CC0-1.0",
+	"CDLA-Permissive-2.0",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## Summary
Adds automated supply-chain enforcement to complement the weekly `cargo audit`.

- **`deny.toml`** — permissive-license allowlist (exact to the tree), `wildcards = deny`, `unknown-registry`/`unknown-git = deny`, `yanked = deny`. `multiple-versions = warn` because today's only duplicates are Windows-target and dev-only `tempfile` crates that never reach the Linux production binary.
- **`audit.yml`** — new `cargo deny` job, installed via `cargo install` (no third-party action).
- **`Cargo.toml`** — exclude `deny.toml` from the published crate.

`cargo deny check` locally: advisories ok, bans ok, licenses ok, sources ok.

Closes #237