### PR TITLE
release: v1.0.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,29 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately**, never in a public issue.
+
+Use GitHub's **"Report a vulnerability"** button under the repository's
+**Security** tab (Security advisories → Report a vulnerability). This opens a
+private channel with the maintainers.
+
+When reporting, include:
+
+- the affected version (`podup --version`) and platform,
+- a description of the issue and its impact,
+- and, where possible, a minimal reproduction.
+
+## Response
+
+- We aim to acknowledge a report within **5 business days**.
+- We will keep you informed of progress and coordinate a disclosure timeline
+  with you once the issue is confirmed.
+- Fixes ship as a new patch release; the advisory is published once users have
+  had a reasonable window to update.
+
+## Scope
+
+This policy covers the `podup` binary and library in this repository. Issues in
+Podman itself should be reported to the
+[Podman project](https://github.com/containers/podman).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
           fi
           echo "Releasing version ${VERSION}."
 
+      - name: Tag must be on main
+        # Releases are cut only from `main` (develop → main merge, then tag).
+        # Refuse a tag pushed to any other branch so an unreviewed commit can
+        # never be published.
+        run: |
+          git fetch --unshallow --no-tags origin main 2>/dev/null \
+            || git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Tagged commit is not reachable from origin/main; releases must be cut from main."
+            exit 1
+          fi
+
       - name: Audit dependencies for known advisories
         # Gate the release on `cargo audit`: a RUSTSEC advisory in a pinned
         # dependency must block publishing, not wait for the weekly cron scan.
@@ -289,7 +301,7 @@ jobs:
           done
           # Sign the supply-chain artifacts so consumers can verify them offline.
           "$venv_py" .github/scripts/sign.py podup.cdx.json
-          python3 .github/scripts/sign.py NOTICES.html
+          "$venv_py" .github/scripts/sign.py NOTICES.html
 
       - name: Create GitHub Release
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.24.1"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "0.24.1"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ async fn main() -> podup::Result<()> {
 podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.1" }
 ```
 
+## 🔒 Stability & versioning
+
+podup follows [Semantic Versioning](https://semver.org/). From **1.0.0** onward:
+
+- The CLI surface (subcommands, flags, exit codes) and the library surface re-exported from the crate root (`parse_file`, `collect_diagnostics`, `Engine`, `ComposeError`, …) are covered by the stability guarantee. Breaking changes bump the major version and are called out in the release notes.
+- Public enums and the compose/quadlet result structs are `#[non_exhaustive]`, so new variants and fields can be added in a minor release without breaking downstream code — always include a wildcard arm and avoid exhaustive struct construction.
+- The libpod wire types are an internal implementation detail (not re-exported) and may change in any release.
+- **MSRV: Rust 1.85.** A bump to the minimum supported Rust version is a minor-version change, never a patch.
+
 ## 📖 Docs
 
 - [Command reference](docs/commands.md) — every subcommand, its options, and what it does

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> podup::Result<()> {
 
 ```toml
 [dependencies]
-podup = { git = "https://github.com/Glyndor/podup", tag = "v0.24.1" }
+podup = "1"
 ```
 
 ## 🔒 Stability & versioning

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,30 @@
+podup (1.0.0) unstable; urgency=medium
+
+  * First stable release. The CLI and the crate-root library surface now carry
+    SemVer stability guarantees (public types are #[non_exhaustive]; MSRV 1.85).
+  * quadlet: emit memory and apparmor through PodmanArgs= instead of the invalid
+    Memory=/AppArmor= keys, which made the generator reject the whole unit; warn
+    on dropped post_start/pre_stop hooks and depends_on health/completion
+    conditions.
+  * compose: map every pull_policy value explicitly (never/if_not_present/local/
+    build); accept absolute include: paths; translate the top-level gpus:
+    shorthand to CDI devices; render restart: as the compose-spec string so
+    `config` output round-trips.
+  * engine: reject remote socket schemes (tcp://, ssh://, http(s)://) with a
+    clear error; surface parsed Podman errors on streaming endpoints.
+  * security: verify XDG_RUNTIME_DIR before staging, drop the chmod-heal TOCTOU
+    window, validate ulimit names and clamp soft above hard, sanitize the
+    short-form Quadlet Secret= name.
+  * library: add collect_diagnostics() so consumers see parse-time warnings.
+  * cli: accept a service filter on `pull`.
+  * docs/packaging: document DOCKER_HOST and the full watch action set, stamp
+    the man-page version/date from the changelog, add SECURITY.md, Recommends
+    podman (>= 5.0).
+  * ci: sign NOTICES.html via the pinned venv and refuse release tags not on
+    main.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Tue, 16 Jun 2026 15:00:00 -0500
+
 podup (0.24.1) unstable; urgency=medium
 
   * Drop-in runtime compatibility fixes:

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Rules-Requires-Root: no
 Package: podup
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Recommends: podman (>= 4.0)
+Recommends: podman (>= 5.0)
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -147,6 +147,12 @@ Default active profiles (see \fB\-\-profile\fR).
 .B PODMAN_SOCKET
 Podman socket path (see \fB\-\-socket\fR).
 .TP
+.B DOCKER_HOST
+Docker-compatible fallback for the Podman socket, used only when
+\fBPODMAN_SOCKET\fR is unset. Must name a local \fBunix://\fR socket
+(or \fBnpipe://\fR on Windows); a remote \fBtcp://\fR or \fBssh://\fR value is
+rejected.
+.TP
 .B RUST_LOG
 Log verbosity filter. With no value set, warnings and errors are shown; set
 e.g. \fBRUST_LOG=podup=info\fR or \fBRUST_LOG=podup=debug\fR for more detail.

--- a/debian/rules
+++ b/debian/rules
@@ -43,6 +43,16 @@ override_dh_auto_install:
 	target/release/podup completions zsh  > debian/podup/usr/share/zsh/vendor-completions/_podup
 	target/release/podup completions fish > debian/podup/usr/share/fish/vendor_completions.d/podup.fish
 
+# Stamp the man page's .TH version and date from debian/changelog so they never
+# drift from the release. The date comes from the changelog entry, not the build
+# clock, to keep the build reproducible.
+override_dh_installman:
+	set -e; \
+	ver=$$(dpkg-parsechangelog --show-field Version | sed 's/-[^-]*$$//'); \
+	dat=$$(LC_ALL=C date -u -d "$$(dpkg-parsechangelog --show-field Date)" +'%B %Y'); \
+	sed -i -E "s/\"podup [0-9]+\.[0-9]+\.[0-9]+\"/\"podup $$ver\"/; s/^\.TH PODUP 1 \"[^\"]*\"/.TH PODUP 1 \"$$dat\"/" debian/podup.1; \
+	dh_installman
+
 override_dh_auto_clean:
 	cargo clean
 	rm -rf debian/cargo-home

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,9 +108,17 @@ prints a `podup: warning:` to stderr noting the files will not run on the host.
 ## Watch
 
 ### `watch`
-Watch for file changes and sync, rebuild or restart services as configured by
-each service's `develop.watch` rules. (`up --watch` does the same after
-starting the stack.)
+Watch for file changes and react as configured by each service's
+`develop.watch` rules. (`up --watch` does the same after starting the stack.)
+The `action` of each rule may be:
+
+| Action | Effect on change |
+|---|---|
+| `sync` | Copy the changed files into the running container. |
+| `rebuild` | Rebuild the image and recreate the container. |
+| `restart` | Restart the container without rebuilding. |
+| `sync+restart` | Sync the files, then restart the container. |
+| `sync+exec` | Sync the files, then run the rule's `exec` command in the container. |
 
 ## Self-update
 
@@ -161,6 +169,7 @@ when both are set.
 | `COMPOSE_PROJECT_NAME` | Default project name (`--project`). |
 | `COMPOSE_PROFILES` | Default active profiles (`--profile`). |
 | `PODMAN_SOCKET` | Podman socket path (`--socket`). |
+| `DOCKER_HOST` | Docker-compatible fallback for the Podman socket, used only when `PODMAN_SOCKET` is unset. Must be a local `unix://` socket (or `npipe://` on Windows); a remote `tcp://`/`ssh://` value is rejected. |
 | `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
 
 ## Exit status

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -164,6 +164,10 @@ a typo or an unmapped feature can't hide. At parse time podup warns about:
 This is what lets a compose file written for a newer Docker or Podman release
 run under podup: unsupported additions surface as warnings instead of vanishing.
 
+The `podup` CLI prints these warnings automatically. If you embed podup as a
+**library**, `parse_file` itself stays quiet — call `podup::collect_diagnostics`
+on the parsed file to obtain the same warnings and surface them to your users.
+
 `extra_hosts` is accepted in both the list (`["host:ip"]`) and mapping
 (`{host: ip}`) forms.
 

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -203,8 +203,11 @@ pub(crate) enum Commands {
 		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
 		cmd: Vec<String>,
 	},
-	/// Pull images for all services.
-	Pull,
+	/// Pull images for the named services, or all services if none are given.
+	Pull {
+		/// Only pull images for these services.
+		services: Vec<String>,
+	},
 	/// Restart services.
 	Restart {
 		/// Only restart this service.

--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -92,6 +92,47 @@ mod tests {
 	}
 
 	#[test]
+	fn merge_adds_and_parent_wins_on_secret_conflict() {
+		use super::super::types::SecretConfig;
+		let secret = |f: &str| SecretConfig {
+			file: Some(f.to_string()),
+			..Default::default()
+		};
+		let mut target = ComposeFile::default();
+		target
+			.secrets
+			.insert("tok".to_string(), secret("parent.txt"));
+		let mut other = ComposeFile::default();
+		other.secrets.insert("tok".to_string(), secret("child.txt"));
+		other.secrets.insert("extra".to_string(), secret("e.txt"));
+		merge_compose_file(&mut target, other);
+		// Parent wins on conflict; the included-only secret is added.
+		assert_eq!(target.secrets["tok"].file.as_deref(), Some("parent.txt"));
+		assert_eq!(target.secrets["extra"].file.as_deref(), Some("e.txt"));
+	}
+
+	#[test]
+	fn merge_adds_and_parent_wins_on_config_conflict() {
+		use super::super::types::ConfigConfig;
+		let config = |f: &str| ConfigConfig {
+			file: Some(f.to_string()),
+			..Default::default()
+		};
+		let mut target = ComposeFile::default();
+		target
+			.configs
+			.insert("cfg".to_string(), config("parent.conf"));
+		let mut other = ComposeFile::default();
+		other
+			.configs
+			.insert("cfg".to_string(), config("child.conf"));
+		other.configs.insert("only".to_string(), config("o.conf"));
+		merge_compose_file(&mut target, other);
+		assert_eq!(target.configs["cfg"].file.as_deref(), Some("parent.conf"));
+		assert_eq!(target.configs["only"].file.as_deref(), Some("o.conf"));
+	}
+
+	#[test]
 	fn merge_empty_other_is_noop() {
 		let mut target = ComposeFile::default();
 		target.services.insert("web".to_string(), svc("nginx:1.25"));

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -77,6 +77,15 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 	Ok(file)
 }
 
+/// Collect parse-time diagnostics for an already-parsed compose file: warnings
+/// about recognized-but-unsupported keys and fields that are accepted but carry
+/// no effect on Podman. The CLI prints these automatically; library consumers
+/// (e.g. panel-agent) can call this to surface the same warnings, since
+/// [`parse_file`] does not emit them itself.
+pub fn collect_diagnostics(file: &ComposeFile) -> Vec<String> {
+	diagnostics::collect(file)
+}
+
 /// Parse and merge multiple compose files (the `-f`/`COMPOSE_FILE` list).
 ///
 /// Files are merged left to right: a later file overrides an earlier one,
@@ -181,6 +190,20 @@ mod tests {
 		let file = parse_str_raw(yaml).unwrap();
 		assert!(file.services.contains_key("web"));
 		assert_eq!(file.services["web"].image.as_deref(), Some("nginx"));
+	}
+
+	#[test]
+	fn collect_diagnostics_surfaces_unknown_keys() {
+		// The public helper lets library consumers see the same warnings the CLI
+		// prints; parse_file itself stays quiet.
+		let file =
+			parse_str_raw("services:\n  web:\n    image: nginx\n    enviroment:\n      - A=1\n")
+				.unwrap();
+		let diags = collect_diagnostics(&file);
+		assert!(
+			diags.iter().any(|d| d.contains("enviroment")),
+			"expected an unknown-key diagnostic, got {diags:?}"
+		);
 	}
 
 	#[test]

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -50,17 +50,15 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 			let rel_path = std::path::Path::new(&rel);
 			// The Compose Specification resolves `include` paths relative to the
 			// including file and treats `../` as canonical (monorepos routinely use
-			// `include: ../shared/compose.yaml`), so parent-directory traversal is
-			// permitted here — consistent with the trusted-input policy applied to
-			// `extends.file` and `env_file`. Absolute paths remain rejected as an
-			// intentional hardening choice: they are not portable across checkouts
-			// and the spec does not require them.
-			if rel_path.is_absolute() {
-				return Err(ComposeError::Include(format!(
-					"include path must be relative, got absolute path: {rel}"
-				)));
-			}
-			let inc_path = dir.join(&rel);
+			// `include: ../shared/compose.yaml`). An absolute path is used as given.
+			// This matches docker-compose and the trusted-input policy already
+			// applied to `extends.file` and `env_file` — the compose file is
+			// trusted input, like a Makefile.
+			let inc_path = if rel_path.is_absolute() {
+				rel_path.to_path_buf()
+			} else {
+				dir.join(&rel)
+			};
 			let inc_dir = project_dir_override.clone().unwrap_or_else(|| {
 				inc_path
 					.parent()

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -121,12 +121,32 @@ pub struct LifecycleHook {
 }
 
 /// Service-level `restart:` policy — `no`, `always`, `unless-stopped`, or `on-failure` (with optional max-retries).
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RestartPolicy {
 	No,
 	Always,
 	OnFailure { max_attempts: Option<u32> },
 	UnlessStopped,
+}
+
+impl Serialize for RestartPolicy {
+	// Emit the compose-spec string form so `config` output round-trips back
+	// through `Deserialize` (the derived form would emit `UnlessStopped`).
+	fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		let s = match self {
+			RestartPolicy::No => "no".to_string(),
+			RestartPolicy::Always => "always".to_string(),
+			RestartPolicy::UnlessStopped => "unless-stopped".to_string(),
+			RestartPolicy::OnFailure {
+				max_attempts: Some(n),
+			} => format!("on-failure:{n}"),
+			RestartPolicy::OnFailure { max_attempts: None } => "on-failure".to_string(),
+		};
+		serializer.serialize_str(&s)
+	}
 }
 
 impl<'de> Deserialize<'de> for RestartPolicy {
@@ -169,6 +189,40 @@ mod tests {
 	#[test]
 	fn depends_on_empty_has_no_names() {
 		assert!(DependsOn::Empty.service_names().is_empty());
+	}
+
+	#[test]
+	fn restart_policy_serializes_to_compose_string() {
+		let ser = |p: &RestartPolicy| serde_yaml::to_string(p).unwrap().trim().to_string();
+		assert_eq!(ser(&RestartPolicy::No), "no");
+		assert_eq!(ser(&RestartPolicy::Always), "always");
+		assert_eq!(ser(&RestartPolicy::UnlessStopped), "unless-stopped");
+		assert_eq!(
+			ser(&RestartPolicy::OnFailure { max_attempts: None }),
+			"on-failure"
+		);
+		assert_eq!(
+			ser(&RestartPolicy::OnFailure {
+				max_attempts: Some(5)
+			}),
+			"on-failure:5"
+		);
+	}
+
+	#[test]
+	fn restart_policy_round_trips_through_yaml() {
+		for input in [
+			"no",
+			"always",
+			"unless-stopped",
+			"on-failure",
+			"on-failure:3",
+		] {
+			let p: RestartPolicy = serde_yaml::from_str(input).unwrap();
+			let out = serde_yaml::to_string(&p).unwrap();
+			let reparsed: RestartPolicy = serde_yaml::from_str(&out).unwrap();
+			assert_eq!(p, reparsed, "round-trip failed for {input}");
+		}
 	}
 
 	#[test]

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -30,6 +30,7 @@ use std::collections::HashMap;
 
 /// Top-level `secrets:` entry — defines a named secret available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct SecretConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
@@ -53,6 +54,7 @@ pub struct SecretConfig {
 
 /// Top-level `configs:` entry — defines a named config available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct ConfigConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
@@ -76,6 +78,7 @@ pub struct ConfigConfig {
 
 /// Root deserialization target for a `docker-compose.yml` file.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct ComposeFile {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub version: Option<String>,

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -62,6 +62,7 @@ pub struct ServiceNetworkConfig {
 
 /// Named network definition in the top-level `networks:` block.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct NetworkConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -20,6 +20,7 @@ use super::{
 
 /// A single service definition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image: Option<String>,

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -106,6 +106,7 @@ impl VolumeMount {
 
 /// Named volume definition in the top-level `volumes:` block.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
 pub struct VolumeConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -35,11 +35,14 @@ impl Engine {
 
 		info!("pulling {image}");
 
-		let pull_policy = match service.pull_policy.as_deref() {
-			Some("always") => "always",
-			Some("newer") => "newer",
-			_ => "missing",
-		};
+		let requested = service.pull_policy.as_deref();
+		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
+			warn!(
+				"unknown pull_policy '{}', defaulting to 'missing'",
+				requested.unwrap_or_default()
+			);
+			"missing"
+		});
 		let mut query = format!("reference={}&policy={}", urlencoded(&image), pull_policy);
 		if let Some(platform) = &service.platform {
 			query.push_str(&format!("&platform={}", urlencoded(platform)));
@@ -382,10 +385,38 @@ fn is_remote_context(context: &str) -> bool {
 	context.contains("://") || context.starts_with("git@")
 }
 
+/// Map a compose `pull_policy:` value to the libpod images/pull `policy`
+/// parameter. `if_not_present` is the spec alias for `missing`; `build` falls
+/// back to `missing` here (its build behavior is handled by the caller). Returns
+/// `None` for an unrecognized value so the caller can warn and default.
+pub(super) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'static str> {
+	match policy {
+		Some("always") => Some("always"),
+		Some("newer") => Some("newer"),
+		Some("never") => Some("never"),
+		None | Some("missing") | Some("if_not_present") | Some("build") => Some("missing"),
+		Some(_) => None,
+	}
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, Engine};
+	use super::{is_remote_context, libpod_pull_policy, Engine};
 	use crate::libpod::Client;
+
+	#[test]
+	fn pull_policy_maps_every_spec_value() {
+		assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
+		assert_eq!(libpod_pull_policy(Some("newer")), Some("newer"));
+		assert_eq!(libpod_pull_policy(Some("never")), Some("never"));
+		assert_eq!(libpod_pull_policy(Some("missing")), Some("missing"));
+		// `if_not_present` is the spec alias for `missing`.
+		assert_eq!(libpod_pull_policy(Some("if_not_present")), Some("missing"));
+		assert_eq!(libpod_pull_policy(Some("build")), Some("missing"));
+		assert_eq!(libpod_pull_policy(None), Some("missing"));
+		// Unknown values are reported (None) so the caller warns.
+		assert_eq!(libpod_pull_policy(Some("bogus")), None);
+	}
 
 	fn engine(base: std::path::PathBuf) -> Engine {
 		Engine::with_base_dir(Client::new("/nonexistent.sock"), "p".into(), base)

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -45,13 +45,6 @@ impl Engine {
 
 		warn_swarm_only_deploy(service_name, service);
 
-		if service.gpus.is_some() {
-			tracing::warn!(
-				"service \"{service_name}\": top-level gpus: is not yet supported \
-				— use deploy.resources.reservations.devices for GPU access"
-			);
-		}
-
 		// --- Environment ---
 		// A bare `KEY` (no `=`) is a passthrough: its value comes from podup's
 		// own environment, matching docker-compose. Drop it only when unset.

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -223,9 +223,12 @@ mod tests {
 		assert_eq!(resolve_bind_source("/abs/path", base), "/abs/path");
 		assert_eq!(resolve_bind_source("./data", base), "/srv/app/./data");
 		assert_eq!(resolve_bind_source("data", base), "/srv/app/data");
-		std::env::set_var("HOME", "/home/u");
-		assert_eq!(resolve_bind_source("~/x", base), "/home/u/x");
-		assert_eq!(resolve_bind_source("~", base), "/home/u");
+		// Mutating HOME via the process env races other tests under the parallel
+		// runner; temp_env::with_var sets and restores it atomically.
+		temp_env::with_var("HOME", Some("/home/u"), || {
+			assert_eq!(resolve_bind_source("~/x", base), "/home/u/x");
+			assert_eq!(resolve_bind_source("~", base), "/home/u");
+		});
 	}
 
 	#[test]

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -117,12 +117,55 @@ pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 	service
 		.ulimits
 		.iter()
-		.map(|(name, cfg)| Ulimit {
-			ulimit_type: name.clone(),
-			soft: ulimit_value(cfg.soft(), name, "soft"),
-			hard: ulimit_value(cfg.hard(), name, "hard"),
+		.filter_map(|(name, cfg)| {
+			if !is_known_ulimit(name) {
+				tracing::warn!("ulimit '{name}' is not a recognized resource name and is ignored");
+				return None;
+			}
+			let soft = ulimit_value(cfg.soft(), name, "soft");
+			let hard = ulimit_value(cfg.hard(), name, "hard");
+			// POSIX requires soft <= hard; a larger soft is invalid and would
+			// produce undefined behaviour at container start. Clamp it down.
+			let soft = if soft > hard {
+				tracing::warn!(
+					"ulimit {name} soft ({soft}) exceeds hard ({hard}); clamping soft to hard"
+				);
+				hard
+			} else {
+				soft
+			};
+			Some(Ulimit {
+				ulimit_type: name.clone(),
+				soft,
+				hard,
+			})
 		})
 		.collect()
+}
+
+/// The Linux rlimit resource names Podman accepts (without the `RLIMIT_`
+/// prefix). A name outside this set is a typo or an injection attempt and is
+/// rejected rather than forwarded verbatim to the API.
+fn is_known_ulimit(name: &str) -> bool {
+	const KNOWN: [&str; 16] = [
+		"core",
+		"cpu",
+		"data",
+		"fsize",
+		"locks",
+		"memlock",
+		"msgqueue",
+		"nice",
+		"nofile",
+		"nproc",
+		"rss",
+		"rtprio",
+		"rttime",
+		"sigpending",
+		"stack",
+		"as",
+	];
+	KNOWN.contains(&name)
 }
 
 /// Convert a compose ulimit value to the libpod `u64`. `-1` is the conventional
@@ -320,6 +363,34 @@ mod tests {
 		let ul = build_ulimits(&svc);
 		assert_eq!(ul[0].soft, 512);
 		assert_eq!(ul[0].hard, 2048);
+	}
+
+	#[test]
+	fn build_ulimits_clamps_soft_above_hard() {
+		use crate::compose::types::UlimitConfig;
+		let mut svc = default_service();
+		svc.ulimits.insert(
+			"nofile".to_string(),
+			UlimitConfig::Pair {
+				soft: 65535,
+				hard: 1024,
+			},
+		);
+		let ul = build_ulimits(&svc);
+		assert_eq!(ul[0].soft, 1024, "soft must be clamped down to hard");
+		assert_eq!(ul[0].hard, 1024);
+	}
+
+	#[test]
+	fn build_ulimits_rejects_unknown_resource_name() {
+		use crate::compose::types::UlimitConfig;
+		let mut svc = default_service();
+		svc.ulimits
+			.insert("bogus,inject=1".to_string(), UlimitConfig::Single(1024));
+		assert!(
+			build_ulimits(&svc).is_empty(),
+			"an unknown ulimit name must be dropped, not forwarded"
+		);
 	}
 
 	// --- cdi devices ---

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -1,7 +1,7 @@
 //! Resource-limit builders: CPU/memory/pids limits, ulimits, and CDI device
 //! reservations.
 
-use crate::compose::types::Service;
+use crate::compose::types::{DeviceReservation, GpuSpec, Service};
 use crate::libpod::types::container::{LinuxResources, Ulimit};
 use crate::size;
 
@@ -156,57 +156,82 @@ const MAX_GPU_DEVICES: i64 = 64;
 pub(crate) fn cdi_devices(service: &Service) -> Vec<String> {
 	let mut out = Vec::new();
 
-	let Some(reservations) = service
+	if let Some(reservations) = service
 		.deploy
 		.as_ref()
 		.and_then(|d| d.resources.as_ref())
 		.and_then(|r| r.reservations.as_ref())
-	else {
-		return out;
-	};
-
-	for dev in &reservations.devices {
-		let is_gpu = dev.capabilities.iter().any(|c| c == "gpu" || c == "nvidia");
-		let driver = dev.driver.as_deref().unwrap_or("nvidia");
-		if !is_gpu || (driver != "nvidia" && !driver.is_empty()) {
-			tracing::warn!(
-				"device reservation (driver {:?}, capabilities {:?}) is not supported and is ignored",
-				dev.driver,
-				dev.capabilities
-			);
-			continue;
+	{
+		for dev in &reservations.devices {
+			push_reservation_devices(dev, &mut out);
 		}
+	}
 
-		if !dev.device_ids.is_empty() {
-			for id in &dev.device_ids {
-				out.push(format!("nvidia.com/gpu={id}"));
-			}
-			continue;
-		}
-
-		match dev.count.as_ref().map(|c| c.to_i64()) {
-			// `count: all` (-1) or unspecified → request every GPU.
-			Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
-			Some(n) if n > 0 => {
-				// Clamp to a sane device count: the value comes from an untrusted
-				// compose file and a huge `count:` would otherwise allocate billions
-				// of device-id strings during spec assembly (OOM) before any
-				// container is created. No host has anywhere near this many GPUs.
-				if n > MAX_GPU_DEVICES {
-					tracing::warn!(
-						"device reservation count {n} exceeds the maximum of {MAX_GPU_DEVICES}; \
-						 clamping (no host has this many GPUs)"
-					);
-				}
-				for i in 0..n.min(MAX_GPU_DEVICES) {
-					out.push(format!("nvidia.com/gpu={i}"));
+	// The top-level `gpus:` shorthand maps to the same NVIDIA CDI devices as a
+	// `deploy.resources.reservations.devices` GPU reservation.
+	if let Some(gpus) = &service.gpus {
+		match gpus {
+			GpuSpec::Devices(devs) => {
+				for dev in devs {
+					push_reservation_devices(dev, &mut out);
 				}
 			}
-			Some(_) => {}
+			// `gpus: all` / `gpus: N` request that many NVIDIA GPUs.
+			GpuSpec::Named(_) | GpuSpec::Count(_) => {
+				push_gpu_count(Some(gpus.to_count()), &mut out)
+			}
 		}
 	}
 
 	out
+}
+
+/// Translate one `devices:` GPU reservation into CDI device names, appending to
+/// `out`. Non-NVIDIA / non-GPU reservations are warned about and skipped.
+fn push_reservation_devices(dev: &DeviceReservation, out: &mut Vec<String>) {
+	let is_gpu = dev.capabilities.iter().any(|c| c == "gpu" || c == "nvidia");
+	let driver = dev.driver.as_deref().unwrap_or("nvidia");
+	if !is_gpu || (driver != "nvidia" && !driver.is_empty()) {
+		tracing::warn!(
+			"device reservation (driver {:?}, capabilities {:?}) is not supported and is ignored",
+			dev.driver,
+			dev.capabilities
+		);
+		return;
+	}
+
+	if !dev.device_ids.is_empty() {
+		for id in &dev.device_ids {
+			out.push(format!("nvidia.com/gpu={id}"));
+		}
+		return;
+	}
+
+	push_gpu_count(dev.count.as_ref().map(|c| c.to_i64()), out);
+}
+
+/// Append `count` NVIDIA CDI device names to `out`. `-1`/`None` means "all".
+fn push_gpu_count(count: Option<i64>, out: &mut Vec<String>) {
+	match count {
+		// `count: all` (-1) or unspecified → request every GPU.
+		Some(-1) | None => out.push("nvidia.com/gpu=all".to_string()),
+		Some(n) if n > 0 => {
+			// Clamp to a sane device count: the value comes from an untrusted
+			// compose file and a huge `count:` would otherwise allocate billions
+			// of device-id strings during spec assembly (OOM) before any
+			// container is created. No host has anywhere near this many GPUs.
+			if n > MAX_GPU_DEVICES {
+				tracing::warn!(
+					"GPU device count {n} exceeds the maximum of {MAX_GPU_DEVICES}; \
+					 clamping (no host has this many GPUs)"
+				);
+			}
+			for i in 0..n.min(MAX_GPU_DEVICES) {
+				out.push(format!("nvidia.com/gpu={i}"));
+			}
+		}
+		Some(_) => {}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -326,6 +351,32 @@ mod tests {
 			"services:\n  app:\n    image: x\n    deploy:\n      resources:\n        reservations:\n          devices:\n            - capabilities: [gpu]\n              device_ids: [\"GPU-abc\", \"1\"]\n",
 		);
 		assert_eq!(got, vec!["nvidia.com/gpu=GPU-abc", "nvidia.com/gpu=1"]);
+	}
+
+	#[test]
+	fn cdi_top_level_gpus_all() {
+		assert_eq!(
+			cdi_for("services:\n  app:\n    image: x\n    gpus: all\n"),
+			vec!["nvidia.com/gpu=all"]
+		);
+	}
+
+	#[test]
+	fn cdi_top_level_gpus_count() {
+		assert_eq!(
+			cdi_for("services:\n  app:\n    image: x\n    gpus: 2\n"),
+			vec!["nvidia.com/gpu=0", "nvidia.com/gpu=1"]
+		);
+	}
+
+	#[test]
+	fn cdi_top_level_gpus_device_list() {
+		assert_eq!(
+			cdi_for(
+				"services:\n  app:\n    image: x\n    gpus:\n      - capabilities: [gpu]\n        device_ids: [\"GPU-xyz\"]\n",
+			),
+			vec!["nvidia.com/gpu=GPU-xyz"]
+		);
 	}
 
 	#[test]

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -225,11 +225,19 @@ impl Engine {
 
 	/// Pull images for all services that declare an `image:` key, concurrently.
 	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
+		self.pull_services(file, &[]).await
+	}
+
+	/// Pull images for the named services (or every service when `services` is
+	/// empty), matching `docker compose pull [SERVICE...]`.
+	pub async fn pull_services(&self, file: &ComposeFile, services: &[String]) -> Result<()> {
 		let futs: Vec<_> = file
 			.services
-			.values()
-			.filter(|s| s.image.is_some())
-			.map(|s| self.pull_image(s))
+			.iter()
+			.filter(|(name, s)| {
+				s.image.is_some() && (services.is_empty() || services.iter().any(|w| w == *name))
+			})
+			.map(|(_, s)| self.pull_image(s))
 			.collect();
 
 		let results = futures_util::future::join_all(futs).await;

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -46,7 +46,14 @@ pub(super) fn staging_base() -> Result<PathBuf> {
 	let euid = unsafe { libc::geteuid() };
 
 	let base = match std::env::var_os("XDG_RUNTIME_DIR") {
-		Some(dir) if Path::new(&dir).is_absolute() => PathBuf::from(dir).join("podup"),
+		Some(dir) if Path::new(&dir).is_absolute() => {
+			let xdg = PathBuf::from(&dir);
+			// The runtime dir must itself be a private directory owned by us. A
+			// hostile XDG_RUNTIME_DIR pointing at a shared/world-writable path
+			// would otherwise host secret staging under another user's control.
+			verify_private_dir(&xdg, euid)?;
+			xdg.join("podup")
+		}
 		_ => std::env::temp_dir().join(format!("podup-{euid}")),
 	};
 
@@ -109,7 +116,7 @@ pub(super) fn reject_dangerous_secret_mode(mode: u32, ctx: &str) -> Result<()> {
 /// `verify_private_dir` then rejects anything not ours (fail closed).
 #[cfg(unix)]
 fn ensure_private_dir(dir: &Path, euid: u32) -> Result<()> {
-	use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+	use std::os::unix::fs::DirBuilderExt;
 
 	std::fs::DirBuilder::new()
 		.recursive(true)
@@ -117,12 +124,11 @@ fn ensure_private_dir(dir: &Path, euid: u32) -> Result<()> {
 		.create(dir)
 		.map_err(ComposeError::Io)?;
 
-	let meta = std::fs::symlink_metadata(dir).map_err(ComposeError::Io)?;
-	if meta.is_dir() {
-		std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
-			.map_err(ComposeError::Io)?;
-	}
-
+	// No chmod-healing of a pre-existing directory: re-applying the mode through
+	// the path would be a TOCTOU window (a symlink swapped in between the stat
+	// and the chmod). A freshly created directory is already 0700 from the mode
+	// above; a pre-existing directory with the wrong owner or mode is rejected
+	// by verify_private_dir below (fail closed).
 	verify_private_dir(dir, euid)
 }
 
@@ -253,16 +259,21 @@ mod ensure_dir_tests {
 	}
 
 	#[test]
-	fn heals_drifted_permissions_on_owned_dir() {
+	fn drifted_permissions_on_existing_dir_fail_closed() {
+		// A pre-existing directory with looser-than-0700 permissions is rejected
+		// rather than chmod-healed: healing through the path would be a TOCTOU
+		// window, and failing closed never writes secrets under a dir another
+		// user may currently access.
 		let root = tempfile::tempdir().expect("tempdir");
 		let dir = root.path().join("base");
 		std::fs::create_dir(&dir).expect("mkdir");
 		std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
 		// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
 		let euid = unsafe { libc::geteuid() };
-		ensure_private_dir(&dir, euid).expect("healed dir");
+		assert!(ensure_private_dir(&dir, euid).is_err());
+		// Permissions are left untouched (no chmod attempted).
 		let meta = std::fs::metadata(&dir).expect("metadata");
-		assert_eq!(meta.mode() & 0o777, 0o700);
+		assert_eq!(meta.mode() & 0o777, 0o755);
 	}
 
 	#[test]

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -6,25 +6,48 @@
 use std::fmt;
 
 /// All errors produced by podup.
+///
+/// `#[non_exhaustive]`: new variants may be added in a minor release, so
+/// downstream `match` arms must include a wildcard.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ComposeError {
+	/// The compose YAML could not be deserialized.
 	Parse(serde_yaml::Error),
+	/// A referenced compose/include/extends file does not exist.
 	FileNotFound(String),
+	/// An underlying filesystem operation failed.
 	Io(std::io::Error),
+	/// The Podman libpod API returned an error or could not be reached.
 	Podman(crate::libpod::PodmanError),
+	/// A named service is not defined in the compose file.
 	ServiceNotFound(String),
+	/// `depends_on` forms a cycle, so no valid start order exists.
 	CircularDependency(String),
+	/// A service has neither an `image:` nor a `build:` section.
 	NoImageOrBuild(String),
+	/// A `${VAR}` with the `?err` modifier was required but unset.
 	RequiredVarNotSet { var: String, msg: String },
+	/// A service did not become healthy within its dependency wait window.
 	HealthCheckTimeout(String),
+	/// A `ports:` entry could not be parsed.
 	InvalidPort(String),
+	/// Image build failed (context assembly or the Podman build step).
 	Build(String),
+	/// `extends:` could not be resolved (missing file/service or a cycle).
 	Extends(String),
+	/// `include:` could not be resolved or merged.
 	Include(String),
+	/// The `watch` command failed (filesystem watch or sync action).
 	Watch(String),
+	/// A compose feature is recognized but unsupported on Podman/podup.
 	Unsupported(String),
+	/// A `run` container exited; carries its non-zero exit code so the CLI can
+	/// propagate it as its own process exit status.
 	RunExited(i64),
+	/// `podup update` (self-update) failed.
 	Update(String),
+	/// An `external: true` secret/config/network/volume is absent.
 	ExternalNotFound(String),
 }
 

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -25,8 +25,8 @@ pub mod substitute;
 pub mod update;
 
 pub use compose::{
-	parse_file, parse_file_with_env_files, parse_files_with_env_files, parse_str, parse_str_raw,
-	resolve_levels, resolve_order,
+	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
+	parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
 pub use engine::{is_safe_project_name, Engine, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -194,6 +194,18 @@ impl Client {
 		})
 	}
 
+	/// For streaming endpoints: return the response on success, otherwise read
+	/// the body and surface it through [`check_status`] so the caller gets the
+	/// parsed Podman error message rather than the raw JSON body.
+	async fn stream_or_err(resp: Response<Incoming>) -> Result<Response<Incoming>> {
+		if resp.status().is_success() {
+			return Ok(resp);
+		}
+		let (status, body) = Self::read_body(resp).await?;
+		Self::check_status(status, &body)?;
+		unreachable!("check_status returns Err for a non-success status")
+	}
+
 	// ---------------------------------------------------------------------------
 	// Request helpers
 	// ---------------------------------------------------------------------------
@@ -219,15 +231,7 @@ impl Client {
 	/// `GET` → return raw `Response<Incoming>` for streaming.
 	pub async fn get_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with JSON body → deserialize JSON response.
@@ -276,15 +280,7 @@ impl Client {
 			Full::new(Bytes::from(json)),
 			Some("application/json"),
 		)?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with empty body → ignore response body (expect 2xx or 304).
@@ -302,15 +298,7 @@ impl Client {
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with empty body → deserialize JSON response.
@@ -330,15 +318,7 @@ impl Client {
 		content_type: &str,
 	) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
-		let resp = self.send(req).await?;
-		if !resp.status().is_success() {
-			let (status, body) = Self::read_body(resp).await?;
-			return Err(PodmanError::Api {
-				status: status.as_u16(),
-				message: String::from_utf8_lossy(&body).into_owned(),
-			});
-		}
-		Ok(resp)
+		Self::stream_or_err(self.send(req).await?).await
 	}
 
 	/// `POST` with a raw-bytes body → deserialize JSON response.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -360,7 +360,7 @@ async fn run() -> podup::Result<()> {
 			engine.logs(&file, service.as_deref(), follow).await?
 		}
 		Commands::Exec { service, cmd } => engine.exec(&file, &service, cmd).await?,
-		Commands::Pull => engine.pull(&file).await?,
+		Commands::Pull { services } => engine.pull_services(&file, &services).await?,
 		Commands::Restart { service } => engine.restart(&file, service.as_deref()).await?,
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -3,7 +3,7 @@
 // libc FFI (getuid) is needed here; the block carries a soundness comment.
 #![allow(unsafe_code)]
 
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 use crate::libpod::Client;
 #[cfg(any(not(windows), test))]
 use std::path::Path;
@@ -27,6 +27,13 @@ const DEFAULT_PIPE: &str = "//./pipe/podman-machine-default";
 pub fn connect(socket_path: Option<&str>) -> Result<Client> {
 	let default_path = default_socket_path();
 	let raw = socket_path.unwrap_or(&default_path);
+	if let Some(scheme) = remote_scheme(raw) {
+		return Err(ComposeError::Unsupported(format!(
+			"remote Podman over `{scheme}` is not supported; podup talks to a local \
+			 rootless socket. Point PODMAN_SOCKET/--socket at a unix:// socket path \
+			 (or an npipe:// pipe on Windows)."
+		)));
+	}
 	let path = raw
 		.strip_prefix("unix://")
 		.or_else(|| raw.strip_prefix("npipe://"))
@@ -34,17 +41,23 @@ pub fn connect(socket_path: Option<&str>) -> Result<Client> {
 	Ok(Client::new(path))
 }
 
-/// Strips the `unix://` or `npipe://` scheme prefix before passing the path to [`connect`].
+/// Detect a non-local socket scheme (`tcp://`, `ssh://`, `http(s)://`, `fd://`).
+/// `unix://`/`npipe://` and plain paths are local and return `None`.
+fn remote_scheme(raw: &str) -> Option<&'static str> {
+	const REMOTE: [&str; 5] = ["tcp://", "ssh://", "http://", "https://", "fd://"];
+	REMOTE.into_iter().find(|s| raw.starts_with(s))
+}
+
+/// Read the Podman socket from the environment (`PODMAN_SOCKET`, then
+/// `DOCKER_HOST` as a Docker-compatible fallback) and connect. A `unix://` /
+/// `npipe://` scheme is stripped by [`connect`]; a remote scheme is rejected
+/// there with a clear error.
 pub fn connect_from_env() -> Result<Client> {
 	let socket = std::env::var("PODMAN_SOCKET")
 		.or_else(|_| std::env::var("DOCKER_HOST"))
 		.ok();
 
-	let path = socket.as_deref().and_then(|s| {
-		s.strip_prefix("unix://")
-			.or_else(|| s.strip_prefix("npipe://"))
-	});
-	connect(path)
+	connect(socket.as_deref())
 }
 
 #[cfg(not(windows))]
@@ -257,5 +270,28 @@ mod tests {
 	fn connect_passes_plain_path_unchanged() {
 		let c = connect(Some("/run/user/1000/podman/podman.sock")).unwrap();
 		drop(c);
+	}
+
+	#[test]
+	fn connect_rejects_remote_schemes() {
+		for raw in [
+			"tcp://127.0.0.1:2375",
+			"ssh://user@host/run/podman.sock",
+			"http://localhost:8080",
+			"https://localhost:8080",
+			"fd://3",
+		] {
+			assert!(
+				matches!(connect(Some(raw)), Err(ComposeError::Unsupported(_))),
+				"{raw} should be rejected as unsupported"
+			);
+		}
+	}
+
+	#[test]
+	fn remote_scheme_ignores_local_sockets() {
+		assert!(remote_scheme("/run/podman.sock").is_none());
+		assert!(remote_scheme("unix:///run/podman.sock").is_none());
+		assert!(remote_scheme("npipe:////./pipe/podman").is_none());
 	}
 }

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -20,6 +20,7 @@ use unit::{container_unit, network_unit, volume_unit};
 
 /// A single generated unit file: its name and full contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct QuadletUnit {
 	/// File name, e.g. `web.container` or `db-data.volume`.
 	pub filename: String,
@@ -30,6 +31,7 @@ pub struct QuadletUnit {
 /// The result of a generation run: the units plus any warnings about set but
 /// unmapped fields.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct QuadletOutput {
 	/// Generated unit files, in a deterministic order.
 	pub units: Vec<QuadletUnit>,

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -137,7 +137,7 @@ services:
 		"Sysctl=net.core.somaxconn=1024",
 		"Ulimit=nofile=1024:2048",
 		"ShmSize=64m",
-		"Memory=512m",
+		"PodmanArgs=--memory=512m",
 		"PidsLimit=100",
 		"UserNS=keep-id",
 		"StopSignal=SIGTERM",
@@ -251,8 +251,41 @@ networks:
 		"LogDriver=journald",
 		"LogOpt=tag=mytag",
 		"NetworkAlias=web-alias",
-		"Memory=256m",
+		"PodmanArgs=--memory=256m",
 	] {
 		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
+	}
+}
+
+#[test]
+fn memory_and_apparmor_render_as_podman_args_not_invalid_keys() {
+	// `Memory=` and `AppArmor=` are not valid Quadlet [Container] keys in Podman
+	// 5.x; emitting them makes the generator reject the whole unit. They must be
+	// expressed through `PodmanArgs=` instead.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    mem_limit: 512m
+    security_opt:
+      - "apparmor=my-profile"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("PodmanArgs=--memory=512m"),
+		"missing memory PodmanArgs in:\n{c}"
+	);
+	assert!(
+		c.contains("PodmanArgs=--security-opt apparmor=my-profile"),
+		"missing apparmor PodmanArgs in:\n{c}"
+	);
+	for forbidden in ["\nMemory=", "\nAppArmor="] {
+		assert!(
+			!c.contains(forbidden),
+			"emitted invalid key `{}` in:\n{c}",
+			forbidden.trim()
+		);
 	}
 }

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -110,7 +110,9 @@ fn map_security_opt(opt: &str, container: &mut Section, name: &str, warnings: &m
 		.strip_prefix("apparmor=")
 		.or_else(|| opt.strip_prefix("apparmor:"))
 	{
-		container.add("AppArmor", profile.to_string());
+		// Quadlet has no `AppArmor=` key in Podman 5.x; the generator rejects the
+		// whole unit on an unknown key. Pass it through as a raw podman flag.
+		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
 	} else if let Some(label) = opt.strip_prefix("label=") {
 		if label == "disable" {
 			container.add("SecurityLabelDisable", "true".to_string());
@@ -334,7 +336,9 @@ pub(super) fn container_unit(
 		container.add("ShmSize", shm.clone());
 	}
 	if let Some(mem) = &service.mem_limit {
-		container.add("Memory", mem.clone());
+		// `Memory=` is not a valid Quadlet key in Podman 5.x (the generator
+		// rejects the unit); express the limit as a raw podman flag.
+		container.add("PodmanArgs", format!("--memory={mem}"));
 	}
 	if let Some(pids) = service.pids_limit {
 		container.add("PidsLimit", pids.to_string());
@@ -393,7 +397,7 @@ pub(super) fn container_unit(
 			.and_then(|r| r.limits.as_ref())
 			.and_then(|l| l.memory.as_ref())
 		{
-			container.add("Memory", mem.clone());
+			container.add("PodmanArgs", format!("--memory={mem}"));
 		}
 	}
 	for secret in &service.secrets {

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -68,7 +68,9 @@ fn secret_field(value: &str) -> String {
 /// (`name[,target=,uid=,gid=,mode=]`).
 fn render_secret(secret: &ServiceSecretRef) -> String {
 	match secret {
-		ServiceSecretRef::Short(name) => name.clone(),
+		// Sanitize the short-form name too: `Secret=` is an option list, so a
+		// `,`/`=` in the name would inject extra options (same guard as Long).
+		ServiceSecretRef::Short(name) => secret_field(name),
 		ServiceSecretRef::Long {
 			source,
 			target,

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -1,6 +1,6 @@
 //! Report compose fields that are set but have no Quadlet mapping.
 
-use crate::compose::types::Service;
+use crate::compose::types::{DependsOn, Service, ServiceCondition};
 
 /// Warn for fields that are set but have no Quadlet mapping, so the operator
 /// knows the generated unit is incomplete rather than discovering it at run
@@ -45,6 +45,31 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"privileged",
 			"is not mapped; add PodmanArgs manually if required",
 		);
+	}
+	if !service.post_start.is_empty() {
+		warn(
+			"post_start",
+			"hooks have no Quadlet equivalent and are skipped",
+		);
+	}
+	if !service.pre_stop.is_empty() {
+		warn(
+			"pre_stop",
+			"hooks have no Quadlet equivalent and are skipped",
+		);
+	}
+	// systemd `After=`/`Requires=` order startup but cannot gate it on a
+	// dependency becoming healthy or completing; those conditions are dropped.
+	if let DependsOn::Map(deps) = &service.depends_on {
+		if deps
+			.values()
+			.any(|c| c.condition != ServiceCondition::ServiceStarted)
+		{
+			warn(
+				"depends_on",
+				"condition service_healthy/service_completed_successfully is not enforceable in Quadlet; only start ordering is emitted",
+			);
+		}
 	}
 }
 

--- a/tests/parse/anchors.rs
+++ b/tests/parse/anchors.rs
@@ -88,24 +88,14 @@ services:
 }
 
 #[test]
-fn include_absolute_path_rejected() {
+fn include_missing_path_errors() {
+	// `include:` resolves absolute and `../` paths (trusted input); a path that
+	// does not exist still fails cleanly rather than being silently ignored.
 	let dir = tempfile::tempdir().unwrap();
 	let main = dir.path().join("docker-compose.yml");
 	writeln!(
 		std::fs::File::create(&main).unwrap(),
-		"include:\n  - /etc/passwd\nservices:\n  app:\n    image: alpine"
-	)
-	.unwrap();
-	assert!(parse_file(&main).is_err());
-}
-
-#[test]
-fn include_parent_traversal_rejected() {
-	let dir = tempfile::tempdir().unwrap();
-	let main = dir.path().join("docker-compose.yml");
-	writeln!(
-		std::fs::File::create(&main).unwrap(),
-		"include:\n  - ../../secret.yml\nservices:\n  app:\n    image: alpine"
+		"include:\n  - /nonexistent/podup-does-not-exist.yml\nservices:\n  app:\n    image: alpine"
 	)
 	.unwrap();
 	assert!(parse_file(&main).is_err());

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -75,25 +75,41 @@ services:
 }
 
 #[test]
-fn include_absolute_path_is_rejected() {
-	// Absolute include paths remain rejected as intentional hardening: they are
-	// not portable across checkouts and the spec does not require them.
+fn include_absolute_path_resolves() {
+	// docker-compose accepts absolute include paths; the compose file is trusted
+	// input (like a Makefile), so podup resolves them as given rather than
+	// rejecting them.
 	let dir = tempfile::tempdir().unwrap();
+
+	let shared = dir.path().join("shared.yml");
+	writeln!(
+		std::fs::File::create(&shared).unwrap(),
+		r#"
+services:
+  shared_svc:
+    image: alpine
+"#
+	)
+	.unwrap();
+
 	let main = dir.path().join("docker-compose.yml");
 	writeln!(
 		std::fs::File::create(&main).unwrap(),
 		r#"
 include:
-  - /etc/shared.yml
+  - {}
 
 services:
   app:
     image: nginx
-"#
+"#,
+		shared.display()
 	)
 	.unwrap();
 
-	assert!(parse_file(&main).is_err());
+	let file = parse_file(&main).unwrap();
+	assert!(file.services.contains_key("app"));
+	assert!(file.services.contains_key("shared_svc"));
 }
 
 #[test]


### PR DESCRIPTION
Promote develop to main for the **v1.0.0** stable release.

Merge commit (not squash) per the release flow. After this lands, tag `v1.0.0` on main to trigger the signed release build (binaries + Debian packages + SBOM + attestations + crates.io publish).

Contents: the v1.0.0 bump (#406) plus the pre-1.0 hardening batch #396–#405. See the v1.0.0 changelog entry for the summary.