### PR TITLE
docs: document Podman >= 5.0 requirement, apt distribution path, and security-model updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ flowchart LR
 - 📦 **Single binary** — statically musl-linked on Linux, no runtime dependencies
 - 🦀 **Library too** — embed the parser and engine in your own Rust project
 
+## ✅ Requirements
+
+- **Podman ≥ 5.0** — podup talks to Podman's native libpod REST API (the
+  `/v5.0.0/libpod` surface) and assumes a Podman 5.x engine. Rootless is the
+  default and recommended posture.
+- **Supported platforms:**
+  - **Linux** (x86_64, arm64) — talks to the rootless Podman socket directly.
+  - **macOS** (x86_64, arm64) — via `podman machine` (applehv or vz backend);
+    podup uses the host-side `unix://` socket.
+  - **Windows** (x86_64, arm64) — via `podman machine`; podup uses the host-side
+    `npipe://` named pipe.
+
+The socket must be local: only `unix://` (and `npipe://` on Windows) are
+accepted — remote `tcp://`/`ssh://` endpoints are rejected.
+
 ## 📥 Install
 
 Linux and macOS:

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -14,6 +14,21 @@ list) and translates it into rootless Podman operations over Podman's native
 libpod REST API. It is a single static binary with no daemon and no Python
 runtime, usable both as a standalone docker-compose replacement and as a Rust
 library.
+.PP
+.B podup
+requires
+.B Podman 5.0
+or newer: it targets the
+.B /v5.0.0/libpod
+API surface. The socket must be local \(em a
+.B unix://
+path (or an
+.B npipe://
+pipe on Windows); remote
+.B tcp://
+or
+.B ssh://
+endpoints are rejected.
 .SH GLOBAL OPTIONS
 .TP
 .BR \-f ", " \-\-file " " \fIPATH\fR

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -1,8 +1,11 @@
 # Debian packaging
 
-podup targets inclusion in the official Debian and Ubuntu archives. The
-`debian/` directory in this repository builds a working package today; this
-page tracks what that gives us and what the official archive still requires.
+podup is distributed for Debian and Ubuntu through the self-hosted signed apt
+repository at [`apt.glyndor.net`](https://apt.glyndor.net) — that is the
+supported path, described below. Inclusion in the official Debian/Ubuntu
+archives is explicitly **not** a goal. The `debian/` directory in this
+repository builds the `.deb` that the apt repository serves; this page covers
+how to build it and how it is published.
 
 ## Build a .deb locally
 
@@ -85,24 +88,21 @@ the `Glyndor/apt` repo.
 - `debian/copyright` — DEP-5, Apache-2.0
 - Source format `3.0 (native)` — the repository is upstream
 
-## Path to the official archive (owner actions)
+## Not the official Debian/Ubuntu archive
 
-1. **Fully offline builds** — the archive forbids network access at build
-   time. Options: `debcargo` (packages each crate dependency) or a vendored
-   source tarball. Decision pending; `debcargo` is the route the Debian Rust
-   team maintains.
-2. **ITP bug** — file an *Intent to Package* against `wnpp` from the
-   maintainer's identity.
-3. **Sponsorship** — upload through a Debian Developer (the Rust team's
-   `team+rust@tracker.debian.org` is the natural reviewer for a Rust tool).
-4. **crates.io publication** — the name `podup` is verified available and
-   the crate metadata is in place (`cargo package` verifies clean), so
-   publication is a single `cargo publish` with the owner's registry
-   token. `debcargo` consumes crates.io releases, so publishing first
-   simplifies everything.
-5. **Stability promise** — official packages imply SemVer discipline, which
-   `1.0.0` (already shipped) puts in force: the CLI surface is stable and
-   breaking changes wait for a major bump.
+Uploading podup to the official Debian or Ubuntu archive is **not** a goal. The
+self-hosted `apt.glyndor.net` repository above is the supported distribution
+channel: it gives Debian/Ubuntu users `apt`-managed installs and upgrades
+without the archive's process overhead (an ITP bug, a Debian Developer sponsor,
+and fully offline `debcargo`/vendored builds), and it stays in lockstep with
+each release on its own schedule.
+
+The packaging mechanics carry over regardless of channel:
+
+- **SemVer discipline** — `1.0.0` (already shipped) is in force: the CLI surface
+  is stable and breaking changes wait for a major bump.
+- **crates.io** — the crate metadata is in place (`cargo package` verifies
+  clean) for publishing podup as a library; this is independent of the `.deb`.
 
 ## Versioning
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -15,6 +15,12 @@ separately in [self-update.md](self-update.md).
   them. Fields that assume more (`privileged`, `oom_kill_disable`,
   `mem_swappiness`, `cpu_rt_*`) are forwarded but warned about, since they are
   reduced or ineffective rootless.
+- The libpod socket is **strictly local**. Only a `unix://` socket path (or an
+  `npipe://` named pipe on Windows) is accepted, whether it comes from
+  `--socket`, `PODMAN_SOCKET`, `DOCKER_HOST`, or auto-detection. Remote schemes
+  (`tcp://`, `ssh://`, `http(s)://`, `fd://`) are **rejected fail-closed** —
+  podup never connects to a remote engine, so the socket boundary is always a
+  local one.
 - podup keeps **no persistent state** of its own outside the Podman objects it
   creates and a per-project advisory lock file under the user's runtime
   directory.
@@ -23,7 +29,7 @@ separately in [self-update.md](self-update.md).
 
 | Boundary | Trusted? | Notes |
 |----------|----------|-------|
-| Podman socket (`PODMAN_SOCKET`/`DOCKER_HOST`) | Trusted | Whoever can reach it controls the engine; this is the primary boundary. |
+| Podman socket (`PODMAN_SOCKET`/`DOCKER_HOST`) | Trusted, local-only | Whoever can reach it controls the engine; this is the primary boundary. Only `unix://`/`npipe://` are accepted — remote schemes are rejected fail-closed. |
 | Compose file and its referenced files | **Trusted input** | Treated like a Makefile (see below). |
 | Release artifacts (`podup update`, installer) | Untrusted transport | Verified against an embedded Ed25519 key + provenance attestation, fail-closed. |
 | Container filesystem (e.g. `cp` archives) | Untrusted | Tar extraction refuses path-traversal (zip-slip) entries. |
@@ -37,6 +43,25 @@ file (`extends.file`, `env_file`, `label_file`, `include`) may reference paths
 outside the project directory, including `../`. Do **not** run podup on a compose
 file from an untrusted source. (`include` still rejects absolute paths as
 non-portable, but this is hardening, not a security guarantee.)
+
+## Container hardening (compose security keys)
+
+The compose keys that constrain a container are translated onto Podman's
+`SpecGenerator` and take effect on the running container — they are not silently
+dropped. Everything below remains bounded by the rootless ceiling: a key can
+only tighten, never widen, what the launching user already has.
+
+- `security_opt` is parsed into the matching SpecGenerator fields:
+  - `no-new-privileges` → `no_new_privileges`
+  - `seccomp=<profile.json>` (and `seccomp=unconfined`) → `seccomp_profile_path`
+  - `apparmor=<profile>` → `apparmor_profile`
+  - `label=<opt>` (SELinux user/role/type/level, or `label=disable`) →
+    `selinux_opts`
+  - `mask=<paths>` / `unmask=<paths>` → `mask` / `unmask`
+- `device_cgroup_rules` entries are parsed and applied as the container's device
+  cgroup rules (a malformed entry is warned about and skipped, not fatal).
+- CDI devices (Container Device Interface, e.g. `nvidia.com/gpu=all`) requested
+  under `devices:` are passed through to Podman, which resolves them by name.
 
 ## Secret and config handling
 


### PR DESCRIPTION
Closes #551