### PR TITLE
feat(cli): add -t/--timeout to up/down/stop/restart

### DIFF
--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -72,6 +72,9 @@ pub(crate) enum Commands {
 		/// Do not start linked services (depends_on) of the named services.
 		#[arg(long)]
 		no_deps: bool,
+		/// Seconds to wait for containers to stop when recreating, before killing them.
+		#[arg(short = 't', long)]
+		timeout: Option<i32>,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]
@@ -82,6 +85,9 @@ pub(crate) enum Commands {
 		/// Also remove named volumes declared in the compose file.
 		#[arg(short = 'v', long)]
 		volumes: bool,
+		/// Seconds to wait for containers to stop before killing them.
+		#[arg(short = 't', long)]
+		timeout: Option<i32>,
 	},
 	/// Start existing stopped containers.
 	Start {
@@ -91,6 +97,9 @@ pub(crate) enum Commands {
 	},
 	/// Stop running containers without removing them.
 	Stop {
+		/// Seconds to wait for containers to stop before killing them.
+		#[arg(short = 't', long)]
+		timeout: Option<i32>,
 		/// Stop only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
@@ -210,6 +219,9 @@ pub(crate) enum Commands {
 	},
 	/// Restart services.
 	Restart {
+		/// Seconds to wait for containers to stop before killing them.
+		#[arg(short = 't', long)]
+		timeout: Option<i32>,
 		/// Only restart this service.
 		service: Option<String>,
 	},

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -6,7 +6,7 @@ use tracing::info;
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
-use super::{filter_services, grace_period_secs, RunOptions};
+use super::{filter_services, RunOptions};
 use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
 
@@ -26,7 +26,7 @@ impl Engine {
 			let service = &file.services[name];
 
 			for container_name in self.replica_names(name, service) {
-				let grace = grace_period_secs(service);
+				let grace = self.grace_period_secs(service);
 				let stop_path = format!(
 					"{API_PREFIX}/containers/{}/stop?t={grace}",
 					crate::libpod::urlencoded(&container_name),
@@ -50,7 +50,7 @@ impl Engine {
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
 					for dep_container in self.replica_names(dep_name, dep_service) {
-						let grace = grace_period_secs(dep_service);
+						let grace = self.grace_period_secs(dep_service);
 						let stop_path = format!(
 							"{API_PREFIX}/containers/{}/stop?t={grace}",
 							crate::libpod::urlencoded(&dep_container),
@@ -87,7 +87,7 @@ impl Engine {
 		for name in &order {
 			let service = &file.services[name];
 			for container_name in self.replica_names(name, service) {
-				let grace = grace_period_secs(service);
+				let grace = self.grace_period_secs(service);
 				let path = format!(
 					"{API_PREFIX}/containers/{}/stop?t={grace}",
 					crate::libpod::urlencoded(&container_name),

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -11,7 +11,7 @@ use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
-use targets::{expand_targets, filter_services, grace_period_secs};
+use targets::{expand_targets, filter_services};
 
 use super::container::config_hash;
 
@@ -279,7 +279,7 @@ impl Engine {
 					}
 				}
 
-				let grace = grace_period_secs(service);
+				let grace = self.grace_period_secs(service);
 				let stop_path = format!(
 					"{API_PREFIX}/containers/{}/stop?t={grace}",
 					crate::libpod::urlencoded(&container_name),

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -6,13 +6,23 @@ use std::collections::HashSet;
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 
-pub(super) fn grace_period_secs(service: &Service) -> i32 {
+/// The per-service shutdown grace from `stop_grace_period` (default 10s).
+pub(super) fn service_grace_period_secs(service: &Service) -> i32 {
 	service
 		.stop_grace_period
 		.as_deref()
 		.and_then(crate::size::parse_duration_secs)
 		.and_then(|s| i32::try_from(s).ok())
 		.unwrap_or(10)
+}
+
+impl crate::engine::Engine {
+	/// Shutdown grace (seconds) for a service: the CLI `-t/--timeout` override
+	/// when set, otherwise the service's `stop_grace_period`.
+	pub(super) fn grace_period_secs(&self, service: &Service) -> i32 {
+		self.stop_timeout
+			.unwrap_or_else(|| service_grace_period_secs(service))
+	}
 }
 
 /// Return the ordered service names filtered to `target_services`.

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -41,6 +41,10 @@ pub struct Engine {
 	pub(super) client: Client,
 	pub(super) project: String,
 	pub(super) base_dir: PathBuf,
+	/// Optional CLI `-t/--timeout` override (seconds) for container shutdown
+	/// grace; when set it takes precedence over each service's
+	/// `stop_grace_period`. `None` falls back to the per-service value.
+	pub(super) stop_timeout: Option<i32>,
 }
 
 impl Engine {
@@ -50,6 +54,7 @@ impl Engine {
 			client,
 			project,
 			base_dir: std::env::current_dir().unwrap_or_default(),
+			stop_timeout: None,
 		}
 	}
 
@@ -59,7 +64,14 @@ impl Engine {
 			client,
 			project,
 			base_dir,
+			stop_timeout: None,
 		}
+	}
+
+	/// Set the CLI `-t/--timeout` shutdown-grace override (seconds). Builder-style.
+	pub fn with_stop_timeout(mut self, timeout: Option<i32>) -> Self {
+		self.stop_timeout = timeout;
+		self
 	}
 
 	pub(super) async fn run_lifecycle_hook(

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -268,7 +268,17 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;
-	let engine = podup::Engine::with_base_dir(client, project, base_dir);
+	// The `-t/--timeout` shutdown-grace override applies to every command that
+	// stops containers (up recreate, down, stop, restart).
+	let stop_timeout = match &cli.command {
+		Commands::Up { timeout, .. }
+		| Commands::Down { timeout, .. }
+		| Commands::Stop { timeout, .. }
+		| Commands::Restart { timeout, .. } => *timeout,
+		_ => None,
+	};
+	let engine =
+		podup::Engine::with_base_dir(client, project, base_dir).with_stop_timeout(stop_timeout);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,
@@ -289,6 +299,7 @@ async fn run() -> podup::Result<()> {
 			no_recreate,
 			force_recreate,
 			no_deps,
+			timeout: _,
 			services,
 		} => {
 			if remove_orphans {
@@ -315,9 +326,15 @@ async fn run() -> podup::Result<()> {
 				let _ = engine.stop(&file, &[]).await;
 			}
 		}
-		Commands::Down { volumes } => engine.down_with_options(&file, volumes).await?,
+		Commands::Down {
+			volumes,
+			timeout: _,
+		} => engine.down_with_options(&file, volumes).await?,
 		Commands::Start { services } => engine.start(&file, &services).await?,
-		Commands::Stop { services } => engine.stop(&file, &services).await?,
+		Commands::Stop {
+			services,
+			timeout: _,
+		} => engine.stop(&file, &services).await?,
 		Commands::Build { services } => engine.build_all(&file, &services).await?,
 		Commands::Rm { force, services } => engine.rm(&file, &services, force).await?,
 		Commands::Kill { signal, services } => engine.kill(&file, &services, &signal).await?,
@@ -361,7 +378,10 @@ async fn run() -> podup::Result<()> {
 		}
 		Commands::Exec { service, cmd } => engine.exec(&file, &service, cmd).await?,
 		Commands::Pull { services } => engine.pull_services(&file, &services).await?,
-		Commands::Restart { service } => engine.restart(&file, service.as_deref()).await?,
+		Commands::Restart {
+			service,
+			timeout: _,
+		} => engine.restart(&file, service.as_deref()).await?,
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -73,3 +73,21 @@ fn help_and_version_are_blank_line_framed() {
 		);
 	}
 }
+
+/// `-t/--timeout` (shutdown grace) is accepted by every command that stops
+/// containers — up, down, stop, restart — matching docker compose.
+#[test]
+fn timeout_flag_is_accepted_by_stop_commands() {
+	for cmd in ["up", "down", "stop", "restart"] {
+		let output = Command::new(bin())
+			.args([cmd, "--help"])
+			.output()
+			.expect("run <cmd> --help");
+		assert!(output.status.success(), "`{cmd} --help` failed");
+		let stdout = String::from_utf8_lossy(&output.stdout);
+		assert!(
+			stdout.contains("--timeout"),
+			"`{cmd}` is missing the --timeout flag; got:\n{stdout}"
+		);
+	}
+}


### PR DESCRIPTION
Closes #411 (part of the CLI parity epic #410).

## What
`docker compose` accepts `-t/--timeout SECONDS` on `up`, `down`, `stop`, and `restart` to override the container shutdown grace before SIGKILL. podup always used the per-service `stop_grace_period`. This adds the flag to all four commands.

## How
Minimal blast radius: the override lives on the `Engine` (`stop_timeout: Option<i32>`, set via `with_stop_timeout`). `grace_period_secs` becomes an `Engine` method returning the CLI override when set, else `service_grace_period_secs` (the per-service `stop_grace_period`, default 10s). No public method signatures change, so existing callers and tests are untouched.

## Verification
- CLI test asserts `--timeout` is accepted by up/down/stop/restart.
- Full `cargo test --all-features` green (622 lib + 103 integration).
- Real Podman sanity: `podup stop -t 1` → exit 0, container `exited`.
- fmt + clippy clean.

Closes #411.