### PR TITLE
fix(engine): drive healthchecks on-demand so up --wait works without systemd

### DIFF
--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -5,12 +5,24 @@
 //! [`Engine::wait_completed`] polls until the container exits with code 0 (used for
 //! `condition: service_completed_successfully`).
 
+use std::time::Duration;
+
+use serde::Deserialize;
+
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::ContainerInspect;
 use crate::libpod::API_PREFIX;
 
 use super::Engine;
+
+/// Response from `GET {API_PREFIX}/containers/{name}/healthcheck`, which *runs*
+/// the container's healthcheck on demand and reports the resulting status.
+#[derive(Deserialize)]
+struct HealthCheckRun {
+	#[serde(rename = "Status")]
+	status: Option<String>,
+}
 
 /// Per-poll verdict while waiting for `service_healthy`.
 enum HealthVerdict {
@@ -126,22 +138,32 @@ impl Engine {
 			HealthVerdict::Pending => {}
 		}
 
-		// Block server-side until the container reports healthy, bounded by the
-		// same time budget the poll loop used (interval × iterations), instead of
-		// issuing O(iterations) inspect calls.
-		let budget = std::time::Duration::from_secs(poll_secs * iterations);
+		// Actively drive the healthcheck on demand. A server-side
+		// `wait?condition=healthy` only returns once the health *status* flips to
+		// `healthy`, but Podman updates that status only when the healthcheck runs
+		// — and it schedules those runs via systemd transient timers. Without
+		// systemd (containers, minimal hosts) the timer never fires and the status
+		// stays `starting`, so the wait would block until the whole budget elapsed.
+		//
+		// `GET {API_PREFIX}/containers/{name}/healthcheck` *runs* the check and
+		// returns the resulting status, so polling it works with or without
+		// systemd, on Podman 4.9.3 and 5.x alike. Extra on-demand runs on a
+		// systemd host are harmless.
 		let path = format!(
-			"{API_PREFIX}/containers/{}/wait?condition=healthy",
+			"{API_PREFIX}/containers/{}/healthcheck",
 			crate::libpod::urlencoded(container_name),
 		);
-		match tokio::time::timeout(budget, self.client.post_empty_json::<i64>(&path)).await {
-			Ok(Ok(_)) => Ok(()),
-			Ok(Err(e)) => {
-				tracing::debug!("{container_name} wait?condition=healthy failed: {e}");
-				Err(ComposeError::HealthCheckTimeout(container_name.into()))
+		for _ in 0..iterations {
+			match self.client.get_json::<HealthCheckRun>(&path).await {
+				Ok(run) if run.status.as_deref() == Some("healthy") => return Ok(()),
+				Ok(_) => {}
+				// A transient error (container not yet running, 409, 500, …) just
+				// means "not healthy yet" — keep polling rather than failing hard.
+				Err(e) => tracing::debug!("{container_name} healthcheck run failed: {e}"),
 			}
-			Err(_elapsed) => Err(ComposeError::HealthCheckTimeout(container_name.into())),
+			tokio::time::sleep(Duration::from_secs(poll_secs)).await;
 		}
+		Err(ComposeError::HealthCheckTimeout(container_name.into()))
 	}
 
 	/// Wait until a container exits, then require status 0.

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -194,6 +194,12 @@ async fn cli_down_rmi_all_succeeds_and_removes_containers() {
 	// throwaway, project-unique local image and reference THAT here. Removing it
 	// leaves `alpine:latest` intact for the concurrent tests.
 	let throwaway = format!("localhost/podup-rmitest-{proj}:latest");
+	// In a clean environment `alpine:latest` may not be pulled yet, so `podman
+	// tag` would fail with "image not known". Pull first; ignore the result so a
+	// pre-existing image (or an offline cache) still works.
+	let _ = Command::new("podman")
+		.args(["pull", "alpine:latest"])
+		.output();
 	let tag = Command::new("podman")
 		.args(["tag", "alpine:latest", &throwaway])
 		.output()


### PR DESCRIPTION
Closes #503

## Problem

`up --wait` (and any `depends_on … condition: service_healthy`) could spuriously fail with `HealthCheckTimeout` on hosts without systemd.

`wait_healthy` inspected the container once (keeping the already-healthy and no-effective-healthcheck short-circuits) and then blocked on:

```
POST {API_PREFIX}/containers/{name}/wait?condition=healthy
```

That server-side wait only returns once the container's health **status** flips to `healthy`. But Podman updates that status **only when the healthcheck actually runs**, and it schedules those runs via systemd transient timers. Without systemd (inside containers, minimal hosts) the timer never fires, the status stays `starting`, and the wait blocks until the entire timeout budget is exhausted, surfacing as a `HealthCheckTimeout`.

## Fix

Replace the server-side `wait?condition=healthy` block with an **active poll** of:

```
GET {API_PREFIX}/containers/{name}/healthcheck
```

Verified evidence: this endpoint **runs** the healthcheck on demand and returns `{"Status":"healthy|starting|unhealthy", ...}`. The endpoint exists on both Podman 4.9.3 and 5.x.

The loop is bounded by the existing `health_poll_plan` budget (`poll_secs`, `iterations`):

- each iteration GETs the healthcheck endpoint (running the check) and parses `Status`;
- a request error (container not yet running / 409 / 500) is treated as "not healthy yet" — logged at debug, loop continues, no hard failure;
- `Status == "healthy"` → `Ok(())`;
- otherwise `sleep(poll_secs)` and retry; budget exhausted → `HealthCheckTimeout`.

This works with or without systemd (extra on-demand runs on a systemd host are harmless). The initial inspect and its short-circuits (`Healthy → Ok`, `NoHealthcheck → Ok`, `Pending → continue`), `health_poll_plan`, `classify_health`, and `wait_completed` are unchanged. No public API change.

## Test robustness

`tests/engine_integration/cli3.rs::cli_down_rmi_all_succeeds_and_removes_containers` ran `podman tag alpine:latest <throwaway>`, which fails with "image not known" in a clean environment. Added a `podman pull alpine:latest` (result ignored, so a pre-existing/cached image still works) before the tag.

## Validation

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, `cargo build --all-features`, `cargo test --lib --all-features` (699 passed), and `cargo test --all-features --no-run` all pass.

The `wait_healthy` loop is integration-only (needs a live socket); `cli_up_wait_returns_when_healthy` covers it. **Integration validation against Podman 5.8.x by the maintainer is required.**
