### PR TITLE
release: v0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.1" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.24.1) unstable; urgency=medium
+
+  * Drop-in runtime compatibility fixes:
+    - Resolve a relative `file:` secret/config or bind source against the
+      project directory when the compose file is given as a bare name, rather
+      than the working directory the Podman service later runs in.
+    - Keep `up` idempotent over an existing named volume (Podman's libpod
+      volume-create reports an existing volume as HTTP 500, not 409).
+    - Register each service's name as a network alias so a service is reachable
+      by its service name on shared networks.
+    - Render a multi-line `command:` as a valid single-line Quadlet `Exec=`.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 16 Jun 2026 16:30:00 -0500
+
 podup (0.24.0) unstable; urgency=medium
 
   * Security/robustness hardening from a pre-launch review:

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.24.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.24.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Patch release bumping to 0.24.1 (Cargo, Cargo.lock, debian/changelog, man-page `.TH`, README lib tag).

Contents — the drop-in runtime compatibility fixes merged in #378:
- relative `file:` sources resolved against the project directory for a bare compose filename (#374)
- idempotent `up` over an existing named volume (#375)
- service reachable by its service name on shared networks (#376)
- valid single-line Quadlet `Exec=` for a multi-line `command:` (#377)