### PR TITLE
fix(engine): wait on first replica for scaled depends_on dependencies

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -267,9 +267,7 @@ impl Engine {
 			if !service_in_profiles(dep_service, active) {
 				continue;
 			}
-			// A scaled dependency (`deploy.replicas`/`scale`/`--scale` > 1) has
-			// no base-named container; its replicas are `{base}-1..N`. Wait on the
-			// first replica, matching `wait_services_healthy`.
+			// Scaled dep has no base-named container; wait on its first replica.
 			let dep_container = self.first_replica_name(&dep, dep_service);
 
 			let wait = match condition {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -267,7 +267,10 @@ impl Engine {
 			if !service_in_profiles(dep_service, active) {
 				continue;
 			}
-			let dep_container = self.container_name(&dep, dep_service);
+			// A scaled dependency (`deploy.replicas`/`scale`/`--scale` > 1) has
+			// no base-named container; its replicas are `{base}-1..N`. Wait on the
+			// first replica, matching `wait_services_healthy`.
+			let dep_container = self.first_replica_name(&dep, dep_service);
 
 			let wait = match condition {
 				ServiceCondition::ServiceStarted => Ok(()),

--- a/tests/engine_integration/group_a2.rs
+++ b/tests/engine_integration/group_a2.rs
@@ -213,6 +213,26 @@ async fn depends_on_service_completed() {
 	engine.down(&file).await.unwrap();
 }
 
+// Regression: a dependency scaled to >1 has no base-named container, only
+// `{base}-1..N`. The readiness wait must target the first replica, not the
+// (nonexistent) base name, or `up` 404s and aborts despite the dep completing.
+#[tokio::test]
+async fn depends_on_scaled_service_completed() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("cmpscale");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  init:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"exit 0\"]\n    deploy:\n      replicas: 2\n  app:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    depends_on:\n      init:\n        condition: service_completed_successfully\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Profiles
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`up`'s per-service `depends_on` readiness wait resolved the dependency container with `container_name()` (the unsuffixed base name). A dependency scaled with `deploy.replicas`/`scale`/`--scale` > 1 has **no** base-named container — its replicas are `{base}-1..N`.

Effect on a service depending on a scaled dependency:
- `condition: service_completed_successfully` → `GET /containers/{base}/wait` 404s → surfaces as `HealthCheckTimeout` and aborts `up` even though the dep completed.
- `condition: service_healthy` → 404 treated as 'pending' → `up` blocks for the full poll budget then times out.

## Fix

Use `first_replica_name()` at the call site, matching the sibling `wait_services_healthy` (`internal/engine/health.rs:105`). Single-replica deps are unaffected — `first_replica_name` returns the base name when replicas ≤ 1.

## Test

Adds `depends_on_scaled_service_completed` integration case: a `deploy.replicas: 2` init service that `exit 0`s, with an app depending on it via `condition: service_completed_successfully`. Fails on the old code (404 on the base name), passes with the fix.

Closes #509