### PR TITLE
feat(quadlet): map the full first-class container key set

### DIFF
--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -275,9 +275,7 @@ services:
 services:
   s:
     image: x
-    healthcheck:
-      test: ["CMD", "true"]
-    network_mode: host
+    network_mode: "container:other"
     privileged: true
     profiles: [debug]
     volumes_from:
@@ -289,7 +287,6 @@ services:
 		let out = generate(&file, "p");
 		let joined = out.warnings.join("\n");
 		for needle in [
-			"healthcheck",
 			"network_mode",
 			"privileged",
 			"profiles",
@@ -297,6 +294,73 @@ services:
 			"scale/replicas",
 		] {
 			assert!(joined.contains(needle), "expected warning for {needle}");
+		}
+	}
+
+	#[test]
+	fn maps_extended_container_field_set() {
+		let yaml = r#"
+services:
+  app:
+    image: x
+    container_name: custom
+    env_file:
+      - ./app.env
+    tmpfs:
+      - /run
+    sysctls:
+      net.core.somaxconn: "1024"
+    ulimits:
+      nofile:
+        soft: 1024
+        hard: 2048
+    shm_size: 64m
+    mem_limit: 512m
+    pids_limit: 100
+    userns_mode: keep-id
+    stop_signal: SIGTERM
+    stop_grace_period: 30s
+    devices:
+      - /dev/fuse
+    dns:
+      - 1.1.1.1
+    extra_hosts:
+      - "db:10.0.0.2"
+    annotations:
+      run.oci.keep: "1"
+    network_mode: host
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 5s
+      retries: 3
+    restart: "on-failure:5"
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "app.container").contents;
+		for needle in [
+			"ContainerName=custom",
+			"EnvironmentFile=./app.env",
+			"Tmpfs=/run",
+			"Sysctl=net.core.somaxconn=1024",
+			"Ulimit=nofile=1024:2048",
+			"ShmSize=64m",
+			"Memory=512m",
+			"PidsLimit=100",
+			"UserNS=keep-id",
+			"StopSignal=SIGTERM",
+			"StopTimeout=30",
+			"AddDevice=/dev/fuse",
+			"DNS=1.1.1.1",
+			"AddHost=db:10.0.0.2",
+			"Annotation=run.oci.keep=1",
+			"Network=host",
+			"HealthCmd=curl -f http://localhost",
+			"HealthInterval=5s",
+			"HealthRetries=3",
+			"StartLimitBurst=5",
+		] {
+			assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
 		}
 	}
 

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -1,7 +1,8 @@
 //! Build the individual `.network`, `.volume` and `.container` units.
 
-use crate::compose::types::{PortMapping, Service};
+use crate::compose::types::{Command, PortMapping, RestartPolicy, Service};
 use crate::ports::parse_ports;
+use crate::size::parse_duration_secs;
 
 use super::render::{
 	render_command, render_publish_port, render_restart, render_volume, safe_unit_stem,
@@ -9,6 +10,50 @@ use super::render::{
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;
+
+/// Map a compose `healthcheck:` onto the Quadlet `Health*=` keys. A disabled
+/// healthcheck emits `HealthCmd=none`; otherwise the compose test (with any
+/// leading `CMD`/`CMD-SHELL`/`NONE` sentinel stripped) and the timing fields
+/// are rendered.
+fn render_healthcheck(service: &Service, container: &mut Section) {
+	let Some(hc) = &service.healthcheck else {
+		return;
+	};
+	if hc.is_disabled() {
+		container.add("HealthCmd", "none".to_string());
+		return;
+	}
+	if let Some(test) = &hc.test {
+		let cmd = match test {
+			Command::Shell(s) => s.clone(),
+			Command::Exec(parts) => {
+				let body = match parts.first().map(String::as_str) {
+					Some("CMD") | Some("CMD-SHELL") | Some("NONE") => &parts[1..],
+					_ => &parts[..],
+				};
+				body.join(" ")
+			}
+		};
+		if !cmd.is_empty() {
+			container.add("HealthCmd", cmd);
+		}
+	}
+	if let Some(v) = &hc.interval {
+		container.add("HealthInterval", v.clone());
+	}
+	if let Some(v) = &hc.timeout {
+		container.add("HealthTimeout", v.clone());
+	}
+	if let Some(v) = hc.retries {
+		container.add("HealthRetries", v.to_string());
+	}
+	if let Some(v) = &hc.start_period {
+		container.add("HealthStartPeriod", v.clone());
+	}
+	if let Some(v) = &hc.start_interval {
+		container.add("HealthStartupInterval", v.clone());
+	}
+}
 
 pub(super) fn network_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
 	let value = sanitize_value(&format!("{project}_{name}"));
@@ -47,7 +92,13 @@ pub(super) fn container_unit(
 	}
 
 	let mut container = Section::new("Container");
-	container.add("ContainerName", name.to_string());
+	container.add(
+		"ContainerName",
+		service
+			.container_name
+			.clone()
+			.unwrap_or_else(|| name.to_string()),
+	);
 	if let Some(image) = &service.image {
 		container.add("Image", image.clone());
 	}
@@ -112,9 +163,79 @@ pub(super) fn container_unit(
 		container.add("Exec", render_command(command));
 	}
 
+	for ann in sorted_label_pairs(service.annotations.to_map()) {
+		container.add("Annotation", format!("{}={}", ann.0, ann.1));
+	}
+	for entry in service.env_file.to_entries() {
+		container.add("EnvironmentFile", entry.path().to_string());
+	}
+	for t in service.tmpfs.to_list() {
+		container.add("Tmpfs", t);
+	}
+	for (key, val) in sorted_label_pairs(service.sysctls.to_map()) {
+		container.add("Sysctl", format!("{key}={val}"));
+	}
+	for (name, limit) in &service.ulimits {
+		let soft = limit.soft();
+		let hard = limit.hard();
+		let value = if soft == hard {
+			format!("{name}={soft}")
+		} else {
+			format!("{name}={soft}:{hard}")
+		};
+		container.add("Ulimit", value);
+	}
+	for dev in &service.devices {
+		container.add("AddDevice", dev.clone());
+	}
+	for host in &service.extra_hosts {
+		container.add("AddHost", host.clone());
+	}
+	for d in service.dns.to_list() {
+		container.add("DNS", d);
+	}
+	for d in service.dns_search.to_list() {
+		container.add("DNSSearch", d);
+	}
+	for d in service.dns_opt.to_list() {
+		container.add("DNSOption", d);
+	}
+	if let Some(shm) = &service.shm_size {
+		container.add("ShmSize", shm.clone());
+	}
+	if let Some(mem) = &service.mem_limit {
+		container.add("Memory", mem.clone());
+	}
+	if let Some(pids) = service.pids_limit {
+		container.add("PidsLimit", pids.to_string());
+	}
+	if let Some(userns) = &service.userns_mode {
+		container.add("UserNS", userns.clone());
+	}
+	if let Some(signal) = &service.stop_signal {
+		container.add("StopSignal", signal.clone());
+	}
+	if let Some(grace) = &service.stop_grace_period {
+		if let Some(secs) = parse_duration_secs(grace) {
+			container.add("StopTimeout", secs.to_string());
+		}
+	}
+	// `network_mode: host` maps to `Network=host`; other modes (service:/
+	// container:) have no Quadlet key and are reported by collect_warnings.
+	if service.network_mode.as_deref() == Some("host") {
+		container.add("Network", "host".to_string());
+	}
+	render_healthcheck(service, &mut container);
+
 	let mut svc = Section::new("Service");
 	if let Some(restart) = &service.restart {
 		svc.add("Restart", render_restart(restart));
+		if let RestartPolicy::OnFailure {
+			max_attempts: Some(n),
+		} = restart
+		{
+			svc.add("StartLimitBurst", n.to_string());
+		}
 	}
 
 	collect_warnings(name, service, warnings);

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -24,9 +24,6 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"is ignored; Quadlet emits a single container per service",
 		);
 	}
-	if service.healthcheck.is_some() {
-		warn("healthcheck", "is not yet mapped to HealthCmd directives");
-	}
 	if !service.secrets.is_empty() {
 		warn(
 			"secrets",
@@ -39,8 +36,12 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 	if !service.volumes_from.is_empty() {
 		warn("volumes_from", "has no Quadlet equivalent and is skipped");
 	}
-	if service.network_mode.is_some() {
-		warn("network_mode", "is not mapped; use networks instead");
+	// `network_mode: host` maps to `Network=host`; other modes have no key.
+	if service.network_mode.as_deref().is_some_and(|m| m != "host") {
+		warn(
+			"network_mode",
+			"is not mapped (only `host` is supported); use networks instead",
+		);
 	}
 	if !service.profiles.is_empty() {
 		warn("profiles", "have no Quadlet equivalent and are ignored");
@@ -67,7 +68,7 @@ services:
     build: .
     scale: 3
     privileged: true
-    network_mode: host
+    network_mode: "container:other"
     volumes_from:
       - other
     profiles:
@@ -92,7 +93,6 @@ configs:
 		for field in [
 			"build",
 			"scale/replicas",
-			"healthcheck",
 			"secrets",
 			"configs",
 			"volumes_from",


### PR DESCRIPTION
Closes #287.

## What
`generate quadlet` silently dropped a cluster of compose fields that have direct `podman-systemd.unit(5)` keys. Now mapped:

| compose | Quadlet |
|---|---|
| env_file | EnvironmentFile= |
| tmpfs / sysctls / ulimits | Tmpfs= / Sysctl= / Ulimit= |
| shm_size / mem_limit / pids_limit | ShmSize= / Memory= / PidsLimit= |
| devices / dns* / extra_hosts | AddDevice= / DNS*= / AddHost= |
| stop_signal / stop_grace_period | StopSignal= / StopTimeout= |
| annotations / userns_mode | Annotation= / UserNS= |
| healthcheck | HealthCmd= + Health{Interval,Timeout,Retries,StartPeriod,StartupInterval}= |
| network_mode: host | Network=host |
| restart on-failure:N | [Service] StartLimitBurst=N |
| container_name override | ContainerName= (was always the service key) |

Only genuinely-unmappable features still warn (build, scale, secrets, configs, volumes_from, profiles, privileged, non-host network_mode).

## Tests
- new `maps_extended_container_field_set` asserts every new key renders.
- warnings tests updated (healthcheck/host no longer warn). Full lib suite 540 green.

`Closes #N` is inert on squash to develop; will close manually.