### PR TITLE
ci(release): sign NOTICES.html via the venv, guard releases to main, podman>=5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
           fi
           echo "Releasing version ${VERSION}."
 
+      - name: Tag must be on main
+        # Releases are cut only from `main` (develop → main merge, then tag).
+        # Refuse a tag pushed to any other branch so an unreviewed commit can
+        # never be published.
+        run: |
+          git fetch --unshallow --no-tags origin main 2>/dev/null \
+            || git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Tagged commit is not reachable from origin/main; releases must be cut from main."
+            exit 1
+          fi
+
       - name: Audit dependencies for known advisories
         # Gate the release on `cargo audit`: a RUSTSEC advisory in a pinned
         # dependency must block publishing, not wait for the weekly cron scan.
@@ -289,7 +301,7 @@ jobs:
           done
           # Sign the supply-chain artifacts so consumers can verify them offline.
           "$venv_py" .github/scripts/sign.py podup.cdx.json
-          python3 .github/scripts/sign.py NOTICES.html
+          "$venv_py" .github/scripts/sign.py NOTICES.html
 
       - name: Create GitHub Release
         env:

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Rules-Requires-Root: no
 Package: podup
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Recommends: podman (>= 4.0)
+Recommends: podman (>= 5.0)
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides


### PR DESCRIPTION
Closes #395

- **NOTICES.html** was signed with system `python3` (release.yml:292), bypassing the pinned venv used for every other artifact — the exact pattern that broke the v0.24.1 macOS signing. Now uses `$venv_py`.
- **Release guard**: `release.yml` fired on any `v*` tag on any branch. A new verify step refuses a tag not reachable from `origin/main`, so only reviewed, promoted commits can be published.
- **debian/control**: `Recommends: podman (>= 5.0)` to match the engine's libpod v5 requirement (was 4.0).

Follow-up (infra, not code): promoting `cargo audit` to a required status check on the develop ruleset (#395) is an owner action and is left to do separately; the weekly audit cron and the release-time audit gate already cover the supply chain in the meantime.

## Test plan
- `release.yml` parses as valid YAML; the signing step is now uniform on `$venv_py`.
- No code changes; existing CI unaffected.