### PR TITLE
feat(cli): down --remove-orphans and restart --no-deps

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -68,7 +68,8 @@ projects, \fB\-q\fR/\fB\-\-quiet\fR prints names only, \fB\-\-format\fR selects
 .TP
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named
-volumes declared in the compose file.
+volumes declared in the compose file; \fB\-\-remove\-orphans\fR also removes
+containers for services no longer in the file.
 .TP
 .B start
 Start existing stopped containers.
@@ -139,7 +140,8 @@ Execute a command in a running service container.
 Pull images for all services.
 .TP
 .B restart \fR[\fISERVICE\fR]
-Restart services, or one named service.
+Restart services, or one named service. \fB\-\-no\-deps\fR skips
+cascade-restarting dependents with a \fBdepends_on\fR restart condition.
 .TP
 .B config
 Print the resolved compose file after substitution, extends and include.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,12 +39,14 @@ Create and start all services (or only the named ones, plus their transitive
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared
-in the compose file.
+in the compose file; `--remove-orphans` also removes containers for services no
+longer in the file.
 
 ### `start` / `stop` / `restart`
 Start existing stopped containers, stop running ones without removing them, or
 restart them. `start`/`stop` accept a trailing service list; `restart [SERVICE]`
-restarts everything or one service.
+restarts everything or one service. `restart --no-deps` skips cascade-restarting
+dependents that declare a `depends_on` restart condition.
 
 ### `scale <SERVICE=N>...`
 Set the number of running containers for one or more services, creating missing

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -98,6 +98,9 @@ pub(crate) enum Commands {
 		/// Also remove named volumes declared in the compose file.
 		#[arg(short = 'v', long)]
 		volumes: bool,
+		/// Remove containers for services not defined in the compose file.
+		#[arg(long)]
+		remove_orphans: bool,
 		/// Seconds to wait for containers to stop before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
@@ -352,6 +355,9 @@ pub(crate) enum Commands {
 		/// Seconds to wait for containers to stop before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
+		/// Do not restart dependent services (depends_on with a restart condition).
+		#[arg(long)]
+		no_deps: bool,
 		/// Only restart this service.
 		service: Option<String>,
 	},

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -13,6 +13,17 @@ use crate::libpod::API_PREFIX;
 impl Engine {
 	/// Restart the named service (or all services). Dependents with a `restart` condition in `depends_on` are also restarted.
 	pub async fn restart(&self, file: &ComposeFile, service_name: Option<&str>) -> Result<()> {
+		self.restart_with_options(file, service_name, false).await
+	}
+
+	/// Restart with options. When `no_deps` is true, dependents with a
+	/// `depends_on` restart condition are NOT cascade-restarted.
+	pub async fn restart_with_options(
+		&self,
+		file: &ComposeFile,
+		service_name: Option<&str>,
+		no_deps: bool,
+	) -> Result<()> {
 		let names: Vec<String> = if let Some(svc) = service_name {
 			if !file.services.contains_key(svc) {
 				return Err(ComposeError::ServiceNotFound(svc.into()));
@@ -41,6 +52,9 @@ impl Engine {
 				info!("restarted {container_name}");
 			}
 
+			if no_deps {
+				continue;
+			}
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
 					for dep_container in self.replica_names(dep_name, dep_service) {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -231,8 +231,14 @@ async fn run() -> podup::Result<()> {
 		}
 		Commands::Down {
 			volumes,
+			remove_orphans,
 			timeout: _,
-		} => engine.down_with_options(&file, volumes).await?,
+		} => {
+			if remove_orphans {
+				engine.remove_orphans(&file).await?;
+			}
+			engine.down_with_options(&file, volumes).await?
+		}
 		Commands::Start { services } => engine.start(&file, &services).await?,
 		Commands::Stop {
 			services,
@@ -410,7 +416,12 @@ async fn run() -> podup::Result<()> {
 		Commands::Restart {
 			service,
 			timeout: _,
-		} => engine.restart(&file, service.as_deref()).await?,
+			no_deps,
+		} => {
+			engine
+				.restart_with_options(&file, service.as_deref(), no_deps)
+				.await?
+		}
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -44,3 +44,70 @@ async fn cli_logs_tail_limits_output() {
 		.output()
 		.unwrap();
 }
+
+fn run(args: &[&str]) -> std::process::Output {
+	Command::new(bin()).args(args).output().unwrap()
+}
+
+fn ps_all_count(compose: &str, proj: &str) -> usize {
+	String::from_utf8_lossy(&run(&["-f", compose, "-p", proj, "ps", "-a", "-q"]).stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count()
+}
+
+#[tokio::test]
+async fn cli_down_remove_orphans_drops_undeclared_containers() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-orphan", std::process::id());
+	let two = dir.path().join("two.yml");
+	let one = dir.path().join("one.yml");
+	let svc = "image: alpine:latest\n    command: [\"sleep\", \"infinity\"]";
+	fs::write(
+		&two,
+		format!("services:\n  web:\n    {svc}\n  extra:\n    {svc}\n"),
+	)
+	.unwrap();
+	fs::write(&one, format!("services:\n  web:\n    {svc}\n")).unwrap();
+	let (two, one) = (two.to_str().unwrap(), one.to_str().unwrap());
+
+	run(&["-f", two, "-p", &proj, "up", "-d"]);
+	assert_eq!(ps_all_count(two, &proj), 2);
+
+	// Down against the one-service file: --remove-orphans must also drop `extra`.
+	let down = run(&["-f", one, "-p", &proj, "down", "--remove-orphans"]);
+	assert!(down.status.success(), "down failed: {:?}", down.stderr);
+	assert_eq!(
+		ps_all_count(one, &proj),
+		0,
+		"--remove-orphans must remove the undeclared container too"
+	);
+}
+
+#[tokio::test]
+async fn cli_restart_no_deps_succeeds() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-nodeps", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	let restart = run(&["-f", c, "-p", &proj, "restart", "--no-deps", "web"]);
+	assert!(
+		restart.status.success(),
+		"restart --no-deps failed: {:?}",
+		restart.stderr
+	);
+	run(&["-f", c, "-p", &proj, "down"]);
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). Two more docker-compose flags:

- **`down --remove-orphans`** — also removes containers for services no longer in the compose file (reuses the existing `remove_orphans` pass, mirroring `up --remove-orphans`).
- **`restart --no-deps`** — skips cascade-restarting dependents that declare a `depends_on` restart condition. Threaded through a new `restart_with_options` wrapper so the existing public `restart` signature is unchanged (**non-breaking**).

## Test plan

- Real-Podman integration tests (Podman 5.4.2): `down --remove-orphans` against a one-service file drops both the declared container **and** the undeclared orphan (`ps -a` → 0); `restart --no-deps` of a service succeeds.
- Full suite green (lib 647 + integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.

## Docs

`docs/commands.md` (down + restart) and the man page updated.