### PR TITLE
release: v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.22.2"
+version = "0.23.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.22.2" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.23.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+podup (0.23.0) unstable; urgency=medium
+
+  * Inline `content:`/`environment:` secrets and configs are now injected as
+    Podman-native secrets (created over the libpod API under a project-scoped,
+    `podup.project`-labelled name) instead of being written to a per-user host
+    staging directory and bind-mounted. `file:` sources keep their read-only
+    bind-mount and `external:` sources are unchanged.
+  * Rotating an inline secret/config value now recreates the dependent
+    container on the next `up` (the resolved value folds into the config-hash),
+    preserving the previous live-bind-mount behaviour.
+  * `podup down` removes the internal native secrets it created (guarded by the
+    `podup.project` label so a same-named secret created by hand is left
+    untouched); `external:` secrets are never removed.
+  * Docs: install URLs switched to per-OS `/<product>/install/{unix,windows,apt}`
+    paths.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Mon, 15 Jun 2026 14:30:00 -0500
+
 podup (0.22.2) unstable; urgency=medium
 
   * Test-only: add deterministic offline coverage for the self-update failure

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.22.2" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.23.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Version bump to **0.23.0** ahead of promoting develop→main.

- Crate version, `debian/changelog`, `debian/podup.1` (.TH), README install tag → 0.23.0.
- Release covers: native libpod secret injection for inline secrets/configs (#332), per-OS install URL docs (#334).

Refs #322