### PR TITLE
chore: bump version to 0.22.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.1" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.2" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+podup (0.22.2) unstable; urgency=medium
+
+  * Test-only: add deterministic offline coverage for the self-update failure
+    paths (malformed release metadata, missing install target, HTTP transport
+    errors). No behaviour or public-API change.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 15 Jun 2026 00:00:00 -0500
+
 podup (0.22.1) unstable; urgency=medium
 
   * Internal hygiene only, no behaviour change: rename the `fsutil` module to

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.22.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.22.2" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Test-only patch **0.22.2**: completes the self-update failure-path coverage (#278, PRs #304/#308). No behaviour/public-API change → PATCH. Bumps Cargo.toml, Cargo.lock, debian/changelog, `.TH`, README lib tag.