### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (1.1.1) unstable; urgency=medium
+
+  * engine: drive healthchecks on demand instead of relying on Podman's
+    systemd-scheduled timers, so `up --wait` and `depends_on: service_healthy`
+    complete in environments without systemd (containers, minimal hosts) rather
+    than hanging until the timeout. Restores docker-compose parity for
+    healthcheck-gated startup.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 19 Jun 2026 17:00:00 -0500
+
 podup (1.1.0) unstable; urgency=medium
 
   * cli: docker-compose command and flag parity — new subcommands (scale, create,

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 1.1.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 1.1.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Patch release: ships the healthcheck-on-demand fix (#503) so `up --wait` / `depends_on: service_healthy` work without systemd. Bumps Cargo + debian/changelog + man page.