### PR TITLE
fix(cli): reject --index 0 and validate braced substitution variable names

### DIFF
--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -289,8 +289,13 @@ impl Engine {
 	) -> Result<String> {
 		match index {
 			Some(i) => {
+				// `--index` is 1-based; `0` is an invalid index, not "first replica".
+				let idx = (i as usize).checked_sub(1).ok_or_else(|| {
+					ComposeError::ServiceNotFound(format!(
+						"{service_name} (replica index {i}: indexes are 1-based)"
+					))
+				})?;
 				let names = self.replica_names(service_name, service);
-				let idx = (i as usize).saturating_sub(1);
 				names.get(idx).cloned().ok_or_else(|| {
 					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
 				})
@@ -330,4 +335,85 @@ fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Resul
 		}
 	}
 	Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::libpod::Client;
+
+	fn engine(project: &str) -> Engine {
+		Engine::with_base_dir(
+			Client::new("/nonexistent.sock"),
+			project.into(),
+			std::env::temp_dir(),
+		)
+	}
+
+	fn scaled_service(replicas: u32) -> Service {
+		Service {
+			scale: Some(replicas),
+			..Service::default()
+		}
+	}
+
+	#[test]
+	fn replica_name_at_index_zero_is_rejected() {
+		// `--index` is 1-based; index 0 must be an error, never replica 1.
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		let err = e
+			.replica_name_at("web", &svc, Some(0))
+			.expect_err("index 0 must be rejected");
+		assert!(
+			matches!(err, ComposeError::ServiceNotFound(ref m) if m.contains("1-based")),
+			"unexpected error: {err:?}"
+		);
+	}
+
+	#[test]
+	fn replica_name_at_index_one_is_first_replica() {
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		assert_eq!(
+			e.replica_name_at("web", &svc, Some(1)).unwrap(),
+			"proj-web-1"
+		);
+	}
+
+	#[test]
+	fn replica_name_at_index_n_is_nth_replica() {
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		assert_eq!(
+			e.replica_name_at("web", &svc, Some(3)).unwrap(),
+			"proj-web-3"
+		);
+	}
+
+	#[test]
+	fn replica_name_at_out_of_range_is_rejected() {
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		assert!(e.replica_name_at("web", &svc, Some(4)).is_err());
+	}
+
+	#[test]
+	fn replica_name_at_none_is_first_replica() {
+		let e = engine("proj");
+		// Single replica: the unsuffixed container name.
+		assert_eq!(
+			e.replica_name_at("web", &Service::default(), None).unwrap(),
+			"proj-web"
+		);
+		// Multiple replicas: the first suffixed name.
+		assert_eq!(
+			e.replica_name_at("web", &scaled_service(3), None).unwrap(),
+			"proj-web-1"
+		);
+	}
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -28,6 +28,9 @@ pub enum ComposeError {
 	NoImageOrBuild(String),
 	/// A `${VAR}` with the `?err` modifier was required but unset.
 	RequiredVarNotSet { var: String, msg: String },
+	/// A `${…}` interpolation reference is malformed (e.g. an invalid character
+	/// in the variable name, as in `${FOO BAR}` or `${FOO.BAR}`).
+	InvalidSubstitution(String),
 	/// A service did not become healthy within its dependency wait window.
 	HealthCheckTimeout(String),
 	/// A `ports:` entry could not be parsed.
@@ -70,6 +73,9 @@ impl fmt::Display for ComposeError {
 			Self::NoImageOrBuild(s) => write!(f, "service '{s}' has no image or build config"),
 			Self::RequiredVarNotSet { var, msg } => {
 				write!(f, "required variable '{var}' is not set: {msg}")
+			}
+			Self::InvalidSubstitution(s) => {
+				write!(f, "invalid variable substitution: {s}")
 			}
 			Self::HealthCheckTimeout(s) => write!(f, "health check timeout for container '{s}'"),
 			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -47,57 +47,59 @@ pub(super) enum Modifier {
 }
 
 /// Parse the content inside `${…}`.  The opening `{` has already been consumed.
+///
+/// The variable name is collected with [`is_var_char`] (matching the unbraced
+/// `$VAR` path and the compose-spec grammar). After the name, only a modifier
+/// delimiter (`}`, `:`, `-`, `+`, `?`) or end-of-input may follow; any other
+/// trailing character (a space in `${FOO BAR}`, a dot in `${FOO.BAR}`, …) makes
+/// the reference malformed and is rejected rather than folded into the lookup
+/// key.
 pub(super) fn parse_braced_var(
 	chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
 ) -> Result<(String, Modifier)> {
-	let mut name = String::new();
+	let name = collect_var_name(chars);
 
-	loop {
-		match chars.peek() {
-			None => {
-				return Ok((name, Modifier::None));
-			}
-			Some('}') => {
-				chars.next();
-				return Ok((name, Modifier::None));
-			}
-			Some(':') => {
-				chars.next();
-				// Peek at what follows `:`.
-				let modifier = match chars.peek() {
-					Some('-') => {
-						chars.next();
-						Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
-					}
-					Some('+') => {
-						chars.next();
-						Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
-					}
-					Some('?') => {
-						chars.next();
-						Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
-					}
-					_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)),
-				};
-				return Ok((name, modifier));
-			}
-			Some('-') => {
-				chars.next();
-				return Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))));
-			}
-			Some('+') => {
-				chars.next();
-				return Ok((name, Modifier::AltIfSet(collect_until_close(chars))));
-			}
-			Some('?') => {
-				chars.next();
-				return Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))));
-			}
-			Some(&c) => {
-				name.push(c);
-				chars.next();
-			}
+	match chars.peek() {
+		None => Ok((name, Modifier::None)),
+		Some('}') => {
+			chars.next();
+			Ok((name, Modifier::None))
 		}
+		Some(':') => {
+			chars.next();
+			// Peek at what follows `:`.
+			let modifier = match chars.peek() {
+				Some('-') => {
+					chars.next();
+					Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
+				}
+				Some('+') => {
+					chars.next();
+					Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
+				}
+				Some('?') => {
+					chars.next();
+					Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
+				}
+				_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)),
+			};
+			Ok((name, modifier))
+		}
+		Some('-') => {
+			chars.next();
+			Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))))
+		}
+		Some('+') => {
+			chars.next();
+			Ok((name, Modifier::AltIfSet(collect_until_close(chars))))
+		}
+		Some('?') => {
+			chars.next();
+			Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))))
+		}
+		Some(&c) => Err(ComposeError::InvalidSubstitution(format!(
+			"unexpected character {c:?} in variable name '${{{name}…}}'"
+		))),
 	}
 }
 
@@ -254,6 +256,46 @@ mod tests {
 		let mut it = peekable("V:x}");
 		let (_, modifier) = parse_braced_var(&mut it).unwrap();
 		assert!(matches!(modifier, Modifier::DefaultIfUnsetOrEmpty(s) if s == "x"));
+	}
+
+	// --- parse_braced_var: name validation ---
+
+	#[test]
+	fn parse_valid_braced_var() {
+		let mut it = peekable("FOO}");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::None));
+	}
+
+	#[test]
+	fn parse_valid_braced_var_with_default() {
+		let mut it = peekable("FOO:-default}");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::DefaultIfUnsetOrEmpty(s) if s == "default"));
+	}
+
+	#[test]
+	fn parse_braced_var_rejects_space_in_name() {
+		// `${FOO BAR}` must not produce a lookup key containing a space.
+		let mut it = peekable("FOO BAR}");
+		let err = parse_braced_var(&mut it).expect_err("space in name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
+	#[test]
+	fn parse_braced_var_rejects_dot_in_name() {
+		// `${FOO.BAR}` must not produce a lookup key containing a dot.
+		let mut it = peekable("FOO.BAR}");
+		let err = parse_braced_var(&mut it).expect_err("dot in name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
 	}
 
 	// --- resolve_modifier ---


### PR DESCRIPTION
## Summary

Two correctness fixes for invalid CLI/compose input that was previously
accepted silently.

### 1. `--index 0` rejected as out of range (`replica_name_at`)

The 1-based `--index` flag (used by `exec`, `cp`, `commit`, `export`)
mapped index `0` to replica index `0` via `(i as usize).saturating_sub(1)`,
silently returning the **first** replica instead of rejecting the invalid
1-based index. It now uses `checked_sub(1)` and errors on `0` with a clear
"indexes are 1-based" message.

### 2. Braced substitution variable names validated (`parse_braced_var`)

`${...}` name collection accumulated any character that was not a
`}`/`:`/`-`/`+`/`?` delimiter, so `${FOO BAR}` and `${FOO.BAR}` produced a
lookup key containing spaces/dots. The name is now collected with
`is_var_char` — matching the unbraced `$VAR` path and the compose-spec
grammar — and any trailing junk before a modifier delimiter is rejected via
a new `InvalidSubstitution` error. Valid forms (`${FOO}`, `${FOO:-default}`,
including defaults that contain spaces/dots) are unaffected.

## Tests

- `replica_name_at`: index 0 → error, index 1 → first replica, index N →
  Nth replica, out-of-range → error, `None` → first replica.
- `parse_braced_var`: `${FOO BAR}` → error, `${FOO.BAR}` → error, `${FOO}`
  and `${FOO:-default}` → valid.

`cargo fmt`, `clippy -D warnings`, `build --all-features`, and
`test --lib --all-features` (660 passing) all green. Public API and
behaviour for valid input are unchanged.

Closes #483
