### PR TITLE
release: v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (1.1.1) unstable; urgency=medium
+
+  * engine: drive healthchecks on demand instead of relying on Podman's
+    systemd-scheduled timers, so `up --wait` and `depends_on: service_healthy`
+    complete in environments without systemd (containers, minimal hosts) rather
+    than hanging until the timeout. Restores docker-compose parity for
+    healthcheck-gated startup.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 19 Jun 2026 17:00:00 -0500
+
 podup (1.1.0) unstable; urgency=medium
 
   * cli: docker-compose command and flag parity — new subcommands (scale, create,

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 1.1.0" "User Commands"
+.TH PODUP 1 "June 2026" "podup 1.1.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -5,12 +5,24 @@
 //! [`Engine::wait_completed`] polls until the container exits with code 0 (used for
 //! `condition: service_completed_successfully`).
 
+use std::time::Duration;
+
+use serde::Deserialize;
+
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::ContainerInspect;
 use crate::libpod::API_PREFIX;
 
 use super::Engine;
+
+/// Response from `GET {API_PREFIX}/containers/{name}/healthcheck`, which *runs*
+/// the container's healthcheck on demand and reports the resulting status.
+#[derive(Deserialize)]
+struct HealthCheckRun {
+	#[serde(rename = "Status")]
+	status: Option<String>,
+}
 
 /// Per-poll verdict while waiting for `service_healthy`.
 enum HealthVerdict {
@@ -126,22 +138,32 @@ impl Engine {
 			HealthVerdict::Pending => {}
 		}
 
-		// Block server-side until the container reports healthy, bounded by the
-		// same time budget the poll loop used (interval × iterations), instead of
-		// issuing O(iterations) inspect calls.
-		let budget = std::time::Duration::from_secs(poll_secs * iterations);
+		// Actively drive the healthcheck on demand. A server-side
+		// `wait?condition=healthy` only returns once the health *status* flips to
+		// `healthy`, but Podman updates that status only when the healthcheck runs
+		// — and it schedules those runs via systemd transient timers. Without
+		// systemd (containers, minimal hosts) the timer never fires and the status
+		// stays `starting`, so the wait would block until the whole budget elapsed.
+		//
+		// `GET {API_PREFIX}/containers/{name}/healthcheck` *runs* the check and
+		// returns the resulting status, so polling it works with or without
+		// systemd, on Podman 4.9.3 and 5.x alike. Extra on-demand runs on a
+		// systemd host are harmless.
 		let path = format!(
-			"{API_PREFIX}/containers/{}/wait?condition=healthy",
+			"{API_PREFIX}/containers/{}/healthcheck",
 			crate::libpod::urlencoded(container_name),
 		);
-		match tokio::time::timeout(budget, self.client.post_empty_json::<i64>(&path)).await {
-			Ok(Ok(_)) => Ok(()),
-			Ok(Err(e)) => {
-				tracing::debug!("{container_name} wait?condition=healthy failed: {e}");
-				Err(ComposeError::HealthCheckTimeout(container_name.into()))
+		for _ in 0..iterations {
+			match self.client.get_json::<HealthCheckRun>(&path).await {
+				Ok(run) if run.status.as_deref() == Some("healthy") => return Ok(()),
+				Ok(_) => {}
+				// A transient error (container not yet running, 409, 500, …) just
+				// means "not healthy yet" — keep polling rather than failing hard.
+				Err(e) => tracing::debug!("{container_name} healthcheck run failed: {e}"),
 			}
-			Err(_elapsed) => Err(ComposeError::HealthCheckTimeout(container_name.into())),
+			tokio::time::sleep(Duration::from_secs(poll_secs)).await;
 		}
+		Err(ComposeError::HealthCheckTimeout(container_name.into()))
 	}
 
 	/// Wait until a container exits, then require status 0.

--- a/tests/engine_integration/cli3.rs
+++ b/tests/engine_integration/cli3.rs
@@ -194,6 +194,12 @@ async fn cli_down_rmi_all_succeeds_and_removes_containers() {
 	// throwaway, project-unique local image and reference THAT here. Removing it
 	// leaves `alpine:latest` intact for the concurrent tests.
 	let throwaway = format!("localhost/podup-rmitest-{proj}:latest");
+	// In a clean environment `alpine:latest` may not be pulled yet, so `podman
+	// tag` would fail with "image not known". Pull first; ignore the result so a
+	// pre-existing image (or an offline cache) still works.
+	let _ = Command::new("podman")
+		.args(["pull", "alpine:latest"])
+		.output();
 	let tag = Command::new("podman")
 		.args(["tag", "alpine:latest", &throwaway])
 		.output()


### PR DESCRIPTION
Promotes develop to main for v1.1.1.

Patch: `up --wait` / `depends_on: service_healthy` no longer hang in environments without systemd — podup now drives healthchecks on demand instead of waiting on Podman's systemd-scheduled timers (#503). Validated 45/45 on Podman 5.8.2 in a non-systemd container.

After merge: tag v1.1.1 → release.yml signs + publishes.