### PR TITLE
feat(cli): up --no-start

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -49,8 +49,8 @@ Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
 \fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
 \fB\-\-scale\fR \fISERVICE=N\fR (repeatable), \fB\-\-pull\fR \fIpolicy\fR,
-\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR. Accepts a trailing list of services to
-bring up (with their transitive depends_on).
+\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-no\-start\fR. Accepts a trailing
+list of services to bring up (with their transitive depends_on).
 .TP
 .B scale \fISERVICE=N\fR...
 Set the number of running containers for services, creating missing replicas and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,6 +39,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
 | `--no-build` | Do not build images, even for services with a `build:` section. |
 | `--quiet-pull` | Suppress image-pull progress output. |
+| `--no-start` | Create the containers but do not start them. |
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -119,6 +119,9 @@ pub(crate) enum Commands {
 		/// Suppress image-pull progress output.
 		#[arg(long)]
 		quiet_pull: bool,
+		/// Create containers but do not start them.
+		#[arg(long)]
+		no_start: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -16,28 +16,7 @@ mod startup;
 use cli::*;
 use generate::write_quadlet;
 use resolve::*;
-use startup::{init_tracing, internal_error_notice, parse_cli};
-
-/// Whether a command creates, destroys, or changes the state of containers and
-/// so must hold the exclusive project lock.
-fn is_mutating(command: &Commands) -> bool {
-	matches!(
-		command,
-		Commands::Up { .. }
-			| Commands::Down { .. }
-			| Commands::Start { .. }
-			| Commands::Stop { .. }
-			| Commands::Build { .. }
-			| Commands::Rm { .. }
-			| Commands::Kill { .. }
-			| Commands::Pause { .. }
-			| Commands::Unpause { .. }
-			| Commands::Run { .. }
-			| Commands::Restart { .. }
-			| Commands::Scale { .. }
-			| Commands::Create { .. }
-	)
-}
+use startup::{init_tracing, internal_error_notice, is_mutating, parse_cli};
 
 fn main() {
 	// Replace the default panic output (a raw Rust backtrace) with a `podup:`
@@ -240,6 +219,7 @@ async fn run() -> podup::Result<()> {
 			pull: _,
 			no_build: _,
 			quiet_pull: _,
+			no_start,
 			services,
 		} => {
 			if remove_orphans {
@@ -247,6 +227,21 @@ async fn run() -> podup::Result<()> {
 			}
 			if build {
 				engine.build_all(&file, &services).await?;
+			}
+			// `--no-start` creates the containers but never starts them, so the
+			// wait/watch/attach steps below do not apply.
+			if no_start {
+				engine
+					.create_with_options(
+						&file,
+						&cli.profile,
+						&services,
+						no_recreate,
+						force_recreate,
+						no_deps,
+					)
+					.await?;
+				return Ok(());
 			}
 			engine
 				.up_with_options(

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -10,7 +10,28 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
-use crate::cli::Cli;
+use crate::cli::{Cli, Commands};
+
+/// Whether a command creates, destroys, or changes the state of containers and
+/// so must hold the exclusive project lock.
+pub(crate) fn is_mutating(command: &Commands) -> bool {
+	matches!(
+		command,
+		Commands::Up { .. }
+			| Commands::Down { .. }
+			| Commands::Start { .. }
+			| Commands::Stop { .. }
+			| Commands::Build { .. }
+			| Commands::Rm { .. }
+			| Commands::Kill { .. }
+			| Commands::Pause { .. }
+			| Commands::Unpause { .. }
+			| Commands::Run { .. }
+			| Commands::Restart { .. }
+			| Commands::Scale { .. }
+			| Commands::Create { .. }
+	)
+}
 
 /// Canonical project URL, reused for the bug-report hint on internal errors.
 const REPO_URL: &str = "https://github.com/Glyndor/podup";

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -250,3 +250,29 @@ async fn cli_pull_quiet_succeeds() {
 	let pull = run(&["-f", compose.to_str().unwrap(), "-p", &proj, "pull", "-q"]);
 	assert!(pull.status.success(), "pull -q failed: {:?}", pull.stderr);
 }
+
+#[tokio::test]
+async fn cli_up_no_start_creates_without_starting() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-nostart", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let up = run(&["-f", c, "-p", &proj, "up", "--no-start"]);
+	assert!(up.status.success(), "up --no-start failed: {:?}", up.stderr);
+	assert_eq!(ps_all_count(c, &proj), 1, "container must be created");
+	let running = String::from_utf8_lossy(&run(&["-f", c, "-p", &proj, "ps", "-q"]).stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count();
+	assert_eq!(running, 0, "--no-start must not start the container");
+	run(&["-f", c, "-p", &proj, "down"]);
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). `up --no-start` creates the service containers but does not start them — reusing the create path (`run_up` with `start = false`) and skipping the wait/watch/attach steps.

> `up --wait` was prototyped alongside this but **deferred**: it surfaced a real pre-existing bug — a compose `healthcheck.interval` is not mapped to the container's `Healthcheck.Interval` (it lands `Interval = 0s`), so Podman never runs the periodic check and the status stays `starting`; a health wait then never completes. Filed as **#450** (P2). `--wait` should follow once that is fixed.

## Test plan

- Real-Podman integration test (Podman 5.4.2): `up --no-start` creates the container (visible with `ps -a`) but leaves it stopped (`ps` shows none).
- Full suite green (lib 647 + bin + integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit (`is_mutating` moved into the `startup` module to keep `main.rs` under it).

## Docs

`docs/commands.md` (up table) and the man page updated.