### PR TITLE
feat(cli): rm -s/--stop, port --index, start --wait/--wait-timeout

### DIFF
--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -120,6 +120,12 @@ pub(crate) enum Commands {
 	},
 	/// Start existing stopped containers.
 	Start {
+		/// Wait until services are running/healthy before returning.
+		#[arg(long)]
+		wait: bool,
+		/// Maximum seconds to wait with --wait before giving up.
+		#[arg(long)]
+		wait_timeout: Option<u64>,
 		/// Start only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
@@ -215,6 +221,9 @@ pub(crate) enum Commands {
 		/// Also remove anonymous volumes attached to the containers.
 		#[arg(short = 'v', long)]
 		volumes: bool,
+		/// Stop the containers (gracefully) before removing them.
+		#[arg(short = 's', long)]
+		stop: bool,
 		/// Remove only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
@@ -336,6 +345,9 @@ pub(crate) enum Commands {
 		/// Protocol (tcp or udp).
 		#[arg(long, default_value = "tcp")]
 		proto: String,
+		/// Index of the container when the service has multiple replicas (1-based).
+		#[arg(long)]
+		index: Option<u32>,
 	},
 	/// List images used by services.
 	#[command(alias = "image")]
@@ -449,11 +461,10 @@ pub(crate) enum Commands {
 	Watch,
 	/// Update podup to the latest signed release.
 	///
-	/// Downloads the release binary for this platform and replaces the running
-	/// executable, but only after verifying the release's Ed25519 signature
-	/// against the public key embedded in this build and matching its SHA-256
-	/// checksum. Verification fails closed: a missing key, bad signature, or
-	/// checksum mismatch aborts without touching the installed binary.
+	/// Replaces the running executable only after verifying the release's
+	/// Ed25519 signature against the embedded public key and matching its
+	/// SHA-256 checksum; verification fails closed (bad/missing key, signature,
+	/// or checksum aborts without touching the installed binary).
 	#[cfg(feature = "update")]
 	Update {
 		/// Report whether a newer release exists without installing it.
@@ -463,11 +474,7 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		force: bool,
 	},
-	/// Print a shell completion script to stdout.
-	///
-	/// Generates a completion script for the named shell from the CLI
-	/// definition. Source it from your shell's startup (or install the file the
-	/// Debian package ships) to get tab completion for podup commands and flags.
+	/// Print a shell completion script to stdout for the named shell.
 	#[cfg(feature = "completions")]
 	Completions {
 		/// Shell to generate completions for (bash, zsh, fish, powershell, elvish).

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -92,7 +92,26 @@ pub(crate) async fn dispatch(
 					.await?;
 			}
 		}
-		Commands::Start { services } => engine.start(file, &services).await?,
+		Commands::Start {
+			wait,
+			wait_timeout,
+			services,
+		} => {
+			engine.start(file, &services).await?;
+			if wait {
+				let fut = engine.wait_services_healthy(file, &services);
+				match wait_timeout {
+					Some(secs) => tokio::time::timeout(std::time::Duration::from_secs(secs), fut)
+						.await
+						.map_err(|_| {
+							podup::ComposeError::Unsupported(
+								"start --wait timed out before services became healthy".into(),
+							)
+						})??,
+					None => fut.await?,
+				}
+			}
+		}
 		Commands::Stop {
 			services,
 			timeout: _,
@@ -134,8 +153,14 @@ pub(crate) async fn dispatch(
 		Commands::Rm {
 			force,
 			volumes,
+			stop,
 			services,
 		} => {
+			// `-s/--stop` gracefully stops the targets first so they can be
+			// removed without `--force`.
+			if stop {
+				engine.stop(file, &services).await?;
+			}
 			engine
 				.rm_with_options(file, &services, force, volumes)
 				.await?
@@ -241,7 +266,12 @@ pub(crate) async fn dispatch(
 			service,
 			private_port,
 			proto,
-		} => engine.port(file, &service, private_port, &proto).await?,
+			index,
+		} => {
+			engine
+				.port_with_index(file, &service, private_port, &proto, index)
+				.await?
+		}
 		Commands::Images { quiet, format } => {
 			engine
 				.images_with_options(

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -65,11 +65,25 @@ impl Engine {
 		private_port: u16,
 		proto: &str,
 	) -> Result<()> {
+		self.port_with_index(file, service_name, private_port, proto, None)
+			.await
+	}
+
+	/// Like [`Engine::port`] but targets a specific replica via `--index`
+	/// (1-based); `None` uses the first replica.
+	pub async fn port_with_index(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		private_port: u16,
+		proto: &str,
+		index: Option<u32>,
+	) -> Result<()> {
 		let service = file
 			.services
 			.get(service_name)
 			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.first_replica_name(service_name, service);
+		let container_name = self.replica_name_at(service_name, service, index)?;
 
 		let path = format!(
 			"{API_PREFIX}/containers/{}/json",

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -298,3 +298,70 @@ async fn cli_up_wait_returns_when_healthy() {
 	assert!(up.status.success(), "up --wait failed: {:?}", up.stderr);
 	run(&["-f", c, "-p", &proj, "down"]);
 }
+
+#[tokio::test]
+async fn cli_rm_stop_removes_running_container() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-rmstop", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	assert_eq!(ps_all_count(c, &proj), 1, "container should exist after up");
+
+	// `rm -s` (no -f) must stop the running container first, then remove it.
+	let rm = run(&["-f", c, "-p", &proj, "rm", "-s", "web"]);
+	assert!(rm.status.success(), "rm -s failed: {:?}", rm.stderr);
+	assert_eq!(
+		ps_all_count(c, &proj),
+		0,
+		"rm -s must remove the running container"
+	);
+
+	run(&["-f", c, "-p", &proj, "down"]);
+}
+
+#[tokio::test]
+async fn cli_start_wait_returns_after_starting() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-startwait", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	// Create the container without starting, then `start --wait` must start it
+	// and return (no healthcheck → ready once started).
+	run(&["-f", c, "-p", &proj, "up", "--no-start"]);
+	let start = run(&[
+		"-f",
+		c,
+		"-p",
+		&proj,
+		"start",
+		"--wait",
+		"--wait-timeout",
+		"30",
+	]);
+	assert!(
+		start.status.success(),
+		"start --wait failed: {:?}",
+		start.stderr
+	);
+
+	run(&["-f", c, "-p", &proj, "down"]);
+}

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -302,6 +302,18 @@ async fn port_scaled_service_targets_first_replica() {
 
 	engine.up(&file).await.unwrap();
 	engine.port(&file, "worker", 80, "tcp").await.unwrap();
+	// --index targets a valid replica; an out-of-range index errors.
+	engine
+		.port_with_index(&file, "worker", 80, "tcp", Some(2))
+		.await
+		.unwrap();
+	let bad = engine
+		.port_with_index(&file, "worker", 80, "tcp", Some(9))
+		.await;
+	assert!(
+		matches!(bad, Err(podup::ComposeError::ServiceNotFound(_))),
+		"out-of-range port --index must error, got {bad:?}"
+	);
 	engine.down(&file).await.unwrap();
 }
 


### PR DESCRIPTION
## What
Three more rows of the CLI-parity epic #410.

- **rm `-s/--stop`** — gracefully stop the targeted containers before removing them (removable without `--force`).
- **port `--index`** — target a specific replica of a scaled service (new `port_with_index`, shares the replica resolver, errors out of range).
- **start `--wait` / `--wait-timeout`** — block until started services are running/healthy, optionally bounded by a timeout (reuses `wait_services_healthy`).

`rm --stop` and `start --wait` are orchestrated in the dispatch layer over existing engine methods; only `port` needed a new (additive) method.

## Tests
CLI tests for `rm -s` (removes a running container) and `start --wait` (returns after starting); engine test for `port --index` valid + out-of-range. fmt/clippy/doc/line-limit clean locally.

Refs #410