### PR TITLE
chore: trim dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,54 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -144,10 +100,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -176,12 +130,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -557,12 +505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,25 +634,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -766,7 +693,6 @@ dependencies = [
  "clap_complete",
  "ed25519-dalek",
  "flate2",
- "futures-core",
  "futures-util",
  "http-body-util",
  "hyper",
@@ -1094,12 +1020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,7 +1141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
@@ -1299,12 +1218,6 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,15 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "syn
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
-clap = { version = "4", features = ["derive", "env"] }
-clap_complete = "4"
+clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "derive", "env"] }
+clap_complete = { version = "4", optional = true }
 indexmap = { version = "2", features = ["serde"] }
-futures-core = { version = "0.3", default-features = false }
-futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"
@@ -50,8 +49,9 @@ sha2 = "0.10"
 libc = "0.2"
 
 [features]
-default = ["watch"]
+default = ["watch", "completions"]
 watch = ["notify"]
+completions = ["dep:clap_complete"]
 test-helpers = []
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,17 +41,20 @@ notify = { version = "8", optional = true }
 # Self-update: HTTPS fetch of signed release assets and verification.
 # ureq (rustls + webpki roots) keeps static musl builds self-contained; the
 # Ed25519 signature pinned to an embedded key is the real trust anchor, not TLS.
-ureq = { version = "3", default-features = false, features = ["rustls"] }
-ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+ureq = { version = "3", default-features = false, features = ["rustls"], optional = true }
+ed25519-dalek = { version = "2", default-features = false, features = ["std"], optional = true }
 sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [features]
-default = ["watch", "completions"]
+default = ["watch", "completions", "update"]
 watch = ["notify"]
 completions = ["dep:clap_complete"]
+# Self-update over HTTPS with Ed25519 verification. Off for package-manager
+# builds (Debian/apt) where the manager owns upgrades; on for direct tarballs.
+update = ["dep:ureq", "dep:ed25519-dalek"]
 test-helpers = []
 
 [dev-dependencies]

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,11 @@ export CARGO_UNSTABLE_OFFLINE = true
 CARGO_FLAGS = --frozen --offline
 endif
 
+# Drop the self-update stack (ureq + TLS + Ed25519) from the packaged binary:
+# apt owns upgrades on Debian, so `podup update` is disabled here. `completions`
+# stays on — the install step below generates the shell scripts from the binary.
+CARGO_FEATURES = --no-default-features --features watch,completions
+
 %:
 	dh $@
 
@@ -22,10 +27,10 @@ override_dh_auto_build:
 ifneq ($(wildcard vendor/),)
 	$(if $(wildcard .cargo/config.toml),,$(MAKE) -f debian/rules debian/cargo-config)
 endif
-	cargo build --release --locked $(CARGO_FLAGS)
+	cargo build --release --locked $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 override_dh_auto_test:
-	cargo test --release --locked $(CARGO_FLAGS)
+	cargo test --release --locked $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 override_dh_auto_install:
 	install -D -m 0755 target/release/podup debian/podup/usr/bin/podup

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+#[cfg(feature = "completions")]
 use clap_complete::Shell;
 
 #[derive(Parser)]
@@ -238,6 +239,7 @@ pub(crate) enum Commands {
 	/// Generates a completion script for the named shell from the CLI
 	/// definition. Source it from your shell's startup (or install the file the
 	/// Debian package ships) to get tab completion for podup commands and flags.
+	#[cfg(feature = "completions")]
 	Completions {
 		/// Shell to generate completions for (bash, zsh, fish, powershell, elvish).
 		shell: Shell,

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -226,6 +226,7 @@ pub(crate) enum Commands {
 	/// against the public key embedded in this build and matching its SHA-256
 	/// checksum. Verification fails closed: a missing key, bad signature, or
 	/// checksum mismatch aborts without touching the installed binary.
+	#[cfg(feature = "update")]
 	Update {
 		/// Report whether a newer release exists without installing it.
 		#[arg(long)]

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -21,6 +21,7 @@ pub mod ports;
 pub mod quadlet;
 pub mod size;
 pub mod substitute;
+#[cfg(feature = "update")]
 pub mod update;
 
 pub use compose::{

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -5,7 +5,7 @@
 //! Stream type 1 = stdout, 2 = stderr.
 
 use bytes::Bytes;
-use futures_core::Stream;
+use futures_util::stream::Stream;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use std::pin::Pin;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -6,7 +6,9 @@
 use std::path::Path;
 use std::process;
 
-use clap::{CommandFactory, Parser};
+#[cfg(feature = "completions")]
+use clap::CommandFactory;
+use clap::Parser;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
@@ -184,6 +186,7 @@ async fn run() -> podup::Result<()> {
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.
+	#[cfg(feature = "completions")]
 	if let Commands::Completions { shell } = cli.command {
 		let mut cmd = Cli::command();
 		let name = cmd.get_name().to_string();
@@ -338,6 +341,7 @@ async fn run() -> podup::Result<()> {
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
+		#[cfg(feature = "completions")]
 		Commands::Completions { .. } => unreachable!("handled before compose parsing"),
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -159,6 +159,7 @@ async fn main() {
 	match run().await {
 		Ok(()) => {}
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
+		#[cfg(feature = "update")]
 		Err(e @ podup::ComposeError::Update(_)) => {
 			eprintln!("podup: error: {e}");
 			process::exit(podup::update::exit_code(&e));
@@ -197,6 +198,7 @@ async fn run() -> podup::Result<()> {
 	// `update` operates on the binary itself, not a compose project, so it runs
 	// before any compose file is parsed or Podman is contacted. The network and
 	// filesystem work is blocking; keep it off the async path entirely.
+	#[cfg(feature = "update")]
 	if let Commands::Update { check, force } = cli.command {
 		let opts = podup::update::UpdateOptions {
 			check_only: check,
@@ -340,6 +342,7 @@ async fn run() -> podup::Result<()> {
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
+		#[cfg(feature = "update")]
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
 		#[cfg(feature = "completions")]
 		Commands::Completions { .. } => unreachable!("handled before compose parsing"),


### PR DESCRIPTION
Trims unnecessary crates from the build. Draft — more dependency cleanups may still be added to this branch.

## Pure trims (production binary, all platforms)
- Drop dead `ansi` feature from `tracing-subscriber` — removes `nu-ansi-term` (#246)
- Remove no-op `async-await` feature from `futures-util` (#247)
- Drop redundant direct `futures-core` dep; `futures-util` re-exports `Stream` (#248)
- Feature-gate `clap_complete` behind a default-on `completions` feature (#249)
- Trim `clap` default features: drop `color` + `suggestions` — removes 7 crates (#251)

8 crates removed from the default shipped binary: `nu-ansi-term`, `anstream`, `anstyle-parse`, `anstyle-query`, `colorchoice`, `is_terminal_polyfill`, `once_cell_polyfill`, `strsim`.

## Feature-gate self-update (#253)
`podup update` is the only consumer of `ureq` + `ed25519-dalek`, which pull the whole TLS + Ed25519 subtree. Gated behind a default-on `update` feature; the Debian package now builds `--no-default-features --features watch,completions`, dropping ~24 crates (Linux; ~41 in the cross-platform lock incl. `windows-sys 0.52`) from the packaged binary. Tarball builds are unchanged. `sha2` stays (used by the engine).

| Channel | watch | completions | update |
|---|---|---|---|
| Linux/macOS/Windows tarball | on | on | on |
| Debian .deb | on | on | off |

## Verification
- `cargo clippy --all-targets` clean (default + Debian combo)
- tests pass for default and `--no-default-features --features watch,completions`
- builds verified: default, `--no-default-features`, `watch`-only, `completions`-only, Debian combo
- `podup update` present in default `--help`, absent in the Debian combo; `completions` works in both

Closes #246 #247 #248 #249 #251 #253

> Note: `Closes` is inert on squash-merge to `develop`; issues will be closed manually after merge.