### PR TITLE
docs: DOCKER_HOST, watch actions, man auto-version, SECURITY.md, library diagnostics

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,29 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately**, never in a public issue.
+
+Use GitHub's **"Report a vulnerability"** button under the repository's
+**Security** tab (Security advisories → Report a vulnerability). This opens a
+private channel with the maintainers.
+
+When reporting, include:
+
+- the affected version (`podup --version`) and platform,
+- a description of the issue and its impact,
+- and, where possible, a minimal reproduction.
+
+## Response
+
+- We aim to acknowledge a report within **5 business days**.
+- We will keep you informed of progress and coordinate a disclosure timeline
+  with you once the issue is confirmed.
+- Fixes ship as a new patch release; the advisory is published once users have
+  had a reasonable window to update.
+
+## Scope
+
+This policy covers the `podup` binary and library in this repository. Issues in
+Podman itself should be reported to the
+[Podman project](https://github.com/containers/podman).

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.1" }
+podup = "1"
 ```
 
 ## 🔒 Stability & versioning

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -147,6 +147,12 @@ Default active profiles (see \fB\-\-profile\fR).
 .B PODMAN_SOCKET
 Podman socket path (see \fB\-\-socket\fR).
 .TP
+.B DOCKER_HOST
+Docker-compatible fallback for the Podman socket, used only when
+\fBPODMAN_SOCKET\fR is unset. Must name a local \fBunix://\fR socket
+(or \fBnpipe://\fR on Windows); a remote \fBtcp://\fR or \fBssh://\fR value is
+rejected.
+.TP
 .B RUST_LOG
 Log verbosity filter. With no value set, warnings and errors are shown; set
 e.g. \fBRUST_LOG=podup=info\fR or \fBRUST_LOG=podup=debug\fR for more detail.

--- a/debian/rules
+++ b/debian/rules
@@ -43,6 +43,16 @@ override_dh_auto_install:
 	target/release/podup completions zsh  > debian/podup/usr/share/zsh/vendor-completions/_podup
 	target/release/podup completions fish > debian/podup/usr/share/fish/vendor_completions.d/podup.fish
 
+# Stamp the man page's .TH version and date from debian/changelog so they never
+# drift from the release. The date comes from the changelog entry, not the build
+# clock, to keep the build reproducible.
+override_dh_installman:
+	set -e; \
+	ver=$$(dpkg-parsechangelog --show-field Version | sed 's/-[^-]*$$//'); \
+	dat=$$(LC_ALL=C date -u -d "$$(dpkg-parsechangelog --show-field Date)" +'%B %Y'); \
+	sed -i -E "s/\"podup [0-9]+\.[0-9]+\.[0-9]+\"/\"podup $$ver\"/; s/^\.TH PODUP 1 \"[^\"]*\"/.TH PODUP 1 \"$$dat\"/" debian/podup.1; \
+	dh_installman
+
 override_dh_auto_clean:
 	cargo clean
 	rm -rf debian/cargo-home

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,9 +108,17 @@ prints a `podup: warning:` to stderr noting the files will not run on the host.
 ## Watch
 
 ### `watch`
-Watch for file changes and sync, rebuild or restart services as configured by
-each service's `develop.watch` rules. (`up --watch` does the same after
-starting the stack.)
+Watch for file changes and react as configured by each service's
+`develop.watch` rules. (`up --watch` does the same after starting the stack.)
+The `action` of each rule may be:
+
+| Action | Effect on change |
+|---|---|
+| `sync` | Copy the changed files into the running container. |
+| `rebuild` | Rebuild the image and recreate the container. |
+| `restart` | Restart the container without rebuilding. |
+| `sync+restart` | Sync the files, then restart the container. |
+| `sync+exec` | Sync the files, then run the rule's `exec` command in the container. |
 
 ## Self-update
 
@@ -161,6 +169,7 @@ when both are set.
 | `COMPOSE_PROJECT_NAME` | Default project name (`--project`). |
 | `COMPOSE_PROFILES` | Default active profiles (`--profile`). |
 | `PODMAN_SOCKET` | Podman socket path (`--socket`). |
+| `DOCKER_HOST` | Docker-compatible fallback for the Podman socket, used only when `PODMAN_SOCKET` is unset. Must be a local `unix://` socket (or `npipe://` on Windows); a remote `tcp://`/`ssh://` value is rejected. |
 | `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
 
 ## Exit status

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -164,6 +164,10 @@ a typo or an unmapped feature can't hide. At parse time podup warns about:
 This is what lets a compose file written for a newer Docker or Podman release
 run under podup: unsupported additions surface as warnings instead of vanishing.
 
+The `podup` CLI prints these warnings automatically. If you embed podup as a
+**library**, `parse_file` itself stays quiet — call `podup::collect_diagnostics`
+on the parsed file to obtain the same warnings and surface them to your users.
+
 `extra_hosts` is accepted in both the list (`["host:ip"]`) and mapping
 (`{host: ip}`) forms.
 


### PR DESCRIPTION
Closes #394

- Document `DOCKER_HOST` in the command reference and man-page ENVIRONMENT sections.
- List all five `develop.watch` actions (added sync+restart, sync+exec).
- Stamp the man-page `.TH` version/date from `debian/changelog` at build (reproducible — uses the changelog date), so it never drifts.
- Add `.github/SECURITY.md` (private disclosure policy; enables the Report a vulnerability button).
- Fix the docker-migration over-promise: note that library consumers must call `collect_diagnostics` to see warnings.
- Point the README library snippet at the crates.io form (`podup = "1"`) for 1.0.

## Test plan
- Man-page TH substitution dry-run verified against the current changelog.
- No code changes.