### PR TITLE
feat(cli): push command — completes the create/push/stats/ls set

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -79,6 +79,12 @@ Stop running containers without removing them.
 .B build
 Build or rebuild service images.
 .TP
+.B push
+Push each service's image to its registry (imageless services are skipped).
+Credentials come from \fBpodman login\fR. \fB\-\-ignore\-push\-failures\fR
+continues after a failure; \fB\-\-tls\-verify false\fR allows an insecure
+registry.
+.TP
 .B rm
 Remove stopped service containers. \fB\-f\fR/\fB\-\-force\fR removes running
 containers (stopping them first).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,6 +63,13 @@ trailing service list. A later `up`/`start` runs the created containers.
 ### `build`
 Build or rebuild service images (optionally only the named services).
 
+### `push`
+Push each service's `image:` to its registry (services without an image are
+skipped). Credentials come from `podman login`. `--ignore-push-failures`
+continues after a failure; `--tls-verify false` allows an insecure/HTTP
+registry (omit it to keep Podman's default verification). Accepts a trailing
+service list.
+
 ### `rm`
 Remove stopped service containers. `-f, --force` stops and removes running ones.
 

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -159,6 +159,19 @@ pub(crate) enum Commands {
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,
 	},
+	/// Push service images to their registry.
+	Push {
+		/// Continue pushing the remaining services after a failure.
+		#[arg(long)]
+		ignore_push_failures: bool,
+		/// Verify the registry's TLS certificate (set false for an insecure
+		/// or local HTTP registry). Omitted leaves Podman's default (on).
+		#[arg(long)]
+		tls_verify: Option<bool>,
+		/// Push only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
 	/// Build or rebuild service images.
 	Build {
 		/// Do not use cache when building the image.

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -7,6 +7,8 @@
 
 mod context;
 mod pull;
+mod push;
+pub use push::PushOptions;
 
 use bytes::Bytes;
 use futures_util::StreamExt;

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -1,0 +1,97 @@
+//! Image push to a registry (docker compose `push`).
+
+use futures_util::StreamExt;
+use tracing::{info, warn};
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::image::ImagePullProgress;
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::super::Engine;
+
+/// Options for [`Engine::push`], mirroring `docker compose push` (plus a Podman
+/// `--tls-verify` escape hatch for insecure/local registries).
+#[derive(Debug, Clone, Default)]
+pub struct PushOptions {
+	/// Continue with the remaining services after a push fails.
+	pub ignore_failures: bool,
+	/// Override TLS verification of the registry. `None` leaves Podman's default
+	/// (verify on); `Some(false)` allows an insecure/HTTP registry.
+	pub tls_verify: Option<bool>,
+}
+
+impl Engine {
+	/// Push each service's image to its registry. Services without an `image:`
+	/// (build-only or imageless) are skipped. Registry credentials come from
+	/// Podman's auth file (`podman login`), so no auth handling is needed here.
+	pub async fn push(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: PushOptions,
+	) -> Result<()> {
+		for svc in target_services {
+			if !file.services.contains_key(svc) {
+				return Err(ComposeError::ServiceNotFound(svc.clone()));
+			}
+		}
+
+		for (name, service) in &file.services {
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
+				continue;
+			}
+			let Some(image) = service.image.as_deref() else {
+				tracing::debug!("{name}: no image to push, skipping");
+				continue;
+			};
+			if let Err(e) = self.push_image(image, &opts).await {
+				if opts.ignore_failures {
+					warn!("push {image} failed (ignored): {e}");
+				} else {
+					return Err(e);
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Push a single image ref and drain its progress stream, surfacing a
+	/// mid-stream `error` line as a failure.
+	async fn push_image(&self, image: &str, opts: &PushOptions) -> Result<()> {
+		info!("pushing {image}");
+		let mut query = format!("destination={}", urlencoded(image));
+		if let Some(tls) = opts.tls_verify {
+			query.push_str(&format!("&tlsVerify={tls}"));
+		}
+		let path = format!("{API_PREFIX}/images/{}/push?{query}", urlencoded(image));
+
+		let resp = self
+			.client
+			.post_empty_stream(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
+		let mut stream_error: Option<String> = None;
+		while let Some(result) = stream.next().await {
+			match result {
+				Ok(progress) => {
+					if !progress.stream.is_empty() {
+						info!("{}", progress.stream.trim_end());
+					}
+					if !progress.error.is_empty() {
+						stream_error = Some(progress.error.clone());
+					}
+				}
+				Err(e) => stream_error = Some(e.to_string()),
+			}
+		}
+		match stream_error {
+			Some(err) => Err(ComposeError::Build(format!("push {image}: {err}"))),
+			None => {
+				info!("pushed {image}");
+				Ok(())
+			}
+		}
+	}
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -5,7 +5,7 @@
 mod build;
 mod container;
 mod copy;
-pub use build::BuildOptions;
+pub use build::{BuildOptions, PushOptions};
 pub use lifecycle::RunOptions;
 pub use lock::ProjectLock;
 pub use query::{ExecOptions, ImagesOptions, PsOptions};

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -30,7 +30,7 @@ pub use compose::{
 };
 pub use engine::{
 	is_safe_project_name, list_projects, BuildOptions, Engine, ExecOptions, ImagesOptions,
-	LsOptions, ProjectLock, PsOptions, RunOptions,
+	LsOptions, ProjectLock, PsOptions, PushOptions, RunOptions,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -7,66 +7,16 @@ use std::process;
 
 #[cfg(feature = "completions")]
 use clap::CommandFactory;
-use clap::Parser;
-use tracing::{Event, Subscriber};
-use tracing_subscriber::fmt::format::Writer;
-use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
-use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::EnvFilter;
 
 mod cli;
 mod generate;
 mod resolve;
+mod startup;
 
 use cli::*;
 use generate::write_quadlet;
 use resolve::*;
-
-/// Canonical project URL, reused for the bug-report hint on internal errors.
-const REPO_URL: &str = "https://github.com/Glyndor/podup";
-
-/// Event formatter that renders every diagnostic as `podup: <level>: <message>`
-/// on a single line, matching the prefix used by the CLI's own `eprintln!`
-/// warnings and errors. This unifies the compose forward-compat diagnostics
-/// (emitted via `tracing::warn!`) with the rest of podup's user-facing output.
-struct PodupFormat;
-
-impl<S, N> FormatEvent<S, N> for PodupFormat
-where
-	S: Subscriber + for<'a> LookupSpan<'a>,
-	N: for<'a> FormatFields<'a> + 'static,
-{
-	fn format_event(
-		&self,
-		ctx: &FmtContext<'_, S, N>,
-		mut writer: Writer<'_>,
-		event: &Event<'_>,
-	) -> std::fmt::Result {
-		write!(writer, "podup: {}: ", level_word(*event.metadata().level()))?;
-		ctx.field_format().format_fields(writer.by_ref(), event)?;
-		writeln!(writer)
-	}
-}
-
-/// Map a tracing level to the user-facing word used in `podup:` output.
-fn level_word(level: tracing::Level) -> &'static str {
-	match level {
-		tracing::Level::ERROR => "error",
-		tracing::Level::WARN => "warning",
-		tracing::Level::INFO => "info",
-		tracing::Level::DEBUG => "debug",
-		tracing::Level::TRACE => "trace",
-	}
-}
-
-/// Guidance printed after an internal error or panic: where to report it and a
-/// reminder to scrub secrets first. Kept off ordinary, user-correctable errors.
-fn internal_error_notice() -> String {
-	format!(
-		"podup: this looks like a bug; re-run with RUST_LOG=debug and report it at {REPO_URL}/issues\n\
-		 podup: redact secrets (passwords, tokens, resolved env values) from any logs before sharing"
-	)
-}
+use startup::{init_tracing, internal_error_notice, parse_cli};
 
 /// Whether a command creates, destroys, or changes the state of containers and
 /// so must hold the exclusive project lock.
@@ -134,31 +84,8 @@ fn run_to_exit() {
 }
 
 async fn run() -> podup::Result<()> {
-	// Surface diagnostics by default: with no `RUST_LOG` set, show warnings (so
-	// the forward-compat "unknown field" notices are never silently dropped),
-	// and write them to stderr so a command's stdout stays a clean pipe.
-	tracing_subscriber::fmt()
-		.with_env_filter(
-			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
-		)
-		.with_writer(std::io::stderr)
-		.event_format(PodupFormat)
-		.init();
-
-	// Frame `--help`/`--version` output with a blank line top and bottom. clap
-	// trims template/before/after-help edges, so wrap the rendered text here.
-	let cli = match Cli::try_parse() {
-		Ok(cli) => cli,
-		Err(e) => match e.kind() {
-			clap::error::ErrorKind::DisplayHelp
-			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
-			| clap::error::ErrorKind::DisplayVersion => {
-				print!("\n{e}\n");
-				process::exit(0);
-			}
-			_ => e.exit(),
-		},
-	};
+	init_tracing();
+	let cli = parse_cli();
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.
@@ -398,6 +325,22 @@ async fn run() -> podup::Result<()> {
 			no_stream,
 			services,
 		} => engine.stats(&file, &services, no_stream).await?,
+		Commands::Push {
+			ignore_push_failures,
+			tls_verify,
+			services,
+		} => {
+			engine
+				.push(
+					&file,
+					&services,
+					podup::PushOptions {
+						ignore_failures: ignore_push_failures,
+						tls_verify,
+					},
+				)
+				.await?
+		}
 		Commands::Port {
 			service,
 			private_port,
@@ -460,30 +403,4 @@ async fn run() -> podup::Result<()> {
 	}
 
 	Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn level_words_match_user_facing_terms() {
-		assert_eq!(level_word(tracing::Level::WARN), "warning");
-		assert_eq!(level_word(tracing::Level::ERROR), "error");
-	}
-
-	#[test]
-	fn internal_error_notice_reports_and_warns_on_secrets() {
-		let notice = internal_error_notice();
-		assert!(notice.contains(REPO_URL), "points at the issue tracker");
-		assert!(notice.contains("/issues"));
-		assert!(
-			notice.contains("redact"),
-			"reminds the user to scrub secrets"
-		);
-		assert!(
-			notice.contains("RUST_LOG=debug"),
-			"tells the user what to capture"
-		);
-	}
 }

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -1,0 +1,115 @@
+//! CLI startup helpers: diagnostic log formatting, tracing initialization, the
+//! internal-error notice, and argument parsing with framed help output.
+
+use std::process;
+
+use clap::Parser;
+use tracing::{Event, Subscriber};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::EnvFilter;
+
+use crate::cli::Cli;
+
+/// Canonical project URL, reused for the bug-report hint on internal errors.
+const REPO_URL: &str = "https://github.com/Glyndor/podup";
+
+/// Event formatter that renders every diagnostic as `podup: <level>: <message>`
+/// on a single line, matching the prefix used by the CLI's own `eprintln!`
+/// warnings and errors. This unifies the compose forward-compat diagnostics
+/// (emitted via `tracing::warn!`) with the rest of podup's user-facing output.
+struct PodupFormat;
+
+impl<S, N> FormatEvent<S, N> for PodupFormat
+where
+	S: Subscriber + for<'a> LookupSpan<'a>,
+	N: for<'a> FormatFields<'a> + 'static,
+{
+	fn format_event(
+		&self,
+		ctx: &FmtContext<'_, S, N>,
+		mut writer: Writer<'_>,
+		event: &Event<'_>,
+	) -> std::fmt::Result {
+		write!(writer, "podup: {}: ", level_word(*event.metadata().level()))?;
+		ctx.field_format().format_fields(writer.by_ref(), event)?;
+		writeln!(writer)
+	}
+}
+
+/// Map a tracing level to the user-facing word used in `podup:` output.
+fn level_word(level: tracing::Level) -> &'static str {
+	match level {
+		tracing::Level::ERROR => "error",
+		tracing::Level::WARN => "warning",
+		tracing::Level::INFO => "info",
+		tracing::Level::DEBUG => "debug",
+		tracing::Level::TRACE => "trace",
+	}
+}
+
+/// Guidance printed after an internal error or panic: where to report it and a
+/// reminder to scrub secrets first. Kept off ordinary, user-correctable errors.
+pub(crate) fn internal_error_notice() -> String {
+	format!(
+		"podup: this looks like a bug; re-run with RUST_LOG=debug and report it at {REPO_URL}/issues\n\
+		 podup: redact secrets (passwords, tokens, resolved env values) from any logs before sharing"
+	)
+}
+
+/// Initialize the global tracing subscriber: warnings by default (so the
+/// forward-compat "unknown field" notices are never silently dropped), written
+/// to stderr in the `podup: <level>: <msg>` format so stdout stays a clean pipe.
+pub(crate) fn init_tracing() {
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+		)
+		.with_writer(std::io::stderr)
+		.event_format(PodupFormat)
+		.init();
+}
+
+/// Parse the CLI, framing `--help`/`--version` output with a blank line top and
+/// bottom (clap trims template edges, so wrap the rendered text here).
+pub(crate) fn parse_cli() -> Cli {
+	match Cli::try_parse() {
+		Ok(cli) => cli,
+		Err(e) => match e.kind() {
+			clap::error::ErrorKind::DisplayHelp
+			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+			| clap::error::ErrorKind::DisplayVersion => {
+				print!("\n{e}\n");
+				process::exit(0);
+			}
+			_ => e.exit(),
+		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn level_words_match_user_facing_terms() {
+		assert_eq!(level_word(tracing::Level::WARN), "warning");
+		assert_eq!(level_word(tracing::Level::ERROR), "error");
+	}
+
+	#[test]
+	fn internal_error_notice_reports_and_warns_on_secrets() {
+		let notice = internal_error_notice();
+		assert!(notice.contains(REPO_URL), "points at the issue tracker");
+		assert!(notice.contains("/issues"));
+		assert!(
+			notice.contains("redact"),
+			"reminds the user to scrub secrets"
+		);
+		assert!(
+			notice.contains("RUST_LOG=debug"),
+			"tells the user what to capture"
+		);
+	}
+}

--- a/tests/engine_integration/cli2.rs
+++ b/tests/engine_integration/cli2.rs
@@ -44,6 +44,59 @@ async fn cli_rm_subcommand() {
 }
 
 #[tokio::test]
+async fn cli_push_skips_service_without_image() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-pushskip", std::process::id());
+	// A build-only service has no `image:` to push, so push is a no-op success.
+	fs::write(&compose, "services:\n  app:\n    build: .\n").unwrap();
+	let push = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "push"])
+		.output()
+		.unwrap();
+	assert!(
+		push.status.success(),
+		"push of an imageless service must succeed: {:?}",
+		String::from_utf8_lossy(&push.stderr)
+	);
+}
+
+#[tokio::test]
+async fn cli_push_to_unreachable_registry_errors() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-pushfail", std::process::id());
+	// Port 1 refuses connections, so the push must fail with a non-zero exit.
+	fs::write(
+		&compose,
+		"services:\n  app:\n    image: localhost:1/podup-nope:1\n",
+	)
+	.unwrap();
+	let push = Command::new(bin())
+		.args([
+			"-f",
+			compose.to_str().unwrap(),
+			"-p",
+			&proj,
+			"push",
+			"--tls-verify",
+			"false",
+		])
+		.output()
+		.unwrap();
+	assert!(
+		!push.status.success(),
+		"push to an unreachable registry must fail"
+	);
+}
+
+#[tokio::test]
 async fn cli_stats_no_stream_reports_running_container() {
 	if super::podman().await.is_none() {
 		return;


### PR DESCRIPTION
## What

Adds `push`, the last of the four #415 commands — so **#415 can close** with this.

`push [--ignore-push-failures] [--tls-verify <bool>] [SERVICE...]` pushes each service's `image:` to its registry via the libpod `/images/{name}/push` endpoint:

- Credentials come from Podman's auth file (`podman login`), so no auth handling is needed in podup.
- Services without an `image:` (build-only/imageless) are skipped.
- `--ignore-push-failures` continues after a failure; otherwise the first failure stops the run.
- `--tls-verify false` allows an insecure/local HTTP registry (Podman parity flag); omitting it keeps Podman's verify-on default. A mid-stream `error` line fails the push.

## Test plan

- Real-Podman integration tests (Podman 5.4.2): `push` of an imageless service succeeds (no-op); `push` to an unreachable registry exits non-zero. (Registry-free so they run in CI.)
- Manually verified end to end against a local `registry:2`: `push --tls-verify false` lands the image in the registry catalog; the default (TLS) push to the HTTP registry fails with a clear error.
- Full suite green (lib + 113 integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.

## Structure

`main.rs` hit the 500-line limit, so the diagnostic log formatter, tracing init, the internal-error notice, and the help-framed CLI parse moved into a new `startup` module.