### PR TITLE
fix(engine): keep deploy.labels off containers and warn on multi-platform builds

### DIFF
--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -186,10 +186,14 @@ impl Engine {
 		} else {
 			None
 		};
-		let platform = if let BuildConfig::Config { platforms, .. } = build {
-			platforms.first().cloned()
-		} else {
-			None
+		let platform = match build {
+			BuildConfig::Config { platforms, .. } => platforms.first().inspect(|first| {
+				let rest_count = platforms.len() - 1;
+				if rest_count > 0 {
+					warn!("build.platforms: libpod builds one platform per request; building {first}, ignoring {rest_count} other(s)");
+				}
+			}).cloned(),
+			_ => None,
 		};
 		let shmsize = build
 			.shm_size()

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -19,7 +19,8 @@ use super::container_config::{
 	build_ulimits, cdi_devices,
 };
 use super::container_fields::{
-	build_blkio_config, build_label_file_labels, parse_device, warn_swarm_only_deploy,
+	build_blkio_config, build_label_file_labels, parse_device, resolve_container_labels,
+	warn_swarm_only_deploy,
 };
 use super::network::resolve_network_mode;
 use super::volume_mounts::build_mounts_all;
@@ -112,15 +113,9 @@ impl Engine {
 
 		// --- Labels ---
 		let label_file_labels = build_label_file_labels(service, &self.base_dir);
-		let mut labels = service.labels.to_map();
-		for (k, v) in label_file_labels {
-			labels.entry(k).or_insert(v);
-		}
-		if let Some(deploy) = &service.deploy {
-			for (k, v) in deploy.labels.to_map() {
-				labels.entry(k).or_insert(v);
-			}
-		}
+		// Per the Compose Specification, deploy.labels are set on the service
+		// only and must NOT be applied to containers, so they are not merged here.
+		let mut labels = resolve_container_labels(service, label_file_labels);
 		labels.insert("podup.project".to_string(), self.project.clone());
 		labels.insert("podup.service".to_string(), service_name.to_string());
 		labels.insert("podup.config-hash".to_string(), config_hash(service, file)?);

--- a/internal/engine/container_fields.rs
+++ b/internal/engine/container_fields.rs
@@ -160,6 +160,23 @@ pub(super) fn build_label_file_labels(
 	labels
 }
 
+/// Resolve the user-facing labels for a container.
+///
+/// Merges `service.labels` with any labels sourced from `label_file`, with
+/// `service.labels` taking precedence. Per the Compose Specification,
+/// `deploy.labels` are set on the service only and are deliberately NOT applied
+/// to containers, matching docker-compose v2 behaviour.
+pub(super) fn resolve_container_labels(
+	service: &Service,
+	label_file_labels: HashMap<String, String>,
+) -> HashMap<String, String> {
+	let mut labels = service.labels.to_map();
+	for (k, v) in label_file_labels {
+		labels.entry(k).or_insert(v);
+	}
+	labels
+}
+
 // ---------------------------------------------------------------------------
 // Swarm-only deploy field diagnostics
 // ---------------------------------------------------------------------------
@@ -309,5 +326,69 @@ mod tests {
 			..Default::default()
 		});
 		warn_swarm_only_deploy("web", &svc);
+	}
+
+	// --- container label resolution ---
+
+	#[test]
+	fn resolve_container_labels_keeps_service_labels() {
+		use crate::compose::types::primitives::Labels;
+		use indexmap::IndexMap;
+		let mut svc = default_service();
+		let mut map = IndexMap::new();
+		map.insert("com.example.team".to_string(), "blue".to_string());
+		svc.labels = Labels::Map(map);
+
+		let labels = resolve_container_labels(&svc, HashMap::new());
+		assert_eq!(
+			labels.get("com.example.team").map(String::as_str),
+			Some("blue")
+		);
+	}
+
+	#[test]
+	fn resolve_container_labels_does_not_apply_deploy_labels() {
+		use crate::compose::types::primitives::Labels;
+		use crate::compose::types::DeployConfig;
+		use indexmap::IndexMap;
+		let mut svc = default_service();
+		let mut svc_map = IndexMap::new();
+		svc_map.insert("com.example.service".to_string(), "on".to_string());
+		svc.labels = Labels::Map(svc_map);
+		let mut deploy_map = IndexMap::new();
+		deploy_map.insert("com.example.deploy".to_string(), "swarm".to_string());
+		svc.deploy = Some(DeployConfig {
+			labels: Labels::Map(deploy_map),
+			..Default::default()
+		});
+
+		let labels = resolve_container_labels(&svc, HashMap::new());
+		// Per the Compose Specification, deploy.labels are NOT applied to the container.
+		assert!(!labels.contains_key("com.example.deploy"));
+		// Service labels still apply.
+		assert_eq!(
+			labels.get("com.example.service").map(String::as_str),
+			Some("on")
+		);
+	}
+
+	#[test]
+	fn resolve_container_labels_service_overrides_label_file() {
+		use crate::compose::types::primitives::Labels;
+		use indexmap::IndexMap;
+		let mut svc = default_service();
+		let mut map = IndexMap::new();
+		map.insert("shared".to_string(), "from-service".to_string());
+		svc.labels = Labels::Map(map);
+		let mut file_labels = HashMap::new();
+		file_labels.insert("shared".to_string(), "from-file".to_string());
+		file_labels.insert("only-file".to_string(), "yes".to_string());
+
+		let labels = resolve_container_labels(&svc, file_labels);
+		assert_eq!(
+			labels.get("shared").map(String::as_str),
+			Some("from-service")
+		);
+		assert_eq!(labels.get("only-file").map(String::as_str), Some("yes"));
 	}
 }

--- a/tests/engine_integration/group_a3.rs
+++ b/tests/engine_integration/group_a3.rs
@@ -61,7 +61,8 @@ async fn service_with_expose_deploy_labels_annotations_tmpfs() {
 	let proj = proj("sdl");
 	let engine = Engine::new(client, proj.clone());
 	// expose covers container.rs L56-63
-	// deploy.labels covers container.rs L76-78
+	// deploy.labels are accepted but, per the Compose Specification, are set on
+	// the service only and must not be applied to the container
 	// annotations covers container.rs L81-82
 	// long-form tmpfs volume covers container.rs L107-113 and L139
 	let file = parse_str(


### PR DESCRIPTION
Closes #499

Two Compose-fidelity fixes, verified against compose-go/v2.

## 1. deploy.labels must not be applied to containers

Per the Compose Specification (deploy.md): "labels are only set on the
service and not on any containers." docker-compose v2
(`mergeLabels(service.Labels, service.CustomLabels)`) never folds
`deploy.labels` into container labels; podup previously diverged by merging
them in `internal/engine/container/mod.rs`.

Container labels are now resolved through a dedicated
`resolve_container_labels` helper that merges `service.labels` with
`label_file` labels (service labels win) and no longer folds in
`deploy.labels`. The three internal `podup.*` labels
(project/service/config-hash) are unaffected.

## 2. Warn when build.platforms lists more than one platform

The libpod build API accepts a single `platform` per request (architectural
limit), so only `platforms.first()` is forwarded. Additional entries were
dropped silently; podup now emits a `tracing::warn!` naming the platform
being built and the number ignored. Behaviour is otherwise unchanged.

## Tests

- Unit tests on `resolve_container_labels` proving `service.labels` and the
  internal `podup.*` labels are kept while `deploy.labels` are not applied,
  and that `service.labels` override `label_file` labels.
- Stale "deploy.labels covers ..." coverage comment in the integration test
  updated to the correct expectation.
- The single-platform forwarding limit and warn are covered by inspection.

## Verification

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo build --all-features`, `cargo test --lib --all-features` (699 passed),
`cargo test --all-features --no-run` all pass. All touched files stay under
the 500-line limit.
