### PR TITLE
fix(quadlet): emit memory and apparmor via PodmanArgs, warn on dropped semantics

### DIFF
--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -137,7 +137,7 @@ services:
 		"Sysctl=net.core.somaxconn=1024",
 		"Ulimit=nofile=1024:2048",
 		"ShmSize=64m",
-		"Memory=512m",
+		"PodmanArgs=--memory=512m",
 		"PidsLimit=100",
 		"UserNS=keep-id",
 		"StopSignal=SIGTERM",
@@ -251,8 +251,41 @@ networks:
 		"LogDriver=journald",
 		"LogOpt=tag=mytag",
 		"NetworkAlias=web-alias",
-		"Memory=256m",
+		"PodmanArgs=--memory=256m",
 	] {
 		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
+	}
+}
+
+#[test]
+fn memory_and_apparmor_render_as_podman_args_not_invalid_keys() {
+	// `Memory=` and `AppArmor=` are not valid Quadlet [Container] keys in Podman
+	// 5.x; emitting them makes the generator reject the whole unit. They must be
+	// expressed through `PodmanArgs=` instead.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    mem_limit: 512m
+    security_opt:
+      - "apparmor=my-profile"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("PodmanArgs=--memory=512m"),
+		"missing memory PodmanArgs in:\n{c}"
+	);
+	assert!(
+		c.contains("PodmanArgs=--security-opt apparmor=my-profile"),
+		"missing apparmor PodmanArgs in:\n{c}"
+	);
+	for forbidden in ["\nMemory=", "\nAppArmor="] {
+		assert!(
+			!c.contains(forbidden),
+			"emitted invalid key `{}` in:\n{c}",
+			forbidden.trim()
+		);
 	}
 }

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -110,7 +110,9 @@ fn map_security_opt(opt: &str, container: &mut Section, name: &str, warnings: &m
 		.strip_prefix("apparmor=")
 		.or_else(|| opt.strip_prefix("apparmor:"))
 	{
-		container.add("AppArmor", profile.to_string());
+		// Quadlet has no `AppArmor=` key in Podman 5.x; the generator rejects the
+		// whole unit on an unknown key. Pass it through as a raw podman flag.
+		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
 	} else if let Some(label) = opt.strip_prefix("label=") {
 		if label == "disable" {
 			container.add("SecurityLabelDisable", "true".to_string());
@@ -334,7 +336,9 @@ pub(super) fn container_unit(
 		container.add("ShmSize", shm.clone());
 	}
 	if let Some(mem) = &service.mem_limit {
-		container.add("Memory", mem.clone());
+		// `Memory=` is not a valid Quadlet key in Podman 5.x (the generator
+		// rejects the unit); express the limit as a raw podman flag.
+		container.add("PodmanArgs", format!("--memory={mem}"));
 	}
 	if let Some(pids) = service.pids_limit {
 		container.add("PidsLimit", pids.to_string());
@@ -393,7 +397,7 @@ pub(super) fn container_unit(
 			.and_then(|r| r.limits.as_ref())
 			.and_then(|l| l.memory.as_ref())
 		{
-			container.add("Memory", mem.clone());
+			container.add("PodmanArgs", format!("--memory={mem}"));
 		}
 	}
 	for secret in &service.secrets {

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -1,6 +1,6 @@
 //! Report compose fields that are set but have no Quadlet mapping.
 
-use crate::compose::types::Service;
+use crate::compose::types::{DependsOn, Service, ServiceCondition};
 
 /// Warn for fields that are set but have no Quadlet mapping, so the operator
 /// knows the generated unit is incomplete rather than discovering it at run
@@ -45,6 +45,31 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"privileged",
 			"is not mapped; add PodmanArgs manually if required",
 		);
+	}
+	if !service.post_start.is_empty() {
+		warn(
+			"post_start",
+			"hooks have no Quadlet equivalent and are skipped",
+		);
+	}
+	if !service.pre_stop.is_empty() {
+		warn(
+			"pre_stop",
+			"hooks have no Quadlet equivalent and are skipped",
+		);
+	}
+	// systemd `After=`/`Requires=` order startup but cannot gate it on a
+	// dependency becoming healthy or completing; those conditions are dropped.
+	if let DependsOn::Map(deps) = &service.depends_on {
+		if deps
+			.values()
+			.any(|c| c.condition != ServiceCondition::ServiceStarted)
+		{
+			warn(
+				"depends_on",
+				"condition service_healthy/service_completed_successfully is not enforceable in Quadlet; only start ordering is emitted",
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #387

Quadlet export emitted `Memory=` and `AppArmor=`, which are not valid Quadlet `[Container]` keys in Podman 5.x — the generator rejects the unit (`unsupported key 'Memory'`), so any service with a memory limit or an apparmor profile produced a broken export. Both are now emitted via `PodmanArgs=`.

Also adds warnings for `post_start`/`pre_stop` hooks and `depends_on` `service_healthy`/`service_completed_successfully` conditions, which had no Quadlet mapping but were dropped silently.

## Test plan
- New unit test asserts memory/apparmor render as `PodmanArgs=` and never as the invalid bare keys.
- Updated the two field-mapping tests.
- Verified end-to-end on Podman 5.4.2: `podup generate quadlet` output passes `/usr/libexec/podman/quadlet -dryrun` with no `unsupported key` error; the resulting `ExecStart` carries `--memory=256m --security-opt apparmor=unconfined`.
- fmt, clippy (-D warnings), full test suite green.