### PR TITLE
release: v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.24.1"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.24.1"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,30 @@
+podup (1.0.0) unstable; urgency=medium
+
+  * First stable release. The CLI and the crate-root library surface now carry
+    SemVer stability guarantees (public types are #[non_exhaustive]; MSRV 1.85).
+  * quadlet: emit memory and apparmor through PodmanArgs= instead of the invalid
+    Memory=/AppArmor= keys, which made the generator reject the whole unit; warn
+    on dropped post_start/pre_stop hooks and depends_on health/completion
+    conditions.
+  * compose: map every pull_policy value explicitly (never/if_not_present/local/
+    build); accept absolute include: paths; translate the top-level gpus:
+    shorthand to CDI devices; render restart: as the compose-spec string so
+    `config` output round-trips.
+  * engine: reject remote socket schemes (tcp://, ssh://, http(s)://) with a
+    clear error; surface parsed Podman errors on streaming endpoints.
+  * security: verify XDG_RUNTIME_DIR before staging, drop the chmod-heal TOCTOU
+    window, validate ulimit names and clamp soft above hard, sanitize the
+    short-form Quadlet Secret= name.
+  * library: add collect_diagnostics() so consumers see parse-time warnings.
+  * cli: accept a service filter on `pull`.
+  * docs/packaging: document DOCKER_HOST and the full watch action set, stamp
+    the man-page version/date from the changelog, add SECURITY.md, Recommends
+    podman (>= 5.0).
+  * ci: sign NOTICES.html via the pinned venv and refuse release tags not on
+    main.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 16 Jun 2026 15:00:00 -0500
+
 podup (0.24.1) unstable; urgency=medium
 
   * Drop-in runtime compatibility fixes:


### PR DESCRIPTION
Bumps the crate, lockfile and Debian changelog to **1.0.0** — the first stable release.

1.0.0 freezes the CLI and the crate-root library surface under SemVer (public types are `#[non_exhaustive]`, MSRV 1.85) and bundles the pre-1.0 hardening batch shipped in #396–#405:
- quadlet `PodmanArgs=` correctness (#396)
- compose-spec fidelity: pull_policy, absolute include, gpus→CDI, restart serialization (#397)
- runtime: remote-socket rejection, streaming error parsing (#398)
- library API stabilization + collect_diagnostics (#399)
- security: staging TOCTOU/XDG, ulimit validation, quadlet secret sanitize (#400)
- ci/release hardening (#401)
- docs + SECURITY.md + man auto-version (#402)
- test race fix + coverage (#403)
- pull service filter (#405)

After this lands on develop it is promoted to main and tagged `v1.0.0`.

## Verification (integrated develop, Podman 5.4.2)
- fmt, clippy -D warnings, ~985 tests, cargo deny/audit, line-limit all green; coverage 92.2%.
- Real e2e: up/down, DNS-by-name, secret delivery, `config` restart casing, quadlet PodmanArgs (no invalid keys), pull filter — all verified, artifacts cleaned.