### PR TITLE
chore: bump version to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.1" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+podup (0.22.1) unstable; urgency=medium
+
+  * Internal hygiene only, no behaviour change: rename the `fsutil` module to
+    `filesystem`, split `compose/diagnostics.rs` into a `diagnostics/` directory,
+    and add failure-path unit tests for the self-update metadata parser and the
+    binary-install swap.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 17:30:00 -0500
+
 podup (0.22.0) unstable; urgency=medium
 
   * Drop-in fidelity: `extends.file` now accepts `../` and absolute paths (the

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.22.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.22.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Internal-hygiene patch release **0.22.1**: `fsutil`→`filesystem` rename + `diagnostics/` split (#279 partial, PR #303) and self-update failure-path tests (#278 partial, PR #304). No behaviour or public-API change → PATCH.

Bumps Cargo.toml, Cargo.lock, debian/changelog, `debian/podup.1` `.TH`, README lib tag.