### PR TITLE
test(engine): deterministic coverage for depends_on health/completion gating

### DIFF
--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -7,9 +7,72 @@
 
 use crate::compose::types::Service;
 use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::{ContainerInspect, ContainerState};
 use crate::libpod::API_PREFIX;
 
 use super::Engine;
+
+/// Per-poll verdict while waiting for `service_healthy`.
+enum HealthVerdict {
+	/// The runtime reports the container as `healthy`.
+	Healthy,
+	/// The container has no effective healthcheck, so `healthy` is unreachable;
+	/// treat the dependency as satisfied rather than blocking until timeout.
+	NoHealthcheck,
+	/// Not healthy yet — keep polling.
+	Pending,
+}
+
+/// Per-poll verdict while waiting for `service_completed_successfully`.
+enum CompletionVerdict {
+	/// The container exited with status 0.
+	Succeeded,
+	/// The container exited with a non-zero status — the dependency failed.
+	Failed,
+	/// Not exited yet — keep polling.
+	Pending,
+}
+
+/// Classify a container inspect while waiting for `service_healthy`.
+///
+/// Pure decision logic for [`Engine::wait_healthy`], split out so the gating
+/// behaviour can be unit-tested without a live Podman socket.
+fn classify_health(info: &ContainerInspect) -> HealthVerdict {
+	if let Some(state) = &info.state {
+		if let Some(health) = &state.health {
+			if health.status.as_deref() == Some("healthy") {
+				return HealthVerdict::Healthy;
+			}
+		}
+	}
+	if !info
+		.config
+		.as_ref()
+		.map(|c| c.has_healthcheck())
+		.unwrap_or(false)
+	{
+		return HealthVerdict::NoHealthcheck;
+	}
+	HealthVerdict::Pending
+}
+
+/// Classify a container state while waiting for `service_completed_successfully`.
+///
+/// Pure decision logic for [`Engine::wait_completed`], split out so the
+/// fail-closed-on-non-zero-exit gating can be unit-tested without Podman. A
+/// missing exit code is treated as failure (`unwrap_or(-1)`).
+fn classify_completion(state: Option<&ContainerState>) -> CompletionVerdict {
+	match state {
+		Some(s) if s.status.as_deref() == Some("exited") => {
+			if s.exit_code.unwrap_or(-1) == 0 {
+				CompletionVerdict::Succeeded
+			} else {
+				CompletionVerdict::Failed
+			}
+		}
+		_ => CompletionVerdict::Pending,
+	}
+}
 
 impl Engine {
 	/// Poll a container until its health status is `healthy` or timeout.
@@ -44,20 +107,15 @@ impl Engine {
 					continue;
 				}
 			};
-			if let Some(state) = &info.state {
-				if let Some(health) = &state.health {
-					if health.status.as_deref() == Some("healthy") {
-						return Ok(());
-					}
+			match classify_health(&info) {
+				HealthVerdict::Healthy => return Ok(()),
+				HealthVerdict::NoHealthcheck => {
+					tracing::debug!(
+						"{container_name} has no effective healthcheck; treating service_healthy as satisfied"
+					);
+					return Ok(());
 				}
-			}
-			// No `healthy` status yet. If the container has no effective
-			// healthcheck, it never will — treat the dependency as satisfied.
-			if !info.config.map(|c| c.has_healthcheck()).unwrap_or(false) {
-				tracing::debug!(
-					"{container_name} has no effective healthcheck; treating service_healthy as satisfied"
-				);
-				return Ok(());
+				HealthVerdict::Pending => {}
 			}
 			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 		}
@@ -86,18 +144,102 @@ impl Engine {
 					continue;
 				}
 			};
-			if let Some(state) = info.state {
-				if state.status.as_deref() == Some("exited") {
-					if state.exit_code.unwrap_or(-1) == 0 {
-						return Ok(());
-					}
+			match classify_completion(info.state.as_ref()) {
+				CompletionVerdict::Succeeded => return Ok(()),
+				CompletionVerdict::Failed => {
 					return Err(ComposeError::HealthCheckTimeout(format!(
 						"{container_name} exited with non-zero status"
 					)));
 				}
+				CompletionVerdict::Pending => {}
 			}
 			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 		}
 		Err(ComposeError::HealthCheckTimeout(container_name.into()))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn inspect(json: &str) -> ContainerInspect {
+		serde_json::from_str(json).expect("fixture parses")
+	}
+
+	// --- wait_completed gating (service_completed_successfully) ---------------
+
+	#[test]
+	fn completion_exited_zero_succeeds() {
+		let info = inspect(r#"{"State":{"Status":"exited","ExitCode":0}}"#);
+		assert!(matches!(
+			classify_completion(info.state.as_ref()),
+			CompletionVerdict::Succeeded
+		));
+	}
+
+	#[test]
+	fn completion_exited_nonzero_fails() {
+		let info = inspect(r#"{"State":{"Status":"exited","ExitCode":1}}"#);
+		assert!(matches!(
+			classify_completion(info.state.as_ref()),
+			CompletionVerdict::Failed
+		));
+	}
+
+	#[test]
+	fn completion_exited_missing_code_fails_closed() {
+		// No ExitCode → unwrap_or(-1) → must be treated as failure, never success.
+		let info = inspect(r#"{"State":{"Status":"exited"}}"#);
+		assert!(matches!(
+			classify_completion(info.state.as_ref()),
+			CompletionVerdict::Failed
+		));
+	}
+
+	#[test]
+	fn completion_running_pends() {
+		let info = inspect(r#"{"State":{"Status":"running","ExitCode":0}}"#);
+		assert!(matches!(
+			classify_completion(info.state.as_ref()),
+			CompletionVerdict::Pending
+		));
+	}
+
+	#[test]
+	fn completion_no_state_pends() {
+		let info = inspect("{}");
+		assert!(matches!(
+			classify_completion(info.state.as_ref()),
+			CompletionVerdict::Pending
+		));
+	}
+
+	// --- wait_healthy gating (service_healthy) -------------------------------
+
+	#[test]
+	fn health_reported_healthy() {
+		let info = inspect(r#"{"State":{"Status":"running","Health":{"Status":"healthy"}}}"#);
+		assert!(matches!(classify_health(&info), HealthVerdict::Healthy));
+	}
+
+	#[test]
+	fn health_no_effective_healthcheck_is_satisfied() {
+		// A disabled healthcheck (Test ["NONE"]) can never report healthy, so the
+		// dependency short-circuits as satisfied rather than blocking to timeout.
+		let info =
+			inspect(r#"{"State":{"Status":"running"},"Config":{"Healthcheck":{"Test":["NONE"]}}}"#);
+		assert!(matches!(
+			classify_health(&info),
+			HealthVerdict::NoHealthcheck
+		));
+	}
+
+	#[test]
+	fn health_starting_with_healthcheck_pends() {
+		let info = inspect(
+			r#"{"State":{"Status":"running","Health":{"Status":"starting"}},"Config":{"Healthcheck":{"Test":["CMD","true"]}}}"#,
+		);
+		assert!(matches!(classify_health(&info), HealthVerdict::Pending));
 	}
 }


### PR DESCRIPTION
Closes #359.

`engine/health.rs` `wait_healthy` / `wait_completed` drive the `depends_on` conditions `service_healthy` and `service_completed_successfully` and had **0 unit tests** — only the live-Podman integration suite exercised them.

The decision extracted here matters most for `wait_completed`: a container that exits **non-zero** must fail the dependency, so a one-shot init/migration container that fails blocks its dependents from starting. A regression in that comparison would silently treat a failed init as success, and nothing tested it.

## Change
- Extract the per-poll branch logic into pure `classify_health` / `classify_completion` functions returning a verdict enum. The polling/sleep loops are unchanged — pure relocation.
- Add 8 unit tests using JSON inspect fixtures (no Podman): exited-zero, exited-nonzero, exited-missing-code (fails closed), still-running, absent state; and healthy / no-effective-healthcheck / still-starting.

The JSON fixtures also exercise the real PascalCase wire deserialization (`State`/`ExitCode`/`Health`/`Config`/`Healthcheck`).

## Verification
- `cargo test --lib` 587 passed (was 579).
- `cargo test --all-features --test engine_integration` 100 passed (real rootless Podman).
- `cargo fmt --check` clean, `cargo clippy --lib --all-features` clean.
- `health.rs` 238 lines (under the 500 limit).