### PR TITLE
docs: man-page BUGS section + Quadlet/completions feature bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ flowchart LR
 - 🔢 **Replicas** — `scale:` and `deploy.replicas` with named replica containers
 - 🔐 **Secrets & configs** — inline content, file, environment, and `external: true` Podman-native secret sources, staged securely
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
+- ⚙️ **Systemd Quadlet export** — `generate quadlet` emits native `podman-systemd.unit` files to run your stack under systemd, no daemon
+- ⌨️ **Shell completions** — `completions <shell>` for bash, zsh, fish and more (the Debian package installs them)
 - 📦 **Single binary** — statically musl-linked on Linux, no runtime dependencies
 - 🦀 **Library too** — embed the parser and engine in your own Rust project
 

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -175,3 +175,5 @@ Project environment file, loaded for variable interpolation.
 .BR podman-systemd.unit (5)
 .PP
 Full documentation at: \fIhttps://github.com/Glyndor/podup\fR
+.SH BUGS
+Report bugs at \fIhttps://github.com/Glyndor/podup/issues\fR.


### PR DESCRIPTION
Closes #276.

- Add `.SH BUGS` to `debian/podup.1` (Debian convention; lintian/sponsor expect it). Verified it renders cleanly with `groff -man -ww`.
- Add README feature bullets for Systemd Quadlet export and shell completions.

Note: the audit's suggested `down`/`exec`/`logs` option tables were checked against the CLI — those commands have no undocumented options, so `docs/commands.md` is left unchanged.

> `Closes` is inert on squash-merge to develop — close manually after merge.