### PR TITLE
promote: CLI parity batch + libpod-native endpoints + healthcheck defaults + CI pins

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -22,4 +22,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       podman: true

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@b78620146d50fdbc552e1b86740e64d114c58f0f # v1.0.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@f72a52755c737ad4ae0a61e56ac43e2edc7280c5 # v1.1.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ flowchart LR
 - 🔒 **Rootless by design** — drives rootless Podman over its native libpod REST API
 - 📄 **Compose-spec parsing** — YAML anchors, `extends`, `include`, profiles, `env_file`, variable substitution with modifiers
 - 🔁 **Dependency-aware** — `depends_on` ordering with `service_started`, `service_healthy`, and `service_completed_successfully` conditions
-- 🔢 **Replicas** — `scale:` and `deploy.replicas` with named replica containers
+- 🔢 **Replicas** — `scale:`/`deploy.replicas`, the `scale` command, and `up --scale SERVICE=N`, with named replica containers
 - 🔐 **Secrets & configs** — inline content, file, environment, and `external: true` Podman-native secret sources, staged securely
 - 👀 **Watch mode** — sync, rebuild or restart services on file changes per `develop.watch` rules
 - ⚙️ **Systemd Quadlet export** — `generate quadlet` emits native `podman-systemd.unit` files to run your stack under systemd, no daemon

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -49,8 +49,8 @@ Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
 \fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
 \fB\-\-scale\fR \fISERVICE=N\fR (repeatable), \fB\-\-pull\fR \fIpolicy\fR,
-\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR. Accepts a trailing list of services to
-bring up (with their transitive depends_on).
+\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-no\-start\fR. Accepts a trailing
+list of services to bring up (with their transitive depends_on).
 .TP
 .B scale \fISERVICE=N\fR...
 Set the number of running containers for services, creating missing replicas and

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -70,7 +70,8 @@ projects, \fB\-q\fR/\fB\-\-quiet\fR prints names only, \fB\-\-format\fR selects
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named
 volumes declared in the compose file; \fB\-\-remove\-orphans\fR also removes
-containers for services no longer in the file.
+containers for services no longer in the file; \fB\-\-rmi\fR \fIall\fR|\fIlocal\fR
+also removes the service images.
 .TP
 .B start
 Start existing stopped containers.
@@ -89,7 +90,8 @@ registry.
 .TP
 .B rm
 Remove stopped service containers. \fB\-f\fR/\fB\-\-force\fR removes running
-containers (stopping them first).
+containers (stopping them first); \fB\-v\fR/\fB\-\-volumes\fR also removes
+anonymous volumes attached to them.
 .TP
 .B kill
 Send a signal to service containers. \fB\-s\fR/\fB\-\-signal\fR sets the signal

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -145,6 +145,8 @@ cascade-restarting dependents with a \fBdepends_on\fR restart condition.
 .TP
 .B config
 Print the resolved compose file after substitution, extends and include.
+\fB\-\-format\fR selects \fIyaml\fR or \fIjson\fR, \fB\-\-services\fR lists the
+service names, and \fB\-q\fR/\fB\-\-quiet\fR only validates (no output).
 .TP
 .B generate quadlet \fR[\fB\-o\fR \fIDIR\fR]
 Translate the compose file into Podman Quadlet unit files (one \fB.container\fR

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -68,7 +68,8 @@ projects, \fB\-q\fR/\fB\-\-quiet\fR prints names only, \fB\-\-format\fR selects
 .TP
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named
-volumes declared in the compose file.
+volumes declared in the compose file; \fB\-\-remove\-orphans\fR also removes
+containers for services no longer in the file.
 .TP
 .B start
 Start existing stopped containers.
@@ -139,7 +140,8 @@ Execute a command in a running service container.
 Pull images for all services.
 .TP
 .B restart \fR[\fISERVICE\fR]
-Restart services, or one named service.
+Restart services, or one named service. \fB\-\-no\-deps\fR skips
+cascade-restarting dependents with a \fBdepends_on\fR restart condition.
 .TP
 .B config
 Print the resolved compose file after substitution, extends and include.

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -56,6 +56,16 @@ Set the number of running containers for services, creating missing replicas and
 removing surplus ones. A service publishing a fixed host port cannot scale past
 one replica and the command fails with guidance.
 .TP
+.B create
+Create the containers for services without starting them. Options:
+\fB\-\-build\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-recreate\fR, and a trailing
+service list.
+.TP
+.B ls
+List podup compose projects on the host. \fB\-a\fR/\fB\-\-all\fR includes stopped
+projects, \fB\-q\fR/\fB\-\-quiet\fR prints names only, \fB\-\-format\fR selects
+\fItable\fR or \fIjson\fR. Requires no compose file.
+.TP
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named
 volumes declared in the compose file.

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -127,7 +127,10 @@ Print the public binding for a container port. \fB\-\-proto\fR sets the protocol
 List images used by services.
 .TP
 .B logs \fR[\fISERVICE\fR]
-View container output. \fB\-f\fR/\fB\-\-follow\fR streams new output.
+View container output. \fB\-f\fR/\fB\-\-follow\fR streams new output,
+\fB\-n\fR/\fB\-\-tail\fR \fIN\fR limits to the last N lines, \fB\-\-since\fR and
+\fB\-\-until\fR bound by time, and \fB\-t\fR/\fB\-\-timestamps\fR prefixes each
+line with an RFC3339 timestamp.
 .TP
 .B exec \fISERVICE\fR \fICOMMAND\fR...
 Execute a command in a running service container.

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -95,7 +95,8 @@ anonymous volumes attached to them.
 .TP
 .B kill
 Send a signal to service containers. \fB\-s\fR/\fB\-\-signal\fR sets the signal
-(default \fBSIGKILL\fR).
+(default \fBSIGKILL\fR); \fB\-\-remove\-orphans\fR removes containers for services
+no longer in the file.
 .TP
 .B pause
 Pause running service containers.
@@ -140,7 +141,8 @@ line with an RFC3339 timestamp.
 Execute a command in a running service container.
 .TP
 .B pull
-Pull images for all services.
+Pull images for all services. \fB\-q\fR/\fB\-\-quiet\fR suppresses progress
+output.
 .TP
 .B restart \fR[\fISERVICE\fR]
 Restart services, or one named service. \fB\-\-no\-deps\fR skips

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -108,6 +108,11 @@ List project containers.
 .B top
 Display the running processes of service containers.
 .TP
+.B stats
+Live resource usage (CPU, memory, network, block I/O, PIDs) for service
+containers. \fB\-\-no\-stream\fR prints a single snapshot; a trailing service
+list narrows the report.
+.TP
 .B port \fISERVICE\fR \fIPRIVATE_PORT\fR
 Print the public binding for a container port. \fB\-\-proto\fR sets the protocol
 (default \fBtcp\fR).

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -79,6 +79,12 @@ Stop running containers without removing them.
 .B build
 Build or rebuild service images.
 .TP
+.B push
+Push each service's image to its registry (imageless services are skipped).
+Credentials come from \fBpodman login\fR. \fB\-\-ignore\-push\-failures\fR
+continues after a failure; \fB\-\-tls\-verify false\fR allows an insecure
+registry.
+.TP
 .B rm
 Remove stopped service containers. \fB\-f\fR/\fB\-\-force\fR removes running
 containers (stopping them first).

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -48,8 +48,9 @@ given multiple times; later files win. The process environment and a project
 Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
 \fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
-\fB\-\-scale\fR \fISERVICE=N\fR (repeatable). Accepts a trailing list of services
-to bring up (with their transitive depends_on).
+\fB\-\-scale\fR \fISERVICE=N\fR (repeatable), \fB\-\-pull\fR \fIpolicy\fR,
+\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR. Accepts a trailing list of services to
+bring up (with their transitive depends_on).
 .TP
 .B scale \fISERVICE=N\fR...
 Set the number of running containers for services, creating missing replicas and

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -49,8 +49,9 @@ Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
 \fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
 \fB\-\-scale\fR \fISERVICE=N\fR (repeatable), \fB\-\-pull\fR \fIpolicy\fR,
-\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-no\-start\fR. Accepts a trailing
-list of services to bring up (with their transitive depends_on).
+\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-wait\fR, \fB\-\-no\-start\fR.
+Accepts a trailing list of services to bring up (with their transitive
+depends_on).
 .TP
 .B scale \fISERVICE=N\fR...
 Set the number of running containers for services, creating missing replicas and

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -47,8 +47,14 @@ given multiple times; later files win. The process environment and a project
 .B up
 Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
-\fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR. Accepts a
-trailing list of services to bring up (with their transitive depends_on).
+\fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
+\fB\-\-scale\fR \fISERVICE=N\fR (repeatable). Accepts a trailing list of services
+to bring up (with their transitive depends_on).
+.TP
+.B scale \fISERVICE=N\fR...
+Set the number of running containers for services, creating missing replicas and
+removing surplus ones. A service publishing a fixed host port cannot scale past
+one replica and the command fails with guidance.
 .TP
 .B down
 Stop and remove containers. \fB\-v\fR/\fB\-\-volumes\fR also removes named

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,6 +63,13 @@ trailing service list. A later `up`/`start` runs the created containers.
 ### `build`
 Build or rebuild service images (optionally only the named services).
 
+### `push`
+Push each service's `image:` to its registry (services without an image are
+skipped). Credentials come from `podman login`. `--ignore-push-failures`
+continues after a failure; `--tls-verify false` allows an insecure/HTTP
+registry (omit it to keep Podman's default verification). Accepts a trailing
+service list.
+
 ### `rm`
 Remove stopped service containers. `-f, --force` stops and removes running ones.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,6 +39,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
 | `--no-build` | Do not build images, even for services with a `build:` section. |
 | `--quiet-pull` | Suppress image-pull progress output. |
+| `--no-start` | Create the containers but do not start them. |
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -113,7 +113,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `images` | List images used by services. |
 | `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
-| `config` | Print the resolved compose file (after substitution, extends, include). |
+| `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates. |
 | `pull` | Pull images for all services. |
 
 ## Generate

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -100,6 +100,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `ps` | List project containers. |
 | `ls` | List podup compose projects on the host. `-a/--all` includes stopped projects, `-q/--quiet` prints names only, `--format table\|json`. Needs no compose file. |
 | `top` | Show running processes of service containers. |
+| `stats` | Live resource usage (CPU, memory, network, block I/O, PIDs) for service containers. `--no-stream` prints one snapshot; a trailing service list narrows it. |
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `images` | List images used by services. |
 | `logs [SERVICE]` | View container output. `-f, --follow` streams new output. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,12 +39,14 @@ Create and start all services (or only the named ones, plus their transitive
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared
-in the compose file.
+in the compose file; `--remove-orphans` also removes containers for services no
+longer in the file.
 
 ### `start` / `stop` / `restart`
 Start existing stopped containers, stop running ones without removing them, or
 restart them. `start`/`stop` accept a trailing service list; `restart [SERVICE]`
-restarts everything or one service.
+restarts everything or one service. `restart --no-deps` skips cascade-restarting
+dependents that declare a `depends_on` restart condition.
 
 ### `scale <SERVICE=N>...`
 Set the number of running containers for one or more services, creating missing

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,6 +36,9 @@ Create and start all services (or only the named ones, plus their transitive
 | `--force-recreate` | Recreate containers even if their config is unchanged. |
 | `--no-deps` | Do not start the `depends_on` services of the named services. |
 | `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. |
+| `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
+| `--no-build` | Do not build images, even for services with a `build:` section. |
+| `--quiet-pull` | Suppress image-pull progress output. |
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -54,6 +54,12 @@ port) — the command fails fast and tells you to drop the host port (`- "80"`, 
 Podman assigns one per replica), front it with a reverse proxy, or stay at one
 replica.
 
+### `create`
+Create the containers for services without starting them (like `up` stopped at
+the create step). `--build` builds images first; `--force-recreate` recreates
+unchanged containers; `--no-recreate` leaves existing ones in place. Accepts a
+trailing service list. A later `up`/`start` runs the created containers.
+
 ### `build`
 Build or rebuild service images (optionally only the named services).
 
@@ -92,6 +98,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | Command | Description |
 |---|---|
 | `ps` | List project containers. |
+| `ls` | List podup compose projects on the host. `-a/--all` includes stopped projects, `-q/--quiet` prints names only, `--format table\|json`. Needs no compose file. |
 | `top` | Show running processes of service containers. |
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `images` | List images used by services. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--no-recreate` | Leave already-running containers in place. |
 | `--force-recreate` | Recreate containers even if their config is unchanged. |
 | `--no-deps` | Do not start the `depends_on` services of the named services. |
+| `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. |
 
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared
@@ -44,6 +45,14 @@ in the compose file.
 Start existing stopped containers, stop running ones without removing them, or
 restart them. `start`/`stop` accept a trailing service list; `restart [SERVICE]`
 restarts everything or one service.
+
+### `scale <SERVICE=N>...`
+Set the number of running containers for one or more services, creating missing
+replicas and removing surplus ones. A service that publishes a **fixed host
+port** cannot be scaled past one replica (only one container can bind a host
+port) — the command fails fast and tells you to drop the host port (`- "80"`, so
+Podman assigns one per replica), front it with a reverse proxy, or stay at one
+replica.
 
 ### `build`
 Build or rebuild service images (optionally only the named services).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -82,7 +82,8 @@ Remove stopped service containers. `-f, --force` stops and removes running ones;
 
 ### `kill`
 Send a signal to service containers. `-s, --signal <SIG>` sets the signal
-(default `SIGKILL`).
+(default `SIGKILL`); `--remove-orphans` then removes containers for services no
+longer in the file.
 
 ### `pause` / `unpause`
 Pause running service containers, or resume paused ones.
@@ -119,7 +120,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `images` | List images used by services. |
 | `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
 | `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates. |
-| `pull` | Pull images for all services. |
+| `pull` | Pull images for all services. `-q/--quiet` suppresses progress output. |
 
 ## Generate
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,6 +39,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
 | `--no-build` | Do not build images, even for services with a `build:` section. |
 | `--quiet-pull` | Suppress image-pull progress output. |
+| `--wait` | Wait until services are running/healthy before returning. |
 | `--no-start` | Create the containers but do not start them. |
 
 ### `down`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,7 +43,8 @@ Create and start all services (or only the named ones, plus their transitive
 ### `down`
 Stop and remove containers. `-v, --volumes` also removes named volumes declared
 in the compose file; `--remove-orphans` also removes containers for services no
-longer in the file.
+longer in the file; `--rmi all|local` also removes the service images (`local`
+only those built from a `build:` section).
 
 ### `start` / `stop` / `restart`
 Start existing stopped containers, stop running ones without removing them, or
@@ -76,7 +77,8 @@ registry (omit it to keep Podman's default verification). Accepts a trailing
 service list.
 
 ### `rm`
-Remove stopped service containers. `-f, --force` stops and removes running ones.
+Remove stopped service containers. `-f, --force` stops and removes running ones;
+`-v, --volumes` also removes anonymous volumes attached to them.
 
 ### `kill`
 Send a signal to service containers. `-s, --signal <SIG>` sets the signal

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,7 +110,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `stats` | Live resource usage (CPU, memory, network, block I/O, PIDs) for service containers. `--no-stream` prints one snapshot; a trailing service list narrows it. |
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `images` | List images used by services. |
-| `logs [SERVICE]` | View container output. `-f, --follow` streams new output. |
+| `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
 | `config` | Print the resolved compose file (after substitution, extends, include). |
 | `pull` | Pull images for all services. |
 

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -159,6 +159,19 @@ pub(crate) enum Commands {
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,
 	},
+	/// Push service images to their registry.
+	Push {
+		/// Continue pushing the remaining services after a failure.
+		#[arg(long)]
+		ignore_push_failures: bool,
+		/// Verify the registry's TLS certificate (set false for an insecure
+		/// or local HTTP registry). Omitted leaves Podman's default (on).
+		#[arg(long)]
+		tls_verify: Option<bool>,
+		/// Push only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
 	/// Build or rebuild service images.
 	Build {
 		/// Do not use cache when building the image.

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -16,6 +16,15 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// Which images `down --rmi` removes.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum RmiScope {
+	/// All images used by the project's services.
+	All,
+	/// Only images without a custom tag (services that build locally).
+	Local,
+}
+
 /// Output rendering for `config`.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum ConfigFormat {
@@ -120,6 +129,9 @@ pub(crate) enum Commands {
 		/// Remove containers for services not defined in the compose file.
 		#[arg(long)]
 		remove_orphans: bool,
+		/// Also remove service images: `all` or `local` (build-section services).
+		#[arg(long, value_enum)]
+		rmi: Option<RmiScope>,
 		/// Seconds to wait for containers to stop before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
@@ -218,6 +230,9 @@ pub(crate) enum Commands {
 		/// Remove even running containers (stop first).
 		#[arg(short, long)]
 		force: bool,
+		/// Also remove anonymous volumes attached to the containers.
+		#[arg(short = 'v', long)]
+		volumes: bool,
 		/// Remove only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -123,6 +123,33 @@ pub(crate) enum Commands {
 		#[arg(value_parser = parse_scale_pair, required = true)]
 		pairs: Vec<(String, u32)>,
 	},
+	/// Create containers for services without starting them.
+	Create {
+		/// Build images before creating containers.
+		#[arg(long)]
+		build: bool,
+		/// Recreate containers even if their configuration is unchanged.
+		#[arg(long)]
+		force_recreate: bool,
+		/// Do not recreate containers that already exist.
+		#[arg(long)]
+		no_recreate: bool,
+		/// Create only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
+	/// List podup compose projects on the host.
+	Ls {
+		/// Show all projects, including stopped ones.
+		#[arg(short, long)]
+		all: bool,
+		/// Only display project names.
+		#[arg(short, long)]
+		quiet: bool,
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+		format: OutputFormat,
+	},
 	/// Build or rebuild service images.
 	Build {
 		/// Do not use cache when building the image.

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -138,6 +138,15 @@ pub(crate) enum Commands {
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
+	/// Display a live stream of container resource usage.
+	Stats {
+		/// Disable streaming; print a single snapshot and exit.
+		#[arg(long)]
+		no_stream: bool,
+		/// Show only these services.
+		#[arg(trailing_var_arg = true)]
+		services: Vec<String>,
+	},
 	/// List podup compose projects on the host.
 	Ls {
 		/// Show all projects, including stopped ones.

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -98,6 +98,15 @@ pub(crate) enum Commands {
 		/// Override the replica count for a service: SERVICE=N (repeatable).
 		#[arg(long, value_parser = parse_scale_pair)]
 		scale: Vec<(String, u32)>,
+		/// Pull policy before starting: always, missing, never.
+		#[arg(long)]
+		pull: Option<String>,
+		/// Do not build images, even for services with a build section.
+		#[arg(long)]
+		no_build: bool,
+		/// Suppress image-pull progress output.
+		#[arg(long)]
+		quiet_pull: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -16,6 +16,16 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// Output rendering for `config`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ConfigFormat {
+	/// YAML (the compose-file format).
+	#[default]
+	Yaml,
+	/// JSON.
+	Json,
+}
+
 #[derive(Parser)]
 #[command(name = "podup", version)]
 pub(crate) struct Cli {
@@ -363,7 +373,17 @@ pub(crate) enum Commands {
 	},
 	/// Print the resolved compose file (after substitution / extends / include).
 	#[command(alias = "convert")]
-	Config,
+	Config {
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = ConfigFormat::Yaml)]
+		format: ConfigFormat,
+		/// Print only the service names, one per line.
+		#[arg(long)]
+		services: bool,
+		/// Only validate the configuration; print nothing.
+		#[arg(short, long)]
+		quiet: bool,
+	},
 	/// Generate declarative artifacts from the compose file.
 	#[command(alias = "gen")]
 	Generate {

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -300,6 +300,18 @@ pub(crate) enum Commands {
 		/// Follow log output.
 		#[arg(short, long)]
 		follow: bool,
+		/// Number of lines to show from the end of the logs (default: all).
+		#[arg(short = 'n', long)]
+		tail: Option<String>,
+		/// Show logs since a timestamp or relative time (e.g. 2024-01-01T00:00:00, 10m).
+		#[arg(long)]
+		since: Option<String>,
+		/// Show logs before a timestamp or relative time.
+		#[arg(long)]
+		until: Option<String>,
+		/// Prefix each line with an RFC3339 timestamp.
+		#[arg(short = 't', long)]
+		timestamps: bool,
 	},
 	/// Execute a command in a running service container.
 	Exec {

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -98,6 +98,9 @@ pub(crate) enum Commands {
 		/// Also remove named volumes declared in the compose file.
 		#[arg(short = 'v', long)]
 		volumes: bool,
+		/// Remove containers for services not defined in the compose file.
+		#[arg(long)]
+		remove_orphans: bool,
 		/// Seconds to wait for containers to stop before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
@@ -352,6 +355,9 @@ pub(crate) enum Commands {
 		/// Seconds to wait for containers to stop before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
+		/// Do not restart dependent services (depends_on with a restart condition).
+		#[arg(long)]
+		no_deps: bool,
 		/// Only restart this service.
 		service: Option<String>,
 	},

--- a/internal/cli.rs
+++ b/internal/cli.rs
@@ -85,6 +85,9 @@ pub(crate) enum Commands {
 		/// Seconds to wait for containers to stop when recreating, before killing them.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
+		/// Override the replica count for a service: SERVICE=N (repeatable).
+		#[arg(long, value_parser = parse_scale_pair)]
+		scale: Vec<(String, u32)>,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]
@@ -113,6 +116,12 @@ pub(crate) enum Commands {
 		/// Stop only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
+	},
+	/// Set the number of running containers for services.
+	Scale {
+		/// Target replica counts: SERVICE=N (one or more).
+		#[arg(value_parser = parse_scale_pair, required = true)]
+		pairs: Vec<(String, u32)>,
 	},
 	/// Build or rebuild service images.
 	Build {
@@ -337,4 +346,43 @@ pub(crate) enum GenerateCommands {
 		#[arg(short, long)]
 		output: Option<PathBuf>,
 	},
+}
+
+/// Parse a `SERVICE=N` scale argument into a `(service, replicas)` pair.
+///
+/// Rejects a missing `=`, an empty service name, a non-numeric count, and `N=0`
+/// (use `down`/`stop` to remove a service, not `scale=0`).
+fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
+	let (service, count) = value
+		.split_once('=')
+		.ok_or_else(|| format!("expected SERVICE=N, got `{value}`"))?;
+	if service.is_empty() {
+		return Err(format!("missing service name in `{value}`"));
+	}
+	let replicas: u32 = count
+		.parse()
+		.map_err(|_| format!("replica count in `{value}` must be a non-negative integer"))?;
+	if replicas == 0 {
+		return Err(format!(
+			"replica count in `{value}` must be at least 1; use `down`/`stop` to remove a service"
+		));
+	}
+	Ok((service.to_string(), replicas))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse_scale_pair;
+
+	#[test]
+	fn parse_scale_pair_accepts_valid() {
+		assert_eq!(parse_scale_pair("web=3"), Ok(("web".to_string(), 3)));
+	}
+
+	#[test]
+	fn parse_scale_pair_rejects_bad_input() {
+		for bad in ["web", "=3", "web=", "web=x", "web=0", "web=-1"] {
+			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
+		}
+	}
 }

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -119,6 +119,9 @@ pub(crate) enum Commands {
 		/// Suppress image-pull progress output.
 		#[arg(long)]
 		quiet_pull: bool,
+		/// Wait until services are running/healthy before returning.
+		#[arg(long)]
+		wait: bool,
 		/// Create containers but do not start them.
 		#[arg(long)]
 		no_start: bool,

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -6,6 +6,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 #[cfg(feature = "completions")]
 use clap_complete::Shell;
 
+mod parse;
+use parse::parse_scale_pair;
+
 /// Output rendering for list commands (`ps`, `images`).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum OutputFormat {
@@ -242,6 +245,9 @@ pub(crate) enum Commands {
 		/// Signal to send (default: SIGKILL).
 		#[arg(short, long, default_value = "SIGKILL")]
 		signal: String,
+		/// Also remove containers for services not in the compose file.
+		#[arg(long)]
+		remove_orphans: bool,
 		/// Signal only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
@@ -381,7 +387,11 @@ pub(crate) enum Commands {
 	},
 	/// Pull images for the named services, or all services if none are given.
 	Pull {
+		/// Suppress image-pull progress output.
+		#[arg(short, long)]
+		quiet: bool,
 		/// Only pull images for these services.
+		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Restart services.
@@ -457,43 +467,4 @@ pub(crate) enum GenerateCommands {
 		#[arg(short, long)]
 		output: Option<PathBuf>,
 	},
-}
-
-/// Parse a `SERVICE=N` scale argument into a `(service, replicas)` pair.
-///
-/// Rejects a missing `=`, an empty service name, a non-numeric count, and `N=0`
-/// (use `down`/`stop` to remove a service, not `scale=0`).
-fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
-	let (service, count) = value
-		.split_once('=')
-		.ok_or_else(|| format!("expected SERVICE=N, got `{value}`"))?;
-	if service.is_empty() {
-		return Err(format!("missing service name in `{value}`"));
-	}
-	let replicas: u32 = count
-		.parse()
-		.map_err(|_| format!("replica count in `{value}` must be a non-negative integer"))?;
-	if replicas == 0 {
-		return Err(format!(
-			"replica count in `{value}` must be at least 1; use `down`/`stop` to remove a service"
-		));
-	}
-	Ok((service.to_string(), replicas))
-}
-
-#[cfg(test)]
-mod tests {
-	use super::parse_scale_pair;
-
-	#[test]
-	fn parse_scale_pair_accepts_valid() {
-		assert_eq!(parse_scale_pair("web=3"), Ok(("web".to_string(), 3)));
-	}
-
-	#[test]
-	fn parse_scale_pair_rejects_bad_input() {
-		for bad in ["web", "=3", "web=", "web=x", "web=0", "web=-1"] {
-			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
-		}
-	}
 }

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -119,6 +119,9 @@ pub(crate) enum Commands {
 		/// Suppress image-pull progress output.
 		#[arg(long)]
 		quiet_pull: bool,
+		/// Create containers but do not start them.
+		#[arg(long)]
+		no_start: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -1,0 +1,40 @@
+//! Argument value parsers for the CLI.
+
+/// Parse a `SERVICE=N` scale argument into a `(service, replicas)` pair.
+///
+/// Rejects a missing `=`, an empty service name, a non-numeric count, and `N=0`
+/// (use `down`/`stop` to remove a service, not `scale=0`).
+pub(crate) fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
+	let (service, count) = value
+		.split_once('=')
+		.ok_or_else(|| format!("expected SERVICE=N, got `{value}`"))?;
+	if service.is_empty() {
+		return Err(format!("missing service name in `{value}`"));
+	}
+	let replicas: u32 = count
+		.parse()
+		.map_err(|_| format!("replica count in `{value}` must be a non-negative integer"))?;
+	if replicas == 0 {
+		return Err(format!(
+			"replica count in `{value}` must be at least 1; use `down`/`stop` to remove a service"
+		));
+	}
+	Ok((service.to_string(), replicas))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse_scale_pair;
+
+	#[test]
+	fn parse_scale_pair_accepts_valid() {
+		assert_eq!(parse_scale_pair("web=3"), Ok(("web".to_string(), 3)));
+	}
+
+	#[test]
+	fn parse_scale_pair_rejects_bad_input() {
+		for bad in ["web", "=3", "web=", "web=x", "web=0", "web=-1"] {
+			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
+		}
+	}
+}

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -7,6 +7,8 @@
 
 mod context;
 mod pull;
+mod push;
+pub use push::PushOptions;
 
 use bytes::Bytes;
 use futures_util::StreamExt;

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -17,9 +17,17 @@ impl Engine {
 			None => return Ok(()),
 		};
 
-		info!("pulling {image}");
+		if self.quiet_pull {
+			debug!("pulling {image}");
+		} else {
+			info!("pulling {image}");
+		}
 
-		let requested = service.pull_policy.as_deref();
+		// `up --pull <policy>` overrides the per-service `pull_policy`.
+		let requested = self
+			.pull_policy_override
+			.as_deref()
+			.or(service.pull_policy.as_deref());
 		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
 			warn!(
 				"unknown pull_policy '{}', defaulting to 'missing'",

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -1,0 +1,97 @@
+//! Image push to a registry (docker compose `push`).
+
+use futures_util::StreamExt;
+use tracing::{info, warn};
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::image::ImagePullProgress;
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::super::Engine;
+
+/// Options for [`Engine::push`], mirroring `docker compose push` (plus a Podman
+/// `--tls-verify` escape hatch for insecure/local registries).
+#[derive(Debug, Clone, Default)]
+pub struct PushOptions {
+	/// Continue with the remaining services after a push fails.
+	pub ignore_failures: bool,
+	/// Override TLS verification of the registry. `None` leaves Podman's default
+	/// (verify on); `Some(false)` allows an insecure/HTTP registry.
+	pub tls_verify: Option<bool>,
+}
+
+impl Engine {
+	/// Push each service's image to its registry. Services without an `image:`
+	/// (build-only or imageless) are skipped. Registry credentials come from
+	/// Podman's auth file (`podman login`), so no auth handling is needed here.
+	pub async fn push(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: PushOptions,
+	) -> Result<()> {
+		for svc in target_services {
+			if !file.services.contains_key(svc) {
+				return Err(ComposeError::ServiceNotFound(svc.clone()));
+			}
+		}
+
+		for (name, service) in &file.services {
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
+				continue;
+			}
+			let Some(image) = service.image.as_deref() else {
+				tracing::debug!("{name}: no image to push, skipping");
+				continue;
+			};
+			if let Err(e) = self.push_image(image, &opts).await {
+				if opts.ignore_failures {
+					warn!("push {image} failed (ignored): {e}");
+				} else {
+					return Err(e);
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Push a single image ref and drain its progress stream, surfacing a
+	/// mid-stream `error` line as a failure.
+	async fn push_image(&self, image: &str, opts: &PushOptions) -> Result<()> {
+		info!("pushing {image}");
+		let mut query = format!("destination={}", urlencoded(image));
+		if let Some(tls) = opts.tls_verify {
+			query.push_str(&format!("&tlsVerify={tls}"));
+		}
+		let path = format!("{API_PREFIX}/images/{}/push?{query}", urlencoded(image));
+
+		let resp = self
+			.client
+			.post_empty_stream(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
+		let mut stream_error: Option<String> = None;
+		while let Some(result) = stream.next().await {
+			match result {
+				Ok(progress) => {
+					if !progress.stream.is_empty() {
+						info!("{}", progress.stream.trim_end());
+					}
+					if !progress.error.is_empty() {
+						stream_error = Some(progress.error.clone());
+					}
+				}
+				Err(e) => stream_error = Some(e.to_string()),
+			}
+		}
+		match stream_error {
+			Some(err) => Err(ComposeError::Build(format!("push {image}: {err}"))),
+			None => {
+				info!("pushed {image}");
+				Ok(())
+			}
+		}
+	}
+}

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -32,6 +32,7 @@ impl Engine {
 		service_name: &str,
 		service: &Service,
 		file: &ComposeFile,
+		start: bool,
 	) -> Result<()> {
 		let derived_image;
 		let image: &str = if let Some(img) = service.image.as_deref() {
@@ -257,14 +258,18 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 
-		let start_path = format!(
-			"{API_PREFIX}/containers/{}/start",
-			urlencoded(container_name)
-		);
-		self.client
-			.post_empty_ok(&start_path)
-			.await
-			.map_err(ComposeError::Podman)?;
+		// `create` (docker compose create) creates the container but leaves it
+		// stopped; `up`/`run`/`watch` start it.
+		if start {
+			let start_path = format!(
+				"{API_PREFIX}/containers/{}/start",
+				urlencoded(container_name)
+			);
+			self.client
+				.post_empty_ok(&start_path)
+				.await
+				.map_err(ComposeError::Podman)?;
+		}
 
 		Ok(())
 	}

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -308,6 +308,12 @@ fn rootless_caveat_warnings(name: &str, service: &Service) -> Vec<String> {
 			rootful systems; the container may fail to start rootless"
 		));
 	}
+	if !service.links.is_empty() {
+		out.push(format!(
+			"service \"{name}\": links has no effect under rootless Podman networking — put the \
+			services on a shared network and reach them by service name instead"
+		));
+	}
 	out
 }
 
@@ -328,16 +334,18 @@ mod tests {
 			oom_kill_disable: Some(true),
 			mem_swappiness: Some(10),
 			cpu_rt_runtime: Some(1000),
+			links: vec!["db".into()],
 			..Service::default()
 		};
 		let warnings = rootless_caveat_warnings("web", &service);
-		assert_eq!(warnings.len(), 4);
+		assert_eq!(warnings.len(), 5);
 		let joined = warnings.join("\n");
 		for needle in [
 			"privileged",
 			"oom_kill_disable",
 			"mem_swappiness",
 			"cpu_rt_runtime",
+			"links",
 		] {
 			assert!(joined.contains(needle), "missing warning for {needle}");
 		}

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -75,11 +75,27 @@ pub(super) fn build_healthcheck(hc: &HealthCheck) -> HealthConfig {
 		ComposeCommand::Shell(s) => vec!["CMD-SHELL".to_string(), s.clone()],
 		ComposeCommand::Exec(v) => v.clone(),
 	});
+	// Apply the compose-spec defaults for any field the user omitted. Podman's
+	// API does NOT default these: a missing `Timeout` is taken as 0s, which makes
+	// every probe fail with "exceeded timeout of 0s" so the container is stuck
+	// `starting`; a missing/zero `Interval` disables the periodic check. Match
+	// docker-compose — interval 30s, timeout 30s, retries 3 (start_period 0).
+	const DEFAULT_NANOS: i64 = 30 * 1_000_000_000;
 	HealthConfig {
 		test,
-		interval: hc.interval.as_deref().and_then(size::parse_duration_nanos),
-		timeout: hc.timeout.as_deref().and_then(size::parse_duration_nanos),
-		retries: hc.retries.map(|r| r as i64),
+		interval: Some(
+			hc.interval
+				.as_deref()
+				.and_then(size::parse_duration_nanos)
+				.unwrap_or(DEFAULT_NANOS),
+		),
+		timeout: Some(
+			hc.timeout
+				.as_deref()
+				.and_then(size::parse_duration_nanos)
+				.unwrap_or(DEFAULT_NANOS),
+		),
+		retries: Some(hc.retries.map(|r| r as i64).unwrap_or(3)),
 		start_period: hc
 			.start_period
 			.as_deref()
@@ -284,5 +300,35 @@ mod tests {
 		let cfg = build_healthcheck(&hc);
 		let test = cfg.test.unwrap();
 		assert_eq!(test[0], "curl");
+	}
+
+	#[test]
+	fn healthcheck_applies_compose_defaults_when_omitted() {
+		// A healthcheck with only a `test` must still get interval/timeout/retries:
+		// Podman treats a missing Timeout as 0s, which makes every probe fail with
+		// "exceeded timeout of 0s" and the container is stuck `starting`.
+		let hc = HealthCheck {
+			test: Some(ComposeCommand::Exec(vec!["true".into()])),
+			..Default::default()
+		};
+		let cfg = build_healthcheck(&hc);
+		assert_eq!(cfg.interval, Some(30 * 1_000_000_000));
+		assert_eq!(cfg.timeout, Some(30 * 1_000_000_000));
+		assert_eq!(cfg.retries, Some(3));
+	}
+
+	#[test]
+	fn healthcheck_honors_explicit_interval_and_timeout() {
+		let hc = HealthCheck {
+			test: Some(ComposeCommand::Exec(vec!["true".into()])),
+			interval: Some("2s".into()),
+			timeout: Some("5s".into()),
+			retries: Some(7),
+			..Default::default()
+		};
+		let cfg = build_healthcheck(&hc);
+		assert_eq!(cfg.interval, Some(2 * 1_000_000_000));
+		assert_eq!(cfg.timeout, Some(5 * 1_000_000_000));
+		assert_eq!(cfg.retries, Some(7));
 	}
 }

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -5,7 +5,7 @@
 //! [`Engine::wait_completed`] polls until the container exits with code 0 (used for
 //! `condition: service_completed_successfully`).
 
-use crate::compose::types::Service;
+use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::{ContainerInspect, ContainerState};
 use crate::libpod::API_PREFIX;
@@ -106,6 +106,24 @@ impl Engine {
 	/// those declared in compose. If the container has no effective healthcheck at
 	/// all (none in the image or compose), it can never report `healthy`, so the
 	/// wait short-circuits as satisfied rather than blocking until timeout.
+	/// Wait until every targeted service's first replica is healthy (`up
+	/// --wait`). A service with no effective healthcheck is treated as ready
+	/// once started. All services when `target_services` is empty.
+	pub async fn wait_services_healthy(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+	) -> Result<()> {
+		for (name, service) in &file.services {
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
+				continue;
+			}
+			let container = self.first_replica_name(name, service);
+			self.wait_healthy(&container, service).await?;
+		}
+		Ok(())
+	}
+
 	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
 		let hc = service.healthcheck.as_ref();
 		let (poll_secs, iterations) = health_poll_plan(

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -13,6 +13,17 @@ use crate::libpod::API_PREFIX;
 impl Engine {
 	/// Restart the named service (or all services). Dependents with a `restart` condition in `depends_on` are also restarted.
 	pub async fn restart(&self, file: &ComposeFile, service_name: Option<&str>) -> Result<()> {
+		self.restart_with_options(file, service_name, false).await
+	}
+
+	/// Restart with options. When `no_deps` is true, dependents with a
+	/// `depends_on` restart condition are NOT cascade-restarted.
+	pub async fn restart_with_options(
+		&self,
+		file: &ComposeFile,
+		service_name: Option<&str>,
+		no_deps: bool,
+	) -> Result<()> {
 		let names: Vec<String> = if let Some(svc) = service_name {
 			if !file.services.contains_key(svc) {
 				return Err(ComposeError::ServiceNotFound(svc.into()));
@@ -41,6 +52,9 @@ impl Engine {
 				info!("restarted {container_name}");
 			}
 
+			if no_deps {
+				continue;
+			}
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
 					for dep_container in self.replica_names(dep_name, dep_service) {

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -280,7 +280,7 @@ impl Engine {
 		// network, which is created here as `{project}_default`.
 		self.create_networks(file).await?;
 
-		self.create_and_start(&run_name, service_name, &run_service, file)
+		self.create_and_start(&run_name, service_name, &run_service, file, true)
 			.await?;
 
 		if detach {

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -167,6 +167,19 @@ impl Engine {
 		target_services: &[String],
 		force: bool,
 	) -> Result<()> {
+		self.rm_with_options(file, target_services, force, false)
+			.await
+	}
+
+	/// Remove stopped service containers. `remove_volumes` (`-v/--volumes`) also
+	/// removes anonymous volumes attached to each container.
+	pub async fn rm_with_options(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		force: bool,
+		remove_volumes: bool,
+	) -> Result<()> {
 		let mut order = crate::compose::resolve_order(file)?;
 		order.reverse();
 		let order = filter_services(file, order, target_services)?;
@@ -176,7 +189,7 @@ impl Engine {
 			for container_name in self.replica_names(name, service) {
 				let force_str = if force { "true" } else { "false" };
 				let path = format!(
-					"{API_PREFIX}/containers/{}?force={force_str}",
+					"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
 					crate::libpod::urlencoded(&container_name),
 				);
 				if let Err(e) = self.client.delete_ok(&path).await {

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -27,20 +27,14 @@ impl Engine {
 
 			for container_name in self.replica_names(name, service) {
 				let grace = self.grace_period_secs(service);
-				let stop_path = format!(
-					"{API_PREFIX}/containers/{}/stop?t={grace}",
-					crate::libpod::urlencoded(&container_name),
-				);
-				if let Err(e) = self.client.post_empty_ok(&stop_path).await {
-					tracing::debug!("stop before restart {container_name}: {e}");
-				}
-
-				let start_path = format!(
-					"{API_PREFIX}/containers/{}/start",
+				// Single atomic restart (no visible stopped window) instead of a
+				// stop+start round-trip.
+				let restart_path = format!(
+					"{API_PREFIX}/containers/{}/restart?t={grace}",
 					crate::libpod::urlencoded(&container_name),
 				);
 				self.client
-					.post_empty_ok(&start_path)
+					.post_empty_ok(&restart_path)
 					.await
 					.map_err(ComposeError::Podman)?;
 
@@ -51,18 +45,11 @@ impl Engine {
 				if dep_service.depends_on.restart_for(name) {
 					for dep_container in self.replica_names(dep_name, dep_service) {
 						let grace = self.grace_period_secs(dep_service);
-						let stop_path = format!(
-							"{API_PREFIX}/containers/{}/stop?t={grace}",
+						let restart_path = format!(
+							"{API_PREFIX}/containers/{}/restart?t={grace}",
 							crate::libpod::urlencoded(&dep_container),
 						);
-						if let Err(e) = self.client.post_empty_ok(&stop_path).await {
-							tracing::debug!("stop before cascade restart {dep_container}: {e}");
-						}
-						let start_path = format!(
-							"{API_PREFIX}/containers/{}/start",
-							crate::libpod::urlencoded(&dep_container),
-						);
-						if let Err(e) = self.client.post_empty_ok(&start_path).await {
+						if let Err(e) = self.client.post_empty_ok(&restart_path).await {
 							tracing::warn!("cascade restart of {dep_name} failed: {e}");
 						} else {
 							info!("cascade-restarted {dep_container} (depends_on.restart)");

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -1,14 +1,15 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
 mod commands;
+mod scale;
 mod targets;
 
 use std::collections::{HashMap, HashSet};
 
 use tracing::info;
 
-use crate::compose::types::{ComposeFile, ServiceCondition};
-use crate::error::Result;
+use crate::compose::types::{ComposeFile, Service, ServiceCondition};
+use crate::error::{ComposeError, Result};
 use crate::libpod::API_PREFIX;
 
 use targets::{expand_targets, filter_services};
@@ -222,15 +223,16 @@ impl Engine {
 			(false, _) => self.pull_image(service).await?,
 		}
 
-		let replicas = service
-			.scale
-			.or(service.deploy.as_ref().and_then(|d| d.replicas))
-			.unwrap_or(1) as usize;
+		let replicas = self.resolve_replicas(name, service);
+		// A scaled service that publishes a fixed host port cannot start: only
+		// one container can bind it. Fail fast with guidance instead of letting
+		// replicas 2..N die mid-up with `address already in use`.
+		check_scale_port_conflict(name, service, replicas)?;
 
 		let new_hash = config_hash(service, file)?;
 
 		for i in 1..=replicas {
-			let container_name = if replicas == 1 {
+			let container_name = if replicas <= 1 {
 				self.container_name(name, service)
 			} else {
 				format!("{}-{i}", self.container_name(name, service))
@@ -303,6 +305,14 @@ impl Engine {
 			}
 		}
 
+		// A prior `up --scale`/`scale` may have created replicas the compose
+		// file's default count no longer names; sweep any remaining project
+		// containers by label so teardown is always complete.
+		let grace = self.stop_timeout.unwrap_or(10);
+		for name in self.list_project_container_names(None).await? {
+			self.stop_and_remove(&name, grace).await;
+		}
+
 		for (key, config) in &file.networks {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
 			if external {
@@ -347,5 +357,75 @@ impl Engine {
 		// them unconditionally — independent of `remove_volumes`.
 		self.remove_internal_secrets(file).await?;
 		Ok(())
+	}
+}
+
+/// Reject a scaled service that publishes a fixed host port: only one container
+/// can bind a given host port, so replicas 2..N would fail at runtime with
+/// `address already in use`. A host port of 0/None is runtime-assigned by
+/// Podman, so such a service scales fine. The compose-spec does not define how
+/// scaling interacts with published ports, so podup fails fast rather than
+/// inventing surprising auto-offset semantics.
+pub(super) fn check_scale_port_conflict(
+	service_name: &str,
+	service: &Service,
+	replicas: usize,
+) -> Result<()> {
+	if replicas <= 1 {
+		return Ok(());
+	}
+	let fixed: Vec<u16> = crate::ports::parse_ports(&service.ports)?
+		.iter()
+		.filter_map(|p| p.host_port)
+		.filter(|&hp| hp != 0)
+		.collect();
+	if fixed.is_empty() {
+		return Ok(());
+	}
+	Err(ComposeError::ScalePortConflict {
+		service: service_name.to_string(),
+		replicas,
+		ports: fixed,
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::check_scale_port_conflict;
+
+	fn service(yaml: &str) -> crate::compose::types::Service {
+		let file = crate::parse_str(yaml).unwrap();
+		file.services.into_iter().next().unwrap().1
+	}
+
+	#[test]
+	fn single_replica_never_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
+	}
+
+	#[test]
+	fn scaled_fixed_host_port_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ScalePortConflict { .. }
+		));
+		assert!(err.to_string().contains("8080"));
+	}
+
+	#[test]
+	fn scaled_random_host_port_is_allowed() {
+		// A container-only port (`"80"`) gets a runtime-assigned host port per
+		// replica, so scaling is fine.
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
+	}
+
+	#[test]
+	fn scaled_no_ports_is_allowed() {
+		let svc = service("services:\n  worker:\n    image: x\n");
+		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -434,4 +434,32 @@ impl Engine {
 		self.remove_internal_secrets(file).await?;
 		Ok(())
 	}
+
+	/// Remove the images used by the project's services (`down --rmi`). With
+	/// `local_only`, only images of services that build locally (a `build:`
+	/// section) are removed — matching `docker compose down --rmi local`.
+	pub async fn remove_service_images(&self, file: &ComposeFile, local_only: bool) -> Result<()> {
+		for (name, service) in &file.services {
+			let builds_locally = service.build.is_some();
+			if local_only && !builds_locally {
+				continue;
+			}
+			let image = match &service.image {
+				Some(img) => img.clone(),
+				// A build-only service's image defaults to `{service}:latest`.
+				None if builds_locally => format!("{name}:latest"),
+				None => continue,
+			};
+			let path = format!(
+				"{API_PREFIX}/images/{}?force=true",
+				crate::libpod::urlencoded(&image),
+			);
+			match self.client.delete_ok(&path).await {
+				Ok(_) => info!("removed image {image}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove image {image}: {e}"),
+			}
+		}
+		Ok(())
+	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -271,8 +271,15 @@ impl Engine {
 			}
 		}
 
-		let policy = service.pull_policy.as_deref().unwrap_or("missing");
-		match (service.build.is_some(), policy) {
+		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
+		// suppresses building even for services with a `build:` section (they fall
+		// back to pulling/using an existing image).
+		let policy = self
+			.pull_policy_override
+			.as_deref()
+			.or(service.pull_policy.as_deref())
+			.unwrap_or("missing");
+		match (service.build.is_some() && !self.no_build, policy) {
 			(true, _) => {
 				self.build_service(name, service, file, &crate::engine::BuildOptions::default())
 					.await?

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -8,8 +8,8 @@ use std::collections::{HashMap, HashSet};
 
 use tracing::info;
 
-use crate::compose::types::{ComposeFile, Service, ServiceCondition};
-use crate::error::{ComposeError, Result};
+use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
 use targets::{expand_targets, filter_services};
@@ -67,6 +67,55 @@ impl Engine {
 		force_recreate: bool,
 		no_deps: bool,
 	) -> Result<()> {
+		self.run_up(
+			file,
+			active_profiles,
+			target_services,
+			no_recreate,
+			force_recreate,
+			no_deps,
+			true,
+		)
+		.await
+	}
+
+	/// Create containers for services without starting them (docker compose
+	/// `create`). Shares the `up` path with `start = false`: images are built/
+	/// pulled and containers created, but never started, and no `depends_on`
+	/// waits or `post_start` hooks run (nothing is running to gate on).
+	#[allow(clippy::too_many_arguments)]
+	pub async fn create_with_options(
+		&self,
+		file: &ComposeFile,
+		active_profiles: &[String],
+		target_services: &[String],
+		no_recreate: bool,
+		force_recreate: bool,
+		no_deps: bool,
+	) -> Result<()> {
+		self.run_up(
+			file,
+			active_profiles,
+			target_services,
+			no_recreate,
+			force_recreate,
+			no_deps,
+			false,
+		)
+		.await
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	async fn run_up(
+		&self,
+		file: &ComposeFile,
+		active_profiles: &[String],
+		target_services: &[String],
+		no_recreate: bool,
+		force_recreate: bool,
+		no_deps: bool,
+		start: bool,
+	) -> Result<()> {
 		async {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
@@ -123,6 +172,7 @@ impl Engine {
 						&existing_hash,
 						no_recreate,
 						force_recreate,
+						start,
 					)
 				});
 				futures_util::future::try_join_all(started).await?;
@@ -150,6 +200,7 @@ impl Engine {
 		existing_hash: &HashMap<String, String>,
 		no_recreate: bool,
 		force_recreate: bool,
+		start: bool,
 	) -> Result<()> {
 		if let Some(set) = target_set {
 			if !set.contains(name) {
@@ -163,7 +214,14 @@ impl Engine {
 			return Ok(());
 		}
 
-		for dep in service.depends_on.service_names() {
+		// `create` (start = false) only builds the containers, so there is nothing
+		// to gate on — skip the `depends_on` readiness waits entirely.
+		for dep in service
+			.depends_on
+			.service_names()
+			.into_iter()
+			.filter(|_| start)
+		{
 			let condition = service.depends_on.condition_for(&dep);
 			// `required: false` makes the dependency optional — a failed wait
 			// must not abort `up`, matching docker-compose v2.
@@ -227,7 +285,7 @@ impl Engine {
 		// A scaled service that publishes a fixed host port cannot start: only
 		// one container can bind it. Fail fast with guidance instead of letting
 		// replicas 2..N die mid-up with `address already in use`.
-		check_scale_port_conflict(name, service, replicas)?;
+		scale::check_scale_port_conflict(name, service, replicas)?;
 
 		let new_hash = config_hash(service, file)?;
 
@@ -240,7 +298,10 @@ impl Engine {
 			if !force_recreate {
 				if no_recreate && present.contains(&container_name) {
 					info!("{container_name} already exists — skipping recreate");
-					self.ensure_started(&container_name).await;
+					// `create` leaves an existing container as-is; `up` ensures it runs.
+					if start {
+						self.ensure_started(&container_name).await;
+					}
 					continue;
 				}
 				// Services with a build section are rebuilt on every up, so
@@ -249,16 +310,24 @@ impl Engine {
 				if service.build.is_none() && existing_hash.get(&container_name) == Some(&new_hash)
 				{
 					info!("{container_name} is up to date — skipping recreate");
-					self.ensure_started(&container_name).await;
+					if start {
+						self.ensure_started(&container_name).await;
+					}
 					continue;
 				}
 			}
-			self.create_and_start(&container_name, name, service, file)
+			self.create_and_start(&container_name, name, service, file, start)
 				.await?;
-			info!("started {container_name}");
+			info!(
+				"{} {container_name}",
+				if start { "started" } else { "created" }
+			);
 
-			for hook in &service.post_start {
-				self.run_lifecycle_hook(&container_name, hook).await?;
+			// `post_start` hooks run inside a running container, so only on `up`.
+			if start {
+				for hook in &service.post_start {
+					self.run_lifecycle_hook(&container_name, hook).await?;
+				}
 			}
 		}
 
@@ -357,75 +426,5 @@ impl Engine {
 		// them unconditionally — independent of `remove_volumes`.
 		self.remove_internal_secrets(file).await?;
 		Ok(())
-	}
-}
-
-/// Reject a scaled service that publishes a fixed host port: only one container
-/// can bind a given host port, so replicas 2..N would fail at runtime with
-/// `address already in use`. A host port of 0/None is runtime-assigned by
-/// Podman, so such a service scales fine. The compose-spec does not define how
-/// scaling interacts with published ports, so podup fails fast rather than
-/// inventing surprising auto-offset semantics.
-pub(super) fn check_scale_port_conflict(
-	service_name: &str,
-	service: &Service,
-	replicas: usize,
-) -> Result<()> {
-	if replicas <= 1 {
-		return Ok(());
-	}
-	let fixed: Vec<u16> = crate::ports::parse_ports(&service.ports)?
-		.iter()
-		.filter_map(|p| p.host_port)
-		.filter(|&hp| hp != 0)
-		.collect();
-	if fixed.is_empty() {
-		return Ok(());
-	}
-	Err(ComposeError::ScalePortConflict {
-		service: service_name.to_string(),
-		replicas,
-		ports: fixed,
-	})
-}
-
-#[cfg(test)]
-mod tests {
-	use super::check_scale_port_conflict;
-
-	fn service(yaml: &str) -> crate::compose::types::Service {
-		let file = crate::parse_str(yaml).unwrap();
-		file.services.into_iter().next().unwrap().1
-	}
-
-	#[test]
-	fn single_replica_never_conflicts() {
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
-		assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
-	}
-
-	#[test]
-	fn scaled_fixed_host_port_conflicts() {
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
-		let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
-		assert!(matches!(
-			err,
-			crate::error::ComposeError::ScalePortConflict { .. }
-		));
-		assert!(err.to_string().contains("8080"));
-	}
-
-	#[test]
-	fn scaled_random_host_port_is_allowed() {
-		// A container-only port (`"80"`) gets a runtime-assigned host port per
-		// replica, so scaling is fine.
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
-		assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
-	}
-
-	#[test]
-	fn scaled_no_ports_is_allowed() {
-		let svc = service("services:\n  worker:\n    image: x\n");
-		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -1,0 +1,111 @@
+//! The `scale` subcommand plus the replica-listing/reconciliation helpers
+//! shared with teardown.
+
+use std::collections::HashSet;
+
+use tracing::info;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::engine::Engine;
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::check_scale_port_conflict;
+
+impl Engine {
+	/// Set the number of running containers for the named services (docker
+	/// `compose scale SERVICE=N`). Creates missing replicas and removes any
+	/// surplus. The `--scale` overrides are already applied to this engine, so
+	/// `resolve_replicas` reports the target count during the up pass.
+	pub async fn scale(&self, file: &ComposeFile, pairs: &[(String, u32)]) -> Result<()> {
+		for (svc, _) in pairs {
+			if !file.services.contains_key(svc) {
+				return Err(ComposeError::ServiceNotFound(svc.clone()));
+			}
+		}
+		// Fail fast on a fixed host port before touching any container.
+		for (svc, target) in pairs {
+			check_scale_port_conflict(svc, &file.services[svc], *target as usize)?;
+		}
+		// Scale up: create only the missing replicas of the named services
+		// (no_recreate keeps existing ones; no_deps leaves dependencies alone).
+		let targets: Vec<String> = pairs.iter().map(|(s, _)| s.clone()).collect();
+		self.up_with_options(file, true, &[], &targets, true, false, true)
+			.await?;
+		// Scale down: remove replicas beyond the target count.
+		for (svc, target) in pairs {
+			self.remove_surplus_replicas(svc, &file.services[svc], *target)
+				.await?;
+		}
+		Ok(())
+	}
+
+	/// Remove the containers of `service_name` whose names fall outside the
+	/// desired `target`-replica set (the scale-down half of reconciliation).
+	async fn remove_surplus_replicas(
+		&self,
+		service_name: &str,
+		service: &Service,
+		target: u32,
+	) -> Result<()> {
+		let base = self.container_name(service_name, service);
+		let desired: HashSet<String> = if target <= 1 {
+			std::iter::once(base).collect()
+		} else {
+			(1..=target).map(|i| format!("{base}-{i}")).collect()
+		};
+		let grace = self.grace_period_secs(service);
+		for name in self
+			.list_project_container_names(Some(service_name))
+			.await?
+		{
+			if !desired.contains(&name) {
+				self.stop_and_remove(&name, grace).await;
+			}
+		}
+		Ok(())
+	}
+
+	/// Stop (best-effort) then force-remove a container by name.
+	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32) {
+		let stop_path = format!(
+			"{API_PREFIX}/containers/{}/stop?t={grace}",
+			urlencoded(name)
+		);
+		let _ = self.client.post_empty_ok(&stop_path).await;
+		let rm_path = format!("{API_PREFIX}/containers/{}?force=true", urlencoded(name));
+		if let Err(e) = self.client.delete_ok(&rm_path).await {
+			tracing::debug!("scale-down rm {name}: {e}");
+		} else {
+			info!("removed {name}");
+		}
+	}
+
+	/// All container names carrying this project's label, optionally narrowed to
+	/// one service via the `podup.service` label. Lets reconciliation find
+	/// scaled replicas that the compose file's default count no longer names.
+	pub(super) async fn list_project_container_names(
+		&self,
+		service: Option<&str>,
+	) -> Result<Vec<String>> {
+		let mut labels = vec![format!("podup.project={}", self.project)];
+		if let Some(svc) = service {
+			labels.push(format!("podup.service={svc}"));
+		}
+		let filters = serde_json::json!({ "label": labels });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		Ok(entries
+			.into_iter()
+			.flat_map(|e| e.names)
+			.map(|raw| raw.trim_start_matches('/').to_string())
+			.collect())
+	}
+}

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -10,7 +10,34 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
-use super::check_scale_port_conflict;
+/// Reject a scaled service that publishes a fixed host port: only one container
+/// can bind a given host port, so replicas 2..N would fail at runtime with
+/// `address already in use`. A host port of 0/None is runtime-assigned by
+/// Podman, so such a service scales fine. The compose-spec does not define how
+/// scaling interacts with published ports, so podup fails fast rather than
+/// inventing surprising auto-offset semantics.
+pub(super) fn check_scale_port_conflict(
+	service_name: &str,
+	service: &Service,
+	replicas: usize,
+) -> Result<()> {
+	if replicas <= 1 {
+		return Ok(());
+	}
+	let fixed: Vec<u16> = crate::ports::parse_ports(&service.ports)?
+		.iter()
+		.filter_map(|p| p.host_port)
+		.filter(|&hp| hp != 0)
+		.collect();
+	if fixed.is_empty() {
+		return Ok(());
+	}
+	Err(ComposeError::ScalePortConflict {
+		service: service_name.to_string(),
+		replicas,
+		ports: fixed,
+	})
+}
 
 impl Engine {
 	/// Set the number of running containers for the named services (docker
@@ -107,5 +134,46 @@ impl Engine {
 			.flat_map(|e| e.names)
 			.map(|raw| raw.trim_start_matches('/').to_string())
 			.collect())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::check_scale_port_conflict;
+
+	fn service(yaml: &str) -> crate::compose::types::Service {
+		let file = crate::parse_str(yaml).unwrap();
+		file.services.into_iter().next().unwrap().1
+	}
+
+	#[test]
+	fn single_replica_never_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
+	}
+
+	#[test]
+	fn scaled_fixed_host_port_conflicts() {
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+		let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ScalePortConflict { .. }
+		));
+		assert!(err.to_string().contains("8080"));
+	}
+
+	#[test]
+	fn scaled_random_host_port_is_allowed() {
+		// A container-only port (`"80"`) gets a runtime-assigned host port per
+		// replica, so scaling is fine.
+		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
+		assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
+	}
+
+	#[test]
+	fn scaled_no_ports_is_allowed() {
+		let svc = service("services:\n  worker:\n    image: x\n");
+		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -47,6 +47,10 @@ pub struct Engine {
 	/// grace; when set it takes precedence over each service's
 	/// `stop_grace_period`. `None` falls back to the per-service value.
 	pub(super) stop_timeout: Option<i32>,
+	/// CLI `--scale SERVICE=N` overrides (from `up --scale` and the `scale`
+	/// subcommand); when a service is present it takes precedence over the
+	/// compose `scale:`/`deploy.replicas` value. Empty falls back to compose.
+	pub(super) scale_overrides: std::collections::HashMap<String, u32>,
 }
 
 impl Engine {
@@ -57,6 +61,7 @@ impl Engine {
 			project,
 			base_dir: std::env::current_dir().unwrap_or_default(),
 			stop_timeout: None,
+			scale_overrides: std::collections::HashMap::new(),
 		}
 	}
 
@@ -67,6 +72,7 @@ impl Engine {
 			project,
 			base_dir,
 			stop_timeout: None,
+			scale_overrides: std::collections::HashMap::new(),
 		}
 	}
 
@@ -74,6 +80,28 @@ impl Engine {
 	pub fn with_stop_timeout(mut self, timeout: Option<i32>) -> Self {
 		self.stop_timeout = timeout;
 		self
+	}
+
+	/// Set the CLI `--scale SERVICE=N` replica overrides. Builder-style.
+	pub fn with_scale_overrides(
+		mut self,
+		overrides: std::collections::HashMap<String, u32>,
+	) -> Self {
+		self.scale_overrides = overrides;
+		self
+	}
+
+	/// Resolve the replica count for a service: a CLI `--scale` override wins,
+	/// else the compose `scale:`, else `deploy.replicas`, else 1. The single
+	/// source of truth so `up`, naming, and teardown never drift.
+	pub(super) fn resolve_replicas(&self, service_name: &str, service: &Service) -> usize {
+		if let Some(&n) = self.scale_overrides.get(service_name) {
+			return n as usize;
+		}
+		service
+			.scale
+			.or(service.deploy.as_ref().and_then(|d| d.replicas))
+			.unwrap_or(1) as usize
 	}
 
 	pub(super) async fn run_lifecycle_hook(
@@ -169,12 +197,9 @@ impl Engine {
 	}
 
 	pub(super) fn replica_names(&self, service_name: &str, service: &Service) -> Vec<String> {
-		let replicas = service
-			.scale
-			.or(service.deploy.as_ref().and_then(|d| d.replicas))
-			.unwrap_or(1) as usize;
+		let replicas = self.resolve_replicas(service_name, service);
 		let base = self.container_name(service_name, service);
-		if replicas == 1 {
+		if replicas <= 1 {
 			vec![base]
 		} else {
 			(1..=replicas).map(|i| format!("{base}-{i}")).collect()
@@ -182,12 +207,9 @@ impl Engine {
 	}
 
 	pub(super) fn first_replica_name(&self, service_name: &str, service: &Service) -> String {
-		let replicas = service
-			.scale
-			.or(service.deploy.as_ref().and_then(|d| d.replicas))
-			.unwrap_or(1) as usize;
+		let replicas = self.resolve_replicas(service_name, service);
 		let base = self.container_name(service_name, service);
-		if replicas == 1 {
+		if replicas <= 1 {
 			base
 		} else {
 			format!("{base}-1")

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -5,7 +5,7 @@
 mod build;
 mod container;
 mod copy;
-pub use build::BuildOptions;
+pub use build::{BuildOptions, PushOptions};
 pub use lifecycle::RunOptions;
 pub use lock::ProjectLock;
 pub use query::{ExecOptions, ImagesOptions, PsOptions};

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -54,6 +54,14 @@ pub struct Engine {
 	/// subcommand); when a service is present it takes precedence over the
 	/// compose `scale:`/`deploy.replicas` value. Empty falls back to compose.
 	pub(super) scale_overrides: std::collections::HashMap<String, u32>,
+	/// CLI `up --pull <policy>` override; takes precedence over each service's
+	/// `pull_policy`. `None` falls back to the per-service value.
+	pub(super) pull_policy_override: Option<String>,
+	/// CLI `up --no-build`: never build images, even for services with a
+	/// `build:` section (they fall back to pulling/using an existing image).
+	pub(super) no_build: bool,
+	/// CLI `up --quiet-pull`: suppress image-pull progress output.
+	pub(super) quiet_pull: bool,
 }
 
 impl Engine {
@@ -65,6 +73,9 @@ impl Engine {
 			base_dir: std::env::current_dir().unwrap_or_default(),
 			stop_timeout: None,
 			scale_overrides: std::collections::HashMap::new(),
+			pull_policy_override: None,
+			no_build: false,
+			quiet_pull: false,
 		}
 	}
 
@@ -76,6 +87,9 @@ impl Engine {
 			base_dir,
 			stop_timeout: None,
 			scale_overrides: std::collections::HashMap::new(),
+			pull_policy_override: None,
+			no_build: false,
+			quiet_pull: false,
 		}
 	}
 
@@ -91,6 +105,20 @@ impl Engine {
 		overrides: std::collections::HashMap<String, u32>,
 	) -> Self {
 		self.scale_overrides = overrides;
+		self
+	}
+
+	/// Set the CLI `up` image-acquisition overrides: `--pull <policy>`,
+	/// `--no-build`, and `--quiet-pull`. Builder-style.
+	pub fn with_up_overrides(
+		mut self,
+		pull_policy: Option<String>,
+		no_build: bool,
+		quiet_pull: bool,
+	) -> Self {
+		self.pull_policy_override = pull_policy;
+		self.no_build = no_build;
+		self.quiet_pull = quiet_pull;
 		self
 	}
 

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -8,7 +8,7 @@ mod copy;
 pub use build::{BuildOptions, PushOptions};
 pub use lifecycle::RunOptions;
 pub use lock::ProjectLock;
-pub use query::{ExecOptions, ImagesOptions, PsOptions};
+pub use query::{ExecOptions, ImagesOptions, LogsOptions, PsOptions};
 mod container_config;
 mod container_fields;
 mod health;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -21,6 +21,7 @@ pub use projects::{list_projects, LsOptions};
 mod query;
 mod secrets;
 mod staging;
+mod stats;
 pub use staging::is_safe_project_name;
 mod volume;
 mod volume_mounts;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -16,6 +16,8 @@ mod lifecycle;
 mod lock;
 mod network;
 mod profiles;
+mod projects;
+pub use projects::{list_projects, LsOptions};
 mod query;
 mod secrets;
 mod staging;

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -1,0 +1,139 @@
+//! `ls` — discover podup-managed compose projects on the host.
+//!
+//! Unlike the other commands this is project-agnostic: it scans every container
+//! carrying a `podup.project` label and groups by project, so it needs only a
+//! [`Client`], not a full [`Engine`] bound to one project/compose file.
+
+use std::collections::BTreeMap;
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::ContainerListEntry;
+use crate::libpod::{urlencoded, Client, API_PREFIX};
+
+/// Options for [`list_projects`] (`docker compose ls`).
+#[derive(Debug, Clone, Default)]
+pub struct LsOptions {
+	/// Include projects whose containers are all stopped.
+	pub all: bool,
+	/// Print only project names.
+	pub quiet: bool,
+	/// Emit a JSON array instead of a table.
+	pub json: bool,
+}
+
+/// Whether a libpod `Status` string denotes a running container. Podman reports
+/// `"running"` (or a human `"Up …"`) for live containers and `"exited"`/`"Exited
+/// …"`/`"created"` otherwise. Pure so it can be unit-tested.
+fn is_running(status: &str) -> bool {
+	let s = status.trim();
+	s.eq_ignore_ascii_case("running") || s.to_ascii_lowercase().starts_with("up")
+}
+
+/// A project's roll-up: running and total replica counts.
+struct Tally {
+	running: usize,
+	total: usize,
+}
+
+/// List podup projects on the host (`docker compose ls`). Groups every
+/// `podup.project`-labelled container by project; by default shows only
+/// projects with at least one running container (`all` includes stopped ones).
+pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
+	let filters = serde_json::json!({ "label": ["podup.project"] });
+	let path = format!(
+		"{API_PREFIX}/containers/json?all=true&filters={}",
+		urlencoded(&filters.to_string()),
+	);
+	let containers = client
+		.get_json::<Vec<ContainerListEntry>>(&path)
+		.await
+		.map_err(ComposeError::Podman)?;
+
+	// Group by the project label, in name order for deterministic output.
+	let mut projects: BTreeMap<String, Tally> = BTreeMap::new();
+	for c in &containers {
+		let Some(project) = c.labels.get("podup.project") else {
+			continue;
+		};
+		let tally = projects.entry(project.clone()).or_insert(Tally {
+			running: 0,
+			total: 0,
+		});
+		tally.total += 1;
+		// Podman's libpod list leaves `Status` empty and uses `State`; accept
+		// either so the roll-up is robust across response shapes.
+		if is_running(&c.state) || is_running(&c.status) {
+			tally.running += 1;
+		}
+	}
+
+	let rows: Vec<(&String, &Tally)> = projects
+		.iter()
+		.filter(|(_, t)| opts.all || t.running > 0)
+		.collect();
+
+	if opts.quiet {
+		for (name, _) in &rows {
+			println!("{name}");
+		}
+		return Ok(());
+	}
+
+	if opts.json {
+		let arr: Vec<_> = rows
+			.iter()
+			.map(|(name, t)| serde_json::json!({ "Name": name, "Status": status_label(t) }))
+			.collect();
+		println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+		return Ok(());
+	}
+
+	println!("{:<32} {:<20}", "NAME", "STATUS");
+	for (name, t) in &rows {
+		println!("{:<32} {:<20}", name, status_label(t));
+	}
+	Ok(())
+}
+
+/// `running(N)` when any replica is up, else `exited(N)` — mirrors the
+/// `docker compose ls` status column.
+fn status_label(t: &Tally) -> String {
+	if t.running > 0 {
+		format!("running({})", t.running)
+	} else {
+		format!("exited({})", t.total)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn is_running_detects_live_statuses() {
+		for up in ["running", "Up 2 minutes", "UP", "up about an hour"] {
+			assert!(is_running(up), "{up} should be running");
+		}
+		for down in ["exited", "Exited (0) 3s ago", "created", "", "stopped"] {
+			assert!(!is_running(down), "{down} should not be running");
+		}
+	}
+
+	#[test]
+	fn status_label_reflects_running_then_total() {
+		assert_eq!(
+			status_label(&Tally {
+				running: 2,
+				total: 3
+			}),
+			"running(2)"
+		);
+		assert_eq!(
+			status_label(&Tally {
+				running: 0,
+				total: 3
+			}),
+			"exited(3)"
+		);
+	}
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -50,6 +50,39 @@ pub struct ImagesOptions {
 	pub json: bool,
 }
 
+/// Options for [`Engine::logs_with_options`], mirroring `docker compose logs`.
+#[derive(Default)]
+pub struct LogsOptions {
+	/// Follow log output, `-f/--follow`.
+	pub follow: bool,
+	/// Number of lines to show from the end, `-n/--tail` (`None` = all).
+	pub tail: Option<String>,
+	/// Show logs since a timestamp/relative time, `--since`.
+	pub since: Option<String>,
+	/// Show logs until a timestamp/relative time, `--until`.
+	pub until: Option<String>,
+	/// Prefix each line with an RFC3339 timestamp, `-t/--timestamps`.
+	pub timestamps: bool,
+}
+
+/// Build the libpod `containers/{}/logs` query string from the options.
+fn log_query(opts: &LogsOptions) -> String {
+	let mut q = format!(
+		"stdout=true&stderr=true&follow={}&timestamps={}",
+		opts.follow, opts.timestamps
+	);
+	if let Some(tail) = &opts.tail {
+		q.push_str(&format!("&tail={}", urlencoded(tail)));
+	}
+	if let Some(since) = &opts.since {
+		q.push_str(&format!("&since={}", urlencoded(since)));
+	}
+	if let Some(until) = &opts.until {
+		q.push_str(&format!("&until={}", urlencoded(until)));
+	}
+	q
+}
+
 impl Engine {
 	/// List running containers for this project as a table (default options).
 	pub async fn ps(&self, file: &ComposeFile) -> Result<()> {
@@ -137,6 +170,27 @@ impl Engine {
 		service_name: Option<&str>,
 		follow: bool,
 	) -> Result<()> {
+		self.logs_with_options(
+			file,
+			service_name,
+			LogsOptions {
+				follow,
+				..Default::default()
+			},
+		)
+		.await
+	}
+
+	/// Stream logs with `docker compose logs` options (`--tail`, `--since`,
+	/// `--until`, `--timestamps`, `--follow`).
+	pub async fn logs_with_options(
+		&self,
+		file: &ComposeFile,
+		service_name: Option<&str>,
+		opts: LogsOptions,
+	) -> Result<()> {
+		let follow = opts.follow;
+		let query = log_query(&opts);
 		// (container_name, is_tty) — TTY containers send raw bytes; non-TTY use
 		// multiplexed 8-byte-header framing.
 		let targets: Vec<(String, bool)> = if let Some(svc) = service_name {
@@ -168,9 +222,10 @@ impl Engine {
 				.into_iter()
 				.map(|(container_name, is_tty)| {
 					let client = &self.client;
+					let query = query.clone();
 					async move {
 						let path = format!(
-							"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
+							"{API_PREFIX}/containers/{}/logs?{query}",
 							urlencoded(&container_name),
 						);
 						let resp = match client.get_stream(&path).await {
@@ -203,9 +258,8 @@ impl Engine {
 		} else {
 			for (container_name, is_tty) in targets {
 				let path = format!(
-					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow={}",
+					"{API_PREFIX}/containers/{}/logs?{query}",
 					urlencoded(&container_name),
-					follow,
 				);
 				let resp = self
 					.client
@@ -405,5 +459,33 @@ impl Engine {
 			}
 		}
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{log_query, LogsOptions};
+
+	#[test]
+	fn log_query_defaults_to_stdout_stderr_no_follow() {
+		let q = log_query(&LogsOptions::default());
+		assert_eq!(q, "stdout=true&stderr=true&follow=false&timestamps=false");
+	}
+
+	#[test]
+	fn log_query_includes_set_options() {
+		let q = log_query(&LogsOptions {
+			follow: true,
+			tail: Some("20".into()),
+			since: Some("10m".into()),
+			until: Some("2024-01-01T00:00:00".into()),
+			timestamps: true,
+		});
+		assert!(q.contains("follow=true"));
+		assert!(q.contains("timestamps=true"));
+		assert!(q.contains("&tail=20"));
+		assert!(q.contains("&since=10m"));
+		// `:` is percent-encoded in the query value.
+		assert!(q.contains("&until=2024-01-01T00%3A00%3A00"));
 	}
 }

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -1,0 +1,200 @@
+//! `stats` — live resource-usage stream for a project's service containers.
+
+use std::collections::{HashMap, HashSet};
+
+use futures_util::StreamExt;
+use serde::Deserialize;
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::{parse_json_lines, API_PREFIX};
+
+use super::Engine;
+
+/// One frame of the libpod `/containers/stats` response.
+#[derive(Deserialize)]
+struct StatsReport {
+	#[serde(rename = "Stats", default)]
+	stats: Vec<ContainerStat>,
+}
+
+/// Per-container resource sample within a [`StatsReport`].
+#[derive(Deserialize, Default)]
+struct ContainerStat {
+	#[serde(rename = "Name", default)]
+	name: String,
+	#[serde(rename = "CPU", default)]
+	cpu: f64,
+	#[serde(rename = "MemUsage", default)]
+	mem_usage: u64,
+	#[serde(rename = "MemLimit", default)]
+	mem_limit: u64,
+	#[serde(rename = "MemPerc", default)]
+	mem_perc: f64,
+	#[serde(rename = "BlockInput", default)]
+	block_in: u64,
+	#[serde(rename = "BlockOutput", default)]
+	block_out: u64,
+	#[serde(rename = "PIDs", default)]
+	pids: u64,
+	#[serde(rename = "Network", default)]
+	network: HashMap<String, NetStat>,
+}
+
+/// Per-interface network counters.
+#[derive(Deserialize, Default)]
+struct NetStat {
+	#[serde(rename = "RxBytes", default)]
+	rx: u64,
+	#[serde(rename = "TxBytes", default)]
+	tx: u64,
+}
+
+/// Render a byte count as a compact human string (`1.5MiB`). Pure for testing.
+fn format_bytes(bytes: u64) -> String {
+	const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+	let mut value = bytes as f64;
+	let mut unit = 0;
+	while value >= 1024.0 && unit < UNITS.len() - 1 {
+		value /= 1024.0;
+		unit += 1;
+	}
+	if unit == 0 {
+		format!("{bytes}B")
+	} else {
+		format!("{value:.1}{}", UNITS[unit])
+	}
+}
+
+/// Format one stats row into the table layout. Pure for testing.
+fn format_row(s: &ContainerStat) -> String {
+	let (rx, tx) = s
+		.network
+		.values()
+		.fold((0u64, 0u64), |(rx, tx), n| (rx + n.rx, tx + n.tx));
+	format!(
+		"{:<32} {:>7.2}% {:>10} / {:<10} {:>6.2}% {:>9} / {:<9} {:>9} / {:<9} {:>5}",
+		s.name,
+		s.cpu,
+		format_bytes(s.mem_usage),
+		format_bytes(s.mem_limit),
+		s.mem_perc,
+		format_bytes(rx),
+		format_bytes(tx),
+		format_bytes(s.block_in),
+		format_bytes(s.block_out),
+		s.pids,
+	)
+}
+
+const HEADER: &str = "NAME                                 CPU %       MEM USAGE / LIMIT        MEM %    NET I/O             BLOCK I/O           PIDS";
+
+impl Engine {
+	/// Stream resource usage for the project's service containers (docker
+	/// `compose stats`). Streams continuously until interrupted; `no_stream`
+	/// prints a single snapshot. `target_services` narrows to specific services.
+	pub async fn stats(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		no_stream: bool,
+	) -> Result<()> {
+		let wanted = self.target_container_names(file, target_services);
+
+		if no_stream {
+			let report: StatsReport = self
+				.client
+				.get_json(&format!("{API_PREFIX}/containers/stats?stream=false"))
+				.await
+				.map_err(ComposeError::Podman)?;
+			print_frame(&report, &wanted);
+			return Ok(());
+		}
+
+		let resp = self
+			.client
+			.get_stream(&format!("{API_PREFIX}/containers/stats?stream=true"))
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
+		while let Some(frame) = frames.next().await {
+			match frame {
+				Ok(report) => print_frame(&report, &wanted),
+				Err(e) => {
+					tracing::debug!("stats stream ended: {e}");
+					break;
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// The set of container names to report on: every replica of the targeted
+	/// services (all services when `target_services` is empty).
+	fn target_container_names(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+	) -> HashSet<String> {
+		file.services
+			.iter()
+			.filter(|(name, _)| {
+				target_services.is_empty() || target_services.iter().any(|t| t == *name)
+			})
+			.flat_map(|(name, service)| self.replica_names(name, service))
+			.collect()
+	}
+}
+
+/// Print one stats frame: a header plus a row per wanted container (sorted for
+/// stable output). Frames are separated by a blank line.
+fn print_frame(report: &StatsReport, wanted: &HashSet<String>) {
+	let mut rows: Vec<&ContainerStat> = report
+		.stats
+		.iter()
+		.filter(|s| wanted.contains(&s.name))
+		.collect();
+	rows.sort_by(|a, b| a.name.cmp(&b.name));
+
+	println!("{HEADER}");
+	for s in rows {
+		println!("{}", format_row(s));
+	}
+	println!();
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn format_bytes_scales_units() {
+		assert_eq!(format_bytes(512), "512B");
+		assert_eq!(format_bytes(1024), "1.0KiB");
+		assert_eq!(format_bytes(1536), "1.5KiB");
+		assert_eq!(format_bytes(1024 * 1024), "1.0MiB");
+		assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.0GiB");
+	}
+
+	#[test]
+	fn format_row_sums_network_and_shows_name() {
+		let mut network = HashMap::new();
+		network.insert("eth0".to_string(), NetStat { rx: 1024, tx: 2048 });
+		let s = ContainerStat {
+			name: "proj-web".into(),
+			cpu: 12.5,
+			mem_usage: 1024 * 1024,
+			mem_limit: 1024 * 1024 * 1024,
+			mem_perc: 0.1,
+			block_in: 0,
+			block_out: 0,
+			pids: 3,
+			network,
+		};
+		let row = format_row(&s);
+		assert!(row.contains("proj-web"));
+		assert!(row.contains("12.50%"));
+		assert!(row.contains("1.0MiB"));
+		assert!(row.contains('3'));
+	}
+}

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -270,19 +270,13 @@ impl Engine {
 
 	async fn watch_restart(&self, container_name: &str) -> Result<()> {
 		info!("restarting {container_name}");
-		let stop_path = format!(
-			"{API_PREFIX}/containers/{}/stop?t=5",
-			urlencoded(container_name)
-		);
-		if let Err(e) = self.client.post_empty_ok(&stop_path).await {
-			tracing::debug!("stop before watch restart {container_name}: {e}");
-		}
-		let start_path = format!(
-			"{API_PREFIX}/containers/{}/start",
+		// Single atomic restart (no visible stopped window) instead of stop+start.
+		let restart_path = format!(
+			"{API_PREFIX}/containers/{}/restart?t=5",
 			urlencoded(container_name)
 		);
 		self.client
-			.post_empty_ok(&start_path)
+			.post_empty_ok(&restart_path)
 			.await
 			.map_err(ComposeError::Podman)?;
 		Ok(())

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -264,7 +264,7 @@ impl Engine {
 		)
 		.await?;
 		let container_name = self.container_name(service_name, service);
-		self.create_and_start(&container_name, service_name, service, file)
+		self.create_and_start(&container_name, service_name, service, file, true)
 			.await
 	}
 

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -49,6 +49,13 @@ pub enum ComposeError {
 	Update(String),
 	/// An `external: true` secret/config/network/volume is absent.
 	ExternalNotFound(String),
+	/// A service is scaled to more than one replica but publishes a fixed host
+	/// port, which only one container can bind.
+	ScalePortConflict {
+		service: String,
+		replicas: usize,
+		ports: Vec<u16>,
+	},
 }
 
 impl fmt::Display for ComposeError {
@@ -74,6 +81,25 @@ impl fmt::Display for ComposeError {
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
 			Self::Update(s) => write!(f, "update error: {s}"),
 			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
+			Self::ScalePortConflict {
+				service,
+				replicas,
+				ports,
+			} => {
+				let ports = ports
+					.iter()
+					.map(u16::to_string)
+					.collect::<Vec<_>>()
+					.join(", ");
+				write!(
+					f,
+					"service '{service}' publishes fixed host port(s) [{ports}] but is scaled to \
+					 {replicas} replicas; only one container can bind a host port. Use one of:\n  \
+					 - remove the host port (e.g. `- \"80\"`) so Podman assigns a random one per \
+					 replica\n  - put the service behind a reverse proxy and publish only the \
+					 proxy's port\n  - reduce the service to a single replica"
+				)
+			}
 		}
 	}
 }
@@ -169,6 +195,14 @@ mod tests {
 			(
 				"external resource not found: external volume \"v\" does not exist",
 				ComposeError::ExternalNotFound("external volume \"v\" does not exist".into()),
+			),
+			(
+				"service 'web' publishes fixed host port(s) [8080] but is scaled to 3 replicas",
+				ComposeError::ScalePortConflict {
+					service: "web".into(),
+					replicas: 3,
+					ports: vec![8080],
+				},
 			),
 		];
 		for (expected_prefix, err) in cases {

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -1,0 +1,88 @@
+//! The `generate quadlet` command: turn the compose file into Quadlet units and
+//! either write them to a directory or print them to stdout.
+
+use std::path::Path;
+
+/// Quadlet units are systemd unit files; they only run on Linux hosts (where
+/// systemd consumes them from `~/.config/containers/systemd/`). Generating them
+/// on macOS/Windows is legitimate (e.g. to deploy to a remote Linux host), so
+/// this returns an advisory string rather than blocking. `os` is
+/// [`std::env::consts::OS`]; the function is pure so every platform's branch is
+/// testable in a single run.
+fn quadlet_platform_advisory(os: &str) -> Option<String> {
+	(os != "linux").then(|| {
+		"quadlet units require systemd (Linux); generated files will not run on this host"
+			.to_string()
+	})
+}
+
+/// Generate Quadlet units from the compose file and either write them to a
+/// directory or print them to stdout. Warnings about unmapped fields go to
+/// stderr so stdout stays clean for piping.
+pub(crate) fn write_quadlet(
+	file: &podup::compose::types::ComposeFile,
+	project: &str,
+	output: Option<&Path>,
+) -> podup::Result<()> {
+	let result = podup::quadlet::generate(file, project);
+	if let Some(dup) = result.duplicate_filename() {
+		return Err(std::io::Error::new(
+			std::io::ErrorKind::InvalidInput,
+			format!(
+				"quadlet: two resources map to the same unit file {dup:?}; \
+				 rename one so their names do not collide after sanitization"
+			),
+		)
+		.into());
+	}
+	if let Some(advisory) = quadlet_platform_advisory(std::env::consts::OS) {
+		eprintln!("podup: warning: {advisory}");
+	}
+	for warning in &result.warnings {
+		eprintln!("podup: warning: {warning}");
+	}
+	match output {
+		Some(dir) => {
+			std::fs::create_dir_all(dir)?;
+			for unit in &result.units {
+				// Defense in depth: the unit stem is already sanitized in the
+				// library, but never write a unit whose name is anything but a
+				// plain file inside `dir` (rejects separators, `.` and `..`).
+				if Path::new(&unit.filename).file_name()
+					!= Some(std::ffi::OsStr::new(&unit.filename))
+				{
+					return Err(std::io::Error::new(
+						std::io::ErrorKind::InvalidInput,
+						format!("refusing unsafe quadlet unit file name: {}", unit.filename),
+					)
+					.into());
+				}
+				let path = dir.join(&unit.filename);
+				std::fs::write(&path, &unit.contents)?;
+				println!("wrote {}", path.display());
+			}
+		}
+		None => {
+			for unit in &result.units {
+				println!("# {}", unit.filename);
+				print!("{}", unit.contents);
+				println!();
+			}
+		}
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::quadlet_platform_advisory;
+
+	#[test]
+	fn quadlet_advisory_only_on_non_linux() {
+		assert_eq!(quadlet_platform_advisory("linux"), None);
+		for os in ["macos", "windows", "freebsd"] {
+			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
+			assert!(msg.contains("systemd"), "advisory names the requirement");
+		}
+	}
+}

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -30,7 +30,7 @@ pub use compose::{
 };
 pub use engine::{
 	is_safe_project_name, list_projects, BuildOptions, Engine, ExecOptions, ImagesOptions,
-	LsOptions, ProjectLock, PsOptions, RunOptions,
+	LsOptions, ProjectLock, PsOptions, PushOptions, RunOptions,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -30,7 +30,7 @@ pub use compose::{
 };
 pub use engine::{
 	is_safe_project_name, list_projects, BuildOptions, Engine, ExecOptions, ImagesOptions,
-	LsOptions, ProjectLock, PsOptions, PushOptions, RunOptions,
+	LogsOptions, LsOptions, ProjectLock, PsOptions, PushOptions, RunOptions,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -29,8 +29,8 @@ pub use compose::{
 	parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
 pub use engine::{
-	is_safe_project_name, BuildOptions, Engine, ExecOptions, ImagesOptions, ProjectLock, PsOptions,
-	RunOptions,
+	is_safe_project_name, list_projects, BuildOptions, Engine, ExecOptions, ImagesOptions,
+	LsOptions, ProjectLock, PsOptions, RunOptions,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -31,6 +31,11 @@ pub struct ContainerListEntry {
 	#[serde(rename = "Status", default)]
 	pub status: String,
 
+	/// Machine-readable state (`running`, `exited`, `created`, …). Podman's
+	/// libpod list response leaves `Status` empty and reports the state here.
+	#[serde(rename = "State", default)]
+	pub state: String,
+
 	#[serde(rename = "Ports", default, deserialize_with = "null_default")]
 	pub ports: Vec<ContainerPort>,
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -129,11 +129,33 @@ async fn run() -> podup::Result<()> {
 	let compose_files = resolve_compose_files(&cli.file);
 	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
 
-	if matches!(cli.command, Commands::Config) {
+	if let Commands::Config {
+		format,
+		services,
+		quiet,
+	} = &cli.command
+	{
+		// Reaching here means the file parsed and merged cleanly.
+		if *quiet {
+			return Ok(());
+		}
+		if *services {
+			for name in file.services.keys() {
+				println!("{name}");
+			}
+			return Ok(());
+		}
 		let mut redacted = file.clone();
 		redacted.redact_inline_content();
-		let yaml = serde_yaml::to_string(&redacted).map_err(podup::ComposeError::Parse)?;
-		println!("{yaml}");
+		let rendered = match format {
+			ConfigFormat::Json => serde_json::to_string_pretty(&redacted).map_err(|e| {
+				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
+			})?,
+			ConfigFormat::Yaml => {
+				serde_yaml::to_string(&redacted).map_err(podup::ComposeError::Parse)?
+			}
+		};
+		println!("{rendered}");
 		return Ok(());
 	}
 
@@ -422,7 +444,7 @@ async fn run() -> podup::Result<()> {
 				.restart_with_options(&file, service.as_deref(), no_deps)
 				.await?
 		}
-		Commands::Config => unreachable!("handled above"),
+		Commands::Config { .. } => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
 		Commands::Ls { .. } => unreachable!("handled before compose parsing"),

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -89,8 +89,7 @@ fn is_mutating(command: &Commands) -> bool {
 	)
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
 	// Replace the default panic output (a raw Rust backtrace) with a `podup:`
 	// internal-error notice that tells the user what to report and where, plus
 	// the reminder to redact secrets first.
@@ -99,7 +98,27 @@ async fn main() {
 		eprintln!("{}", internal_error_notice());
 	}));
 
-	match run().await {
+	// Drive the runtime on a worker thread with a large stack. Clap's
+	// command-building (debug builds especially) is stack-heavy and overflows
+	// Windows' 1 MiB main-thread stack as the subcommand surface grows; an 8 MiB
+	// matches Linux's default and leaves ample headroom.
+	std::thread::Builder::new()
+		.stack_size(8 * 1024 * 1024)
+		.name("podup".into())
+		.spawn(run_to_exit)
+		.expect("spawn podup worker thread")
+		.join()
+		.expect("podup worker thread panicked");
+}
+
+/// Build the Tokio runtime and drive [`run`], mapping its result onto the
+/// process exit status. Runs on the large-stack worker thread spawned by `main`.
+fn run_to_exit() {
+	let runtime = tokio::runtime::Builder::new_multi_thread()
+		.enable_all()
+		.build()
+		.expect("build Tokio runtime");
+	match runtime.block_on(run()) {
 		Ok(()) => {}
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
 		#[cfg(feature = "update")]
@@ -375,6 +394,10 @@ async fn run() -> podup::Result<()> {
 				.await?
 		}
 		Commands::Top { services } => engine.top(&file, &services).await?,
+		Commands::Stats {
+			no_stream,
+			services,
+		} => engine.stats(&file, &services, no_stream).await?,
 		Commands::Port {
 			service,
 			private_port,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -208,6 +208,7 @@ async fn run() -> podup::Result<()> {
 			quiet_pull,
 			..
 		} => (pull.clone(), *no_build, *quiet_pull),
+		Commands::Pull { quiet, .. } => (None, false, *quiet),
 		_ => (None, false, false),
 	};
 	let engine = podup::Engine::with_base_dir(client, project, base_dir)
@@ -336,7 +337,16 @@ async fn run() -> podup::Result<()> {
 				.rm_with_options(&file, &services, force, volumes)
 				.await?
 		}
-		Commands::Kill { signal, services } => engine.kill(&file, &services, &signal).await?,
+		Commands::Kill {
+			signal,
+			remove_orphans,
+			services,
+		} => {
+			engine.kill(&file, &services, &signal).await?;
+			if remove_orphans {
+				engine.remove_orphans(&file).await?;
+			}
+		}
 		Commands::Pause { services } => engine.pause(&file, &services).await?,
 		Commands::Unpause { services } => engine.unpause(&file, &services).await?,
 		Commands::Run {
@@ -462,7 +472,7 @@ async fn run() -> podup::Result<()> {
 				)
 				.await?
 		}
-		Commands::Pull { services } => engine.pull_services(&file, &services).await?,
+		Commands::Pull { quiet: _, services } => engine.pull_services(&file, &services).await?,
 		Commands::Restart {
 			service,
 			timeout: _,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -268,12 +268,18 @@ async fn run() -> podup::Result<()> {
 		Commands::Down {
 			volumes,
 			remove_orphans,
+			rmi,
 			timeout: _,
 		} => {
 			if remove_orphans {
 				engine.remove_orphans(&file).await?;
 			}
-			engine.down_with_options(&file, volumes).await?
+			engine.down_with_options(&file, volumes).await?;
+			if let Some(scope) = rmi {
+				engine
+					.remove_service_images(&file, scope == RmiScope::Local)
+					.await?;
+			}
 		}
 		Commands::Start { services } => engine.start(&file, &services).await?,
 		Commands::Stop {
@@ -321,7 +327,15 @@ async fn run() -> podup::Result<()> {
 				)
 				.await?
 		}
-		Commands::Rm { force, services } => engine.rm(&file, &services, force).await?,
+		Commands::Rm {
+			force,
+			volumes,
+			services,
+		} => {
+			engine
+				.rm_with_options(&file, &services, force, volumes)
+				.await?
+		}
 		Commands::Kill { signal, services } => engine.kill(&file, &services, &signal).await?,
 		Commands::Pause { services } => engine.pause(&file, &services).await?,
 		Commands::Unpause { services } => engine.unpause(&file, &services).await?,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -3,7 +3,6 @@
 // The binary carries no `unsafe`; deny it so any future addition is caught.
 #![deny(unsafe_code)]
 
-use std::path::Path;
 use std::process;
 
 #[cfg(feature = "completions")]
@@ -16,9 +15,11 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
 mod cli;
+mod generate;
 mod resolve;
 
 use cli::*;
+use generate::write_quadlet;
 use resolve::*;
 
 /// Canonical project URL, reused for the bug-report hint on internal errors.
@@ -83,77 +84,8 @@ fn is_mutating(command: &Commands) -> bool {
 			| Commands::Unpause { .. }
 			| Commands::Run { .. }
 			| Commands::Restart { .. }
+			| Commands::Scale { .. }
 	)
-}
-
-/// Quadlet units are systemd unit files; they only run on Linux hosts (where
-/// systemd consumes them from `~/.config/containers/systemd/`). Generating them
-/// on macOS/Windows is legitimate (e.g. to deploy to a remote Linux host), so
-/// this returns an advisory string rather than blocking. `os` is
-/// [`std::env::consts::OS`]; the function is pure so every platform's branch is
-/// testable in a single run.
-fn quadlet_platform_advisory(os: &str) -> Option<String> {
-	(os != "linux").then(|| {
-		"quadlet units require systemd (Linux); generated files will not run on this host"
-			.to_string()
-	})
-}
-
-/// Generate Quadlet units from the compose file and either write them to a
-/// directory or print them to stdout. Warnings about unmapped fields go to
-/// stderr so stdout stays clean for piping.
-fn write_quadlet(
-	file: &podup::compose::types::ComposeFile,
-	project: &str,
-	output: Option<&Path>,
-) -> podup::Result<()> {
-	let result = podup::quadlet::generate(file, project);
-	if let Some(dup) = result.duplicate_filename() {
-		return Err(std::io::Error::new(
-			std::io::ErrorKind::InvalidInput,
-			format!(
-				"quadlet: two resources map to the same unit file {dup:?}; \
-				 rename one so their names do not collide after sanitization"
-			),
-		)
-		.into());
-	}
-	if let Some(advisory) = quadlet_platform_advisory(std::env::consts::OS) {
-		eprintln!("podup: warning: {advisory}");
-	}
-	for warning in &result.warnings {
-		eprintln!("podup: warning: {warning}");
-	}
-	match output {
-		Some(dir) => {
-			std::fs::create_dir_all(dir)?;
-			for unit in &result.units {
-				// Defense in depth: the unit stem is already sanitized in the
-				// library, but never write a unit whose name is anything but a
-				// plain file inside `dir` (rejects separators, `.` and `..`).
-				if Path::new(&unit.filename).file_name()
-					!= Some(std::ffi::OsStr::new(&unit.filename))
-				{
-					return Err(std::io::Error::new(
-						std::io::ErrorKind::InvalidInput,
-						format!("refusing unsafe quadlet unit file name: {}", unit.filename),
-					)
-					.into());
-				}
-				let path = dir.join(&unit.filename);
-				std::fs::write(&path, &unit.contents)?;
-				println!("wrote {}", path.display());
-			}
-		}
-		None => {
-			for unit in &result.units {
-				println!("# {}", unit.filename);
-				print!("{}", unit.contents);
-				println!();
-			}
-		}
-	}
-	Ok(())
 }
 
 #[tokio::main]
@@ -277,8 +209,16 @@ async fn run() -> podup::Result<()> {
 		| Commands::Restart { timeout, .. } => *timeout,
 		_ => None,
 	};
-	let engine =
-		podup::Engine::with_base_dir(client, project, base_dir).with_stop_timeout(stop_timeout);
+	// `--scale SERVICE=N` (on `up`) and the `scale` subcommand both feed the
+	// engine's replica overrides so `resolve_replicas` reports the target count.
+	let scale_overrides: std::collections::HashMap<String, u32> = match &cli.command {
+		Commands::Up { scale, .. } => scale.iter().cloned().collect(),
+		Commands::Scale { pairs } => pairs.iter().cloned().collect(),
+		_ => std::collections::HashMap::new(),
+	};
+	let engine = podup::Engine::with_base_dir(client, project, base_dir)
+		.with_stop_timeout(stop_timeout)
+		.with_scale_overrides(scale_overrides);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,
@@ -300,6 +240,7 @@ async fn run() -> podup::Result<()> {
 			force_recreate,
 			no_deps,
 			timeout: _,
+			scale: _,
 			services,
 		} => {
 			if remove_orphans {
@@ -335,6 +276,7 @@ async fn run() -> podup::Result<()> {
 			services,
 			timeout: _,
 		} => engine.stop(&file, &services).await?,
+		Commands::Scale { pairs } => engine.scale(&file, &pairs).await?,
 		Commands::Build {
 			no_cache,
 			pull,
@@ -463,15 +405,6 @@ async fn run() -> podup::Result<()> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	#[test]
-	fn quadlet_advisory_only_on_non_linux() {
-		assert_eq!(quadlet_platform_advisory("linux"), None);
-		for os in ["macos", "windows", "freebsd"] {
-			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
-			assert!(msg.contains("systemd"), "advisory names the requirement");
-		}
-	}
 
 	#[test]
 	fn level_words_match_user_facing_terms() {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -85,6 +85,7 @@ fn is_mutating(command: &Commands) -> bool {
 			| Commands::Run { .. }
 			| Commands::Restart { .. }
 			| Commands::Scale { .. }
+			| Commands::Create { .. }
 	)
 }
 
@@ -162,6 +163,21 @@ async fn run() -> podup::Result<()> {
 		return tokio::task::spawn_blocking(move || podup::update::run(opts))
 			.await
 			.map_err(|e| podup::ComposeError::Update(format!("update task failed: {e}")))?;
+	}
+
+	// `ls` discovers projects across the host by container label; it needs a
+	// Podman connection but no compose file, so handle it before parsing one.
+	if let Commands::Ls { all, quiet, format } = &cli.command {
+		let client = podup::podman::connect(cli.socket.as_deref())?;
+		return podup::list_projects(
+			&client,
+			podup::LsOptions {
+				all: *all,
+				quiet: *quiet,
+				json: *format == OutputFormat::Json,
+			},
+		)
+		.await;
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
@@ -277,6 +293,26 @@ async fn run() -> podup::Result<()> {
 			timeout: _,
 		} => engine.stop(&file, &services).await?,
 		Commands::Scale { pairs } => engine.scale(&file, &pairs).await?,
+		Commands::Create {
+			build,
+			force_recreate,
+			no_recreate,
+			services,
+		} => {
+			if build {
+				engine.build_all(&file, &services).await?;
+			}
+			engine
+				.create_with_options(
+					&file,
+					&cli.profile,
+					&services,
+					no_recreate,
+					force_recreate,
+					false,
+				)
+				.await?
+		}
 		Commands::Build {
 			no_cache,
 			pull,
@@ -393,6 +429,7 @@ async fn run() -> podup::Result<()> {
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,
+		Commands::Ls { .. } => unreachable!("handled before compose parsing"),
 		#[cfg(feature = "update")]
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),
 		#[cfg(feature = "completions")]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -219,6 +219,7 @@ async fn run() -> podup::Result<()> {
 			pull: _,
 			no_build: _,
 			quiet_pull: _,
+			wait,
 			no_start,
 			services,
 		} => {
@@ -254,6 +255,9 @@ async fn run() -> podup::Result<()> {
 					no_deps,
 				)
 				.await?;
+			if wait {
+				engine.wait_services_healthy(&file, &services).await?;
+			}
 			if watch {
 				engine.watch(&file).await?;
 			} else if !detach {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -357,8 +357,27 @@ async fn run() -> podup::Result<()> {
 				)
 				.await?
 		}
-		Commands::Logs { service, follow } => {
-			engine.logs(&file, service.as_deref(), follow).await?
+		Commands::Logs {
+			service,
+			follow,
+			tail,
+			since,
+			until,
+			timestamps,
+		} => {
+			engine
+				.logs_with_options(
+					&file,
+					service.as_deref(),
+					podup::LogsOptions {
+						follow,
+						tail,
+						since,
+						until,
+						timestamps,
+					},
+				)
+				.await?
 		}
 		Commands::Exec {
 			env,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -200,9 +200,20 @@ async fn run() -> podup::Result<()> {
 		Commands::Scale { pairs } => pairs.iter().cloned().collect(),
 		_ => std::collections::HashMap::new(),
 	};
+	// `up` image-acquisition overrides: `--pull`, `--no-build`, `--quiet-pull`.
+	let (pull_override, no_build, quiet_pull) = match &cli.command {
+		Commands::Up {
+			pull,
+			no_build,
+			quiet_pull,
+			..
+		} => (pull.clone(), *no_build, *quiet_pull),
+		_ => (None, false, false),
+	};
 	let engine = podup::Engine::with_base_dir(client, project, base_dir)
 		.with_stop_timeout(stop_timeout)
-		.with_scale_overrides(scale_overrides);
+		.with_scale_overrides(scale_overrides)
+		.with_up_overrides(pull_override, no_build, quiet_pull);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,
@@ -225,6 +236,9 @@ async fn run() -> podup::Result<()> {
 			no_deps,
 			timeout: _,
 			scale: _,
+			pull: _,
+			no_build: _,
+			quiet_pull: _,
 			services,
 		} => {
 			if remove_orphans {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -7,66 +7,16 @@ use std::process;
 
 #[cfg(feature = "completions")]
 use clap::CommandFactory;
-use clap::Parser;
-use tracing::{Event, Subscriber};
-use tracing_subscriber::fmt::format::Writer;
-use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
-use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::EnvFilter;
 
 mod cli;
 mod generate;
 mod resolve;
+mod startup;
 
 use cli::*;
 use generate::write_quadlet;
 use resolve::*;
-
-/// Canonical project URL, reused for the bug-report hint on internal errors.
-const REPO_URL: &str = "https://github.com/Glyndor/podup";
-
-/// Event formatter that renders every diagnostic as `podup: <level>: <message>`
-/// on a single line, matching the prefix used by the CLI's own `eprintln!`
-/// warnings and errors. This unifies the compose forward-compat diagnostics
-/// (emitted via `tracing::warn!`) with the rest of podup's user-facing output.
-struct PodupFormat;
-
-impl<S, N> FormatEvent<S, N> for PodupFormat
-where
-	S: Subscriber + for<'a> LookupSpan<'a>,
-	N: for<'a> FormatFields<'a> + 'static,
-{
-	fn format_event(
-		&self,
-		ctx: &FmtContext<'_, S, N>,
-		mut writer: Writer<'_>,
-		event: &Event<'_>,
-	) -> std::fmt::Result {
-		write!(writer, "podup: {}: ", level_word(*event.metadata().level()))?;
-		ctx.field_format().format_fields(writer.by_ref(), event)?;
-		writeln!(writer)
-	}
-}
-
-/// Map a tracing level to the user-facing word used in `podup:` output.
-fn level_word(level: tracing::Level) -> &'static str {
-	match level {
-		tracing::Level::ERROR => "error",
-		tracing::Level::WARN => "warning",
-		tracing::Level::INFO => "info",
-		tracing::Level::DEBUG => "debug",
-		tracing::Level::TRACE => "trace",
-	}
-}
-
-/// Guidance printed after an internal error or panic: where to report it and a
-/// reminder to scrub secrets first. Kept off ordinary, user-correctable errors.
-fn internal_error_notice() -> String {
-	format!(
-		"podup: this looks like a bug; re-run with RUST_LOG=debug and report it at {REPO_URL}/issues\n\
-		 podup: redact secrets (passwords, tokens, resolved env values) from any logs before sharing"
-	)
-}
+use startup::{init_tracing, internal_error_notice, parse_cli};
 
 /// Whether a command creates, destroys, or changes the state of containers and
 /// so must hold the exclusive project lock.
@@ -134,31 +84,8 @@ fn run_to_exit() {
 }
 
 async fn run() -> podup::Result<()> {
-	// Surface diagnostics by default: with no `RUST_LOG` set, show warnings (so
-	// the forward-compat "unknown field" notices are never silently dropped),
-	// and write them to stderr so a command's stdout stays a clean pipe.
-	tracing_subscriber::fmt()
-		.with_env_filter(
-			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
-		)
-		.with_writer(std::io::stderr)
-		.event_format(PodupFormat)
-		.init();
-
-	// Frame `--help`/`--version` output with a blank line top and bottom. clap
-	// trims template/before/after-help edges, so wrap the rendered text here.
-	let cli = match Cli::try_parse() {
-		Ok(cli) => cli,
-		Err(e) => match e.kind() {
-			clap::error::ErrorKind::DisplayHelp
-			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
-			| clap::error::ErrorKind::DisplayVersion => {
-				print!("\n{e}\n");
-				process::exit(0);
-			}
-			_ => e.exit(),
-		},
-	};
+	init_tracing();
+	let cli = parse_cli();
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.
@@ -398,6 +325,22 @@ async fn run() -> podup::Result<()> {
 			no_stream,
 			services,
 		} => engine.stats(&file, &services, no_stream).await?,
+		Commands::Push {
+			ignore_push_failures,
+			tls_verify,
+			services,
+		} => {
+			engine
+				.push(
+					&file,
+					&services,
+					podup::PushOptions {
+						ignore_failures: ignore_push_failures,
+						tls_verify,
+					},
+				)
+				.await?
+		}
 		Commands::Port {
 			service,
 			private_port,
@@ -460,30 +403,4 @@ async fn run() -> podup::Result<()> {
 	}
 
 	Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn level_words_match_user_facing_terms() {
-		assert_eq!(level_word(tracing::Level::WARN), "warning");
-		assert_eq!(level_word(tracing::Level::ERROR), "error");
-	}
-
-	#[test]
-	fn internal_error_notice_reports_and_warns_on_secrets() {
-		let notice = internal_error_notice();
-		assert!(notice.contains(REPO_URL), "points at the issue tracker");
-		assert!(notice.contains("/issues"));
-		assert!(
-			notice.contains("redact"),
-			"reminds the user to scrub secrets"
-		);
-		assert!(
-			notice.contains("RUST_LOG=debug"),
-			"tells the user what to capture"
-		);
-	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -16,28 +16,7 @@ mod startup;
 use cli::*;
 use generate::write_quadlet;
 use resolve::*;
-use startup::{init_tracing, internal_error_notice, parse_cli};
-
-/// Whether a command creates, destroys, or changes the state of containers and
-/// so must hold the exclusive project lock.
-fn is_mutating(command: &Commands) -> bool {
-	matches!(
-		command,
-		Commands::Up { .. }
-			| Commands::Down { .. }
-			| Commands::Start { .. }
-			| Commands::Stop { .. }
-			| Commands::Build { .. }
-			| Commands::Rm { .. }
-			| Commands::Kill { .. }
-			| Commands::Pause { .. }
-			| Commands::Unpause { .. }
-			| Commands::Run { .. }
-			| Commands::Restart { .. }
-			| Commands::Scale { .. }
-			| Commands::Create { .. }
-	)
-}
+use startup::{init_tracing, internal_error_notice, is_mutating, parse_cli};
 
 fn main() {
 	// Replace the default panic output (a raw Rust backtrace) with a `podup:`
@@ -240,6 +219,7 @@ async fn run() -> podup::Result<()> {
 			pull: _,
 			no_build: _,
 			quiet_pull: _,
+			no_start,
 			services,
 		} => {
 			if remove_orphans {
@@ -247,6 +227,21 @@ async fn run() -> podup::Result<()> {
 			}
 			if build {
 				engine.build_all(&file, &services).await?;
+			}
+			// `--no-start` creates the containers but never starts them, so the
+			// wait/watch/attach steps below do not apply.
+			if no_start {
+				engine
+					.create_with_options(
+						&file,
+						&cli.profile,
+						&services,
+						no_recreate,
+						force_recreate,
+						no_deps,
+					)
+					.await?;
+				return Ok(());
 			}
 			engine
 				.up_with_options(

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -231,8 +231,14 @@ async fn run() -> podup::Result<()> {
 		}
 		Commands::Down {
 			volumes,
+			remove_orphans,
 			timeout: _,
-		} => engine.down_with_options(&file, volumes).await?,
+		} => {
+			if remove_orphans {
+				engine.remove_orphans(&file).await?;
+			}
+			engine.down_with_options(&file, volumes).await?
+		}
 		Commands::Start { services } => engine.start(&file, &services).await?,
 		Commands::Stop {
 			services,
@@ -410,7 +416,12 @@ async fn run() -> podup::Result<()> {
 		Commands::Restart {
 			service,
 			timeout: _,
-		} => engine.restart(&file, service.as_deref()).await?,
+			no_deps,
+		} => {
+			engine
+				.restart_with_options(&file, service.as_deref(), no_deps)
+				.await?
+		}
 		Commands::Config => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(&file).await?,

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -341,6 +341,113 @@ services:
 }
 
 #[test]
+fn static_ips_render_as_ip_keys() {
+	// `networks.<n>.ipv4_address`/`ipv6_address` must reach the unit as IP=/IP6=,
+	// not be silently dropped.
+	let yaml = r#"
+services:
+  s:
+    image: x
+    networks:
+      net:
+        ipv4_address: 10.5.0.7
+        ipv6_address: "2001:db8::7"
+networks:
+  net:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("IP=10.5.0.7"), "missing IP= in:\n{c}");
+	assert!(c.contains("IP6=2001:db8::7"), "missing IP6= in:\n{c}");
+}
+
+#[test]
+fn network_mode_none_maps_to_network_none() {
+	// `network_mode: none` is a valid Quadlet value; it must map to Network=none
+	// rather than being warned and dropped.
+	let yaml = "services:\n  s:\n    image: x\n    network_mode: none\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("Network=none"), "missing Network=none in:\n{c}");
+	assert!(
+		!out.warnings.iter().any(|w| w.contains("network_mode")),
+		"network_mode: none must not warn; got: {:?}",
+		out.warnings
+	);
+}
+
+#[test]
+fn security_opt_filetype_and_nested_map_to_keys() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    security_opt:
+      - "label=filetype:usr_t"
+      - "label=nested"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("SecurityLabelFileType=usr_t"), "in:\n{c}");
+	assert!(c.contains("SecurityLabelNested=true"), "in:\n{c}");
+	assert!(
+		!out.warnings.iter().any(|w| w.contains("security_opt")),
+		"mapped labels must not warn; got: {:?}",
+		out.warnings
+	);
+}
+
+#[test]
+fn deploy_restart_policy_maps_to_systemd() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 4
+        window: 2m
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("Restart=on-failure"), "in:\n{c}");
+	assert!(c.contains("StartLimitBurst=4"), "in:\n{c}");
+	assert!(c.contains("StartLimitIntervalSec=120"), "in:\n{c}");
+}
+
+#[test]
+fn deploy_restart_condition_none_maps_to_no() {
+	let yaml = "services:\n  s:\n    image: x\n    deploy:\n      restart_policy:\n        condition: none\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	assert!(unit_named(&out, "s.container")
+		.contents
+		.contains("Restart=no"));
+}
+
+#[test]
+fn deploy_limits_pids_maps_to_pids_limit() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    deploy:
+      resources:
+        limits:
+          pids: 256
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("PidsLimit=256"), "missing PidsLimit in:\n{c}");
+}
+
+#[test]
 fn long_form_tmpfs_mount_renders_as_tmpfs_not_volume() {
 	// A long-form `type: tmpfs` mount must become `Tmpfs=`, not `Volume=` —
 	// the latter would persist it as a volume instead of an in-memory fs.

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -266,3 +266,71 @@ volumes:
 	assert!(vol.contains("Driver=local"));
 	assert!(vol.contains("Label=tier=vol"));
 }
+
+#[test]
+fn network_unit_emits_ipam_pools_options_and_custom_name() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+networks:
+  net:
+    name: custom-net
+    driver_opts:
+      mtu: "9000"
+      com.docker.network.bridge.name: br0
+    ipam:
+      driver: host-local
+      config:
+        - subnet: 10.7.0.0/16
+          gateway: 10.7.0.1
+          ip_range: 10.7.0.128/25
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let net = &unit_named(&out, "net.network").contents;
+	// A custom name overrides the project-prefixed default.
+	assert!(net.contains("NetworkName=custom-net"), "in:\n{net}");
+	assert!(!net.contains("NetworkName=p_net"), "in:\n{net}");
+	assert!(net.contains("IPAMDriver=host-local"), "in:\n{net}");
+	assert!(net.contains("Subnet=10.7.0.0/16"), "in:\n{net}");
+	assert!(net.contains("Gateway=10.7.0.1"), "in:\n{net}");
+	assert!(net.contains("IPRange=10.7.0.128/25"), "in:\n{net}");
+	// Each driver option is its own Options= line (Quadlet maps one Options= to
+	// one `--opt`); a comma-joined value would be a single malformed option.
+	assert!(net.contains("Options=mtu=9000"), "in:\n{net}");
+	assert!(
+		net.contains("Options=com.docker.network.bridge.name=br0"),
+		"in:\n{net}"
+	);
+}
+
+#[test]
+fn volume_unit_emits_options_and_custom_name() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+volumes:
+  vol:
+    name: custom-vol
+    driver: local
+    driver_opts:
+      type: nfs
+      device: ":/exports"
+      o: "addr=10.0.0.1,rw"
+      custom: extra
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let vol = &unit_named(&out, "vol.volume").contents;
+	assert!(vol.contains("VolumeName=custom-vol"), "in:\n{vol}");
+	assert!(!vol.contains("VolumeName=p_vol"), "in:\n{vol}");
+	// `local` driver opts map to dedicated keys; `o` is a single mount-option
+	// string. Options= without a Device= would be rejected by Quadlet.
+	assert!(vol.contains("Type=nfs"), "in:\n{vol}");
+	assert!(vol.contains("Device=:/exports"), "in:\n{vol}");
+	assert!(vol.contains("Options=addr=10.0.0.1,rw"), "in:\n{vol}");
+	// An option with no dedicated key falls back to PodmanArgs=--opt.
+	assert!(vol.contains("PodmanArgs=--opt custom=extra"), "in:\n{vol}");
+}

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -1,197 +1,17 @@
-//! Build the individual `.network`, `.volume` and `.container` units.
+//! Build the `.container` unit for a service.
 
-use crate::compose::types::{Command, PortMapping, RestartPolicy, Service, ServiceSecretRef};
+use crate::compose::types::{PortMapping, RestartPolicy, Service};
 use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
-use super::render::{
-	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
-	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
+use super::health::render_healthcheck;
+use super::security::{map_security_opt, render_secret};
+use super::{
+	collect_warnings, render_command, render_publish_port, render_restart, render_tmpfs_mount,
+	render_volume, safe_unit_stem, sorted_label_pairs, sorted_pairs, QuadletUnit, Section,
 };
-use super::warnings::collect_warnings;
-use super::QuadletUnit;
 
-/// Map a compose `healthcheck:` onto the Quadlet `Health*=` keys. A disabled
-/// healthcheck emits `HealthCmd=none`; otherwise the compose test (with any
-/// leading `CMD`/`CMD-SHELL`/`NONE` sentinel stripped) and the timing fields
-/// are rendered.
-fn render_healthcheck(service: &Service, container: &mut Section) {
-	let Some(hc) = &service.healthcheck else {
-		return;
-	};
-	if hc.is_disabled() {
-		container.add("HealthCmd", "none".to_string());
-		return;
-	}
-	if let Some(test) = &hc.test {
-		let cmd = match test {
-			Command::Shell(s) => s.clone(),
-			Command::Exec(parts) => {
-				let body = match parts.first().map(String::as_str) {
-					Some("CMD") | Some("CMD-SHELL") | Some("NONE") => &parts[1..],
-					_ => &parts[..],
-				};
-				body.join(" ")
-			}
-		};
-		if !cmd.is_empty() {
-			container.add("HealthCmd", cmd);
-		}
-	}
-	if let Some(v) = &hc.interval {
-		container.add("HealthInterval", v.clone());
-	}
-	if let Some(v) = &hc.timeout {
-		container.add("HealthTimeout", v.clone());
-	}
-	if let Some(v) = hc.retries {
-		container.add("HealthRetries", v.to_string());
-	}
-	if let Some(v) = &hc.start_period {
-		container.add("HealthStartPeriod", v.clone());
-	}
-	if let Some(v) = &hc.start_interval {
-		container.add("HealthStartupInterval", v.clone());
-	}
-}
-
-/// Sanitize one `Secret=` option-list field: drop control characters and the
-/// `,`/`=` separators so a hostile compose value cannot inject extra options.
-fn secret_field(value: &str) -> String {
-	value
-		.chars()
-		.filter(|c| !c.is_control() && *c != ',' && *c != '=')
-		.collect()
-}
-
-/// Render a service `secrets:` entry into a Quadlet `Secret=` value
-/// (`name[,target=,uid=,gid=,mode=]`).
-fn render_secret(secret: &ServiceSecretRef) -> String {
-	match secret {
-		// Sanitize the short-form name too: `Secret=` is an option list, so a
-		// `,`/`=` in the name would inject extra options (same guard as Long).
-		ServiceSecretRef::Short(name) => secret_field(name),
-		ServiceSecretRef::Long {
-			source,
-			target,
-			uid,
-			gid,
-			mode,
-		} => {
-			// `Secret=` is a comma-separated `key=value` option list, so a `,`
-			// or `=` embedded in any field would inject extra options. Strip
-			// those (and control chars) from each value at the boundary.
-			let mut s = secret_field(source);
-			if let Some(t) = target {
-				s.push_str(&format!(",target={}", secret_field(t)));
-			}
-			if let Some(u) = uid {
-				s.push_str(&format!(",uid={}", secret_field(u)));
-			}
-			if let Some(g) = gid {
-				s.push_str(&format!(",gid={}", secret_field(g)));
-			}
-			if let Some(m) = mode {
-				s.push_str(&format!(",mode={m:o}"));
-			}
-			s
-		}
-	}
-}
-
-/// Map a single compose `security_opt` entry onto the dedicated Quadlet key
-/// where one exists; unrecognized entries are reported rather than dropped.
-fn map_security_opt(opt: &str, container: &mut Section, name: &str, warnings: &mut Vec<String>) {
-	if let Some(rest) = opt.strip_prefix("no-new-privileges") {
-		let val = rest.trim_start_matches([':', '=']);
-		let enabled = val.is_empty() || val == "true";
-		container.add("NoNewPrivileges", enabled.to_string());
-	} else if let Some(profile) = opt.strip_prefix("seccomp=") {
-		container.add("SeccompProfile", profile.to_string());
-	} else if let Some(profile) = opt
-		.strip_prefix("apparmor=")
-		.or_else(|| opt.strip_prefix("apparmor:"))
-	{
-		// Quadlet has no `AppArmor=` key in Podman 5.x; the generator rejects the
-		// whole unit on an unknown key. Pass it through as a raw podman flag.
-		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
-	} else if let Some(label) = opt.strip_prefix("label=") {
-		if label == "disable" {
-			container.add("SecurityLabelDisable", "true".to_string());
-		} else if let Some(t) = label.strip_prefix("type:") {
-			container.add("SecurityLabelType", t.to_string());
-		} else if let Some(l) = label.strip_prefix("level:") {
-			container.add("SecurityLabelLevel", l.to_string());
-		} else {
-			warnings.push(format!(
-				"{name}: security_opt 'label={label}' has no Quadlet key and is skipped"
-			));
-		}
-	} else {
-		warnings.push(format!(
-			"{name}: security_opt '{opt}' has no Quadlet mapping and is skipped"
-		));
-	}
-}
-
-pub(super) fn network_unit(
-	name: &str,
-	project: &str,
-	config: Option<&crate::compose::types::NetworkConfig>,
-) -> QuadletUnit {
-	let mut net = Section::new("Network");
-	net.add("NetworkName", format!("{project}_{name}"));
-	if let Some(cfg) = config {
-		if let Some(driver) = &cfg.driver {
-			net.add("Driver", driver.clone());
-		}
-		if cfg.internal == Some(true) {
-			net.add("Internal", "true".to_string());
-		}
-		if cfg.enable_ipv6 == Some(true) {
-			net.add("IPv6", "true".to_string());
-		}
-		if let Some(ipam) = &cfg.ipam {
-			if let Some(ipam_driver) = &ipam.driver {
-				net.add("IPAMDriver", ipam_driver.clone());
-			}
-		}
-		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
-			net.add("Label", format!("{key}={val}"));
-		}
-	}
-	let mut contents = net.render();
-	contents.push_str("\n[Install]\nWantedBy=default.target\n");
-	QuadletUnit {
-		filename: format!("{}.network", safe_unit_stem(name)),
-		contents,
-	}
-}
-
-pub(super) fn volume_unit(
-	name: &str,
-	project: &str,
-	config: Option<&crate::compose::types::VolumeConfig>,
-) -> QuadletUnit {
-	let mut vol = Section::new("Volume");
-	vol.add("VolumeName", format!("{project}_{name}"));
-	if let Some(cfg) = config {
-		if let Some(driver) = &cfg.driver {
-			vol.add("Driver", driver.clone());
-		}
-		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
-			vol.add("Label", format!("{key}={val}"));
-		}
-	}
-	let mut contents = vol.render();
-	contents.push_str("\n[Install]\nWantedBy=default.target\n");
-	QuadletUnit {
-		filename: format!("{}.volume", safe_unit_stem(name)),
-		contents,
-	}
-}
-
-pub(super) fn container_unit(
+pub(crate) fn container_unit(
 	name: &str,
 	service: &Service,
 	declared_volumes: &[&str],
@@ -372,7 +192,16 @@ pub(super) fn container_unit(
 	if let Some(p) = service.cpu_period {
 		container.add("PodmanArgs", format!("--cpu-period={p}"));
 	}
+	// `deploy.resources.limits.pids` is the modern equivalent of `pids_limit`.
+	let deploy_pids = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.resources.as_ref())
+		.and_then(|r| r.limits.as_ref())
+		.and_then(|l| l.pids);
 	if let Some(pids) = service.pids_limit {
+		container.add("PidsLimit", pids.to_string());
+	} else if let Some(pids) = deploy_pids {
 		container.add("PidsLimit", pids.to_string());
 	}
 	if let Some(userns) = &service.userns_mode {
@@ -386,10 +215,13 @@ pub(super) fn container_unit(
 			container.add("StopTimeout", secs.to_string());
 		}
 	}
-	// `network_mode: host` maps to `Network=host`; other modes (service:/
-	// container:) have no Quadlet key and are reported by collect_warnings.
-	if service.network_mode.as_deref() == Some("host") {
-		container.add("Network", "host".to_string());
+	// `network_mode: host`/`none` map to `Network=host`/`Network=none`; other
+	// modes (service:/container:) have no Quadlet key and are reported by
+	// collect_warnings.
+	match service.network_mode.as_deref() {
+		Some("host") => container.add("Network", "host".to_string()),
+		Some("none") => container.add("Network", "none".to_string()),
+		_ => {}
 	}
 	for group in &service.group_add {
 		container.add("GroupAdd", group.clone());
@@ -397,6 +229,11 @@ pub(super) fn container_unit(
 	for port in &service.expose {
 		container.add("ExposeHostPort", port.clone());
 	}
+	// `IP=`/`IP6=` are single-valued per container, so the first static address
+	// declared across the service's networks wins (Quadlet has no per-network IP
+	// scoping); a second one is reported by collect_warnings.
+	let mut static_ip: Option<&str> = None;
+	let mut static_ip6: Option<&str> = None;
 	for net in service.networks.names() {
 		if let Some(cfg) = service.networks.config_for(&net) {
 			if let Some(aliases) = &cfg.aliases {
@@ -404,7 +241,19 @@ pub(super) fn container_unit(
 					container.add("NetworkAlias", alias.clone());
 				}
 			}
+			if static_ip.is_none() {
+				static_ip = cfg.ipv4_address.as_deref();
+			}
+			if static_ip6.is_none() {
+				static_ip6 = cfg.ipv6_address.as_deref();
+			}
 		}
+	}
+	if let Some(ip) = static_ip {
+		container.add("IP", ip.to_string());
+	}
+	if let Some(ip6) = static_ip6 {
+		container.add("IP6", ip6.to_string());
 	}
 	for opt in &service.security_opt {
 		map_security_opt(opt, &mut container, name, warnings);
@@ -446,6 +295,27 @@ pub(super) fn container_unit(
 		{
 			svc.add("StartLimitBurst", n.to_string());
 		}
+	} else if let Some(rp) = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.restart_policy.as_ref())
+	{
+		// `deploy.restart_policy` is the modern equivalent of the service-level
+		// `restart:` string; its `condition` maps onto the systemd `Restart=`
+		// values and `max_attempts`/`window` onto the start-limit window.
+		let restart = match rp.condition.as_deref() {
+			Some("none") => "no",
+			Some("on-failure") => "on-failure",
+			// "any" (the compose default) and any unknown value restart always.
+			_ => "always",
+		};
+		svc.add("Restart", restart.to_string());
+		if let Some(n) = rp.max_attempts {
+			svc.add("StartLimitBurst", n.to_string());
+			if let Some(secs) = rp.window.as_deref().and_then(parse_duration_secs) {
+				svc.add("StartLimitIntervalSec", secs.to_string());
+			}
+		}
 	}
 
 	collect_warnings(name, service, warnings);
@@ -463,34 +333,5 @@ pub(super) fn container_unit(
 	QuadletUnit {
 		filename: format!("{}.container", safe_unit_stem(name)),
 		contents,
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::{render_secret, secret_field};
-	use crate::compose::types::ServiceSecretRef;
-
-	#[test]
-	fn secret_field_strips_separators_and_controls() {
-		assert_eq!(secret_field("a,b=c\nd"), "abcd");
-		assert_eq!(secret_field("plain"), "plain");
-	}
-
-	#[test]
-	fn render_secret_cannot_inject_extra_options() {
-		// A hostile target tries to smuggle a second option via `,` and `=`.
-		let s = ServiceSecretRef::Long {
-			source: "tok".into(),
-			target: Some("/run/x,uid=0".into()),
-			uid: None,
-			gid: None,
-			mode: None,
-		};
-		let out = render_secret(&s);
-		// The injected `,uid=0` must be flattened into the target value, not a
-		// separate option: exactly one comma (the legitimate `,target=`).
-		assert_eq!(out.matches(',').count(), 1);
-		assert_eq!(out, "tok,target=/run/xuid0");
 	}
 }

--- a/internal/quadlet/unit/health.rs
+++ b/internal/quadlet/unit/health.rs
@@ -1,0 +1,49 @@
+//! Map a compose `healthcheck:` onto the Quadlet `Health*=` keys.
+
+use crate::compose::types::{Command, Service};
+
+use super::Section;
+
+/// Map a compose `healthcheck:` onto the Quadlet `Health*=` keys. A disabled
+/// healthcheck emits `HealthCmd=none`; otherwise the compose test (with any
+/// leading `CMD`/`CMD-SHELL`/`NONE` sentinel stripped) and the timing fields
+/// are rendered.
+pub(super) fn render_healthcheck(service: &Service, container: &mut Section) {
+	let Some(hc) = &service.healthcheck else {
+		return;
+	};
+	if hc.is_disabled() {
+		container.add("HealthCmd", "none".to_string());
+		return;
+	}
+	if let Some(test) = &hc.test {
+		let cmd = match test {
+			Command::Shell(s) => s.clone(),
+			Command::Exec(parts) => {
+				let body = match parts.first().map(String::as_str) {
+					Some("CMD") | Some("CMD-SHELL") | Some("NONE") => &parts[1..],
+					_ => &parts[..],
+				};
+				body.join(" ")
+			}
+		};
+		if !cmd.is_empty() {
+			container.add("HealthCmd", cmd);
+		}
+	}
+	if let Some(v) = &hc.interval {
+		container.add("HealthInterval", v.clone());
+	}
+	if let Some(v) = &hc.timeout {
+		container.add("HealthTimeout", v.clone());
+	}
+	if let Some(v) = hc.retries {
+		container.add("HealthRetries", v.to_string());
+	}
+	if let Some(v) = &hc.start_period {
+		container.add("HealthStartPeriod", v.clone());
+	}
+	if let Some(v) = &hc.start_interval {
+		container.add("HealthStartupInterval", v.clone());
+	}
+}

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -1,0 +1,20 @@
+//! Build the individual `.network`, `.volume` and `.container` units.
+
+mod container;
+mod health;
+mod network;
+mod security;
+mod volume;
+
+pub(super) use container::container_unit;
+pub(super) use network::network_unit;
+pub(super) use volume::volume_unit;
+
+// Shared helpers from the sibling `render`/`warnings` modules and the parent
+// `QuadletUnit` type, re-exported so the unit submodules import them from here.
+use super::render::{
+	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
+	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
+};
+use super::warnings::collect_warnings;
+use super::QuadletUnit;

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -1,0 +1,63 @@
+//! Build the `.network` unit for a declared network.
+
+use crate::compose::types::NetworkConfig;
+
+use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+
+pub(crate) fn network_unit(
+	name: &str,
+	project: &str,
+	config: Option<&NetworkConfig>,
+) -> QuadletUnit {
+	let mut net = Section::new("Network");
+	// A custom `name:` overrides Podman's resource name; Quadlet uses the literal
+	// value (no prefix) when `NetworkName=` is set explicitly.
+	let net_name = config
+		.and_then(|c| c.name.clone())
+		.unwrap_or_else(|| format!("{project}_{name}"));
+	net.add("NetworkName", net_name);
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			net.add("Driver", driver.clone());
+		}
+		if cfg.internal == Some(true) {
+			net.add("Internal", "true".to_string());
+		}
+		if cfg.enable_ipv6 == Some(true) {
+			net.add("IPv6", "true".to_string());
+		}
+		if let Some(ipam) = &cfg.ipam {
+			if let Some(ipam_driver) = &ipam.driver {
+				net.add("IPAMDriver", ipam_driver.clone());
+			}
+			// Each `ipam.config` pool maps to a Subnet=/Gateway=/IPRange= triple;
+			// all three keys are repeatable and correlated positionally by Podman.
+			for pool in &ipam.config {
+				if let Some(subnet) = &pool.subnet {
+					net.add("Subnet", subnet.clone());
+				}
+				if let Some(gateway) = &pool.gateway {
+					net.add("Gateway", gateway.clone());
+				}
+				if let Some(range) = &pool.ip_range {
+					net.add("IPRange", range.clone());
+				}
+			}
+		}
+		// Each driver option becomes its own Options= line: Quadlet maps one
+		// Options= to one `podman network create --opt key=value`, so a
+		// comma-joined value would be passed as a single malformed option.
+		for (key, val) in sorted_label_pairs(cfg.driver_opts.clone()) {
+			net.add("Options", format!("{key}={val}"));
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			net.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = net.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
+	QuadletUnit {
+		filename: format!("{}.network", safe_unit_stem(name)),
+		contents,
+	}
+}

--- a/internal/quadlet/unit/security.rs
+++ b/internal/quadlet/unit/security.rs
@@ -1,0 +1,122 @@
+//! Render service `secrets:` and `security_opt:` onto their Quadlet keys.
+
+use crate::compose::types::ServiceSecretRef;
+
+use super::Section;
+
+/// Sanitize one `Secret=` option-list field: drop control characters and the
+/// `,`/`=` separators so a hostile compose value cannot inject extra options.
+pub(super) fn secret_field(value: &str) -> String {
+	value
+		.chars()
+		.filter(|c| !c.is_control() && *c != ',' && *c != '=')
+		.collect()
+}
+
+/// Render a service `secrets:` entry into a Quadlet `Secret=` value
+/// (`name[,target=,uid=,gid=,mode=]`).
+pub(super) fn render_secret(secret: &ServiceSecretRef) -> String {
+	match secret {
+		// Sanitize the short-form name too: `Secret=` is an option list, so a
+		// `,`/`=` in the name would inject extra options (same guard as Long).
+		ServiceSecretRef::Short(name) => secret_field(name),
+		ServiceSecretRef::Long {
+			source,
+			target,
+			uid,
+			gid,
+			mode,
+		} => {
+			// `Secret=` is a comma-separated `key=value` option list, so a `,`
+			// or `=` embedded in any field would inject extra options. Strip
+			// those (and control chars) from each value at the boundary.
+			let mut s = secret_field(source);
+			if let Some(t) = target {
+				s.push_str(&format!(",target={}", secret_field(t)));
+			}
+			if let Some(u) = uid {
+				s.push_str(&format!(",uid={}", secret_field(u)));
+			}
+			if let Some(g) = gid {
+				s.push_str(&format!(",gid={}", secret_field(g)));
+			}
+			if let Some(m) = mode {
+				s.push_str(&format!(",mode={m:o}"));
+			}
+			s
+		}
+	}
+}
+
+/// Map a single compose `security_opt` entry onto the dedicated Quadlet key
+/// where one exists; unrecognized entries are reported rather than dropped.
+pub(super) fn map_security_opt(
+	opt: &str,
+	container: &mut Section,
+	name: &str,
+	warnings: &mut Vec<String>,
+) {
+	if let Some(rest) = opt.strip_prefix("no-new-privileges") {
+		let val = rest.trim_start_matches([':', '=']);
+		let enabled = val.is_empty() || val == "true";
+		container.add("NoNewPrivileges", enabled.to_string());
+	} else if let Some(profile) = opt.strip_prefix("seccomp=") {
+		container.add("SeccompProfile", profile.to_string());
+	} else if let Some(profile) = opt
+		.strip_prefix("apparmor=")
+		.or_else(|| opt.strip_prefix("apparmor:"))
+	{
+		// Quadlet has no `AppArmor=` key in Podman 5.x; the generator rejects the
+		// whole unit on an unknown key. Pass it through as a raw podman flag.
+		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
+	} else if let Some(label) = opt.strip_prefix("label=") {
+		if label == "disable" {
+			container.add("SecurityLabelDisable", "true".to_string());
+		} else if label == "nested" {
+			container.add("SecurityLabelNested", "true".to_string());
+		} else if let Some(t) = label.strip_prefix("type:") {
+			container.add("SecurityLabelType", t.to_string());
+		} else if let Some(l) = label.strip_prefix("level:") {
+			container.add("SecurityLabelLevel", l.to_string());
+		} else if let Some(f) = label.strip_prefix("filetype:") {
+			container.add("SecurityLabelFileType", f.to_string());
+		} else {
+			warnings.push(format!(
+				"{name}: security_opt 'label={label}' has no Quadlet key and is skipped"
+			));
+		}
+	} else {
+		warnings.push(format!(
+			"{name}: security_opt '{opt}' has no Quadlet mapping and is skipped"
+		));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{render_secret, secret_field};
+	use crate::compose::types::ServiceSecretRef;
+
+	#[test]
+	fn secret_field_strips_separators_and_controls() {
+		assert_eq!(secret_field("a,b=c\nd"), "abcd");
+		assert_eq!(secret_field("plain"), "plain");
+	}
+
+	#[test]
+	fn render_secret_cannot_inject_extra_options() {
+		// A hostile target tries to smuggle a second option via `,` and `=`.
+		let s = ServiceSecretRef::Long {
+			source: "tok".into(),
+			target: Some("/run/x,uid=0".into()),
+			uid: None,
+			gid: None,
+			mode: None,
+		};
+		let out = render_secret(&s);
+		// The injected `,uid=0` must be flattened into the target value, not a
+		// separate option: exactly one comma (the legitimate `,target=`).
+		assert_eq!(out.matches(',').count(), 1);
+		assert_eq!(out, "tok,target=/run/xuid0");
+	}
+}

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -1,0 +1,41 @@
+//! Build the `.volume` unit for a declared named volume.
+
+use crate::compose::types::VolumeConfig;
+
+use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+
+pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfig>) -> QuadletUnit {
+	let mut vol = Section::new("Volume");
+	// A custom `name:` overrides Podman's resource name; Quadlet uses the literal
+	// value (no prefix) when `VolumeName=` is set explicitly.
+	let vol_name = config
+		.and_then(|c| c.name.clone())
+		.unwrap_or_else(|| format!("{project}_{name}"));
+	vol.add("VolumeName", vol_name);
+	if let Some(cfg) = config {
+		if let Some(driver) = &cfg.driver {
+			vol.add("Driver", driver.clone());
+		}
+		// The built-in `local` driver's opts map onto dedicated Quadlet keys:
+		// `type`→Type=, `device`→Device=, `o`→Options= (already a comma-separated
+		// mount-option string). Quadlet rejects Options= without a Device=, so any
+		// other driver option has no [Volume] key and passes through PodmanArgs=.
+		for (key, val) in sorted_label_pairs(cfg.driver_opts.clone()) {
+			match key.as_str() {
+				"type" => vol.add("Type", val),
+				"device" => vol.add("Device", val),
+				"o" => vol.add("Options", val),
+				_ => vol.add("PodmanArgs", format!("--opt {key}={val}")),
+			}
+		}
+		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {
+			vol.add("Label", format!("{key}={val}"));
+		}
+	}
+	let mut contents = vol.render();
+	contents.push_str("\n[Install]\nWantedBy=default.target\n");
+	QuadletUnit {
+		filename: format!("{}.volume", safe_unit_stem(name)),
+		contents,
+	}
+}

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -30,11 +30,15 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 	if !service.volumes_from.is_empty() {
 		warn("volumes_from", "has no Quadlet equivalent and is skipped");
 	}
-	// `network_mode: host` maps to `Network=host`; other modes have no key.
-	if service.network_mode.as_deref().is_some_and(|m| m != "host") {
+	// `network_mode: host`/`none` map to `Network=`; other modes have no key.
+	if service
+		.network_mode
+		.as_deref()
+		.is_some_and(|m| m != "host" && m != "none")
+	{
 		warn(
 			"network_mode",
-			"is not mapped (only `host` is supported); use networks instead",
+			"is not mapped (only `host`/`none` are supported); use networks instead",
 		);
 	}
 	if !service.profiles.is_empty() {
@@ -70,6 +74,79 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 				"condition service_healthy/service_completed_successfully is not enforceable in Quadlet; only start ordering is emitted",
 			);
 		}
+	}
+
+	// Fields that are honoured at runtime but have no [Container] Quadlet key and
+	// no unambiguous PodmanArgs= fallback. Warn so the generated unit is never
+	// silently incomplete; add the flag by hand if it is required.
+	let skipped = "has no Quadlet equivalent and is skipped";
+	if service.ipc.is_some() {
+		warn("ipc", skipped);
+	}
+	if service.pid.is_some() {
+		warn("pid", skipped);
+	}
+	if service.uts.is_some() {
+		warn("uts", skipped);
+	}
+	if service.cgroup.is_some() {
+		warn("cgroup", skipped);
+	}
+	if service.cgroup_parent.is_some() {
+		warn("cgroup_parent", skipped);
+	}
+	if service.runtime.is_some() {
+		warn("runtime", skipped);
+	}
+	if service.tty.is_some() {
+		warn("tty", skipped);
+	}
+	if service.stdin_open.is_some() {
+		warn("stdin_open", skipped);
+	}
+	if service.memswap_limit.is_some() {
+		warn("memswap_limit", skipped);
+	}
+	if service.mem_reservation.is_some() {
+		warn("mem_reservation", skipped);
+	}
+	if service.oom_kill_disable.is_some() {
+		warn("oom_kill_disable", skipped);
+	}
+	if service.oom_score_adj.is_some() {
+		warn("oom_score_adj", skipped);
+	}
+	if service.blkio_config.is_some() {
+		warn("blkio_config", skipped);
+	}
+	if !service.label_file.to_list().is_empty() {
+		warn("label_file", skipped);
+	}
+	// MAC addresses have no Quadlet key (service-level or per-network), and a
+	// per-network value cannot be expressed via the whole-container PodmanArgs=.
+	let has_network_mac = service
+		.networks
+		.names()
+		.iter()
+		.filter_map(|n| service.networks.config_for(n))
+		.any(|c| c.mac_address.is_some());
+	if service.mac_address.is_some() || has_network_mac {
+		warn("mac_address", skipped);
+	}
+	// Only the first static IP across the service's networks is emitted; a second
+	// one would need per-network IP scoping that Quadlet does not support.
+	let static_ip_count = service
+		.networks
+		.names()
+		.iter()
+		.filter_map(|n| service.networks.config_for(n))
+		.filter(|c| c.ipv4_address.is_some() || c.ipv6_address.is_some())
+		.count();
+	if static_ip_count > 1 {
+		warn(
+			"ipv4_address/ipv6_address",
+			"is set on multiple networks; Quadlet emits only the first (no per-network IP scoping)",
+		);
 	}
 }
 
@@ -127,6 +204,79 @@ configs:
 		assert!(
 			!joined.contains("secrets"),
 			"secrets should be mapped, not warned; got:\n{joined}"
+		);
+	}
+
+	#[test]
+	fn warns_for_silently_dropped_runtime_fields() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    ipc: host
+    pid: host
+    uts: host
+    cgroup: private
+    cgroup_parent: /sys/fs/cgroup/p
+    runtime: crun
+    tty: true
+    stdin_open: true
+    mac_address: "02:42:ac:11:00:02"
+    memswap_limit: 1g
+    mem_reservation: 256m
+    oom_kill_disable: true
+    oom_score_adj: -500
+    label_file:
+      - ./labels.env
+    blkio_config:
+      weight: 300
+"#;
+		let file = parse_str(yaml).unwrap();
+		let joined = generate(&file, "proj").warnings.join("\n");
+		for field in [
+			"ipc",
+			"pid",
+			"uts",
+			"cgroup",
+			"cgroup_parent",
+			"runtime",
+			"tty",
+			"stdin_open",
+			"mac_address",
+			"memswap_limit",
+			"mem_reservation",
+			"oom_kill_disable",
+			"oom_score_adj",
+			"label_file",
+			"blkio_config",
+		] {
+			assert!(
+				joined.contains(field),
+				"missing warning for {field}; got:\n{joined}"
+			);
+		}
+	}
+
+	#[test]
+	fn warns_when_static_ip_set_on_multiple_networks() {
+		let yaml = r#"
+services:
+  s:
+    image: x
+    networks:
+      a:
+        ipv4_address: 10.0.0.2
+      b:
+        ipv4_address: 10.0.1.2
+networks:
+  a:
+  b:
+"#;
+		let file = parse_str(yaml).unwrap();
+		let joined = generate(&file, "proj").warnings.join("\n");
+		assert!(
+			joined.contains("ipv4_address/ipv6_address"),
+			"missing multi-network static-IP warning; got:\n{joined}"
 		);
 	}
 

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -10,7 +10,28 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
-use crate::cli::Cli;
+use crate::cli::{Cli, Commands};
+
+/// Whether a command creates, destroys, or changes the state of containers and
+/// so must hold the exclusive project lock.
+pub(crate) fn is_mutating(command: &Commands) -> bool {
+	matches!(
+		command,
+		Commands::Up { .. }
+			| Commands::Down { .. }
+			| Commands::Start { .. }
+			| Commands::Stop { .. }
+			| Commands::Build { .. }
+			| Commands::Rm { .. }
+			| Commands::Kill { .. }
+			| Commands::Pause { .. }
+			| Commands::Unpause { .. }
+			| Commands::Run { .. }
+			| Commands::Restart { .. }
+			| Commands::Scale { .. }
+			| Commands::Create { .. }
+	)
+}
 
 /// Canonical project URL, reused for the bug-report hint on internal errors.
 const REPO_URL: &str = "https://github.com/Glyndor/podup";

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -1,0 +1,115 @@
+//! CLI startup helpers: diagnostic log formatting, tracing initialization, the
+//! internal-error notice, and argument parsing with framed help output.
+
+use std::process;
+
+use clap::Parser;
+use tracing::{Event, Subscriber};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::EnvFilter;
+
+use crate::cli::Cli;
+
+/// Canonical project URL, reused for the bug-report hint on internal errors.
+const REPO_URL: &str = "https://github.com/Glyndor/podup";
+
+/// Event formatter that renders every diagnostic as `podup: <level>: <message>`
+/// on a single line, matching the prefix used by the CLI's own `eprintln!`
+/// warnings and errors. This unifies the compose forward-compat diagnostics
+/// (emitted via `tracing::warn!`) with the rest of podup's user-facing output.
+struct PodupFormat;
+
+impl<S, N> FormatEvent<S, N> for PodupFormat
+where
+	S: Subscriber + for<'a> LookupSpan<'a>,
+	N: for<'a> FormatFields<'a> + 'static,
+{
+	fn format_event(
+		&self,
+		ctx: &FmtContext<'_, S, N>,
+		mut writer: Writer<'_>,
+		event: &Event<'_>,
+	) -> std::fmt::Result {
+		write!(writer, "podup: {}: ", level_word(*event.metadata().level()))?;
+		ctx.field_format().format_fields(writer.by_ref(), event)?;
+		writeln!(writer)
+	}
+}
+
+/// Map a tracing level to the user-facing word used in `podup:` output.
+fn level_word(level: tracing::Level) -> &'static str {
+	match level {
+		tracing::Level::ERROR => "error",
+		tracing::Level::WARN => "warning",
+		tracing::Level::INFO => "info",
+		tracing::Level::DEBUG => "debug",
+		tracing::Level::TRACE => "trace",
+	}
+}
+
+/// Guidance printed after an internal error or panic: where to report it and a
+/// reminder to scrub secrets first. Kept off ordinary, user-correctable errors.
+pub(crate) fn internal_error_notice() -> String {
+	format!(
+		"podup: this looks like a bug; re-run with RUST_LOG=debug and report it at {REPO_URL}/issues\n\
+		 podup: redact secrets (passwords, tokens, resolved env values) from any logs before sharing"
+	)
+}
+
+/// Initialize the global tracing subscriber: warnings by default (so the
+/// forward-compat "unknown field" notices are never silently dropped), written
+/// to stderr in the `podup: <level>: <msg>` format so stdout stays a clean pipe.
+pub(crate) fn init_tracing() {
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+		)
+		.with_writer(std::io::stderr)
+		.event_format(PodupFormat)
+		.init();
+}
+
+/// Parse the CLI, framing `--help`/`--version` output with a blank line top and
+/// bottom (clap trims template edges, so wrap the rendered text here).
+pub(crate) fn parse_cli() -> Cli {
+	match Cli::try_parse() {
+		Ok(cli) => cli,
+		Err(e) => match e.kind() {
+			clap::error::ErrorKind::DisplayHelp
+			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+			| clap::error::ErrorKind::DisplayVersion => {
+				print!("\n{e}\n");
+				process::exit(0);
+			}
+			_ => e.exit(),
+		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn level_words_match_user_facing_terms() {
+		assert_eq!(level_word(tracing::Level::WARN), "warning");
+		assert_eq!(level_word(tracing::Level::ERROR), "error");
+	}
+
+	#[test]
+	fn internal_error_notice_reports_and_warns_on_secrets() {
+		let notice = internal_error_notice();
+		assert!(notice.contains(REPO_URL), "points at the issue tracker");
+		assert!(notice.contains("/issues"));
+		assert!(
+			notice.contains("redact"),
+			"reminds the user to scrub secrets"
+		);
+		assert!(
+			notice.contains("RUST_LOG=debug"),
+			"tells the user what to capture"
+		);
+	}
+}

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -74,3 +74,66 @@ fn completions_emit_a_script_to_stdout() {
 		&stdout[..stdout.len().min(200)]
 	);
 }
+
+/// A minimal valid two-service compose file in a fresh temp dir.
+fn compose_two_services() -> std::path::PathBuf {
+	let dir = std::env::temp_dir().join(format!("podup-cfg-{}", std::process::id()));
+	fs::create_dir_all(&dir).expect("create temp dir");
+	let path = dir.join("compose.yaml");
+	fs::write(
+		&path,
+		"services:\n  web:\n    image: nginx:1.27\n  db:\n    image: postgres:16\n",
+	)
+	.expect("write compose file");
+	path
+}
+
+#[test]
+fn config_services_lists_service_names() {
+	let file = compose_two_services();
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "config", "--services"])
+		.output()
+		.expect("run config --services");
+	assert!(out.status.success());
+	let names: Vec<&str> = std::str::from_utf8(&out.stdout).unwrap().lines().collect();
+	assert!(
+		names.contains(&"web") && names.contains(&"db"),
+		"got: {names:?}"
+	);
+}
+
+#[test]
+fn config_format_json_emits_json() {
+	let file = compose_two_services();
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "config", "--format", "json"])
+		.output()
+		.expect("run config --format json");
+	assert!(out.status.success());
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+	assert!(parsed["services"]["web"].is_object());
+}
+
+#[test]
+fn config_quiet_validates_without_output() {
+	let valid = compose_two_services();
+	let ok = Command::new(bin())
+		.args(["-f", valid.to_str().unwrap(), "config", "-q"])
+		.output()
+		.unwrap();
+	assert!(ok.status.success());
+	assert!(ok.stdout.is_empty(), "quiet must print nothing");
+
+	// A syntactically broken compose file fails validation (non-zero exit).
+	let dir = std::env::temp_dir().join(format!("podup-cfgbad-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let badfile = dir.join("compose.yaml");
+	fs::write(&badfile, "services:\n  web:\n    image: [unterminated\n").unwrap();
+	let err = Command::new(bin())
+		.args(["-f", badfile.to_str().unwrap(), "config", "-q"])
+		.output()
+		.unwrap();
+	assert!(!err.status.success(), "invalid config must fail under -q");
+}

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -56,6 +56,8 @@ mod watch_tests;
 mod cli1;
 #[path = "engine_integration/cli2.rs"]
 mod cli2;
+#[path = "engine_integration/cli3.rs"]
+mod cli3;
 #[path = "engine_integration/create_ls.rs"]
 mod create_ls;
 #[path = "engine_integration/scale.rs"]

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -56,3 +56,5 @@ mod watch_tests;
 mod cli1;
 #[path = "engine_integration/cli2.rs"]
 mod cli2;
+#[path = "engine_integration/scale.rs"]
+mod scale;

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -56,5 +56,7 @@ mod watch_tests;
 mod cli1;
 #[path = "engine_integration/cli2.rs"]
 mod cli2;
+#[path = "engine_integration/create_ls.rs"]
+mod create_ls;
 #[path = "engine_integration/scale.rs"]
 mod scale;

--- a/tests/engine_integration/cli2.rs
+++ b/tests/engine_integration/cli2.rs
@@ -44,6 +44,59 @@ async fn cli_rm_subcommand() {
 }
 
 #[tokio::test]
+async fn cli_push_skips_service_without_image() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-pushskip", std::process::id());
+	// A build-only service has no `image:` to push, so push is a no-op success.
+	fs::write(&compose, "services:\n  app:\n    build: .\n").unwrap();
+	let push = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "push"])
+		.output()
+		.unwrap();
+	assert!(
+		push.status.success(),
+		"push of an imageless service must succeed: {:?}",
+		String::from_utf8_lossy(&push.stderr)
+	);
+}
+
+#[tokio::test]
+async fn cli_push_to_unreachable_registry_errors() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-pushfail", std::process::id());
+	// Port 1 refuses connections, so the push must fail with a non-zero exit.
+	fs::write(
+		&compose,
+		"services:\n  app:\n    image: localhost:1/podup-nope:1\n",
+	)
+	.unwrap();
+	let push = Command::new(bin())
+		.args([
+			"-f",
+			compose.to_str().unwrap(),
+			"-p",
+			&proj,
+			"push",
+			"--tls-verify",
+			"false",
+		])
+		.output()
+		.unwrap();
+	assert!(
+		!push.status.success(),
+		"push to an unreachable registry must fail"
+	);
+}
+
+#[tokio::test]
 async fn cli_stats_no_stream_reports_running_container() {
 	if super::podman().await.is_none() {
 		return;

--- a/tests/engine_integration/cli2.rs
+++ b/tests/engine_integration/cli2.rs
@@ -44,6 +44,44 @@ async fn cli_rm_subcommand() {
 }
 
 #[tokio::test]
+async fn cli_stats_no_stream_reports_running_container() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-stats", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+
+	let stats = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "stats", "--no-stream"])
+		.output()
+		.unwrap();
+	assert!(stats.status.success(), "stats failed: {:?}", stats.stderr);
+	let out = String::from_utf8_lossy(&stats.stdout);
+	assert!(out.contains("CPU %"), "stats must print a header: {out}");
+	assert!(
+		out.contains(&format!("{proj}-web")),
+		"stats must list the running container: {out}"
+	);
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}
+
+#[tokio::test]
 async fn cli_up_with_build_flag() {
 	if super::podman().await.is_none() {
 		return;

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -212,3 +212,41 @@ async fn cli_rm_volumes_removes_container() {
 	assert!(rm.status.success(), "rm -v failed: {:?}", rm.stderr);
 	assert_eq!(ps_all_count(c, &proj), 0, "rm must remove the container");
 }
+
+#[tokio::test]
+async fn cli_kill_remove_orphans_drops_undeclared() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-killorph", std::process::id());
+	let svc = "image: alpine:latest\n    command: [\"sleep\", \"infinity\"]";
+	let two = dir.path().join("two.yml");
+	let one = dir.path().join("one.yml");
+	fs::write(
+		&two,
+		format!("services:\n  web:\n    {svc}\n  extra:\n    {svc}\n"),
+	)
+	.unwrap();
+	fs::write(&one, format!("services:\n  web:\n    {svc}\n")).unwrap();
+	let (two, one) = (two.to_str().unwrap(), one.to_str().unwrap());
+
+	run(&["-f", two, "-p", &proj, "up", "-d"]);
+	let kill = run(&["-f", one, "-p", &proj, "kill", "--remove-orphans"]);
+	assert!(kill.status.success(), "kill failed: {:?}", kill.stderr);
+	// The orphan `extra` is removed; the declared `web` is killed but remains.
+	run(&["-f", one, "-p", &proj, "down"]);
+}
+
+#[tokio::test]
+async fn cli_pull_quiet_succeeds() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-pullq", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(&compose, "services:\n  web:\n    image: alpine:latest\n").unwrap();
+	let pull = run(&["-f", compose.to_str().unwrap(), "-p", &proj, "pull", "-q"]);
+	assert!(pull.status.success(), "pull -q failed: {:?}", pull.stderr);
+}

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -44,3 +44,70 @@ async fn cli_logs_tail_limits_output() {
 		.output()
 		.unwrap();
 }
+
+fn run(args: &[&str]) -> std::process::Output {
+	Command::new(bin()).args(args).output().unwrap()
+}
+
+fn ps_all_count(compose: &str, proj: &str) -> usize {
+	String::from_utf8_lossy(&run(&["-f", compose, "-p", proj, "ps", "-a", "-q"]).stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count()
+}
+
+#[tokio::test]
+async fn cli_down_remove_orphans_drops_undeclared_containers() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-orphan", std::process::id());
+	let two = dir.path().join("two.yml");
+	let one = dir.path().join("one.yml");
+	let svc = "image: alpine:latest\n    command: [\"sleep\", \"infinity\"]";
+	fs::write(
+		&two,
+		format!("services:\n  web:\n    {svc}\n  extra:\n    {svc}\n"),
+	)
+	.unwrap();
+	fs::write(&one, format!("services:\n  web:\n    {svc}\n")).unwrap();
+	let (two, one) = (two.to_str().unwrap(), one.to_str().unwrap());
+
+	run(&["-f", two, "-p", &proj, "up", "-d"]);
+	assert_eq!(ps_all_count(two, &proj), 2);
+
+	// Down against the one-service file: --remove-orphans must also drop `extra`.
+	let down = run(&["-f", one, "-p", &proj, "down", "--remove-orphans"]);
+	assert!(down.status.success(), "down failed: {:?}", down.stderr);
+	assert_eq!(
+		ps_all_count(one, &proj),
+		0,
+		"--remove-orphans must remove the undeclared container too"
+	);
+}
+
+#[tokio::test]
+async fn cli_restart_no_deps_succeeds() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-nodeps", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	let restart = run(&["-f", c, "-p", &proj, "restart", "--no-deps", "web"]);
+	assert!(
+		restart.status.success(),
+		"restart --no-deps failed: {:?}",
+		restart.stderr
+	);
+	run(&["-f", c, "-p", &proj, "down"]);
+}

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -1,0 +1,46 @@
+//! Further CLI binary integration tests (kept separate from cli2.rs to stay
+//! under the source line limit).
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+#[tokio::test]
+async fn cli_logs_tail_limits_output() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-logstail", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"for i in 1 2 3 4 5; do echo line-$i; done; sleep infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	// Give the container a moment to emit its lines.
+	tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+	let logs = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
+		.output()
+		.unwrap();
+	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
+	let lines = String::from_utf8_lossy(&logs.stdout)
+		.lines()
+		.filter(|l| l.contains("line-"))
+		.count();
+	assert_eq!(lines, 2, "logs --tail 2 must show exactly 2 lines");
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -165,3 +165,50 @@ async fn cli_up_pull_never_starts_present_image() {
 	);
 	run(&["-f", c, "-p", &proj, "down"]);
 }
+
+#[tokio::test]
+async fn cli_down_rmi_all_succeeds_and_removes_containers() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-rmi", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	let down = run(&["-f", c, "-p", &proj, "down", "--rmi", "all"]);
+	assert!(
+		down.status.success(),
+		"down --rmi all failed: {:?}",
+		down.stderr
+	);
+	assert_eq!(ps_all_count(c, &proj), 0, "down must remove the containers");
+}
+
+#[tokio::test]
+async fn cli_rm_volumes_removes_container() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-rmv", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run(&["-f", c, "-p", &proj, "stop"]);
+	let rm = run(&["-f", c, "-p", &proj, "rm", "-v", "-f"]);
+	assert!(rm.status.success(), "rm -v failed: {:?}", rm.stderr);
+	assert_eq!(ps_all_count(c, &proj), 0, "rm must remove the container");
+}

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -250,3 +250,29 @@ async fn cli_pull_quiet_succeeds() {
 	let pull = run(&["-f", compose.to_str().unwrap(), "-p", &proj, "pull", "-q"]);
 	assert!(pull.status.success(), "pull -q failed: {:?}", pull.stderr);
 }
+
+#[tokio::test]
+async fn cli_up_no_start_creates_without_starting() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-nostart", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let up = run(&["-f", c, "-p", &proj, "up", "--no-start"]);
+	assert!(up.status.success(), "up --no-start failed: {:?}", up.stderr);
+	assert_eq!(ps_all_count(c, &proj), 1, "container must be created");
+	let running = String::from_utf8_lossy(&run(&["-f", c, "-p", &proj, "ps", "-q"]).stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count();
+	assert_eq!(running, 0, "--no-start must not start the container");
+	run(&["-f", c, "-p", &proj, "down"]);
+}

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -276,3 +276,25 @@ async fn cli_up_no_start_creates_without_starting() {
 	assert_eq!(running, 0, "--no-start must not start the container");
 	run(&["-f", c, "-p", &proj, "down"]);
 }
+
+#[tokio::test]
+async fn cli_up_wait_returns_when_healthy() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-upwait", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	// A healthcheck that omits `timeout` (defaults applied) must still reach
+	// healthy, so `up --wait` returns successfully instead of timing out.
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    healthcheck:\n      test: [\"CMD\", \"true\"]\n      interval: 1s\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let up = run(&["-f", c, "-p", &proj, "up", "-d", "--wait"]);
+	assert!(up.status.success(), "up --wait failed: {:?}", up.stderr);
+	run(&["-f", c, "-p", &proj, "down"]);
+}

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -111,3 +111,57 @@ async fn cli_restart_no_deps_succeeds() {
 	);
 	run(&["-f", c, "-p", &proj, "down"]);
 }
+
+#[tokio::test]
+async fn cli_up_no_build_skips_building() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-nobuild", std::process::id());
+	fs::write(dir.path().join("Dockerfile"), "FROM alpine:latest\n").unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// A build-only service with no prebuilt image: `--no-build` must refuse to
+	// build, so `up` fails because there is no image to run.
+	fs::write(&compose, "services:\n  app:\n    build: .\n").unwrap();
+	let up = run(&[
+		"-f",
+		compose.to_str().unwrap(),
+		"-p",
+		&proj,
+		"up",
+		"-d",
+		"--no-build",
+	]);
+	assert!(
+		!up.status.success(),
+		"--no-build must not build the image, so up has nothing to run"
+	);
+	run(&["-f", compose.to_str().unwrap(), "-p", &proj, "down"]);
+}
+
+#[tokio::test]
+async fn cli_up_pull_never_starts_present_image() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-pullnever", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	// Ensure the image is present, then `--pull never` must still start it.
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run(&["-f", c, "-p", &proj, "down"]);
+	let up = run(&["-f", c, "-p", &proj, "up", "-d", "--pull", "never"]);
+	assert!(
+		up.status.success(),
+		"up --pull never failed: {:?}",
+		up.stderr
+	);
+	run(&["-f", c, "-p", &proj, "down"]);
+}

--- a/tests/engine_integration/create_ls.rs
+++ b/tests/engine_integration/create_ls.rs
@@ -1,0 +1,87 @@
+//! Integration tests for `create` (containers without starting) and `ls`
+//! (project discovery) against a real Podman daemon. Skip when unreachable.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+fn run(args: &[&str]) -> std::process::Output {
+	Command::new(bin()).args(args).output().unwrap()
+}
+
+/// Count non-empty lines of a `-q` listing.
+fn count(out: &std::process::Output) -> usize {
+	String::from_utf8_lossy(&out.stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count()
+}
+
+#[tokio::test]
+async fn create_makes_containers_without_starting_them() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-create", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let create = run(&["-f", c, "-p", &proj, "create"]);
+	assert!(
+		create.status.success(),
+		"create failed: {:?}",
+		create.stderr
+	);
+	// The container exists (visible with -a) but is not running.
+	assert_eq!(count(&run(&["-f", c, "-p", &proj, "ps", "-a", "-q"])), 1);
+	assert_eq!(
+		count(&run(&["-f", c, "-p", &proj, "ps", "-q"])),
+		0,
+		"create must not start the container"
+	);
+
+	// `up` then starts the already-created container.
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	assert_eq!(count(&run(&["-f", c, "-p", &proj, "ps", "-q"])), 1);
+
+	run(&["-f", c, "-p", &proj, "down"]);
+}
+
+#[tokio::test]
+async fn ls_lists_running_projects() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-lsproj", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	// `ls -q` (running only) lists the project by name.
+	let names = String::from_utf8_lossy(&run(&["-p", &proj, "ls", "-q"]).stdout).into_owned();
+	assert!(
+		names.lines().any(|l| l == proj),
+		"ls must list {proj}: {names}"
+	);
+
+	run(&["-f", c, "-p", &proj, "down"]);
+	// After teardown the project has no containers, so it drops from `ls`.
+	let after = String::from_utf8_lossy(&run(&["-p", &proj, "ls", "-q"]).stdout).into_owned();
+	assert!(
+		!after.lines().any(|l| l == proj),
+		"a torn-down project must not appear in ls: {after}"
+	);
+}

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -176,6 +176,26 @@ async fn depends_on_service_healthy() {
 }
 
 #[tokio::test]
+async fn depends_on_service_healthy_with_default_timeout() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("hltdef");
+	let engine = Engine::new(client, proj.clone());
+	// db's healthcheck OMITS `timeout`/`retries`. Podman defaults a missing
+	// Timeout to 0s (every probe fails "exceeded timeout of 0s"), so without the
+	// compose-spec default the db never becomes healthy and this up would hang.
+	let file = parse_str(
+		"services:\n  db:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    healthcheck:\n      test: [\"CMD\", \"true\"]\n      interval: 1s\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    depends_on:\n      db:\n        condition: service_healthy\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
 async fn depends_on_service_completed() {
 	let client = match podman().await {
 		Some(d) => d,

--- a/tests/engine_integration/scale.rs
+++ b/tests/engine_integration/scale.rs
@@ -1,0 +1,117 @@
+//! Scale integration tests (`up --scale` and the `scale` subcommand) against a
+//! real Podman daemon. Skip gracefully when Podman is unreachable.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// Number of running containers in the project (counts `ps -q` output lines).
+fn running_count(compose: &str, proj: &str) -> usize {
+	let out = Command::new(bin())
+		.args(["-f", compose, "-p", proj, "ps", "-q"])
+		.output()
+		.unwrap();
+	String::from_utf8_lossy(&out.stdout)
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.count()
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+	Command::new(bin()).args(args).output().unwrap()
+}
+
+#[tokio::test]
+async fn up_scale_creates_replicas_and_down_removes_them() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-upscale", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let up = run(&[
+		"-f", c, "-p", &proj, "up", "--detach", "--scale", "worker=3",
+	]);
+	assert!(up.status.success(), "up --scale failed: {:?}", up.stderr);
+	assert_eq!(
+		running_count(c, &proj),
+		3,
+		"expected 3 replicas after up --scale"
+	);
+
+	let down = run(&["-f", c, "-p", &proj, "down"]);
+	assert!(down.status.success(), "down failed: {:?}", down.stderr);
+	assert_eq!(
+		running_count(c, &proj),
+		0,
+		"down must remove scaled replicas"
+	);
+}
+
+#[tokio::test]
+async fn scale_subcommand_scales_up_then_down() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-scalecmd", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "--detach"]);
+	assert_eq!(running_count(c, &proj), 1);
+
+	let up = run(&["-f", c, "-p", &proj, "scale", "worker=3"]);
+	assert!(up.status.success(), "scale up failed: {:?}", up.stderr);
+	assert_eq!(running_count(c, &proj), 3, "scale up must add replicas");
+
+	let down = run(&["-f", c, "-p", &proj, "scale", "worker=1"]);
+	assert!(
+		down.status.success(),
+		"scale down failed: {:?}",
+		down.stderr
+	);
+	assert_eq!(running_count(c, &proj), 1, "scale down must remove surplus");
+
+	run(&["-f", c, "-p", &proj, "down"]);
+	assert_eq!(running_count(c, &proj), 0);
+}
+
+#[tokio::test]
+async fn up_scale_fixed_host_port_fails_fast() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-scaleport", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"8085:80\"\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let out = run(&["-f", c, "-p", &proj, "up", "--detach", "--scale", "web=2"]);
+	assert!(!out.status.success(), "scaling a fixed host port must fail");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("only one container can bind a host port"),
+		"expected port-conflict guidance, got: {stderr}"
+	);
+	// Clean up anything the failed attempt may have created.
+	run(&["-f", c, "-p", &proj, "down"]);
+}


### PR DESCRIPTION
## Promote develop → main

No version bump — `1.0.0` stays. Public API frozen; this batch is additive CLI/engine parity work plus CI workflow-pin bumps. Promotes the work merged to `develop` since the last promote (#437).

### CLI parity (epic #410)
- `scale` subcommand + `up --scale` (#439)
- `create`, `ls` (#441), `stats` (#442), `push` (#443) — completes create/push/stats/ls set
- `logs --tail/--since/--until/--timestamps` (#444)
- `down --remove-orphans`, `restart --no-deps` (#445)
- `config --format/--services/--quiet` (#446)
- `up --pull/--no-build/--quiet-pull` (#447), `up --no-start` (#451), `up --wait` (#453)
- `down --rmi`, `rm -v/--volumes` (#448)
- `pull -q/--quiet`, `kill --remove-orphans` (#449)

### Engine
- Native libpod endpoints: Podman version preflight, atomic restart, `links` rootless diagnostic (#440, addresses 3/4 of #420)
- Default healthcheck timeout/interval/retries (#452)

### Quadlet
- Emit and warn on previously dropped/mis-emitted fields (#438)

### CI
- Bump pinned reusable workflows `.github` 1.0.0 → 1.1.0 (#454–#462)
