### PR TITLE
promote: exec flags -e/-u/-w/--privileged/-d/--index (#413)

### DIFF
--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -206,6 +206,27 @@ pub(crate) enum Commands {
 	},
 	/// Execute a command in a running service container.
 	Exec {
+		/// Set environment variables (KEY=VAL); may be repeated.
+		#[arg(short, long = "env")]
+		env: Vec<String>,
+		/// Run the command as this user (name or UID[:GID]).
+		#[arg(short, long)]
+		user: Option<String>,
+		/// Working directory inside the container.
+		#[arg(short, long)]
+		workdir: Option<String>,
+		/// Give extended privileges to the command.
+		#[arg(long)]
+		privileged: bool,
+		/// Detach: run the command in the background.
+		#[arg(short, long)]
+		detach: bool,
+		/// Disable pseudo-TTY allocation (podup never allocates one; accepted for compatibility).
+		#[arg(short = 'T', long = "no-TTY")]
+		no_tty: bool,
+		/// Index of the container when the service has multiple replicas (1-based).
+		#[arg(long)]
+		index: Option<u32>,
 		/// Service name.
 		service: String,
 		/// Command (and arguments) to execute.

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -7,6 +7,7 @@ mod container;
 mod copy;
 pub use lifecycle::RunOptions;
 pub use lock::ProjectLock;
+pub use query::ExecOptions;
 mod container_config;
 mod container_fields;
 mod health;

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -13,6 +13,23 @@ use super::Engine;
 
 mod inspect;
 
+/// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
+#[derive(Default)]
+pub struct ExecOptions {
+	/// Extra environment variables (`KEY=VAL`), `-e/--env`.
+	pub env: Vec<String>,
+	/// Run as this user, `-u/--user`.
+	pub user: Option<String>,
+	/// Working directory inside the container, `-w/--workdir`.
+	pub workdir: Option<String>,
+	/// Run with extended privileges, `--privileged`.
+	pub privileged: bool,
+	/// Detach: start the exec and return without streaming output, `-d/--detach`.
+	pub detach: bool,
+	/// 1-based replica index for a scaled service, `--index` (default: first).
+	pub index: Option<u32>,
+}
+
 impl Engine {
 	/// List containers for this project: name, image, command, state, and port bindings.
 	pub async fn ps(&self, _file: &ComposeFile) -> Result<()> {
@@ -155,23 +172,50 @@ impl Engine {
 		Ok(())
 	}
 
-	/// Run a command in the first replica of the named service. Exits with the command's exit code.
+	/// Run a command in the first replica of the named service with default
+	/// options. Exits with the command's exit code.
 	pub async fn exec(
 		&self,
 		file: &ComposeFile,
 		service_name: &str,
 		cmd: Vec<String>,
 	) -> Result<()> {
+		self.exec_with_options(file, service_name, cmd, ExecOptions::default())
+			.await
+	}
+
+	/// Run a command in a service container with `docker compose exec`-style
+	/// overrides (env, user, workdir, privileged, detach, replica index).
+	pub async fn exec_with_options(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		cmd: Vec<String>,
+		opts: ExecOptions,
+	) -> Result<()> {
 		let service = file
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.first_replica_name(service_name, service);
+		let container_name = match opts.index {
+			Some(i) => {
+				let names = self.replica_names(service_name, service);
+				let idx = (i as usize).saturating_sub(1);
+				names.get(idx).cloned().ok_or_else(|| {
+					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
+				})?
+			}
+			None => self.first_replica_name(service_name, service),
+		};
 
 		let exec_cfg = ExecCreateConfig {
 			cmd: Some(cmd),
 			attach_stdout: Some(true),
 			attach_stderr: Some(true),
+			user: opts.user.clone(),
+			working_dir: opts.workdir.clone(),
+			privileged: opts.privileged.then_some(true),
+			env: (!opts.env.is_empty()).then(|| opts.env.clone()),
 			..Default::default()
 		};
 		let create_path = format!(
@@ -184,6 +228,23 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let exec_id = resp.id;
+
+		// `-d/--detach`: start the exec and return without streaming output or
+		// waiting for the exit code. The server returns immediately, so the
+		// response body is dropped.
+		if opts.detach {
+			let start_cfg = ExecStartConfig {
+				detach: true,
+				tty: false,
+			};
+			let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
+			let _ = self
+				.client
+				.post_json_stream(&start_path, &start_cfg)
+				.await
+				.map_err(ComposeError::Podman)?;
+			return Ok(());
+		}
 
 		let start_cfg = ExecStartConfig {
 			detach: false,

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -28,7 +28,7 @@ pub use compose::{
 	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
 	parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
-pub use engine::{is_safe_project_name, Engine, ProjectLock, RunOptions};
+pub use engine::{is_safe_project_name, Engine, ExecOptions, ProjectLock, RunOptions};
 pub use error::{ComposeError, Result};
 pub use libpod::Client;
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -376,7 +376,33 @@ async fn run() -> podup::Result<()> {
 		Commands::Logs { service, follow } => {
 			engine.logs(&file, service.as_deref(), follow).await?
 		}
-		Commands::Exec { service, cmd } => engine.exec(&file, &service, cmd).await?,
+		Commands::Exec {
+			env,
+			user,
+			workdir,
+			privileged,
+			detach,
+			no_tty: _,
+			index,
+			service,
+			cmd,
+		} => {
+			engine
+				.exec_with_options(
+					&file,
+					&service,
+					cmd,
+					podup::ExecOptions {
+						env,
+						user,
+						workdir,
+						privileged,
+						detach,
+						index,
+					},
+				)
+				.await?
+		}
 		Commands::Pull { services } => engine.pull_services(&file, &services).await?,
 		Commands::Restart {
 			service,

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -91,3 +91,21 @@ fn timeout_flag_is_accepted_by_stop_commands() {
 		);
 	}
 }
+
+/// `exec` accepts the docker-compose-style overrides (`-e/-u/-w/--privileged/
+/// --index`).
+#[test]
+fn exec_accepts_override_flags() {
+	let output = Command::new(bin())
+		.args(["exec", "--help"])
+		.output()
+		.expect("run exec --help");
+	assert!(output.status.success(), "`exec --help` failed");
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	for flag in ["--env", "--user", "--workdir", "--privileged", "--index"] {
+		assert!(
+			stdout.contains(flag),
+			"`exec` is missing the {flag} flag; got:\n{stdout}"
+		);
+	}
+}

--- a/tests/engine_integration/group_a1.rs
+++ b/tests/engine_integration/group_a1.rs
@@ -249,7 +249,49 @@ async fn exec_command_in_container() {
 
 	engine.up(&file).await.unwrap();
 	engine
-		.exec(&file, "web", vec!["echo".to_string(), "test".to_string()])
+		.exec_with_options(
+			&file,
+			"web",
+			vec!["echo".to_string(), "test".to_string()],
+			podup::ExecOptions::default(),
+		)
+		.await
+		.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
+async fn exec_with_options_user_workdir_env() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("excopt");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// Podman accepts user/workdir/env on the exec; a bad workdir or user would
+	// make this error, so success exercises the option plumbing end to end.
+	engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"pwd; echo $FOO".to_string(),
+			],
+			podup::ExecOptions {
+				user: Some("root".to_string()),
+				workdir: Some("/tmp".to_string()),
+				env: vec!["FOO=bar".to_string()],
+				..Default::default()
+			},
+		)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -269,7 +311,12 @@ async fn exec_unknown_service_fails() {
 	.unwrap();
 
 	let err = engine
-		.exec(&file, "nonexistent", vec!["echo".to_string()])
+		.exec_with_options(
+			&file,
+			"nonexistent",
+			vec!["echo".to_string()],
+			podup::ExecOptions::default(),
+		)
 		.await
 		.unwrap_err();
 	assert!(matches!(err, podup::ComposeError::ServiceNotFound(_)));

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -38,10 +38,11 @@ async fn inline_secret_materialized() {
 	// Inline content is created as a Podman-native secret and mounted at the
 	// usual /run/secrets/<name> path — verify by exec-ing a read.
 	engine
-		.exec(
+		.exec_with_options(
 			&file,
 			"web",
 			vec!["cat".to_string(), "/run/secrets/mysecret".to_string()],
+			podup::ExecOptions::default(),
 		)
 		.await
 		.unwrap();

--- a/tests/engine_integration/group_a3.rs
+++ b/tests/engine_integration/group_a3.rs
@@ -234,10 +234,11 @@ async fn secret_long_form_ref() {
 
 	engine.up(&file).await.unwrap();
 	engine
-		.exec(
+		.exec_with_options(
 			&file,
 			"web",
 			vec!["cat".to_string(), "/run/secrets/custom_name".to_string()],
+			podup::ExecOptions::default(),
 		)
 		.await
 		.unwrap();
@@ -259,10 +260,11 @@ async fn config_long_form_ref() {
 
 	engine.up(&file).await.unwrap();
 	engine
-		.exec(
+		.exec_with_options(
 			&file,
 			"web",
 			vec!["cat".to_string(), "/etc/app.conf".to_string()],
+			podup::ExecOptions::default(),
 		)
 		.await
 		.unwrap();

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -282,7 +282,12 @@ async fn exec_scaled_service_targets_first_replica() {
 
 	engine.up(&file).await.unwrap();
 	engine
-		.exec(&file, "worker", vec!["echo".to_string(), "ok".to_string()])
+		.exec_with_options(
+			&file,
+			"worker",
+			vec!["echo".to_string(), "ok".to_string()],
+			podup::ExecOptions::default(),
+		)
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();


### PR DESCRIPTION
Promote #428 (closes #413) to main. No tag. Adds docker-compose-style exec overrides; non-breaking (exec_with_options wrapper). CI-green on develop, real-Podman verified.