### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.20.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+podup (0.21.0) unstable; urgency=medium
+
+  * Inject `external: true` secrets and configs as Podman-native secrets, mounted
+    from an existing `podman secret`; a missing secret now fails `up` with a clear
+    message instead of starting a container that silently lacks it.
+  * Warn when a per-service `gw_priority` is dropped (unsupported by Podman).
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 10:06:02 -0500
+
 podup (0.20.0) unstable; urgency=medium
 
   * Build and publish an arm64 Debian package in addition to amd64, so podup can

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.20.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.21.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Bumps the crate to 0.21.0 and adds the matching `debian/changelog` stanza, man-page `.TH` version, and README lib pin.

Release contents since v0.20.0:
- #269 — inject `external: true` secrets and configs as Podman-native secrets (fail-closed preflight).
- #268 — warn on silently-dropped `gw_priority`.