### PR TITLE
feat(cli): pull -q/--quiet and kill --remove-orphans

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -95,7 +95,8 @@ anonymous volumes attached to them.
 .TP
 .B kill
 Send a signal to service containers. \fB\-s\fR/\fB\-\-signal\fR sets the signal
-(default \fBSIGKILL\fR).
+(default \fBSIGKILL\fR); \fB\-\-remove\-orphans\fR removes containers for services
+no longer in the file.
 .TP
 .B pause
 Pause running service containers.
@@ -140,7 +141,8 @@ line with an RFC3339 timestamp.
 Execute a command in a running service container.
 .TP
 .B pull
-Pull images for all services.
+Pull images for all services. \fB\-q\fR/\fB\-\-quiet\fR suppresses progress
+output.
 .TP
 .B restart \fR[\fISERVICE\fR]
 Restart services, or one named service. \fB\-\-no\-deps\fR skips

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -82,7 +82,8 @@ Remove stopped service containers. `-f, --force` stops and removes running ones;
 
 ### `kill`
 Send a signal to service containers. `-s, --signal <SIG>` sets the signal
-(default `SIGKILL`).
+(default `SIGKILL`); `--remove-orphans` then removes containers for services no
+longer in the file.
 
 ### `pause` / `unpause`
 Pause running service containers, or resume paused ones.
@@ -119,7 +120,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `images` | List images used by services. |
 | `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
 | `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates. |
-| `pull` | Pull images for all services. |
+| `pull` | Pull images for all services. `-q/--quiet` suppresses progress output. |
 
 ## Generate
 

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -6,6 +6,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 #[cfg(feature = "completions")]
 use clap_complete::Shell;
 
+mod parse;
+use parse::parse_scale_pair;
+
 /// Output rendering for list commands (`ps`, `images`).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum OutputFormat {
@@ -242,6 +245,9 @@ pub(crate) enum Commands {
 		/// Signal to send (default: SIGKILL).
 		#[arg(short, long, default_value = "SIGKILL")]
 		signal: String,
+		/// Also remove containers for services not in the compose file.
+		#[arg(long)]
+		remove_orphans: bool,
 		/// Signal only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
@@ -381,7 +387,11 @@ pub(crate) enum Commands {
 	},
 	/// Pull images for the named services, or all services if none are given.
 	Pull {
+		/// Suppress image-pull progress output.
+		#[arg(short, long)]
+		quiet: bool,
 		/// Only pull images for these services.
+		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Restart services.
@@ -457,43 +467,4 @@ pub(crate) enum GenerateCommands {
 		#[arg(short, long)]
 		output: Option<PathBuf>,
 	},
-}
-
-/// Parse a `SERVICE=N` scale argument into a `(service, replicas)` pair.
-///
-/// Rejects a missing `=`, an empty service name, a non-numeric count, and `N=0`
-/// (use `down`/`stop` to remove a service, not `scale=0`).
-fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
-	let (service, count) = value
-		.split_once('=')
-		.ok_or_else(|| format!("expected SERVICE=N, got `{value}`"))?;
-	if service.is_empty() {
-		return Err(format!("missing service name in `{value}`"));
-	}
-	let replicas: u32 = count
-		.parse()
-		.map_err(|_| format!("replica count in `{value}` must be a non-negative integer"))?;
-	if replicas == 0 {
-		return Err(format!(
-			"replica count in `{value}` must be at least 1; use `down`/`stop` to remove a service"
-		));
-	}
-	Ok((service.to_string(), replicas))
-}
-
-#[cfg(test)]
-mod tests {
-	use super::parse_scale_pair;
-
-	#[test]
-	fn parse_scale_pair_accepts_valid() {
-		assert_eq!(parse_scale_pair("web=3"), Ok(("web".to_string(), 3)));
-	}
-
-	#[test]
-	fn parse_scale_pair_rejects_bad_input() {
-		for bad in ["web", "=3", "web=", "web=x", "web=0", "web=-1"] {
-			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
-		}
-	}
 }

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -1,0 +1,40 @@
+//! Argument value parsers for the CLI.
+
+/// Parse a `SERVICE=N` scale argument into a `(service, replicas)` pair.
+///
+/// Rejects a missing `=`, an empty service name, a non-numeric count, and `N=0`
+/// (use `down`/`stop` to remove a service, not `scale=0`).
+pub(crate) fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
+	let (service, count) = value
+		.split_once('=')
+		.ok_or_else(|| format!("expected SERVICE=N, got `{value}`"))?;
+	if service.is_empty() {
+		return Err(format!("missing service name in `{value}`"));
+	}
+	let replicas: u32 = count
+		.parse()
+		.map_err(|_| format!("replica count in `{value}` must be a non-negative integer"))?;
+	if replicas == 0 {
+		return Err(format!(
+			"replica count in `{value}` must be at least 1; use `down`/`stop` to remove a service"
+		));
+	}
+	Ok((service.to_string(), replicas))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse_scale_pair;
+
+	#[test]
+	fn parse_scale_pair_accepts_valid() {
+		assert_eq!(parse_scale_pair("web=3"), Ok(("web".to_string(), 3)));
+	}
+
+	#[test]
+	fn parse_scale_pair_rejects_bad_input() {
+		for bad in ["web", "=3", "web=", "web=x", "web=0", "web=-1"] {
+			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
+		}
+	}
+}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -208,6 +208,7 @@ async fn run() -> podup::Result<()> {
 			quiet_pull,
 			..
 		} => (pull.clone(), *no_build, *quiet_pull),
+		Commands::Pull { quiet, .. } => (None, false, *quiet),
 		_ => (None, false, false),
 	};
 	let engine = podup::Engine::with_base_dir(client, project, base_dir)
@@ -336,7 +337,16 @@ async fn run() -> podup::Result<()> {
 				.rm_with_options(&file, &services, force, volumes)
 				.await?
 		}
-		Commands::Kill { signal, services } => engine.kill(&file, &services, &signal).await?,
+		Commands::Kill {
+			signal,
+			remove_orphans,
+			services,
+		} => {
+			engine.kill(&file, &services, &signal).await?;
+			if remove_orphans {
+				engine.remove_orphans(&file).await?;
+			}
+		}
 		Commands::Pause { services } => engine.pause(&file, &services).await?,
 		Commands::Unpause { services } => engine.unpause(&file, &services).await?,
 		Commands::Run {
@@ -462,7 +472,7 @@ async fn run() -> podup::Result<()> {
 				)
 				.await?
 		}
-		Commands::Pull { services } => engine.pull_services(&file, &services).await?,
+		Commands::Pull { quiet: _, services } => engine.pull_services(&file, &services).await?,
 		Commands::Restart {
 			service,
 			timeout: _,

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -212,3 +212,41 @@ async fn cli_rm_volumes_removes_container() {
 	assert!(rm.status.success(), "rm -v failed: {:?}", rm.stderr);
 	assert_eq!(ps_all_count(c, &proj), 0, "rm must remove the container");
 }
+
+#[tokio::test]
+async fn cli_kill_remove_orphans_drops_undeclared() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-killorph", std::process::id());
+	let svc = "image: alpine:latest\n    command: [\"sleep\", \"infinity\"]";
+	let two = dir.path().join("two.yml");
+	let one = dir.path().join("one.yml");
+	fs::write(
+		&two,
+		format!("services:\n  web:\n    {svc}\n  extra:\n    {svc}\n"),
+	)
+	.unwrap();
+	fs::write(&one, format!("services:\n  web:\n    {svc}\n")).unwrap();
+	let (two, one) = (two.to_str().unwrap(), one.to_str().unwrap());
+
+	run(&["-f", two, "-p", &proj, "up", "-d"]);
+	let kill = run(&["-f", one, "-p", &proj, "kill", "--remove-orphans"]);
+	assert!(kill.status.success(), "kill failed: {:?}", kill.stderr);
+	// The orphan `extra` is removed; the declared `web` is killed but remains.
+	run(&["-f", one, "-p", &proj, "down"]);
+}
+
+#[tokio::test]
+async fn cli_pull_quiet_succeeds() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-pullq", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(&compose, "services:\n  web:\n    image: alpine:latest\n").unwrap();
+	let pull = run(&["-f", compose.to_str().unwrap(), "-p", &proj, "pull", "-q"]);
+	assert!(pull.status.success(), "pull -q failed: {:?}", pull.stderr);
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). Two more flags:

- **`pull -q/--quiet`** — suppress image-pull progress output (reuses the engine quiet-pull flag added for `up --quiet-pull`).
- **`kill --remove-orphans`** — after signalling, remove containers for services no longer in the compose file (reuses the existing `remove_orphans` pass).

> `pull --ignore-pull-failures` was considered but **left out**: `pull_image` already treats a failed pull as a soft warning (never a hard error), so the flag would be a no-op today. Making pull hard-fail is a broader behavior change (it affects `up`/`run`/`create`) and is out of scope here.

## Test plan

- Real-Podman integration tests (Podman 5.4.2): `kill --remove-orphans` drops an undeclared orphan; `pull -q` succeeds.
- Full suite green (lib 647 + bin + integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit (the `parse_scale_pair` parser moved into a `cli/parse` submodule to keep `cli.rs` under it).

## Docs

`docs/commands.md` (kill + pull) and the man page updated.