### PR TITLE
chore: fix stale doc link, ASCII-ize a log string, cover shell in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,10 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
+[*.sh]
+indent_style = tab
+indent_size = 4
+
 [*.{yml,yaml,toml,json}]
 indent_style = space
 indent_size = 2

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -1,7 +1,7 @@
 //! Pure configuration builders for container creation: restart policy, logging,
 //! healthcheck, resource limits, and ulimits.
 //!
-//! Device, blkio, tmpfs, and label-file helpers live in [`super::container_misc`].
+//! Device, blkio, tmpfs, and label-file helpers live in [`super::container_fields`].
 
 use crate::compose::types::{
 	Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart, Service,

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -79,7 +79,7 @@ fn acquire(file: &std::fs::File) -> Result<()> {
 	}
 	let err = std::io::Error::last_os_error();
 	if err.raw_os_error() == Some(libc::EWOULDBLOCK) {
-		tracing::info!("waiting for project lock held by another podup process…");
+		tracing::info!("waiting for project lock held by another podup process...");
 		// SAFETY: same invariants as the non-blocking call above.
 		let rc = unsafe { libc::flock(fd, libc::LOCK_EX) };
 		if rc != 0 {


### PR DESCRIPTION
Small standards-cleanup wins from a code-hygiene audit:

- Fix the stale `super::container_misc` intra-doc link (module was renamed to `container_fields`).
- Replace a non-ASCII ellipsis (U+2026) in the project-lock wait log with ASCII `...`.
- Add a `[*.sh]` stanza to `.editorconfig`.

Verified: `cargo doc -D warnings` clean (intra-doc link resolves), lock tests pass, fmt clean.

The larger preventive items (4 files near the 500-line cap, `fsutil` rename) are tracked in #279 — no hard violations exist, so they are deliberately not bundled here.

> `Closes` is inert on squash-merge to develop.
