### PR TITLE
fix(secrets): reject colon-injection in file: binds + validate names

### DIFF
--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -46,7 +46,7 @@ impl Engine {
 					// to the project dir (not the Podman service's cwd) and `~` is
 					// expanded — same handling as `volumes:`.
 					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(format!("{resolved}:{target}:ro"));
+					binds.push(make_bind(&name, &resolved, &target)?);
 				}
 			}
 		}
@@ -67,7 +67,7 @@ impl Engine {
 				if let Some(host_path) = &def.file {
 					let target = target_override.unwrap_or_else(|| format!("/{name}"));
 					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(format!("{resolved}:{target}:ro"));
+					binds.push(make_bind(&name, &resolved, &target)?);
 				}
 			}
 		}
@@ -205,6 +205,28 @@ impl Engine {
 	}
 }
 
+/// Build a `source:target:ro` bind string for a `file:` secret/config, rejecting
+/// a colon in either the resolved host path or the target.
+///
+/// The bind string is later split with `splitn(3, ':')`; a stray colon in the
+/// source or target shifts the field boundaries — redirecting the mount
+/// destination, or merging the `:ro` flag into a malformed `rw:ro` token that
+/// silently drops the read-only guarantee. A colon is not meaningful in a
+/// container mount path, so reject it at the boundary instead of mis-parsing.
+fn make_bind(name: &str, resolved: &str, target: &str) -> Result<String> {
+	if resolved.contains(':') {
+		return Err(ComposeError::Unsupported(format!(
+			"secret/config '{name}': host path must not contain a colon: {resolved}"
+		)));
+	}
+	if target.contains(':') {
+		return Err(ComposeError::Unsupported(format!(
+			"secret/config '{name}': mount target must not contain a colon: {target}"
+		)));
+	}
+	Ok(format!("{resolved}:{target}:ro"))
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -245,6 +267,16 @@ mod tests {
 			.build_config_binds(&file.services["web"], &file)
 			.unwrap();
 		assert_eq!(binds, vec!["/etc/app/cfg.yaml:/cfg:ro"]);
+	}
+
+	#[test]
+	fn make_bind_rejects_colon_in_path_or_target() {
+		assert!(make_bind("s", "/host/a:b", "/run/secrets/s").is_err());
+		assert!(make_bind("s", "/host/a", "/run/secrets/s:rw").is_err());
+		assert_eq!(
+			make_bind("s", "/host/a", "/run/secrets/s").unwrap(),
+			"/host/a:/run/secrets/s:ro"
+		);
 	}
 
 	#[test]

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -107,6 +107,16 @@ fn resolve_source(
 	if external {
 		return Ok(Source::External(external_name.unwrap_or(name).to_string()));
 	}
+	let is_inline = content.is_some() || environment.is_some();
+	if is_inline && !staging::is_safe_project_name(name) {
+		// The name becomes part of the project-scoped Podman secret name and a URL
+		// query parameter, so require a bounded, well-formed identifier rather than
+		// an arbitrary (possibly huge or control-laden) YAML key.
+		return Err(ComposeError::Unsupported(format!(
+			"{kind} name {name:?} must be ASCII alphanumeric/dash/underscore/dot, \
+			 at most 128 chars, and not start with a dot"
+		)));
+	}
 	if let Some(content) = content {
 		return Ok(Source::Inline(
 			scoped_name(project, kind, name),
@@ -387,6 +397,16 @@ mod tests {
 		assert!(check_secret_size("s", MAX_SECRET_BYTES).is_err());
 		assert!(check_secret_size("s", MAX_SECRET_BYTES - 1).is_ok());
 		assert!(check_secret_size("s", 1).is_ok());
+	}
+
+	#[test]
+	fn inline_secret_with_unsafe_name_is_rejected() {
+		// A path-traversal / control-laden key must not become a Podman secret name.
+		let file = crate::compose::parse_str_raw(
+			"services:\n  web:\n    image: x\n    secrets: ['../evil']\nsecrets:\n  '../evil':\n    content: data\n",
+		)
+		.unwrap();
+		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #342.

- **bind colon injection** (MED): `file:` secret/config binds reject a colon in the resolved host path or the target, so a compose author can't redirect the mount or destroy the `:ro` flag via `splitn(3, ':')` field-shifting.
- **name validation** (LOW): an inline `content:`/`environment:` secret/config name must be a bounded identifier (alnum/-/_/., ≤128, no leading dot) since it becomes a Podman secret name + URL query param.

Unit tests added (make_bind colon rejection, unsafe-name rejection).