### PR TITLE
feat(cli): config --no-interpolate and --resolve-image-digests

### DIFF
--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -32,14 +32,12 @@ pub(crate) struct Cli {
 	#[arg(long, value_delimiter = ',', env = "COMPOSE_PROFILES", global = true)]
 	pub(crate) profile: Vec<String>,
 
-	/// Base directory for resolving relative paths (env_file, build context,
-	/// bind mounts, config/secret file sources). Defaults to the directory
-	/// containing the compose file.
+	/// Base directory for relative paths (env_file, build context, bind mounts,
+	/// config/secret sources). Defaults to the compose file's directory.
 	#[arg(long, global = true)]
 	pub(crate) project_directory: Option<PathBuf>,
 
-	/// Additional env file(s) for the interpolation variable map (repeatable;
-	/// later files win). Process env and a project `.env` still take precedence.
+	/// Extra env file(s) for interpolation (repeatable, later win; process env and `.env` still win).
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
 
@@ -57,7 +55,7 @@ pub(crate) enum Commands {
 		/// Build images before starting containers.
 		#[arg(long)]
 		build: bool,
-		/// Watch for file changes and sync/rebuild/restart per develop.watch rules.
+		/// Watch and sync/rebuild/restart per develop.watch rules.
 		#[arg(short, long)]
 		watch: bool,
 		/// Remove containers for services not defined in the compose file.
@@ -72,7 +70,7 @@ pub(crate) enum Commands {
 		/// Do not start linked services (depends_on) of the named services.
 		#[arg(long)]
 		no_deps: bool,
-		/// Seconds to wait for containers to stop when recreating, before killing them.
+		/// Seconds to wait for a container to stop when recreating.
 		#[arg(short = 't', long)]
 		timeout: Option<i32>,
 		/// Override the replica count for a service: SERVICE=N (repeatable).
@@ -99,8 +97,7 @@ pub(crate) enum Commands {
 		/// Recreate anonymous volumes instead of keeping the previous ones.
 		#[arg(short = 'V', long)]
 		renew_anon_volumes: bool,
-		/// Bring up only these services (and their transitive depends_on).
-		/// If omitted, brings up every service in the compose file.
+		/// Bring up only these services (and their depends_on); default: all.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
@@ -187,8 +184,7 @@ pub(crate) enum Commands {
 		/// Continue pushing the remaining services after a failure.
 		#[arg(long)]
 		ignore_push_failures: bool,
-		/// Verify the registry's TLS certificate (set false for an insecure
-		/// or local HTTP registry). Omitted leaves Podman's default (on).
+		/// Verify the registry TLS cert (false for insecure/HTTP; default on).
 		#[arg(long)]
 		tls_verify: Option<bool>,
 		/// Push only these services.
@@ -452,7 +448,7 @@ pub(crate) enum Commands {
 		/// Only restart this service.
 		service: Option<String>,
 	},
-	/// Print the resolved compose file (after substitution / extends / include).
+	/// Print the resolved compose file (substitution/extends/include applied).
 	#[command(alias = "convert")]
 	Config {
 		/// Output format.
@@ -464,6 +460,12 @@ pub(crate) enum Commands {
 		/// Only validate the configuration; print nothing.
 		#[arg(short, long)]
 		quiet: bool,
+		/// Leave ${VAR} placeholders literal instead of interpolating them.
+		#[arg(long)]
+		no_interpolate: bool,
+		/// Rewrite each service image to its registry digest (repo@sha256:...).
+		#[arg(long)]
+		resolve_image_digests: bool,
 	},
 	/// Generate declarative artifacts from the compose file.
 	#[command(alias = "gen")]

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -29,9 +29,21 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 /// effect for the top-level file and any included files; the process
 /// environment and a project `.env` still take precedence.
 pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<ComposeFile> {
+	parse_file_with_env_files_interp(path, env_files, true)
+}
+
+/// Like [`parse_file_with_env_files`] but with explicit control over variable
+/// interpolation. `interpolate = false` (the `config --no-interpolate` path)
+/// leaves `${VAR}` placeholders literal while still resolving
+/// `extends:`/`include:`/merge.
+pub fn parse_file_with_env_files_interp(
+	path: &Path,
+	env_files: &[String],
+	interpolate: bool,
+) -> Result<ComposeFile> {
 	let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 	let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
-	let mut file = parse_file_inner_with_env(&abs, &dir, env_files)?;
+	let mut file = parse_file_inner_with_env(&abs, &dir, env_files, interpolate)?;
 
 	let includes = std::mem::take(&mut file.include);
 	for inc in includes {
@@ -67,7 +79,8 @@ pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<Co
 			});
 			let mut combined_env_files = env_files.to_vec();
 			combined_env_files.extend(extra_env_files.iter().cloned());
-			let mut included = parse_file_inner_with_env(&inc_path, &inc_dir, &combined_env_files)?;
+			let mut included =
+				parse_file_inner_with_env(&inc_path, &inc_dir, &combined_env_files, interpolate)?;
 			anchor::anchor_compose_file(&mut included, &inc_dir);
 			include::merge_compose_file(&mut file, included);
 		}
@@ -94,13 +107,24 @@ pub fn collect_diagnostics(file: &ComposeFile) -> Vec<String> {
 /// resolve against the first file's directory, matching the compose project
 /// directory. `env_files` feed interpolation for every file.
 pub fn parse_files_with_env_files(paths: &[PathBuf], env_files: &[String]) -> Result<ComposeFile> {
+	parse_files_with_env_files_interp(paths, env_files, true)
+}
+
+/// Like [`parse_files_with_env_files`] but with explicit interpolation control.
+/// `interpolate = false` backs `config --no-interpolate`: `${VAR}` placeholders
+/// are left literal across all merged files.
+pub fn parse_files_with_env_files_interp(
+	paths: &[PathBuf],
+	env_files: &[String],
+	interpolate: bool,
+) -> Result<ComposeFile> {
 	let mut iter = paths.iter();
 	let first = iter
 		.next()
 		.ok_or_else(|| ComposeError::FileNotFound("no compose file given".to_string()))?;
-	let mut merged = parse_file_with_env_files(first, env_files)?;
+	let mut merged = parse_file_with_env_files_interp(first, env_files, interpolate)?;
 	for path in iter {
-		let other = parse_file_with_env_files(path, env_files)?;
+		let other = parse_file_with_env_files_interp(path, env_files, interpolate)?;
 		merge_override(&mut merged, other);
 	}
 	normalize_default_network(&mut merged);
@@ -180,13 +204,14 @@ pub fn parse_str_raw(content: &str) -> Result<ComposeFile> {
 }
 
 pub(crate) fn parse_file_inner(path: &Path, dir: &Path) -> Result<ComposeFile> {
-	parse_file_inner_with_env(path, dir, &[])
+	parse_file_inner_with_env(path, dir, &[], true)
 }
 
 pub(crate) fn parse_file_inner_with_env(
 	path: &Path,
 	dir: &Path,
 	extra_env_files: &[String],
+	interpolate: bool,
 ) -> Result<ComposeFile> {
 	let content = crate::filesystem::read_to_string_capped(path).map_err(|e| {
 		if e.kind() == std::io::ErrorKind::NotFound {
@@ -195,13 +220,19 @@ pub(crate) fn parse_file_inner_with_env(
 			ComposeError::Io(e)
 		}
 	})?;
-	let vars = if extra_env_files.is_empty() {
-		substitute::build_vars(dir)
+	// `config --no-interpolate` leaves `${VAR}` placeholders literal; otherwise
+	// substitute against the env/.env/env-file variable map.
+	let yaml = if interpolate {
+		let vars = if extra_env_files.is_empty() {
+			substitute::build_vars(dir)
+		} else {
+			substitute::build_vars_with_env_files(dir, extra_env_files)
+		};
+		substitute::substitute(&content, &vars)?
 	} else {
-		substitute::build_vars_with_env_files(dir, extra_env_files)
+		content
 	};
-	let substituted = substitute::substitute(&content, &vars)?;
-	merge::deserialize_with_merge(&substituted)
+	merge::deserialize_with_merge(&yaml)
 }
 
 #[cfg(test)]

--- a/internal/engine/config_digests.rs
+++ b/internal/engine/config_digests.rs
@@ -1,0 +1,37 @@
+//! `config --resolve-image-digests`: pin each service image to its registry
+//! digest.
+//!
+//! Like `ls`, this is project-agnostic — it needs only a [`Client`] to inspect
+//! images, not a full [`Engine`] — so it lives as a free function.
+
+use crate::compose::types::ComposeFile;
+use crate::error::Result;
+use crate::libpod::types::image::ImageInspect;
+use crate::libpod::{urlencoded, Client, API_PREFIX};
+
+/// Return a copy of `file` with every service `image:` rewritten to its registry
+/// digest (`repo@sha256:...`), matching `docker compose config
+/// --resolve-image-digests`. An image with no registry digest in local storage
+/// (e.g. built locally, or never pulled) is left unchanged with a warning.
+pub async fn resolve_image_digests(client: &Client, file: &ComposeFile) -> Result<ComposeFile> {
+	let mut out = file.clone();
+	for (name, svc) in out.services.iter_mut() {
+		let Some(image) = svc.image.clone() else {
+			continue;
+		};
+		let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image));
+		match client.get_json::<ImageInspect>(&path).await {
+			Ok(info) => match info.repo_digests.into_iter().next() {
+				Some(digest) => svc.image = Some(digest),
+				None => tracing::warn!(
+					"config --resolve-image-digests: no registry digest for {image} \
+					 (service {name}); left unchanged"
+				),
+			},
+			Err(e) => tracing::warn!(
+				"config --resolve-image-digests: cannot inspect {image} (service {name}): {e}"
+			),
+		}
+	}
+	Ok(out)
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -3,6 +3,8 @@
 //! Translates a parsed [`ComposeFile`] into Podman API calls via the libpod REST API.
 
 mod build;
+mod config_digests;
+pub use config_digests::resolve_image_digests;
 mod container;
 mod copy;
 pub use build::{BuildOptions, PullOptions, PushOptions};

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -26,12 +26,12 @@ pub mod update;
 
 pub use compose::{
 	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
-	parse_str, parse_str_raw, resolve_levels, resolve_order,
+	parse_files_with_env_files_interp, parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
 pub use engine::{
-	is_safe_project_name, list_projects, BuildOptions, CpOptions, Engine, ExecOptions,
-	ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions, PushOptions,
-	RunOptions, RunOverrides, VolumesOptions,
+	is_safe_project_name, list_projects, resolve_image_digests, BuildOptions, CpOptions, Engine,
+	ExecOptions, ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions,
+	PushOptions, RunOptions, RunOverrides, VolumesOptions,
 };
 pub use error::{ComposeError, Result};
 pub use libpod::Client;

--- a/internal/libpod/types/image.rs
+++ b/internal/libpod/types/image.rs
@@ -34,4 +34,9 @@ pub struct BuildErrorDetail {
 pub struct ImageInspect {
 	#[serde(rename = "Id", default)]
 	pub id: String,
+	/// Registry digest references (`repo@sha256:...`) for the image, when it was
+	/// pulled from (or pushed to) a registry. Used by `config
+	/// --resolve-image-digests`. Empty for purely local/built images.
+	#[serde(rename = "RepoDigests", default)]
+	pub repo_digests: Vec<String>,
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -113,9 +113,26 @@ async fn run() -> podup::Result<()> {
 		format,
 		services,
 		quiet,
+		no_interpolate,
+		resolve_image_digests,
 	} = &cli.command
 	{
-		return startup::render_config(&file, format, *services, *quiet);
+		// `--no-interpolate` re-parses with substitution disabled; `file` (already
+		// parsed with interpolation) is used otherwise.
+		let parsed = if *no_interpolate {
+			podup::parse_files_with_env_files_interp(&compose_files, &cli.env_file, false)?
+		} else {
+			file
+		};
+		// `--resolve-image-digests` pins each image to its registry digest, which
+		// needs a Podman connection to inspect images.
+		let resolved = if *resolve_image_digests {
+			let client = podup::podman::connect(cli.socket.as_deref())?;
+			podup::resolve_image_digests(&client, &parsed).await?
+		} else {
+			parsed
+		};
+		return startup::render_config(&resolved, format, *services, *quiet);
 	}
 
 	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -137,3 +137,44 @@ fn config_quiet_validates_without_output() {
 		.unwrap();
 	assert!(!err.status.success(), "invalid config must fail under -q");
 }
+
+#[test]
+fn config_no_interpolate_keeps_placeholders_literal() {
+	let dir = std::env::temp_dir().join(format!("podup-noint-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: \"alpine:${PODUP_TAG}\"\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	// Default config interpolates ${PODUP_TAG} (unset → empty).
+	let interp = Command::new(bin())
+		.args(["-f", c, "config"])
+		.env_remove("PODUP_TAG")
+		.output()
+		.unwrap();
+	assert!(interp.status.success());
+	assert!(
+		!String::from_utf8_lossy(&interp.stdout).contains("${PODUP_TAG}"),
+		"default config must interpolate the placeholder"
+	);
+
+	// --no-interpolate leaves it literal.
+	let raw = Command::new(bin())
+		.args(["-f", c, "config", "--no-interpolate"])
+		.env_remove("PODUP_TAG")
+		.output()
+		.unwrap();
+	assert!(
+		raw.status.success(),
+		"config --no-interpolate failed: {:?}",
+		raw.stderr
+	);
+	assert!(
+		String::from_utf8_lossy(&raw.stdout).contains("${PODUP_TAG}"),
+		"--no-interpolate must keep ${{PODUP_TAG}} literal"
+	);
+}

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -406,3 +406,34 @@ async fn cli_volumes_lists_named_volumes() {
 		"volumes --format json must include the volume: {parsed}"
 	);
 }
+
+#[tokio::test]
+async fn cli_config_resolve_image_digests_pins_digest() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-digests", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	// Ensure the image (with its registry digest) is present locally.
+	run(&["-f", c, "-p", &proj, "pull"]);
+
+	let out = run(&["-f", c, "-p", &proj, "config", "--resolve-image-digests"]);
+	assert!(
+		out.status.success(),
+		"config --resolve-image-digests failed: {:?}",
+		out.stderr
+	);
+	let yaml = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		yaml.contains("alpine@sha256:"),
+		"image must be pinned to a registry digest, got: {yaml}"
+	);
+}


### PR DESCRIPTION
## What
Completes the `config` row of the CLI-parity epic #410.

- **`--no-interpolate`** — leave `${VAR}` placeholders literal while still resolving extends/include/merge. Threads an interpolation flag through the parse pipeline (new additive `parse_files_with_env_files_interp` / `parse_file_with_env_files_interp`; existing functions delegate with `interpolate = true`).
- **`--resolve-image-digests`** — rewrite each service `image:` to its registry digest (`repo@sha256:...`) via a client-only `resolve_image_digests` helper (adds `RepoDigests` to `ImageInspect`). Images with no registry digest in local storage are left unchanged with a warning.

## API freeze
All additions are new functions/fields; existing signatures unchanged.

## Tests
- `config --no-interpolate` keeps `${VAR}` literal vs default interpolation (no Podman needed).
- `config --resolve-image-digests` pins `alpine:latest` to `alpine@sha256:...` (Podman-guarded).

fmt/clippy/doc/line-limit clean locally.

Refs #410