### PR TITLE
fix: correct project name in NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-podman-compose
+podup
 Copyright 2026 Glyndor


### PR DESCRIPTION
## What

The Apache-2.0 `NOTICE` file named `podman-compose` instead of `podup`:

```
-podman-compose
+podup
 Copyright 2026 Glyndor
```

## Why

Leftover from the relicense template (introduced in the Apache-2.0 relicense commit). The NOTICE file must attribute *this* project, not an unrelated tool. It is a public-facing attribution file required by Apache-2.0 §4(d).

## Scope

One line. No code change. Targets `develop`.