### PR TITLE
feat(cli): pull --ignore-pull-failures/--include-deps/--policy

### DIFF
--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -393,6 +393,15 @@ pub(crate) enum Commands {
 		/// Suppress image-pull progress output.
 		#[arg(short, long)]
 		quiet: bool,
+		/// Continue pulling the remaining services after a failure.
+		#[arg(long)]
+		ignore_pull_failures: bool,
+		/// Also pull images for the named services' depends_on services.
+		#[arg(long)]
+		include_deps: bool,
+		/// Pull policy: always, missing, never, newer, build (overrides per-service pull_policy).
+		#[arg(long)]
+		policy: Option<String>,
 		/// Only pull images for these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,6 +8,7 @@
 mod context;
 mod pull;
 mod push;
+pub use pull::PullOptions;
 pub use push::PushOptions;
 
 use bytes::Bytes;

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -3,14 +3,98 @@
 use futures_util::StreamExt;
 use tracing::{debug, info, warn};
 
-use crate::compose::types::Service;
+use std::collections::HashSet;
+
+use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImagePullProgress;
 use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::super::Engine;
 
+/// Options for [`Engine::pull_services_with_options`], mirroring `docker
+/// compose pull` flags. The `--policy` override is carried on the engine (see
+/// [`Engine::with_up_overrides`]), not here.
+#[derive(Default)]
+pub struct PullOptions {
+	/// Warn and continue instead of aborting on the first failure,
+	/// `--ignore-pull-failures`.
+	pub ignore_failures: bool,
+	/// Also pull each named service's transitive `depends_on`, `--include-deps`.
+	pub include_deps: bool,
+}
+
 impl Engine {
+	/// Pull images for all services that declare an `image:` key, concurrently.
+	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
+		self.pull_services(file, &[]).await
+	}
+
+	/// Pull images for the named services (or every service when `services` is
+	/// empty), matching `docker compose pull [SERVICE...]`.
+	pub async fn pull_services(&self, file: &ComposeFile, services: &[String]) -> Result<()> {
+		self.pull_services_with_options(file, services, PullOptions::default())
+			.await
+	}
+
+	/// Pull service images with `docker compose pull` options:
+	/// `--include-deps` (also pull each named service's transitive
+	/// `depends_on`) and `--ignore-pull-failures` (warn and continue instead of
+	/// aborting on the first failure). The `--policy` override is applied via
+	/// the engine's pull-policy override (see [`Engine::with_up_overrides`]).
+	pub async fn pull_services_with_options(
+		&self,
+		file: &ComposeFile,
+		services: &[String],
+		opts: PullOptions,
+	) -> Result<()> {
+		// `--include-deps` widens the explicit service list to its transitive
+		// depends_on closure; an empty list already means "every service".
+		let wanted: Option<HashSet<String>> = match (services.is_empty(), opts.include_deps) {
+			(true, _) => None,
+			(false, true) => Some(pull_dep_closure(file, services)),
+			(false, false) => Some(services.iter().cloned().collect()),
+		};
+
+		let futs: Vec<_> = file
+			.services
+			.iter()
+			.filter(|(name, s)| {
+				s.image.is_some()
+					&& wanted
+						.as_ref()
+						.is_none_or(|set| set.contains(name.as_str()))
+			})
+			.map(|(name, s)| async move {
+				// The libpod pull stream reports failure as an in-band progress
+				// line, so `pull_image` returns Ok even when the pull failed;
+				// confirm the image actually landed in local storage.
+				let _ = self.pull_image(s).await;
+				let image = s.image.clone().unwrap_or_default();
+				(
+					name.clone(),
+					image.clone(),
+					self.image_present(&image).await,
+				)
+			})
+			.collect();
+
+		let results = futures_util::future::join_all(futs).await;
+		for (name, image, present) in results {
+			if present {
+				continue;
+			}
+			if opts.ignore_failures {
+				tracing::warn!("pull {name} ({image}) failed — ignored");
+			} else {
+				return Err(ComposeError::Build(format!(
+					"failed to pull image {image} for service {name}"
+				)));
+			}
+		}
+		Ok(())
+	}
+
 	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
 		let image = match &service.image {
 			Some(img) => img.clone(),
@@ -64,6 +148,37 @@ impl Engine {
 
 		Ok(())
 	}
+
+	/// Whether an image reference is present in local storage. Used by the
+	/// `pull` command to verify each pull actually landed (the streaming pull
+	/// endpoint reports failures as in-band progress lines, not an HTTP error).
+	async fn image_present(&self, image: &str) -> bool {
+		let path = format!("{API_PREFIX}/images/{}/json", urlencoded(image));
+		self.client
+			.get_json::<crate::libpod::types::image::ImageInspect>(&path)
+			.await
+			.is_ok()
+	}
+}
+
+/// The transitive `depends_on` closure of `services` (including the services
+/// themselves), for `pull --include-deps`.
+fn pull_dep_closure(file: &ComposeFile, services: &[String]) -> HashSet<String> {
+	let mut set = HashSet::new();
+	let mut stack: Vec<String> = services.to_vec();
+	while let Some(name) = stack.pop() {
+		if !set.insert(name.clone()) {
+			continue;
+		}
+		if let Some(svc) = file.services.get(&name) {
+			for dep in svc.depends_on.service_names() {
+				if !set.contains(&dep) {
+					stack.push(dep);
+				}
+			}
+		}
+	}
+	set
 }
 
 /// Map a compose `pull_policy:` value to the libpod images/pull `policy`
@@ -82,7 +197,29 @@ pub(in crate::engine) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'st
 
 #[cfg(test)]
 mod tests {
-	use super::libpod_pull_policy;
+	use super::{libpod_pull_policy, pull_dep_closure};
+
+	#[test]
+	fn dep_closure_includes_transitive_dependencies() {
+		let file = crate::parse_str(
+			"services:\n  web:\n    image: a\n    depends_on:\n      - api\n  api:\n    image: b\n    depends_on:\n      - db\n  db:\n    image: c\n  lone:\n    image: d\n",
+		)
+		.unwrap();
+		let mut got: Vec<String> = pull_dep_closure(&file, &["web".to_string()])
+			.into_iter()
+			.collect();
+		got.sort();
+		assert_eq!(got, vec!["api", "db", "web"]);
+	}
+
+	#[test]
+	fn dep_closure_of_leaf_is_just_itself() {
+		let file = crate::parse_str("services:\n  db:\n    image: c\n").unwrap();
+		let got: Vec<String> = pull_dep_closure(&file, &["db".to_string()])
+			.into_iter()
+			.collect();
+		assert_eq!(got, vec!["db"]);
+	}
 
 	#[test]
 	fn pull_policy_maps_every_spec_value() {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -5,7 +5,7 @@
 mod build;
 mod container;
 mod copy;
-pub use build::{BuildOptions, PushOptions};
+pub use build::{BuildOptions, PullOptions, PushOptions};
 pub use lifecycle::{RunOptions, RunOverrides};
 pub use lock::ProjectLock;
 pub use query::{ExecOptions, ImagesOptions, LogsOptions, PsOptions};

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -400,30 +400,6 @@ impl Engine {
 		Ok(())
 	}
 
-	/// Pull images for all services that declare an `image:` key, concurrently.
-	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
-		self.pull_services(file, &[]).await
-	}
-
-	/// Pull images for the named services (or every service when `services` is
-	/// empty), matching `docker compose pull [SERVICE...]`.
-	pub async fn pull_services(&self, file: &ComposeFile, services: &[String]) -> Result<()> {
-		let futs: Vec<_> = file
-			.services
-			.iter()
-			.filter(|(name, s)| {
-				s.image.is_some() && (services.is_empty() || services.iter().any(|w| w == *name))
-			})
-			.map(|(_, s)| self.pull_image(s))
-			.collect();
-
-		let results = futures_util::future::join_all(futs).await;
-		for r in results {
-			r?;
-		}
-		Ok(())
-	}
-
 	/// Remove containers labelled for this project that are not defined in the current compose file.
 	pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
 		let label = format!("podup.project={}", self.project);

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -30,7 +30,8 @@ pub use compose::{
 };
 pub use engine::{
 	is_safe_project_name, list_projects, BuildOptions, Engine, ExecOptions, ImagesOptions,
-	LogsOptions, LsOptions, ProjectLock, PsOptions, PushOptions, RunOptions, RunOverrides,
+	LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions, PushOptions, RunOptions,
+	RunOverrides,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -166,7 +166,7 @@ async fn run() -> podup::Result<()> {
 			quiet_pull,
 			..
 		} => (pull.clone(), *no_build, *quiet_pull),
-		Commands::Pull { quiet, .. } => (None, false, *quiet),
+		Commands::Pull { quiet, policy, .. } => (policy.clone(), false, *quiet),
 		_ => (None, false, false),
 	};
 	let engine = podup::Engine::with_base_dir(client, project, base_dir)
@@ -459,7 +459,24 @@ async fn run() -> podup::Result<()> {
 				)
 				.await?
 		}
-		Commands::Pull { quiet: _, services } => engine.pull_services(&file, &services).await?,
+		Commands::Pull {
+			quiet: _,
+			ignore_pull_failures,
+			include_deps,
+			policy: _,
+			services,
+		} => {
+			engine
+				.pull_services_with_options(
+					&file,
+					&services,
+					podup::PullOptions {
+						ignore_failures: ignore_pull_failures,
+						include_deps,
+					},
+				)
+				.await?
+		}
 		Commands::Restart {
 			service,
 			timeout: _,

--- a/tests/engine_integration/group_a1.rs
+++ b/tests/engine_integration/group_a1.rs
@@ -339,6 +339,41 @@ async fn pull_images() {
 }
 
 #[tokio::test]
+async fn pull_ignore_failures_continues_past_bad_image() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("plif");
+	let engine = Engine::new(client, proj.clone());
+	// A bogus registry/image alongside a good one: the bad pull fails.
+	let file = parse_str(
+		"services:\n  good:\n    image: alpine:latest\n  bad:\n    image: localhost:1/nope:nope\n",
+	)
+	.unwrap();
+
+	// Without --ignore-pull-failures the bad image aborts the whole pull.
+	let strict = engine.pull(&file).await;
+	assert!(strict.is_err(), "bad image must fail a strict pull");
+
+	// With --ignore-pull-failures the failure is logged and pull returns Ok.
+	let lenient = engine
+		.pull_services_with_options(
+			&file,
+			&[],
+			podup::PullOptions {
+				ignore_failures: true,
+				include_deps: false,
+			},
+		)
+		.await;
+	assert!(
+		lenient.is_ok(),
+		"ignore-pull-failures must not abort: {lenient:?}"
+	);
+}
+
+#[tokio::test]
 async fn remove_orphans_no_orphans() {
 	let client = match podman().await {
 		Some(d) => d,


### PR DESCRIPTION
## What
Closes the `pull` row of the CLI-parity epic #410.

## Flags added
- `--policy <always|missing|never|newer|build>` — overrides each service's `pull_policy` (threads through the same engine override as `up --pull`)
- `--include-deps` — also pull the named services' transitive `depends_on`
- `--ignore-pull-failures` — warn and continue instead of failing

## Note on failure detection
The libpod pull stream reports failures as in-band JSON progress lines (the HTTP response stays 200), so `pull_image` can't surface them as an error without destabilising the shared `up` path under concurrent pulls. Instead, `pull` now verifies each image is present in local storage after pulling and errors by default when one is missing; `--ignore-pull-failures` downgrades that to a warning. `up`'s pull behaviour is unchanged.

## Structure
Pull command logic moved from `query/mod.rs` to `build/pull.rs` (next to `pull_image`) to stay under the file-size limit. Public API freeze respected — `PullOptions` is a new additive struct + new `pull_services_with_options` method.

## Tests
Unit tests for the dependency closure; integration test for `--ignore-pull-failures` continuing past a bad image. fmt/clippy/doc/line-limit clean locally.

Refs #410