### PR TITLE
fix(engine): skip dependency readiness waits under up --no-deps

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -12,7 +12,7 @@ use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
-use targets::{expand_targets, filter_services};
+use targets::{expand_targets, filter_services, in_started_set};
 
 use super::container::config_hash;
 
@@ -246,6 +246,16 @@ impl Engine {
 			.into_iter()
 			.filter(|_| start)
 		{
+			// Under `--no-deps` (and partial target lists) a dependency may have
+			// been intentionally excluded from the started set. docker-compose
+			// skips its readiness condition in that case; matching that avoids
+			// waiting on (and 404-ing against) a container that was never
+			// created.
+			if !in_started_set(target_set, &dep) {
+				tracing::debug!("{dep} not in started target set — skipping {name} readiness wait");
+				continue;
+			}
+
 			let condition = service.depends_on.condition_for(&dep);
 			// `required: false` makes the dependency optional — a failed wait
 			// must not abort `up`, matching docker-compose v2.

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -80,10 +80,26 @@ pub(super) fn expand_targets(
 	Some(set)
 }
 
+/// Whether `name` is part of the started set described by `target_set`.
+///
+/// `target_set` is `None` when no explicit target list was given (every
+/// service is in scope, so the answer is always `true`). Otherwise a name is
+/// "started" only if it is present in the set. Under `up --no-deps`,
+/// [`expand_targets`] omits the targets' dependencies, so this returns `false`
+/// for an intentionally-excluded dependency — letting the caller skip its
+/// `depends_on` readiness wait, matching docker-compose.
+pub(super) fn in_started_set(target_set: &Option<HashSet<String>>, name: &str) -> bool {
+	match target_set {
+		None => true,
+		Some(set) => set.contains(name),
+	}
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{expand_targets, filter_services};
+	use super::{expand_targets, filter_services, in_started_set};
 	use crate::compose::types::{ComposeFile, Service};
+	use std::collections::HashSet;
 
 	fn file_with_services(names: &[&str]) -> ComposeFile {
 		let mut file = ComposeFile::default();
@@ -157,5 +173,41 @@ mod tests {
 		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
 		assert!(set.contains("web"));
 		assert!(!set.contains("db"));
+	}
+
+	// --- in_started_set ---
+
+	#[test]
+	fn in_started_set_none_is_always_true() {
+		// No explicit target list: every service (including any dependency)
+		// is in scope, so the readiness wait is never skipped.
+		assert!(in_started_set(&None, "anything"));
+	}
+
+	#[test]
+	fn in_started_set_member_is_true() {
+		let set: HashSet<String> = ["web".to_string(), "db".to_string()].into_iter().collect();
+		assert!(in_started_set(&Some(set), "db"));
+	}
+
+	#[test]
+	fn in_started_set_excluded_dep_is_false() {
+		// Mirrors `up web --no-deps`: `expand_targets` yields {web} only, so the
+		// excluded dependency `db` is not in the started set and its readiness
+		// wait must be skipped.
+		let file = file_web_depends_db();
+		let target_set = expand_targets(&file, &["web".to_string()], true);
+		assert!(in_started_set(&target_set, "web"));
+		assert!(!in_started_set(&target_set, "db"));
+	}
+
+	#[test]
+	fn in_started_set_partial_target_includes_transitive_dep() {
+		// `up web` (without --no-deps) pulls `db` into the set, so its readiness
+		// wait is still honored.
+		let file = file_web_depends_db();
+		let target_set = expand_targets(&file, &["web".to_string()], false);
+		assert!(in_started_set(&target_set, "web"));
+		assert!(in_started_set(&target_set, "db"));
 	}
 }


### PR DESCRIPTION
## Problem

Under `up --no-deps`, podup still ran the `depends_on` readiness wait for dependencies that were intentionally excluded from the started set. In `internal/engine/lifecycle/mod.rs`, the `depends_on` wait loop in `up_one_service` was gated only by `start`, not by whether the dependency was actually in scope. So for a target service whose excluded dependency declared `service_healthy` / `service_completed_successfully`, podup inspected/waited on a container that was never created → 404 → `up` fails.

docker-compose skips dependency condition checks under `--no-deps`. The sibling `run` path already handles `--no-deps` correctly; this mirrors that intent for `up`/`create`.

## Fix

Skip the readiness wait for any dependency that is not in the started target set. A new `in_started_set(target_set, name)` predicate (in `lifecycle/targets.rs`, alongside `expand_targets`) centralizes the decision:

- `target_set` is `None` when no explicit target list was given → everything is in scope → never skip (no behaviour change for plain `up`).
- `expand_targets` already omits the targets' dependencies under `--no-deps`, so a present-but-absent name means "deliberately excluded" → skip its wait.

Preferring "skip deps not in the target set" (over a bare `no_deps` boolean) also makes **partial target lists** correct, and leaves behaviour identical when `--no-deps` is absent (the set then contains the transitive deps).

## Tests

Unit tests in `internal/engine/lifecycle/targets.rs` cover the predicate (the decision is now fully unit-testable, so no live-socket integration test is required):

- `in_started_set_none_is_always_true` — plain `up` never skips.
- `in_started_set_member_is_true` — in-scope dep is waited on.
- `in_started_set_excluded_dep_is_false` — mirrors `up web --no-deps`; excluded `db` is skipped.
- `in_started_set_partial_target_includes_transitive_dep` — `up web` (no `--no-deps`) still honors `db`'s wait.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --all-features`, and `cargo test --lib --all-features` (655 passed) all pass.

Closes #478