### PR TITLE
test(engine): fix flaky shared alpine:latest image race

### DIFF
--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -25,13 +25,28 @@ async fn cli_logs_tail_limits_output() {
 		.args(["-f", c, "-p", &proj, "up", "-d"])
 		.output()
 		.unwrap();
-	// Give the container a moment to emit its lines.
-	tokio::time::sleep(std::time::Duration::from_millis(800)).await;
 
-	let logs = Command::new(bin())
-		.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
-		.output()
-		.unwrap();
+	// Poll until the container has emitted its lines instead of sleeping a fixed
+	// duration: `logs --tail 2` must eventually show exactly 2 `line-` rows.
+	let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+	let mut logs;
+	loop {
+		logs = Command::new(bin())
+			.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
+			.output()
+			.unwrap();
+		let lines = String::from_utf8_lossy(&logs.stdout)
+			.lines()
+			.filter(|l| l.contains("line-"))
+			.count();
+		if logs.status.success() && lines == 2 {
+			break;
+		}
+		if tokio::time::Instant::now() >= deadline {
+			break;
+		}
+		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+	}
 	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
 	let lines = String::from_utf8_lossy(&logs.stdout)
 		.lines()
@@ -173,10 +188,28 @@ async fn cli_down_rmi_all_succeeds_and_removes_containers() {
 	}
 	let dir = tempdir().unwrap();
 	let proj = format!("t{}-rmi", std::process::id());
+
+	// `--rmi all` deletes the image referenced by the compose file. Tests run in
+	// parallel and several rely on the shared `alpine:latest` image, so we tag a
+	// throwaway, project-unique local image and reference THAT here. Removing it
+	// leaves `alpine:latest` intact for the concurrent tests.
+	let throwaway = format!("localhost/podup-rmitest-{proj}:latest");
+	let tag = Command::new("podman")
+		.args(["tag", "alpine:latest", &throwaway])
+		.output()
+		.unwrap();
+	assert!(
+		tag.status.success(),
+		"tagging throwaway image failed: {:?}",
+		tag.stderr
+	);
+
 	let compose = dir.path().join("docker-compose.yml");
 	fs::write(
 		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+		format!(
+			"services:\n  web:\n    image: {throwaway}\n    command: [\"sleep\", \"infinity\"]\n"
+		),
 	)
 	.unwrap();
 	let c = compose.to_str().unwrap();
@@ -189,6 +222,20 @@ async fn cli_down_rmi_all_succeeds_and_removes_containers() {
 		down.stderr
 	);
 	assert_eq!(ps_all_count(c, &proj), 0, "down must remove the containers");
+
+	// The shared base image must survive; only the throwaway tag was removed.
+	let present = Command::new("podman")
+		.args(["image", "exists", &throwaway])
+		.status()
+		.unwrap();
+	assert!(
+		!present.success(),
+		"down --rmi all must remove the throwaway image"
+	);
+	// Best-effort cleanup in case the assertion above ever changes.
+	let _ = Command::new("podman")
+		.args(["rmi", "-f", &throwaway])
+		.output();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #485

## Problem

`cli_down_rmi_all_succeeds_and_removes_containers` (tests/engine_integration/cli3.rs) ran `down --rmi all` against a compose file referencing the **shared** `alpine:latest` image. Cargo runs integration tests in parallel, so when this test deleted `alpine:latest`, concurrent tests doing `up --pull never` (`cli_up_pull_never_starts_present_image`) or `up --no-start` (`cli_up_no_start_creates_without_starting`) intermittently failed with `no such image: alpine:latest` — a different pair failing each run.

## Changes

- **Isolate the rmi-all image.** The test now tags a throwaway, project-unique local image (`localhost/podup-rmitest-<proj>:latest`) from `alpine:latest` and references *that* in its compose file, so `--rmi all` only removes the throwaway tag. Added assertions that the throwaway image is gone after `down` and (implicitly) that the shared base image is left intact, plus best-effort cleanup.
- **Remove timing-fragile sleep.** Replaced the fixed `sleep(800ms)` in `cli_logs_tail_limits_output` with a poll-until-condition loop (matching the poll-helper pattern in `tests/engine_integration/watch.rs`) that waits until `logs --tail 2` shows exactly two lines, up to a 30s deadline.

## Verification (local, Podman 5.4.2)

- Reproduced the setup and confirmed the fix: ran the rmi test together with `cli_up_pull_never_starts_present_image`, `cli_up_no_start_creates_without_starting` and `cli_logs_tail_limits_output` in parallel — all pass, and `alpine:latest` survives.
- Ran the full `cli3` module twice with `--test-threads=8`: 15/15 pass both times, no `no such image` flake, `alpine:latest` still present, no leftover throwaway tags.
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --all-features` all clean.

`cli3.rs` is now 486 lines (under the 500-line limit).