### PR TITLE
Ignore local tooling scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@ debian/files
 debian/*.substvars
 debian/*.log
 .cargo/config.toml
+
+# Agent / AI-tool artifacts — never commit (zero AI trace).
+.claude/
+.agents/
+.cursor/
+.aider*
+.continue/
+.playwright-mcp/
+**/*-mcp/


### PR DESCRIPTION
Some local editor and tooling scratch directories were ignored only by my machine-global gitignore, so a clone or CI without it could accidentally commit them. Ignoring them in-repo makes the protection portable across machines.