### PR TITLE
release: v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,54 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -144,10 +100,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -176,12 +130,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -557,12 +505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,25 +634,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -766,7 +693,6 @@ dependencies = [
  "clap_complete",
  "ed25519-dalek",
  "flate2",
- "futures-core",
  "futures-util",
  "http-body-util",
  "hyper",
@@ -1094,12 +1020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,7 +1141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
@@ -1299,12 +1218,6 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,15 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "syn
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
-clap = { version = "4", features = ["derive", "env"] }
-clap_complete = "4"
+clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "derive", "env"] }
+clap_complete = { version = "4", optional = true }
 indexmap = { version = "2", features = ["serde"] }
-futures-core = { version = "0.3", default-features = false }
-futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 bytes = "1"
@@ -42,16 +41,20 @@ notify = { version = "8", optional = true }
 # Self-update: HTTPS fetch of signed release assets and verification.
 # ureq (rustls + webpki roots) keeps static musl builds self-contained; the
 # Ed25519 signature pinned to an embedded key is the real trust anchor, not TLS.
-ureq = { version = "3", default-features = false, features = ["rustls"] }
-ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+ureq = { version = "3", default-features = false, features = ["rustls"], optional = true }
+ed25519-dalek = { version = "2", default-features = false, features = ["std"], optional = true }
 sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [features]
-default = ["watch"]
+default = ["watch", "completions", "update"]
 watch = ["notify"]
+completions = ["dep:clap_complete"]
+# Self-update over HTTPS with Ed25519 verification. Off for package-manager
+# builds (Debian/apt) where the manager owns upgrades; on for direct tarballs.
+update = ["dep:ureq", "dep:ed25519-dalek"]
 test-helpers = []
 
 [dev-dependencies]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.18.0) unstable; urgency=medium
+
+  * Trim dependencies: drop the dead "ansi" tracing-subscriber feature, the
+    no-op futures-util "async-await" feature, the redundant direct futures-core
+    dependency, and clap's default "color"/"suggestions" features — removing
+    eight crates from the binary.
+  * Feature-gate self-update behind a default-on "update" feature; the Debian
+    package now builds without it (apt owns upgrades), dropping the TLS and
+    Ed25519 stack (~24 crates) from the packaged binary.
+  * Accept up to two release signing keys, so the signing key can be rotated
+    across two releases without stranding installed binaries.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 20:46:36 -0500
+
 podup (0.17.1) unstable; urgency=medium
 
   * Stop rejecting absolute and parent-relative "env_file" and "label_file"

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.17.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.18.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,11 @@ export CARGO_UNSTABLE_OFFLINE = true
 CARGO_FLAGS = --frozen --offline
 endif
 
+# Drop the self-update stack (ureq + TLS + Ed25519) from the packaged binary:
+# apt owns upgrades on Debian, so `podup update` is disabled here. `completions`
+# stays on — the install step below generates the shell scripts from the binary.
+CARGO_FEATURES = --no-default-features --features watch,completions
+
 %:
 	dh $@
 
@@ -22,10 +27,10 @@ override_dh_auto_build:
 ifneq ($(wildcard vendor/),)
 	$(if $(wildcard .cargo/config.toml),,$(MAKE) -f debian/rules debian/cargo-config)
 endif
-	cargo build --release --locked $(CARGO_FLAGS)
+	cargo build --release --locked $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 override_dh_auto_test:
-	cargo test --release --locked $(CARGO_FLAGS)
+	cargo test --release --locked $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 override_dh_auto_install:
 	install -D -m 0755 target/release/podup debian/podup/usr/bin/podup

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -7,9 +7,9 @@ install a modified binary.
 
 ## Trust anchor
 
-The trust anchor is **not** the download domain, DNS, or TLS. It is an **Ed25519
-public key compiled into the binary** (`internal/update/verify.rs`,
-`RELEASE_PUBKEY`). The matching private key exists only as the
+The trust anchor is **not** the download domain, DNS, or TLS. It is the set of
+**Ed25519 public keys compiled into the binary** (`internal/update/verify.rs`,
+`RELEASE_PUBKEYS`). The matching private key exists only as the
 `RELEASE_SIGN_KEY` GitHub Actions secret and signs every release in CI
 (`.github/workflows/release.yml`).
 
@@ -47,20 +47,24 @@ build-provenance attestation (`gh attestation verify`). If neither verifier is
 available it refuses to install. `PODUP_INSECURE_SKIP_VERIFY=1` is the explicit,
 documented opt-out (checksum only) for constrained environments.
 
-## The embedded public key
+## The embedded public keys
 
-The release public key is embedded in three places, all holding the same key
-(base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`):
+Each consumer holds **up to two** accepted release keys — an active key plus an
+empty rotation slot. The active key (base64
+`APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`) is embedded in three places:
 
-- `internal/update/verify.rs` — `RELEASE_PUBKEY` (raw 32 bytes).
-- `install.sh` — `PODUP_RELEASE_PUBKEY_B64` default (base64, unpadded).
-- `install.ps1` — `PubKeyB64` default (base64, unpadded).
+- `internal/update/verify.rs` — `RELEASE_PUBKEYS[0]` (raw 32 bytes); slot 1 is
+  `[0u8; 32]` until a second key is rolled in.
+- `install.sh` — `PODUP_RELEASE_PUBKEY_B64` default; `PODUP_RELEASE_PUBKEY2_B64`
+  is the (empty) rotation slot.
+- `install.ps1` — `PubKeyB64` default; `PubKey2B64` is the rotation slot.
 
-It is verified against the genuine published `SHA256SUMS.sig` by the
+A signature is trusted if it validates under **any** non-empty key. The active
+key is verified against the genuine published `SHA256SUMS.sig` by the
 `embedded_key_verifies_real_release` regression test, so an accidental or
-malicious edit to the constant fails CI. If the key is ever zeroed, both the
-binary and the installer fail closed and install nothing. The same key signs
-`podup`, `panel`, and `panel-agent` releases (shared `RELEASE_SIGN_KEY`).
+malicious edit to the constant fails CI. If every key is zeroed, both the binary
+and the installer fail closed and install nothing. The same key signs `podup`,
+`panel`, and `panel-agent` releases (shared `RELEASE_SIGN_KEY`).
 
 ### Deriving the public key from the signing secret
 
@@ -82,11 +86,24 @@ print("verify.rs bytes   :", ", ".join(str(b) for b in raw))
 ```
 
 Paste the base64 form into `install.sh` and `install.ps1`, and the byte array
-into `RELEASE_PUBKEY`.
+into `RELEASE_PUBKEYS`.
 
 ### Key rotation
 
-Rotating the signing key requires shipping a new binary that embeds the new
-public key *before* the first release signed with the new private key — older
-binaries verify only against the key they were built with. Plan a release that
-updates the embedded key, then switch the CI secret on the following release.
+Because each binary accepts up to two keys, the signing key can be rotated
+**without stranding installed binaries** — even if the private key leaks. Run the
+two-release procedure:
+
+1. **Transition release.** Add the new key to the rotation slot so the binary
+   embeds `[old, new]` (and add `PODUP_RELEASE_PUBKEY2_B64` / `PubKey2B64` to the
+   installers). Keep `RELEASE_SIGN_KEY` set to the **old** key so `SHA256SUMS` is
+   signed by `old`. Binaries already in the field trust only `old`, so they
+   accept this release and upgrade — gaining `new` in the process.
+2. **Retire release.** Move `new` into slot 0 and zero the rotation slot so the
+   binary embeds `[new]`, and switch the CI `RELEASE_SIGN_KEY` secret to the
+   **new** key. Every binary from step 1 trusts `new`, so all installs converge
+   on the new key and `old` is retired.
+
+During step 1 the leaked `old` key is still accepted for one release — an
+unavoidable cost of any rotation. The GitHub build-provenance attestation, which
+does not depend on the signing key, still proves origin during the window.

--- a/install.ps1
+++ b/install.ps1
@@ -84,10 +84,14 @@ try {
 	# If neither verifier can run, the install fails closed. Set
 	# PODUP_INSECURE_SKIP_VERIFY=1 to explicitly opt out (checksum only).
 
-	# Baked-in base64 (unpadded) raw Ed25519 public key (32 bytes) matching the
-	# release signing key (RELEASE_SIGN_KEY). Verified against the genuine published
-	# SHA256SUMS.sig. Override for a fork via the PODUP_RELEASE_PUBKEY_B64 env var.
-	$PubKeyB64 = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y' }
+	# Baked-in base64 (unpadded) raw Ed25519 public keys (32 bytes each) matching
+	# the release signing key (RELEASE_SIGN_KEY). Up to two are accepted: the
+	# second is empty except during a key rotation, when it holds the new key so a
+	# release signed by either key verifies. The signature passes if any key
+	# validates. Override for a fork via PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64.
+	$PubKeyB64  = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y' }
+	$PubKey2B64 = if ($env:PODUP_RELEASE_PUBKEY2_B64) { $env:PODUP_RELEASE_PUBKEY2_B64 } else { '' }
+	$PubKeys = @($PubKeyB64, $PubKey2B64 | Where-Object { $_ })
 
 	$verified = $false
 
@@ -109,7 +113,7 @@ try {
 	}
 
 	Write-LogInfo 'Verifying SHA256SUMS signature ...'
-	if ($PubKeyB64) {
+	if ($PubKeys.Count -gt 0) {
 		$python = Find-Python
 		if ($python) {
 			$pyScript = Join-Path $TmpDir 'verify_ed25519.py'
@@ -118,16 +122,19 @@ try {
 import base64, sys
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.exceptions import InvalidSignature
-sig_file, data_file, pubkey_b64 = sys.argv[1], sys.argv[2], sys.argv[3]
-key = Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "=="))
-try:
-    key.verify(open(sig_file, "rb").read(), open(data_file, "rb").read())
-    sys.exit(0)
-except InvalidSignature:
-    sys.exit(1)
+sig_file, data_file = sys.argv[1], sys.argv[2]
+sig = open(sig_file, "rb").read()
+data = open(data_file, "rb").read()
+for pubkey_b64 in sys.argv[3:]:
+    try:
+        Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "==")).verify(sig, data)
+        sys.exit(0)
+    except (InvalidSignature, ValueError):
+        continue
+sys.exit(1)
 '@
 			Set-Content -Path $pyScript -Value $pySource -Encoding ASCII
-			$pyArgs = $python.Pre + @($pyScript, $sigPath, $sumsPath, $PubKeyB64)
+			$pyArgs = $python.Pre + @($pyScript, $sigPath, $sumsPath) + $PubKeys
 			& $python.Exe @pyArgs
 			if ($LASTEXITCODE -eq 0) {
 				Write-LogOk 'SHA256SUMS signature verified'

--- a/install.sh
+++ b/install.sh
@@ -81,27 +81,37 @@ curl --proto '=https' --tlsv1.2 -fsSL -o "${TMP_DIR}/SHA256SUMS.sig" \
 # If neither verifier can run, the install fails closed. Set
 # PODUP_INSECURE_SKIP_VERIFY=1 to explicitly opt out (checksum only).
 
-# Baked-in base64 (unpadded) raw Ed25519 public key (32 bytes) matching the
-# release signing key (RELEASE_SIGN_KEY). Verified against the genuine published
-# SHA256SUMS.sig. Override for a fork via the PODUP_RELEASE_PUBKEY_B64 env var.
+# Baked-in base64 (unpadded) raw Ed25519 public keys (32 bytes each) matching the
+# release signing key (RELEASE_SIGN_KEY). Up to two are accepted: the second is
+# empty except during a key rotation, when it holds the new key so a release
+# signed by either key verifies. The signature passes if any key validates.
+# Override for a fork via the PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64 env vars.
 PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y}"
+PODUP_RELEASE_PUBKEY2_B64="${PODUP_RELEASE_PUBKEY2_B64:-}"
+
+PUBKEYS=()
+[[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]  && PUBKEYS+=("$PODUP_RELEASE_PUBKEY_B64")
+[[ -n "$PODUP_RELEASE_PUBKEY2_B64" ]] && PUBKEYS+=("$PODUP_RELEASE_PUBKEY2_B64")
 
 verified=0
 
 log_info "Verifying SHA256SUMS signature ..."
-if [[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]; then
+if [[ ${#PUBKEYS[@]} -gt 0 ]]; then
 	if command -v python3 >/dev/null 2>&1 && python3 -c "from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey" 2>/dev/null; then
-		if python3 - "${TMP_DIR}/SHA256SUMS.sig" "${TMP_DIR}/SHA256SUMS" "$PODUP_RELEASE_PUBKEY_B64" <<'PYEOF'
+		if python3 - "${TMP_DIR}/SHA256SUMS.sig" "${TMP_DIR}/SHA256SUMS" "${PUBKEYS[@]}" <<'PYEOF'
 import base64, sys
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.exceptions import InvalidSignature
-sig_file, data_file, pubkey_b64 = sys.argv[1], sys.argv[2], sys.argv[3]
-key = Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "=="))
-try:
-    key.verify(open(sig_file, "rb").read(), open(data_file, "rb").read())
-    sys.exit(0)
-except InvalidSignature:
-    sys.exit(1)
+sig_file, data_file = sys.argv[1], sys.argv[2]
+sig = open(sig_file, "rb").read()
+data = open(data_file, "rb").read()
+for pubkey_b64 in sys.argv[3:]:
+    try:
+        Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64 + "==")).verify(sig, data)
+        sys.exit(0)
+    except (InvalidSignature, ValueError):
+        continue
+sys.exit(1)
 PYEOF
 		then
 			log_ok "SHA256SUMS signature verified"

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+#[cfg(feature = "completions")]
 use clap_complete::Shell;
 
 #[derive(Parser)]
@@ -225,6 +226,7 @@ pub(crate) enum Commands {
 	/// against the public key embedded in this build and matching its SHA-256
 	/// checksum. Verification fails closed: a missing key, bad signature, or
 	/// checksum mismatch aborts without touching the installed binary.
+	#[cfg(feature = "update")]
 	Update {
 		/// Report whether a newer release exists without installing it.
 		#[arg(long)]
@@ -238,6 +240,7 @@ pub(crate) enum Commands {
 	/// Generates a completion script for the named shell from the CLI
 	/// definition. Source it from your shell's startup (or install the file the
 	/// Debian package ships) to get tab completion for podup commands and flags.
+	#[cfg(feature = "completions")]
 	Completions {
 		/// Shell to generate completions for (bash, zsh, fish, powershell, elvish).
 		shell: Shell,

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -21,6 +21,7 @@ pub mod ports;
 pub mod quadlet;
 pub mod size;
 pub mod substitute;
+#[cfg(feature = "update")]
 pub mod update;
 
 pub use compose::{

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -5,7 +5,7 @@
 //! Stream type 1 = stdout, 2 = stderr.
 
 use bytes::Bytes;
-use futures_core::Stream;
+use futures_util::stream::Stream;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use std::pin::Pin;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -6,7 +6,9 @@
 use std::path::Path;
 use std::process;
 
-use clap::{CommandFactory, Parser};
+#[cfg(feature = "completions")]
+use clap::CommandFactory;
+use clap::Parser;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
@@ -157,6 +159,7 @@ async fn main() {
 	match run().await {
 		Ok(()) => {}
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
+		#[cfg(feature = "update")]
 		Err(e @ podup::ComposeError::Update(_)) => {
 			eprintln!("podup: error: {e}");
 			process::exit(podup::update::exit_code(&e));
@@ -184,6 +187,7 @@ async fn run() -> podup::Result<()> {
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.
+	#[cfg(feature = "completions")]
 	if let Commands::Completions { shell } = cli.command {
 		let mut cmd = Cli::command();
 		let name = cmd.get_name().to_string();
@@ -194,6 +198,7 @@ async fn run() -> podup::Result<()> {
 	// `update` operates on the binary itself, not a compose project, so it runs
 	// before any compose file is parsed or Podman is contacted. The network and
 	// filesystem work is blocking; keep it off the async path entirely.
+	#[cfg(feature = "update")]
 	if let Commands::Update { check, force } = cli.command {
 		let opts = podup::update::UpdateOptions {
 			check_only: check,
@@ -337,7 +342,9 @@ async fn run() -> podup::Result<()> {
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
+		#[cfg(feature = "update")]
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
+		#[cfg(feature = "completions")]
 		Commands::Completions { .. } => unreachable!("handled before compose parsing"),
 	}
 

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -3,7 +3,7 @@
 //! Flow: resolve the latest release tag, compare against the compiled-in
 //! version, and (unless `--check`) download the platform binary plus the signed
 //! `SHA256SUMS` manifest. The manifest's Ed25519 signature is verified against
-//! the public key embedded in this binary (`verify::RELEASE_PUBKEY`); only
+//! the public keys embedded in this binary (`verify::RELEASE_PUBKEYS`); only
 //! then is the binary's digest checked against the manifest and the running
 //! executable atomically replaced. Every step fails closed — a missing key,
 //! bad signature, or checksum mismatch aborts before anything is written.

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -1,8 +1,8 @@
 //! Verification primitives for self-update — the security core.
 //!
-//! Trust anchor is the Ed25519 public key embedded in this binary
-//! ([`RELEASE_PUBKEY`]), not the download domain or TLS. A release is accepted
-//! only if `SHA256SUMS` carries a valid signature from the matching private key
+//! Trust anchor is the set of Ed25519 public keys embedded in this binary
+//! ([`RELEASE_PUBKEYS`]), not the download domain or TLS. A release is accepted
+//! only if `SHA256SUMS` carries a valid signature from a matching private key
 //! (held in CI as `RELEASE_SIGN_KEY`) and the downloaded binary's SHA-256 digest
 //! appears in that signed manifest. Every check fails closed.
 
@@ -11,18 +11,33 @@ use sha2::{Digest, Sha256};
 
 use crate::ComposeError;
 
-/// Raw 32-byte Ed25519 public key matching the Glyndor release signing key
-/// (`RELEASE_SIGN_KEY`, base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`).
-/// The key is public by design — its integrity comes from being baked into the
-/// signed, build-provenance-attested binary, so an attacker cannot swap it
-/// without invalidating the binary itself.
+/// Accepted Ed25519 release public keys — at most two. Slot 0 is the active key
+/// (`RELEASE_SIGN_KEY`, base64 `APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y=`);
+/// slot 1 is the all-zero placeholder except during a key rotation, when it
+/// carries the second accepted key. A signature is trusted if it validates under
+/// any non-placeholder key. The keys are public by design — their integrity
+/// comes from being baked into the signed, build-provenance-attested binary, so
+/// an attacker cannot swap them without invalidating the binary itself.
 ///
 /// Verified against the genuine published `SHA256SUMS.sig` (see
-/// `embedded_key_verifies_real_release`). [`release_pubkey`] still fails closed
-/// if this is ever zeroed, so a misbuild can never trust an unverifiable release.
-pub const RELEASE_PUBKEY: [u8; 32] = [
-	0, 248, 126, 146, 30, 181, 116, 151, 147, 208, 124, 198, 248, 164, 23, 16, 188, 195, 140, 174,
-	28, 114, 250, 152, 244, 175, 133, 166, 211, 153, 223, 230,
+/// `embedded_key_verifies_real_release`). [`release_pubkeys`] still fails closed
+/// if both are zeroed, so a misbuild can never trust an unverifiable release.
+///
+/// # Key rotation (run if the private key may be compromised)
+///
+/// 1. Ship a release embedding `[old, new]` with `SHA256SUMS` signed by the
+///    **old** key. Binaries in the field trust only `old`, so they accept it and
+///    upgrade, picking up `new` in the process.
+/// 2. Ship the next release embedding `[new, zero]` signed by the **new** key.
+///    Every binary from step 1 trusts `new`, so the old key is retired and all
+///    installs converge on the new key.
+pub const RELEASE_PUBKEYS: [[u8; 32]; 2] = [
+	[
+		0, 248, 126, 146, 30, 181, 116, 151, 147, 208, 124, 198, 248, 164, 23, 16, 188, 195, 140,
+		174, 28, 114, 250, 152, 244, 175, 133, 166, 211, 153, 223, 230,
+	],
+	// Rotation slot — all-zero until a second key is being rolled in.
+	[0u8; 32],
 ];
 
 /// A parsed `MAJOR.MINOR.PATCH` version, ordered for comparison.
@@ -60,35 +75,53 @@ pub fn parse_version(s: &str) -> crate::Result<Version> {
 	})
 }
 
-/// Decode the embedded release public key, failing closed if it is still the
-/// all-zero placeholder (verification key not configured for this build).
-pub fn release_pubkey() -> crate::Result<VerifyingKey> {
-	if RELEASE_PUBKEY == [0u8; 32] {
+/// Decode the configured release public keys, skipping empty rotation slots.
+/// Fails closed if none remain (verification key not configured for this build)
+/// or a configured key is malformed.
+pub fn release_pubkeys() -> crate::Result<Vec<VerifyingKey>> {
+	let mut keys = Vec::new();
+	for raw in &RELEASE_PUBKEYS {
+		if raw == &[0u8; 32] {
+			continue;
+		}
+		let key = VerifyingKey::from_bytes(raw)
+			.map_err(|e| ComposeError::Update(format!("embedded release key is invalid: {e}")))?;
+		keys.push(key);
+	}
+	if keys.is_empty() {
 		return Err(ComposeError::Update(
 			"release verification key not configured in this build; refusing to self-update"
 				.to_string(),
 		));
 	}
-	VerifyingKey::from_bytes(&RELEASE_PUBKEY)
-		.map_err(|e| ComposeError::Update(format!("embedded release key is invalid: {e}")))
+	Ok(keys)
 }
 
-/// Verify that `signature` (raw 64-byte Ed25519) over `message` was produced by
-/// the embedded release key. Fails closed on a wrong length, bad key, or any
-/// mismatch.
-pub fn verify_signature(message: &[u8], signature: &[u8]) -> crate::Result<()> {
-	let key = release_pubkey()?;
+/// Verify that `signature` (raw 64-byte Ed25519) over `message` validates under
+/// any of `keys`. Fails closed on a wrong length or a mismatch against every
+/// key. Kept separate from [`verify_signature`] so the multi-key logic is
+/// testable without touching the embedded constant.
+fn verify_with_keys(keys: &[VerifyingKey], message: &[u8], signature: &[u8]) -> crate::Result<()> {
 	let sig = Signature::from_slice(signature).map_err(|_| {
 		ComposeError::Update(format!(
 			"malformed signature: expected 64 bytes, got {}",
 			signature.len()
 		))
 	})?;
-	key.verify(message, &sig).map_err(|_| {
-		ComposeError::Update(
+	if keys.iter().any(|key| key.verify(message, &sig).is_ok()) {
+		Ok(())
+	} else {
+		Err(ComposeError::Update(
 			"signature verification failed — release may be tampered or unsigned".to_string(),
-		)
-	})
+		))
+	}
+}
+
+/// Verify that `signature` (raw 64-byte Ed25519) over `message` was produced by
+/// one of the accepted release keys. Fails closed on a wrong length, no
+/// configured key, or a mismatch against every key.
+pub fn verify_signature(message: &[u8], signature: &[u8]) -> crate::Result<()> {
+	verify_with_keys(&release_pubkeys()?, message, signature)
 }
 
 /// Verify `signature` against the embedded key using an explicitly supplied key
@@ -213,20 +246,47 @@ mod tests {
 	#[test]
 	fn embedded_key_is_configured_and_rejects_garbage() {
 		// A real key is baked in; it must load and reject a bogus signature.
-		assert_ne!(RELEASE_PUBKEY, [0u8; 32]);
-		assert!(release_pubkey().is_ok());
+		assert_ne!(RELEASE_PUBKEYS[0], [0u8; 32]);
+		assert!(release_pubkeys().is_ok());
 		assert!(verify_signature(b"data", &[0u8; 64]).is_err());
 	}
 
 	#[test]
 	fn zeroed_key_would_fail_closed() {
 		// Defence in depth: an all-zero key is a valid curve point, so the
-		// explicit guard in `release_pubkey` — not the curve math — is what
-		// refuses to trust an unverifiable release if the key is ever zeroed.
+		// explicit guard in `release_pubkeys` — not the curve math — is what
+		// refuses to trust an unverifiable release if every key is zeroed.
 		assert!(VerifyingKey::from_bytes(&[0u8; 32]).is_ok());
 		let is_placeholder = |key: [u8; 32]| key == [0u8; 32];
 		assert!(is_placeholder([0u8; 32]));
-		assert!(!is_placeholder(RELEASE_PUBKEY));
+		assert!(!is_placeholder(RELEASE_PUBKEYS[0]));
+	}
+
+	#[test]
+	fn accepts_signature_from_any_configured_key() {
+		// Rotation: a binary embedding two keys must accept a release signed by
+		// EITHER, so an in-field binary can upgrade across a key change.
+		let (sk_a, vk_a) = test_keypair();
+		let sk_b = SigningKey::from_bytes(&[9u8; 32]);
+		let vk_b = sk_b.verifying_key();
+		let msg = b"SHA256SUMS payload";
+
+		let sig_b = sk_b.sign(msg).to_bytes();
+		verify_with_keys(&[vk_a, vk_b], msg, &sig_b).unwrap();
+
+		let sig_a = sk_a.sign(msg).to_bytes();
+		verify_with_keys(&[vk_a, vk_b], msg, &sig_a).unwrap();
+	}
+
+	#[test]
+	fn rejects_signature_from_unconfigured_key() {
+		// A signature from a key that is NOT in the accepted set must fail, even
+		// though other keys are configured.
+		let (_sk_a, vk_a) = test_keypair();
+		let sk_x = SigningKey::from_bytes(&[3u8; 32]);
+		let msg = b"payload";
+		let sig_x = sk_x.sign(msg).to_bytes();
+		assert!(verify_with_keys(&[vk_a], msg, &sig_x).is_err());
 	}
 
 	#[test]


### PR DESCRIPTION
## podup v0.18.0

### Dependency trims (#246 #247 #248 #249 #251)
Remove eight crates from the binary: drop the dead `ansi` tracing-subscriber feature, the no-op `async-await` futures-util feature, the redundant direct `futures-core` dep, and clap's default `color`/`suggestions` features.

### Self-update feature-gate (#253)
`podup update` is now behind a default-on `update` feature. The Debian package builds without it (apt owns upgrades), dropping the TLS + Ed25519 stack (~24 crates, -1.57 MiB / -30% of the .deb binary). Tarball builds are unchanged.

### Two-key signing rotation (#255)
The self-update trust anchor accepts up to two embedded Ed25519 keys, so the signing key can be rotated across two releases without stranding installed binaries.

Full verification green on develop (clippy, full test suite, all feature combos, macOS/Windows tests, dpkg-buildpackage, semver checks).