### PR TITLE
feat(cli): accept a service filter on pull

### DIFF
--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -203,8 +203,11 @@ pub(crate) enum Commands {
 		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
 		cmd: Vec<String>,
 	},
-	/// Pull images for all services.
-	Pull,
+	/// Pull images for the named services, or all services if none are given.
+	Pull {
+		/// Only pull images for these services.
+		services: Vec<String>,
+	},
 	/// Restart services.
 	Restart {
 		/// Only restart this service.

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -225,11 +225,19 @@ impl Engine {
 
 	/// Pull images for all services that declare an `image:` key, concurrently.
 	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
+		self.pull_services(file, &[]).await
+	}
+
+	/// Pull images for the named services (or every service when `services` is
+	/// empty), matching `docker compose pull [SERVICE...]`.
+	pub async fn pull_services(&self, file: &ComposeFile, services: &[String]) -> Result<()> {
 		let futs: Vec<_> = file
 			.services
-			.values()
-			.filter(|s| s.image.is_some())
-			.map(|s| self.pull_image(s))
+			.iter()
+			.filter(|(name, s)| {
+				s.image.is_some() && (services.is_empty() || services.iter().any(|w| w == *name))
+			})
+			.map(|(_, s)| self.pull_image(s))
 			.collect();
 
 		let results = futures_util::future::join_all(futs).await;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -360,7 +360,7 @@ async fn run() -> podup::Result<()> {
 			engine.logs(&file, service.as_deref(), follow).await?
 		}
 		Commands::Exec { service, cmd } => engine.exec(&file, &service, cmd).await?,
-		Commands::Pull => engine.pull(&file).await?,
+		Commands::Pull { services } => engine.pull_services(&file, &services).await?,
 		Commands::Restart { service } => engine.restart(&file, service.as_deref()).await?,
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),


### PR DESCRIPTION
Part of #391 (pull parity).

`docker compose pull [SERVICE...]` accepts an optional service filter; podup only pulled all services. Adds the optional list via a new non-breaking `pull_services` engine method (`pull` delegates to it).

The `up --scale`/`scale` half of #391 is deferred to #404: it would change the frozen public `Engine` API and is purely additive, so it is better as a post-1.0 minor release. `deploy.replicas`/`scale:` already work today.

## Test plan
- Verified on Podman 5.4.2: `podup pull a` pulls only service `a`; `pull` still pulls all; help shows `[SERVICES]...`.
- Full suite + clippy (-D warnings) green.