### PR TITLE
docs: correct command-flag and gpus references; fix RmiScope::Local doc

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -142,13 +142,13 @@ selects a replica (1-based) of a scaled service.
 
 | Command | Description |
 |---|---|
-| `ps` | List project containers. |
+| `ps` | List project containers. `-a/--all` includes stopped containers, `-q/--quiet` prints container IDs only, `--format table\|json`. |
 | `ls` | List podup compose projects on the host. `-a/--all` includes stopped projects, `-q/--quiet` prints names only, `--format table\|json`. Needs no compose file. |
 | `top` | Show running processes of service containers. |
 | `stats` | Live resource usage (CPU, memory, network, block I/O, PIDs) for service containers. `--no-stream` prints one snapshot; a trailing service list narrows it. |
 | `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
 | `events` | Stream Podman events for this project's containers. `--json` emits each event as a JSON line instead of a summary. |
-| `images` | List images used by services. |
+| `images` | List images used by services. `-q/--quiet` prints image IDs only, `--format table\|json`. |
 | `volumes [SERVICE...]` | List the project's named volumes. `-q/--quiet` prints names only, `--format table\|json`; a trailing service list narrows it to volumes those services mount. |
 | `logs [SERVICE]` | View container output. `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
 | `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates, `--no-interpolate` leaves `${VAR}` placeholders literal, `--resolve-image-digests` rewrites each service `image:` to its registry digest (`repo@sha256:...`). |

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -187,7 +187,6 @@ untrusted Makefile.
 | Feature | Status |
 |---|---|
 | `env_file.format` values other than `dotenv` | Error is emitted; only the `dotenv` format is accepted |
-| `gpus:` as a list of device objects | Use `deploy.resources.reservations.devices` for GPU reservations; the scalar `gpus: all` / `gpus: N` shorthand is supported |
 | `provider:` / model-runner services (`provider`, top-level `models`) | No rootless Podman equivalent; reported as an unknown key |
 | Container naming | A single-replica service is named `<project>-<service>` (e.g. `myapp-web`); docker-compose v2 always appends a `-1` replica index (`myapp-web-1`). Scaled replicas (>1) do get the `-N` suffix. Scripts that reference containers by exact name should account for this. |
 | Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -17,7 +17,7 @@ pub(crate) enum OutputFormat {
 pub(crate) enum RmiScope {
 	/// All images used by the project's services.
 	All,
-	/// Only images without a custom tag (services that build locally).
+	/// Only images built locally from a service `build:` section.
 	Local,
 }
 

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -331,6 +331,7 @@ impl Engine {
 
 #[cfg(feature = "test-helpers")]
 impl Engine {
+	/// Test seam: copy `src` into `container` at `target` via the watch sync path.
 	pub async fn test_sync_to_container(
 		&self,
 		container: &str,
@@ -340,10 +341,12 @@ impl Engine {
 		self.sync_to_container(container, src, target).await
 	}
 
+	/// Test seam: run the watch restart action against `container_name`.
 	pub async fn test_watch_restart(&self, container_name: &str) -> Result<()> {
 		self.watch_restart(container_name).await
 	}
 
+	/// Test seam: run the watch exec action (`cmd`) against `container_name`.
 	pub async fn test_watch_exec(&self, container_name: &str, cmd: Vec<String>) -> Result<()> {
 		self.watch_exec(container_name, cmd).await
 	}


### PR DESCRIPTION
Accuracy fixes surfaced by the docs/standards sweep, each verified against code:

- **commands.md** — the Inspection table's `ps` and `images` rows omitted flags their siblings document. `ps` takes `-a/--all`, `-q/--quiet` (container IDs), `--format table|json`; `images` takes `-q/--quiet` (image IDs), `--format` (`internal/cli/commands.rs:283-293,366-373`).
- **docker-migration.md** — removed the 'Not yet supported' row claiming `gpus:` list-of-device-objects is unsupported; the list form is handled via `GpuSpec::Devices` → NVIDIA CDI (`internal/engine/container_config/resources.rs:215-219`).
- **cli/types.rs** — `RmiScope::Local` doc said 'images without a custom tag', but the implementation keys off `service.build.is_some()`. Aligned with the implementation and `docs/commands.md:49`.
- **watch/mod.rs** — added doc comments to the three `test-helpers`-gated public seams.

Closes #514