### PR TITLE
release: v0.21.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,10 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
+[*.sh]
+indent_style = tab
+indent_size = 4
+
 [*.{yml,yaml,toml,json}]
 indent_style = space
 indent_size = 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ flowchart LR
 - 🔢 **Replicas** — `scale:` and `deploy.replicas` with named replica containers
 - 🔐 **Secrets & configs** — inline content, file, environment, and `external: true` Podman-native secret sources, staged securely
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
+- ⚙️ **Systemd Quadlet export** — `generate quadlet` emits native `podman-systemd.unit` files to run your stack under systemd, no daemon
+- ⌨️ **Shell completions** — `completions <shell>` for bash, zsh, fish and more (the Debian package installs them)
 - 📦 **Single binary** — statically musl-linked on Linux, no runtime dependencies
 - 🦀 **Library too** — embed the parser and engine in your own Rust project
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.1" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.21.1) unstable; urgency=medium
+
+  * Security: reject setuid/setgid/sticky/execute mode bits on `external: true`
+    Podman-native secrets and configs, matching the guard already applied to the
+    bind-mount materialisation path.
+  * Security: cap the self-update release-metadata read so a hostile or broken
+    endpoint cannot stream an unbounded JSON body into memory.
+  * Add a man-page BUGS section and surface Quadlet export and shell completions
+    in the README feature list.
+  * Fix a stale intra-doc link, replace a non-ASCII log message, and add a shell
+    stanza to `.editorconfig`.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 14:36:35 -0500
+
 podup (0.21.0) unstable; urgency=medium
 
   * Inject `external: true` secrets and configs as Podman-native secrets, mounted

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -175,3 +175,5 @@ Project environment file, loaded for variable interpolation.
 .BR podman-systemd.unit (5)
 .PP
 Full documentation at: \fIhttps://github.com/Glyndor/podup\fR
+.SH BUGS
+Report bugs at \fIhttps://github.com/Glyndor/podup/issues\fR.

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.21.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.21.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -1,7 +1,7 @@
 //! Pure configuration builders for container creation: restart policy, logging,
 //! healthcheck, resource limits, and ulimits.
 //!
-//! Device, blkio, tmpfs, and label-file helpers live in [`super::container_misc`].
+//! Device, blkio, tmpfs, and label-file helpers live in [`super::container_fields`].
 
 use crate::compose::types::{
 	Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart, Service,

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -79,7 +79,7 @@ fn acquire(file: &std::fs::File) -> Result<()> {
 	}
 	let err = std::io::Error::last_os_error();
 	if err.raw_os_error() == Some(libc::EWOULDBLOCK) {
-		tracing::info!("waiting for project lock held by another podup process…");
+		tracing::info!("waiting for project lock held by another podup process...");
 		// SAFETY: same invariants as the non-blocking call above.
 		let rc = unsafe { libc::flock(fd, libc::LOCK_EX) };
 		if rc != 0 {

--- a/internal/engine/secrets.rs
+++ b/internal/engine/secrets.rs
@@ -183,7 +183,7 @@ impl Engine {
 		service: &Service,
 		file: &ComposeFile,
 	) -> Result<Vec<Secret>> {
-		let secrets = collect_native_secrets(service, file);
+		let secrets = collect_native_secrets(service, file)?;
 		for secret in &secrets {
 			self.ensure_external_exists("secret", "secrets", &secret.source)
 				.await?;
@@ -228,7 +228,11 @@ impl Engine {
 /// daemon: every `external: true` secret and config it references becomes a
 /// [`Secret`] pointing at an existing `podman secret`. Pure, so the mapping is
 /// unit-testable; [`Engine::build_native_secrets`] adds the existence preflight.
-fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Vec<Secret> {
+///
+/// A dangerous `mode:` (execute, setuid, setgid or sticky bits) on any
+/// reference is rejected here — the same class of check `apply_mode` enforces
+/// for the bind-mount path — so a hostile mode never reaches the daemon.
+fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Result<Vec<Secret>> {
 	let mut secrets = Vec::new();
 
 	for secret_ref in &service.secrets {
@@ -255,7 +259,7 @@ fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Vec<Secret> 
 				// find /run/secrets/<name> even when the Podman secret is named
 				// differently); a long-form target overrides it.
 				let target = target_override.unwrap_or(name);
-				secrets.push(native_secret(source, target, mode, uid, gid));
+				secrets.push(native_secret(source, target, mode, uid, gid)?);
 			}
 		}
 	}
@@ -283,30 +287,35 @@ fn collect_native_secrets(service: &Service, file: &ComposeFile) -> Vec<Secret> 
 				// Configs default to an absolute container-root path, matching the
 				// bind-mount config behaviour; an absolute target is used as-is.
 				let target = target_override.unwrap_or_else(|| format!("/{name}"));
-				secrets.push(native_secret(source, target, mode, uid, gid));
+				secrets.push(native_secret(source, target, mode, uid, gid)?);
 			}
 		}
 	}
 
-	secrets
+	Ok(secrets)
 }
 
-/// Assemble one [`Secret`] from a compose reference. `uid`/`gid` are numeric in
-/// libpod, so non-numeric values (a user/group name) are dropped to the default.
+/// Assemble one [`Secret`] from a compose reference. A dangerous `mode:`
+/// (execute/setuid/setgid/sticky) is rejected before the spec is built so it
+/// never reaches Podman. `uid`/`gid` are numeric in libpod, so non-numeric
+/// values (a user/group name) are dropped to the default.
 fn native_secret(
 	source: String,
 	target: String,
 	mode: Option<u32>,
 	uid: Option<String>,
 	gid: Option<String>,
-) -> Secret {
-	Secret {
+) -> Result<Secret> {
+	if let Some(m) = mode {
+		staging::reject_dangerous_secret_mode(m, &source)?;
+	}
+	Ok(Secret {
 		source,
 		target: Some(target),
 		uid: uid.and_then(|s| s.parse().ok()),
 		gid: gid.and_then(|s| s.parse().ok()),
 		mode,
-	}
+	})
 }
 
 #[cfg(test)]
@@ -361,7 +370,7 @@ mod tests {
 		// defaults to that name so apps still read /run/secrets/<name>.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		assert_eq!(secrets[0].source, "tok");
 		assert_eq!(secrets[0].target.as_deref(), Some("tok"));
@@ -374,7 +383,7 @@ mod tests {
 		// is the actual Podman secret to look up. Numeric uid/gid/mode pass through.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        target: app_tok\n        uid: \"100\"\n        gid: \"101\"\n        mode: 256\nsecrets:\n  tok:\n    external: true\n    name: real_tok\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		let s = &secrets[0];
 		assert_eq!(s.source, "real_tok");
@@ -390,7 +399,7 @@ mod tests {
 		// bind-mount config behaviour; an absolute target is mounted as-is.
 		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		assert_eq!(secrets[0].source, "cfg");
 		assert_eq!(secrets[0].target.as_deref(), Some("/cfg"));
@@ -401,7 +410,7 @@ mod tests {
 		// A `file:` secret is materialised as a bind mount, not a native secret.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert!(secrets.is_empty());
 	}
 
@@ -411,8 +420,45 @@ mod tests {
 		// equivalent here and falls back to the default rather than erroring.
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        uid: appuser\nsecrets:\n  tok:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let secrets = collect_native_secrets(&file.services["web"], &file);
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
 		assert_eq!(secrets.len(), 1);
 		assert!(secrets[0].uid.is_none());
+	}
+
+	#[test]
+	fn native_secret_rejects_setuid_mode() {
+		// A hostile compose file requesting setuid on an external secret must be
+		// refused before the spec reaches Podman — the same guard the bind-mount
+		// path enforces. 0o4000 is setuid.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 2048\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		assert!(collect_native_secrets(&file.services["web"], &file).is_err());
+	}
+
+	#[test]
+	fn native_secret_rejects_execute_mode() {
+		// 0o777 (= 511) sets execute bits; a secret holds data, never code.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 511\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		assert!(collect_native_secrets(&file.services["web"], &file).is_err());
+	}
+
+	#[test]
+	fn native_config_rejects_setgid_mode() {
+		// External configs share the same mode guard. 0o2000 (= 1024) is setgid.
+		let yaml = "services:\n  web:\n    image: nginx\n    configs:\n      - source: cfg\n        mode: 1024\nconfigs:\n  cfg:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		assert!(collect_native_secrets(&file.services["web"], &file).is_err());
+	}
+
+	#[test]
+	fn native_secret_allows_world_readable_mode() {
+		// 0o444 (= 292, world-readable) is the Podman/compose default for a
+		// native secret materialised inside the container — it must be allowed,
+		// unlike the shared-host bind-mount path which rejects o+r.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 292\nsecrets:\n  tok:\n    external: true\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let secrets = collect_native_secrets(&file.services["web"], &file).unwrap();
+		assert_eq!(secrets[0].mode, Some(0o444));
 	}
 }

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -119,16 +119,38 @@ pub(super) fn write_private_file(path: &std::path::Path, content: &[u8]) -> Resu
 	std::fs::write(path, content).map_err(ComposeError::Io)
 }
 
+/// Reject permission bits that are dangerous on a secret/config file no matter
+/// where it is materialised: any execute bit (`0o111`) and the setuid/setgid/
+/// sticky bits (`0o7000`). A secret/config holds data, never code, so these are
+/// a misconfiguration or an attack and are refused unconditionally. `ctx` names
+/// the offending secret/config in the error message.
+///
+/// Unlike [`apply_mode`], this does **not** reject group/world-read bits: a
+/// Podman-native secret is materialised inside the container's own mount
+/// namespace (not the shared host staging directory) and `0o444` is the
+/// Podman/compose default, so a readable mode is legitimate for that path.
+pub(super) fn reject_dangerous_secret_mode(mode: u32, ctx: &str) -> Result<()> {
+	if mode & 0o111 != 0 {
+		return Err(ComposeError::Unsupported(format!(
+			"mode {mode:#o} for {ctx} sets an execute bit on a secret/config; \
+			 a secret holds data, never code (use e.g. 0o400 or 0o444)"
+		)));
+	}
+	if mode & (0o4000 | 0o2000 | 0o1000) != 0 {
+		return Err(ComposeError::Unsupported(format!(
+			"mode {mode:#o} for {ctx} sets setuid, setgid, or sticky bits on a \
+			 secret/config; these are refused (use e.g. 0o400 or 0o444)"
+		)));
+	}
+	Ok(())
+}
+
 /// Apply a compose `mode:` value (octal unix permissions) to `path`.
 ///
-/// Rejects:
-/// - group-readable (`g+r`, 0o040) or world-readable (`o+r`, 0o004) bits — a
-///   secret or config file must never be readable by other users.
-/// - any execute bit (`0o111`) — a secret/config file holds data, never code,
-///   so the execute bit has no legitimate use and is rejected unconditionally.
-/// - setuid (0o4000), setgid (0o2000), or sticky (0o1000) bits — these have no
-///   legitimate use on a secret/config data file and are either a
-///   misconfiguration or an attack attempt; reject unconditionally.
+/// Rejects, on top of [`reject_dangerous_secret_mode`] (execute, setuid,
+/// setgid, sticky), the group-readable (`g+r`, 0o040) and world-readable
+/// (`o+r`, 0o004) bits — a secret/config materialised on the shared host
+/// staging directory must never be readable by another local user.
 #[cfg(unix)]
 pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
 	use std::os::unix::fs::PermissionsExt;
@@ -140,20 +162,7 @@ pub(super) fn apply_mode(path: &Path, mode: u32) -> Result<()> {
 			path.display()
 		)));
 	}
-	if mode & 0o111 != 0 {
-		return Err(ComposeError::Unsupported(format!(
-			"mode {mode:#o} for {} sets an execute bit on a secret/config file; \
-			 only plain owner read/write bits are permitted (e.g. 0o400 or 0o600)",
-			path.display()
-		)));
-	}
-	if mode & (0o4000 | 0o2000 | 0o1000) != 0 {
-		return Err(ComposeError::Unsupported(format!(
-			"mode {mode:#o} for {} sets setuid, setgid, or sticky bits on a secret/config file; \
-			 only plain owner read/write bits are permitted (e.g. 0o400 or 0o600)",
-			path.display()
-		)));
-	}
+	reject_dangerous_secret_mode(mode, &path.display().to_string())?;
 	std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(ComposeError::Io)
 }
 

--- a/internal/update/github.rs
+++ b/internal/update/github.rs
@@ -18,6 +18,11 @@ pub const REPO: &str = "Glyndor/podup";
 /// broken endpoint streaming unbounded data into memory).
 const MAX_ASSET_BYTES: u64 = 128 * 1024 * 1024;
 
+/// Hard cap on the release-metadata JSON response. A `releases/latest` payload
+/// is a few KiB; 1 MiB is generous headroom while still bounding memory if a
+/// hostile or broken endpoint streams an oversized body.
+const MAX_METADATA_BYTES: u64 = 1024 * 1024;
+
 /// Fetches release metadata and assets from GitHub.
 pub struct GitHubSource {
 	repo: String,
@@ -45,18 +50,18 @@ impl Default for GitHubSource {
 	}
 }
 
-/// Read at most `MAX_ASSET_BYTES` from `reader`, erroring if the stream exceeds
-/// the cap rather than truncating silently.
-fn read_capped(mut reader: impl Read) -> crate::Result<Vec<u8>> {
+/// Read at most `cap` bytes from `reader`, erroring if the stream exceeds the
+/// cap rather than truncating silently.
+fn read_capped(mut reader: impl Read, cap: u64) -> crate::Result<Vec<u8>> {
 	let mut buf = Vec::new();
 	let read = reader
 		.by_ref()
-		.take(MAX_ASSET_BYTES + 1)
+		.take(cap + 1)
 		.read_to_end(&mut buf)
 		.map_err(ComposeError::Io)?;
-	if read as u64 > MAX_ASSET_BYTES {
+	if read as u64 > cap {
 		return Err(ComposeError::Update(
-			"release asset exceeds the maximum allowed size".to_string(),
+			"release data exceeds the maximum allowed size".to_string(),
 		));
 	}
 	Ok(buf)
@@ -65,21 +70,19 @@ fn read_capped(mut reader: impl Read) -> crate::Result<Vec<u8>> {
 impl ReleaseSource for GitHubSource {
 	fn latest_version(&self) -> crate::Result<String> {
 		let url = format!("https://api.github.com/repos/{}/releases/latest", self.repo);
-		let body = self
+		let resp = self
 			.agent
 			.get(&url)
 			.header("Accept", "application/vnd.github+json")
 			.call()
-			.map_err(|e| ComposeError::Update(format!("cannot reach GitHub releases API: {e}")))?
-			.body_mut()
-			.read_to_string()
-			.map_err(|e| ComposeError::Update(format!("failed reading release metadata: {e}")))?;
+			.map_err(|e| ComposeError::Update(format!("cannot reach GitHub releases API: {e}")))?;
+		let body = read_capped(resp.into_body().into_reader(), MAX_METADATA_BYTES)?;
 
 		#[derive(serde::Deserialize)]
 		struct Latest {
 			tag_name: String,
 		}
-		let latest: Latest = serde_json::from_str(&body)
+		let latest: Latest = serde_json::from_slice(&body)
 			.map_err(|e| ComposeError::Update(format!("malformed release metadata: {e}")))?;
 		Ok(latest.tag_name)
 	}
@@ -96,7 +99,7 @@ impl ReleaseSource for GitHubSource {
 			.get(&url)
 			.call()
 			.map_err(|e| ComposeError::Update(format!("download failed for {asset}: {e}")))?;
-		read_capped(resp.into_body().into_reader())
+		read_capped(resp.into_body().into_reader(), MAX_ASSET_BYTES)
 	}
 }
 
@@ -104,25 +107,43 @@ impl ReleaseSource for GitHubSource {
 mod tests {
 	use super::*;
 
+	/// A reader that yields zero bytes forever — used to exercise the cap.
+	struct Endless;
+	impl Read for Endless {
+		fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+			for b in buf.iter_mut() {
+				*b = 0;
+			}
+			Ok(buf.len())
+		}
+	}
+
 	#[test]
 	fn read_capped_accepts_small() {
 		let data = b"hello world".to_vec();
-		let got = read_capped(&data[..]).unwrap();
+		let got = read_capped(&data[..], MAX_ASSET_BYTES).unwrap();
 		assert_eq!(got, data);
 	}
 
 	#[test]
 	fn read_capped_rejects_oversize() {
-		struct Endless;
-		impl Read for Endless {
-			fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-				for b in buf.iter_mut() {
-					*b = 0;
-				}
-				Ok(buf.len())
-			}
-		}
-		assert!(read_capped(Endless).is_err());
+		assert!(read_capped(Endless, MAX_ASSET_BYTES).is_err());
+	}
+
+	#[test]
+	fn read_capped_enforces_metadata_cap() {
+		// The metadata cap is far smaller than the asset cap; an endless stream
+		// must be rejected once it crosses the 1 MiB metadata bound.
+		assert!(read_capped(Endless, MAX_METADATA_BYTES).is_err());
+	}
+
+	#[test]
+	fn read_capped_accepts_up_to_cap() {
+		// Exactly `cap` bytes is allowed; cap+1 is rejected.
+		let exactly = [0u8; 8];
+		assert!(read_capped(&exactly[..], 8).is_ok());
+		let over = [0u8; 9];
+		assert!(read_capped(&over[..], 8).is_err());
 	}
 
 	#[test]


### PR DESCRIPTION
Patch release. Security + docs + hygiene since v0.21.0:

- **Security** #273 — reject setuid/setgid/sticky/execute mode bits on `external: true` Podman-native secrets/configs (the bind-mount guard was missing on the native path added in #269).
- **Security** #275 — cap the self-update release-metadata read against an unbounded JSON body.
- **Docs** #277 — man-page `.SH BUGS`; README Quadlet/completions feature bullets.
- **Hygiene** #280 — stale intra-doc link, ASCII-only log string, `.editorconfig [*.sh]`.

No public API change. Merges to main and the signed `v0.21.1` tag trigger the release workflow (binaries + crates.io + apt refresh).