### PR TITLE
fix(libpod): correct wire keys for extra_hosts, ulimits, volume driver_opts

### DIFF
--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -92,7 +92,9 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub netns: Option<Namespace>,
 
-	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	// Podman's SpecGenerator names this field `hostadd` (there is no `extra_hosts`
+	// key); without the rename every extra_hosts entry is silently dropped.
+	#[serde(rename = "hostadd", skip_serializing_if = "Vec::is_empty", default)]
 	pub extra_hosts: Vec<String>,
 
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -142,7 +144,10 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub resource_limits: Option<LinuxResources>,
 
-	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	// Podman's SpecGenerator names this field `r_limits` (POSIX rlimits); without
+	// the rename every ulimits entry is silently dropped. The per-element shape
+	// (`{type, soft, hard}`) already matches Podman's POSIXRlimit.
+	#[serde(rename = "r_limits", skip_serializing_if = "Vec::is_empty", default)]
 	pub ulimits: Vec<Ulimit>,
 
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -208,4 +213,40 @@ pub struct SpecGenerator {
 	// Storage options
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub storage_opts: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{SpecGenerator, Ulimit};
+
+	#[test]
+	fn extra_hosts_serialize_as_hostadd() {
+		let spec = SpecGenerator {
+			extra_hosts: vec!["db:10.0.0.2".to_string()],
+			..Default::default()
+		};
+		let v = serde_json::to_value(&spec).unwrap();
+		// Podman's SpecGenerator key is `hostadd`; `extra_hosts` matches no field
+		// and is silently dropped.
+		assert_eq!(v["hostadd"][0], "db:10.0.0.2");
+		assert!(v.get("extra_hosts").is_none(), "stale extra_hosts key: {v}");
+	}
+
+	#[test]
+	fn ulimits_serialize_as_r_limits_with_posix_shape() {
+		let spec = SpecGenerator {
+			ulimits: vec![Ulimit {
+				ulimit_type: "nofile".to_string(),
+				soft: 1024,
+				hard: 2048,
+			}],
+			..Default::default()
+		};
+		let v = serde_json::to_value(&spec).unwrap();
+		// Podman's key is `r_limits`; the element shape is POSIXRlimit {type, soft, hard}.
+		assert!(v.get("ulimits").is_none(), "stale ulimits key: {v}");
+		assert_eq!(v["r_limits"][0]["type"], "nofile");
+		assert_eq!(v["r_limits"][0]["soft"], 1024);
+		assert_eq!(v["r_limits"][0]["hard"], 2048);
+	}
 }

--- a/internal/libpod/types/volume.rs
+++ b/internal/libpod/types/volume.rs
@@ -13,9 +13,34 @@ pub struct VolumeCreateOptions {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
-	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
+	// Podman's VolumeCreateOptions carries no json tags, so its body decodes by
+	// Go field name (case-insensitively): the driver-options map is `Options`, not
+	// `driver_opts`. Without this rename volume driver_opts (NFS/CIFS/tmpfs) are
+	// silently dropped while name/driver/labels still match case-insensitively.
+	#[serde(rename = "Options", skip_serializing_if = "HashMap::is_empty", default)]
 	pub driver_opts: HashMap<String, String>,
 
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub labels: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::VolumeCreateOptions;
+
+	#[test]
+	fn driver_opts_serialize_as_options_not_driver_opts() {
+		let mut opts = VolumeCreateOptions {
+			driver: Some("local".to_string()),
+			..Default::default()
+		};
+		opts.driver_opts
+			.insert("type".to_string(), "nfs".to_string());
+		let v = serde_json::to_value(&opts).unwrap();
+		// Podman's VolumeCreateOptions has no json tag on the options map, so the
+		// wire key must be `Options`; `driver_opts` would be silently dropped.
+		assert!(v.get("Options").is_some(), "expected Options key: {v}");
+		assert!(v.get("driver_opts").is_none(), "stale driver_opts key: {v}");
+		assert_eq!(v["Options"]["type"], "nfs");
+	}
 }


### PR DESCRIPTION
## What

Three libpod request fields serialized under keys Podman 5.x does not recognize, so the values were **silently dropped** — `up()` still succeeds, which is why the integration suite never caught it. All three verified against the Podman 5.4.2 source (#510).

| field | was | Podman 5.x key | source |
|---|---|---|---|
| `extra_hosts` | `extra_hosts` | `hostadd` | `ContainerNetworkConfig.HostAdd json:"hostadd"` (specgen.go) — no `extra_hosts` field exists |
| `ulimits` | `ulimits` | `r_limits` | `ContainerResourceConfig.Rlimits json:"r_limits"`, element `POSIXRlimit{type,soft,hard}` (already matched) |
| volume `driver_opts` | `driver_opts` | `Options` | `VolumeCreateOptions` has **no json tags**; `json.Decode` matches Go field names case-insensitively, so `name`/`driver`/`labels` worked but `driver_opts` matched no field |

Since the old keys are provably ignored by Podman, these fixes cannot regress a currently-working field — they restore features that were inert (`extra_hosts:`, `ulimits:`, and volume `driver_opts:` for NFS/CIFS/tmpfs).

## Tests

Wire-format regression tests assert each field serializes under the Podman key and not the stale one (`extra_hosts_serialize_as_hostadd`, `ulimits_serialize_as_r_limits_with_posix_shape`, `driver_opts_serialize_as_options_not_driver_opts`). These guard the contract in CI without a running Podman.

## Not in this PR

The remaining #510 items are structural, not key renames, and warrant on-Podman-5 `inspect` validation before landing — left tracked in #510:
- `security_opt` must be **decomposed** into `selinux_opts`/`apparmor_profile`/`seccomp_profile_path`/`no_new_privileges`/`mask`/`unmask` (no `security_opt` field exists — currently all dropped, a security-relevant gap).
- `device_cgroup_rule` expects `[]LinuxDeviceCgroup`, not `[]string` (a non-empty `device_cgroup_rules:` would error).
- `cdi_devices` has no SpecGenerator field in 5.x; CDI names must be injected via the `devices` array.

Refs #510