### PR TITLE
feat(cli): up --scale and a scale subcommand for docker-compose parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ flowchart LR
 - 🔒 **Rootless by design** — drives rootless Podman over its native libpod REST API
 - 📄 **Compose-spec parsing** — YAML anchors, `extends`, `include`, profiles, `env_file`, variable substitution with modifiers
 - 🔁 **Dependency-aware** — `depends_on` ordering with `service_started`, `service_healthy`, and `service_completed_successfully` conditions
-- 🔢 **Replicas** — `scale:` and `deploy.replicas` with named replica containers
+- 🔢 **Replicas** — `scale:`/`deploy.replicas`, the `scale` command, and `up --scale SERVICE=N`, with named replica containers
 - 🔐 **Secrets & configs** — inline content, file, environment, and `external: true` Podman-native secret sources, staged securely
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
 - ⚙️ **Systemd Quadlet export** — `generate quadlet` emits native `podman-systemd.unit` files to run your stack under systemd, no daemon

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -47,8 +47,14 @@ given multiple times; later files win. The process environment and a project
 .B up
 Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
-\fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR. Accepts a
-trailing list of services to bring up (with their transitive depends_on).
+\fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
+\fB\-\-scale\fR \fISERVICE=N\fR (repeatable). Accepts a trailing list of services
+to bring up (with their transitive depends_on).
+.TP
+.B scale \fISERVICE=N\fR...
+Set the number of running containers for services, creating missing replicas and
+removing surplus ones. A service publishing a fixed host port cannot scale past
+one replica and the command fails with guidance.
 .TP
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--no-recreate` | Leave already-running containers in place. |
 | `--force-recreate` | Recreate containers even if their config is unchanged. |
 | `--no-deps` | Do not start the `depends_on` services of the named services. |
+| `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. |
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared
@@ -44,6 +45,14 @@ in the compose file.
 Start existing stopped containers, stop running ones without removing them, or
 restart them. `start`/`stop` accept a trailing service list; `restart [SERVICE]`
 restarts everything or one service.
+
+### `scale <SERVICE=N>...`
+Set the number of running containers for one or more services, creating missing
+replicas and removing surplus ones. A service that publishes a **fixed host
+port** cannot be scaled past one replica (only one container can bind a host
+port) — the command fails fast and tells you to drop the host port (`- "80"`, so
+Podman assigns one per replica), front it with a reverse proxy, or stay at one
+replica.
 
 ### `build`
 Build or rebuild service images (optionally only the named services).

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -85,6 +85,9 @@ pub(crate) enum Commands {
 		/// Seconds to wait for containers to stop when recreating, before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
+		/// Override the replica count for a service: SERVICE=N (repeatable).
+		#[arg(long, value_parser = parse_scale_pair)]
+		scale: Vec<(String, u32)>,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]
@@ -113,6 +116,12 @@ pub(crate) enum Commands {
 		/// Stop only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
+	},
+	/// Set the number of running containers for services.
+	Scale {
+		/// Target replica counts: SERVICE=N (one or more).
+		#[arg(value_parser = parse_scale_pair, required = true)]
+		pairs: Vec<(String, u32)>,
 	},
 	/// Build or rebuild service images.
 	Build {
@@ -337,4 +346,43 @@ pub(crate) enum GenerateCommands {
 		#[arg(short, long)]
 		output: Option<PathBuf>,
 	},
+}
+
+/// Parse a `SERVICE=N` scale argument into a `(service, replicas)` pair.
+///
+/// Rejects a missing `=`, an empty service name, a non-numeric count, and `N=0`
+/// (use `down`/`stop` to remove a service, not `scale=0`).
+fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
+	let (service, count) = value
+		.split_once('=')
+		.ok_or_else(|| format!("expected SERVICE=N, got `{value}`"))?;
+	if service.is_empty() {
+		return Err(format!("missing service name in `{value}`"));
+	}
+	let replicas: u32 = count
+		.parse()
+		.map_err(|_| format!("replica count in `{value}` must be a non-negative integer"))?;
+	if replicas == 0 {
+		return Err(format!(
+			"replica count in `{value}` must be at least 1; use `down`/`stop` to remove a service"
+		));
+	}
+	Ok((service.to_string(), replicas))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse_scale_pair;
+
+	#[test]
+	fn parse_scale_pair_accepts_valid() {
+		assert_eq!(parse_scale_pair("web=3"), Ok(("web".to_string(), 3)));
+	}
+
+	#[test]
+	fn parse_scale_pair_rejects_bad_input() {
+		for bad in ["web", "=3", "web=", "web=x", "web=0", "web=-1"] {
+			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
+		}
+	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -1,14 +1,15 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
 mod commands;
+mod scale;
 mod targets;
 
 use std::collections::{HashMap, HashSet};
 
 use tracing::info;
 
-use crate::compose::types::{ComposeFile, ServiceCondition};
-use crate::error::Result;
+use crate::compose::types::{ComposeFile, Service, ServiceCondition};
+use crate::error::{ComposeError, Result};
 use crate::libpod::API_PREFIX;
 
 use targets::{expand_targets, filter_services};
@@ -222,15 +223,16 @@ impl Engine {
 			(false, _) => self.pull_image(service).await?,
 		}
 
-		let replicas = service
-			.scale
-			.or(service.deploy.as_ref().and_then(|d| d.replicas))
-			.unwrap_or(1) as usize;
+		let replicas = self.resolve_replicas(name, service);
+		// A scaled service that publishes a fixed host port cannot start: only
+		// one container can bind it. Fail fast with guidance instead of letting
+		// replicas 2..N die mid-up with `address already in use`.
+		check_scale_port_conflict(name, service, replicas)?;
 
 		let new_hash = config_hash(service, file)?;
 
 		for i in 1..=replicas {
-			let container_name = if replicas == 1 {
+			let container_name = if replicas <= 1 {
 				self.container_name(name, service)
 			} else {
 				format!("{}-{i}", self.container_name(name, service))
@@ -303,6 +305,14 @@ impl Engine {
 			}
 		}
 
+		// A prior `up --scale`/`scale` may have created replicas the compose
+		// file's default count no longer names; sweep any remaining project
+		// containers by label so teardown is always complete.
+		let grace = self.stop_timeout.unwrap_or(10);
+		for name in self.list_project_container_names(None).await? {
+			self.stop_and_remove(&name, grace).await;
+		}
+
 		for (key, config) in &file.networks {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
@@ -347,5 +357,75 @@ impl Engine {
 		// them unconditionally — independent of `remove_volumes`.
 		self.remove_internal_secrets(file).await?;
 		Ok(())
+	}
+}
+
+/// Reject a scaled service that publishes a fixed host port: only one container
+/// can bind a given host port, so replicas 2..N would fail at runtime with
+/// `address already in use`. A host port of 0/None is runtime-assigned by
+/// Podman, so such a service scales fine. The compose-spec does not define how
+/// scaling interacts with published ports, so podup fails fast rather than
+/// inventing surprising auto-offset semantics.
+pub(super) fn check_scale_port_conflict(
+	service_name: &str,
+	service: &Service,
+	replicas: usize,
+) -> Result<()> {
+	if replicas <= 1 {
+		return Ok(());
+	}
+	let fixed: Vec<u16> = crate::ports::parse_ports(&service.ports)?
+		.iter()
+		.filter_map(|p| p.host_port)
+		.filter(|&hp| hp != 0)
+		.collect();
+	if fixed.is_empty() {
+		return Ok(());
+	}
+	Err(ComposeError::ScalePortConflict {
+		service: service_name.to_string(),
+		replicas,
+		ports: fixed,
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::check_scale_port_conflict;
+
+	fn service(yaml: &str) -> crate::compose::types::Service {
+		let file = crate::parse_str(yaml).unwrap();
+		file.services.into_iter().next().unwrap().1
+	}
+
+	#[test]
+	fn single_replica_never_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
+	}
+
+	#[test]
+	fn scaled_fixed_host_port_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ScalePortConflict { .. }
+		));
+		assert!(err.to_string().contains("8080"));
+	}
+
+	#[test]
+	fn scaled_random_host_port_is_allowed() {
+		// A container-only port (`"80"`) gets a runtime-assigned host port per
+		// replica, so scaling is fine.
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
+	}
+
+	#[test]
+	fn scaled_no_ports_is_allowed() {
+		let svc = service("services:\n  worker:\n    image: x\n");
+		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -1,0 +1,111 @@
+//! The `scale` subcommand plus the replica-listing/reconciliation helpers
+//! shared with teardown.
+
+use std::collections::HashSet;
+
+use tracing::info;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::engine::Engine;
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::check_scale_port_conflict;
+
+impl Engine {
+	/// Set the number of running containers for the named services (docker
+	/// `compose scale SERVICE=N`). Creates missing replicas and removes any
+	/// surplus. The `--scale` overrides are already applied to this engine, so
+	/// `resolve_replicas` reports the target count during the up pass.
+	pub async fn scale(&self, file: &ComposeFile, pairs: &[(String, u32)]) -> Result<()> {
+		for (svc, _) in pairs {
+			if !file.services.contains_key(svc) {
+				return Err(ComposeError::ServiceNotFound(svc.clone()));
+			}
+		}
+		// Fail fast on a fixed host port before touching any container.
+		for (svc, target) in pairs {
+			check_scale_port_conflict(svc, &file.services[svc], *target as usize)?;
+		}
+		// Scale up: create only the missing replicas of the named services
+		// (no_recreate keeps existing ones; no_deps leaves dependencies alone).
+		let targets: Vec<String> = pairs.iter().map(|(s, _)| s.clone()).collect();
+		self.up_with_options(file, true, &[], &targets, true, false, true)
+			.await?;
+		// Scale down: remove replicas beyond the target count.
+		for (svc, target) in pairs {
+			self.remove_surplus_replicas(svc, &file.services[svc], *target)
+				.await?;
+		}
+		Ok(())
+	}
+
+	/// Remove the containers of `service_name` whose names fall outside the
+	/// desired `target`-replica set (the scale-down half of reconciliation).
+	async fn remove_surplus_replicas(
+		&self,
+		service_name: &str,
+		service: &Service,
+		target: u32,
+	) -> Result<()> {
+		let base = self.container_name(service_name, service);
+		let desired: HashSet<String> = if target <= 1 {
+			std::iter::once(base).collect()
+		} else {
+			(1..=target).map(|i| format!("{base}-{i}")).collect()
+		};
+		let grace = self.grace_period_secs(service);
+		for name in self
+			.list_project_container_names(Some(service_name))
+			.await?
+		{
+			if !desired.contains(&name) {
+				self.stop_and_remove(&name, grace).await;
+			}
+		}
+		Ok(())
+	}
+
+	/// Stop (best-effort) then force-remove a container by name.
+	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32) {
+		let stop_path = format!(
+			"{API_PREFIX}/containers/{}/stop?t={grace}",
+			urlencoded(name)
+		);
+		let _ = self.client.post_empty_ok(&stop_path).await;
+		let rm_path = format!("{API_PREFIX}/containers/{}?force=true", urlencoded(name));
+		if let Err(e) = self.client.delete_ok(&rm_path).await {
+			tracing::debug!("scale-down rm {name}: {e}");
+		} else {
+			info!("removed {name}");
+		}
+	}
+
+	/// All container names carrying this project's label, optionally narrowed to
+	/// one service via the `podup.service` label. Lets reconciliation find
+	/// scaled replicas that the compose file's default count no longer names.
+	pub(super) async fn list_project_container_names(
+		&self,
+		service: Option<&str>,
+	) -> Result<Vec<String>> {
+		let mut labels = vec![format!("podup.project={}", self.project)];
+		if let Some(svc) = service {
+			labels.push(format!("podup.service={svc}"));
+		}
+		let filters = serde_json::json!({ "label": labels });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		Ok(entries
+			.into_iter()
+			.flat_map(|e| e.names)
+			.map(|raw| raw.trim_start_matches('/').to_string())
+			.collect())
+	}
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -47,6 +47,10 @@ pub struct Engine {
 	/// grace; when set it takes precedence over each service's
 	/// `stop_grace_period`. `None` falls back to the per-service value.
 	pub(super) stop_timeout: Option<i32>,
+	/// CLI `--scale SERVICE=N` overrides (from `up --scale` and the `scale`
+	/// subcommand); when a service is present it takes precedence over the
+	/// compose `scale:`/`deploy.replicas` value. Empty falls back to compose.
+	pub(super) scale_overrides: std::collections::HashMap<String, u32>,
 }
 
 impl Engine {
@@ -57,6 +61,7 @@ impl Engine {
 			project,
 			base_dir: std::env::current_dir().unwrap_or_default(),
 			stop_timeout: None,
+			scale_overrides: std::collections::HashMap::new(),
 		}
 	}
 
@@ -67,6 +72,7 @@ impl Engine {
 			project,
 			base_dir,
 			stop_timeout: None,
+			scale_overrides: std::collections::HashMap::new(),
 		}
 	}
 
@@ -74,6 +80,28 @@ impl Engine {
 	pub fn with_stop_timeout(mut self, timeout: Option<i32>) -> Self {
 		self.stop_timeout = timeout;
 		self
+	}
+
+	/// Set the CLI `--scale SERVICE=N` replica overrides. Builder-style.
+	pub fn with_scale_overrides(
+		mut self,
+		overrides: std::collections::HashMap<String, u32>,
+	) -> Self {
+		self.scale_overrides = overrides;
+		self
+	}
+
+	/// Resolve the replica count for a service: a CLI `--scale` override wins,
+	/// else the compose `scale:`, else `deploy.replicas`, else 1. The single
+	/// source of truth so `up`, naming, and teardown never drift.
+	pub(super) fn resolve_replicas(&self, service_name: &str, service: &Service) -> usize {
+		if let Some(&n) = self.scale_overrides.get(service_name) {
+			return n as usize;
+		}
+		service
+			.scale
+			.or(service.deploy.as_ref().and_then(|d| d.replicas))
+			.unwrap_or(1) as usize
 	}
 
 	pub(super) async fn run_lifecycle_hook(
@@ -169,12 +197,9 @@ impl Engine {
 	}
 
 	pub(super) fn replica_names(&self, service_name: &str, service: &Service) -> Vec<String> {
-		let replicas = service
-			.scale
-			.or(service.deploy.as_ref().and_then(|d| d.replicas))
-			.unwrap_or(1) as usize;
+		let replicas = self.resolve_replicas(service_name, service);
 		let base = self.container_name(service_name, service);
-		if replicas == 1 {
+		if replicas <= 1 {
 			vec![base]
 		} else {
 			(1..=replicas).map(|i| format!("{base}-{i}")).collect()
@@ -182,12 +207,9 @@ impl Engine {
 	}
 
 	pub(super) fn first_replica_name(&self, service_name: &str, service: &Service) -> String {
-		let replicas = service
-			.scale
-			.or(service.deploy.as_ref().and_then(|d| d.replicas))
-			.unwrap_or(1) as usize;
+		let replicas = self.resolve_replicas(service_name, service);
 		let base = self.container_name(service_name, service);
-		if replicas == 1 {
+		if replicas <= 1 {
 			base
 		} else {
 			format!("{base}-1")

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -49,6 +49,13 @@ pub enum ComposeError {
 	Update(String),
 	/// An `external: true` secret/config/network/volume is absent.
 	ExternalNotFound(String),
+	/// A service is scaled to more than one replica but publishes a fixed host
+	/// port, which only one container can bind.
+	ScalePortConflict {
+		service: String,
+		replicas: usize,
+		ports: Vec<u16>,
+	},
 }
 
 impl fmt::Display for ComposeError {
@@ -74,6 +81,25 @@ impl fmt::Display for ComposeError {
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
 			Self::Update(s) => write!(f, "update error: {s}"),
 			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
+			Self::ScalePortConflict {
+				service,
+				replicas,
+				ports,
+			} => {
+				let ports = ports
+					.iter()
+					.map(u16::to_string)
+					.collect::<Vec<_>>()
+					.join(", ");
+				write!(
+					f,
+					"service '{service}' publishes fixed host port(s) [{ports}] but is scaled to \
+					 {replicas} replicas; only one container can bind a host port. Use one of:\n  \
+					 - remove the host port (e.g. `- \"80\"`) so Podman assigns a random one per \
+					 replica\n  - put the service behind a reverse proxy and publish only the \
+					 proxy's port\n  - reduce the service to a single replica"
+				)
+			}
 		}
 	}
 }
@@ -169,6 +195,14 @@ mod tests {
 			(
 				"external resource not found: external volume \"v\" does not exist",
 				ComposeError::ExternalNotFound("external volume \"v\" does not exist".into()),
+			),
+			(
+				"service 'web' publishes fixed host port(s) [8080] but is scaled to 3 replicas",
+				ComposeError::ScalePortConflict {
+					service: "web".into(),
+					replicas: 3,
+					ports: vec![8080],
+				},
 			),
 		];
 		for (expected_prefix, err) in cases {

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -1,0 +1,88 @@
+//! The `generate quadlet` command: turn the compose file into Quadlet units and
+//! either write them to a directory or print them to stdout.
+
+use std::path::Path;
+
+/// Quadlet units are systemd unit files; they only run on Linux hosts (where
+/// systemd consumes them from `~/.config/containers/systemd/`). Generating them
+/// on macOS/Windows is legitimate (e.g. to deploy to a remote Linux host), so
+/// this returns an advisory string rather than blocking. `os` is
+/// [`std::env::consts::OS`]; the function is pure so every platform's branch is
+/// testable in a single run.
+fn quadlet_platform_advisory(os: &str) -> Option<String> {
+	(os != "linux").then(|| {
+		"quadlet units require systemd (Linux); generated files will not run on this host"
+			.to_string()
+	})
+}
+
+/// Generate Quadlet units from the compose file and either write them to a
+/// directory or print them to stdout. Warnings about unmapped fields go to
+/// stderr so stdout stays clean for piping.
+pub(crate) fn write_quadlet(
+	file: &podup::compose::types::ComposeFile,
+	project: &str,
+	output: Option<&Path>,
+) -> podup::Result<()> {
+	let result = podup::quadlet::generate(file, project);
+	if let Some(dup) = result.duplicate_filename() {
+		return Err(std::io::Error::new(
+			std::io::ErrorKind::InvalidInput,
+			format!(
+				"quadlet: two resources map to the same unit file {dup:?}; \
+				 rename one so their names do not collide after sanitization"
+			),
+		)
+		.into());
+	}
+	if let Some(advisory) = quadlet_platform_advisory(std::env::consts::OS) {
+		eprintln!("podup: warning: {advisory}");
+	}
+	for warning in &result.warnings {
+		eprintln!("podup: warning: {warning}");
+	}
+	match output {
+		Some(dir) => {
+			std::fs::create_dir_all(dir)?;
+			for unit in &result.units {
+				// Defense in depth: the unit stem is already sanitized in the
+				// library, but never write a unit whose name is anything but a
+				// plain file inside `dir` (rejects separators, `.` and `..`).
+				if Path::new(&unit.filename).file_name()
+					!= Some(std::ffi::OsStr::new(&unit.filename))
+				{
+					return Err(std::io::Error::new(
+						std::io::ErrorKind::InvalidInput,
+						format!("refusing unsafe quadlet unit file name: {}", unit.filename),
+					)
+					.into());
+				}
+				let path = dir.join(&unit.filename);
+				std::fs::write(&path, &unit.contents)?;
+				println!("wrote {}", path.display());
+			}
+		}
+		None => {
+			for unit in &result.units {
+				println!("# {}", unit.filename);
+				print!("{}", unit.contents);
+				println!();
+			}
+		}
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::quadlet_platform_advisory;
+
+	#[test]
+	fn quadlet_advisory_only_on_non_linux() {
+		assert_eq!(quadlet_platform_advisory("linux"), None);
+		for os in ["macos", "windows", "freebsd"] {
+			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
+			assert!(msg.contains("systemd"), "advisory names the requirement");
+		}
+	}
+}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -83,6 +83,7 @@ fn is_mutating(command: &Commands) -> bool {
 			| Commands::Unpause { .. }
 			| Commands::Run { .. }
 			| Commands::Restart { .. }
+			| Commands::Scale { .. }
 	)
 }
 
@@ -277,8 +278,16 @@ async fn run() -> podup::Result<()> {
 		| Commands::Restart { timeout, .. } => *timeout,
 		_ => None,
 	};
-	let engine =
-		podup::Engine::with_base_dir(client, project, base_dir).with_stop_timeout(stop_timeout);
+	// `--scale SERVICE=N` (on `up`) and the `scale` subcommand both feed the
+	// engine's replica overrides so `resolve_replicas` reports the target count.
+	let scale_overrides: std::collections::HashMap<String, u32> = match &cli.command {
+		Commands::Up { scale, .. } => scale.iter().cloned().collect(),
+		Commands::Scale { pairs } => pairs.iter().cloned().collect(),
+		_ => std::collections::HashMap::new(),
+	};
+	let engine = podup::Engine::with_base_dir(client, project, base_dir)
+		.with_stop_timeout(stop_timeout)
+		.with_scale_overrides(scale_overrides);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,
@@ -300,6 +309,7 @@ async fn run() -> podup::Result<()> {
 			force_recreate,
 			no_deps,
 			timeout: _,
+			scale: _,
 			services,
 		} => {
 			if remove_orphans {
@@ -335,6 +345,7 @@ async fn run() -> podup::Result<()> {
 			services,
 			timeout: _,
 		} => engine.stop(&file, &services).await?,
+		Commands::Scale { pairs } => engine.scale(&file, &pairs).await?,
 		Commands::Build {
 			no_cache,
 			pull,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -3,7 +3,6 @@
 // The binary carries no `unsafe`; deny it so any future addition is caught.
 #![deny(unsafe_code)]
 
-use std::path::Path;
 use std::process;
 
 #[cfg(feature = "completions")]
@@ -16,9 +15,11 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
 mod cli;
+mod generate;
 mod resolve;
 
 use cli::*;
+use generate::write_quadlet;
 use resolve::*;
 
 /// Canonical project URL, reused for the bug-report hint on internal errors.
@@ -85,76 +86,6 @@ fn is_mutating(command: &Commands) -> bool {
 			| Commands::Restart { .. }
 			| Commands::Scale { .. }
 	)
-}
-
-/// Quadlet units are systemd unit files; they only run on Linux hosts (where
-/// systemd consumes them from `~/.config/containers/systemd/`). Generating them
-/// on macOS/Windows is legitimate (e.g. to deploy to a remote Linux host), so
-/// this returns an advisory string rather than blocking. `os` is
-/// [`std::env::consts::OS`]; the function is pure so every platform's branch is
-/// testable in a single run.
-fn quadlet_platform_advisory(os: &str) -> Option<String> {
-	(os != "linux").then(|| {
-		"quadlet units require systemd (Linux); generated files will not run on this host"
-			.to_string()
-	})
-}
-
-/// Generate Quadlet units from the compose file and either write them to a
-/// directory or print them to stdout. Warnings about unmapped fields go to
-/// stderr so stdout stays clean for piping.
-fn write_quadlet(
-	file: &podup::compose::types::ComposeFile,
-	project: &str,
-	output: Option<&Path>,
-) -> podup::Result<()> {
-	let result = podup::quadlet::generate(file, project);
-	if let Some(dup) = result.duplicate_filename() {
-		return Err(std::io::Error::new(
-			std::io::ErrorKind::InvalidInput,
-			format!(
-				"quadlet: two resources map to the same unit file {dup:?}; \
-				 rename one so their names do not collide after sanitization"
-			),
-		)
-		.into());
-	}
-	if let Some(advisory) = quadlet_platform_advisory(std::env::consts::OS) {
-		eprintln!("podup: warning: {advisory}");
-	}
-	for warning in &result.warnings {
-		eprintln!("podup: warning: {warning}");
-	}
-	match output {
-		Some(dir) => {
-			std::fs::create_dir_all(dir)?;
-			for unit in &result.units {
-				// Defense in depth: the unit stem is already sanitized in the
-				// library, but never write a unit whose name is anything but a
-				// plain file inside `dir` (rejects separators, `.` and `..`).
-				if Path::new(&unit.filename).file_name()
-					!= Some(std::ffi::OsStr::new(&unit.filename))
-				{
-					return Err(std::io::Error::new(
-						std::io::ErrorKind::InvalidInput,
-						format!("refusing unsafe quadlet unit file name: {}", unit.filename),
-					)
-					.into());
-				}
-				let path = dir.join(&unit.filename);
-				std::fs::write(&path, &unit.contents)?;
-				println!("wrote {}", path.display());
-			}
-		}
-		None => {
-			for unit in &result.units {
-				println!("# {}", unit.filename);
-				print!("{}", unit.contents);
-				println!();
-			}
-		}
-	}
-	Ok(())
 }
 
 #[tokio::main]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -407,15 +407,6 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn quadlet_advisory_only_on_non_linux() {
-		assert_eq!(quadlet_platform_advisory("linux"), None);
-		for os in ["macos", "windows", "freebsd"] {
-			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
-			assert!(msg.contains("systemd"), "advisory names the requirement");
-		}
-	}
-
-	#[test]
 	fn level_words_match_user_facing_terms() {
 		assert_eq!(level_word(tracing::Level::WARN), "warning");
 		assert_eq!(level_word(tracing::Level::ERROR), "error");

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -56,3 +56,5 @@ mod watch_tests;
 mod cli1;
 #[path = "engine_integration/cli2.rs"]
 mod cli2;
+#[path = "engine_integration/scale.rs"]
+mod scale;

--- a/tests/engine_integration/scale.rs
+++ b/tests/engine_integration/scale.rs
@@ -1,0 +1,117 @@
+//! Scale integration tests (`up --scale` and the `scale` subcommand) against a
+//! real Podman daemon. Skip gracefully when Podman is unreachable.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// Number of running containers in the project (counts `ps -q` output lines).
+fn running_count(compose: &str, proj: &str) -> usize {
+	let out = Command::new(bin())
+		.args(["-f", compose, "-p", proj, "ps", "-q"])
+		.output()
+		.unwrap();
+	String::from_utf8_lossy(&out.stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count()
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+	Command::new(bin()).args(args).output().unwrap()
+}
+
+#[tokio::test]
+async fn up_scale_creates_replicas_and_down_removes_them() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-upscale", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let up = run(&[
+		"-f", c, "-p", &proj, "up", "--detach", "--scale", "worker=3",
+	]);
+	assert!(up.status.success(), "up --scale failed: {:?}", up.stderr);
+	assert_eq!(
+		running_count(c, &proj),
+		3,
+		"expected 3 replicas after up --scale"
+	);
+
+	let down = run(&["-f", c, "-p", &proj, "down"]);
+	assert!(down.status.success(), "down failed: {:?}", down.stderr);
+	assert_eq!(
+		running_count(c, &proj),
+		0,
+		"down must remove scaled replicas"
+	);
+}
+
+#[tokio::test]
+async fn scale_subcommand_scales_up_then_down() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-scalecmd", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "--detach"]);
+	assert_eq!(running_count(c, &proj), 1);
+
+	let up = run(&["-f", c, "-p", &proj, "scale", "worker=3"]);
+	assert!(up.status.success(), "scale up failed: {:?}", up.stderr);
+	assert_eq!(running_count(c, &proj), 3, "scale up must add replicas");
+
+	let down = run(&["-f", c, "-p", &proj, "scale", "worker=1"]);
+	assert!(
+		down.status.success(),
+		"scale down failed: {:?}",
+		down.stderr
+	);
+	assert_eq!(running_count(c, &proj), 1, "scale down must remove surplus");
+
+	run(&["-f", c, "-p", &proj, "down"]);
+	assert_eq!(running_count(c, &proj), 0);
+}
+
+#[tokio::test]
+async fn up_scale_fixed_host_port_fails_fast() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-scaleport", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"8085:80\"\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let out = run(&["-f", c, "-p", &proj, "up", "--detach", "--scale", "web=2"]);
+	assert!(!out.status.success(), "scaling a fixed host port must fail");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("only one container can bind a host port"),
+		"expected port-conflict guidance, got: {stderr}"
+	);
+	// Clean up anything the failed attempt may have created.
+	run(&["-f", c, "-p", &proj, "down"]);
+}


### PR DESCRIPTION
## What

Closes #404.

Adds runtime replica overrides for docker-compose parity:

- **`up --scale SERVICE=N`** (repeatable) overrides a service's replica count for that run.
- **`scale SERVICE=N...`** subcommand reconciles running containers to the target count — creating missing replicas **and removing surplus ones**.

## How

- A single **`Engine::resolve_replicas`** (precedence: CLI `--scale` > `scale:` > `deploy.replicas` > 1) now backs `replica_names`/`first_replica_name` and the up loop, so naming never drifts across `up`/`down`/listing — the primary risk called out in the issue plan.
- **Scale-down** enumerates the project's containers by the `podup.service` label and removes those outside the target set; **`down`** additionally sweeps leftover scaled replicas by the `podup.project` label, so a scaled-up project always tears down cleanly (podup is stateless — it can't recompute extra replicas a later `down` didn't ask for).
- **Port-conflict guard (fail-fast):** a scaled service publishing a **fixed host port** is rejected with actionable guidance (`ScalePortConflict`) before any container is created — only one container can bind a host port. A random/absent host port (`- "80"`) scales fine. The compose-spec does not define scale↔ports, so podup fails fast rather than inventing auto-offset semantics.
- Overrides flow through the existing builder pattern (`Engine::with_scale_overrides`), mirroring `with_stop_timeout` — **no existing public signature changed** (non-breaking, additive).

## Test plan

- Pure unit tests: the port-conflict guard (fixed→error, random/absent→ok, single replica→ok), `parse_scale_pair` (rejects `web`, `=3`, `web=`, `web=x`, `web=0`, `web=-1`), and the `ScalePortConflict` Display.
- **Real-Podman integration tests (Podman 5.4.2)**, all green:
  - `up --scale worker=3` → 3 running; `down` → 0.
  - `scale worker=3` then `scale worker=1` → exact counts (covers scale-up **and** scale-down).
  - `up --scale web=2` on a fixed host port → fails fast with the guidance message, no containers created.
- Full suite (`cargo test --features test-helpers`) green; `cargo fmt --check` clean; no new clippy warnings; all touched files under the 500-line limit.

## Docs

README feature bullet, `docs/commands.md` (`up --scale` + a `scale` entry with the host-port note), and the man page updated.