### PR TITLE
feat(cli): up --wait

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -49,8 +49,9 @@ Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
 \fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
 \fB\-\-scale\fR \fISERVICE=N\fR (repeatable), \fB\-\-pull\fR \fIpolicy\fR,
-\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-no\-start\fR. Accepts a trailing
-list of services to bring up (with their transitive depends_on).
+\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-wait\fR, \fB\-\-no\-start\fR.
+Accepts a trailing list of services to bring up (with their transitive
+depends_on).
 .TP
 .B scale \fISERVICE=N\fR...
 Set the number of running containers for services, creating missing replicas and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,6 +39,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
 | `--no-build` | Do not build images, even for services with a `build:` section. |
 | `--quiet-pull` | Suppress image-pull progress output. |
+| `--wait` | Wait until services are running/healthy before returning. |
 | `--no-start` | Create the containers but do not start them. |
 
 ### `down`

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -119,6 +119,9 @@ pub(crate) enum Commands {
 		/// Suppress image-pull progress output.
 		#[arg(long)]
 		quiet_pull: bool,
+		/// Wait until services are running/healthy before returning.
+		#[arg(long)]
+		wait: bool,
 		/// Create containers but do not start them.
 		#[arg(long)]
 		no_start: bool,

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -5,7 +5,7 @@
 //! [`Engine::wait_completed`] polls until the container exits with code 0 (used for
 //! `condition: service_completed_successfully`).
 
-use crate::compose::types::Service;
+use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::{ContainerInspect, ContainerState};
 use crate::libpod::API_PREFIX;
@@ -106,6 +106,24 @@ impl Engine {
 	/// those declared in compose. If the container has no effective healthcheck at
 	/// all (none in the image or compose), it can never report `healthy`, so the
 	/// wait short-circuits as satisfied rather than blocking until timeout.
+	/// Wait until every targeted service's first replica is healthy (`up
+	/// --wait`). A service with no effective healthcheck is treated as ready
+	/// once started. All services when `target_services` is empty.
+	pub async fn wait_services_healthy(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+	) -> Result<()> {
+		for (name, service) in &file.services {
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
+				continue;
+			}
+			let container = self.first_replica_name(name, service);
+			self.wait_healthy(&container, service).await?;
+		}
+		Ok(())
+	}
+
 	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
 		let hc = service.healthcheck.as_ref();
 		let (poll_secs, iterations) = health_poll_plan(

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -219,6 +219,7 @@ async fn run() -> podup::Result<()> {
 			pull: _,
 			no_build: _,
 			quiet_pull: _,
+			wait,
 			no_start,
 			services,
 		} => {
@@ -254,6 +255,9 @@ async fn run() -> podup::Result<()> {
 					no_deps,
 				)
 				.await?;
+			if wait {
+				engine.wait_services_healthy(&file, &services).await?;
+			}
 			if watch {
 				engine.watch(&file).await?;
 			} else if !detach {

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -276,3 +276,25 @@ async fn cli_up_no_start_creates_without_starting() {
 	assert_eq!(running, 0, "--no-start must not start the container");
 	run(&["-f", c, "-p", &proj, "down"]);
 }
+
+#[tokio::test]
+async fn cli_up_wait_returns_when_healthy() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-upwait", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	// A healthcheck that omits `timeout` (defaults applied) must still reach
+	// healthy, so `up --wait` returns successfully instead of timing out.
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    healthcheck:\n      test: [\"CMD\", \"true\"]\n      interval: 1s\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let up = run(&["-f", c, "-p", &proj, "up", "-d", "--wait"]);
+	assert!(up.status.success(), "up --wait failed: {:?}", up.stderr);
+	run(&["-f", c, "-p", &proj, "down"]);
+}


### PR DESCRIPTION
## What

Part of #410 (CLI flag parity). `up --wait` blocks until each targeted service's first replica is healthy before returning (a service with no effective healthcheck is ready once started), via `wait_services_healthy` (reuses the existing `wait_healthy`).

This was deferred from the `up --no-start` PR because it surfaced #450 (healthcheck timeout defaulting to 0s → stuck `starting`). With #450 fixed, a default-timeout healthcheck reaches healthy, so `--wait` completes instead of timing out.

## Test plan

- Real-Podman integration test (Podman 5.4.2): `up --wait` on a service whose healthcheck **omits `timeout`** returns successfully (relies on the #450 default-timeout fix).
- Full suite green (lib 649 + bin + integration); `cargo fmt --check` clean; no new clippy warnings; the Debian feature build compiles; all files under the 500-line limit.

## Docs

`docs/commands.md` (up table) and the man page updated.