### PR TITLE
chore: bump version to 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.1" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.21.1) unstable; urgency=medium
+
+  * Security: reject setuid/setgid/sticky/execute mode bits on `external: true`
+    Podman-native secrets and configs, matching the guard already applied to the
+    bind-mount materialisation path.
+  * Security: cap the self-update release-metadata read so a hostile or broken
+    endpoint cannot stream an unbounded JSON body into memory.
+  * Add a man-page BUGS section and surface Quadlet export and shell completions
+    in the README feature list.
+  * Fix a stale intra-doc link, replace a non-ASCII log message, and add a shell
+    stanza to `.editorconfig`.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 14:36:35 -0500
+
 podup (0.21.0) unstable; urgency=medium
 
   * Inject `external: true` secrets and configs as Podman-native secrets, mounted

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.21.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.21.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Patch release prep. Bumps `Cargo.toml`, `Cargo.lock`, `debian/changelog`, the man-page `.TH`, and the README library tag to 0.21.1.

Bundles the four fixes merged to develop since v0.21.0:
- #273 reject dangerous mode bits on native external secrets/configs (security)
- #275 cap the self-update release-metadata read (security)
- #277 man-page BUGS section + README Quadlet/completions bullets
- #280 stale doc link, ASCII log string, `.editorconfig [*.sh]`

No public API change (semver patch).