### PR TITLE
release: v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ flowchart LR
 - 📄 **Compose-spec parsing** — YAML anchors, `extends`, `include`, profiles, `env_file`, variable substitution with modifiers
 - 🔁 **Dependency-aware** — `depends_on` ordering with `service_started`, `service_healthy`, and `service_completed_successfully` conditions
 - 🔢 **Replicas** — `scale:` and `deploy.replicas` with named replica containers
-- 🔐 **Secrets & configs** — inline content, file, and environment sources staged securely
+- 🔐 **Secrets & configs** — inline content, file, environment, and `external: true` Podman-native secret sources, staged securely
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
 - 📦 **Single binary** — statically musl-linked on Linux, no runtime dependencies
 - 🦀 **Library too** — embed the parser and engine in your own Rust project

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.20.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+podup (0.21.0) unstable; urgency=medium
+
+  * Inject `external: true` secrets and configs as Podman-native secrets, mounted
+    from an existing `podman secret`; a missing secret now fails `up` with a clear
+    message instead of starting a container that silently lacks it.
+  * Warn when a per-service `gw_priority` is dropped (unsupported by Podman).
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 10:06:02 -0500
+
 podup (0.20.0) unstable; urgency=medium
 
   * Build and publish an arm64 Debian package in addition to amd64, so podup can

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.20.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.21.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -15,7 +15,7 @@ Every core Compose spec key is supported:
 | Environment | `environment`, `env_file` (dotenv format), variable substitution (`${VAR:-default}`) |
 | Networking | `ports`, `expose`, `networks`, `network_mode`, `hostname`, `domainname`, `dns`, `dns_search`, `extra_hosts` |
 | Volumes | `volumes` (bind, named, tmpfs, npipe), `tmpfs`, `volumes_from` |
-| Secrets / configs | `secrets`, `configs` (file, inline content, environment source) |
+| Secrets / configs | `secrets`, `configs` (file, inline content, environment source, and `external: true` Podman-native secrets) |
 | Dependencies | `depends_on` (with `condition:` — `service_started`, `service_healthy`, `service_completed_successfully`) |
 | Health checks | `healthcheck` (test, interval, timeout, retries, start_period, disable) |
 | Lifecycle hooks | `post_start`, `pre_stop` |
@@ -28,6 +28,34 @@ Every core Compose spec key is supported:
 | Metadata | `labels`, `annotations`, `container_name`, `profiles` |
 | Logging | `logging` (driver + options) |
 | Compose features | `extends`, `include`, YAML anchors, x-extensions, `develop.watch` |
+
+### External secrets and configs
+
+A secret or config declared `external: true` is mounted from an existing
+Podman secret rather than from a file in the project tree — the recommended
+pattern for production credentials, since the secret material never lands in a
+bind-mounted file. Create the secret before running, exactly as you would with
+`docker secret`:
+
+```sh
+printf '%s' "$DB_PASSWORD" | podman secret create db_password -
+```
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    secrets:
+      - db_password
+secrets:
+  db_password:
+    external: true
+```
+
+The secret appears at `/run/secrets/db_password` (configs use the long-form
+`target:` path). If the named Podman secret does not exist, `podup up` fails
+fast rather than starting a container without it. Use a top-level `name:` when
+the Podman secret is named differently from the compose reference.
 
 ## Rootless Podman differences
 

--- a/internal/compose/diagnostics.rs
+++ b/internal/compose/diagnostics.rs
@@ -21,8 +21,6 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	ignored_build_fields(file, &mut out);
 	ignored_network_fields(file, &mut out);
 	ignored_service_network_fields(file, &mut out);
-	ignored_secret_fields(file, &mut out);
-	ignored_config_fields(file, &mut out);
 	out
 }
 
@@ -207,35 +205,6 @@ fn ignored_service_network_fields(file: &ComposeFile, out: &mut Vec<String>) {
 	}
 }
 
-/// Secrets podup parses but cannot inject. Only `file:`, `environment:` and
-/// inline `content:` sources are materialized into the container; an
-/// `external: true` secret has no Podman-native injection path, so it is absent
-/// at runtime — a silent failure for anything that reads `/run/secrets/<name>`.
-fn ignored_secret_fields(file: &ComposeFile, out: &mut Vec<String>) {
-	for (name, cfg) in &file.secrets {
-		if cfg.external == Some(true) {
-			out.push(format!(
-				"secret '{name}': external secrets are not injected — podup supports only \
-				 file:, environment: and inline content: sources, so this secret is absent \
-				 from every service that references it"
-			));
-		}
-	}
-}
-
-/// Configs podup parses but cannot inject, mirroring `ignored_secret_fields`.
-fn ignored_config_fields(file: &ComposeFile, out: &mut Vec<String>) {
-	for (name, cfg) in &file.configs {
-		if cfg.external == Some(true) {
-			out.push(format!(
-				"config '{name}': external configs are not injected — podup supports only \
-				 file:, environment: and inline content: sources, so this config is absent \
-				 from every service that references it"
-			));
-		}
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use crate::parse_str;
@@ -326,30 +295,6 @@ mod tests {
 		assert!(msgs
 			.iter()
 			.any(|m| m.contains("volume 'data'") && m.contains("externl")));
-	}
-
-	#[test]
-	fn warns_on_external_secret() {
-		let msgs = diagnostics_for(
-			"services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n",
-		);
-		assert!(
-			msgs.iter()
-				.any(|m| m.contains("secret 'tok'") && m.contains("external")),
-			"got: {msgs:?}"
-		);
-	}
-
-	#[test]
-	fn warns_on_external_config() {
-		let msgs = diagnostics_for(
-			"services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    external: true\n",
-		);
-		assert!(
-			msgs.iter()
-				.any(|m| m.contains("config 'cfg'") && m.contains("external")),
-			"got: {msgs:?}"
-		);
 	}
 
 	#[test]

--- a/internal/compose/diagnostics.rs
+++ b/internal/compose/diagnostics.rs
@@ -20,6 +20,9 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	ignored_service_fields(file, &mut out);
 	ignored_build_fields(file, &mut out);
 	ignored_network_fields(file, &mut out);
+	ignored_service_network_fields(file, &mut out);
+	ignored_secret_fields(file, &mut out);
+	ignored_config_fields(file, &mut out);
 	out
 }
 
@@ -187,6 +190,52 @@ fn ignored_network_fields(file: &ComposeFile, out: &mut Vec<String>) {
 	}
 }
 
+/// Per-service network attachment fields podup parses but cannot forward.
+/// `gw_priority` has no Podman equivalent, so the engine drops it silently.
+fn ignored_service_network_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		for name in def.networks.names() {
+			if let Some(c) = def.networks.config_for(&name) {
+				if c.gw_priority.is_some() {
+					out.push(format!(
+						"service '{service}' network '{name}': gw_priority is not supported \
+						 by Podman and is ignored"
+					));
+				}
+			}
+		}
+	}
+}
+
+/// Secrets podup parses but cannot inject. Only `file:`, `environment:` and
+/// inline `content:` sources are materialized into the container; an
+/// `external: true` secret has no Podman-native injection path, so it is absent
+/// at runtime — a silent failure for anything that reads `/run/secrets/<name>`.
+fn ignored_secret_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (name, cfg) in &file.secrets {
+		if cfg.external == Some(true) {
+			out.push(format!(
+				"secret '{name}': external secrets are not injected — podup supports only \
+				 file:, environment: and inline content: sources, so this secret is absent \
+				 from every service that references it"
+			));
+		}
+	}
+}
+
+/// Configs podup parses but cannot inject, mirroring `ignored_secret_fields`.
+fn ignored_config_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (name, cfg) in &file.configs {
+		if cfg.external == Some(true) {
+			out.push(format!(
+				"config '{name}': external configs are not injected — podup supports only \
+				 file:, environment: and inline content: sources, so this config is absent \
+				 from every service that references it"
+			));
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::parse_str;
@@ -277,6 +326,49 @@ mod tests {
 		assert!(msgs
 			.iter()
 			.any(|m| m.contains("volume 'data'") && m.contains("externl")));
+	}
+
+	#[test]
+	fn warns_on_external_secret() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("secret 'tok'") && m.contains("external")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_external_config() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    external: true\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("config 'cfg'") && m.contains("external")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_service_network_gw_priority() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    networks:\n      net:\n        gw_priority: 10\nnetworks:\n  net:\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("gw_priority")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn file_secret_produces_no_diagnostics() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n",
+		);
+		assert!(msgs.is_empty(), "unexpected diagnostics: {msgs:?}");
 	}
 
 	#[test]

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -66,6 +66,9 @@ impl Engine {
 		// --- Secrets and configs become bind mounts ---
 		let secret_binds = self.build_secret_binds(service, file)?;
 		let config_binds = self.build_config_binds(service, file)?;
+		// `external: true` secrets/configs are injected as Podman-native secrets
+		// (preflighted for existence), not bind mounts.
+		let native_secrets = self.build_native_secrets(service, file).await?;
 		let (mut mounts, mut named_volumes) =
 			build_mounts_all(service, &self.base_dir, &secret_binds, &config_binds);
 		// Resolve relative bind sources against the project base directory (and
@@ -215,6 +218,7 @@ impl Engine {
 			mounts,
 			volumes: named_volumes,
 			volumes_from: service.volumes_from.clone(),
+			secrets: native_secrets,
 			userns,
 			pidns,
 			ipcns,

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -15,6 +15,7 @@ mod lock;
 mod network;
 mod profiles;
 mod query;
+mod secrets;
 mod staging;
 pub use staging::is_safe_project_name;
 mod volume;

--- a/internal/engine/secrets.rs
+++ b/internal/engine/secrets.rs
@@ -1,0 +1,418 @@
+//! Secret and config materialisation.
+//!
+//! [`Engine::build_secret_binds`] and [`Engine::build_config_binds`] materialise
+//! `file:`, inline `content:` and `environment:` secret/config sources into a
+//! restricted temp directory and return their bind strings.
+//! [`Engine::build_native_secrets`] maps `external: true` secrets/configs to
+//! Podman-native secrets attached to the container create spec.
+
+use crate::compose::types::{
+	ComposeFile, ConfigConfig, SecretConfig, Service, ServiceConfigRef, ServiceSecretRef,
+};
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::Secret;
+
+use super::{staging, Engine};
+
+impl Engine {
+	pub(super) fn build_secret_binds(
+		&self,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<Vec<String>> {
+		let mut binds = Vec::new();
+		for secret_ref in &service.secrets {
+			let (name, target_override, ref_mode, ref_uid, ref_gid) = match secret_ref {
+				ServiceSecretRef::Short(s) => (s.clone(), None, None, None, None),
+				ServiceSecretRef::Long {
+					source,
+					target,
+					mode,
+					uid,
+					gid,
+				} => (
+					source.clone(),
+					target.clone(),
+					*mode,
+					uid.clone(),
+					gid.clone(),
+				),
+			};
+			if let Some(config) = file.secrets.get(&name) {
+				let target = target_override.unwrap_or_else(|| format!("/run/secrets/{name}"));
+				match config {
+					SecretConfig {
+						file: Some(host_path),
+						..
+					} => {
+						// Resolve like a bind-mount source: a relative `file:` is
+						// anchored to the project dir (not the Podman service's cwd)
+						// and `~` is expanded — same handling as `volumes:`, which
+						// already mount arbitrary host paths.
+						let resolved =
+							super::container::resolve_bind_source(host_path, &self.base_dir);
+						binds.push(format!("{resolved}:{target}:ro"));
+					}
+					SecretConfig {
+						content: Some(content),
+						..
+					} => {
+						let path = self.materialize_inline_full(
+							"secrets",
+							&name,
+							content.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					SecretConfig {
+						environment: Some(env_var),
+						..
+					} => {
+						let value = std::env::var(env_var).map_err(|_| {
+							ComposeError::Unsupported(format!(
+								"secret '{name}' references env var '{env_var}' which is not set"
+							))
+						})?;
+						let path = self.materialize_inline_full(
+							"secrets",
+							&name,
+							value.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					// `external: true` secrets are injected natively — see
+					// build_native_secrets — not as bind mounts, so skip them here.
+					_ => {}
+				}
+			}
+		}
+		Ok(binds)
+	}
+
+	pub(super) fn build_config_binds(
+		&self,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<Vec<String>> {
+		let mut binds = Vec::new();
+		for config_ref in &service.configs {
+			let (name, target_override, ref_mode, ref_uid, ref_gid) = match config_ref {
+				ServiceConfigRef::Short(s) => (s.clone(), None, None, None, None),
+				ServiceConfigRef::Long {
+					source,
+					target,
+					mode,
+					uid,
+					gid,
+				} => (
+					source.clone(),
+					target.clone(),
+					*mode,
+					uid.clone(),
+					gid.clone(),
+				),
+			};
+			if let Some(cfg) = file.configs.get(&name) {
+				let target = target_override.unwrap_or_else(|| format!("/{name}"));
+				match cfg {
+					ConfigConfig {
+						file: Some(host_path),
+						..
+					} => {
+						// Resolve like a bind-mount source: anchor a relative path to
+						// the project dir and expand `~`, matching `volumes:` handling.
+						let resolved =
+							super::container::resolve_bind_source(host_path, &self.base_dir);
+						binds.push(format!("{resolved}:{target}:ro"));
+					}
+					ConfigConfig {
+						content: Some(content),
+						..
+					} => {
+						let path = self.materialize_inline_full(
+							"configs",
+							&name,
+							content.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					ConfigConfig {
+						environment: Some(env_var),
+						..
+					} => {
+						let value = std::env::var(env_var).map_err(|_| {
+							ComposeError::Unsupported(format!(
+								"config '{name}' references env var '{env_var}' which is not set"
+							))
+						})?;
+						let path = self.materialize_inline_full(
+							"configs",
+							&name,
+							value.as_bytes(),
+							ref_mode,
+							ref_uid.as_deref(),
+							ref_gid.as_deref(),
+						)?;
+						binds.push(format!("{}:{target}:ro", path.display()));
+					}
+					// `external: true` configs are injected natively — see
+					// build_native_secrets — not as bind mounts, so skip them here.
+					_ => {}
+				}
+			}
+		}
+		Ok(binds)
+	}
+
+	/// Build the Podman-native secret references for a service: every `external:
+	/// true` secret and config it references, mapped to an existing `podman
+	/// secret` and mounted into the container. Each source is preflighted with
+	/// [`Engine::ensure_external_exists`] so a missing secret fails closed with a
+	/// clear message instead of starting a container that lacks it.
+	pub(super) async fn build_native_secrets(
+		&self,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<Vec<Secret>> {
+		let secrets = collect_native_secrets(service, file);
+		for secret in &secrets {
+			self.ensure_external_exists("secret", "secrets", &secret.source)
+				.await?;
+		}
+		Ok(secrets)
+	}
+
+	fn materialize_inline_full(
+		&self,
+		kind: &str,
+		name: &str,
+		content: &[u8],
+		mode: Option<u32>,
+		uid: Option<&str>,
+		gid: Option<&str>,
+	) -> Result<std::path::PathBuf> {
+		if std::path::Path::new(name)
+			.components()
+			.any(|c| !matches!(c, std::path::Component::Normal(_)))
+		{
+			return Err(ComposeError::Unsupported(format!(
+				"{kind} name must not contain path separators or '..': {name}"
+			)));
+		}
+
+		let dir = self.staging_dir()?.join(kind);
+		staging::create_private_subdir(&dir)?;
+
+		let path = dir.join(name);
+		staging::write_private_file(&path, content)?;
+
+		if let Some(m) = mode {
+			staging::apply_mode(&path, m)?;
+		}
+		staging::apply_owner(&path, uid, gid);
+
+		Ok(path)
+	}
+}
+
+/// Collect the Podman-native secret specs for a service without touching the
+/// daemon: every `external: true` secret and config it references becomes a
+/// [`Secret`] pointing at an existing `podman secret`. Pure, so the mapping is
+/// unit-testable; [`Engine::build_native_secrets`] adds the existence preflight.
+fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Vec<Secret> {
+	let mut secrets = Vec::new();
+
+	for secret_ref in &service.secrets {
+		let (name, target_override, mode, uid, gid) = match secret_ref {
+			ServiceSecretRef::Short(s) => (s.clone(), None, None, None, None),
+			ServiceSecretRef::Long {
+				source,
+				target,
+				mode,
+				uid,
+				gid,
+			} => (
+				source.clone(),
+				target.clone(),
+				*mode,
+				uid.clone(),
+				gid.clone(),
+			),
+		};
+		if let Some(def) = file.secrets.get(&name) {
+			if def.external == Some(true) {
+				let source = def.name.clone().unwrap_or_else(|| name.clone());
+				// Default the mount filename to the compose name (so apps still
+				// find /run/secrets/<name> even when the Podman secret is named
+				// differently); a long-form target overrides it.
+				let target = target_override.unwrap_or(name);
+				secrets.push(native_secret(source, target, mode, uid, gid));
+			}
+		}
+	}
+
+	for config_ref in &service.configs {
+		let (name, target_override, mode, uid, gid) = match config_ref {
+			ServiceConfigRef::Short(s) => (s.clone(), None, None, None, None),
+			ServiceConfigRef::Long {
+				source,
+				target,
+				mode,
+				uid,
+				gid,
+			} => (
+				source.clone(),
+				target.clone(),
+				*mode,
+				uid.clone(),
+				gid.clone(),
+			),
+		};
+		if let Some(def) = file.configs.get(&name) {
+			if def.external == Some(true) {
+				let source = def.name.clone().unwrap_or_else(|| name.clone());
+				// Configs default to an absolute container-root path, matching the
+				// bind-mount config behaviour; an absolute target is used as-is.
+				let target = target_override.unwrap_or_else(|| format!("/{name}"));
+				secrets.push(native_secret(source, target, mode, uid, gid));
+			}
+		}
+	}
+
+	secrets
+}
+
+/// Assemble one [`Secret`] from a compose reference. `uid`/`gid` are numeric in
+/// libpod, so non-numeric values (a user/group name) are dropped to the default.
+fn native_secret(
+	source: String,
+	target: String,
+	mode: Option<u32>,
+	uid: Option<String>,
+	gid: Option<String>,
+) -> Secret {
+	Secret {
+		source,
+		target: Some(target),
+		uid: uid.and_then(|s| s.parse().ok()),
+		gid: gid.and_then(|s| s.parse().ok()),
+		mode,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::libpod::Client;
+	use std::path::PathBuf;
+
+	fn engine_with_base(base: &str) -> Engine {
+		Engine::with_base_dir(
+			Client::new("unused"),
+			"proj".to_string(),
+			PathBuf::from(base),
+		)
+	}
+
+	#[test]
+	fn secret_file_relative_path_is_anchored_to_base_dir() {
+		// A relative `file:` must resolve against the project dir, not the
+		// Podman service's cwd — same as a bind-mount source. Build the expected
+		// path via `Path::join` so the separator is correct on every platform.
+		let base = PathBuf::from("/srv/project");
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: secret.txt\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let engine = engine_with_base(&base.to_string_lossy());
+		let binds = engine
+			.build_secret_binds(&file.services["web"], &file)
+			.unwrap();
+		let expected = format!("{}:/run/secrets/tok:ro", base.join("secret.txt").display());
+		assert_eq!(binds, vec![expected]);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn config_file_absolute_path_is_passed_through() {
+		// Absolute paths are honored unchanged (compose allows mounting any host
+		// file, exactly as `volumes:` does). Uses a Unix-absolute path, so the
+		// assertion is gated to Unix.
+		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: /etc/app/cfg.yaml\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let engine = engine_with_base("/srv/project");
+		let binds = engine
+			.build_config_binds(&file.services["web"], &file)
+			.unwrap();
+		assert_eq!(binds, vec!["/etc/app/cfg.yaml:/cfg:ro"]);
+	}
+
+	#[test]
+	fn external_secret_becomes_native_targeting_compose_name() {
+		// An `external: true` secret maps to a Podman-native secret. With no
+		// custom name the source equals the compose name, and the mount filename
+		// defaults to that name so apps still read /run/secrets/<name>.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let secrets = collect_native_secrets(&file.services["web"], &file);
+		assert_eq!(secrets.len(), 1);
+		assert_eq!(secrets[0].source, "tok");
+		assert_eq!(secrets[0].target.as_deref(), Some("tok"));
+		assert!(secrets[0].uid.is_none() && secrets[0].gid.is_none() && secrets[0].mode.is_none());
+	}
+
+	#[test]
+	fn external_secret_long_form_maps_source_target_and_perms() {
+		// A long-form ref overrides the mount name, and a custom top-level `name:`
+		// is the actual Podman secret to look up. Numeric uid/gid/mode pass through.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        target: app_tok\n        uid: \"100\"\n        gid: \"101\"\n        mode: 256\nsecrets:\n  tok:\n    external: true\n    name: real_tok\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let secrets = collect_native_secrets(&file.services["web"], &file);
+		assert_eq!(secrets.len(), 1);
+		let s = &secrets[0];
+		assert_eq!(s.source, "real_tok");
+		assert_eq!(s.target.as_deref(), Some("app_tok"));
+		assert_eq!(s.uid, Some(100));
+		assert_eq!(s.gid, Some(101));
+		assert_eq!(s.mode, Some(256));
+	}
+
+	#[test]
+	fn external_config_becomes_native_with_absolute_default_target() {
+		// Configs default to an absolute container-root path, matching the
+		// bind-mount config behaviour; an absolute target is mounted as-is.
+		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let secrets = collect_native_secrets(&file.services["web"], &file);
+		assert_eq!(secrets.len(), 1);
+		assert_eq!(secrets[0].source, "cfg");
+		assert_eq!(secrets[0].target.as_deref(), Some("/cfg"));
+	}
+
+	#[test]
+	fn non_external_secret_is_not_a_native_secret() {
+		// A `file:` secret is materialised as a bind mount, not a native secret.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let secrets = collect_native_secrets(&file.services["web"], &file);
+		assert!(secrets.is_empty());
+	}
+
+	#[test]
+	fn non_numeric_uid_drops_to_default() {
+		// libpod secret uid/gid are numeric; a user/group name has no native
+		// equivalent here and falls back to the default rather than erroring.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        uid: appuser\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let secrets = collect_native_secrets(&file.services["web"], &file);
+		assert_eq!(secrets.len(), 1);
+		assert!(secrets[0].uid.is_none());
+	}
+}

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -1,17 +1,15 @@
-//! Volume creation and secret/config materialisation.
+//! Volume creation and external-resource preflight.
 //!
-//! [`Engine::create_volumes`] pre-creates named volumes before containers start.
-//! [`Engine::build_secret_binds`] and [`Engine::build_config_binds`] materialise
-//! inline secrets/configs to a restricted temp directory. Bind-string and
-//! Mount-API helpers live in [`super::volume_mounts`].
+//! [`Engine::create_volumes`] pre-creates named volumes before containers start
+//! and [`Engine::ensure_external_exists`] verifies declared external resources.
+//! Secret/config materialisation lives in [`super::secrets`]; bind-string and
+//! Mount-API helpers in [`super::volume_mounts`].
 
 use std::collections::HashMap;
 
 use tracing::info;
 
-use crate::compose::types::{
-	ComposeFile, ConfigConfig, SecretConfig, Service, ServiceConfigRef, ServiceSecretRef,
-};
+use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::volume::VolumeCreateOptions;
 use crate::libpod::{urlencoded, API_PREFIX};
@@ -77,7 +75,8 @@ impl Engine {
 		Ok(())
 	}
 
-	/// Verify an `external: true` volume/network already exists on the host.
+	/// Verify an `external: true` resource (volume, network or secret) already
+	/// exists on the host.
 	///
 	/// The compose spec requires podup to error when an external resource is
 	/// declared but absent, rather than silently skipping it and letting
@@ -98,211 +97,13 @@ impl Engine {
 		}
 	}
 
-	pub(super) fn build_secret_binds(
-		&self,
-		service: &Service,
-		file: &ComposeFile,
-	) -> Result<Vec<String>> {
-		let mut binds = Vec::new();
-		for secret_ref in &service.secrets {
-			let (name, target_override, ref_mode, ref_uid, ref_gid) = match secret_ref {
-				ServiceSecretRef::Short(s) => (s.clone(), None, None, None, None),
-				ServiceSecretRef::Long {
-					source,
-					target,
-					mode,
-					uid,
-					gid,
-				} => (
-					source.clone(),
-					target.clone(),
-					*mode,
-					uid.clone(),
-					gid.clone(),
-				),
-			};
-			if let Some(config) = file.secrets.get(&name) {
-				let target = target_override.unwrap_or_else(|| format!("/run/secrets/{name}"));
-				match config {
-					SecretConfig {
-						file: Some(host_path),
-						..
-					} => {
-						// Resolve like a bind-mount source: a relative `file:` is
-						// anchored to the project dir (not the Podman service's cwd)
-						// and `~` is expanded — same handling as `volumes:`, which
-						// already mount arbitrary host paths.
-						let resolved =
-							super::container::resolve_bind_source(host_path, &self.base_dir);
-						binds.push(format!("{resolved}:{target}:ro"));
-					}
-					SecretConfig {
-						content: Some(content),
-						..
-					} => {
-						let path = self.materialize_inline_full(
-							"secrets",
-							&name,
-							content.as_bytes(),
-							ref_mode,
-							ref_uid.as_deref(),
-							ref_gid.as_deref(),
-						)?;
-						binds.push(format!("{}:{target}:ro", path.display()));
-					}
-					SecretConfig {
-						environment: Some(env_var),
-						..
-					} => {
-						let value = std::env::var(env_var).map_err(|_| {
-							ComposeError::Unsupported(format!(
-								"secret '{name}' references env var '{env_var}' which is not set"
-							))
-						})?;
-						let path = self.materialize_inline_full(
-							"secrets",
-							&name,
-							value.as_bytes(),
-							ref_mode,
-							ref_uid.as_deref(),
-							ref_gid.as_deref(),
-						)?;
-						binds.push(format!("{}:{target}:ro", path.display()));
-					}
-					SecretConfig {
-						external: Some(true),
-						..
-					} => {
-						tracing::debug!("external secret {name} — relying on runtime injection");
-					}
-					_ => {}
-				}
-			}
-		}
-		Ok(binds)
-	}
-
-	pub(super) fn build_config_binds(
-		&self,
-		service: &Service,
-		file: &ComposeFile,
-	) -> Result<Vec<String>> {
-		let mut binds = Vec::new();
-		for config_ref in &service.configs {
-			let (name, target_override, ref_mode, ref_uid, ref_gid) = match config_ref {
-				ServiceConfigRef::Short(s) => (s.clone(), None, None, None, None),
-				ServiceConfigRef::Long {
-					source,
-					target,
-					mode,
-					uid,
-					gid,
-				} => (
-					source.clone(),
-					target.clone(),
-					*mode,
-					uid.clone(),
-					gid.clone(),
-				),
-			};
-			if let Some(cfg) = file.configs.get(&name) {
-				let target = target_override.unwrap_or_else(|| format!("/{name}"));
-				match cfg {
-					ConfigConfig {
-						file: Some(host_path),
-						..
-					} => {
-						// Resolve like a bind-mount source: anchor a relative path to
-						// the project dir and expand `~`, matching `volumes:` handling.
-						let resolved =
-							super::container::resolve_bind_source(host_path, &self.base_dir);
-						binds.push(format!("{resolved}:{target}:ro"));
-					}
-					ConfigConfig {
-						content: Some(content),
-						..
-					} => {
-						let path = self.materialize_inline_full(
-							"configs",
-							&name,
-							content.as_bytes(),
-							ref_mode,
-							ref_uid.as_deref(),
-							ref_gid.as_deref(),
-						)?;
-						binds.push(format!("{}:{target}:ro", path.display()));
-					}
-					ConfigConfig {
-						environment: Some(env_var),
-						..
-					} => {
-						let value = std::env::var(env_var).map_err(|_| {
-							ComposeError::Unsupported(format!(
-								"config '{name}' references env var '{env_var}' which is not set"
-							))
-						})?;
-						let path = self.materialize_inline_full(
-							"configs",
-							&name,
-							value.as_bytes(),
-							ref_mode,
-							ref_uid.as_deref(),
-							ref_gid.as_deref(),
-						)?;
-						binds.push(format!("{}:{target}:ro", path.display()));
-					}
-					ConfigConfig {
-						external: Some(true),
-						..
-					} => {
-						tracing::debug!("external config {name} — relying on runtime injection");
-					}
-					_ => {}
-				}
-			}
-		}
-		Ok(binds)
-	}
-
-	fn materialize_inline_full(
-		&self,
-		kind: &str,
-		name: &str,
-		content: &[u8],
-		mode: Option<u32>,
-		uid: Option<&str>,
-		gid: Option<&str>,
-	) -> Result<std::path::PathBuf> {
-		if std::path::Path::new(name)
-			.components()
-			.any(|c| !matches!(c, std::path::Component::Normal(_)))
-		{
-			return Err(ComposeError::Unsupported(format!(
-				"{kind} name must not contain path separators or '..': {name}"
-			)));
-		}
-
-		let dir = self.staging_dir()?.join(kind);
-		staging::create_private_subdir(&dir)?;
-
-		let path = dir.join(name);
-		staging::write_private_file(&path, content)?;
-
-		if let Some(m) = mode {
-			staging::apply_mode(&path, m)?;
-		}
-		staging::apply_owner(&path, uid, gid);
-
-		Ok(path)
-	}
-
 	pub(super) fn cleanup_temp_dir(&self) {
 		if let Ok(dir) = self.staging_dir() {
 			let _ = std::fs::remove_dir_all(dir);
 		}
 	}
 
-	fn staging_dir(&self) -> Result<std::path::PathBuf> {
+	pub(super) fn staging_dir(&self) -> Result<std::path::PathBuf> {
 		if !staging::is_safe_project_name(&self.project) {
 			return Err(ComposeError::Unsupported(format!(
 				"project name must be ASCII alphanumeric/dash/underscore/dot \
@@ -311,51 +112,5 @@ impl Engine {
 			)));
 		}
 		Ok(staging::staging_base()?.join(&self.project))
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use crate::libpod::Client;
-	use std::path::PathBuf;
-
-	fn engine_with_base(base: &str) -> Engine {
-		Engine::with_base_dir(
-			Client::new("unused"),
-			"proj".to_string(),
-			PathBuf::from(base),
-		)
-	}
-
-	#[test]
-	fn secret_file_relative_path_is_anchored_to_base_dir() {
-		// A relative `file:` must resolve against the project dir, not the
-		// Podman service's cwd — same as a bind-mount source. Build the expected
-		// path via `Path::join` so the separator is correct on every platform.
-		let base = PathBuf::from("/srv/project");
-		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: secret.txt\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let engine = engine_with_base(&base.to_string_lossy());
-		let binds = engine
-			.build_secret_binds(&file.services["web"], &file)
-			.unwrap();
-		let expected = format!("{}:/run/secrets/tok:ro", base.join("secret.txt").display());
-		assert_eq!(binds, vec![expected]);
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn config_file_absolute_path_is_passed_through() {
-		// Absolute paths are honored unchanged (compose allows mounting any host
-		// file, exactly as `volumes:` does). Uses a Unix-absolute path, so the
-		// assertion is gated to Unix.
-		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: /etc/app/cfg.yaml\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let engine = engine_with_base("/srv/project");
-		let binds = engine
-			.build_config_binds(&file.services["web"], &file)
-			.unwrap();
-		assert_eq!(binds, vec!["/etc/app/cfg.yaml:/cfg:ro"]);
 	}
 }

--- a/internal/libpod/types/container/mod.rs
+++ b/internal/libpod/types/container/mod.rs
@@ -12,5 +12,5 @@ pub use response::{
 pub use spec::{
 	HealthConfig, LinuxBlockIO, LinuxCPU, LinuxDevice, LinuxDeviceCgroup, LinuxMemory, LinuxPids,
 	LinuxResources, LinuxThrottleDevice, LinuxWeightDevice, LogConfig, Mount, NamedVolume,
-	Namespace, PerNetworkOptions, PortMapping, SpecGenerator, Ulimit,
+	Namespace, PerNetworkOptions, PortMapping, Secret, SpecGenerator, Ulimit,
 };

--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -111,6 +111,11 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub volumes_from: Vec<String>,
 
+	// Podman-native secrets (also used for external configs): each references an
+	// existing `podman secret` by name and is mounted into the container.
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	pub secrets: Vec<Secret>,
+
 	// Namespace modes
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub userns: Option<Namespace>,

--- a/internal/libpod/types/container/spec/parts.rs
+++ b/internal/libpod/types/container/spec/parts.rs
@@ -26,6 +26,29 @@ pub struct PortMapping {
 	pub range: Option<u16>,
 }
 
+/// A Podman-native secret attached to a container create spec, equivalent to
+/// `podman run --secret`. Mirrors the libpod `Secret` type, which carries no
+/// JSON tags upstream, so the wire keys are PascalCase (`Source`, `Target`, …).
+/// `Source` names an existing Podman secret; `Target` is the mount destination
+/// (a bare name lands under `/run/secrets/`, an absolute path is used as-is).
+#[derive(Serialize, Default)]
+pub struct Secret {
+	#[serde(rename = "Source")]
+	pub source: String,
+
+	#[serde(rename = "Target", skip_serializing_if = "Option::is_none")]
+	pub target: Option<String>,
+
+	#[serde(rename = "UID", skip_serializing_if = "Option::is_none")]
+	pub uid: Option<u32>,
+
+	#[serde(rename = "GID", skip_serializing_if = "Option::is_none")]
+	pub gid: Option<u32>,
+
+	#[serde(rename = "Mode", skip_serializing_if = "Option::is_none")]
+	pub mode: Option<u32>,
+}
+
 /// Per-network connection options (for SpecGenerator `networks` map).
 #[derive(Serialize, Default)]
 pub struct PerNetworkOptions {

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -92,23 +92,6 @@ fn env_secret_materialized() {
 }
 
 #[tokio::test]
-async fn external_secret_skipped() {
-	let client = match podman().await {
-		Some(d) => d,
-		None => return,
-	};
-	let proj = proj("xsec");
-	let engine = Engine::new(client, proj.clone());
-	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - extsecret\nsecrets:\n  extsecret:\n    external: true\n",
-	)
-	.unwrap();
-
-	engine.up(&file).await.unwrap();
-	engine.down(&file).await.unwrap();
-}
-
-#[tokio::test]
 async fn invalid_secret_name_rejected() {
 	let client = match podman().await {
 		Some(d) => d,

--- a/tests/engine_integration/group_a3.rs
+++ b/tests/engine_integration/group_a3.rs
@@ -296,6 +296,84 @@ async fn external_volume_missing_errors_on_up() {
 }
 
 // ---------------------------------------------------------------------------
+// External (Podman-native) secret injection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn external_secret_missing_errors_on_up() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("exsec");
+	let engine = Engine::new(client, proj.clone());
+	// An `external: true` secret that no `podman secret` backs must fail closed,
+	// like an external volume, rather than start a container missing the secret.
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets: [absent-secret]\nsecrets:\n  absent-secret:\n    external: true\n",
+	)
+	.unwrap();
+
+	let result = engine.up(&file).await;
+	assert!(
+		matches!(result, Err(podup::ComposeError::ExternalNotFound(_))),
+		"expected ExternalNotFound, got {result:?}"
+	);
+}
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn external_secret_injected_into_container() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("insec");
+	let secret_name = format!("{proj}-tok");
+
+	// Create the backing Podman secret out-of-band — the external-secret idiom.
+	// Skip the test if the podman CLI is unavailable (socket alone is not enough).
+	let dir = tempfile::tempdir().unwrap();
+	let secret_src = dir.path().join("tok");
+	fs::write(&secret_src, b"native-secret-value").unwrap();
+	let created = std::process::Command::new("podman")
+		.args([
+			"secret",
+			"create",
+			&secret_name,
+			secret_src.to_str().unwrap(),
+		])
+		.status();
+	match created {
+		Ok(s) if s.success() => {}
+		_ => return,
+	}
+
+	// The compose name is `tok` (→ /run/secrets/tok); the actual secret is named
+	// differently, exercising the source/target split.
+	let yaml = format!(
+		"services:\n  app:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n    name: {secret_name}\n"
+	);
+	let file = parse_str(&yaml).unwrap();
+	let engine = Engine::new(client, proj.clone());
+	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-app");
+	let out = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/run/secrets/tok".into()])
+		.await
+		.unwrap_or_default();
+	engine.down(&file).await.unwrap();
+	let _ = std::process::Command::new("podman")
+		.args(["secret", "rm", &secret_name])
+		.status();
+
+	assert!(
+		out.contains("native-secret-value"),
+		"external secret was not injected at /run/secrets/tok: {out:?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
 // Orphan removal
 // ---------------------------------------------------------------------------
 

--- a/tests/engine_integration/group_a4.rs
+++ b/tests/engine_integration/group_a4.rs
@@ -103,25 +103,53 @@ async fn wait_completed_polling() {
 }
 
 // ---------------------------------------------------------------------------
-// External config skipped
+// External (Podman-native) config injection
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "test-helpers")]
 #[tokio::test]
-async fn external_config_skipped() {
+async fn external_config_injected_into_container() {
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,
 	};
-	let proj = proj("xcfg");
-	let engine = Engine::new(client, proj.clone());
-	// Covers volume.rs L215 (external config debug log)
-	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    configs:\n      - extcfg\nconfigs:\n  extcfg:\n    external: true\n",
-	)
-	.unwrap();
+	let proj = proj("incfg");
+	let secret_name = format!("{proj}-cfg");
 
+	// External configs are backed by Podman secrets too; create one out-of-band.
+	let dir = tempfile::tempdir().unwrap();
+	let src = dir.path().join("cfg");
+	fs::write(&src, b"native-config-value").unwrap();
+	match std::process::Command::new("podman")
+		.args(["secret", "create", &secret_name, src.to_str().unwrap()])
+		.status()
+	{
+		Ok(s) if s.success() => {}
+		_ => return,
+	}
+
+	// A long-form absolute target must land the config at that exact path, not
+	// under /run/secrets — the config-specific behaviour.
+	let yaml = format!(
+		"services:\n  app:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    configs:\n      - source: cfg\n        target: /etc/app.conf\nconfigs:\n  cfg:\n    external: true\n    name: {secret_name}\n"
+	);
+	let file = parse_str(&yaml).unwrap();
+	let engine = Engine::new(client, proj.clone());
 	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-app");
+	let out = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/etc/app.conf".into()])
+		.await
+		.unwrap_or_default();
 	engine.down(&file).await.unwrap();
+	let _ = std::process::Command::new("podman")
+		.args(["secret", "rm", &secret_name])
+		.status();
+
+	assert!(
+		out.contains("native-config-value"),
+		"external config was not injected at /etc/app.conf: {out:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Release v0.21.0

### Features
- **External secrets and configs** (#269) — `external: true` secrets and configs are now injected as Podman-native secrets, mounted from an existing `podman secret`. A missing secret fails `up` closed with a clear message instead of starting a container without it. Removes the main blocker for migrating podman-compose stacks that use `podman secret create`.

### Fixes
- Warn on silently-dropped per-service `gw_priority` (#268).