### PR TITLE
feat(cli): up --pull/--no-build/--quiet-pull

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -48,8 +48,9 @@ given multiple times; later files win. The process environment and a project
 Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
 \fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
-\fB\-\-scale\fR \fISERVICE=N\fR (repeatable). Accepts a trailing list of services
-to bring up (with their transitive depends_on).
+\fB\-\-scale\fR \fISERVICE=N\fR (repeatable), \fB\-\-pull\fR \fIpolicy\fR,
+\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR. Accepts a trailing list of services to
+bring up (with their transitive depends_on).
 .TP
 .B scale \fISERVICE=N\fR...
 Set the number of running containers for services, creating missing replicas and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,6 +36,9 @@ Create and start all services (or only the named ones, plus their transitive
 | `--force-recreate` | Recreate containers even if their config is unchanged. |
 | `--no-deps` | Do not start the `depends_on` services of the named services. |
 | `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. |
+| `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
+| `--no-build` | Do not build images, even for services with a `build:` section. |
+| `--quiet-pull` | Suppress image-pull progress output. |
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -98,6 +98,15 @@ pub(crate) enum Commands {
 		/// Override the replica count for a service: SERVICE=N (repeatable).
 		#[arg(long, value_parser = parse_scale_pair)]
 		scale: Vec<(String, u32)>,
+		/// Pull policy before starting: always, missing, never.
+		#[arg(long)]
+		pull: Option<String>,
+		/// Do not build images, even for services with a build section.
+		#[arg(long)]
+		no_build: bool,
+		/// Suppress image-pull progress output.
+		#[arg(long)]
+		quiet_pull: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -17,9 +17,17 @@ impl Engine {
 			None => return Ok(()),
 		};
 
-		info!("pulling {image}");
+		if self.quiet_pull {
+			debug!("pulling {image}");
+		} else {
+			info!("pulling {image}");
+		}
 
-		let requested = service.pull_policy.as_deref();
+		// `up --pull <policy>` overrides the per-service `pull_policy`.
+		let requested = self
+			.pull_policy_override
+			.as_deref()
+			.or(service.pull_policy.as_deref());
 		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
 			warn!(
 				"unknown pull_policy '{}', defaulting to 'missing'",

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -271,8 +271,15 @@ impl Engine {
 			}
 		}
 
-		let policy = service.pull_policy.as_deref().unwrap_or("missing");
-		match (service.build.is_some(), policy) {
+		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
+		// suppresses building even for services with a `build:` section (they fall
+		// back to pulling/using an existing image).
+		let policy = self
+			.pull_policy_override
+			.as_deref()
+			.or(service.pull_policy.as_deref())
+			.unwrap_or("missing");
+		match (service.build.is_some() && !self.no_build, policy) {
 			(true, _) => {
 				self.build_service(name, service, file, &crate::engine::BuildOptions::default())
 					.await?

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -54,6 +54,14 @@ pub struct Engine {
 	/// subcommand); when a service is present it takes precedence over the
 	/// compose `scale:`/`deploy.replicas` value. Empty falls back to compose.
 	pub(super) scale_overrides: std::collections::HashMap<String, u32>,
+	/// CLI `up --pull <policy>` override; takes precedence over each service's
+	/// `pull_policy`. `None` falls back to the per-service value.
+	pub(super) pull_policy_override: Option<String>,
+	/// CLI `up --no-build`: never build images, even for services with a
+	/// `build:` section (they fall back to pulling/using an existing image).
+	pub(super) no_build: bool,
+	/// CLI `up --quiet-pull`: suppress image-pull progress output.
+	pub(super) quiet_pull: bool,
 }
 
 impl Engine {
@@ -65,6 +73,9 @@ impl Engine {
 			base_dir: std::env::current_dir().unwrap_or_default(),
 			stop_timeout: None,
 			scale_overrides: std::collections::HashMap::new(),
+			pull_policy_override: None,
+			no_build: false,
+			quiet_pull: false,
 		}
 	}
 
@@ -76,6 +87,9 @@ impl Engine {
 			base_dir,
 			stop_timeout: None,
 			scale_overrides: std::collections::HashMap::new(),
+			pull_policy_override: None,
+			no_build: false,
+			quiet_pull: false,
 		}
 	}
 
@@ -91,6 +105,20 @@ impl Engine {
 		overrides: std::collections::HashMap<String, u32>,
 	) -> Self {
 		self.scale_overrides = overrides;
+		self
+	}
+
+	/// Set the CLI `up` image-acquisition overrides: `--pull <policy>`,
+	/// `--no-build`, and `--quiet-pull`. Builder-style.
+	pub fn with_up_overrides(
+		mut self,
+		pull_policy: Option<String>,
+		no_build: bool,
+		quiet_pull: bool,
+	) -> Self {
+		self.pull_policy_override = pull_policy;
+		self.no_build = no_build;
+		self.quiet_pull = quiet_pull;
 		self
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -200,9 +200,20 @@ async fn run() -> podup::Result<()> {
 		Commands::Scale { pairs } => pairs.iter().cloned().collect(),
 		_ => std::collections::HashMap::new(),
 	};
+	// `up` image-acquisition overrides: `--pull`, `--no-build`, `--quiet-pull`.
+	let (pull_override, no_build, quiet_pull) = match &cli.command {
+		Commands::Up {
+			pull,
+			no_build,
+			quiet_pull,
+			..
+		} => (pull.clone(), *no_build, *quiet_pull),
+		_ => (None, false, false),
+	};
 	let engine = podup::Engine::with_base_dir(client, project, base_dir)
 		.with_stop_timeout(stop_timeout)
-		.with_scale_overrides(scale_overrides);
+		.with_scale_overrides(scale_overrides)
+		.with_up_overrides(pull_override, no_build, quiet_pull);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,
@@ -225,6 +236,9 @@ async fn run() -> podup::Result<()> {
 			no_deps,
 			timeout: _,
 			scale: _,
+			pull: _,
+			no_build: _,
+			quiet_pull: _,
 			services,
 		} => {
 			if remove_orphans {

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -111,3 +111,57 @@ async fn cli_restart_no_deps_succeeds() {
 	);
 	run(&["-f", c, "-p", &proj, "down"]);
 }
+
+#[tokio::test]
+async fn cli_up_no_build_skips_building() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-nobuild", std::process::id());
+	fs::write(dir.path().join("Dockerfile"), "FROM alpine:latest\n").unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// A build-only service with no prebuilt image: `--no-build` must refuse to
+	// build, so `up` fails because there is no image to run.
+	fs::write(&compose, "services:\n  app:\n    build: .\n").unwrap();
+	let up = run(&[
+		"-f",
+		compose.to_str().unwrap(),
+		"-p",
+		&proj,
+		"up",
+		"-d",
+		"--no-build",
+	]);
+	assert!(
+		!up.status.success(),
+		"--no-build must not build the image, so up has nothing to run"
+	);
+	run(&["-f", compose.to_str().unwrap(), "-p", &proj, "down"]);
+}
+
+#[tokio::test]
+async fn cli_up_pull_never_starts_present_image() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-pullnever", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	// Ensure the image is present, then `--pull never` must still start it.
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run(&["-f", c, "-p", &proj, "down"]);
+	let up = run(&["-f", c, "-p", &proj, "up", "-d", "--pull", "never"]);
+	assert!(
+		up.status.success(),
+		"up --pull never failed: {:?}",
+		up.stderr
+	);
+	run(&["-f", c, "-p", &proj, "down"]);
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). `up` gains the `docker compose up` image-acquisition overrides:

- `--pull <policy>` — override each service's `pull_policy` (`always`/`missing`/`never`).
- `--no-build` — skip building even for services with a `build:` section (they fall back to pulling/using an existing image).
- `--quiet-pull` — suppress image-pull progress output.

The overrides live on the `Engine` via a new `with_up_overrides` builder (mirroring `with_stop_timeout`/`with_scale_overrides`), so the up-path method signatures are unchanged.

## Test plan

- Real-Podman integration tests (Podman 5.4.2): `up --no-build` on a build-only service fails (it refuses to build, so there's no image to run); `up --pull never` starts a service whose image is already present.
- Manually verified `--quiet-pull` suppresses the `pulling` line.
- Full suite green (lib 647 + bin + integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.

## Docs

`docs/commands.md` (up table) and the man page updated.