### PR TITLE
feat: two-key rotation for self-update signing key

### DIFF
--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -7,9 +7,9 @@ install a modified binary.
 
 ## Trust anchor
 
-The trust anchor is **not** the download domain, DNS, or TLS. It is an **Ed25519
-public key compiled into the binary** (`internal/update/verify.rs`,
-`RELEASE_PUBKEY`). The matching private key exists only as the
+The trust anchor is **not** the download domain, DNS, or TLS. It is the set of
+**Ed25519 public keys compiled into the binary** (`internal/update/verify.rs`,
+`RELEASE_PUBKEYS`). The matching private key exists only as the
 `RELEASE_SIGN_KEY` GitHub Actions secret and signs every release in CI
 (`.github/workflows/release.yml`).
 
@@ -47,20 +47,24 @@ build-provenance attestation (`gh attestation verify`). If neither verifier is
 available it refuses to install. `PODUP_INSECURE_SKIP_VERIFY=1` is the explicit,
 documented opt-out (checksum only) for constrained environments.
 
-## The embedded public key
+## The embedded public keys
 
-The release public key is embedded in three places, all holding the same key
-(base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`):
+Each consumer holds **up to two** accepted release keys — an active key plus an
+empty rotation slot. The active key (base64
+`APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`) is embedded in three places:
 
-- `internal/update/verify.rs` — `RELEASE_PUBKEY` (raw 32 bytes).
-- `install.sh` — `PODUP_RELEASE_PUBKEY_B64` default (base64, unpadded).
-- `install.ps1` — `PubKeyB64` default (base64, unpadded).
+- `internal/update/verify.rs` — `RELEASE_PUBKEYS[0]` (raw 32 bytes); slot 1 is
+  `[0u8; 32]` until a second key is rolled in.
+- `install.sh` — `PODUP_RELEASE_PUBKEY_B64` default; `PODUP_RELEASE_PUBKEY2_B64`
+  is the (empty) rotation slot.
+- `install.ps1` — `PubKeyB64` default; `PubKey2B64` is the rotation slot.
 
-It is verified against the genuine published `SHA256SUMS.sig` by the
+A signature is trusted if it validates under **any** non-empty key. The active
+key is verified against the genuine published `SHA256SUMS.sig` by the
 `embedded_key_verifies_real_release` regression test, so an accidental or
-malicious edit to the constant fails CI. If the key is ever zeroed, both the
-binary and the installer fail closed and install nothing. The same key signs
-`podup`, `panel`, and `panel-agent` releases (shared `RELEASE_SIGN_KEY`).
+malicious edit to the constant fails CI. If every key is zeroed, both the binary
+and the installer fail closed and install nothing. The same key signs `podup`,
+`panel`, and `panel-agent` releases (shared `RELEASE_SIGN_KEY`).
 
 ### Deriving the public key from the signing secret
 
@@ -82,11 +86,24 @@ print("verify.rs bytes   :", ", ".join(str(b) for b in raw))
 ```
 
 Paste the base64 form into `install.sh` and `install.ps1`, and the byte array
-into `RELEASE_PUBKEY`.
+into `RELEASE_PUBKEYS`.
 
 ### Key rotation
 
-Rotating the signing key requires shipping a new binary that embeds the new
-public key *before* the first release signed with the new private key — older
-binaries verify only against the key they were built with. Plan a release that
-updates the embedded key, then switch the CI secret on the following release.
+Because each binary accepts up to two keys, the signing key can be rotated
+**without stranding installed binaries** — even if the private key leaks. Run the
+two-release procedure:
+
+1. **Transition release.** Add the new key to the rotation slot so the binary
+   embeds `[old, new]` (and add `PODUP_RELEASE_PUBKEY2_B64` / `PubKey2B64` to the
+   installers). Keep `RELEASE_SIGN_KEY` set to the **old** key so `SHA256SUMS` is
+   signed by `old`. Binaries already in the field trust only `old`, so they
+   accept this release and upgrade — gaining `new` in the process.
+2. **Retire release.** Move `new` into slot 0 and zero the rotation slot so the
+   binary embeds `[new]`, and switch the CI `RELEASE_SIGN_KEY` secret to the
+   **new** key. Every binary from step 1 trusts `new`, so all installs converge
+   on the new key and `old` is retired.
+
+During step 1 the leaked `old` key is still accepted for one release — an
+unavoidable cost of any rotation. The GitHub build-provenance attestation, which
+does not depend on the signing key, still proves origin during the window.

--- a/install.ps1
+++ b/install.ps1
@@ -84,10 +84,14 @@ try {
 	# If neither verifier can run, the install fails closed. Set
 	# PODUP_INSECURE_SKIP_VERIFY=1 to explicitly opt out (checksum only).
 
-	# Baked-in base64 (unpadded) raw Ed25519 public key (32 bytes) matching the
-	# release signing key (RELEASE_SIGN_KEY). Verified against the genuine published
-	# SHA256SUMS.sig. Override for a fork via the PODUP_RELEASE_PUBKEY_B64 env var.
-	$PubKeyB64 = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y' }
+	# Baked-in base64 (unpadded) raw Ed25519 public keys (32 bytes each) matching
+	# the release signing key (RELEASE_SIGN_KEY). Up to two are accepted: the
+	# second is empty except during a key rotation, when it holds the new key so a
+	# release signed by either key verifies. The signature passes if any key
+	# validates. Override for a fork via PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64.
+	$PubKeyB64  = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y' }
+	$PubKey2B64 = if ($env:PODUP_RELEASE_PUBKEY2_B64) { $env:PODUP_RELEASE_PUBKEY2_B64 } else { '' }
+	$PubKeys = @($PubKeyB64, $PubKey2B64 | Where-Object { $_ })
 
 	$verified = $false
 
@@ -109,7 +113,7 @@ try {
 	}
 
 	Write-LogInfo 'Verifying SHA256SUMS signature ...'
-	if ($PubKeyB64) {
+	if ($PubKeys.Count -gt 0) {
 		$python = Find-Python
 		if ($python) {
 			$pyScript = Join-Path $TmpDir 'verify_ed25519.py'
@@ -118,16 +122,19 @@ try {
 import base64, sys
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.exceptions import InvalidSignature
-sig_file, data_file, pubkey_b64 = sys.argv[1], sys.argv[2], sys.argv[3]
-key = Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "=="))
-try:
-    key.verify(open(sig_file, "rb").read(), open(data_file, "rb").read())
-    sys.exit(0)
-except InvalidSignature:
-    sys.exit(1)
+sig_file, data_file = sys.argv[1], sys.argv[2]
+sig = open(sig_file, "rb").read()
+data = open(data_file, "rb").read()
+for pubkey_b64 in sys.argv[3:]:
+    try:
+        Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "==")).verify(sig, data)
+        sys.exit(0)
+    except (InvalidSignature, ValueError):
+        continue
+sys.exit(1)
 '@
 			Set-Content -Path $pyScript -Value $pySource -Encoding ASCII
-			$pyArgs = $python.Pre + @($pyScript, $sigPath, $sumsPath, $PubKeyB64)
+			$pyArgs = $python.Pre + @($pyScript, $sigPath, $sumsPath) + $PubKeys
 			& $python.Exe @pyArgs
 			if ($LASTEXITCODE -eq 0) {
 				Write-LogOk 'SHA256SUMS signature verified'

--- a/install.sh
+++ b/install.sh
@@ -81,27 +81,37 @@ curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS.sig" \
 # If neither verifier can run, the install fails closed. Set
 # PODUP_INSECURE_SKIP_VERIFY=1 to explicitly opt out (checksum only).
 
-# Baked-in base64 (unpadded) raw Ed25519 public key (32 bytes) matching the
-# release signing key (RELEASE_SIGN_KEY). Verified against the genuine published
-# SHA256SUMS.sig. Override for a fork via the PODUP_RELEASE_PUBKEY_B64 env var.
+# Baked-in base64 (unpadded) raw Ed25519 public keys (32 bytes each) matching the
+# release signing key (RELEASE_SIGN_KEY). Up to two are accepted: the second is
+# empty except during a key rotation, when it holds the new key so a release
+# signed by either key verifies. The signature passes if any key validates.
+# Override for a fork via the PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64 env vars.
 PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y}"
+PODUP_RELEASE_PUBKEY2_B64="${PODUP_RELEASE_PUBKEY2_B64:-}"
+
+PUBKEYS=()
+[[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]  && PUBKEYS+=("$PODUP_RELEASE_PUBKEY_B64")
+[[ -n "$PODUP_RELEASE_PUBKEY2_B64" ]] && PUBKEYS+=("$PODUP_RELEASE_PUBKEY2_B64")
 
 verified=0
 
 log_info "Verifying SHA256SUMS signature ..."
-if [[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]; then
+if [[ ${#PUBKEYS[@]} -gt 0 ]]; then
 	if command -v python3 >/dev/null 2>&1 && python3 -c "from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey" 2>/dev/null; then
-		if python3 - "${TMP_DIR}/SHA256SUMS.sig" "${TMP_DIR}/SHA256SUMS" "$PODUP_RELEASE_PUBKEY_B64" <<'PYEOF'
+		if python3 - "${TMP_DIR}/SHA256SUMS.sig" "${TMP_DIR}/SHA256SUMS" "${PUBKEYS[@]}" <<'PYEOF'
 import base64, sys
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.exceptions import InvalidSignature
-sig_file, data_file, pubkey_b64 = sys.argv[1], sys.argv[2], sys.argv[3]
-key = Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "=="))
-try:
-    key.verify(open(sig_file, "rb").read(), open(data_file, "rb").read())
-    sys.exit(0)
-except InvalidSignature:
-    sys.exit(1)
+sig_file, data_file = sys.argv[1], sys.argv[2]
+sig = open(sig_file, "rb").read()
+data = open(data_file, "rb").read()
+for pubkey_b64 in sys.argv[3:]:
+    try:
+        Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "==")).verify(sig, data)
+        sys.exit(0)
+    except (InvalidSignature, ValueError):
+        continue
+sys.exit(1)
 PYEOF
 		then
 			log_ok "SHA256SUMS signature verified"

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -3,7 +3,7 @@
 //! Flow: resolve the latest release tag, compare against the compiled-in
 //! version, and (unless `--check`) download the platform binary plus the signed
 //! `SHA256SUMS` manifest. The manifest's Ed25519 signature is verified against
-//! the public key embedded in this binary (`verify::RELEASE_PUBKEY`); only
+//! the public keys embedded in this binary (`verify::RELEASE_PUBKEYS`); only
 //! then is the binary's digest checked against the manifest and the running
 //! executable atomically replaced. Every step fails closed — a missing key,
 //! bad signature, or checksum mismatch aborts before anything is written.

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -1,8 +1,8 @@
 //! Verification primitives for self-update — the security core.
 //!
-//! Trust anchor is the Ed25519 public key embedded in this binary
-//! ([`RELEASE_PUBKEY`]), not the download domain or TLS. A release is accepted
-//! only if `SHA256SUMS` carries a valid signature from the matching private key
+//! Trust anchor is the set of Ed25519 public keys embedded in this binary
+//! ([`RELEASE_PUBKEYS`]), not the download domain or TLS. A release is accepted
+//! only if `SHA256SUMS` carries a valid signature from a matching private key
 //! (held in CI as `RELEASE_SIGN_KEY`) and the downloaded binary's SHA-256 digest
 //! appears in that signed manifest. Every check fails closed.
 
@@ -11,18 +11,33 @@ use sha2::{Digest, Sha256};
 
 use crate::ComposeError;
 
-/// Raw 32-byte Ed25519 public key matching the Glyndor release signing key
-/// (`RELEASE_SIGN_KEY`, base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`).
-/// The key is public by design — its integrity comes from being baked into the
-/// signed, build-provenance-attested binary, so an attacker cannot swap it
-/// without invalidating the binary itself.
+/// Accepted Ed25519 release public keys — at most two. Slot 0 is the active key
+/// (`RELEASE_SIGN_KEY`, base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`);
+/// slot 1 is the all-zero placeholder except during a key rotation, when it
+/// carries the second accepted key. A signature is trusted if it validates under
+/// any non-placeholder key. The keys are public by design — their integrity
+/// comes from being baked into the signed, build-provenance-attested binary, so
+/// an attacker cannot swap them without invalidating the binary itself.
 ///
 /// Verified against the genuine published `SHA256SUMS.sig` (see
-/// `embedded_key_verifies_real_release`). [`release_pubkey`] still fails closed
-/// if this is ever zeroed, so a misbuild can never trust an unverifiable release.
-pub const RELEASE_PUBKEY: [u8; 32] = [
-	0, 248, 126, 146, 30, 181, 116, 151, 147, 208, 124, 198, 248, 164, 23, 16, 188, 195, 140, 174,
-	28, 114, 250, 152, 244, 175, 133, 166, 211, 153, 223, 230,
+/// `embedded_key_verifies_real_release`). [`release_pubkeys`] still fails closed
+/// if both are zeroed, so a misbuild can never trust an unverifiable release.
+///
+/// # Key rotation (run if the private key may be compromised)
+///
+/// 1. Ship a release embedding `[old, new]` with `SHA256SUMS` signed by the
+///    **old** key. Binaries in the field trust only `old`, so they accept it and
+///    upgrade, picking up `new` in the process.
+/// 2. Ship the next release embedding `[new, zero]` signed by the **new** key.
+///    Every binary from step 1 trusts `new`, so the old key is retired and all
+///    installs converge on the new key.
+pub const RELEASE_PUBKEYS: [[u8; 32]; 2] = [
+	[
+		0, 248, 126, 146, 30, 181, 116, 151, 147, 208, 124, 198, 248, 164, 23, 16, 188, 195, 140,
+		174, 28, 114, 250, 152, 244, 175, 133, 166, 211, 153, 223, 230,
+	],
+	// Rotation slot — all-zero until a second key is being rolled in.
+	[0u8; 32],
 ];
 
 /// A parsed `MAJOR.MINOR.PATCH` version, ordered for comparison.
@@ -60,35 +75,53 @@ pub fn parse_version(s: &str) -> crate::Result<Version> {
 	})
 }
 
-/// Decode the embedded release public key, failing closed if it is still the
-/// all-zero placeholder (verification key not configured for this build).
-pub fn release_pubkey() -> crate::Result<VerifyingKey> {
-	if RELEASE_PUBKEY == [0u8; 32] {
+/// Decode the configured release public keys, skipping empty rotation slots.
+/// Fails closed if none remain (verification key not configured for this build)
+/// or a configured key is malformed.
+pub fn release_pubkeys() -> crate::Result<Vec<VerifyingKey>> {
+	let mut keys = Vec::new();
+	for raw in &RELEASE_PUBKEYS {
+		if raw == &[0u8; 32] {
+			continue;
+		}
+		let key = VerifyingKey::from_bytes(raw)
+			.map_err(|e| ComposeError::Update(format!("embedded release key is invalid: {e}")))?;
+		keys.push(key);
+	}
+	if keys.is_empty() {
 		return Err(ComposeError::Update(
 			"release verification key not configured in this build; refusing to self-update"
 				.to_string(),
 		));
 	}
-	VerifyingKey::from_bytes(&RELEASE_PUBKEY)
-		.map_err(|e| ComposeError::Update(format!("embedded release key is invalid: {e}")))
+	Ok(keys)
 }
 
-/// Verify that `signature` (raw 64-byte Ed25519) over `message` was produced by
-/// the embedded release key. Fails closed on a wrong length, bad key, or any
-/// mismatch.
-pub fn verify_signature(message: &[u8], signature: &[u8]) -> crate::Result<()> {
-	let key = release_pubkey()?;
+/// Verify that `signature` (raw 64-byte Ed25519) over `message` validates under
+/// any of `keys`. Fails closed on a wrong length or a mismatch against every
+/// key. Kept separate from [`verify_signature`] so the multi-key logic is
+/// testable without touching the embedded constant.
+fn verify_with_keys(keys: &[VerifyingKey], message: &[u8], signature: &[u8]) -> crate::Result<()> {
 	let sig = Signature::from_slice(signature).map_err(|_| {
 		ComposeError::Update(format!(
 			"malformed signature: expected 64 bytes, got {}",
 			signature.len()
 		))
 	})?;
-	key.verify(message, &sig).map_err(|_| {
-		ComposeError::Update(
+	if keys.iter().any(|key| key.verify(message, &sig).is_ok()) {
+		Ok(())
+	} else {
+		Err(ComposeError::Update(
 			"signature verification failed — release may be tampered or unsigned".to_string(),
-		)
-	})
+		))
+	}
+}
+
+/// Verify that `signature` (raw 64-byte Ed25519) over `message` was produced by
+/// one of the accepted release keys. Fails closed on a wrong length, no
+/// configured key, or a mismatch against every key.
+pub fn verify_signature(message: &[u8], signature: &[u8]) -> crate::Result<()> {
+	verify_with_keys(&release_pubkeys()?, message, signature)
 }
 
 /// Verify `signature` against the embedded key using an explicitly supplied key
@@ -213,20 +246,47 @@ mod tests {
 	#[test]
 	fn embedded_key_is_configured_and_rejects_garbage() {
 		// A real key is baked in; it must load and reject a bogus signature.
-		assert_ne!(RELEASE_PUBKEY, [0u8; 32]);
-		assert!(release_pubkey().is_ok());
+		assert_ne!(RELEASE_PUBKEYS[0], [0u8; 32]);
+		assert!(release_pubkeys().is_ok());
 		assert!(verify_signature(b"data", &[0u8; 64]).is_err());
 	}
 
 	#[test]
 	fn zeroed_key_would_fail_closed() {
 		// Defence in depth: an all-zero key is a valid curve point, so the
-		// explicit guard in `release_pubkey` — not the curve math — is what
-		// refuses to trust an unverifiable release if the key is ever zeroed.
+		// explicit guard in `release_pubkeys` — not the curve math — is what
+		// refuses to trust an unverifiable release if every key is zeroed.
 		assert!(VerifyingKey::from_bytes(&[0u8; 32]).is_ok());
 		let is_placeholder = |key: [u8; 32]| key == [0u8; 32];
 		assert!(is_placeholder([0u8; 32]));
-		assert!(!is_placeholder(RELEASE_PUBKEY));
+		assert!(!is_placeholder(RELEASE_PUBKEYS[0]));
+	}
+
+	#[test]
+	fn accepts_signature_from_any_configured_key() {
+		// Rotation: a binary embedding two keys must accept a release signed by
+		// EITHER, so an in-field binary can upgrade across a key change.
+		let (sk_a, vk_a) = test_keypair();
+		let sk_b = SigningKey::from_bytes(&[9u8; 32]);
+		let vk_b = sk_b.verifying_key();
+		let msg = b"SHA256SUMS payload";
+
+		let sig_b = sk_b.sign(msg).to_bytes();
+		verify_with_keys(&[vk_a, vk_b], msg, &sig_b).unwrap();
+
+		let sig_a = sk_a.sign(msg).to_bytes();
+		verify_with_keys(&[vk_a, vk_b], msg, &sig_a).unwrap();
+	}
+
+	#[test]
+	fn rejects_signature_from_unconfigured_key() {
+		// A signature from a key that is NOT in the accepted set must fail, even
+		// though other keys are configured.
+		let (_sk_a, vk_a) = test_keypair();
+		let sk_x = SigningKey::from_bytes(&[3u8; 32]);
+		let msg = b"payload";
+		let sig_x = sk_x.sign(msg).to_bytes();
+		assert!(verify_with_keys(&[vk_a], msg, &sig_x).is_err());
 	}
 
 	#[test]


### PR DESCRIPTION
Replace the single embedded release key with up to two, so the Ed25519 signing key can be rotated without stranding installed binaries — even if the private key leaks.

## Problem
The self-update trust anchor was one embedded key (`RELEASE_PUBKEY`). Rotating it stranded every installed binary: they trust only the old key, so a release signed by a new key fails closed and users must reinstall.

## Change
- `internal/update/verify.rs`: `RELEASE_PUBKEY: [u8;32]` → `RELEASE_PUBKEYS: [[u8;32]; 2]` (slot 1 = all-zero rotation slot). New `release_pubkeys()` collects non-empty keys (fails closed if none); `verify_with_keys()` accepts a signature that validates under **any** key.
- `install.sh` / `install.ps1`: add `PODUP_RELEASE_PUBKEY2_B64` / `PubKey2B64`; the Python verifier loops over all configured keys.
- `docs/self-update.md`: documents the two-release rotation procedure.

## Rotation procedure
1. **Transition:** embed `[old, new]`, sign `SHA256SUMS` with **old** — in-field binaries (trust old) upgrade and pick up new.
2. **Retire:** embed `[new]`, switch CI secret to **new** — every binary from step 1 trusts new; old retired.

Accepted cost: the leaked old key stays valid for one transition release (inherent to any rotation); GitHub build-provenance attestation still proves origin during the window.

## Verification
- `cargo clippy --all-targets --all-features` clean
- full test suite passes; new tests `accepts_signature_from_any_configured_key` + `rejects_signature_from_unconfigured_key`
- `bash -n install.sh` clean; multi-key Python loop tested end-to-end (signed by the 2nd key with `[A,B]` → accepted; with `[A]` only → rejected)

Closes #255