### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+podup (1.2.0) unstable; urgency=medium
+
+  * quadlet: map `security_opt` mask/unmask to the corresponding [Container]
+    keys and warn on fields that have no Quadlet equivalent instead of dropping
+    them silently.
+  * libpod: correct the wire keys for `extra_hosts`, `ulimits` and volume
+    `driver_opts`, and decompose `security_opt`, structure `device_cgroup_rule`
+    and route CDI devices natively, so these compose fields reach Podman 5
+    intact.
+  * compose: surface `network_mode: bridge`, `aux_addresses` and
+    `restart_policy` fields that were being dropped; union `depends_on` across
+    `extends` and merge top-level models correctly.
+  * engine: wait on the first replica when a scaled service is referenced by
+    `depends_on`, so scaled startup ordering matches docker-compose.
+  * packaging: drop the no-op `CARGO_UNSTABLE_OFFLINE`, refresh the control
+    description, and inherit the org-wide community-health files instead of
+    carrying stale local copies.
+  * release: sign the installers, cover the SBOM and NOTICES in SHA256SUMS, and
+    clean the build tree before packaging.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Mon, 22 Jun 2026 12:00:00 -0500
+
 podup (1.1.1) unstable; urgency=medium
 
   * engine: drive healthchecks on demand instead of relying on Podman's

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 1.1.1" "User Commands"
+.TH PODUP 1 "June 2026" "podup 1.2.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS


### PR DESCRIPTION
Minor release rolling up everything on develop since v1.1.1.

Highlights:
- libpod: correct wire keys for `extra_hosts`, `ulimits`, volume `driver_opts`; decompose `security_opt`, structure `device_cgroup_rule`, route CDI devices natively (#525, #526)
- quadlet: map `security_opt` mask/unmask and warn on dropped fields (#523)
- compose: surface `network_mode: bridge`, `aux_addresses`, `restart_policy` drops; union `depends_on` across `extends` (#521, #522)
- engine: wait on first replica for scaled `depends_on` (#515)
- packaging/release: signed installers, SBOM/NOTICES in SHA256SUMS, control + community-health cleanup (#519, #524)

Bumps Cargo.toml, Cargo.lock, debian/changelog and the man page to 1.2.0.