### PR TITLE
ci(release): fix SBOM mv self-collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,11 @@ jobs:
           cargo install --locked cargo-cyclonedx
           cargo install --locked --features cli cargo-about
           cargo cyclonedx --format json --all-features
-          mv "$(ls ./*.cdx.json | head -n1)" podup.cdx.json
+          # cargo-cyclonedx names the file after the package (podup.cdx.json),
+          # so only rename when an older/different layout emitted another name —
+          # mv onto itself errors ("are the same file").
+          src="$(ls ./*.cdx.json | head -n1)"
+          [ "$src" = "./podup.cdx.json" ] || mv "$src" podup.cdx.json
           cargo about generate about.hbs > NOTICES.html
 
       - name: Generate checksums


### PR DESCRIPTION
v0.23.0 release publish failed at the SBOM step: `cargo-cyclonedx` 0.5.9 already emits `podup.cdx.json`, so `mv ./podup.cdx.json podup.cdx.json` errored ("are the same file"). Rename only when the name differs. Nothing was published (failure was before Create Release/crates.io/apt), so v0.23.0 will be re-tagged after this lands.