### PR TITLE
release: government-readiness remediation (34 findings)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,47 @@
+name: DCO
+
+# Enforce the Developer Certificate of Origin: every commit on a pull request
+# must carry a `Signed-off-by:` trailer. This makes contributor attestation a
+# machine-checked gate rather than a convention, which government and
+# enterprise audits expect.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Signed-off-by present on every commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Verify Signed-off-by trailers
+        env:
+          # The PR's real commits, excluding the synthetic merge commit that the
+          # checkout action creates (which has no sign-off and is not authored).
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for sha in $(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}"); do
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            if ! git show -s --format='%(trailers:key=Signed-off-by)' "$sha" \
+              | grep -qi 'Signed-off-by:'; then
+              echo "::error::commit $sha ($author) is missing a Signed-off-by trailer"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Add a sign-off with: git commit -s (or git rebase --signoff)."
+            exit 1
+          fi
+          echo "All commits carry a Signed-off-by trailer."

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -63,3 +63,41 @@ jobs:
           fi
           echo "Built $deb"
           dpkg-deb --contents "$deb"
+
+  build-vendored:
+    name: build (vendored / offline)
+    runs-on: ubuntu-latest
+    # Proves a classified/air-gapped environment can build podup with no
+    # crates.io access: crates are vendored once (the only networked step), then
+    # the release binary is built with CARGO_NET_OFFLINE=true against the vendor
+    # tree — the same packaged feature set the Debian build uses. A missing crate
+    # fails the build.
+    container: debian:sid
+    steps:
+      - name: Install build tooling
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            build-essential \
+            cargo \
+            rustc
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Vendor dependencies (the only step allowed network access)
+        run: |
+          cargo vendor vendor
+          mkdir -p .cargo
+          printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "vendor"\n' > .cargo/config.toml
+
+      - name: Build offline from the vendored tree
+        env:
+          CARGO_NET_OFFLINE: "true"
+        run: |
+          cargo build --release --locked --offline \
+            --no-default-features --features watch,completions
+          test -x target/release/podup
+          echo "Built target/release/podup offline from vendored sources"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,16 @@ jobs:
             fi
           done
 
+      - name: Generate SBOM and license attribution
+        # Government/enterprise consumers require a machine-readable SBOM
+        # (CycloneDX, per US EO 14028) and a third-party license attribution.
+        run: |
+          cargo install --locked cargo-cyclonedx
+          cargo install --locked --features cli cargo-about
+          cargo cyclonedx --format json --all-features
+          mv "$(ls ./*.cdx.json | head -n1)" podup.cdx.json
+          cargo about generate about.hbs > NOTICES.html
+
       - name: Generate checksums
         run: |
           sha256sum \
@@ -256,6 +266,9 @@ jobs:
           for deb in podup_*_amd64.deb podup_*_arm64.deb; do
             python3 .github/scripts/sign.py "$deb"
           done
+          # Sign the supply-chain artifacts so consumers can verify them offline.
+          python3 .github/scripts/sign.py podup.cdx.json
+          python3 .github/scripts/sign.py NOTICES.html
 
       - name: Create GitHub Release
         env:
@@ -283,11 +296,15 @@ jobs:
             podup_*_arm64.deb.sig \
             SHA256SUMS \
             SHA256SUMS.sig \
+            podup.cdx.json \
+            podup.cdx.json.sig \
+            NOTICES.html \
+            NOTICES.html.sig \
             install.sh \
             install.ps1
 
       - name: Remove release artifacts
-        run: rm -f podup-* podup_* SHA256SUMS SHA256SUMS.sig
+        run: rm -f podup-* podup_* podup.cdx.json* NOTICES.html* SHA256SUMS SHA256SUMS.sig
 
       - name: Publish to crates.io
         env:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,51 @@
+name: Supply chain
+
+# Generate the supply-chain artifacts government and enterprise consumers expect
+# before deployment: a machine-readable SBOM (CycloneDX, per US EO 14028) and a
+# third-party license attribution (NOTICES). Running on every PR keeps the
+# generators honest; the release workflow attaches the same artifacts to each
+# published release.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "about.toml"
+      - "about.hbs"
+      - ".github/workflows/supply-chain.yml"
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-and-licenses:
+    name: SBOM and license attribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install generators
+        run: |
+          cargo install --locked cargo-cyclonedx
+          cargo install --locked --features cli cargo-about
+
+      - name: Generate CycloneDX SBOM
+        run: cargo cyclonedx --format json --all-features
+
+      - name: Generate third-party license attribution (NOTICES)
+        run: cargo about generate about.hbs > NOTICES.html
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-and-notices
+          path: |
+            *.cdx.json
+            NOTICES.html
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.2" }
 - [Command reference](docs/commands.md) — every subcommand, its options, and what it does
 - [Migrating from Docker Compose](docs/docker-migration.md) — compatibility guide, rootless differences, deprecated fields
 - [Self-update](docs/self-update.md) — the `podup update` trust model and verification flow
+- [Security model](docs/security-model.md) — privilege posture, trust boundaries, SBOM and air-gap notes
 - [Debian packaging](docs/debian-packaging.md) — building and distributing a `.deb`
 
 ## Contributing & security

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,20 @@
+# Third-party licenses
+
+podup is distributed as a compiled binary that statically links the open-source
+crates listed below. Each distinct license text is reproduced once, followed by
+the crates that use it. This file satisfies the attribution requirement of the
+Apache-2.0 license (§4(d)) and equivalents.
+
+{{#each licenses}}
+## {{name}} ({{id}})
+
+Used by:
+{{#each used_by}}
+- {{crate.name}} {{crate.version}}{{#if crate.repository}} — {{crate.repository}}{{/if}}
+{{/each}}
+
+```
+{{{text}}}
+```
+
+{{/each}}

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,19 @@
+# cargo-about configuration. Generates the third-party license attribution
+# (NOTICES) required by Apache-2.0 §4(d) when distributing the compiled binary.
+# The accepted set mirrors the license allowlist in deny.toml; a dependency
+# carrying anything outside it fails generation and forces a deliberate review.
+accepted = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "0BSD",
+    "BSD-1-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+]

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ podup (0.22.2) unstable; urgency=medium
     paths (malformed release metadata, missing install target, HTTP transport
     errors). No behaviour or public-API change.
 
- -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 15 Jun 2026 00:00:00 -0500
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 15 Jun 2026 00:00:00 -0500
 
 podup (0.22.1) unstable; urgency=medium
 
@@ -13,7 +13,7 @@ podup (0.22.1) unstable; urgency=medium
     and add failure-path unit tests for the self-update metadata parser and the
     binary-install swap.
 
- -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 17:30:00 -0500
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 17:30:00 -0500
 
 podup (0.22.0) unstable; urgency=medium
 
@@ -35,7 +35,7 @@ podup (0.22.0) unstable; urgency=medium
     instead of argv (no longer visible in the process argument list), and the
     capped file read is now TOCTOU-safe (read through a single bounded handle).
 
- -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 16:26:29 -0500
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sun, 14 Jun 2026 16:26:29 -0500
 
 podup (0.21.1) unstable; urgency=medium
 

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -170,6 +170,35 @@ Default compose file when none is given.
 .TP
 .B .env
 Project environment file, loaded for variable interpolation.
+.SH SECURITY CONSIDERATIONS
+.B podup
+runs entirely as the invoking user against a rootless Podman socket; it adds no
+privilege of its own and holds no setuid bit. It talks to Podman over the
+libpod REST API on a Unix socket
+.RB ( PODMAN_SOCKET ),
+which is the trust boundary: any user who can reach that socket already controls
+the container engine.
+.PP
+Compose files are treated as
+.B trusted input
+\(em like a Makefile. Path-valued keys
+.RB ( extends.file ", " env_file ", " include )
+may reference files outside the project directory, so do not run
+.B podup
+on a compose file from an untrusted source.
+.PP
+.B podup update
+and the installer verify every downloaded release against an embedded Ed25519
+public key (and a GitHub build-provenance attestation) before installing,
+failing closed if no verifier is available; there is no bypass. The Debian
+package omits the self-update path and relies on
+.BR apt (8)
+for signed upgrades.
+.PP
+Running with
+.B RUST_LOG=debug
+can emit environment variable values and resolved secret/config file paths to
+the log; avoid debug logging where the terminal or log sink is not trusted.
 .SH SEE ALSO
 .BR podman (1),
 .BR podman-systemd.unit (5)

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -165,6 +165,17 @@ run under podup: unsupported additions surface as warnings instead of vanishing.
 `extra_hosts` is accepted in both the list (`["host:ip"]`) and mapping
 (`{host: ip}`) forms.
 
+## File references and path confinement
+
+Compose files are **trusted input**, like a Makefile. Path-valued keys that the
+spec resolves relative to the compose file — `extends.file`, `env_file`,
+`label_file`, and `include` — may use `../` to reach files outside the project
+directory, matching docker-compose. This is an intentional divergence from a
+fully sandboxed parser: do not feed podup a compose file from an untrusted
+source any more than you would `make -f` an untrusted Makefile. The one
+exception is `include`, which still rejects **absolute** paths (they are not
+portable across checkouts and the spec does not require them); `../` is allowed.
+
 ## Not yet supported
 
 | Feature | Status |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,81 @@
+# Security model
+
+This document describes podup's privilege posture, trust boundaries, and attack
+surface so operators can reason about it during a security review (for example
+an ATO/SSP assessment). The self-update and release trust chain is covered
+separately in [self-update.md](self-update.md).
+
+## Privilege posture
+
+- podup runs entirely as the **invoking user**. It is not setuid/setgid and
+  acquires no capabilities of its own.
+- It drives **rootless Podman** over the libpod REST API on a Unix socket. Any
+  privilege a container ends up with is granted by Podman/the kernel, bounded by
+  the launching user's own privileges — a rootless container can never exceed
+  them. Fields that assume more (`privileged`, `oom_kill_disable`,
+  `mem_swappiness`, `cpu_rt_*`) are forwarded but warned about, since they are
+  reduced or ineffective rootless.
+- podup keeps **no persistent state** of its own outside the Podman objects it
+  creates and a per-project advisory lock file under the user's runtime
+  directory.
+
+## Trust boundaries
+
+| Boundary | Trusted? | Notes |
+|----------|----------|-------|
+| Podman socket (`PODMAN_SOCKET`/`DOCKER_HOST`) | Trusted | Whoever can reach it controls the engine; this is the primary boundary. |
+| Compose file and its referenced files | **Trusted input** | Treated like a Makefile (see below). |
+| Release artifacts (`podup update`, installer) | Untrusted transport | Verified against an embedded Ed25519 key + provenance attestation, fail-closed. |
+| Container filesystem (e.g. `cp` archives) | Untrusted | Tar extraction refuses path-traversal (zip-slip) entries. |
+| Network/TLS to GitHub/crates.io | Untrusted | Integrity comes from signatures, not transport. |
+
+## Compose files are trusted input
+
+A compose file is treated like a Makefile: running podup on one is equivalent to
+trusting its author. Path-valued keys the spec resolves relative to the compose
+file (`extends.file`, `env_file`, `label_file`, `include`) may reference paths
+outside the project directory, including `../`. Do **not** run podup on a compose
+file from an untrusted source. (`include` still rejects absolute paths as
+non-portable, but this is hardening, not a security guarantee.)
+
+## Secret and config handling
+
+- `secrets:`/`configs:` sourced from files or inline content are staged into a
+  per-user directory created `0700`, owned by and accessible only to the
+  invoking user; the staging directory is verified (ownership + mode, symlinks
+  rejected) before use and cleaned up afterwards.
+- `external: true` secrets/configs are injected as Podman-native secrets
+  (pre-flighted for existence), not staged on disk.
+- Dangerous secret file modes (setuid/setgid/sticky/executable) are rejected.
+- The `config` subcommand redacts inline `content:` secrets before printing.
+
+## Logging and information disclosure
+
+- Default logging does not print secret values. Running with `RUST_LOG=debug`
+  can emit environment variable values and resolved secret/config file paths;
+  avoid debug logging where the terminal or log sink is not trusted.
+- podup writes no secret material to its own persistent state.
+
+## Supply chain
+
+- Dependencies are pinned in `Cargo.lock`; `cargo deny` enforces a license
+  allowlist and bans yanked crates, and `cargo audit` runs weekly in CI.
+- No third-party CI actions are used — only GitHub-owned (SHA-pinned) actions.
+- Releases are Ed25519-signed and carry GitHub build-provenance attestations; a
+  CycloneDX SBOM and third-party license attribution are published with each
+  release. See [self-update.md](self-update.md) for verification steps.
+- The Debian package can be built fully offline from a vendored crate tree, for
+  air-gapped/classified environments.
+
+## Memory safety
+
+The crate forbids `unsafe` by default (`#![deny(unsafe_code)]`). The few
+unavoidable FFI calls (rootless uid/gid lookups, `flock`, `stat`) are isolated,
+individually justified with safety comments, and unit-tested.
+
+## Reporting
+
+Report vulnerabilities privately via the repository's **Security tab → Report a
+vulnerability** (never a public issue). See the organization
+[security policy](https://github.com/Glyndor/.github/blob/main/SECURITY.md) for
+response targets.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -109,3 +109,50 @@ two-release procedure:
 During step 1 the leaked `old` key is still accepted for one release — an
 unavoidable cost of any rotation. The GitHub build-provenance attestation, which
 does not depend on the signing key, still proves origin during the window.
+
+## Verifying a release independently
+
+Operators who want to verify a release without trusting the installer can do so
+with standard tooling. The GitHub build-provenance attestation proves the binary
+came from this repository's release workflow:
+
+```bash
+gh attestation verify podup-linux-x86_64 --repo Glyndor/podup
+```
+
+To verify the Ed25519 signature over `SHA256SUMS` offline (no GitHub CLI), use
+the embedded public key:
+
+```bash
+python3 - <<'PY'
+import base64
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+key = Ed25519PublicKey.from_public_bytes(
+    base64.b64decode("APh+kh61dJeT0HzG+KQXELzDjK4ccvqY9K+FptOZ3+Y" + "=="))
+key.verify(open("SHA256SUMS.sig", "rb").read(), open("SHA256SUMS", "rb").read())
+print("SHA256SUMS signature OK")
+PY
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+The release also ships a CycloneDX SBOM (`podup.cdx.json`) and a third-party
+license attribution (`NOTICES.html`), each with a detached `.sig` that verifies
+against the same key.
+
+## Air-gapped installation
+
+Networks that block outbound GitHub have no opt-out from verification — they
+carry the artifacts across the boundary instead:
+
+1. On a connected host, download the platform binary, `SHA256SUMS`,
+   `SHA256SUMS.sig` (and optionally the SBOM/NOTICES and their `.sig` files).
+2. Transfer them to the isolated host on approved media.
+3. Verify the Ed25519 signature and checksum there with the offline snippet
+   above — the embedded key is the trust anchor, so no network is needed.
+4. Install the verified binary manually (`install -m 0755 podup-linux-x86_64
+   /usr/local/bin/podup`).
+
+For building from source in an air-gapped environment, vendor the crates on a
+connected host (`cargo vendor vendor`), include the `vendor/` tree in the source
+tarball, and build the Debian package offline — `debian/rules` automatically
+switches Cargo to `--frozen --offline` when `vendor/` is present.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -44,8 +44,10 @@ The one-line installer applies the same fail-closed policy. It requires **at
 least one** strong proof to succeed — the Ed25519 signature (when `python3` +
 `cryptography` and a configured public key are present) **or** the GitHub
 build-provenance attestation (`gh attestation verify`). If neither verifier is
-available it refuses to install. `PODUP_INSECURE_SKIP_VERIFY=1` is the explicit,
-documented opt-out (checksum only) for constrained environments.
+available it refuses to install. There is **no opt-out**: a checksum alone is not
+a trust anchor, so a verifier (`gh` or `python3` + `cryptography`) must be present
+at install time. The `--apt` path likewise verifies the keyring package's Ed25519
+signature before installing it as root.
 
 ## The embedded public keys
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,6 @@
 #   PODUP_VERSION              Release tag to install (e.g. v0.3.0). Default: latest.
 #   PODUP_INSTALL_DIR          Installation directory. Default: %LOCALAPPDATA%\Programs\podup.
 #   PODUP_RELEASE_PUBKEY_B64   Override the baked-in Ed25519 release public key (for forks).
-#   PODUP_INSECURE_SKIP_VERIFY Set to 1 to accept checksum-only verification.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -81,8 +80,7 @@ try {
 	# SHA256SUMS. The binary is trusted only after at least one cryptographic proof
 	# tied to the release key or the repository's build identity succeeds — the
 	# Ed25519 signature over SHA256SUMS, or the GitHub build-provenance attestation.
-	# If neither verifier can run, the install fails closed. Set
-	# PODUP_INSECURE_SKIP_VERIFY=1 to explicitly opt out (checksum only).
+	# If neither verifier can run, the install fails closed.
 
 	# Baked-in base64 (unpadded) raw Ed25519 public keys (32 bytes each) matching
 	# the release signing key (RELEASE_SIGN_KEY). Up to two are accepted: the
@@ -166,13 +164,11 @@ sys.exit(1)
 		Write-LogInfo 'GitHub CLI with attestation support not found — cannot check attestation'
 	}
 
-	# Fail closed unless a strong proof succeeded or the user explicitly opts out.
+	# Fail closed: a strong cryptographic proof is mandatory. A checksum alone is not
+	# a trust anchor, and there is no opt-out — hardened environments require
+	# verifiable supply-chain integrity at install time.
 	if (-not $verified) {
-		if ($env:PODUP_INSECURE_SKIP_VERIFY -eq '1') {
-			Write-LogInfo 'PODUP_INSECURE_SKIP_VERIFY=1 — proceeding with checksum verification only'
-		} else {
-			Fail "No signature or attestation verifier available. Install 'gh' (>= 2.49) or python3 with the 'cryptography' package, set PODUP_RELEASE_PUBKEY_B64, or re-run with PODUP_INSECURE_SKIP_VERIFY=1 to accept checksum-only verification."
-		}
+		Fail "No signature or attestation verifier available. Install 'gh' (>= 2.49) or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, then re-run."
 	}
 
 	Write-LogInfo 'Verifying SHA-256 checksum ...'

--- a/install.sh
+++ b/install.sh
@@ -159,13 +159,27 @@ install_apt() {
 	command -v dpkg >/dev/null 2>&1 || fail "--apt requires dpkg"
 
 	# Bootstrap the repository over HTTPS by installing the glyndor-archive-keyring
-	# package, which registers the signing key and source list. This curl step has
-	# the same trust as running this installer; from then on apt verifies every
-	# package against the repository's GPG signature, and key renewals arrive
+	# package, which registers the signing key and source list. The package is
+	# verified against the embedded Ed25519 release key before it is installed, so
+	# a tampered CDN or MITM cannot inject a rogue keyring. From then on apt verifies
+	# every package against the repository's GPG signature, and key renewals arrive
 	# automatically through apt upgrade.
 	local kr="glyndor-archive-keyring.deb"
 	log_info "Setting up the Glyndor apt repository ..."
 	download "https://apt.glyndor.net/${kr}" "${TMP_DIR}/${kr}"
+	download "https://apt.glyndor.net/${kr}.sig" "${TMP_DIR}/${kr}.sig"
+
+	# Fail closed: the keyring package is installed as root, so it must carry a
+	# valid Ed25519 signature from the release key. No checksum-only fallback.
+	log_info "Verifying keyring package signature ..."
+	local kr_rc=0
+	ed25519_verify "${TMP_DIR}/${kr}.sig" "${TMP_DIR}/${kr}" || kr_rc=$?
+	case "$kr_rc" in
+		0) log_ok "Keyring signature verified" ;;
+		1) fail "Keyring signature verification failed — aborting (package may be tampered)" ;;
+		2) fail "Cannot verify keyring signature: install python3 with the 'cryptography' package (and a configured release key) — aborting" ;;
+	esac
+
 	run_root dpkg -i "${TMP_DIR}/${kr}"
 	run_root apt-get update
 	log_info "Installing podup ..."
@@ -187,8 +201,7 @@ install_binary() {
 	# SHA256SUMS. The binary is trusted only after at least one cryptographic proof
 	# tied to the release key or the repository's build identity succeeds — the
 	# Ed25519 signature over SHA256SUMS, or the GitHub build-provenance attestation.
-	# If neither verifier can run, the install fails closed. Set
-	# PODUP_INSECURE_SKIP_VERIFY=1 to explicitly opt out (checksum only).
+	# If neither verifier can run, the install fails closed.
 	local verified=0 rc=0
 
 	log_info "Verifying SHA256SUMS signature ..."
@@ -217,15 +230,12 @@ install_binary() {
 		log_info "GitHub CLI with attestation support not found — cannot check attestation"
 	fi
 
-	# Fail closed unless a strong proof succeeded or the user explicitly opts out.
+	# Fail closed: a strong cryptographic proof is mandatory. A checksum alone is
+	# not a trust anchor, and there is no opt-out — government and hardened
+	# environments require verifiable supply-chain integrity at install time.
 	if [[ "$verified" -ne 1 ]]; then
-		if [[ "${PODUP_INSECURE_SKIP_VERIFY:-0}" == "1" ]]; then
-			log_info "PODUP_INSECURE_SKIP_VERIFY=1 — proceeding with checksum verification only"
-		else
-			fail "No signature or attestation verifier available. Install 'gh' (>= 2.49) \
-or python3 with the 'cryptography' package, set PODUP_RELEASE_PUBKEY_B64, or re-run \
-with PODUP_INSECURE_SKIP_VERIFY=1 to accept checksum-only verification."
-		fi
+		fail "No signature or attestation verifier available. Install 'gh' (>= 2.49) \
+or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, then re-run."
 	fi
 
 	verify_checksum "$ARTIFACT"

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -32,7 +32,7 @@ pub(crate) struct Cli {
 	pub(crate) socket: Option<String>,
 
 	/// Active profiles (comma-separated).  May also be set via `COMPOSE_PROFILES`.
-	#[arg(long, value_delimiter = ',', global = true)]
+	#[arg(long, value_delimiter = ',', env = "COMPOSE_PROFILES", global = true)]
 	pub(crate) profile: Vec<String>,
 
 	/// Base directory for resolving relative paths (env_file, build context,

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -7,11 +7,7 @@ use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
 #[derive(Parser)]
-#[command(
-	name = "podup",
-	version,
-	about = "docker-compose translator for Podman"
-)]
+#[command(name = "podup", version)]
 pub(crate) struct Cli {
 	/// Path to the compose file. May also be set via `COMPOSE_FILE`. When
 	/// unset, the compose-spec precedence list is probed in the current
@@ -106,6 +102,7 @@ pub(crate) enum Commands {
 		services: Vec<String>,
 	},
 	/// Remove stopped service containers.
+	#[command(alias = "remove")]
 	Rm {
 		/// Remove even running containers (stop first).
 		#[arg(short, long)]
@@ -130,6 +127,7 @@ pub(crate) enum Commands {
 		services: Vec<String>,
 	},
 	/// Resume paused service containers.
+	#[command(alias = "resume")]
 	Unpause {
 		/// Unpause only these services.
 		#[arg(trailing_var_arg = true)]
@@ -186,8 +184,10 @@ pub(crate) enum Commands {
 		proto: String,
 	},
 	/// List images used by services.
+	#[command(alias = "image")]
 	Images,
 	/// View output from containers.
+	#[command(alias = "log")]
 	Logs {
 		/// Only show logs for this service.
 		service: Option<String>,
@@ -211,8 +211,10 @@ pub(crate) enum Commands {
 		service: Option<String>,
 	},
 	/// Print the resolved compose file (after substitution / extends / include).
+	#[command(alias = "convert")]
 	Config,
 	/// Generate declarative artifacts from the compose file.
+	#[command(alias = "gen")]
 	Generate {
 		#[command(subcommand)]
 		kind: GenerateCommands,

--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -131,12 +131,6 @@ pub(super) fn ignored_service_network_fields(file: &ComposeFile, out: &mut Vec<S
 						 by Podman and is ignored"
 					));
 				}
-				if c.interface_name.is_some() {
-					out.push(format!(
-						"service '{service}' network '{name}': interface_name is not \
-						 forwarded to Podman and is ignored"
-					));
-				}
 			}
 		}
 	}

--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -271,13 +271,15 @@ mod tests {
 	}
 
 	#[test]
-	fn warns_on_interface_name() {
+	fn does_not_warn_on_interface_name() {
+		// interface_name IS forwarded to Podman (PerNetworkOptions.interface_name),
+		// so it must not produce a "not forwarded / ignored" warning.
 		let msgs = diagnostics_for(
 			"services:\n  web:\n    image: nginx\n    networks:\n      net:\n        interface_name: eth9\nnetworks:\n  net:\n",
 		);
 		assert!(
-			msgs.iter().any(|m| m.contains("interface_name")),
-			"got: {msgs:?}"
+			!msgs.iter().any(|m| m.contains("interface_name")),
+			"interface_name should not be reported as ignored; got: {msgs:?}"
 		);
 	}
 

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -2,8 +2,9 @@
 //!
 //! Scalar fields take the override when present, else the base. Collection
 //! fields (env vars, labels, maps) are merged with the override winning on
-//! overlapping keys; list-shaped fields take the override wholesale when
-//! non-empty, otherwise fall back to the base.
+//! overlapping keys. Sequence fields are combined per the Compose
+//! Specification's `extends` rules: referenced (base) items first, then the
+//! extending service's items, with duplicates removed — not replaced wholesale.
 
 use super::super::types::{
 	DependsOn, EnvFile, EnvVars, Labels, Service, ServiceNetworks, StringOrList, Sysctls,
@@ -46,12 +47,24 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		Labels::Map(map)
 	}
 
-	fn merge_vec<T: Clone>(base: Vec<T>, over: Vec<T>) -> Vec<T> {
-		if over.is_empty() {
-			base
-		} else {
-			over
+	fn merge_vec<T: Clone + serde::Serialize>(base: Vec<T>, over: Vec<T>) -> Vec<T> {
+		// Compose `extends` combines sequences: base items first, then the
+		// extending service's items, dropping exact duplicates. Equality is by
+		// serialized form so the element types need not implement PartialEq.
+		let mut seen: Vec<String> = base
+			.iter()
+			.filter_map(|item| serde_yaml::to_string(item).ok())
+			.collect();
+		let mut out = base;
+		for item in over {
+			match serde_yaml::to_string(&item) {
+				Ok(key) if seen.contains(&key) => continue,
+				Ok(key) => seen.push(key),
+				Err(_) => {}
+			}
+			out.push(item);
 		}
+		out
 	}
 
 	fn merge_sol(base: StringOrList, over: StringOrList) -> StringOrList {
@@ -197,7 +210,7 @@ mod tests {
 	use crate::parse_str;
 
 	#[test]
-	fn override_list_field_replaces_base_wholesale() {
+	fn extends_unions_sequence_fields() {
 		let yaml = r#"
 services:
   base:
@@ -211,8 +224,28 @@ services:
       - "90:90"
 "#;
 		let file = parse_str(yaml).unwrap();
-		// A non-empty override list replaces the base list entirely, not appends.
-		assert_eq!(file.services["app"].ports.len(), 1);
+		// Compose `extends` combines sequences (base first, then the extending
+		// service's items) rather than replacing the base wholesale.
+		assert_eq!(file.services["app"].ports.len(), 3);
+	}
+
+	#[test]
+	fn extends_dedups_identical_sequence_entries() {
+		let yaml = r#"
+services:
+  base:
+    image: alpine
+    ports:
+      - "80:80"
+  app:
+    extends: base
+    ports:
+      - "80:80"
+      - "90:90"
+"#;
+		let file = parse_str(yaml).unwrap();
+		// An exact duplicate from the extending service is dropped.
+		assert_eq!(file.services["app"].ports.len(), 2);
 	}
 
 	#[test]

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -45,17 +45,16 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 		};
 		for rel in inc.paths() {
 			let rel_path = std::path::Path::new(&rel);
+			// The Compose Specification resolves `include` paths relative to the
+			// including file and treats `../` as canonical (monorepos routinely use
+			// `include: ../shared/compose.yaml`), so parent-directory traversal is
+			// permitted here — consistent with the trusted-input policy applied to
+			// `extends.file` and `env_file`. Absolute paths remain rejected as an
+			// intentional hardening choice: they are not portable across checkouts
+			// and the spec does not require them.
 			if rel_path.is_absolute() {
 				return Err(ComposeError::Include(format!(
 					"include path must be relative, got absolute path: {rel}"
-				)));
-			}
-			if rel_path
-				.components()
-				.any(|c| c == std::path::Component::ParentDir)
-			{
-				return Err(ComposeError::Include(format!(
-					"include path must not traverse parent directories: {rel}"
 				)));
 			}
 			let inc_path = dir.join(&rel);

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -185,6 +185,10 @@ impl Engine {
 			);
 		}
 
+		for warning in rootless_caveat_warnings(service_name, service) {
+			tracing::warn!("{warning}");
+		}
+
 		let spec = SpecGenerator {
 			name: container_name.to_string(),
 			image: image.to_string(),
@@ -278,5 +282,71 @@ impl Engine {
 	/// in the top-level `volumes:` map (anonymous/implicit) are left unchanged.
 	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> String {
 		resolve_volume_name(reference, &self.project, file)
+	}
+}
+
+/// Compose fields Podman accepts but cannot honor (or that fail) under rootless
+/// Podman on cgroups v2. Returns advisory messages; pure so it can be
+/// unit-tested. The wording mirrors podman-run(1) so operators are not misled
+/// into assuming a no-op limit took effect.
+fn rootless_caveat_warnings(name: &str, service: &Service) -> Vec<String> {
+	let mut out = Vec::new();
+	if service.privileged == Some(true) {
+		out.push(format!(
+			"service \"{name}\": privileged has reduced effect under rootless Podman — a \
+			container cannot gain more privileges than the user that launched it"
+		));
+	}
+	if service.oom_kill_disable.is_some() {
+		out.push(format!(
+			"service \"{name}\": oom_kill_disable is not supported on cgroups v2 systems and \
+			is ignored"
+		));
+	}
+	if service.mem_swappiness.is_some() {
+		out.push(format!(
+			"service \"{name}\": mem_swappiness is only supported on cgroups v1 rootful systems \
+			and is ignored otherwise"
+		));
+	}
+	if service.cpu_rt_runtime.is_some() || service.cpu_rt_period.is_some() {
+		out.push(format!(
+			"service \"{name}\": cpu_rt_runtime/cpu_rt_period are only supported on cgroups v1 \
+			rootful systems; the container may fail to start rootless"
+		));
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::rootless_caveat_warnings;
+	use crate::compose::types::Service;
+
+	#[test]
+	fn no_caveat_warnings_for_plain_service() {
+		assert!(rootless_caveat_warnings("web", &Service::default()).is_empty());
+	}
+
+	#[test]
+	fn warns_for_each_rootless_caveat_field() {
+		let service = Service {
+			privileged: Some(true),
+			oom_kill_disable: Some(true),
+			mem_swappiness: Some(10),
+			cpu_rt_runtime: Some(1000),
+			..Service::default()
+		};
+		let warnings = rootless_caveat_warnings("web", &service);
+		assert_eq!(warnings.len(), 4);
+		let joined = warnings.join("\n");
+		for needle in [
+			"privileged",
+			"oom_kill_disable",
+			"mem_swappiness",
+			"cpu_rt_runtime",
+		] {
+			assert!(joined.contains(needle), "missing warning for {needle}");
+		}
 	}
 }

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -81,31 +81,9 @@ impl Engine {
 			std::env::current_dir().map_err(ComposeError::Io)?
 		};
 
-		tokio::task::spawn_blocking(move || -> Result<()> {
-			let cursor = std::io::Cursor::new(tar_bytes);
-			let mut archive = tar::Archive::new(cursor);
-			// Extract entry-by-entry rather than `archive.unpack`: a malicious or
-			// compromised container can craft tar entries whose paths contain `..`
-			// or are absolute, escaping `dst_path` and overwriting host files
-			// (zip-slip). `unpack_in` refuses such entries, returning `Ok(false)`;
-			// we turn that into a hard error so the copy fails loudly instead of
-			// silently skipping data.
-			for entry in archive.entries().map_err(ComposeError::Io)? {
-				let mut entry = entry.map_err(ComposeError::Io)?;
-				if !entry.unpack_in(&dst_path).map_err(ComposeError::Io)? {
-					let p = entry
-						.path()
-						.map(|p| p.display().to_string())
-						.unwrap_or_else(|_| "<unprintable>".into());
-					return Err(ComposeError::Build(format!(
-						"cp: refusing archive entry that escapes destination: {p}"
-					)));
-				}
-			}
-			Ok(())
-		})
-		.await
-		.map_err(|e| ComposeError::Build(e.to_string()))??;
+		tokio::task::spawn_blocking(move || extract_tar_guarded(&tar_bytes, &dst_path))
+			.await
+			.map_err(|e| ComposeError::Build(e.to_string()))??;
 
 		Ok(())
 	}
@@ -181,6 +159,33 @@ fn pack_path(src: &Path) -> Result<Vec<u8>> {
 		.into_inner()
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 	gz.finish().map_err(|e| ComposeError::Build(e.to_string()))
+}
+
+/// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
+/// entry whose path would escape it (zip-slip).
+///
+/// Extract entry-by-entry rather than `archive.unpack`: a malicious or
+/// compromised container can craft tar entries whose paths contain `..` or are
+/// absolute, escaping `dst_dir` and overwriting host files. `unpack_in` refuses
+/// such entries, returning `Ok(false)`; we turn that into a hard error so the
+/// copy fails loudly instead of silently skipping data. Pure and synchronous so
+/// the guard can be unit-tested without a container.
+fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
+	let cursor = std::io::Cursor::new(tar_bytes);
+	let mut archive = tar::Archive::new(cursor);
+	for entry in archive.entries().map_err(ComposeError::Io)? {
+		let mut entry = entry.map_err(ComposeError::Io)?;
+		if !entry.unpack_in(dst_dir).map_err(ComposeError::Io)? {
+			let p = entry
+				.path()
+				.map(|p| p.display().to_string())
+				.unwrap_or_else(|_| "<unprintable>".into());
+			return Err(ComposeError::Build(format!(
+				"cp: refusing archive entry that escapes destination: {p}"
+			)));
+		}
+	}
+	Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -259,5 +264,51 @@ mod tests {
 		let result = super::pack_path(&subdir);
 		assert!(result.is_ok());
 		assert!(!result.unwrap().is_empty());
+	}
+
+	/// Build an uncompressed tar archive with a single entry at `path`. The name
+	/// is written straight into the GNU header so a hostile `..` path can be
+	/// forged (the safe `set_path`/`append_data` helpers reject `..`).
+	fn tar_bytes_with(path: &str, data: &[u8]) -> Vec<u8> {
+		let mut header = tar::Header::new_gnu();
+		header.set_size(data.len() as u64);
+		header.set_mode(0o644);
+		header.set_entry_type(tar::EntryType::Regular);
+		let name = path.as_bytes();
+		header.as_gnu_mut().expect("gnu header").name[..name.len()].copy_from_slice(name);
+		header.set_cksum();
+		let mut builder = tar::Builder::new(Vec::new());
+		builder.append(&header, data).expect("append");
+		builder.into_inner().expect("finish")
+	}
+
+	#[test]
+	fn extract_tar_guarded_writes_benign_entry() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let bytes = tar_bytes_with("hello.txt", b"hi");
+		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
+		assert_eq!(
+			std::fs::read(dir.path().join("hello.txt")).expect("read"),
+			b"hi"
+		);
+	}
+
+	#[test]
+	fn extract_tar_guarded_rejects_parent_traversal() {
+		// A compromised container can return a tar whose entry escapes the
+		// destination via `..`; the guard must refuse it and write nothing.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("dest");
+		std::fs::create_dir(&dst).expect("mkdir");
+		let bytes = tar_bytes_with("../evil.txt", b"pwned");
+		let err = super::extract_tar_guarded(&bytes, &dst).unwrap_err();
+		assert!(
+			format!("{err}").contains("escapes destination"),
+			"expected a zip-slip refusal, got: {err}"
+		);
+		assert!(
+			!dir.path().join("evil.txt").exists(),
+			"traversal entry must not be written outside the destination"
+		);
 	}
 }

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -126,9 +126,8 @@ mod tests {
 	#[test]
 	fn second_holder_blocks_until_first_releases() {
 		use std::sync::atomic::{AtomicBool, Ordering};
-		use std::sync::Arc;
+		use std::sync::{Arc, Barrier};
 		use std::thread;
-		use std::time::Duration;
 
 		// Two engines contend for the same project lock. The first holds it; the
 		// second must take the blocking `LOCK_EX` path in `acquire` and only
@@ -138,7 +137,12 @@ mod tests {
 
 		let released = Arc::new(AtomicBool::new(false));
 		let flag = Arc::clone(&released);
+		// A rendezvous removes the need for a timing sleep: both threads clear the
+		// barrier, then the waiter immediately enters the blocking acquire path.
+		let barrier = Arc::new(Barrier::new(2));
+		let waiter_barrier = Arc::clone(&barrier);
 		let waiter = thread::spawn(move || {
+			waiter_barrier.wait();
 			let _guard = engine(project).lock_project().expect("second acquire");
 			assert!(
 				flag.load(Ordering::SeqCst),
@@ -146,8 +150,11 @@ mod tests {
 			);
 		});
 
-		// Give the waiter time to reach the blocking flock call, then release.
-		thread::sleep(Duration::from_millis(100));
+		// The lock is exclusive, so the waiter cannot acquire until `held` is
+		// dropped; the store is sequenced before the drop, so the waiter is
+		// guaranteed to observe `released == true`. This is deterministic — it
+		// never depends on how long the waiter takes to reach `flock`.
+		barrier.wait();
 		released.store(true, Ordering::SeqCst);
 		drop(held);
 

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -107,9 +107,14 @@ pub(super) fn build_per_network_options(
 		if let Some(m) = mac {
 			opts.static_mac = Some(m.to_string());
 		}
+		// Forward per-attachment driver options. `priority` is surfaced by Compose
+		// as a dedicated field but Podman consumes it as a driver option, so fold
+		// it in alongside any explicit `driver_opts`.
+		let mut driver_opts = c.driver_opts.clone();
 		if let Some(prio) = c.priority {
-			let mut driver_opts = HashMap::new();
 			driver_opts.insert("priority".to_string(), prio.to_string());
+		}
+		if !driver_opts.is_empty() {
 			opts.driver_opts = Some(driver_opts);
 		}
 		if let Some(iface) = &c.interface_name {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -183,7 +183,20 @@ async fn run() -> podup::Result<()> {
 		.event_format(PodupFormat)
 		.init();
 
-	let cli = Cli::parse();
+	// Frame `--help`/`--version` output with a blank line top and bottom. clap
+	// trims template/before/after-help edges, so wrap the rendered text here.
+	let cli = match Cli::try_parse() {
+		Ok(cli) => cli,
+		Err(e) => match e.kind() {
+			clap::error::ErrorKind::DisplayHelp
+			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+			| clap::error::ErrorKind::DisplayVersion => {
+				print!("\n{e}\n");
+				process::exit(0);
+			}
+			_ => e.exit(),
+		},
+	};
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -46,19 +46,40 @@ pub struct QuadletOutput {
 pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 	let mut out = QuadletOutput::default();
 
+	// External networks/volumes are assumed to pre-exist. Emitting a unit would
+	// make systemd try to (re-)create them, so skip them here; the container unit
+	// references such resources by their existing name instead.
 	for (name, cfg) in &file.networks {
-		out.units.push(network_unit(name, project, cfg.is_some()));
+		if cfg.as_ref().is_some_and(|c| c.external == Some(true)) {
+			continue;
+		}
+		out.units.push(network_unit(name, project, cfg.as_ref()));
 	}
 	for (name, cfg) in &file.volumes {
-		out.units.push(volume_unit(name, project, cfg.is_some()));
+		if cfg.as_ref().is_some_and(|c| c.external == Some(true)) {
+			continue;
+		}
+		out.units.push(volume_unit(name, project, cfg.as_ref()));
 	}
 
-	let declared_volumes: Vec<&str> = file.volumes.keys().map(String::as_str).collect();
+	let declared_volumes: Vec<&str> = file
+		.volumes
+		.iter()
+		.filter(|(_, cfg)| cfg.as_ref().is_none_or(|c| c.external != Some(true)))
+		.map(|(name, _)| name.as_str())
+		.collect();
+	let declared_networks: Vec<&str> = file
+		.networks
+		.iter()
+		.filter(|(_, cfg)| cfg.as_ref().is_none_or(|c| c.external != Some(true)))
+		.map(|(name, _)| name.as_str())
+		.collect();
 	for (name, service) in &file.services {
 		out.units.push(container_unit(
 			name,
 			service,
 			&declared_volumes,
+			&declared_networks,
 			&mut out.warnings,
 		));
 	}
@@ -194,7 +215,10 @@ services:
 		let out = generate(&file, "proj");
 		let c = &unit_named(&out, "app.container").contents;
 		assert!(c.contains("HostName=app-host"));
-		assert!(c.contains("User=1000:1000"));
+		// `user: "1000:1000"` splits into separate User=/Group= keys.
+		assert!(c.contains("User=1000"));
+		assert!(c.contains("Group=1000"));
+		assert!(!c.contains("User=1000:1000"));
 		assert!(c.contains("WorkingDir=/srv"));
 		assert!(c.contains("ReadOnly=true"));
 		assert!(c.contains("RunInit=true"));
@@ -409,5 +433,174 @@ services:
 		let c = &unit_named(&out, "s.container").contents;
 		assert!(c.contains("PublishPort=80"));
 		assert!(!c.contains("PublishPort=:80"));
+	}
+
+	#[test]
+	fn external_network_and_volume_emit_no_unit_and_use_bare_name() {
+		let yaml = r#"
+services:
+  web:
+    image: nginx
+    networks:
+      - extnet
+    volumes:
+      - extvol:/data
+networks:
+  extnet:
+    external: true
+volumes:
+  extvol:
+    external: true
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "proj");
+		// No unit is generated for external resources.
+		assert!(!out.units.iter().any(|u| u.filename == "extnet.network"));
+		assert!(!out.units.iter().any(|u| u.filename == "extvol.volume"));
+		// The container references them by their existing name, not `.network`/`.volume`.
+		let c = &unit_named(&out, "web.container").contents;
+		assert!(c.contains("Network=extnet"));
+		assert!(!c.contains("Network=extnet.network"));
+		assert!(c.contains("Volume=extvol:/data"));
+		assert!(!c.contains("extvol.volume"));
+	}
+
+	#[test]
+	fn user_with_gid_splits_into_user_and_group() {
+		let yaml = "services:\n  s:\n    image: x\n    user: \"1000:2000\"\n";
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(c.contains("User=1000"));
+		assert!(c.contains("Group=2000"));
+		assert!(!c.contains("User=1000:2000"));
+	}
+
+	#[test]
+	fn long_form_bind_selinux_and_propagation_preserved() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    volumes:
+      - type: bind
+        source: /host/data
+        target: /data
+        bind:
+          selinux: z
+          propagation: rshared
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(
+			c.contains("Volume=/host/data:/data:z,rshared"),
+			"selinux/propagation must be preserved; got:\n{c}"
+		);
+	}
+
+	#[test]
+	fn service_secret_maps_to_secret_key() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    secrets:
+      - tok
+      - source: cred
+        target: /run/cred
+        uid: "100"
+secrets:
+  tok:
+    file: ./tok
+  cred:
+    file: ./cred
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(c.contains("Secret=tok"));
+		assert!(c.contains("Secret=cred,target=/run/cred,uid=100"));
+		assert!(!out.warnings.iter().any(|w| w.contains("secrets")));
+	}
+
+	#[test]
+	fn maps_previously_dropped_container_fields() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    group_add:
+      - audio
+    expose:
+      - "8080"
+    security_opt:
+      - "no-new-privileges:true"
+      - "seccomp=/etc/seccomp.json"
+      - "label=type:container_t"
+    pull_policy: always
+    logging:
+      driver: journald
+      options:
+        tag: mytag
+    networks:
+      net:
+        aliases:
+          - web-alias
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+networks:
+  net:
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		for needle in [
+			"GroupAdd=audio",
+			"ExposeHostPort=8080",
+			"NoNewPrivileges=true",
+			"SeccompProfile=/etc/seccomp.json",
+			"SecurityLabelType=container_t",
+			"Pull=always",
+			"LogDriver=journald",
+			"LogOpt=tag=mytag",
+			"NetworkAlias=web-alias",
+			"Memory=256m",
+		] {
+			assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
+		}
+	}
+
+	#[test]
+	fn network_and_volume_units_carry_config_keys() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+networks:
+  net:
+    driver: bridge
+    internal: true
+    enable_ipv6: true
+    labels:
+      tier: net
+volumes:
+  vol:
+    driver: local
+    labels:
+      tier: vol
+"#;
+		let file = parse_str(yaml).unwrap();
+		let out = generate(&file, "p");
+		let net = &unit_named(&out, "net.network").contents;
+		assert!(net.contains("Driver=bridge"));
+		assert!(net.contains("Internal=true"));
+		assert!(net.contains("IPv6=true"));
+		assert!(net.contains("Label=tier=net"));
+		let vol = &unit_named(&out, "vol.volume").contents;
+		assert!(vol.contains("Driver=local"));
+		assert!(vol.contains("Label=tier=vol"));
 	}
 }

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -45,6 +45,8 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 			source,
 			target,
 			read_only,
+			bind,
+			volume,
 			..
 		} => {
 			let src = source.clone().unwrap_or_default();
@@ -53,13 +55,34 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 			} else {
 				src
 			};
+			// Collect mount options into the trailing `:opt,opt` field so nothing
+			// is dropped: SELinux relabel (`z`/`Z`) and bind propagation are
+			// security- and correctness-relevant on hardened hosts.
+			let mut opts: Vec<String> = Vec::new();
+			if *read_only == Some(true) {
+				opts.push("ro".to_string());
+			}
+			if let Some(b) = bind {
+				if let Some(selinux) = &b.selinux {
+					opts.push(selinux.clone());
+				}
+				if let Some(propagation) = &b.propagation {
+					opts.push(propagation.clone());
+				}
+			}
+			if let Some(v) = volume {
+				if v.nocopy == Some(true) {
+					opts.push("nocopy".to_string());
+				}
+			}
 			let mut out = if src.is_empty() {
 				target.clone()
 			} else {
 				format!("{src}:{target}")
 			};
-			if *read_only == Some(true) {
-				out.push_str(":ro");
+			if !opts.is_empty() {
+				out.push(':');
+				out.push_str(&opts.join(","));
 			}
 			out
 		}

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -1,12 +1,12 @@
 //! Build the individual `.network`, `.volume` and `.container` units.
 
-use crate::compose::types::{Command, PortMapping, RestartPolicy, Service};
+use crate::compose::types::{Command, PortMapping, RestartPolicy, Service, ServiceSecretRef};
 use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
 use super::render::{
 	render_command, render_publish_port, render_restart, render_volume, safe_unit_stem,
-	sanitize_value, sorted_label_pairs, sorted_pairs, Section,
+	sorted_label_pairs, sorted_pairs, Section,
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;
@@ -55,19 +55,120 @@ fn render_healthcheck(service: &Service, container: &mut Section) {
 	}
 }
 
-pub(super) fn network_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
-	let value = sanitize_value(&format!("{project}_{name}"));
-	let contents =
-		format!("[Network]\nNetworkName={value}\n\n[Install]\nWantedBy=default.target\n");
+/// Render a service `secrets:` entry into a Quadlet `Secret=` value
+/// (`name[,target=,uid=,gid=,mode=]`).
+fn render_secret(secret: &ServiceSecretRef) -> String {
+	match secret {
+		ServiceSecretRef::Short(name) => name.clone(),
+		ServiceSecretRef::Long {
+			source,
+			target,
+			uid,
+			gid,
+			mode,
+		} => {
+			let mut s = source.clone();
+			if let Some(t) = target {
+				s.push_str(&format!(",target={t}"));
+			}
+			if let Some(u) = uid {
+				s.push_str(&format!(",uid={u}"));
+			}
+			if let Some(g) = gid {
+				s.push_str(&format!(",gid={g}"));
+			}
+			if let Some(m) = mode {
+				s.push_str(&format!(",mode={m:o}"));
+			}
+			s
+		}
+	}
+}
+
+/// Map a single compose `security_opt` entry onto the dedicated Quadlet key
+/// where one exists; unrecognized entries are reported rather than dropped.
+fn map_security_opt(opt: &str, container: &mut Section, name: &str, warnings: &mut Vec<String>) {
+	if let Some(rest) = opt.strip_prefix("no-new-privileges") {
+		let val = rest.trim_start_matches([':', '=']);
+		let enabled = val.is_empty() || val == "true";
+		container.add("NoNewPrivileges", enabled.to_string());
+	} else if let Some(profile) = opt.strip_prefix("seccomp=") {
+		container.add("SeccompProfile", profile.to_string());
+	} else if let Some(profile) = opt
+		.strip_prefix("apparmor=")
+		.or_else(|| opt.strip_prefix("apparmor:"))
+	{
+		container.add("AppArmor", profile.to_string());
+	} else if let Some(label) = opt.strip_prefix("label=") {
+		if label == "disable" {
+			container.add("SecurityLabelDisable", "true".to_string());
+		} else if let Some(t) = label.strip_prefix("type:") {
+			container.add("SecurityLabelType", t.to_string());
+		} else if let Some(l) = label.strip_prefix("level:") {
+			container.add("SecurityLabelLevel", l.to_string());
+		} else {
+			warnings.push(format!(
+				"{name}: security_opt 'label={label}' has no Quadlet key and is skipped"
+			));
+		}
+	} else {
+		warnings.push(format!(
+			"{name}: security_opt '{opt}' has no Quadlet mapping and is skipped"
+		));
+	}
+}
+
+pub(super) fn network_unit(
+	name: &str,
+	project: &str,
+	config: Option<&crate::compose::types::NetworkConfig>,
+) -> QuadletUnit {
+	let mut net = Section::new("Network");
+	net.add("NetworkName", format!("{project}_{name}"));
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			net.add("Driver", driver.clone());
+		}
+		if cfg.internal == Some(true) {
+			net.add("Internal", "true".to_string());
+		}
+		if cfg.enable_ipv6 == Some(true) {
+			net.add("IPv6", "true".to_string());
+		}
+		if let Some(ipam) = &cfg.ipam {
+			if let Some(ipam_driver) = &ipam.driver {
+				net.add("IPAMDriver", ipam_driver.clone());
+			}
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			net.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = net.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
 	QuadletUnit {
 		filename: format!("{}.network", safe_unit_stem(name)),
 		contents,
 	}
 }
 
-pub(super) fn volume_unit(name: &str, project: &str, _has_config: bool) -> QuadletUnit {
-	let value = sanitize_value(&format!("{project}_{name}"));
-	let contents = format!("[Volume]\nVolumeName={value}\n\n[Install]\nWantedBy=default.target\n");
+pub(super) fn volume_unit(
+	name: &str,
+	project: &str,
+	config: Option<&crate::compose::types::VolumeConfig>,
+) -> QuadletUnit {
+	let mut vol = Section::new("Volume");
+	vol.add("VolumeName", format!("{project}_{name}"));
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			vol.add("Driver", driver.clone());
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			vol.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = vol.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
 	QuadletUnit {
 		filename: format!("{}.volume", safe_unit_stem(name)),
 		contents,
@@ -78,6 +179,7 @@ pub(super) fn container_unit(
 	name: &str,
 	service: &Service,
 	declared_volumes: &[&str],
+	declared_networks: &[&str],
 	warnings: &mut Vec<String>,
 ) -> QuadletUnit {
 	let mut unit = Section::new("Unit");
@@ -106,7 +208,16 @@ pub(super) fn container_unit(
 		container.add("HostName", hostname.clone());
 	}
 	if let Some(user) = &service.user {
-		container.add("User", user.clone());
+		// Quadlet `User=` takes a UID/username only; a `uid:gid` compose value
+		// must be split so the GID lands in the dedicated `Group=` key (Quadlet
+		// recombines them into `--user uid:gid`).
+		match user.split_once(':') {
+			Some((uid, gid)) => {
+				container.add("User", uid.to_string());
+				container.add("Group", gid.to_string());
+			}
+			None => container.add("User", user.clone()),
+		}
 	}
 	if let Some(wd) = &service.working_dir {
 		container.add("WorkingDir", wd.clone());
@@ -145,7 +256,14 @@ pub(super) fn container_unit(
 		container.add("Volume", render_volume(vol, declared_volumes));
 	}
 	for net in service.networks.names() {
-		container.add("Network", format!("{net}.network"));
+		// A declared (non-external) network is backed by a generated `.network`
+		// unit; an external network is referenced by its existing name directly,
+		// since no unit is emitted for it.
+		if declared_networks.contains(&net.as_str()) {
+			container.add("Network", format!("{net}.network"));
+		} else {
+			container.add("Network", net.clone());
+		}
 	}
 	for (key, val) in sorted_label_pairs(service.labels.to_map()) {
 		container.add("Label", format!("{key}={val}"));
@@ -224,6 +342,50 @@ pub(super) fn container_unit(
 	// container:) have no Quadlet key and are reported by collect_warnings.
 	if service.network_mode.as_deref() == Some("host") {
 		container.add("Network", "host".to_string());
+	}
+	for group in &service.group_add {
+		container.add("GroupAdd", group.clone());
+	}
+	for port in &service.expose {
+		container.add("ExposeHostPort", port.clone());
+	}
+	for net in service.networks.names() {
+		if let Some(cfg) = service.networks.config_for(&net) {
+			if let Some(aliases) = &cfg.aliases {
+				for alias in aliases {
+					container.add("NetworkAlias", alias.clone());
+				}
+			}
+		}
+	}
+	for opt in &service.security_opt {
+		map_security_opt(opt, &mut container, name, warnings);
+	}
+	if let Some(logging) = &service.logging {
+		if let Some(driver) = &logging.driver {
+			container.add("LogDriver", driver.clone());
+		}
+		for (key, val) in sorted_label_pairs(logging.options.clone()) {
+			container.add("LogOpt", format!("{key}={val}"));
+		}
+	}
+	if let Some(pull) = &service.pull_policy {
+		container.add("Pull", pull.clone());
+	}
+	// `deploy.resources.limits.memory` is the modern equivalent of `mem_limit`.
+	if service.mem_limit.is_none() {
+		if let Some(mem) = service
+			.deploy
+			.as_ref()
+			.and_then(|d| d.resources.as_ref())
+			.and_then(|r| r.limits.as_ref())
+			.and_then(|l| l.memory.as_ref())
+		{
+			container.add("Memory", mem.clone());
+		}
+	}
+	for secret in &service.secrets {
+		container.add("Secret", render_secret(secret));
 	}
 	render_healthcheck(service, &mut container);
 

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -24,12 +24,6 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"is ignored; Quadlet emits a single container per service",
 		);
 	}
-	if !service.secrets.is_empty() {
-		warn(
-			"secrets",
-			"are not yet mapped to Quadlet Secret= directives",
-		);
-	}
 	if !service.configs.is_empty() {
 		warn("configs", "have no Quadlet equivalent and are skipped");
 	}
@@ -93,7 +87,6 @@ configs:
 		for field in [
 			"build",
 			"scale/replicas",
-			"secrets",
 			"configs",
 			"volumes_from",
 			"network_mode",
@@ -105,6 +98,11 @@ configs:
 				"missing warning for {field}; got:\n{joined}"
 			);
 		}
+		// secrets are now mapped to Secret=, so they must NOT warn.
+		assert!(
+			!joined.contains("secrets"),
+			"secrets should be mapped, not warned; got:\n{joined}"
+		);
 	}
 
 	#[test]

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -1,0 +1,75 @@
+//! CLI surface checks for the convenience command aliases and the blank-line
+//! framing around `--help`/`--version` output. Aliases are hidden (they must
+//! resolve when typed but stay out of the top-level help listing), and the
+//! help/version text is wrapped with one blank line top and bottom.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Every hidden alias must resolve to its canonical command: invoking
+/// `<alias> --help` exits 0 and prints that command's help (clap rejects an
+/// unknown subcommand with a non-zero exit instead).
+#[test]
+fn aliases_resolve_to_their_command() {
+	let cases = [
+		("convert", "resolved compose file"),
+		("gen", "declarative artifacts"),
+		("resume", "Resume paused"),
+		("remove", "Remove stopped"),
+		("log", "output from containers"),
+		("image", "images used by services"),
+	];
+	for (alias, needle) in cases {
+		let output = Command::new(bin())
+			.args([alias, "--help"])
+			.output()
+			.expect("run alias --help");
+		assert!(
+			output.status.success(),
+			"alias `{alias}` did not resolve (exit {:?})",
+			output.status.code()
+		);
+		let stdout = String::from_utf8_lossy(&output.stdout);
+		assert!(
+			stdout.contains(needle),
+			"alias `{alias}` help missing {needle:?}; got:\n{stdout}"
+		);
+	}
+}
+
+/// Aliases are hidden: the top-level `--help` lists canonical commands only,
+/// never the alias spellings.
+#[test]
+fn aliases_stay_out_of_top_level_help() {
+	let output = Command::new(bin())
+		.arg("--help")
+		.output()
+		.expect("run --help");
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	for alias in ["convert", "resume", "remove"] {
+		assert!(
+			!stdout.lines().any(|l| l.trim_start().starts_with(alias)),
+			"alias `{alias}` leaked into top-level help"
+		);
+	}
+}
+
+/// `--help` and `--version` are framed with exactly one blank line at the top
+/// and bottom.
+#[test]
+fn help_and_version_are_blank_line_framed() {
+	for flag in ["--help", "--version"] {
+		let output = Command::new(bin()).arg(flag).output().expect("run flag");
+		assert!(output.status.success());
+		let stdout = String::from_utf8_lossy(&output.stdout);
+		assert!(stdout.starts_with('\n'), "{flag}: no leading blank line");
+		assert!(stdout.ends_with("\n\n"), "{flag}: no trailing blank line");
+		assert!(
+			!stdout.starts_with("\n\n"),
+			"{flag}: more than one leading blank line"
+		);
+	}
+}

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -36,6 +36,67 @@ services:
 }
 
 #[test]
+fn include_parent_relative_path_resolves() {
+	// The Compose Specification treats `../` as a canonical include path
+	// (monorepos reference shared compose files one level up). It must resolve,
+	// not be rejected as path traversal.
+	let dir = tempfile::tempdir().unwrap();
+
+	let shared = dir.path().join("shared.yml");
+	writeln!(
+		std::fs::File::create(&shared).unwrap(),
+		r#"
+services:
+  shared_svc:
+    image: alpine
+"#
+	)
+	.unwrap();
+
+	let sub = dir.path().join("project");
+	std::fs::create_dir(&sub).unwrap();
+	let main = sub.join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		r#"
+include:
+  - ../shared.yml
+
+services:
+  app:
+    image: nginx
+"#
+	)
+	.unwrap();
+
+	let file = parse_file(&main).unwrap();
+	assert!(file.services.contains_key("app"));
+	assert!(file.services.contains_key("shared_svc"));
+}
+
+#[test]
+fn include_absolute_path_is_rejected() {
+	// Absolute include paths remain rejected as intentional hardening: they are
+	// not portable across checkouts and the spec does not require them.
+	let dir = tempfile::tempdir().unwrap();
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		r#"
+include:
+  - /etc/shared.yml
+
+services:
+  app:
+    image: nginx
+"#
+	)
+	.unwrap();
+
+	assert!(parse_file(&main).is_err());
+}
+
+#[test]
 fn include_long_form_parses() {
 	let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
Promotes the government-enterprise readiness remediation to main. Eight squashed PRs (#323-#330) closing issues #314-#321.

## Security (P0)
- install.sh: verify keyring \`.deb\` Ed25519 signature before \`dpkg -i\`; removed \`PODUP_INSECURE_SKIP_VERIFY\` bypass (fail-closed). (#314)

## Drop-in parity (P1, verified vs compose-spec)
- include allows \`../\`; extends unions+dedups sequences; networks driver_opts forwarded; \`COMPOSE_PROFILES\` env wired; false interface_name warning removed. (#315)

## Quadlet (P1, verified vs podman-systemd.unit(5))
- User/Group split, external-resource unit skip, SELinux \`:z\`/\`:Z\`, \`Secret=\`, group_add/expose/security_opt/logging/pull_policy/aliases/deploy-memory mapping, network/volume unit keys. (#316)

## Engine / tests (P1)
- Rootless caveat warnings (privileged/oom_kill_disable/mem_swappiness/cpu_rt_*). (#317)
- zip-slip guard unit test + deterministic lock-contention test (Barrier). (#318)

## Supply chain / docs (P2)
- Air-gapped offline build job, CycloneDX SBOM, license attribution (NOTICES), DCO enforcement. (#319)
- security-model.md threat model, independent + air-gap verification, man SECURITY CONSIDERATIONS, changelog maintainer normalized. (#320)
- Hidden CLI aliases + blank-line-framed help. (#321)

## Deferred
- #322 (native libpod secret injection) — P3 architectural improvement; the staging path is already secure. Left open as tracked future work.

fmt + clippy clean; 557 lib tests pass on the integrated branch.