### PR TITLE
chore: enforce the file-size limit via line-limit reusable

### DIFF
--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -1,0 +1,14 @@
+name: Line limit
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  line-limit:
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0


### PR DESCRIPTION
Release: add the line-limit reusable as a required check (soft 300 / hard 500).