### PR TITLE
chore: release v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+podup (0.17.0) unstable; urgency=medium
+
+  * Security: the self-update temporary file is now created with mode 0600 and
+    widened to the target's mode afterwards, so the new binary's bytes are never
+    world-readable in a shared directory during the write window.
+  * Security: reject absolute and parent-escaping paths in "env_file" and
+    "label_file" (consistent with "extends"/"include"), and bound "label_file"
+    and ".dockerignore" reads with the shared size cap.
+  * Document RUST_LOG and the exit-status codes in the man page (.SH ENVIRONMENT
+    and a new .SH EXIT STATUS) and in the command reference.
+  * Add a cargo-deny supply-chain policy (license allowlist, wildcard and
+    unknown-source denial) run weekly alongside cargo audit.
+  * Internal: split five engine/libpod files that were approaching the
+    500-line limit into focused submodules; no behaviour change.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 14:30:00 -0500
+
 podup (0.16.0) unstable; urgency=medium
 
   * Ship a signed Debian package (podup_<version>_amd64.deb) as a release asset,

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.16.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.17.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Version bump to 0.17.0 for the standalone hardening batch (#232, #234, #236, #238, #240).

- `Cargo.toml` / `Cargo.lock` → 0.17.0
- `debian/changelog` 0.17.0 entry
- man-page `.TH` → podup 0.17.0

Merges to develop, then a release PR promotes develop → main.