### PR TITLE
build(release): sign installers, cover SBOM/NOTICES in SHA256SUMS, clean build tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,10 @@ jobs:
             podup-windows-arm64.exe \
             podup_*_amd64.deb \
             podup_*_arm64.deb \
+            podup.cdx.json \
+            NOTICES.html \
+            install.sh \
+            install.ps1 \
             > SHA256SUMS
 
       - name: Sign SHA256SUMS and the Debian packages
@@ -302,6 +306,10 @@ jobs:
           # Sign the supply-chain artifacts so consumers can verify them offline.
           "$venv_py" .github/scripts/sign.py podup.cdx.json
           "$venv_py" .github/scripts/sign.py NOTICES.html
+          # Sign the installers so a user pinning PODUP_VERSION can verify the
+          # script they pipe to a shell, not just the binaries it fetches.
+          "$venv_py" .github/scripts/sign.py install.sh
+          "$venv_py" .github/scripts/sign.py install.ps1
 
       - name: Create GitHub Release
         env:
@@ -334,10 +342,12 @@ jobs:
             NOTICES.html \
             NOTICES.html.sig \
             install.sh \
-            install.ps1
+            install.sh.sig \
+            install.ps1 \
+            install.ps1.sig
 
       - name: Remove release artifacts
-        run: rm -f podup-* podup_* podup.cdx.json* NOTICES.html* SHA256SUMS SHA256SUMS.sig
+        run: rm -f podup-* podup_* podup.cdx.json* NOTICES.html* SHA256SUMS SHA256SUMS.sig install.sh.sig install.ps1.sig
 
       - name: Publish to crates.io
         env:

--- a/debian/rules
+++ b/debian/rules
@@ -50,12 +50,20 @@ override_dh_installman:
 	set -e; \
 	ver=$$(dpkg-parsechangelog --show-field Version | sed 's/-[^-]*$$//'); \
 	dat=$$(LC_ALL=C date -u -d "$$(dpkg-parsechangelog --show-field Date)" +'%B %Y'); \
+	cp -p debian/podup.1 debian/podup.1.bak; \
 	sed -i -E "s/\"podup [0-9]+\.[0-9]+\.[0-9]+\"/\"podup $$ver\"/; s/^\.TH PODUP 1 \"[^\"]*\"/.TH PODUP 1 \"$$dat\"/" debian/podup.1; \
-	dh_installman
+	dh_installman; \
+	mv debian/podup.1.bak debian/podup.1
 
 override_dh_auto_clean:
 	cargo clean
 	rm -rf debian/cargo-home
+	# A vendored build writes .cargo/config.toml pointing at vendor/; drop it so a
+	# later non-vendored build does not fail on missing vendored sources.
+	rm -f .cargo/config.toml
+	# Restore the man page if an installman run was interrupted before it could
+	# revert its in-place version stamp.
+	test ! -f debian/podup.1.bak || mv debian/podup.1.bak debian/podup.1
 
 # Generate .cargo/config.toml pointing at the vendor tree (only when vendored).
 debian/cargo-config:

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -49,6 +49,11 @@ a trust anchor, so a verifier (`gh` or `python3` + `cryptography`) must be prese
 at install time. The `--apt` path likewise verifies the keyring package's Ed25519
 signature before installing it as root.
 
+`install.sh` and `install.ps1` are themselves listed in the signed `SHA256SUMS`
+manifest and carry their own `install.sh.sig` / `install.ps1.sig`, so a user
+pinning a version can verify the script before piping it to a shell — the script
+is no longer the one unverifiable link in the chain.
+
 ## The embedded public keys
 
 Each consumer holds **up to two** accepted release keys — an active key plus an


### PR DESCRIPTION
## What

Supply-chain & reproducibility gaps in the release/Debian path (#518), items 1–4. Item 5 stays documented-pending.

1. **Installers are now verifiable.** `install.sh` / `install.ps1` were uploaded as release assets but absent from `SHA256SUMS` and unsigned, so a user pinning `PODUP_VERSION` could not cryptographically verify the script they pipe to a shell. Both are now hashed into the signed manifest, signed, and their `.sig` files uploaded.
2. **SBOM + NOTICES covered by the signed manifest.** `podup.cdx.json` and `NOTICES.html` were signed individually but not in `SHA256SUMS`; added so they verify offline from the manifest alone.
3. **Man-page stamp no longer dirties the tree.** `override_dh_installman` ran `sed -i` on the tracked `debian/podup.1` with no revert. It now stamps a copy and restores the pristine file; `override_dh_auto_clean` also reverts a leftover `.bak` from an interrupted run.
4. **Stale `.cargo/config.toml` removed on clean.** A vendored build leaves it pointing at `vendor/`, breaking a later non-vendored build. `override_dh_auto_clean` now `rm -f`s it.

Item 5 (non-vendored `dpkg-buildpackage` reaching crates.io at build time) needs the air-gapped/reproducible path first and stays tracked in `docs/debian-packaging.md`.

## Verification

- `release.yml` parses as valid YAML; the asset-name contract and the `debian` job (which exercises `clean` and `installman`) run on this PR.
- Signing additions reuse the existing `sign.py` venv flow unchanged.

Closes #518