### PR TITLE
test(engine): cover zip-slip guard, deterministic lock-contention test

### DIFF
--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -81,31 +81,9 @@ impl Engine {
 			std::env::current_dir().map_err(ComposeError::Io)?
 		};
 
-		tokio::task::spawn_blocking(move || -> Result<()> {
-			let cursor = std::io::Cursor::new(tar_bytes);
-			let mut archive = tar::Archive::new(cursor);
-			// Extract entry-by-entry rather than `archive.unpack`: a malicious or
-			// compromised container can craft tar entries whose paths contain `..`
-			// or are absolute, escaping `dst_path` and overwriting host files
-			// (zip-slip). `unpack_in` refuses such entries, returning `Ok(false)`;
-			// we turn that into a hard error so the copy fails loudly instead of
-			// silently skipping data.
-			for entry in archive.entries().map_err(ComposeError::Io)? {
-				let mut entry = entry.map_err(ComposeError::Io)?;
-				if !entry.unpack_in(&dst_path).map_err(ComposeError::Io)? {
-					let p = entry
-						.path()
-						.map(|p| p.display().to_string())
-						.unwrap_or_else(|_| "<unprintable>".into());
-					return Err(ComposeError::Build(format!(
-						"cp: refusing archive entry that escapes destination: {p}"
-					)));
-				}
-			}
-			Ok(())
-		})
-		.await
-		.map_err(|e| ComposeError::Build(e.to_string()))??;
+		tokio::task::spawn_blocking(move || extract_tar_guarded(&tar_bytes, &dst_path))
+			.await
+			.map_err(|e| ComposeError::Build(e.to_string()))??;
 
 		Ok(())
 	}
@@ -181,6 +159,33 @@ fn pack_path(src: &Path) -> Result<Vec<u8>> {
 		.into_inner()
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 	gz.finish().map_err(|e| ComposeError::Build(e.to_string()))
+}
+
+/// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
+/// entry whose path would escape it (zip-slip).
+///
+/// Extract entry-by-entry rather than `archive.unpack`: a malicious or
+/// compromised container can craft tar entries whose paths contain `..` or are
+/// absolute, escaping `dst_dir` and overwriting host files. `unpack_in` refuses
+/// such entries, returning `Ok(false)`; we turn that into a hard error so the
+/// copy fails loudly instead of silently skipping data. Pure and synchronous so
+/// the guard can be unit-tested without a container.
+fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
+	let cursor = std::io::Cursor::new(tar_bytes);
+	let mut archive = tar::Archive::new(cursor);
+	for entry in archive.entries().map_err(ComposeError::Io)? {
+		let mut entry = entry.map_err(ComposeError::Io)?;
+		if !entry.unpack_in(dst_dir).map_err(ComposeError::Io)? {
+			let p = entry
+				.path()
+				.map(|p| p.display().to_string())
+				.unwrap_or_else(|_| "<unprintable>".into());
+			return Err(ComposeError::Build(format!(
+				"cp: refusing archive entry that escapes destination: {p}"
+			)));
+		}
+	}
+	Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -259,5 +264,51 @@ mod tests {
 		let result = super::pack_path(&subdir);
 		assert!(result.is_ok());
 		assert!(!result.unwrap().is_empty());
+	}
+
+	/// Build an uncompressed tar archive with a single entry at `path`. The name
+	/// is written straight into the GNU header so a hostile `..` path can be
+	/// forged (the safe `set_path`/`append_data` helpers reject `..`).
+	fn tar_bytes_with(path: &str, data: &[u8]) -> Vec<u8> {
+		let mut header = tar::Header::new_gnu();
+		header.set_size(data.len() as u64);
+		header.set_mode(0o644);
+		header.set_entry_type(tar::EntryType::Regular);
+		let name = path.as_bytes();
+		header.as_gnu_mut().expect("gnu header").name[..name.len()].copy_from_slice(name);
+		header.set_cksum();
+		let mut builder = tar::Builder::new(Vec::new());
+		builder.append(&header, data).expect("append");
+		builder.into_inner().expect("finish")
+	}
+
+	#[test]
+	fn extract_tar_guarded_writes_benign_entry() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let bytes = tar_bytes_with("hello.txt", b"hi");
+		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
+		assert_eq!(
+			std::fs::read(dir.path().join("hello.txt")).expect("read"),
+			b"hi"
+		);
+	}
+
+	#[test]
+	fn extract_tar_guarded_rejects_parent_traversal() {
+		// A compromised container can return a tar whose entry escapes the
+		// destination via `..`; the guard must refuse it and write nothing.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("dest");
+		std::fs::create_dir(&dst).expect("mkdir");
+		let bytes = tar_bytes_with("../evil.txt", b"pwned");
+		let err = super::extract_tar_guarded(&bytes, &dst).unwrap_err();
+		assert!(
+			format!("{err}").contains("escapes destination"),
+			"expected a zip-slip refusal, got: {err}"
+		);
+		assert!(
+			!dir.path().join("evil.txt").exists(),
+			"traversal entry must not be written outside the destination"
+		);
 	}
 }

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -126,9 +126,8 @@ mod tests {
 	#[test]
 	fn second_holder_blocks_until_first_releases() {
 		use std::sync::atomic::{AtomicBool, Ordering};
-		use std::sync::Arc;
+		use std::sync::{Arc, Barrier};
 		use std::thread;
-		use std::time::Duration;
 
 		// Two engines contend for the same project lock. The first holds it; the
 		// second must take the blocking `LOCK_EX` path in `acquire` and only
@@ -138,7 +137,12 @@ mod tests {
 
 		let released = Arc::new(AtomicBool::new(false));
 		let flag = Arc::clone(&released);
+		// A rendezvous removes the need for a timing sleep: both threads clear the
+		// barrier, then the waiter immediately enters the blocking acquire path.
+		let barrier = Arc::new(Barrier::new(2));
+		let waiter_barrier = Arc::clone(&barrier);
 		let waiter = thread::spawn(move || {
+			waiter_barrier.wait();
 			let _guard = engine(project).lock_project().expect("second acquire");
 			assert!(
 				flag.load(Ordering::SeqCst),
@@ -146,8 +150,11 @@ mod tests {
 			);
 		});
 
-		// Give the waiter time to reach the blocking flock call, then release.
-		thread::sleep(Duration::from_millis(100));
+		// The lock is exclusive, so the waiter cannot acquire until `held` is
+		// dropped; the store is sequenced before the drop, so the waiter is
+		// guaranteed to observe `released == true`. This is deterministic — it
+		// never depends on how long the waiter takes to reach `flock`.
+		barrier.wait();
 		released.store(true, Ordering::SeqCst);
 		drop(held);
 


### PR DESCRIPTION
Closes #318 (inert on squash->develop; close manually).

- **#23** zip-slip guard extracted to a pure `extract_tar_guarded()` + 2 unit tests (forged `../evil.txt` refused; benign entry extracts).
- **#24** lock-contention test: `thread::sleep` -> `Barrier` rendezvous; assertion now deterministic (exclusive lock + sequenced store-before-drop).
- **#22** coverage gate confirmed by CI Coverage job on this HEAD.

fmt+clippy clean, 549 lib tests pass.