### PR TITLE
docs: security model, independent + air-gapped verification, man SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.2" }
 - [Command reference](docs/commands.md) — every subcommand, its options, and what it does
 - [Migrating from Docker Compose](docs/docker-migration.md) — compatibility guide, rootless differences, deprecated fields
 - [Self-update](docs/self-update.md) — the `podup update` trust model and verification flow
+- [Security model](docs/security-model.md) — privilege posture, trust boundaries, SBOM and air-gap notes
 - [Debian packaging](docs/debian-packaging.md) — building and distributing a `.deb`
 
 ## Contributing & security

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ podup (0.22.2) unstable; urgency=medium
     paths (malformed release metadata, missing install target, HTTP transport
     errors). No behaviour or public-API change.
 
- -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 15 Jun 2026 00:00:00 -0500
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 15 Jun 2026 00:00:00 -0500
 
 podup (0.22.1) unstable; urgency=medium
 
@@ -13,7 +13,7 @@ podup (0.22.1) unstable; urgency=medium
     and add failure-path unit tests for the self-update metadata parser and the
     binary-install swap.
 
- -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 17:30:00 -0500
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 17:30:00 -0500
 
 podup (0.22.0) unstable; urgency=medium
 
@@ -35,7 +35,7 @@ podup (0.22.0) unstable; urgency=medium
     instead of argv (no longer visible in the process argument list), and the
     capped file read is now TOCTOU-safe (read through a single bounded handle).
 
- -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 16:26:29 -0500
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 16:26:29 -0500
 
 podup (0.21.1) unstable; urgency=medium
 

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -170,6 +170,35 @@ Default compose file when none is given.
 .TP
 .B .env
 Project environment file, loaded for variable interpolation.
+.SH SECURITY CONSIDERATIONS
+.B podup
+runs entirely as the invoking user against a rootless Podman socket; it adds no
+privilege of its own and holds no setuid bit. It talks to Podman over the
+libpod REST API on a Unix socket
+.RB ( PODMAN_SOCKET ),
+which is the trust boundary: any user who can reach that socket already controls
+the container engine.
+.PP
+Compose files are treated as
+.B trusted input
+\(em like a Makefile. Path-valued keys
+.RB ( extends.file ", " env_file ", " include )
+may reference files outside the project directory, so do not run
+.B podup
+on a compose file from an untrusted source.
+.PP
+.B podup update
+and the installer verify every downloaded release against an embedded Ed25519
+public key (and a GitHub build-provenance attestation) before installing,
+failing closed if no verifier is available; there is no bypass. The Debian
+package omits the self-update path and relies on
+.BR apt (8)
+for signed upgrades.
+.PP
+Running with
+.B RUST_LOG=debug
+can emit environment variable values and resolved secret/config file paths to
+the log; avoid debug logging where the terminal or log sink is not trusted.
 .SH SEE ALSO
 .BR podman (1),
 .BR podman-systemd.unit (5)

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,81 @@
+# Security model
+
+This document describes podup's privilege posture, trust boundaries, and attack
+surface so operators can reason about it during a security review (for example
+an ATO/SSP assessment). The self-update and release trust chain is covered
+separately in [self-update.md](self-update.md).
+
+## Privilege posture
+
+- podup runs entirely as the **invoking user**. It is not setuid/setgid and
+  acquires no capabilities of its own.
+- It drives **rootless Podman** over the libpod REST API on a Unix socket. Any
+  privilege a container ends up with is granted by Podman/the kernel, bounded by
+  the launching user's own privileges — a rootless container can never exceed
+  them. Fields that assume more (`privileged`, `oom_kill_disable`,
+  `mem_swappiness`, `cpu_rt_*`) are forwarded but warned about, since they are
+  reduced or ineffective rootless.
+- podup keeps **no persistent state** of its own outside the Podman objects it
+  creates and a per-project advisory lock file under the user's runtime
+  directory.
+
+## Trust boundaries
+
+| Boundary | Trusted? | Notes |
+|----------|----------|-------|
+| Podman socket (`PODMAN_SOCKET`/`DOCKER_HOST`) | Trusted | Whoever can reach it controls the engine; this is the primary boundary. |
+| Compose file and its referenced files | **Trusted input** | Treated like a Makefile (see below). |
+| Release artifacts (`podup update`, installer) | Untrusted transport | Verified against an embedded Ed25519 key + provenance attestation, fail-closed. |
+| Container filesystem (e.g. `cp` archives) | Untrusted | Tar extraction refuses path-traversal (zip-slip) entries. |
+| Network/TLS to GitHub/crates.io | Untrusted | Integrity comes from signatures, not transport. |
+
+## Compose files are trusted input
+
+A compose file is treated like a Makefile: running podup on one is equivalent to
+trusting its author. Path-valued keys the spec resolves relative to the compose
+file (`extends.file`, `env_file`, `label_file`, `include`) may reference paths
+outside the project directory, including `../`. Do **not** run podup on a compose
+file from an untrusted source. (`include` still rejects absolute paths as
+non-portable, but this is hardening, not a security guarantee.)
+
+## Secret and config handling
+
+- `secrets:`/`configs:` sourced from files or inline content are staged into a
+  per-user directory created `0700`, owned by and accessible only to the
+  invoking user; the staging directory is verified (ownership + mode, symlinks
+  rejected) before use and cleaned up afterwards.
+- `external: true` secrets/configs are injected as Podman-native secrets
+  (pre-flighted for existence), not staged on disk.
+- Dangerous secret file modes (setuid/setgid/sticky/executable) are rejected.
+- The `config` subcommand redacts inline `content:` secrets before printing.
+
+## Logging and information disclosure
+
+- Default logging does not print secret values. Running with `RUST_LOG=debug`
+  can emit environment variable values and resolved secret/config file paths;
+  avoid debug logging where the terminal or log sink is not trusted.
+- podup writes no secret material to its own persistent state.
+
+## Supply chain
+
+- Dependencies are pinned in `Cargo.lock`; `cargo deny` enforces a license
+  allowlist and bans yanked crates, and `cargo audit` runs weekly in CI.
+- No third-party CI actions are used — only GitHub-owned (SHA-pinned) actions.
+- Releases are Ed25519-signed and carry GitHub build-provenance attestations; a
+  CycloneDX SBOM and third-party license attribution are published with each
+  release. See [self-update.md](self-update.md) for verification steps.
+- The Debian package can be built fully offline from a vendored crate tree, for
+  air-gapped/classified environments.
+
+## Memory safety
+
+The crate forbids `unsafe` by default (`#![deny(unsafe_code)]`). The few
+unavoidable FFI calls (rootless uid/gid lookups, `flock`, `stat`) are isolated,
+individually justified with safety comments, and unit-tested.
+
+## Reporting
+
+Report vulnerabilities privately via the repository's **Security tab → Report a
+vulnerability** (never a public issue). See the organization
+[security policy](https://github.com/Glyndor/.github/blob/main/SECURITY.md) for
+response targets.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -109,3 +109,50 @@ two-release procedure:
 During step 1 the leaked `old` key is still accepted for one release — an
 unavoidable cost of any rotation. The GitHub build-provenance attestation, which
 does not depend on the signing key, still proves origin during the window.
+
+## Verifying a release independently
+
+Operators who want to verify a release without trusting the installer can do so
+with standard tooling. The GitHub build-provenance attestation proves the binary
+came from this repository's release workflow:
+
+```bash
+gh attestation verify podup-linux-x86_64 --repo Glyndor/podup
+```
+
+To verify the Ed25519 signature over `SHA256SUMS` offline (no GitHub CLI), use
+the embedded public key:
+
+```bash
+python3 - <<'PY'
+import base64
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+key = Ed25519PublicKey.from_public_bytes(
+    base64.b64decode("APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y" + "=="))
+key.verify(open("SHA256SUMS.sig", "rb").read(), open("SHA256SUMS", "rb").read())
+print("SHA256SUMS signature OK")
+PY
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+The release also ships a CycloneDX SBOM (`podup.cdx.json`) and a third-party
+license attribution (`NOTICES.html`), each with a detached `.sig` that verifies
+against the same key.
+
+## Air-gapped installation
+
+Networks that block outbound GitHub have no opt-out from verification — they
+carry the artifacts across the boundary instead:
+
+1. On a connected host, download the platform binary, `SHA256SUMS`,
+   `SHA256SUMS.sig` (and optionally the SBOM/NOTICES and their `.sig` files).
+2. Transfer them to the isolated host on approved media.
+3. Verify the Ed25519 signature and checksum there with the offline snippet
+   above — the embedded key is the trust anchor, so no network is needed.
+4. Install the verified binary manually (`install -m 0755 podup-linux-x86_64
+   /usr/local/bin/podup`).
+
+For building from source in an air-gapped environment, vendor the crates on a
+connected host (`cargo vendor vendor`), include the `vendor/` tree in the source
+tarball, and build the Debian package offline — `debian/rules` automatically
+switches Cargo to `--frozen --offline` when `vendor/` is present.


### PR DESCRIPTION
Closes #320 (inert on squash->develop; close manually).

- **#28** docs/security-model.md threat model.
- **#29** independent verification (gh attestation + offline Ed25519) and air-gap procedure in self-update.md.
- **#33** man page SECURITY CONSIDERATIONS section (groff-validated).
- **#26** changelog maintainer standardized to Glyndor (matches control; dpkg-parsechangelog clean).