### PR TITLE
fix(compose): union depends_on across extends and merge top-level models

### DIFF
--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -7,7 +7,8 @@
 //! extending service's items, with duplicates removed — not replaced wholesale.
 
 use super::super::types::{
-	DependsOn, EnvFile, EnvVars, Labels, Service, ServiceNetworks, StringOrList, Sysctls,
+	DependsOn, DependsOnCondition, EnvFile, EnvVars, Labels, Service, ServiceCondition,
+	ServiceNetworks, StringOrList, Sysctls,
 };
 
 pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) -> Service {
@@ -83,6 +84,43 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		}
 	}
 
+	// compose-go unions `depends_on` across `extends`: the base's dependencies and
+	// the extending service's are both kept, the override winning per service key
+	// (same rule as `environment`). A bare-list entry canonicalizes to the default
+	// `service_started` condition, which matches `DependsOn`'s list-form defaults.
+	fn merge_depends_on(base: DependsOn, over: DependsOn) -> DependsOn {
+		if matches!(over, DependsOn::Empty) {
+			return base;
+		}
+		if matches!(base, DependsOn::Empty) {
+			return over;
+		}
+		fn to_map(d: DependsOn) -> indexmap::IndexMap<String, DependsOnCondition> {
+			match d {
+				DependsOn::Empty => indexmap::IndexMap::new(),
+				DependsOn::List(v) => v
+					.into_iter()
+					.map(|name| {
+						(
+							name,
+							DependsOnCondition {
+								condition: ServiceCondition::ServiceStarted,
+								restart: None,
+								required: None,
+							},
+						)
+					})
+					.collect(),
+				DependsOn::Map(m) => m,
+			}
+		}
+		let mut merged = to_map(base);
+		for (k, v) in to_map(over) {
+			merged.insert(k, v);
+		}
+		DependsOn::Map(merged)
+	}
+
 	Service {
 		image: opt(override_svc.image, base.image),
 		build: override_svc.build.or(base.build),
@@ -113,11 +151,7 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		dns_search: merge_sol(base.dns_search, override_svc.dns_search),
 		dns_opt: merge_sol(base.dns_opt, override_svc.dns_opt),
 		network_mode: override_svc.network_mode.or(base.network_mode),
-		depends_on: if matches!(override_svc.depends_on, DependsOn::Empty) {
-			base.depends_on
-		} else {
-			override_svc.depends_on
-		},
+		depends_on: merge_depends_on(base.depends_on, override_svc.depends_on),
 		healthcheck: override_svc.healthcheck.or(base.healthcheck),
 		restart: override_svc.restart.or(base.restart),
 		stop_signal: override_svc.stop_signal.or(base.stop_signal),
@@ -306,6 +340,56 @@ services:
 		assert_eq!(
 			file.services["app"].depends_on.service_names(),
 			vec!["db".to_string()]
+		);
+	}
+
+	#[test]
+	fn extends_unions_depends_on() {
+		let yaml = r#"
+services:
+  db:
+    image: postgres
+  cache:
+    image: redis
+  base:
+    image: alpine
+    depends_on:
+      - db
+  app:
+    extends: base
+    depends_on:
+      - cache
+"#;
+		let file = parse_str(yaml).unwrap();
+		// compose-go unions the base and extending depends_on rather than letting
+		// the override replace the base wholesale.
+		let mut names = file.services["app"].depends_on.service_names();
+		names.sort();
+		assert_eq!(names, vec!["cache".to_string(), "db".to_string()]);
+	}
+
+	#[test]
+	fn extends_depends_on_override_wins_on_conflict() {
+		let yaml = r#"
+services:
+  db:
+    image: postgres
+  base:
+    image: alpine
+    depends_on:
+      db:
+        condition: service_started
+  app:
+    extends: base
+    depends_on:
+      db:
+        condition: service_healthy
+"#;
+		let file = parse_str(yaml).unwrap();
+		// On an overlapping key the extending service's condition wins.
+		assert_eq!(
+			file.services["app"].depends_on.condition_for("db"),
+			crate::compose::types::ServiceCondition::ServiceHealthy
 		);
 	}
 

--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -8,8 +8,9 @@ use super::types::ComposeFile;
 
 /// Merge `other` into `target`.
 ///
-/// Services / volumes / networks / secrets / configs from `other` are added;
-/// existing entries in `target` win on conflict (parent file overrides included content).
+/// Services / volumes / networks / secrets / configs / models from `other` are
+/// added; existing entries in `target` win on conflict (parent file overrides
+/// included content).
 pub(super) fn merge_compose_file(target: &mut ComposeFile, other: ComposeFile) {
 	for (k, v) in other.services {
 		target.services.entry(k).or_insert(v);
@@ -25,6 +26,9 @@ pub(super) fn merge_compose_file(target: &mut ComposeFile, other: ComposeFile) {
 	}
 	for (k, v) in other.configs {
 		target.configs.entry(k).or_insert(v);
+	}
+	for (k, v) in other.models {
+		target.models.entry(k).or_insert(v);
 	}
 }
 
@@ -109,6 +113,24 @@ mod tests {
 		// Parent wins on conflict; the included-only secret is added.
 		assert_eq!(target.secrets["tok"].file.as_deref(), Some("parent.txt"));
 		assert_eq!(target.secrets["extra"].file.as_deref(), Some("e.txt"));
+	}
+
+	#[test]
+	fn merge_adds_and_parent_wins_on_model_conflict() {
+		use super::super::types::ModelConfig;
+		let model = |m: &str| ModelConfig {
+			model: Some(m.to_string()),
+			..Default::default()
+		};
+		let mut target = ComposeFile::default();
+		target.models.insert("llm".to_string(), model("parent/m"));
+		let mut other = ComposeFile::default();
+		other.models.insert("llm".to_string(), model("child/m"));
+		other.models.insert("extra".to_string(), model("e/m"));
+		merge_compose_file(&mut target, other);
+		// Parent wins on conflict; the included-only model is added.
+		assert_eq!(target.models["llm"].model.as_deref(), Some("parent/m"));
+		assert_eq!(target.models["extra"].model.as_deref(), Some("e/m"));
 	}
 
 	#[test]

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -182,6 +182,9 @@ fn merge_override(target: &mut ComposeFile, other: ComposeFile) {
 	for (k, v) in other.configs {
 		target.configs.insert(k, v);
 	}
+	for (k, v) in other.models {
+		target.models.insert(k, v);
+	}
 }
 
 /// Parse a compose YAML string (no file I/O).
@@ -284,6 +287,26 @@ mod tests {
 		let yaml = "services:\n  web:\n    image: nginx\n    environment:\n      - A=1\n";
 		let file = parse_str_raw(yaml).unwrap();
 		assert!(file.services["web"].unknown.is_empty());
+	}
+
+	// Multi-file `-f` override merge
+
+	#[test]
+	fn merge_override_adds_models_and_override_wins() {
+		use crate::compose::types::ModelConfig;
+		let model = |m: &str| ModelConfig {
+			model: Some(m.to_string()),
+			..Default::default()
+		};
+		let mut target = ComposeFile::default();
+		target.models.insert("llm".to_string(), model("base/m"));
+		let mut other = ComposeFile::default();
+		other.models.insert("llm".to_string(), model("over/m"));
+		other.models.insert("extra".to_string(), model("e/m"));
+		merge_override(&mut target, other);
+		// Override file wins on conflict; the override-only model is added.
+		assert_eq!(target.models["llm"].model.as_deref(), Some("over/m"));
+		assert_eq!(target.models["extra"].model.as_deref(), Some("e/m"));
 	}
 
 	// YAML merge keys (<<)


### PR DESCRIPTION
## What

Two compose merge-semantics divergences from compose-go, found in the v1.1.1 sweep (#512):

1. **`extends` now unions `depends_on`.** Before, a non-empty overriding `depends_on` replaced the base's entirely — so a service extending a base that depends on `db` and adding `cache` ended up with only `cache`. `merge_service` now merges both maps the same way it already merges `environment`, the override winning per service key. Bare-list entries canonicalize to the default `service_started` condition, matching `DependsOn`'s list-form semantics, so no behavior changes for the common short form.
2. **Top-level `models:` now survives multi-file merges.** It was missing from both `merge_compose_file` (include) and `merge_override` (`-f`), so a `models` block declared in an included or secondary file was silently dropped. Added alongside `volumes`/`networks`/`secrets`/`configs`: included files defer to the parent, later `-f` files override.

## Tests

- `extends_unions_depends_on` — base + extending deps are both kept
- `extends_depends_on_override_wins_on_conflict` — override condition wins on an overlapping key
- `merge_adds_and_parent_wins_on_model_conflict` (include) and `merge_override_adds_models_and_override_wins` (`-f`)

Existing `empty_override_keeps_base_depends_on` still passes. Full lib suite green; fmt clean.

Closes #512