### PR TITLE
release: v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.23.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+podup (0.24.0) unstable; urgency=medium
+
+  * Security/robustness hardening from a pre-launch review:
+    - Reject YAML documents whose alias use could amplify into out-of-memory,
+      clamp an explicit GPU `count:`, reject invalid negative ulimits, and add a
+      read timeout to buffered Podman responses (file-borne DoS).
+    - `cp` from a container now honours the user's destination filename instead
+      of the daemon-supplied tar entry name, bounds the buffered archive, and
+      strips group/other-write and setuid/setgid/sticky bits on extracted files;
+      `watch` no longer dereferences symlinks when syncing.
+    - Lifecycle hooks now fail when the exec exits non-zero (a failing
+      `post_start` no longer silently succeeds); the service config-hash fails
+      closed on serialization error; Quadlet export errors on unit-name
+      collisions instead of silently overwriting.
+    - `file:` secret/config binds reject colon-injection that could redirect the
+      mount or drop the read-only flag, and inline secret/config names are
+      validated.
+    - Self-update writes its temp binary with O_EXCL + O_NOFOLLOW, masks
+      setuid/setgid bits, and verifies the signed manifest before downloading.
+    - Releases are gated on `cargo audit` and the SBOM generators are pinned.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Mon, 15 Jun 2026 17:00:00 -0500
+
 podup (0.23.0) unstable; urgency=medium
 
   * Inline `content:`/`environment:` secrets and configs are now injected as

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.23.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.24.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Version bump to **0.24.0** (security-hardening release) ahead of promoting develop→main.

Bumps crate, Cargo.lock, README install tag, `debian/podup.1` (.TH), and `debian/changelog`.

Covers #339–#344 (the pre-launch review remediation: DoS caps, cp/watch write safety, fail-closed correctness, bind-string colon guard, self-update hardening, cargo-audit gate + pinned SBOM tools).