### PR TITLE
fix(engine): bound file-borne resource exhaustion (DoS caps)

### DIFF
--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -290,11 +290,80 @@ pub(crate) fn parse_file_inner_with_env(
 	deserialize_with_merge(&substituted)
 }
 
+/// Upper bound on YAML alias references in a document that uses anchors, and on
+/// the size of such a document. serde_yaml_ng already aborts deeply *nested*
+/// alias expansion (its repetition limit), but a flat document with many alias
+/// references to a non-trivial anchor expands *linearly* while the `Value` tree
+/// is built and can exhaust memory — a ~46 KB file can allocate gigabytes. Real
+/// compose files use a handful of anchors, so these caps never trigger in
+/// practice; the worst-case expansion they allow (refs × doc size) stays bounded.
+const MAX_ALIAS_REFS: usize = 100;
+const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
+
 fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
+	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
 	apply_merge_keys(&mut value);
 	let file: ComposeFile = serde_yaml::from_value(value)?;
 	Ok(file)
+}
+
+/// Reject YAML documents whose alias use could amplify into an out-of-memory
+/// expansion (a "billion-laughs" linear cousin) before they reach the parser.
+fn guard_alias_expansion(content: &str) -> Result<()> {
+	let refs = count_alias_refs(content);
+	if refs == 0 {
+		return Ok(());
+	}
+	if content.len() > MAX_ALIAS_DOC_BYTES {
+		return Err(ComposeError::Unsupported(format!(
+			"compose document uses YAML aliases and is {} bytes; documents using anchors/aliases \
+			 must be at most {MAX_ALIAS_DOC_BYTES} bytes — inline the repeated content instead",
+			content.len()
+		)));
+	}
+	if refs > MAX_ALIAS_REFS {
+		return Err(ComposeError::Unsupported(format!(
+			"compose document uses {refs} YAML alias references; at most {MAX_ALIAS_REFS} are \
+			 allowed — inline the repeated content instead"
+		)));
+	}
+	Ok(())
+}
+
+/// Count YAML alias references (`*anchor`) outside quoted scalars and comments.
+///
+/// A heuristic — it does not fully parse YAML — but it only needs to bound a
+/// DoS and it is conservative: `*` inside single/double quotes or after `#` is
+/// ignored, and an alias is counted only when `*` sits at a node position and is
+/// followed by an anchor-name character.
+fn count_alias_refs(content: &str) -> usize {
+	let mut count = 0;
+	for line in content.lines() {
+		let mut chars = line.chars().peekable();
+		let (mut in_single, mut in_double) = (false, false);
+		let mut prev: Option<char> = None;
+		while let Some(c) = chars.next() {
+			match c {
+				'\'' if !in_double => in_single = !in_single,
+				'"' if !in_single => in_double = !in_double,
+				'#' if !in_single && !in_double => break,
+				'*' if !in_single && !in_double => {
+					let at_node =
+						matches!(prev, None | Some(' ' | '\t' | '[' | '{' | ',' | ':'));
+					let next_ok = chars
+						.peek()
+						.is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_' || *n == '-');
+					if at_node && next_ok {
+						count += 1;
+					}
+				}
+				_ => {}
+			}
+			prev = Some(c);
+		}
+	}
+	count
 }
 
 /// Recursively resolve YAML merge keys (`<<: *anchor`) in a `Value` tree.
@@ -359,6 +428,42 @@ mod tests {
 	#[test]
 	fn parse_str_raw_invalid_yaml_is_error() {
 		assert!(parse_str_raw(": : :").is_err());
+	}
+
+	// alias-expansion guard
+
+	#[test]
+	fn count_alias_refs_ignores_quotes_comments_and_globs() {
+		assert_eq!(count_alias_refs("a: &x 1\nb: *x\n"), 1);
+		assert_eq!(count_alias_refs("c: [*x, *x, *x]\n"), 3);
+		// `*` in quoted strings, comments, and globs (`*.txt`, `**`) are not aliases.
+		assert_eq!(count_alias_refs("cmd: \"rm *x\"\nd: 1 # *x\ng: ['*.txt', '**']\n"), 0);
+	}
+
+	#[test]
+	fn guard_allows_normal_anchored_file() {
+		// A handful of merge-key aliases in a small file is fine.
+		let yaml = "x: &d {a: 1}\nweb: {<<: *d}\napi: {<<: *d}\n";
+		assert!(guard_alias_expansion(yaml).is_ok());
+	}
+
+	#[test]
+	fn guard_rejects_linear_alias_amplification() {
+		// Many references to one anchor — the OOM vector serde_yaml_ng does not bound.
+		let mut yaml = String::from("anchor: &a [x, y, z]\nlist:\n");
+		for _ in 0..(MAX_ALIAS_REFS + 50) {
+			yaml.push_str("  - *a\n");
+		}
+		let err = guard_alias_expansion(&yaml).unwrap_err();
+		assert!(format!("{err}").contains("alias references"));
+	}
+
+	#[test]
+	fn guard_rejects_large_aliased_document() {
+		let mut yaml = String::from("anchor: &a 1\nb: *a\n");
+		yaml.push_str(&format!("pad: \"{}\"\n", "p".repeat(MAX_ALIAS_DOC_BYTES)));
+		let err = guard_alias_expansion(&yaml).unwrap_err();
+		assert!(format!("{err}").contains("at most"));
 	}
 
 	// resolve_order

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -349,8 +349,7 @@ fn count_alias_refs(content: &str) -> usize {
 				'"' if !in_single => in_double = !in_double,
 				'#' if !in_single && !in_double => break,
 				'*' if !in_single && !in_double => {
-					let at_node =
-						matches!(prev, None | Some(' ' | '\t' | '[' | '{' | ',' | ':'));
+					let at_node = matches!(prev, None | Some(' ' | '\t' | '[' | '{' | ',' | ':'));
 					let next_ok = chars
 						.peek()
 						.is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_' || *n == '-');
@@ -437,7 +436,10 @@ mod tests {
 		assert_eq!(count_alias_refs("a: &x 1\nb: *x\n"), 1);
 		assert_eq!(count_alias_refs("c: [*x, *x, *x]\n"), 3);
 		// `*` in quoted strings, comments, and globs (`*.txt`, `**`) are not aliases.
-		assert_eq!(count_alias_refs("cmd: \"rm *x\"\nd: 1 # *x\ng: ['*.txt', '**']\n"), 0);
+		assert_eq!(
+			count_alias_refs("cmd: \"rm *x\"\nd: 1 # *x\ng: ['*.txt', '**']\n"),
+			0
+		);
 	}
 
 	#[test]

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -119,11 +119,33 @@ pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 		.iter()
 		.map(|(name, cfg)| Ulimit {
 			ulimit_type: name.clone(),
-			soft: cfg.soft() as u64,
-			hard: cfg.hard() as u64,
+			soft: ulimit_value(cfg.soft(), name, "soft"),
+			hard: ulimit_value(cfg.hard(), name, "hard"),
 		})
 		.collect()
 }
+
+/// Convert a compose ulimit value to the libpod `u64`. `-1` is the conventional
+/// "unlimited" sentinel (`u64::MAX`); any other negative value is invalid and
+/// would otherwise wrap to a huge number via `as u64`, so it is rejected to `0`
+/// with a warning instead of silently becoming an enormous limit.
+fn ulimit_value(value: i64, name: &str, which: &str) -> u64 {
+	match value {
+		-1 => u64::MAX,
+		v if v < 0 => {
+			tracing::warn!(
+				"ulimit {name} {which} value {v} is invalid (only -1 means unlimited); using 0"
+			);
+			0
+		}
+		v => v as u64,
+	}
+}
+
+/// Upper bound on an explicit GPU `count:` — clamps an untrusted compose value
+/// so a huge count cannot allocate billions of device-id strings (OOM). Far
+/// above any real host's GPU count.
+const MAX_GPU_DEVICES: i64 = 64;
 
 /// Map `deploy.resources.reservations.devices` GPU reservations to Podman CDI
 /// device names (e.g. `nvidia.com/gpu=all`).
@@ -166,7 +188,17 @@ pub(crate) fn cdi_devices(service: &Service) -> Vec<String> {
 			// `count: all` (-1) or unspecified → request every GPU.
 			Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
 			Some(n) if n > 0 => {
-				for i in 0..n {
+				// Clamp to a sane device count: the value comes from an untrusted
+				// compose file and a huge `count:` would otherwise allocate billions
+				// of device-id strings during spec assembly (OOM) before any
+				// container is created. No host has anywhere near this many GPUs.
+				if n > MAX_GPU_DEVICES {
+					tracing::warn!(
+						"device reservation count {n} exceeds the maximum of {MAX_GPU_DEVICES}; \
+						 clamping (no host has this many GPUs)"
+					);
+				}
+				for i in 0..n.min(MAX_GPU_DEVICES) {
 					out.push(format!("nvidia.com/gpu={i}"));
 				}
 			}
@@ -307,5 +339,36 @@ mod tests {
 	#[test]
 	fn cdi_absent_without_deploy() {
 		assert!(cdi_devices(&default_service()).is_empty());
+	}
+
+	// --- ulimit value conversion ---
+
+	#[test]
+	fn ulimit_minus_one_is_unlimited() {
+		assert_eq!(ulimit_value(-1, "nofile", "soft"), u64::MAX);
+	}
+
+	#[test]
+	fn ulimit_other_negative_clamped_to_zero() {
+		// Must not wrap to a huge u64 via `as`.
+		assert_eq!(ulimit_value(-5, "nofile", "soft"), 0);
+	}
+
+	#[test]
+	fn ulimit_positive_passes_through() {
+		assert_eq!(ulimit_value(1024, "nofile", "hard"), 1024);
+	}
+
+	// --- gpu count clamp ---
+
+	#[test]
+	fn cdi_gpu_count_is_clamped() {
+		let yaml = format!(
+			"services:\n  g:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              count: {}\n",
+			MAX_GPU_DEVICES + 10_000
+		);
+		let file = crate::compose::parse_str(&yaml).unwrap();
+		let out = cdi_devices(&file.services["g"]);
+		assert_eq!(out.len(), MAX_GPU_DEVICES as usize);
 	}
 }

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -29,6 +29,12 @@ use sync::{build_sync_tar, is_ignored, is_included};
 
 use super::Engine;
 
+/// Bound on the in-flight watch-event queue (events are dropped when full; a
+/// later event re-triggers the sync) and on the paths coalesced into one batch.
+/// Together they keep memory bounded under heavy filesystem churn.
+const WATCH_CHANNEL_CAP: usize = 1024;
+const WATCH_MAX_BATCH_PATHS: usize = 4096;
+
 // ---------------------------------------------------------------------------
 // Rule tracking
 // ---------------------------------------------------------------------------
@@ -82,10 +88,14 @@ impl Engine {
 			}
 		}
 
-		let (tx, mut rx) = mpsc::unbounded_channel::<notify::Result<notify::Event>>();
+		// Bounded channel: under heavy filesystem churn an unbounded queue (and the
+		// per-batch path accumulation below) can grow without limit. Drop events
+		// when the buffer is full — a later event re-triggers the sync, so no state
+		// is permanently lost, but memory stays bounded.
+		let (tx, mut rx) = mpsc::channel::<notify::Result<notify::Event>>(WATCH_CHANNEL_CAP);
 		let mut watcher = RecommendedWatcher::new(
 			move |res| {
-				let _ = tx.send(res);
+				let _ = tx.try_send(res);
 			},
 			notify::Config::default(),
 		)
@@ -117,8 +127,14 @@ impl Engine {
 
 			let mut paths = event.paths;
 			let deadline = tokio::time::Instant::now() + debounce;
-			while let Ok(Some(Ok(e))) = tokio::time::timeout_at(deadline, rx.recv()).await {
-				paths.extend(e.paths);
+			// Coalesce events within the debounce window, but stop accumulating once
+			// the batch is large so a burst of churn cannot grow `paths` without
+			// bound; the remaining events fall into the next batch.
+			while paths.len() < WATCH_MAX_BATCH_PATHS {
+				match tokio::time::timeout_at(deadline, rx.recv()).await {
+					Ok(Some(Ok(e))) => paths.extend(e.paths),
+					_ => break,
+				}
 			}
 
 			'outer: for path in &paths {

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -28,6 +28,12 @@ const MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
 /// connect only — it does not limit the duration of a streaming response body.
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Ceiling on reading a *buffered* (non-streaming) response body. Without it a
+/// daemon that accepts the request, sends headers, then stalls would hang the
+/// CLI forever. Streaming helpers (logs, attach, archive) are deliberately not
+/// bounded by this — they are long-lived by design.
+const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Result alias for libpod client calls, fixing the error to [`PodmanError`].
 pub type Result<T> = std::result::Result<T, PodmanError>;
 
@@ -143,15 +149,23 @@ impl Client {
 	/// [`MAX_RESPONSE_BYTES`] so a rogue or runaway daemon cannot exhaust memory.
 	async fn read_body(resp: Response<Incoming>) -> Result<(StatusCode, Vec<u8>)> {
 		let status = resp.status();
-		let bytes = Limited::new(resp.into_body(), MAX_RESPONSE_BYTES)
-			.collect()
-			.await
-			.map_err(|e| PodmanError::Api {
-				status: 0,
-				message: format!("reading response body: {e}"),
-			})?
-			.to_bytes();
-		Ok((status, bytes.to_vec()))
+		let collected = tokio::time::timeout(
+			READ_TIMEOUT,
+			Limited::new(resp.into_body(), MAX_RESPONSE_BYTES).collect(),
+		)
+		.await
+		.map_err(|_| PodmanError::Api {
+			status: 0,
+			message: format!(
+				"timed out after {}s reading the response body from the Podman socket",
+				READ_TIMEOUT.as_secs()
+			),
+		})?
+		.map_err(|e| PodmanError::Api {
+			status: 0,
+			message: format!("reading response body: {e}"),
+		})?;
+		Ok((status, collected.to_bytes().to_vec()))
 	}
 
 	/// Check status code; on error parse the Podman error message.


### PR DESCRIPTION
Closes #339.

Pre-launch review DoS hardening:
- **YAML alias amplification** (compose/mod.rs): reject documents whose alias references could expand to OOM. Nested billion-laughs is already caught by serde_yaml_ng; this bounds the *linear* vector (verified: a 46 KB file OOMs today). Caps: ≤100 alias refs, ≤512 KB for alias-bearing docs. Normal anchored files unaffected.
- **GPU count clamp** (resources.rs): clamp untrusted `count:` to 64 (no host has more); huge values OOM'd during spec assembly.
- **ulimit** (resources.rs): negatives other than -1 no longer wrap to a huge u64.
- **HTTP read timeout** (libpod/client): buffered responses time out (120 s); streaming helpers exempt.
- **watch** bounded channel + batch coalescing cap.

Unit tests added (alias guard, ulimit, gpu clamp). cp buffering (also in #339) is handled with the rest of the cp work in the #340 PR to keep copy.rs edits in one place.