### PR TITLE
feat(cli): logs --tail/--since/--until/--timestamps

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -127,7 +127,10 @@ Print the public binding for a container port. \fB\-\-proto\fR sets the protocol
 List images used by services.
 .TP
 .B logs \fR[\fISERVICE\fR]
-View container output. \fB\-f\fR/\fB\-\-follow\fR streams new output.
+View container output. \fB\-f\fR/\fB\-\-follow\fR streams new output,
+\fB\-n\fR/\fB\-\-tail\fR \fIN\fR limits to the last N lines, \fB\-\-since\fR and
+\fB\-\-until\fR bound by time, and \fB\-t\fR/\fB\-\-timestamps\fR prefixes each
+line with an RFC3339 timestamp.
 .TP
 .B exec \fISERVICE\fR \fICOMMAND\fR...
 Execute a command in a running service container.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,7 +110,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `stats` | Live resource usage (CPU, memory, network, block I/O, PIDs) for service containers. `--no-stream` prints one snapshot; a trailing service list narrows it. |
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `images` | List images used by services. |
-| `logs [SERVICE]` | View container output. `-f, --follow` streams new output. |
+| `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
 | `config` | Print the resolved compose file (after substitution, extends, include). |
 | `pull` | Pull images for all services. |
 

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -300,6 +300,18 @@ pub(crate) enum Commands {
 		/// Follow log output.
 		#[arg(short, long)]
 		follow: bool,
+		/// Number of lines to show from the end of the logs (default: all).
+		#[arg(short = 'n', long)]
+		tail: Option<String>,
+		/// Show logs since a timestamp or relative time (e.g. 2024-01-01T00:00:00, 10m).
+		#[arg(long)]
+		since: Option<String>,
+		/// Show logs before a timestamp or relative time.
+		#[arg(long)]
+		until: Option<String>,
+		/// Prefix each line with an RFC3339 timestamp.
+		#[arg(short = 't', long)]
+		timestamps: bool,
 	},
 	/// Execute a command in a running service container.
 	Exec {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -8,7 +8,7 @@ mod copy;
 pub use build::{BuildOptions, PushOptions};
 pub use lifecycle::RunOptions;
 pub use lock::ProjectLock;
-pub use query::{ExecOptions, ImagesOptions, PsOptions};
+pub use query::{ExecOptions, ImagesOptions, LogsOptions, PsOptions};
 mod container_config;
 mod container_fields;
 mod health;

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -50,6 +50,39 @@ pub struct ImagesOptions {
 	pub json: bool,
 }
 
+/// Options for [`Engine::logs_with_options`], mirroring `docker compose logs`.
+#[derive(Default)]
+pub struct LogsOptions {
+	/// Follow log output, `-f/--follow`.
+	pub follow: bool,
+	/// Number of lines to show from the end, `-n/--tail` (`None` = all).
+	pub tail: Option<String>,
+	/// Show logs since a timestamp/relative time, `--since`.
+	pub since: Option<String>,
+	/// Show logs until a timestamp/relative time, `--until`.
+	pub until: Option<String>,
+	/// Prefix each line with an RFC3339 timestamp, `-t/--timestamps`.
+	pub timestamps: bool,
+}
+
+/// Build the libpod `containers/{}/logs` query string from the options.
+fn log_query(opts: &LogsOptions) -> String {
+	let mut q = format!(
+		"stdout=true&stderr=true&follow={}&timestamps={}",
+		opts.follow, opts.timestamps
+	);
+	if let Some(tail) = &opts.tail {
+		q.push_str(&format!("&tail={}", urlencoded(tail)));
+	}
+	if let Some(since) = &opts.since {
+		q.push_str(&format!("&since={}", urlencoded(since)));
+	}
+	if let Some(until) = &opts.until {
+		q.push_str(&format!("&until={}", urlencoded(until)));
+	}
+	q
+}
+
 impl Engine {
 	/// List running containers for this project as a table (default options).
 	pub async fn ps(&self, file: &ComposeFile) -> Result<()> {
@@ -137,6 +170,27 @@ impl Engine {
 		service_name: Option<&str>,
 		follow: bool,
 	) -> Result<()> {
+		self.logs_with_options(
+			file,
+			service_name,
+			LogsOptions {
+				follow,
+				..Default::default()
+			},
+		)
+		.await
+	}
+
+	/// Stream logs with `docker compose logs` options (`--tail`, `--since`,
+	/// `--until`, `--timestamps`, `--follow`).
+	pub async fn logs_with_options(
+		&self,
+		file: &ComposeFile,
+		service_name: Option<&str>,
+		opts: LogsOptions,
+	) -> Result<()> {
+		let follow = opts.follow;
+		let query = log_query(&opts);
 		// (container_name, is_tty) — TTY containers send raw bytes; non-TTY use
 		// multiplexed 8-byte-header framing.
 		let targets: Vec<(String, bool)> = if let Some(svc) = service_name {
@@ -168,9 +222,10 @@ impl Engine {
 				.into_iter()
 				.map(|(container_name, is_tty)| {
 					let client = &self.client;
+					let query = query.clone();
 					async move {
 						let path = format!(
-							"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
+							"{API_PREFIX}/containers/{}/logs?{query}",
 							urlencoded(&container_name),
 						);
 						let resp = match client.get_stream(&path).await {
@@ -203,9 +258,8 @@ impl Engine {
 		} else {
 			for (container_name, is_tty) in targets {
 				let path = format!(
-					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow={}",
+					"{API_PREFIX}/containers/{}/logs?{query}",
 					urlencoded(&container_name),
-					follow,
 				);
 				let resp = self
 					.client
@@ -405,5 +459,33 @@ impl Engine {
 			}
 		}
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{log_query, LogsOptions};
+
+	#[test]
+	fn log_query_defaults_to_stdout_stderr_no_follow() {
+		let q = log_query(&LogsOptions::default());
+		assert_eq!(q, "stdout=true&stderr=true&follow=false&timestamps=false");
+	}
+
+	#[test]
+	fn log_query_includes_set_options() {
+		let q = log_query(&LogsOptions {
+			follow: true,
+			tail: Some("20".into()),
+			since: Some("10m".into()),
+			until: Some("2024-01-01T00:00:00".into()),
+			timestamps: true,
+		});
+		assert!(q.contains("follow=true"));
+		assert!(q.contains("timestamps=true"));
+		assert!(q.contains("&tail=20"));
+		assert!(q.contains("&since=10m"));
+		// `:` is percent-encoded in the query value.
+		assert!(q.contains("&until=2024-01-01T00%3A00%3A00"));
 	}
 }

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -30,7 +30,7 @@ pub use compose::{
 };
 pub use engine::{
 	is_safe_project_name, list_projects, BuildOptions, Engine, ExecOptions, ImagesOptions,
-	LsOptions, ProjectLock, PsOptions, PushOptions, RunOptions,
+	LogsOptions, LsOptions, ProjectLock, PsOptions, PushOptions, RunOptions,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -357,8 +357,27 @@ async fn run() -> podup::Result<()> {
 				)
 				.await?
 		}
-		Commands::Logs { service, follow } => {
-			engine.logs(&file, service.as_deref(), follow).await?
+		Commands::Logs {
+			service,
+			follow,
+			tail,
+			since,
+			until,
+			timestamps,
+		} => {
+			engine
+				.logs_with_options(
+					&file,
+					service.as_deref(),
+					podup::LogsOptions {
+						follow,
+						tail,
+						since,
+						until,
+						timestamps,
+					},
+				)
+				.await?
 		}
 		Commands::Exec {
 			env,

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -56,6 +56,8 @@ mod watch_tests;
 mod cli1;
 #[path = "engine_integration/cli2.rs"]
 mod cli2;
+#[path = "engine_integration/cli3.rs"]
+mod cli3;
 #[path = "engine_integration/create_ls.rs"]
 mod create_ls;
 #[path = "engine_integration/scale.rs"]

--- a/tests/engine_integration/cli2.rs
+++ b/tests/engine_integration/cli2.rs
@@ -97,45 +97,6 @@ async fn cli_push_to_unreachable_registry_errors() {
 }
 
 #[tokio::test]
-async fn cli_logs_tail_limits_output() {
-	if super::podman().await.is_none() {
-		return;
-	}
-	let dir = tempdir().unwrap();
-	let compose = dir.path().join("docker-compose.yml");
-	let proj = format!("t{}-logstail", std::process::id());
-	fs::write(
-		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"for i in 1 2 3 4 5; do echo line-$i; done; sleep infinity\"]\n",
-	)
-	.unwrap();
-	let c = compose.to_str().unwrap();
-
-	Command::new(bin())
-		.args(["-f", c, "-p", &proj, "up", "-d"])
-		.output()
-		.unwrap();
-	// Give the container a moment to emit its lines.
-	tokio::time::sleep(std::time::Duration::from_millis(800)).await;
-
-	let logs = Command::new(bin())
-		.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
-		.output()
-		.unwrap();
-	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
-	let lines = String::from_utf8_lossy(&logs.stdout)
-		.lines()
-		.filter(|l| l.contains("line-"))
-		.count();
-	assert_eq!(lines, 2, "logs --tail 2 must show exactly 2 lines");
-
-	Command::new(bin())
-		.args(["-f", c, "-p", &proj, "down"])
-		.output()
-		.unwrap();
-}
-
-#[tokio::test]
 async fn cli_stats_no_stream_reports_running_container() {
 	if super::podman().await.is_none() {
 		return;

--- a/tests/engine_integration/cli2.rs
+++ b/tests/engine_integration/cli2.rs
@@ -97,6 +97,45 @@ async fn cli_push_to_unreachable_registry_errors() {
 }
 
 #[tokio::test]
+async fn cli_logs_tail_limits_output() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-logstail", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"for i in 1 2 3 4 5; do echo line-$i; done; sleep infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	// Give the container a moment to emit its lines.
+	tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+	let logs = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
+		.output()
+		.unwrap();
+	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
+	let lines = String::from_utf8_lossy(&logs.stdout)
+		.lines()
+		.filter(|l| l.contains("line-"))
+		.count();
+	assert_eq!(lines, 2, "logs --tail 2 must show exactly 2 lines");
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}
+
+#[tokio::test]
 async fn cli_stats_no_stream_reports_running_container() {
 	if super::podman().await.is_none() {
 		return;

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -1,0 +1,46 @@
+//! Further CLI binary integration tests (kept separate from cli2.rs to stay
+//! under the source line limit).
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+#[tokio::test]
+async fn cli_logs_tail_limits_output() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-logstail", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"for i in 1 2 3 4 5; do echo line-$i; done; sleep infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	// Give the container a moment to emit its lines.
+	tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+	let logs = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
+		.output()
+		.unwrap();
+	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
+	let lines = String::from_utf8_lossy(&logs.stdout)
+		.lines()
+		.filter(|l| l.contains("line-"))
+		.count();
+	assert_eq!(lines, 2, "logs --tail 2 must show exactly 2 lines");
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). Adds the `docker compose logs` output filters that podup lacked:

- `-n/--tail <N>` — show only the last N lines (default: all)
- `--since` / `--until` — bound by timestamp or relative time (e.g. `10m`)
- `-t/--timestamps` — prefix each line with an RFC3339 timestamp

All thread to the libpod `containers/{}/logs` query. A new `LogsOptions` + `logs_with_options` wrapper carries them so the existing public `logs(file, service, follow)` signature is unchanged (**non-breaking**); a shared `log_query` helper builds the query string for both the concurrent-follow and sequential paths.

## Test plan

- Unit tests for `log_query` (defaults + all options set, including percent-encoding of `:` in a timestamp).
- Real-Podman integration test (Podman 5.4.2): `logs --tail 2` on a service that prints 5 lines shows exactly 2. Manually verified `-t` (RFC3339 prefix) and the default (all lines).
- Full suite green (lib 647 + 113 integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.

## Docs

`docs/commands.md` (logs row) and the man page updated.