### PR TITLE
fix(engine): default healthcheck timeout/interval/retries

### DIFF
--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -75,11 +75,27 @@ pub(super) fn build_healthcheck(hc: &HealthCheck) -> HealthConfig {
 		ComposeCommand::Shell(s) => vec!["CMD-SHELL".to_string(), s.clone()],
 		ComposeCommand::Exec(v) => v.clone(),
 	});
+	// Apply the compose-spec defaults for any field the user omitted. Podman's
+	// API does NOT default these: a missing `Timeout` is taken as 0s, which makes
+	// every probe fail with "exceeded timeout of 0s" so the container is stuck
+	// `starting`; a missing/zero `Interval` disables the periodic check. Match
+	// docker-compose — interval 30s, timeout 30s, retries 3 (start_period 0).
+	const DEFAULT_NANOS: i64 = 30 * 1_000_000_000;
 	HealthConfig {
 		test,
-		interval: hc.interval.as_deref().and_then(size::parse_duration_nanos),
-		timeout: hc.timeout.as_deref().and_then(size::parse_duration_nanos),
-		retries: hc.retries.map(|r| r as i64),
+		interval: Some(
+			hc.interval
+				.as_deref()
+				.and_then(size::parse_duration_nanos)
+				.unwrap_or(DEFAULT_NANOS),
+		),
+		timeout: Some(
+			hc.timeout
+				.as_deref()
+				.and_then(size::parse_duration_nanos)
+				.unwrap_or(DEFAULT_NANOS),
+		),
+		retries: Some(hc.retries.map(|r| r as i64).unwrap_or(3)),
 		start_period: hc
 			.start_period
 			.as_deref()
@@ -284,5 +300,35 @@ mod tests {
 		let cfg = build_healthcheck(&hc);
 		let test = cfg.test.unwrap();
 		assert_eq!(test[0], "curl");
+	}
+
+	#[test]
+	fn healthcheck_applies_compose_defaults_when_omitted() {
+		// A healthcheck with only a `test` must still get interval/timeout/retries:
+		// Podman treats a missing Timeout as 0s, which makes every probe fail with
+		// "exceeded timeout of 0s" and the container is stuck `starting`.
+		let hc = HealthCheck {
+			test: Some(ComposeCommand::Exec(vec!["true".into()])),
+			..Default::default()
+		};
+		let cfg = build_healthcheck(&hc);
+		assert_eq!(cfg.interval, Some(30 * 1_000_000_000));
+		assert_eq!(cfg.timeout, Some(30 * 1_000_000_000));
+		assert_eq!(cfg.retries, Some(3));
+	}
+
+	#[test]
+	fn healthcheck_honors_explicit_interval_and_timeout() {
+		let hc = HealthCheck {
+			test: Some(ComposeCommand::Exec(vec!["true".into()])),
+			interval: Some("2s".into()),
+			timeout: Some("5s".into()),
+			retries: Some(7),
+			..Default::default()
+		};
+		let cfg = build_healthcheck(&hc);
+		assert_eq!(cfg.interval, Some(2 * 1_000_000_000));
+		assert_eq!(cfg.timeout, Some(5 * 1_000_000_000));
+		assert_eq!(cfg.retries, Some(7));
 	}
 }

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -176,6 +176,26 @@ async fn depends_on_service_healthy() {
 }
 
 #[tokio::test]
+async fn depends_on_service_healthy_with_default_timeout() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("hltdef");
+	let engine = Engine::new(client, proj.clone());
+	// db's healthcheck OMITS `timeout`/`retries`. Podman defaults a missing
+	// Timeout to 0s (every probe fails "exceeded timeout of 0s"), so without the
+	// compose-spec default the db never becomes healthy and this up would hang.
+	let file = parse_str(
+		"services:\n  db:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    healthcheck:\n      test: [\"CMD\", \"true\"]\n      interval: 1s\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    depends_on:\n      db:\n        condition: service_healthy\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
 async fn depends_on_service_completed() {
 	let client = match podman().await {
 		Some(d) => d,


### PR DESCRIPTION
## What

Closes #450.

A compose healthcheck that omits `timeout` (or `interval`/`retries`) produced a container `Healthconfig` with those fields unset. **Podman's API does not default them** — a missing `Timeout` is taken as `0s`, so every probe fails with *"healthcheck command exceeded timeout of 0s"* and the container is stuck `starting` forever. That made `depends_on: { condition: service_healthy }` waits time out and blocked a future `up --wait`.

Apply the compose-spec defaults when a field is omitted: **interval 30s, timeout 30s, retries 3** (`start_period` stays 0). Explicit values are unchanged.

## Evidence

Before — `podman inspect` of a podup container whose compose healthcheck set only `test` + `interval`:
```
{"Test":["CMD","true"],"Interval":2000000000,"Retries":5}   # no Timeout → 0s
$ podman healthcheck run …
Error: healthcheck command exceeded timeout of 0s          # stuck "starting"
```
After:
```
{"Test":["CMD","true"],"Interval":2000000000,"Timeout":30000000000,"Retries":5}
status → healthy
```

## Test plan

- Unit tests: `build_healthcheck` applies the defaults when omitted, and honours explicit `interval`/`timeout`/`retries`.
- Real-Podman integration test (Podman 5.4.2): `depends_on: service_healthy` where the dependency's healthcheck **omits `timeout`** now completes (previously hung to timeout).
- Full suite green (lib 649 + bin + integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.