### PR TITLE
refactor(api): stabilize the public library surface for 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ async fn main() -> podup::Result<()> {
 podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.1" }
 ```
 
+## 🔒 Stability & versioning
+
+podup follows [Semantic Versioning](https://semver.org/). From **1.0.0** onward:
+
+- The CLI surface (subcommands, flags, exit codes) and the library surface re-exported from the crate root (`parse_file`, `collect_diagnostics`, `Engine`, `ComposeError`, …) are covered by the stability guarantee. Breaking changes bump the major version and are called out in the release notes.
+- Public enums and the compose/quadlet result structs are `#[non_exhaustive]`, so new variants and fields can be added in a minor release without breaking downstream code — always include a wildcard arm and avoid exhaustive struct construction.
+- The libpod wire types are an internal implementation detail (not re-exported) and may change in any release.
+- **MSRV: Rust 1.85.** A bump to the minimum supported Rust version is a minor-version change, never a patch.
+
 ## 📖 Docs
 
 - [Command reference](docs/commands.md) — every subcommand, its options, and what it does

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -77,6 +77,15 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 	Ok(file)
 }
 
+/// Collect parse-time diagnostics for an already-parsed compose file: warnings
+/// about recognized-but-unsupported keys and fields that are accepted but carry
+/// no effect on Podman. The CLI prints these automatically; library consumers
+/// (e.g. panel-agent) can call this to surface the same warnings, since
+/// [`parse_file`] does not emit them itself.
+pub fn collect_diagnostics(file: &ComposeFile) -> Vec<String> {
+	diagnostics::collect(file)
+}
+
 /// Parse and merge multiple compose files (the `-f`/`COMPOSE_FILE` list).
 ///
 /// Files are merged left to right: a later file overrides an earlier one,
@@ -181,6 +190,20 @@ mod tests {
 		let file = parse_str_raw(yaml).unwrap();
 		assert!(file.services.contains_key("web"));
 		assert_eq!(file.services["web"].image.as_deref(), Some("nginx"));
+	}
+
+	#[test]
+	fn collect_diagnostics_surfaces_unknown_keys() {
+		// The public helper lets library consumers see the same warnings the CLI
+		// prints; parse_file itself stays quiet.
+		let file =
+			parse_str_raw("services:\n  web:\n    image: nginx\n    enviroment:\n      - A=1\n")
+				.unwrap();
+		let diags = collect_diagnostics(&file);
+		assert!(
+			diags.iter().any(|d| d.contains("enviroment")),
+			"expected an unknown-key diagnostic, got {diags:?}"
+		);
 	}
 
 	#[test]

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -30,6 +30,7 @@ use std::collections::HashMap;
 
 /// Top-level `secrets:` entry — defines a named secret available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct SecretConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
@@ -53,6 +54,7 @@ pub struct SecretConfig {
 
 /// Top-level `configs:` entry — defines a named config available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct ConfigConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
@@ -76,6 +78,7 @@ pub struct ConfigConfig {
 
 /// Root deserialization target for a `docker-compose.yml` file.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct ComposeFile {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub version: Option<String>,

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -62,6 +62,7 @@ pub struct ServiceNetworkConfig {
 
 /// Named network definition in the top-level `networks:` block.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct NetworkConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -20,6 +20,7 @@ use super::{
 
 /// A single service definition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image: Option<String>,

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -106,6 +106,7 @@ impl VolumeMount {
 
 /// Named volume definition in the top-level `volumes:` block.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct VolumeConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -6,25 +6,48 @@
 use std::fmt;
 
 /// All errors produced by podup.
+///
+/// `#[non_exhaustive]`: new variants may be added in a minor release, so
+/// downstream `match` arms must include a wildcard.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ComposeError {
+	/// The compose YAML could not be deserialized.
 	Parse(serde_yaml::Error),
+	/// A referenced compose/include/extends file does not exist.
 	FileNotFound(String),
+	/// An underlying filesystem operation failed.
 	Io(std::io::Error),
+	/// The Podman libpod API returned an error or could not be reached.
 	Podman(crate::libpod::PodmanError),
+	/// A named service is not defined in the compose file.
 	ServiceNotFound(String),
+	/// `depends_on` forms a cycle, so no valid start order exists.
 	CircularDependency(String),
+	/// A service has neither an `image:` nor a `build:` section.
 	NoImageOrBuild(String),
+	/// A `${VAR}` with the `?err` modifier was required but unset.
 	RequiredVarNotSet { var: String, msg: String },
+	/// A service did not become healthy within its dependency wait window.
 	HealthCheckTimeout(String),
+	/// A `ports:` entry could not be parsed.
 	InvalidPort(String),
+	/// Image build failed (context assembly or the Podman build step).
 	Build(String),
+	/// `extends:` could not be resolved (missing file/service or a cycle).
 	Extends(String),
+	/// `include:` could not be resolved or merged.
 	Include(String),
+	/// The `watch` command failed (filesystem watch or sync action).
 	Watch(String),
+	/// A compose feature is recognized but unsupported on Podman/podup.
 	Unsupported(String),
+	/// A `run` container exited; carries its non-zero exit code so the CLI can
+	/// propagate it as its own process exit status.
 	RunExited(i64),
+	/// `podup update` (self-update) failed.
 	Update(String),
+	/// An `external: true` secret/config/network/volume is absent.
 	ExternalNotFound(String),
 }
 

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -25,8 +25,8 @@ pub mod substitute;
 pub mod update;
 
 pub use compose::{
-	parse_file, parse_file_with_env_files, parse_files_with_env_files, parse_str, parse_str_raw,
-	resolve_levels, resolve_order,
+	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
+	parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
 pub use engine::{is_safe_project_name, Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -20,6 +20,7 @@ use unit::{container_unit, network_unit, volume_unit};
 
 /// A single generated unit file: its name and full contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct QuadletUnit {
 	/// File name, e.g. `web.container` or `db-data.volume`.
 	pub filename: String,
@@ -30,6 +31,7 @@ pub struct QuadletUnit {
 /// The result of a generation run: the units plus any warnings about set but
 /// unmapped fields.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct QuadletOutput {
 	/// Generated unit files, in a deterministic order.
 	pub units: Vec<QuadletUnit>,


### PR DESCRIPTION
Closes #389

Hardens the public API ahead of the 1.0.0 SemVer freeze:

- `#[non_exhaustive]` on `ComposeError` and the compose/quadlet result structs (`ComposeFile`, `Service`, `SecretConfig`, `ConfigConfig`, `NetworkConfig`, `VolumeConfig`, `QuadletUnit`, `QuadletOutput`) so variants/fields can be added in a minor release without breaking downstream.
- Documented every `ComposeError` variant (including `RunExited`'s exit-code payload).
- New public `collect_diagnostics(&ComposeFile)` — `parse_file` stayed silent, so library consumers (panel-agent) never saw the unsupported-field warnings the CLI prints.
- README **Stability & versioning** section: SemVer guarantee, the non_exhaustive contract, libpod wire types are internal, MSRV 1.85 policy.

Note: the audit's claim that lib.rs re-exports raw libpod wire types was inaccurate — `libpod` is already `pub(crate)`; only the opaque `Client` handle (a required `Engine::new` argument) is public, and the wire types are private. No lib.rs restructuring needed.

`breaking`: the non_exhaustive additions are technically breaking for any external exhaustive match/struct-literal; intended and covered by the 1.0.0 major.

## Test plan
- New tests: collect_diagnostics surfaces unknown-key warnings.
- Full suite + clippy (-D warnings) green; no internal exhaustive-match breakage.