### PR TITLE
chore: bump version to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.18.0) unstable; urgency=medium
+
+  * Trim dependencies: drop the dead "ansi" tracing-subscriber feature, the
+    no-op futures-util "async-await" feature, the redundant direct futures-core
+    dependency, and clap's default "color"/"suggestions" features — removing
+    eight crates from the binary.
+  * Feature-gate self-update behind a default-on "update" feature; the Debian
+    package now builds without it (apt owns upgrades), dropping the TLS and
+    Ed25519 stack (~24 crates) from the packaged binary.
+  * Accept up to two release signing keys, so the signing key can be rotated
+    across two releases without stranding installed binaries.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 20:46:36 -0500
+
 podup (0.17.1) unstable; urgency=medium
 
   * Stop rejecting absolute and parent-relative "env_file" and "label_file"

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.17.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.18.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Bumps version to 0.18.0 (Cargo.toml, Cargo.lock, debian/changelog, man `.TH`) ahead of the develop->main release PR.

Changes since 0.17.1:
- Dependency trims (#252): -8 crates from the binary.
- Self-update feature-gate (#252): Debian package drops the TLS+Ed25519 stack.
- Two-key signing rotation (#256).