### PR TITLE
release: v0.20.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,12 +140,20 @@ jobs:
           if-no-files-found: error
 
   build-deb:
-    name: Build Debian package
+    name: Build Debian package (${{ matrix.arch }})
     needs: verify
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     container: debian:sid
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Install build tooling
         env:
@@ -166,14 +174,16 @@ jobs:
 
       - name: Build the package
         run: |
+          # dpkg-buildpackage builds for the host architecture, so each runner
+          # produces its own arch's .deb natively.
           dpkg-checkbuilddeps
           dpkg-buildpackage -us -uc -b
 
       - name: Stage the .deb into the workspace
         run: |
-          deb=$(ls ../podup_*_amd64.deb 2>/dev/null | head -n1)
+          deb=$(ls ../podup_*_${{ matrix.arch }}.deb 2>/dev/null | head -n1)
           if [ -z "$deb" ]; then
-            echo "::error::no .deb artifact was produced"
+            echo "::error::no ${{ matrix.arch }} .deb artifact was produced"
             exit 1
           fi
           cp "$deb" "$(basename "$deb")"
@@ -182,8 +192,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: podup-deb
-          path: podup_*_amd64.deb
+          name: podup-deb-${{ matrix.arch }}
+          path: podup_*_${{ matrix.arch }}.deb
           retention-days: 1
           if-no-files-found: error
 
@@ -206,15 +216,14 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Resolve Debian package name
+      - name: Verify both Debian packages are present
         run: |
-          deb=$(ls podup_*_amd64.deb 2>/dev/null | head -n1)
-          if [ -z "$deb" ]; then
-            echo "::error::Debian package artifact missing"
-            exit 1
-          fi
-          echo "DEB=$deb" >> "$GITHUB_ENV"
-          echo "Releasing Debian package $deb"
+          for arch in amd64 arm64; do
+            if ! ls podup_*_${arch}.deb >/dev/null 2>&1; then
+              echo "::error::Debian package artifact for ${arch} is missing"
+              exit 1
+            fi
+          done
 
       - name: Generate checksums
         run: |
@@ -225,10 +234,11 @@ jobs:
             podup-darwin-x86_64 \
             podup-windows-x86_64.exe \
             podup-windows-arm64.exe \
-            "$DEB" \
+            podup_*_amd64.deb \
+            podup_*_arm64.deb \
             > SHA256SUMS
 
-      - name: Sign SHA256SUMS and the Debian package
+      - name: Sign SHA256SUMS and the Debian packages
         env:
           RELEASE_SIGN_KEY: ${{ secrets.RELEASE_SIGN_KEY }}
           PYTHONUTF8: "1"
@@ -240,7 +250,9 @@ jobs:
           fi
           python3 -m pip install --quiet --require-hashes -r .github/scripts/sign-requirements.txt
           python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" SHA256SUMS
-          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "$DEB"
+          for deb in podup_*_amd64.deb podup_*_arm64.deb; do
+            python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "$deb"
+          done
 
       - name: Create GitHub Release
         env:
@@ -262,8 +274,10 @@ jobs:
             podup-windows-x86_64.exe.sig \
             podup-windows-arm64.exe \
             podup-windows-arm64.exe.sig \
-            "$DEB" \
-            "$DEB.sig" \
+            podup_*_amd64.deb \
+            podup_*_amd64.deb.sig \
+            podup_*_arm64.deb \
+            podup_*_arm64.deb.sig \
             SHA256SUMS \
             SHA256SUMS.sig \
             install.sh \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ cargo build --release
 
 ### Debian / Ubuntu (apt)
 
-On amd64 Debian and Ubuntu, install from the Glyndor apt repository so updates
-arrive through `apt upgrade`:
+On Debian and Ubuntu (amd64 and arm64), install from the Glyndor apt repository
+so updates arrive through `apt upgrade`:
 
 ```bash
 curl -fsSL https://glyndor.net/install/podup | bash -s -- --apt
@@ -124,7 +124,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.19.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.20.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+podup (0.20.0) unstable; urgency=medium
+
+  * Build and publish an arm64 Debian package in addition to amd64, so podup can
+    be installed with apt on arm64 Debian/Ubuntu (Raspberry Pi, ARM servers).
+  * install.sh --apt now supports arm64.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 00:41:13 -0500
+
 podup (0.19.0) unstable; urgency=medium
 
   * Add a signed apt repository for amd64 Debian/Ubuntu, published to

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.19.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.20.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -30,15 +30,15 @@ upgrade with `apt` instead.
 
 ## apt repository (apt.glyndor.net)
 
-For amd64 Debian and Ubuntu, podup is served from the **Glyndor apt
+For Debian and Ubuntu (amd64 and arm64), podup is served from the **Glyndor apt
 repository** at `https://apt.glyndor.net`, alongside other Glyndor packages.
 The repository lives in its own repo, [Glyndor/apt](https://github.com/Glyndor/apt):
 a workflow there downloads the latest amd64 `.deb` release asset of each tracked
 product, builds a signed `reprepro` repository, and publishes it to GitHub
 Pages. It is rebuilt fresh each run, so it always carries the current version of
 every package (no old-version support). podup's only responsibility is to attach
-a `podup_<version>_amd64.deb` asset to each release — which `build-deb` in
-`release.yml` already does.
+a `podup_<version>_<arch>.deb` asset (amd64 and arm64) to each release — which
+the `build-deb` matrix in `release.yml` already does.
 
 ### One-line setup
 

--- a/install.sh
+++ b/install.sh
@@ -157,8 +157,6 @@ install_apt() {
 	[[ "$OS" == "linux" ]] || fail "--apt is only supported on Debian/Ubuntu Linux"
 	command -v apt-get >/dev/null 2>&1 || fail "--apt requires apt-get (Debian/Ubuntu)"
 	command -v dpkg >/dev/null 2>&1 || fail "--apt requires dpkg"
-	[[ "$ARCH" == "x86_64" ]] || fail \
-		"the Glyndor apt repository is amd64-only for now; on ${ARCH} install without --apt"
 
 	# Bootstrap the repository over HTTPS by installing the glyndor-archive-keyring
 	# package, which registers the signing key and source list. This curl step has


### PR DESCRIPTION
## v0.20.0

arm64 Debian package + apt support.

- `build-deb` matrix builds amd64 + arm64 `.deb`, both signed and attached.
- `install.sh --apt` works on arm64.
- Central Glyndor/apt repo already serves amd64+arm64; this ships the arm64 asset.

Merge as a **merge commit**, then tag v0.20.0.