### PR TITLE
release: v0.22.0

### DIFF
--- a/.github/scripts/sign.py
+++ b/.github/scripts/sign.py
@@ -2,25 +2,33 @@
 """Sign a file with an Ed25519 private key (raw 32-byte seed, base64-encoded).
 
 Usage:
-  sign.py <base64-private-key> <input-file> [<output-sig-file>]
+  sign.py <input-file> [<output-sig-file>]
+
+The private key is read from the RELEASE_SIGN_KEY environment variable (raw
+32-byte Ed25519 seed in standard base64), never from the command line, so the
+secret is not exposed in the process argument list (/proc/<pid>/cmdline).
 
 If output-sig-file is omitted, writes to <input-file>.sig.
-The key must be the raw 32-byte Ed25519 seed in standard base64.
 """
 import base64
+import os
 import sys
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 def main() -> None:
-	if len(sys.argv) < 3:
+	if len(sys.argv) < 2:
 		print(__doc__, file=sys.stderr)
 		sys.exit(1)
 
-	key_b64 = sys.argv[1]
-	input_file = sys.argv[2]
-	sig_file = sys.argv[3] if len(sys.argv) > 3 else input_file + ".sig"
+	key_b64 = os.environ.get("RELEASE_SIGN_KEY")
+	if not key_b64:
+		print("RELEASE_SIGN_KEY is not set in the environment", file=sys.stderr)
+		sys.exit(1)
+
+	input_file = sys.argv[1]
+	sig_file = sys.argv[2] if len(sys.argv) > 2 else input_file + ".sig"
 
 	key_bytes = base64.b64decode(key_b64 + "==")
 	private_key = Ed25519PrivateKey.from_private_bytes(key_bytes)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,9 @@ jobs:
             exit 1
           fi
           python3 -m pip install --quiet --require-hashes -r .github/scripts/sign-requirements.txt
-          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "${{ matrix.asset }}"
+          # The key is passed via RELEASE_SIGN_KEY in the environment, not as a
+          # CLI argument, so it never appears in the process argument list.
+          python3 .github/scripts/sign.py "${{ matrix.asset }}"
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -249,9 +251,10 @@ jobs:
             exit 1
           fi
           python3 -m pip install --quiet --require-hashes -r .github/scripts/sign-requirements.txt
-          python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" SHA256SUMS
+          # The key is read from RELEASE_SIGN_KEY in the environment, not argv.
+          python3 .github/scripts/sign.py SHA256SUMS
           for deb in podup_*_amd64.deb podup_*_arm64.deb; do
-            python3 .github/scripts/sign.py "$RELEASE_SIGN_KEY" "$deb"
+            python3 .github/scripts/sign.py "$deb"
           done
 
       - name: Create GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ podup generate quadlet -o ~/.config/containers/systemd  # emit systemd Quadlet u
 | Runtime | single static binary | Go binary + Docker daemon | Python + pip packages |
 | Root required | no | typically yes (daemon) | no |
 | Implementation | Rust | Go | Python |
+| Podman API | native libpod REST | n/a | Podman CLI shell-out |
+| Systemd Quadlet export | yes (`generate quadlet`) | no | no |
+| Platforms | Linux · macOS · Windows (single binary) | Linux · macOS · Windows | wherever Python runs |
+| Compose-spec depth | `extends`, profiles, `develop.watch`, inline secrets/configs | full | partial |
 
 ## 🦀 Library usage
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.21.1" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+podup (0.22.0) unstable; urgency=medium
+
+  * Drop-in fidelity: `extends.file` now accepts `../` and absolute paths (the
+    compose file is trusted input, matching docker-compose and podman-compose),
+    and `depends_on` `required: false` is honored so an optional dependency that
+    fails its condition no longer aborts `up`.
+  * Parse-time diagnostics now warn on previously silent drops: service `attach`,
+    long-form port `mode`, per-mount volume `driver_config`, per-network
+    `interface_name`, and non-external secret/config `driver`/`template_driver`.
+  * Quadlet export now maps the full first-class container key set
+    (`env_file`, `tmpfs`, `sysctls`, `ulimits`, resource limits, `devices`,
+    `dns*`, `extra_hosts`, `stop_signal`/`stop_grace_period`, `annotations`,
+    `userns_mode`, healthcheck, `network_mode: host`, `container_name`, and
+    `restart on-failure:N` -> `StartLimitBurst`).
+  * Engine targets the Podman 5 libpod API (`/v5.0.0/libpod`, Podman >= 5.0) and
+    resolves the macOS `applehv`/`vz` machine-provider sockets.
+  * Security: the release signing key is passed to `sign.py` via the environment
+    instead of argv (no longer visible in the process argument list), and the
+    capped file read is now TOCTOU-safe (read through a single bounded handle).
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 16:26:29 -0500
+
 podup (0.21.1) unstable; urgency=medium
 
   * Security: reject setuid/setgid/sticky/execute mode bits on `external: true`

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.21.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.22.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -16,12 +16,13 @@ page.
 
 ## Prebuilt .deb from releases
 
-Each tagged release attaches a signed `podup_<version>_amd64.deb` (with its
+Each tagged release attaches a signed `.deb` per architecture —
+`podup_<version>_amd64.deb` and `podup_<version>_arm64.deb` (each with its
 `.sig`, and an entry in the release `SHA256SUMS`) built on Debian sid. Install
-it directly:
+the one matching your architecture directly:
 
 ```bash
-sudo apt install ./podup_<version>_amd64.deb
+sudo apt install ./podup_<version>_amd64.deb   # or _arm64.deb on aarch64
 ```
 
 `podup update` refuses to self-replace a binary installed this way — it would

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -177,13 +177,9 @@ run under podup: unsupported additions surface as warnings instead of vanishing.
 ## Enabling verbose output
 
 Run with `RUST_LOG=podup=debug` to see network creation, container lifecycle
-events, and deprecation warnings:
-
-```bash
-RUST_LOG=podup=warn podup up     # warnings only (default level)
-RUST_LOG=podup=info podup up     # info + warnings
-RUST_LOG=podup=debug podup up    # full trace
-```
+events, and the parse-time warnings podup emits for any compose field it cannot
+translate. See the [`RUST_LOG` reference in `commands.md`](commands.md#environment)
+for the full level table.
 
 ## Quick compatibility checklist
 

--- a/internal/compose/diagnostics.rs
+++ b/internal/compose/diagnostics.rs
@@ -8,7 +8,7 @@
 //! the operator hearing about it — the same guarantee that lets podup absorb
 //! future Docker/Podman compose additions gracefully.
 
-use super::types::{BuildConfig, ComposeFile};
+use super::types::{BuildConfig, ComposeFile, PortMapping, VolumeMount};
 
 /// Collect a warning for every parsed-but-unsupported key or field in `file`.
 /// Pure (no logging) so it can be unit-tested; the caller emits the messages.
@@ -18,9 +18,12 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	unknown_service_keys(file, &mut out);
 	nested_unknown_keys(file, &mut out);
 	ignored_service_fields(file, &mut out);
+	ignored_port_fields(file, &mut out);
+	ignored_volume_mount_fields(file, &mut out);
 	ignored_build_fields(file, &mut out);
 	ignored_network_fields(file, &mut out);
 	ignored_service_network_fields(file, &mut out);
+	ignored_secret_config_drivers(file, &mut out);
 	out
 }
 
@@ -127,6 +130,46 @@ fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) {
 				 rootless Podman equivalent and is ignored"
 			));
 		}
+		if def.attach.is_some() {
+			out.push(format!(
+				"service '{service}': attach is not honored; podup follows its own \
+				 attach/detach logic for `up` log streaming"
+			));
+		}
+	}
+}
+
+/// Long-form port fields podup parses but does not forward to Podman.
+fn ignored_port_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		for port in &def.ports {
+			if let PortMapping::Long { mode: Some(m), .. } = port {
+				out.push(format!(
+					"service '{service}': port mode '{m}' is a Swarm/ingress control \
+					 with no single-host Podman equivalent and is ignored"
+				));
+			}
+		}
+	}
+}
+
+/// Per-mount long-form volume options podup parses but does not forward.
+fn ignored_volume_mount_fields(file: &ComposeFile, out: &mut Vec<String>) {
+	for (service, def) in &file.services {
+		for mount in &def.volumes {
+			if let VolumeMount::Long {
+				volume: Some(opts), ..
+			} = mount
+			{
+				if opts.driver_config.is_some() {
+					out.push(format!(
+						"service '{service}' volume '{}': per-mount driver_config is not \
+						 forwarded to Podman and is ignored",
+						mount.target()
+					));
+				}
+			}
+		}
 	}
 }
 
@@ -200,6 +243,49 @@ fn ignored_service_network_fields(file: &ComposeFile, out: &mut Vec<String>) {
 						 by Podman and is ignored"
 					));
 				}
+				if c.interface_name.is_some() {
+					out.push(format!(
+						"service '{service}' network '{name}': interface_name is not \
+						 forwarded to Podman and is ignored"
+					));
+				}
+			}
+		}
+	}
+}
+
+/// Top-level secret/config driver fields. An external secret-store driver
+/// (Vault, AWS SM, etc.) on a non-`external` definition is not honored — podup
+/// only stages `file`/`content`/`environment` sources and routes `external:
+/// true` to Podman-native secrets — so warn rather than mount nothing silently.
+fn ignored_secret_config_drivers(file: &ComposeFile, out: &mut Vec<String>) {
+	for (name, cfg) in &file.secrets {
+		if cfg.external != Some(true) {
+			if cfg.driver.is_some() {
+				out.push(format!(
+					"secret '{name}': driver is an external secret-store plugin that podup \
+					 does not invoke; the secret will not be staged"
+				));
+			}
+			if cfg.template_driver.is_some() {
+				out.push(format!(
+					"secret '{name}': template_driver is not supported and is ignored"
+				));
+			}
+		}
+	}
+	for (name, cfg) in &file.configs {
+		if cfg.external != Some(true) {
+			if cfg.driver.is_some() {
+				out.push(format!(
+					"config '{name}': driver is an external plugin that podup does not \
+					 invoke; the config will not be staged"
+				));
+			}
+			if cfg.template_driver.is_some() {
+				out.push(format!(
+					"config '{name}': template_driver is not supported and is ignored"
+				));
 			}
 		}
 	}
@@ -320,5 +406,69 @@ mod tests {
 	fn clean_file_produces_no_diagnostics() {
 		let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    cpu_shares: 512\n");
 		assert!(msgs.is_empty(), "unexpected diagnostics: {msgs:?}");
+	}
+
+	#[test]
+	fn warns_on_attach() {
+		let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    attach: false\n");
+		assert!(
+			msgs.iter().any(|m| m.contains("attach is not honored")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_long_port_mode() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    ports:\n      - target: 80\n        published: 8080\n        mode: host\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("port mode 'host'")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_per_mount_driver_config() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    volumes:\n      - type: volume\n        source: data\n        target: /data\n        volume:\n          driver_config:\n            name: local\nvolumes:\n  data:\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("per-mount driver_config")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_interface_name() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    networks:\n      net:\n        interface_name: eth9\nnetworks:\n  net:\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("interface_name")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_non_external_secret_driver() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    driver: vault\n",
+		);
+		assert!(
+			msgs.iter().any(|m| m.contains("secret 'tok': driver")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn external_secret_driver_produces_no_diagnostic() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n    driver: vault\n",
+		);
+		assert!(
+			!msgs.iter().any(|m| m.contains("driver")),
+			"unexpected: {msgs:?}"
+		);
 	}
 }

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -123,11 +123,9 @@ fn resolve_one_extends(
 	let base_name = extends.service().to_string();
 
 	let base_service = if let Some(file_path) = extends.file() {
-		if !is_safe_extends_path(file_path) {
-			return Err(ComposeError::Extends(format!(
-				"service '{name}' extends.file must be a relative path with no parent traversal: {file_path}"
-			)));
-		}
+		// The compose file is trusted input (like a Makefile): `extends.file`
+		// may use `../` or absolute paths, matching docker-compose and
+		// podman-compose. Do not confine it.
 		let abs = base_dir.join(file_path);
 		let abs = abs.canonicalize().unwrap_or(abs);
 		let dir = abs
@@ -174,13 +172,6 @@ fn resolve_one_extends(
 	Ok(())
 }
 
-/// Security check: reject `extends.file` with absolute or parent-traversing paths.
-///
-/// Exposed for unit testing.
-pub(crate) fn is_safe_extends_path(path: &str) -> bool {
-	crate::fsutil::is_safe_relative_path(path)
-}
-
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
@@ -196,33 +187,6 @@ mod tests {
 			image: Some(image.to_string()),
 			..Default::default()
 		}
-	}
-
-	// is_safe_extends_path
-
-	#[test]
-	fn safe_path_relative() {
-		assert!(is_safe_extends_path("other.yml"));
-	}
-
-	#[test]
-	fn safe_path_subdirectory() {
-		assert!(is_safe_extends_path("bases/db.yml"));
-	}
-
-	#[test]
-	fn unsafe_path_absolute() {
-		assert!(!is_safe_extends_path("/etc/compose.yml"));
-	}
-
-	#[test]
-	fn unsafe_path_parent_traversal() {
-		assert!(!is_safe_extends_path("../secret.yml"));
-	}
-
-	#[test]
-	fn unsafe_path_nested_traversal() {
-		assert!(!is_safe_extends_path("a/../../etc/passwd"));
 	}
 
 	// merge_service — scalar fields

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -287,4 +287,17 @@ mod tests {
 		assert_eq!(r.source(), "my-secret");
 		assert_eq!(r.target(), Some("/run/secrets/my-secret"));
 	}
+
+	#[test]
+	fn secret_ref_long_no_target() {
+		let r = ServiceSecretRef::Long {
+			source: "my-secret".to_string(),
+			target: None,
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		assert_eq!(r.source(), "my-secret");
+		assert!(r.target().is_none());
+	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -170,6 +170,9 @@ impl Engine {
 
 		for dep in service.depends_on.service_names() {
 			let condition = service.depends_on.condition_for(&dep);
+			// `required: false` makes the dependency optional — a failed wait
+			// must not abort `up`, matching docker-compose v2.
+			let required = service.depends_on.required_for(&dep);
 			let dep_service = match file.services.get(&dep) {
 				Some(s) => s,
 				None => continue,
@@ -179,8 +182,8 @@ impl Engine {
 			}
 			let dep_container = self.container_name(&dep, dep_service);
 
-			match condition {
-				ServiceCondition::ServiceStarted => {}
+			let wait = match condition {
+				ServiceCondition::ServiceStarted => Ok(()),
 				ServiceCondition::ServiceHealthy => {
 					// Wait unless the healthcheck is explicitly disabled in
 					// compose. With no compose healthcheck we still wait:
@@ -195,13 +198,23 @@ impl Engine {
 						tracing::debug!(
 							"{dep} healthcheck disabled — skipping service_healthy wait"
 						);
+						Ok(())
 					} else {
-						self.wait_healthy(&dep_container, dep_service).await?;
+						self.wait_healthy(&dep_container, dep_service).await
 					}
 				}
 				ServiceCondition::ServiceCompletedSuccessfully => {
-					self.wait_completed(&dep_container).await?;
+					self.wait_completed(&dep_container).await
 				}
+			};
+			match wait {
+				Ok(()) => {}
+				Err(e) if !required => {
+					tracing::debug!(
+						"optional dependency {dep} (required: false) did not satisfy its condition: {e}"
+					);
+				}
+				Err(e) => return Err(e),
 			}
 		}
 

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -122,4 +122,35 @@ mod tests {
 		assert!(engine("../evil").lock_project().is_err());
 		assert!(engine(".hidden").lock_project().is_err());
 	}
+
+	#[test]
+	fn second_holder_blocks_until_first_releases() {
+		use std::sync::atomic::{AtomicBool, Ordering};
+		use std::sync::Arc;
+		use std::thread;
+		use std::time::Duration;
+
+		// Two engines contend for the same project lock. The first holds it; the
+		// second must take the blocking `LOCK_EX` path in `acquire` and only
+		// succeed after the first guard is dropped. `released` proves the order.
+		let project = "podup-lock-contention";
+		let held = engine(project).lock_project().expect("first acquire");
+
+		let released = Arc::new(AtomicBool::new(false));
+		let flag = Arc::clone(&released);
+		let waiter = thread::spawn(move || {
+			let _guard = engine(project).lock_project().expect("second acquire");
+			assert!(
+				flag.load(Ordering::SeqCst),
+				"second holder acquired the lock before the first released it"
+			);
+		});
+
+		// Give the waiter time to reach the blocking flock call, then release.
+		thread::sleep(Duration::from_millis(100));
+		released.store(true, Ordering::SeqCst);
+		drop(held);
+
+		waiter.join().expect("waiter thread panicked");
+	}
 }

--- a/internal/fsutil.rs
+++ b/internal/fsutil.rs
@@ -1,27 +1,7 @@
 //! Filesystem helpers shared across parsing paths.
 
 use std::io;
-use std::path::{Component, Path};
-
-/// Reject a file reference that is absolute or escapes the project directory.
-///
-/// podup only reads files that live at or below the directory of the compose
-/// file being processed. A reference that is absolute, rooted (`/etc/passwd`,
-/// which is not `is_absolute()` on Windows but still escapes via the root
-/// separator), or contains a `..` component is refused so a compose file cannot
-/// turn podup into a confused deputy that reads arbitrary host paths. Shared by
-/// the `extends`, `env_file`, and `label_file` readers.
-pub(crate) fn is_safe_relative_path(path: impl AsRef<Path>) -> bool {
-	let fp = path.as_ref();
-	if fp.is_absolute() {
-		return false;
-	}
-	let mut comps = fp.components();
-	if comps.clone().next() == Some(Component::RootDir) {
-		return false;
-	}
-	!comps.any(|c| c == Component::ParentDir)
-}
+use std::path::Path;
 
 /// Upper bound on the size of any compose, include, extends, or env file podup
 /// will read into memory. Bounds memory use on an accidentally huge or hostile
@@ -53,24 +33,7 @@ fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
 
 #[cfg(test)]
 mod tests {
-	use super::{is_safe_relative_path, read_to_string_capped_with};
-
-	#[test]
-	fn accepts_relative_subpaths() {
-		assert!(is_safe_relative_path("labels.env"));
-		assert!(is_safe_relative_path("config/labels.env"));
-	}
-
-	#[test]
-	fn rejects_absolute_paths() {
-		assert!(!is_safe_relative_path("/etc/passwd"));
-	}
-
-	#[test]
-	fn rejects_parent_traversal() {
-		assert!(!is_safe_relative_path("../secret.env"));
-		assert!(!is_safe_relative_path("a/../../etc/passwd"));
-	}
+	use super::read_to_string_capped_with;
 
 	#[test]
 	fn reads_file_within_limit() {

--- a/internal/fsutil.rs
+++ b/internal/fsutil.rs
@@ -1,6 +1,7 @@
 //! Filesystem helpers shared across parsing paths.
 
 use std::io;
+use std::io::Read;
 use std::path::Path;
 
 /// Upper bound on the size of any compose, include, extends, or env file podup
@@ -17,18 +18,20 @@ pub(crate) fn read_to_string_capped(path: impl AsRef<Path>) -> io::Result<String
 }
 
 fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
-	let meta = std::fs::metadata(path)?;
-	if meta.len() > max {
+	// Read through a single file handle capped at `max + 1` bytes. Reading
+	// rather than stat-then-read closes the TOCTOU window: a writer that grows
+	// the file (or swaps in a symlink) after a size check cannot make podup
+	// read past the cap, because the limit is enforced on the read itself.
+	let file = std::fs::File::open(path)?;
+	let mut buf = String::new();
+	let read = file.take(max + 1).read_to_string(&mut buf)?;
+	if read as u64 > max {
 		return Err(io::Error::new(
 			io::ErrorKind::InvalidData,
-			format!(
-				"{} is {} bytes, larger than the {max} byte limit",
-				path.display(),
-				meta.len()
-			),
+			format!("{} is larger than the {max} byte limit", path.display()),
 		));
 	}
-	std::fs::read_to_string(path)
+	Ok(buf)
 }
 
 #[cfg(test)]

--- a/internal/libpod/mod.rs
+++ b/internal/libpod/mod.rs
@@ -13,10 +13,12 @@ pub mod types;
 ///
 /// Podman's libpod routes are version-namespaced: an unversioned path such as
 /// `/libpod/containers/json` is not guaranteed to resolve, so every request
-/// must carry the API version. `v4.0.0` is the published libpod API version
-/// this client targets. The version-independent `/libpod/_ping` endpoint is
-/// the sole exception and deliberately omits this prefix.
-pub(crate) const API_PREFIX: &str = "/v4.0.0/libpod";
+/// must carry the API version. `v5.0.0` is the current published libpod API
+/// version this client targets; podup requires Podman >= 5.0. Podman keeps the
+/// route surface backward-compatible within a major version. The
+/// version-independent `/libpod/_ping` endpoint is the sole exception and
+/// deliberately omits this prefix.
+pub(crate) const API_PREFIX: &str = "/v5.0.0/libpod";
 
 pub(crate) use client::urlencoded;
 pub use client::Client;

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -100,12 +100,17 @@ fn runtime_candidates(uid: u32, xdg_runtime_dir: Option<&str>) -> Vec<String> {
 }
 
 /// Socket candidates on macOS: the host-side sockets `podman machine`
-/// creates, newest layout first.
+/// creates, newest layout first. Podman 5 names the per-provider directory
+/// after the active machine provider (`applehv` by default, `vz` for the
+/// Virtualization.framework backend), so those are tried before the older
+/// `qemu`/default layouts.
 #[cfg(any(target_os = "macos", test))]
 fn machine_candidates(home: &str) -> Vec<String> {
 	let machine_dir = format!("{home}/.local/share/containers/podman/machine");
 	vec![
 		format!("{machine_dir}/podman.sock"),
+		format!("{machine_dir}/applehv/podman.sock"),
+		format!("{machine_dir}/vz/podman.sock"),
 		format!("{machine_dir}/qemu/podman.sock"),
 		format!("{machine_dir}/podman-machine-default/podman.sock"),
 	]
@@ -228,6 +233,8 @@ mod tests {
 			machine_candidates("/Users/dev"),
 			vec![
 				format!("{machine_dir}/podman.sock"),
+				format!("{machine_dir}/applehv/podman.sock"),
+				format!("{machine_dir}/vz/podman.sock"),
 				format!("{machine_dir}/qemu/podman.sock"),
 				format!("{machine_dir}/podman-machine-default/podman.sock"),
 			]

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -275,9 +275,7 @@ services:
 services:
   s:
     image: x
-    healthcheck:
-      test: ["CMD", "true"]
-    network_mode: host
+    network_mode: "container:other"
     privileged: true
     profiles: [debug]
     volumes_from:
@@ -289,7 +287,6 @@ services:
 		let out = generate(&file, "p");
 		let joined = out.warnings.join("\n");
 		for needle in [
-			"healthcheck",
 			"network_mode",
 			"privileged",
 			"profiles",
@@ -297,6 +294,73 @@ services:
 			"scale/replicas",
 		] {
 			assert!(joined.contains(needle), "expected warning for {needle}");
+		}
+	}
+
+	#[test]
+	fn maps_extended_container_field_set() {
+		let yaml = r#"
+services:
+  app:
+    image: x
+    container_name: custom
+    env_file:
+      - ./app.env
+    tmpfs:
+      - /run
+    sysctls:
+      net.core.somaxconn: "1024"
+    ulimits:
+      nofile:
+        soft: 1024
+        hard: 2048
+    shm_size: 64m
+    mem_limit: 512m
+    pids_limit: 100
+    userns_mode: keep-id
+    stop_signal: SIGTERM
+    stop_grace_period: 30s
+    devices:
+      - /dev/fuse
+    dns:
+      - 1.1.1.1
+    extra_hosts:
+      - "db:10.0.0.2"
+    annotations:
+      run.oci.keep: "1"
+    network_mode: host
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 5s
+      retries: 3
+    restart: "on-failure:5"
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "app.container").contents;
+		for needle in [
+			"ContainerName=custom",
+			"EnvironmentFile=./app.env",
+			"Tmpfs=/run",
+			"Sysctl=net.core.somaxconn=1024",
+			"Ulimit=nofile=1024:2048",
+			"ShmSize=64m",
+			"Memory=512m",
+			"PidsLimit=100",
+			"UserNS=keep-id",
+			"StopSignal=SIGTERM",
+			"StopTimeout=30",
+			"AddDevice=/dev/fuse",
+			"DNS=1.1.1.1",
+			"AddHost=db:10.0.0.2",
+			"Annotation=run.oci.keep=1",
+			"Network=host",
+			"HealthCmd=curl -f http://localhost",
+			"HealthInterval=5s",
+			"HealthRetries=3",
+			"StartLimitBurst=5",
+		] {
+			assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
 		}
 	}
 

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -1,7 +1,8 @@
 //! Build the individual `.network`, `.volume` and `.container` units.
 
-use crate::compose::types::{PortMapping, Service};
+use crate::compose::types::{Command, PortMapping, RestartPolicy, Service};
 use crate::ports::parse_ports;
+use crate::size::parse_duration_secs;
 
 use super::render::{
 	render_command, render_publish_port, render_restart, render_volume, safe_unit_stem,
@@ -9,6 +10,50 @@ use super::render::{
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;
+
+/// Map a compose `healthcheck:` onto the Quadlet `Health*=` keys. A disabled
+/// healthcheck emits `HealthCmd=none`; otherwise the compose test (with any
+/// leading `CMD`/`CMD-SHELL`/`NONE` sentinel stripped) and the timing fields
+/// are rendered.
+fn render_healthcheck(service: &Service, container: &mut Section) {
+	let Some(hc) = &service.healthcheck else {
+		return;
+	};
+	if hc.is_disabled() {
+		container.add("HealthCmd", "none".to_string());
+		return;
+	}
+	if let Some(test) = &hc.test {
+		let cmd = match test {
+			Command::Shell(s) => s.clone(),
+			Command::Exec(parts) => {
+				let body = match parts.first().map(String::as_str) {
+					Some("CMD") | Some("CMD-SHELL") | Some("NONE") => &parts[1..],
+					_ => &parts[..],
+				};
+				body.join(" ")
+			}
+		};
+		if !cmd.is_empty() {
+			container.add("HealthCmd", cmd);
+		}
+	}
+	if let Some(v) = &hc.interval {
+		container.add("HealthInterval", v.clone());
+	}
+	if let Some(v) = &hc.timeout {
+		container.add("HealthTimeout", v.clone());
+	}
+	if let Some(v) = hc.retries {
+		container.add("HealthRetries", v.to_string());
+	}
+	if let Some(v) = &hc.start_period {
+		container.add("HealthStartPeriod", v.clone());
+	}
+	if let Some(v) = &hc.start_interval {
+		container.add("HealthStartupInterval", v.clone());
+	}
+}
 
 pub(super) fn network_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
 	let value = sanitize_value(&format!("{project}_{name}"));
@@ -47,7 +92,13 @@ pub(super) fn container_unit(
 	}
 
 	let mut container = Section::new("Container");
-	container.add("ContainerName", name.to_string());
+	container.add(
+		"ContainerName",
+		service
+			.container_name
+			.clone()
+			.unwrap_or_else(|| name.to_string()),
+	);
 	if let Some(image) = &service.image {
 		container.add("Image", image.clone());
 	}
@@ -112,9 +163,79 @@ pub(super) fn container_unit(
 		container.add("Exec", render_command(command));
 	}
 
+	for ann in sorted_label_pairs(service.annotations.to_map()) {
+		container.add("Annotation", format!("{}={}", ann.0, ann.1));
+	}
+	for entry in service.env_file.to_entries() {
+		container.add("EnvironmentFile", entry.path().to_string());
+	}
+	for t in service.tmpfs.to_list() {
+		container.add("Tmpfs", t);
+	}
+	for (key, val) in sorted_label_pairs(service.sysctls.to_map()) {
+		container.add("Sysctl", format!("{key}={val}"));
+	}
+	for (name, limit) in &service.ulimits {
+		let soft = limit.soft();
+		let hard = limit.hard();
+		let value = if soft == hard {
+			format!("{name}={soft}")
+		} else {
+			format!("{name}={soft}:{hard}")
+		};
+		container.add("Ulimit", value);
+	}
+	for dev in &service.devices {
+		container.add("AddDevice", dev.clone());
+	}
+	for host in &service.extra_hosts {
+		container.add("AddHost", host.clone());
+	}
+	for d in service.dns.to_list() {
+		container.add("DNS", d);
+	}
+	for d in service.dns_search.to_list() {
+		container.add("DNSSearch", d);
+	}
+	for d in service.dns_opt.to_list() {
+		container.add("DNSOption", d);
+	}
+	if let Some(shm) = &service.shm_size {
+		container.add("ShmSize", shm.clone());
+	}
+	if let Some(mem) = &service.mem_limit {
+		container.add("Memory", mem.clone());
+	}
+	if let Some(pids) = service.pids_limit {
+		container.add("PidsLimit", pids.to_string());
+	}
+	if let Some(userns) = &service.userns_mode {
+		container.add("UserNS", userns.clone());
+	}
+	if let Some(signal) = &service.stop_signal {
+		container.add("StopSignal", signal.clone());
+	}
+	if let Some(grace) = &service.stop_grace_period {
+		if let Some(secs) = parse_duration_secs(grace) {
+			container.add("StopTimeout", secs.to_string());
+		}
+	}
+	// `network_mode: host` maps to `Network=host`; other modes (service:/
+	// container:) have no Quadlet key and are reported by collect_warnings.
+	if service.network_mode.as_deref() == Some("host") {
+		container.add("Network", "host".to_string());
+	}
+	render_healthcheck(service, &mut container);
+
 	let mut svc = Section::new("Service");
 	if let Some(restart) = &service.restart {
 		svc.add("Restart", render_restart(restart));
+		if let RestartPolicy::OnFailure {
+			max_attempts: Some(n),
+		} = restart
+		{
+			svc.add("StartLimitBurst", n.to_string());
+		}
 	}
 
 	collect_warnings(name, service, warnings);

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -24,9 +24,6 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"is ignored; Quadlet emits a single container per service",
 		);
 	}
-	if service.healthcheck.is_some() {
-		warn("healthcheck", "is not yet mapped to HealthCmd directives");
-	}
 	if !service.secrets.is_empty() {
 		warn(
 			"secrets",
@@ -39,8 +36,12 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 	if !service.volumes_from.is_empty() {
 		warn("volumes_from", "has no Quadlet equivalent and is skipped");
 	}
-	if service.network_mode.is_some() {
-		warn("network_mode", "is not mapped; use networks instead");
+	// `network_mode: host` maps to `Network=host`; other modes have no key.
+	if service.network_mode.as_deref().is_some_and(|m| m != "host") {
+		warn(
+			"network_mode",
+			"is not mapped (only `host` is supported); use networks instead",
+		);
 	}
 	if !service.profiles.is_empty() {
 		warn("profiles", "have no Quadlet equivalent and are ignored");
@@ -67,7 +68,7 @@ services:
     build: .
     scale: 3
     privileged: true
-    network_mode: host
+    network_mode: "container:other"
     volumes_from:
       - other
     profiles:
@@ -92,7 +93,6 @@ configs:
 		for field in [
 			"build",
 			"scale/replicas",
-			"healthcheck",
 			"secrets",
 			"configs",
 			"volumes_from",

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -170,8 +170,9 @@ pub fn sha256_hex(data: &[u8]) -> String {
 	let digest = Sha256::digest(data);
 	let mut out = String::with_capacity(64);
 	for byte in digest {
-		out.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
-		out.push(char::from_digit((byte & 0xf) as u32, 16).unwrap());
+		// Each nibble is in 0..=15, always a valid radix-16 digit.
+		out.push(char::from_digit((byte >> 4) as u32, 16).expect("high nibble is a hex digit"));
+		out.push(char::from_digit((byte & 0xf) as u32, 16).expect("low nibble is a hex digit"));
 	}
 	out
 }

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -175,6 +175,44 @@ services:
 }
 
 #[test]
+fn extends_external_file_parent_traversal_is_allowed() {
+	// The compose file is trusted input: `extends.file` with `../` must resolve,
+	// matching docker-compose and podman-compose (monorepo shared-base pattern).
+	let dir = tempfile::tempdir().unwrap();
+
+	let common_path = dir.path().join("common.yml");
+	let mut f = std::fs::File::create(&common_path).unwrap();
+	writeln!(
+		f,
+		r#"
+services:
+  base:
+    image: alpine
+"#
+	)
+	.unwrap();
+
+	let sub = dir.path().join("stack");
+	std::fs::create_dir(&sub).unwrap();
+	let main_path = sub.join("docker-compose.yml");
+	let mut m = std::fs::File::create(&main_path).unwrap();
+	writeln!(
+		m,
+		r#"
+services:
+  app:
+    extends:
+      service: base
+      file: ../common.yml
+"#
+	)
+	.unwrap();
+
+	let file = parse_file(&main_path).unwrap();
+	assert_eq!(file.services["app"].image.as_deref(), Some("alpine"));
+}
+
+#[test]
 fn extends_external_file_anchors_relative_paths() {
 	let dir = tempfile::tempdir().unwrap();
 	let sub = dir.path().join("svc");


### PR DESCRIPTION
Promote develop to main for the **v0.22.0** release.

## Included (all merged to develop, CI green)
- #295 drop-in compose fidelity: `extends.file` `../`/absolute allowed, `depends_on.required: false` honored, silent-drop diagnostics (#283/#284/#286/#291)
- #296 Quadlet first-class key coverage (#287)
- #297 Podman 5 libpod API + macOS applehv/vz sockets (#285/#288)
- #298 security: signing key via env not argv, TOCTOU-safe read cap, unwrap→expect (#289/#290/#292)
- #299 lock-contention + secret-ref tests (#293)
- #300 docs: comparison table, RUST_LOG cross-link, arm64 .deb (#294)
- #301 version bump to 0.22.0

After merge, tag `v0.22.0` on main triggers the release workflow (signed binaries + per-arch .deb + crates.io + apt dispatch).

MINOR bump: engine now requires Podman >= 5.0; `extends`/`depends_on` behavior changed.