### PR TITLE
feat(cli): build flags --no-cache/--pull/--build-arg/-q

### DIFF
--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -106,6 +106,18 @@ pub(crate) enum Commands {
 	},
 	/// Build or rebuild service images.
 	Build {
+		/// Do not use cache when building the image.
+		#[arg(long)]
+		no_cache: bool,
+		/// Always attempt to pull a newer version of the base image.
+		#[arg(long)]
+		pull: bool,
+		/// Set build-time variables (KEY=VAL); may be repeated.
+		#[arg(long = "build-arg")]
+		build_arg: Vec<String>,
+		/// Suppress the build output.
+		#[arg(short, long)]
+		quiet: bool,
 		/// Build only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -6,14 +6,15 @@
 //! passed as the `target=` query parameter — the full Dockerfile is always sent.
 
 mod context;
+mod pull;
 
 use bytes::Bytes;
 use futures_util::StreamExt;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::compose::types::{BuildConfig, Service};
 use crate::error::{ComposeError, Result};
-use crate::libpod::types::image::{BuildOutput, ImagePullProgress};
+use crate::libpod::types::image::BuildOutput;
 use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
 use crate::size;
@@ -26,53 +27,22 @@ use super::Engine;
 /// specs (`id=NAME,src=ENTRY`) for the libpod build endpoint.
 type ResolvedBuildSecrets = (Vec<(String, Vec<u8>)>, Vec<String>);
 
+/// `docker compose build`-style CLI overrides. Each augments (never weakens)
+/// the per-service `build:` config: a flag forces the behaviour on even when
+/// the compose file leaves it off.
+#[derive(Default, Clone)]
+pub struct BuildOptions {
+	/// Force a cache-less build (`--no-cache`).
+	pub no_cache: bool,
+	/// Always attempt to pull a newer base image (`--pull`).
+	pub pull: bool,
+	/// Extra build args (`KEY=VAL`); override the compose `build.args` on conflict.
+	pub build_args: Vec<String>,
+	/// Suppress build output (`-q/--quiet`).
+	pub quiet: bool,
+}
+
 impl Engine {
-	pub(super) async fn pull_image(&self, service: &Service) -> Result<()> {
-		let image = match &service.image {
-			Some(img) => img.clone(),
-			None => return Ok(()),
-		};
-
-		info!("pulling {image}");
-
-		let requested = service.pull_policy.as_deref();
-		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
-			warn!(
-				"unknown pull_policy '{}', defaulting to 'missing'",
-				requested.unwrap_or_default()
-			);
-			"missing"
-		});
-		let mut query = format!("reference={}&policy={}", urlencoded(&image), pull_policy);
-		if let Some(platform) = &service.platform {
-			query.push_str(&format!("&platform={}", urlencoded(platform)));
-		}
-
-		let path = format!("{API_PREFIX}/images/pull?{query}");
-		let resp = self
-			.client
-			.post_empty_stream(&path)
-			.await
-			.map_err(ComposeError::Podman)?;
-		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
-
-		while let Some(result) = stream.next().await {
-			match result {
-				Ok(progress) => {
-					if !progress.stream.is_empty() {
-						debug!("{}", progress.stream.trim_end());
-					}
-					if !progress.error.is_empty() {
-						warn!("pull error: {}", progress.error);
-					}
-				}
-				Err(e) => warn!("pull warning: {e}"),
-			}
-		}
-
-		Ok(())
-	}
-
 	/// Build (or rebuild) images for services that have a `build:` block.
 	///
 	/// If `target_services` is empty, every service with a build config is built.
@@ -81,6 +51,18 @@ impl Engine {
 		&self,
 		file: &crate::compose::types::ComposeFile,
 		target_services: &[String],
+	) -> Result<()> {
+		self.build_all_with_options(file, target_services, &BuildOptions::default())
+			.await
+	}
+
+	/// Build service images with `docker compose build`-style overrides
+	/// (`--no-cache`, `--pull`, `--build-arg`, `--quiet`).
+	pub async fn build_all_with_options(
+		&self,
+		file: &crate::compose::types::ComposeFile,
+		target_services: &[String],
+		opts: &BuildOptions,
 	) -> Result<()> {
 		let names: Vec<String> = if target_services.is_empty() {
 			file.services.keys().cloned().collect()
@@ -96,7 +78,7 @@ impl Engine {
 		for name in &names {
 			let service = &file.services[name];
 			if service.build.is_some() {
-				self.build_service(name, service, file).await?;
+				self.build_service(name, service, file, opts).await?;
 			}
 		}
 		Ok(())
@@ -107,6 +89,7 @@ impl Engine {
 		service_name: &str,
 		service: &Service,
 		file: &crate::compose::types::ComposeFile,
+		opts: &BuildOptions,
 	) -> Result<()> {
 		let build = match &service.build {
 			Some(b) => b,
@@ -178,6 +161,16 @@ impl Engine {
 			let value = v.unwrap_or_else(|| std::env::var(&k).unwrap_or_default());
 			build_args.insert(k, value);
 		}
+		// CLI `--build-arg KEY=VAL` overrides the compose `build.args`. A bare
+		// `KEY` (no `=`) takes its value from the process environment, matching
+		// docker compose.
+		for entry in &opts.build_args {
+			let (k, v) = match entry.split_once('=') {
+				Some((k, v)) => (k.to_string(), v.to_string()),
+				None => (entry.clone(), std::env::var(entry).unwrap_or_default()),
+			};
+			build_args.insert(k, v);
+		}
 
 		let mut labels: std::collections::HashMap<String, String> =
 			std::collections::HashMap::new();
@@ -227,10 +220,10 @@ impl Engine {
 		let mut qs = format!(
 			"t={}&rm=true&nocache={}",
 			urlencoded(&tag),
-			build.no_cache()
+			build.no_cache() || opts.no_cache
 		);
 		qs.push_str(&format!("&dockerfile={}", urlencoded(&dockerfile_name)));
-		if build.pull() {
+		if build.pull() || opts.pull {
 			qs.push_str("&pull=true");
 		}
 		if let Some(p) = &platform {
@@ -295,7 +288,7 @@ impl Engine {
 		while let Some(result) = stream.next().await {
 			match result {
 				Ok(output) => {
-					if !output.stream.is_empty() {
+					if !opts.quiet && !output.stream.is_empty() {
 						print!("{}", output.stream);
 					}
 					if let Some(err) = output.error_detail.and_then(|e| e.message) {
@@ -385,38 +378,10 @@ fn is_remote_context(context: &str) -> bool {
 	context.contains("://") || context.starts_with("git@")
 }
 
-/// Map a compose `pull_policy:` value to the libpod images/pull `policy`
-/// parameter. `if_not_present` is the spec alias for `missing`; `build` falls
-/// back to `missing` here (its build behavior is handled by the caller). Returns
-/// `None` for an unrecognized value so the caller can warn and default.
-pub(super) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'static str> {
-	match policy {
-		Some("always") => Some("always"),
-		Some("newer") => Some("newer"),
-		Some("never") => Some("never"),
-		None | Some("missing") | Some("if_not_present") | Some("build") => Some("missing"),
-		Some(_) => None,
-	}
-}
-
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, libpod_pull_policy, Engine};
+	use super::{is_remote_context, Engine};
 	use crate::libpod::Client;
-
-	#[test]
-	fn pull_policy_maps_every_spec_value() {
-		assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
-		assert_eq!(libpod_pull_policy(Some("newer")), Some("newer"));
-		assert_eq!(libpod_pull_policy(Some("never")), Some("never"));
-		assert_eq!(libpod_pull_policy(Some("missing")), Some("missing"));
-		// `if_not_present` is the spec alias for `missing`.
-		assert_eq!(libpod_pull_policy(Some("if_not_present")), Some("missing"));
-		assert_eq!(libpod_pull_policy(Some("build")), Some("missing"));
-		assert_eq!(libpod_pull_policy(None), Some("missing"));
-		// Unknown values are reported (None) so the caller warns.
-		assert_eq!(libpod_pull_policy(Some("bogus")), None);
-	}
 
 	fn engine(base: std::path::PathBuf) -> Engine {
 		Engine::with_base_dir(Client::new("/nonexistent.sock"), "p".into(), base)

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -1,0 +1,92 @@
+//! Image pull from a registry (the non-build half of image acquisition).
+
+use futures_util::StreamExt;
+use tracing::{debug, info, warn};
+
+use crate::compose::types::Service;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::image::ImagePullProgress;
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::super::Engine;
+
+impl Engine {
+	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
+		let image = match &service.image {
+			Some(img) => img.clone(),
+			None => return Ok(()),
+		};
+
+		info!("pulling {image}");
+
+		let requested = service.pull_policy.as_deref();
+		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
+			warn!(
+				"unknown pull_policy '{}', defaulting to 'missing'",
+				requested.unwrap_or_default()
+			);
+			"missing"
+		});
+		let mut query = format!("reference={}&policy={}", urlencoded(&image), pull_policy);
+		if let Some(platform) = &service.platform {
+			query.push_str(&format!("&platform={}", urlencoded(platform)));
+		}
+
+		let path = format!("{API_PREFIX}/images/pull?{query}");
+		let resp = self
+			.client
+			.post_empty_stream(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
+
+		while let Some(result) = stream.next().await {
+			match result {
+				Ok(progress) => {
+					if !progress.stream.is_empty() {
+						debug!("{}", progress.stream.trim_end());
+					}
+					if !progress.error.is_empty() {
+						warn!("pull error: {}", progress.error);
+					}
+				}
+				Err(e) => warn!("pull warning: {e}"),
+			}
+		}
+
+		Ok(())
+	}
+}
+
+/// Map a compose `pull_policy:` value to the libpod images/pull `policy`
+/// parameter. `if_not_present` is the spec alias for `missing`; `build` falls
+/// back to `missing` here (its build behavior is handled by the caller). Returns
+/// `None` for an unrecognized value so the caller can warn and default.
+pub(in crate::engine) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'static str> {
+	match policy {
+		Some("always") => Some("always"),
+		Some("newer") => Some("newer"),
+		Some("never") => Some("never"),
+		None | Some("missing") | Some("if_not_present") | Some("build") => Some("missing"),
+		Some(_) => None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::libpod_pull_policy;
+
+	#[test]
+	fn pull_policy_maps_every_spec_value() {
+		assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
+		assert_eq!(libpod_pull_policy(Some("newer")), Some("newer"));
+		assert_eq!(libpod_pull_policy(Some("never")), Some("never"));
+		assert_eq!(libpod_pull_policy(Some("missing")), Some("missing"));
+		// `if_not_present` is the spec alias for `missing`.
+		assert_eq!(libpod_pull_policy(Some("if_not_present")), Some("missing"));
+		assert_eq!(libpod_pull_policy(Some("build")), Some("missing"));
+		assert_eq!(libpod_pull_policy(None), Some("missing"));
+		// Unknown values are reported (None) so the caller warns.
+		assert_eq!(libpod_pull_policy(Some("bogus")), None);
+	}
+}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -214,7 +214,10 @@ impl Engine {
 
 		let policy = service.pull_policy.as_deref().unwrap_or("missing");
 		match (service.build.is_some(), policy) {
-			(true, _) => self.build_service(name, service, file).await?,
+			(true, _) => {
+				self.build_service(name, service, file, &crate::engine::BuildOptions::default())
+					.await?
+			}
 			(false, "never") => {}
 			(false, _) => self.pull_image(service).await?,
 		}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -5,6 +5,7 @@
 mod build;
 mod container;
 mod copy;
+pub use build::BuildOptions;
 pub use lifecycle::RunOptions;
 pub use lock::ProjectLock;
 pub use query::ExecOptions;

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -256,7 +256,13 @@ impl Engine {
 			None => return Ok(()),
 		};
 		info!("rebuilding {service_name}");
-		self.build_service(service_name, service, file).await?;
+		self.build_service(
+			service_name,
+			service,
+			file,
+			&crate::engine::BuildOptions::default(),
+		)
+		.await?;
 		let container_name = self.container_name(service_name, service);
 		self.create_and_start(&container_name, service_name, service, file)
 			.await

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -28,7 +28,9 @@ pub use compose::{
 	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
 	parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
-pub use engine::{is_safe_project_name, Engine, ExecOptions, ProjectLock, RunOptions};
+pub use engine::{
+	is_safe_project_name, BuildOptions, Engine, ExecOptions, ProjectLock, RunOptions,
+};
 pub use error::{ComposeError, Result};
 pub use libpod::Client;
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -335,7 +335,26 @@ async fn run() -> podup::Result<()> {
 			services,
 			timeout: _,
 		} => engine.stop(&file, &services).await?,
-		Commands::Build { services } => engine.build_all(&file, &services).await?,
+		Commands::Build {
+			no_cache,
+			pull,
+			build_arg,
+			quiet,
+			services,
+		} => {
+			engine
+				.build_all_with_options(
+					&file,
+					&services,
+					&podup::BuildOptions {
+						no_cache,
+						pull,
+						build_args: build_arg,
+						quiet,
+					},
+				)
+				.await?
+		}
 		Commands::Rm { force, services } => engine.rm(&file, &services, force).await?,
 		Commands::Kill { signal, services } => engine.kill(&file, &services, &signal).await?,
 		Commands::Pause { services } => engine.pause(&file, &services).await?,

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -109,3 +109,21 @@ fn exec_accepts_override_flags() {
 		);
 	}
 }
+
+/// `build` accepts the docker-compose build overrides (`--no-cache`, `--pull`,
+/// `--build-arg`, `-q/--quiet`).
+#[test]
+fn build_accepts_override_flags() {
+	let output = Command::new(bin())
+		.args(["build", "--help"])
+		.output()
+		.expect("run build --help");
+	assert!(output.status.success(), "`build --help` failed");
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	for flag in ["--no-cache", "--pull", "--build-arg", "--quiet"] {
+		assert!(
+			stdout.contains(flag),
+			"`build` is missing the {flag} flag; got:\n{stdout}"
+		);
+	}
+}

--- a/tests/engine_integration/group_a3.rs
+++ b/tests/engine_integration/group_a3.rs
@@ -150,6 +150,36 @@ async fn build_with_args_and_extra_tags() {
 }
 
 #[tokio::test]
+async fn build_with_cli_no_cache_and_build_arg() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("bco");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let tag = format!("podup-test-bco-{}:latest", std::process::id());
+	let yaml = format!(
+		"services:\n  app:\n    build:\n      context: .\n      dockerfile_inline: |\n        FROM alpine:latest\n        ARG VERSION=0\n        RUN echo Version $VERSION\n      args:\n        VERSION: \"1.0\"\n    image: {tag}\n    command: [\"sleep\", \"infinity\"]\n"
+	);
+	let file = parse_str(&yaml).unwrap();
+
+	// CLI overrides: force no-cache and override the compose VERSION build arg.
+	engine
+		.build_all_with_options(
+			&file,
+			&[],
+			&podup::BuildOptions {
+				no_cache: true,
+				build_args: vec!["VERSION=2.0".to_string()],
+				..Default::default()
+			},
+		)
+		.await
+		.unwrap();
+}
+
+#[tokio::test]
 async fn build_inline_dockerfile() {
 	let client = match podman().await {
 		Some(d) => d,


### PR DESCRIPTION
Closes #414 (part of CLI parity epic #410).

## What
`podup build` took only service names. Adds the docker compose build overrides: `--no-cache`, `--pull`, `--build-arg KEY=VAL` (repeatable), `-q/--quiet`.

## How
New `BuildOptions` struct: each flag augments the per-service `build:` config — forces no-cache/pull on, overrides `build.args` on conflict (`KEY` without `=` reads the env), and `-q` suppresses build output. Non-breaking: `Engine::build_all` kept as a default wrapper; overrides go through `Engine::build_all_with_options` (mirrors `up`/`up_with_options`).

## Scope
BuildKit-only flags (`--builder`/`--sbom`/`--provenance`/`--ssh`) out of scope; `--push` tracked separately under #410.

## Verification
- Real Podman: `build_with_cli_no_cache_and_build_arg` builds with `no_cache=true` + `--build-arg VERSION=2.0` override → ok.
- CLI flag-surface test; fmt + clippy clean; non-breaking (semver-safe wrapper).

Closes #414.