### PR TITLE
docs: sharpen comparison table, cross-link RUST_LOG, note arm64 .deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ podup generate quadlet -o ~/.config/containers/systemd  # emit systemd Quadlet u
 | Runtime | single static binary | Go binary + Docker daemon | Python + pip packages |
 | Root required | no | typically yes (daemon) | no |
 | Implementation | Rust | Go | Python |
+| Podman API | native libpod REST | n/a | Podman CLI shell-out |
+| Systemd Quadlet export | yes (`generate quadlet`) | no | no |
+| Platforms | Linux · macOS · Windows (single binary) | Linux · macOS · Windows | wherever Python runs |
+| Compose-spec depth | `extends`, profiles, `develop.watch`, inline secrets/configs | full | partial |
 
 ## 🦀 Library usage
 

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -16,12 +16,13 @@ page.
 
 ## Prebuilt .deb from releases
 
-Each tagged release attaches a signed `podup_<version>_amd64.deb` (with its
+Each tagged release attaches a signed `.deb` per architecture —
+`podup_<version>_amd64.deb` and `podup_<version>_arm64.deb` (each with its
 `.sig`, and an entry in the release `SHA256SUMS`) built on Debian sid. Install
-it directly:
+the one matching your architecture directly:
 
 ```bash
-sudo apt install ./podup_<version>_amd64.deb
+sudo apt install ./podup_<version>_amd64.deb   # or _arm64.deb on aarch64
 ```
 
 `podup update` refuses to self-replace a binary installed this way — it would

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -177,13 +177,9 @@ run under podup: unsupported additions surface as warnings instead of vanishing.
 ## Enabling verbose output
 
 Run with `RUST_LOG=podup=debug` to see network creation, container lifecycle
-events, and deprecation warnings:
-
-```bash
-RUST_LOG=podup=warn podup up     # warnings only (default level)
-RUST_LOG=podup=info podup up     # info + warnings
-RUST_LOG=podup=debug podup up    # full trace
-```
+events, and the parse-time warnings podup emits for any compose field it cannot
+translate. See the [`RUST_LOG` reference in `commands.md`](commands.md#environment)
+for the full level table.
 
 ## Quick compatibility checklist
 


### PR DESCRIPTION
Refs #294.

- **README** comparison table adds the differentiators a chooser actually cares about: native libpod REST vs Podman-CLI shell-out, Systemd Quadlet export (unique to podup), Linux/macOS/Windows single binary, and Compose-spec depth (extends/profiles/watch/inline secrets).
- **docs/docker-migration.md** drops the duplicated RUST_LOG level table and cross-links `commands.md#environment` (single source of truth).
- **docs/debian-packaging.md** prebuilt-.deb section documents the `arm64` asset, not just `amd64`.

Deferred: the asciinema GIF / `docs/assets/` visual hook (needs a recorded terminal cast) — #294 stays open for it.