### PR TITLE
release: v0.23.0 (SBOM publish fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,11 @@ jobs:
           cargo install --locked cargo-cyclonedx
           cargo install --locked --features cli cargo-about
           cargo cyclonedx --format json --all-features
-          mv "$(ls ./*.cdx.json | head -n1)" podup.cdx.json
+          # cargo-cyclonedx names the file after the package (podup.cdx.json),
+          # so only rename when an older/different layout emitted another name —
+          # mv onto itself errors ("are the same file").
+          src="$(ls ./*.cdx.json | head -n1)"
+          [ "$src" = "./podup.cdx.json" ] || mv "$src" podup.cdx.json
           cargo about generate about.hbs > NOTICES.html
 
       - name: Generate checksums


### PR DESCRIPTION
Promote develop→main: includes the SBOM mv fix (#337) so the v0.23.0 release publish step succeeds. Version already at 0.23.0 (#335). v0.23.0 will be re-tagged on the new main tip after merge.