### PR TITLE
fix(security): staging TOCTOU + XDG check, ulimit validation, Quadlet secret sanitization

### DIFF
--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -117,12 +117,55 @@ pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 	service
 		.ulimits
 		.iter()
-		.map(|(name, cfg)| Ulimit {
-			ulimit_type: name.clone(),
-			soft: ulimit_value(cfg.soft(), name, "soft"),
-			hard: ulimit_value(cfg.hard(), name, "hard"),
+		.filter_map(|(name, cfg)| {
+			if !is_known_ulimit(name) {
+				tracing::warn!("ulimit '{name}' is not a recognized resource name and is ignored");
+				return None;
+			}
+			let soft = ulimit_value(cfg.soft(), name, "soft");
+			let hard = ulimit_value(cfg.hard(), name, "hard");
+			// POSIX requires soft <= hard; a larger soft is invalid and would
+			// produce undefined behaviour at container start. Clamp it down.
+			let soft = if soft > hard {
+				tracing::warn!(
+					"ulimit {name} soft ({soft}) exceeds hard ({hard}); clamping soft to hard"
+				);
+				hard
+			} else {
+				soft
+			};
+			Some(Ulimit {
+				ulimit_type: name.clone(),
+				soft,
+				hard,
+			})
 		})
 		.collect()
+}
+
+/// The Linux rlimit resource names Podman accepts (without the `RLIMIT_`
+/// prefix). A name outside this set is a typo or an injection attempt and is
+/// rejected rather than forwarded verbatim to the API.
+fn is_known_ulimit(name: &str) -> bool {
+	const KNOWN: [&str; 16] = [
+		"core",
+		"cpu",
+		"data",
+		"fsize",
+		"locks",
+		"memlock",
+		"msgqueue",
+		"nice",
+		"nofile",
+		"nproc",
+		"rss",
+		"rtprio",
+		"rttime",
+		"sigpending",
+		"stack",
+		"as",
+	];
+	KNOWN.contains(&name)
 }
 
 /// Convert a compose ulimit value to the libpod `u64`. `-1` is the conventional
@@ -320,6 +363,34 @@ mod tests {
 		let ul = build_ulimits(&svc);
 		assert_eq!(ul[0].soft, 512);
 		assert_eq!(ul[0].hard, 2048);
+	}
+
+	#[test]
+	fn build_ulimits_clamps_soft_above_hard() {
+		use crate::compose::types::UlimitConfig;
+		let mut svc = default_service();
+		svc.ulimits.insert(
+			"nofile".to_string(),
+			UlimitConfig::Pair {
+				soft: 65535,
+				hard: 1024,
+			},
+		);
+		let ul = build_ulimits(&svc);
+		assert_eq!(ul[0].soft, 1024, "soft must be clamped down to hard");
+		assert_eq!(ul[0].hard, 1024);
+	}
+
+	#[test]
+	fn build_ulimits_rejects_unknown_resource_name() {
+		use crate::compose::types::UlimitConfig;
+		let mut svc = default_service();
+		svc.ulimits
+			.insert("bogus,inject=1".to_string(), UlimitConfig::Single(1024));
+		assert!(
+			build_ulimits(&svc).is_empty(),
+			"an unknown ulimit name must be dropped, not forwarded"
+		);
 	}
 
 	// --- cdi devices ---

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -46,7 +46,14 @@ pub(super) fn staging_base() -> Result<PathBuf> {
 	let euid = unsafe { libc::geteuid() };
 
 	let base = match std::env::var_os("XDG_RUNTIME_DIR") {
-		Some(dir) if Path::new(&dir).is_absolute() => PathBuf::from(dir).join("podup"),
+		Some(dir) if Path::new(&dir).is_absolute() => {
+			let xdg = PathBuf::from(&dir);
+			// The runtime dir must itself be a private directory owned by us. A
+			// hostile XDG_RUNTIME_DIR pointing at a shared/world-writable path
+			// would otherwise host secret staging under another user's control.
+			verify_private_dir(&xdg, euid)?;
+			xdg.join("podup")
+		}
 		_ => std::env::temp_dir().join(format!("podup-{euid}")),
 	};
 
@@ -109,7 +116,7 @@ pub(super) fn reject_dangerous_secret_mode(mode: u32, ctx: &str) -> Result<()> {
 /// `verify_private_dir` then rejects anything not ours (fail closed).
 #[cfg(unix)]
 fn ensure_private_dir(dir: &Path, euid: u32) -> Result<()> {
-	use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+	use std::os::unix::fs::DirBuilderExt;
 
 	std::fs::DirBuilder::new()
 		.recursive(true)
@@ -117,12 +124,11 @@ fn ensure_private_dir(dir: &Path, euid: u32) -> Result<()> {
 		.create(dir)
 		.map_err(ComposeError::Io)?;
 
-	let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
-	if meta.is_dir() {
-		std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
-			.map_err(ComposeError::Io)?;
-	}
-
+	// No chmod-healing of a pre-existing directory: re-applying the mode through
+	// the path would be a TOCTOU window (a symlink swapped in between the stat
+	// and the chmod). A freshly created directory is already 0700 from the mode
+	// above; a pre-existing directory with the wrong owner or mode is rejected
+	// by verify_private_dir below (fail closed).
 	verify_private_dir(dir, euid)
 }
 
@@ -253,16 +259,21 @@ mod ensure_dir_tests {
 	}
 
 	#[test]
-	fn heals_drifted_permissions_on_owned_dir() {
+	fn drifted_permissions_on_existing_dir_fail_closed() {
+		// A pre-existing directory with looser-than-0700 permissions is rejected
+		// rather than chmod-healed: healing through the path would be a TOCTOU
+		// window, and failing closed never writes secrets under a dir another
+		// user may currently access.
 		let root = tempfile::tempdir().expect("tempdir");
 		let dir = root.path().join("base");
 		std::fs::create_dir(&dir).expect("mkdir");
 		std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
 		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
 		let euid = unsafe { libc::geteuid() };
-		ensure_private_dir(&dir, euid).expect("healed dir");
+		assert!(ensure_private_dir(&dir, euid).is_err());
+		// Permissions are left untouched (no chmod attempted).
 		let meta = std::fs::metadata(&dir).expect("metadata");
-		assert_eq!(meta.mode() & 0o777, 0o700);
+		assert_eq!(meta.mode() & 0o777, 0o755);
 	}
 
 	#[test]

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -68,7 +68,9 @@ fn secret_field(value: &str) -> String {
 /// (`name[,target=,uid=,gid=,mode=]`).
 fn render_secret(secret: &ServiceSecretRef) -> String {
 	match secret {
-		ServiceSecretRef::Short(name) => name.clone(),
+		// Sanitize the short-form name too: `Secret=` is an option list, so a
+		// `,`/`=` in the name would inject extra options (same guard as Long).
+		ServiceSecretRef::Short(name) => secret_field(name),
 		ServiceSecretRef::Long {
 			source,
 			target,


### PR DESCRIPTION
Closes #392

ASVS L3 / secure-by-default hardening:
- **staging**: `XDG_RUNTIME_DIR` is now verified to be a private dir owned by the user before staging secrets under it; `ensure_private_dir` no longer chmod-heals a pre-existing directory through its path (a TOCTOU window) — it fails closed instead.
- **ulimits**: resource names are checked against an allowlist (was an injection surface) and a soft limit above hard is clamped (was undefined behaviour at start).
- **quadlet**: the short-form `Secret=` name is sanitized like the long form, closing an option-list injection.

## Test plan
- New tests: drifted-perms dir fails closed; ulimit soft>hard clamps; unknown ulimit name dropped.
- Full suite + clippy (-D warnings) green.