### PR TITLE
fix(engine): reject remote socket schemes, surface parsed errors on streaming endpoints

### DIFF
--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -194,6 +194,18 @@ impl Client {
 		})
 	}
 
+	/// For streaming endpoints: return the response on success, otherwise read
+	/// the body and surface it through [`check_status`] so the caller gets the
+	/// parsed Podman error message rather than the raw JSON body.
+	async fn stream_or_err(resp: Response<Incoming>) -> Result<Response<Incoming>> {
+		if resp.status().is_success() {
+			return Ok(resp);
+		}
+		let (status, body) = Self::read_body(resp).await?;
+		Self::check_status(status, &body)?;
+		unreachable!("check_status returns Err for a non-success status")
+	}
+
 	// ---------------------------------------------------------------------------
 	// Request helpers
 	// ---------------------------------------------------------------------------
@@ -219,15 +231,7 @@ impl Client {
 	/// `GET` → return raw `Response<Incoming>` for streaming.
 	pub async fn get_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with JSON body → deserialize JSON response.
@@ -276,15 +280,7 @@ impl Client {
 			Full::new(Bytes::from(json)),
 			Some("application/json"),
 		)?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with empty body → ignore response body (expect 2xx or 304).
@@ -302,15 +298,7 @@ impl Client {
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with empty body → deserialize JSON response.
@@ -330,15 +318,7 @@ impl Client {
 		content_type: &str,
 	) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with a raw-bytes body → deserialize JSON response.

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -3,7 +3,7 @@
 // libc FFI (getuid) is needed here; the block carries a soundness comment.
 #![allow(unsafe_code)]
 
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 use crate::libpod::Client;
 #[cfg(any(not(windows), test))]
 use std::path::Path;
@@ -27,6 +27,13 @@ const DEFAULT_PIPE: &str = "//./pipe/podman-machine-default";
 pub fn connect(socket_path: Option<&str>) -> Result<Client> {
 	let default_path = default_socket_path();
 	let raw = socket_path.unwrap_or(&default_path);
+	if let Some(scheme) = remote_scheme(raw) {
+		return Err(ComposeError::Unsupported(format!(
+			"remote Podman over `{scheme}` is not supported; podup talks to a local \
+			 rootless socket. Point PODMAN_SOCKET/--socket at a unix:// socket path \
+			 (or an npipe:// pipe on Windows)."
+		)));
+	}
 	let path = raw
 		.strip_prefix("unix://")
 		.or_else(|| raw.strip_prefix("npipe://"))
@@ -34,17 +41,23 @@ pub fn connect(socket_path: Option<&str>) -> Result<Client> {
 	Ok(Client::new(path))
 }
 
-/// Strips the `unix://` or `npipe://` scheme prefix before passing the path to [`connect`].
+/// Detect a non-local socket scheme (`tcp://`, `ssh://`, `http(s)://`, `fd://`).
+/// `unix://`/`npipe://` and plain paths are local and return `None`.
+fn remote_scheme(raw: &str) -> Option<&'static str> {
+	const REMOTE: [&str; 5] = ["tcp://", "ssh://", "http://", "https://", "fd://"];
+	REMOTE.into_iter().find(|s| raw.starts_with(s))
+}
+
+/// Read the Podman socket from the environment (`PODMAN_SOCKET`, then
+/// `DOCKER_HOST` as a Docker-compatible fallback) and connect. A `unix://` /
+/// `npipe://` scheme is stripped by [`connect`]; a remote scheme is rejected
+/// there with a clear error.
 pub fn connect_from_env() -> Result<Client> {
 	let socket = std::env::var("PODMAN_SOCKET")
 		.or_else(|_| std::env::var("DOCKER_HOST"))
 		.ok();
 
-	let path = socket.as_deref().and_then(|s| {
-		s.strip_prefix("unix://")
-			.or_else(|| s.strip_prefix("npipe://"))
-	});
-	connect(path)
+	connect(socket.as_deref())
 }
 
 #[cfg(not(windows))]
@@ -257,5 +270,28 @@ mod tests {
 	fn connect_passes_plain_path_unchanged() {
 		let c = connect(Some("/run/user/1000/podman/podman.sock")).unwrap();
 		drop(c);
+	}
+
+	#[test]
+	fn connect_rejects_remote_schemes() {
+		for raw in [
+			"tcp://127.0.0.1:2375",
+			"ssh://user@host/run/podman.sock",
+			"http://localhost:8080",
+			"https://localhost:8080",
+			"fd://3",
+		] {
+			assert!(
+				matches!(connect(Some(raw)), Err(ComposeError::Unsupported(_))),
+				"{raw} should be rejected as unsupported"
+			);
+		}
+	}
+
+	#[test]
+	fn remote_scheme_ignores_local_sockets() {
+		assert!(remote_scheme("/run/podman.sock").is_none());
+		assert!(remote_scheme("unix:///run/podman.sock").is_none());
+		assert!(remote_scheme("npipe:////./pipe/podman").is_none());
 	}
 }


### PR DESCRIPTION
Closes #390

- **Remote sockets**: a `tcp://`/`ssh://`/`http(s)://`/`fd://` value in `PODMAN_SOCKET`/`DOCKER_HOST` was handed to the Unix-socket connector as a path (opaque error) or silently dropped. It now returns a clear `unsupported feature` error. `DOCKER_HOST` remains a documented local-socket fallback.
- **Streaming errors**: the four streaming client helpers bypassed `check_status`, so an error on a streaming endpoint surfaced the raw JSON body instead of the parsed Podman message. They now share a `stream_or_err` helper.

## Test plan
- Unit tests: `connect` rejects every remote scheme; `remote_scheme` ignores local sockets.
- Verified on Podman 5.4.2: `PODMAN_SOCKET=tcp://… podup ps` prints the actionable error and exits 1.
- fmt, clippy (-D warnings), full suite green.

Note: proactive Podman-version negotiation (the third item in #390) is deferred; `_ping` already gives a clear failure and the engine targets the v5 libpod surface.