### PR TITLE
chore(packaging): drop no-op CARGO_UNSTABLE_OFFLINE; refresh control description

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,10 +16,9 @@ Recommends: podman (>= 5.0)
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides
- the full compose workflow (up, down, start, stop, ps, logs, exec, run,
- cp, build, pull, restart, rm, kill, pause, unpause, top, port, images,
- config, watch) as a single static binary with no daemon and no Python
- runtime.
+ the full Compose workflow — lifecycle, build/push, exec/run, inspection
+ and Quadlet generation — as a single static binary with no daemon and
+ no Python runtime. Run `podup --help` for the complete command list.
  .
  It supports compose-spec parsing including YAML anchors, extends,
  include, profiles, env_file and variable substitution, with

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,6 @@ export CARGO_TARGET_DIR = $(CURDIR)/target
 # the source tarball.
 ifneq ($(wildcard vendor/),)
 export CARGO_NET_OFFLINE = true
-export CARGO_UNSTABLE_OFFLINE = true
 CARGO_FLAGS = --frozen --offline
 endif
 


### PR DESCRIPTION
Two safe packaging-hygiene fixes from the release/Debian sweep:

- **`debian/rules`** — removed `export CARGO_UNSTABLE_OFFLINE = true`. It is not a real Cargo environment variable and never enforced anything; the offline guarantee for vendored builds comes from `CARGO_NET_OFFLINE` (kept) plus `--frozen --offline`.
- **`debian/control`** — the long description enumerated a stale ~20-command list. `apt show podup` is user-visible metadata; replaced the brittle enumeration with a category summary pointing at `podup --help` so it can't drift again.

No behavior change to the built package. The riskier release-flow items (signing install scripts, SBOM/NOTICES in SHA256SUMS, reproducible .deb toolchain, man-page sed clean-revert) are tracked separately in #518.

Closes #517