### PR TITLE
chore: bump version to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.16.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.19.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (0.19.0) unstable; urgency=medium
+
+  * Add a signed apt repository for amd64 Debian/Ubuntu, published to
+    https://apt.glyndor.net. Install with `install.sh --apt` and update through
+    `apt upgrade`.
+  * Ship the repository signing key as the podup-archive-keyring package so apt
+    owns the key file and key renewals propagate automatically.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 13 Jun 2026 22:57:42 -0500
+
 podup (0.18.0) unstable; urgency=medium
 
   * Trim dependencies: drop the dead "ansi" tracing-subscriber feature, the

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.18.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.19.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Release prep for v0.19.0 (signed apt repository, #259).

- Cargo.toml + Cargo.lock → 0.19.0
- debian/changelog: 0.19.0 stanza
- debian/podup.1 .TH → 0.19.0
- README lib snippet tag v0.16.0 → v0.19.0 (clears the long-standing drift)