### PR TITLE
fix(libpod): decompose security_opt, structure device_cgroup_rule, route CDI devices

### DIFF
--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -22,6 +22,7 @@ use super::container_fields::{
 	build_blkio_config, build_label_file_labels, parse_device, resolve_container_labels,
 	warn_swarm_only_deploy,
 };
+use super::container_security::{cdi_device, parse_device_cgroup_rule, parse_security_opts};
 use super::network::resolve_network_mode;
 use super::volume_mounts::build_mounts_all;
 use super::Engine;
@@ -138,7 +139,24 @@ impl Engine {
 		let ulimits = build_ulimits(service);
 
 		// --- Devices ---
-		let devices: Vec<_> = service.devices.iter().map(|s| parse_device(s)).collect();
+		let mut devices: Vec<_> = service.devices.iter().map(|s| parse_device(s)).collect();
+		// CDI device names ride in the same array; Podman pulls them out by path.
+		devices.extend(cdi_devices(service).into_iter().map(cdi_device));
+
+		// --- Security options (decomposed onto SpecGenerator fields) ---
+		let security = parse_security_opts(service);
+
+		// --- Device cgroup rules (parsed to structured form; skip malformed) ---
+		let device_cgroup_rule = service
+			.device_cgroup_rules
+			.iter()
+			.filter_map(|r| {
+				parse_device_cgroup_rule(r).or_else(|| {
+					tracing::warn!("device_cgroup_rules entry '{r}' is malformed and is ignored");
+					None
+				})
+			})
+			.collect();
 
 		// --- Namespace modes ---
 		let pidns = service.pid.as_deref().map(Namespace::parse);
@@ -204,7 +222,12 @@ impl Engine {
 			cap_drop: service.cap_drop.clone(),
 			privileged: service.privileged,
 			read_only_filesystem: service.read_only,
-			security_opt: service.security_opt.clone(),
+			selinux_opts: security.selinux_opts,
+			apparmor_profile: security.apparmor_profile,
+			seccomp_profile_path: security.seccomp_profile_path,
+			no_new_privileges: security.no_new_privileges,
+			mask: security.mask,
+			unmask: security.unmask,
 			sysctl,
 			expose,
 			portmappings,
@@ -233,8 +256,7 @@ impl Engine {
 			restart_policy,
 			restart_tries,
 			devices,
-			cdi_devices: cdi_devices(service),
-			device_cgroup_rule: service.device_cgroup_rules.clone(),
+			device_cgroup_rule,
 			groups: service.group_add.clone(),
 			oom_score_adj: service.oom_score_adj,
 			runtime: service.runtime.clone(),

--- a/internal/engine/container_security.rs
+++ b/internal/engine/container_security.rs
@@ -1,0 +1,181 @@
+//! Security/device builders that translate compose fields onto the dedicated
+//! Podman SpecGenerator fields: `security_opt` decomposition, `device_cgroup_rules`
+//! parsing, and CDI device injection. Podman 5.x has no `security_opt` or
+//! `cdi_devices` SpecGenerator field, and `device_cgroup_rule` is structured, not
+//! a string list — sending the compose shapes verbatim silently drops them (or,
+//! for cgroup rules, fails the request), so each is converted here.
+
+use tracing::warn;
+
+use crate::compose::types::Service;
+use crate::libpod::types::container::{LinuxDevice, LinuxDeviceCgroup};
+
+/// Build a `LinuxDevice` carrying a CDI qualified name (e.g. `nvidia.com/gpu=all`).
+///
+/// Podman 5.x has no SpecGenerator CDI field: `ExtractCDIDevices` scans the
+/// `devices` array and pulls out any entry whose `path` is a CDI qualified name,
+/// ignoring the major/minor/type fields entirely. So the name rides in as the
+/// device path with the device-node fields left zeroed.
+pub(crate) fn cdi_device(name: String) -> LinuxDevice {
+	LinuxDevice {
+		path: name,
+		device_type: String::new(),
+		major: 0,
+		minor: 0,
+		file_mode: None,
+		uid: None,
+		gid: None,
+	}
+}
+
+/// Decomposed `security_opt:` values, matching Podman's SpecGenerator security
+/// fields (it has no single `security_opt` field — see [`parse_security_opts`]).
+#[derive(Default)]
+pub(crate) struct SecurityOptions {
+	pub selinux_opts: Vec<String>,
+	pub apparmor_profile: Option<String>,
+	pub seccomp_profile_path: Option<String>,
+	pub no_new_privileges: Option<bool>,
+	pub mask: Vec<String>,
+	pub unmask: Vec<String>,
+}
+
+/// Split each compose `security_opt:` entry onto the dedicated SpecGenerator
+/// field Podman expects. Compose accepts both `:` and `=` separators; the value
+/// is taken after the first one. Mirrors Podman's own `--security-opt` parser:
+/// `mask` is colon-split, the rest take the value whole.
+pub(crate) fn parse_security_opts(service: &Service) -> SecurityOptions {
+	let mut out = SecurityOptions::default();
+	for opt in &service.security_opt {
+		let (key, val) = match opt.find([':', '=']) {
+			Some(i) => (&opt[..i], &opt[i + 1..]),
+			None => (opt.as_str(), ""),
+		};
+		match key {
+			"no-new-privileges" => {
+				out.no_new_privileges = Some(val.is_empty() || val.eq_ignore_ascii_case("true"));
+			}
+			"label" => out.selinux_opts.push(val.to_string()),
+			"apparmor" => out.apparmor_profile = Some(val.to_string()),
+			"seccomp" => out.seccomp_profile_path = Some(val.to_string()),
+			"mask" => out.mask.extend(val.split(':').map(str::to_string)),
+			"unmask" => out.unmask.push(val.to_string()),
+			other => warn!("security_opt '{other}' has no SpecGenerator field and is ignored"),
+		}
+	}
+	out
+}
+
+/// Parse one `device_cgroup_rules:` entry (`"<type> <major>:<minor> <access>"`,
+/// e.g. `c 1:3 rwm` or `a *:* rwm`) into the structured `LinuxDeviceCgroup`
+/// Podman expects. `*` means "all" (a `None` major/minor). Returns `None` on a
+/// malformed rule so the caller can warn and skip it rather than send a body
+/// Podman rejects.
+pub(crate) fn parse_device_cgroup_rule(rule: &str) -> Option<LinuxDeviceCgroup> {
+	let mut fields = rule.split_whitespace();
+	let device_type = fields.next()?;
+	let major_minor = fields.next()?;
+	let access = fields.next()?;
+	if fields.next().is_some() {
+		return None;
+	}
+	let (major, minor) = major_minor.split_once(':')?;
+	let num = |s: &str| -> Option<Option<i64>> {
+		if s == "*" {
+			Some(None)
+		} else {
+			s.parse::<i64>().ok().map(Some)
+		}
+	};
+	Some(LinuxDeviceCgroup {
+		allow: true,
+		device_type: Some(device_type.to_string()),
+		major: num(major)?,
+		minor: num(minor)?,
+		access: Some(access.to_string()),
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn svc_with_security(opts: &[&str]) -> Service {
+		Service {
+			security_opt: opts.iter().map(|s| s.to_string()).collect(),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn security_opts_decompose_each_kind() {
+		// Compose colon-form and equals-form both parse.
+		let svc = svc_with_security(&[
+			"no-new-privileges:true",
+			"label=type:container_t",
+			"apparmor:my-profile",
+			"seccomp=unconfined",
+			"mask=/proc/kcore:/proc/timer_list",
+			"unmask:ALL",
+		]);
+		let s = parse_security_opts(&svc);
+		assert_eq!(s.no_new_privileges, Some(true));
+		assert_eq!(s.selinux_opts, vec!["type:container_t".to_string()]);
+		assert_eq!(s.apparmor_profile.as_deref(), Some("my-profile"));
+		assert_eq!(s.seccomp_profile_path.as_deref(), Some("unconfined"));
+		// mask is colon-split like Podman's own parser; unmask is kept whole.
+		assert_eq!(
+			s.mask,
+			vec!["/proc/kcore".to_string(), "/proc/timer_list".to_string()]
+		);
+		assert_eq!(s.unmask, vec!["ALL".to_string()]);
+	}
+
+	#[test]
+	fn no_new_privileges_bare_is_true_and_false_parses() {
+		assert_eq!(
+			parse_security_opts(&svc_with_security(&["no-new-privileges"])).no_new_privileges,
+			Some(true)
+		);
+		assert_eq!(
+			parse_security_opts(&svc_with_security(&["no-new-privileges=false"])).no_new_privileges,
+			Some(false)
+		);
+	}
+
+	#[test]
+	fn unknown_security_opt_is_skipped_not_panicked() {
+		let s = parse_security_opts(&svc_with_security(&["proc-opts=nosuid"]));
+		assert!(s.selinux_opts.is_empty() && s.apparmor_profile.is_none());
+	}
+
+	#[test]
+	fn device_cgroup_rule_parses_numbers_and_wildcards() {
+		let r = parse_device_cgroup_rule("c 1:3 rwm").unwrap();
+		assert!(r.allow);
+		assert_eq!(r.device_type.as_deref(), Some("c"));
+		assert_eq!(r.major, Some(1));
+		assert_eq!(r.minor, Some(3));
+		assert_eq!(r.access.as_deref(), Some("rwm"));
+
+		let wild = parse_device_cgroup_rule("a *:* rwm").unwrap();
+		assert_eq!(wild.major, None);
+		assert_eq!(wild.minor, None);
+	}
+
+	#[test]
+	fn malformed_device_cgroup_rule_is_none() {
+		assert!(parse_device_cgroup_rule("c 1:3").is_none()); // missing access
+		assert!(parse_device_cgroup_rule("c 13 rwm").is_none()); // no major:minor split
+		assert!(parse_device_cgroup_rule("c x:3 rwm").is_none()); // non-numeric, non-*
+		assert!(parse_device_cgroup_rule("c 1:3 rwm extra").is_none()); // too many fields
+	}
+
+	#[test]
+	fn cdi_device_carries_name_as_path() {
+		let d = cdi_device("nvidia.com/gpu=all".to_string());
+		assert_eq!(d.path, "nvidia.com/gpu=all");
+		assert_eq!(d.major, 0);
+		assert_eq!(d.minor, 0);
+	}
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -16,6 +16,7 @@ pub use lock::ProjectLock;
 pub use query::{ExecOptions, ImagesOptions, LogsOptions, PsOptions};
 mod container_config;
 mod container_fields;
+mod container_security;
 mod health;
 mod lifecycle;
 mod lock;

--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -73,8 +73,27 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub read_only_filesystem: Option<bool>,
 
+	// Podman's SpecGenerator has no `security_opt` field; the compose list is
+	// decomposed into these dedicated fields. A plain `security_opt` array is
+	// silently ignored, so every option (incl. no-new-privileges/seccomp/apparmor)
+	// would otherwise be dropped.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	pub security_opt: Vec<String>,
+	pub selinux_opts: Vec<String>,
+
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub apparmor_profile: Option<String>,
+
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub seccomp_profile_path: Option<String>,
+
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub no_new_privileges: Option<bool>,
+
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	pub mask: Vec<String>,
+
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	pub unmask: Vec<String>,
 
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub sysctl: HashMap<String, String>,
@@ -172,16 +191,16 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart_tries: Option<u64>,
 
-	// Devices
+	// Devices. Podman 5.x has no SpecGenerator CDI field; CDI device names (e.g.
+	// `nvidia.com/gpu=all`) are recognized by ExtractCDIDevices from this array by
+	// their qualified path, so they are appended here as `LinuxDevice` entries.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub devices: Vec<LinuxDevice>,
 
-	/// CDI device names (e.g. `nvidia.com/gpu=all`) for GPU/accelerator access.
+	// Podman expects structured cgroup rules ([]LinuxDeviceCgroup), not strings; a
+	// string array would fail to deserialize.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	pub cdi_devices: Vec<String>,
-
-	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	pub device_cgroup_rule: Vec<String>,
+	pub device_cgroup_rule: Vec<LinuxDeviceCgroup>,
 
 	// Groups
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -217,7 +236,61 @@ pub struct SpecGenerator {
 
 #[cfg(test)]
 mod tests {
-	use super::{SpecGenerator, Ulimit};
+	use super::{LinuxDeviceCgroup, SpecGenerator, Ulimit};
+
+	#[test]
+	fn security_fields_serialize_decomposed_not_as_security_opt() {
+		let spec = SpecGenerator {
+			selinux_opts: vec!["disable".to_string()],
+			apparmor_profile: Some("prof".to_string()),
+			seccomp_profile_path: Some("unconfined".to_string()),
+			no_new_privileges: Some(true),
+			mask: vec!["/proc/kcore".to_string()],
+			unmask: vec!["ALL".to_string()],
+			..Default::default()
+		};
+		let v = serde_json::to_value(&spec).unwrap();
+		// SpecGenerator has no `security_opt` field — the value must arrive decomposed.
+		assert!(
+			v.get("security_opt").is_none(),
+			"stale security_opt key: {v}"
+		);
+		assert_eq!(v["selinux_opts"][0], "disable");
+		assert_eq!(v["apparmor_profile"], "prof");
+		assert_eq!(v["seccomp_profile_path"], "unconfined");
+		assert_eq!(v["no_new_privileges"], true);
+		assert_eq!(v["mask"][0], "/proc/kcore");
+		assert_eq!(v["unmask"][0], "ALL");
+	}
+
+	#[test]
+	fn device_cgroup_rule_serializes_as_struct_array() {
+		let spec = SpecGenerator {
+			device_cgroup_rule: vec![LinuxDeviceCgroup {
+				allow: true,
+				device_type: Some("c".to_string()),
+				major: Some(1),
+				minor: None,
+				access: Some("rwm".to_string()),
+			}],
+			..Default::default()
+		};
+		let v = serde_json::to_value(&spec).unwrap();
+		// Podman expects []LinuxDeviceCgroup objects, not strings.
+		assert_eq!(v["device_cgroup_rule"][0]["allow"], true);
+		assert_eq!(v["device_cgroup_rule"][0]["type"], "c");
+		assert_eq!(v["device_cgroup_rule"][0]["major"], 1);
+		// minor=None must be omitted (means "all").
+		assert!(v["device_cgroup_rule"][0].get("minor").is_none());
+		assert_eq!(v["device_cgroup_rule"][0]["access"], "rwm");
+	}
+
+	#[test]
+	fn no_cdi_devices_key_is_emitted() {
+		// Podman 5.x has no cdi_devices field; CDI names ride in `devices`.
+		let v = serde_json::to_value(SpecGenerator::default()).unwrap();
+		assert!(v.get("cdi_devices").is_none(), "stale cdi_devices key: {v}");
+	}
 
 	#[test]
 	fn extra_hosts_serialize_as_hostadd() {


### PR DESCRIPTION
## What

Completes #510 — the three structural wire-shape fixes (the pure renames landed in #525). All verified against the Podman 5.4.2 source; each was a silent drop (or a rejected body) because the compose shape doesn't match Podman's SpecGenerator.

| field | problem | fix |
|---|---|---|
| `security_opt` | **no such SpecGenerator field** — the whole array was dropped, incl. `no-new-privileges`/`seccomp`/`apparmor` (silent security gap) | decompose into `selinux_opts` / `apparmor_profile` / `seccomp_profile_path` / `no_new_privileges` / `mask` / `unmask` |
| `device_cgroup_rule` | field is `[]LinuxDeviceCgroup`, podup sent `[]string` → deserialize error | parse `"<type> <major>:<minor> <access>"` → struct (`*` ⇒ all); warn+skip malformed |
| `cdi_devices` | no such field in 5.x — GPU CDI reservations dropped | append CDI names as `devices` (`LinuxDevice`) entries; `ExtractCDIDevices` picks them up by qualified path |

### Source basis
- `pkg/specgenutil/specgen.go` — `--security-opt` parser: `label`→SelinuxOpts (whole), `apparmor`/`seccomp`→profile, `no-new-privileges`→bool, `mask`→colon-split, `unmask`→whole. podup's `parse_security_opts` mirrors it (and accepts compose's `:` form).
- `pkg/specgen/generate/container_create.go` — `ExtractCDIDevices` keys only on `device.Path` via `parser.IsQualifiedName`; major/minor/type ignored.
- `pkg/specgen/specgen.go` — `DeviceCgroupRule []spec.LinuxDeviceCgroup`.

## Tests

New `container_security` module + tests: security-opt decomposition (both separators, bare/explicit no-new-privileges, unknown-skipped), cgroup-rule parsing (numbers, `*`, malformed), CDI device shape. Spec serialization tests assert the decomposed/struct wire shapes and that no stale `security_opt`/`cdi_devices` key is emitted. These lock the wire contract in CI without a Podman.

## Follow-up

An on-Podman-5 `podman container inspect` e2e (per the issue) is still worthwhile to confirm end-to-end, but the silent-drop bug class is now guarded at the wire level.

Closes #510