### PR TITLE
chore: consume shared reusable workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,29 +5,9 @@ on:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   audit:
-    name: cargo audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --version "^0.22" --locked
-
-      - name: Run cargo audit
-        run: cargo audit
-
-  deny:
-    name: cargo deny
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --version "^0.19" --locked
-
-      - name: Run cargo deny
-        run: cargo deny check
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@91a23397a14f0efb46e2b354d72df0e10a0004b6 # main

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,10 +1,5 @@
 name: DCO
 
-# Enforce the Developer Certificate of Origin: every commit on a pull request
-# must carry a `Signed-off-by:` trailer. This makes contributor attestation a
-# machine-checked gate rather than a convention, which government and
-# enterprise audits expect.
-
 on:
   pull_request:
     branches:
@@ -16,32 +11,4 @@ permissions:
 
 jobs:
   dco:
-    name: Signed-off-by present on every commit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-
-      - name: Verify Signed-off-by trailers
-        env:
-          # The PR's real commits, excluding the synthetic merge commit that the
-          # checkout action creates (which has no sign-off and is not authored).
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          missing=0
-          for sha in $(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}"); do
-            author="$(git show -s --format='%an <%ae>' "$sha")"
-            if ! git show -s --format='%(trailers:key=Signed-off-by)' "$sha" \
-              | grep -qi 'Signed-off-by:'; then
-              echo "::error::commit $sha ($author) is missing a Signed-off-by trailer"
-              missing=1
-            fi
-          done
-          if [ "$missing" -ne 0 ]; then
-            echo "Add a sign-off with: git commit -s (or git rebase --signoff)."
-            exit 1
-          fi
-          echo "All commits carry a Signed-off-by trailer."
+    uses: Glyndor/.github/.github/workflows/dco.yml@91a23397a14f0efb46e2b354d72df0e10a0004b6 # main

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,13 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    name: shellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Syntax check
-        run: bash -n install.sh
-
-      - name: Run shellcheck
-        run: shellcheck --severity=style install.sh
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@91a23397a14f0efb46e2b354d72df0e10a0004b6 # main

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,15 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    name: develop-only
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require develop as source branch
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          if [ "$HEAD_REF" != "develop" ]; then
-            echo "::error::Pull requests into main must come from develop (got $HEAD_REF)."
-            exit 1
-          fi
-          echo "Source branch is develop."
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@91a23397a14f0efb46e2b354d72df0e10a0004b6 # main

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,11 +1,5 @@
 name: Supply chain
 
-# Generate the supply-chain artifacts government and enterprise consumers expect
-# before deployment: a machine-readable SBOM (CycloneDX, per US EO 14028) and a
-# third-party license attribution (NOTICES). Running on every PR keeps the
-# generators honest; the release workflow attaches the same artifacts to each
-# published release.
-
 on:
   pull_request:
     branches:
@@ -25,27 +19,5 @@ permissions:
   contents: read
 
 jobs:
-  sbom-and-licenses:
-    name: SBOM and license attribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install generators
-        run: |
-          cargo install --locked cargo-cyclonedx --version "^0.5"
-          cargo install --locked --features cli cargo-about --version "^0.9"
-
-      - name: Generate CycloneDX SBOM
-        run: cargo cyclonedx --format json --all-features
-
-      - name: Generate third-party license attribution (NOTICES)
-        run: cargo about generate about.hbs > NOTICES.html
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sbom-and-notices
-          path: |
-            *.cdx.json
-            NOTICES.html
-          if-no-files-found: error
+  supply-chain:
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@91a23397a14f0efb46e2b354d72df0e10a0004b6 # main


### PR DESCRIPTION
Replace bespoke dco, audit, supply-chain, lint-shell and main-guard workflows with calls to the org reusables in `Glyndor/.github`, pinned by SHA. Behavior unchanged; logic now centralized.

Note: the `develop-only` required status check is renamed to `develop-only / develop-only` (reusable workflow nesting). The protect-main ruleset will be updated to match before the release PR to main.