### PR TITLE
docs: switch install URLs to per-OS /<product>/install/{unix,windows,apt}

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ flowchart LR
 Linux and macOS:
 
 ```bash
-curl -fsSL https://glyndor.net/install/podup | bash
+curl -fsSL https://glyndor.net/podup/install/unix | bash
 ```
 
 Windows (PowerShell):
 
 ```powershell
-irm https://glyndor.net/install/podup.ps1 | iex
+irm https://glyndor.net/podup/install/windows | iex
 ```
 
 Binaries for Linux and macOS (x86_64 and arm64) plus Windows (x86_64 and
@@ -64,7 +64,7 @@ On Debian and Ubuntu (amd64 and arm64), install from the Glyndor apt repository
 so updates arrive through `apt upgrade`:
 
 ```bash
-curl -fsSL https://glyndor.net/install/podup | bash -s -- --apt
+curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
 ```
 
 This installs the `glyndor-archive-keyring` package (registering the signed

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -44,7 +44,7 @@ the `build-deb` matrix in `release.yml` already does.
 ### One-line setup
 
 ```bash
-curl -fsSL https://glyndor.net/install/podup | bash -s -- --apt
+curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
 ```
 
 This downloads `glyndor-archive-keyring.deb` over HTTPS, installs it (registering

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@
 # installs it.
 #
 # Usage:
-#   irm https://glyndor.net/install/podup.ps1 | iex
+#   irm https://glyndor.net/podup/install/windows | iex
 #
 # Environment:
 #   PODUP_VERSION              Release tag to install (e.g. v0.3.0). Default: latest.

--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,12 @@
 # Default: download a release binary, verify it and install it to a directory.
 # Updates come from `podup update`.
 #
-#   curl -fsSL https://glyndor.net/install/podup | bash
+#   curl -fsSL https://glyndor.net/podup/install/unix | bash
 #
 # --apt (Debian/Ubuntu, amd64): set up the Glyndor apt repository and install
 # with apt. Updates — including signing-key renewals — come from `apt upgrade`.
 #
-#   curl -fsSL https://glyndor.net/install/podup | bash -s -- --apt
+#   curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
 #
 # Environment:
 #   PODUP_VERSION      Release tag to install (e.g. v0.3.0). Default: latest.


### PR DESCRIPTION
## What

Update all in-repo install-URL references to the new explicit per-OS, product-scoped redirect scheme:

| Path | Target |
|---|---|
| `/<product>/install/unix` | `install.sh` (Linux + macOS) |
| `/<product>/install/windows` | `install.ps1` |
| `/<product>/install/apt` | `glyndor-archive-keyring.deb` |

## Why

The old single redirect `glyndor.net/install/*` → `Glyndor/${1}/.../install.sh` resolved `${1}=podup.ps1` for the Windows one-liner, hitting a non-existent repo → **404**. The suffix scheme also can't map an OS to a different asset filename. Explicit per-OS rules fix both; `unix` names the script honestly (serves macOS too) and dodges `*.sh` scanner noise.

## Changes

- `README.md` — install + apt one-liners
- `docs/debian-packaging.md` — apt one-liner
- `install.sh`, `install.ps1` — header usage comments

`debian/changelog` left untouched (historical record). Cloudflare redirect rules configured out-of-band and verified end-to-end (unix → bash shebang, windows → `#Requires -Version`, apt → `.deb` magic bytes).

Closes #333