### PR TITLE
fix(security): harden signing-key handling, read cap, and hex helper

### DIFF
--- a/.github/scripts/sign.py
+++ b/.github/scripts/sign.py
@@ -2,25 +2,33 @@
 """Sign a file with an Ed25519 private key (raw 32-byte seed, base64-encoded).
 
 Usage:
-  sign.py <base64-private-key> <input-file> [<output-sig-file>]
+  sign.py <input-file> [<output-sig-file>]
+
+The private key is read from the RELEASE_SIGN_KEY environment variable (raw
+32-byte Ed25519 seed in standard base64), never from the command line, so the
+secret is not exposed in the process argument list (/proc/<pid>/cmdline).
 
 If output-sig-file is omitted, writes to <input-file>.sig.
-The key must be the raw 32-byte Ed25519 seed in standard base64.
 """
 import base64
+import os
 import sys
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 def main() -> None:
-	if len(sys.argv) < 3:
+	if len(sys.argv) < 2:
 		print(__doc__, file=sys.stderr)
 		sys.exit(1)
 
-	key_b64 = sys.argv[1]
-	input_file = sys.argv[2]
-	sig_file = sys.argv[3] if len(sys.argv) > 3 else input_file + ".sig"
+	key_b64 = os.environ.get("RELEASE_SIGN_KEY")
+	if not key_b64:
+		print("RELEASE_SIGN_KEY is not set in the environment", file=sys.stderr)
+		sys.exit(1)
+
+	input_file = sys.argv[1]
+	sig_file = sys.argv[2] if len(sys.argv) > 2 else input_file + ".sig"
 
 	key_bytes = base64.b64decode(key_b64 + "==")
 	private_key = Ed25519PrivateKey.from_private_bytes(key_bytes)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,9 @@ jobs:
             exit 1
           fi
           python3 -m pip install --quiet --require-hashes -r .github/scripts/sign-requirements.txt
-          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "${{ matrix.asset }}"
+          # The key is passed via RELEASE_SIGN_KEY in the environment, not as a
+          # CLI argument, so it never appears in the process argument list.
+          python3 .github/scripts/sign.py "${{ matrix.asset }}"
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -249,9 +251,10 @@ jobs:
             exit 1
           fi
           python3 -m pip install --quiet --require-hashes -r .github/scripts/sign-requirements.txt
-          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" SHA256SUMS
+          # The key is read from RELEASE_SIGN_KEY in the environment, not argv.
+          python3 .github/scripts/sign.py SHA256SUMS
           for deb in podup_*_amd64.deb podup_*_arm64.deb; do
-            python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "$deb"
+            python3 .github/scripts/sign.py "$deb"
           done
 
       - name: Create GitHub Release

--- a/internal/fsutil.rs
+++ b/internal/fsutil.rs
@@ -1,6 +1,7 @@
 //! Filesystem helpers shared across parsing paths.
 
 use std::io;
+use std::io::Read;
 use std::path::{Component, Path};
 
 /// Reject a file reference that is absolute or escapes the project directory.
@@ -37,18 +38,20 @@ pub(crate) fn read_to_string_capped(path: impl AsRef<Path>) -> io::Result<String
 }
 
 fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
-	let meta = std::fs::metadata(path)?;
-	if meta.len() > max {
+	// Read through a single file handle capped at `max + 1` bytes. Reading
+	// rather than stat-then-read closes the TOCTOU window: a writer that grows
+	// the file (or swaps in a symlink) after a size check cannot make podup
+	// read past the cap, because the limit is enforced on the read itself.
+	let file = std::fs::File::open(path)?;
+	let mut buf = String::new();
+	let read = file.take(max + 1).read_to_string(&mut buf)?;
+	if read as u64 > max {
 		return Err(io::Error::new(
 			io::ErrorKind::InvalidData,
-			format!(
-				"{} is {} bytes, larger than the {max} byte limit",
-				path.display(),
-				meta.len()
-			),
+			format!("{} is larger than the {max} byte limit", path.display()),
 		));
 	}
-	std::fs::read_to_string(path)
+	Ok(buf)
 }
 
 #[cfg(test)]

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -170,8 +170,9 @@ pub fn sha256_hex(data: &[u8]) -> String {
 	let digest = Sha256::digest(data);
 	let mut out = String::with_capacity(64);
 	for byte in digest {
-		out.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
-		out.push(char::from_digit((byte & 0xf) as u32, 16).unwrap());
+		// Each nibble is in 0..=15, always a valid radix-16 digit.
+		out.push(char::from_digit((byte >> 4) as u32, 16).expect("high nibble is a hex digit"));
+		out.push(char::from_digit((byte & 0xf) as u32, 16).expect("low nibble is a hex digit"));
 	}
 	out
 }


### PR DESCRIPTION
Closes #289, closes #290, closes #292.

- **#289** `sign.py` reads `RELEASE_SIGN_KEY` from the environment, not `sys.argv`, so the base64 Ed25519 seed is no longer visible in `/proc/<pid>/cmdline` to a co-executing process on the runner. `release.yml` invocations updated.
- **#292** `read_to_string_capped` opens one file handle and reads through `take(max + 1)`, enforcing the cap on the read itself — a racing writer can no longer grow the file past the limit between a stat and a read. The `/tmp` staging-fallback race is already DoS-only and fails closed in `verify_private_dir` (documented in `staging.rs`).
- **#290** the two provably-infallible `unwrap()` in `sha256_hex` are now `expect(..)` with a justification.

Tests: fsutil + update::verify suites green; `sign.py` parses clean. `Closes #N` inert on squash to develop.