### PR TITLE
test: cover update metadata-parse and install failure paths

### DIFF
--- a/internal/update/github.rs
+++ b/internal/update/github.rs
@@ -67,6 +67,19 @@ fn read_capped(mut reader: impl Read, cap: u64) -> crate::Result<Vec<u8>> {
 	Ok(buf)
 }
 
+/// Parse the `tag_name` out of a GitHub "latest release" JSON body. Split from
+/// the HTTP call so the malformed-metadata failure paths are unit-testable
+/// without a network seam.
+fn parse_latest_tag(body: &[u8]) -> crate::Result<String> {
+	#[derive(serde::Deserialize)]
+	struct Latest {
+		tag_name: String,
+	}
+	let latest: Latest = serde_json::from_slice(body)
+		.map_err(|e| ComposeError::Update(format!("malformed release metadata: {e}")))?;
+	Ok(latest.tag_name)
+}
+
 impl ReleaseSource for GitHubSource {
 	fn latest_version(&self) -> crate::Result<String> {
 		let url = format!("https://api.github.com/repos/{}/releases/latest", self.repo);
@@ -77,14 +90,7 @@ impl ReleaseSource for GitHubSource {
 			.call()
 			.map_err(|e| ComposeError::Update(format!("cannot reach GitHub releases API: {e}")))?;
 		let body = read_capped(resp.into_body().into_reader(), MAX_METADATA_BYTES)?;
-
-		#[derive(serde::Deserialize)]
-		struct Latest {
-			tag_name: String,
-		}
-		let latest: Latest = serde_json::from_slice(&body)
-			.map_err(|e| ComposeError::Update(format!("malformed release metadata: {e}")))?;
-		Ok(latest.tag_name)
+		parse_latest_tag(&body)
 	}
 
 	fn fetch(&self, asset: &str) -> crate::Result<Vec<u8>> {
@@ -150,5 +156,24 @@ mod tests {
 	fn default_uses_canonical_repo() {
 		let src = GitHubSource::default();
 		assert_eq!(src.repo, REPO);
+	}
+
+	#[test]
+	fn parse_latest_tag_extracts_tag() {
+		let tag = parse_latest_tag(br#"{"tag_name":"v1.2.3","name":"r"}"#).unwrap();
+		assert_eq!(tag, "v1.2.3");
+	}
+
+	#[test]
+	fn parse_latest_tag_rejects_malformed_json() {
+		assert!(parse_latest_tag(b"not json at all").is_err());
+		assert!(parse_latest_tag(b"").is_err());
+	}
+
+	#[test]
+	fn parse_latest_tag_rejects_missing_field() {
+		// Well-formed JSON object without `tag_name` must fail, not default.
+		let err = parse_latest_tag(br#"{"name":"release"}"#).unwrap_err();
+		assert!(err.to_string().contains("malformed release metadata"));
 	}
 }

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -288,6 +288,17 @@ mod tests {
 	}
 
 	#[test]
+	fn install_at_fails_when_target_dir_is_missing() {
+		// A target whose parent directory does not exist must fail (the sibling
+		// temp cannot be created) and must not leave anything behind.
+		let dir = tempfile::tempdir().unwrap();
+		let missing = dir.path().join("no-such-subdir");
+		let target = missing.join("podup");
+		assert!(install_at(&target, b"data").is_err());
+		assert!(!missing.exists(), "must not create the missing parent dir");
+	}
+
+	#[test]
 	fn require_platform_asset_is_consistent() {
 		match (platform_asset(), require_platform_asset()) {
 			(Some(a), Ok(b)) => assert_eq!(a, b),


### PR DESCRIPTION
Refs #278.

- Extracted `parse_latest_tag` from the HTTP call in `update/github.rs` so the malformed / empty / missing-`tag_name` metadata failure paths are unit-testable without a network seam (3 new tests).
- Added an `install_at` failure test: a target under a missing parent dir errors and leaves nothing behind.

Tests: 544 lib green, clippy clean.

Remaining on #278: the HTTP-transport error branch in `latest_version`/`fetch` still needs a mock-HTTP or injected-agent seam — larger, kept open.