### PR TITLE
chore: fill copyright owner in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Glyndor
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace the Apache-2.0 appendix placeholder `Copyright [yyyy] [name of copyright owner]` with `Copyright 2026 Glyndor`.

Cosmetic/legal hygiene; license detection unaffected.

Closes #353