### PR TITLE
fix(quadlet): render long-form tmpfs mounts as Tmpfs= not Volume=

### DIFF
--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::compose::types::{Command, RestartPolicy, VolumeMount};
+use crate::compose::types::{Command, RestartPolicy, VolumeMount, VolumeType};
 use crate::ports::ParsedPort;
 
 pub(super) fn render_publish_port(p: &ParsedPort) -> String {
@@ -86,6 +86,37 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 			}
 			out
 		}
+	}
+}
+
+/// If `vol` is a long-form `type: tmpfs` mount, render it as a Quadlet `Tmpfs=`
+/// value (`target[:size=…,mode=…]`); otherwise return `None` so the caller emits
+/// a normal `Volume=`. A tmpfs mount written as `Volume=` would create a
+/// persistent named/anonymous volume instead of an in-memory filesystem — a
+/// silent semantic inversion. Size/mode mirror the runtime mount options.
+pub(super) fn render_tmpfs_mount(vol: &VolumeMount) -> Option<String> {
+	let VolumeMount::Long {
+		volume_type: VolumeType::Tmpfs,
+		target,
+		tmpfs,
+		..
+	} = vol
+	else {
+		return None;
+	};
+	let mut opts: Vec<String> = Vec::new();
+	if let Some(t) = tmpfs {
+		if let Some(size) = t.size {
+			opts.push(format!("size={size}"));
+		}
+		if let Some(mode) = t.mode {
+			opts.push(format!("mode={mode:o}"));
+		}
+	}
+	if opts.is_empty() {
+		Some(target.clone())
+	} else {
+		Some(format!("{target}:{}", opts.join(",")))
 	}
 }
 

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -339,3 +339,31 @@ services:
 		"missing deploy cpus PodmanArgs in:\n{c}"
 	);
 }
+
+#[test]
+fn long_form_tmpfs_mount_renders_as_tmpfs_not_volume() {
+	// A long-form `type: tmpfs` mount must become `Tmpfs=`, not `Volume=` —
+	// the latter would persist it as a volume instead of an in-memory fs.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    volumes:
+      - type: tmpfs
+        target: /cache
+        tmpfs:
+          size: 64000000
+          mode: 0o755
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("Tmpfs=/cache:size=64000000,mode=755"),
+		"tmpfs not rendered as Tmpfs= with options in:\n{c}"
+	);
+	assert!(
+		!c.contains("Volume=/cache"),
+		"tmpfs wrongly emitted as a Volume in:\n{c}"
+	);
+}

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -5,8 +5,8 @@ use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
 use super::render::{
-	render_command, render_publish_port, render_restart, render_volume, safe_unit_stem,
-	sorted_label_pairs, sorted_pairs, Section,
+	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
+	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;
@@ -269,7 +269,13 @@ pub(super) fn container_unit(
 	}
 
 	for vol in &service.volumes {
-		container.add("Volume", render_volume(vol, declared_volumes));
+		// A long-form `type: tmpfs` mount maps to `Tmpfs=`, not `Volume=`
+		// (which would persist it as a volume rather than an in-memory fs).
+		if let Some(t) = render_tmpfs_mount(vol) {
+			container.add("Tmpfs", t);
+		} else {
+			container.add("Volume", render_volume(vol, declared_volumes));
+		}
 	}
 	for net in service.networks.names() {
 		// A declared (non-external) network is backed by a generated `.network`


### PR DESCRIPTION
First fix from #419.

## Problem
A long-form volume with `type: tmpfs` went through the generic `Volume=` path, which Quadlet treats as a persistent named/anonymous volume — silently inverting an in-memory tmpfs into durable storage. (Top-level `tmpfs:` shorthand was already correct.)

## Fix
`render_tmpfs_mount` (in `render.rs`, which has line-budget headroom) detects a long-form `type: tmpfs` mount and the container builder routes it to `Tmpfs=<target>[:size=,mode=]`, mirroring the runtime mount options (mode rendered octal, matching `volume_mounts`).

Unit test asserts `Tmpfs=/cache:size=…,mode=755` is emitted and `Volume=/cache` is not.

## Note — #419 stays open
The remaining #419 items (ipv4/ipv6_address → `IP=`/`IP6=`, `network_mode: none` → `Network=none`, security `label=filetype/nested`, network/volume `ipam`/`driver_opts`/custom-`name`, the `PodmanArgs=` fallback class + `warnings.rs` coverage) require adding to `network_unit`/`volume_unit`/`container_unit`. **`internal/quadlet/unit.rs` is at 496/500**, so that work must first split the file (e.g. extract `network_unit`/`volume_unit` into their own module). Deferred to a follow-up PR.

Refs #419.