### PR TITLE
feat(cli): hidden command aliases and blank-line-framed help

### DIFF
--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -7,11 +7,7 @@ use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
 #[derive(Parser)]
-#[command(
-	name = "podup",
-	version,
-	about = "docker-compose translator for Podman"
-)]
+#[command(name = "podup", version)]
 pub(crate) struct Cli {
 	/// Path to the compose file. May also be set via `COMPOSE_FILE`. When
 	/// unset, the compose-spec precedence list is probed in the current
@@ -106,6 +102,7 @@ pub(crate) enum Commands {
 		services: Vec<String>,
 	},
 	/// Remove stopped service containers.
+	#[command(alias = "remove")]
 	Rm {
 		/// Remove even running containers (stop first).
 		#[arg(short, long)]
@@ -130,6 +127,7 @@ pub(crate) enum Commands {
 		services: Vec<String>,
 	},
 	/// Resume paused service containers.
+	#[command(alias = "resume")]
 	Unpause {
 		/// Unpause only these services.
 		#[arg(trailing_var_arg = true)]
@@ -186,8 +184,10 @@ pub(crate) enum Commands {
 		proto: String,
 	},
 	/// List images used by services.
+	#[command(alias = "image")]
 	Images,
 	/// View output from containers.
+	#[command(alias = "log")]
 	Logs {
 		/// Only show logs for this service.
 		service: Option<String>,
@@ -211,8 +211,10 @@ pub(crate) enum Commands {
 		service: Option<String>,
 	},
 	/// Print the resolved compose file (after substitution / extends / include).
+	#[command(alias = "convert")]
 	Config,
 	/// Generate declarative artifacts from the compose file.
+	#[command(alias = "gen")]
 	Generate {
 		#[command(subcommand)]
 		kind: GenerateCommands,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -183,7 +183,20 @@ async fn run() -> podup::Result<()> {
 		.event_format(PodupFormat)
 		.init();
 
-	let cli = Cli::parse();
+	// Frame `--help`/`--version` output with a blank line top and bottom. clap
+	// trims template/before/after-help edges, so wrap the rendered text here.
+	let cli = match Cli::try_parse() {
+		Ok(cli) => cli,
+		Err(e) => match e.kind() {
+			clap::error::ErrorKind::DisplayHelp
+			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+			| clap::error::ErrorKind::DisplayVersion => {
+				print!("\n{e}\n");
+				process::exit(0);
+			}
+			_ => e.exit(),
+		},
+	};
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -1,0 +1,75 @@
+//! CLI surface checks for the convenience command aliases and the blank-line
+//! framing around `--help`/`--version` output. Aliases are hidden (they must
+//! resolve when typed but stay out of the top-level help listing), and the
+//! help/version text is wrapped with one blank line top and bottom.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Every hidden alias must resolve to its canonical command: invoking
+/// `<alias> --help` exits 0 and prints that command's help (clap rejects an
+/// unknown subcommand with a non-zero exit instead).
+#[test]
+fn aliases_resolve_to_their_command() {
+	let cases = [
+		("convert", "resolved compose file"),
+		("gen", "declarative artifacts"),
+		("resume", "Resume paused"),
+		("remove", "Remove stopped"),
+		("log", "output from containers"),
+		("image", "images used by services"),
+	];
+	for (alias, needle) in cases {
+		let output = Command::new(bin())
+			.args([alias, "--help"])
+			.output()
+			.expect("run alias --help");
+		assert!(
+			output.status.success(),
+			"alias `{alias}` did not resolve (exit {:?})",
+			output.status.code()
+		);
+		let stdout = String::from_utf8_lossy(&output.stdout);
+		assert!(
+			stdout.contains(needle),
+			"alias `{alias}` help missing {needle:?}; got:\n{stdout}"
+		);
+	}
+}
+
+/// Aliases are hidden: the top-level `--help` lists canonical commands only,
+/// never the alias spellings.
+#[test]
+fn aliases_stay_out_of_top_level_help() {
+	let output = Command::new(bin())
+		.arg("--help")
+		.output()
+		.expect("run --help");
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	for alias in ["convert", "resume", "remove"] {
+		assert!(
+			!stdout.lines().any(|l| l.trim_start().starts_with(alias)),
+			"alias `{alias}` leaked into top-level help"
+		);
+	}
+}
+
+/// `--help` and `--version` are framed with exactly one blank line at the top
+/// and bottom.
+#[test]
+fn help_and_version_are_blank_line_framed() {
+	for flag in ["--help", "--version"] {
+		let output = Command::new(bin()).arg(flag).output().expect("run flag");
+		assert!(output.status.success());
+		let stdout = String::from_utf8_lossy(&output.stdout);
+		assert!(stdout.starts_with('\n'), "{flag}: no leading blank line");
+		assert!(stdout.ends_with("\n\n"), "{flag}: no trailing blank line");
+		assert!(
+			!stdout.starts_with("\n\n"),
+			"{flag}: more than one leading blank line"
+		);
+	}
+}


### PR DESCRIPTION
Closes #321 (inert on squash->develop; close manually).

**#32** Lands the previously-uncommitted CLI work properly (branch + issue + tests): hidden aliases remove/resume/image/log/convert/gen, and blank-line framing around --help/--version. +tests/cli_aliases.rs (3 tests). fmt+clippy clean.