### PR TITLE
release: v1.1.0

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         target: [parse_compose, substitute, size, dotenv, stream_frame]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install nightly toolchain
         run: |

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -23,7 +23,7 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Syntax check
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
@@ -109,7 +109,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
@@ -195,7 +195,7 @@ jobs:
             cargo \
             rustc
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
@@ -232,7 +232,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         # Gate the release on `cargo audit`: a RUSTSEC advisory in a pinned
         # dependency must block publishing, not wait for the weekly cron scan.
         run: |
-          cargo install cargo-audit --version "^0.22" --locked
+          cargo install cargo-audit --version "=0.22.2" --locked
           cargo audit
 
   build:
@@ -256,8 +256,8 @@ jobs:
         # Government/enterprise consumers require a machine-readable SBOM
         # (CycloneDX, per US EO 14028) and a third-party license attribution.
         run: |
-          cargo install --locked cargo-cyclonedx --version "^0.5"
-          cargo install --locked --features cli cargo-about --version "^0.9"
+          cargo install --locked cargo-cyclonedx --version "=0.5.9"
+          cargo install --locked --features cli cargo-about --version "=0.9.0"
           cargo cyclonedx --format json --all-features
           # cargo-cyclonedx names the file after the package (podup.cdx.json),
           # so only rename when an older/different layout emitted another name —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,12 +285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,24 +349,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -467,19 +444,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -535,12 +506,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -711,16 +676,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -1027,9 +982,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,7 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1168,12 +1123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,62 +1200,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1481,100 +1378,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ flowchart LR
 
 ## ✨ Features
 
-- 🚀 **Drop-in workflow** — `up`, `down`, `start`, `stop`, `ps`, `logs`, `exec`, `run`, `cp`, `build`, `pull`, `restart`, `rm`, `kill`, `pause`, `unpause`, `top`, `port`, `images`, `config`, `watch`
+- 🚀 **Drop-in workflow** — `up`, `down`, `start`, `stop`, `ps`, `logs`, `exec`, `run`, `cp`, `build`, `pull`, `restart`, `rm`, `kill`, `pause`, `unpause`, `top`, `port`, `images`, `volumes`, `events`, `config` …and more — see the [command reference](docs/commands.md)
 - 🔒 **Rootless by design** — drives rootless Podman over its native libpod REST API
 - 📄 **Compose-spec parsing** — YAML anchors, `extends`, `include`, profiles, `env_file`, variable substitution with modifiers
 - 🔁 **Dependency-aware** — `depends_on` ordering with `service_started`, `service_healthy`, and `service_completed_successfully` conditions

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (1.1.0) unstable; urgency=medium
+
+  * cli: docker-compose command and flag parity — new subcommands (scale, create,
+    ls, stats, push, events, attach, wait, commit, export, volumes) and extensive
+    flag coverage across up/down/run/exec/logs/pull/build/cp/config/rm/start/kill.
+  * engine: send stop_signal to libpod as an integer (string form returned HTTP
+    500, breaking container creation); capture protocol and range on the container
+    port response; tolerate a null network map in stats frames.
+  * engine: skip dependency readiness waits under `up --no-deps`; resolve a scaled
+    service target for `network_mode: service:<name>`; translate bind selinux
+    shared/private to z/Z; warn on external_links under rootless; keep deploy.labels
+    off containers (they are service-scoped per the Compose Specification); warn
+    when build.platforms lists more than one platform.
+  * compose: build context is now optional (dockerfile_inline-only builds);
+    non-dotenv env_file format warns instead of erroring; the first build tag is
+    used as the primary image when image: is unset; parse credential_spec,
+    isolation, provider, use_api_socket and the top-level models element.
+  * quadlet: skip the no-equivalent healthcheck start_interval with a warning;
+    sanitize dependency names in After=/Requires=/Wants=; map network_mode
+    service:/container: to Network=X.container; drop [Install] from .volume and
+    .network units; map privileged to PodmanArgs=--privileged.
+  * cli: reject --index 0 as out of range; validate braced substitution variable
+    names.
+  * build: pin SBOM and audit tooling to exact versions; refresh webpki-roots,
+    getrandom and syn.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 19 Jun 2026 12:00:00 -0500
+
 podup (1.0.0) unstable; urgency=medium
 
   * First stable release. The CLI and the crate-root library surface now carry

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 0.24.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 1.1.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS
@@ -108,11 +108,30 @@ Resume paused service containers.
 .B run \fISERVICE\fR [\fICOMMAND\fR...]
 Run a one-off command in a new service container. Options: \fB\-\-rm\fR
 (default true), \fB\-d\fR/\fB\-\-detach\fR, \fB\-e\fR/\fB\-\-env\fR KEY=VAL,
-\fB\-\-name\fR, \fB\-\-service\-ports\fR.
+\fB\-\-name\fR, \fB\-P\fR/\fB\-\-service\-ports\fR,
+\fB\-u\fR/\fB\-\-user\fR, \fB\-w\fR/\fB\-\-workdir\fR, \fB\-\-entrypoint\fR,
+\fB\-v\fR/\fB\-\-volume\fR (repeatable), \fB\-p\fR/\fB\-\-publish\fR (repeatable),
+\fB\-i\fR/\fB\-\-interactive\fR, \fB\-T\fR/\fB\-\-no\-TTY\fR, \fB\-\-no\-deps\fR.
 .TP
 .B cp \fISRC\fR \fIDST\fR
 Copy files between a service container and the host. Use \fBSERVICE:PATH\fR for
 the container side.
+.TP
+.B attach \fISERVICE\fR
+Attach to a service container's output (stdout/stderr), streaming it until the
+container exits.
+.TP
+.B wait \fR[\fISERVICE\fR...]
+Block until the named service containers (default: all) stop, printing each
+container's exit code.
+.TP
+.B commit \fISERVICE\fR \fIIMAGE\fR
+Commit a service container to a new image reference (\fBrepo[:tag]\fR).
+\fB\-\-index\fR selects a replica (1-based) of a scaled service.
+.TP
+.B export \fISERVICE\fR
+Export a service container's filesystem as a tar archive. \fB\-o\fR/\fB\-\-output\fR
+writes to a file instead of stdout; \fB\-\-index\fR selects a replica (1-based).
 .TP
 .B ps
 List project containers.
@@ -129,8 +148,17 @@ list narrows the report.
 Print the public binding for a container port. \fB\-\-proto\fR sets the protocol
 (default \fBtcp\fR).
 .TP
+.B events
+Stream Podman events for this project's containers. \fB\-\-json\fR emits each
+event as a JSON line instead of a summary.
+.TP
 .B images
 List images used by services.
+.TP
+.B volumes \fR[\fISERVICE\fR...]
+List the project's named volumes. \fB\-q\fR/\fB\-\-quiet\fR prints names only,
+\fB\-\-format\fR selects \fItable\fR or \fIjson\fR, and a trailing service list
+narrows the report to volumes those services mount.
 .TP
 .B logs \fR[\fISERVICE\fR]
 View container output. \fB\-f\fR/\fB\-\-follow\fR streams new output,
@@ -152,7 +180,10 @@ cascade-restarting dependents with a \fBdepends_on\fR restart condition.
 .B config
 Print the resolved compose file after substitution, extends and include.
 \fB\-\-format\fR selects \fIyaml\fR or \fIjson\fR, \fB\-\-services\fR lists the
-service names, and \fB\-q\fR/\fB\-\-quiet\fR only validates (no output).
+service names, \fB\-q\fR/\fB\-\-quiet\fR only validates (no output),
+\fB\-\-no\-interpolate\fR leaves \fB${VAR}\fR placeholders literal, and
+\fB\-\-resolve\-image\-digests\fR rewrites each service \fBimage:\fR to its
+registry digest (\fBrepo@sha256:...\fR).
 .TP
 .B generate quadlet \fR[\fB\-o\fR \fIDIR\fR]
 Translate the compose file into Podman Quadlet unit files (one \fB.container\fR

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -101,14 +101,42 @@ Run a one-off command in a new container for the service.
 | `-d, --detach` | Run in the background. |
 | `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. |
 | `--name <NAME>` | Override the container name. |
-| `--service-ports` | Publish the service's declared ports (off by default). |
+| `-P, --service-ports` | Publish the service's declared ports (off by default). |
+| `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. |
+| `-w, --workdir <PATH>` | Working directory inside the container. |
+| `--entrypoint <CMD>` | Override the image entrypoint. |
+| `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. |
+| `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. |
+| `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). |
+| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). |
+| `--no-deps` | Do not start the `depends_on` services before running. |
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
 
 ### `cp <SRC> <DST>`
 Copy files between a container and the host. Use `SERVICE:PATH` for the
-container side, e.g. `podup cp web:/app/data ./local`.
+container side, e.g. `podup cp web:/app/data ./local`. `--index <N>` targets a
+specific replica (1-based) of a scaled service; `-L/--follow-link` follows
+symlinks in the host source before copying into the container; `-a/--archive` is
+accepted for compatibility (no effect under rootless Podman).
+
+### `attach <SERVICE>`
+Attach to a service container's output (stdout/stderr), streaming it until the
+container exits or you detach.
+
+### `wait [SERVICE...]`
+Block until the named service containers (default: all) stop, printing each
+container's exit code as it does.
+
+### `commit <SERVICE> <IMAGE>`
+Commit a service container's current state to a new image reference
+(`repo[:tag]`). `--index <N>` selects a replica (1-based) of a scaled service.
+
+### `export <SERVICE>`
+Export a service container's filesystem as a tar archive. By default the archive
+goes to stdout; `-o, --output <FILE>` writes it to a file instead. `--index <N>`
+selects a replica (1-based) of a scaled service.
 
 ## Inspection
 
@@ -119,9 +147,11 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `top` | Show running processes of service containers. |
 | `stats` | Live resource usage (CPU, memory, network, block I/O, PIDs) for service containers. `--no-stream` prints one snapshot; a trailing service list narrows it. |
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
+| `events` | Stream Podman events for this project's containers. `--json` emits each event as a JSON line instead of a summary. |
 | `images` | List images used by services. |
+| `volumes [SERVICE...]` | List the project's named volumes. `-q/--quiet` prints names only, `--format table\|json`; a trailing service list narrows it to volumes those services mount. |
 | `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
-| `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates. |
+| `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates, `--no-interpolate` leaves `${VAR}` placeholders literal, `--resolve-image-digests` rewrites each service `image:` to its registry digest (`repo@sha256:...`). |
 | `pull` | Pull images for all services. `-q/--quiet` suppresses progress output. |
 
 ## Generate

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -100,8 +100,9 @@ the `Glyndor/apt` repo.
    publication is a single `cargo publish` with the owner's registry
    token. `debcargo` consumes crates.io releases, so publishing first
    simplifies everything.
-5. **Stability promise** — official packages imply SemVer discipline and a
-   `1.0.0` once the CLI surface is settled.
+5. **Stability promise** — official packages imply SemVer discipline, which
+   `1.0.0` (already shipped) puts in force: the CLI surface is stable and
+   breaking changes wait for a major bump.
 
 ## Versioning
 

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -176,11 +176,11 @@ on the parsed file to obtain the same warnings and surface them to your users.
 Compose files are **trusted input**, like a Makefile. Path-valued keys that the
 spec resolves relative to the compose file — `extends.file`, `env_file`,
 `label_file`, and `include` — may use `../` to reach files outside the project
-directory, matching docker-compose. This is an intentional divergence from a
-fully sandboxed parser: do not feed podup a compose file from an untrusted
-source any more than you would `make -f` an untrusted Makefile. The one
-exception is `include`, which still rejects **absolute** paths (they are not
-portable across checkouts and the spec does not require them); `../` is allowed.
+directory, matching docker-compose. Absolute paths are accepted too (an
+absolute `include:` is used as given, as in docker-compose). This is an
+intentional divergence from a fully sandboxed parser: do not feed podup a
+compose file from an untrusted source any more than you would `make -f` an
+untrusted Makefile.
 
 ## Not yet supported
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #
 #   curl -fsSL https://glyndor.net/podup/install/unix | bash
 #
-# --apt (Debian/Ubuntu, amd64): set up the Glyndor apt repository and install
+# --apt (Debian/Ubuntu, amd64/arm64): set up the Glyndor apt repository and install
 # with apt. Updates — including signing-key renewals — come from `apt upgrade`.
 #
 #   curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt

--- a/internal/compose/anchor.rs
+++ b/internal/compose/anchor.rs
@@ -42,8 +42,12 @@ pub(super) fn anchor_service(svc: &mut Service, dir: &Path) {
 				}
 			}
 			BuildConfig::Config { context, .. } => {
-				if let Some(a) = anchor_context(context, dir) {
-					*context = a;
+				// An absent `context` defaults to the project directory `.`;
+				// anchor that default to the included file's directory so a
+				// `dockerfile_inline`-only build resolves against the right dir.
+				let effective = context.as_deref().unwrap_or(".");
+				if let Some(a) = anchor_context(effective, dir) {
+					*context = Some(a);
 				}
 			}
 		}

--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -24,6 +24,30 @@ pub(super) fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) 
 				 attach/detach logic for `up` log streaming"
 			));
 		}
+		if def.credential_spec.is_some() {
+			out.push(format!(
+				"service '{service}': credential_spec is a Windows managed-service-account \
+				 control with no rootless Podman equivalent and is not honored"
+			));
+		}
+		if def.isolation.is_some() {
+			out.push(format!(
+				"service '{service}': isolation has no rootless Podman equivalent and is \
+				 not honored"
+			));
+		}
+		if def.provider.is_some() {
+			out.push(format!(
+				"service '{service}': provider delegates the service lifecycle to an \
+				 external plugin that podup does not invoke; the service is not honored"
+			));
+		}
+		if def.use_api_socket.is_some() {
+			out.push(format!(
+				"service '{service}': use_api_socket has no podup equivalent and is not \
+				 honored"
+			));
+		}
 		for entry in def.env_file.to_entries() {
 			if let EnvFileEntry::Config {
 				format: Some(fmt), ..
@@ -35,6 +59,17 @@ pub(super) fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) 
 				));
 			}
 		}
+	}
+}
+
+/// Top-level `models:` (Compose v2.38) — podup runs no model runner, so any
+/// declared model is parsed for fidelity but not honored.
+pub(super) fn ignored_models(file: &ComposeFile, out: &mut Vec<String>) {
+	for name in file.models.keys() {
+		out.push(format!(
+			"model '{name}': podup runs no model runner, so the models element is not \
+			 honored"
+		));
 	}
 }
 

--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -12,7 +12,7 @@ use super::types::ComposeFile;
 
 mod ignored_fields;
 use ignored_fields::{
-	ignored_build_fields, ignored_network_fields, ignored_port_fields,
+	ignored_build_fields, ignored_models, ignored_network_fields, ignored_port_fields,
 	ignored_secret_config_drivers, ignored_service_fields, ignored_service_network_fields,
 	ignored_volume_mount_fields,
 };
@@ -31,6 +31,7 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	ignored_network_fields(file, &mut out);
 	ignored_service_network_fields(file, &mut out);
 	ignored_secret_config_drivers(file, &mut out);
+	ignored_models(file, &mut out);
 	out
 }
 
@@ -76,6 +77,23 @@ fn nested_unknown_keys(file: &ComposeFile, out: &mut Vec<String>) {
 				);
 			}
 		}
+		if let Some(cred) = &def.credential_spec {
+			push_unknown(
+				&format!("service '{service}' credential_spec"),
+				&cred.unknown,
+				out,
+			);
+		}
+		if let Some(provider) = &def.provider {
+			push_unknown(
+				&format!("service '{service}' provider"),
+				&provider.unknown,
+				out,
+			);
+		}
+	}
+	for (name, model) in &file.models {
+		push_unknown(&format!("model '{name}'"), &model.unknown, out);
 	}
 	for (name, cfg) in &file.networks {
 		if let Some(c) = cfg {
@@ -382,6 +400,97 @@ mod tests {
 		assert!(
 			!msgs.iter().any(|m| m.contains("driver")),
 			"unexpected: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_credential_spec_not_honored() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\n    credential_spec:\n      config: my-spec\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("credential_spec") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		// The recognized key must not also produce a generic "unknown key" warning.
+		assert!(
+			!msgs
+				.iter()
+				.any(|m| m.contains("unknown key 'credential_spec'")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_service_isolation_not_honored() {
+		let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    isolation: hyperv\n");
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("isolation") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		assert!(!msgs.iter().any(|m| m.contains("unknown key 'isolation'")));
+	}
+
+	#[test]
+	fn warns_on_provider_not_honored() {
+		let msgs = diagnostics_for("services:\n  db:\n    provider:\n      type: awesomecloud\n");
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("provider") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		assert!(!msgs.iter().any(|m| m.contains("unknown key 'provider'")));
+	}
+
+	#[test]
+	fn warns_on_use_api_socket_not_honored() {
+		let msgs =
+			diagnostics_for("services:\n  web:\n    image: nginx\n    use_api_socket: true\n");
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("use_api_socket") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		assert!(!msgs
+			.iter()
+			.any(|m| m.contains("unknown key 'use_api_socket'")));
+	}
+
+	#[test]
+	fn warns_on_top_level_models_not_honored() {
+		let msgs = diagnostics_for(
+			"services:\n  web:\n    image: nginx\nmodels:\n  llm:\n    model: ai/model\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("model 'llm'") && m.contains("not honored")),
+			"got: {msgs:?}"
+		);
+		// `models` is now a recognized top-level element, not an unknown key.
+		assert!(
+			!msgs
+				.iter()
+				.any(|m| m.contains("unknown top-level key 'models'")),
+			"got: {msgs:?}"
+		);
+	}
+
+	#[test]
+	fn warns_on_typo_inside_provider_and_models() {
+		let msgs = diagnostics_for(
+			"services:\n  db:\n    provider:\n      type: cloud\n      optoins: {}\nmodels:\n  llm:\n    modle: ai/model\n",
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("provider") && m.contains("optoins")),
+			"got: {msgs:?}"
+		);
+		assert!(
+			msgs.iter()
+				.any(|m| m.contains("model 'llm'") && m.contains("modle")),
+			"got: {msgs:?}"
 		);
 	}
 }

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -194,6 +194,10 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		deploy: override_svc.deploy.or(base.deploy),
 		develop: override_svc.develop.or(base.develop),
 		gpus: override_svc.gpus.or(base.gpus),
+		credential_spec: override_svc.credential_spec.or(base.credential_spec),
+		isolation: override_svc.isolation.or(base.isolation),
+		provider: override_svc.provider.or(base.provider),
+		use_api_socket: override_svc.use_api_socket.or(base.use_api_socket),
 		unknown: {
 			// Keep unknown keys from both sides so a typo in either the base or
 			// the overriding service is still surfaced; the override wins on

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -14,17 +14,23 @@ use super::{EnvVars, Labels, StringOrList, UlimitConfig};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IncludeConfig {
+	/// Short form: a single Compose file path to include.
 	Path(String),
+	/// Long form: one or more paths with optional env-file and project directory overrides.
 	Long {
+		/// One or more Compose file paths to include.
 		path: StringOrList,
+		/// Env file(s) used to interpolate the included files.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		env_file: Option<StringOrList>,
+		/// Base directory for resolving relative paths in the included files.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		project_directory: Option<String>,
 	},
 }
 
 impl IncludeConfig {
+	/// Returns the included Compose file paths.
 	pub fn paths(&self) -> Vec<String> {
 		match self {
 			IncludeConfig::Path(p) => vec![p.clone()],
@@ -37,15 +43,20 @@ impl IncludeConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ExtendsConfig {
+	/// Short form: the name of a service in the current file to extend.
 	Service(String),
+	/// Long form: a service name plus the file it is defined in.
 	Long {
+		/// Name of the service to extend.
 		service: String,
+		/// File the extended service is defined in; the current file if absent.
 		#[serde(skip_serializing_if = "Option::is_none")]
 		file: Option<String>,
 	},
 }
 
 impl ExtendsConfig {
+	/// Returns the name of the service being extended.
 	pub fn service(&self) -> &str {
 		match self {
 			ExtendsConfig::Service(s) => s,
@@ -53,6 +64,7 @@ impl ExtendsConfig {
 		}
 	}
 
+	/// Returns the file the extended service is defined in, if specified.
 	pub fn file(&self) -> Option<&str> {
 		match self {
 			ExtendsConfig::Service(_) => None,
@@ -66,58 +78,84 @@ impl ExtendsConfig {
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum BuildConfig {
+	/// Short form: a bare build context path.
 	Context(String),
+	/// Long form: the full set of build options.
 	Config {
+		/// Build context path; defaults to the project directory `.` if absent.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		context: Option<String>,
+		/// Path to the Dockerfile relative to the context.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		dockerfile: Option<String>,
+		/// Inline Dockerfile contents, used in place of a Dockerfile path.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		dockerfile_inline: Option<String>,
+		/// Build-time arguments passed to the builder.
 		#[serde(default)]
 		args: EnvVars,
+		/// Target build stage to build in a multi-stage Dockerfile.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		target: Option<String>,
+		/// Sources to consider for build cache resolution.
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		cache_from: Vec<String>,
+		/// Export locations for the build cache.
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		cache_to: Vec<String>,
+		/// Labels applied to the resulting image.
 		#[serde(default)]
 		labels: Labels,
+		/// Size of `/dev/shm` available to the build.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		shm_size: Option<String>,
+		/// Network mode containers use during the build.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		network: Option<String>,
+		/// Target platforms to build the image for.
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		platforms: Vec<String>,
+		/// Named additional build contexts (`name -> source`).
 		#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 		additional_contexts: HashMap<String, String>,
+		/// Whether to build without using any cache.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		no_cache: Option<bool>,
+		/// Whether to always attempt to pull newer versions of base images.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		pull: Option<bool>,
+		/// Extra `host:ip` mappings added to the build container's `/etc/hosts`.
 		#[serde(
 			default,
 			deserialize_with = "super::primitives::deserialize_extra_hosts",
 			skip_serializing_if = "Vec::is_empty"
 		)]
 		extra_hosts: Vec<String>,
+		/// Image references to tag the built image with.
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		tags: Vec<String>,
+		/// Whether to run the build with elevated privileges.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		privileged: Option<bool>,
+		/// SSH agent sockets or keys exposed to the build.
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		ssh: Vec<String>,
+		/// Names of top-level secrets exposed to the build.
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		secrets: Vec<String>,
+		/// Resource limits applied to the build container.
 		#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 		ulimits: IndexMap<String, UlimitConfig>,
+		/// Build isolation technology to use.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		isolation: Option<String>,
+		/// Extra privileged entitlements granted to the build.
 		#[serde(default, skip_serializing_if = "Vec::is_empty")]
 		entitlements: Vec<String>,
+		/// Provenance attestation setting for the build.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		provenance: Option<serde_yaml::Value>,
+		/// Whether to generate an SBOM attestation for the build.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		sbom: Option<bool>,
 	},
@@ -136,6 +174,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the Dockerfile path, if set.
 	pub fn dockerfile(&self) -> Option<&str> {
 		match self {
 			BuildConfig::Context(_) => None,
@@ -143,6 +182,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the build arguments.
 	pub fn args(&self) -> EnvVars {
 		match self {
 			BuildConfig::Context(_) => EnvVars::Empty,
@@ -150,6 +190,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the target build stage, if set.
 	pub fn target(&self) -> Option<&str> {
 		match self {
 			BuildConfig::Context(_) => None,
@@ -157,6 +198,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns whether the build should ignore the cache.
 	pub fn no_cache(&self) -> bool {
 		match self {
 			BuildConfig::Context(_) => false,
@@ -164,6 +206,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns whether the build should always pull newer base images.
 	pub fn pull(&self) -> bool {
 		match self {
 			BuildConfig::Context(_) => false,
@@ -171,6 +214,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the `/dev/shm` size for the build, if set.
 	pub fn shm_size(&self) -> Option<&str> {
 		match self {
 			BuildConfig::Context(_) => None,
@@ -178,6 +222,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the extra `host:ip` mappings for the build.
 	pub fn extra_hosts(&self) -> &[String] {
 		match self {
 			BuildConfig::Context(_) => &[],
@@ -185,6 +230,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the image tags to apply to the built image.
 	pub fn tags(&self) -> &[String] {
 		match self {
 			BuildConfig::Context(_) => &[],
@@ -192,6 +238,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the cache sources for the build.
 	pub fn cache_from(&self) -> &[String] {
 		match self {
 			BuildConfig::Context(_) => &[],
@@ -199,6 +246,7 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the inline Dockerfile contents, if set.
 	pub fn dockerfile_inline(&self) -> Option<&str> {
 		match self {
 			BuildConfig::Context(_) => None,

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -68,7 +68,8 @@ impl ExtendsConfig {
 pub enum BuildConfig {
 	Context(String),
 	Config {
-		context: String,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		context: Option<String>,
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		dockerfile: Option<String>,
 		#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -123,10 +124,15 @@ pub enum BuildConfig {
 }
 
 impl BuildConfig {
+	/// Build context path.
+	///
+	/// In the long form, `context` is optional per the Compose Spec (v2.22+):
+	/// a `build:` block carrying only `dockerfile_inline:` has no context and
+	/// defaults to the project directory `.`.
 	pub fn context(&self) -> &str {
 		match self {
 			BuildConfig::Context(ctx) => ctx,
-			BuildConfig::Config { context, .. } => context,
+			BuildConfig::Config { context, .. } => context.as_deref().unwrap_or("."),
 		}
 	}
 
@@ -300,7 +306,7 @@ mod tests {
 	#[test]
 	fn build_config_long_form_context() {
 		let b = BuildConfig::Config {
-			context: "./app".into(),
+			context: Some("./app".into()),
 			dockerfile: Some("Dockerfile.prod".into()),
 			dockerfile_inline: None,
 			args: EnvVars::Empty,
@@ -329,5 +335,15 @@ mod tests {
 		assert_eq!(b.dockerfile(), Some("Dockerfile.prod"));
 		assert_eq!(b.target(), Some("release"));
 		assert!(b.no_cache());
+	}
+
+	#[test]
+	fn build_with_only_dockerfile_inline_defaults_context_to_dot() {
+		// Compose Spec (v2.22+): `build:` may carry only `dockerfile_inline:` with
+		// no `context:` — the context then defaults to the project directory `.`.
+		let b: BuildConfig = serde_yaml::from_str("dockerfile_inline: |\n  FROM alpine\n").unwrap();
+		assert!(matches!(b, BuildConfig::Config { .. }));
+		assert_eq!(b.context(), ".");
+		assert_eq!(b.dockerfile_inline(), Some("FROM alpine\n"));
 	}
 }

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -20,24 +20,34 @@ use super::Labels;
 /// and emit a warning at runtime.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployConfig {
+	/// Desired number of container replicas.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub replicas: Option<u32>,
+	/// Resource limits and reservations.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub resources: Option<ResourcesConfig>,
+	/// Restart policy for the service's containers.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart_policy: Option<DeployRestartPolicy>,
+	/// Rolling update configuration (Swarm-only; parsed but ignored).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub update_config: Option<DeployUpdateConfig>,
+	/// Rollback configuration (Swarm-only; parsed but ignored).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub rollback_config: Option<DeployUpdateConfig>,
+	/// Service endpoint mode (Swarm-only; parsed but ignored).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub endpoint_mode: Option<String>,
+	/// Replication mode, `replicated` or `global` (Swarm-only; parsed but ignored).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mode: Option<String>,
+	/// Labels applied to the service.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Placement constraints (Swarm-only; parsed but ignored).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub placement: Option<DeployPlacement>,
+	/// Unrecognized keys preserved verbatim for round-tripping.
 	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
 	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
@@ -45,8 +55,10 @@ pub struct DeployConfig {
 /// Resource constraints under `deploy.resources:` — holds `limits` and `reservations`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourcesConfig {
+	/// Hard upper bounds on resource usage.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub limits: Option<ResourceSpec>,
+	/// Resources guaranteed to the service.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub reservations: Option<ResourceSpec>,
 }
@@ -54,12 +66,16 @@ pub struct ResourcesConfig {
 /// A single resource specification: CPU shares, memory limit, pids limit, and device access.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourceSpec {
+	/// CPU limit expressed in cores (e.g. `"0.5"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpus: Option<String>,
+	/// Memory limit as a size string (e.g. `"512M"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub memory: Option<String>,
+	/// Maximum number of process IDs.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pids: Option<u64>,
+	/// Device reservations such as GPUs.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub devices: Vec<DeviceReservation>,
 }
@@ -71,14 +87,19 @@ pub struct ResourceSpec {
 /// `deploy.resources.reservations.devices` — generic device reservation.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeviceReservation {
+	/// Required device capabilities (e.g. `gpu`, `compute`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub capabilities: Vec<String>,
+	/// Number of matching devices to reserve, or `all`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub count: Option<CountOrAll>,
+	/// Specific device IDs to reserve.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_ids: Vec<String>,
+	/// Device driver name.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Driver-specific options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub options: HashMap<String, String>,
 }
@@ -87,11 +108,14 @@ pub struct DeviceReservation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CountOrAll {
+	/// String form, `"all"`.
 	Named(String),
+	/// Numeric device count.
 	N(i64),
 }
 
 impl CountOrAll {
+	/// Returns the count as an integer, with `-1` representing `all`.
 	pub fn to_i64(&self) -> i64 {
 		match self {
 			CountOrAll::Named(_) => -1,
@@ -118,12 +142,16 @@ mod tests {
 /// Restart policy under `deploy.restart_policy:` — distinct from the service-level `restart:` string.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployRestartPolicy {
+	/// When to restart, e.g. `on-failure` or `any`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub condition: Option<String>,
+	/// Delay between restart attempts (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub delay: Option<String>,
+	/// Maximum restart attempts before giving up.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub max_attempts: Option<u32>,
+	/// Window over which attempts are counted (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub window: Option<String>,
 }
@@ -131,16 +159,22 @@ pub struct DeployRestartPolicy {
 /// Update (and rollback) configuration — reused for both `deploy.update_config` and `deploy.rollback_config`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployUpdateConfig {
+	/// Number of containers updated at once.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub parallelism: Option<u32>,
+	/// Delay between updating batches (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub delay: Option<String>,
+	/// Action taken if an update fails.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub failure_action: Option<String>,
+	/// Time to monitor each task for failure (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub monitor: Option<String>,
+	/// Failure ratio tolerated before the update is considered failed.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub max_failure_ratio: Option<f64>,
+	/// Order of stopping old and starting new containers.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub order: Option<String>,
 }
@@ -148,10 +182,13 @@ pub struct DeployUpdateConfig {
 /// Placement constraints and preferences controlling which nodes a service's containers may run on.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployPlacement {
+	/// Node constraints that must be satisfied.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub constraints: Vec<String>,
+	/// Soft placement preferences.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub preferences: Vec<serde_yaml::Value>,
+	/// Maximum replicas allowed on a single node.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub max_replicas_per_node: Option<u32>,
 }

--- a/internal/compose/types/env.rs
+++ b/internal/compose/types/env.rs
@@ -11,13 +11,17 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum EnvVars {
+	/// The field was absent.
 	#[default]
 	Empty,
+	/// List form: `KEY=VAL` or bare `KEY` entries.
 	List(Vec<String>),
+	/// Map form: keys to optional values (a null value inherits from the host).
 	Map(IndexMap<String, Option<serde_yaml::Value>>),
 }
 
 impl EnvVars {
+	/// Returns the variables as a map, where `None` means inherit from the host.
 	pub fn to_map(&self) -> HashMap<String, Option<String>> {
 		match self {
 			EnvVars::Empty => HashMap::new(),
@@ -46,6 +50,7 @@ impl EnvVars {
 		}
 	}
 
+	/// Returns whether no environment variables are defined.
 	pub fn is_empty(&self) -> bool {
 		match self {
 			EnvVars::Empty => true,
@@ -59,17 +64,23 @@ impl EnvVars {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum EnvFileEntry {
+	/// Short form: a bare env file path.
 	Path(String),
+	/// Long form: an env file path with `required`/`format` options.
 	Config {
+		/// Path to the env file.
 		path: String,
+		/// Whether a missing file is an error; `true` if absent.
 		#[serde(skip_serializing_if = "Option::is_none")]
 		required: Option<bool>,
+		/// Env file format selector (e.g. `raw`).
 		#[serde(skip_serializing_if = "Option::is_none")]
 		format: Option<String>,
 	},
 }
 
 impl EnvFileEntry {
+	/// Returns the env file path.
 	pub fn path(&self) -> &str {
 		match self {
 			EnvFileEntry::Path(p) => p,
@@ -90,13 +101,17 @@ impl EnvFileEntry {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum EnvFile {
+	/// The field was absent.
 	#[default]
 	Empty,
+	/// A single env file entry.
 	Single(EnvFileEntry),
+	/// A list of env file entries.
 	List(Vec<EnvFileEntry>),
 }
 
 impl EnvFile {
+	/// Returns all env file entries.
 	pub fn to_entries(&self) -> Vec<EnvFileEntry> {
 		match self {
 			EnvFile::Empty => vec![],
@@ -113,6 +128,7 @@ impl EnvFile {
 			.collect()
 	}
 
+	/// Returns whether no env files are defined.
 	pub fn is_empty(&self) -> bool {
 		match self {
 			EnvFile::Empty => true,

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -16,13 +16,17 @@ use super::primitives::Command;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum DependsOn {
+	/// No dependencies declared.
 	#[default]
 	Empty,
+	/// Short form: a bare list of service names.
 	List(Vec<String>),
+	/// Long form: per-dependency conditions keyed by service name.
 	Map(IndexMap<String, DependsOnCondition>),
 }
 
 impl DependsOn {
+	/// Returns the names of all dependency services.
 	pub fn service_names(&self) -> Vec<String> {
 		match self {
 			DependsOn::Empty => vec![],
@@ -31,6 +35,7 @@ impl DependsOn {
 		}
 	}
 
+	/// Returns the start condition for a dependency, defaulting to `service_started`.
 	pub fn condition_for(&self, service: &str) -> ServiceCondition {
 		match self {
 			DependsOn::Map(m) => m
@@ -41,6 +46,7 @@ impl DependsOn {
 		}
 	}
 
+	/// Returns whether the dependent should restart when this dependency restarts.
 	pub fn restart_for(&self, service: &str) -> bool {
 		match self {
 			DependsOn::Map(m) => m.get(service).and_then(|c| c.restart).unwrap_or(false),
@@ -48,6 +54,7 @@ impl DependsOn {
 		}
 	}
 
+	/// Returns whether the dependency is required, defaulting to `true`.
 	pub fn required_for(&self, service: &str) -> bool {
 		match self {
 			DependsOn::Map(m) => m.get(service).and_then(|c| c.required).unwrap_or(true),
@@ -59,9 +66,12 @@ impl DependsOn {
 /// Long-form per-dependency entry in `depends_on:` — holds the condition and restart flag.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DependsOnCondition {
+	/// Condition the dependency must reach before the dependent starts.
 	pub condition: ServiceCondition,
+	/// Whether the dependent restarts when this dependency is restarted.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub restart: Option<bool>,
+	/// Whether the dependency must be present; `true` if absent.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub required: Option<bool>,
 }
@@ -70,34 +80,46 @@ pub struct DependsOnCondition {
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ServiceCondition {
+	/// The dependency container has started.
 	#[default]
 	ServiceStarted,
+	/// The dependency container has passed its health check.
 	ServiceHealthy,
+	/// The dependency container has exited successfully.
 	ServiceCompletedSuccessfully,
 }
 
 /// Inline `healthcheck:` block. `disable: true` overrides any inherited health check.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct HealthCheck {
+	/// Command run to determine container health.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub test: Option<Command>,
+	/// Time between health check runs (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub interval: Option<String>,
+	/// Maximum time a single check may run before failing (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub timeout: Option<String>,
+	/// Consecutive failures before the container is marked unhealthy.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub retries: Option<u32>,
+	/// Grace period after start before failures count (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub start_period: Option<String>,
+	/// Check interval used during the start period (duration string).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub start_interval: Option<String>,
+	/// Whether to disable any inherited health check.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub disable: Option<bool>,
+	/// Unrecognized keys preserved verbatim for round-tripping.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
 
 impl HealthCheck {
+	/// Returns whether the health check is disabled, either via `disable: true` or a `NONE` test.
 	pub fn is_disabled(&self) -> bool {
 		if self.disable.unwrap_or(false) {
 			return true;
@@ -109,13 +131,18 @@ impl HealthCheck {
 /// A single `post_start` or `pre_stop` lifecycle hook entry.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LifecycleHook {
+	/// Command executed for the hook.
 	pub command: Command,
+	/// User the hook command runs as.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
+	/// Whether the hook runs with elevated privileges.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
+	/// Working directory for the hook command.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub working_dir: Option<String>,
+	/// Environment variables set for the hook command.
 	#[serde(default)]
 	pub environment: EnvVars,
 }
@@ -123,9 +150,16 @@ pub struct LifecycleHook {
 /// Service-level `restart:` policy — `no`, `always`, `unless-stopped`, or `on-failure` (with optional max-retries).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RestartPolicy {
+	/// Never restart the container.
 	No,
+	/// Always restart the container when it stops.
 	Always,
-	OnFailure { max_attempts: Option<u32> },
+	/// Restart on non-zero exit, up to `max_attempts` times if set.
+	OnFailure {
+		/// Maximum restart attempts; unlimited if absent.
+		max_attempts: Option<u32>,
+	},
+	/// Restart unless the container was explicitly stopped.
 	UnlessStopped,
 }
 

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -76,6 +76,28 @@ pub struct ConfigConfig {
 	pub template_driver: Option<String>,
 }
 
+/// Top-level `models:` entry (Compose v2.38) — declares an AI model the
+/// project depends on. podup runs no model runner, so the diagnostics pass
+/// reports any declared model as not honored; the fields are parsed for
+/// fidelity and round-tripped by `config`.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
+pub struct ModelConfig {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub model: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub context_size: Option<u64>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub runtime_flags: Vec<String>,
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	pub model_variables: HashMap<String, String>,
+	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
+}
+
 /// Root deserialization target for a `docker-compose.yml` file.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
@@ -96,6 +118,11 @@ pub struct ComposeFile {
 	pub secrets: IndexMap<String, SecretConfig>,
 	#[serde(default)]
 	pub configs: IndexMap<String, ConfigConfig>,
+	/// Top-level `models:` element (Compose v2.38). Parsed for fidelity; podup
+	/// runs no model runner, so the diagnostics pass reports declared models as
+	/// not honored.
+	#[serde(default)]
+	pub models: IndexMap<String, ModelConfig>,
 	/// Top-level `x-*` extension fields — preserved and round-tripped via `config` subcommand.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub extensions: IndexMap<String, serde_yaml::Value>,

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -14,13 +14,17 @@ use super::Labels;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum ServiceNetworks {
+	/// No networks declared.
 	#[default]
 	Empty,
+	/// Short form: a bare list of network names.
 	List(Vec<String>),
+	/// Long form: per-network attachment options keyed by network name.
 	Map(IndexMap<String, Option<ServiceNetworkConfig>>),
 }
 
 impl ServiceNetworks {
+	/// Returns the names of all attached networks.
 	pub fn names(&self) -> Vec<String> {
 		match self {
 			ServiceNetworks::Empty => vec![],
@@ -29,6 +33,7 @@ impl ServiceNetworks {
 		}
 	}
 
+	/// Returns the attachment options for a network, if any are set.
 	pub fn config_for(&self, name: &str) -> Option<&ServiceNetworkConfig> {
 		match self {
 			ServiceNetworks::Map(m) => m.get(name).and_then(|c| c.as_ref()),
@@ -40,22 +45,31 @@ impl ServiceNetworks {
 /// Per-network attachment options: aliases, static IPv4/IPv6, link-local addresses, and priority.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ServiceNetworkConfig {
+	/// Additional network aliases the container is reachable by.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub aliases: Option<Vec<String>>,
+	/// Static IPv4 address on this network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipv4_address: Option<String>,
+	/// Static IPv6 address on this network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipv6_address: Option<String>,
+	/// Link-local IP addresses for this attachment.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub link_local_ips: Vec<String>,
+	/// Attachment priority used to order multiple networks.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub priority: Option<u32>,
+	/// Static MAC address for this attachment.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mac_address: Option<String>,
+	/// Driver-specific options for this attachment.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub driver_opts: HashMap<String, String>,
+	/// Priority used to select the default gateway among networks.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gw_priority: Option<u32>,
+	/// Name of the interface created inside the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub interface_name: Option<String>,
 }
@@ -64,26 +78,37 @@ pub struct ServiceNetworkConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct NetworkConfig {
+	/// Network driver name; the runtime default is used if absent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Driver-specific options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub driver_opts: HashMap<String, String>,
+	/// Whether the network is externally managed and not created by podup.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub external: Option<bool>,
+	/// Custom network name overriding the project-prefixed default.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Whether the network is isolated from external connectivity.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub internal: Option<bool>,
+	/// Whether IPv6 is enabled on the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub enable_ipv6: Option<bool>,
+	/// Whether IPv4 is enabled on the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub enable_ipv4: Option<bool>,
+	/// Whether standalone containers may attach to the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attachable: Option<bool>,
+	/// IP address management configuration.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipam: Option<IpamConfig>,
+	/// Labels applied to the network.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Unrecognized keys preserved verbatim for round-tripping.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
@@ -91,12 +116,16 @@ pub struct NetworkConfig {
 /// `ipam:` block inside a top-level network definition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct IpamConfig {
+	/// IPAM driver name.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Subnet/range pool definitions.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub config: Vec<IpamPool>,
+	/// Driver-specific IPAM options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub options: HashMap<String, String>,
+	/// Unrecognized keys preserved verbatim for round-tripping.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
@@ -104,12 +133,16 @@ pub struct IpamConfig {
 /// A single subnet/range entry within `ipam.config`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct IpamPool {
+	/// Subnet in CIDR notation.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub subnet: Option<String>,
+	/// Gateway address for the subnet.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gateway: Option<String>,
+	/// Range within the subnet to allocate addresses from.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ip_range: Option<String>,
+	/// Reserved auxiliary addresses (`name -> address`).
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub aux_addresses: HashMap<String, String>,
 }

--- a/internal/compose/types/ports.rs
+++ b/internal/compose/types/ports.rs
@@ -13,11 +13,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringOrU16 {
+	/// String form, e.g. a quoted port or range like `"8080-8090"`.
 	String(String),
+	/// Numeric port form.
 	Number(u16),
 }
 
 impl StringOrU16 {
+	/// Returns the value as a string.
 	pub fn as_str_val(&self) -> String {
 		match self {
 			StringOrU16::String(s) => s.clone(),
@@ -53,19 +56,28 @@ mod tests {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PortMapping {
+	/// Short form: a `host:container[/proto]` string.
 	Short(String),
+	/// Long form: each port field expressed individually.
 	Long {
+		/// Container port being exposed.
 		target: u16,
+		/// Host port (or range) the target is published to.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		published: Option<StringOrU16>,
+		/// Transport protocol (`tcp` or `udp`).
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		protocol: Option<String>,
+		/// Host IP to bind the published port to.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		host_ip: Option<String>,
+		/// Publishing mode (`host` or `ingress`).
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		mode: Option<String>,
+		/// Application-level protocol hint (e.g. `http`).
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		app_protocol: Option<String>,
+		/// Human-readable name for the port mapping.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		name: Option<String>,
 	},

--- a/internal/compose/types/primitives.rs
+++ b/internal/compose/types/primitives.rs
@@ -36,11 +36,14 @@ where
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Command {
+	/// Shell form: a single string run via `sh -c`.
 	Shell(String),
+	/// Exec form: an explicit argument vector run without a shell.
 	Exec(Vec<String>),
 }
 
 impl Command {
+	/// Returns the command as an exec argument vector, wrapping a shell string in `sh -c`.
 	pub fn to_exec(&self) -> Vec<String> {
 		match self {
 			Command::Shell(s) => vec!["sh".into(), "-c".into(), s.clone()],
@@ -48,6 +51,7 @@ impl Command {
 		}
 	}
 
+	/// Returns the raw arguments without wrapping a shell string in `sh -c`.
 	pub fn to_argv(&self) -> Vec<String> {
 		match self {
 			Command::Shell(s) => vec![s.clone()],
@@ -60,13 +64,17 @@ impl Command {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum StringOrList {
+	/// The field was absent.
 	#[default]
 	Empty,
+	/// A single string value.
 	Single(String),
+	/// A list of string values.
 	List(Vec<String>),
 }
 
 impl StringOrList {
+	/// Returns the value as a list of strings.
 	pub fn to_list(&self) -> Vec<String> {
 		match self {
 			StringOrList::Empty => vec![],
@@ -75,6 +83,7 @@ impl StringOrList {
 		}
 	}
 
+	/// Returns whether the field holds no values.
 	pub fn is_empty(&self) -> bool {
 		match self {
 			StringOrList::Empty => true,
@@ -88,13 +97,17 @@ impl StringOrList {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum Labels {
+	/// The field was absent.
 	#[default]
 	Empty,
+	/// List form: `KEY=VALUE` entries.
 	List(Vec<String>),
+	/// Map form: key-value pairs.
 	Map(IndexMap<String, String>),
 }
 
 impl Labels {
+	/// Returns the labels as a key-value map, splitting list entries on the first `=`.
 	pub fn to_map(&self) -> HashMap<String, String> {
 		match self {
 			Labels::Empty => HashMap::new(),
@@ -112,6 +125,7 @@ impl Labels {
 		}
 	}
 
+	/// Returns whether no labels are defined.
 	pub fn is_empty(&self) -> bool {
 		match self {
 			Labels::Empty => true,
@@ -124,8 +138,10 @@ impl Labels {
 /// `logging:` configuration — driver name and driver-specific options.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct LoggingConfig {
+	/// Logging driver name; the runtime default is used if absent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Driver-specific options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub options: HashMap<String, String>,
 }
@@ -134,13 +150,17 @@ pub struct LoggingConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum Sysctls {
+	/// The field was absent.
 	#[default]
 	Empty,
+	/// List form: `key=value` entries.
 	List(Vec<String>),
+	/// Map form: kernel parameter keys to values.
 	Map(IndexMap<String, serde_yaml::Value>),
 }
 
 impl Sysctls {
+	/// Returns the sysctls as a key-value map, stringifying scalar values.
 	pub fn to_map(&self) -> HashMap<String, String> {
 		match self {
 			Sysctls::Empty => HashMap::new(),

--- a/internal/compose/types/resources.rs
+++ b/internal/compose/types/resources.rs
@@ -10,11 +10,19 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum UlimitConfig {
+	/// Single value applied to both the soft and hard limit.
 	Single(i64),
-	Pair { soft: i64, hard: i64 },
+	/// Explicit soft and hard limit pair.
+	Pair {
+		/// Soft limit value.
+		soft: i64,
+		/// Hard limit value.
+		hard: i64,
+	},
 }
 
 impl UlimitConfig {
+	/// Returns the soft limit.
 	pub fn soft(&self) -> i64 {
 		match self {
 			UlimitConfig::Single(n) => *n,
@@ -22,6 +30,7 @@ impl UlimitConfig {
 		}
 	}
 
+	/// Returns the hard limit.
 	pub fn hard(&self) -> i64 {
 		match self {
 			UlimitConfig::Single(n) => *n,
@@ -33,16 +42,22 @@ impl UlimitConfig {
 /// `blkio_config:` service field — controls I/O weight and per-device rate limits.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BlkioConfig {
+	/// Default block I/O weight for the service (10-1000).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub weight: Option<u16>,
+	/// Per-device I/O weight overrides.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub weight_device: Vec<BlkioWeightDevice>,
+	/// Per-device read rate limits in bytes/second.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_read_bps: Vec<BlkioRateDevice>,
+	/// Per-device write rate limits in bytes/second.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_write_bps: Vec<BlkioRateDevice>,
+	/// Per-device read rate limits in IOPS.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_read_iops: Vec<BlkioRateDevice>,
+	/// Per-device write rate limits in IOPS.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_write_iops: Vec<BlkioRateDevice>,
 }
@@ -50,14 +65,18 @@ pub struct BlkioConfig {
 /// Per-device I/O weight entry under `blkio_config.weight_device`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioWeightDevice {
+	/// Host device path the weight applies to.
 	pub path: String,
+	/// I/O weight for the device (10-1000).
 	pub weight: u16,
 }
 
 /// Per-device rate limit under `blkio_config` — used for both bps and iops limits.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioRateDevice {
+	/// Host device path the limit applies to.
 	pub path: String,
+	/// Rate limit value, as a number or size string.
 	pub rate: serde_yaml::Value,
 }
 
@@ -79,8 +98,11 @@ impl BlkioRateDevice {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GpuSpec {
+	/// Shorthand string form, e.g. `"all"`.
 	Named(String),
+	/// Number of GPUs to expose.
 	Count(u32),
+	/// Explicit device reservation list.
 	Devices(Vec<super::deploy::DeviceReservation>),
 }
 

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -216,11 +216,66 @@ pub struct Service {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gpus: Option<GpuSpec>,
 
+	/// `credential_spec:` — Windows managed-service-account credential source
+	/// (`config`/`file`/`registry`). Parsed for fidelity; podup has no rootless
+	/// Podman equivalent, so the diagnostics pass reports it as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub credential_spec: Option<CredentialSpec>,
+
+	/// `isolation:` — container isolation technology (e.g. `default`, `process`,
+	/// `hyperv`). Distinct from `build.isolation`. Parsed for fidelity; podup has
+	/// no rootless Podman equivalent, so it is reported as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub isolation: Option<String>,
+
+	/// `provider:` (Compose v2.36) — delegates the service lifecycle to an
+	/// external provider plugin. Parsed for fidelity; podup invokes no provider
+	/// plugins, so it is reported as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub provider: Option<ProviderConfig>,
+
+	/// `use_api_socket:` (Compose v2.37.1) — bind-mount the Docker API socket and
+	/// forward credentials into the container. Parsed for fidelity; podup has no
+	/// equivalent, so it is reported as not honored.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub use_api_socket: Option<bool>,
+
 	/// Keys present in the YAML that don't map to a known service field. Captured
 	/// (rather than silently dropped) so the parser can warn about likely typos
 	/// while still tolerating compose-spec `x-*` extensions and forward-compatible
 	/// keys. Not part of the container spec; round-tripped by the `config`
 	/// subcommand to preserve fidelity.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
+}
+
+/// `credential_spec:` — source of a Windows managed-service-account credential
+/// spec. Exactly one of `config`/`file`/`registry` is expected per the Compose
+/// Spec; podup parses all three for fidelity but honors none.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
+pub struct CredentialSpec {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub config: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub registry: Option<String>,
+	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
+	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+	pub unknown: IndexMap<String, serde_yaml::Value>,
+}
+
+/// `provider:` (Compose v2.36) — names an external provider plugin (`type`) and
+/// its free-form `options`. Parsed for fidelity; podup invokes no providers.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[non_exhaustive]
+pub struct ProviderConfig {
+	#[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
+	pub provider_type: Option<String>,
+	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+	pub options: IndexMap<String, serde_yaml::Value>,
+	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -14,20 +14,28 @@ use super::Labels;
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum VolumeType {
+	/// A named or anonymous managed volume.
 	Volume,
+	/// A host path bind mount.
 	Bind,
+	/// An in-memory tmpfs mount.
 	Tmpfs,
+	/// A Windows named-pipe mount.
 	Npipe,
+	/// A cluster (Swarm) volume.
 	Cluster,
 }
 
 /// Sub-options for a `bind`-type volume mount.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BindOptions {
+	/// Mount propagation mode (e.g. `rprivate`, `rshared`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub propagation: Option<String>,
+	/// Whether to create the host path if it does not exist.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub create_host_path: Option<bool>,
+	/// SELinux relabeling option (`z` shared or `Z` private).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub selinux: Option<String>,
 }
@@ -35,12 +43,16 @@ pub struct BindOptions {
 /// Sub-options for a `volume`-type mount — nocopy flag and optional driver config.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VolumeOptions {
+	/// Whether to skip copying existing target contents into the volume.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub nocopy: Option<bool>,
+	/// Labels applied to the volume.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Volume driver name and options.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver_config: Option<DriverConfig>,
+	/// Path within the volume to mount instead of its root.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub subpath: Option<String>,
 }
@@ -48,8 +60,10 @@ pub struct VolumeOptions {
 /// Driver name and key-value options nested under `VolumeOptions`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DriverConfig {
+	/// Volume driver name.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Driver-specific options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub options: HashMap<String, String>,
 }
@@ -57,8 +71,10 @@ pub struct DriverConfig {
 /// Sub-options for a `tmpfs`-type mount — size and mode.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct TmpfsOptions {
+	/// Size of the tmpfs mount in bytes.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub size: Option<u64>,
+	/// File mode of the tmpfs mount.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mode: Option<u32>,
 }
@@ -68,27 +84,38 @@ pub struct TmpfsOptions {
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum VolumeMount {
+	/// Short form: a `source:target[:options]` string.
 	Short(String),
+	/// Long form: an explicitly typed mount with per-type options.
 	Long {
+		/// Mount type selecting which options block applies.
 		#[serde(rename = "type")]
 		volume_type: VolumeType,
+		/// Mount source — host path, volume name, or omitted for anonymous/tmpfs.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		source: Option<String>,
+		/// Mount target path inside the container.
 		target: String,
+		/// Whether the mount is read-only.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		read_only: Option<bool>,
+		/// Bind-specific options, when `volume_type` is `bind`.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		bind: Option<BindOptions>,
+		/// Volume-specific options, when `volume_type` is `volume`.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		volume: Option<VolumeOptions>,
+		/// Tmpfs-specific options, when `volume_type` is `tmpfs`.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		tmpfs: Option<TmpfsOptions>,
+		/// Mount consistency requirement (a no-op outside Docker Desktop).
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		consistency: Option<String>,
 	},
 }
 
 impl VolumeMount {
+	/// Returns the container-side target path of the mount.
 	pub fn target(&self) -> &str {
 		match self {
 			VolumeMount::Short(s) => {
@@ -108,16 +135,22 @@ impl VolumeMount {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct VolumeConfig {
+	/// Volume driver name; the runtime default is used if absent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Driver-specific options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub driver_opts: HashMap<String, String>,
+	/// Whether the volume is externally managed and not created by podup.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub external: Option<bool>,
+	/// Custom volume name overriding the project-prefixed default.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Labels applied to the volume.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Unrecognized keys preserved verbatim for round-tripping.
 	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
 	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
@@ -126,21 +159,29 @@ pub struct VolumeConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceConfigRef {
+	/// Short form: the name of a top-level config to mount.
 	Short(String),
+	/// Long form: a config name with mount target and ownership options.
 	Long {
+		/// Name of the top-level config to mount.
 		source: String,
+		/// Mount path inside the container; defaults to `/<source>` if absent.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		target: Option<String>,
+		/// Owner UID of the mounted file.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		uid: Option<String>,
+		/// Owner GID of the mounted file.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		gid: Option<String>,
+		/// File permission mode of the mounted file.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		mode: Option<u32>,
 	},
 }
 
 impl ServiceConfigRef {
+	/// Returns the name of the referenced top-level config.
 	pub fn source(&self) -> &str {
 		match self {
 			ServiceConfigRef::Short(s) => s,
@@ -148,6 +189,7 @@ impl ServiceConfigRef {
 		}
 	}
 
+	/// Returns the container mount target, if specified.
 	pub fn target(&self) -> Option<&str> {
 		match self {
 			ServiceConfigRef::Short(_) => None,
@@ -160,21 +202,29 @@ impl ServiceConfigRef {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceSecretRef {
+	/// Short form: the name of a top-level secret to mount.
 	Short(String),
+	/// Long form: a secret name with mount target and ownership options.
 	Long {
+		/// Name of the top-level secret to mount.
 		source: String,
+		/// Mount path; defaults to `/run/secrets/<source>` if absent.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		target: Option<String>,
+		/// Owner UID of the mounted file.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		uid: Option<String>,
+		/// Owner GID of the mounted file.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		gid: Option<String>,
+		/// File permission mode of the mounted file.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		mode: Option<u32>,
 	},
 }
 
 impl ServiceSecretRef {
+	/// Returns the name of the referenced top-level secret.
 	pub fn source(&self) -> &str {
 		match self {
 			ServiceSecretRef::Short(s) => s,
@@ -182,6 +232,7 @@ impl ServiceSecretRef {
 		}
 	}
 
+	/// Returns the container mount target, if specified.
 	pub fn target(&self) -> Option<&str> {
 		match self {
 			ServiceSecretRef::Short(_) => None,

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -186,10 +186,14 @@ impl Engine {
 		} else {
 			None
 		};
-		let platform = if let BuildConfig::Config { platforms, .. } = build {
-			platforms.first().cloned()
-		} else {
-			None
+		let platform = match build {
+			BuildConfig::Config { platforms, .. } => platforms.first().inspect(|first| {
+				let rest_count = platforms.len() - 1;
+				if rest_count > 0 {
+					warn!("build.platforms: libpod builds one platform per request; building {first}, ignoring {rest_count} other(s)");
+				}
+			}).cloned(),
+			_ => None,
 		};
 		let shmsize = build
 			.shm_size()

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -101,10 +101,7 @@ impl Engine {
 
 		let context_str = build.context().to_string();
 		let remote_context = is_remote_context(&context_str);
-		let tag = service
-			.image
-			.clone()
-			.unwrap_or_else(|| format!("{}:latest", service_name));
+		let tag = primary_build_tag(service_name, service.image.as_deref(), build.tags());
 
 		// A Git/URL context is cloned server-side by Podman via the `remote`
 		// query parameter — there is no local directory to tar. Tar-only features
@@ -356,8 +353,15 @@ impl Engine {
 	}
 
 	/// Apply any `build.tags` aliases to the freshly built image.
+	///
+	/// The primary `tag` is skipped: when no `image:` is set it is already
+	/// `tags[0]`, which the build itself produced, so re-tagging it onto itself
+	/// would be a no-op API call.
 	async fn apply_extra_tags(&self, build: &BuildConfig, tag: &str) {
 		for extra_tag in build.tags() {
+			if extra_tag == tag {
+				continue;
+			}
 			let (repo, tag_str) = extra_tag
 				.rsplit_once(':')
 				.map(|(r, t)| (r.to_string(), t.to_string()))
@@ -381,9 +385,25 @@ fn is_remote_context(context: &str) -> bool {
 	context.contains("://") || context.starts_with("git@")
 }
 
+/// Pick the primary image tag for a built service.
+///
+/// Precedence matches compose-go: an explicit `image:` wins; otherwise the
+/// first entry of `build.tags` is used as the primary tag; with neither, the
+/// image is named `{service}:latest`. Any remaining `build.tags` are applied
+/// as extra tags by [`Engine::apply_extra_tags`].
+fn primary_build_tag(service_name: &str, image: Option<&str>, tags: &[String]) -> String {
+	if let Some(image) = image {
+		return image.to_string();
+	}
+	if let Some(first) = tags.first() {
+		return first.clone();
+	}
+	format!("{service_name}:latest")
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, Engine};
+	use super::{is_remote_context, primary_build_tag, Engine};
 	use crate::libpod::Client;
 
 	fn engine(base: std::path::PathBuf) -> Engine {
@@ -438,6 +458,29 @@ mod tests {
 		assert!(!is_remote_context("."));
 		assert!(!is_remote_context("./build"));
 		assert!(!is_remote_context("/abs/path"));
+	}
+
+	#[test]
+	fn primary_tag_prefers_explicit_image() {
+		let tags = vec!["registry/app:1.0".to_string()];
+		assert_eq!(
+			primary_build_tag("app", Some("myimage:2.0"), &tags),
+			"myimage:2.0"
+		);
+	}
+
+	#[test]
+	fn primary_tag_uses_first_build_tag_when_image_unset() {
+		let tags = vec![
+			"registry/app:1.0".to_string(),
+			"registry/app:latest".to_string(),
+		];
+		assert_eq!(primary_build_tag("app", None, &tags), "registry/app:1.0");
+	}
+
+	#[test]
+	fn primary_tag_falls_back_to_service_latest() {
+		assert_eq!(primary_build_tag("app", None, &[]), "app:latest");
 	}
 
 	#[test]

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -322,6 +322,12 @@ fn rootless_caveat_warnings(name: &str, service: &Service) -> Vec<String> {
 			services on a shared network and reach them by service name instead"
 		));
 	}
+	if !service.external_links.is_empty() {
+		out.push(format!(
+			"service \"{name}\": external_links has no effect under rootless Podman networking — \
+			attach the target container to a shared network and reach it by service name instead"
+		));
+	}
 	out
 }
 
@@ -343,10 +349,11 @@ mod tests {
 			mem_swappiness: Some(10),
 			cpu_rt_runtime: Some(1000),
 			links: vec!["db".into()],
+			external_links: vec!["legacy_db:db".into()],
 			..Service::default()
 		};
 		let warnings = rootless_caveat_warnings("web", &service);
-		assert_eq!(warnings.len(), 5);
+		assert_eq!(warnings.len(), 6);
 		let joined = warnings.join("\n");
 		for needle in [
 			"privileged",
@@ -354,6 +361,7 @@ mod tests {
 			"mem_swappiness",
 			"cpu_rt_runtime",
 			"links",
+			"external_links",
 		] {
 			assert!(joined.contains(needle), "missing warning for {needle}");
 		}

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -11,7 +11,7 @@ use crate::libpod::API_PREFIX;
 use crate::{ports, size};
 
 mod resolve;
-use resolve::{build_env, resolve_links, resolve_volume_name};
+use resolve::{build_env, resolve_links, resolve_stop_signal, resolve_volume_name};
 pub(crate) use resolve::{config_hash, resolve_bind_source};
 
 use super::container_config::{
@@ -183,6 +183,12 @@ impl Engine {
 			tracing::warn!("{warning}");
 		}
 
+		let stop_signal = service
+			.stop_signal
+			.as_deref()
+			.map(resolve_stop_signal)
+			.transpose()?;
+
 		let spec = SpecGenerator {
 			name: container_name.to_string(),
 			image: image.to_string(),
@@ -193,7 +199,7 @@ impl Engine {
 			stdin: service.stdin_open,
 			user: service.user.clone(),
 			work_dir: service.working_dir.clone(),
-			stop_signal: service.stop_signal.clone(),
+			stop_signal,
 			stop_timeout,
 			hostname: service.hostname.clone(),
 			domainname: service.domainname.clone(),

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -19,7 +19,8 @@ use super::container_config::{
 	build_ulimits, cdi_devices,
 };
 use super::container_fields::{
-	build_blkio_config, build_label_file_labels, parse_device, warn_swarm_only_deploy,
+	build_blkio_config, build_label_file_labels, parse_device, resolve_container_labels,
+	warn_swarm_only_deploy,
 };
 use super::network::resolve_network_mode;
 use super::volume_mounts::build_mounts_all;
@@ -112,15 +113,9 @@ impl Engine {
 
 		// --- Labels ---
 		let label_file_labels = build_label_file_labels(service, &self.base_dir);
-		let mut labels = service.labels.to_map();
-		for (k, v) in label_file_labels {
-			labels.entry(k).or_insert(v);
-		}
-		if let Some(deploy) = &service.deploy {
-			for (k, v) in deploy.labels.to_map() {
-				labels.entry(k).or_insert(v);
-			}
-		}
+		// Per the Compose Specification, deploy.labels are set on the service
+		// only and must NOT be applied to containers, so they are not merged here.
+		let mut labels = resolve_container_labels(service, label_file_labels);
 		labels.insert("podup.project".to_string(), self.project.clone());
 		labels.insert("podup.service".to_string(), service_name.to_string());
 		labels.insert("podup.config-hash".to_string(), config_hash(service, file)?);

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -187,10 +187,88 @@ pub(super) fn build_env(service: &Service, base_dir: &Path) -> Result<Vec<String
 	))
 }
 
+/// Resolve a compose `stop_signal:` value to its numeric `syscall.Signal`.
+///
+/// libpod's `SpecGenerator.stop_signal` is an integer; sending the signal name
+/// as a string returns HTTP 500. Accepts a bare number (`"15"`), a signal name
+/// with or without the `SIG` prefix (`"SIGTERM"`, `"term"`), case-insensitively.
+/// An unrecognized name returns a clear [`ComposeError::Unsupported`] rather than
+/// silently dropping the value.
+pub(super) fn resolve_stop_signal(signal: &str) -> Result<i64> {
+	let trimmed = signal.trim();
+	if let Ok(num) = trimmed.parse::<i64>() {
+		return Ok(num);
+	}
+	let upper = trimmed.to_ascii_uppercase();
+	let name = upper.strip_prefix("SIG").unwrap_or(&upper);
+	signal_number(name)
+		.ok_or_else(|| ComposeError::Unsupported(format!("unknown stop_signal '{signal}'")))
+}
+
+/// Map a bare (no `SIG` prefix) upper-case signal name to its Linux number.
+fn signal_number(name: &str) -> Option<i64> {
+	let n = match name {
+		"HUP" => 1,
+		"INT" => 2,
+		"QUIT" => 3,
+		"ILL" => 4,
+		"TRAP" => 5,
+		"ABRT" | "IOT" => 6,
+		"BUS" => 7,
+		"FPE" => 8,
+		"KILL" => 9,
+		"USR1" => 10,
+		"SEGV" => 11,
+		"USR2" => 12,
+		"PIPE" => 13,
+		"ALRM" => 14,
+		"TERM" => 15,
+		"STKFLT" => 16,
+		"CHLD" | "CLD" => 17,
+		"CONT" => 18,
+		"STOP" => 19,
+		"TSTP" => 20,
+		"TTIN" => 21,
+		"TTOU" => 22,
+		"URG" => 23,
+		"XCPU" => 24,
+		"XFSZ" => 25,
+		"VTALRM" => 26,
+		"PROF" => 27,
+		"WINCH" => 28,
+		"IO" | "POLL" => 29,
+		"PWR" => 30,
+		"SYS" => 31,
+		_ => return None,
+	};
+	Some(n)
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{config_hash, resolve_links, resolve_volume_name};
+	use super::{config_hash, resolve_links, resolve_stop_signal, resolve_volume_name};
 	use crate::parse_str;
+
+	#[test]
+	fn stop_signal_resolves_names_numbers_and_prefixes() {
+		// Named, case-insensitive, with and without the SIG prefix.
+		assert_eq!(resolve_stop_signal("SIGTERM").unwrap(), 15);
+		assert_eq!(resolve_stop_signal("TERM").unwrap(), 15);
+		assert_eq!(resolve_stop_signal("sigterm").unwrap(), 15);
+		assert_eq!(resolve_stop_signal("SIGKILL").unwrap(), 9);
+		assert_eq!(resolve_stop_signal("hup").unwrap(), 1);
+		assert_eq!(resolve_stop_signal("SIGUSR1").unwrap(), 10);
+		assert_eq!(resolve_stop_signal("SIGUSR2").unwrap(), 12);
+		// Bare numbers pass through (optionally surrounded by whitespace).
+		assert_eq!(resolve_stop_signal("15").unwrap(), 15);
+		assert_eq!(resolve_stop_signal(" 9 ").unwrap(), 9);
+	}
+
+	#[test]
+	fn stop_signal_unknown_name_errors() {
+		let err = resolve_stop_signal("SIGNOPE").unwrap_err();
+		assert!(err.to_string().contains("SIGNOPE"), "got: {err}");
+	}
 
 	#[test]
 	fn links_resolve_to_container_names_external_links_verbatim() {

--- a/internal/engine/container_fields.rs
+++ b/internal/engine/container_fields.rs
@@ -160,6 +160,23 @@ pub(super) fn build_label_file_labels(
 	labels
 }
 
+/// Resolve the user-facing labels for a container.
+///
+/// Merges `service.labels` with any labels sourced from `label_file`, with
+/// `service.labels` taking precedence. Per the Compose Specification,
+/// `deploy.labels` are set on the service only and are deliberately NOT applied
+/// to containers, matching docker-compose v2 behaviour.
+pub(super) fn resolve_container_labels(
+	service: &Service,
+	label_file_labels: HashMap<String, String>,
+) -> HashMap<String, String> {
+	let mut labels = service.labels.to_map();
+	for (k, v) in label_file_labels {
+		labels.entry(k).or_insert(v);
+	}
+	labels
+}
+
 // ---------------------------------------------------------------------------
 // Swarm-only deploy field diagnostics
 // ---------------------------------------------------------------------------
@@ -309,5 +326,69 @@ mod tests {
 			..Default::default()
 		});
 		warn_swarm_only_deploy("web", &svc);
+	}
+
+	// --- container label resolution ---
+
+	#[test]
+	fn resolve_container_labels_keeps_service_labels() {
+		use crate::compose::types::primitives::Labels;
+		use indexmap::IndexMap;
+		let mut svc = default_service();
+		let mut map = IndexMap::new();
+		map.insert("com.example.team".to_string(), "blue".to_string());
+		svc.labels = Labels::Map(map);
+
+		let labels = resolve_container_labels(&svc, HashMap::new());
+		assert_eq!(
+			labels.get("com.example.team").map(String::as_str),
+			Some("blue")
+		);
+	}
+
+	#[test]
+	fn resolve_container_labels_does_not_apply_deploy_labels() {
+		use crate::compose::types::primitives::Labels;
+		use crate::compose::types::DeployConfig;
+		use indexmap::IndexMap;
+		let mut svc = default_service();
+		let mut svc_map = IndexMap::new();
+		svc_map.insert("com.example.service".to_string(), "on".to_string());
+		svc.labels = Labels::Map(svc_map);
+		let mut deploy_map = IndexMap::new();
+		deploy_map.insert("com.example.deploy".to_string(), "swarm".to_string());
+		svc.deploy = Some(DeployConfig {
+			labels: Labels::Map(deploy_map),
+			..Default::default()
+		});
+
+		let labels = resolve_container_labels(&svc, HashMap::new());
+		// Per the Compose Specification, deploy.labels are NOT applied to the container.
+		assert!(!labels.contains_key("com.example.deploy"));
+		// Service labels still apply.
+		assert_eq!(
+			labels.get("com.example.service").map(String::as_str),
+			Some("on")
+		);
+	}
+
+	#[test]
+	fn resolve_container_labels_service_overrides_label_file() {
+		use crate::compose::types::primitives::Labels;
+		use indexmap::IndexMap;
+		let mut svc = default_service();
+		let mut map = IndexMap::new();
+		map.insert("shared".to_string(), "from-service".to_string());
+		svc.labels = Labels::Map(map);
+		let mut file_labels = HashMap::new();
+		file_labels.insert("shared".to_string(), "from-file".to_string());
+		file_labels.insert("only-file".to_string(), "yes".to_string());
+
+		let labels = resolve_container_labels(&svc, file_labels);
+		assert_eq!(
+			labels.get("shared").map(String::as_str),
+			Some("from-service")
+		);
+		assert_eq!(labels.get("only-file").map(String::as_str), Some("yes"));
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -12,7 +12,7 @@ use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
-use targets::{expand_targets, filter_services};
+use targets::{expand_targets, filter_services, in_started_set};
 
 use super::container::config_hash;
 
@@ -246,6 +246,16 @@ impl Engine {
 			.into_iter()
 			.filter(|_| start)
 		{
+			// Under `--no-deps` (and partial target lists) a dependency may have
+			// been intentionally excluded from the started set. docker-compose
+			// skips its readiness condition in that case; matching that avoids
+			// waiting on (and 404-ing against) a container that was never
+			// created.
+			if !in_started_set(target_set, &dep) {
+				tracing::debug!("{dep} not in started target set — skipping {name} readiness wait");
+				continue;
+			}
+
 			let condition = service.depends_on.condition_for(&dep);
 			// `required: false` makes the dependency optional — a failed wait
 			// must not abort `up`, matching docker-compose v2.

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -80,10 +80,26 @@ pub(super) fn expand_targets(
 	Some(set)
 }
 
+/// Whether `name` is part of the started set described by `target_set`.
+///
+/// `target_set` is `None` when no explicit target list was given (every
+/// service is in scope, so the answer is always `true`). Otherwise a name is
+/// "started" only if it is present in the set. Under `up --no-deps`,
+/// [`expand_targets`] omits the targets' dependencies, so this returns `false`
+/// for an intentionally-excluded dependency — letting the caller skip its
+/// `depends_on` readiness wait, matching docker-compose.
+pub(super) fn in_started_set(target_set: &Option<HashSet<String>>, name: &str) -> bool {
+	match target_set {
+		None => true,
+		Some(set) => set.contains(name),
+	}
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{expand_targets, filter_services};
+	use super::{expand_targets, filter_services, in_started_set};
 	use crate::compose::types::{ComposeFile, Service};
+	use std::collections::HashSet;
 
 	fn file_with_services(names: &[&str]) -> ComposeFile {
 		let mut file = ComposeFile::default();
@@ -157,5 +173,41 @@ mod tests {
 		let set = expand_targets(&file, &["web".to_string()], true).unwrap();
 		assert!(set.contains("web"));
 		assert!(!set.contains("db"));
+	}
+
+	// --- in_started_set ---
+
+	#[test]
+	fn in_started_set_none_is_always_true() {
+		// No explicit target list: every service (including any dependency)
+		// is in scope, so the readiness wait is never skipped.
+		assert!(in_started_set(&None, "anything"));
+	}
+
+	#[test]
+	fn in_started_set_member_is_true() {
+		let set: HashSet<String> = ["web".to_string(), "db".to_string()].into_iter().collect();
+		assert!(in_started_set(&Some(set), "db"));
+	}
+
+	#[test]
+	fn in_started_set_excluded_dep_is_false() {
+		// Mirrors `up web --no-deps`: `expand_targets` yields {web} only, so the
+		// excluded dependency `db` is not in the started set and its readiness
+		// wait must be skipped.
+		let file = file_web_depends_db();
+		let target_set = expand_targets(&file, &["web".to_string()], true);
+		assert!(in_started_set(&target_set, "web"));
+		assert!(!in_started_set(&target_set, "db"));
+	}
+
+	#[test]
+	fn in_started_set_partial_target_includes_transitive_dep() {
+		// `up web` (without --no-deps) pulls `db` into the set, so its readiness
+		// wait is still honored.
+		let file = file_web_depends_db();
+		let target_set = expand_targets(&file, &["web".to_string()], false);
+		assert!(in_started_set(&target_set, "web"));
+		assert!(in_started_set(&target_set, "db"));
 	}
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -289,8 +289,13 @@ impl Engine {
 	) -> Result<String> {
 		match index {
 			Some(i) => {
+				// `--index` is 1-based; `0` is an invalid index, not "first replica".
+				let idx = (i as usize).checked_sub(1).ok_or_else(|| {
+					ComposeError::ServiceNotFound(format!(
+						"{service_name} (replica index {i}: indexes are 1-based)"
+					))
+				})?;
 				let names = self.replica_names(service_name, service);
-				let idx = (i as usize).saturating_sub(1);
 				names.get(idx).cloned().ok_or_else(|| {
 					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
 				})
@@ -330,4 +335,85 @@ fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Resul
 		}
 	}
 	Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::libpod::Client;
+
+	fn engine(project: &str) -> Engine {
+		Engine::with_base_dir(
+			Client::new("/nonexistent.sock"),
+			project.into(),
+			std::env::temp_dir(),
+		)
+	}
+
+	fn scaled_service(replicas: u32) -> Service {
+		Service {
+			scale: Some(replicas),
+			..Service::default()
+		}
+	}
+
+	#[test]
+	fn replica_name_at_index_zero_is_rejected() {
+		// `--index` is 1-based; index 0 must be an error, never replica 1.
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		let err = e
+			.replica_name_at("web", &svc, Some(0))
+			.expect_err("index 0 must be rejected");
+		assert!(
+			matches!(err, ComposeError::ServiceNotFound(ref m) if m.contains("1-based")),
+			"unexpected error: {err:?}"
+		);
+	}
+
+	#[test]
+	fn replica_name_at_index_one_is_first_replica() {
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		assert_eq!(
+			e.replica_name_at("web", &svc, Some(1)).unwrap(),
+			"proj-web-1"
+		);
+	}
+
+	#[test]
+	fn replica_name_at_index_n_is_nth_replica() {
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		assert_eq!(
+			e.replica_name_at("web", &svc, Some(3)).unwrap(),
+			"proj-web-3"
+		);
+	}
+
+	#[test]
+	fn replica_name_at_out_of_range_is_rejected() {
+		let e = engine("proj");
+		let svc = scaled_service(3);
+		assert!(e.replica_name_at("web", &svc, Some(4)).is_err());
+	}
+
+	#[test]
+	fn replica_name_at_none_is_first_replica() {
+		let e = engine("proj");
+		// Single replica: the unsuffixed container name.
+		assert_eq!(
+			e.replica_name_at("web", &Service::default(), None).unwrap(),
+			"proj-web"
+		);
+		// Multiple replicas: the first suffixed name.
+		assert_eq!(
+			e.replica_name_at("web", &scaled_service(3), None).unwrap(),
+			"proj-web-1"
+		);
+	}
 }

--- a/internal/engine/network.rs
+++ b/internal/engine/network.rs
@@ -124,9 +124,10 @@ pub(super) fn build_per_network_options(
 		if let Some(iface) = &c.interface_name {
 			opts.interface_name = Some(iface.clone());
 		}
-		if c.gw_priority.is_some() {
-			tracing::debug!("network gw_priority is not supported by Podman and is ignored");
-		}
+		// `gw_priority` has no Podman equivalent and is dropped. The user-facing
+		// notice is emitted once, at parse time, by the compose diagnostics (see
+		// internal/compose/diagnostics/ignored_fields.rs); re-emitting it here on
+		// every engine build would double-warn, so no engine-time log is needed.
 	} else if let Some(mac) = fallback_mac {
 		opts.static_mac = Some(mac.to_string());
 	}
@@ -155,11 +156,7 @@ pub(super) fn resolve_network_mode(
 			let cname = file
 				.services
 				.get(svc_name)
-				.map(|s| {
-					s.container_name
-						.clone()
-						.unwrap_or_else(|| format!("{project}-{svc_name}"))
-				})
+				.map(|s| resolve_target_container_name(svc_name, s, project))
 				.unwrap_or_else(|| svc_name.to_string());
 			Namespace::container(cname)
 		} else {
@@ -186,6 +183,35 @@ pub(super) fn resolve_network_mode(
 	let netns = (!networks.is_empty()).then(|| Namespace::new("bridge"));
 
 	(netns, networks)
+}
+
+/// Resolve the container name that a `network_mode: service:<name>` reference
+/// should attach to.
+///
+/// An explicit `container_name` is honoured verbatim. Otherwise the name is
+/// derived from the project + service. A scaled service (replicas > 1 via
+/// `deploy.replicas` or `scale:`) has no base-named container — its replicas are
+/// `{project}-{svc}-1..N` — so we point at replica `-1`, matching docker-compose,
+/// which attaches `network_mode: service:` references to the first replica.
+fn resolve_target_container_name(svc_name: &str, service: &Service, project: &str) -> String {
+	if let Some(name) = &service.container_name {
+		return name.clone();
+	}
+	let base = format!("{project}-{svc_name}");
+	if service_replicas(service) > 1 {
+		format!("{base}-1")
+	} else {
+		base
+	}
+}
+
+/// Number of replicas a service declares in the compose file, via `scale:` or
+/// `deploy.replicas`. Defaults to 1. Does not consult CLI `--scale` overrides.
+fn service_replicas(service: &Service) -> u32 {
+	service
+		.scale
+		.or(service.deploy.as_ref().and_then(|d| d.replicas))
+		.unwrap_or(1)
 }
 
 /// Resolve the actual network name on the host for a compose network key.
@@ -287,187 +313,5 @@ fn lease_range_from_cidr(cidr: &str) -> Option<LeaseRange> {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
-	use super::*;
-	use crate::compose::types::{ComposeFile, NetworkConfig, Service};
-
-	fn empty_file() -> ComposeFile {
-		ComposeFile::default()
-	}
-
-	fn file_with_named_network(key: &str, name: &str) -> ComposeFile {
-		let cfg = NetworkConfig {
-			name: Some(name.to_string()),
-			..Default::default()
-		};
-		let mut file = empty_file();
-		file.networks.insert(key.to_string(), Some(cfg));
-		file
-	}
-
-	#[test]
-	fn resolve_network_name_key_not_found_prefixes_project() {
-		let file = empty_file();
-		assert_eq!(resolve_network_name("mynet", &file, "proj"), "proj_mynet");
-	}
-
-	#[test]
-	fn resolve_network_name_uses_config_name_over_prefix() {
-		let file = file_with_named_network("mynet", "custom-net-name");
-		assert_eq!(
-			resolve_network_name("mynet", &file, "proj"),
-			"custom-net-name"
-		);
-	}
-
-	#[test]
-	fn resolve_network_name_external_uses_key_not_prefix() {
-		let cfg = NetworkConfig {
-			external: Some(true),
-			..Default::default()
-		};
-		let mut file = empty_file();
-		file.networks.insert("shared".to_string(), Some(cfg));
-		assert_eq!(resolve_network_name("shared", &file, "proj"), "shared");
-	}
-
-	#[test]
-	fn resolve_network_mode_explicit_mode() {
-		let svc = Service {
-			network_mode: Some("host".to_string()),
-			..Default::default()
-		};
-		let file = empty_file();
-		let (ns, nets) = resolve_network_mode("web", &svc, &file, "proj");
-		assert!(ns.is_some());
-		assert_eq!(ns.unwrap().nsmode, "host");
-		assert!(nets.is_empty());
-	}
-
-	#[test]
-	fn resolve_network_mode_no_networks() {
-		let svc = Service::default();
-		let file = empty_file();
-		let (ns, nets) = resolve_network_mode("web", &svc, &file, "proj");
-		assert!(ns.is_none());
-		assert!(nets.is_empty());
-	}
-
-	#[test]
-	fn build_per_network_options_seeds_service_name_alias() {
-		// With no explicit config, the service name is still registered as an
-		// alias so siblings can reach the service by name.
-		let opts = build_per_network_options("web", None, None);
-		assert_eq!(opts.aliases, vec!["web".to_string()]);
-		assert!(opts.static_ips.is_empty());
-	}
-
-	#[test]
-	fn build_per_network_options_empty_service_name_adds_no_alias() {
-		let opts = build_per_network_options("", None, None);
-		assert!(opts.aliases.is_empty());
-	}
-
-	#[test]
-	fn build_per_network_options_with_aliases() {
-		use crate::compose::types::ServiceNetworkConfig;
-		let cfg = ServiceNetworkConfig {
-			aliases: Some(vec!["api".to_string()]),
-			..Default::default()
-		};
-		// The service name is prepended ahead of any explicit aliases.
-		let opts = build_per_network_options("web", Some(&cfg), None);
-		assert_eq!(opts.aliases, vec!["web".to_string(), "api".to_string()]);
-	}
-
-	#[test]
-	fn build_per_network_options_does_not_duplicate_service_name() {
-		use crate::compose::types::ServiceNetworkConfig;
-		let cfg = ServiceNetworkConfig {
-			aliases: Some(vec!["web".to_string(), "api".to_string()]),
-			..Default::default()
-		};
-		// An explicit alias equal to the service name is not duplicated.
-		let opts = build_per_network_options("web", Some(&cfg), None);
-		assert_eq!(opts.aliases, vec!["web".to_string(), "api".to_string()]);
-	}
-
-	#[test]
-	fn build_per_network_options_with_ipv4() {
-		use crate::compose::types::ServiceNetworkConfig;
-		let cfg = ServiceNetworkConfig {
-			ipv4_address: Some("10.0.0.5".to_string()),
-			..Default::default()
-		};
-		let opts = build_per_network_options("web", Some(&cfg), None);
-		assert!(opts.static_ips.contains(&"10.0.0.5".to_string()));
-	}
-
-	#[test]
-	fn fallback_mac_applied_when_no_config() {
-		let opts = build_per_network_options("web", None, Some("02:42:ac:11:00:02"));
-		assert_eq!(opts.static_mac.as_deref(), Some("02:42:ac:11:00:02"));
-	}
-
-	#[test]
-	fn lease_range_ipv4_reserves_network_and_broadcast() {
-		let lr = lease_range_from_cidr("172.28.5.0/24").unwrap();
-		assert_eq!(lr.start_ip.as_deref(), Some("172.28.5.1"));
-		assert_eq!(lr.end_ip.as_deref(), Some("172.28.5.254"));
-	}
-
-	#[test]
-	fn lease_range_ipv4_slash31_uses_both_addresses() {
-		let lr = lease_range_from_cidr("10.0.0.0/31").unwrap();
-		assert_eq!(lr.start_ip.as_deref(), Some("10.0.0.0"));
-		assert_eq!(lr.end_ip.as_deref(), Some("10.0.0.1"));
-	}
-
-	#[test]
-	fn lease_range_ipv6_full_span() {
-		let lr = lease_range_from_cidr("2001:db8::/120").unwrap();
-		assert_eq!(lr.start_ip.as_deref(), Some("2001:db8::"));
-		assert_eq!(lr.end_ip.as_deref(), Some("2001:db8::ff"));
-	}
-
-	#[test]
-	fn lease_range_invalid_cidr_is_none() {
-		assert!(lease_range_from_cidr("not-a-cidr").is_none());
-		assert!(lease_range_from_cidr("10.0.0.0/40").is_none());
-	}
-
-	#[test]
-	fn ipam_options_include_driver_and_options() {
-		use crate::compose::types::IpamConfig;
-		let ipam = IpamConfig {
-			driver: Some("host-local".into()),
-			options: [("foo".to_string(), "bar".to_string())].into(),
-			..Default::default()
-		};
-		let opts = build_ipam_options(&ipam);
-		assert_eq!(opts.get("driver").map(String::as_str), Some("host-local"));
-		assert_eq!(opts.get("foo").map(String::as_str), Some("bar"));
-	}
-
-	#[test]
-	fn per_network_interface_name_forwarded() {
-		use crate::compose::types::ServiceNetworkConfig;
-		let cfg = ServiceNetworkConfig {
-			interface_name: Some("eth1".into()),
-			..Default::default()
-		};
-		let opts = build_per_network_options("web", Some(&cfg), None);
-		assert_eq!(opts.interface_name.as_deref(), Some("eth1"));
-	}
-
-	#[test]
-	fn per_network_mac_takes_precedence_over_fallback() {
-		use crate::compose::types::ServiceNetworkConfig;
-		let cfg = ServiceNetworkConfig {
-			mac_address: Some("aa:bb:cc:dd:ee:ff".to_string()),
-			..Default::default()
-		};
-		let opts = build_per_network_options("web", Some(&cfg), Some("02:42:ac:11:00:03"));
-		assert_eq!(opts.static_mac.as_deref(), Some("aa:bb:cc:dd:ee:ff"));
-	}
-}
+#[path = "network_tests.rs"]
+mod tests;

--- a/internal/engine/network_tests.rs
+++ b/internal/engine/network_tests.rs
@@ -1,0 +1,266 @@
+use super::*;
+use crate::compose::types::{ComposeFile, NetworkConfig, Service};
+
+fn empty_file() -> ComposeFile {
+	ComposeFile::default()
+}
+
+fn file_with_named_network(key: &str, name: &str) -> ComposeFile {
+	let cfg = NetworkConfig {
+		name: Some(name.to_string()),
+		..Default::default()
+	};
+	let mut file = empty_file();
+	file.networks.insert(key.to_string(), Some(cfg));
+	file
+}
+
+#[test]
+fn resolve_network_name_key_not_found_prefixes_project() {
+	let file = empty_file();
+	assert_eq!(resolve_network_name("mynet", &file, "proj"), "proj_mynet");
+}
+
+#[test]
+fn resolve_network_name_uses_config_name_over_prefix() {
+	let file = file_with_named_network("mynet", "custom-net-name");
+	assert_eq!(
+		resolve_network_name("mynet", &file, "proj"),
+		"custom-net-name"
+	);
+}
+
+#[test]
+fn resolve_network_name_external_uses_key_not_prefix() {
+	let cfg = NetworkConfig {
+		external: Some(true),
+		..Default::default()
+	};
+	let mut file = empty_file();
+	file.networks.insert("shared".to_string(), Some(cfg));
+	assert_eq!(resolve_network_name("shared", &file, "proj"), "shared");
+}
+
+#[test]
+fn resolve_network_mode_explicit_mode() {
+	let svc = Service {
+		network_mode: Some("host".to_string()),
+		..Default::default()
+	};
+	let file = empty_file();
+	let (ns, nets) = resolve_network_mode("web", &svc, &file, "proj");
+	assert!(ns.is_some());
+	assert_eq!(ns.unwrap().nsmode, "host");
+	assert!(nets.is_empty());
+}
+
+fn file_with_service(svc_name: &str, svc: Service) -> ComposeFile {
+	let mut file = empty_file();
+	file.services.insert(svc_name.to_string(), svc);
+	file
+}
+
+#[test]
+fn network_mode_service_single_replica_uses_base_name() {
+	let target = Service::default();
+	let file = file_with_service("db", target);
+	let svc = Service {
+		network_mode: Some("service:db".to_string()),
+		..Default::default()
+	};
+	let (ns, _) = resolve_network_mode("web", &svc, &file, "proj");
+	let ns = ns.unwrap();
+	assert_eq!(ns.nsmode, "container");
+	assert_eq!(ns.value.as_deref(), Some("proj-db"));
+}
+
+#[test]
+fn network_mode_service_scaled_replicas_resolves_replica_one() {
+	// `scale:`/`deploy.replicas` > 1 means the base name does not exist —
+	// docker-compose attaches to replica `-1`.
+	let target = Service {
+		scale: Some(3),
+		..Default::default()
+	};
+	let file = file_with_service("db", target);
+	let svc = Service {
+		network_mode: Some("service:db".to_string()),
+		..Default::default()
+	};
+	let (ns, _) = resolve_network_mode("web", &svc, &file, "proj");
+	assert_eq!(ns.unwrap().value.as_deref(), Some("proj-db-1"));
+}
+
+#[test]
+fn network_mode_service_deploy_replicas_resolves_replica_one() {
+	use crate::compose::types::DeployConfig;
+	let target = Service {
+		deploy: Some(DeployConfig {
+			replicas: Some(2),
+			..Default::default()
+		}),
+		..Default::default()
+	};
+	let file = file_with_service("db", target);
+	let svc = Service {
+		network_mode: Some("service:db".to_string()),
+		..Default::default()
+	};
+	let (ns, _) = resolve_network_mode("web", &svc, &file, "proj");
+	assert_eq!(ns.unwrap().value.as_deref(), Some("proj-db-1"));
+}
+
+#[test]
+fn network_mode_service_container_name_wins_over_replica() {
+	// An explicit container_name is honoured verbatim even when scaled.
+	let target = Service {
+		scale: Some(4),
+		container_name: Some("custom-db".to_string()),
+		..Default::default()
+	};
+	let file = file_with_service("db", target);
+	let svc = Service {
+		network_mode: Some("service:db".to_string()),
+		..Default::default()
+	};
+	let (ns, _) = resolve_network_mode("web", &svc, &file, "proj");
+	assert_eq!(ns.unwrap().value.as_deref(), Some("custom-db"));
+}
+
+#[test]
+fn network_mode_service_unknown_target_uses_raw_name() {
+	let file = empty_file();
+	let svc = Service {
+		network_mode: Some("service:missing".to_string()),
+		..Default::default()
+	};
+	let (ns, _) = resolve_network_mode("web", &svc, &file, "proj");
+	assert_eq!(ns.unwrap().value.as_deref(), Some("missing"));
+}
+
+#[test]
+fn resolve_network_mode_no_networks() {
+	let svc = Service::default();
+	let file = empty_file();
+	let (ns, nets) = resolve_network_mode("web", &svc, &file, "proj");
+	assert!(ns.is_none());
+	assert!(nets.is_empty());
+}
+
+#[test]
+fn build_per_network_options_seeds_service_name_alias() {
+	// With no explicit config, the service name is still registered as an
+	// alias so siblings can reach the service by name.
+	let opts = build_per_network_options("web", None, None);
+	assert_eq!(opts.aliases, vec!["web".to_string()]);
+	assert!(opts.static_ips.is_empty());
+}
+
+#[test]
+fn build_per_network_options_empty_service_name_adds_no_alias() {
+	let opts = build_per_network_options("", None, None);
+	assert!(opts.aliases.is_empty());
+}
+
+#[test]
+fn build_per_network_options_with_aliases() {
+	use crate::compose::types::ServiceNetworkConfig;
+	let cfg = ServiceNetworkConfig {
+		aliases: Some(vec!["api".to_string()]),
+		..Default::default()
+	};
+	// The service name is prepended ahead of any explicit aliases.
+	let opts = build_per_network_options("web", Some(&cfg), None);
+	assert_eq!(opts.aliases, vec!["web".to_string(), "api".to_string()]);
+}
+
+#[test]
+fn build_per_network_options_does_not_duplicate_service_name() {
+	use crate::compose::types::ServiceNetworkConfig;
+	let cfg = ServiceNetworkConfig {
+		aliases: Some(vec!["web".to_string(), "api".to_string()]),
+		..Default::default()
+	};
+	// An explicit alias equal to the service name is not duplicated.
+	let opts = build_per_network_options("web", Some(&cfg), None);
+	assert_eq!(opts.aliases, vec!["web".to_string(), "api".to_string()]);
+}
+
+#[test]
+fn build_per_network_options_with_ipv4() {
+	use crate::compose::types::ServiceNetworkConfig;
+	let cfg = ServiceNetworkConfig {
+		ipv4_address: Some("10.0.0.5".to_string()),
+		..Default::default()
+	};
+	let opts = build_per_network_options("web", Some(&cfg), None);
+	assert!(opts.static_ips.contains(&"10.0.0.5".to_string()));
+}
+
+#[test]
+fn fallback_mac_applied_when_no_config() {
+	let opts = build_per_network_options("web", None, Some("02:42:ac:11:00:02"));
+	assert_eq!(opts.static_mac.as_deref(), Some("02:42:ac:11:00:02"));
+}
+
+#[test]
+fn lease_range_ipv4_reserves_network_and_broadcast() {
+	let lr = lease_range_from_cidr("172.28.5.0/24").unwrap();
+	assert_eq!(lr.start_ip.as_deref(), Some("172.28.5.1"));
+	assert_eq!(lr.end_ip.as_deref(), Some("172.28.5.254"));
+}
+
+#[test]
+fn lease_range_ipv4_slash31_uses_both_addresses() {
+	let lr = lease_range_from_cidr("10.0.0.0/31").unwrap();
+	assert_eq!(lr.start_ip.as_deref(), Some("10.0.0.0"));
+	assert_eq!(lr.end_ip.as_deref(), Some("10.0.0.1"));
+}
+
+#[test]
+fn lease_range_ipv6_full_span() {
+	let lr = lease_range_from_cidr("2001:db8::/120").unwrap();
+	assert_eq!(lr.start_ip.as_deref(), Some("2001:db8::"));
+	assert_eq!(lr.end_ip.as_deref(), Some("2001:db8::ff"));
+}
+
+#[test]
+fn lease_range_invalid_cidr_is_none() {
+	assert!(lease_range_from_cidr("not-a-cidr").is_none());
+	assert!(lease_range_from_cidr("10.0.0.0/40").is_none());
+}
+
+#[test]
+fn ipam_options_include_driver_and_options() {
+	use crate::compose::types::IpamConfig;
+	let ipam = IpamConfig {
+		driver: Some("host-local".into()),
+		options: [("foo".to_string(), "bar".to_string())].into(),
+		..Default::default()
+	};
+	let opts = build_ipam_options(&ipam);
+	assert_eq!(opts.get("driver").map(String::as_str), Some("host-local"));
+	assert_eq!(opts.get("foo").map(String::as_str), Some("bar"));
+}
+
+#[test]
+fn per_network_interface_name_forwarded() {
+	use crate::compose::types::ServiceNetworkConfig;
+	let cfg = ServiceNetworkConfig {
+		interface_name: Some("eth1".into()),
+		..Default::default()
+	};
+	let opts = build_per_network_options("web", Some(&cfg), None);
+	assert_eq!(opts.interface_name.as_deref(), Some("eth1"));
+}
+
+#[test]
+fn per_network_mac_takes_precedence_over_fallback() {
+	use crate::compose::types::ServiceNetworkConfig;
+	let cfg = ServiceNetworkConfig {
+		mac_address: Some("aa:bb:cc:dd:ee:ff".to_string()),
+		..Default::default()
+	};
+	let opts = build_per_network_options("web", Some(&cfg), Some("02:42:ac:11:00:03"));
+	assert_eq!(opts.static_mac.as_deref(), Some("aa:bb:cc:dd:ee:ff"));
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -143,8 +143,13 @@ impl Engine {
 				.ports
 				.iter()
 				.map(|p| {
+					let proto = p
+						.protocol
+						.as_deref()
+						.map(|proto| format!("/{proto}"))
+						.unwrap_or_default();
 					format!(
-						"{}:{}->{}",
+						"{}:{}->{}{proto}",
 						p.host_ip.as_deref().unwrap_or(""),
 						p.host_port.unwrap_or(0),
 						p.container_port,

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -7,9 +7,38 @@ use serde::Deserialize;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
-use crate::libpod::{parse_json_lines, API_PREFIX};
+use crate::libpod::{parse_json_lines, urlencoded, API_PREFIX};
 
 use super::Engine;
+
+/// Build the `&containers=<a,b,c>` query fragment scoping a stats request to the
+/// `wanted` containers, or an empty string when none are wanted (which falls
+/// back to the daemon default). Names are sorted for a stable URL and each is
+/// URL-encoded; the comma separators are intentionally left literal.
+fn containers_query(wanted: &HashSet<String>) -> String {
+	if wanted.is_empty() {
+		return String::new();
+	}
+	let mut names: Vec<&String> = wanted.iter().collect();
+	names.sort();
+	let joined = names
+		.iter()
+		.map(|n| urlencoded(n))
+		.collect::<Vec<_>>()
+		.join(",");
+	format!("&containers={joined}")
+}
+
+/// Deserialize a map field, treating an explicit JSON `null` as the default
+/// (empty) map. libpod sends `"Network": null` for a container with no
+/// interfaces, which plain `#[serde(default)]` does not tolerate.
+fn null_default<'de, D, T>(d: D) -> std::result::Result<T, D::Error>
+where
+	D: serde::Deserializer<'de>,
+	T: Default + Deserialize<'de>,
+{
+	Option::<T>::deserialize(d).map(|v| v.unwrap_or_default())
+}
 
 /// One frame of the libpod `/containers/stats` response.
 #[derive(Deserialize)]
@@ -37,7 +66,10 @@ struct ContainerStat {
 	block_out: u64,
 	#[serde(rename = "PIDs", default)]
 	pids: u64,
-	#[serde(rename = "Network", default)]
+	// `#[serde(default)]` also tolerates an explicit `null` frame value: libpod
+	// sends `"network": null` for a container with no interfaces, which would
+	// otherwise fail with `invalid type: null, expected a map`.
+	#[serde(rename = "Network", default, deserialize_with = "null_default")]
 	network: HashMap<String, NetStat>,
 }
 
@@ -101,10 +133,17 @@ impl Engine {
 	) -> Result<()> {
 		let wanted = self.target_container_names(file, target_services);
 
+		// Scope the stats stream to just the wanted containers server-side via the
+		// `containers=` query param, so the daemon does not sample every container
+		// on the host (the response is still filtered locally by `wanted`).
+		let containers = containers_query(&wanted);
+
 		if no_stream {
 			let report: StatsReport = self
 				.client
-				.get_json(&format!("{API_PREFIX}/containers/stats?stream=false"))
+				.get_json(&format!(
+					"{API_PREFIX}/containers/stats?stream=false{containers}"
+				))
 				.await
 				.map_err(ComposeError::Podman)?;
 			print_frame(&report, &wanted);
@@ -113,7 +152,9 @@ impl Engine {
 
 		let resp = self
 			.client
-			.get_stream(&format!("{API_PREFIX}/containers/stats?stream=true"))
+			.get_stream(&format!(
+				"{API_PREFIX}/containers/stats?stream=true{containers}"
+			))
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
@@ -196,5 +237,38 @@ mod tests {
 		assert!(row.contains("12.50%"));
 		assert!(row.contains("1.0MiB"));
 		assert!(row.contains('3'));
+	}
+
+	#[test]
+	fn stat_tolerates_null_network() {
+		// libpod sends `"Network": null` for a container with no interfaces; it
+		// must deserialize to an empty map rather than erroring.
+		let json = r#"{"Name":"proj-web","CPU":1.0,"Network":null}"#;
+		let stat: ContainerStat = serde_json::from_str(json).unwrap();
+		assert_eq!(stat.name, "proj-web");
+		assert!(stat.network.is_empty());
+	}
+
+	#[test]
+	fn stat_tolerates_missing_network() {
+		let json = r#"{"Name":"proj-web"}"#;
+		let stat: ContainerStat = serde_json::from_str(json).unwrap();
+		assert!(stat.network.is_empty());
+	}
+
+	#[test]
+	fn containers_query_is_sorted_and_scoped() {
+		let mut wanted = HashSet::new();
+		wanted.insert("proj-web-1".to_string());
+		wanted.insert("proj-db-1".to_string());
+		assert_eq!(
+			containers_query(&wanted),
+			"&containers=proj-db-1,proj-web-1"
+		);
+	}
+
+	#[test]
+	fn containers_query_empty_when_none_wanted() {
+		assert_eq!(containers_query(&HashSet::new()), "");
 	}
 }

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -123,7 +123,21 @@ pub(super) fn extend_bind_opts_str(opts: &mut Vec<String>, b: Option<&BindOption
 		opts.push(p.clone());
 	}
 	if let Some(s) = &b.selinux {
-		opts.push(s.clone());
+		opts.push(map_selinux_option(s));
+	}
+}
+
+/// Translate a Compose `bind.selinux` value into the Podman mount option.
+///
+/// Compose spells the SELinux relabel mode as `shared`/`private`; Podman's mount
+/// options are `z` (shared label, usable by multiple containers) and `Z` (private
+/// label, scoped to one container). Map those two words; pass anything else
+/// through verbatim so a caller can still supply a raw `z`/`Z` directly.
+fn map_selinux_option(value: &str) -> String {
+	match value {
+		"shared" => "z".to_string(),
+		"private" => "Z".to_string(),
+		other => other.to_string(),
 	}
 }
 
@@ -136,7 +150,37 @@ pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOp
 
 #[cfg(test)]
 mod tests {
-	use super::{is_bind_source, split_volume_spec};
+	use super::{extend_bind_opts_str, is_bind_source, map_selinux_option, split_volume_spec};
+	use crate::compose::types::BindOptions;
+
+	#[test]
+	fn selinux_shared_maps_to_lowercase_z() {
+		assert_eq!(map_selinux_option("shared"), "z");
+	}
+
+	#[test]
+	fn selinux_private_maps_to_uppercase_z() {
+		assert_eq!(map_selinux_option("private"), "Z");
+	}
+
+	#[test]
+	fn selinux_other_values_pass_through() {
+		// A raw Podman option (or any unrecognised value) is forwarded verbatim.
+		assert_eq!(map_selinux_option("z"), "z");
+		assert_eq!(map_selinux_option("Z"), "Z");
+		assert_eq!(map_selinux_option("custom"), "custom");
+	}
+
+	#[test]
+	fn extend_bind_opts_translates_selinux() {
+		let bind = BindOptions {
+			selinux: Some("private".into()),
+			..Default::default()
+		};
+		let mut opts = Vec::new();
+		extend_bind_opts_str(&mut opts, Some(&bind));
+		assert!(opts.contains(&"Z".to_string()), "expected Z, got {opts:?}");
+	}
 
 	#[test]
 	fn windows_drive_source_is_a_bind_not_a_named_volume() {

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -42,9 +42,12 @@ pub fn load_env_file_entries(
 		} = entry
 		{
 			if fmt != "dotenv" {
-				return Err(ComposeError::Unsupported(format!(
-					"env_file format '{fmt}' not supported (only 'dotenv')"
-				)));
+				// compose-go logs a warning and falls back to dotenv parsing
+				// rather than failing the file; match that lenient behaviour.
+				tracing::warn!(
+					"env_file format '{fmt}' is not supported; parsing '{}' as dotenv",
+					entry.path()
+				);
 			}
 		}
 
@@ -162,14 +165,18 @@ mod tests {
 	}
 
 	#[test]
-	fn unsupported_format_returns_error() {
+	fn non_dotenv_format_warns_and_parses_as_dotenv() {
+		// compose-go logs a warning for an unknown `format` and falls back to
+		// dotenv parsing rather than failing; podup must not error here.
 		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
 		let entries = vec![EnvFileEntry::Config {
 			path: ".env".into(),
 			required: Some(false),
 			format: Some("json".into()),
 		}];
-		assert!(load_env_file_entries(&entries, dir.path()).is_err());
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("bar"));
 	}
 
 	#[test]

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -28,6 +28,9 @@ pub enum ComposeError {
 	NoImageOrBuild(String),
 	/// A `${VAR}` with the `?err` modifier was required but unset.
 	RequiredVarNotSet { var: String, msg: String },
+	/// A `${…}` interpolation reference is malformed (e.g. an invalid character
+	/// in the variable name, as in `${FOO BAR}` or `${FOO.BAR}`).
+	InvalidSubstitution(String),
 	/// A service did not become healthy within its dependency wait window.
 	HealthCheckTimeout(String),
 	/// A `ports:` entry could not be parsed.
@@ -70,6 +73,9 @@ impl fmt::Display for ComposeError {
 			Self::NoImageOrBuild(s) => write!(f, "service '{s}' has no image or build config"),
 			Self::RequiredVarNotSet { var, msg } => {
 				write!(f, "required variable '{var}' is not set: {msg}")
+			}
+			Self::InvalidSubstitution(s) => {
+				write!(f, "invalid variable substitution: {s}")
 			}
 			Self::HealthCheckTimeout(s) => write!(f, "health check timeout for container '{s}'"),
 			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -49,6 +49,15 @@ pub struct ContainerPort {
 	pub host_ip: Option<String>,
 	pub host_port: Option<u16>,
 	pub container_port: u16,
+	/// Transport protocol of the mapping (`tcp`/`udp`/`sctp`), surfaced in `ps`.
+	#[serde(default)]
+	pub protocol: Option<String>,
+	/// Number of consecutive ports this entry covers when libpod collapses a
+	/// published range into a single record. Captured for fidelity; not yet
+	/// rendered, so it is read by serde only.
+	#[serde(default)]
+	#[allow(dead_code)]
+	pub range: Option<u16>,
 }
 
 /// Response from `GET /libpod/containers/{name}/json`.

--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -38,8 +38,11 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub work_dir: Option<String>,
 
+	/// Stop signal as a numeric `syscall.Signal`. libpod rejects a string here
+	/// with HTTP 500, so the compose `stop_signal:` name is resolved to its
+	/// integer number before being sent.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub stop_signal: Option<String>,
+	pub stop_signal: Option<i64>,
 
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_timeout: Option<u64>,

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -130,8 +130,7 @@ fn warns_for_every_unmapped_field() {
 services:
   s:
     image: x
-    network_mode: "container:other"
-    privileged: true
+    network_mode: "bridge:custom"
     profiles: [debug]
     volumes_from:
       - other
@@ -141,13 +140,7 @@ services:
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
 	let joined = out.warnings.join("\n");
-	for needle in [
-		"network_mode",
-		"privileged",
-		"profiles",
-		"volumes_from",
-		"scale/replicas",
-	] {
+	for needle in ["network_mode", "profiles", "volumes_from", "scale/replicas"] {
 		assert!(joined.contains(needle), "expected warning for {needle}");
 	}
 }
@@ -333,4 +326,124 @@ volumes:
 	assert!(vol.contains("Options=addr=10.0.0.1,rw"), "in:\n{vol}");
 	// An option with no dedicated key falls back to PodmanArgs=--opt.
 	assert!(vol.contains("PodmanArgs=--opt custom=extra"), "in:\n{vol}");
+}
+
+#[test]
+fn healthcheck_start_interval_is_warned_and_omitted() {
+	// `start_interval` has no Quadlet/Podman equivalent: it must not emit a
+	// `HealthStartupInterval=` (which drives an unrelated, no-op startup
+	// healthcheck) and must instead produce a warning.
+	let yaml = r#"
+services:
+  s:
+    image: x
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 5s
+      start_interval: 2s
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("HealthInterval=5s"), "in:\n{c}");
+	assert!(
+		!c.contains("HealthStartupInterval"),
+		"start_interval must not emit HealthStartupInterval=; got:\n{c}"
+	);
+	let joined = out.warnings.join("\n");
+	assert!(
+		joined.contains("start_interval"),
+		"start_interval must warn; got:\n{joined}"
+	);
+}
+
+#[test]
+fn dependency_unit_names_are_sanitized_in_ordering() {
+	// A dependency whose compose key sanitizes to a different stem must be
+	// referenced by that stem in After=/Requires=, matching the generated unit.
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+    depends_on:
+      - "db:1"
+  ? "db:1"
+  : { image: postgres }
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "proj");
+	let web = &unit_named(&out, "web.container").contents;
+	assert!(web.contains("After=db_1.service"), "in:\n{web}");
+	assert!(web.contains("Requires=db_1.service"), "in:\n{web}");
+	// The raw, unsanitized name must not leak into the ordering directives.
+	assert!(!web.contains("db:1.service"), "in:\n{web}");
+	// The dependency's own unit really is named with the sanitized stem.
+	unit_named(&out, "db_1.container");
+}
+
+#[test]
+fn network_mode_service_and_container_map_to_dot_container() {
+	// `network_mode: service:X` / `container:X` reuse another container's netns,
+	// which Quadlet expresses as `Network={X}.container`.
+	for (mode, target) in [("service:db", "db"), ("container:sidecar", "sidecar")] {
+		let yaml = format!("services:\n  s:\n    image: x\n    network_mode: \"{mode}\"\n");
+		let file = parse_str(&yaml).unwrap();
+		let out = generate(&file, "p");
+		let c = &unit_named(&out, "s.container").contents;
+		assert!(
+			c.contains(&format!("Network={target}.container")),
+			"{mode} must map to Network={target}.container; got:\n{c}"
+		);
+	}
+}
+
+#[test]
+fn network_mode_service_target_is_sanitized() {
+	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:web:1\"\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("Network=web_1.container"), "in:\n{c}");
+}
+
+#[test]
+fn volume_and_network_units_have_no_install_section() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+networks:
+  net:
+volumes:
+  vol:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let net = &unit_named(&out, "net.network").contents;
+	let vol = &unit_named(&out, "vol.volume").contents;
+	assert!(
+		!net.contains("[Install]") && !net.contains("WantedBy"),
+		".network must carry no [Install]; got:\n{net}"
+	);
+	assert!(
+		!vol.contains("[Install]") && !vol.contains("WantedBy"),
+		".volume must carry no [Install]; got:\n{vol}"
+	);
+	// The container unit still carries its [Install].
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("[Install]") && c.contains("WantedBy=default.target"));
+}
+
+#[test]
+fn privileged_maps_to_podman_arg() {
+	let yaml = "services:\n  s:\n    image: x\n    privileged: true\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(c.contains("PodmanArgs=--privileged"), "in:\n{c}");
+	assert!(
+		!out.warnings.iter().any(|w| w.contains("privileged")),
+		"privileged must be mapped, not warned; got: {:?}",
+		out.warnings
+	);
 }

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -21,11 +21,15 @@ pub(crate) fn container_unit(
 	let mut unit = Section::new("Unit");
 	unit.add("Description", format!("{name} (podup)"));
 	for dep in service.depends_on.service_names() {
-		unit.add("After", format!("{dep}.service"));
+		// The dependency's generated unit is named `{safe_unit_stem(dep)}.container`,
+		// so its service is `{safe_unit_stem(dep)}.service`; reference that, not the
+		// raw compose key, or the ordering would target a non-existent unit.
+		let dep_service = format!("{}.service", safe_unit_stem(&dep));
+		unit.add("After", dep_service.clone());
 		if service.depends_on.required_for(&dep) {
-			unit.add("Requires", format!("{dep}.service"));
+			unit.add("Requires", dep_service);
 		} else {
-			unit.add("Wants", format!("{dep}.service"));
+			unit.add("Wants", dep_service);
 		}
 	}
 
@@ -60,6 +64,11 @@ pub(crate) fn container_unit(
 	}
 	if service.read_only == Some(true) {
 		container.add("ReadOnly", "true".to_string());
+	}
+	if service.privileged == Some(true) {
+		// No dedicated [Container] key exists for privileged mode; pass it through
+		// as a raw podman flag, like the other escape-hatch fields.
+		container.add("PodmanArgs", "--privileged".to_string());
 	}
 	if service.init == Some(true) {
 		container.add("RunInit", "true".to_string());
@@ -215,13 +224,23 @@ pub(crate) fn container_unit(
 			container.add("StopTimeout", secs.to_string());
 		}
 	}
-	// `network_mode: host`/`none` map to `Network=host`/`Network=none`; other
-	// modes (service:/container:) have no Quadlet key and are reported by
+	// `network_mode: host`/`none` map to `Network=host`/`Network=none`.
+	// `service:X`/`container:X` reuse another container's netns, which Quadlet
+	// expresses as `Network={X}.container` (the `.container` special case);
+	// other modes (bridge:, custom, …) have no key and are reported by
 	// collect_warnings.
 	match service.network_mode.as_deref() {
 		Some("host") => container.add("Network", "host".to_string()),
 		Some("none") => container.add("Network", "none".to_string()),
-		_ => {}
+		Some(m) => {
+			if let Some(target) = m
+				.strip_prefix("service:")
+				.or_else(|| m.strip_prefix("container:"))
+			{
+				container.add("Network", format!("{}.container", safe_unit_stem(target)));
+			}
+		}
+		None => {}
 	}
 	for group in &service.group_add {
 		container.add("GroupAdd", group.clone());
@@ -284,7 +303,7 @@ pub(crate) fn container_unit(
 	for secret in &service.secrets {
 		container.add("Secret", render_secret(secret));
 	}
-	render_healthcheck(service, &mut container);
+	render_healthcheck(name, service, &mut container, warnings);
 
 	let mut svc = Section::new("Service");
 	if let Some(restart) = &service.restart {

--- a/internal/quadlet/unit/health.rs
+++ b/internal/quadlet/unit/health.rs
@@ -7,8 +7,14 @@ use super::Section;
 /// Map a compose `healthcheck:` onto the Quadlet `Health*=` keys. A disabled
 /// healthcheck emits `HealthCmd=none`; otherwise the compose test (with any
 /// leading `CMD`/`CMD-SHELL`/`NONE` sentinel stripped) and the timing fields
-/// are rendered.
-pub(super) fn render_healthcheck(service: &Service, container: &mut Section) {
+/// are rendered. Fields with no Quadlet/Podman equivalent push a warning into
+/// `warnings` instead of being silently dropped.
+pub(super) fn render_healthcheck(
+	name: &str,
+	service: &Service,
+	container: &mut Section,
+	warnings: &mut Vec<String>,
+) {
 	let Some(hc) = &service.healthcheck else {
 		return;
 	};
@@ -43,7 +49,15 @@ pub(super) fn render_healthcheck(service: &Service, container: &mut Section) {
 	if let Some(v) = &hc.start_period {
 		container.add("HealthStartPeriod", v.clone());
 	}
-	if let Some(v) = &hc.start_interval {
-		container.add("HealthStartupInterval", v.clone());
+	if hc.start_interval.is_some() {
+		// Compose `start_interval` (the probe interval during the start period)
+		// has no Quadlet/Podman equivalent. The Quadlet `HealthStartupInterval=`
+		// key drives Podman's separate *startup healthcheck* feature, which is a
+		// no-op without a `HealthStartupCmd=`; Podman 5.x exposes no
+		// `--health-start-interval`. Skip it and warn rather than emit a key that
+		// silently does nothing.
+		warnings.push(format!(
+			"{name}: healthcheck.start_interval has no Quadlet/Podman equivalent and is skipped"
+		));
 	}
 }

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -54,8 +54,10 @@ pub(crate) fn network_unit(
 			net.add("Label", format!("{key}={val}"));
 		}
 	}
-	let mut contents = net.render();
-	contents.push_str("\n[Install]\nWantedBy=default.target\n");
+	// No [Install] section: the spec defines none for `.network` units, which are
+	// pulled in automatically as dependencies of the `.container` units that use
+	// them. Only `.container` units carry [Install].
+	let contents = net.render();
 	QuadletUnit {
 		filename: format!("{}.network", safe_unit_stem(name)),
 		contents,

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -32,8 +32,10 @@ pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfi
 			vol.add("Label", format!("{key}={val}"));
 		}
 	}
-	let mut contents = vol.render();
-	contents.push_str("\n[Install]\nWantedBy=default.target\n");
+	// No [Install] section: the spec defines none for `.volume` units, which are
+	// pulled in automatically as dependencies of the `.container` units that use
+	// them. Only `.container` units carry [Install].
+	let contents = vol.render();
 	QuadletUnit {
 		filename: format!("{}.volume", safe_unit_stem(name)),
 		contents,

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -30,25 +30,19 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 	if !service.volumes_from.is_empty() {
 		warn("volumes_from", "has no Quadlet equivalent and is skipped");
 	}
-	// `network_mode: host`/`none` map to `Network=`; other modes have no key.
-	if service
-		.network_mode
-		.as_deref()
-		.is_some_and(|m| m != "host" && m != "none")
-	{
+	// `host`/`none` map to `Network=`, and `service:X`/`container:X` map to
+	// `Network=X.container`; only the remaining modes (bridge:, custom, …) have
+	// no key.
+	if service.network_mode.as_deref().is_some_and(|m| {
+		m != "host" && m != "none" && !m.starts_with("service:") && !m.starts_with("container:")
+	}) {
 		warn(
 			"network_mode",
-			"is not mapped (only `host`/`none` are supported); use networks instead",
+			"is not mapped (only `host`/`none`/`service:`/`container:` are supported); use networks instead",
 		);
 	}
 	if !service.profiles.is_empty() {
 		warn("profiles", "have no Quadlet equivalent and are ignored");
-	}
-	if service.privileged == Some(true) {
-		warn(
-			"privileged",
-			"is not mapped; add PodmanArgs manually if required",
-		);
 	}
 	if !service.post_start.is_empty() {
 		warn(
@@ -163,8 +157,7 @@ services:
     image: app:1.0
     build: .
     scale: 3
-    privileged: true
-    network_mode: "container:other"
+    network_mode: "bridge:custom"
     volumes_from:
       - other
     profiles:
@@ -193,7 +186,6 @@ configs:
 			"volumes_from",
 			"network_mode",
 			"profiles",
-			"privileged",
 		] {
 			assert!(
 				joined.contains(field),
@@ -205,6 +197,26 @@ configs:
 			!joined.contains("secrets"),
 			"secrets should be mapped, not warned; got:\n{joined}"
 		);
+		// privileged is now mapped to PodmanArgs=--privileged, not warned.
+		assert!(
+			!joined.contains("privileged"),
+			"privileged should be mapped, not warned; got:\n{joined}"
+		);
+	}
+
+	#[test]
+	fn service_and_container_network_modes_are_mapped_not_warned() {
+		// `service:X`/`container:X` map to `Network=X.container`, so they must not
+		// warn; only other unmapped modes (bridge:, custom, …) warn.
+		for mode in ["service:db", "container:other"] {
+			let yaml = format!("services:\n  s:\n    image: x\n    network_mode: \"{mode}\"\n");
+			let file = parse_str(&yaml).unwrap();
+			let joined = generate(&file, "proj").warnings.join("\n");
+			assert!(
+				!joined.contains("network_mode"),
+				"{mode} should be mapped, not warned; got:\n{joined}"
+			);
+		}
 	}
 
 	#[test]

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -47,57 +47,59 @@ pub(super) enum Modifier {
 }
 
 /// Parse the content inside `${…}`.  The opening `{` has already been consumed.
+///
+/// The variable name is collected with [`is_var_char`] (matching the unbraced
+/// `$VAR` path and the compose-spec grammar). After the name, only a modifier
+/// delimiter (`}`, `:`, `-`, `+`, `?`) or end-of-input may follow; any other
+/// trailing character (a space in `${FOO BAR}`, a dot in `${FOO.BAR}`, …) makes
+/// the reference malformed and is rejected rather than folded into the lookup
+/// key.
 pub(super) fn parse_braced_var(
 	chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
 ) -> Result<(String, Modifier)> {
-	let mut name = String::new();
+	let name = collect_var_name(chars);
 
-	loop {
-		match chars.peek() {
-			None => {
-				return Ok((name, Modifier::None));
-			}
-			Some('}') => {
-				chars.next();
-				return Ok((name, Modifier::None));
-			}
-			Some(':') => {
-				chars.next();
-				// Peek at what follows `:`.
-				let modifier = match chars.peek() {
-					Some('-') => {
-						chars.next();
-						Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
-					}
-					Some('+') => {
-						chars.next();
-						Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
-					}
-					Some('?') => {
-						chars.next();
-						Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
-					}
-					_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)),
-				};
-				return Ok((name, modifier));
-			}
-			Some('-') => {
-				chars.next();
-				return Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))));
-			}
-			Some('+') => {
-				chars.next();
-				return Ok((name, Modifier::AltIfSet(collect_until_close(chars))));
-			}
-			Some('?') => {
-				chars.next();
-				return Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))));
-			}
-			Some(&c) => {
-				name.push(c);
-				chars.next();
-			}
+	match chars.peek() {
+		None => Ok((name, Modifier::None)),
+		Some('}') => {
+			chars.next();
+			Ok((name, Modifier::None))
 		}
+		Some(':') => {
+			chars.next();
+			// Peek at what follows `:`.
+			let modifier = match chars.peek() {
+				Some('-') => {
+					chars.next();
+					Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
+				}
+				Some('+') => {
+					chars.next();
+					Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
+				}
+				Some('?') => {
+					chars.next();
+					Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
+				}
+				_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)),
+			};
+			Ok((name, modifier))
+		}
+		Some('-') => {
+			chars.next();
+			Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))))
+		}
+		Some('+') => {
+			chars.next();
+			Ok((name, Modifier::AltIfSet(collect_until_close(chars))))
+		}
+		Some('?') => {
+			chars.next();
+			Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))))
+		}
+		Some(&c) => Err(ComposeError::InvalidSubstitution(format!(
+			"unexpected character {c:?} in variable name '${{{name}…}}'"
+		))),
 	}
 }
 
@@ -254,6 +256,46 @@ mod tests {
 		let mut it = peekable("V:x}");
 		let (_, modifier) = parse_braced_var(&mut it).unwrap();
 		assert!(matches!(modifier, Modifier::DefaultIfUnsetOrEmpty(s) if s == "x"));
+	}
+
+	// --- parse_braced_var: name validation ---
+
+	#[test]
+	fn parse_valid_braced_var() {
+		let mut it = peekable("FOO}");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::None));
+	}
+
+	#[test]
+	fn parse_valid_braced_var_with_default() {
+		let mut it = peekable("FOO:-default}");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "FOO");
+		assert!(matches!(modifier, Modifier::DefaultIfUnsetOrEmpty(s) if s == "default"));
+	}
+
+	#[test]
+	fn parse_braced_var_rejects_space_in_name() {
+		// `${FOO BAR}` must not produce a lookup key containing a space.
+		let mut it = peekable("FOO BAR}");
+		let err = parse_braced_var(&mut it).expect_err("space in name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
+	#[test]
+	fn parse_braced_var_rejects_dot_in_name() {
+		// `${FOO.BAR}` must not produce a lookup key containing a dot.
+		let mut it = peekable("FOO.BAR}");
+		let err = parse_braced_var(&mut it).expect_err("dot in name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
 	}
 
 	// --- resolve_modifier ---

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -25,13 +25,28 @@ async fn cli_logs_tail_limits_output() {
 		.args(["-f", c, "-p", &proj, "up", "-d"])
 		.output()
 		.unwrap();
-	// Give the container a moment to emit its lines.
-	tokio::time::sleep(std::time::Duration::from_millis(800)).await;
 
-	let logs = Command::new(bin())
-		.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
-		.output()
-		.unwrap();
+	// Poll until the container has emitted its lines instead of sleeping a fixed
+	// duration: `logs --tail 2` must eventually show exactly 2 `line-` rows.
+	let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+	let mut logs;
+	loop {
+		logs = Command::new(bin())
+			.args(["-f", c, "-p", &proj, "logs", "--tail", "2"])
+			.output()
+			.unwrap();
+		let lines = String::from_utf8_lossy(&logs.stdout)
+			.lines()
+			.filter(|l| l.contains("line-"))
+			.count();
+		if logs.status.success() && lines == 2 {
+			break;
+		}
+		if tokio::time::Instant::now() >= deadline {
+			break;
+		}
+		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+	}
 	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
 	let lines = String::from_utf8_lossy(&logs.stdout)
 		.lines()
@@ -173,10 +188,28 @@ async fn cli_down_rmi_all_succeeds_and_removes_containers() {
 	}
 	let dir = tempdir().unwrap();
 	let proj = format!("t{}-rmi", std::process::id());
+
+	// `--rmi all` deletes the image referenced by the compose file. Tests run in
+	// parallel and several rely on the shared `alpine:latest` image, so we tag a
+	// throwaway, project-unique local image and reference THAT here. Removing it
+	// leaves `alpine:latest` intact for the concurrent tests.
+	let throwaway = format!("localhost/podup-rmitest-{proj}:latest");
+	let tag = Command::new("podman")
+		.args(["tag", "alpine:latest", &throwaway])
+		.output()
+		.unwrap();
+	assert!(
+		tag.status.success(),
+		"tagging throwaway image failed: {:?}",
+		tag.stderr
+	);
+
 	let compose = dir.path().join("docker-compose.yml");
 	fs::write(
 		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+		format!(
+			"services:\n  web:\n    image: {throwaway}\n    command: [\"sleep\", \"infinity\"]\n"
+		),
 	)
 	.unwrap();
 	let c = compose.to_str().unwrap();
@@ -189,6 +222,20 @@ async fn cli_down_rmi_all_succeeds_and_removes_containers() {
 		down.stderr
 	);
 	assert_eq!(ps_all_count(c, &proj), 0, "down must remove the containers");
+
+	// The shared base image must survive; only the throwaway tag was removed.
+	let present = Command::new("podman")
+		.args(["image", "exists", &throwaway])
+		.status()
+		.unwrap();
+	assert!(
+		!present.success(),
+		"down --rmi all must remove the throwaway image"
+	);
+	// Best-effort cleanup in case the assertion above ever changes.
+	let _ = Command::new("podman")
+		.args(["rmi", "-f", &throwaway])
+		.output();
 }
 
 #[tokio::test]

--- a/tests/engine_integration/group_a3.rs
+++ b/tests/engine_integration/group_a3.rs
@@ -61,7 +61,8 @@ async fn service_with_expose_deploy_labels_annotations_tmpfs() {
 	let proj = proj("sdl");
 	let engine = Engine::new(client, proj.clone());
 	// expose covers container.rs L56-63
-	// deploy.labels covers container.rs L76-78
+	// deploy.labels are accepted but, per the Compose Specification, are set on
+	// the service only and must not be applied to the container
 	// annotations covers container.rs L81-82
 	// long-form tmpfs volume covers container.rs L107-113 and L139
 	let file = parse_str(

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -10,5 +10,7 @@ mod extends;
 mod fields;
 #[path = "parse/include.rs"]
 mod include;
+#[path = "parse/new_keys.rs"]
+mod new_keys;
 #[path = "parse/order.rs"]
 mod order;

--- a/tests/parse/new_keys.rs
+++ b/tests/parse/new_keys.rs
@@ -1,0 +1,151 @@
+//! Parse coverage for compose-spec keys that previously fell into the
+//! `unknown`/`extensions` bucket: `credential_spec`, `isolation`, `provider`,
+//! `use_api_socket` (service-level) and the top-level `models` element. Each
+//! must deserialize into its dedicated field and no longer trip the generic
+//! "unknown key" diagnostic; the not-honored diagnostic is asserted in
+//! `tests/cli_diagnostics.rs` and the diagnostics unit tests.
+use podup::parse_str;
+
+#[test]
+fn credential_spec_object_parses_into_field() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+    credential_spec:
+      config: my-credential-spec
+"#;
+	let svc = &parse_str(yaml).unwrap().services["web"];
+	let cred = svc
+		.credential_spec
+		.as_ref()
+		.expect("credential_spec parsed");
+	assert_eq!(cred.config.as_deref(), Some("my-credential-spec"));
+	assert!(cred.file.is_none());
+	assert!(cred.registry.is_none());
+	// Must not leak into the unknown-key bucket.
+	assert!(!svc.unknown.contains_key("credential_spec"));
+}
+
+#[test]
+fn credential_spec_file_and_registry_parse() {
+	let yaml = r#"
+services:
+  a:
+    image: nginx
+    credential_spec:
+      file: spec.json
+  b:
+    image: nginx
+    credential_spec:
+      registry: my-registry-value
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.services["a"]
+			.credential_spec
+			.as_ref()
+			.unwrap()
+			.file
+			.as_deref(),
+		Some("spec.json")
+	);
+	assert_eq!(
+		file.services["b"]
+			.credential_spec
+			.as_ref()
+			.unwrap()
+			.registry
+			.as_deref(),
+		Some("my-registry-value")
+	);
+}
+
+#[test]
+fn service_isolation_parses_into_field() {
+	let yaml = "services:\n  web:\n    image: nginx\n    isolation: hyperv\n";
+	let svc = &parse_str(yaml).unwrap().services["web"];
+	assert_eq!(svc.isolation.as_deref(), Some("hyperv"));
+	assert!(!svc.unknown.contains_key("isolation"));
+}
+
+#[test]
+fn provider_object_parses_into_field() {
+	let yaml = r#"
+services:
+  db:
+    provider:
+      type: awesomecloud
+      options:
+        type: mysql
+        size: 256
+"#;
+	let svc = &parse_str(yaml).unwrap().services["db"];
+	let provider = svc.provider.as_ref().expect("provider parsed");
+	assert_eq!(provider.provider_type.as_deref(), Some("awesomecloud"));
+	assert_eq!(
+		provider.options.get("type").and_then(|v| v.as_str()),
+		Some("mysql")
+	);
+	assert!(!svc.unknown.contains_key("provider"));
+}
+
+#[test]
+fn use_api_socket_parses_into_field() {
+	let yaml = "services:\n  web:\n    image: nginx\n    use_api_socket: true\n";
+	let svc = &parse_str(yaml).unwrap().services["web"];
+	assert_eq!(svc.use_api_socket, Some(true));
+	assert!(!svc.unknown.contains_key("use_api_socket"));
+}
+
+#[test]
+fn top_level_models_parses_into_field() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+models:
+  llm:
+    model: ai/model
+    context_size: 1024
+    runtime_flags:
+      - "--a-flag"
+      - "--another-flag=42"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let model = file.models.get("llm").expect("model parsed");
+	assert_eq!(model.model.as_deref(), Some("ai/model"));
+	assert_eq!(model.context_size, Some(1024));
+	assert_eq!(model.runtime_flags.len(), 2);
+	// Top-level models must not land in the extensions bucket.
+	assert!(!file.extensions.contains_key("models"));
+}
+
+#[test]
+fn new_keys_produce_no_unknown_key_diagnostic() {
+	// All five keys together: none should be reported as an unknown/typo key
+	// (the not-honored warnings are a separate, expected signal).
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+    isolation: default
+    use_api_socket: true
+    credential_spec:
+      file: spec.json
+    provider:
+      type: cloud
+models:
+  llm:
+    model: ai/model
+"#;
+	let file = parse_str(yaml).unwrap();
+	let svc = &file.services["web"];
+	for key in ["isolation", "use_api_socket", "credential_spec", "provider"] {
+		assert!(
+			!svc.unknown.contains_key(key),
+			"service key '{key}' leaked into unknown bucket"
+		);
+	}
+	assert!(!file.extensions.contains_key("models"));
+}

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -84,11 +84,11 @@ networks:
 
 	assert_eq!(
 		unit(&out, "cache.volume"),
-		"[Volume]\nVolumeName=myproj_cache\n\n[Install]\nWantedBy=default.target\n"
+		"[Volume]\nVolumeName=myproj_cache\n"
 	);
 	assert_eq!(
 		unit(&out, "backend.network"),
-		"[Network]\nNetworkName=myproj_backend\n\n[Install]\nWantedBy=default.target\n"
+		"[Network]\nNetworkName=myproj_backend\n"
 	);
 }
 


### PR DESCRIPTION
Promotes develop to main for the v1.1.0 release.

Accumulated since v1.0.0 (backward-compatible, no breaking changes):
- **CLI parity**: scale, create, ls, stats, push, events, attach, wait, commit, export, volumes subcommands + broad flag coverage across up/down/run/exec/logs/pull/build/cp/config/rm/start/kill.
- **Engine correctness**: integer stop_signal (string → HTTP 500), port protocol/range, null-tolerant stats, up --no-deps readiness, scaled network_mode target, selinux z/Z bind translation, deploy.labels kept off containers, multi-platform build warning.
- **Compose fidelity**: optional build context, lenient env_file format, primary build tag, parse credential_spec/isolation/provider/use_api_socket/models.
- **Quadlet**: healthcheck start_interval, dependency name sanitization, network_mode service:/container: mapping, [Install] dropped from volume/network units, privileged via PodmanArgs.
- **CLI**: reject --index 0, validate braced substitution names.
- **Build/deps**: pinned SBOM/audit tooling, refreshed webpki-roots/getrandom/syn.

After merge: tag v1.1.0 on main → release.yml signs + publishes.