### PR TITLE
promote: drop-in fixes (default network, restart any→always, quadlet CPU/tmpfs, NOTICE)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-podman-compose
+podup
 Copyright 2026 Glyndor

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{ComposeError, Result};
 use crate::substitute;
-use types::ComposeFile;
+use types::{ComposeFile, ServiceNetworks};
 
 pub use order::{resolve_levels, resolve_order};
 
@@ -103,10 +103,36 @@ pub fn parse_files_with_env_files(paths: &[PathBuf], env_files: &[String]) -> Re
 		let other = parse_file_with_env_files(path, env_files)?;
 		merge_override(&mut merged, other);
 	}
+	normalize_default_network(&mut merged);
 	for warning in diagnostics::collect(&merged) {
 		tracing::warn!("{warning}");
 	}
 	Ok(merged)
+}
+
+/// Synthesize the implicit `default` network, matching docker-compose: any
+/// service that declares neither `networks:` nor `network_mode` is attached to
+/// a project `default` network. Without this, such services are created with no
+/// network namespace at all — they get no IP and cannot resolve each other by
+/// name, silently breaking the common no-`networks:`-block compose file.
+///
+/// The `default` network is created as `{project}_default` (see
+/// `resolve_network_name`) unless the file already defines a top-level
+/// `networks.default`, whose configuration is then respected. Idempotent.
+pub(crate) fn normalize_default_network(file: &mut ComposeFile) {
+	let needs_default = file
+		.services
+		.values()
+		.any(|svc| svc.network_mode.is_none() && matches!(svc.networks, ServiceNetworks::Empty));
+	if !needs_default {
+		return;
+	}
+	file.networks.entry("default".to_string()).or_insert(None);
+	for svc in file.services.values_mut() {
+		if svc.network_mode.is_none() && matches!(svc.networks, ServiceNetworks::Empty) {
+			svc.networks = ServiceNetworks::List(vec!["default".to_string()]);
+		}
+	}
 }
 
 /// Merge `other` into `target` with `other` winning (compose `-f` override
@@ -236,5 +262,48 @@ mod tests {
 		let yaml = "x-defaults: &defaults\n  image: nginx\n  restart: always\nservices:\n  web:\n    <<: *defaults\n    ports: ['80:80']\n";
 		let file = parse_str_raw(yaml).unwrap();
 		assert_eq!(file.services["web"].image.as_deref(), Some("nginx"));
+	}
+
+	// Default-network synthesis (#417)
+
+	#[test]
+	fn normalize_attaches_bare_service_to_default_network() {
+		let mut file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
+		normalize_default_network(&mut file);
+		assert!(file.networks.contains_key("default"));
+		assert_eq!(file.services["web"].networks.names(), vec!["default"]);
+	}
+
+	#[test]
+	fn normalize_leaves_service_with_explicit_networks_untouched() {
+		let mut file = parse_str(
+			"services:\n  web:\n    image: nginx\n    networks: [front]\nnetworks:\n  front:\n",
+		)
+		.unwrap();
+		normalize_default_network(&mut file);
+		assert_eq!(file.services["web"].networks.names(), vec!["front"]);
+		// No default network is synthesized when nothing needs it.
+		assert!(!file.networks.contains_key("default"));
+	}
+
+	#[test]
+	fn normalize_skips_service_with_network_mode() {
+		let mut file =
+			parse_str("services:\n  web:\n    image: nginx\n    network_mode: host\n").unwrap();
+		normalize_default_network(&mut file);
+		assert!(file.services["web"].networks.names().is_empty());
+		assert!(!file.networks.contains_key("default"));
+	}
+
+	#[test]
+	fn normalize_respects_explicit_default_network_config() {
+		let mut file = parse_str(
+			"services:\n  web:\n    image: nginx\nnetworks:\n  default:\n    driver: bridge\n",
+		)
+		.unwrap();
+		normalize_default_network(&mut file);
+		// The user-defined `default` config is kept, not overwritten with None.
+		assert!(file.networks["default"].is_some());
+		assert_eq!(file.services["web"].networks.names(), vec!["default"]);
 	}
 }

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -34,9 +34,14 @@ pub(super) fn build_restart_policy(service: &Service) -> (Option<String>, Option
 		.as_ref()
 		.and_then(|d| d.restart_policy.as_ref())
 	{
+		// Compose `restart_policy.condition`: `any` (the default) means restart
+		// under any circumstance, which docker-compose maps to `always` — not
+		// `unless-stopped` (the latter would skip restarts after an explicit
+		// stop, diverging from docker-compose).
 		let name = match drp.condition.as_deref().unwrap_or("any") {
 			"none" => "no",
 			"on-failure" => "on-failure",
+			"any" => "always",
 			_ => "unless-stopped",
 		};
 		return (Some(name.to_string()), drp.max_attempts.map(|n| n as u64));
@@ -176,6 +181,34 @@ mod tests {
 		});
 		let (name, _) = build_restart_policy(&svc);
 		assert_eq!(name.as_deref(), Some("no"));
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_any_maps_to_always() {
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy {
+				condition: Some("any".into()),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+		let (name, _) = build_restart_policy(&svc);
+		assert_eq!(name.as_deref(), Some("always"));
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_default_condition_is_always() {
+		// An unset `condition` defaults to `any` per the compose spec → `always`.
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy::default()),
+			..Default::default()
+		});
+		let (name, _) = build_restart_policy(&svc);
+		assert_eq!(name.as_deref(), Some("always"));
 	}
 
 	// --- log config ---

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -288,6 +288,11 @@ impl Engine {
 		// the 8-byte header, which would produce garbled output.
 		run_service.tty = None;
 
+		// Ensure the project networks exist (compose `run` brings them up like
+		// `up` does); the service may reference the synthesized `default`
+		// network, which is created here as `{project}_default`.
+		self.create_networks(file).await?;
+
 		self.create_and_start(&run_name, service_name, &run_service, file)
 			.await?;
 

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::compose::types::{Command, RestartPolicy, VolumeMount};
+use crate::compose::types::{Command, RestartPolicy, VolumeMount, VolumeType};
 use crate::ports::ParsedPort;
 
 pub(super) fn render_publish_port(p: &ParsedPort) -> String {
@@ -86,6 +86,37 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 			}
 			out
 		}
+	}
+}
+
+/// If `vol` is a long-form `type: tmpfs` mount, render it as a Quadlet `Tmpfs=`
+/// value (`target[:size=…,mode=…]`); otherwise return `None` so the caller emits
+/// a normal `Volume=`. A tmpfs mount written as `Volume=` would create a
+/// persistent named/anonymous volume instead of an in-memory filesystem — a
+/// silent semantic inversion. Size/mode mirror the runtime mount options.
+pub(super) fn render_tmpfs_mount(vol: &VolumeMount) -> Option<String> {
+	let VolumeMount::Long {
+		volume_type: VolumeType::Tmpfs,
+		target,
+		tmpfs,
+		..
+	} = vol
+	else {
+		return None;
+	};
+	let mut opts: Vec<String> = Vec::new();
+	if let Some(t) = tmpfs {
+		if let Some(size) = t.size {
+			opts.push(format!("size={size}"));
+		}
+		if let Some(mode) = t.mode {
+			opts.push(format!("mode={mode:o}"));
+		}
+	}
+	if opts.is_empty() {
+		Some(target.clone())
+	} else {
+		Some(format!("{target}:{}", opts.join(",")))
 	}
 }
 

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -339,3 +339,31 @@ services:
 		"missing deploy cpus PodmanArgs in:\n{c}"
 	);
 }
+
+#[test]
+fn long_form_tmpfs_mount_renders_as_tmpfs_not_volume() {
+	// A long-form `type: tmpfs` mount must become `Tmpfs=`, not `Volume=` —
+	// the latter would persist it as a volume instead of an in-memory fs.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    volumes:
+      - type: tmpfs
+        target: /cache
+        tmpfs:
+          size: 64000000
+          mode: 0o755
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("Tmpfs=/cache:size=64000000,mode=755"),
+		"tmpfs not rendered as Tmpfs= with options in:\n{c}"
+	);
+	assert!(
+		!c.contains("Volume=/cache"),
+		"tmpfs wrongly emitted as a Volume in:\n{c}"
+	);
+}

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -289,3 +289,53 @@ services:
 		);
 	}
 }
+
+#[test]
+fn cpu_limits_render_as_podman_args() {
+	// CPU limits have no native [Container] Quadlet key; they must round-trip
+	// through PodmanArgs= rather than being silently dropped.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    cpus: "1.5"
+    cpuset: "0,1"
+    cpu_shares: 512
+    cpu_quota: 50000
+    cpu_period: 100000
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	for expected in [
+		"PodmanArgs=--cpus=1.5",
+		"PodmanArgs=--cpuset-cpus=0,1",
+		"PodmanArgs=--cpu-shares=512",
+		"PodmanArgs=--cpu-quota=50000",
+		"PodmanArgs=--cpu-period=100000",
+	] {
+		assert!(c.contains(expected), "missing `{expected}` in:\n{c}");
+	}
+}
+
+#[test]
+fn deploy_limits_cpus_render_as_podman_args() {
+	// `deploy.resources.limits.cpus` is the modern equivalent of `cpus` and
+	// must reach the unit too when the top-level `cpus` is absent.
+	let yaml = r#"
+services:
+  s:
+    image: app:1.0
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("PodmanArgs=--cpus=2"),
+		"missing deploy cpus PodmanArgs in:\n{c}"
+	);
+}

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -5,8 +5,8 @@ use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
 use super::render::{
-	render_command, render_publish_port, render_restart, render_volume, safe_unit_stem,
-	sorted_label_pairs, sorted_pairs, Section,
+	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
+	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;
@@ -269,7 +269,13 @@ pub(super) fn container_unit(
 	}
 
 	for vol in &service.volumes {
-		container.add("Volume", render_volume(vol, declared_volumes));
+		// A long-form `type: tmpfs` mount maps to `Tmpfs=`, not `Volume=`
+		// (which would persist it as a volume rather than an in-memory fs).
+		if let Some(t) = render_tmpfs_mount(vol) {
+			container.add("Tmpfs", t);
+		} else {
+			container.add("Volume", render_volume(vol, declared_volumes));
+		}
 	}
 	for net in service.networks.names() {
 		// A declared (non-external) network is backed by a generated `.network`

--- a/internal/quadlet/unit.rs
+++ b/internal/quadlet/unit.rs
@@ -342,6 +342,30 @@ pub(super) fn container_unit(
 		// rejects the unit); express the limit as a raw podman flag.
 		container.add("PodmanArgs", format!("--memory={mem}"));
 	}
+	// CPU limits have no native [Container] Quadlet key (unlike Memory=/
+	// PidsLimit=), so they go through PodmanArgs=, mirroring --memory above.
+	// `cpus` falls back to the modern `deploy.resources.limits.cpus`.
+	let deploy_cpus = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.resources.as_ref())
+		.and_then(|r| r.limits.as_ref())
+		.and_then(|l| l.cpus.as_deref());
+	if let Some(c) = service.cpus.as_deref().or(deploy_cpus) {
+		container.add("PodmanArgs", format!("--cpus={c}"));
+	}
+	if let Some(cs) = &service.cpuset {
+		container.add("PodmanArgs", format!("--cpuset-cpus={cs}"));
+	}
+	if let Some(sh) = service.cpu_shares {
+		container.add("PodmanArgs", format!("--cpu-shares={sh}"));
+	}
+	if let Some(q) = service.cpu_quota {
+		container.add("PodmanArgs", format!("--cpu-quota={q}"));
+	}
+	if let Some(p) = service.cpu_period {
+		container.add("PodmanArgs", format!("--cpu-period={p}"));
+	}
 	if let Some(pids) = service.pids_limit {
 		container.add("PidsLimit", pids.to_string());
 	}

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -9,7 +9,7 @@
 //! crate root so the submodules can reach them via `use super::*;`.
 use std::fs;
 
-use podup::{parse_str, Client, Engine};
+use podup::{parse_files_with_env_files, parse_str, Client, Engine};
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -371,3 +371,49 @@ async fn sibling_resolves_service_by_name_on_shared_network() {
 		"service `server` was not reachable by its service name: {out:?}"
 	);
 }
+
+// ---------------------------------------------------------------------------
+// With NO `networks:` block, services still reach each other by service name
+// (the synthesized `default` network — docker-compose parity, #417)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn sibling_resolves_service_by_name_without_networks_block() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("dnsdef");
+	let engine = Engine::new(client, proj.clone());
+
+	// No top-level `networks:` and no per-service `networks:` — the common case.
+	// Parse through the real CLI entry point so the implicit `default` network
+	// is synthesized; `parse_str` deliberately does not normalize.
+	let dir = tempfile::tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  server:\n    image: busybox:latest\n    command: [\"sh\", \"-c\", \"mkdir -p /www; echo ok > /www/index.html; exec httpd -f -p 80 -h /www\"]\n  client:\n    image: busybox:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let file = parse_files_with_env_files(&[compose], &[]).unwrap();
+
+	engine.up(&file).await.unwrap();
+	let out = engine
+		.test_exec_capture(
+			&format!("{proj}-client"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"for i in $(seq 1 30); do wget -q -O - http://server:80/ && exit 0; sleep 0.3; done; exit 1".into(),
+			],
+		)
+		.await;
+	engine.down(&file).await.unwrap();
+	let out = out.expect("exec in client container failed");
+	assert!(
+		out.contains("ok"),
+		"service `server` was not reachable by name without a networks: block: {out:?}"
+	);
+}


### PR DESCRIPTION
Promote verified develop fixes to main (merge, **no tag** — not a release; tag is cut later when releasing).

Brings to main:
- #421 (closes #417, P1): synthesize `<project>_default` network so services with no `networks:` block resolve each other by name. Real-Podman verified.
- #422 (#418 item 1): `deploy.restart_policy.condition: any` → `always`.
- #423 (closes #408): quadlet emits CPU limits via `PodmanArgs=`.
- #424 (#419 item 1): quadlet long-form tmpfs → `Tmpfs=`.
- #409: NOTICE `podman-compose` → `podup`.

All merged to develop individually with CI green + unit/integration tests. No public API change (bug fixes); no version bump, no release.