### PR TITLE
feat(cli): config --format/--services/--quiet

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -145,6 +145,8 @@ cascade-restarting dependents with a \fBdepends_on\fR restart condition.
 .TP
 .B config
 Print the resolved compose file after substitution, extends and include.
+\fB\-\-format\fR selects \fIyaml\fR or \fIjson\fR, \fB\-\-services\fR lists the
+service names, and \fB\-q\fR/\fB\-\-quiet\fR only validates (no output).
 .TP
 .B generate quadlet \fR[\fB\-o\fR \fIDIR\fR]
 Translate the compose file into Podman Quadlet unit files (one \fB.container\fR

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -113,7 +113,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `images` | List images used by services. |
 | `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
-| `config` | Print the resolved compose file (after substitution, extends, include). |
+| `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates. |
 | `pull` | Pull images for all services. |
 
 ## Generate

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -16,6 +16,16 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// Output rendering for `config`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ConfigFormat {
+	/// YAML (the compose-file format).
+	#[default]
+	Yaml,
+	/// JSON.
+	Json,
+}
+
 #[derive(Parser)]
 #[command(name = "podup", version)]
 pub(crate) struct Cli {
@@ -363,7 +373,17 @@ pub(crate) enum Commands {
 	},
 	/// Print the resolved compose file (after substitution / extends / include).
 	#[command(alias = "convert")]
-	Config,
+	Config {
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = ConfigFormat::Yaml)]
+		format: ConfigFormat,
+		/// Print only the service names, one per line.
+		#[arg(long)]
+		services: bool,
+		/// Only validate the configuration; print nothing.
+		#[arg(short, long)]
+		quiet: bool,
+	},
 	/// Generate declarative artifacts from the compose file.
 	#[command(alias = "gen")]
 	Generate {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -129,11 +129,33 @@ async fn run() -> podup::Result<()> {
 	let compose_files = resolve_compose_files(&cli.file);
 	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
 
-	if matches!(cli.command, Commands::Config) {
+	if let Commands::Config {
+		format,
+		services,
+		quiet,
+	} = &cli.command
+	{
+		// Reaching here means the file parsed and merged cleanly.
+		if *quiet {
+			return Ok(());
+		}
+		if *services {
+			for name in file.services.keys() {
+				println!("{name}");
+			}
+			return Ok(());
+		}
 		let mut redacted = file.clone();
 		redacted.redact_inline_content();
-		let yaml = serde_yaml::to_string(&redacted).map_err(podup::ComposeError::Parse)?;
-		println!("{yaml}");
+		let rendered = match format {
+			ConfigFormat::Json => serde_json::to_string_pretty(&redacted).map_err(|e| {
+				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
+			})?,
+			ConfigFormat::Yaml => {
+				serde_yaml::to_string(&redacted).map_err(podup::ComposeError::Parse)?
+			}
+		};
+		println!("{rendered}");
 		return Ok(());
 	}
 
@@ -422,7 +444,7 @@ async fn run() -> podup::Result<()> {
 				.restart_with_options(&file, service.as_deref(), no_deps)
 				.await?
 		}
-		Commands::Config => unreachable!("handled above"),
+		Commands::Config { .. } => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
 		Commands::Ls { .. } => unreachable!("handled before compose parsing"),

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -74,3 +74,66 @@ fn completions_emit_a_script_to_stdout() {
 		&stdout[..stdout.len().min(200)]
 	);
 }
+
+/// A minimal valid two-service compose file in a fresh temp dir.
+fn compose_two_services() -> std::path::PathBuf {
+	let dir = std::env::temp_dir().join(format!("podup-cfg-{}", std::process::id()));
+	fs::create_dir_all(&dir).expect("create temp dir");
+	let path = dir.join("compose.yaml");
+	fs::write(
+		&path,
+		"services:\n  web:\n    image: nginx:1.27\n  db:\n    image: postgres:16\n",
+	)
+	.expect("write compose file");
+	path
+}
+
+#[test]
+fn config_services_lists_service_names() {
+	let file = compose_two_services();
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "config", "--services"])
+		.output()
+		.expect("run config --services");
+	assert!(out.status.success());
+	let names: Vec<&str> = std::str::from_utf8(&out.stdout).unwrap().lines().collect();
+	assert!(
+		names.contains(&"web") && names.contains(&"db"),
+		"got: {names:?}"
+	);
+}
+
+#[test]
+fn config_format_json_emits_json() {
+	let file = compose_two_services();
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "config", "--format", "json"])
+		.output()
+		.expect("run config --format json");
+	assert!(out.status.success());
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+	assert!(parsed["services"]["web"].is_object());
+}
+
+#[test]
+fn config_quiet_validates_without_output() {
+	let valid = compose_two_services();
+	let ok = Command::new(bin())
+		.args(["-f", valid.to_str().unwrap(), "config", "-q"])
+		.output()
+		.unwrap();
+	assert!(ok.status.success());
+	assert!(ok.stdout.is_empty(), "quiet must print nothing");
+
+	// A syntactically broken compose file fails validation (non-zero exit).
+	let dir = std::env::temp_dir().join(format!("podup-cfgbad-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let badfile = dir.join("compose.yaml");
+	fs::write(&badfile, "services:\n  web:\n    image: [unterminated\n").unwrap();
+	let err = Command::new(bin())
+		.args(["-f", badfile.to_str().unwrap(), "config", "-q"])
+		.output()
+		.unwrap();
+	assert!(!err.status.success(), "invalid config must fail under -q");
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). `config` gains the `docker compose config` output options:

- `--format yaml|json` (default `yaml`) — render the resolved file as JSON too.
- `--services` — list the service names, one per line.
- `-q/--quiet` — only validate the merged configuration; print nothing.

`config` stays compose-file-only (it never contacts Podman). `-q` validation works because the file is fully parsed/merged before the command runs, so a broken or unmergeable file exits non-zero with no output.

## Test plan

- CLI tests (no Podman needed): `--services` lists `web`/`db`; `--format json` emits parseable JSON with the services object; `-q` is silent + exit 0 on a valid file and non-zero on a syntactically broken one.
- Full suite green (lib 647 + bin + diagnostics); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.

## Docs

`docs/commands.md` (config row) and the man page updated.