### PR TITLE
fix: reject dangerous mode bits on native external secrets/configs

### DIFF
--- a/internal/engine/secrets.rs
+++ b/internal/engine/secrets.rs
@@ -183,7 +183,7 @@ impl Engine {
 		service: &Service,
 		file: &ComposeFile,
 	) -> Result<Vec<Secret>> {
-		let secrets = collect_native_secrets(service, file);
+		let secrets = collect_native_secrets(service, file)?;
 		for secret in &secrets {
 			self.ensure_external_exists("secret", "secrets", &secret.source)
 				.await?;
@@ -228,7 +228,11 @@ impl Engine {
 /// daemon: every `external: true` secret and config it references becomes a
 /// [`Secret`] pointing at an existing `podman secret`. Pure, so the mapping is
 /// unit-testable; [`Engine::build_native_secrets`] adds the existence preflight.
-fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Vec<Secret> {
+///
+/// A dangerous `mode:` (execute, setuid, setgid or sticky bits) on any
+/// reference is rejected here — the same class of check `apply_mode` enforces
+/// for the bind-mount path — so a hostile mode never reaches the daemon.
+fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Result<Vec<Secret>> {
 	let mut secrets = Vec::new();
 
 	for secret_ref in &service.secrets {
@@ -255,7 +259,7 @@ fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Vec<Secret> 
 				// find /run/secrets/<name> even when the Podman secret is named
 				// differently); a long-form target overrides it.
 				let target = target_override.unwrap_or(name);
-				secrets.push(native_secret(source, target, mode, uid, gid));
+				secrets.push(native_secret(source, target, mode, uid, gid)?);
 			}
 		}
 	}
@@ -283,30 +287,35 @@ fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Vec<Secret> 
 				// Configs default to an absolute container-root path, matching the
 				// bind-mount config behaviour; an absolute target is used as-is.
 				let target = target_override.unwrap_or_else(|| format!("/{name}"));
-				secrets.push(native_secret(source, target, mode, uid, gid));
+				secrets.push(native_secret(source, target, mode, uid, gid)?);
 			}
 		}
 	}
 
-	secrets
+	Ok(secrets)
 }
 
-/// Assemble one [`Secret`] from a compose reference. `uid`/`gid` are numeric in
-/// libpod, so non-numeric values (a user/group name) are dropped to the default.
+/// Assemble one [`Secret`] from a compose reference. A dangerous `mode:`
+/// (execute/setuid/setgid/sticky) is rejected before the spec is built so it
+/// never reaches Podman. `uid`/`gid` are numeric in libpod, so non-numeric
+/// values (a user/group name) are dropped to the default.
 fn native_secret(
 	source: String,
 	target: String,
 	mode: Option<u32>,
 	uid: Option<String>,
 	gid: Option<String>,
-) -> Secret {
-	Secret {
+) -> Result<Secret> {
+	if let Some(m) = mode {
+		staging::reject_dangerous_secret_mode(m, &source)?;
+	}
+	Ok(Secret {
 		source,
 		target: Some(target),
 		uid: uid.and_then(|s| s.parse().ok()),
 		gid: gid.and_then(|s| s.parse().ok()),
 		mode,
-	}
+	})
 }
 
 #[cfg(test)]
@@ -361,7 +370,7 @@ mod tests {
 		// defaults to that name so apps still read /run/secrets/<name>.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		assert_eq!(secrets[0].source, "tok");
 		assert_eq!(secrets[0].target.as_deref(), Some("tok"));
@@ -374,7 +383,7 @@ mod tests {
 		// is the actual Podman secret to look up. Numeric uid/gid/mode pass through.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        target: app_tok\n        uid: \"100\"\n        gid: \"101\"\n        mode: 256\nsecrets:\n  tok:\n    external: true\n    name: real_tok\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		let s = &secrets[0];
 		assert_eq!(s.source, "real_tok");
@@ -390,7 +399,7 @@ mod tests {
 		// bind-mount config behaviour; an absolute target is mounted as-is.
 		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		assert_eq!(secrets[0].source, "cfg");
 		assert_eq!(secrets[0].target.as_deref(), Some("/cfg"));
@@ -401,7 +410,7 @@ mod tests {
 		// A `file:` secret is materialised as a bind mount, not a native secret.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert!(secrets.is_empty());
 	}
 
@@ -411,8 +420,45 @@ mod tests {
 		// equivalent here and falls back to the default rather than erroring.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        uid: appuser\nsecrets:\n  tok:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		assert!(secrets[0].uid.is_none());
+	}
+
+	#[test]
+	fn native_secret_rejects_setuid_mode() {
+		// A hostile compose file requesting setuid on an external secret must be
+		// refused before the spec reaches Podman — the same guard the bind-mount
+		// path enforces. 0o4000 is setuid.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 2048\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		assert!(collect_native_secrets(&file.services["web"], &file).is_err());
+	}
+
+	#[test]
+	fn native_secret_rejects_execute_mode() {
+		// 0o777 (= 511) sets execute bits; a secret holds data, never code.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 511\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		assert!(collect_native_secrets(&file.services["web"], &file).is_err());
+	}
+
+	#[test]
+	fn native_config_rejects_setgid_mode() {
+		// External configs share the same mode guard. 0o2000 (= 1024) is setgid.
+		let yaml = "services:\n  web:\n    image: nginx\n    configs:\n      - source: cfg\n        mode: 1024\nconfigs:\n  cfg:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		assert!(collect_native_secrets(&file.services["web"], &file).is_err());
+	}
+
+	#[test]
+	fn native_secret_allows_world_readable_mode() {
+		// 0o444 (= 292, world-readable) is the Podman/compose default for a
+		// native secret materialised inside the container — it must be allowed,
+		// unlike the shared-host bind-mount path which rejects o+r.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 292\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
+		assert_eq!(secrets[0].mode, Some(0o444));
 	}
 }

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -119,16 +119,38 @@ pub(super) fn write_private_file(path: &std::path::Path, content: &[u8]) -> Resu
 	std::fs::write(path, content).map_err(ComposeError::Io)
 }
 
+/// Reject permission bits that are dangerous on a secret/config file no matter
+/// where it is materialised: any execute bit (`0o111`) and the setuid/setgid/
+/// sticky bits (`0o7000`). A secret/config holds data, never code, so these are
+/// a misconfiguration or an attack and are refused unconditionally. `ctx` names
+/// the offending secret/config in the error message.
+///
+/// Unlike [`apply_mode`], this does **not** reject group/world-read bits: a
+/// Podman-native secret is materialised inside the container's own mount
+/// namespace (not the shared host staging directory) and `0o444` is the
+/// Podman/compose default, so a readable mode is legitimate for that path.
+pub(super) fn reject_dangerous_secret_mode(mode: u32, ctx: &str) -> Result<()> {
+	if mode & 0o111 != 0 {
+		return Err(ComposeError::Unsupported(format!(
+			"mode {mode:#o} for {ctx} sets an execute bit on a secret/config; \
+			 a secret holds data, never code (use e.g. 0o400 or 0o444)"
+		)));
+	}
+	if mode & (0o4000 | 0o2000 | 0o1000) != 0 {
+		return Err(ComposeError::Unsupported(format!(
+			"mode {mode:#o} for {ctx} sets setuid, setgid, or sticky bits on a \
+			 secret/config; these are refused (use e.g. 0o400 or 0o444)"
+		)));
+	}
+	Ok(())
+}
+
 /// Apply a compose `mode:` value (octal unix permissions) to `path`.
 ///
-/// Rejects:
-/// - group-readable (`g+r`, 0o040) or world-readable (`o+r`, 0o004) bits — a
-///   secret or config file must never be readable by other users.
-/// - any execute bit (`0o111`) — a secret/config file holds data, never code,
-///   so the execute bit has no legitimate use and is rejected unconditionally.
-/// - setuid (0o4000), setgid (0o2000), or sticky (0o1000) bits — these have no
-///   legitimate use on a secret/config data file and are either a
-///   misconfiguration or an attack attempt; reject unconditionally.
+/// Rejects, on top of [`reject_dangerous_secret_mode`] (execute, setuid,
+/// setgid, sticky), the group-readable (`g+r`, 0o040) and world-readable
+/// (`o+r`, 0o004) bits — a secret/config materialised on the shared host
+/// staging directory must never be readable by another local user.
 #[cfg(unix)]
 pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
 	use std::os::unix::fs::PermissionsExt;
@@ -140,20 +162,7 @@ pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
 			path.display()
 		)));
 	}
-	if mode & 0o111 != 0 {
-		return Err(ComposeError::Unsupported(format!(
-			"mode {mode:#o} for {} sets an execute bit on a secret/config file; \
-			 only plain owner read/write bits are permitted (e.g. 0o400 or 0o600)",
-			path.display()
-		)));
-	}
-	if mode & (0o4000 | 0o2000 | 0o1000) != 0 {
-		return Err(ComposeError::Unsupported(format!(
-			"mode {mode:#o} for {} sets setuid, setgid, or sticky bits on a secret/config file; \
-			 only plain owner read/write bits are permitted (e.g. 0o400 or 0o600)",
-			path.display()
-		)));
-	}
+	reject_dangerous_secret_mode(mode, &path.display().to_string())?;
 	std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(ComposeError::Io)
 }
 


### PR DESCRIPTION
Closes #272.

## Summary

The native-secret path added in #269 passed the compose `mode:` value straight into the Podman secret spec, bypassing the setuid/setgid/sticky/execute rejection that `apply_mode` already enforces for the bind-mount materialisation path. A hostile compose file could request a Podman-native external secret with e.g. mode `0o4777` (setuid) or `0o777` (execute), which Podman would apply to the in-container secret file.

## Changes

- Factor the dangerous-bit check out of `apply_mode` into the shared `reject_dangerous_secret_mode` (cross-platform) and call it from `native_secret`.
- Group/world-read bits stay allowed on the native path: a native secret is materialised inside the container's own mount namespace and `0o444` is the Podman/compose default. The shared host staging directory still rejects `g+r`/`o+r` via `apply_mode`.
- `collect_native_secrets`/`native_secret` now return `Result`.

## Tests

Four new unit tests: setuid, execute, and setgid rejection, plus the world-readable (`0o444`) allowance. Full lib suite green (537), clippy + fmt clean.

> Note: `Closes #272` is inert on squash-merge to develop — close manually after merge.