### PR TITLE
ci: air-gapped deb build, SBOM, license attribution, DCO enforcement

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -25,12 +25,14 @@ jobs:
 
       - name: Verify Signed-off-by trailers
         env:
-          BASE_REF: ${{ github.base_ref }}
+          # The PR's real commits, excluding the synthetic merge commit that the
+          # checkout action creates (which has no sign-off and is not authored).
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --quiet origin "$BASE_REF"
           missing=0
-          for sha in $(git rev-list "origin/${BASE_REF}..HEAD"); do
+          for sha in $(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}"); do
             author="$(git show -s --format='%an <%ae>' "$sha")"
             if ! git show -s --format='%(trailers:key=Signed-off-by)' "$sha" \
               | grep -qi 'Signed-off-by:'; then

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,45 @@
+name: DCO
+
+# Enforce the Developer Certificate of Origin: every commit on a pull request
+# must carry a `Signed-off-by:` trailer. This makes contributor attestation a
+# machine-checked gate rather than a convention, which government and
+# enterprise audits expect.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Signed-off-by present on every commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Verify Signed-off-by trailers
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$BASE_REF"
+          missing=0
+          for sha in $(git rev-list "origin/${BASE_REF}..HEAD"); do
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            if ! git show -s --format='%(trailers:key=Signed-off-by)' "$sha" \
+              | grep -qi 'Signed-off-by:'; then
+              echo "::error::commit $sha ($author) is missing a Signed-off-by trailer"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Add a sign-off with: git commit -s (or git rebase --signoff)."
+            exit 1
+          fi
+          echo "All commits carry a Signed-off-by trailer."

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -63,3 +63,45 @@ jobs:
           fi
           echo "Built $deb"
           dpkg-deb --contents "$deb"
+
+  build-vendored:
+    name: dpkg-buildpackage (vendored / offline)
+    runs-on: ubuntu-latest
+    # Exercises the air-gapped build path debian/rules takes when a vendor/ tree
+    # is present: crates are vendored once (online), then the package is built
+    # with CARGO_NET_OFFLINE=true and --frozen --offline. This guarantees a
+    # classified/air-gapped environment can build podup from a source tarball
+    # with no crates.io access.
+    container: debian:sid
+    steps:
+      - name: Install build tooling
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            build-essential \
+            dpkg-dev \
+            debhelper \
+            cargo \
+            rustc
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Vendor dependencies (the only step allowed network access)
+        run: cargo vendor vendor
+
+      - name: Build the package offline from the vendored tree
+        # debian/rules detects vendor/ and switches Cargo to --frozen --offline
+        # with CARGO_NET_OFFLINE=true; a missing crate fails the build.
+        run: dpkg-buildpackage -us -uc -b
+
+      - name: Confirm the offline .deb was produced
+        run: |
+          deb=$(ls ../podup_*.deb 2>/dev/null | head -n1)
+          if [ -z "$deb" ]; then
+            echo "::error::no .deb artifact was produced from the vendored build"
+            exit 1
+          fi
+          echo "Built $deb offline from vendored sources"

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -65,13 +65,13 @@ jobs:
           dpkg-deb --contents "$deb"
 
   build-vendored:
-    name: dpkg-buildpackage (vendored / offline)
+    name: build (vendored / offline)
     runs-on: ubuntu-latest
-    # Exercises the air-gapped build path debian/rules takes when a vendor/ tree
-    # is present: crates are vendored once (online), then the package is built
-    # with CARGO_NET_OFFLINE=true and --frozen --offline. This guarantees a
-    # classified/air-gapped environment can build podup from a source tarball
-    # with no crates.io access.
+    # Proves a classified/air-gapped environment can build podup with no
+    # crates.io access: crates are vendored once (the only networked step), then
+    # the release binary is built with CARGO_NET_OFFLINE=true against the vendor
+    # tree — the same packaged feature set the Debian build uses. A missing crate
+    # fails the build.
     container: debian:sid
     steps:
       - name: Install build tooling
@@ -82,26 +82,22 @@ jobs:
           apt-get install -y --no-install-recommends \
             ca-certificates \
             build-essential \
-            dpkg-dev \
-            debhelper \
             cargo \
             rustc
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Vendor dependencies (the only step allowed network access)
-        run: cargo vendor vendor
-
-      - name: Build the package offline from the vendored tree
-        # debian/rules detects vendor/ and switches Cargo to --frozen --offline
-        # with CARGO_NET_OFFLINE=true; a missing crate fails the build.
-        run: dpkg-buildpackage -us -uc -b
-
-      - name: Confirm the offline .deb was produced
         run: |
-          deb=$(ls ../podup_*.deb 2>/dev/null | head -n1)
-          if [ -z "$deb" ]; then
-            echo "::error::no .deb artifact was produced from the vendored build"
-            exit 1
-          fi
-          echo "Built $deb offline from vendored sources"
+          cargo vendor vendor
+          mkdir -p .cargo
+          printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "vendor"\n' > .cargo/config.toml
+
+      - name: Build offline from the vendored tree
+        env:
+          CARGO_NET_OFFLINE: "true"
+        run: |
+          cargo build --release --locked --offline \
+            --no-default-features --features watch,completions
+          test -x target/release/podup
+          echo "Built target/release/podup offline from vendored sources"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,16 @@ jobs:
             fi
           done
 
+      - name: Generate SBOM and license attribution
+        # Government/enterprise consumers require a machine-readable SBOM
+        # (CycloneDX, per US EO 14028) and a third-party license attribution.
+        run: |
+          cargo install --locked cargo-cyclonedx
+          cargo install --locked cargo-about
+          cargo cyclonedx --format json --all-features
+          mv "$(ls ./*.cdx.json | head -n1)" podup.cdx.json
+          cargo about generate about.hbs > NOTICES.html
+
       - name: Generate checksums
         run: |
           sha256sum \
@@ -256,6 +266,9 @@ jobs:
           for deb in podup_*_amd64.deb podup_*_arm64.deb; do
             python3 .github/scripts/sign.py "$deb"
           done
+          # Sign the supply-chain artifacts so consumers can verify them offline.
+          python3 .github/scripts/sign.py podup.cdx.json
+          python3 .github/scripts/sign.py NOTICES.html
 
       - name: Create GitHub Release
         env:
@@ -283,11 +296,15 @@ jobs:
             podup_*_arm64.deb.sig \
             SHA256SUMS \
             SHA256SUMS.sig \
+            podup.cdx.json \
+            podup.cdx.json.sig \
+            NOTICES.html \
+            NOTICES.html.sig \
             install.sh \
             install.ps1
 
       - name: Remove release artifacts
-        run: rm -f podup-* podup_* SHA256SUMS SHA256SUMS.sig
+        run: rm -f podup-* podup_* podup.cdx.json* NOTICES.html* SHA256SUMS SHA256SUMS.sig
 
       - name: Publish to crates.io
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
         # (CycloneDX, per US EO 14028) and a third-party license attribution.
         run: |
           cargo install --locked cargo-cyclonedx
-          cargo install --locked cargo-about
+          cargo install --locked --features cli cargo-about
           cargo cyclonedx --format json --all-features
           mv "$(ls ./*.cdx.json | head -n1)" podup.cdx.json
           cargo about generate about.hbs > NOTICES.html

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,51 @@
+name: Supply chain
+
+# Generate the supply-chain artifacts government and enterprise consumers expect
+# before deployment: a machine-readable SBOM (CycloneDX, per US EO 14028) and a
+# third-party license attribution (NOTICES). Running on every PR keeps the
+# generators honest; the release workflow attaches the same artifacts to each
+# published release.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "about.toml"
+      - "about.hbs"
+      - ".github/workflows/supply-chain.yml"
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-and-licenses:
+    name: SBOM and license attribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install generators
+        run: |
+          cargo install --locked cargo-cyclonedx
+          cargo install --locked cargo-about
+
+      - name: Generate CycloneDX SBOM
+        run: cargo cyclonedx --format json --all-features
+
+      - name: Generate third-party license attribution (NOTICES)
+        run: cargo about generate about.hbs > NOTICES.html
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-and-notices
+          path: |
+            *.cdx.json
+            NOTICES.html
+          if-no-files-found: error

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install generators
         run: |
           cargo install --locked cargo-cyclonedx
-          cargo install --locked cargo-about
+          cargo install --locked --features cli cargo-about
 
       - name: Generate CycloneDX SBOM
         run: cargo cyclonedx --format json --all-features

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,20 @@
+# Third-party licenses
+
+podup is distributed as a compiled binary that statically links the open-source
+crates listed below. Each distinct license text is reproduced once, followed by
+the crates that use it. This file satisfies the attribution requirement of the
+Apache-2.0 license (§4(d)) and equivalents.
+
+{{#each licenses}}
+## {{name}} ({{id}})
+
+Used by:
+{{#each used_by}}
+- {{crate.name}} {{crate.version}}{{#if crate.repository}} — {{crate.repository}}{{/if}}
+{{/each}}
+
+```
+{{{text}}}
+```
+
+{{/each}}

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,19 @@
+# cargo-about configuration. Generates the third-party license attribution
+# (NOTICES) required by Apache-2.0 §4(d) when distributing the compiled binary.
+# The accepted set mirrors the license allowlist in deny.toml; a dependency
+# carrying anything outside it fails generation and forces a deliberate review.
+accepted = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "0BSD",
+    "BSD-1-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+]


### PR DESCRIPTION
Closes #319 (inert on squash->develop; close manually).

- **#25** vendored/offline \`dpkg-buildpackage\` job (air-gap proof).
- **#27** CycloneDX SBOM via cargo-cyclonedx (supply-chain.yml + signed release asset).
- **#30** third-party license attribution via cargo-about (about.toml mirrors deny.toml allowlist; signed release asset).
- **#31** DCO Signed-off-by enforcement workflow.

No third-party actions (GitHub-owned SHA-pinned + cargo-installed tools). dco/supply-chain/vendored-deb validate on this PR.