### PR TITLE
feat(cli): down --rmi and rm -v/--volumes

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -70,7 +70,8 @@ projects, \fB\-q\fR/\fB\-\-quiet\fR prints names only, \fB\-\-format\fR selects
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named
 volumes declared in the compose file; \fB\-\-remove\-orphans\fR also removes
-containers for services no longer in the file.
+containers for services no longer in the file; \fB\-\-rmi\fR \fIall\fR|\fIlocal\fR
+also removes the service images.
 .TP
 .B start
 Start existing stopped containers.
@@ -89,7 +90,8 @@ registry.
 .TP
 .B rm
 Remove stopped service containers. \fB\-f\fR/\fB\-\-force\fR removes running
-containers (stopping them first).
+containers (stopping them first); \fB\-v\fR/\fB\-\-volumes\fR also removes
+anonymous volumes attached to them.
 .TP
 .B kill
 Send a signal to service containers. \fB\-s\fR/\fB\-\-signal\fR sets the signal

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,7 +43,8 @@ Create and start all services (or only the named ones, plus their transitive
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared
 in the compose file; `--remove-orphans` also removes containers for services no
-longer in the file.
+longer in the file; `--rmi all|local` also removes the service images (`local`
+only those built from a `build:` section).
 
 ### `start` / `stop` / `restart`
 Start existing stopped containers, stop running ones without removing them, or
@@ -76,7 +77,8 @@ registry (omit it to keep Podman's default verification). Accepts a trailing
 service list.
 
 ### `rm`
-Remove stopped service containers. `-f, --force` stops and removes running ones.
+Remove stopped service containers. `-f, --force` stops and removes running ones;
+`-v, --volumes` also removes anonymous volumes attached to them.
 
 ### `kill`
 Send a signal to service containers. `-s, --signal <SIG>` sets the signal

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -16,6 +16,15 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// Which images `down --rmi` removes.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum RmiScope {
+	/// All images used by the project's services.
+	All,
+	/// Only images without a custom tag (services that build locally).
+	Local,
+}
+
 /// Output rendering for `config`.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum ConfigFormat {
@@ -120,6 +129,9 @@ pub(crate) enum Commands {
 		/// Remove containers for services not defined in the compose file.
 		#[arg(long)]
 		remove_orphans: bool,
+		/// Also remove service images: `all` or `local` (build-section services).
+		#[arg(long, value_enum)]
+		rmi: Option<RmiScope>,
 		/// Seconds to wait for containers to stop before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
@@ -218,6 +230,9 @@ pub(crate) enum Commands {
 		/// Remove even running containers (stop first).
 		#[arg(short, long)]
 		force: bool,
+		/// Also remove anonymous volumes attached to the containers.
+		#[arg(short = 'v', long)]
+		volumes: bool,
 		/// Remove only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -167,6 +167,19 @@ impl Engine {
 		target_services: &[String],
 		force: bool,
 	) -> Result<()> {
+		self.rm_with_options(file, target_services, force, false)
+			.await
+	}
+
+	/// Remove stopped service containers. `remove_volumes` (`-v/--volumes`) also
+	/// removes anonymous volumes attached to each container.
+	pub async fn rm_with_options(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		force: bool,
+		remove_volumes: bool,
+	) -> Result<()> {
 		let mut order = crate::compose::resolve_order(file)?;
 		order.reverse();
 		let order = filter_services(file, order, target_services)?;
@@ -176,7 +189,7 @@ impl Engine {
 			for container_name in self.replica_names(name, service) {
 				let force_str = if force { "true" } else { "false" };
 				let path = format!(
-					"{API_PREFIX}/containers/{}?force={force_str}",
+					"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
 					crate::libpod::urlencoded(&container_name),
 				);
 				if let Err(e) = self.client.delete_ok(&path).await {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -434,4 +434,32 @@ impl Engine {
 		self.remove_internal_secrets(file).await?;
 		Ok(())
 	}
+
+	/// Remove the images used by the project's services (`down --rmi`). With
+	/// `local_only`, only images of services that build locally (a `build:`
+	/// section) are removed — matching `docker compose down --rmi local`.
+	pub async fn remove_service_images(&self, file: &ComposeFile, local_only: bool) -> Result<()> {
+		for (name, service) in &file.services {
+			let builds_locally = service.build.is_some();
+			if local_only && !builds_locally {
+				continue;
+			}
+			let image = match &service.image {
+				Some(img) => img.clone(),
+				// A build-only service's image defaults to `{service}:latest`.
+				None if builds_locally => format!("{name}:latest"),
+				None => continue,
+			};
+			let path = format!(
+				"{API_PREFIX}/images/{}?force=true",
+				crate::libpod::urlencoded(&image),
+			);
+			match self.client.delete_ok(&path).await {
+				Ok(_) => info!("removed image {image}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove image {image}: {e}"),
+			}
+		}
+		Ok(())
+	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -268,12 +268,18 @@ async fn run() -> podup::Result<()> {
 		Commands::Down {
 			volumes,
 			remove_orphans,
+			rmi,
 			timeout: _,
 		} => {
 			if remove_orphans {
 				engine.remove_orphans(&file).await?;
 			}
-			engine.down_with_options(&file, volumes).await?
+			engine.down_with_options(&file, volumes).await?;
+			if let Some(scope) = rmi {
+				engine
+					.remove_service_images(&file, scope == RmiScope::Local)
+					.await?;
+			}
 		}
 		Commands::Start { services } => engine.start(&file, &services).await?,
 		Commands::Stop {
@@ -321,7 +327,15 @@ async fn run() -> podup::Result<()> {
 				)
 				.await?
 		}
-		Commands::Rm { force, services } => engine.rm(&file, &services, force).await?,
+		Commands::Rm {
+			force,
+			volumes,
+			services,
+		} => {
+			engine
+				.rm_with_options(&file, &services, force, volumes)
+				.await?
+		}
 		Commands::Kill { signal, services } => engine.kill(&file, &services, &signal).await?,
 		Commands::Pause { services } => engine.pause(&file, &services).await?,
 		Commands::Unpause { services } => engine.unpause(&file, &services).await?,

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -165,3 +165,50 @@ async fn cli_up_pull_never_starts_present_image() {
 	);
 	run(&["-f", c, "-p", &proj, "down"]);
 }
+
+#[tokio::test]
+async fn cli_down_rmi_all_succeeds_and_removes_containers() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-rmi", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	let down = run(&["-f", c, "-p", &proj, "down", "--rmi", "all"]);
+	assert!(
+		down.status.success(),
+		"down --rmi all failed: {:?}",
+		down.stderr
+	);
+	assert_eq!(ps_all_count(c, &proj), 0, "down must remove the containers");
+}
+
+#[tokio::test]
+async fn cli_rm_volumes_removes_container() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-rmv", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run(&["-f", c, "-p", &proj, "stop"]);
+	let rm = run(&["-f", c, "-p", &proj, "rm", "-v", "-f"]);
+	assert!(rm.status.success(), "rm -v failed: {:?}", rm.stderr);
+	assert_eq!(ps_all_count(c, &proj), 0, "rm must remove the container");
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). Two more teardown flags:

- **`down --rmi all|local`** — remove the service images after teardown (`local` = only services that build locally from a `build:` section). New additive `Engine::remove_service_images`.
- **`rm -v/--volumes`** — also remove anonymous volumes attached to the containers, via a new `rm_with_options` wrapper so the existing public `rm` signature is unchanged.

Both are **additive** to the public API.

## Test plan

- Real-Podman integration tests (Podman 5.4.2): `down --rmi all` succeeds and removes the containers; `rm -v -f` removes a stopped container. Manually verified `down --rmi all` actually deletes the image (image count 1 → 0).
- Full suite green (lib 647 + bin + integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.

## Docs

`docs/commands.md` (down + rm) and the man page updated.