### PR TITLE
release: v0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+podup (0.17.1) unstable; urgency=medium
+
+  * Stop rejecting absolute and parent-relative "env_file" and "label_file"
+    paths. podman, podman-compose, and docker-compose all accept them (a shared
+    "../secrets/.env" in a monorepo is a common, valid layout), so confining
+    them broke compose files that work everywhere else. The 0600 self-update
+    temp file and the size caps on "label_file"/".dockerignore" reads from
+    0.17.0 are retained; only the path confinement is reverted.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 15:10:00 -0500
+
 podup (0.17.0) unstable; urgency=medium
 
   * Security: the self-update temporary file is now created with mode 0600 and

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.17.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.17.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/engine/container_fields.rs
+++ b/internal/engine/container_fields.rs
@@ -132,11 +132,11 @@ pub(super) fn build_label_file_labels(
 ) -> HashMap<String, String> {
 	let mut labels = HashMap::new();
 	for path in service.label_file.to_list() {
-		if !crate::fsutil::is_safe_relative_path(&path) {
-			warn!("label_file: refusing absolute or parent-escaping path {path}");
-			continue;
-		}
-		let full = base_dir.join(&path);
+		let full = if std::path::Path::new(&path).is_absolute() {
+			std::path::PathBuf::from(&path)
+		} else {
+			base_dir.join(&path)
+		};
 		let content = match crate::fsutil::read_to_string_capped(&full) {
 			Ok(c) => c,
 			Err(e) => {

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -48,13 +48,7 @@ pub fn load_env_file_entries(
 			}
 		}
 
-		let rel = entry.path();
-		if !crate::fsutil::is_safe_relative_path(rel) {
-			return Err(ComposeError::Unsupported(format!(
-				"env_file '{rel}' must be a path inside the project directory"
-			)));
-		}
-		let abs = base_dir.join(rel);
+		let abs = base_dir.join(entry.path());
 		let content = match crate::fsutil::read_to_string_capped(&abs) {
 			Ok(c) => c,
 			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -179,19 +173,17 @@ mod tests {
 	}
 
 	#[test]
-	fn rejects_absolute_env_file_path() {
-		let dir = tempfile::tempdir().unwrap();
-		let entries = vec![EnvFileEntry::Path("/etc/passwd".into())];
-		let err = load_env_file_entries(&entries, dir.path()).unwrap_err();
-		assert!(matches!(err, ComposeError::Unsupported(_)));
-	}
-
-	#[test]
-	fn rejects_parent_escaping_env_file_path() {
-		let dir = tempfile::tempdir().unwrap();
-		let entries = vec![EnvFileEntry::Path("../outside.env".into())];
-		let err = load_env_file_entries(&entries, dir.path()).unwrap_err();
-		assert!(matches!(err, ComposeError::Unsupported(_)));
+	fn loads_parent_relative_env_file() {
+		// docker-compose, podman, and podman-compose all accept env_file paths
+		// outside the project directory (e.g. a shared `../secrets/.env` in a
+		// monorepo); podup must too.
+		let root = tempfile::tempdir().unwrap();
+		std::fs::write(root.path().join("shared.env"), "FOO=bar\n").unwrap();
+		let project = root.path().join("project");
+		std::fs::create_dir(&project).unwrap();
+		let entries = vec![EnvFileEntry::Path("../shared.env".into())];
+		let m = load_env_file_entries(&entries, &project).unwrap();
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("bar"));
 	}
 
 	// merge_env


### PR DESCRIPTION
Patch release: restore compose-spec compatibility for `env_file`/`label_file` paths (#244, closes #243).

v0.17.0 over-confined those paths (stricter than podman/podman-compose/docker-compose); v0.17.1 reverts the confinement while keeping the 0600 self-update temp file and the read size caps from v0.17.0.

Merge (not squash). Tag v0.17.1 after merge to publish.