### PR TITLE
fix(quadlet): emit CPU resource limits via PodmanArgs

### DIFF
--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -289,3 +289,53 @@ services:
 		);
 	}
 }
+
+#[test]
+fn cpu_limits_render_as_podman_args() {
+	// CPU limits have no native [Container] Quadlet key; they must round-trip
+	// through PodmanArgs= rather than being silently dropped.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    cpus: "1.5"
+    cpuset: "0,1"
+    cpu_shares: 512
+    cpu_quota: 50000
+    cpu_period: 100000
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	for expected in [
+		"PodmanArgs=--cpus=1.5",
+		"PodmanArgs=--cpuset-cpus=0,1",
+		"PodmanArgs=--cpu-shares=512",
+		"PodmanArgs=--cpu-quota=50000",
+		"PodmanArgs=--cpu-period=100000",
+	] {
+		assert!(c.contains(expected), "missing `{expected}` in:\n{c}");
+	}
+}
+
+#[test]
+fn deploy_limits_cpus_render_as_podman_args() {
+	// `deploy.resources.limits.cpus` is the modern equivalent of `cpus` and
+	// must reach the unit too when the top-level `cpus` is absent.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("PodmanArgs=--cpus=2"),
+		"missing deploy cpus PodmanArgs in:\n{c}"
+	);
+}

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -342,6 +342,30 @@ pub(super) fn container_unit(
 		// rejects the unit); express the limit as a raw podman flag.
 		container.add("PodmanArgs", format!("--memory={mem}"));
 	}
+	// CPU limits have no native [Container] Quadlet key (unlike Memory=/
+	// PidsLimit=), so they go through PodmanArgs=, mirroring --memory above.
+	// `cpus` falls back to the modern `deploy.resources.limits.cpus`.
+	let deploy_cpus = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.resources.as_ref())
+		.and_then(|r| r.limits.as_ref())
+		.and_then(|l| l.cpus.as_deref());
+	if let Some(c) = service.cpus.as_deref().or(deploy_cpus) {
+		container.add("PodmanArgs", format!("--cpus={c}"));
+	}
+	if let Some(cs) = &service.cpuset {
+		container.add("PodmanArgs", format!("--cpuset-cpus={cs}"));
+	}
+	if let Some(sh) = service.cpu_shares {
+		container.add("PodmanArgs", format!("--cpu-shares={sh}"));
+	}
+	if let Some(q) = service.cpu_quota {
+		container.add("PodmanArgs", format!("--cpu-quota={q}"));
+	}
+	if let Some(p) = service.cpu_period {
+		container.add("PodmanArgs", format!("--cpu-period={p}"));
+	}
 	if let Some(pids) = service.pids_limit {
 		container.add("PidsLimit", pids.to_string());
 	}


### PR DESCRIPTION
Closes #408.

## Problem
`generate quadlet` silently dropped **all** CPU limits (`cpus`, `cpuset`, `cpu_shares`, `cpu_quota`, `cpu_period`) — neither emitted nor warned — while `mem_limit`/`pids_limit` were honored. Inconsistent and surprising: an operator's `cpus: "2"` had no effect in the generated unit.

## Fix
CPU has no native `[Container]` Quadlet key in Podman 5.x (unlike `Memory=`/`PidsLimit=`), so route it through `PodmanArgs=`, mirroring the existing `--memory` handling. `cpus` falls back to `deploy.resources.limits.cpus`.

## Verification
Real `podup generate quadlet` on a service with `cpus`/`cpuset`/`cpu_shares` now emits:
```
PodmanArgs=--cpus=1.5
PodmanArgs=--cpuset-cpus=0,1
PodmanArgs=--cpu-shares=512
```
Unit tests cover the five service-level keys and the deploy fallback. `cargo fmt`/`clippy` clean.

## Note
`internal/quadlet/unit.rs` is now at 490/500 lines. The broader quadlet sweep (#419) will need to split this file to stay under the line-limit gate.