### PR TITLE
fix(quadlet): emit and warn on previously dropped/mis-emitted fields

### DIFF
--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -341,6 +341,113 @@ services:
 }
 
 #[test]
+fn static_ips_render_as_ip_keys() {
+	// `networks.<n>.ipv4_address`/`ipv6_address` must reach the unit as IP=/IP6=,
+	// not be silently dropped.
+	let yaml = r#"
+services:
+  s:
+    image: x
+    networks:
+      net:
+        ipv4_address: 10.5.0.7
+        ipv6_address: "2001:db8::7"
+networks:
+  net:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("IP=10.5.0.7"), "missing IP= in:\n{c}");
+	assert!(c.contains("IP6=2001:db8::7"), "missing IP6= in:\n{c}");
+}
+
+#[test]
+fn network_mode_none_maps_to_network_none() {
+	// `network_mode: none` is a valid Quadlet value; it must map to Network=none
+	// rather than being warned and dropped.
+	let yaml = "services:\n  s:\n    image: x\n    network_mode: none\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("Network=none"), "missing Network=none in:\n{c}");
+	assert!(
+		!out.warnings.iter().any(|w| w.contains("network_mode")),
+		"network_mode: none must not warn; got: {:?}",
+		out.warnings
+	);
+}
+
+#[test]
+fn security_opt_filetype_and_nested_map_to_keys() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    security_opt:
+      - "label=filetype:usr_t"
+      - "label=nested"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("SecurityLabelFileType=usr_t"), "in:\n{c}");
+	assert!(c.contains("SecurityLabelNested=true"), "in:\n{c}");
+	assert!(
+		!out.warnings.iter().any(|w| w.contains("security_opt")),
+		"mapped labels must not warn; got: {:?}",
+		out.warnings
+	);
+}
+
+#[test]
+fn deploy_restart_policy_maps_to_systemd() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 4
+        window: 2m
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("Restart=on-failure"), "in:\n{c}");
+	assert!(c.contains("StartLimitBurst=4"), "in:\n{c}");
+	assert!(c.contains("StartLimitIntervalSec=120"), "in:\n{c}");
+}
+
+#[test]
+fn deploy_restart_condition_none_maps_to_no() {
+	let yaml = "services:\n  s:\n    image: x\n    deploy:\n      restart_policy:\n        condition: none\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	assert!(unit_named(&out, "s.container")
+		.contents
+		.contains("Restart=no"));
+}
+
+#[test]
+fn deploy_limits_pids_maps_to_pids_limit() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    deploy:
+      resources:
+        limits:
+          pids: 256
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("PidsLimit=256"), "missing PidsLimit in:\n{c}");
+}
+
+#[test]
 fn long_form_tmpfs_mount_renders_as_tmpfs_not_volume() {
 	// A long-form `type: tmpfs` mount must become `Tmpfs=`, not `Volume=` —
 	// the latter would persist it as a volume instead of an in-memory fs.

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -266,3 +266,71 @@ volumes:
 	assert!(vol.contains("Driver=local"));
 	assert!(vol.contains("Label=tier=vol"));
 }
+
+#[test]
+fn network_unit_emits_ipam_pools_options_and_custom_name() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+networks:
+  net:
+    name: custom-net
+    driver_opts:
+      mtu: "9000"
+      com.docker.network.bridge.name: br0
+    ipam:
+      driver: host-local
+      config:
+        - subnet: 10.7.0.0/16
+          gateway: 10.7.0.1
+          ip_range: 10.7.0.128/25
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let net = &unit_named(&out, "net.network").contents;
+	// A custom name overrides the project-prefixed default.
+	assert!(net.contains("NetworkName=custom-net"), "in:\n{net}");
+	assert!(!net.contains("NetworkName=p_net"), "in:\n{net}");
+	assert!(net.contains("IPAMDriver=host-local"), "in:\n{net}");
+	assert!(net.contains("Subnet=10.7.0.0/16"), "in:\n{net}");
+	assert!(net.contains("Gateway=10.7.0.1"), "in:\n{net}");
+	assert!(net.contains("IPRange=10.7.0.128/25"), "in:\n{net}");
+	// Each driver option is its own Options= line (Quadlet maps one Options= to
+	// one `--opt`); a comma-joined value would be a single malformed option.
+	assert!(net.contains("Options=mtu=9000"), "in:\n{net}");
+	assert!(
+		net.contains("Options=com.docker.network.bridge.name=br0"),
+		"in:\n{net}"
+	);
+}
+
+#[test]
+fn volume_unit_emits_options_and_custom_name() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+volumes:
+  vol:
+    name: custom-vol
+    driver: local
+    driver_opts:
+      type: nfs
+      device: ":/exports"
+      o: "addr=10.0.0.1,rw"
+      custom: extra
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let vol = &unit_named(&out, "vol.volume").contents;
+	assert!(vol.contains("VolumeName=custom-vol"), "in:\n{vol}");
+	assert!(!vol.contains("VolumeName=p_vol"), "in:\n{vol}");
+	// `local` driver opts map to dedicated keys; `o` is a single mount-option
+	// string. Options= without a Device= would be rejected by Quadlet.
+	assert!(vol.contains("Type=nfs"), "in:\n{vol}");
+	assert!(vol.contains("Device=:/exports"), "in:\n{vol}");
+	assert!(vol.contains("Options=addr=10.0.0.1,rw"), "in:\n{vol}");
+	// An option with no dedicated key falls back to PodmanArgs=--opt.
+	assert!(vol.contains("PodmanArgs=--opt custom=extra"), "in:\n{vol}");
+}

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -1,197 +1,17 @@
-//! Build the individual `.network`, `.volume` and `.container` units.
+//! Build the `.container` unit for a service.
 
-use crate::compose::types::{Command, PortMapping, RestartPolicy, Service, ServiceSecretRef};
+use crate::compose::types::{PortMapping, RestartPolicy, Service};
 use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
-use super::render::{
-	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
-	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
+use super::health::render_healthcheck;
+use super::security::{map_security_opt, render_secret};
+use super::{
+	collect_warnings, render_command, render_publish_port, render_restart, render_tmpfs_mount,
+	render_volume, safe_unit_stem, sorted_label_pairs, sorted_pairs, QuadletUnit, Section,
 };
-use super::warnings::collect_warnings;
-use super::QuadletUnit;
 
-/// Map a compose `healthcheck:` onto the Quadlet `Health*=` keys. A disabled
-/// healthcheck emits `HealthCmd=none`; otherwise the compose test (with any
-/// leading `CMD`/`CMD-SHELL`/`NONE` sentinel stripped) and the timing fields
-/// are rendered.
-fn render_healthcheck(service: &Service, container: &mut Section) {
-	let Some(hc) = &service.healthcheck else {
-		return;
-	};
-	if hc.is_disabled() {
-		container.add("HealthCmd", "none".to_string());
-		return;
-	}
-	if let Some(test) = &hc.test {
-		let cmd = match test {
-			Command::Shell(s) => s.clone(),
-			Command::Exec(parts) => {
-				let body = match parts.first().map(String::as_str) {
-					Some("CMD") | Some("CMD-SHELL") | Some("NONE") => &parts[1..],
-					_ => &parts[..],
-				};
-				body.join(" ")
-			}
-		};
-		if !cmd.is_empty() {
-			container.add("HealthCmd", cmd);
-		}
-	}
-	if let Some(v) = &hc.interval {
-		container.add("HealthInterval", v.clone());
-	}
-	if let Some(v) = &hc.timeout {
-		container.add("HealthTimeout", v.clone());
-	}
-	if let Some(v) = hc.retries {
-		container.add("HealthRetries", v.to_string());
-	}
-	if let Some(v) = &hc.start_period {
-		container.add("HealthStartPeriod", v.clone());
-	}
-	if let Some(v) = &hc.start_interval {
-		container.add("HealthStartupInterval", v.clone());
-	}
-}
-
-/// Sanitize one `Secret=` option-list field: drop control characters and the
-/// `,`/`=` separators so a hostile compose value cannot inject extra options.
-fn secret_field(value: &str) -> String {
-	value
-		.chars()
-		.filter(|c| !c.is_control() && *c != ',' && *c != '=')
-		.collect()
-}
-
-/// Render a service `secrets:` entry into a Quadlet `Secret=` value
-/// (`name[,target=,uid=,gid=,mode=]`).
-fn render_secret(secret: &ServiceSecretRef) -> String {
-	match secret {
-		// Sanitize the short-form name too: `Secret=` is an option list, so a
-		// `,`/`=` in the name would inject extra options (same guard as Long).
-		ServiceSecretRef::Short(name) => secret_field(name),
-		ServiceSecretRef::Long {
-			source,
-			target,
-			uid,
-			gid,
-			mode,
-		} => {
-			// `Secret=` is a comma-separated `key=value` option list, so a `,`
-			// or `=` embedded in any field would inject extra options. Strip
-			// those (and control chars) from each value at the boundary.
-			let mut s = secret_field(source);
-			if let Some(t) = target {
-				s.push_str(&format!(",target={}", secret_field(t)));
-			}
-			if let Some(u) = uid {
-				s.push_str(&format!(",uid={}", secret_field(u)));
-			}
-			if let Some(g) = gid {
-				s.push_str(&format!(",gid={}", secret_field(g)));
-			}
-			if let Some(m) = mode {
-				s.push_str(&format!(",mode={m:o}"));
-			}
-			s
-		}
-	}
-}
-
-/// Map a single compose `security_opt` entry onto the dedicated Quadlet key
-/// where one exists; unrecognized entries are reported rather than dropped.
-fn map_security_opt(opt: &str, container: &mut Section, name: &str, warnings: &mut Vec<String>) {
-	if let Some(rest) = opt.strip_prefix("no-new-privileges") {
-		let val = rest.trim_start_matches([':', '=']);
-		let enabled = val.is_empty() || val == "true";
-		container.add("NoNewPrivileges", enabled.to_string());
-	} else if let Some(profile) = opt.strip_prefix("seccomp=") {
-		container.add("SeccompProfile", profile.to_string());
-	} else if let Some(profile) = opt
-		.strip_prefix("apparmor=")
-		.or_else(|| opt.strip_prefix("apparmor:"))
-	{
-		// Quadlet has no `AppArmor=` key in Podman 5.x; the generator rejects the
-		// whole unit on an unknown key. Pass it through as a raw podman flag.
-		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
-	} else if let Some(label) = opt.strip_prefix("label=") {
-		if label == "disable" {
-			container.add("SecurityLabelDisable", "true".to_string());
-		} else if let Some(t) = label.strip_prefix("type:") {
-			container.add("SecurityLabelType", t.to_string());
-		} else if let Some(l) = label.strip_prefix("level:") {
-			container.add("SecurityLabelLevel", l.to_string());
-		} else {
-			warnings.push(format!(
-				"{name}: security_opt 'label={label}' has no Quadlet key and is skipped"
-			));
-		}
-	} else {
-		warnings.push(format!(
-			"{name}: security_opt '{opt}' has no Quadlet mapping and is skipped"
-		));
-	}
-}
-
-pub(super) fn network_unit(
-	name: &str,
-	project: &str,
-	config: Option<&crate::compose::types::NetworkConfig>,
-) -> QuadletUnit {
-	let mut net = Section::new("Network");
-	net.add("NetworkName", format!("{project}_{name}"));
-	if let Some(cfg) = config {
-		if let Some(driver) = &cfg.driver {
-			net.add("Driver", driver.clone());
-		}
-		if cfg.internal == Some(true) {
-			net.add("Internal", "true".to_string());
-		}
-		if cfg.enable_ipv6 == Some(true) {
-			net.add("IPv6", "true".to_string());
-		}
-		if let Some(ipam) = &cfg.ipam {
-			if let Some(ipam_driver) = &ipam.driver {
-				net.add("IPAMDriver", ipam_driver.clone());
-			}
-		}
-		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
-			net.add("Label", format!("{key}={val}"));
-		}
-	}
-	let mut contents = net.render();
-	contents.push_str("\n[Install]\nWantedBy=default.target\n");
-	QuadletUnit {
-		filename: format!("{}.network", safe_unit_stem(name)),
-		contents,
-	}
-}
-
-pub(super) fn volume_unit(
-	name: &str,
-	project: &str,
-	config: Option<&crate::compose::types::VolumeConfig>,
-) -> QuadletUnit {
-	let mut vol = Section::new("Volume");
-	vol.add("VolumeName", format!("{project}_{name}"));
-	if let Some(cfg) = config {
-		if let Some(driver) = &cfg.driver {
-			vol.add("Driver", driver.clone());
-		}
-		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
-			vol.add("Label", format!("{key}={val}"));
-		}
-	}
-	let mut contents = vol.render();
-	contents.push_str("\n[Install]\nWantedBy=default.target\n");
-	QuadletUnit {
-		filename: format!("{}.volume", safe_unit_stem(name)),
-		contents,
-	}
-}
-
-pub(super) fn container_unit(
+pub(crate) fn container_unit(
 	name: &str,
 	service: &Service,
 	declared_volumes: &[&str],
@@ -372,7 +192,16 @@ pub(super) fn container_unit(
 	if let Some(p) = service.cpu_period {
 		container.add("PodmanArgs", format!("--cpu-period={p}"));
 	}
+	// `deploy.resources.limits.pids` is the modern equivalent of `pids_limit`.
+	let deploy_pids = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.resources.as_ref())
+		.and_then(|r| r.limits.as_ref())
+		.and_then(|l| l.pids);
 	if let Some(pids) = service.pids_limit {
+		container.add("PidsLimit", pids.to_string());
+	} else if let Some(pids) = deploy_pids {
 		container.add("PidsLimit", pids.to_string());
 	}
 	if let Some(userns) = &service.userns_mode {
@@ -386,10 +215,13 @@ pub(super) fn container_unit(
 			container.add("StopTimeout", secs.to_string());
 		}
 	}
-	// `network_mode: host` maps to `Network=host`; other modes (service:/
-	// container:) have no Quadlet key and are reported by collect_warnings.
-	if service.network_mode.as_deref() == Some("host") {
-		container.add("Network", "host".to_string());
+	// `network_mode: host`/`none` map to `Network=host`/`Network=none`; other
+	// modes (service:/container:) have no Quadlet key and are reported by
+	// collect_warnings.
+	match service.network_mode.as_deref() {
+		Some("host") => container.add("Network", "host".to_string()),
+		Some("none") => container.add("Network", "none".to_string()),
+		_ => {}
 	}
 	for group in &service.group_add {
 		container.add("GroupAdd", group.clone());
@@ -397,6 +229,11 @@ pub(super) fn container_unit(
 	for port in &service.expose {
 		container.add("ExposeHostPort", port.clone());
 	}
+	// `IP=`/`IP6=` are single-valued per container, so the first static address
+	// declared across the service's networks wins (Quadlet has no per-network IP
+	// scoping); a second one is reported by collect_warnings.
+	let mut static_ip: Option<&str> = None;
+	let mut static_ip6: Option<&str> = None;
 	for net in service.networks.names() {
 		if let Some(cfg) = service.networks.config_for(&net) {
 			if let Some(aliases) = &cfg.aliases {
@@ -404,7 +241,19 @@ pub(super) fn container_unit(
 					container.add("NetworkAlias", alias.clone());
 				}
 			}
+			if static_ip.is_none() {
+				static_ip = cfg.ipv4_address.as_deref();
+			}
+			if static_ip6.is_none() {
+				static_ip6 = cfg.ipv6_address.as_deref();
+			}
 		}
+	}
+	if let Some(ip) = static_ip {
+		container.add("IP", ip.to_string());
+	}
+	if let Some(ip6) = static_ip6 {
+		container.add("IP6", ip6.to_string());
 	}
 	for opt in &service.security_opt {
 		map_security_opt(opt, &mut container, name, warnings);
@@ -446,6 +295,27 @@ pub(super) fn container_unit(
 		{
 			svc.add("StartLimitBurst", n.to_string());
 		}
+	} else if let Some(rp) = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.restart_policy.as_ref())
+	{
+		// `deploy.restart_policy` is the modern equivalent of the service-level
+		// `restart:` string; its `condition` maps onto the systemd `Restart=`
+		// values and `max_attempts`/`window` onto the start-limit window.
+		let restart = match rp.condition.as_deref() {
+			Some("none") => "no",
+			Some("on-failure") => "on-failure",
+			// "any" (the compose default) and any unknown value restart always.
+			_ => "always",
+		};
+		svc.add("Restart", restart.to_string());
+		if let Some(n) = rp.max_attempts {
+			svc.add("StartLimitBurst", n.to_string());
+			if let Some(secs) = rp.window.as_deref().and_then(parse_duration_secs) {
+				svc.add("StartLimitIntervalSec", secs.to_string());
+			}
+		}
 	}
 
 	collect_warnings(name, service, warnings);
@@ -463,34 +333,5 @@ pub(super) fn container_unit(
 	QuadletUnit {
 		filename: format!("{}.container", safe_unit_stem(name)),
 		contents,
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::{render_secret, secret_field};
-	use crate::compose::types::ServiceSecretRef;
-
-	#[test]
-	fn secret_field_strips_separators_and_controls() {
-		assert_eq!(secret_field("a,b=c\nd"), "abcd");
-		assert_eq!(secret_field("plain"), "plain");
-	}
-
-	#[test]
-	fn render_secret_cannot_inject_extra_options() {
-		// A hostile target tries to smuggle a second option via `,` and `=`.
-		let s = ServiceSecretRef::Long {
-			source: "tok".into(),
-			target: Some("/run/x,uid=0".into()),
-			uid: None,
-			gid: None,
-			mode: None,
-		};
-		let out = render_secret(&s);
-		// The injected `,uid=0` must be flattened into the target value, not a
-		// separate option: exactly one comma (the legitimate `,target=`).
-		assert_eq!(out.matches(',').count(), 1);
-		assert_eq!(out, "tok,target=/run/xuid0");
 	}
 }

--- a/internal/quadlet/unit/health.rs
+++ b/internal/quadlet/unit/health.rs
@@ -1,0 +1,49 @@
+//! Map a compose `healthcheck:` onto the Quadlet `Health*=` keys.
+
+use crate::compose::types::{Command, Service};
+
+use super::Section;
+
+/// Map a compose `healthcheck:` onto the Quadlet `Health*=` keys. A disabled
+/// healthcheck emits `HealthCmd=none`; otherwise the compose test (with any
+/// leading `CMD`/`CMD-SHELL`/`NONE` sentinel stripped) and the timing fields
+/// are rendered.
+pub(super) fn render_healthcheck(service: &Service, container: &mut Section) {
+	let Some(hc) = &service.healthcheck else {
+		return;
+	};
+	if hc.is_disabled() {
+		container.add("HealthCmd", "none".to_string());
+		return;
+	}
+	if let Some(test) = &hc.test {
+		let cmd = match test {
+			Command::Shell(s) => s.clone(),
+			Command::Exec(parts) => {
+				let body = match parts.first().map(String::as_str) {
+					Some("CMD") | Some("CMD-SHELL") | Some("NONE") => &parts[1..],
+					_ => &parts[..],
+				};
+				body.join(" ")
+			}
+		};
+		if !cmd.is_empty() {
+			container.add("HealthCmd", cmd);
+		}
+	}
+	if let Some(v) = &hc.interval {
+		container.add("HealthInterval", v.clone());
+	}
+	if let Some(v) = &hc.timeout {
+		container.add("HealthTimeout", v.clone());
+	}
+	if let Some(v) = hc.retries {
+		container.add("HealthRetries", v.to_string());
+	}
+	if let Some(v) = &hc.start_period {
+		container.add("HealthStartPeriod", v.clone());
+	}
+	if let Some(v) = &hc.start_interval {
+		container.add("HealthStartupInterval", v.clone());
+	}
+}

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -1,0 +1,20 @@
+//! Build the individual `.network`, `.volume` and `.container` units.
+
+mod container;
+mod health;
+mod network;
+mod security;
+mod volume;
+
+pub(super) use container::container_unit;
+pub(super) use network::network_unit;
+pub(super) use volume::volume_unit;
+
+// Shared helpers from the sibling `render`/`warnings` modules and the parent
+// `QuadletUnit` type, re-exported so the unit submodules import them from here.
+use super::render::{
+	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
+	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
+};
+use super::warnings::collect_warnings;
+use super::QuadletUnit;

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -1,0 +1,63 @@
+//! Build the `.network` unit for a declared network.
+
+use crate::compose::types::NetworkConfig;
+
+use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+
+pub(crate) fn network_unit(
+	name: &str,
+	project: &str,
+	config: Option<&NetworkConfig>,
+) -> QuadletUnit {
+	let mut net = Section::new("Network");
+	// A custom `name:` overrides Podman's resource name; Quadlet uses the literal
+	// value (no prefix) when `NetworkName=` is set explicitly.
+	let net_name = config
+		.and_then(|c| c.name.clone())
+		.unwrap_or_else(|| format!("{project}_{name}"));
+	net.add("NetworkName", net_name);
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			net.add("Driver", driver.clone());
+		}
+		if cfg.internal == Some(true) {
+			net.add("Internal", "true".to_string());
+		}
+		if cfg.enable_ipv6 == Some(true) {
+			net.add("IPv6", "true".to_string());
+		}
+		if let Some(ipam) = &cfg.ipam {
+			if let Some(ipam_driver) = &ipam.driver {
+				net.add("IPAMDriver", ipam_driver.clone());
+			}
+			// Each `ipam.config` pool maps to a Subnet=/Gateway=/IPRange= triple;
+			// all three keys are repeatable and correlated positionally by Podman.
+			for pool in &ipam.config {
+				if let Some(subnet) = &pool.subnet {
+					net.add("Subnet", subnet.clone());
+				}
+				if let Some(gateway) = &pool.gateway {
+					net.add("Gateway", gateway.clone());
+				}
+				if let Some(range) = &pool.ip_range {
+					net.add("IPRange", range.clone());
+				}
+			}
+		}
+		// Each driver option becomes its own Options= line: Quadlet maps one
+		// Options= to one `podman network create --opt key=value`, so a
+		// comma-joined value would be passed as a single malformed option.
+		for (key, val) in sorted_label_pairs(cfg.driver_opts.clone()) {
+			net.add("Options", format!("{key}={val}"));
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			net.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = net.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
+	QuadletUnit {
+		filename: format!("{}.network", safe_unit_stem(name)),
+		contents,
+	}
+}

--- a/internal/quadlet/unit/security.rs
+++ b/internal/quadlet/unit/security.rs
@@ -1,0 +1,122 @@
+//! Render service `secrets:` and `security_opt:` onto their Quadlet keys.
+
+use crate::compose::types::ServiceSecretRef;
+
+use super::Section;
+
+/// Sanitize one `Secret=` option-list field: drop control characters and the
+/// `,`/`=` separators so a hostile compose value cannot inject extra options.
+pub(super) fn secret_field(value: &str) -> String {
+	value
+		.chars()
+		.filter(|c| !c.is_control() && *c != ',' && *c != '=')
+		.collect()
+}
+
+/// Render a service `secrets:` entry into a Quadlet `Secret=` value
+/// (`name[,target=,uid=,gid=,mode=]`).
+pub(super) fn render_secret(secret: &ServiceSecretRef) -> String {
+	match secret {
+		// Sanitize the short-form name too: `Secret=` is an option list, so a
+		// `,`/`=` in the name would inject extra options (same guard as Long).
+		ServiceSecretRef::Short(name) => secret_field(name),
+		ServiceSecretRef::Long {
+			source,
+			target,
+			uid,
+			gid,
+			mode,
+		} => {
+			// `Secret=` is a comma-separated `key=value` option list, so a `,`
+			// or `=` embedded in any field would inject extra options. Strip
+			// those (and control chars) from each value at the boundary.
+			let mut s = secret_field(source);
+			if let Some(t) = target {
+				s.push_str(&format!(",target={}", secret_field(t)));
+			}
+			if let Some(u) = uid {
+				s.push_str(&format!(",uid={}", secret_field(u)));
+			}
+			if let Some(g) = gid {
+				s.push_str(&format!(",gid={}", secret_field(g)));
+			}
+			if let Some(m) = mode {
+				s.push_str(&format!(",mode={m:o}"));
+			}
+			s
+		}
+	}
+}
+
+/// Map a single compose `security_opt` entry onto the dedicated Quadlet key
+/// where one exists; unrecognized entries are reported rather than dropped.
+pub(super) fn map_security_opt(
+	opt: &str,
+	container: &mut Section,
+	name: &str,
+	warnings: &mut Vec<String>,
+) {
+	if let Some(rest) = opt.strip_prefix("no-new-privileges") {
+		let val = rest.trim_start_matches([':', '=']);
+		let enabled = val.is_empty() || val == "true";
+		container.add("NoNewPrivileges", enabled.to_string());
+	} else if let Some(profile) = opt.strip_prefix("seccomp=") {
+		container.add("SeccompProfile", profile.to_string());
+	} else if let Some(profile) = opt
+		.strip_prefix("apparmor=")
+		.or_else(|| opt.strip_prefix("apparmor:"))
+	{
+		// Quadlet has no `AppArmor=` key in Podman 5.x; the generator rejects the
+		// whole unit on an unknown key. Pass it through as a raw podman flag.
+		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
+	} else if let Some(label) = opt.strip_prefix("label=") {
+		if label == "disable" {
+			container.add("SecurityLabelDisable", "true".to_string());
+		} else if label == "nested" {
+			container.add("SecurityLabelNested", "true".to_string());
+		} else if let Some(t) = label.strip_prefix("type:") {
+			container.add("SecurityLabelType", t.to_string());
+		} else if let Some(l) = label.strip_prefix("level:") {
+			container.add("SecurityLabelLevel", l.to_string());
+		} else if let Some(f) = label.strip_prefix("filetype:") {
+			container.add("SecurityLabelFileType", f.to_string());
+		} else {
+			warnings.push(format!(
+				"{name}: security_opt 'label={label}' has no Quadlet key and is skipped"
+			));
+		}
+	} else {
+		warnings.push(format!(
+			"{name}: security_opt '{opt}' has no Quadlet mapping and is skipped"
+		));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{render_secret, secret_field};
+	use crate::compose::types::ServiceSecretRef;
+
+	#[test]
+	fn secret_field_strips_separators_and_controls() {
+		assert_eq!(secret_field("a,b=c\nd"), "abcd");
+		assert_eq!(secret_field("plain"), "plain");
+	}
+
+	#[test]
+	fn render_secret_cannot_inject_extra_options() {
+		// A hostile target tries to smuggle a second option via `,` and `=`.
+		let s = ServiceSecretRef::Long {
+			source: "tok".into(),
+			target: Some("/run/x,uid=0".into()),
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		let out = render_secret(&s);
+		// The injected `,uid=0` must be flattened into the target value, not a
+		// separate option: exactly one comma (the legitimate `,target=`).
+		assert_eq!(out.matches(',').count(), 1);
+		assert_eq!(out, "tok,target=/run/xuid0");
+	}
+}

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -1,0 +1,41 @@
+//! Build the `.volume` unit for a declared named volume.
+
+use crate::compose::types::VolumeConfig;
+
+use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+
+pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfig>) -> QuadletUnit {
+	let mut vol = Section::new("Volume");
+	// A custom `name:` overrides Podman's resource name; Quadlet uses the literal
+	// value (no prefix) when `VolumeName=` is set explicitly.
+	let vol_name = config
+		.and_then(|c| c.name.clone())
+		.unwrap_or_else(|| format!("{project}_{name}"));
+	vol.add("VolumeName", vol_name);
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			vol.add("Driver", driver.clone());
+		}
+		// The built-in `local` driver's opts map onto dedicated Quadlet keys:
+		// `type`→Type=, `device`→Device=, `o`→Options= (already a comma-separated
+		// mount-option string). Quadlet rejects Options= without a Device=, so any
+		// other driver option has no [Volume] key and passes through PodmanArgs=.
+		for (key, val) in sorted_label_pairs(cfg.driver_opts.clone()) {
+			match key.as_str() {
+				"type" => vol.add("Type", val),
+				"device" => vol.add("Device", val),
+				"o" => vol.add("Options", val),
+				_ => vol.add("PodmanArgs", format!("--opt {key}={val}")),
+			}
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			vol.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = vol.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
+	QuadletUnit {
+		filename: format!("{}.volume", safe_unit_stem(name)),
+		contents,
+	}
+}

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -30,11 +30,15 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 	if !service.volumes_from.is_empty() {
 		warn("volumes_from", "has no Quadlet equivalent and is skipped");
 	}
-	// `network_mode: host` maps to `Network=host`; other modes have no key.
-	if service.network_mode.as_deref().is_some_and(|m| m != "host") {
+	// `network_mode: host`/`none` map to `Network=`; other modes have no key.
+	if service
+		.network_mode
+		.as_deref()
+		.is_some_and(|m| m != "host" && m != "none")
+	{
 		warn(
 			"network_mode",
-			"is not mapped (only `host` is supported); use networks instead",
+			"is not mapped (only `host`/`none` are supported); use networks instead",
 		);
 	}
 	if !service.profiles.is_empty() {
@@ -70,6 +74,79 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 				"condition service_healthy/service_completed_successfully is not enforceable in Quadlet; only start ordering is emitted",
 			);
 		}
+	}
+
+	// Fields that are honoured at runtime but have no [Container] Quadlet key and
+	// no unambiguous PodmanArgs= fallback. Warn so the generated unit is never
+	// silently incomplete; add the flag by hand if it is required.
+	let skipped = "has no Quadlet equivalent and is skipped";
+	if service.ipc.is_some() {
+		warn("ipc", skipped);
+	}
+	if service.pid.is_some() {
+		warn("pid", skipped);
+	}
+	if service.uts.is_some() {
+		warn("uts", skipped);
+	}
+	if service.cgroup.is_some() {
+		warn("cgroup", skipped);
+	}
+	if service.cgroup_parent.is_some() {
+		warn("cgroup_parent", skipped);
+	}
+	if service.runtime.is_some() {
+		warn("runtime", skipped);
+	}
+	if service.tty.is_some() {
+		warn("tty", skipped);
+	}
+	if service.stdin_open.is_some() {
+		warn("stdin_open", skipped);
+	}
+	if service.memswap_limit.is_some() {
+		warn("memswap_limit", skipped);
+	}
+	if service.mem_reservation.is_some() {
+		warn("mem_reservation", skipped);
+	}
+	if service.oom_kill_disable.is_some() {
+		warn("oom_kill_disable", skipped);
+	}
+	if service.oom_score_adj.is_some() {
+		warn("oom_score_adj", skipped);
+	}
+	if service.blkio_config.is_some() {
+		warn("blkio_config", skipped);
+	}
+	if !service.label_file.to_list().is_empty() {
+		warn("label_file", skipped);
+	}
+	// MAC addresses have no Quadlet key (service-level or per-network), and a
+	// per-network value cannot be expressed via the whole-container PodmanArgs=.
+	let has_network_mac = service
+		.networks
+		.names()
+		.iter()
+		.filter_map(|n| service.networks.config_for(n))
+		.any(|c| c.mac_address.is_some());
+	if service.mac_address.is_some() || has_network_mac {
+		warn("mac_address", skipped);
+	}
+	// Only the first static IP across the service's networks is emitted; a second
+	// one would need per-network IP scoping that Quadlet does not support.
+	let static_ip_count = service
+		.networks
+		.names()
+		.iter()
+		.filter_map(|n| service.networks.config_for(n))
+		.filter(|c| c.ipv4_address.is_some() || c.ipv6_address.is_some())
+		.count();
+	if static_ip_count > 1 {
+		warn(
+			"ipv4_address/ipv6_address",
+			"is set on multiple networks; Quadlet emits only the first (no per-network IP scoping)",
+		);
 	}
 }
 
@@ -127,6 +204,79 @@ configs:
 		assert!(
 			!joined.contains("secrets"),
 			"secrets should be mapped, not warned; got:\n{joined}"
+		);
+	}
+
+	#[test]
+	fn warns_for_silently_dropped_runtime_fields() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    ipc: host
+    pid: host
+    uts: host
+    cgroup: private
+    cgroup_parent: /sys/fs/cgroup/p
+    runtime: crun
+    tty: true
+    stdin_open: true
+    mac_address: "02:42:ac:11:00:02"
+    memswap_limit: 1g
+    mem_reservation: 256m
+    oom_kill_disable: true
+    oom_score_adj: -500
+    label_file:
+      - ./labels.env
+    blkio_config:
+      weight: 300
+"#;
+		let file = parse_str(yaml).unwrap();
+		let joined = generate(&file, "proj").warnings.join("\n");
+		for field in [
+			"ipc",
+			"pid",
+			"uts",
+			"cgroup",
+			"cgroup_parent",
+			"runtime",
+			"tty",
+			"stdin_open",
+			"mac_address",
+			"memswap_limit",
+			"mem_reservation",
+			"oom_kill_disable",
+			"oom_score_adj",
+			"label_file",
+			"blkio_config",
+		] {
+			assert!(
+				joined.contains(field),
+				"missing warning for {field}; got:\n{joined}"
+			);
+		}
+	}
+
+	#[test]
+	fn warns_when_static_ip_set_on_multiple_networks() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    networks:
+      a:
+        ipv4_address: 10.0.0.2
+      b:
+        ipv4_address: 10.0.1.2
+networks:
+  a:
+  b:
+"#;
+		let file = parse_str(yaml).unwrap();
+		let joined = generate(&file, "proj").warnings.join("\n");
+		assert!(
+			joined.contains("ipv4_address/ipv6_address"),
+			"missing multi-network static-IP warning; got:\n{joined}"
 		);
 	}
 


### PR DESCRIPTION
## What

Closes #419.

A quadlet-export audit found fields parsed and applied at runtime but dropped or mis-emitted by `generate quadlet`. This fixes the mis-emitted ones and adds warnings for the silent-drop class, so a generated unit is never quietly incomplete.

### Mapped / fixed (were wrong or missing)
- `networks.<n>.ipv4_address`/`ipv6_address` → `IP=`/`IP6=` (first address across the service's networks; Quadlet has no per-network IP scoping — a second one warns)
- `network_mode: none` → `Network=none` (was warned and dropped)
- `security_opt: label=filetype:X` / `label=nested` → `SecurityLabelFileType=` / `SecurityLabelNested=`
- top-level volume/network custom `name:` → overrides the project-prefixed `VolumeName=`/`NetworkName=`
- `ipam.config[]` pools → `Subnet=`/`Gateway=`/`IPRange=` (repeatable, positionally correlated)
- volume/network `driver_opts` → networks emit one `Options=` per option (one `--opt` each); local-driver volume opts `type`/`device`/`o` map to `Type=`/`Device=`/`Options=`, others fall back to `PodmanArgs=--opt` (Quadlet rejects `Options=` without `Device=`)
- `deploy.restart_policy` → `Restart=`/`StartLimitBurst=`/`StartLimitIntervalSec=`
- `deploy.resources.limits.pids` → `PidsLimit=`

### Warned (no Quadlet key, no clean fallback)
`ipc`, `pid`, `uts`, `cgroup`, `cgroup_parent`, `runtime`, `tty`, `stdin_open`, `mac_address` (service- and network-level), `memswap_limit`, `mem_reservation`, `oom_kill_disable`, `oom_score_adj`, `blkio_config`, `label_file`.

Long-form `type: tmpfs` (already routed to `Tmpfs=`) and the apparmor `PodmanArgs=` fallback are unchanged — `AppArmor=` is still not a valid Quadlet key in Podman 5.x.

## Structure

`unit.rs` crossed the 500-line hard limit, so it is split into a `unit/` module: `container`, `network`, `volume`, `health`, `security`.

## Test plan

- 10 new unit tests covering every mapping above plus the warning class; full suite green (`cargo test`), `cargo fmt --check` clean, no new clippy warnings.
- Output verified against the **Podman 5.4.2 quadlet generator** (`/usr/libexec/podman/quadlet --dryrun`) on a real compose file exercising all the new fields: all `.container`/`.network`/`.volume` units convert without error and produce the expected `podman run`/`network create`/`volume create` commands. This caught a real bug — a blind comma-joined `Options=` is invalid on a `[Volume]` (`Options can't be used without Device`) and produces one malformed `--opt` on a `[Network]` — now fixed.