### PR TITLE
feat(cli): up --timestamps and -V/--renew-anon-volumes

### DIFF
--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -14,17 +14,13 @@ pub(crate) use types::{ConfigFormat, OutputFormat, RmiScope};
 #[derive(Parser)]
 #[command(name = "podup", version)]
 pub(crate) struct Cli {
-	/// Path to the compose file. May also be set via `COMPOSE_FILE`. When
-	/// unset, the compose-spec precedence list is probed in the current
-	/// directory (compose.yaml, compose.yml, docker-compose.yaml,
-	/// docker-compose.yml).
+	/// Path to the compose file (or `COMPOSE_FILE`). Unset: probe the
+	/// compose-spec precedence list (compose.yaml/.yml, docker-compose.yaml/.yml).
 	#[arg(short, long)]
 	pub(crate) file: Vec<PathBuf>,
 
-	/// Project name (used as a prefix for container names). May also be set via
-	/// `COMPOSE_PROJECT_NAME`. When unset, the compose-spec precedence applies:
-	/// the top-level `name:` field, then the sanitized basename of the project
-	/// directory.
+	/// Project name, the container-name prefix (or `COMPOSE_PROJECT_NAME`).
+	/// Unset: the top-level `name:`, then the sanitized project-directory basename.
 	#[arg(short, long, env = "COMPOSE_PROJECT_NAME")]
 	pub(crate) project: Option<String>,
 
@@ -42,9 +38,8 @@ pub(crate) struct Cli {
 	#[arg(long, global = true)]
 	pub(crate) project_directory: Option<PathBuf>,
 
-	/// Additional env file(s) loaded into the variable map used for
-	/// interpolation. May be given multiple times; later files win. The
-	/// process environment and a project `.env` still take precedence.
+	/// Additional env file(s) for the interpolation variable map (repeatable;
+	/// later files win). Process env and a project `.env` still take precedence.
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
 
@@ -98,6 +93,12 @@ pub(crate) enum Commands {
 		/// Create containers but do not start them.
 		#[arg(long)]
 		no_start: bool,
+		/// Prefix attached log lines with a timestamp (ignored with -d).
+		#[arg(long)]
+		timestamps: bool,
+		/// Recreate anonymous volumes instead of keeping the previous ones.
+		#[arg(short = 'V', long)]
+		renew_anon_volumes: bool,
 		/// Bring up only these services (and their transitive depends_on).
 		/// If omitted, brings up every service in the compose file.
 		#[arg(trailing_var_arg = true)]

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -32,6 +32,8 @@ pub(crate) async fn dispatch(
 			quiet_pull: _,
 			wait,
 			no_start,
+			timestamps,
+			renew_anon_volumes: _,
 			services,
 		} => {
 			if remove_orphans {
@@ -72,7 +74,7 @@ pub(crate) async fn dispatch(
 			if watch {
 				engine.watch(file).await?;
 			} else if !detach {
-				engine.attach_logs(file).await?;
+				engine.attach_logs_with_options(file, timestamps).await?;
 				let _ = engine.stop(file, &[]).await;
 			}
 		}

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -244,10 +244,13 @@ impl Engine {
 			..Default::default()
 		};
 
-		// Remove any existing container (idempotent restart).
+		// Remove any existing container (idempotent restart). `up
+		// -V/--renew-anon-volumes` also drops its old anonymous volumes (v=true)
+		// so they are recreated fresh instead of orphaned.
 		let rm_path = format!(
-			"{API_PREFIX}/containers/{}?force=true",
-			urlencoded(container_name)
+			"{API_PREFIX}/containers/{}?force=true&v={}",
+			urlencoded(container_name),
+			self.renew_anon_volumes,
 		);
 		if let Err(e) = self.client.delete_ok(&rm_path).await {
 			tracing::debug!("pre-create delete {container_name}: {e}");

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -66,6 +66,9 @@ pub struct Engine {
 	/// CLI `run`-only flag overrides (user/workdir/entrypoint/volume/publish/
 	/// interactive/no-deps); empty by default.
 	pub(super) run_overrides: lifecycle::RunOverrides,
+	/// CLI `up -V/--renew-anon-volumes`: when recreating a container, also remove
+	/// its old anonymous volumes instead of leaving them orphaned.
+	pub(super) renew_anon_volumes: bool,
 }
 
 impl Engine {
@@ -81,6 +84,7 @@ impl Engine {
 			no_build: false,
 			quiet_pull: false,
 			run_overrides: lifecycle::RunOverrides::default(),
+			renew_anon_volumes: false,
 		}
 	}
 
@@ -96,6 +100,7 @@ impl Engine {
 			no_build: false,
 			quiet_pull: false,
 			run_overrides: lifecycle::RunOverrides::default(),
+			renew_anon_volumes: false,
 		}
 	}
 
@@ -132,6 +137,13 @@ impl Engine {
 	/// --no-deps`). Builder-style; consumed by [`Engine::run`].
 	pub fn with_run_overrides(mut self, overrides: RunOverrides) -> Self {
 		self.run_overrides = overrides;
+		self
+	}
+
+	/// Set the CLI `up -V/--renew-anon-volumes` flag. Builder-style; when set,
+	/// recreating a container also removes its old anonymous volumes.
+	pub fn with_renew_anon_volumes(mut self, renew: bool) -> Self {
+		self.renew_anon_volumes = renew;
 		self
 	}
 

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -181,6 +181,17 @@ impl Engine {
 
 	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
 	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
+		self.attach_logs_with_options(file, false).await
+	}
+
+	/// Like [`Engine::attach_logs`] but with `up --timestamps` support: when
+	/// `timestamps` is set, each streamed line carries the libpod RFC3339
+	/// timestamp prefix.
+	pub async fn attach_logs_with_options(
+		&self,
+		file: &ComposeFile,
+		timestamps: bool,
+	) -> Result<()> {
 		// Carry (display_name, container_name, is_tty) so the log parser matches
 		// the container's framing mode: TTY containers emit raw bytes; non-TTY
 		// containers emit multiplexed 8-byte-header frames.
@@ -210,7 +221,7 @@ impl Engine {
 			.map(|(display, cname, is_tty)| {
 				let prefix = display.clone();
 				let path = format!(
-					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
+					"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true&timestamps={timestamps}",
 					urlencoded(cname),
 				);
 				let client = &self.client;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -170,11 +170,21 @@ async fn run() -> podup::Result<()> {
 		Commands::Pull { quiet, policy, .. } => (policy.clone(), false, *quiet),
 		_ => (None, false, false),
 	};
+	// `up -V/--renew-anon-volumes`: recreate anonymous volumes on container
+	// recreation instead of leaving the old ones orphaned.
+	let renew_anon_volumes = matches!(
+		&cli.command,
+		Commands::Up {
+			renew_anon_volumes: true,
+			..
+		}
+	);
 	let engine = podup::Engine::with_base_dir(client, project, base_dir)
 		.with_stop_timeout(stop_timeout)
 		.with_scale_overrides(scale_overrides)
 		.with_up_overrides(pull_override, no_build, quiet_pull)
-		.with_run_overrides(startup::run_overrides_for(&cli.command));
+		.with_run_overrides(startup::run_overrides_for(&cli.command))
+		.with_renew_anon_volumes(renew_anon_volumes);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,

--- a/tests/engine_integration/group_b1.rs
+++ b/tests/engine_integration/group_b1.rs
@@ -428,3 +428,59 @@ async fn sibling_resolves_service_by_name_without_networks_block() {
 		"service `server` was not reachable by name without a networks: block: {out:?}"
 	);
 }
+
+// ---------------------------------------------------------------------------
+// up -V/--renew-anon-volumes and up --timestamps
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn engine_up_renew_anon_volumes_recreates_cleanly() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("renew");
+	// `with_renew_anon_volumes` makes the recreate delete drop old anon volumes
+	// (v=true); a forced re-up must still succeed.
+	let engine = Engine::new(client, proj.clone()).with_renew_anon_volumes(true);
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// Force recreate: the v=true delete path runs for the existing container.
+	let second = engine
+		.up_with_options(&file, false, &[], &[], false, true, false)
+		.await;
+	engine.down(&file).await.unwrap();
+	second.expect("forced re-up with --renew-anon-volumes must succeed");
+}
+
+#[tokio::test]
+async fn engine_attach_logs_timestamps_returns_when_container_exits() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("ats");
+	let engine = Engine::new(client, proj.clone());
+	// A short-lived container: its follow log stream closes on exit, so
+	// attach_logs returns instead of blocking.
+	let file =
+		parse_str("services:\n  job:\n    image: alpine:latest\n    command: [\"echo\", \"hi\"]\n")
+			.unwrap();
+
+	engine.up(&file).await.unwrap();
+	let res = tokio::time::timeout(
+		std::time::Duration::from_secs(20),
+		engine.attach_logs_with_options(&file, true),
+	)
+	.await;
+	engine.down(&file).await.unwrap();
+	assert!(
+		res.is_ok(),
+		"attach_logs --timestamps did not return for an exited container"
+	);
+	res.unwrap().unwrap();
+}


### PR DESCRIPTION
## What
Completes the `up` row of the CLI-parity epic #410.

- **`--timestamps`** — prefix attached log lines with the libpod RFC3339 timestamp (new `attach_logs_with_options`; ignored with `-d`, where nothing is attached).
- **`-V/--renew-anon-volumes`** — when recreating a container, also remove its old anonymous volumes (delete with `v=true`) instead of leaving them orphaned. Carried on the engine via `with_renew_anon_volumes`.

## API freeze
`attach_logs_with_options` and `with_renew_anon_volumes` are additive; existing `attach_logs` delegates.

## Tests
Engine tests: forced re-up under `--renew-anon-volumes` succeeds (exercises the `v=true` delete); `attach_logs --timestamps` returns when the container exits. fmt/clippy/doc/line-limit clean locally.

Refs #410