### PR TITLE
refactor: split five files approaching the 500-line limit

### DIFF
--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -2,14 +2,17 @@
 //! [`Service`] and starts the container.
 
 use std::collections::HashMap;
-use std::path::Path;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::{LinuxResources, Namespace, SpecGenerator};
 use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
-use crate::{env_file, ports, size};
+use crate::{ports, size};
+
+mod resolve;
+use resolve::{build_env, resolve_links, resolve_volume_name};
+pub(crate) use resolve::{config_hash, resolve_bind_source};
 
 use super::container_config::{
 	build_healthcheck, build_log_config, build_resource_limits, build_restart_policy,
@@ -271,210 +274,5 @@ impl Engine {
 	/// in the top-level `volumes:` map (anonymous/implicit) are left unchanged.
 	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> String {
 		resolve_volume_name(reference, &self.project, file)
-	}
-}
-
-/// Resolve a named-volume reference to the volume name `create_volumes`
-/// produced: a custom `name:`, the raw name for an external volume, or the
-/// `{project}_{name}` form. References not declared in the top-level `volumes:`
-/// map (anonymous/implicit) are returned unchanged.
-fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> String {
-	match file.volumes.get(reference) {
-		Some(cfg) => {
-			if let Some(name) = cfg.as_ref().and_then(|c| c.name.as_deref()) {
-				name.to_string()
-			} else if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
-				reference.to_string()
-			} else {
-				format!("{project}_{reference}")
-			}
-		}
-		None => reference.to_string(),
-	}
-}
-
-/// Resolve a bind-mount source path: expand a leading `~`, then make a relative
-/// path absolute against the project base directory. Absolute paths (including
-/// staged secret/config files) are returned unchanged.
-pub(super) fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
-	if src.is_empty() {
-		return src.to_string();
-	}
-	let expanded = if let Some(rest) = src.strip_prefix("~/") {
-		// Join with the platform separator rather than hardcoding `/`, and look
-		// up the home directory in a platform-correct way (USERPROFILE on
-		// native Windows, where HOME is usually unset).
-		match home_dir() {
-			Some(home) => home.join(rest).to_string_lossy().into_owned(),
-			None => src.to_string(),
-		}
-	} else if src == "~" {
-		home_dir()
-			.map(|h| h.to_string_lossy().into_owned())
-			.unwrap_or_else(|| src.to_string())
-	} else {
-		src.to_string()
-	};
-	if Path::new(&expanded).is_absolute() {
-		expanded
-	} else {
-		base_dir.join(&expanded).to_string_lossy().into_owned()
-	}
-}
-
-/// The current user's home directory. Prefers `HOME` (set on Unix and most
-/// shells), falling back to `USERPROFILE` for native Windows where `HOME` is
-/// usually absent. Empty values are treated as unset.
-fn home_dir() -> Option<std::path::PathBuf> {
-	std::env::var_os("HOME")
-		.or_else(|| std::env::var_os("USERPROFILE"))
-		.filter(|v| !v.is_empty())
-		.map(std::path::PathBuf::from)
-}
-
-/// Resolve a service's `links` to concrete container references.
-///
-/// A compose `links:` entry names a sibling service; it is rewritten to that
-/// service's container name with the service name kept as the network alias
-/// (`{container}:{alias}`), so the linked container is reachable by the compose
-/// service name. `external_links` reference containers outside the project and
-/// are passed through verbatim.
-fn resolve_links(service: &Service, file: &ComposeFile, project: &str) -> Vec<String> {
-	let mut links: Vec<String> = service
-		.links
-		.iter()
-		.map(|link| {
-			let (target, alias) = link.split_once(':').unwrap_or((link, link));
-			let container = file
-				.services
-				.get(target)
-				.map(|svc| {
-					svc.container_name
-						.clone()
-						.unwrap_or_else(|| format!("{project}-{target}"))
-				})
-				.unwrap_or_else(|| target.to_string());
-			format!("{container}:{alias}")
-		})
-		.collect();
-	links.extend(service.external_links.iter().cloned());
-	links
-}
-
-/// Stable content hash of a service definition, stored as the
-/// `podup.config-hash` label. On `up`, comparing this against the label on an
-/// existing container tells podup whether the service configuration changed
-/// and the container must be recreated, or is unchanged and can be left as is.
-pub(crate) fn config_hash(service: &Service) -> String {
-	use sha2::{Digest, Sha256};
-	// Canonicalise through `serde_json::Value` first: object keys are emitted in
-	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
-	// between runs and flap the hash into a spurious recreate.
-	let serialized = serde_json::to_value(service)
-		.and_then(|v| serde_json::to_vec(&v))
-		.unwrap_or_default();
-	Sha256::digest(&serialized)
-		.iter()
-		.map(|b| format!("{b:02x}"))
-		.collect()
-}
-
-fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
-	let entries = service.env_file.to_entries();
-	let env_file_vars = if !entries.is_empty() {
-		env_file::load_env_file_entries(&entries, base_dir)?
-	} else {
-		HashMap::new()
-	};
-	Ok(env_file::merge_env(
-		service.environment.to_map(),
-		env_file_vars,
-	))
-}
-
-#[cfg(test)]
-mod tests {
-	use super::{config_hash, resolve_links, resolve_volume_name};
-	use crate::parse_str;
-
-	#[test]
-	fn links_resolve_to_container_names_external_links_verbatim() {
-		let file = parse_str(
-			"services:\n  db:\n    image: x\n  web:\n    image: x\n    links:\n      - db\n      - db:primary\n    external_links:\n      - legacy_db:db\n",
-		)
-		.unwrap();
-		let links = resolve_links(&file.services["web"], &file, "proj");
-		assert!(links.contains(&"proj-db:db".to_string()));
-		assert!(links.contains(&"proj-db:primary".to_string()));
-		assert!(links.contains(&"legacy_db:db".to_string()));
-	}
-
-	#[test]
-	fn links_honour_custom_container_name() {
-		let file = parse_str(
-			"services:\n  db:\n    image: x\n    container_name: my-db\n  web:\n    image: x\n    links:\n      - db\n",
-		)
-		.unwrap();
-		let links = resolve_links(&file.services["web"], &file, "proj");
-		assert_eq!(links, vec!["my-db:db".to_string()]);
-	}
-
-	#[test]
-	#[cfg(unix)]
-	fn bind_source_resolution() {
-		use super::resolve_bind_source;
-		use std::path::Path;
-		let base = Path::new("/srv/app");
-		assert_eq!(resolve_bind_source("/abs/path", base), "/abs/path");
-		assert_eq!(resolve_bind_source("./data", base), "/srv/app/./data");
-		assert_eq!(resolve_bind_source("data", base), "/srv/app/data");
-		std::env::set_var("HOME", "/home/u");
-		assert_eq!(resolve_bind_source("~/x", base), "/home/u/x");
-		assert_eq!(resolve_bind_source("~", base), "/home/u");
-	}
-
-	#[test]
-	fn volume_name_resolution() {
-		let f = parse_str(
-			"services:\n  s:\n    image: x\nvolumes:\n  data:\n  ext:\n    external: true\n  custom:\n    name: my-vol\n",
-		)
-		.unwrap();
-		assert_eq!(resolve_volume_name("data", "proj", &f), "proj_data");
-		assert_eq!(resolve_volume_name("ext", "proj", &f), "ext");
-		assert_eq!(resolve_volume_name("custom", "proj", &f), "my-vol");
-		// Not declared in top-level volumes -> left as-is.
-		assert_eq!(resolve_volume_name("anon", "proj", &f), "anon");
-	}
-
-	#[test]
-	fn config_hash_is_stable_and_sensitive() {
-		let a = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
-		let b = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
-		let c = parse_str("services:\n  web:\n    image: nginx:1.28\n").unwrap();
-		let ha = config_hash(&a.services["web"]);
-		let hb = config_hash(&b.services["web"]);
-		let hc = config_hash(&c.services["web"]);
-		assert_eq!(ha, hb, "same config produces the same hash");
-		assert_ne!(ha, hc, "a changed image produces a different hash");
-		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
-	}
-
-	#[test]
-	fn config_hash_stable_despite_map_field_order() {
-		// `storage_opt` is a HashMap; canonical serialisation must sort its keys
-		// so the hash does not flap and trigger a spurious recreate on `up`.
-		let a = parse_str(
-			"services:\n  web:\n    image: x\n    storage_opt:\n      size: \"10G\"\n      foo: bar\n      baz: qux\n",
-		)
-		.unwrap();
-		let b = parse_str(
-			"services:\n  web:\n    image: x\n    storage_opt:\n      baz: qux\n      size: \"10G\"\n      foo: bar\n",
-		)
-		.unwrap();
-		assert_eq!(
-			config_hash(&a.services["web"]),
-			config_hash(&b.services["web"]),
-			"hash must be independent of storage_opt key order",
-		);
 	}
 }

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -1,0 +1,213 @@
+//! Name, path, link, and config-hash resolution for container creation.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::env_file;
+use crate::error::Result;
+
+/// Resolve a named-volume reference to the volume name `create_volumes`
+/// produced: a custom `name:`, the raw name for an external volume, or the
+/// `{project}_{name}` form. References not declared in the top-level `volumes:`
+/// map (anonymous/implicit) are returned unchanged.
+pub(super) fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> String {
+	match file.volumes.get(reference) {
+		Some(cfg) => {
+			if let Some(name) = cfg.as_ref().and_then(|c| c.name.as_deref()) {
+				name.to_string()
+			} else if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
+				reference.to_string()
+			} else {
+				format!("{project}_{reference}")
+			}
+		}
+		None => reference.to_string(),
+	}
+}
+
+/// Resolve a bind-mount source path: expand a leading `~`, then make a relative
+/// path absolute against the project base directory. Absolute paths (including
+/// staged secret/config files) are returned unchanged.
+pub(crate) fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
+	if src.is_empty() {
+		return src.to_string();
+	}
+	let expanded = if let Some(rest) = src.strip_prefix("~/") {
+		// Join with the platform separator rather than hardcoding `/`, and look
+		// up the home directory in a platform-correct way (USERPROFILE on
+		// native Windows, where HOME is usually unset).
+		match home_dir() {
+			Some(home) => home.join(rest).to_string_lossy().into_owned(),
+			None => src.to_string(),
+		}
+	} else if src == "~" {
+		home_dir()
+			.map(|h| h.to_string_lossy().into_owned())
+			.unwrap_or_else(|| src.to_string())
+	} else {
+		src.to_string()
+	};
+	if Path::new(&expanded).is_absolute() {
+		expanded
+	} else {
+		base_dir.join(&expanded).to_string_lossy().into_owned()
+	}
+}
+
+/// The current user's home directory. Prefers `HOME` (set on Unix and most
+/// shells), falling back to `USERPROFILE` for native Windows where `HOME` is
+/// usually absent. Empty values are treated as unset.
+fn home_dir() -> Option<std::path::PathBuf> {
+	std::env::var_os("HOME")
+		.or_else(|| std::env::var_os("USERPROFILE"))
+		.filter(|v| !v.is_empty())
+		.map(std::path::PathBuf::from)
+}
+
+/// Resolve a service's `links` to concrete container references.
+///
+/// A compose `links:` entry names a sibling service; it is rewritten to that
+/// service's container name with the service name kept as the network alias
+/// (`{container}:{alias}`), so the linked container is reachable by the compose
+/// service name. `external_links` reference containers outside the project and
+/// are passed through verbatim.
+pub(super) fn resolve_links(service: &Service, file: &ComposeFile, project: &str) -> Vec<String> {
+	let mut links: Vec<String> = service
+		.links
+		.iter()
+		.map(|link| {
+			let (target, alias) = link.split_once(':').unwrap_or((link, link));
+			let container = file
+				.services
+				.get(target)
+				.map(|svc| {
+					svc.container_name
+						.clone()
+						.unwrap_or_else(|| format!("{project}-{target}"))
+				})
+				.unwrap_or_else(|| target.to_string());
+			format!("{container}:{alias}")
+		})
+		.collect();
+	links.extend(service.external_links.iter().cloned());
+	links
+}
+
+/// Stable content hash of a service definition, stored as the
+/// `podup.config-hash` label. On `up`, comparing this against the label on an
+/// existing container tells podup whether the service configuration changed
+/// and the container must be recreated, or is unchanged and can be left as is.
+pub(crate) fn config_hash(service: &Service) -> String {
+	use sha2::{Digest, Sha256};
+	// Canonicalise through `serde_json::Value` first: object keys are emitted in
+	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
+	// between runs and flap the hash into a spurious recreate.
+	let serialized = serde_json::to_value(service)
+		.and_then(|v| serde_json::to_vec(&v))
+		.unwrap_or_default();
+	Sha256::digest(&serialized)
+		.iter()
+		.map(|b| format!("{b:02x}"))
+		.collect()
+}
+
+pub(super) fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
+	let entries = service.env_file.to_entries();
+	let env_file_vars = if !entries.is_empty() {
+		env_file::load_env_file_entries(&entries, base_dir)?
+	} else {
+		HashMap::new()
+	};
+	Ok(env_file::merge_env(
+		service.environment.to_map(),
+		env_file_vars,
+	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{config_hash, resolve_links, resolve_volume_name};
+	use crate::parse_str;
+
+	#[test]
+	fn links_resolve_to_container_names_external_links_verbatim() {
+		let file = parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    links:\n      - db\n      - db:primary\n    external_links:\n      - legacy_db:db\n",
+		)
+		.unwrap();
+		let links = resolve_links(&file.services["web"], &file, "proj");
+		assert!(links.contains(&"proj-db:db".to_string()));
+		assert!(links.contains(&"proj-db:primary".to_string()));
+		assert!(links.contains(&"legacy_db:db".to_string()));
+	}
+
+	#[test]
+	fn links_honour_custom_container_name() {
+		let file = parse_str(
+			"services:\n  db:\n    image: x\n    container_name: my-db\n  web:\n    image: x\n    links:\n      - db\n",
+		)
+		.unwrap();
+		let links = resolve_links(&file.services["web"], &file, "proj");
+		assert_eq!(links, vec!["my-db:db".to_string()]);
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn bind_source_resolution() {
+		use super::resolve_bind_source;
+		use std::path::Path;
+		let base = Path::new("/srv/app");
+		assert_eq!(resolve_bind_source("/abs/path", base), "/abs/path");
+		assert_eq!(resolve_bind_source("./data", base), "/srv/app/./data");
+		assert_eq!(resolve_bind_source("data", base), "/srv/app/data");
+		std::env::set_var("HOME", "/home/u");
+		assert_eq!(resolve_bind_source("~/x", base), "/home/u/x");
+		assert_eq!(resolve_bind_source("~", base), "/home/u");
+	}
+
+	#[test]
+	fn volume_name_resolution() {
+		let f = parse_str(
+			"services:\n  s:\n    image: x\nvolumes:\n  data:\n  ext:\n    external: true\n  custom:\n    name: my-vol\n",
+		)
+		.unwrap();
+		assert_eq!(resolve_volume_name("data", "proj", &f), "proj_data");
+		assert_eq!(resolve_volume_name("ext", "proj", &f), "ext");
+		assert_eq!(resolve_volume_name("custom", "proj", &f), "my-vol");
+		// Not declared in top-level volumes -> left as-is.
+		assert_eq!(resolve_volume_name("anon", "proj", &f), "anon");
+	}
+
+	#[test]
+	fn config_hash_is_stable_and_sensitive() {
+		let a = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let b = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let c = parse_str("services:\n  web:\n    image: nginx:1.28\n").unwrap();
+		let ha = config_hash(&a.services["web"]);
+		let hb = config_hash(&b.services["web"]);
+		let hc = config_hash(&c.services["web"]);
+		assert_eq!(ha, hb, "same config produces the same hash");
+		assert_ne!(ha, hc, "a changed image produces a different hash");
+		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
+	}
+
+	#[test]
+	fn config_hash_stable_despite_map_field_order() {
+		// `storage_opt` is a HashMap; canonical serialisation must sort its keys
+		// so the hash does not flap and trigger a spurious recreate on `up`.
+		let a = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      size: \"10G\"\n      foo: bar\n      baz: qux\n",
+		)
+		.unwrap();
+		let b = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      baz: qux\n      size: \"10G\"\n      foo: bar\n",
+		)
+		.unwrap();
+		assert_eq!(
+			config_hash(&a.services["web"]),
+			config_hash(&b.services["web"]),
+			"hash must be independent of storage_opt key order",
+		);
+	}
+}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -1,14 +1,17 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
 mod commands;
+mod targets;
 
 use std::collections::{HashMap, HashSet};
 
 use tracing::info;
 
-use crate::compose::types::{ComposeFile, Service, ServiceCondition};
-use crate::error::{ComposeError, Result};
+use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::error::Result;
 use crate::libpod::API_PREFIX;
+
+use targets::{expand_targets, filter_services, grace_period_secs};
 
 use super::container::config_hash;
 
@@ -332,157 +335,5 @@ impl Engine {
 
 		self.cleanup_temp_dir();
 		Ok(())
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-pub(super) fn grace_period_secs(service: &Service) -> i32 {
-	service
-		.stop_grace_period
-		.as_deref()
-		.and_then(crate::size::parse_duration_secs)
-		.and_then(|s| i32::try_from(s).ok())
-		.unwrap_or(10)
-}
-
-/// Return the ordered service names filtered to `target_services`.
-///
-/// Returns an error if any name in `target_services` is not in the file.
-pub(super) fn filter_services(
-	file: &crate::compose::types::ComposeFile,
-	order: Vec<String>,
-	target_services: &[String],
-) -> Result<Vec<String>> {
-	if target_services.is_empty() {
-		return Ok(order);
-	}
-	for name in target_services {
-		if !file.services.contains_key(name) {
-			return Err(ComposeError::ServiceNotFound(name.clone()));
-		}
-	}
-	let set: std::collections::HashSet<&str> = target_services.iter().map(|s| s.as_str()).collect();
-	Ok(order
-		.into_iter()
-		.filter(|n| set.contains(n.as_str()))
-		.collect())
-}
-
-/// Resolve which services `up` should start given an explicit target list.
-///
-/// Returns `None` when no targets are given (start everything). Otherwise the
-/// set contains the targets plus, unless `no_deps` is set, their transitive
-/// `depends_on` services.
-fn expand_targets(
-	file: &ComposeFile,
-	target_services: &[String],
-	no_deps: bool,
-) -> Option<HashSet<String>> {
-	if target_services.is_empty() {
-		return None;
-	}
-	let mut set = HashSet::new();
-	let mut stack: Vec<String> = target_services.to_vec();
-	while let Some(name) = stack.pop() {
-		if !set.insert(name.clone()) {
-			continue;
-		}
-		if !no_deps {
-			if let Some(service) = file.services.get(&name) {
-				for dep in service.depends_on.service_names() {
-					if !set.contains(&dep) {
-						stack.push(dep);
-					}
-				}
-			}
-		}
-	}
-	Some(set)
-}
-
-// ---------------------------------------------------------------------------
-// Unit tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-	use super::{expand_targets, filter_services};
-	use crate::compose::types::{ComposeFile, Service};
-
-	fn file_with_services(names: &[&str]) -> ComposeFile {
-		let mut file = ComposeFile::default();
-		for &name in names {
-			file.services.insert(name.to_string(), Service::default());
-		}
-		file
-	}
-
-	#[test]
-	fn filter_empty_target_returns_all() {
-		let file = file_with_services(&["a", "b", "c"]);
-		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-		let result = filter_services(&file, order.clone(), &[]).unwrap();
-		assert_eq!(result, order);
-	}
-
-	#[test]
-	fn filter_target_subset_returns_intersection() {
-		let file = file_with_services(&["a", "b", "c"]);
-		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-		let result = filter_services(&file, order, &["b".to_string()]).unwrap();
-		assert_eq!(result, vec!["b".to_string()]);
-	}
-
-	#[test]
-	fn filter_target_preserves_order() {
-		let file = file_with_services(&["a", "b", "c"]);
-		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-		let result = filter_services(&file, order, &["c".to_string(), "a".to_string()]).unwrap();
-		assert_eq!(result, vec!["a".to_string(), "c".to_string()]);
-	}
-
-	#[test]
-	fn filter_unknown_service_returns_error() {
-		let file = file_with_services(&["a"]);
-		let order = vec!["a".to_string()];
-		let err = filter_services(&file, order, &["z".to_string()]).unwrap_err();
-		assert!(matches!(
-			err,
-			crate::error::ComposeError::ServiceNotFound(_)
-		));
-	}
-
-	// --- expand_targets ---
-
-	fn file_web_depends_db() -> ComposeFile {
-		crate::parse_str(
-			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
-		)
-		.unwrap()
-	}
-
-	#[test]
-	fn expand_targets_empty_is_none() {
-		let file = file_web_depends_db();
-		assert!(expand_targets(&file, &[], false).is_none());
-	}
-
-	#[test]
-	fn expand_targets_includes_dependencies() {
-		let file = file_web_depends_db();
-		let set = expand_targets(&file, &["web".to_string()], false).unwrap();
-		assert!(set.contains("web"));
-		assert!(set.contains("db"));
-	}
-
-	#[test]
-	fn expand_targets_no_deps_excludes_dependencies() {
-		let file = file_web_depends_db();
-		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
-		assert!(set.contains("web"));
-		assert!(!set.contains("db"));
 	}
 }

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -1,0 +1,151 @@
+//! Service-selection helpers for lifecycle commands: stop grace period,
+//! target-list filtering, and `depends_on` expansion.
+
+use std::collections::HashSet;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::error::{ComposeError, Result};
+
+pub(super) fn grace_period_secs(service: &Service) -> i32 {
+	service
+		.stop_grace_period
+		.as_deref()
+		.and_then(crate::size::parse_duration_secs)
+		.and_then(|s| i32::try_from(s).ok())
+		.unwrap_or(10)
+}
+
+/// Return the ordered service names filtered to `target_services`.
+///
+/// Returns an error if any name in `target_services` is not in the file.
+pub(super) fn filter_services(
+	file: &ComposeFile,
+	order: Vec<String>,
+	target_services: &[String],
+) -> Result<Vec<String>> {
+	if target_services.is_empty() {
+		return Ok(order);
+	}
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	let set: std::collections::HashSet<&str> = target_services.iter().map(|s| s.as_str()).collect();
+	Ok(order
+		.into_iter()
+		.filter(|n| set.contains(n.as_str()))
+		.collect())
+}
+
+/// Resolve which services `up` should start given an explicit target list.
+///
+/// Returns `None` when no targets are given (start everything). Otherwise the
+/// set contains the targets plus, unless `no_deps` is set, their transitive
+/// `depends_on` services.
+pub(super) fn expand_targets(
+	file: &ComposeFile,
+	target_services: &[String],
+	no_deps: bool,
+) -> Option<HashSet<String>> {
+	if target_services.is_empty() {
+		return None;
+	}
+	let mut set = HashSet::new();
+	let mut stack: Vec<String> = target_services.to_vec();
+	while let Some(name) = stack.pop() {
+		if !set.insert(name.clone()) {
+			continue;
+		}
+		if !no_deps {
+			if let Some(service) = file.services.get(&name) {
+				for dep in service.depends_on.service_names() {
+					if !set.contains(&dep) {
+						stack.push(dep);
+					}
+				}
+			}
+		}
+	}
+	Some(set)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{expand_targets, filter_services};
+	use crate::compose::types::{ComposeFile, Service};
+
+	fn file_with_services(names: &[&str]) -> ComposeFile {
+		let mut file = ComposeFile::default();
+		for &name in names {
+			file.services.insert(name.to_string(), Service::default());
+		}
+		file
+	}
+
+	#[test]
+	fn filter_empty_target_returns_all() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order.clone(), &[]).unwrap();
+		assert_eq!(result, order);
+	}
+
+	#[test]
+	fn filter_target_subset_returns_intersection() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order, &["b".to_string()]).unwrap();
+		assert_eq!(result, vec!["b".to_string()]);
+	}
+
+	#[test]
+	fn filter_target_preserves_order() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order, &["c".to_string(), "a".to_string()]).unwrap();
+		assert_eq!(result, vec!["a".to_string(), "c".to_string()]);
+	}
+
+	#[test]
+	fn filter_unknown_service_returns_error() {
+		let file = file_with_services(&["a"]);
+		let order = vec!["a".to_string()];
+		let err = filter_services(&file, order, &["z".to_string()]).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ServiceNotFound(_)
+		));
+	}
+
+	// --- expand_targets ---
+
+	fn file_web_depends_db() -> ComposeFile {
+		crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn expand_targets_empty_is_none() {
+		let file = file_web_depends_db();
+		assert!(expand_targets(&file, &[], false).is_none());
+	}
+
+	#[test]
+	fn expand_targets_includes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], false).unwrap();
+		assert!(set.contains("web"));
+		assert!(set.contains("db"));
+	}
+
+	#[test]
+	fn expand_targets_no_deps_excludes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
+		assert!(set.contains("web"));
+		assert!(!set.contains("db"));
+	}
+}

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -1,0 +1,213 @@
+//! Container inspection commands: top, port, images, and log attachment.
+
+use futures_util::StreamExt;
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::image::ImageInspect;
+use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
+
+use super::Engine;
+
+impl Engine {
+	/// Display running processes in each service container (`docker compose top`).
+	///
+	/// If `target_services` is empty, all services are queried.
+	pub async fn top(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
+		let names: Vec<String> = if target_services.is_empty() {
+			file.services.keys().cloned().collect()
+		} else {
+			for name in target_services {
+				if !file.services.contains_key(name) {
+					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
+				}
+			}
+			target_services.to_vec()
+		};
+
+		for name in &names {
+			let service = &file.services[name];
+			for container_name in self.replica_names(name, service) {
+				let path = format!(
+					"{API_PREFIX}/containers/{}/top",
+					urlencoded(&container_name),
+				);
+				match self
+					.client
+					.get_json::<crate::libpod::types::container::TopResponse>(&path)
+					.await
+				{
+					Ok(result) => {
+						println!("{container_name}");
+						if let Some(titles) = &result.titles {
+							println!("{}", titles.join("\t"));
+						}
+						if let Some(processes) = &result.processes {
+							for row in processes {
+								println!("{}", row.join("\t"));
+							}
+						}
+					}
+					Err(e) => tracing::warn!("top {container_name}: {e}"),
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Print the public port for a given private port of a service container.
+	///
+	/// `proto` should be `"tcp"` or `"udp"`. Prints `HOST:PORT` to stdout.
+	pub async fn port(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		private_port: u16,
+		proto: &str,
+	) -> Result<()> {
+		let service = file
+			.services
+			.get(service_name)
+			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
+		let container_name = self.first_replica_name(service_name, service);
+
+		let path = format!(
+			"{API_PREFIX}/containers/{}/json",
+			urlencoded(&container_name),
+		);
+		let info = self
+			.client
+			.get_json::<crate::libpod::types::container::ContainerInspect>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		let key = format!("{private_port}/{proto}");
+		let binding = info
+			.network_settings
+			.and_then(|ns| ns.ports.get(&key).cloned().flatten())
+			.and_then(|bindings| bindings.into_iter().next());
+
+		match binding {
+			Some(b) => {
+				let host = b.host_ip.as_deref().unwrap_or("0.0.0.0");
+				let port = b.host_port.as_deref().unwrap_or("");
+				println!("{host}:{port}");
+			}
+			None => println!(),
+		}
+		Ok(())
+	}
+
+	/// List images used by each service.
+	pub async fn images(&self, file: &ComposeFile) -> Result<()> {
+		println!(
+			"{:<30} {:<25} {:<15} {:<20}",
+			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
+		);
+		for (name, service) in &file.services {
+			let image_ref = match &service.image {
+				Some(img) => img.clone(),
+				None if service.build.is_some() => format!("{name}:latest"),
+				None => continue,
+			};
+			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
+			match self.client.get_json::<ImageInspect>(&path).await {
+				Ok(img) => {
+					let (repo, tag) = image_ref
+						.rsplit_once(':')
+						.map(|(r, t)| (r.to_string(), t.to_string()))
+						.unwrap_or_else(|| (image_ref.clone(), "latest".to_string()));
+					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
+					println!("{name:<30} {repo:<25} {tag:<15} {id:<20}");
+				}
+				Err(e) => tracing::warn!("images {name}: {e}"),
+			}
+		}
+		Ok(())
+	}
+
+	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
+	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
+		// Carry (display_name, container_name, is_tty) so the log parser matches
+		// the container's framing mode: TTY containers emit raw bytes; non-TTY
+		// containers emit multiplexed 8-byte-header frames.
+		let attached: Vec<(String, String, bool)> = file
+			.services
+			.iter()
+			.filter(|(_, s)| s.attach.unwrap_or(true))
+			.flat_map(|(name, s)| {
+				let proj_prefix = format!("{}-", self.project);
+				let is_tty = s.tty.unwrap_or(false);
+				self.replica_names(name, s).into_iter().map(move |cname| {
+					let display = cname
+						.strip_prefix(proj_prefix.as_str())
+						.map(|s| s.to_string())
+						.unwrap_or_else(|| cname.clone());
+					(display, cname, is_tty)
+				})
+			})
+			.collect();
+
+		if attached.is_empty() {
+			return Ok(());
+		}
+
+		let streams: Vec<_> = attached
+			.iter()
+			.map(|(display, cname, is_tty)| {
+				let prefix = display.clone();
+				let path = format!(
+					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
+					urlencoded(cname),
+				);
+				let client = &self.client;
+				let is_tty = *is_tty;
+				async move {
+					let resp = match client.get_stream(&path).await {
+						Ok(r) => r,
+						Err(e) => {
+							tracing::warn!("attach_logs {prefix}: {e}");
+							return;
+						}
+					};
+					// TTY containers produce raw bytes (stdout/stderr merged).
+					// Non-TTY containers produce multiplexed frames with 8-byte headers.
+					let mut stream = if is_tty {
+						crate::libpod::parse_raw(resp.into_body())
+					} else {
+						crate::libpod::parse_multiplexed(resp.into_body())
+					};
+					while let Some(msg) = stream.next().await {
+						match msg {
+							Ok(LogOutput::StdOut { message }) => {
+								print!("{prefix} | {}", String::from_utf8_lossy(&message));
+							}
+							Ok(LogOutput::StdErr { message }) => {
+								eprint!("{prefix} | {}", String::from_utf8_lossy(&message));
+							}
+							Err(_) => break,
+						}
+					}
+				}
+			})
+			.collect();
+
+		#[cfg(unix)]
+		{
+			use tokio::signal::unix::{signal, SignalKind};
+			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+			tokio::select! {
+				_ = futures_util::future::join_all(streams) => {}
+				_ = tokio::signal::ctrl_c() => {}
+				_ = sigterm.recv() => {}
+			}
+		}
+		#[cfg(not(unix))]
+		tokio::select! {
+			_ = futures_util::future::join_all(streams) => {}
+			_ = tokio::signal::ctrl_c() => {}
+		}
+
+		Ok(())
+	}
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -1,4 +1,4 @@
-//! Query and observation commands: ps, logs, exec, pull, remove_orphans, attach_logs, top, port, images.
+//! Query and observation commands: ps, logs, exec, pull, remove_orphans.
 
 use futures_util::StreamExt;
 
@@ -7,10 +7,11 @@ use crate::error::{ComposeError, Result};
 use crate::libpod::types::exec::{
 	ExecCreateConfig, ExecCreateResponse, ExecInspect, ExecStartConfig,
 };
-use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
+
+mod inspect;
 
 impl Engine {
 	/// List containers for this project: name, image, command, state, and port bindings.
@@ -272,207 +273,6 @@ impl Engine {
 				}
 			}
 		}
-		Ok(())
-	}
-
-	/// Display running processes in each service container (`docker compose top`).
-	///
-	/// If `target_services` is empty, all services are queried.
-	pub async fn top(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let names: Vec<String> = if target_services.is_empty() {
-			file.services.keys().cloned().collect()
-		} else {
-			for name in target_services {
-				if !file.services.contains_key(name) {
-					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
-				}
-			}
-			target_services.to_vec()
-		};
-
-		for name in &names {
-			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/top",
-					urlencoded(&container_name),
-				);
-				match self
-					.client
-					.get_json::<crate::libpod::types::container::TopResponse>(&path)
-					.await
-				{
-					Ok(result) => {
-						println!("{container_name}");
-						if let Some(titles) = &result.titles {
-							println!("{}", titles.join("\t"));
-						}
-						if let Some(processes) = &result.processes {
-							for row in processes {
-								println!("{}", row.join("\t"));
-							}
-						}
-					}
-					Err(e) => tracing::warn!("top {container_name}: {e}"),
-				}
-			}
-		}
-		Ok(())
-	}
-
-	/// Print the public port for a given private port of a service container.
-	///
-	/// `proto` should be `"tcp"` or `"udp"`. Prints `HOST:PORT` to stdout.
-	pub async fn port(
-		&self,
-		file: &ComposeFile,
-		service_name: &str,
-		private_port: u16,
-		proto: &str,
-	) -> Result<()> {
-		let service = file
-			.services
-			.get(service_name)
-			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.first_replica_name(service_name, service);
-
-		let path = format!(
-			"{API_PREFIX}/containers/{}/json",
-			urlencoded(&container_name),
-		);
-		let info = self
-			.client
-			.get_json::<crate::libpod::types::container::ContainerInspect>(&path)
-			.await
-			.map_err(ComposeError::Podman)?;
-
-		let key = format!("{private_port}/{proto}");
-		let binding = info
-			.network_settings
-			.and_then(|ns| ns.ports.get(&key).cloned().flatten())
-			.and_then(|bindings| bindings.into_iter().next());
-
-		match binding {
-			Some(b) => {
-				let host = b.host_ip.as_deref().unwrap_or("0.0.0.0");
-				let port = b.host_port.as_deref().unwrap_or("");
-				println!("{host}:{port}");
-			}
-			None => println!(),
-		}
-		Ok(())
-	}
-
-	/// List images used by each service.
-	pub async fn images(&self, file: &ComposeFile) -> Result<()> {
-		println!(
-			"{:<30} {:<25} {:<15} {:<20}",
-			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
-		);
-		for (name, service) in &file.services {
-			let image_ref = match &service.image {
-				Some(img) => img.clone(),
-				None if service.build.is_some() => format!("{name}:latest"),
-				None => continue,
-			};
-			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
-			match self.client.get_json::<ImageInspect>(&path).await {
-				Ok(img) => {
-					let (repo, tag) = image_ref
-						.rsplit_once(':')
-						.map(|(r, t)| (r.to_string(), t.to_string()))
-						.unwrap_or_else(|| (image_ref.clone(), "latest".to_string()));
-					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
-					println!("{name:<30} {repo:<25} {tag:<15} {id:<20}");
-				}
-				Err(e) => tracing::warn!("images {name}: {e}"),
-			}
-		}
-		Ok(())
-	}
-
-	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
-	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
-		// Carry (display_name, container_name, is_tty) so the log parser matches
-		// the container's framing mode: TTY containers emit raw bytes; non-TTY
-		// containers emit multiplexed 8-byte-header frames.
-		let attached: Vec<(String, String, bool)> = file
-			.services
-			.iter()
-			.filter(|(_, s)| s.attach.unwrap_or(true))
-			.flat_map(|(name, s)| {
-				let proj_prefix = format!("{}-", self.project);
-				let is_tty = s.tty.unwrap_or(false);
-				self.replica_names(name, s).into_iter().map(move |cname| {
-					let display = cname
-						.strip_prefix(proj_prefix.as_str())
-						.map(|s| s.to_string())
-						.unwrap_or_else(|| cname.clone());
-					(display, cname, is_tty)
-				})
-			})
-			.collect();
-
-		if attached.is_empty() {
-			return Ok(());
-		}
-
-		let streams: Vec<_> = attached
-			.iter()
-			.map(|(display, cname, is_tty)| {
-				let prefix = display.clone();
-				let path = format!(
-					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
-					urlencoded(cname),
-				);
-				let client = &self.client;
-				let is_tty = *is_tty;
-				async move {
-					let resp = match client.get_stream(&path).await {
-						Ok(r) => r,
-						Err(e) => {
-							tracing::warn!("attach_logs {prefix}: {e}");
-							return;
-						}
-					};
-					// TTY containers produce raw bytes (stdout/stderr merged).
-					// Non-TTY containers produce multiplexed frames with 8-byte headers.
-					let mut stream = if is_tty {
-						crate::libpod::parse_raw(resp.into_body())
-					} else {
-						crate::libpod::parse_multiplexed(resp.into_body())
-					};
-					while let Some(msg) = stream.next().await {
-						match msg {
-							Ok(LogOutput::StdOut { message }) => {
-								print!("{prefix} | {}", String::from_utf8_lossy(&message));
-							}
-							Ok(LogOutput::StdErr { message }) => {
-								eprint!("{prefix} | {}", String::from_utf8_lossy(&message));
-							}
-							Err(_) => break,
-						}
-					}
-				}
-			})
-			.collect();
-
-		#[cfg(unix)]
-		{
-			use tokio::signal::unix::{signal, SignalKind};
-			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
-			tokio::select! {
-				_ = futures_util::future::join_all(streams) => {}
-				_ = tokio::signal::ctrl_c() => {}
-				_ = sigterm.recv() => {}
-			}
-		}
-		#[cfg(not(unix))]
-		tokio::select! {
-			_ = futures_util::future::join_all(streams) => {}
-			_ = tokio::signal::ctrl_c() => {}
-		}
-
 		Ok(())
 	}
 }

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -7,8 +7,14 @@
 
 use std::path::Path;
 
-use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
+use crate::compose::types::{Service, VolumeMount, VolumeType};
 use crate::libpod::types::container::{Mount, NamedVolume};
+
+mod spec;
+use spec::{
+	access_opts, extend_bind_opts_str, extend_volume_opts_str, parse_bind_string,
+	parse_volume_string,
+};
 
 /// Build all OCI mounts and named volume attachments for a container.
 ///
@@ -143,168 +149,14 @@ pub(crate) fn build_mounts_all(
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parse a short-form volume string `"src:dst"` or `"src:dst:opts"`.
-///
-/// Returns `Some((mount, named))` where exactly one of the two is `Some`.
-/// Named volumes go to `SpecGenerator.volumes`; bind mounts go to `mounts`.
-fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> {
-	let (src, dst, opts_str) = split_volume_spec(s);
-	let opts: Vec<String> = opts_str
-		.split(',')
-		.map(|o| o.trim().to_string())
-		.filter(|o| !o.is_empty())
-		.collect();
-	if is_bind_source(src) {
-		Some((
-			Some(Mount {
-				mount_type: "bind".into(),
-				source: if src.is_empty() {
-					None
-				} else {
-					Some(src.to_string())
-				},
-				destination: dst.to_string(),
-				options: opts,
-			}),
-			None,
-		))
-	} else {
-		Some((
-			None,
-			Some(NamedVolume {
-				name: src.to_string(),
-				dest: dst.to_string(),
-				options: opts,
-				sub_path: None,
-			}),
-		))
-	}
-}
-
-/// Whether `s` begins with a Windows drive-letter prefix (e.g. `C:`), so the
-/// colon that follows is part of the path rather than a `src:dst` separator.
-fn has_windows_drive_prefix(s: &str) -> bool {
-	let b = s.as_bytes();
-	b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':'
-}
-
-/// Classify a short-form volume source. A leading `/`, `.` or `~` marks a host
-/// path bind; a Windows drive prefix (`C:\...`) does too. Anything else is a
-/// named volume.
-fn is_bind_source(src: &str) -> bool {
-	src.starts_with('/')
-		|| src.starts_with('.')
-		|| src.starts_with('~')
-		|| has_windows_drive_prefix(src)
-}
-
-/// Split a short-form volume spec into `(src, dst, opts)`. Colons separate the
-/// fields, except the colon in a leading Windows drive prefix, which belongs to
-/// the source path. The destination is always an in-container (Unix) path, so
-/// only the source can carry a drive letter.
-fn split_volume_spec(s: &str) -> (&str, &str, &str) {
-	let scan_from = if has_windows_drive_prefix(s) { 2 } else { 0 };
-	let seps: Vec<usize> = s
-		.bytes()
-		.enumerate()
-		.skip(scan_from)
-		.filter(|&(_, b)| b == b':')
-		.map(|(i, _)| i)
-		.take(2)
-		.collect();
-	match seps.as_slice() {
-		[] => (s, s, ""),
-		[a] => (&s[..*a], &s[a + 1..], ""),
-		[a, b] => (&s[..*a], &s[a + 1..*b], &s[b + 1..]),
-		_ => unreachable!("take(2) yields at most two separators"),
-	}
-}
-
-/// Parse a pre-built bind string (secret/config) — always produces a bind Mount.
-fn parse_bind_string(s: &str) -> Option<Mount> {
-	let parts: Vec<&str> = s.splitn(3, ':').collect();
-	let (src, dst, opts_str) = match parts.len() {
-		1 => (parts[0], parts[0], ""),
-		2 => (parts[0], parts[1], ""),
-		_ => (parts[0], parts[1], parts[2]),
-	};
-	let opts: Vec<String> = opts_str
-		.split(',')
-		.map(|o| o.trim().to_string())
-		.filter(|o| !o.is_empty())
-		.collect();
-	Some(Mount {
-		mount_type: "bind".into(),
-		source: if src.is_empty() {
-			None
-		} else {
-			Some(src.to_string())
-		},
-		destination: dst.to_string(),
-		options: opts,
-	})
-}
-
-fn access_opts(read_only: Option<bool>) -> Vec<String> {
-	if read_only.unwrap_or(false) {
-		vec!["ro".into()]
-	} else {
-		vec!["rw".into()]
-	}
-}
-
-fn extend_bind_opts_str(opts: &mut Vec<String>, b: Option<&BindOptions>) {
-	let Some(b) = b else { return };
-	if let Some(p) = &b.propagation {
-		opts.push(p.clone());
-	}
-	if let Some(s) = &b.selinux {
-		opts.push(s.clone());
-	}
-}
-
-fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOptions>) {
-	let Some(v) = v else { return };
-	if v.nocopy.unwrap_or(false) {
-		opts.push("nocopy".into());
-	}
-}
-
-// ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
-	use super::{build_mounts_all, is_bind_source, split_volume_spec};
+	use super::build_mounts_all;
 	use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
 	use std::path::Path;
-
-	#[test]
-	fn windows_drive_source_is_a_bind_not_a_named_volume() {
-		// `C:\data:/in/container` — the drive colon must not be read as the
-		// src/dst separator, and the source must classify as a bind.
-		assert_eq!(
-			split_volume_spec(r"C:\data:/in/container"),
-			(r"C:\data", "/in/container", "")
-		);
-		assert!(is_bind_source(r"C:\data"));
-		assert!(is_bind_source("D:/forward/slash"));
-	}
-
-	#[test]
-	fn unix_volume_split_is_unchanged() {
-		assert_eq!(split_volume_spec("vol:/data"), ("vol", "/data", ""));
-		assert_eq!(split_volume_spec("./src:/dst:ro"), ("./src", "/dst", "ro"));
-		assert_eq!(split_volume_spec("named"), ("named", "named", ""));
-		assert!(!is_bind_source("named"));
-		assert!(is_bind_source("/abs"));
-		assert!(is_bind_source("./rel"));
-		assert!(is_bind_source("~/home"));
-	}
 
 	fn svc_with_volumes(vols: Vec<VolumeMount>) -> Service {
 		Service {

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -1,0 +1,163 @@
+//! Short-form volume-spec string parsing.
+//!
+//! Splits `"src:dst[:opts]"` strings (and pre-built secret/config bind strings)
+//! into OCI `Mount` / `NamedVolume` parts, handling the Windows drive-letter
+//! colon so it is not mistaken for the `src:dst` separator.
+
+use crate::compose::types::{BindOptions, VolumeOptions};
+use crate::libpod::types::container::{Mount, NamedVolume};
+
+/// Parse a short-form volume string `"src:dst"` or `"src:dst:opts"`.
+///
+/// Returns `Some((mount, named))` where exactly one of the two is `Some`.
+/// Named volumes go to `SpecGenerator.volumes`; bind mounts go to `mounts`.
+pub(super) fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> {
+	let (src, dst, opts_str) = split_volume_spec(s);
+	let opts: Vec<String> = opts_str
+		.split(',')
+		.map(|o| o.trim().to_string())
+		.filter(|o| !o.is_empty())
+		.collect();
+	if is_bind_source(src) {
+		Some((
+			Some(Mount {
+				mount_type: "bind".into(),
+				source: if src.is_empty() {
+					None
+				} else {
+					Some(src.to_string())
+				},
+				destination: dst.to_string(),
+				options: opts,
+			}),
+			None,
+		))
+	} else {
+		Some((
+			None,
+			Some(NamedVolume {
+				name: src.to_string(),
+				dest: dst.to_string(),
+				options: opts,
+				sub_path: None,
+			}),
+		))
+	}
+}
+
+/// Whether `s` begins with a Windows drive-letter prefix (e.g. `C:`), so the
+/// colon that follows is part of the path rather than a `src:dst` separator.
+fn has_windows_drive_prefix(s: &str) -> bool {
+	let b = s.as_bytes();
+	b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':'
+}
+
+/// Classify a short-form volume source. A leading `/`, `.` or `~` marks a host
+/// path bind; a Windows drive prefix (`C:\...`) does too. Anything else is a
+/// named volume.
+fn is_bind_source(src: &str) -> bool {
+	src.starts_with('/')
+		|| src.starts_with('.')
+		|| src.starts_with('~')
+		|| has_windows_drive_prefix(src)
+}
+
+/// Split a short-form volume spec into `(src, dst, opts)`. Colons separate the
+/// fields, except the colon in a leading Windows drive prefix, which belongs to
+/// the source path. The destination is always an in-container (Unix) path, so
+/// only the source can carry a drive letter.
+fn split_volume_spec(s: &str) -> (&str, &str, &str) {
+	let scan_from = if has_windows_drive_prefix(s) { 2 } else { 0 };
+	let seps: Vec<usize> = s
+		.bytes()
+		.enumerate()
+		.skip(scan_from)
+		.filter(|&(_, b)| b == b':')
+		.map(|(i, _)| i)
+		.take(2)
+		.collect();
+	match seps.as_slice() {
+		[] => (s, s, ""),
+		[a] => (&s[..*a], &s[a + 1..], ""),
+		[a, b] => (&s[..*a], &s[a + 1..*b], &s[b + 1..]),
+		_ => unreachable!("take(2) yields at most two separators"),
+	}
+}
+
+/// Parse a pre-built bind string (secret/config) — always produces a bind Mount.
+pub(super) fn parse_bind_string(s: &str) -> Option<Mount> {
+	let parts: Vec<&str> = s.splitn(3, ':').collect();
+	let (src, dst, opts_str) = match parts.len() {
+		1 => (parts[0], parts[0], ""),
+		2 => (parts[0], parts[1], ""),
+		_ => (parts[0], parts[1], parts[2]),
+	};
+	let opts: Vec<String> = opts_str
+		.split(',')
+		.map(|o| o.trim().to_string())
+		.filter(|o| !o.is_empty())
+		.collect();
+	Some(Mount {
+		mount_type: "bind".into(),
+		source: if src.is_empty() {
+			None
+		} else {
+			Some(src.to_string())
+		},
+		destination: dst.to_string(),
+		options: opts,
+	})
+}
+
+pub(super) fn access_opts(read_only: Option<bool>) -> Vec<String> {
+	if read_only.unwrap_or(false) {
+		vec!["ro".into()]
+	} else {
+		vec!["rw".into()]
+	}
+}
+
+pub(super) fn extend_bind_opts_str(opts: &mut Vec<String>, b: Option<&BindOptions>) {
+	let Some(b) = b else { return };
+	if let Some(p) = &b.propagation {
+		opts.push(p.clone());
+	}
+	if let Some(s) = &b.selinux {
+		opts.push(s.clone());
+	}
+}
+
+pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOptions>) {
+	let Some(v) = v else { return };
+	if v.nocopy.unwrap_or(false) {
+		opts.push("nocopy".into());
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{is_bind_source, split_volume_spec};
+
+	#[test]
+	fn windows_drive_source_is_a_bind_not_a_named_volume() {
+		// `C:\data:/in/container` — the drive colon must not be read as the
+		// src/dst separator, and the source must classify as a bind.
+		assert_eq!(
+			split_volume_spec(r"C:\data:/in/container"),
+			(r"C:\data", "/in/container", "")
+		);
+		assert!(is_bind_source(r"C:\data"));
+		assert!(is_bind_source("D:/forward/slash"));
+	}
+
+	#[test]
+	fn unix_volume_split_is_unchanged() {
+		assert_eq!(split_volume_spec("vol:/data"), ("vol", "/data", ""));
+		assert_eq!(split_volume_spec("./src:/dst:ro"), ("./src", "/dst", "ro"));
+		assert_eq!(split_volume_spec("named"), ("named", "named", ""));
+		assert!(!is_bind_source("named"));
+		assert!(is_bind_source("/abs"));
+		assert!(is_bind_source("./rel"));
+		assert!(is_bind_source("~/home"));
+	}
+}

--- a/internal/libpod/client/encode.rs
+++ b/internal/libpod/client/encode.rs
@@ -1,0 +1,75 @@
+//! Percent-encoding for libpod REST path segments.
+
+/// Percent-encode a string for use as a single URL path/query segment, encoding
+/// everything outside the RFC 3986 unreserved set so container names, project
+/// names, and tags can contain arbitrary bytes without breaking the request.
+pub(crate) fn urlencoded(s: &str) -> String {
+	let mut out = String::with_capacity(s.len());
+	for b in s.bytes() {
+		match b {
+			b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+				out.push(b as char);
+			}
+			_ => {
+				out.push('%');
+				out.push(
+					char::from_digit((b >> 4) as u32, 16)
+						.unwrap()
+						.to_ascii_uppercase(),
+				);
+				out.push(
+					char::from_digit((b & 0xf) as u32, 16)
+						.unwrap()
+						.to_ascii_uppercase(),
+				);
+			}
+		}
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::urlencoded;
+
+	#[test]
+	fn unreserved_chars_pass_through() {
+		assert_eq!(urlencoded("abc-XYZ_0.9~"), "abc-XYZ_0.9~");
+	}
+
+	#[test]
+	fn space_encoded() {
+		assert_eq!(urlencoded("hello world"), "hello%20world");
+	}
+
+	#[test]
+	fn slash_encoded() {
+		assert_eq!(urlencoded("a/b"), "a%2Fb");
+	}
+
+	#[test]
+	fn colon_encoded() {
+		assert_eq!(urlencoded("myproj:v1"), "myproj%3Av1");
+	}
+
+	#[test]
+	fn empty_string() {
+		assert_eq!(urlencoded(""), "");
+	}
+
+	#[test]
+	fn unicode_byte_encoded() {
+		// '€' = 0xE2 0x82 0xAC in UTF-8
+		assert_eq!(urlencoded("€"), "%E2%82%AC");
+	}
+
+	#[test]
+	fn container_name_typical() {
+		assert_eq!(urlencoded("myproject-web"), "myproject-web");
+	}
+
+	#[test]
+	fn container_name_with_brackets() {
+		assert_eq!(urlencoded("a[b]"), "a%5Bb%5D");
+	}
+}

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -14,6 +14,9 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::error::PodmanError;
 
+mod encode;
+pub(crate) use encode::urlencoded;
+
 type BoxBody = Full<Bytes>;
 
 /// Upper bound on a buffered (non-streaming) response body. Caps memory use
@@ -344,81 +347,11 @@ impl Client {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// URL encoding helpers
-// ---------------------------------------------------------------------------
-
-pub(crate) fn urlencoded(s: &str) -> String {
-	let mut out = String::with_capacity(s.len());
-	for b in s.bytes() {
-		match b {
-			b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-				out.push(b as char);
-			}
-			_ => {
-				out.push('%');
-				out.push(
-					char::from_digit((b >> 4) as u32, 16)
-						.unwrap()
-						.to_ascii_uppercase(),
-				);
-				out.push(
-					char::from_digit((b & 0xf) as u32, 16)
-						.unwrap()
-						.to_ascii_uppercase(),
-				);
-			}
-		}
-	}
-	out
-}
-
 #[cfg(test)]
 mod tests {
 	use hyper::StatusCode;
 
-	use super::{urlencoded, Client};
-
-	#[test]
-	fn unreserved_chars_pass_through() {
-		assert_eq!(urlencoded("abc-XYZ_0.9~"), "abc-XYZ_0.9~");
-	}
-
-	#[test]
-	fn space_encoded() {
-		assert_eq!(urlencoded("hello world"), "hello%20world");
-	}
-
-	#[test]
-	fn slash_encoded() {
-		assert_eq!(urlencoded("a/b"), "a%2Fb");
-	}
-
-	#[test]
-	fn colon_encoded() {
-		assert_eq!(urlencoded("myproj:v1"), "myproj%3Av1");
-	}
-
-	#[test]
-	fn empty_string() {
-		assert_eq!(urlencoded(""), "");
-	}
-
-	#[test]
-	fn unicode_byte_encoded() {
-		// '€' = 0xE2 0x82 0xAC in UTF-8
-		assert_eq!(urlencoded("€"), "%E2%82%AC");
-	}
-
-	#[test]
-	fn container_name_typical() {
-		assert_eq!(urlencoded("myproject-web"), "myproject-web");
-	}
-
-	#[test]
-	fn container_name_with_brackets() {
-		assert_eq!(urlencoded("a[b]"), "a%5Bb%5D");
-	}
+	use super::Client;
 
 	// ---------------------------------------------------------------------------
 	// check_status tests


### PR DESCRIPTION
## Summary
Pure-relocation splits of five engine/libpod files within ~12 lines of the 500-line cap. No logic changes; unit tests move with the code they cover.

| File | Before | After |
|---|---|---|
| `engine/volume_mounts.rs` | 498 | `mod.rs` 350 + `spec.rs` 163 |
| `engine/lifecycle/mod.rs` | 488 | `mod.rs` 339 + `targets.rs` 151 |
| `libpod/client.rs` | 485 | `mod.rs` 418 + `encode.rs` 75 |
| `engine/container.rs` | 480 | `mod.rs` 278 + `resolve.rs` 213 |
| `engine/query.rs` | 478 | `mod.rs` 278 + `inspect.rs` 213 |

## Tests
`cargo build`, `cargo clippy --all-targets`, lib suite (512), and the parse/substitute/quadlet/ports/size/env_file/secret suites all green.

Closes #239