### PR TITLE
fix(libpod): target the Podman 5 API surface

### DIFF
--- a/internal/libpod/mod.rs
+++ b/internal/libpod/mod.rs
@@ -13,10 +13,12 @@ pub mod types;
 ///
 /// Podman's libpod routes are version-namespaced: an unversioned path such as
 /// `/libpod/containers/json` is not guaranteed to resolve, so every request
-/// must carry the API version. `v4.0.0` is the published libpod API version
-/// this client targets. The version-independent `/libpod/_ping` endpoint is
-/// the sole exception and deliberately omits this prefix.
-pub(crate) const API_PREFIX: &str = "/v4.0.0/libpod";
+/// must carry the API version. `v5.0.0` is the current published libpod API
+/// version this client targets; podup requires Podman >= 5.0. Podman keeps the
+/// route surface backward-compatible within a major version. The
+/// version-independent `/libpod/_ping` endpoint is the sole exception and
+/// deliberately omits this prefix.
+pub(crate) const API_PREFIX: &str = "/v5.0.0/libpod";
 
 pub(crate) use client::urlencoded;
 pub use client::Client;

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -100,12 +100,17 @@ fn runtime_candidates(uid: u32, xdg_runtime_dir: Option<&str>) -> Vec<String> {
 }
 
 /// Socket candidates on macOS: the host-side sockets `podman machine`
-/// creates, newest layout first.
+/// creates, newest layout first. Podman 5 names the per-provider directory
+/// after the active machine provider (`applehv` by default, `vz` for the
+/// Virtualization.framework backend), so those are tried before the older
+/// `qemu`/default layouts.
 #[cfg(any(target_os = "macos", test))]
 fn machine_candidates(home: &str) -> Vec<String> {
 	let machine_dir = format!("{home}/.local/share/containers/podman/machine");
 	vec![
 		format!("{machine_dir}/podman.sock"),
+		format!("{machine_dir}/applehv/podman.sock"),
+		format!("{machine_dir}/vz/podman.sock"),
 		format!("{machine_dir}/qemu/podman.sock"),
 		format!("{machine_dir}/podman-machine-default/podman.sock"),
 	]
@@ -228,6 +233,8 @@ mod tests {
 			machine_candidates("/Users/dev"),
 			vec![
 				format!("{machine_dir}/podman.sock"),
+				format!("{machine_dir}/applehv/podman.sock"),
+				format!("{machine_dir}/vz/podman.sock"),
 				format!("{machine_dir}/qemu/podman.sock"),
 				format!("{machine_dir}/podman-machine-default/podman.sock"),
 			]


### PR DESCRIPTION
Closes #285, closes #288.

- **#285** `API_PREFIX` `/v4.0.0/libpod` -> `/v5.0.0/libpod`. The current libpod REST API is 5.0.0 (Podman 5.x, latest 5.8.1); podup now targets it and documents a Podman >= 5.0 minimum. Route surface is backward-compatible within a major version, so the existing endpoint set is unchanged.
- **#288** macOS socket discovery now includes the Podman 5 `applehv` (default) and `vz` machine-provider socket directories, tried before the legacy `qemu`/default paths — no longer reliant on the `podman machine inspect` fallback.

Tests: `machine_candidates_cover_known_layouts` updated; lib suite green. `Closes #N` inert on squash to develop.