### PR TITLE
feat(cli): create and ls commands for docker-compose parity

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -56,6 +56,16 @@ Set the number of running containers for services, creating missing replicas and
 removing surplus ones. A service publishing a fixed host port cannot scale past
 one replica and the command fails with guidance.
 .TP
+.B create
+Create the containers for services without starting them. Options:
+\fB\-\-build\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-recreate\fR, and a trailing
+service list.
+.TP
+.B ls
+List podup compose projects on the host. \fB\-a\fR/\fB\-\-all\fR includes stopped
+projects, \fB\-q\fR/\fB\-\-quiet\fR prints names only, \fB\-\-format\fR selects
+\fItable\fR or \fIjson\fR. Requires no compose file.
+.TP
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named
 volumes declared in the compose file.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -54,6 +54,12 @@ port) — the command fails fast and tells you to drop the host port (`- "80"`, 
 Podman assigns one per replica), front it with a reverse proxy, or stay at one
 replica.
 
+### `create`
+Create the containers for services without starting them (like `up` stopped at
+the create step). `--build` builds images first; `--force-recreate` recreates
+unchanged containers; `--no-recreate` leaves existing ones in place. Accepts a
+trailing service list. A later `up`/`start` runs the created containers.
+
 ### `build`
 Build or rebuild service images (optionally only the named services).
 
@@ -92,6 +98,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | Command | Description |
 |---|---|
 | `ps` | List project containers. |
+| `ls` | List podup compose projects on the host. `-a/--all` includes stopped projects, `-q/--quiet` prints names only, `--format table\|json`. Needs no compose file. |
 | `top` | Show running processes of service containers. |
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `images` | List images used by services. |

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -123,6 +123,33 @@ pub(crate) enum Commands {
 		#[arg(value_parser = parse_scale_pair, required = true)]
 		pairs: Vec<(String, u32)>,
 	},
+	/// Create containers for services without starting them.
+	Create {
+		/// Build images before creating containers.
+		#[arg(long)]
+		build: bool,
+		/// Recreate containers even if their configuration is unchanged.
+		#[arg(long)]
+		force_recreate: bool,
+		/// Do not recreate containers that already exist.
+		#[arg(long)]
+		no_recreate: bool,
+		/// Create only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
+	/// List podup compose projects on the host.
+	Ls {
+		/// Show all projects, including stopped ones.
+		#[arg(short, long)]
+		all: bool,
+		/// Only display project names.
+		#[arg(short, long)]
+		quiet: bool,
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+		format: OutputFormat,
+	},
 	/// Build or rebuild service images.
 	Build {
 		/// Do not use cache when building the image.

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -32,6 +32,7 @@ impl Engine {
 		service_name: &str,
 		service: &Service,
 		file: &ComposeFile,
+		start: bool,
 	) -> Result<()> {
 		let derived_image;
 		let image: &str = if let Some(img) = service.image.as_deref() {
@@ -257,14 +258,18 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 
-		let start_path = format!(
-			"{API_PREFIX}/containers/{}/start",
-			urlencoded(container_name)
-		);
-		self.client
-			.post_empty_ok(&start_path)
-			.await
-			.map_err(ComposeError::Podman)?;
+		// `create` (docker compose create) creates the container but leaves it
+		// stopped; `up`/`run`/`watch` start it.
+		if start {
+			let start_path = format!(
+				"{API_PREFIX}/containers/{}/start",
+				urlencoded(container_name)
+			);
+			self.client
+				.post_empty_ok(&start_path)
+				.await
+				.map_err(ComposeError::Podman)?;
+		}
 
 		Ok(())
 	}

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -280,7 +280,7 @@ impl Engine {
 		// network, which is created here as `{project}_default`.
 		self.create_networks(file).await?;
 
-		self.create_and_start(&run_name, service_name, &run_service, file)
+		self.create_and_start(&run_name, service_name, &run_service, file, true)
 			.await?;
 
 		if detach {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -8,8 +8,8 @@ use std::collections::{HashMap, HashSet};
 
 use tracing::info;
 
-use crate::compose::types::{ComposeFile, Service, ServiceCondition};
-use crate::error::{ComposeError, Result};
+use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
 use targets::{expand_targets, filter_services};
@@ -67,6 +67,55 @@ impl Engine {
 		force_recreate: bool,
 		no_deps: bool,
 	) -> Result<()> {
+		self.run_up(
+			file,
+			active_profiles,
+			target_services,
+			no_recreate,
+			force_recreate,
+			no_deps,
+			true,
+		)
+		.await
+	}
+
+	/// Create containers for services without starting them (docker compose
+	/// `create`). Shares the `up` path with `start = false`: images are built/
+	/// pulled and containers created, but never started, and no `depends_on`
+	/// waits or `post_start` hooks run (nothing is running to gate on).
+	#[allow(clippy::too_many_arguments)]
+	pub async fn create_with_options(
+		&self,
+		file: &ComposeFile,
+		active_profiles: &[String],
+		target_services: &[String],
+		no_recreate: bool,
+		force_recreate: bool,
+		no_deps: bool,
+	) -> Result<()> {
+		self.run_up(
+			file,
+			active_profiles,
+			target_services,
+			no_recreate,
+			force_recreate,
+			no_deps,
+			false,
+		)
+		.await
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	async fn run_up(
+		&self,
+		file: &ComposeFile,
+		active_profiles: &[String],
+		target_services: &[String],
+		no_recreate: bool,
+		force_recreate: bool,
+		no_deps: bool,
+		start: bool,
+	) -> Result<()> {
 		async {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
@@ -123,6 +172,7 @@ impl Engine {
 						&existing_hash,
 						no_recreate,
 						force_recreate,
+						start,
 					)
 				});
 				futures_util::future::try_join_all(started).await?;
@@ -150,6 +200,7 @@ impl Engine {
 		existing_hash: &HashMap<String, String>,
 		no_recreate: bool,
 		force_recreate: bool,
+		start: bool,
 	) -> Result<()> {
 		if let Some(set) = target_set {
 			if !set.contains(name) {
@@ -163,7 +214,14 @@ impl Engine {
 			return Ok(());
 		}
 
-		for dep in service.depends_on.service_names() {
+		// `create` (start = false) only builds the containers, so there is nothing
+		// to gate on — skip the `depends_on` readiness waits entirely.
+		for dep in service
+			.depends_on
+			.service_names()
+			.into_iter()
+			.filter(|_| start)
+		{
 			let condition = service.depends_on.condition_for(&dep);
 			// `required: false` makes the dependency optional — a failed wait
 			// must not abort `up`, matching docker-compose v2.
@@ -227,7 +285,7 @@ impl Engine {
 		// A scaled service that publishes a fixed host port cannot start: only
 		// one container can bind it. Fail fast with guidance instead of letting
 		// replicas 2..N die mid-up with `address already in use`.
-		check_scale_port_conflict(name, service, replicas)?;
+		scale::check_scale_port_conflict(name, service, replicas)?;
 
 		let new_hash = config_hash(service, file)?;
 
@@ -240,7 +298,10 @@ impl Engine {
 			if !force_recreate {
 				if no_recreate && present.contains(&container_name) {
 					info!("{container_name} already exists — skipping recreate");
-					self.ensure_started(&container_name).await;
+					// `create` leaves an existing container as-is; `up` ensures it runs.
+					if start {
+						self.ensure_started(&container_name).await;
+					}
 					continue;
 				}
 				// Services with a build section are rebuilt on every up, so
@@ -249,16 +310,24 @@ impl Engine {
 				if service.build.is_none() && existing_hash.get(&container_name) == Some(&new_hash)
 				{
 					info!("{container_name} is up to date — skipping recreate");
-					self.ensure_started(&container_name).await;
+					if start {
+						self.ensure_started(&container_name).await;
+					}
 					continue;
 				}
 			}
-			self.create_and_start(&container_name, name, service, file)
+			self.create_and_start(&container_name, name, service, file, start)
 				.await?;
-			info!("started {container_name}");
+			info!(
+				"{} {container_name}",
+				if start { "started" } else { "created" }
+			);
 
-			for hook in &service.post_start {
-				self.run_lifecycle_hook(&container_name, hook).await?;
+			// `post_start` hooks run inside a running container, so only on `up`.
+			if start {
+				for hook in &service.post_start {
+					self.run_lifecycle_hook(&container_name, hook).await?;
+				}
 			}
 		}
 
@@ -357,75 +426,5 @@ impl Engine {
 		// them unconditionally — independent of `remove_volumes`.
 		self.remove_internal_secrets(file).await?;
 		Ok(())
-	}
-}
-
-/// Reject a scaled service that publishes a fixed host port: only one container
-/// can bind a given host port, so replicas 2..N would fail at runtime with
-/// `address already in use`. A host port of 0/None is runtime-assigned by
-/// Podman, so such a service scales fine. The compose-spec does not define how
-/// scaling interacts with published ports, so podup fails fast rather than
-/// inventing surprising auto-offset semantics.
-pub(super) fn check_scale_port_conflict(
-	service_name: &str,
-	service: &Service,
-	replicas: usize,
-) -> Result<()> {
-	if replicas <= 1 {
-		return Ok(());
-	}
-	let fixed: Vec<u16> = crate::ports::parse_ports(&service.ports)?
-		.iter()
-		.filter_map(|p| p.host_port)
-		.filter(|&hp| hp != 0)
-		.collect();
-	if fixed.is_empty() {
-		return Ok(());
-	}
-	Err(ComposeError::ScalePortConflict {
-		service: service_name.to_string(),
-		replicas,
-		ports: fixed,
-	})
-}
-
-#[cfg(test)]
-mod tests {
-	use super::check_scale_port_conflict;
-
-	fn service(yaml: &str) -> crate::compose::types::Service {
-		let file = crate::parse_str(yaml).unwrap();
-		file.services.into_iter().next().unwrap().1
-	}
-
-	#[test]
-	fn single_replica_never_conflicts() {
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
-		assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
-	}
-
-	#[test]
-	fn scaled_fixed_host_port_conflicts() {
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
-		let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
-		assert!(matches!(
-			err,
-			crate::error::ComposeError::ScalePortConflict { .. }
-		));
-		assert!(err.to_string().contains("8080"));
-	}
-
-	#[test]
-	fn scaled_random_host_port_is_allowed() {
-		// A container-only port (`"80"`) gets a runtime-assigned host port per
-		// replica, so scaling is fine.
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
-		assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
-	}
-
-	#[test]
-	fn scaled_no_ports_is_allowed() {
-		let svc = service("services:\n  worker:\n    image: x\n");
-		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -10,7 +10,34 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
-use super::check_scale_port_conflict;
+/// Reject a scaled service that publishes a fixed host port: only one container
+/// can bind a given host port, so replicas 2..N would fail at runtime with
+/// `address already in use`. A host port of 0/None is runtime-assigned by
+/// Podman, so such a service scales fine. The compose-spec does not define how
+/// scaling interacts with published ports, so podup fails fast rather than
+/// inventing surprising auto-offset semantics.
+pub(super) fn check_scale_port_conflict(
+	service_name: &str,
+	service: &Service,
+	replicas: usize,
+) -> Result<()> {
+	if replicas <= 1 {
+		return Ok(());
+	}
+	let fixed: Vec<u16> = crate::ports::parse_ports(&service.ports)?
+		.iter()
+		.filter_map(|p| p.host_port)
+		.filter(|&hp| hp != 0)
+		.collect();
+	if fixed.is_empty() {
+		return Ok(());
+	}
+	Err(ComposeError::ScalePortConflict {
+		service: service_name.to_string(),
+		replicas,
+		ports: fixed,
+	})
+}
 
 impl Engine {
 	/// Set the number of running containers for the named services (docker
@@ -107,5 +134,46 @@ impl Engine {
 			.flat_map(|e| e.names)
 			.map(|raw| raw.trim_start_matches('/').to_string())
 			.collect())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::check_scale_port_conflict;
+
+	fn service(yaml: &str) -> crate::compose::types::Service {
+		let file = crate::parse_str(yaml).unwrap();
+		file.services.into_iter().next().unwrap().1
+	}
+
+	#[test]
+	fn single_replica_never_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
+	}
+
+	#[test]
+	fn scaled_fixed_host_port_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ScalePortConflict { .. }
+		));
+		assert!(err.to_string().contains("8080"));
+	}
+
+	#[test]
+	fn scaled_random_host_port_is_allowed() {
+		// A container-only port (`"80"`) gets a runtime-assigned host port per
+		// replica, so scaling is fine.
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
+	}
+
+	#[test]
+	fn scaled_no_ports_is_allowed() {
+		let svc = service("services:\n  worker:\n    image: x\n");
+		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -16,6 +16,8 @@ mod lifecycle;
 mod lock;
 mod network;
 mod profiles;
+mod projects;
+pub use projects::{list_projects, LsOptions};
 mod query;
 mod secrets;
 mod staging;

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -1,0 +1,139 @@
+//! `ls` — discover podup-managed compose projects on the host.
+//!
+//! Unlike the other commands this is project-agnostic: it scans every container
+//! carrying a `podup.project` label and groups by project, so it needs only a
+//! [`Client`], not a full [`Engine`] bound to one project/compose file.
+
+use std::collections::BTreeMap;
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::ContainerListEntry;
+use crate::libpod::{urlencoded, Client, API_PREFIX};
+
+/// Options for [`list_projects`] (`docker compose ls`).
+#[derive(Debug, Clone, Default)]
+pub struct LsOptions {
+	/// Include projects whose containers are all stopped.
+	pub all: bool,
+	/// Print only project names.
+	pub quiet: bool,
+	/// Emit a JSON array instead of a table.
+	pub json: bool,
+}
+
+/// Whether a libpod `Status` string denotes a running container. Podman reports
+/// `"running"` (or a human `"Up …"`) for live containers and `"exited"`/`"Exited
+/// …"`/`"created"` otherwise. Pure so it can be unit-tested.
+fn is_running(status: &str) -> bool {
+	let s = status.trim();
+	s.eq_ignore_ascii_case("running") || s.to_ascii_lowercase().starts_with("up")
+}
+
+/// A project's roll-up: running and total replica counts.
+struct Tally {
+	running: usize,
+	total: usize,
+}
+
+/// List podup projects on the host (`docker compose ls`). Groups every
+/// `podup.project`-labelled container by project; by default shows only
+/// projects with at least one running container (`all` includes stopped ones).
+pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
+	let filters = serde_json::json!({ "label": ["podup.project"] });
+	let path = format!(
+		"{API_PREFIX}/containers/json?all=true&filters={}",
+		urlencoded(&filters.to_string()),
+	);
+	let containers = client
+		.get_json::<Vec<ContainerListEntry>>(&path)
+		.await
+		.map_err(ComposeError::Podman)?;
+
+	// Group by the project label, in name order for deterministic output.
+	let mut projects: BTreeMap<String, Tally> = BTreeMap::new();
+	for c in &containers {
+		let Some(project) = c.labels.get("podup.project") else {
+			continue;
+		};
+		let tally = projects.entry(project.clone()).or_insert(Tally {
+			running: 0,
+			total: 0,
+		});
+		tally.total += 1;
+		// Podman's libpod list leaves `Status` empty and uses `State`; accept
+		// either so the roll-up is robust across response shapes.
+		if is_running(&c.state) || is_running(&c.status) {
+			tally.running += 1;
+		}
+	}
+
+	let rows: Vec<(&String, &Tally)> = projects
+		.iter()
+		.filter(|(_, t)| opts.all || t.running > 0)
+		.collect();
+
+	if opts.quiet {
+		for (name, _) in &rows {
+			println!("{name}");
+		}
+		return Ok(());
+	}
+
+	if opts.json {
+		let arr: Vec<_> = rows
+			.iter()
+			.map(|(name, t)| serde_json::json!({ "Name": name, "Status": status_label(t) }))
+			.collect();
+		println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+		return Ok(());
+	}
+
+	println!("{:<32} {:<20}", "NAME", "STATUS");
+	for (name, t) in &rows {
+		println!("{:<32} {:<20}", name, status_label(t));
+	}
+	Ok(())
+}
+
+/// `running(N)` when any replica is up, else `exited(N)` — mirrors the
+/// `docker compose ls` status column.
+fn status_label(t: &Tally) -> String {
+	if t.running > 0 {
+		format!("running({})", t.running)
+	} else {
+		format!("exited({})", t.total)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn is_running_detects_live_statuses() {
+		for up in ["running", "Up 2 minutes", "UP", "up about an hour"] {
+			assert!(is_running(up), "{up} should be running");
+		}
+		for down in ["exited", "Exited (0) 3s ago", "created", "", "stopped"] {
+			assert!(!is_running(down), "{down} should not be running");
+		}
+	}
+
+	#[test]
+	fn status_label_reflects_running_then_total() {
+		assert_eq!(
+			status_label(&Tally {
+				running: 2,
+				total: 3
+			}),
+			"running(2)"
+		);
+		assert_eq!(
+			status_label(&Tally {
+				running: 0,
+				total: 3
+			}),
+			"exited(3)"
+		);
+	}
+}

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -264,7 +264,7 @@ impl Engine {
 		)
 		.await?;
 		let container_name = self.container_name(service_name, service);
-		self.create_and_start(&container_name, service_name, service, file)
+		self.create_and_start(&container_name, service_name, service, file, true)
 			.await
 	}
 

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -29,8 +29,8 @@ pub use compose::{
 	parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
 pub use engine::{
-	is_safe_project_name, BuildOptions, Engine, ExecOptions, ImagesOptions, ProjectLock, PsOptions,
-	RunOptions,
+	is_safe_project_name, list_projects, BuildOptions, Engine, ExecOptions, ImagesOptions,
+	LsOptions, ProjectLock, PsOptions, RunOptions,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -31,6 +31,11 @@ pub struct ContainerListEntry {
 	#[serde(rename = "Status", default)]
 	pub status: String,
 
+	/// Machine-readable state (`running`, `exited`, `created`, …). Podman's
+	/// libpod list response leaves `Status` empty and reports the state here.
+	#[serde(rename = "State", default)]
+	pub state: String,
+
 	#[serde(rename = "Ports", default, deserialize_with = "null_default")]
 	pub ports: Vec<ContainerPort>,
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -85,6 +85,7 @@ fn is_mutating(command: &Commands) -> bool {
 			| Commands::Run { .. }
 			| Commands::Restart { .. }
 			| Commands::Scale { .. }
+			| Commands::Create { .. }
 	)
 }
 
@@ -162,6 +163,21 @@ async fn run() -> podup::Result<()> {
 		return tokio::task::spawn_blocking(move || podup::update::run(opts))
 			.await
 			.map_err(|e| podup::ComposeError::Update(format!("update task failed: {e}")))?;
+	}
+
+	// `ls` discovers projects across the host by container label; it needs a
+	// Podman connection but no compose file, so handle it before parsing one.
+	if let Commands::Ls { all, quiet, format } = &cli.command {
+		let client = podup::podman::connect(cli.socket.as_deref())?;
+		return podup::list_projects(
+			&client,
+			podup::LsOptions {
+				all: *all,
+				quiet: *quiet,
+				json: *format == OutputFormat::Json,
+			},
+		)
+		.await;
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
@@ -277,6 +293,26 @@ async fn run() -> podup::Result<()> {
 			timeout: _,
 		} => engine.stop(&file, &services).await?,
 		Commands::Scale { pairs } => engine.scale(&file, &pairs).await?,
+		Commands::Create {
+			build,
+			force_recreate,
+			no_recreate,
+			services,
+		} => {
+			if build {
+				engine.build_all(&file, &services).await?;
+			}
+			engine
+				.create_with_options(
+					&file,
+					&cli.profile,
+					&services,
+					no_recreate,
+					force_recreate,
+					false,
+				)
+				.await?
+		}
 		Commands::Build {
 			no_cache,
 			pull,
@@ -394,6 +430,7 @@ async fn run() -> podup::Result<()> {
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
 		#[cfg(feature = "update")]
+		Commands::Ls { .. } => unreachable!("handled before compose parsing"),
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
 		#[cfg(feature = "completions")]
 		Commands::Completions { .. } => unreachable!("handled before compose parsing"),

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -429,8 +429,8 @@ async fn run() -> podup::Result<()> {
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
-		#[cfg(feature = "update")]
 		Commands::Ls { .. } => unreachable!("handled before compose parsing"),
+		#[cfg(feature = "update")]
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
 		#[cfg(feature = "completions")]
 		Commands::Completions { .. } => unreachable!("handled before compose parsing"),

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -56,5 +56,7 @@ mod watch_tests;
 mod cli1;
 #[path = "engine_integration/cli2.rs"]
 mod cli2;
+#[path = "engine_integration/create_ls.rs"]
+mod create_ls;
 #[path = "engine_integration/scale.rs"]
 mod scale;

--- a/tests/engine_integration/create_ls.rs
+++ b/tests/engine_integration/create_ls.rs
@@ -1,0 +1,87 @@
+//! Integration tests for `create` (containers without starting) and `ls`
+//! (project discovery) against a real Podman daemon. Skip when unreachable.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+fn run(args: &[&str]) -> std::process::Output {
+	Command::new(bin()).args(args).output().unwrap()
+}
+
+/// Count non-empty lines of a `-q` listing.
+fn count(out: &std::process::Output) -> usize {
+	String::from_utf8_lossy(&out.stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count()
+}
+
+#[tokio::test]
+async fn create_makes_containers_without_starting_them() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-create", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let create = run(&["-f", c, "-p", &proj, "create"]);
+	assert!(
+		create.status.success(),
+		"create failed: {:?}",
+		create.stderr
+	);
+	// The container exists (visible with -a) but is not running.
+	assert_eq!(count(&run(&["-f", c, "-p", &proj, "ps", "-a", "-q"])), 1);
+	assert_eq!(
+		count(&run(&["-f", c, "-p", &proj, "ps", "-q"])),
+		0,
+		"create must not start the container"
+	);
+
+	// `up` then starts the already-created container.
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	assert_eq!(count(&run(&["-f", c, "-p", &proj, "ps", "-q"])), 1);
+
+	run(&["-f", c, "-p", &proj, "down"]);
+}
+
+#[tokio::test]
+async fn ls_lists_running_projects() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-lsproj", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	// `ls -q` (running only) lists the project by name.
+	let names = String::from_utf8_lossy(&run(&["-p", &proj, "ls", "-q"]).stdout).into_owned();
+	assert!(
+		names.lines().any(|l| l == proj),
+		"ls must list {proj}: {names}"
+	);
+
+	run(&["-f", c, "-p", &proj, "down"]);
+	// After teardown the project has no containers, so it drops from `ls`.
+	let after = String::from_utf8_lossy(&run(&["-p", &proj, "ls", "-q"]).stdout).into_owned();
+	assert!(
+		!after.lines().any(|l| l == proj),
+		"a torn-down project must not appear in ls: {after}"
+	);
+}


### PR DESCRIPTION
## What

Two of the four commands in #415 (CLI command parity). **#415 stays open** for `push` (needs registry auth) and `stats` (needs a resource-usage stream) — heavier, separate concerns.

### `create`
`create [--build] [--force-recreate] [--no-recreate] [SERVICE...]` creates the service containers without starting them (docker compose `create`). A later `up`/`start` runs them.

Implementation shares the `up` path: a new private `run_up(..., start: bool)` backs both `up_with_options` (start=true) and a new `create_with_options` (start=false). `up_with_options` keeps its exact signature (**non-breaking**). With `start=false`, no container is started, and `depends_on` waits + `post_start` hooks are skipped (nothing is running to gate on).

### `ls`
`ls [-a/--all] [-q/--quiet] [--format table|json]` lists podup compose projects on the host by scanning the `podup.project` label and grouping by project (running by default; `-a` includes stopped). It needs a Podman connection but **no compose file**, so `main` handles it before parsing one (free fn `engine::list_projects`).

`ContainerListEntry` gains a `State` field: Podman's libpod list response leaves `Status` empty and reports `running`/`exited` in `State` — the project roll-up reads `State` (with a `Status` fallback).

## Test plan

- Unit tests: `is_running` (state strings), `status_label` (`running(N)`/`exited(N)`), and the relocated scale port-conflict guard.
- Real-Podman integration tests (Podman 5.4.2), green: `create` leaves containers stopped (visible with `ps -a`, absent from `ps`), and a later `up` starts them; `ls -q` lists a running project and drops it after `down`.
- Full suite (`cargo test --features test-helpers`) green; `cargo fmt --check` clean; no new clippy warnings; all touched files under the 500-line limit (the scale port-conflict guard moved into `scale.rs` to keep `lifecycle/mod.rs` under it).

## Docs

`docs/commands.md` (create + ls) and the man page updated.