### PR TITLE
release: v0.24.0 — pre-launch security hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
           fi
           echo "Releasing version ${VERSION}."
 
+      - name: Audit dependencies for known advisories
+        # Gate the release on `cargo audit`: a RUSTSEC advisory in a pinned
+        # dependency must block publishing, not wait for the weekly cron scan.
+        run: |
+          cargo install cargo-audit --version "^0.22" --locked
+          cargo audit
+
   build:
     name: Build ${{ matrix.asset }}
     needs: verify
@@ -231,8 +238,8 @@ jobs:
         # Government/enterprise consumers require a machine-readable SBOM
         # (CycloneDX, per US EO 14028) and a third-party license attribution.
         run: |
-          cargo install --locked cargo-cyclonedx
-          cargo install --locked --features cli cargo-about
+          cargo install --locked cargo-cyclonedx --version "^0.5"
+          cargo install --locked --features cli cargo-about --version "^0.9"
           cargo cyclonedx --format json --all-features
           # cargo-cyclonedx names the file after the package (podup.cdx.json),
           # so only rename when an older/different layout emitted another name —

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Install generators
         run: |
-          cargo install --locked cargo-cyclonedx
-          cargo install --locked --features cli cargo-about
+          cargo install --locked cargo-cyclonedx --version "^0.5"
+          cargo install --locked --features cli cargo-about --version "^0.9"
 
       - name: Generate CycloneDX SBOM
         run: cargo cyclonedx --format json --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.23.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.0" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+podup (0.24.0) unstable; urgency=medium
+
+  * Security/robustness hardening from a pre-launch review:
+    - Reject YAML documents whose alias use could amplify into out-of-memory,
+      clamp an explicit GPU `count:`, reject invalid negative ulimits, and add a
+      read timeout to buffered Podman responses (file-borne DoS).
+    - `cp` from a container now honours the user's destination filename instead
+      of the daemon-supplied tar entry name, bounds the buffered archive, and
+      strips group/other-write and setuid/setgid/sticky bits on extracted files;
+      `watch` no longer dereferences symlinks when syncing.
+    - Lifecycle hooks now fail when the exec exits non-zero (a failing
+      `post_start` no longer silently succeeds); the service config-hash fails
+      closed on serialization error; Quadlet export errors on unit-name
+      collisions instead of silently overwriting.
+    - `file:` secret/config binds reject colon-injection that could redirect the
+      mount or drop the read-only flag, and inline secret/config names are
+      validated.
+    - Self-update writes its temp binary with O_EXCL + O_NOFOLLOW, masks
+      setuid/setgid bits, and verifies the signed manifest before downloading.
+    - Releases are gated on `cargo audit` and the SBOM generators are pinned.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Mon, 15 Jun 2026 17:00:00 -0500
+
 podup (0.23.0) unstable; urgency=medium
 
   * Inline `content:`/`environment:` secrets and configs are now injected as

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.23.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.24.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -290,11 +290,79 @@ pub(crate) fn parse_file_inner_with_env(
 	deserialize_with_merge(&substituted)
 }
 
+/// Upper bound on YAML alias references in a document that uses anchors, and on
+/// the size of such a document. serde_yaml_ng already aborts deeply *nested*
+/// alias expansion (its repetition limit), but a flat document with many alias
+/// references to a non-trivial anchor expands *linearly* while the `Value` tree
+/// is built and can exhaust memory — a ~46 KB file can allocate gigabytes. Real
+/// compose files use a handful of anchors, so these caps never trigger in
+/// practice; the worst-case expansion they allow (refs × doc size) stays bounded.
+const MAX_ALIAS_REFS: usize = 100;
+const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
+
 fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
+	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
 	apply_merge_keys(&mut value);
 	let file: ComposeFile = serde_yaml::from_value(value)?;
 	Ok(file)
+}
+
+/// Reject YAML documents whose alias use could amplify into an out-of-memory
+/// expansion (a "billion-laughs" linear cousin) before they reach the parser.
+fn guard_alias_expansion(content: &str) -> Result<()> {
+	let refs = count_alias_refs(content);
+	if refs == 0 {
+		return Ok(());
+	}
+	if content.len() > MAX_ALIAS_DOC_BYTES {
+		return Err(ComposeError::Unsupported(format!(
+			"compose document uses YAML aliases and is {} bytes; documents using anchors/aliases \
+			 must be at most {MAX_ALIAS_DOC_BYTES} bytes — inline the repeated content instead",
+			content.len()
+		)));
+	}
+	if refs > MAX_ALIAS_REFS {
+		return Err(ComposeError::Unsupported(format!(
+			"compose document uses {refs} YAML alias references; at most {MAX_ALIAS_REFS} are \
+			 allowed — inline the repeated content instead"
+		)));
+	}
+	Ok(())
+}
+
+/// Count YAML alias references (`*anchor`) outside quoted scalars and comments.
+///
+/// A heuristic — it does not fully parse YAML — but it only needs to bound a
+/// DoS and it is conservative: `*` inside single/double quotes or after `#` is
+/// ignored, and an alias is counted only when `*` sits at a node position and is
+/// followed by an anchor-name character.
+fn count_alias_refs(content: &str) -> usize {
+	let mut count = 0;
+	for line in content.lines() {
+		let mut chars = line.chars().peekable();
+		let (mut in_single, mut in_double) = (false, false);
+		let mut prev: Option<char> = None;
+		while let Some(c) = chars.next() {
+			match c {
+				'\'' if !in_double => in_single = !in_single,
+				'"' if !in_single => in_double = !in_double,
+				'#' if !in_single && !in_double => break,
+				'*' if !in_single && !in_double => {
+					let at_node = matches!(prev, None | Some(' ' | '\t' | '[' | '{' | ',' | ':'));
+					let next_ok = chars
+						.peek()
+						.is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_' || *n == '-');
+					if at_node && next_ok {
+						count += 1;
+					}
+				}
+				_ => {}
+			}
+			prev = Some(c);
+		}
+	}
+	count
 }
 
 /// Recursively resolve YAML merge keys (`<<: *anchor`) in a `Value` tree.
@@ -359,6 +427,45 @@ mod tests {
 	#[test]
 	fn parse_str_raw_invalid_yaml_is_error() {
 		assert!(parse_str_raw(": : :").is_err());
+	}
+
+	// alias-expansion guard
+
+	#[test]
+	fn count_alias_refs_ignores_quotes_comments_and_globs() {
+		assert_eq!(count_alias_refs("a: &x 1\nb: *x\n"), 1);
+		assert_eq!(count_alias_refs("c: [*x, *x, *x]\n"), 3);
+		// `*` in quoted strings, comments, and globs (`*.txt`, `**`) are not aliases.
+		assert_eq!(
+			count_alias_refs("cmd: \"rm *x\"\nd: 1 # *x\ng: ['*.txt', '**']\n"),
+			0
+		);
+	}
+
+	#[test]
+	fn guard_allows_normal_anchored_file() {
+		// A handful of merge-key aliases in a small file is fine.
+		let yaml = "x: &d {a: 1}\nweb: {<<: *d}\napi: {<<: *d}\n";
+		assert!(guard_alias_expansion(yaml).is_ok());
+	}
+
+	#[test]
+	fn guard_rejects_linear_alias_amplification() {
+		// Many references to one anchor — the OOM vector serde_yaml_ng does not bound.
+		let mut yaml = String::from("anchor: &a [x, y, z]\nlist:\n");
+		for _ in 0..(MAX_ALIAS_REFS + 50) {
+			yaml.push_str("  - *a\n");
+		}
+		let err = guard_alias_expansion(&yaml).unwrap_err();
+		assert!(format!("{err}").contains("alias references"));
+	}
+
+	#[test]
+	fn guard_rejects_large_aliased_document() {
+		let mut yaml = String::from("anchor: &a 1\nb: *a\n");
+		yaml.push_str(&format!("pad: \"{}\"\n", "p".repeat(MAX_ALIAS_DOC_BYTES)));
+		let err = guard_alias_expansion(&yaml).unwrap_err();
+		assert!(format!("{err}").contains("at most"));
 	}
 
 	// resolve_order

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -129,7 +129,7 @@ impl Engine {
 		}
 		labels.insert("podup.project".to_string(), self.project.clone());
 		labels.insert("podup.service".to_string(), service_name.to_string());
-		labels.insert("podup.config-hash".to_string(), config_hash(service, file));
+		labels.insert("podup.config-hash".to_string(), config_hash(service, file)?);
 
 		// annotations
 		let annotations: HashMap<String, String> = service.annotations.to_map();

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::env_file;
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 
 /// Resolve a named-volume reference to the volume name `create_volumes`
 /// produced: a custom `name:`, the raw name for an external volume, or the
@@ -106,15 +106,18 @@ pub(super) fn resolve_links(service: &Service, file: &ComposeFile, project: &str
 /// Podman-native secrets, so the recreate must be driven by the hash. `file:`
 /// sources stay live bind-mounts and `external:` sources are by-reference, so
 /// neither needs to influence the hash.
-pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> String {
+pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> Result<String> {
 	use sha2::{Digest, Sha256};
 	let mut hasher = Sha256::new();
 	// Canonicalise through `serde_json::Value` first: object keys are emitted in
 	// sorted order, so map-typed fields (e.g. `storage_opt`) cannot reorder
-	// between runs and flap the hash into a spurious recreate.
+	// between runs and flap the hash into a spurious recreate. Fail closed if
+	// serialization fails (e.g. a non-scalar mapping key in an `x-` extension):
+	// returning an empty/default hash would make distinct services hash
+	// identically and silently suppress recreation and inline-secret rotation.
 	let serialized = serde_json::to_value(service)
 		.and_then(|v| serde_json::to_vec(&v))
-		.unwrap_or_default();
+		.map_err(|e| ComposeError::Unsupported(format!("cannot hash service config: {e}")))?;
 	hasher.update(&serialized);
 	for secret_ref in &service.secrets {
 		if let Some(def) = file.secrets.get(secret_ref.source()) {
@@ -138,11 +141,11 @@ pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> String {
 			);
 		}
 	}
-	hasher
+	Ok(hasher
 		.finalize()
 		.iter()
 		.map(|b| format!("{b:02x}"))
-		.collect()
+		.collect())
 }
 
 /// Fold an inline secret/config's resolved bytes into the config hasher. Inline
@@ -243,9 +246,9 @@ mod tests {
 		let a = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
 		let b = parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
 		let c = parse_str("services:\n  web:\n    image: nginx:1.28\n").unwrap();
-		let ha = config_hash(&a.services["web"], &a);
-		let hb = config_hash(&b.services["web"], &b);
-		let hc = config_hash(&c.services["web"], &c);
+		let ha = config_hash(&a.services["web"], &a).unwrap();
+		let hb = config_hash(&b.services["web"], &b).unwrap();
+		let hc = config_hash(&c.services["web"], &c).unwrap();
 		assert_eq!(ha, hb, "same config produces the same hash");
 		assert_ne!(ha, hc, "a changed image produces a different hash");
 		assert_eq!(ha.len(), 64, "sha-256 hex is 64 chars");
@@ -264,8 +267,8 @@ mod tests {
 		)
 		.unwrap();
 		assert_ne!(
-			config_hash(&a.services["web"], &a),
-			config_hash(&b.services["web"], &b),
+			config_hash(&a.services["web"], &a).unwrap(),
+			config_hash(&b.services["web"], &b).unwrap(),
 			"changed inline secret content must change the hash",
 		);
 	}
@@ -285,8 +288,8 @@ mod tests {
 		// The service definition is identical; only the top-level external name
 		// differs, which is resolved at attach time, not baked into the hash.
 		assert_eq!(
-			config_hash(&a.services["web"], &a),
-			config_hash(&b.services["web"], &b),
+			config_hash(&a.services["web"], &a).unwrap(),
+			config_hash(&b.services["web"], &b).unwrap(),
 		);
 	}
 
@@ -303,8 +306,8 @@ mod tests {
 		)
 		.unwrap();
 		assert_eq!(
-			config_hash(&a.services["web"], &a),
-			config_hash(&b.services["web"], &b),
+			config_hash(&a.services["web"], &a).unwrap(),
+			config_hash(&b.services["web"], &b).unwrap(),
 			"hash must be independent of storage_opt key order",
 		);
 	}

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -119,11 +119,33 @@ pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 		.iter()
 		.map(|(name, cfg)| Ulimit {
 			ulimit_type: name.clone(),
-			soft: cfg.soft() as u64,
-			hard: cfg.hard() as u64,
+			soft: ulimit_value(cfg.soft(), name, "soft"),
+			hard: ulimit_value(cfg.hard(), name, "hard"),
 		})
 		.collect()
 }
+
+/// Convert a compose ulimit value to the libpod `u64`. `-1` is the conventional
+/// "unlimited" sentinel (`u64::MAX`); any other negative value is invalid and
+/// would otherwise wrap to a huge number via `as u64`, so it is rejected to `0`
+/// with a warning instead of silently becoming an enormous limit.
+fn ulimit_value(value: i64, name: &str, which: &str) -> u64 {
+	match value {
+		-1 => u64::MAX,
+		v if v < 0 => {
+			tracing::warn!(
+				"ulimit {name} {which} value {v} is invalid (only -1 means unlimited); using 0"
+			);
+			0
+		}
+		v => v as u64,
+	}
+}
+
+/// Upper bound on an explicit GPU `count:` — clamps an untrusted compose value
+/// so a huge count cannot allocate billions of device-id strings (OOM). Far
+/// above any real host's GPU count.
+const MAX_GPU_DEVICES: i64 = 64;
 
 /// Map `deploy.resources.reservations.devices` GPU reservations to Podman CDI
 /// device names (e.g. `nvidia.com/gpu=all`).
@@ -166,7 +188,17 @@ pub(crate) fn cdi_devices(service: &Service) -> Vec<String> {
 			// `count: all` (-1) or unspecified → request every GPU.
 			Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
 			Some(n) if n > 0 => {
-				for i in 0..n {
+				// Clamp to a sane device count: the value comes from an untrusted
+				// compose file and a huge `count:` would otherwise allocate billions
+				// of device-id strings during spec assembly (OOM) before any
+				// container is created. No host has anywhere near this many GPUs.
+				if n > MAX_GPU_DEVICES {
+					tracing::warn!(
+						"device reservation count {n} exceeds the maximum of {MAX_GPU_DEVICES}; \
+						 clamping (no host has this many GPUs)"
+					);
+				}
+				for i in 0..n.min(MAX_GPU_DEVICES) {
 					out.push(format!("nvidia.com/gpu={i}"));
 				}
 			}
@@ -307,5 +339,36 @@ mod tests {
 	#[test]
 	fn cdi_absent_without_deploy() {
 		assert!(cdi_devices(&default_service()).is_empty());
+	}
+
+	// --- ulimit value conversion ---
+
+	#[test]
+	fn ulimit_minus_one_is_unlimited() {
+		assert_eq!(ulimit_value(-1, "nofile", "soft"), u64::MAX);
+	}
+
+	#[test]
+	fn ulimit_other_negative_clamped_to_zero() {
+		// Must not wrap to a huge u64 via `as`.
+		assert_eq!(ulimit_value(-5, "nofile", "soft"), 0);
+	}
+
+	#[test]
+	fn ulimit_positive_passes_through() {
+		assert_eq!(ulimit_value(1024, "nofile", "hard"), 1024);
+	}
+
+	// --- gpu count clamp ---
+
+	#[test]
+	fn cdi_gpu_count_is_clamped() {
+		let yaml = format!(
+			"services:\n  g:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              count: {}\n",
+			MAX_GPU_DEVICES + 10_000
+		);
+		let file = crate::compose::parse_str(&yaml).unwrap();
+		let out = cdi_devices(&file.services["g"]);
+		assert_eq!(out.len(), MAX_GPU_DEVICES as usize);
 	}
 }

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use bytes::Bytes;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use http_body_util::BodyExt;
+use http_body_util::{BodyExt, Limited};
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
@@ -13,6 +13,11 @@ use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
 
 use super::Engine;
+
+/// Upper bound on a container→host `cp` archive buffered in memory. Without it a
+/// hostile or huge container path would OOM the CLI. Generous (covers ordinary
+/// file/dir copies); larger transfers should use `podman cp` directly.
+const MAX_CP_ARCHIVE_BYTES: usize = 1024 * 1024 * 1024;
 
 impl Engine {
 	/// Copy between a service container and the local filesystem.
@@ -62,26 +67,22 @@ impl Engine {
 			.get_stream(&path)
 			.await
 			.map_err(ComposeError::Podman)?;
-		let tar_bytes = resp
-			.into_body()
+		// Cap the buffered archive so a huge/hostile container path cannot OOM the
+		// CLI (the streaming `get_stream` path bypasses the client's own cap).
+		let tar_bytes = Limited::new(resp.into_body(), MAX_CP_ARCHIVE_BYTES)
 			.collect()
 			.await
-			.map_err(|e| ComposeError::Podman(crate::libpod::PodmanError::Hyper(e)))?
+			.map_err(|_| {
+				ComposeError::Unsupported(format!(
+					"cp: container archive exceeds {MAX_CP_ARCHIVE_BYTES} bytes; \
+					 copy fewer files or use `podman cp` for very large transfers"
+				))
+			})?
 			.to_bytes()
 			.to_vec();
 
-		let dst_path = if dst.is_dir() {
-			dst.to_path_buf()
-		} else if let Some(parent) = dst.parent() {
-			if !parent.as_os_str().is_empty() && !parent.exists() {
-				std::fs::create_dir_all(parent).map_err(ComposeError::Io)?;
-			}
-			parent.to_path_buf()
-		} else {
-			std::env::current_dir().map_err(ComposeError::Io)?
-		};
-
-		tokio::task::spawn_blocking(move || extract_tar_guarded(&tar_bytes, &dst_path))
+		let dst = dst.to_path_buf();
+		tokio::task::spawn_blocking(move || extract_archive(&tar_bytes, &dst))
 			.await
 			.map_err(|e| ComposeError::Build(e.to_string()))??;
 
@@ -161,8 +162,24 @@ fn pack_path(src: &Path) -> Result<Vec<u8>> {
 	gz.finish().map_err(|e| ComposeError::Build(e.to_string()))
 }
 
+/// Route a container archive to the host destination.
+///
+/// docker/podman `cp` semantics: when `dst` is an existing directory the archive
+/// is extracted into it; otherwise `dst` names the target file and the archive
+/// must contain a single regular file, whose **content** is written to exactly
+/// `dst` — the daemon-supplied entry name is ignored. This matters for security:
+/// a hostile image must not be able to choose the on-host filename (e.g. drop a
+/// `.bashrc`/`authorized_keys` into the destination directory).
+fn extract_archive(tar_bytes: &[u8], dst: &Path) -> Result<()> {
+	if dst.is_dir() {
+		return extract_tar_guarded(tar_bytes, dst);
+	}
+	write_single_entry_to(tar_bytes, dst)
+}
+
 /// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
-/// entry whose path would escape it (zip-slip).
+/// entry whose path would escape it (zip-slip) and stripping group/other-write
+/// and setuid/setgid/sticky bits the (untrusted) container set on each entry.
 ///
 /// Extract entry-by-entry rather than `archive.unpack`: a malicious or
 /// compromised container can craft tar entries whose paths contain `..` or are
@@ -175,6 +192,8 @@ fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
 	let mut archive = tar::Archive::new(cursor);
 	for entry in archive.entries().map_err(ComposeError::Io)? {
 		let mut entry = entry.map_err(ComposeError::Io)?;
+		let rel = entry.path().map(|p| p.into_owned()).ok();
+		let mode = entry.header().mode().ok();
 		if !entry.unpack_in(dst_dir).map_err(ComposeError::Io)? {
 			let p = entry
 				.path()
@@ -184,9 +203,80 @@ fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
 				"cp: refusing archive entry that escapes destination: {p}"
 			)));
 		}
+		if let (Some(rel), Some(mode)) = (rel, mode) {
+			sanitize_extracted_mode(&dst_dir.join(rel), mode);
+		}
 	}
 	Ok(())
 }
+
+/// Write the single regular-file entry of `tar_bytes` to exactly `dst`,
+/// honouring the user's destination filename rather than the daemon's. Errors
+/// if the archive is empty, holds more than one entry, or the entry is not a
+/// regular file (those cases only make sense against a directory destination).
+fn write_single_entry_to(tar_bytes: &[u8], dst: &Path) -> Result<()> {
+	use std::io::Read;
+
+	if let Some(parent) = dst.parent() {
+		if !parent.as_os_str().is_empty() && !parent.exists() {
+			std::fs::create_dir_all(parent).map_err(ComposeError::Io)?;
+		}
+	}
+
+	let cursor = std::io::Cursor::new(tar_bytes);
+	let mut archive = tar::Archive::new(cursor);
+	let mut written = false;
+	for entry in archive.entries().map_err(ComposeError::Io)? {
+		let mut entry = entry.map_err(ComposeError::Io)?;
+		if entry.header().entry_type() != tar::EntryType::Regular {
+			return Err(ComposeError::Unsupported(format!(
+				"cp: destination {} is not a directory but the source is not a single file",
+				dst.display()
+			)));
+		}
+		if written {
+			return Err(ComposeError::Unsupported(format!(
+				"cp: destination {} is not a directory but the source has multiple entries",
+				dst.display()
+			)));
+		}
+		let mode = entry.header().mode().ok();
+		let mut buf = Vec::new();
+		entry.read_to_end(&mut buf).map_err(ComposeError::Io)?;
+		std::fs::write(dst, &buf).map_err(ComposeError::Io)?;
+		if let Some(mode) = mode {
+			sanitize_extracted_mode(dst, mode);
+		}
+		written = true;
+	}
+	if !written {
+		return Err(ComposeError::Build(
+			"cp: container archive was empty".into(),
+		));
+	}
+	Ok(())
+}
+
+/// Strip group/other-write and setuid/setgid/sticky bits from a file extracted
+/// from an untrusted container, keeping the owner and read/execute bits. No-op
+/// on non-files (e.g. symlinks) and on non-unix platforms.
+#[cfg(unix)]
+fn sanitize_extracted_mode(path: &Path, mode: u32) {
+	use std::os::unix::fs::PermissionsExt;
+	let Ok(meta) = std::fs::symlink_metadata(path) else {
+		return;
+	};
+	if !meta.is_file() {
+		return;
+	}
+	let masked = mode & 0o7777 & !0o022 & !0o7000;
+	if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(masked)) {
+		tracing::warn!("cp: could not set permissions on {}: {e}", path.display());
+	}
+}
+
+#[cfg(not(unix))]
+fn sanitize_extracted_mode(_path: &Path, _mode: u32) {}
 
 // ---------------------------------------------------------------------------
 // Unit tests
@@ -291,6 +381,64 @@ mod tests {
 			std::fs::read(dir.path().join("hello.txt")).expect("read"),
 			b"hi"
 		);
+	}
+
+	#[test]
+	fn extract_archive_to_file_honors_user_filename() {
+		// dst is NOT a dir: the single entry's content must land at exactly `dst`,
+		// ignoring the daemon-supplied entry name (a hostile image must not pick
+		// the on-host filename).
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("myname.txt");
+		let bytes = tar_bytes_with("evil-name", b"payload");
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert_eq!(std::fs::read(&dst).expect("read"), b"payload");
+		assert!(
+			!dir.path().join("evil-name").exists(),
+			"daemon entry name must not be used as the on-host filename"
+		);
+	}
+
+	#[test]
+	fn extract_archive_to_file_rejects_multiple_entries() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("out.txt");
+		let mut builder = tar::Builder::new(Vec::new());
+		for n in ["a.txt", "b.txt"] {
+			let mut h = tar::Header::new_gnu();
+			h.set_size(1);
+			h.set_mode(0o644);
+			h.set_entry_type(tar::EntryType::Regular);
+			h.set_path(n).expect("path");
+			h.set_cksum();
+			builder.append(&h, &b"x"[..]).expect("append");
+		}
+		let bytes = builder.into_inner().expect("finish");
+		assert!(super::extract_archive(&bytes, &dst).is_err());
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn extract_strips_group_other_write_and_special_bits() {
+		use std::os::unix::fs::PermissionsExt;
+		let dir = tempfile::tempdir().expect("tempdir");
+		// World-writable + setuid entry from an untrusted container.
+		let mut h = tar::Header::new_gnu();
+		h.set_size(2);
+		h.set_mode(0o4777);
+		h.set_entry_type(tar::EntryType::Regular);
+		h.set_path("f").expect("path");
+		h.set_cksum();
+		let mut builder = tar::Builder::new(Vec::new());
+		builder.append(&h, &b"hi"[..]).expect("append");
+		let bytes = builder.into_inner().expect("finish");
+		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
+		let mode = std::fs::metadata(dir.path().join("f"))
+			.expect("meta")
+			.permissions()
+			.mode() & 0o7777;
+		assert_eq!(mode & 0o022, 0, "group/other write must be stripped");
+		assert_eq!(mode & 0o7000, 0, "setuid/setgid/sticky must be stripped");
 	}
 
 	#[test]

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -224,7 +224,7 @@ impl Engine {
 			.or(service.deploy.as_ref().and_then(|d| d.replicas))
 			.unwrap_or(1) as usize;
 
-		let new_hash = config_hash(service, file);
+		let new_hash = config_hash(service, file)?;
 
 		for i in 1..=replicas {
 			let container_name = if replicas == 1 {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -123,6 +123,27 @@ impl Engine {
 			}
 		}
 
+		// A hook that exits non-zero must surface as an error (matching
+		// `Engine::run`): otherwise a failing `post_start` readiness/init step is
+		// silently treated as success and dependents start against a container
+		// that never initialised. `pre_stop` callers deliberately ignore the Err.
+		let inspect_path = format!(
+			"{API_PREFIX}/exec/{}/json",
+			crate::libpod::urlencoded(&exec_id)
+		);
+		let inspect: crate::libpod::types::exec::ExecInspect = self
+			.client
+			.get_json(&inspect_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		if let Some(code) = inspect.exit_code {
+			if code != 0 {
+				return Err(ComposeError::Build(format!(
+					"lifecycle hook exited with status {code}"
+				)));
+			}
+		}
+
 		Ok(())
 	}
 

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -46,7 +46,7 @@ impl Engine {
 					// to the project dir (not the Podman service's cwd) and `~` is
 					// expanded — same handling as `volumes:`.
 					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(format!("{resolved}:{target}:ro"));
+					binds.push(make_bind(&name, &resolved, &target)?);
 				}
 			}
 		}
@@ -67,7 +67,7 @@ impl Engine {
 				if let Some(host_path) = &def.file {
 					let target = target_override.unwrap_or_else(|| format!("/{name}"));
 					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(format!("{resolved}:{target}:ro"));
+					binds.push(make_bind(&name, &resolved, &target)?);
 				}
 			}
 		}
@@ -205,6 +205,28 @@ impl Engine {
 	}
 }
 
+/// Build a `source:target:ro` bind string for a `file:` secret/config, rejecting
+/// a colon in either the resolved host path or the target.
+///
+/// The bind string is later split with `splitn(3, ':')`; a stray colon in the
+/// source or target shifts the field boundaries — redirecting the mount
+/// destination, or merging the `:ro` flag into a malformed `rw:ro` token that
+/// silently drops the read-only guarantee. A colon is not meaningful in a
+/// container mount path, so reject it at the boundary instead of mis-parsing.
+fn make_bind(name: &str, resolved: &str, target: &str) -> Result<String> {
+	if resolved.contains(':') {
+		return Err(ComposeError::Unsupported(format!(
+			"secret/config '{name}': host path must not contain a colon: {resolved}"
+		)));
+	}
+	if target.contains(':') {
+		return Err(ComposeError::Unsupported(format!(
+			"secret/config '{name}': mount target must not contain a colon: {target}"
+		)));
+	}
+	Ok(format!("{resolved}:{target}:ro"))
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -245,6 +267,16 @@ mod tests {
 			.build_config_binds(&file.services["web"], &file)
 			.unwrap();
 		assert_eq!(binds, vec!["/etc/app/cfg.yaml:/cfg:ro"]);
+	}
+
+	#[test]
+	fn make_bind_rejects_colon_in_path_or_target() {
+		assert!(make_bind("s", "/host/a:b", "/run/secrets/s").is_err());
+		assert!(make_bind("s", "/host/a", "/run/secrets/s:rw").is_err());
+		assert_eq!(
+			make_bind("s", "/host/a", "/run/secrets/s").unwrap(),
+			"/host/a:/run/secrets/s:ro"
+		);
 	}
 
 	#[test]

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -107,6 +107,16 @@ fn resolve_source(
 	if external {
 		return Ok(Source::External(external_name.unwrap_or(name).to_string()));
 	}
+	let is_inline = content.is_some() || environment.is_some();
+	if is_inline && !staging::is_safe_project_name(name) {
+		// The name becomes part of the project-scoped Podman secret name and a URL
+		// query parameter, so require a bounded, well-formed identifier rather than
+		// an arbitrary (possibly huge or control-laden) YAML key.
+		return Err(ComposeError::Unsupported(format!(
+			"{kind} name {name:?} must be ASCII alphanumeric/dash/underscore/dot, \
+			 at most 128 chars, and not start with a dot"
+		)));
+	}
 	if let Some(content) = content {
 		return Ok(Source::Inline(
 			scoped_name(project, kind, name),
@@ -387,6 +397,16 @@ mod tests {
 		assert!(check_secret_size("s", MAX_SECRET_BYTES).is_err());
 		assert!(check_secret_size("s", MAX_SECRET_BYTES - 1).is_ok());
 		assert!(check_secret_size("s", 1).is_ok());
+	}
+
+	#[test]
+	fn inline_secret_with_unsafe_name_is_rejected() {
+		// A path-traversal / control-laden key must not become a Podman secret name.
+		let file = crate::compose::parse_str_raw(
+			"services:\n  web:\n    image: x\n    secrets: ['../evil']\nsecrets:\n  '../evil':\n    content: data\n",
+		)
+		.unwrap();
+		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
 	}
 
 	#[test]

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -75,16 +75,12 @@ pub(crate) fn build_mounts_all(
 
 					if let Some(b) = bind {
 						if b.create_host_path.unwrap_or(false) && !src.is_empty() {
-							let abs = if Path::new(src).is_absolute() {
-								std::path::PathBuf::from(src)
-							} else {
-								base_dir.join(src)
-							};
+							// Resolve exactly like the mount source (expand `~`, anchor a
+							// relative path to the project dir) so the directory is created
+							// at the path actually bind-mounted — not a literal `~` dir.
+							let abs = super::container::resolve_bind_source(src, base_dir);
 							if let Err(e) = std::fs::create_dir_all(&abs) {
-								tracing::warn!(
-									"create_host_path: failed to create {}: {e}",
-									abs.display()
-								);
+								tracing::warn!("create_host_path: failed to create {abs}: {e}");
 							}
 						}
 					}

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -29,6 +29,12 @@ use sync::{build_sync_tar, is_ignored, is_included};
 
 use super::Engine;
 
+/// Bound on the in-flight watch-event queue (events are dropped when full; a
+/// later event re-triggers the sync) and on the paths coalesced into one batch.
+/// Together they keep memory bounded under heavy filesystem churn.
+const WATCH_CHANNEL_CAP: usize = 1024;
+const WATCH_MAX_BATCH_PATHS: usize = 4096;
+
 // ---------------------------------------------------------------------------
 // Rule tracking
 // ---------------------------------------------------------------------------
@@ -82,10 +88,14 @@ impl Engine {
 			}
 		}
 
-		let (tx, mut rx) = mpsc::unbounded_channel::<notify::Result<notify::Event>>();
+		// Bounded channel: under heavy filesystem churn an unbounded queue (and the
+		// per-batch path accumulation below) can grow without limit. Drop events
+		// when the buffer is full — a later event re-triggers the sync, so no state
+		// is permanently lost, but memory stays bounded.
+		let (tx, mut rx) = mpsc::channel::<notify::Result<notify::Event>>(WATCH_CHANNEL_CAP);
 		let mut watcher = RecommendedWatcher::new(
 			move |res| {
-				let _ = tx.send(res);
+				let _ = tx.try_send(res);
 			},
 			notify::Config::default(),
 		)
@@ -117,8 +127,14 @@ impl Engine {
 
 			let mut paths = event.paths;
 			let deadline = tokio::time::Instant::now() + debounce;
-			while let Ok(Some(Ok(e))) = tokio::time::timeout_at(deadline, rx.recv()).await {
-				paths.extend(e.paths);
+			// Coalesce events within the debounce window, but stop accumulating once
+			// the batch is large so a burst of churn cannot grow `paths` without
+			// bound; the remaining events fall into the next batch.
+			while paths.len() < WATCH_MAX_BATCH_PATHS {
+				match tokio::time::timeout_at(deadline, rx.recv()).await {
+					Ok(Some(Ok(e))) => paths.extend(e.paths),
+					_ => break,
+				}
 			}
 
 			'outer: for path in &paths {

--- a/internal/engine/watch/sync.rs
+++ b/internal/engine/watch/sync.rs
@@ -14,13 +14,20 @@ use crate::error::{ComposeError, Result};
 pub(super) fn build_sync_tar(src: &Path) -> Result<Vec<u8>> {
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
+	// Do not dereference symlinks: a symlink inside the watched tree would
+	// otherwise copy the contents of its (possibly out-of-tree) target into the
+	// container. Store the link itself instead.
+	tar.follow_symlinks(false);
 
 	if src.is_dir() {
 		for abs in super::super::walk_dir(src).map_err(ComposeError::Io)? {
 			let rel = abs
 				.strip_prefix(src)
 				.map_err(|_| ComposeError::Build("path strip".into()))?;
-			if abs.is_dir() {
+			// Classify without following symlinks so a symlink-to-dir is stored as
+			// a link, not dereferenced.
+			let is_dir = abs.symlink_metadata().map(|m| m.is_dir()).unwrap_or(false);
+			if is_dir {
 				tar.append_dir(rel, &abs)
 					.map_err(|e| ComposeError::Build(e.to_string()))?;
 			} else {

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -28,6 +28,12 @@ const MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
 /// connect only — it does not limit the duration of a streaming response body.
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Ceiling on reading a *buffered* (non-streaming) response body. Without it a
+/// daemon that accepts the request, sends headers, then stalls would hang the
+/// CLI forever. Streaming helpers (logs, attach, archive) are deliberately not
+/// bounded by this — they are long-lived by design.
+const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Result alias for libpod client calls, fixing the error to [`PodmanError`].
 pub type Result<T> = std::result::Result<T, PodmanError>;
 
@@ -143,15 +149,23 @@ impl Client {
 	/// [`MAX_RESPONSE_BYTES`] so a rogue or runaway daemon cannot exhaust memory.
 	async fn read_body(resp: Response<Incoming>) -> Result<(StatusCode, Vec<u8>)> {
 		let status = resp.status();
-		let bytes = Limited::new(resp.into_body(), MAX_RESPONSE_BYTES)
-			.collect()
-			.await
-			.map_err(|e| PodmanError::Api {
-				status: 0,
-				message: format!("reading response body: {e}"),
-			})?
-			.to_bytes();
-		Ok((status, bytes.to_vec()))
+		let collected = tokio::time::timeout(
+			READ_TIMEOUT,
+			Limited::new(resp.into_body(), MAX_RESPONSE_BYTES).collect(),
+		)
+		.await
+		.map_err(|_| PodmanError::Api {
+			status: 0,
+			message: format!(
+				"timed out after {}s reading the response body from the Podman socket",
+				READ_TIMEOUT.as_secs()
+			),
+		})?
+		.map_err(|e| PodmanError::Api {
+			status: 0,
+			message: format!("reading response body: {e}"),
+		})?;
+		Ok((status, collected.to_bytes().to_vec()))
 	}
 
 	/// Check status code; on error parse the Podman error message.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -108,6 +108,16 @@ fn write_quadlet(
 	output: Option<&Path>,
 ) -> podup::Result<()> {
 	let result = podup::quadlet::generate(file, project);
+	if let Some(dup) = result.duplicate_filename() {
+		return Err(std::io::Error::new(
+			std::io::ErrorKind::InvalidInput,
+			format!(
+				"quadlet: two resources map to the same unit file {dup:?}; \
+				 rename one so their names do not collide after sanitization"
+			),
+		)
+		.into());
+	}
 	if let Some(advisory) = quadlet_platform_advisory(std::env::consts::OS) {
 		eprintln!("podup: warning: {advisory}");
 	}

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -37,6 +37,21 @@ pub struct QuadletOutput {
 	pub warnings: Vec<String>,
 }
 
+impl QuadletOutput {
+	/// The first unit file name that two different units share, if any. Distinct
+	/// compose keys can sanitize to the same stem (e.g. `web:1` and `web_1` both
+	/// become `web_1`); writing them would silently overwrite one unit, dropping
+	/// a service/network/volume from the export. Callers surface this as an error
+	/// instead of clobbering.
+	pub fn duplicate_filename(&self) -> Option<&str> {
+		let mut seen = std::collections::HashSet::new();
+		self.units
+			.iter()
+			.find(|u| !seen.insert(u.filename.as_str()))
+			.map(|u| u.filename.as_str())
+	}
+}
+
 /// Translate a compose file into Quadlet units for the given project name.
 ///
 /// Emits one `.container` per service, one `.network` per declared network,
@@ -97,6 +112,21 @@ mod tests {
 			.iter()
 			.find(|u| u.filename == filename)
 			.unwrap_or_else(|| panic!("no unit named {filename}"))
+	}
+
+	#[test]
+	fn duplicate_filename_detects_collision() {
+		let mk = |n: &str| QuadletUnit {
+			filename: n.to_string(),
+			contents: String::new(),
+		};
+		let mut out = QuadletOutput {
+			units: vec![mk("web.container"), mk("db.volume")],
+			..Default::default()
+		};
+		assert_eq!(out.duplicate_filename(), None);
+		out.units.push(mk("web.container"));
+		assert_eq!(out.duplicate_filename(), Some("web.container"));
 	}
 
 	#[test]

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -55,6 +55,15 @@ fn render_healthcheck(service: &Service, container: &mut Section) {
 	}
 }
 
+/// Sanitize one `Secret=` option-list field: drop control characters and the
+/// `,`/`=` separators so a hostile compose value cannot inject extra options.
+fn secret_field(value: &str) -> String {
+	value
+		.chars()
+		.filter(|c| !c.is_control() && *c != ',' && *c != '=')
+		.collect()
+}
+
 /// Render a service `secrets:` entry into a Quadlet `Secret=` value
 /// (`name[,target=,uid=,gid=,mode=]`).
 fn render_secret(secret: &ServiceSecretRef) -> String {
@@ -67,15 +76,18 @@ fn render_secret(secret: &ServiceSecretRef) -> String {
 			gid,
 			mode,
 		} => {
-			let mut s = source.clone();
+			// `Secret=` is a comma-separated `key=value` option list, so a `,`
+			// or `=` embedded in any field would inject extra options. Strip
+			// those (and control chars) from each value at the boundary.
+			let mut s = secret_field(source);
 			if let Some(t) = target {
-				s.push_str(&format!(",target={t}"));
+				s.push_str(&format!(",target={}", secret_field(t)));
 			}
 			if let Some(u) = uid {
-				s.push_str(&format!(",uid={u}"));
+				s.push_str(&format!(",uid={}", secret_field(u)));
 			}
 			if let Some(g) = gid {
-				s.push_str(&format!(",gid={g}"));
+				s.push_str(&format!(",gid={}", secret_field(g)));
 			}
 			if let Some(m) = mode {
 				s.push_str(&format!(",mode={m:o}"));
@@ -415,5 +427,34 @@ pub(super) fn container_unit(
 	QuadletUnit {
 		filename: format!("{}.container", safe_unit_stem(name)),
 		contents,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{render_secret, secret_field};
+	use crate::compose::types::ServiceSecretRef;
+
+	#[test]
+	fn secret_field_strips_separators_and_controls() {
+		assert_eq!(secret_field("a,b=c\nd"), "abcd");
+		assert_eq!(secret_field("plain"), "plain");
+	}
+
+	#[test]
+	fn render_secret_cannot_inject_extra_options() {
+		// A hostile target tries to smuggle a second option via `,` and `=`.
+		let s = ServiceSecretRef::Long {
+			source: "tok".into(),
+			target: Some("/run/x,uid=0".into()),
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		let out = render_secret(&s);
+		// The injected `,uid=0` must be flattened into the target value, not a
+		// separate option: exactly one comma (the legitimate `,target=`).
+		assert_eq!(out.matches(',').count(), 1);
+		assert_eq!(out, "tok,target=/run/xuid0");
 	}
 }

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -129,10 +129,16 @@ fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> 
 	#[cfg(unix)]
 	let mut f = {
 		use std::os::unix::fs::OpenOptionsExt;
+		// Remove any stale temp (e.g. from a crashed run); unlinking a symlink
+		// removes the link itself and does not follow it.
+		let _ = std::fs::remove_file(tmp);
+		// `create_new` (O_EXCL) + O_NOFOLLOW: never follow or clobber a pre-planted
+		// symlink in a shared/attacker-writable install directory, so the verified
+		// bytes can only land in our own freshly created file.
 		std::fs::OpenOptions::new()
 			.write(true)
-			.create(true)
-			.truncate(true)
+			.create_new(true)
+			.custom_flags(libc::O_NOFOLLOW)
 			.mode(0o600)
 			.open(tmp)
 			.map_err(|e| {
@@ -149,8 +155,12 @@ fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> 
 	#[cfg(unix)]
 	{
 		use std::os::unix::fs::PermissionsExt;
+		// Copy the target's permission bits, but mask off setuid/setgid/sticky
+		// (`& 0o777`): podup is an ordinary binary, and propagating a special bit
+		// from a tampered target onto the freshly installed binary would be a
+		// privilege-escalation footgun.
 		let mode = std::fs::metadata(target)
-			.map(|m| m.permissions().mode())
+			.map(|m| m.permissions().mode() & 0o777)
 			.unwrap_or(0o755);
 		std::fs::set_permissions(tmp, std::fs::Permissions::from_mode(mode))
 			.map_err(ComposeError::Io)?;
@@ -271,6 +281,23 @@ mod tests {
 
 		install_at(&target, b"new").unwrap();
 		let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+		assert_eq!(mode & 0o777, 0o755);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn install_at_strips_setuid_from_target_mode() {
+		use std::os::unix::fs::PermissionsExt;
+		let dir = tempfile::tempdir().unwrap();
+		let target = dir.path().join("podup");
+		std::fs::write(&target, b"old").unwrap();
+		// A tampered/setuid target must not propagate its special bits onto the
+		// freshly installed binary.
+		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o4755)).unwrap();
+
+		install_at(&target, b"new").unwrap();
+		let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+		assert_eq!(mode & 0o7000, 0, "setuid/setgid/sticky must be stripped");
 		assert_eq!(mode & 0o777, 0o755);
 	}
 

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -83,14 +83,18 @@ fn run_with_guard(
 	}
 
 	let asset = install::require_platform_asset()?;
-	println!("downloading {asset} ({latest_tag}) ...");
-	let binary = source.fetch(asset)?;
+
+	// Security gate: fetch and verify the signed manifest *before* downloading the
+	// binary, so a tampered/unsigned release is rejected without first buffering a
+	// large attacker-controlled payload. The binary's digest is then checked
+	// against the verified manifest (fail-closed).
 	let sha256sums = source.fetch("SHA256SUMS")?;
 	let signature = source.fetch("SHA256SUMS.sig")?;
-
-	// Security gate: signed manifest first, then the binary's digest against it.
 	verify::verify_signature(&sha256sums, &signature)?;
 	let expected = verify::expected_digest(&sha256sums, asset)?;
+
+	println!("downloading {asset} ({latest_tag}) ...");
+	let binary = source.fetch(asset)?;
 	verify::verify_digest(&binary, &expected)?;
 	println!("signature and checksum verified");
 


### PR DESCRIPTION
Promote develop → main for the **v0.24.0** release.

## Included (pre-launch review remediation)
- **#345** file-borne DoS caps (YAML alias amplification, GPU count, ulimit, daemon read timeout)
- **#346** cp/watch write safety (honour user dst, bound archive, mask modes, no symlink follow)
- **#347** fail-closed correctness (hook exit code, config-hash, quadlet collisions)
- **#348** secret bind-string colon-injection guard + name validation
- **#349** self-update hardening (O_EXCL + O_NOFOLLOW, setuid mask, verify-before-download)
- **#350** cargo-audit release gate + pinned SBOM generators
- **#351** version bump to 0.24.0

## After merge
Tag `v0.24.0` on main → release.yml builds and publishes.

Closes #339, #340, #341, #342, #343, #344