### PR TITLE
release: v0.22.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.1" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.2" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+podup (0.22.2) unstable; urgency=medium
+
+  * Test-only: add deterministic offline coverage for the self-update failure
+    paths (malformed release metadata, missing install target, HTTP transport
+    errors). No behaviour or public-API change.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 15 Jun 2026 00:00:00 -0500
+
 podup (0.22.1) unstable; urgency=medium
 
   * Internal hygiene only, no behaviour change: rename the `fsutil` module to

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.22.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.22.2" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/update/github.rs
+++ b/internal/update/github.rs
@@ -27,6 +27,11 @@ const MAX_METADATA_BYTES: u64 = 1024 * 1024;
 pub struct GitHubSource {
 	repo: String,
 	agent: ureq::Agent,
+	/// Base for the releases API (`https://api.github.com`). Overridable in
+	/// tests so the transport-error path can be exercised offline.
+	api_base: String,
+	/// Base for asset downloads (`https://github.com`). Overridable in tests.
+	dl_base: String,
 }
 
 impl GitHubSource {
@@ -40,7 +45,19 @@ impl GitHubSource {
 		Self {
 			repo: repo.into(),
 			agent,
+			api_base: "https://api.github.com".to_string(),
+			dl_base: "https://github.com".to_string(),
 		}
+	}
+
+	/// Construct with overridden host bases — test seam for the transport-error
+	/// path (point at a closed local port to force a connection failure).
+	#[cfg(test)]
+	fn with_bases(repo: impl Into<String>, api_base: &str, dl_base: &str) -> Self {
+		let mut s = Self::new(repo);
+		s.api_base = api_base.to_string();
+		s.dl_base = dl_base.to_string();
+		s
 	}
 }
 
@@ -82,7 +99,7 @@ fn parse_latest_tag(body: &[u8]) -> crate::Result<String> {
 
 impl ReleaseSource for GitHubSource {
 	fn latest_version(&self) -> crate::Result<String> {
-		let url = format!("https://api.github.com/repos/{}/releases/latest", self.repo);
+		let url = format!("{}/repos/{}/releases/latest", self.api_base, self.repo);
 		let resp = self
 			.agent
 			.get(&url)
@@ -97,8 +114,8 @@ impl ReleaseSource for GitHubSource {
 		// Pinned to the latest release; `ureq` follows GitHub's redirect to the
 		// asset host. Always HTTPS — the URL is a compile-time constant scheme.
 		let url = format!(
-			"https://github.com/{}/releases/latest/download/{asset}",
-			self.repo
+			"{}/{}/releases/latest/download/{asset}",
+			self.dl_base, self.repo
 		);
 		let resp = self
 			.agent
@@ -175,5 +192,26 @@ mod tests {
 		// Well-formed JSON object without `tag_name` must fail, not default.
 		let err = parse_latest_tag(br#"{"name":"release"}"#).unwrap_err();
 		assert!(err.to_string().contains("malformed release metadata"));
+	}
+
+	#[test]
+	fn latest_version_maps_transport_error() {
+		// Port 1 is closed → connection refused, offline and deterministic. The
+		// transport failure must map to the friendly "cannot reach" error.
+		use crate::update::ReleaseSource;
+		let src = GitHubSource::with_bases(REPO, "http://127.0.0.1:1", "http://127.0.0.1:1");
+		let err = src.latest_version().unwrap_err();
+		assert!(
+			err.to_string().contains("cannot reach GitHub releases API"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn fetch_maps_transport_error() {
+		use crate::update::ReleaseSource;
+		let src = GitHubSource::with_bases(REPO, "http://127.0.0.1:1", "http://127.0.0.1:1");
+		let err = src.fetch("podup-linux-x86_64").unwrap_err();
+		assert!(err.to_string().contains("download failed"), "got: {err}");
 	}
 }


### PR DESCRIPTION
Promote develop to main for the **v0.22.2** patch release.

Test-only (no behaviour/API change): completes self-update failure-path coverage (#278 — PRs #304/#308) + the version bump (#310).

After merge, tag `v0.22.2` on main triggers the release workflow (signed binaries + per-arch .deb + crates.io).