### PR TITLE
fix(network): synthesize a default network for services with no networks: block

### DIFF
--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{ComposeError, Result};
 use crate::substitute;
-use types::ComposeFile;
+use types::{ComposeFile, ServiceNetworks};
 
 pub use order::{resolve_levels, resolve_order};
 
@@ -103,10 +103,36 @@ pub fn parse_files_with_env_files(paths: &[PathBuf], env_files: &[String]) -> Re
 		let other = parse_file_with_env_files(path, env_files)?;
 		merge_override(&mut merged, other);
 	}
+	normalize_default_network(&mut merged);
 	for warning in diagnostics::collect(&merged) {
 		tracing::warn!("{warning}");
 	}
 	Ok(merged)
+}
+
+/// Synthesize the implicit `default` network, matching docker-compose: any
+/// service that declares neither `networks:` nor `network_mode` is attached to
+/// a project `default` network. Without this, such services are created with no
+/// network namespace at all — they get no IP and cannot resolve each other by
+/// name, silently breaking the common no-`networks:`-block compose file.
+///
+/// The `default` network is created as `{project}_default` (see
+/// `resolve_network_name`) unless the file already defines a top-level
+/// `networks.default`, whose configuration is then respected. Idempotent.
+pub(crate) fn normalize_default_network(file: &mut ComposeFile) {
+	let needs_default = file
+		.services
+		.values()
+		.any(|svc| svc.network_mode.is_none() && matches!(svc.networks, ServiceNetworks::Empty));
+	if !needs_default {
+		return;
+	}
+	file.networks.entry("default".to_string()).or_insert(None);
+	for svc in file.services.values_mut() {
+		if svc.network_mode.is_none() && matches!(svc.networks, ServiceNetworks::Empty) {
+			svc.networks = ServiceNetworks::List(vec!["default".to_string()]);
+		}
+	}
 }
 
 /// Merge `other` into `target` with `other` winning (compose `-f` override
@@ -236,5 +262,48 @@ mod tests {
 		let yaml = "x-defaults: &defaults\n  image: nginx\n  restart: always\nservices:\n  web:\n    <<: *defaults\n    ports: ['80:80']\n";
 		let file = parse_str_raw(yaml).unwrap();
 		assert_eq!(file.services["web"].image.as_deref(), Some("nginx"));
+	}
+
+	// Default-network synthesis (#417)
+
+	#[test]
+	fn normalize_attaches_bare_service_to_default_network() {
+		let mut file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
+		normalize_default_network(&mut file);
+		assert!(file.networks.contains_key("default"));
+		assert_eq!(file.services["web"].networks.names(), vec!["default"]);
+	}
+
+	#[test]
+	fn normalize_leaves_service_with_explicit_networks_untouched() {
+		let mut file = parse_str(
+			"services:\n  web:\n    image: nginx\n    networks: [front]\nnetworks:\n  front:\n",
+		)
+		.unwrap();
+		normalize_default_network(&mut file);
+		assert_eq!(file.services["web"].networks.names(), vec!["front"]);
+		// No default network is synthesized when nothing needs it.
+		assert!(!file.networks.contains_key("default"));
+	}
+
+	#[test]
+	fn normalize_skips_service_with_network_mode() {
+		let mut file =
+			parse_str("services:\n  web:\n    image: nginx\n    network_mode: host\n").unwrap();
+		normalize_default_network(&mut file);
+		assert!(file.services["web"].networks.names().is_empty());
+		assert!(!file.networks.contains_key("default"));
+	}
+
+	#[test]
+	fn normalize_respects_explicit_default_network_config() {
+		let mut file = parse_str(
+			"services:\n  web:\n    image: nginx\nnetworks:\n  default:\n    driver: bridge\n",
+		)
+		.unwrap();
+		normalize_default_network(&mut file);
+		// The user-defined `default` config is kept, not overwritten with None.
+		assert!(file.networks["default"].is_some());
+		assert_eq!(file.services["web"].networks.names(), vec!["default"]);
 	}
 }

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -288,6 +288,11 @@ impl Engine {
 		// the 8-byte header, which would produce garbled output.
 		run_service.tty = None;
 
+		// Ensure the project networks exist (compose `run` brings them up like
+		// `up` does); the service may reference the synthesized `default`
+		// network, which is created here as `{project}_default`.
+		self.create_networks(file).await?;
+
 		self.create_and_start(&run_name, service_name, &run_service, file)
 			.await?;
 

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -9,7 +9,7 @@
 //! crate root so the submodules can reach them via `use super::*;`.
 use std::fs;
 
-use podup::{parse_str, Client, Engine};
+use podup::{parse_files_with_env_files, parse_str, Client, Engine};
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -371,3 +371,49 @@ async fn sibling_resolves_service_by_name_on_shared_network() {
 		"service `server` was not reachable by its service name: {out:?}"
 	);
 }
+
+// ---------------------------------------------------------------------------
+// With NO `networks:` block, services still reach each other by service name
+// (the synthesized `default` network — docker-compose parity, #417)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn sibling_resolves_service_by_name_without_networks_block() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("dnsdef");
+	let engine = Engine::new(client, proj.clone());
+
+	// No top-level `networks:` and no per-service `networks:` — the common case.
+	// Parse through the real CLI entry point so the implicit `default` network
+	// is synthesized; `parse_str` deliberately does not normalize.
+	let dir = tempfile::tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  server:\n    image: busybox:latest\n    command: [\"sh\", \"-c\", \"mkdir -p /www; echo ok > /www/index.html; exec httpd -f -p 80 -h /www\"]\n  client:\n    image: busybox:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let file = parse_files_with_env_files(&[compose], &[]).unwrap();
+
+	engine.up(&file).await.unwrap();
+	let out = engine
+		.test_exec_capture(
+			&format!("{proj}-client"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"for i in $(seq 1 30); do wget -q -O - http://server:80/ && exit 0; sleep 0.3; done; exit 1".into(),
+			],
+		)
+		.await;
+	engine.down(&file).await.unwrap();
+	let out = out.expect("exec in client container failed");
+	assert!(
+		out.contains("ok"),
+		"service `server` was not reachable by name without a networks: block: {out:?}"
+	);
+}


### PR DESCRIPTION
Fixes the P1 in #417 (empirically confirmed on Podman 5.4.2).

## Problem

docker-compose attaches every service that declares neither `networks:` nor `network_mode` to an implicit `<project>_default` network, so services resolve each other by name out of the box. podup created such services with **no network namespace at all** — they got no IP and could not reach each other — and `up` exited 0 with no warning. The common no-`networks:`-block compose file silently produced mutually-unreachable containers.

## Fix

`normalize_default_network` runs on the parsed file at the `-f`/`COMPOSE_FILE` entry point (`parse_files_with_env_files`, the path that feeds the engine, `config`, and `quadlet`): any service with neither `networks:` nor `network_mode` is attached to a `default` network, created as `{project}_default` (DNS-enabled) unless the file defines a top-level `networks.default` (whose config is then respected). Idempotent; `parse_str` deliberately stays un-normalized for unit tests.

The `run` one-off path now also calls `create_networks` so it can attach to the synthesized default (matching `docker compose run`).

## Verification (real Podman 5.4.2, rootless, netavark)

Before: two-service file, no `networks:` block → `NetworkSettings.Networks = null`, no IP, `getent hosts <service>` fails.
After: services land on `{project}_default`, `getent hosts <service>` resolves, sibling reachable by service name.

- New integration test `sibling_resolves_service_by_name_without_networks_block` (goes through the real normalized entry point).
- 4 unit tests: bare service attached; explicit `networks:` untouched; `network_mode` skipped; user-defined `default` config respected.
- Full `cargo test --all-features` green; `cargo fmt --check` and `cargo clippy --all-features --all-targets` clean.

## Note

`config` output now canonically includes `networks: default:` for such files, matching `docker compose config`.

Refs #417 (close on merge to develop).