### PR TITLE
ci: gate releases on cargo-audit, pin SBOM generators

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
           fi
           echo "Releasing version ${VERSION}."
 
+      - name: Audit dependencies for known advisories
+        # Gate the release on `cargo audit`: a RUSTSEC advisory in a pinned
+        # dependency must block publishing, not wait for the weekly cron scan.
+        run: |
+          cargo install cargo-audit --version "^0.22" --locked
+          cargo audit
+
   build:
     name: Build ${{ matrix.asset }}
     needs: verify
@@ -231,8 +238,8 @@ jobs:
         # Government/enterprise consumers require a machine-readable SBOM
         # (CycloneDX, per US EO 14028) and a third-party license attribution.
         run: |
-          cargo install --locked cargo-cyclonedx
-          cargo install --locked --features cli cargo-about
+          cargo install --locked cargo-cyclonedx --version "^0.5"
+          cargo install --locked --features cli cargo-about --version "^0.9"
           cargo cyclonedx --format json --all-features
           # cargo-cyclonedx names the file after the package (podup.cdx.json),
           # so only rename when an older/different layout emitted another name —

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Install generators
         run: |
-          cargo install --locked cargo-cyclonedx
-          cargo install --locked --features cli cargo-about
+          cargo install --locked cargo-cyclonedx --version "^0.5"
+          cargo install --locked --features cli cargo-about --version "^0.9"
 
       - name: Generate CycloneDX SBOM
         run: cargo cyclonedx --format json --all-features


### PR DESCRIPTION
Closes #344.

- **cargo-audit release gate** (MED): `cargo audit` runs in release.yml's verify job (gates the whole release). Verified clean locally (174 deps, no advisories).
- **pin SBOM tools** (MED): cargo-cyclonedx `^0.5`, cargo-about `^0.9` in release.yml + supply-chain.yml, so a tool bump can't silently change output or break the release.

Note: cargo-audit/cargo-deny in audit.yml are already `--version`-constrained (`^0.22`/`^0.19`), and the reusable CI already runs an MSRV (1.85) job — so finding #25/#26 needed no change.