### PR TITLE
feat(cli): events and attach commands

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -262,9 +262,8 @@ pub(crate) enum Commands {
 		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
 		cmd: Vec<String>,
 	},
-	/// Copy files between a service container and the local filesystem.
-	///
-	/// Use SERVICE:PATH for the container side (e.g. `web:/app/data ./local`).
+	/// Copy files between a service container and the host (SERVICE:PATH for the
+	/// container side, e.g. `web:/app/data ./local`).
 	Cp {
 		/// Source path. Use SERVICE:PATH for a container path.
 		src: String,
@@ -297,6 +296,17 @@ pub(crate) enum Commands {
 		/// Show only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
+	},
+	/// Stream Podman events for this project's containers.
+	Events {
+		/// Emit each event as a JSON line instead of a summary.
+		#[arg(long)]
+		json: bool,
+	},
+	/// Attach to a service container's output (stdout/stderr).
+	Attach {
+		/// Service whose container to attach to.
+		service: String,
 	},
 	/// Block until service containers stop, printing each exit code.
 	Wait {
@@ -467,12 +477,9 @@ pub(crate) enum Commands {
 	},
 	/// Watch for file changes and sync/rebuild/restart as configured by develop.watch.
 	Watch,
-	/// Update podup to the latest signed release.
-	///
-	/// Replaces the running executable only after verifying the release's
-	/// Ed25519 signature against the embedded public key and matching its
-	/// SHA-256 checksum; verification fails closed (bad/missing key, signature,
-	/// or checksum aborts without touching the installed binary).
+	/// Update podup to the latest signed release (Ed25519 signature + SHA-256
+	/// verified against the embedded key; fails closed, leaving the binary
+	/// untouched on any mismatch).
 	#[cfg(feature = "update")]
 	Update {
 		/// Report whether a newer release exists without installing it.

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -244,6 +244,8 @@ pub(crate) async fn dispatch(
 				.await?
 		}
 		Commands::Top { services } => engine.top(file, &services).await?,
+		Commands::Events { json } => engine.stream_events(json).await?,
+		Commands::Attach { service } => engine.attach(file, &service).await?,
 		Commands::Wait { services } => engine.wait_services(file, &services).await?,
 		Commands::Commit {
 			service,

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -1,0 +1,90 @@
+//! `events` — stream Podman events scoped to the project (`docker compose
+//! events`). Filters the libpod event stream by the `podup.project` label.
+
+use futures_util::StreamExt;
+use serde_json::Value;
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::Engine;
+
+impl Engine {
+	/// Stream events for this project's containers until interrupted. With
+	/// `json`, each event is printed as a compact JSON line; otherwise as
+	/// `TYPE ACTION NAME`.
+	pub async fn stream_events(&self, json: bool) -> Result<()> {
+		let filters = serde_json::json!({
+			"label": [format!("podup.project={}", self.project)],
+		});
+		let path = format!(
+			"{API_PREFIX}/events?stream=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let resp = self
+			.client
+			.get_stream(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut stream = crate::libpod::parse_json_lines::<Value>(resp.into_body());
+		while let Some(event) = stream.next().await {
+			match event {
+				Ok(value) => println!("{}", format_event(&value, json)),
+				Err(e) => tracing::warn!("events: {e}"),
+			}
+		}
+		Ok(())
+	}
+}
+
+/// Render one event. `json` emits the raw object as a compact line; otherwise a
+/// `TYPE ACTION NAME` summary, tolerant of both the docker-compat shape
+/// (`Type`/`Action`/`Actor.Attributes.name`) and the libpod-native one
+/// (`status`/`id`).
+fn format_event(value: &Value, json: bool) -> String {
+	if json {
+		return serde_json::to_string(value).unwrap_or_default();
+	}
+	let typ = value.get("Type").and_then(Value::as_str).unwrap_or("");
+	let action = value
+		.get("Action")
+		.or_else(|| value.get("status"))
+		.and_then(Value::as_str)
+		.unwrap_or("");
+	let name = value
+		.pointer("/Actor/Attributes/name")
+		.or_else(|| value.get("id"))
+		.and_then(Value::as_str)
+		.unwrap_or("");
+	format!("{typ} {action} {name}").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::format_event;
+	use serde_json::json;
+
+	#[test]
+	fn formats_docker_compat_shape() {
+		let ev = json!({
+			"Type": "container",
+			"Action": "start",
+			"Actor": { "Attributes": { "name": "web-1" } },
+		});
+		assert_eq!(format_event(&ev, false), "container start web-1");
+	}
+
+	#[test]
+	fn formats_libpod_native_shape() {
+		let ev = json!({ "Type": "container", "status": "die", "id": "abc123" });
+		assert_eq!(format_event(&ev, false), "container die abc123");
+	}
+
+	#[test]
+	fn json_mode_emits_raw_object() {
+		let ev = json!({ "Type": "container", "Action": "start" });
+		let out = format_event(&ev, true);
+		assert!(out.contains("\"Type\":\"container\""));
+		assert!(out.contains("\"Action\":\"start\""));
+	}
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -8,6 +8,7 @@ pub use config_digests::resolve_image_digests;
 mod commit_export;
 mod container;
 mod copy;
+mod events;
 pub use build::{BuildOptions, PullOptions, PushOptions};
 pub use copy::CpOptions;
 pub use lifecycle::{RunOptions, RunOverrides};

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -179,6 +179,47 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Attach to a single service container's output (`docker compose attach`).
+	///
+	/// Streams the first replica's stdout/stderr (follow) to this process's
+	/// stdout/stderr with no prefix, until the container stops. podup never
+	/// attaches STDIN (it allocates no TTY), so this is output-only.
+	pub async fn attach(&self, file: &ComposeFile, service_name: &str) -> Result<()> {
+		let service = file
+			.services
+			.get(service_name)
+			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
+		let container = self.first_replica_name(service_name, service);
+		let is_tty = service.tty.unwrap_or(false);
+
+		let path = format!(
+			"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
+			urlencoded(&container),
+		);
+		let resp = self
+			.client
+			.get_stream(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut stream = if is_tty {
+			crate::libpod::parse_raw(resp.into_body())
+		} else {
+			crate::libpod::parse_multiplexed(resp.into_body())
+		};
+		while let Some(msg) = stream.next().await {
+			match msg {
+				Ok(LogOutput::StdOut { message }) => {
+					print!("{}", String::from_utf8_lossy(&message));
+				}
+				Ok(LogOutput::StdErr { message }) => {
+					eprint!("{}", String::from_utf8_lossy(&message));
+				}
+				Err(_) => break,
+			}
+		}
+		Ok(())
+	}
+
 	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
 	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
 		self.attach_logs_with_options(file, false).await

--- a/tests/engine_integration/niche.rs
+++ b/tests/engine_integration/niche.rs
@@ -100,3 +100,50 @@ async fn cli_commit_creates_image() {
 	assert!(out.status.success(), "commit failed: {:?}", out.stderr);
 	assert!(exists, "commit must create the target image");
 }
+
+#[tokio::test]
+async fn cli_attach_streams_output_until_exit() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-attach", std::process::id());
+	let compose = dir.path().join("docker-compose.yml");
+	// Emits a line then exits shortly after, so attach streams output and the
+	// follow stream closes (attach returns) rather than blocking forever.
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo attached-hi; sleep 1\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	let out = run(&["-f", c, "-p", &proj, "attach", "web"]);
+	run(&["-f", c, "-p", &proj, "down"]);
+	assert!(out.status.success(), "attach failed: {:?}", out.stderr);
+	assert!(
+		String::from_utf8_lossy(&out.stdout).contains("attached-hi"),
+		"attach must stream the container's output"
+	);
+}
+
+#[tokio::test]
+async fn engine_events_stream_connects() {
+	let client = match super::podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let engine = Engine::new(client, proj("events"));
+	// The stream runs until interrupted; bound it with a short timeout. A
+	// timeout (not an error) means the event stream connected and stayed open.
+	let res = tokio::time::timeout(
+		std::time::Duration::from_millis(800),
+		engine.stream_events(true),
+	)
+	.await;
+	assert!(
+		res.is_err(),
+		"events stream should stay open until interrupted"
+	);
+}


### PR DESCRIPTION
## What
The final two commands of the CLI-parity epic #410.

- **`events`** — stream Podman events scoped to the project (filtered by the `podup.project` label), printed as `TYPE ACTION NAME` or, with `--json`, raw JSON lines.
- **`attach`** — stream a single service container's stdout/stderr (follow) to this process until the container stops. podup allocates no TTY, so attach is **output-only** (no STDIN), consistent with run/exec.

## Tests
Unit tests for event formatting (docker-compat + libpod-native shapes, JSON mode); integration tests for `attach` streaming output until exit and the `events` stream connecting/staying open. fmt/clippy/doc/line-limit clean locally.

With this, every command and flag listed in #410 (outside the documented buildx/Docker-Cloud out-of-scope set) is implemented.

Refs #410