### PR TITLE
chore: pin reusable workflows to .github v1.0.0

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -22,4 +22,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@ef351e0a6632c3688a32c524d09f56abb1c6e2ba # main
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@ef351e0a6632c3688a32c524d09f56abb1c6e2ba # main
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@2de584f368690524992185b30e23f342c19aab23 # main
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       podman: true

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@ef351e0a6632c3688a32c524d09f56abb1c6e2ba # main
+    uses: Glyndor/.github/.github/workflows/dco.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@ef351e0a6632c3688a32c524d09f56abb1c6e2ba # main
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@ef351e0a6632c3688a32c524d09f56abb1c6e2ba # main
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@ef351e0a6632c3688a32c524d09f56abb1c6e2ba # main
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@ef351e0a6632c3688a32c524d09f56abb1c6e2ba # main
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0


### PR DESCRIPTION
Bump all `Glyndor/.github` reusable refs to the v1.0.0 SHA with `# v1.0.0` comment. Enables Dependabot to track future releases and pulls in the hardened reusables (cargo-tool caching, debian:trixie, env-passed inputs).