### PR TITLE
release: v0.17.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,3 +19,15 @@ jobs:
 
       - name: Run cargo audit
         run: cargo audit
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version "^0.19" --locked
+
+      - name: Run cargo deny
+        run: cargo deny check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Glyndor/podup"
 readme = "README.md"
 keywords = ["podman", "compose", "containers", "docker-compose", "rootless"]
 categories = ["command-line-utilities", "virtualization"]
-exclude = ["/.github", "/debian", "/docs", "/install.sh", "/tests"]
+exclude = ["/.github", "/debian", "/deny.toml", "/docs", "/install.sh", "/tests"]
 
 [[bin]]
 name = "podup"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.14.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.16.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+podup (0.17.0) unstable; urgency=medium
+
+  * Security: the self-update temporary file is now created with mode 0600 and
+    widened to the target's mode afterwards, so the new binary's bytes are never
+    world-readable in a shared directory during the write window.
+  * Security: reject absolute and parent-escaping paths in "env_file" and
+    "label_file" (consistent with "extends"/"include"), and bound "label_file"
+    and ".dockerignore" reads with the shared size cap.
+  * Document RUST_LOG and the exit-status codes in the man page (.SH ENVIRONMENT
+    and a new .SH EXIT STATUS) and in the command reference.
+  * Add a cargo-deny supply-chain policy (license allowlist, wildcard and
+    unknown-source denial) run weekly alongside cargo audit.
+  * Internal: split five engine/libpod files that were approaching the
+    500-line limit into focused submodules; no behaviour change.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 14:30:00 -0500
+
 podup (0.16.0) unstable; urgency=medium
 
   * Ship a signed Debian package (podup_<version>_amd64.deb) as a release asset,

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.16.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.17.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -146,6 +146,23 @@ Default active profiles (see \fB\-\-profile\fR).
 .TP
 .B PODMAN_SOCKET
 Podman socket path (see \fB\-\-socket\fR).
+.TP
+.B RUST_LOG
+Log verbosity filter. With no value set, warnings and errors are shown; set
+e.g. \fBRUST_LOG=podup=info\fR or \fBRUST_LOG=podup=debug\fR for more detail.
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+A command failed (for example a parse error or a Podman error).
+.TP
+.B 2
+\fBupdate\fR failed to verify or install a release.
+.PP
+\fBrun\fR propagates the container's own exit code verbatim, so any other
+non-zero status comes from the container that was run.
 .SH FILES
 .TP
 .B docker-compose.yml

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,43 @@
+# cargo-deny configuration. Enforces the supply-chain policy locally and in CI:
+# audited advisories, a permissive-license allowlist, and a ban on wildcard
+# version requirements. Duplicate versions are reported (warn) rather than
+# denied: the only duplicates today come from the Windows target and the
+# dev-only tempfile tree, none of which reach the Linux production binary.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.9
+# Every license present in the dependency tree. A crate carrying anything not
+# listed here fails the check, forcing a deliberate review before it ships.
+allow = [
+	"Apache-2.0",
+	"Apache-2.0 WITH LLVM-exception",
+	"MIT",
+	"0BSD",
+	"BSD-1-Clause",
+	"BSD-3-Clause",
+	"BSL-1.0",
+	"ISC",
+	"Unicode-3.0",
+	"Unlicense",
+	"Zlib",
+	"CC0-1.0",
+	"CDLA-Permissive-2.0",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -148,3 +148,26 @@ Forward-compatibility warnings about unknown or unsupported compose fields are
 shown by default; set `RUST_LOG=debug` for verbose tracing. An unexpected
 internal error prints a `podup: internal error:` notice with a bug-report link
 and a reminder to redact secrets before sharing logs.
+
+## Environment
+
+Every environment variable `podup` reads, in one place. Each compose variable
+has an equivalent flag (see [Global options](#global-options)); the flag wins
+when both are set.
+
+| Variable | Description |
+|---|---|
+| `COMPOSE_FILE` | Path-separator-delimited list of compose files (`--file`). |
+| `COMPOSE_PROJECT_NAME` | Default project name (`--project`). |
+| `COMPOSE_PROFILES` | Default active profiles (`--profile`). |
+| `PODMAN_SOCKET` | Podman socket path (`--socket`). |
+| `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
+
+## Exit status
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. |
+| `1` | A command failed (parse error, Podman error). |
+| `2` | `update` failed to verify or install a release. |
+| other | `run` propagates the container's own exit code verbatim. |

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -178,22 +178,7 @@ fn resolve_one_extends(
 ///
 /// Exposed for unit testing.
 pub(crate) fn is_safe_extends_path(path: &str) -> bool {
-	let fp = std::path::Path::new(path);
-	if fp.is_absolute() {
-		return false;
-	}
-	// On Windows, paths like "/etc/passwd" are not `is_absolute()` (no drive letter)
-	// but still escape the project directory via the root separator.
-	if fp.components().next() == Some(std::path::Component::RootDir) {
-		return false;
-	}
-	if fp
-		.components()
-		.any(|c| c == std::path::Component::ParentDir)
-	{
-		return false;
-	}
-	true
+	crate::fsutil::is_safe_relative_path(path)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -123,7 +123,7 @@ pub(super) fn map_additional_context(base_dir: &Path, value: &str) -> String {
 
 fn read_dockerignore(context: &Path) -> Vec<String> {
 	let path = context.join(".dockerignore");
-	let Ok(content) = std::fs::read_to_string(path) else {
+	let Ok(content) = crate::fsutil::read_to_string_capped(path) else {
 		return Vec::new();
 	};
 	content

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -2,14 +2,17 @@
 //! [`Service`] and starts the container.
 
 use std::collections::HashMap;
-use std::path::Path;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::{LinuxResources, Namespace, SpecGenerator};
 use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
-use crate::{env_file, ports, size};
+use crate::{ports, size};
+
+mod resolve;
+use resolve::{build_env, resolve_links, resolve_volume_name};
+pub(crate) use resolve::{config_hash, resolve_bind_source};
 
 use super::container_config::{
 	build_healthcheck, build_log_config, build_resource_limits, build_restart_policy,
@@ -271,210 +274,5 @@ impl Engine {
 	/// in the top-level `volumes:` map (anonymous/implicit) are left unchanged.
 	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> String {
 		resolve_volume_name(reference, &self.project, file)
-	}
-}
-
-/// Resolve a named-volume reference to the volume name `create_volumes`
-/// produced: a custom `name:`, the raw name for an external volume, or the
-/// `{project}_{name}` form. References not declared in the top-level `volumes:`
-/// map (anonymous/implicit) are returned unchanged.
-fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> String {
-	match file.volumes.get(reference) {
-		Some(cfg) => {
-			if let Some(name) = cfg.as_ref().and_then(|c| c.name.as_deref()) {
-				name.to_string()
-			} else if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
-				reference.to_string()
-			} else {
-				format!("{project}_{reference}")
-			}
-		}
-		None => reference.to_string(),
-	}
-}
-
-/// Resolve a bind-mount source path: expand a leading `~`, then make a relative
-/// path absolute against the project base directory. Absolute paths (including
-/// staged secret/config files) are returned unchanged.
-pub(super) fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
-	if src.is_empty() {
-		return src.to_string();
-	}
-	let expanded = if let Some(rest) = src.strip_prefix("~/") {
-		// Join with the platform separator rather than hardcoding `/`, and look
-		// up the home directory in a platform-correct way (USERPROFILE on
-		// native Windows, where HOME is usually unset).
-		match home_dir() {
-			Some(home) => home.join(rest).to_string_lossy().into_owned(),
-			None => src.to_string(),
-		}
-	} else if src == "~" {
-		home_dir()
-			.map(|h| h.to_string_lossy().into_owned())
-			.unwrap_or_else(|| src.to_string())
-	} else {
-		src.to_string()
-	};
-	if Path::new(&expanded).is_absolute() {
-		expanded
-	} else {
-		base_dir.join(&expanded).to_string_lossy().into_owned()
-	}
-}
-
-/// The current user's home directory. Prefers `HOME` (set on Unix and most
-/// shells), falling back to `USERPROFILE` for native Windows where `HOME` is
-/// usually absent. Empty values are treated as unset.
-fn home_dir() -> Option<std::path::PathBuf> {
-	std::env::var_os("HOME")
-		.or_else(|| std::env::var_os("USERPROFILE"))
-		.filter(|v| !v.is_empty())
-		.map(std::path::PathBuf::from)
-}
-
-/// Resolve a service's `links` to concrete container references.
-///
-/// A compose `links:` entry names a sibling service; it is rewritten to that
-/// service's container name with the service name kept as the network alias
-/// (`{container}:{alias}`), so the linked container is reachable by the compose
-/// service name. `external_links` reference containers outside the project and
-/// are passed through verbatim.
-fn resolve_links(service: &Service, file: &ComposeFile, project: &str) -> Vec<String> {
-	let mut links: Vec<String> = service
-		.links
-		.iter()
-		.map(|link| {
-			let (target, alias) = link.split_once(':').unwrap_or((link, link));
-			let container = file
-				.services
-				.get(target)
-				.map(|svc| {
-					svc.container_name
-						.clone()
-						.unwrap_or_else(|| format!("{project}-{target}"))
-				})
-				.unwrap_or_else(|| target.to_string());
-			format!("{container}:{alias}")
-		})
-		.collect();
-	links.extend(service.external_links.iter().cloned());
-	links
-}
-
-/// Stable content hash of a service definition, stored as the
-/// `podup.config-hash` label. On `up`, comparing this against the label on an
-/// existing container tells podup whether the service configuration changed
-/// and the container must be recreated, or is unchanged and can be left as is.
-pub(crate) fn config_hash(service: &Service) -> String {
-	use sha2::{Digest, Sha256};
-	// Canonicalise through `serde_json::Value` first: object keys are emitted in
-	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
-	// between runs and flap the hash into a spurious recreate.
-	let serialized = serde_json::to_value(service)
-		.and_then(|v| serde_json::to_vec(&v))
-		.unwrap_or_default();
-	Sha256::digest(&serialized)
-		.iter()
-		.map(|b| format!("{b:02x}"))
-		.collect()
-}
-
-fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
-	let entries = service.env_file.to_entries();
-	let env_file_vars = if !entries.is_empty() {
-		env_file::load_env_file_entries(&entries, base_dir)?
-	} else {
-		HashMap::new()
-	};
-	Ok(env_file::merge_env(
-		service.environment.to_map(),
-		env_file_vars,
-	))
-}
-
-#[cfg(test)]
-mod tests {
-	use super::{config_hash, resolve_links, resolve_volume_name};
-	use crate::parse_str;
-
-	#[test]
-	fn links_resolve_to_container_names_external_links_verbatim() {
-		let file = parse_str(
-			"services:\n  db:\n    image: x\n  web:\n    image: x\n    links:\n      - db\n      - db:primary\n    external_links:\n      - legacy_db:db\n",
-		)
-		.unwrap();
-		let links = resolve_links(&file.services["web"], &file, "proj");
-		assert!(links.contains(&"proj-db:db".to_string()));
-		assert!(links.contains(&"proj-db:primary".to_string()));
-		assert!(links.contains(&"legacy_db:db".to_string()));
-	}
-
-	#[test]
-	fn links_honour_custom_container_name() {
-		let file = parse_str(
-			"services:\n  db:\n    image: x\n    container_name: my-db\n  web:\n    image: x\n    links:\n      - db\n",
-		)
-		.unwrap();
-		let links = resolve_links(&file.services["web"], &file, "proj");
-		assert_eq!(links, vec!["my-db:db".to_string()]);
-	}
-
-	#[test]
-	#[cfg(unix)]
-	fn bind_source_resolution() {
-		use super::resolve_bind_source;
-		use std::path::Path;
-		let base = Path::new("/srv/app");
-		assert_eq!(resolve_bind_source("/abs/path", base), "/abs/path");
-		assert_eq!(resolve_bind_source("./data", base), "/srv/app/./data");
-		assert_eq!(resolve_bind_source("data", base), "/srv/app/data");
-		std::env::set_var("HOME", "/home/u");
-		assert_eq!(resolve_bind_source("~/x", base), "/home/u/x");
-		assert_eq!(resolve_bind_source("~", base), "/home/u");
-	}
-
-	#[test]
-	fn volume_name_resolution() {
-		let f = parse_str(
-			"services:\n  s:\n    image: x\nvolumes:\n  data:\n  ext:\n    external: true\n  custom:\n    name: my-vol\n",
-		)
-		.unwrap();
-		assert_eq!(resolve_volume_name("data", "proj", &f), "proj_data");
-		assert_eq!(resolve_volume_name("ext", "proj", &f), "ext");
-		assert_eq!(resolve_volume_name("custom", "proj", &f), "my-vol");
-		// Not declared in top-level volumes -> left as-is.
-		assert_eq!(resolve_volume_name("anon", "proj", &f), "anon");
-	}
-
-	#[test]
-	fn config_hash_is_stable_and_sensitive() {
-		let a = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
-		let b = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
-		let c = parse_str("services:\n  web:\n    image: nginx:1.28\n").unwrap();
-		let ha = config_hash(&a.services["web"]);
-		let hb = config_hash(&b.services["web"]);
-		let hc = config_hash(&c.services["web"]);
-		assert_eq!(ha, hb, "same config produces the same hash");
-		assert_ne!(ha, hc, "a changed image produces a different hash");
-		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
-	}
-
-	#[test]
-	fn config_hash_stable_despite_map_field_order() {
-		// `storage_opt` is a HashMap; canonical serialisation must sort its keys
-		// so the hash does not flap and trigger a spurious recreate on `up`.
-		let a = parse_str(
-			"services:\n  web:\n    image: x\n    storage_opt:\n      size: \"10G\"\n      foo: bar\n      baz: qux\n",
-		)
-		.unwrap();
-		let b = parse_str(
-			"services:\n  web:\n    image: x\n    storage_opt:\n      baz: qux\n      size: \"10G\"\n      foo: bar\n",
-		)
-		.unwrap();
-		assert_eq!(
-			config_hash(&a.services["web"]),
-			config_hash(&b.services["web"]),
-			"hash must be independent of storage_opt key order",
-		);
 	}
 }

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -1,0 +1,213 @@
+//! Name, path, link, and config-hash resolution for container creation.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::env_file;
+use crate::error::Result;
+
+/// Resolve a named-volume reference to the volume name `create_volumes`
+/// produced: a custom `name:`, the raw name for an external volume, or the
+/// `{project}_{name}` form. References not declared in the top-level `volumes:`
+/// map (anonymous/implicit) are returned unchanged.
+pub(super) fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> String {
+	match file.volumes.get(reference) {
+		Some(cfg) => {
+			if let Some(name) = cfg.as_ref().and_then(|c| c.name.as_deref()) {
+				name.to_string()
+			} else if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
+				reference.to_string()
+			} else {
+				format!("{project}_{reference}")
+			}
+		}
+		None => reference.to_string(),
+	}
+}
+
+/// Resolve a bind-mount source path: expand a leading `~`, then make a relative
+/// path absolute against the project base directory. Absolute paths (including
+/// staged secret/config files) are returned unchanged.
+pub(crate) fn resolve_bind_source(src: &str, base_dir: &Path) -> String {
+	if src.is_empty() {
+		return src.to_string();
+	}
+	let expanded = if let Some(rest) = src.strip_prefix("~/") {
+		// Join with the platform separator rather than hardcoding `/`, and look
+		// up the home directory in a platform-correct way (USERPROFILE on
+		// native Windows, where HOME is usually unset).
+		match home_dir() {
+			Some(home) => home.join(rest).to_string_lossy().into_owned(),
+			None => src.to_string(),
+		}
+	} else if src == "~" {
+		home_dir()
+			.map(|h| h.to_string_lossy().into_owned())
+			.unwrap_or_else(|| src.to_string())
+	} else {
+		src.to_string()
+	};
+	if Path::new(&expanded).is_absolute() {
+		expanded
+	} else {
+		base_dir.join(&expanded).to_string_lossy().into_owned()
+	}
+}
+
+/// The current user's home directory. Prefers `HOME` (set on Unix and most
+/// shells), falling back to `USERPROFILE` for native Windows where `HOME` is
+/// usually absent. Empty values are treated as unset.
+fn home_dir() -> Option<std::path::PathBuf> {
+	std::env::var_os("HOME")
+		.or_else(|| std::env::var_os("USERPROFILE"))
+		.filter(|v| !v.is_empty())
+		.map(std::path::PathBuf::from)
+}
+
+/// Resolve a service's `links` to concrete container references.
+///
+/// A compose `links:` entry names a sibling service; it is rewritten to that
+/// service's container name with the service name kept as the network alias
+/// (`{container}:{alias}`), so the linked container is reachable by the compose
+/// service name. `external_links` reference containers outside the project and
+/// are passed through verbatim.
+pub(super) fn resolve_links(service: &Service, file: &ComposeFile, project: &str) -> Vec<String> {
+	let mut links: Vec<String> = service
+		.links
+		.iter()
+		.map(|link| {
+			let (target, alias) = link.split_once(':').unwrap_or((link, link));
+			let container = file
+				.services
+				.get(target)
+				.map(|svc| {
+					svc.container_name
+						.clone()
+						.unwrap_or_else(|| format!("{project}-{target}"))
+				})
+				.unwrap_or_else(|| target.to_string());
+			format!("{container}:{alias}")
+		})
+		.collect();
+	links.extend(service.external_links.iter().cloned());
+	links
+}
+
+/// Stable content hash of a service definition, stored as the
+/// `podup.config-hash` label. On `up`, comparing this against the label on an
+/// existing container tells podup whether the service configuration changed
+/// and the container must be recreated, or is unchanged and can be left as is.
+pub(crate) fn config_hash(service: &Service) -> String {
+	use sha2::{Digest, Sha256};
+	// Canonicalise through `serde_json::Value` first: object keys are emitted in
+	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
+	// between runs and flap the hash into a spurious recreate.
+	let serialized = serde_json::to_value(service)
+		.and_then(|v| serde_json::to_vec(&v))
+		.unwrap_or_default();
+	Sha256::digest(&serialized)
+		.iter()
+		.map(|b| format!("{b:02x}"))
+		.collect()
+}
+
+pub(super) fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String>> {
+	let entries = service.env_file.to_entries();
+	let env_file_vars = if !entries.is_empty() {
+		env_file::load_env_file_entries(&entries, base_dir)?
+	} else {
+		HashMap::new()
+	};
+	Ok(env_file::merge_env(
+		service.environment.to_map(),
+		env_file_vars,
+	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{config_hash, resolve_links, resolve_volume_name};
+	use crate::parse_str;
+
+	#[test]
+	fn links_resolve_to_container_names_external_links_verbatim() {
+		let file = parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    links:\n      - db\n      - db:primary\n    external_links:\n      - legacy_db:db\n",
+		)
+		.unwrap();
+		let links = resolve_links(&file.services["web"], &file, "proj");
+		assert!(links.contains(&"proj-db:db".to_string()));
+		assert!(links.contains(&"proj-db:primary".to_string()));
+		assert!(links.contains(&"legacy_db:db".to_string()));
+	}
+
+	#[test]
+	fn links_honour_custom_container_name() {
+		let file = parse_str(
+			"services:\n  db:\n    image: x\n    container_name: my-db\n  web:\n    image: x\n    links:\n      - db\n",
+		)
+		.unwrap();
+		let links = resolve_links(&file.services["web"], &file, "proj");
+		assert_eq!(links, vec!["my-db:db".to_string()]);
+	}
+
+	#[test]
+	#[cfg(unix)]
+	fn bind_source_resolution() {
+		use super::resolve_bind_source;
+		use std::path::Path;
+		let base = Path::new("/srv/app");
+		assert_eq!(resolve_bind_source("/abs/path", base), "/abs/path");
+		assert_eq!(resolve_bind_source("./data", base), "/srv/app/./data");
+		assert_eq!(resolve_bind_source("data", base), "/srv/app/data");
+		std::env::set_var("HOME", "/home/u");
+		assert_eq!(resolve_bind_source("~/x", base), "/home/u/x");
+		assert_eq!(resolve_bind_source("~", base), "/home/u");
+	}
+
+	#[test]
+	fn volume_name_resolution() {
+		let f = parse_str(
+			"services:\n  s:\n    image: x\nvolumes:\n  data:\n  ext:\n    external: true\n  custom:\n    name: my-vol\n",
+		)
+		.unwrap();
+		assert_eq!(resolve_volume_name("data", "proj", &f), "proj_data");
+		assert_eq!(resolve_volume_name("ext", "proj", &f), "ext");
+		assert_eq!(resolve_volume_name("custom", "proj", &f), "my-vol");
+		// Not declared in top-level volumes -> left as-is.
+		assert_eq!(resolve_volume_name("anon", "proj", &f), "anon");
+	}
+
+	#[test]
+	fn config_hash_is_stable_and_sensitive() {
+		let a = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let b = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let c = parse_str("services:\n  web:\n    image: nginx:1.28\n").unwrap();
+		let ha = config_hash(&a.services["web"]);
+		let hb = config_hash(&b.services["web"]);
+		let hc = config_hash(&c.services["web"]);
+		assert_eq!(ha, hb, "same config produces the same hash");
+		assert_ne!(ha, hc, "a changed image produces a different hash");
+		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
+	}
+
+	#[test]
+	fn config_hash_stable_despite_map_field_order() {
+		// `storage_opt` is a HashMap; canonical serialisation must sort its keys
+		// so the hash does not flap and trigger a spurious recreate on `up`.
+		let a = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      size: \"10G\"\n      foo: bar\n      baz: qux\n",
+		)
+		.unwrap();
+		let b = parse_str(
+			"services:\n  web:\n    image: x\n    storage_opt:\n      baz: qux\n      size: \"10G\"\n      foo: bar\n",
+		)
+		.unwrap();
+		assert_eq!(
+			config_hash(&a.services["web"]),
+			config_hash(&b.services["web"]),
+			"hash must be independent of storage_opt key order",
+		);
+	}
+}

--- a/internal/engine/container_fields.rs
+++ b/internal/engine/container_fields.rs
@@ -132,14 +132,17 @@ pub(super) fn build_label_file_labels(
 ) -> HashMap<String, String> {
 	let mut labels = HashMap::new();
 	for path in service.label_file.to_list() {
-		let full = if std::path::Path::new(&path).is_absolute() {
-			std::path::PathBuf::from(&path)
-		} else {
-			base_dir.join(&path)
-		};
-		let Ok(content) = std::fs::read_to_string(&full) else {
-			warn!("label_file: cannot read {}", full.display());
+		if !crate::fsutil::is_safe_relative_path(&path) {
+			warn!("label_file: refusing absolute or parent-escaping path {path}");
 			continue;
+		}
+		let full = base_dir.join(&path);
+		let content = match crate::fsutil::read_to_string_capped(&full) {
+			Ok(c) => c,
+			Err(e) => {
+				warn!("label_file: cannot read {}: {e}", full.display());
+				continue;
+			}
 		};
 		for line in content.lines() {
 			let trimmed = line.trim();

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -1,14 +1,17 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
 mod commands;
+mod targets;
 
 use std::collections::{HashMap, HashSet};
 
 use tracing::info;
 
-use crate::compose::types::{ComposeFile, Service, ServiceCondition};
-use crate::error::{ComposeError, Result};
+use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::error::Result;
 use crate::libpod::API_PREFIX;
+
+use targets::{expand_targets, filter_services, grace_period_secs};
 
 use super::container::config_hash;
 
@@ -332,157 +335,5 @@ impl Engine {
 
 		self.cleanup_temp_dir();
 		Ok(())
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-pub(super) fn grace_period_secs(service: &Service) -> i32 {
-	service
-		.stop_grace_period
-		.as_deref()
-		.and_then(crate::size::parse_duration_secs)
-		.and_then(|s| i32::try_from(s).ok())
-		.unwrap_or(10)
-}
-
-/// Return the ordered service names filtered to `target_services`.
-///
-/// Returns an error if any name in `target_services` is not in the file.
-pub(super) fn filter_services(
-	file: &crate::compose::types::ComposeFile,
-	order: Vec<String>,
-	target_services: &[String],
-) -> Result<Vec<String>> {
-	if target_services.is_empty() {
-		return Ok(order);
-	}
-	for name in target_services {
-		if !file.services.contains_key(name) {
-			return Err(ComposeError::ServiceNotFound(name.clone()));
-		}
-	}
-	let set: std::collections::HashSet<&str> = target_services.iter().map(|s| s.as_str()).collect();
-	Ok(order
-		.into_iter()
-		.filter(|n| set.contains(n.as_str()))
-		.collect())
-}
-
-/// Resolve which services `up` should start given an explicit target list.
-///
-/// Returns `None` when no targets are given (start everything). Otherwise the
-/// set contains the targets plus, unless `no_deps` is set, their transitive
-/// `depends_on` services.
-fn expand_targets(
-	file: &ComposeFile,
-	target_services: &[String],
-	no_deps: bool,
-) -> Option<HashSet<String>> {
-	if target_services.is_empty() {
-		return None;
-	}
-	let mut set = HashSet::new();
-	let mut stack: Vec<String> = target_services.to_vec();
-	while let Some(name) = stack.pop() {
-		if !set.insert(name.clone()) {
-			continue;
-		}
-		if !no_deps {
-			if let Some(service) = file.services.get(&name) {
-				for dep in service.depends_on.service_names() {
-					if !set.contains(&dep) {
-						stack.push(dep);
-					}
-				}
-			}
-		}
-	}
-	Some(set)
-}
-
-// ---------------------------------------------------------------------------
-// Unit tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-	use super::{expand_targets, filter_services};
-	use crate::compose::types::{ComposeFile, Service};
-
-	fn file_with_services(names: &[&str]) -> ComposeFile {
-		let mut file = ComposeFile::default();
-		for &name in names {
-			file.services.insert(name.to_string(), Service::default());
-		}
-		file
-	}
-
-	#[test]
-	fn filter_empty_target_returns_all() {
-		let file = file_with_services(&["a", "b", "c"]);
-		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-		let result = filter_services(&file, order.clone(), &[]).unwrap();
-		assert_eq!(result, order);
-	}
-
-	#[test]
-	fn filter_target_subset_returns_intersection() {
-		let file = file_with_services(&["a", "b", "c"]);
-		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-		let result = filter_services(&file, order, &["b".to_string()]).unwrap();
-		assert_eq!(result, vec!["b".to_string()]);
-	}
-
-	#[test]
-	fn filter_target_preserves_order() {
-		let file = file_with_services(&["a", "b", "c"]);
-		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-		let result = filter_services(&file, order, &["c".to_string(), "a".to_string()]).unwrap();
-		assert_eq!(result, vec!["a".to_string(), "c".to_string()]);
-	}
-
-	#[test]
-	fn filter_unknown_service_returns_error() {
-		let file = file_with_services(&["a"]);
-		let order = vec!["a".to_string()];
-		let err = filter_services(&file, order, &["z".to_string()]).unwrap_err();
-		assert!(matches!(
-			err,
-			crate::error::ComposeError::ServiceNotFound(_)
-		));
-	}
-
-	// --- expand_targets ---
-
-	fn file_web_depends_db() -> ComposeFile {
-		crate::parse_str(
-			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
-		)
-		.unwrap()
-	}
-
-	#[test]
-	fn expand_targets_empty_is_none() {
-		let file = file_web_depends_db();
-		assert!(expand_targets(&file, &[], false).is_none());
-	}
-
-	#[test]
-	fn expand_targets_includes_dependencies() {
-		let file = file_web_depends_db();
-		let set = expand_targets(&file, &["web".to_string()], false).unwrap();
-		assert!(set.contains("web"));
-		assert!(set.contains("db"));
-	}
-
-	#[test]
-	fn expand_targets_no_deps_excludes_dependencies() {
-		let file = file_web_depends_db();
-		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
-		assert!(set.contains("web"));
-		assert!(!set.contains("db"));
 	}
 }

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -1,0 +1,151 @@
+//! Service-selection helpers for lifecycle commands: stop grace period,
+//! target-list filtering, and `depends_on` expansion.
+
+use std::collections::HashSet;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::error::{ComposeError, Result};
+
+pub(super) fn grace_period_secs(service: &Service) -> i32 {
+	service
+		.stop_grace_period
+		.as_deref()
+		.and_then(crate::size::parse_duration_secs)
+		.and_then(|s| i32::try_from(s).ok())
+		.unwrap_or(10)
+}
+
+/// Return the ordered service names filtered to `target_services`.
+///
+/// Returns an error if any name in `target_services` is not in the file.
+pub(super) fn filter_services(
+	file: &ComposeFile,
+	order: Vec<String>,
+	target_services: &[String],
+) -> Result<Vec<String>> {
+	if target_services.is_empty() {
+		return Ok(order);
+	}
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	let set: std::collections::HashSet<&str> = target_services.iter().map(|s| s.as_str()).collect();
+	Ok(order
+		.into_iter()
+		.filter(|n| set.contains(n.as_str()))
+		.collect())
+}
+
+/// Resolve which services `up` should start given an explicit target list.
+///
+/// Returns `None` when no targets are given (start everything). Otherwise the
+/// set contains the targets plus, unless `no_deps` is set, their transitive
+/// `depends_on` services.
+pub(super) fn expand_targets(
+	file: &ComposeFile,
+	target_services: &[String],
+	no_deps: bool,
+) -> Option<HashSet<String>> {
+	if target_services.is_empty() {
+		return None;
+	}
+	let mut set = HashSet::new();
+	let mut stack: Vec<String> = target_services.to_vec();
+	while let Some(name) = stack.pop() {
+		if !set.insert(name.clone()) {
+			continue;
+		}
+		if !no_deps {
+			if let Some(service) = file.services.get(&name) {
+				for dep in service.depends_on.service_names() {
+					if !set.contains(&dep) {
+						stack.push(dep);
+					}
+				}
+			}
+		}
+	}
+	Some(set)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{expand_targets, filter_services};
+	use crate::compose::types::{ComposeFile, Service};
+
+	fn file_with_services(names: &[&str]) -> ComposeFile {
+		let mut file = ComposeFile::default();
+		for &name in names {
+			file.services.insert(name.to_string(), Service::default());
+		}
+		file
+	}
+
+	#[test]
+	fn filter_empty_target_returns_all() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order.clone(), &[]).unwrap();
+		assert_eq!(result, order);
+	}
+
+	#[test]
+	fn filter_target_subset_returns_intersection() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order, &["b".to_string()]).unwrap();
+		assert_eq!(result, vec!["b".to_string()]);
+	}
+
+	#[test]
+	fn filter_target_preserves_order() {
+		let file = file_with_services(&["a", "b", "c"]);
+		let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+		let result = filter_services(&file, order, &["c".to_string(), "a".to_string()]).unwrap();
+		assert_eq!(result, vec!["a".to_string(), "c".to_string()]);
+	}
+
+	#[test]
+	fn filter_unknown_service_returns_error() {
+		let file = file_with_services(&["a"]);
+		let order = vec!["a".to_string()];
+		let err = filter_services(&file, order, &["z".to_string()]).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ServiceNotFound(_)
+		));
+	}
+
+	// --- expand_targets ---
+
+	fn file_web_depends_db() -> ComposeFile {
+		crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn expand_targets_empty_is_none() {
+		let file = file_web_depends_db();
+		assert!(expand_targets(&file, &[], false).is_none());
+	}
+
+	#[test]
+	fn expand_targets_includes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], false).unwrap();
+		assert!(set.contains("web"));
+		assert!(set.contains("db"));
+	}
+
+	#[test]
+	fn expand_targets_no_deps_excludes_dependencies() {
+		let file = file_web_depends_db();
+		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
+		assert!(set.contains("web"));
+		assert!(!set.contains("db"));
+	}
+}

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -1,0 +1,213 @@
+//! Container inspection commands: top, port, images, and log attachment.
+
+use futures_util::StreamExt;
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::image::ImageInspect;
+use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
+
+use super::Engine;
+
+impl Engine {
+	/// Display running processes in each service container (`docker compose top`).
+	///
+	/// If `target_services` is empty, all services are queried.
+	pub async fn top(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
+		let names: Vec<String> = if target_services.is_empty() {
+			file.services.keys().cloned().collect()
+		} else {
+			for name in target_services {
+				if !file.services.contains_key(name) {
+					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
+				}
+			}
+			target_services.to_vec()
+		};
+
+		for name in &names {
+			let service = &file.services[name];
+			for container_name in self.replica_names(name, service) {
+				let path = format!(
+					"{API_PREFIX}/containers/{}/top",
+					urlencoded(&container_name),
+				);
+				match self
+					.client
+					.get_json::<crate::libpod::types::container::TopResponse>(&path)
+					.await
+				{
+					Ok(result) => {
+						println!("{container_name}");
+						if let Some(titles) = &result.titles {
+							println!("{}", titles.join("\t"));
+						}
+						if let Some(processes) = &result.processes {
+							for row in processes {
+								println!("{}", row.join("\t"));
+							}
+						}
+					}
+					Err(e) => tracing::warn!("top {container_name}: {e}"),
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Print the public port for a given private port of a service container.
+	///
+	/// `proto` should be `"tcp"` or `"udp"`. Prints `HOST:PORT` to stdout.
+	pub async fn port(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		private_port: u16,
+		proto: &str,
+	) -> Result<()> {
+		let service = file
+			.services
+			.get(service_name)
+			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
+		let container_name = self.first_replica_name(service_name, service);
+
+		let path = format!(
+			"{API_PREFIX}/containers/{}/json",
+			urlencoded(&container_name),
+		);
+		let info = self
+			.client
+			.get_json::<crate::libpod::types::container::ContainerInspect>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		let key = format!("{private_port}/{proto}");
+		let binding = info
+			.network_settings
+			.and_then(|ns| ns.ports.get(&key).cloned().flatten())
+			.and_then(|bindings| bindings.into_iter().next());
+
+		match binding {
+			Some(b) => {
+				let host = b.host_ip.as_deref().unwrap_or("0.0.0.0");
+				let port = b.host_port.as_deref().unwrap_or("");
+				println!("{host}:{port}");
+			}
+			None => println!(),
+		}
+		Ok(())
+	}
+
+	/// List images used by each service.
+	pub async fn images(&self, file: &ComposeFile) -> Result<()> {
+		println!(
+			"{:<30} {:<25} {:<15} {:<20}",
+			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
+		);
+		for (name, service) in &file.services {
+			let image_ref = match &service.image {
+				Some(img) => img.clone(),
+				None if service.build.is_some() => format!("{name}:latest"),
+				None => continue,
+			};
+			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
+			match self.client.get_json::<ImageInspect>(&path).await {
+				Ok(img) => {
+					let (repo, tag) = image_ref
+						.rsplit_once(':')
+						.map(|(r, t)| (r.to_string(), t.to_string()))
+						.unwrap_or_else(|| (image_ref.clone(), "latest".to_string()));
+					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
+					println!("{name:<30} {repo:<25} {tag:<15} {id:<20}");
+				}
+				Err(e) => tracing::warn!("images {name}: {e}"),
+			}
+		}
+		Ok(())
+	}
+
+	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
+	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
+		// Carry (display_name, container_name, is_tty) so the log parser matches
+		// the container's framing mode: TTY containers emit raw bytes; non-TTY
+		// containers emit multiplexed 8-byte-header frames.
+		let attached: Vec<(String, String, bool)> = file
+			.services
+			.iter()
+			.filter(|(_, s)| s.attach.unwrap_or(true))
+			.flat_map(|(name, s)| {
+				let proj_prefix = format!("{}-", self.project);
+				let is_tty = s.tty.unwrap_or(false);
+				self.replica_names(name, s).into_iter().map(move |cname| {
+					let display = cname
+						.strip_prefix(proj_prefix.as_str())
+						.map(|s| s.to_string())
+						.unwrap_or_else(|| cname.clone());
+					(display, cname, is_tty)
+				})
+			})
+			.collect();
+
+		if attached.is_empty() {
+			return Ok(());
+		}
+
+		let streams: Vec<_> = attached
+			.iter()
+			.map(|(display, cname, is_tty)| {
+				let prefix = display.clone();
+				let path = format!(
+					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
+					urlencoded(cname),
+				);
+				let client = &self.client;
+				let is_tty = *is_tty;
+				async move {
+					let resp = match client.get_stream(&path).await {
+						Ok(r) => r,
+						Err(e) => {
+							tracing::warn!("attach_logs {prefix}: {e}");
+							return;
+						}
+					};
+					// TTY containers produce raw bytes (stdout/stderr merged).
+					// Non-TTY containers produce multiplexed frames with 8-byte headers.
+					let mut stream = if is_tty {
+						crate::libpod::parse_raw(resp.into_body())
+					} else {
+						crate::libpod::parse_multiplexed(resp.into_body())
+					};
+					while let Some(msg) = stream.next().await {
+						match msg {
+							Ok(LogOutput::StdOut { message }) => {
+								print!("{prefix} | {}", String::from_utf8_lossy(&message));
+							}
+							Ok(LogOutput::StdErr { message }) => {
+								eprint!("{prefix} | {}", String::from_utf8_lossy(&message));
+							}
+							Err(_) => break,
+						}
+					}
+				}
+			})
+			.collect();
+
+		#[cfg(unix)]
+		{
+			use tokio::signal::unix::{signal, SignalKind};
+			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+			tokio::select! {
+				_ = futures_util::future::join_all(streams) => {}
+				_ = tokio::signal::ctrl_c() => {}
+				_ = sigterm.recv() => {}
+			}
+		}
+		#[cfg(not(unix))]
+		tokio::select! {
+			_ = futures_util::future::join_all(streams) => {}
+			_ = tokio::signal::ctrl_c() => {}
+		}
+
+		Ok(())
+	}
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -1,4 +1,4 @@
-//! Query and observation commands: ps, logs, exec, pull, remove_orphans, attach_logs, top, port, images.
+//! Query and observation commands: ps, logs, exec, pull, remove_orphans.
 
 use futures_util::StreamExt;
 
@@ -7,10 +7,11 @@ use crate::error::{ComposeError, Result};
 use crate::libpod::types::exec::{
 	ExecCreateConfig, ExecCreateResponse, ExecInspect, ExecStartConfig,
 };
-use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
+
+mod inspect;
 
 impl Engine {
 	/// List containers for this project: name, image, command, state, and port bindings.
@@ -272,207 +273,6 @@ impl Engine {
 				}
 			}
 		}
-		Ok(())
-	}
-
-	/// Display running processes in each service container (`docker compose top`).
-	///
-	/// If `target_services` is empty, all services are queried.
-	pub async fn top(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let names: Vec<String> = if target_services.is_empty() {
-			file.services.keys().cloned().collect()
-		} else {
-			for name in target_services {
-				if !file.services.contains_key(name) {
-					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
-				}
-			}
-			target_services.to_vec()
-		};
-
-		for name in &names {
-			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/top",
-					urlencoded(&container_name),
-				);
-				match self
-					.client
-					.get_json::<crate::libpod::types::container::TopResponse>(&path)
-					.await
-				{
-					Ok(result) => {
-						println!("{container_name}");
-						if let Some(titles) = &result.titles {
-							println!("{}", titles.join("\t"));
-						}
-						if let Some(processes) = &result.processes {
-							for row in processes {
-								println!("{}", row.join("\t"));
-							}
-						}
-					}
-					Err(e) => tracing::warn!("top {container_name}: {e}"),
-				}
-			}
-		}
-		Ok(())
-	}
-
-	/// Print the public port for a given private port of a service container.
-	///
-	/// `proto` should be `"tcp"` or `"udp"`. Prints `HOST:PORT` to stdout.
-	pub async fn port(
-		&self,
-		file: &ComposeFile,
-		service_name: &str,
-		private_port: u16,
-		proto: &str,
-	) -> Result<()> {
-		let service = file
-			.services
-			.get(service_name)
-			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.first_replica_name(service_name, service);
-
-		let path = format!(
-			"{API_PREFIX}/containers/{}/json",
-			urlencoded(&container_name),
-		);
-		let info = self
-			.client
-			.get_json::<crate::libpod::types::container::ContainerInspect>(&path)
-			.await
-			.map_err(ComposeError::Podman)?;
-
-		let key = format!("{private_port}/{proto}");
-		let binding = info
-			.network_settings
-			.and_then(|ns| ns.ports.get(&key).cloned().flatten())
-			.and_then(|bindings| bindings.into_iter().next());
-
-		match binding {
-			Some(b) => {
-				let host = b.host_ip.as_deref().unwrap_or("0.0.0.0");
-				let port = b.host_port.as_deref().unwrap_or("");
-				println!("{host}:{port}");
-			}
-			None => println!(),
-		}
-		Ok(())
-	}
-
-	/// List images used by each service.
-	pub async fn images(&self, file: &ComposeFile) -> Result<()> {
-		println!(
-			"{:<30} {:<25} {:<15} {:<20}",
-			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
-		);
-		for (name, service) in &file.services {
-			let image_ref = match &service.image {
-				Some(img) => img.clone(),
-				None if service.build.is_some() => format!("{name}:latest"),
-				None => continue,
-			};
-			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
-			match self.client.get_json::<ImageInspect>(&path).await {
-				Ok(img) => {
-					let (repo, tag) = image_ref
-						.rsplit_once(':')
-						.map(|(r, t)| (r.to_string(), t.to_string()))
-						.unwrap_or_else(|| (image_ref.clone(), "latest".to_string()));
-					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
-					println!("{name:<30} {repo:<25} {tag:<15} {id:<20}");
-				}
-				Err(e) => tracing::warn!("images {name}: {e}"),
-			}
-		}
-		Ok(())
-	}
-
-	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
-	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
-		// Carry (display_name, container_name, is_tty) so the log parser matches
-		// the container's framing mode: TTY containers emit raw bytes; non-TTY
-		// containers emit multiplexed 8-byte-header frames.
-		let attached: Vec<(String, String, bool)> = file
-			.services
-			.iter()
-			.filter(|(_, s)| s.attach.unwrap_or(true))
-			.flat_map(|(name, s)| {
-				let proj_prefix = format!("{}-", self.project);
-				let is_tty = s.tty.unwrap_or(false);
-				self.replica_names(name, s).into_iter().map(move |cname| {
-					let display = cname
-						.strip_prefix(proj_prefix.as_str())
-						.map(|s| s.to_string())
-						.unwrap_or_else(|| cname.clone());
-					(display, cname, is_tty)
-				})
-			})
-			.collect();
-
-		if attached.is_empty() {
-			return Ok(());
-		}
-
-		let streams: Vec<_> = attached
-			.iter()
-			.map(|(display, cname, is_tty)| {
-				let prefix = display.clone();
-				let path = format!(
-					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
-					urlencoded(cname),
-				);
-				let client = &self.client;
-				let is_tty = *is_tty;
-				async move {
-					let resp = match client.get_stream(&path).await {
-						Ok(r) => r,
-						Err(e) => {
-							tracing::warn!("attach_logs {prefix}: {e}");
-							return;
-						}
-					};
-					// TTY containers produce raw bytes (stdout/stderr merged).
-					// Non-TTY containers produce multiplexed frames with 8-byte headers.
-					let mut stream = if is_tty {
-						crate::libpod::parse_raw(resp.into_body())
-					} else {
-						crate::libpod::parse_multiplexed(resp.into_body())
-					};
-					while let Some(msg) = stream.next().await {
-						match msg {
-							Ok(LogOutput::StdOut { message }) => {
-								print!("{prefix} | {}", String::from_utf8_lossy(&message));
-							}
-							Ok(LogOutput::StdErr { message }) => {
-								eprint!("{prefix} | {}", String::from_utf8_lossy(&message));
-							}
-							Err(_) => break,
-						}
-					}
-				}
-			})
-			.collect();
-
-		#[cfg(unix)]
-		{
-			use tokio::signal::unix::{signal, SignalKind};
-			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
-			tokio::select! {
-				_ = futures_util::future::join_all(streams) => {}
-				_ = tokio::signal::ctrl_c() => {}
-				_ = sigterm.recv() => {}
-			}
-		}
-		#[cfg(not(unix))]
-		tokio::select! {
-			_ = futures_util::future::join_all(streams) => {}
-			_ = tokio::signal::ctrl_c() => {}
-		}
-
 		Ok(())
 	}
 }

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -7,8 +7,14 @@
 
 use std::path::Path;
 
-use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
+use crate::compose::types::{Service, VolumeMount, VolumeType};
 use crate::libpod::types::container::{Mount, NamedVolume};
+
+mod spec;
+use spec::{
+	access_opts, extend_bind_opts_str, extend_volume_opts_str, parse_bind_string,
+	parse_volume_string,
+};
 
 /// Build all OCI mounts and named volume attachments for a container.
 ///
@@ -143,168 +149,14 @@ pub(crate) fn build_mounts_all(
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parse a short-form volume string `"src:dst"` or `"src:dst:opts"`.
-///
-/// Returns `Some((mount, named))` where exactly one of the two is `Some`.
-/// Named volumes go to `SpecGenerator.volumes`; bind mounts go to `mounts`.
-fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> {
-	let (src, dst, opts_str) = split_volume_spec(s);
-	let opts: Vec<String> = opts_str
-		.split(',')
-		.map(|o| o.trim().to_string())
-		.filter(|o| !o.is_empty())
-		.collect();
-	if is_bind_source(src) {
-		Some((
-			Some(Mount {
-				mount_type: "bind".into(),
-				source: if src.is_empty() {
-					None
-				} else {
-					Some(src.to_string())
-				},
-				destination: dst.to_string(),
-				options: opts,
-			}),
-			None,
-		))
-	} else {
-		Some((
-			None,
-			Some(NamedVolume {
-				name: src.to_string(),
-				dest: dst.to_string(),
-				options: opts,
-				sub_path: None,
-			}),
-		))
-	}
-}
-
-/// Whether `s` begins with a Windows drive-letter prefix (e.g. `C:`), so the
-/// colon that follows is part of the path rather than a `src:dst` separator.
-fn has_windows_drive_prefix(s: &str) -> bool {
-	let b = s.as_bytes();
-	b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':'
-}
-
-/// Classify a short-form volume source. A leading `/`, `.` or `~` marks a host
-/// path bind; a Windows drive prefix (`C:\...`) does too. Anything else is a
-/// named volume.
-fn is_bind_source(src: &str) -> bool {
-	src.starts_with('/')
-		|| src.starts_with('.')
-		|| src.starts_with('~')
-		|| has_windows_drive_prefix(src)
-}
-
-/// Split a short-form volume spec into `(src, dst, opts)`. Colons separate the
-/// fields, except the colon in a leading Windows drive prefix, which belongs to
-/// the source path. The destination is always an in-container (Unix) path, so
-/// only the source can carry a drive letter.
-fn split_volume_spec(s: &str) -> (&str, &str, &str) {
-	let scan_from = if has_windows_drive_prefix(s) { 2 } else { 0 };
-	let seps: Vec<usize> = s
-		.bytes()
-		.enumerate()
-		.skip(scan_from)
-		.filter(|&(_, b)| b == b':')
-		.map(|(i, _)| i)
-		.take(2)
-		.collect();
-	match seps.as_slice() {
-		[] => (s, s, ""),
-		[a] => (&s[..*a], &s[a + 1..], ""),
-		[a, b] => (&s[..*a], &s[a + 1..*b], &s[b + 1..]),
-		_ => unreachable!("take(2) yields at most two separators"),
-	}
-}
-
-/// Parse a pre-built bind string (secret/config) — always produces a bind Mount.
-fn parse_bind_string(s: &str) -> Option<Mount> {
-	let parts: Vec<&str> = s.splitn(3, ':').collect();
-	let (src, dst, opts_str) = match parts.len() {
-		1 => (parts[0], parts[0], ""),
-		2 => (parts[0], parts[1], ""),
-		_ => (parts[0], parts[1], parts[2]),
-	};
-	let opts: Vec<String> = opts_str
-		.split(',')
-		.map(|o| o.trim().to_string())
-		.filter(|o| !o.is_empty())
-		.collect();
-	Some(Mount {
-		mount_type: "bind".into(),
-		source: if src.is_empty() {
-			None
-		} else {
-			Some(src.to_string())
-		},
-		destination: dst.to_string(),
-		options: opts,
-	})
-}
-
-fn access_opts(read_only: Option<bool>) -> Vec<String> {
-	if read_only.unwrap_or(false) {
-		vec!["ro".into()]
-	} else {
-		vec!["rw".into()]
-	}
-}
-
-fn extend_bind_opts_str(opts: &mut Vec<String>, b: Option<&BindOptions>) {
-	let Some(b) = b else { return };
-	if let Some(p) = &b.propagation {
-		opts.push(p.clone());
-	}
-	if let Some(s) = &b.selinux {
-		opts.push(s.clone());
-	}
-}
-
-fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOptions>) {
-	let Some(v) = v else { return };
-	if v.nocopy.unwrap_or(false) {
-		opts.push("nocopy".into());
-	}
-}
-
-// ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
-	use super::{build_mounts_all, is_bind_source, split_volume_spec};
+	use super::build_mounts_all;
 	use crate::compose::types::{BindOptions, Service, VolumeMount, VolumeOptions, VolumeType};
 	use std::path::Path;
-
-	#[test]
-	fn windows_drive_source_is_a_bind_not_a_named_volume() {
-		// `C:\data:/in/container` — the drive colon must not be read as the
-		// src/dst separator, and the source must classify as a bind.
-		assert_eq!(
-			split_volume_spec(r"C:\data:/in/container"),
-			(r"C:\data", "/in/container", "")
-		);
-		assert!(is_bind_source(r"C:\data"));
-		assert!(is_bind_source("D:/forward/slash"));
-	}
-
-	#[test]
-	fn unix_volume_split_is_unchanged() {
-		assert_eq!(split_volume_spec("vol:/data"), ("vol", "/data", ""));
-		assert_eq!(split_volume_spec("./src:/dst:ro"), ("./src", "/dst", "ro"));
-		assert_eq!(split_volume_spec("named"), ("named", "named", ""));
-		assert!(!is_bind_source("named"));
-		assert!(is_bind_source("/abs"));
-		assert!(is_bind_source("./rel"));
-		assert!(is_bind_source("~/home"));
-	}
 
 	fn svc_with_volumes(vols: Vec<VolumeMount>) -> Service {
 		Service {

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -1,0 +1,163 @@
+//! Short-form volume-spec string parsing.
+//!
+//! Splits `"src:dst[:opts]"` strings (and pre-built secret/config bind strings)
+//! into OCI `Mount` / `NamedVolume` parts, handling the Windows drive-letter
+//! colon so it is not mistaken for the `src:dst` separator.
+
+use crate::compose::types::{BindOptions, VolumeOptions};
+use crate::libpod::types::container::{Mount, NamedVolume};
+
+/// Parse a short-form volume string `"src:dst"` or `"src:dst:opts"`.
+///
+/// Returns `Some((mount, named))` where exactly one of the two is `Some`.
+/// Named volumes go to `SpecGenerator.volumes`; bind mounts go to `mounts`.
+pub(super) fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<NamedVolume>)> {
+	let (src, dst, opts_str) = split_volume_spec(s);
+	let opts: Vec<String> = opts_str
+		.split(',')
+		.map(|o| o.trim().to_string())
+		.filter(|o| !o.is_empty())
+		.collect();
+	if is_bind_source(src) {
+		Some((
+			Some(Mount {
+				mount_type: "bind".into(),
+				source: if src.is_empty() {
+					None
+				} else {
+					Some(src.to_string())
+				},
+				destination: dst.to_string(),
+				options: opts,
+			}),
+			None,
+		))
+	} else {
+		Some((
+			None,
+			Some(NamedVolume {
+				name: src.to_string(),
+				dest: dst.to_string(),
+				options: opts,
+				sub_path: None,
+			}),
+		))
+	}
+}
+
+/// Whether `s` begins with a Windows drive-letter prefix (e.g. `C:`), so the
+/// colon that follows is part of the path rather than a `src:dst` separator.
+fn has_windows_drive_prefix(s: &str) -> bool {
+	let b = s.as_bytes();
+	b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':'
+}
+
+/// Classify a short-form volume source. A leading `/`, `.` or `~` marks a host
+/// path bind; a Windows drive prefix (`C:\...`) does too. Anything else is a
+/// named volume.
+fn is_bind_source(src: &str) -> bool {
+	src.starts_with('/')
+		|| src.starts_with('.')
+		|| src.starts_with('~')
+		|| has_windows_drive_prefix(src)
+}
+
+/// Split a short-form volume spec into `(src, dst, opts)`. Colons separate the
+/// fields, except the colon in a leading Windows drive prefix, which belongs to
+/// the source path. The destination is always an in-container (Unix) path, so
+/// only the source can carry a drive letter.
+fn split_volume_spec(s: &str) -> (&str, &str, &str) {
+	let scan_from = if has_windows_drive_prefix(s) { 2 } else { 0 };
+	let seps: Vec<usize> = s
+		.bytes()
+		.enumerate()
+		.skip(scan_from)
+		.filter(|&(_, b)| b == b':')
+		.map(|(i, _)| i)
+		.take(2)
+		.collect();
+	match seps.as_slice() {
+		[] => (s, s, ""),
+		[a] => (&s[..*a], &s[a + 1..], ""),
+		[a, b] => (&s[..*a], &s[a + 1..*b], &s[b + 1..]),
+		_ => unreachable!("take(2) yields at most two separators"),
+	}
+}
+
+/// Parse a pre-built bind string (secret/config) — always produces a bind Mount.
+pub(super) fn parse_bind_string(s: &str) -> Option<Mount> {
+	let parts: Vec<&str> = s.splitn(3, ':').collect();
+	let (src, dst, opts_str) = match parts.len() {
+		1 => (parts[0], parts[0], ""),
+		2 => (parts[0], parts[1], ""),
+		_ => (parts[0], parts[1], parts[2]),
+	};
+	let opts: Vec<String> = opts_str
+		.split(',')
+		.map(|o| o.trim().to_string())
+		.filter(|o| !o.is_empty())
+		.collect();
+	Some(Mount {
+		mount_type: "bind".into(),
+		source: if src.is_empty() {
+			None
+		} else {
+			Some(src.to_string())
+		},
+		destination: dst.to_string(),
+		options: opts,
+	})
+}
+
+pub(super) fn access_opts(read_only: Option<bool>) -> Vec<String> {
+	if read_only.unwrap_or(false) {
+		vec!["ro".into()]
+	} else {
+		vec!["rw".into()]
+	}
+}
+
+pub(super) fn extend_bind_opts_str(opts: &mut Vec<String>, b: Option<&BindOptions>) {
+	let Some(b) = b else { return };
+	if let Some(p) = &b.propagation {
+		opts.push(p.clone());
+	}
+	if let Some(s) = &b.selinux {
+		opts.push(s.clone());
+	}
+}
+
+pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOptions>) {
+	let Some(v) = v else { return };
+	if v.nocopy.unwrap_or(false) {
+		opts.push("nocopy".into());
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{is_bind_source, split_volume_spec};
+
+	#[test]
+	fn windows_drive_source_is_a_bind_not_a_named_volume() {
+		// `C:\data:/in/container` — the drive colon must not be read as the
+		// src/dst separator, and the source must classify as a bind.
+		assert_eq!(
+			split_volume_spec(r"C:\data:/in/container"),
+			(r"C:\data", "/in/container", "")
+		);
+		assert!(is_bind_source(r"C:\data"));
+		assert!(is_bind_source("D:/forward/slash"));
+	}
+
+	#[test]
+	fn unix_volume_split_is_unchanged() {
+		assert_eq!(split_volume_spec("vol:/data"), ("vol", "/data", ""));
+		assert_eq!(split_volume_spec("./src:/dst:ro"), ("./src", "/dst", "ro"));
+		assert_eq!(split_volume_spec("named"), ("named", "named", ""));
+		assert!(!is_bind_source("named"));
+		assert!(is_bind_source("/abs"));
+		assert!(is_bind_source("./rel"));
+		assert!(is_bind_source("~/home"));
+	}
+}

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -48,7 +48,13 @@ pub fn load_env_file_entries(
 			}
 		}
 
-		let abs = base_dir.join(entry.path());
+		let rel = entry.path();
+		if !crate::fsutil::is_safe_relative_path(rel) {
+			return Err(ComposeError::Unsupported(format!(
+				"env_file '{rel}' must be a path inside the project directory"
+			)));
+		}
+		let abs = base_dir.join(rel);
 		let content = match crate::fsutil::read_to_string_capped(&abs) {
 			Ok(c) => c,
 			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -170,6 +176,22 @@ mod tests {
 			format: Some("json".into()),
 		}];
 		assert!(load_env_file_entries(&entries, dir.path()).is_err());
+	}
+
+	#[test]
+	fn rejects_absolute_env_file_path() {
+		let dir = tempfile::tempdir().unwrap();
+		let entries = vec![EnvFileEntry::Path("/etc/passwd".into())];
+		let err = load_env_file_entries(&entries, dir.path()).unwrap_err();
+		assert!(matches!(err, ComposeError::Unsupported(_)));
+	}
+
+	#[test]
+	fn rejects_parent_escaping_env_file_path() {
+		let dir = tempfile::tempdir().unwrap();
+		let entries = vec![EnvFileEntry::Path("../outside.env".into())];
+		let err = load_env_file_entries(&entries, dir.path()).unwrap_err();
+		assert!(matches!(err, ComposeError::Unsupported(_)));
 	}
 
 	// merge_env

--- a/internal/fsutil.rs
+++ b/internal/fsutil.rs
@@ -1,7 +1,27 @@
 //! Filesystem helpers shared across parsing paths.
 
 use std::io;
-use std::path::Path;
+use std::path::{Component, Path};
+
+/// Reject a file reference that is absolute or escapes the project directory.
+///
+/// podup only reads files that live at or below the directory of the compose
+/// file being processed. A reference that is absolute, rooted (`/etc/passwd`,
+/// which is not `is_absolute()` on Windows but still escapes via the root
+/// separator), or contains a `..` component is refused so a compose file cannot
+/// turn podup into a confused deputy that reads arbitrary host paths. Shared by
+/// the `extends`, `env_file`, and `label_file` readers.
+pub(crate) fn is_safe_relative_path(path: impl AsRef<Path>) -> bool {
+	let fp = path.as_ref();
+	if fp.is_absolute() {
+		return false;
+	}
+	let mut comps = fp.components();
+	if comps.clone().next() == Some(Component::RootDir) {
+		return false;
+	}
+	!comps.any(|c| c == Component::ParentDir)
+}
 
 /// Upper bound on the size of any compose, include, extends, or env file podup
 /// will read into memory. Bounds memory use on an accidentally huge or hostile
@@ -33,7 +53,24 @@ fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
 
 #[cfg(test)]
 mod tests {
-	use super::read_to_string_capped_with;
+	use super::{is_safe_relative_path, read_to_string_capped_with};
+
+	#[test]
+	fn accepts_relative_subpaths() {
+		assert!(is_safe_relative_path("labels.env"));
+		assert!(is_safe_relative_path("config/labels.env"));
+	}
+
+	#[test]
+	fn rejects_absolute_paths() {
+		assert!(!is_safe_relative_path("/etc/passwd"));
+	}
+
+	#[test]
+	fn rejects_parent_traversal() {
+		assert!(!is_safe_relative_path("../secret.env"));
+		assert!(!is_safe_relative_path("a/../../etc/passwd"));
+	}
 
 	#[test]
 	fn reads_file_within_limit() {

--- a/internal/libpod/client/encode.rs
+++ b/internal/libpod/client/encode.rs
@@ -1,0 +1,75 @@
+//! Percent-encoding for libpod REST path segments.
+
+/// Percent-encode a string for use as a single URL path/query segment, encoding
+/// everything outside the RFC 3986 unreserved set so container names, project
+/// names, and tags can contain arbitrary bytes without breaking the request.
+pub(crate) fn urlencoded(s: &str) -> String {
+	let mut out = String::with_capacity(s.len());
+	for b in s.bytes() {
+		match b {
+			b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+				out.push(b as char);
+			}
+			_ => {
+				out.push('%');
+				out.push(
+					char::from_digit((b >> 4) as u32, 16)
+						.unwrap()
+						.to_ascii_uppercase(),
+				);
+				out.push(
+					char::from_digit((b & 0xf) as u32, 16)
+						.unwrap()
+						.to_ascii_uppercase(),
+				);
+			}
+		}
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::urlencoded;
+
+	#[test]
+	fn unreserved_chars_pass_through() {
+		assert_eq!(urlencoded("abc-XYZ_0.9~"), "abc-XYZ_0.9~");
+	}
+
+	#[test]
+	fn space_encoded() {
+		assert_eq!(urlencoded("hello world"), "hello%20world");
+	}
+
+	#[test]
+	fn slash_encoded() {
+		assert_eq!(urlencoded("a/b"), "a%2Fb");
+	}
+
+	#[test]
+	fn colon_encoded() {
+		assert_eq!(urlencoded("myproj:v1"), "myproj%3Av1");
+	}
+
+	#[test]
+	fn empty_string() {
+		assert_eq!(urlencoded(""), "");
+	}
+
+	#[test]
+	fn unicode_byte_encoded() {
+		// '€' = 0xE2 0x82 0xAC in UTF-8
+		assert_eq!(urlencoded("€"), "%E2%82%AC");
+	}
+
+	#[test]
+	fn container_name_typical() {
+		assert_eq!(urlencoded("myproject-web"), "myproject-web");
+	}
+
+	#[test]
+	fn container_name_with_brackets() {
+		assert_eq!(urlencoded("a[b]"), "a%5Bb%5D");
+	}
+}

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -14,6 +14,9 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::error::PodmanError;
 
+mod encode;
+pub(crate) use encode::urlencoded;
+
 type BoxBody = Full<Bytes>;
 
 /// Upper bound on a buffered (non-streaming) response body. Caps memory use
@@ -344,81 +347,11 @@ impl Client {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// URL encoding helpers
-// ---------------------------------------------------------------------------
-
-pub(crate) fn urlencoded(s: &str) -> String {
-	let mut out = String::with_capacity(s.len());
-	for b in s.bytes() {
-		match b {
-			b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-				out.push(b as char);
-			}
-			_ => {
-				out.push('%');
-				out.push(
-					char::from_digit((b >> 4) as u32, 16)
-						.unwrap()
-						.to_ascii_uppercase(),
-				);
-				out.push(
-					char::from_digit((b & 0xf) as u32, 16)
-						.unwrap()
-						.to_ascii_uppercase(),
-				);
-			}
-		}
-	}
-	out
-}
-
 #[cfg(test)]
 mod tests {
 	use hyper::StatusCode;
 
-	use super::{urlencoded, Client};
-
-	#[test]
-	fn unreserved_chars_pass_through() {
-		assert_eq!(urlencoded("abc-XYZ_0.9~"), "abc-XYZ_0.9~");
-	}
-
-	#[test]
-	fn space_encoded() {
-		assert_eq!(urlencoded("hello world"), "hello%20world");
-	}
-
-	#[test]
-	fn slash_encoded() {
-		assert_eq!(urlencoded("a/b"), "a%2Fb");
-	}
-
-	#[test]
-	fn colon_encoded() {
-		assert_eq!(urlencoded("myproj:v1"), "myproj%3Av1");
-	}
-
-	#[test]
-	fn empty_string() {
-		assert_eq!(urlencoded(""), "");
-	}
-
-	#[test]
-	fn unicode_byte_encoded() {
-		// '€' = 0xE2 0x82 0xAC in UTF-8
-		assert_eq!(urlencoded("€"), "%E2%82%AC");
-	}
-
-	#[test]
-	fn container_name_typical() {
-		assert_eq!(urlencoded("myproject-web"), "myproject-web");
-	}
-
-	#[test]
-	fn container_name_with_brackets() {
-		assert_eq!(urlencoded("a[b]"), "a%5Bb%5D");
-	}
+	use super::Client;
 
 	// ---------------------------------------------------------------------------
 	// check_status tests

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -154,3 +154,190 @@ pub(super) fn resolve_modifier(
 		},
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn peekable(s: &str) -> std::iter::Peekable<std::str::Chars<'_>> {
+		s.chars().peekable()
+	}
+
+	fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+		pairs
+			.iter()
+			.map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+			.collect()
+	}
+
+	// --- char predicates ---
+
+	#[test]
+	fn var_start_and_char_classes() {
+		assert!(is_var_start('_'));
+		assert!(is_var_start('a'));
+		assert!(!is_var_start('1'));
+		assert!(!is_var_start('-'));
+		assert!(is_var_char('9'));
+		assert!(!is_var_char('-'));
+	}
+
+	// --- collect_var_name ---
+
+	#[test]
+	fn collect_var_name_stops_at_non_var_char() {
+		let mut it = peekable("NAME-rest");
+		assert_eq!(collect_var_name(&mut it), "NAME");
+		// The `-` and everything after it is left unconsumed.
+		assert_eq!(it.collect::<String>(), "-rest");
+	}
+
+	// --- parse_braced_var: bare + every modifier form ---
+
+	#[test]
+	fn parse_bare_var_consumes_closing_brace() {
+		let mut it = peekable("FOO}tail");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::None));
+		assert_eq!(it.collect::<String>(), "tail");
+	}
+
+	#[test]
+	fn parse_unterminated_var_is_none_modifier() {
+		let mut it = peekable("FOO");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::None));
+	}
+
+	#[test]
+	fn parse_each_modifier_form() {
+		type Check = fn(&Modifier) -> bool;
+		let cases: &[(&str, Check)] = &[
+			(
+				"V:-d}",
+				|m| matches!(m, Modifier::DefaultIfUnsetOrEmpty(s) if s == "d"),
+			),
+			(
+				"V-d}",
+				|m| matches!(m, Modifier::DefaultIfUnset(s) if s == "d"),
+			),
+			(
+				"V:+a}",
+				|m| matches!(m, Modifier::AltIfSetAndNonEmpty(s) if s == "a"),
+			),
+			("V+a}", |m| matches!(m, Modifier::AltIfSet(s) if s == "a")),
+			(
+				"V:?e}",
+				|m| matches!(m, Modifier::ErrorIfUnsetOrEmpty(s) if s == "e"),
+			),
+			(
+				"V?e}",
+				|m| matches!(m, Modifier::ErrorIfUnset(s) if s == "e"),
+			),
+		];
+		for (input, check) in cases {
+			let mut it = peekable(input);
+			let (name, modifier) = parse_braced_var(&mut it).unwrap();
+			assert_eq!(name, "V", "input {input}");
+			assert!(check(&modifier), "modifier mismatch for {input}");
+		}
+	}
+
+	#[test]
+	fn parse_colon_without_known_op_defaults_to_default_if_unset_or_empty() {
+		let mut it = peekable("V:x}");
+		let (_, modifier) = parse_braced_var(&mut it).unwrap();
+		assert!(matches!(modifier, Modifier::DefaultIfUnsetOrEmpty(s) if s == "x"));
+	}
+
+	// --- resolve_modifier ---
+
+	#[test]
+	fn resolve_none_uses_value_or_empty() {
+		let v = vars(&[("A", "1")]);
+		assert_eq!(
+			resolve_modifier("A".into(), Modifier::None, &v).unwrap(),
+			"1"
+		);
+		assert_eq!(
+			resolve_modifier("MISSING".into(), Modifier::None, &v).unwrap(),
+			""
+		);
+	}
+
+	#[test]
+	fn resolve_default_if_unset_or_empty() {
+		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
+		let m = || Modifier::DefaultIfUnsetOrEmpty("def".into());
+		assert_eq!(resolve_modifier("EMPTY".into(), m(), &v).unwrap(), "def");
+		assert_eq!(resolve_modifier("MISSING".into(), m(), &v).unwrap(), "def");
+		assert_eq!(resolve_modifier("SET".into(), m(), &v).unwrap(), "x");
+	}
+
+	#[test]
+	fn resolve_default_if_unset_keeps_empty_value() {
+		let v = vars(&[("EMPTY", "")]);
+		assert_eq!(
+			resolve_modifier("EMPTY".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			""
+		);
+		assert_eq!(
+			resolve_modifier("MISSING".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			"def"
+		);
+	}
+
+	#[test]
+	fn resolve_alt_forms() {
+		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
+		assert_eq!(
+			resolve_modifier("SET".into(), Modifier::AltIfSetAndNonEmpty("a".into()), &v).unwrap(),
+			"a"
+		);
+		assert_eq!(
+			resolve_modifier(
+				"EMPTY".into(),
+				Modifier::AltIfSetAndNonEmpty("a".into()),
+				&v
+			)
+			.unwrap(),
+			""
+		);
+		assert_eq!(
+			resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			"a"
+		);
+		assert_eq!(
+			resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			""
+		);
+	}
+
+	#[test]
+	fn resolve_error_forms() {
+		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
+		assert!(resolve_modifier(
+			"EMPTY".into(),
+			Modifier::ErrorIfUnsetOrEmpty("e".into()),
+			&v
+		)
+		.is_err());
+		assert_eq!(
+			resolve_modifier("SET".into(), Modifier::ErrorIfUnsetOrEmpty("e".into()), &v).unwrap(),
+			"x"
+		);
+		assert!(
+			resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v).is_err()
+		);
+		assert_eq!(
+			resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v).unwrap(),
+			""
+		);
+	}
+}

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -122,6 +122,24 @@ pub fn install_at(target: &Path, new_bytes: &[u8]) -> crate::Result<()> {
 /// Write the new bytes to `tmp`, copy `target`'s permission bits (default 0755
 /// on Unix when the target does not yet exist), and flush to disk.
 fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> {
+	// Create the temp file private (0600) on Unix so the new binary's bytes are
+	// never world-readable in a shared directory (e.g. /usr/local/bin) during the
+	// window before the target's mode is applied. `File::create` honours the
+	// process umask and could otherwise leave a 0644 file readable by other users.
+	#[cfg(unix)]
+	let mut f = {
+		use std::os::unix::fs::OpenOptionsExt;
+		std::fs::OpenOptions::new()
+			.write(true)
+			.create(true)
+			.truncate(true)
+			.mode(0o600)
+			.open(tmp)
+			.map_err(|e| {
+				ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
+			})?
+	};
+	#[cfg(not(unix))]
 	let mut f = std::fs::File::create(tmp).map_err(|e| {
 		ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
 	})?;

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -46,6 +46,17 @@ pub fn run_with(
 	current: &str,
 	opts: UpdateOptions,
 ) -> crate::Result<()> {
+	run_with_guard(source, current, opts, install::managing_package_manager())
+}
+
+/// [`run_with`] with the package-manager guard injected, so the refusal branch
+/// can be exercised without a dpkg-managed binary on the test host.
+fn run_with_guard(
+	source: &dyn ReleaseSource,
+	current: &str,
+	opts: UpdateOptions,
+	managed_by: Option<&str>,
+) -> crate::Result<()> {
 	let current_v = verify::parse_version(current)?;
 	let latest_tag = source.latest_version()?;
 	let latest_v = verify::parse_version(&latest_tag)?;
@@ -67,7 +78,7 @@ pub fn run_with(
 
 	// Refuse to self-replace a package-manager-managed binary (even with
 	// --force): overwriting it would desync the package manager's records.
-	if let Some(pm) = install::managing_package_manager() {
+	if let Some(pm) = managed_by {
 		return Err(install::package_managed_error(pm));
 	}
 
@@ -196,6 +207,48 @@ mod tests {
 		let err = run_with(&src, "0.6.0", UpdateOptions::default()).unwrap_err();
 		assert!(matches!(err, ComposeError::Update(_)));
 		assert!(src.fetched.borrow().contains(&"SHA256SUMS.sig".to_string()));
+	}
+
+	#[test]
+	fn package_managed_binary_refuses_and_does_not_download() {
+		// A newer release is available and --force is set, so the flow reaches the
+		// package-manager guard. With a manager owning the binary it must refuse
+		// before fetching anything.
+		let src = MockSource {
+			latest: "v9.9.9".into(),
+			assets: HashMap::new(),
+			fetched: RefCell::new(Vec::new()),
+		};
+		let opts = UpdateOptions {
+			check_only: false,
+			force: true,
+		};
+		let err = run_with_guard(&src, "0.6.0", opts, Some("apt")).unwrap_err();
+		match err {
+			ComposeError::Update(msg) => assert!(msg.contains("apt")),
+			other => panic!("expected Update error, got {other:?}"),
+		}
+		assert!(
+			src.fetched.borrow().is_empty(),
+			"a package-managed binary must not download an update"
+		);
+	}
+
+	#[test]
+	fn check_only_returns_before_package_manager_guard() {
+		// --check must short-circuit even when a package manager owns the binary,
+		// so `podup update --check` never errors on a deb install.
+		let src = MockSource {
+			latest: "v9.9.9".into(),
+			assets: HashMap::new(),
+			fetched: RefCell::new(Vec::new()),
+		};
+		let opts = UpdateOptions {
+			check_only: true,
+			force: false,
+		};
+		run_with_guard(&src, "0.6.0", opts, Some("apt")).unwrap();
+		assert!(src.fetched.borrow().is_empty());
 	}
 
 	#[test]


### PR DESCRIPTION
Promotes the v0.17.0 standalone hardening batch from develop to main.

Included since v0.16.0:
- #232 security: self-update temp-file 0600, env_file/label_file path guards, bounded label_file/.dockerignore reads
- #234 test: package-manager guard seam coverage + substitution-parser unit tests
- #236 docs: man-page RUST_LOG + EXIT STATUS, canonical env/exit tables, README tag bump
- #238 ci: cargo-deny supply-chain policy
- #240 refactor: split five files near the 500-line cap (pure relocation)
- #241 chore: release v0.17.0 (version bump)

Merge (not squash) per release flow. Tag v0.17.0 to be pushed after merge to trigger the signed release + crates.io publish.