### PR TITLE
fix: honor drop-in compose semantics and warn on dropped keys

### DIFF
--- a/internal/compose/diagnostics.rs
+++ b/internal/compose/diagnostics.rs
@@ -8,7 +8,7 @@
 //! the operator hearing about it — the same guarantee that lets podup absorb
 //! future Docker/Podman compose additions gracefully.
 
-use super::types::{BuildConfig, ComposeFile};
+use super::types::{BuildConfig, ComposeFile, PortMapping, VolumeMount};
 
 /// Collect a warning for every parsed-but-unsupported key or field in `file`.
 /// Pure (no logging) so it can be unit-tested; the caller emits the messages.
@@ -18,9 +18,12 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	unknown_service_keys(file, &mut out);
 	nested_unknown_keys(file, &mut out);
 	ignored_service_fields(file, &mut out);
+	ignored_port_fields(file, &mut out);
+	ignored_volume_mount_fields(file, &mut out);
 	ignored_build_fields(file, &mut out);
 	ignored_network_fields(file, &mut out);
 	ignored_service_network_fields(file, &mut out);
+	ignored_secret_config_drivers(file, &mut out);
 	out
 }
 
@@ -127,6 +130,46 @@ fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) {
 				 rootless Podman equivalent and is ignored"
 			));
 		}
+		if def.attach.is_some() {
+			out.push(format!(
+				"service '{service}': attach is not honored; podup follows its own \
+				 attach/detach logic for `up` log streaming"
+			));
+		}
+	}
+}
+
+/// Long-form port fields podup parses but does not forward to Podman.
+fn ignored_port_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		for port in &def.ports {
+			if let PortMapping::Long { mode: Some(m), .. } = port {
+				out.push(format!(
+					"service '{service}': port mode '{m}' is a Swarm/ingress control \
+					 with no single-host Podman equivalent and is ignored"
+				));
+			}
+		}
+	}
+}
+
+/// Per-mount long-form volume options podup parses but does not forward.
+fn ignored_volume_mount_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		for mount in &def.volumes {
+			if let VolumeMount::Long {
+				volume: Some(opts), ..
+			} = mount
+			{
+				if opts.driver_config.is_some() {
+					out.push(format!(
+						"service '{service}' volume '{}': per-mount driver_config is not \
+						 forwarded to Podman and is ignored",
+						mount.target()
+					));
+				}
+			}
+		}
 	}
 }
 
@@ -200,6 +243,49 @@ fn ignored_service_network_fields(file: &ComposeFile, out: &mut Vec<String>) {
 						 by Podman and is ignored"
 					));
 				}
+				if c.interface_name.is_some() {
+					out.push(format!(
+						"service '{service}' network '{name}': interface_name is not \
+						 forwarded to Podman and is ignored"
+					));
+				}
+			}
+		}
+	}
+}
+
+/// Top-level secret/config driver fields. An external secret-store driver
+/// (Vault, AWS SM, etc.) on a non-`external` definition is not honored — podup
+/// only stages `file`/`content`/`environment` sources and routes `external:
+/// true` to Podman-native secrets — so warn rather than mount nothing silently.
+fn ignored_secret_config_drivers(file: &ComposeFile, out: &mut Vec<String>) {
+	for (name, cfg) in &file.secrets {
+		if cfg.external != Some(true) {
+			if cfg.driver.is_some() {
+				out.push(format!(
+					"secret '{name}': driver is an external secret-store plugin that podup \
+					 does not invoke; the secret will not be staged"
+				));
+			}
+			if cfg.template_driver.is_some() {
+				out.push(format!(
+					"secret '{name}': template_driver is not supported and is ignored"
+				));
+			}
+		}
+	}
+	for (name, cfg) in &file.configs {
+		if cfg.external != Some(true) {
+			if cfg.driver.is_some() {
+				out.push(format!(
+					"config '{name}': driver is an external plugin that podup does not \
+					 invoke; the config will not be staged"
+				));
+			}
+			if cfg.template_driver.is_some() {
+				out.push(format!(
+					"config '{name}': template_driver is not supported and is ignored"
+				));
 			}
 		}
 	}
@@ -320,5 +406,69 @@ mod tests {
 	fn clean_file_produces_no_diagnostics() {
 		let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    cpu_shares: 512\n");
 		assert!(msgs.is_empty(), "unexpected diagnostics: {msgs:?}");
+	}
+
+	#[test]
+	fn warns_on_attach() {
+		let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    attach: false\n");
+		assert!(
+			msgs.iter().any(|m| m.contains("attach is not honored")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_long_port_mode() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    ports:\n      - target: 80\n        published: 8080\n        mode: host\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("port mode 'host'")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_per_mount_driver_config() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    volumes:\n      - type: volume\n        source: data\n        target: /data\n        volume:\n          driver_config:\n            name: local\nvolumes:\n  data:\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("per-mount driver_config")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_interface_name() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    networks:\n      net:\n        interface_name: eth9\nnetworks:\n  net:\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("interface_name")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_non_external_secret_driver() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    driver: vault\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("secret 'tok': driver")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn external_secret_driver_produces_no_diagnostic() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n    driver: vault\n",
+		);
+		assert!(
+			!msgs.iter().any(|m| m.contains("driver")),
+			"unexpected: {msgs:?}"
+		);
 	}
 }

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -123,11 +123,9 @@ fn resolve_one_extends(
 	let base_name = extends.service().to_string();
 
 	let base_service = if let Some(file_path) = extends.file() {
-		if !is_safe_extends_path(file_path) {
-			return Err(ComposeError::Extends(format!(
-				"service '{name}' extends.file must be a relative path with no parent traversal: {file_path}"
-			)));
-		}
+		// The compose file is trusted input (like a Makefile): `extends.file`
+		// may use `../` or absolute paths, matching docker-compose and
+		// podman-compose. Do not confine it.
 		let abs = base_dir.join(file_path);
 		let abs = abs.canonicalize().unwrap_or(abs);
 		let dir = abs
@@ -174,13 +172,6 @@ fn resolve_one_extends(
 	Ok(())
 }
 
-/// Security check: reject `extends.file` with absolute or parent-traversing paths.
-///
-/// Exposed for unit testing.
-pub(crate) fn is_safe_extends_path(path: &str) -> bool {
-	crate::fsutil::is_safe_relative_path(path)
-}
-
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
@@ -196,33 +187,6 @@ mod tests {
 			image: Some(image.to_string()),
 			..Default::default()
 		}
-	}
-
-	// is_safe_extends_path
-
-	#[test]
-	fn safe_path_relative() {
-		assert!(is_safe_extends_path("other.yml"));
-	}
-
-	#[test]
-	fn safe_path_subdirectory() {
-		assert!(is_safe_extends_path("bases/db.yml"));
-	}
-
-	#[test]
-	fn unsafe_path_absolute() {
-		assert!(!is_safe_extends_path("/etc/compose.yml"));
-	}
-
-	#[test]
-	fn unsafe_path_parent_traversal() {
-		assert!(!is_safe_extends_path("../secret.yml"));
-	}
-
-	#[test]
-	fn unsafe_path_nested_traversal() {
-		assert!(!is_safe_extends_path("a/../../etc/passwd"));
 	}
 
 	// merge_service — scalar fields

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -170,6 +170,9 @@ impl Engine {
 
 		for dep in service.depends_on.service_names() {
 			let condition = service.depends_on.condition_for(&dep);
+			// `required: false` makes the dependency optional — a failed wait
+			// must not abort `up`, matching docker-compose v2.
+			let required = service.depends_on.required_for(&dep);
 			let dep_service = match file.services.get(&dep) {
 				Some(s) => s,
 				None => continue,
@@ -179,8 +182,8 @@ impl Engine {
 			}
 			let dep_container = self.container_name(&dep, dep_service);
 
-			match condition {
-				ServiceCondition::ServiceStarted => {}
+			let wait = match condition {
+				ServiceCondition::ServiceStarted => Ok(()),
 				ServiceCondition::ServiceHealthy => {
 					// Wait unless the healthcheck is explicitly disabled in
 					// compose. With no compose healthcheck we still wait:
@@ -195,13 +198,23 @@ impl Engine {
 						tracing::debug!(
 							"{dep} healthcheck disabled — skipping service_healthy wait"
 						);
+						Ok(())
 					} else {
-						self.wait_healthy(&dep_container, dep_service).await?;
+						self.wait_healthy(&dep_container, dep_service).await
 					}
 				}
 				ServiceCondition::ServiceCompletedSuccessfully => {
-					self.wait_completed(&dep_container).await?;
+					self.wait_completed(&dep_container).await
 				}
+			};
+			match wait {
+				Ok(()) => {}
+				Err(e) if !required => {
+					tracing::debug!(
+						"optional dependency {dep} (required: false) did not satisfy its condition: {e}"
+					);
+				}
+				Err(e) => return Err(e),
 			}
 		}
 

--- a/internal/fsutil.rs
+++ b/internal/fsutil.rs
@@ -1,27 +1,7 @@
 //! Filesystem helpers shared across parsing paths.
 
 use std::io;
-use std::path::{Component, Path};
-
-/// Reject a file reference that is absolute or escapes the project directory.
-///
-/// podup only reads files that live at or below the directory of the compose
-/// file being processed. A reference that is absolute, rooted (`/etc/passwd`,
-/// which is not `is_absolute()` on Windows but still escapes via the root
-/// separator), or contains a `..` component is refused so a compose file cannot
-/// turn podup into a confused deputy that reads arbitrary host paths. Shared by
-/// the `extends`, `env_file`, and `label_file` readers.
-pub(crate) fn is_safe_relative_path(path: impl AsRef<Path>) -> bool {
-	let fp = path.as_ref();
-	if fp.is_absolute() {
-		return false;
-	}
-	let mut comps = fp.components();
-	if comps.clone().next() == Some(Component::RootDir) {
-		return false;
-	}
-	!comps.any(|c| c == Component::ParentDir)
-}
+use std::path::Path;
 
 /// Upper bound on the size of any compose, include, extends, or env file podup
 /// will read into memory. Bounds memory use on an accidentally huge or hostile
@@ -53,24 +33,7 @@ fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
 
 #[cfg(test)]
 mod tests {
-	use super::{is_safe_relative_path, read_to_string_capped_with};
-
-	#[test]
-	fn accepts_relative_subpaths() {
-		assert!(is_safe_relative_path("labels.env"));
-		assert!(is_safe_relative_path("config/labels.env"));
-	}
-
-	#[test]
-	fn rejects_absolute_paths() {
-		assert!(!is_safe_relative_path("/etc/passwd"));
-	}
-
-	#[test]
-	fn rejects_parent_traversal() {
-		assert!(!is_safe_relative_path("../secret.env"));
-		assert!(!is_safe_relative_path("a/../../etc/passwd"));
-	}
+	use super::read_to_string_capped_with;
 
 	#[test]
 	fn reads_file_within_limit() {

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -175,6 +175,44 @@ services:
 }
 
 #[test]
+fn extends_external_file_parent_traversal_is_allowed() {
+	// The compose file is trusted input: `extends.file` with `../` must resolve,
+	// matching docker-compose and podman-compose (monorepo shared-base pattern).
+	let dir = tempfile::tempdir().unwrap();
+
+	let common_path = dir.path().join("common.yml");
+	let mut f = std::fs::File::create(&common_path).unwrap();
+	writeln!(
+		f,
+		r#"
+services:
+  base:
+    image: alpine
+"#
+	)
+	.unwrap();
+
+	let sub = dir.path().join("stack");
+	std::fs::create_dir(&sub).unwrap();
+	let main_path = sub.join("docker-compose.yml");
+	let mut m = std::fs::File::create(&main_path).unwrap();
+	writeln!(
+		m,
+		r#"
+services:
+  app:
+    extends:
+      service: base
+      file: ../common.yml
+"#
+	)
+	.unwrap();
+
+	let file = parse_file(&main_path).unwrap();
+	assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
+}
+
+#[test]
 fn extends_external_file_anchors_relative_paths() {
 	let dir = tempfile::tempdir().unwrap();
 	let sub = dir.path().join("svc");


### PR DESCRIPTION
Closes #283, closes #284, closes #286, closes #291.

## What
- **#283** `extends.file` no longer confines `../`/absolute paths — compose is trusted input (reaffirms the v0.17.1 policy). docker-compose and podman-compose both accept these.
- **#284** `depends_on.required: false` is honored: an optional dependency that fails its wait condition no longer aborts `up` (downgraded to a debug log).
- **#286** new parse-time diagnostics for previously silent drops: long-form port `mode`, per-mount volume `driver_config`, non-external secret/config `driver`/`template_driver`.
- **#291** diagnostics for service `attach` and per-network `interface_name`.
- removes the now-unused `is_safe_relative_path` helper.

## Tests
- new regression test: `extends.file: ../common.yml` resolves.
- new diagnostics tests for each warning (and that an `external: true` secret driver stays quiet).
- full lib (537) + parse (166) suites green.

Note: `Closes #N` is inert on squash-merge to develop; issues will be closed manually after merge.