### PR TITLE
fix(compose): optional build context, lenient env_file format, primary build tag

### DIFF
--- a/internal/compose/anchor.rs
+++ b/internal/compose/anchor.rs
@@ -42,8 +42,12 @@ pub(super) fn anchor_service(svc: &mut Service, dir: &Path) {
 				}
 			}
 			BuildConfig::Config { context, .. } => {
-				if let Some(a) = anchor_context(context, dir) {
-					*context = a;
+				// An absent `context` defaults to the project directory `.`;
+				// anchor that default to the included file's directory so a
+				// `dockerfile_inline`-only build resolves against the right dir.
+				let effective = context.as_deref().unwrap_or(".");
+				if let Some(a) = anchor_context(effective, dir) {
+					*context = Some(a);
 				}
 			}
 		}

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -68,7 +68,8 @@ impl ExtendsConfig {
 pub enum BuildConfig {
 	Context(String),
 	Config {
-		context: String,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		context: Option<String>,
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		dockerfile: Option<String>,
 		#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -123,10 +124,15 @@ pub enum BuildConfig {
 }
 
 impl BuildConfig {
+	/// Build context path.
+	///
+	/// In the long form, `context` is optional per the Compose Spec (v2.22+):
+	/// a `build:` block carrying only `dockerfile_inline:` has no context and
+	/// defaults to the project directory `.`.
 	pub fn context(&self) -> &str {
 		match self {
 			BuildConfig::Context(ctx) => ctx,
-			BuildConfig::Config { context, .. } => context,
+			BuildConfig::Config { context, .. } => context.as_deref().unwrap_or("."),
 		}
 	}
 
@@ -300,7 +306,7 @@ mod tests {
 	#[test]
 	fn build_config_long_form_context() {
 		let b = BuildConfig::Config {
-			context: "./app".into(),
+			context: Some("./app".into()),
 			dockerfile: Some("Dockerfile.prod".into()),
 			dockerfile_inline: None,
 			args: EnvVars::Empty,
@@ -329,5 +335,15 @@ mod tests {
 		assert_eq!(b.dockerfile(), Some("Dockerfile.prod"));
 		assert_eq!(b.target(), Some("release"));
 		assert!(b.no_cache());
+	}
+
+	#[test]
+	fn build_with_only_dockerfile_inline_defaults_context_to_dot() {
+		// Compose Spec (v2.22+): `build:` may carry only `dockerfile_inline:` with
+		// no `context:` — the context then defaults to the project directory `.`.
+		let b: BuildConfig = serde_yaml::from_str("dockerfile_inline: |\n  FROM alpine\n").unwrap();
+		assert!(matches!(b, BuildConfig::Config { .. }));
+		assert_eq!(b.context(), ".");
+		assert_eq!(b.dockerfile_inline(), Some("FROM alpine\n"));
 	}
 }

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -101,10 +101,7 @@ impl Engine {
 
 		let context_str = build.context().to_string();
 		let remote_context = is_remote_context(&context_str);
-		let tag = service
-			.image
-			.clone()
-			.unwrap_or_else(|| format!("{}:latest", service_name));
+		let tag = primary_build_tag(service_name, service.image.as_deref(), build.tags());
 
 		// A Git/URL context is cloned server-side by Podman via the `remote`
 		// query parameter — there is no local directory to tar. Tar-only features
@@ -356,8 +353,15 @@ impl Engine {
 	}
 
 	/// Apply any `build.tags` aliases to the freshly built image.
+	///
+	/// The primary `tag` is skipped: when no `image:` is set it is already
+	/// `tags[0]`, which the build itself produced, so re-tagging it onto itself
+	/// would be a no-op API call.
 	async fn apply_extra_tags(&self, build: &BuildConfig, tag: &str) {
 		for extra_tag in build.tags() {
+			if extra_tag == tag {
+				continue;
+			}
 			let (repo, tag_str) = extra_tag
 				.rsplit_once(':')
 				.map(|(r, t)| (r.to_string(), t.to_string()))
@@ -381,9 +385,25 @@ fn is_remote_context(context: &str) -> bool {
 	context.contains("://") || context.starts_with("git@")
 }
 
+/// Pick the primary image tag for a built service.
+///
+/// Precedence matches compose-go: an explicit `image:` wins; otherwise the
+/// first entry of `build.tags` is used as the primary tag; with neither, the
+/// image is named `{service}:latest`. Any remaining `build.tags` are applied
+/// as extra tags by [`Engine::apply_extra_tags`].
+fn primary_build_tag(service_name: &str, image: Option<&str>, tags: &[String]) -> String {
+	if let Some(image) = image {
+		return image.to_string();
+	}
+	if let Some(first) = tags.first() {
+		return first.clone();
+	}
+	format!("{service_name}:latest")
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, Engine};
+	use super::{is_remote_context, primary_build_tag, Engine};
 	use crate::libpod::Client;
 
 	fn engine(base: std::path::PathBuf) -> Engine {
@@ -438,6 +458,29 @@ mod tests {
 		assert!(!is_remote_context("."));
 		assert!(!is_remote_context("./build"));
 		assert!(!is_remote_context("/abs/path"));
+	}
+
+	#[test]
+	fn primary_tag_prefers_explicit_image() {
+		let tags = vec!["registry/app:1.0".to_string()];
+		assert_eq!(
+			primary_build_tag("app", Some("myimage:2.0"), &tags),
+			"myimage:2.0"
+		);
+	}
+
+	#[test]
+	fn primary_tag_uses_first_build_tag_when_image_unset() {
+		let tags = vec![
+			"registry/app:1.0".to_string(),
+			"registry/app:latest".to_string(),
+		];
+		assert_eq!(primary_build_tag("app", None, &tags), "registry/app:1.0");
+	}
+
+	#[test]
+	fn primary_tag_falls_back_to_service_latest() {
+		assert_eq!(primary_build_tag("app", None, &[]), "app:latest");
 	}
 
 	#[test]

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -42,9 +42,12 @@ pub fn load_env_file_entries(
 		} = entry
 		{
 			if fmt != "dotenv" {
-				return Err(ComposeError::Unsupported(format!(
-					"env_file format '{fmt}' not supported (only 'dotenv')"
-				)));
+				// compose-go logs a warning and falls back to dotenv parsing
+				// rather than failing the file; match that lenient behaviour.
+				tracing::warn!(
+					"env_file format '{fmt}' is not supported; parsing '{}' as dotenv",
+					entry.path()
+				);
 			}
 		}
 
@@ -162,14 +165,18 @@ mod tests {
 	}
 
 	#[test]
-	fn unsupported_format_returns_error() {
+	fn non_dotenv_format_warns_and_parses_as_dotenv() {
+		// compose-go logs a warning for an unknown `format` and falls back to
+		// dotenv parsing rather than failing; podup must not error here.
 		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
 		let entries = vec![EnvFileEntry::Config {
 			path: ".env".into(),
 			required: Some(false),
 			format: Some("json".into()),
 		}];
-		assert!(load_env_file_entries(&entries, dir.path()).is_err());
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("bar"));
 	}
 
 	#[test]


### PR DESCRIPTION
Three Compose-Spec fidelity fixes for the `build:` and `env_file:` directives.

## Changes

### 1. `build.context` is now optional (HIGH)
The Compose Spec (v2.22+) allows a long-form build block carrying only `dockerfile_inline:` with no `context:`, which defaults to the project directory `.`. This previously failed with a serde deserialization error.

- `BuildConfig::Config.context` is now `Option<String>`; the `context()` accessor defaults to `.`.
- The include/anchor path materializes the implicit `.` default so a `dockerfile_inline`-only build in an included file resolves against the correct directory.
- Long-form and short-form parsing are unchanged.

### 2. Non-dotenv `env_file` format is no longer fatal (MED)
compose-go logs a warning for an unknown `env_file` `format` and falls back to dotenv parsing rather than failing. podup now demotes the error to a `tracing::warn!` and continues parsing the file as dotenv.

### 3. `build.tags[0]` used as primary image when `image:` unset (MED)
When a service sets no `image:` but provides `build.tags`, compose-go uses `tags[0]` as the primary image tag (the remaining tags become extra tags). podup previously always tagged `{service}:latest`. Primary-tag selection is extracted into a testable `primary_build_tag` helper, and the primary is no longer re-applied as an extra tag.

## Tests
Added unit tests:
- `build_with_only_dockerfile_inline_defaults_context_to_dot`
- `non_dotenv_format_warns_and_parses_as_dotenv`
- `primary_tag_prefers_explicit_image` / `primary_tag_uses_first_build_tag_when_image_unset` / `primary_tag_falls_back_to_service_latest`

`cargo fmt`, `clippy --all-targets --all-features -D warnings`, `build --all-features`, and `test --lib --all-features` (655 passed) all pass.

Closes #480