### PR TITLE
fix(engine): fail-closed correctness (hook exit, config-hash, quadlet)

### DIFF
--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -129,7 +129,7 @@ impl Engine {
 		}
 		labels.insert("podup.project".to_string(), self.project.clone());
 		labels.insert("podup.service".to_string(), service_name.to_string());
-		labels.insert("podup.config-hash".to_string(), config_hash(service, file));
+		labels.insert("podup.config-hash".to_string(), config_hash(service, file)?);
 
 		// annotations
 		let annotations: HashMap<String, String> = service.annotations.to_map();

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::env_file;
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 
 /// Resolve a named-volume reference to the volume name `create_volumes`
 /// produced: a custom `name:`, the raw name for an external volume, or the
@@ -106,15 +106,18 @@ pub(super) fn resolve_links(service: &Service, file: &ComposeFile, project: &str
 /// Podman-native secrets, so the recreate must be driven by the hash. `file:`
 /// sources stay live bind-mounts and `external:` sources are by-reference, so
 /// neither needs to influence the hash.
-pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> String {
+pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> Result<String> {
 	use sha2::{Digest, Sha256};
 	let mut hasher = Sha256::new();
 	// Canonicalise through `serde_json::Value` first: object keys are emitted in
 	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
-	// between runs and flap the hash into a spurious recreate.
+	// between runs and flap the hash into a spurious recreate. Fail closed if
+	// serialization fails (e.g. a non-scalar mapping key in an `x-` extension):
+	// returning an empty/default hash would make distinct services hash
+	// identically and silently suppress recreation and inline-secret rotation.
 	let serialized = serde_json::to_value(service)
 		.and_then(|v| serde_json::to_vec(&v))
-		.unwrap_or_default();
+		.map_err(|e| ComposeError::Unsupported(format!("cannot hash service config: {e}")))?;
 	hasher.update(&serialized);
 	for secret_ref in &service.secrets {
 		if let Some(def) = file.secrets.get(secret_ref.source()) {
@@ -138,11 +141,11 @@ pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> String {
 			);
 		}
 	}
-	hasher
+	Ok(hasher
 		.finalize()
 		.iter()
 		.map(|b| format!("{b:02x}"))
-		.collect()
+		.collect())
 }
 
 /// Fold an inline secret/config's resolved bytes into the config hasher. Inline
@@ -243,9 +246,9 @@ mod tests {
 		let a = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
 		let b = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
 		let c = parse_str("services:\n  web:\n    image: nginx:1.28\n").unwrap();
-		let ha = config_hash(&a.services["web"], &a);
-		let hb = config_hash(&b.services["web"], &b);
-		let hc = config_hash(&c.services["web"], &c);
+		let ha = config_hash(&a.services["web"], &a).unwrap();
+		let hb = config_hash(&b.services["web"], &b).unwrap();
+		let hc = config_hash(&c.services["web"], &c).unwrap();
 		assert_eq!(ha, hb, "same config produces the same hash");
 		assert_ne!(ha, hc, "a changed image produces a different hash");
 		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
@@ -264,8 +267,8 @@ mod tests {
 		)
 		.unwrap();
 		assert_ne!(
-			config_hash(&a.services["web"], &a),
-			config_hash(&b.services["web"], &b),
+			config_hash(&a.services["web"], &a).unwrap(),
+			config_hash(&b.services["web"], &b).unwrap(),
 			"changed inline secret content must change the hash",
 		);
 	}
@@ -285,8 +288,8 @@ mod tests {
 		// The service definition is identical; only the top-level external name
 		// differs, which is resolved at attach time, not baked into the hash.
 		assert_eq!(
-			config_hash(&a.services["web"], &a),
-			config_hash(&b.services["web"], &b),
+			config_hash(&a.services["web"], &a).unwrap(),
+			config_hash(&b.services["web"], &b).unwrap(),
 		);
 	}
 
@@ -303,8 +306,8 @@ mod tests {
 		)
 		.unwrap();
 		assert_eq!(
-			config_hash(&a.services["web"], &a),
-			config_hash(&b.services["web"], &b),
+			config_hash(&a.services["web"], &a).unwrap(),
+			config_hash(&b.services["web"], &b).unwrap(),
 			"hash must be independent of storage_opt key order",
 		);
 	}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -224,7 +224,7 @@ impl Engine {
 			.or(service.deploy.as_ref().and_then(|d| d.replicas))
 			.unwrap_or(1) as usize;
 
-		let new_hash = config_hash(service, file);
+		let new_hash = config_hash(service, file)?;
 
 		for i in 1..=replicas {
 			let container_name = if replicas == 1 {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -123,6 +123,27 @@ impl Engine {
 			}
 		}
 
+		// A hook that exits non-zero must surface as an error (matching
+		// `Engine::run`): otherwise a failing `post_start` readiness/init step is
+		// silently treated as success and dependents start against a container
+		// that never initialised. `pre_stop` callers deliberately ignore the Err.
+		let inspect_path = format!(
+			"{API_PREFIX}/exec/{}/json",
+			crate::libpod::urlencoded(&exec_id)
+		);
+		let inspect: crate::libpod::types::exec::ExecInspect = self
+			.client
+			.get_json(&inspect_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		if let Some(code) = inspect.exit_code {
+			if code != 0 {
+				return Err(ComposeError::Build(format!(
+					"lifecycle hook exited with status {code}"
+				)));
+			}
+		}
+
 		Ok(())
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -108,6 +108,16 @@ fn write_quadlet(
 	output: Option<&Path>,
 ) -> podup::Result<()> {
 	let result = podup::quadlet::generate(file, project);
+	if let Some(dup) = result.duplicate_filename() {
+		return Err(std::io::Error::new(
+			std::io::ErrorKind::InvalidInput,
+			format!(
+				"quadlet: two resources map to the same unit file {dup:?}; \
+				 rename one so their names do not collide after sanitization"
+			),
+		)
+		.into());
+	}
 	if let Some(advisory) = quadlet_platform_advisory(std::env::consts::OS) {
 		eprintln!("podup: warning: {advisory}");
 	}

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -37,6 +37,21 @@ pub struct QuadletOutput {
 	pub warnings: Vec<String>,
 }
 
+impl QuadletOutput {
+	/// The first unit file name that two different units share, if any. Distinct
+	/// compose keys can sanitize to the same stem (e.g. `web:1` and `web_1` both
+	/// become `web_1`); writing them would silently overwrite one unit, dropping
+	/// a service/network/volume from the export. Callers surface this as an error
+	/// instead of clobbering.
+	pub fn duplicate_filename(&self) -> Option<&str> {
+		let mut seen = std::collections::HashSet::new();
+		self.units
+			.iter()
+			.find(|u| !seen.insert(u.filename.as_str()))
+			.map(|u| u.filename.as_str())
+	}
+}
+
 /// Translate a compose file into Quadlet units for the given project name.
 ///
 /// Emits one `.container` per service, one `.network` per declared network,
@@ -97,6 +112,21 @@ mod tests {
 			.iter()
 			.find(|u| u.filename == filename)
 			.unwrap_or_else(|| panic!("no unit named {filename}"))
+	}
+
+	#[test]
+	fn duplicate_filename_detects_collision() {
+		let mk = |n: &str| QuadletUnit {
+			filename: n.to_string(),
+			contents: String::new(),
+		};
+		let mut out = QuadletOutput {
+			units: vec![mk("web.container"), mk("db.volume")],
+			..Default::default()
+		};
+		assert_eq!(out.duplicate_filename(), None);
+		out.units.push(mk("web.container"));
+		assert_eq!(out.duplicate_filename(), Some("web.container"));
 	}
 
 	#[test]

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -55,6 +55,15 @@ fn render_healthcheck(service: &Service, container: &mut Section) {
 	}
 }
 
+/// Sanitize one `Secret=` option-list field: drop control characters and the
+/// `,`/`=` separators so a hostile compose value cannot inject extra options.
+fn secret_field(value: &str) -> String {
+	value
+		.chars()
+		.filter(|c| !c.is_control() && *c != ',' && *c != '=')
+		.collect()
+}
+
 /// Render a service `secrets:` entry into a Quadlet `Secret=` value
 /// (`name[,target=,uid=,gid=,mode=]`).
 fn render_secret(secret: &ServiceSecretRef) -> String {
@@ -67,15 +76,18 @@ fn render_secret(secret: &ServiceSecretRef) -> String {
 			gid,
 			mode,
 		} => {
-			let mut s = source.clone();
+			// `Secret=` is a comma-separated `key=value` option list, so a `,`
+			// or `=` embedded in any field would inject extra options. Strip
+			// those (and control chars) from each value at the boundary.
+			let mut s = secret_field(source);
 			if let Some(t) = target {
-				s.push_str(&format!(",target={t}"));
+				s.push_str(&format!(",target={}", secret_field(t)));
 			}
 			if let Some(u) = uid {
-				s.push_str(&format!(",uid={u}"));
+				s.push_str(&format!(",uid={}", secret_field(u)));
 			}
 			if let Some(g) = gid {
-				s.push_str(&format!(",gid={g}"));
+				s.push_str(&format!(",gid={}", secret_field(g)));
 			}
 			if let Some(m) = mode {
 				s.push_str(&format!(",mode={m:o}"));
@@ -415,5 +427,34 @@ pub(super) fn container_unit(
 	QuadletUnit {
 		filename: format!("{}.container", safe_unit_stem(name)),
 		contents,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{render_secret, secret_field};
+	use crate::compose::types::ServiceSecretRef;
+
+	#[test]
+	fn secret_field_strips_separators_and_controls() {
+		assert_eq!(secret_field("a,b=c\nd"), "abcd");
+		assert_eq!(secret_field("plain"), "plain");
+	}
+
+	#[test]
+	fn render_secret_cannot_inject_extra_options() {
+		// A hostile target tries to smuggle a second option via `,` and `=`.
+		let s = ServiceSecretRef::Long {
+			source: "tok".into(),
+			target: Some("/run/x,uid=0".into()),
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		let out = render_secret(&s);
+		// The injected `,uid=0` must be flattened into the target value, not a
+		// separate option: exactly one comma (the legitimate `,target=`).
+		assert_eq!(out.matches(',').count(), 1);
+		assert_eq!(out, "tok,target=/run/xuid0");
 	}
 }


### PR DESCRIPTION
Closes #341.

- **hook exit code** (HIGH): `run_lifecycle_hook` now inspects `/exec/{id}/json` and errors on non-zero, so a failing `post_start` no longer silently succeeds. `pre_stop` callers still ignore the error.
- **config-hash fail-closed** (MED): propagate serialization errors instead of `unwrap_or_default()` (empty hash → distinct services collide → recreation/rotation silently skipped). Signature now returns `Result`.
- **quadlet stem collision** (MED): `QuadletOutput::duplicate_filename()` + an error at the write site, instead of silently overwriting a unit.
- **quadlet Secret= injection** (LOW): strip `,`/`=`/control chars from option fields.

Unit tests added (duplicate_filename, render_secret sanitization); config_hash tests updated for the Result return.