### PR TITLE
release: v0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.0" }
+podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.1" }
 ```
 
 ## 📖 Docs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (0.24.1) unstable; urgency=medium
+
+  * Drop-in runtime compatibility fixes:
+    - Resolve a relative `file:` secret/config or bind source against the
+      project directory when the compose file is given as a bare name, rather
+      than the working directory the Podman service later runs in.
+    - Keep `up` idempotent over an existing named volume (Podman's libpod
+      volume-create reports an existing volume as HTTP 500, not 409).
+    - Register each service's name as a network alias so a service is reachable
+      by its service name on shared networks.
+    - Render a multi-line `command:` as a valid single-line Quadlet `Exec=`.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 16 Jun 2026 16:30:00 -0500
+
 podup (0.24.0) unstable; urgency=medium
 
   * Security/robustness hardening from a pre-launch review:

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.24.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 0.24.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -114,7 +114,7 @@ impl Engine {
 		let log_configuration = build_log_config(service.logging.as_ref());
 
 		// --- Networks ---
-		let (netns, networks) = resolve_network_mode(service, file, &self.project);
+		let (netns, networks) = resolve_network_mode(service_name, service, file, &self.project);
 
 		// --- Labels ---
 		let label_file_labels = build_label_file_labels(service, &self.base_dir);

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -74,7 +74,10 @@ impl Engine {
 				.await
 			{
 				Ok(_) => info!("created network {network_name}"),
-				Err(ref e) if e.is_status(409) => {}
+				// An existing network is not an error on re-`up`; accept any
+				// already-exists conflict (network-create returns 409, but share
+				// the same predicate as volume-create for consistency).
+				Err(ref e) if e.is_already_exists() => {}
 				Err(e) => return Err(ComposeError::Podman(e)),
 			}
 		}
@@ -87,6 +90,7 @@ impl Engine {
 // ---------------------------------------------------------------------------
 
 pub(super) fn build_per_network_options(
+	service_name: &str,
 	cfg: Option<&ServiceNetworkConfig>,
 	fallback_mac: Option<&str>,
 ) -> PerNetworkOptions {
@@ -127,10 +131,19 @@ pub(super) fn build_per_network_options(
 		opts.static_mac = Some(mac.to_string());
 	}
 
+	// A service is reachable by its service name on every network it joins
+	// (compose-spec DNS contract). Register the service name as a network alias
+	// unless the compose file already lists it, so siblings can resolve it by
+	// name and not only by the container name or the auto-generated id alias.
+	if !service_name.is_empty() && !opts.aliases.iter().any(|a| a == service_name) {
+		opts.aliases.insert(0, service_name.to_string());
+	}
+
 	opts
 }
 
 pub(super) fn resolve_network_mode(
+	service_name: &str,
 	service: &Service,
 	file: &ComposeFile,
 	project: &str,
@@ -161,6 +174,7 @@ pub(super) fn resolve_network_mode(
 		.map(|net_name| {
 			let full = resolve_network_name(net_name, file, project);
 			let opts = build_per_network_options(
+				service_name,
 				service.networks.config_for(net_name),
 				service.mac_address.as_deref(),
 			);
@@ -324,7 +338,7 @@ mod tests {
 			..Default::default()
 		};
 		let file = empty_file();
-		let (ns, nets) = resolve_network_mode(&svc, &file, "proj");
+		let (ns, nets) = resolve_network_mode("web", &svc, &file, "proj");
 		assert!(ns.is_some());
 		assert_eq!(ns.unwrap().nsmode, "host");
 		assert!(nets.is_empty());
@@ -334,26 +348,47 @@ mod tests {
 	fn resolve_network_mode_no_networks() {
 		let svc = Service::default();
 		let file = empty_file();
-		let (ns, nets) = resolve_network_mode(&svc, &file, "proj");
+		let (ns, nets) = resolve_network_mode("web", &svc, &file, "proj");
 		assert!(ns.is_none());
 		assert!(nets.is_empty());
 	}
 
 	#[test]
-	fn build_per_network_options_no_config() {
-		let opts = build_per_network_options(None, None);
-		assert!(opts.aliases.is_empty());
+	fn build_per_network_options_seeds_service_name_alias() {
+		// With no explicit config, the service name is still registered as an
+		// alias so siblings can reach the service by name.
+		let opts = build_per_network_options("web", None, None);
+		assert_eq!(opts.aliases, vec!["web".to_string()]);
 		assert!(opts.static_ips.is_empty());
+	}
+
+	#[test]
+	fn build_per_network_options_empty_service_name_adds_no_alias() {
+		let opts = build_per_network_options("", None, None);
+		assert!(opts.aliases.is_empty());
 	}
 
 	#[test]
 	fn build_per_network_options_with_aliases() {
 		use crate::compose::types::ServiceNetworkConfig;
 		let cfg = ServiceNetworkConfig {
+			aliases: Some(vec!["api".to_string()]),
+			..Default::default()
+		};
+		// The service name is prepended ahead of any explicit aliases.
+		let opts = build_per_network_options("web", Some(&cfg), None);
+		assert_eq!(opts.aliases, vec!["web".to_string(), "api".to_string()]);
+	}
+
+	#[test]
+	fn build_per_network_options_does_not_duplicate_service_name() {
+		use crate::compose::types::ServiceNetworkConfig;
+		let cfg = ServiceNetworkConfig {
 			aliases: Some(vec!["web".to_string(), "api".to_string()]),
 			..Default::default()
 		};
-		let opts = build_per_network_options(Some(&cfg), None);
+		// An explicit alias equal to the service name is not duplicated.
+		let opts = build_per_network_options("web", Some(&cfg), None);
 		assert_eq!(opts.aliases, vec!["web".to_string(), "api".to_string()]);
 	}
 
@@ -364,13 +399,13 @@ mod tests {
 			ipv4_address: Some("10.0.0.5".to_string()),
 			..Default::default()
 		};
-		let opts = build_per_network_options(Some(&cfg), None);
+		let opts = build_per_network_options("web", Some(&cfg), None);
 		assert!(opts.static_ips.contains(&"10.0.0.5".to_string()));
 	}
 
 	#[test]
 	fn fallback_mac_applied_when_no_config() {
-		let opts = build_per_network_options(None, Some("02:42:ac:11:00:02"));
+		let opts = build_per_network_options("web", None, Some("02:42:ac:11:00:02"));
 		assert_eq!(opts.static_mac.as_deref(), Some("02:42:ac:11:00:02"));
 	}
 
@@ -421,7 +456,7 @@ mod tests {
 			interface_name: Some("eth1".into()),
 			..Default::default()
 		};
-		let opts = build_per_network_options(Some(&cfg), None);
+		let opts = build_per_network_options("web", Some(&cfg), None);
 		assert_eq!(opts.interface_name.as_deref(), Some("eth1"));
 	}
 
@@ -432,7 +467,7 @@ mod tests {
 			mac_address: Some("aa:bb:cc:dd:ee:ff".to_string()),
 			..Default::default()
 		};
-		let opts = build_per_network_options(Some(&cfg), Some("02:42:ac:11:00:03"));
+		let opts = build_per_network_options("web", Some(&cfg), Some("02:42:ac:11:00:03"));
 		assert_eq!(opts.static_mac.as_deref(), Some("aa:bb:cc:dd:ee:ff"));
 	}
 }

--- a/internal/engine/volume.rs
+++ b/internal/engine/volume.rs
@@ -68,7 +68,10 @@ impl Engine {
 				.await
 			{
 				Ok(_) => info!("created volume {volume_name}"),
-				Err(ref e) if e.is_status(409) => {}
+				// Podman's libpod volume-create returns 500 (not 409) for an
+				// existing name; treat an already-exists conflict as success so a
+				// re-`up` over an existing named volume stays idempotent.
+				Err(ref e) if e.is_already_exists() => {}
 				Err(e) => return Err(ComposeError::Podman(e)),
 			}
 		}

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -63,6 +63,21 @@ impl PodmanError {
 	pub fn is_status(&self, code: u16) -> bool {
 		matches!(self, Self::Api { status, .. } if *status == code)
 	}
+
+	/// True if this API error reports that the resource already exists: an HTTP
+	/// 409 conflict, or an HTTP 500 whose message says so. Podman's libpod
+	/// volume-create endpoint returns 500 (not 409) for a duplicate name, so an
+	/// idempotent create must accept both to let a re-`up` succeed.
+	pub(crate) fn is_already_exists(&self) -> bool {
+		match self {
+			Self::Api { status: 409, .. } => true,
+			Self::Api {
+				status: 500,
+				message,
+			} => message.contains("already exists"),
+			_ => false,
+		}
+	}
 }
 
 #[cfg(test)]
@@ -84,6 +99,41 @@ mod tests {
 	fn is_status_false_for_non_api() {
 		let e = PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err());
 		assert!(!e.is_status(404));
+	}
+
+	#[test]
+	fn already_exists_accepts_409_and_500_with_message() {
+		// 409 conflict: always an already-exists.
+		assert!(PodmanError::Api {
+			status: 409,
+			message: "network already used".into(),
+		}
+		.is_already_exists());
+		// 500 carrying the libpod "already exists" cause (Podman's volume-create
+		// path) must also count as already-exists for idempotent create.
+		assert!(PodmanError::Api {
+			status: 500,
+			message: "volume with name p_v already exists: volume already exists".into(),
+		}
+		.is_already_exists());
+	}
+
+	#[test]
+	fn already_exists_false_for_other_errors() {
+		// A 500 that is not an already-exists must still propagate.
+		assert!(!PodmanError::Api {
+			status: 500,
+			message: "internal error".into(),
+		}
+		.is_already_exists());
+		assert!(!PodmanError::Api {
+			status: 404,
+			message: "no such volume".into(),
+		}
+		.is_already_exists());
+		assert!(
+			!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_already_exists()
+		);
 	}
 
 	#[test]

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -89,10 +89,53 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 	}
 }
 
+/// Render a compose `command:`/`entrypoint:` into a single-line systemd `Exec=`
+/// value. systemd splits the value on whitespace honouring double-quoted groups
+/// and C-style escapes, so each list element is quoted when it contains
+/// whitespace or quoting characters, and control characters are always escaped.
+/// Without this a multi-line argument (e.g. an `sh -c` block scalar) would emit
+/// raw newlines that spill onto extra physical lines and corrupt the unit file.
 pub(super) fn render_command(command: &Command) -> String {
 	match command {
-		Command::Shell(s) => s.clone(),
-		Command::Exec(parts) => parts.join(" "),
+		// A shell-form command is already a single command line; keep its word
+		// splitting but neutralise control characters so it stays on one line.
+		Command::Shell(s) => escape_exec_control(s),
+		Command::Exec(parts) => parts
+			.iter()
+			.map(|p| quote_exec_arg(p))
+			.collect::<Vec<_>>()
+			.join(" "),
+	}
+}
+
+/// C-escape the characters that must never appear raw in a systemd command line.
+fn escape_exec_control(s: &str) -> String {
+	let mut out = String::with_capacity(s.len());
+	for c in s.chars() {
+		match c {
+			'\\' => out.push_str("\\\\"),
+			'\n' => out.push_str("\\n"),
+			'\r' => out.push_str("\\r"),
+			'\t' => out.push_str("\\t"),
+			_ => out.push(c),
+		}
+	}
+	out
+}
+
+/// Quote a single `Exec=` argument: wrap it in double quotes (escaping `"` and
+/// control characters) when it is empty or contains whitespace or quoting
+/// characters, so systemd keeps it as one argument. Plain arguments pass through
+/// unchanged.
+fn quote_exec_arg(arg: &str) -> String {
+	let needs_quoting = arg.is_empty()
+		|| arg
+			.chars()
+			.any(|c| c.is_whitespace() || matches!(c, '"' | '\'' | '\\' | '$' | '%' | ';'));
+	if needs_quoting {
+		format!("\"{}\"", escape_exec_control(arg).replace('"', "\\\""))
+	} else {
+		arg.to_string()
 	}
 }
 
@@ -201,5 +244,70 @@ mod tests {
 	fn sanitize_value_strips_control_characters() {
 		assert_eq!(sanitize_value("plain"), "plain");
 		assert_eq!(sanitize_value("a\nb\tc\r"), "abc");
+	}
+
+	#[test]
+	fn render_command_exec_quotes_args_with_whitespace() {
+		let cmd = Command::Exec(vec![
+			"server".to_string(),
+			"--port".to_string(),
+			"9000".to_string(),
+		]);
+		// Plain arguments pass through unquoted.
+		assert_eq!(render_command(&cmd), "server --port 9000");
+
+		let cmd = Command::Exec(vec!["echo".to_string(), "hello world".to_string()]);
+		assert_eq!(render_command(&cmd), "echo \"hello world\"");
+	}
+
+	#[test]
+	fn render_command_exec_multiline_arg_stays_one_line() {
+		// A multi-line block-scalar argument (e.g. an `sh -c` script) must be
+		// quoted with its newlines C-escaped so the rendered Exec= never spills
+		// onto a second physical line or mashes adjacent tokens together.
+		let cmd = Command::Exec(vec![
+			"sh".to_string(),
+			"-c".to_string(),
+			"mkdir -p /www\necho hi > /www/index.html\nexec httpd".to_string(),
+		]);
+		let out = render_command(&cmd);
+		assert!(
+			!out.contains('\n'),
+			"rendered Exec must be a single line: {out}"
+		);
+		assert_eq!(
+			out,
+			"sh -c \"mkdir -p /www\\necho hi > /www/index.html\\nexec httpd\""
+		);
+	}
+
+	#[test]
+	fn render_command_exec_escapes_quotes_and_backslashes() {
+		let cmd = Command::Exec(vec![
+			"sh".to_string(),
+			"-c".to_string(),
+			"printf '%s' \"a\\b\"".to_string(),
+		]);
+		let out = render_command(&cmd);
+		assert!(!out.contains('\n'));
+		// The embedded double quotes and backslash are escaped inside the quoted
+		// argument.
+		assert!(out.starts_with("sh -c \""));
+		assert!(out.contains("\\\""));
+		assert!(out.contains("\\\\"));
+	}
+
+	#[test]
+	fn render_command_shell_neutralizes_newlines() {
+		let cmd = Command::Shell("echo a\necho b".to_string());
+		let out = render_command(&cmd);
+		assert!(!out.contains('\n'));
+		assert_eq!(out, "echo a\\necho b");
+
+		// A plain single-line shell command is unchanged.
+		assert_eq!(
+			render_command(&Command::Shell("echo hi".to_string())),
+			"echo hi"
+		);
 	}
 }

--- a/internal/resolve.rs
+++ b/internal/resolve.rs
@@ -38,9 +38,17 @@ pub(crate) fn resolve_compose_files(explicit: &[PathBuf]) -> Vec<PathBuf> {
 /// compose file (compose-spec default), or the current directory when the
 /// compose file has no parent component.
 pub(crate) fn resolve_base_dir(project_directory: Option<&Path>, file: &Path) -> PathBuf {
-	project_directory
-		.map(Path::to_path_buf)
-		.unwrap_or_else(|| file.parent().map(Path::to_path_buf).unwrap_or_default())
+	if let Some(dir) = project_directory {
+		return dir.to_path_buf();
+	}
+	match file.parent() {
+		Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+		// A bare compose filename (e.g. `docker-compose.yml`) has an empty parent
+		// component. Anchor relative paths to the working directory so a relative
+		// `file:` secret/config or bind source resolves against the project
+		// directory, not the working directory the Podman service later runs in.
+		_ => std::env::current_dir().unwrap_or_default(),
+	}
 }
 
 /// Resolve the project name following the compose-spec precedence: an explicit
@@ -144,8 +152,13 @@ mod tests {
 
 	#[test]
 	fn bare_filename_resolves_to_current_dir() {
+		// A bare filename has no directory component, so the base directory must
+		// fall back to the working directory — never an empty path, which would
+		// leave a relative `file:` source to be resolved against the Podman
+		// service's working directory ($HOME) instead of the project directory.
 		let base = resolve_base_dir(None, Path::new("docker-compose.yml"));
-		assert_eq!(base, PathBuf::from(""));
+		assert_eq!(base, std::env::current_dir().unwrap());
+		assert!(base.is_absolute());
 	}
 
 	#[test]

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -305,3 +305,69 @@ async fn port_scaled_service_targets_first_replica() {
 	engine.port(&file, "worker", 80, "tcp").await.unwrap();
 	engine.down(&file).await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// Idempotent re-up over an existing named volume
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn up_is_idempotent_over_existing_named_volume() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("idv");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    volumes:\n      - data:/data\nvolumes:\n  data:\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// A second `up` must succeed even though the named volume already exists.
+	// Podman's libpod volume-create returns HTTP 500 (not 409) for a duplicate
+	// name, so a re-up previously aborted here.
+	let second = engine.up(&file).await;
+	engine.down(&file).await.unwrap();
+	second.expect("second up over an existing named volume must be idempotent");
+}
+
+// ---------------------------------------------------------------------------
+// A sibling resolves a service by its service name on a shared network
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn sibling_resolves_service_by_name_on_shared_network() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("dns");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  server:\n    image: busybox:latest\n    command: [\"sh\", \"-c\", \"mkdir -p /www; echo ok > /www/index.html; exec httpd -f -p 80 -h /www\"]\n    networks:\n      - appnet\n  client:\n    image: busybox:latest\n    command: [\"sleep\", \"infinity\"]\n    networks:\n      - appnet\nnetworks:\n  appnet:\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// The client must reach the server by its compose service name (`server`),
+	// not only by the container name — the service name has to be registered as
+	// a network alias. Retry briefly while the server's httpd comes up.
+	let out = engine
+		.test_exec_capture(
+			&format!("{proj}-client"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"for i in $(seq 1 30); do wget -q -O - http://server:80/ && exit 0; sleep 0.3; done; exit 1".into(),
+			],
+		)
+		.await;
+	engine.down(&file).await.unwrap();
+	let out = out.expect("exec in client container failed");
+	assert!(
+		out.contains("ok"),
+		"service `server` was not reachable by its service name: {out:?}"
+	);
+}


### PR DESCRIPTION
Promote v0.24.1 to main.

Drop-in runtime compatibility fixes (from #378) plus the version bump:
- relative `file:` sources resolved against the project directory for a bare compose filename (#374)
- idempotent `up` over an existing named volume — libpod volume-create returns 500, not 409 (#375)
- service reachable by its service name on shared networks (#376)
- valid single-line Quadlet `Exec=` for a multi-line `command:` (#377)

Tagging `v0.24.1` on main after merge triggers the release workflow.