### PR TITLE
chore: bump version to 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.1" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+podup (0.22.0) unstable; urgency=medium
+
+  * Drop-in fidelity: `extends.file` now accepts `../` and absolute paths (the
+    compose file is trusted input, matching docker-compose and podman-compose),
+    and `depends_on` `required: false` is honored so an optional dependency that
+    fails its condition no longer aborts `up`.
+  * Parse-time diagnostics now warn on previously silent drops: service `attach`,
+    long-form port `mode`, per-mount volume `driver_config`, per-network
+    `interface_name`, and non-external secret/config `driver`/`template_driver`.
+  * Quadlet export now maps the full first-class container key set
+    (`env_file`, `tmpfs`, `sysctls`, `ulimits`, resource limits, `devices`,
+    `dns*`, `extra_hosts`, `stop_signal`/`stop_grace_period`, `annotations`,
+    `userns_mode`, healthcheck, `network_mode: host`, `container_name`, and
+    `restart on-failure:N` -> `StartLimitBurst`).
+  * Engine targets the Podman 5 libpod API (`/v5.0.0/libpod`, Podman >= 5.0) and
+    resolves the macOS `applehv`/`vz` machine-provider sockets.
+  * Security: the release signing key is passed to `sign.py` via the environment
+    instead of argv (no longer visible in the process argument list), and the
+    capped file read is now TOCTOU-safe (read through a single bounded handle).
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 16:26:29 -0500
+
 podup (0.21.1) unstable; urgency=medium
 
   * Security: reject setuid/setgid/sticky/execute mode bits on `external: true`

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.21.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.22.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Version bump to **0.22.0** ahead of the release.

Bumps Cargo.toml, Cargo.lock, `debian/changelog`, `debian/podup.1` `.TH`, and the README library tag. Changelog summarizes the merged work: drop-in fidelity (#283/#284), silent-drop diagnostics (#286/#291), Quadlet key coverage (#287), Podman 5 libpod API + macOS sockets (#285/#288), and the security hardening (#289/#290/#292).

MINOR bump (0.x breaking convention): the engine now requires Podman >= 5.0 and `extends`/`depends_on` behavior changed.