### PR TITLE
feat(compose): parse credential_spec, isolation, provider, use_api_socket and models

### DIFF
--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -24,6 +24,30 @@ pub(super) fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) 
 				 attach/detach logic for `up` log streaming"
 			));
 		}
+		if def.credential_spec.is_some() {
+			out.push(format!(
+				"service '{service}': credential_spec is a Windows managed-service-account \
+				 control with no rootless Podman equivalent and is not honored"
+			));
+		}
+		if def.isolation.is_some() {
+			out.push(format!(
+				"service '{service}': isolation has no rootless Podman equivalent and is \
+				 not honored"
+			));
+		}
+		if def.provider.is_some() {
+			out.push(format!(
+				"service '{service}': provider delegates the service lifecycle to an \
+				 external plugin that podup does not invoke; the service is not honored"
+			));
+		}
+		if def.use_api_socket.is_some() {
+			out.push(format!(
+				"service '{service}': use_api_socket has no podup equivalent and is not \
+				 honored"
+			));
+		}
 		for entry in def.env_file.to_entries() {
 			if let EnvFileEntry::Config {
 				format: Some(fmt), ..
@@ -35,6 +59,17 @@ pub(super) fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) 
 				));
 			}
 		}
+	}
+}
+
+/// Top-level `models:` (Compose v2.38) — podup runs no model runner, so any
+/// declared model is parsed for fidelity but not honored.
+pub(super) fn ignored_models(file: &ComposeFile, out: &mut Vec<String>) {
+	for name in file.models.keys() {
+		out.push(format!(
+			"model '{name}': podup runs no model runner, so the models element is not \
+			 honored"
+		));
 	}
 }
 

--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -12,7 +12,7 @@ use super::types::ComposeFile;
 
 mod ignored_fields;
 use ignored_fields::{
-	ignored_build_fields, ignored_network_fields, ignored_port_fields,
+	ignored_build_fields, ignored_models, ignored_network_fields, ignored_port_fields,
 	ignored_secret_config_drivers, ignored_service_fields, ignored_service_network_fields,
 	ignored_volume_mount_fields,
 };
@@ -31,6 +31,7 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	ignored_network_fields(file, &mut out);
 	ignored_service_network_fields(file, &mut out);
 	ignored_secret_config_drivers(file, &mut out);
+	ignored_models(file, &mut out);
 	out
 }
 
@@ -76,6 +77,23 @@ fn nested_unknown_keys(file: &ComposeFile, out: &mut Vec<String>) {
 				);
 			}
 		}
+		if let Some(cred) = &def.credential_spec {
+			push_unknown(
+				&format!("service '{service}' credential_spec"),
+				&cred.unknown,
+				out,
+			);
+		}
+		if let Some(provider) = &def.provider {
+			push_unknown(
+				&format!("service '{service}' provider"),
+				&provider.unknown,
+				out,
+			);
+		}
+	}
+	for (name, model) in &file.models {
+		push_unknown(&format!("model '{name}'"), &model.unknown, out);
 	}
 	for (name, cfg) in &file.networks {
 		if let Some(c) = cfg {
@@ -382,6 +400,97 @@ mod tests {
 		assert!(
 			!msgs.iter().any(|m| m.contains("driver")),
 			"unexpected: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_credential_spec_not_honored() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    credential_spec:\n      config: my-spec\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("credential_spec") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		// The recognized key must not also produce a generic "unknown key" warning.
+		assert!(
+			!msgs
+				.iter()
+				.any(|m| m.contains("unknown key 'credential_spec'")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_service_isolation_not_honored() {
+		let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    isolation: hyperv\n");
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("isolation") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		assert!(!msgs.iter().any(|m| m.contains("unknown key 'isolation'")));
+	}
+
+	#[test]
+	fn warns_on_provider_not_honored() {
+		let msgs = diagnostics_for("services:\n  db:\n    provider:\n      type: awesomecloud\n");
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("provider") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		assert!(!msgs.iter().any(|m| m.contains("unknown key 'provider'")));
+	}
+
+	#[test]
+	fn warns_on_use_api_socket_not_honored() {
+		let msgs =
+			diagnostics_for("services:\n  web:\n    image: nginx\n    use_api_socket: true\n");
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("use_api_socket") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		assert!(!msgs
+			.iter()
+			.any(|m| m.contains("unknown key 'use_api_socket'")));
+	}
+
+	#[test]
+	fn warns_on_top_level_models_not_honored() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\nmodels:\n  llm:\n    model: ai/model\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("model 'llm'") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		// `models` is now a recognized top-level element, not an unknown key.
+		assert!(
+			!msgs
+				.iter()
+				.any(|m| m.contains("unknown top-level key 'models'")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_typo_inside_provider_and_models() {
+		let msgs = diagnostics_for(
+			"services:\n  db:\n    provider:\n      type: cloud\n      optoins: {}\nmodels:\n  llm:\n    modle: ai/model\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("provider") && m.contains("optoins")),
+			"got: {msgs:?}"
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("model 'llm'") && m.contains("modle")),
+			"got: {msgs:?}"
 		);
 	}
 }

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -194,6 +194,10 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		deploy: override_svc.deploy.or(base.deploy),
 		develop: override_svc.develop.or(base.develop),
 		gpus: override_svc.gpus.or(base.gpus),
+		credential_spec: override_svc.credential_spec.or(base.credential_spec),
+		isolation: override_svc.isolation.or(base.isolation),
+		provider: override_svc.provider.or(base.provider),
+		use_api_socket: override_svc.use_api_socket.or(base.use_api_socket),
 		unknown: {
 			// Keep unknown keys from both sides so a typo in either the base or
 			// the overriding service is still surfaced; the override wins on

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -76,6 +76,28 @@ pub struct ConfigConfig {
 	pub template_driver: Option<String>,
 }
 
+/// Top-level `models:` entry (Compose v2.38) — declares an AI model the
+/// project depends on. podup runs no model runner, so the diagnostics pass
+/// reports any declared model as not honored; the fields are parsed for
+/// fidelity and round-tripped by `config`.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
+pub struct ModelConfig {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub model: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub context_size: Option<u64>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub runtime_flags: Vec<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub model_variables: HashMap<String, String>,
+	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
+}
+
 /// Root deserialization target for a `docker-compose.yml` file.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
@@ -96,6 +118,11 @@ pub struct ComposeFile {
 	pub secrets: IndexMap<String, SecretConfig>,
 	#[serde(default)]
 	pub configs: IndexMap<String, ConfigConfig>,
+	/// Top-level `models:` element (Compose v2.38). Parsed for fidelity; podup
+	/// runs no model runner, so the diagnostics pass reports declared models as
+	/// not honored.
+	#[serde(default)]
+	pub models: IndexMap<String, ModelConfig>,
 	/// Top-level `x-*` extension fields — preserved and round-tripped via `config` subcommand.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub extensions: IndexMap<String, serde_yaml::Value>,

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -216,11 +216,66 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gpus: Option<GpuSpec>,
 
+	/// `credential_spec:` — Windows managed-service-account credential source
+	/// (`config`/`file`/`registry`). Parsed for fidelity; podup has no rootless
+	/// Podman equivalent, so the diagnostics pass reports it as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub credential_spec: Option<CredentialSpec>,
+
+	/// `isolation:` — container isolation technology (e.g. `default`, `process`,
+	/// `hyperv`). Distinct from `build.isolation`. Parsed for fidelity; podup has
+	/// no rootless Podman equivalent, so it is reported as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub isolation: Option<String>,
+
+	/// `provider:` (Compose v2.36) — delegates the service lifecycle to an
+	/// external provider plugin. Parsed for fidelity; podup invokes no provider
+	/// plugins, so it is reported as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub provider: Option<ProviderConfig>,
+
+	/// `use_api_socket:` (Compose v2.37.1) — bind-mount the Docker API socket and
+	/// forward credentials into the container. Parsed for fidelity; podup has no
+	/// equivalent, so it is reported as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub use_api_socket: Option<bool>,
+
 	/// Keys present in the YAML that don't map to a known service field. Captured
 	/// (rather than silently dropped) so the parser can warn about likely typos
 	/// while still tolerating compose-spec `x-*` extensions and forward-compatible
 	/// keys. Not part of the container spec; round-tripped by the `config`
 	/// subcommand to preserve fidelity.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
+}
+
+/// `credential_spec:` — source of a Windows managed-service-account credential
+/// spec. Exactly one of `config`/`file`/`registry` is expected per the Compose
+/// Spec; podup parses all three for fidelity but honors none.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
+pub struct CredentialSpec {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub config: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub registry: Option<String>,
+	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
+}
+
+/// `provider:` (Compose v2.36) — names an external provider plugin (`type`) and
+/// its free-form `options`. Parsed for fidelity; podup invokes no providers.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
+pub struct ProviderConfig {
+	#[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
+	pub provider_type: Option<String>,
+	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+	pub options: IndexMap<String, serde_yaml::Value>,
+	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -10,5 +10,7 @@ mod extends;
 mod fields;
 #[path = "parse/include.rs"]
 mod include;
+#[path = "parse/new_keys.rs"]
+mod new_keys;
 #[path = "parse/order.rs"]
 mod order;

--- a/tests/parse/new_keys.rs
+++ b/tests/parse/new_keys.rs
@@ -1,0 +1,151 @@
+//! Parse coverage for compose-spec keys that previously fell into the
+//! `unknown`/`extensions` bucket: `credential_spec`, `isolation`, `provider`,
+//! `use_api_socket` (service-level) and the top-level `models` element. Each
+//! must deserialize into its dedicated field and no longer trip the generic
+//! "unknown key" diagnostic; the not-honored diagnostic is asserted in
+//! `tests/cli_diagnostics.rs` and the diagnostics unit tests.
+use podup::parse_str;
+
+#[test]
+fn credential_spec_object_parses_into_field() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+    credential_spec:
+      config: my-credential-spec
+"#;
+	let svc = &parse_str(yaml).unwrap().services["web"];
+	let cred = svc
+		.credential_spec
+		.as_ref()
+		.expect("credential_spec parsed");
+	assert_eq!(cred.config.as_deref(), Some("my-credential-spec"));
+	assert!(cred.file.is_none());
+	assert!(cred.registry.is_none());
+	// Must not leak into the unknown-key bucket.
+	assert!(!svc.unknown.contains_key("credential_spec"));
+}
+
+#[test]
+fn credential_spec_file_and_registry_parse() {
+	let yaml = r#"
+services:
+  a:
+    image: nginx
+    credential_spec:
+      file: spec.json
+  b:
+    image: nginx
+    credential_spec:
+      registry: my-registry-value
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.services["a"]
+			.credential_spec
+			.as_ref()
+			.unwrap()
+			.file
+			.as_deref(),
+		Some("spec.json")
+	);
+	assert_eq!(
+		file.services["b"]
+			.credential_spec
+			.as_ref()
+			.unwrap()
+			.registry
+			.as_deref(),
+		Some("my-registry-value")
+	);
+}
+
+#[test]
+fn service_isolation_parses_into_field() {
+	let yaml = "services:\n  web:\n    image: nginx\n    isolation: hyperv\n";
+	let svc = &parse_str(yaml).unwrap().services["web"];
+	assert_eq!(svc.isolation.as_deref(), Some("hyperv"));
+	assert!(!svc.unknown.contains_key("isolation"));
+}
+
+#[test]
+fn provider_object_parses_into_field() {
+	let yaml = r#"
+services:
+  db:
+    provider:
+      type: awesomecloud
+      options:
+        type: mysql
+        size: 256
+"#;
+	let svc = &parse_str(yaml).unwrap().services["db"];
+	let provider = svc.provider.as_ref().expect("provider parsed");
+	assert_eq!(provider.provider_type.as_deref(), Some("awesomecloud"));
+	assert_eq!(
+		provider.options.get("type").and_then(|v| v.as_str()),
+		Some("mysql")
+	);
+	assert!(!svc.unknown.contains_key("provider"));
+}
+
+#[test]
+fn use_api_socket_parses_into_field() {
+	let yaml = "services:\n  web:\n    image: nginx\n    use_api_socket: true\n";
+	let svc = &parse_str(yaml).unwrap().services["web"];
+	assert_eq!(svc.use_api_socket, Some(true));
+	assert!(!svc.unknown.contains_key("use_api_socket"));
+}
+
+#[test]
+fn top_level_models_parses_into_field() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+models:
+  llm:
+    model: ai/model
+    context_size: 1024
+    runtime_flags:
+      - "--a-flag"
+      - "--another-flag=42"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let model = file.models.get("llm").expect("model parsed");
+	assert_eq!(model.model.as_deref(), Some("ai/model"));
+	assert_eq!(model.context_size, Some(1024));
+	assert_eq!(model.runtime_flags.len(), 2);
+	// Top-level models must not land in the extensions bucket.
+	assert!(!file.extensions.contains_key("models"));
+}
+
+#[test]
+fn new_keys_produce_no_unknown_key_diagnostic() {
+	// All five keys together: none should be reported as an unknown/typo key
+	// (the not-honored warnings are a separate, expected signal).
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+    isolation: default
+    use_api_socket: true
+    credential_spec:
+      file: spec.json
+    provider:
+      type: cloud
+models:
+  llm:
+    model: ai/model
+"#;
+	let file = parse_str(yaml).unwrap();
+	let svc = &file.services["web"];
+	for key in ["isolation", "use_api_socket", "credential_spec", "provider"] {
+		assert!(
+			!svc.unknown.contains_key(key),
+			"service key '{key}' leaked into unknown bucket"
+		);
+	}
+	assert!(!file.extensions.contains_key("models"));
+}


### PR DESCRIPTION
Closes #481

Several standard Compose Spec keys previously fell into the `unknown`/`extensions` bucket and emitted a generic "unknown key" diagnostic, so users could not tell a no-op from a typo. This PR recognizes them explicitly:

- `credential_spec` (service-level object: `config`/`file`/`registry`)
- `isolation` (service-level string; distinct from the existing `build.isolation`)
- `provider` (Compose v2.36 object: `type` + `options`)
- `use_api_socket` (Compose v2.37.1 bool)
- `models` (Compose v2.38 top-level element, alongside services/networks/volumes/secrets/configs)

Each now **parses** into its dedicated field (no longer landing in `unknown`/`extensions`) and **warns** via the existing ignored-fields diagnostics as "recognized but not honored" — podup/Podman rootless has no equivalent for any of them. This replaces the generic unknown-key noise and keeps podup's loud-over-silent convention. Typos inside the new sub-objects are still surfaced as unknown-key warnings.

No engine implementation yet — these keys parse and warn; they are not honored by the runtime. Additive only; no behaviour change for existing files.

Tests: parse unit tests proving each key deserializes into its field and produces no unknown-key diagnostic, plus diagnostics tests asserting the not-honored warning fires and that the recognized keys no longer trip the generic unknown-key path.