### PR TITLE
test: cover the project-lock contention path and a secret-ref accessor

### DIFF
--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -287,4 +287,17 @@ mod tests {
 		assert_eq!(r.source(), "my-secret");
 		assert_eq!(r.target(), Some("/run/secrets/my-secret"));
 	}
+
+	#[test]
+	fn secret_ref_long_no_target() {
+		let r = ServiceSecretRef::Long {
+			source: "my-secret".to_string(),
+			target: None,
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		assert_eq!(r.source(), "my-secret");
+		assert!(r.target().is_none());
+	}
 }

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -122,4 +122,35 @@ mod tests {
 		assert!(engine("../evil").lock_project().is_err());
 		assert!(engine(".hidden").lock_project().is_err());
 	}
+
+	#[test]
+	fn second_holder_blocks_until_first_releases() {
+		use std::sync::atomic::{AtomicBool, Ordering};
+		use std::sync::Arc;
+		use std::thread;
+		use std::time::Duration;
+
+		// Two engines contend for the same project lock. The first holds it; the
+		// second must take the blocking `LOCK_EX` path in `acquire` and only
+		// succeed after the first guard is dropped. `released` proves the order.
+		let project = "podup-lock-contention";
+		let held = engine(project).lock_project().expect("first acquire");
+
+		let released = Arc::new(AtomicBool::new(false));
+		let flag = Arc::clone(&released);
+		let waiter = thread::spawn(move || {
+			let _guard = engine(project).lock_project().expect("second acquire");
+			assert!(
+				flag.load(Ordering::SeqCst),
+				"second holder acquired the lock before the first released it"
+			);
+		});
+
+		// Give the waiter time to reach the blocking flock call, then release.
+		thread::sleep(Duration::from_millis(100));
+		released.store(true, Ordering::SeqCst);
+		drop(held);
+
+		waiter.join().expect("waiter thread panicked");
+	}
 }


### PR DESCRIPTION
Refs #293.

- **lock.rs** — new `second_holder_blocks_until_first_releases`: two engines contend for one project lock; the second is forced down the blocking `LOCK_EX` path in `acquire` and an `AtomicBool` proves it only acquires after the first guard drops. Ran 5× with no flakiness.
- **volume.rs** — added the missing `ServiceSecretRef::Long { target: None }` accessor test (the `ServiceConfigRef` equivalents were already covered).

Not included: deterministic unit tests for `engine/health.rs` — its `wait_healthy`/`wait_completed` polling needs a live libpod inspect endpoint and has no mock seam, so it stays covered by the Podman-backed integration suite. Flagging rather than forcing a brittle mock.

`Refs #N` keeps #293 open for the health.rs follow-up; close when that seam lands.