### PR TITLE
fix(compose): pull_policy mapping, absolute include paths, gpus translation, restart serialization

### DIFF
--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -50,17 +50,15 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 			let rel_path = std::path::Path::new(&rel);
 			// The Compose Specification resolves `include` paths relative to the
 			// including file and treats `../` as canonical (monorepos routinely use
-			// `include: ../shared/compose.yaml`), so parent-directory traversal is
-			// permitted here — consistent with the trusted-input policy applied to
-			// `extends.file` and `env_file`. Absolute paths remain rejected as an
-			// intentional hardening choice: they are not portable across checkouts
-			// and the spec does not require them.
-			if rel_path.is_absolute() {
-				return Err(ComposeError::Include(format!(
-					"include path must be relative, got absolute path: {rel}"
-				)));
-			}
-			let inc_path = dir.join(&rel);
+			// `include: ../shared/compose.yaml`). An absolute path is used as given.
+			// This matches docker-compose and the trusted-input policy already
+			// applied to `extends.file` and `env_file` — the compose file is
+			// trusted input, like a Makefile.
+			let inc_path = if rel_path.is_absolute() {
+				rel_path.to_path_buf()
+			} else {
+				dir.join(&rel)
+			};
 			let inc_dir = project_dir_override.clone().unwrap_or_else(|| {
 				inc_path
 					.parent()

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -121,12 +121,32 @@ pub struct LifecycleHook {
 }
 
 /// Service-level `restart:` policy — `no`, `always`, `unless-stopped`, or `on-failure` (with optional max-retries).
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RestartPolicy {
 	No,
 	Always,
 	OnFailure { max_attempts: Option<u32> },
 	UnlessStopped,
+}
+
+impl Serialize for RestartPolicy {
+	// Emit the compose-spec string form so `config` output round-trips back
+	// through `Deserialize` (the derived form would emit `UnlessStopped`).
+	fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		let s = match self {
+			RestartPolicy::No => "no".to_string(),
+			RestartPolicy::Always => "always".to_string(),
+			RestartPolicy::UnlessStopped => "unless-stopped".to_string(),
+			RestartPolicy::OnFailure {
+				max_attempts: Some(n),
+			} => format!("on-failure:{n}"),
+			RestartPolicy::OnFailure { max_attempts: None } => "on-failure".to_string(),
+		};
+		serializer.serialize_str(&s)
+	}
 }
 
 impl<'de> Deserialize<'de> for RestartPolicy {
@@ -169,6 +189,40 @@ mod tests {
 	#[test]
 	fn depends_on_empty_has_no_names() {
 		assert!(DependsOn::Empty.service_names().is_empty());
+	}
+
+	#[test]
+	fn restart_policy_serializes_to_compose_string() {
+		let ser = |p: &RestartPolicy| serde_yaml::to_string(p).unwrap().trim().to_string();
+		assert_eq!(ser(&RestartPolicy::No), "no");
+		assert_eq!(ser(&RestartPolicy::Always), "always");
+		assert_eq!(ser(&RestartPolicy::UnlessStopped), "unless-stopped");
+		assert_eq!(
+			ser(&RestartPolicy::OnFailure { max_attempts: None }),
+			"on-failure"
+		);
+		assert_eq!(
+			ser(&RestartPolicy::OnFailure {
+				max_attempts: Some(5)
+			}),
+			"on-failure:5"
+		);
+	}
+
+	#[test]
+	fn restart_policy_round_trips_through_yaml() {
+		for input in [
+			"no",
+			"always",
+			"unless-stopped",
+			"on-failure",
+			"on-failure:3",
+		] {
+			let p: RestartPolicy = serde_yaml::from_str(input).unwrap();
+			let out = serde_yaml::to_string(&p).unwrap();
+			let reparsed: RestartPolicy = serde_yaml::from_str(&out).unwrap();
+			assert_eq!(p, reparsed, "round-trip failed for {input}");
+		}
 	}
 
 	#[test]

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -35,11 +35,14 @@ impl Engine {
 
 		info!("pulling {image}");
 
-		let pull_policy = match service.pull_policy.as_deref() {
-			Some("always") => "always",
-			Some("newer") => "newer",
-			_ => "missing",
-		};
+		let requested = service.pull_policy.as_deref();
+		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
+			warn!(
+				"unknown pull_policy '{}', defaulting to 'missing'",
+				requested.unwrap_or_default()
+			);
+			"missing"
+		});
 		let mut query = format!("reference={}&policy={}", urlencoded(&image), pull_policy);
 		if let Some(platform) = &service.platform {
 			query.push_str(&format!("&platform={}", urlencoded(platform)));
@@ -382,10 +385,38 @@ fn is_remote_context(context: &str) -> bool {
 	context.contains("://") || context.starts_with("git@")
 }
 
+/// Map a compose `pull_policy:` value to the libpod images/pull `policy`
+/// parameter. `if_not_present` is the spec alias for `missing`; `build` falls
+/// back to `missing` here (its build behavior is handled by the caller). Returns
+/// `None` for an unrecognized value so the caller can warn and default.
+pub(super) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'static str> {
+	match policy {
+		Some("always") => Some("always"),
+		Some("newer") => Some("newer"),
+		Some("never") => Some("never"),
+		None | Some("missing") | Some("if_not_present") | Some("build") => Some("missing"),
+		Some(_) => None,
+	}
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, Engine};
+	use super::{is_remote_context, libpod_pull_policy, Engine};
 	use crate::libpod::Client;
+
+	#[test]
+	fn pull_policy_maps_every_spec_value() {
+		assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
+		assert_eq!(libpod_pull_policy(Some("newer")), Some("newer"));
+		assert_eq!(libpod_pull_policy(Some("never")), Some("never"));
+		assert_eq!(libpod_pull_policy(Some("missing")), Some("missing"));
+		// `if_not_present` is the spec alias for `missing`.
+		assert_eq!(libpod_pull_policy(Some("if_not_present")), Some("missing"));
+		assert_eq!(libpod_pull_policy(Some("build")), Some("missing"));
+		assert_eq!(libpod_pull_policy(None), Some("missing"));
+		// Unknown values are reported (None) so the caller warns.
+		assert_eq!(libpod_pull_policy(Some("bogus")), None);
+	}
 
 	fn engine(base: std::path::PathBuf) -> Engine {
 		Engine::with_base_dir(Client::new("/nonexistent.sock"), "p".into(), base)

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -45,13 +45,6 @@ impl Engine {
 
 		warn_swarm_only_deploy(service_name, service);
 
-		if service.gpus.is_some() {
-			tracing::warn!(
-				"service \"{service_name}\": top-level gpus: is not yet supported \
-				— use deploy.resources.reservations.devices for GPU access"
-			);
-		}
-
 		// --- Environment ---
 		// A bare `KEY` (no `=`) is a passthrough: its value comes from podup's
 		// own environment, matching docker-compose. Drop it only when unset.

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -1,7 +1,7 @@
 //! Resource-limit builders: CPU/memory/pids limits, ulimits, and CDI device
 //! reservations.
 
-use crate::compose::types::Service;
+use crate::compose::types::{DeviceReservation, GpuSpec, Service};
 use crate::libpod::types::container::{LinuxResources, Ulimit};
 use crate::size;
 
@@ -156,57 +156,82 @@ const MAX_GPU_DEVICES: i64 = 64;
 pub(crate) fn cdi_devices(service: &Service) -> Vec<String> {
 	let mut out = Vec::new();
 
-	let Some(reservations) = service
+	if let Some(reservations) = service
 		.deploy
 		.as_ref()
 		.and_then(|d| d.resources.as_ref())
 		.and_then(|r| r.reservations.as_ref())
-	else {
-		return out;
-	};
-
-	for dev in &reservations.devices {
-		let is_gpu = dev.capabilities.iter().any(|c| c == "gpu" || c == "nvidia");
-		let driver = dev.driver.as_deref().unwrap_or("nvidia");
-		if !is_gpu || (driver != "nvidia" && !driver.is_empty()) {
-			tracing::warn!(
-				"device reservation (driver {:?}, capabilities {:?}) is not supported and is ignored",
-				dev.driver,
-				dev.capabilities
-			);
-			continue;
+	{
+		for dev in &reservations.devices {
+			push_reservation_devices(dev, &mut out);
 		}
+	}
 
-		if !dev.device_ids.is_empty() {
-			for id in &dev.device_ids {
-				out.push(format!("nvidia.com/gpu={id}"));
-			}
-			continue;
-		}
-
-		match dev.count.as_ref().map(|c| c.to_i64()) {
-			// `count: all` (-1) or unspecified → request every GPU.
-			Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
-			Some(n) if n > 0 => {
-				// Clamp to a sane device count: the value comes from an untrusted
-				// compose file and a huge `count:` would otherwise allocate billions
-				// of device-id strings during spec assembly (OOM) before any
-				// container is created. No host has anywhere near this many GPUs.
-				if n > MAX_GPU_DEVICES {
-					tracing::warn!(
-						"device reservation count {n} exceeds the maximum of {MAX_GPU_DEVICES}; \
-						 clamping (no host has this many GPUs)"
-					);
-				}
-				for i in 0..n.min(MAX_GPU_DEVICES) {
-					out.push(format!("nvidia.com/gpu={i}"));
+	// The top-level `gpus:` shorthand maps to the same NVIDIA CDI devices as a
+	// `deploy.resources.reservations.devices` GPU reservation.
+	if let Some(gpus) = &service.gpus {
+		match gpus {
+			GpuSpec::Devices(devs) => {
+				for dev in devs {
+					push_reservation_devices(dev, &mut out);
 				}
 			}
-			Some(_) => {}
+			// `gpus: all` / `gpus: N` request that many NVIDIA GPUs.
+			GpuSpec::Named(_) | GpuSpec::Count(_) => {
+				push_gpu_count(Some(gpus.to_count()), &mut out)
+			}
 		}
 	}
 
 	out
+}
+
+/// Translate one `devices:` GPU reservation into CDI device names, appending to
+/// `out`. Non-NVIDIA / non-GPU reservations are warned about and skipped.
+fn push_reservation_devices(dev: &DeviceReservation, out: &mut Vec<String>) {
+	let is_gpu = dev.capabilities.iter().any(|c| c == "gpu" || c == "nvidia");
+	let driver = dev.driver.as_deref().unwrap_or("nvidia");
+	if !is_gpu || (driver != "nvidia" && !driver.is_empty()) {
+		tracing::warn!(
+			"device reservation (driver {:?}, capabilities {:?}) is not supported and is ignored",
+			dev.driver,
+			dev.capabilities
+		);
+		return;
+	}
+
+	if !dev.device_ids.is_empty() {
+		for id in &dev.device_ids {
+			out.push(format!("nvidia.com/gpu={id}"));
+		}
+		return;
+	}
+
+	push_gpu_count(dev.count.as_ref().map(|c| c.to_i64()), out);
+}
+
+/// Append `count` NVIDIA CDI device names to `out`. `-1`/`None` means "all".
+fn push_gpu_count(count: Option<i64>, out: &mut Vec<String>) {
+	match count {
+		// `count: all` (-1) or unspecified → request every GPU.
+		Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
+		Some(n) if n > 0 => {
+			// Clamp to a sane device count: the value comes from an untrusted
+			// compose file and a huge `count:` would otherwise allocate billions
+			// of device-id strings during spec assembly (OOM) before any
+			// container is created. No host has anywhere near this many GPUs.
+			if n > MAX_GPU_DEVICES {
+				tracing::warn!(
+					"GPU device count {n} exceeds the maximum of {MAX_GPU_DEVICES}; \
+					 clamping (no host has this many GPUs)"
+				);
+			}
+			for i in 0..n.min(MAX_GPU_DEVICES) {
+				out.push(format!("nvidia.com/gpu={i}"));
+			}
+		}
+		Some(_) => {}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -326,6 +351,32 @@ mod tests {
 			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              device_ids: [\"GPU-abc\", \"1\"]\n",
 		);
 		assert_eq!(got, vec!["nvidia.com/gpu=GPU-abc", "nvidia.com/gpu=1"]);
+	}
+
+	#[test]
+	fn cdi_top_level_gpus_all() {
+		assert_eq!(
+			cdi_for("services:\n  app:\n    image: x\n    gpus: all\n"),
+			vec!["nvidia.com/gpu=all"]
+		);
+	}
+
+	#[test]
+	fn cdi_top_level_gpus_count() {
+		assert_eq!(
+			cdi_for("services:\n  app:\n    image: x\n    gpus: 2\n"),
+			vec!["nvidia.com/gpu=0", "nvidia.com/gpu=1"]
+		);
+	}
+
+	#[test]
+	fn cdi_top_level_gpus_device_list() {
+		assert_eq!(
+			cdi_for(
+				"services:\n  app:\n    image: x\n    gpus:\n      - capabilities: [gpu]\n        device_ids: [\"GPU-xyz\"]\n",
+			),
+			vec!["nvidia.com/gpu=GPU-xyz"]
+		);
 	}
 
 	#[test]

--- a/tests/parse/anchors.rs
+++ b/tests/parse/anchors.rs
@@ -88,24 +88,14 @@ services:
 }
 
 #[test]
-fn include_absolute_path_rejected() {
+fn include_missing_path_errors() {
+	// `include:` resolves absolute and `../` paths (trusted input); a path that
+	// does not exist still fails cleanly rather than being silently ignored.
 	let dir = tempfile::tempdir().unwrap();
 	let main = dir.path().join("docker-compose.yml");
 	writeln!(
 		std::fs::File::create(&main).unwrap(),
-		"include:\n  - /etc/passwd\nservices:\n  app:\n    image: alpine"
-	)
-	.unwrap();
-	assert!(parse_file(&main).is_err());
-}
-
-#[test]
-fn include_parent_traversal_rejected() {
-	let dir = tempfile::tempdir().unwrap();
-	let main = dir.path().join("docker-compose.yml");
-	writeln!(
-		std::fs::File::create(&main).unwrap(),
-		"include:\n  - ../../secret.yml\nservices:\n  app:\n    image: alpine"
+		"include:\n  - /nonexistent/podup-does-not-exist.yml\nservices:\n  app:\n    image: alpine"
 	)
 	.unwrap();
 	assert!(parse_file(&main).is_err());

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -75,25 +75,41 @@ services:
 }
 
 #[test]
-fn include_absolute_path_is_rejected() {
-	// Absolute include paths remain rejected as intentional hardening: they are
-	// not portable across checkouts and the spec does not require them.
+fn include_absolute_path_resolves() {
+	// docker-compose accepts absolute include paths; the compose file is trusted
+	// input (like a Makefile), so podup resolves them as given rather than
+	// rejecting them.
 	let dir = tempfile::tempdir().unwrap();
+
+	let shared = dir.path().join("shared.yml");
+	writeln!(
+		std::fs::File::create(&shared).unwrap(),
+		r#"
+services:
+  shared_svc:
+    image: alpine
+"#
+	)
+	.unwrap();
+
 	let main = dir.path().join("docker-compose.yml");
 	writeln!(
 		std::fs::File::create(&main).unwrap(),
 		r#"
 include:
-  - /etc/shared.yml
+  - {}
 
 services:
   app:
     image: nginx
-"#
+"#,
+		shared.display()
 	)
 	.unwrap();
 
-	assert!(parse_file(&main).is_err());
+	let file = parse_file(&main).unwrap();
+	assert!(file.services.contains_key("app"));
+	assert!(file.services.contains_key("shared_svc"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #388

Compose-spec drop-in fidelity fixes for 1.0.0:

- **pull_policy**: only `always`/`newer` were handled; `never`, `missing`, `if_not_present`, `build` and unknown values all silently mapped to `missing`. Each spec value is now mapped explicitly (extracted to a unit-tested pure helper) and unknown values warn.
- **include**: absolute paths were rejected, contradicting docker-compose and the project's own trusted-input policy (already applied to `extends.file`/`env_file`). Absolute include paths now resolve.
- **gpus**: the top-level `gpus:` shorthand (`all`/`N`/device-list) was parsed but dropped with a warning; it is now translated to NVIDIA CDI devices like the deploy reservation path.
- **config output**: `RestartPolicy` derived `Serialize`, so `podup config` emitted `UnlessStopped` instead of `unless-stopped` — invalid compose that could not be re-parsed. A custom `Serialize` now emits the canonical string and the value round-trips.

## Test plan
- New unit tests: pull_policy maps every spec value (+ unknown→None); restart serialize + YAML round-trip; gpus all/count/device-list → CDI.
- include absolute-path integration test resolves a real shared file; stale 'rejected' tests updated.
- Verified on Podman 5.4.2: `podup config` now prints `restart: unless-stopped`.
- fmt, clippy (-D warnings), full suite green.