### PR TITLE
fix(quadlet): faithful export of users, secrets, external resources, SELinux

### DIFF
--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -46,19 +46,40 @@ pub struct QuadletOutput {
 pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 	let mut out = QuadletOutput::default();
 
+	// External networks/volumes are assumed to pre-exist. Emitting a unit would
+	// make systemd try to (re-)create them, so skip them here; the container unit
+	// references such resources by their existing name instead.
 	for (name, cfg) in &file.networks {
-		out.units.push(network_unit(name, project, cfg.is_some()));
+		if cfg.as_ref().is_some_and(|c| c.external == Some(true)) {
+			continue;
+		}
+		out.units.push(network_unit(name, project, cfg.as_ref()));
 	}
 	for (name, cfg) in &file.volumes {
-		out.units.push(volume_unit(name, project, cfg.is_some()));
+		if cfg.as_ref().is_some_and(|c| c.external == Some(true)) {
+			continue;
+		}
+		out.units.push(volume_unit(name, project, cfg.as_ref()));
 	}
 
-	let declared_volumes: Vec<&str> = file.volumes.keys().map(String::as_str).collect();
+	let declared_volumes: Vec<&str> = file
+		.volumes
+		.iter()
+		.filter(|(_, cfg)| cfg.as_ref().is_none_or(|c| c.external != Some(true)))
+		.map(|(name, _)| name.as_str())
+		.collect();
+	let declared_networks: Vec<&str> = file
+		.networks
+		.iter()
+		.filter(|(_, cfg)| cfg.as_ref().is_none_or(|c| c.external != Some(true)))
+		.map(|(name, _)| name.as_str())
+		.collect();
 	for (name, service) in &file.services {
 		out.units.push(container_unit(
 			name,
 			service,
 			&declared_volumes,
+			&declared_networks,
 			&mut out.warnings,
 		));
 	}
@@ -194,7 +215,10 @@ services:
 		let out = generate(&file, "proj");
 		let c = &unit_named(&out, "app.container").contents;
 		assert!(c.contains("HostName=app-host"));
-		assert!(c.contains("User=1000:1000"));
+		// `user: "1000:1000"` splits into separate User=/Group= keys.
+		assert!(c.contains("User=1000"));
+		assert!(c.contains("Group=1000"));
+		assert!(!c.contains("User=1000:1000"));
 		assert!(c.contains("WorkingDir=/srv"));
 		assert!(c.contains("ReadOnly=true"));
 		assert!(c.contains("RunInit=true"));
@@ -409,5 +433,174 @@ services:
 		let c = &unit_named(&out, "s.container").contents;
 		assert!(c.contains("PublishPort=80"));
 		assert!(!c.contains("PublishPort=:80"));
+	}
+
+	#[test]
+	fn external_network_and_volume_emit_no_unit_and_use_bare_name() {
+		let yaml = r#"
+services:
+  web:
+    image: nginx
+    networks:
+      - extnet
+    volumes:
+      - extvol:/data
+networks:
+  extnet:
+    external: true
+volumes:
+  extvol:
+    external: true
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+		// No unit is generated for external resources.
+		assert!(!out.units.iter().any(|u| u.filename == "extnet.network"));
+		assert!(!out.units.iter().any(|u| u.filename == "extvol.volume"));
+		// The container references them by their existing name, not `.network`/`.volume`.
+		let c = &unit_named(&out, "web.container").contents;
+		assert!(c.contains("Network=extnet"));
+		assert!(!c.contains("Network=extnet.network"));
+		assert!(c.contains("Volume=extvol:/data"));
+		assert!(!c.contains("extvol.volume"));
+	}
+
+	#[test]
+	fn user_with_gid_splits_into_user_and_group() {
+		let yaml = "services:\n  s:\n    image: x\n    user: \"1000:2000\"\n";
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(c.contains("User=1000"));
+		assert!(c.contains("Group=2000"));
+		assert!(!c.contains("User=1000:2000"));
+	}
+
+	#[test]
+	fn long_form_bind_selinux_and_propagation_preserved() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    volumes:
+      - type: bind
+        source: /host/data
+        target: /data
+        bind:
+          selinux: z
+          propagation: rshared
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(
+			c.contains("Volume=/host/data:/data:z,rshared"),
+			"selinux/propagation must be preserved; got:\n{c}"
+		);
+	}
+
+	#[test]
+	fn service_secret_maps_to_secret_key() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    secrets:
+      - tok
+      - source: cred
+        target: /run/cred
+        uid: "100"
+secrets:
+  tok:
+    file: ./tok
+  cred:
+    file: ./cred
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(c.contains("Secret=tok"));
+		assert!(c.contains("Secret=cred,target=/run/cred,uid=100"));
+		assert!(!out.warnings.iter().any(|w| w.contains("secrets")));
+	}
+
+	#[test]
+	fn maps_previously_dropped_container_fields() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    group_add:
+      - audio
+    expose:
+      - "8080"
+    security_opt:
+      - "no-new-privileges:true"
+      - "seccomp=/etc/seccomp.json"
+      - "label=type:container_t"
+    pull_policy: always
+    logging:
+      driver: journald
+      options:
+        tag: mytag
+    networks:
+      net:
+        aliases:
+          - web-alias
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+networks:
+  net:
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		for needle in [
+			"GroupAdd=audio",
+			"ExposeHostPort=8080",
+			"NoNewPrivileges=true",
+			"SeccompProfile=/etc/seccomp.json",
+			"SecurityLabelType=container_t",
+			"Pull=always",
+			"LogDriver=journald",
+			"LogOpt=tag=mytag",
+			"NetworkAlias=web-alias",
+			"Memory=256m",
+		] {
+			assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
+		}
+	}
+
+	#[test]
+	fn network_and_volume_units_carry_config_keys() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+networks:
+  net:
+    driver: bridge
+    internal: true
+    enable_ipv6: true
+    labels:
+      tier: net
+volumes:
+  vol:
+    driver: local
+    labels:
+      tier: vol
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let net = &unit_named(&out, "net.network").contents;
+		assert!(net.contains("Driver=bridge"));
+		assert!(net.contains("Internal=true"));
+		assert!(net.contains("IPv6=true"));
+		assert!(net.contains("Label=tier=net"));
+		let vol = &unit_named(&out, "vol.volume").contents;
+		assert!(vol.contains("Driver=local"));
+		assert!(vol.contains("Label=tier=vol"));
 	}
 }

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -45,6 +45,8 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 			source,
 			target,
 			read_only,
+			bind,
+			volume,
 			..
 		} => {
 			let src = source.clone().unwrap_or_default();
@@ -53,13 +55,34 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 			} else {
 				src
 			};
+			// Collect mount options into the trailing `:opt,opt` field so nothing
+			// is dropped: SELinux relabel (`z`/`Z`) and bind propagation are
+			// security- and correctness-relevant on hardened hosts.
+			let mut opts: Vec<String> = Vec::new();
+			if *read_only == Some(true) {
+				opts.push("ro".to_string());
+			}
+			if let Some(b) = bind {
+				if let Some(selinux) = &b.selinux {
+					opts.push(selinux.clone());
+				}
+				if let Some(propagation) = &b.propagation {
+					opts.push(propagation.clone());
+				}
+			}
+			if let Some(v) = volume {
+				if v.nocopy == Some(true) {
+					opts.push("nocopy".to_string());
+				}
+			}
 			let mut out = if src.is_empty() {
 				target.clone()
 			} else {
 				format!("{src}:{target}")
 			};
-			if *read_only == Some(true) {
-				out.push_str(":ro");
+			if !opts.is_empty() {
+				out.push(':');
+				out.push_str(&opts.join(","));
 			}
 			out
 		}

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -1,12 +1,12 @@
 //! Build the individual `.network`, `.volume` and `.container` units.
 
-use crate::compose::types::{Command, PortMapping, RestartPolicy, Service};
+use crate::compose::types::{Command, PortMapping, RestartPolicy, Service, ServiceSecretRef};
 use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
 use super::render::{
 	render_command, render_publish_port, render_restart, render_volume, safe_unit_stem,
-	sanitize_value, sorted_label_pairs, sorted_pairs, Section,
+	sorted_label_pairs, sorted_pairs, Section,
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;
@@ -55,19 +55,120 @@ fn render_healthcheck(service: &Service, container: &mut Section) {
 	}
 }
 
-pub(super) fn network_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
-	let value = sanitize_value(&format!("{project}_{name}"));
-	let contents =
-		format!("[Network]\nNetworkName={value}\n\n[Install]\nWantedBy=default.target\n");
+/// Render a service `secrets:` entry into a Quadlet `Secret=` value
+/// (`name[,target=,uid=,gid=,mode=]`).
+fn render_secret(secret: &ServiceSecretRef) -> String {
+	match secret {
+		ServiceSecretRef::Short(name) => name.clone(),
+		ServiceSecretRef::Long {
+			source,
+			target,
+			uid,
+			gid,
+			mode,
+		} => {
+			let mut s = source.clone();
+			if let Some(t) = target {
+				s.push_str(&format!(",target={t}"));
+			}
+			if let Some(u) = uid {
+				s.push_str(&format!(",uid={u}"));
+			}
+			if let Some(g) = gid {
+				s.push_str(&format!(",gid={g}"));
+			}
+			if let Some(m) = mode {
+				s.push_str(&format!(",mode={m:o}"));
+			}
+			s
+		}
+	}
+}
+
+/// Map a single compose `security_opt` entry onto the dedicated Quadlet key
+/// where one exists; unrecognized entries are reported rather than dropped.
+fn map_security_opt(opt: &str, container: &mut Section, name: &str, warnings: &mut Vec<String>) {
+	if let Some(rest) = opt.strip_prefix("no-new-privileges") {
+		let val = rest.trim_start_matches([':', '=']);
+		let enabled = val.is_empty() || val == "true";
+		container.add("NoNewPrivileges", enabled.to_string());
+	} else if let Some(profile) = opt.strip_prefix("seccomp=") {
+		container.add("SeccompProfile", profile.to_string());
+	} else if let Some(profile) = opt
+		.strip_prefix("apparmor=")
+		.or_else(|| opt.strip_prefix("apparmor:"))
+	{
+		container.add("AppArmor", profile.to_string());
+	} else if let Some(label) = opt.strip_prefix("label=") {
+		if label == "disable" {
+			container.add("SecurityLabelDisable", "true".to_string());
+		} else if let Some(t) = label.strip_prefix("type:") {
+			container.add("SecurityLabelType", t.to_string());
+		} else if let Some(l) = label.strip_prefix("level:") {
+			container.add("SecurityLabelLevel", l.to_string());
+		} else {
+			warnings.push(format!(
+				"{name}: security_opt 'label={label}' has no Quadlet key and is skipped"
+			));
+		}
+	} else {
+		warnings.push(format!(
+			"{name}: security_opt '{opt}' has no Quadlet mapping and is skipped"
+		));
+	}
+}
+
+pub(super) fn network_unit(
+	name: &str,
+	project: &str,
+	config: Option<&crate::compose::types::NetworkConfig>,
+) -> QuadletUnit {
+	let mut net = Section::new("Network");
+	net.add("NetworkName", format!("{project}_{name}"));
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			net.add("Driver", driver.clone());
+		}
+		if cfg.internal == Some(true) {
+			net.add("Internal", "true".to_string());
+		}
+		if cfg.enable_ipv6 == Some(true) {
+			net.add("IPv6", "true".to_string());
+		}
+		if let Some(ipam) = &cfg.ipam {
+			if let Some(ipam_driver) = &ipam.driver {
+				net.add("IPAMDriver", ipam_driver.clone());
+			}
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			net.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = net.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
 	QuadletUnit {
 		filename: format!("{}.network", safe_unit_stem(name)),
 		contents,
 	}
 }
 
-pub(super) fn volume_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
-	let value = sanitize_value(&format!("{project}_{name}"));
-	let contents = format!("[Volume]\nVolumeName={value}\n\n[Install]\nWantedBy=default.target\n");
+pub(super) fn volume_unit(
+	name: &str,
+	project: &str,
+	config: Option<&crate::compose::types::VolumeConfig>,
+) -> QuadletUnit {
+	let mut vol = Section::new("Volume");
+	vol.add("VolumeName", format!("{project}_{name}"));
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			vol.add("Driver", driver.clone());
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			vol.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = vol.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
 	QuadletUnit {
 		filename: format!("{}.volume", safe_unit_stem(name)),
 		contents,
@@ -78,6 +179,7 @@ pub(super) fn container_unit(
 	name: &str,
 	service: &Service,
 	declared_volumes: &[&str],
+	declared_networks: &[&str],
 	warnings: &mut Vec<String>,
 ) -> QuadletUnit {
 	let mut unit = Section::new("Unit");
@@ -106,7 +208,16 @@ pub(super) fn container_unit(
 		container.add("HostName", hostname.clone());
 	}
 	if let Some(user) = &service.user {
-		container.add("User", user.clone());
+		// Quadlet `User=` takes a UID/username only; a `uid:gid` compose value
+		// must be split so the GID lands in the dedicated `Group=` key (Quadlet
+		// recombines them into `--user uid:gid`).
+		match user.split_once(':') {
+			Some((uid, gid)) => {
+				container.add("User", uid.to_string());
+				container.add("Group", gid.to_string());
+			}
+			None => container.add("User", user.clone()),
+		}
 	}
 	if let Some(wd) = &service.working_dir {
 		container.add("WorkingDir", wd.clone());
@@ -145,7 +256,14 @@ pub(super) fn container_unit(
 		container.add("Volume", render_volume(vol, declared_volumes));
 	}
 	for net in service.networks.names() {
-		container.add("Network", format!("{net}.network"));
+		// A declared (non-external) network is backed by a generated `.network`
+		// unit; an external network is referenced by its existing name directly,
+		// since no unit is emitted for it.
+		if declared_networks.contains(&net.as_str()) {
+			container.add("Network", format!("{net}.network"));
+		} else {
+			container.add("Network", net.clone());
+		}
 	}
 	for (key, val) in sorted_label_pairs(service.labels.to_map()) {
 		container.add("Label", format!("{key}={val}"));
@@ -224,6 +342,50 @@ pub(super) fn container_unit(
 	// container:) have no Quadlet key and are reported by collect_warnings.
 	if service.network_mode.as_deref() == Some("host") {
 		container.add("Network", "host".to_string());
+	}
+	for group in &service.group_add {
+		container.add("GroupAdd", group.clone());
+	}
+	for port in &service.expose {
+		container.add("ExposeHostPort", port.clone());
+	}
+	for net in service.networks.names() {
+		if let Some(cfg) = service.networks.config_for(&net) {
+			if let Some(aliases) = &cfg.aliases {
+				for alias in aliases {
+					container.add("NetworkAlias", alias.clone());
+				}
+			}
+		}
+	}
+	for opt in &service.security_opt {
+		map_security_opt(opt, &mut container, name, warnings);
+	}
+	if let Some(logging) = &service.logging {
+		if let Some(driver) = &logging.driver {
+			container.add("LogDriver", driver.clone());
+		}
+		for (key, val) in sorted_label_pairs(logging.options.clone()) {
+			container.add("LogOpt", format!("{key}={val}"));
+		}
+	}
+	if let Some(pull) = &service.pull_policy {
+		container.add("Pull", pull.clone());
+	}
+	// `deploy.resources.limits.memory` is the modern equivalent of `mem_limit`.
+	if service.mem_limit.is_none() {
+		if let Some(mem) = service
+			.deploy
+			.as_ref()
+			.and_then(|d| d.resources.as_ref())
+			.and_then(|r| r.limits.as_ref())
+			.and_then(|l| l.memory.as_ref())
+		{
+			container.add("Memory", mem.clone());
+		}
+	}
+	for secret in &service.secrets {
+		container.add("Secret", render_secret(secret));
 	}
 	render_healthcheck(service, &mut container);
 

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -24,12 +24,6 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"is ignored; Quadlet emits a single container per service",
 		);
 	}
-	if !service.secrets.is_empty() {
-		warn(
-			"secrets",
-			"are not yet mapped to Quadlet Secret= directives",
-		);
-	}
 	if !service.configs.is_empty() {
 		warn("configs", "have no Quadlet equivalent and are skipped");
 	}
@@ -93,7 +87,6 @@ configs:
 		for field in [
 			"build",
 			"scale/replicas",
-			"secrets",
 			"configs",
 			"volumes_from",
 			"network_mode",
@@ -105,6 +98,11 @@ configs:
 				"missing warning for {field}; got:\n{joined}"
 			);
 		}
+		// secrets are now mapped to Secret=, so they must NOT warn.
+		assert!(
+			!joined.contains("secrets"),
+			"secrets should be mapped, not warned; got:\n{joined}"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #316 (inert on squash->develop; close manually).

All mappings verified against podman-systemd.unit(5).

| # | Fix |
|---|---|
| #12 | \`user: uid:gid\` -> \`User=\` + \`Group=\` |
| #13 | external net/vol emit no unit; referenced by bare name |
| #14 | long-form bind \`:z\`/\`:Z\` + propagation preserved |
| #15 | \`secrets:\` -> first-class \`Secret=\` |
| #16 | group_add/expose/security_opt/logging/pull_policy/aliases/deploy-memory mapped or reported |
| #17 | \`.network\`/\`.volume\` carry Driver/Internal/IPv6/Label |

## Test
+6 unit tests (external skip, user/group split, SELinux, Secret=, mapped fields, net/vol config keys). Golden integration tests still pass. fmt+clippy clean, 552 lib tests pass.