### PR TITLE
docs: document undocumented public items across internal/

### DIFF
--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -10,6 +10,7 @@ mod types;
 pub(crate) use commands::Commands;
 pub(crate) use types::{ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
 
+/// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
 #[derive(Parser)]
 #[command(name = "podup", version)]
 pub(crate) struct Cli {

--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -1,8 +1,8 @@
 //! `include:` directive — merging externally included compose files.
 //!
 //! Included files are merged into the parent: services, volumes, networks,
-//! secrets, and configs from the included file are added only if the key does
-//! not already exist in the parent (parent wins on conflict).
+//! secrets, configs, and models from the included file are added only if the
+//! key does not already exist in the parent (parent wins on conflict).
 
 use super::types::ComposeFile;
 

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -280,7 +280,7 @@ impl BuildConfig {
 		}
 	}
 
-	/// `build.additional_contexts` — named extra build contexts (`name -> value`).
+	/// `build.additional_contexts` — named extra build contexts (`name -> source`).
 	pub fn additional_contexts(&self) -> Vec<(String, String)> {
 		match self {
 			BuildConfig::Context(_) => Vec::new(),

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -17,16 +17,23 @@ pub struct DevelopConfig {
 /// A single `develop.watch` rule: a path to watch, an action to take, and optional ignore filters.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct WatchRule {
+	/// Host path watched for changes, resolved relative to the project base directory.
 	pub path: String,
+	/// What to do when a watched file changes.
 	pub action: WatchAction,
+	/// Sync destination inside the container; sync actions are skipped when absent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub target: Option<String>,
+	/// Glob patterns (relative to the base dir) whose matches are excluded from triggering.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ignore: Vec<String>,
+	/// Glob allow-list; when non-empty, only matching paths trigger the rule.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub include: Vec<String>,
+	/// When true, copy `path` to `target` once at startup before watching begins.
 	#[serde(default)]
 	pub initial_sync: bool,
+	/// Command run inside the container for the `sync+exec` action.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub exec: Option<WatchExec>,
 	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
@@ -36,11 +43,16 @@ pub struct WatchRule {
 /// Action triggered by a `develop.watch` rule: `sync`, `rebuild`, `restart`, `sync+restart`, or `sync+exec`.
 #[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
 pub enum WatchAction {
+	/// `sync` — copy changed files from `path` into the container at `target`.
 	#[default]
 	Sync,
+	/// `rebuild` — rebuild the service image and recreate the container.
 	Rebuild,
+	/// `restart` — restart the running container without rebuilding.
 	Restart,
+	/// `sync+restart` — sync changed files, then restart the container.
 	SyncAndRestart,
+	/// `sync+exec` — sync changed files, then run the rule's `exec` command in the container.
 	SyncAndExec,
 }
 
@@ -63,6 +75,7 @@ impl<'de> Deserialize<'de> for WatchAction {
 /// Exec command run as part of a `sync+exec` watch action.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchExec {
+	/// Command and arguments executed in the container (argv form, not shell-parsed).
 	pub command: Vec<String>,
 }
 

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -32,22 +32,31 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct SecretConfig {
+	/// Host file supplying the secret value; mutually exclusive with `content` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
+	/// When true, the secret must already exist in the engine; no value source is provided here.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub external: Option<bool>,
+	/// Engine-side name; overrides the map key, and names the pre-existing secret when `external`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Inline secret value; mutually exclusive with `file` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub content: Option<String>,
+	/// Name of an environment variable supplying the value; mutually exclusive with `file` and `content`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub environment: Option<String>,
+	/// Secret driver name (Swarm-style); parsed for fidelity, not honored by podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Options passed to `driver`.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub driver_opts: HashMap<String, String>,
+	/// Labels attached to the secret.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Driver used to render the secret as a template before delivery.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub template_driver: Option<String>,
 }
@@ -56,22 +65,31 @@ pub struct SecretConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ConfigConfig {
+	/// Host file supplying the config value; mutually exclusive with `content` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
+	/// When true, the config must already exist in the engine; no value source is provided here.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub external: Option<bool>,
+	/// Engine-side name; overrides the map key, and names the pre-existing config when `external`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Inline config value; mutually exclusive with `file` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub content: Option<String>,
+	/// Name of an environment variable supplying the value; mutually exclusive with `file` and `content`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub environment: Option<String>,
+	/// Labels attached to the config.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Config driver name (Swarm-style); parsed for fidelity, not honored by podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Options passed to `driver`.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub driver_opts: HashMap<String, String>,
+	/// Driver used to render the config as a template before delivery.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub template_driver: Option<String>,
 }
@@ -83,14 +101,19 @@ pub struct ConfigConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ModelConfig {
+	/// OCI reference of the model artifact to pull.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub model: Option<String>,
+	/// Engine-side name; overrides the map key.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Maximum context window, in tokens.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub context_size: Option<u64>,
+	/// Raw flags forwarded to the model runner's inference engine.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub runtime_flags: Vec<String>,
+	/// Extra variables injected into the model runtime environment.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub model_variables: HashMap<String, String>,
 	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
@@ -102,20 +125,28 @@ pub struct ModelConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ComposeFile {
+	/// Top-level `version:`. Deprecated by the Compose Spec; parsed and round-tripped but otherwise ignored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub version: Option<String>,
+	/// Project name; overrides the directory-derived default.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Other Compose files merged into this project before processing.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub include: Vec<IncludeConfig>,
+	/// Service definitions, keyed by service name.
 	#[serde(default)]
 	pub services: IndexMap<String, Service>,
+	/// Named volumes; a `None` value is a default-configured volume (`name:` with no body).
 	#[serde(default)]
 	pub volumes: IndexMap<String, Option<VolumeConfig>>,
+	/// Named networks; a `None` value is a default-configured network (`name:` with no body).
 	#[serde(default)]
 	pub networks: IndexMap<String, Option<NetworkConfig>>,
+	/// Named secrets available to services.
 	#[serde(default)]
 	pub secrets: IndexMap<String, SecretConfig>,
+	/// Named configs available to services.
 	#[serde(default)]
 	pub configs: IndexMap<String, ConfigConfig>,
 	/// Top-level `models:` element (Compose v2.38). Parsed for fidelity; podup

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -22,197 +22,367 @@ use super::{
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct Service {
+	/// `image:` — container image reference (`name[:tag|@digest]`) to run; if
+	/// absent, `build:` must supply one.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image: Option<String>,
+	/// `build:` — build the image from source instead of (or in addition to)
+	/// pulling `image:`; a string shorthand is the build context path.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub build: Option<BuildConfig>,
+	/// `extends:` — inherit configuration from another service (optionally in
+	/// another file); merged before this service's own keys are applied.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub extends: Option<ExtendsConfig>,
+	/// `command:` — overrides the image `CMD`; string (shell-parsed) or list (exec
+	/// form, no shell).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub command: Option<Command>,
+	/// `entrypoint:` — overrides the image `ENTRYPOINT` and resets any image
+	/// `CMD`; string (shell form) or list (exec form).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub entrypoint: Option<Command>,
 
+	/// `ports:` — published host↔container port mappings (`[host:]container[/proto]`
+	/// or long form); exposes the port outside the container network.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ports: Vec<PortMapping>,
+	/// `expose:` — ports made reachable to linked services only, without
+	/// publishing them on the host.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub expose: Vec<String>,
 
+	/// `environment:` — environment variables set in the container; map or
+	/// `KEY=VALUE` list. Takes precedence over `env_file:`.
 	#[serde(default)]
 	pub environment: EnvVars,
+	/// `env_file:` — file(s) of `KEY=VALUE` lines loaded into the environment;
+	/// overridden by `environment:` on key collision.
 	#[serde(default)]
 	pub env_file: EnvFile,
+	/// `volumes:` — bind mounts, named volumes, and anonymous volumes (short
+	/// `src:dst[:opts]` or long form).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub volumes: Vec<VolumeMount>,
+	/// `tmpfs:` — paths mounted as an in-memory tmpfs inside the container; single
+	/// path or list.
 	#[serde(default)]
 	pub tmpfs: StringOrList,
+	/// `volumes_from:` — mount all volumes from another service or container
+	/// (`name[:ro|rw]`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub volumes_from: Vec<String>,
+	/// `configs:` — top-level configs granted to this service, mounted as files
+	/// (default `/<config-name>`) or exposed per the long form.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub configs: Vec<ServiceConfigRef>,
+	/// `secrets:` — top-level secrets granted to this service, mounted under
+	/// `/run/secrets/` (or the long-form target).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub secrets: Vec<ServiceSecretRef>,
 
+	/// `networks:` — networks this service joins, with optional per-network
+	/// aliases/IPs; absent means the project's default network.
 	#[serde(default)]
 	pub networks: ServiceNetworks,
+	/// `hostname:` — the container's own hostname (its `/etc/hostname` and
+	/// in-container `uname -n`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub hostname: Option<String>,
+	/// `domainname:` — the container's NIS/DNS domain (fully-qualified
+	/// hostname suffix).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub domainname: Option<String>,
+	/// `mac_address:` — fixed MAC for the container's primary interface; a
+	/// documented divergence under rootless Podman where it may be ignored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mac_address: Option<String>,
+	/// `links:` — legacy service links (`service[:alias]`) adding hostname
+	/// entries; superseded by shared networks.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub links: Vec<String>,
+	/// `external_links:` — link to containers outside this compose project
+	/// (`container[:alias]`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub external_links: Vec<String>,
+	/// `extra_hosts:` — extra `/etc/hosts` entries (`hostname:ip`); accepts the
+	/// list or mapping YAML forms.
 	#[serde(
 		default,
 		deserialize_with = "super::primitives::deserialize_extra_hosts",
 		skip_serializing_if = "Vec::is_empty"
 	)]
 	pub extra_hosts: Vec<String>,
+	/// `dns:` — custom DNS server IP(s) for name resolution; single value or list.
 	#[serde(default)]
 	pub dns: StringOrList,
+	/// `dns_search:` — DNS search domains appended to unqualified names; single
+	/// value or list.
 	#[serde(default)]
 	pub dns_search: StringOrList,
+	/// `dns_opt:` — resolver options written to `/etc/resolv.conf` (e.g.
+	/// `ndots:2`); single value or list.
 	#[serde(default)]
 	pub dns_opt: StringOrList,
+	/// `network_mode:` — networking namespace mode (`bridge`, `host`, `none`,
+	/// `service:NAME`, `container:NAME`); mutually exclusive with `networks:`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub network_mode: Option<String>,
 
+	/// `depends_on:` — start/stop ordering and optional `condition:`
+	/// (`service_started`/`service_healthy`/`service_completed_successfully`)
+	/// dependencies on other services.
 	#[serde(default)]
 	pub depends_on: DependsOn,
+	/// `healthcheck:` — command and timing that determine container health;
+	/// `disable: true` turns off any image-defined check.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub healthcheck: Option<HealthCheck>,
 
+	/// `restart:` — restart policy (`no`/`always`/`on-failure[:max]`/
+	/// `unless-stopped`). Takes precedence over `deploy.restart_policy` when both
+	/// are set.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart: Option<RestartPolicy>,
+	/// `stop_signal:` — signal sent to stop the container (e.g. `SIGTERM`,
+	/// `SIGINT`); default `SIGTERM`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_signal: Option<String>,
+	/// `stop_grace_period:` — duration string (e.g. `10s`, `1m30s`) to wait after
+	/// `stop_signal` before `SIGKILL`; default `10s`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_grace_period: Option<String>,
+	/// `profiles:` — activation profiles; the service starts only when one of
+	/// these profiles is enabled (no profiles = always enabled).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub profiles: Vec<String>,
+	/// `post_start:` — lifecycle hook commands run inside the container right
+	/// after it starts (Compose v2.30+).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub post_start: Vec<LifecycleHook>,
+	/// `pre_stop:` — lifecycle hook commands run inside the container just before
+	/// it is stopped (Compose v2.30+).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub pre_stop: Vec<LifecycleHook>,
 
+	/// `labels:` — metadata labels applied to the container; map or `key=value`
+	/// list.
 	#[serde(default)]
 	pub labels: Labels,
+	/// `annotations:` — OCI annotations on the container; distinct from `labels:`,
+	/// passed through to the runtime.
 	#[serde(default)]
 	pub annotations: Labels,
+	/// `container_name:` — explicit container name overriding the generated
+	/// `<project>_<service>_<n>`; forbids scaling above 1 replica.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub container_name: Option<String>,
+	/// `user:` — user (and optional `:group`) the process runs as, by name or
+	/// numeric `UID[:GID]`; overrides the image `USER`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
+	/// `working_dir:` — working directory for the process; overrides the image
+	/// `WORKDIR`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub working_dir: Option<String>,
+	/// `group_add:` — additional groups (name or GID) the process joins, beyond
+	/// its primary group.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub group_add: Vec<String>,
+	/// `platform:` — target platform for the image (`os[/arch[/variant]]`, e.g.
+	/// `linux/amd64`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub platform: Option<String>,
 
+	/// `cap_add:` — Linux capabilities to grant on top of the runtime default set
+	/// (e.g. `NET_ADMIN`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub cap_add: Vec<String>,
+	/// `cap_drop:` — Linux capabilities to drop from the default set (`ALL` drops
+	/// every capability).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub cap_drop: Vec<String>,
+	/// `security_opt:` — runtime security options (e.g. `label:...`, `seccomp=...`,
+	/// `no-new-privileges:true`, `apparmor=...`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub security_opt: Vec<String>,
+	/// `read_only:` — when `true`, mounts the container's root filesystem
+	/// read-only (writes only via volumes/tmpfs). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub read_only: Option<bool>,
+	/// `privileged:` — when `true`, grants extended host privileges; has reduced
+	/// effect under rootless Podman. Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
+	/// `init:` — when `true`, runs an init process (PID 1) that reaps zombies and
+	/// forwards signals. Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub init: Option<bool>,
+	/// `tty:` — when `true`, allocates a pseudo-TTY for the container (akin to
+	/// `docker run -t`). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub tty: Option<bool>,
+	/// `stdin_open:` — when `true`, keeps stdin open for the container (akin to
+	/// `docker run -i`). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stdin_open: Option<bool>,
 
+	/// `runtime:` — OCI runtime to execute the container (e.g. `runc`, `crun`);
+	/// default is the engine's configured runtime.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub runtime: Option<String>,
+	/// `shm_size:` — size of `/dev/shm` as a size string (e.g. `512m`, `1g`);
+	/// bytes if unitless.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub shm_size: Option<String>,
+	/// `userns_mode:` — user-namespace mode (e.g. `host`, `keep-id`) controlling
+	/// UID/GID mapping into the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub userns_mode: Option<String>,
+	/// `pid:` — PID namespace to share (e.g. `host`, `container:NAME`,
+	/// `service:NAME`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pid: Option<String>,
+	/// `ipc:` — IPC namespace mode (e.g. `host`, `shareable`, `service:NAME`,
+	/// `container:NAME`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipc: Option<String>,
+	/// `uts:` — UTS namespace mode; `host` shares the host's hostname/domain
+	/// namespace.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub uts: Option<String>,
+	/// `cgroup_parent:` — optional parent cgroup under which the container's
+	/// cgroup is created.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup_parent: Option<String>,
+	/// `cgroup:` — cgroup namespace mode (`host` or `private`) for the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup: Option<String>,
 
+	/// `devices:` — host devices exposed to the container
+	/// (`host[:container[:perms]]`, perms a subset of `rwm`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub devices: Vec<String>,
+	/// `device_cgroup_rules:` — explicit device cgroup allow/deny rules (e.g.
+	/// `c 1:3 mr`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_cgroup_rules: Vec<String>,
+	/// `storage_opt:` — per-container storage driver options (e.g. `size`) passed
+	/// to the graph driver.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub storage_opt: HashMap<String, String>,
 
+	/// `scale:` — number of replica containers to run. Takes precedence over
+	/// `deploy.replicas`; a CLI `--scale` override wins over both.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub scale: Option<u32>,
+	/// `cpu_shares:` — relative CPU weight under contention (default `1024`);
+	/// proportional share, not a hard cap like `cpus:`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_shares: Option<u64>,
+	/// `cpu_quota:` — CFS hard cap in microseconds of CPU time per `cpu_period`;
+	/// `cpus:` is the higher-level equivalent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_quota: Option<i64>,
+	/// `cpu_period:` — CFS scheduler period in microseconds against which
+	/// `cpu_quota` is measured (default `100000`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_period: Option<u64>,
+	/// `cpuset:` — explicit CPUs/cores the container may run on (e.g. `0-3`,
+	/// `0,2`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpuset: Option<String>,
+	/// `cpus:` — fractional number of CPUs to allow (e.g. `0.5`); a hard cap
+	/// converted to a CFS quota. Top-level value wins over `deploy.resources`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpus: Option<String>,
+	/// `cpu_count:` — number of usable CPUs (Windows containers); not honored on
+	/// Linux/Podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_count: Option<i64>,
+	/// `cpu_percent:` — usable percentage of available CPU (Windows containers);
+	/// not honored on Linux/Podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_percent: Option<i64>,
+	/// `cpu_rt_runtime:` — real-time CPU runtime per period in microseconds for
+	/// real-time scheduling.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_rt_runtime: Option<i64>,
+	/// `cpu_rt_period:` — real-time scheduler period in microseconds for
+	/// real-time scheduling.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_rt_period: Option<i64>,
+	/// `mem_limit:` — hard memory cap as a size string (e.g. `512m`, `1g`); bytes
+	/// if unitless. Top-level value wins over `deploy.resources.limits.memory`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_limit: Option<String>,
+	/// `memswap_limit:` — total memory + swap limit as a size string; `-1` allows
+	/// unlimited swap.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub memswap_limit: Option<String>,
+	/// `mem_reservation:` — soft memory limit (size string, e.g. `256m`) enforced
+	/// under host memory pressure; must be below `mem_limit`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_reservation: Option<String>,
+	/// `mem_swappiness:` — swap tendency for the container's memory, `0`–`100`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_swappiness: Option<i64>,
+	/// `pids_limit:` — maximum number of PIDs the container may create; `-1` for
+	/// unlimited. Top-level value wins over `deploy.resources.limits.pids`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pids_limit: Option<i64>,
+	/// `oom_kill_disable:` — when `true`, disables the OOM killer for the
+	/// container; not supported on cgroups v2.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_kill_disable: Option<bool>,
+	/// `oom_score_adj:` — OOM-killer preference (`-1000`..`1000`); higher makes
+	/// the container likelier to be killed first.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_score_adj: Option<i64>,
+	/// `blkio_config:` — block-IO weights and per-device read/write bandwidth and
+	/// IOPS limits.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub blkio_config: Option<BlkioConfig>,
 
+	/// `logging:` — log driver and its options for the container's stdout/stderr.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub logging: Option<LoggingConfig>,
+	/// `sysctls:` — kernel parameters set in the container's namespace (e.g.
+	/// `net.core.somaxconn`); map or list form.
 	#[serde(default)]
 	pub sysctls: Sysctls,
+	/// `ulimits:` — per-resource process limits (e.g. `nofile`) as a single
+	/// value or `{soft, hard}` pair, keyed by limit name.
 	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 	pub ulimits: IndexMap<String, UlimitConfig>,
 
+	/// `label_file:` — file(s) of `key=value` lines loaded as container labels;
+	/// single path or list (Compose v2.32+).
 	#[serde(default)]
 	pub label_file: StringOrList,
 
+	/// `attach:` — when `false`, `up` does not stream this service's logs to the
+	/// console. Default `true`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attach: Option<bool>,
 
+	/// `pull_policy:` — when to pull the image: `always`, `never`, `missing` (the
+	/// default; alias `if_not_present`), `build`, or `newer`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pull_policy: Option<String>,
 
+	/// `deploy:` — deployment config (replicas, resource limits/reservations,
+	/// restart policy); a fallback for top-level `scale`/`cpus`/`mem_limit`/
+	/// `restart` and the source of Swarm-only fields.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub deploy: Option<DeployConfig>,
 
+	/// `develop:` — `watch` rules driving file-sync/rebuild during development.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub develop: Option<DevelopConfig>,
 
+	/// `gpus:` — GPU devices to expose (`all` or a capability/count spec),
+	/// forwarded as CDI device reservations.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gpus: Option<GpuSpec>,
 
@@ -255,10 +425,14 @@ pub struct Service {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct CredentialSpec {
+	/// `config:` — ID of a Compose config object holding the credential spec.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub config: Option<String>,
+	/// `file:` — path to a credential-spec file, relative to the Docker data
+	/// directory.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
+	/// `registry:` — Windows registry value name holding the credential spec.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub registry: Option<String>,
 	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
@@ -271,8 +445,12 @@ pub struct CredentialSpec {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ProviderConfig {
+	/// `type:` — name of the external provider plugin to delegate the service
+	/// lifecycle to.
 	#[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
 	pub provider_type: Option<String>,
+	/// `options:` — free-form provider-specific parameters passed through to the
+	/// plugin.
 	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 	pub options: IndexMap<String, serde_yaml::Value>,
 	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.

--- a/internal/engine/container/fields.rs
+++ b/internal/engine/container/fields.rs
@@ -19,6 +19,10 @@ use crate::libpod::types::container::{
 // Device helpers
 // ---------------------------------------------------------------------------
 
+/// Parse a compose `devices:` entry (`host:container:permissions`) into a
+/// `LinuxDevice`. The container path defaults to the host path when the
+/// `:container` segment is absent; major/minor/type are derived by `stat`ing the
+/// host node. Trailing permissions, if present, are ignored here.
 pub(crate) fn parse_device(s: &str) -> LinuxDevice {
 	let parts: Vec<&str> = s.splitn(3, ':').collect();
 	let host = parts.first().copied().unwrap_or("").to_string();

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -1,7 +1,7 @@
 //! Pure configuration builders for container creation: restart policy, logging,
 //! healthcheck, resource limits, and ulimits.
 //!
-//! Device, blkio, tmpfs, and label-file helpers live in [`super::container::fields`].
+//! Device, blkio, tmpfs, and label-file helpers live in `super::container::fields`.
 
 use crate::compose::types::{
 	Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart, Service,

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -9,6 +9,11 @@ use crate::size;
 // Resource limits
 // ---------------------------------------------------------------------------
 
+/// Build the OCI `LinuxResources` (memory, CPU, pids) for a service, or `None`
+/// when nothing constrains it. Top-level `mem_limit`/`cpus`/`pids_limit` win;
+/// the modern `deploy.resources` block only fills a value the top level left
+/// unset. A Docker `cpus` (nano-CPU) is converted to an OCI quota over a 100ms
+/// period (`nano / 10_000`, default period `100_000`).
 pub(crate) fn build_resource_limits(service: &Service) -> Option<LinuxResources> {
 	use crate::libpod::types::container::{LinuxCPU, LinuxMemory, LinuxPids};
 
@@ -113,6 +118,10 @@ pub(crate) fn build_resource_limits(service: &Service) -> Option<LinuxResources>
 	})
 }
 
+/// Build the validated `Ulimit` list for a service. Unrecognized resource names
+/// are dropped (not forwarded), `-1` means unlimited (`u64::MAX`) while any other
+/// negative value is rejected to `0`, and a soft limit above its hard limit is
+/// clamped down to the hard limit (POSIX requires soft <= hard).
 pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 	service
 		.ulimits

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -79,17 +79,6 @@ fn health_poll_plan(
 }
 
 impl Engine {
-	/// Poll a container until its health status is `healthy` or timeout.
-	///
-	/// Polls at the compose `healthcheck.interval` (default 2 s) for
-	/// `healthcheck.retries` (default 30) probes, plus extra probes covering
-	/// `healthcheck.start_period` so a slow-starting service is not timed out early.
-	///
-	/// The wait is driven by the container's *effective* healthcheck reported by
-	/// the runtime, so healthchecks inherited from the image count too — not just
-	/// those declared in compose. If the container has no effective healthcheck at
-	/// all (none in the image or compose), it can never report `healthy`, so the
-	/// wait short-circuits as satisfied rather than blocking until timeout.
 	/// Wait until every targeted service's first replica is healthy (`up
 	/// --wait`). A service with no effective healthcheck is treated as ready
 	/// once started. All services when `target_services` is empty.
@@ -108,6 +97,17 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Poll a container until its health status is `healthy` or timeout.
+	///
+	/// Polls at the compose `healthcheck.interval` (default 2 s) for
+	/// `healthcheck.retries` (default 30) probes, plus extra probes covering
+	/// `healthcheck.start_period` so a slow-starting service is not timed out early.
+	///
+	/// The wait is driven by the container's *effective* healthcheck reported by
+	/// the runtime, so healthchecks inherited from the image count too — not just
+	/// those declared in compose. If the container has no effective healthcheck at
+	/// all (none in the image or compose), it can never report `healthy`, so the
+	/// wait short-circuits as satisfied rather than blocking until timeout.
 	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
 		let hc = service.healthcheck.as_ref();
 		let (poll_secs, iterations) = health_poll_plan(

--- a/internal/engine/image/digests.rs
+++ b/internal/engine/image/digests.rs
@@ -2,7 +2,7 @@
 //! digest.
 //!
 //! Like `ls`, this is project-agnostic — it needs only a [`Client`] to inspect
-//! images, not a full [`Engine`] — so it lives as a free function.
+//! images, not a full [`Engine`](crate::engine::Engine) — so it lives as a free function.
 
 use crate::compose::types::ComposeFile;
 use crate::error::Result;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -1,6 +1,6 @@
 //! Container orchestration engine.
 //!
-//! Translates a parsed [`ComposeFile`] into Podman API calls via the libpod REST API.
+//! Translates a parsed [`ComposeFile`](crate::compose::types::ComposeFile) into Podman API calls via the libpod REST API.
 
 mod build;
 mod container;

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -13,6 +13,10 @@ use crate::libpod::API_PREFIX;
 use super::Engine;
 
 impl Engine {
+	/// Pre-create every declared (non-external) network before containers start,
+	/// stamping each with the `podup.project` label and applying driver/IPAM/label
+	/// config. External networks are verified to already exist instead. An
+	/// already-exists conflict on re-`up` is treated as success (idempotent).
 	pub(super) async fn create_networks(&self, file: &ComposeFile) -> Result<()> {
 		for (name, config) in &file.networks {
 			let network_name = config
@@ -89,6 +93,11 @@ impl Engine {
 // Free helpers
 // ---------------------------------------------------------------------------
 
+/// Build the `PerNetworkOptions` for one service's attachment to a single
+/// network: aliases, static IPv4/IPv6 and link-local IPs, MAC (per-network, else
+/// `fallback_mac`), driver options (with `priority` folded in), and interface
+/// name. The service name is always prepended as an alias unless already present,
+/// so siblings resolve the service by name (compose DNS contract).
 pub(super) fn build_per_network_options(
 	service_name: &str,
 	cfg: Option<&ServiceNetworkConfig>,
@@ -143,6 +152,12 @@ pub(super) fn build_per_network_options(
 	opts
 }
 
+/// Resolve a service's networking into a netns `Namespace` and per-network
+/// options. An explicit `network_mode` wins and yields a namespace with no
+/// per-network options (`container:`/`service:` reuse another container's netns,
+/// the service form resolved to its target container name). Otherwise each
+/// declared network is mapped to its options and `bridge` netns is used (libpod
+/// requires `netns=bridge` when explicit networks are attached).
 pub(super) fn resolve_network_mode(
 	service_name: &str,
 	service: &Service,

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -2,7 +2,7 @@
 //!
 //! Unlike the other commands this is project-agnostic: it scans every container
 //! carrying a `podup.project` label and groups by project, so it needs only a
-//! [`Client`], not a full [`Engine`] bound to one project/compose file.
+//! [`Client`], not a full [`Engine`](crate::engine::Engine) bound to one project/compose file.
 
 use std::collections::BTreeMap;
 

--- a/internal/engine/volume/mod.rs
+++ b/internal/engine/volume/mod.rs
@@ -20,6 +20,11 @@ mod list;
 pub use list::VolumesOptions;
 
 impl Engine {
+	/// Pre-create every declared (non-external) named volume before containers
+	/// start, stamping each with the `podup.project` label and applying
+	/// driver/driver-opts/label config. External volumes are verified to already
+	/// exist instead. An already-exists conflict on re-`up` is treated as success
+	/// (libpod returns 500, not 409, for an existing volume name).
 	pub(super) async fn create_volumes(&self, file: &ComposeFile) -> Result<()> {
 		for (name, config) in &file.volumes {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);

--- a/internal/engine/watch/sync.rs
+++ b/internal/engine/watch/sync.rs
@@ -63,6 +63,10 @@ pub(super) fn build_sync_tar(src: &Path, entry_name: &Path) -> Result<Vec<u8>> {
 	Ok(bytes)
 }
 
+/// True when `path` matches a watch-rule `ignore` pattern. A pattern ending in
+/// `/` matches `path` by directory prefix; otherwise it matches an exact path or
+/// a leading path segment (the pattern followed by `/`). Matching is anchored at
+/// the start of `path`.
 pub(super) fn is_ignored(path: &str, patterns: &[String]) -> bool {
 	for pat in patterns {
 		if pat.ends_with('/') {
@@ -78,6 +82,10 @@ pub(super) fn is_ignored(path: &str, patterns: &[String]) -> bool {
 	false
 }
 
+/// True when `path` matches a watch-rule `include` pattern. Unlike
+/// [`is_ignored`], a `*.ext` pattern matches by extension suffix, and a bare name
+/// matches not only an exact path or directory prefix but also a trailing path
+/// segment anywhere in `path` (the pattern preceded by `/`).
 pub(super) fn is_included(path: &str, patterns: &[String]) -> bool {
 	for pat in patterns {
 		if pat.starts_with("*.") {

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -9,31 +9,48 @@
 // new `unsafe` block elsewhere fails the build.
 #![deny(unsafe_code)]
 
+/// Compose-file parsing, `extends:`/`include:` resolution, and topological
+/// service ordering.
 pub mod compose;
 pub(crate) mod dotenv;
 pub(crate) mod engine;
+/// `env_file:` loading: KEY=VALUE pairs from a service's declared files.
 pub mod env_file;
 pub(crate) mod error;
 pub(crate) mod filesystem;
 pub(crate) mod libpod;
+/// Podman socket connection helpers.
 pub mod podman;
+/// Port-mapping parser for the docker-compose `ports:` format variants.
 pub mod ports;
+/// Quadlet export: translate a parsed compose file into Podman systemd units.
 pub mod quadlet;
+/// Memory and CPU value parsers shared by the engine and tests.
 pub mod size;
+/// Docker Compose `${VAR}`/`$VAR` substitution over raw YAML before parsing.
 pub mod substitute;
+/// Secure self-update for the `podup` binary (signature-verified release fetch).
 #[cfg(feature = "update")]
 pub mod update;
 
+/// Compose entry points: the parser variants, diagnostics collection, and
+/// service-ordering helpers, re-exported at the crate root for callers.
 pub use compose::{
 	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
 	parse_files_with_env_files_interp, parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
+/// The lifecycle `Engine` and its per-command option/override types, plus the
+/// project-name/listing helpers — the surface a CLI drives compose operations
+/// through.
 pub use engine::{
 	is_safe_project_name, list_projects, resolve_image_digests, BuildOptions, CpOptions, Engine,
 	ExecOptions, ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions,
 	PushOptions, RunOptions, RunOverrides, VolumesOptions,
 };
+/// The crate's error type and `Result` alias, surfaced so callers handle one
+/// error enum across parsing and engine calls.
 pub use error::{ComposeError, Result};
+/// The libpod `Client`, surfaced for callers that talk to Podman directly.
 pub use libpod::Client;
 
 /// Internal parsers exposed only under `test-helpers` for fuzzing and tests.

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -173,7 +173,7 @@ impl Client {
 	/// With `Some(limit)` a stalled body is aborted once `limit` elapses, yielding
 	/// a timeout [`PodmanError`]. With `None` the future is awaited uncapped, for
 	/// endpoints that legitimately block server-side (the caller supplies its own
-	/// outer budget). Split out from [`read_body`] so the timeout policy is
+	/// outer budget). Split out from [`read_body`](Self::read_body) so the timeout policy is
 	/// testable without a live socket.
 	async fn apply_read_timeout<F, T>(
 		read_timeout: Option<std::time::Duration>,
@@ -223,7 +223,7 @@ impl Client {
 	}
 
 	/// For streaming endpoints: return the response on success, otherwise read
-	/// the body and surface it through [`check_status`] so the caller gets the
+	/// the body and surface it through [`check_status`](Self::check_status) so the caller gets the
 	/// parsed Podman error message rather than the raw JSON body.
 	async fn stream_or_err(resp: Response<Incoming>) -> Result<Response<Incoming>> {
 		if resp.status().is_success() {

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -19,15 +19,21 @@ where
 /// Entry in the `GET /libpod/containers/json` response array.
 #[derive(Deserialize)]
 pub struct ContainerListEntry {
+	/// Full 64-hex container ID.
 	#[serde(rename = "Id", default)]
 	pub id: String,
 
+	/// Container names, each leading-slash-prefixed as Podman reports them
+	/// (e.g. `/web`). A container may carry multiple names/aliases.
 	#[serde(rename = "Names", default, deserialize_with = "null_default")]
 	pub names: Vec<String>,
 
+	/// Image reference the container was created from (name:tag or an ID).
 	#[serde(rename = "Image", default)]
 	pub image: String,
 
+	/// Human-readable status string for `ps` display (e.g. `Up 3 minutes`,
+	/// `Exited (0) 5 seconds ago`). Empty on libpod, which reports `State`.
 	#[serde(rename = "Status", default)]
 	pub status: String,
 
@@ -36,9 +42,11 @@ pub struct ContainerListEntry {
 	#[serde(rename = "State", default)]
 	pub state: String,
 
+	/// Published port mappings for the container.
 	#[serde(rename = "Ports", default, deserialize_with = "null_default")]
 	pub ports: Vec<ContainerPort>,
 
+	/// Container labels (key/value), including compose project/service labels.
 	#[serde(rename = "Labels", default, deserialize_with = "null_default")]
 	pub labels: HashMap<String, String>,
 }
@@ -46,8 +54,11 @@ pub struct ContainerListEntry {
 /// Port mapping entry in container list response.
 #[derive(Deserialize, Default)]
 pub struct ContainerPort {
+	/// Host IP the port is bound to; absent when bound to all interfaces.
 	pub host_ip: Option<String>,
+	/// Port on the host the mapping is published to; absent when not published.
 	pub host_port: Option<u16>,
+	/// Port inside the container that traffic is forwarded to.
 	pub container_port: u16,
 	/// Transport protocol of the mapping (`tcp`/`udp`/`sctp`), surfaced in `ps`.
 	#[serde(default)]
@@ -63,12 +74,15 @@ pub struct ContainerPort {
 /// Response from `GET /libpod/containers/{name}/json`.
 #[derive(Deserialize, Default)]
 pub struct ContainerInspect {
+	/// Runtime state (status, exit code, health).
 	#[serde(rename = "State")]
 	pub state: Option<ContainerState>,
 
+	/// Static configuration the container was created with.
 	#[serde(rename = "Config")]
 	pub config: Option<ContainerConfig>,
 
+	/// Runtime network settings, including resolved host port bindings.
 	#[serde(rename = "NetworkSettings")]
 	pub network_settings: Option<NetworkSettings>,
 }
@@ -76,6 +90,7 @@ pub struct ContainerInspect {
 /// Container config sub-object from inspect.
 #[derive(Deserialize, Default)]
 pub struct ContainerConfig {
+	/// Effective healthcheck, if any; absent when the image declares none.
 	#[serde(rename = "Healthcheck")]
 	pub healthcheck: Option<HealthConfig>,
 }
@@ -94,6 +109,9 @@ impl ContainerConfig {
 /// Effective healthcheck config baked into the container (image or compose).
 #[derive(Deserialize, Default)]
 pub struct HealthConfig {
+	/// Healthcheck command in Docker's `Test` form: the first element is the
+	/// mode (`NONE`, `CMD`, or `CMD-SHELL`) and the rest are its arguments.
+	/// `["NONE"]` means the healthcheck is explicitly disabled; empty means none.
 	#[serde(rename = "Test", default, deserialize_with = "null_default")]
 	pub test: Vec<String>,
 }
@@ -112,6 +130,7 @@ pub struct ContainerState {
 	#[serde(rename = "ExitCode")]
 	pub exit_code: Option<i64>,
 
+	/// Aggregated healthcheck state; absent when the container has no healthcheck.
 	#[serde(rename = "Health")]
 	pub health: Option<HealthState>,
 }
@@ -119,6 +138,7 @@ pub struct ContainerState {
 /// Container health state sub-object.
 #[derive(Deserialize)]
 pub struct HealthState {
+	/// Current health status (`healthy`, `unhealthy`, `starting`).
 	#[serde(rename = "Status")]
 	pub status: Option<String>,
 }
@@ -126,6 +146,9 @@ pub struct HealthState {
 /// Network settings sub-object from container inspect.
 #[derive(Deserialize, Default)]
 pub struct NetworkSettings {
+	/// Resolved port bindings keyed by container port spec (`"80/tcp"`). The
+	/// value is the list of host bindings, or `None`/empty when the port is
+	/// exposed but not published.
 	#[serde(rename = "Ports", default)]
 	pub ports: HashMap<String, Option<Vec<HostBinding>>>,
 }
@@ -133,9 +156,11 @@ pub struct NetworkSettings {
 /// Host port binding from container inspect network settings.
 #[derive(Deserialize, Clone)]
 pub struct HostBinding {
+	/// Host IP the port is bound to; empty/absent means all interfaces.
 	#[serde(rename = "HostIp")]
 	pub host_ip: Option<String>,
 
+	/// Host port as a string, as Podman reports it in inspect output.
 	#[serde(rename = "HostPort")]
 	pub host_port: Option<String>,
 }
@@ -143,9 +168,11 @@ pub struct HostBinding {
 /// Response from `GET /libpod/containers/{name}/top`.
 #[derive(Deserialize, Default)]
 pub struct TopResponse {
+	/// Column headers for the process table (e.g. `PID`, `USER`, `COMMAND`).
 	#[serde(rename = "Titles")]
 	pub titles: Option<Vec<String>>,
 
+	/// One row per process; each row's columns align with `titles`.
 	#[serde(rename = "Processes")]
 	pub processes: Option<Vec<Vec<String>>>,
 }

--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -14,27 +14,36 @@ pub use parts::*;
 /// Full container specification sent to `POST /libpod/containers/create`.
 #[derive(Serialize, Default)]
 pub struct SpecGenerator {
+	/// Container name.
 	pub name: String,
+	/// Image reference to run (name:tag or digest).
 	pub image: String,
 
+	/// Command (`CMD`) override; replaces the image's default command.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub command: Option<Vec<String>>,
 
+	/// Entrypoint override; replaces the image's `ENTRYPOINT`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub entrypoint: Option<Vec<String>>,
 
+	/// Environment variables to set in the container.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub env: HashMap<String, String>,
 
+	/// Allocate a pseudo-TTY for the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub terminal: Option<bool>,
 
+	/// Keep stdin open for the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stdin: Option<bool>,
 
+	/// User to run as (`name`, `uid`, `uid:gid`, or `name:group`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
 
+	/// Working directory inside the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub work_dir: Option<String>,
 
@@ -44,135 +53,172 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_signal: Option<i64>,
 
+	/// Graceful stop timeout, in **seconds**, before SIGKILL.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_timeout: Option<u64>,
 
+	/// Container hostname.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub hostname: Option<String>,
 
+	/// Container NIS domain name.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub domainname: Option<String>,
 
 	// Labels and annotations
+	/// Container labels.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub labels: HashMap<String, String>,
 
+	/// OCI annotations attached to the container.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub annotations: HashMap<String, String>,
 
 	// Capabilities and security
+	/// Linux capabilities to add (without the `CAP_` prefix, e.g. `"NET_ADMIN"`).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub cap_add: Vec<String>,
 
+	/// Linux capabilities to drop (without the `CAP_` prefix).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub cap_drop: Vec<String>,
 
+	/// Run the container privileged (disables most isolation).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
 
+	/// Mount the container's root filesystem read-only.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub read_only_filesystem: Option<bool>,
 
-	// Podman's SpecGenerator has no `security_opt` field; the compose list is
-	// decomposed into these dedicated fields. A plain `security_opt` array is
-	// silently ignored, so every option (incl. no-new-privileges/seccomp/apparmor)
-	// would otherwise be dropped.
+	/// SELinux options (compose `security_opt` `label=...`); Podman's
+	/// SpecGenerator has no `security_opt` field, so the compose list is
+	/// decomposed into these dedicated fields. A plain `security_opt` array is
+	/// silently ignored, so every option (incl. no-new-privileges/seccomp/apparmor)
+	/// would otherwise be dropped.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub selinux_opts: Vec<String>,
 
+	/// AppArmor profile name to apply.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub apparmor_profile: Option<String>,
 
+	/// Path to a seccomp profile JSON file (or `"unconfined"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub seccomp_profile_path: Option<String>,
 
+	/// Set the `no_new_privs` flag, preventing privilege escalation.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub no_new_privileges: Option<bool>,
 
+	/// Additional `/proc` and `/sys` paths to mask (hide).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub mask: Vec<String>,
 
+	/// Paths to unmask (un-hide), reversing default masks; `"ALL"` unmasks all.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub unmask: Vec<String>,
 
+	/// Kernel `sysctl` parameters to set for the container.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub sysctl: HashMap<String, String>,
 
 	// Networking
+	/// Ports to expose without publishing; key = port number, value = protocol
+	/// (`"tcp"`/`"udp"`).
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub expose: HashMap<u16, String>,
 
+	/// Published port mappings.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub portmappings: Vec<PortMapping>,
 
+	/// Networks to connect to; key = network name, value = per-connection options.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub networks: HashMap<String, PerNetworkOptions>,
 
+	/// Network namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub netns: Option<Namespace>,
 
-	// Podman's SpecGenerator names this field `hostadd` (there is no `extra_hosts`
-	// key); without the rename every extra_hosts entry is silently dropped.
+	/// Extra `/etc/hosts` entries (`"host:ip"`). Podman's SpecGenerator names this
+	/// field `hostadd` (there is no `extra_hosts` key); without the rename every
+	/// extra_hosts entry is silently dropped.
 	#[serde(rename = "hostadd", skip_serializing_if = "Vec::is_empty", default)]
 	pub extra_hosts: Vec<String>,
 
+	/// Custom DNS server addresses.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub dns_server: Vec<String>,
 
+	/// DNS search domains.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub dns_search: Vec<String>,
 
+	/// DNS resolver options (`/etc/resolv.conf` `options` lines).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub dns_option: Vec<String>,
 
 	// Volumes and mounts
+	/// OCI mounts (bind/tmpfs/...) attached to the container.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub mounts: Vec<Mount>,
 
+	/// Named-volume attachments.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub volumes: Vec<NamedVolume>,
 
+	/// Container names/IDs to inherit volume mounts from.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub volumes_from: Vec<String>,
 
-	// Podman-native secrets (also used for external configs): each references an
-	// existing `podman secret` by name and is mounted into the container.
+	/// Podman-native secrets (also used for external configs): each references an
+	/// existing `podman secret` by name and is mounted into the container.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub secrets: Vec<Secret>,
 
 	// Namespace modes
+	/// User namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub userns: Option<Namespace>,
 
+	/// PID namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pidns: Option<Namespace>,
 
+	/// IPC namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipcns: Option<Namespace>,
 
+	/// UTS namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub utsns: Option<Namespace>,
 
+	/// Cgroup namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroupns: Option<Namespace>,
 
+	/// Parent cgroup path under which the container's cgroup is created.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup_parent: Option<String>,
 
 	// Resource limits
+	/// CPU/memory/pids/block-I/O resource limits.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub resource_limits: Option<LinuxResources>,
 
-	// Podman's SpecGenerator names this field `r_limits` (POSIX rlimits); without
-	// the rename every ulimits entry is silently dropped. The per-element shape
-	// (`{type, soft, hard}`) already matches Podman's POSIXRlimit.
+	/// POSIX rlimits. Podman's SpecGenerator names this field `r_limits`; without
+	/// the rename every ulimits entry is silently dropped. The per-element shape
+	/// (`{type, soft, hard}`) already matches Podman's POSIXRlimit.
 	#[serde(rename = "r_limits", skip_serializing_if = "Vec::is_empty", default)]
 	pub ulimits: Vec<Ulimit>,
 
+	/// Size of `/dev/shm`, in **bytes**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub shm_size: Option<i64>,
 
 	// Healthcheck
+	/// Main healthcheck configuration.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub healthconfig: Option<HealthConfig>,
 
@@ -193,59 +239,73 @@ pub struct SpecGenerator {
 	pub startup_health_config: Option<StartupHealthCheck>,
 
 	// Logging
+	/// Log driver configuration.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub log_configuration: Option<LogConfig>,
 
 	// Init process
+	/// Run an init process as PID 1 to reap zombies and forward signals.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub init: Option<bool>,
 
 	// Restart policy
+	/// Restart policy name (`"no"`, `"on-failure"`, `"always"`, `"unless-stopped"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart_policy: Option<String>,
 
+	/// Maximum restart attempts (only meaningful for `on-failure`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart_tries: Option<u64>,
 
-	// Devices. Podman 5.x has no SpecGenerator CDI field; CDI device names (e.g.
-	// `nvidia.com/gpu=all`) are recognized by ExtractCDIDevices from this array by
-	// their qualified path, so they are appended here as `LinuxDevice` entries.
+	/// Device nodes to expose. Podman 5.x has no SpecGenerator CDI field; CDI
+	/// device names (e.g. `nvidia.com/gpu=all`) are recognized by ExtractCDIDevices
+	/// from this array by their qualified path, so they are appended here as
+	/// `LinuxDevice` entries.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub devices: Vec<LinuxDevice>,
 
-	// Podman expects structured cgroup rules ([]LinuxDeviceCgroup), not strings; a
-	// string array would fail to deserialize.
+	/// Cgroup device access rules. Podman expects structured rules
+	/// ([`LinuxDeviceCgroup`]), not strings; a string array would fail to
+	/// deserialize.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub device_cgroup_rule: Vec<LinuxDeviceCgroup>,
 
 	// Groups
+	/// Additional supplementary groups (names or GIDs) for the container process.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub groups: Vec<String>,
 
 	// OOM
+	/// OOM-killer score adjustment, `-1000`..=`1000`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_score_adj: Option<i64>,
 
 	// Runtime
+	/// OCI runtime to use (e.g. `"crun"`, `"runc"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub runtime: Option<String>,
 
-	// Links (deprecated in rootless, accepted but may be ignored)
+	/// Legacy container links (deprecated in rootless, accepted but may be ignored).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub links: Vec<String>,
 
 	// Platform selection
+	/// Target image CPU architecture (e.g. `"amd64"`, `"arm64"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image_arch: Option<String>,
 
+	/// Target image OS (e.g. `"linux"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image_os: Option<String>,
 
 	// Volume image handling
+	/// How image-defined `VOLUME`s are handled (e.g. `"anonymous"`, `"tmpfs"`,
+	/// `"ignore"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image_volume_mode: Option<String>,
 
 	// Storage options
+	/// Storage-driver options for the container's root filesystem.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub storage_opts: HashMap<String, String>,
 }

--- a/internal/libpod/types/container/spec/parts.rs
+++ b/internal/libpod/types/container/spec/parts.rs
@@ -11,14 +11,18 @@ use serde::Serialize;
 /// Port mapping for SpecGenerator.
 #[derive(Serialize, Default)]
 pub struct PortMapping {
+	/// Container-side port to publish.
 	pub container_port: u16,
 
+	/// Host-side port to bind; when absent Podman auto-assigns one.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub host_port: Option<u16>,
 
+	/// Host interface address to bind on; empty means all interfaces.
 	#[serde(skip_serializing_if = "String::is_empty", default)]
 	pub host_ip: String,
 
+	/// Transport protocol (`"tcp"` or `"udp"`).
 	pub protocol: String,
 
 	/// Number of ports to map starting from `container_port` (range mapping).
@@ -33,18 +37,24 @@ pub struct PortMapping {
 /// (a bare name lands under `/run/secrets/`, an absolute path is used as-is).
 #[derive(Serialize, Default)]
 pub struct Secret {
+	/// Name of an existing Podman secret to attach.
 	#[serde(rename = "Source")]
 	pub source: String,
 
+	/// Mount destination: a bare name lands under `/run/secrets/`, an absolute
+	/// path is used as-is.
 	#[serde(rename = "Target", skip_serializing_if = "Option::is_none")]
 	pub target: Option<String>,
 
+	/// Owner UID of the mounted secret file.
 	#[serde(rename = "UID", skip_serializing_if = "Option::is_none")]
 	pub uid: Option<u32>,
 
+	/// Owner GID of the mounted secret file.
 	#[serde(rename = "GID", skip_serializing_if = "Option::is_none")]
 	pub gid: Option<u32>,
 
+	/// File mode (permission bits) of the mounted secret, e.g. `0o400`.
 	#[serde(rename = "Mode", skip_serializing_if = "Option::is_none")]
 	pub mode: Option<u32>,
 }
@@ -52,18 +62,23 @@ pub struct Secret {
 /// Per-network connection options (for SpecGenerator `networks` map).
 #[derive(Serialize, Default)]
 pub struct PerNetworkOptions {
+	/// Additional DNS names the container is reachable by on this network.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub aliases: Vec<String>,
 
+	/// Fixed IP addresses to assign on this network.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub static_ips: Vec<String>,
 
+	/// Fixed MAC address for the container's interface on this network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub static_mac: Option<String>,
 
+	/// Name to give the container's network interface on this network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub interface_name: Option<String>,
 
+	/// Driver-specific per-connection options.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver_opts: Option<HashMap<String, String>>,
 }
@@ -71,8 +86,10 @@ pub struct PerNetworkOptions {
 /// Linux network/pid/ipc/uts/cgroup namespace specification.
 #[derive(Serialize, Clone)]
 pub struct Namespace {
+	/// Namespace mode (e.g. `"host"`, `"private"`, `"container"`, `"none"`).
 	pub nsmode: String,
 
+	/// Mode-dependent target, e.g. the container ID for `nsmode == "container"`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub value: Option<String>,
 }
@@ -111,14 +128,18 @@ impl Namespace {
 /// OCI mount specification for SpecGenerator.
 #[derive(Serialize, Default)]
 pub struct Mount {
+	/// OCI mount type (e.g. `"bind"`, `"tmpfs"`, `"volume"`).
 	#[serde(rename = "type")]
 	pub mount_type: String,
 
+	/// Host source path or tmpfs source; absent for anonymous tmpfs mounts.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub source: Option<String>,
 
+	/// Absolute mount path inside the container.
 	pub destination: String,
 
+	/// OCI mount options (e.g. `"ro"`, `"rbind"`, `"nosuid"`).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub options: Vec<String>,
 }
@@ -126,12 +147,15 @@ pub struct Mount {
 /// Named volume attachment for SpecGenerator (goes in `volumes`, not `mounts`).
 #[derive(Serialize, Default)]
 pub struct NamedVolume {
+	/// Name of the Podman volume to attach.
 	#[serde(rename = "Name")]
 	pub name: String,
 
+	/// Absolute mount path inside the container.
 	#[serde(rename = "Dest")]
 	pub dest: String,
 
+	/// Mount options applied to the volume (e.g. `"ro"`, `"z"`).
 	#[serde(rename = "Options", skip_serializing_if = "Vec::is_empty", default)]
 	pub options: Vec<String>,
 
@@ -143,15 +167,19 @@ pub struct NamedVolume {
 /// Linux OCI resource limits for SpecGenerator.
 #[derive(Serialize, Default)]
 pub struct LinuxResources {
+	/// Memory limits sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub memory: Option<LinuxMemory>,
 
+	/// CPU limits sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu: Option<LinuxCPU>,
 
+	/// Process-count (pids) limit sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pids: Option<LinuxPids>,
 
+	/// Block I/O limits sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub block_io: Option<LinuxBlockIO>,
 
@@ -163,18 +191,23 @@ pub struct LinuxResources {
 /// Linux memory resource limits.
 #[derive(Serialize, Default)]
 pub struct LinuxMemory {
+	/// Hard memory limit in **bytes** (`-1` disables the limit).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub limit: Option<i64>,
 
+	/// Soft memory reservation (low-water mark) in **bytes**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub reservation: Option<i64>,
 
+	/// Total memory+swap limit in **bytes** (`-1` disables the limit).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub swap: Option<i64>,
 
+	/// Swap tendency, `0`–`100` (kernel `memory.swappiness`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub swappiness: Option<u64>,
 
+	/// When true, disables the OOM killer for the cgroup.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub disable_oom_killer: Option<bool>,
 }
@@ -182,18 +215,24 @@ pub struct LinuxMemory {
 /// Linux CPU resource limits.
 #[derive(Serialize, Default)]
 pub struct LinuxCPU {
+	/// Relative CPU weight (cgroup `cpu.shares`); proportional, not a hard cap.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub shares: Option<u64>,
 
+	/// CPU time the cgroup may use per `period`, in **microseconds**
+	/// (`-1` disables the quota).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub quota: Option<i64>,
 
+	/// CFS scheduling period in **microseconds** that `quota` applies to.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub period: Option<u64>,
 
+	/// Realtime scheduling period in **microseconds**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub realtime_period: Option<u64>,
 
+	/// Realtime runtime allowed per `realtime_period`, in **microseconds**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub realtime_runtime: Option<i64>,
 
@@ -205,27 +244,34 @@ pub struct LinuxCPU {
 /// Linux pids (process count) limit.
 #[derive(Serialize)]
 pub struct LinuxPids {
+	/// Maximum number of processes the cgroup may spawn (`-1` for unlimited).
 	pub limit: i64,
 }
 
 /// Linux block I/O resource limits.
 #[derive(Serialize, Default)]
 pub struct LinuxBlockIO {
+	/// Default block I/O weight, `10`–`1000` (cgroup `blkio.weight`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub weight: Option<u16>,
 
+	/// Per-device block I/O weight overrides.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub weight_device: Vec<LinuxWeightDevice>,
 
+	/// Per-device read-rate caps; each entry's `rate` is in **bytes per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_read_bps_device: Vec<LinuxThrottleDevice>,
 
+	/// Per-device write-rate caps; each entry's `rate` is in **bytes per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_write_bps_device: Vec<LinuxThrottleDevice>,
 
+	/// Per-device read-rate caps; each entry's `rate` is in **IO ops per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_read_iops_device: Vec<LinuxThrottleDevice>,
 
+	/// Per-device write-rate caps; each entry's `rate` is in **IO ops per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_write_iops_device: Vec<LinuxThrottleDevice>,
 }
@@ -233,9 +279,12 @@ pub struct LinuxBlockIO {
 /// Block device weight entry.
 #[derive(Serialize)]
 pub struct LinuxWeightDevice {
+	/// Device major number.
 	pub major: i64,
+	/// Device minor number.
 	pub minor: i64,
 
+	/// Block I/O weight for this device, `10`–`1000`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub weight: Option<u16>,
 }
@@ -243,25 +292,35 @@ pub struct LinuxWeightDevice {
 /// Block device I/O throttle entry.
 #[derive(Serialize)]
 pub struct LinuxThrottleDevice {
+	/// Device major number.
 	pub major: i64,
+	/// Device minor number.
 	pub minor: i64,
+	/// Throttle rate for this device. Unit depends on the containing list:
+	/// **bytes per second** in `throttle_*_bps_device`, **IO ops per second**
+	/// in `throttle_*_iops_device`.
 	pub rate: u64,
 }
 
 /// cgroup device access rule (for GPU access via `deploy.resources`).
 #[derive(Serialize)]
 pub struct LinuxDeviceCgroup {
+	/// Whether the rule allows (`true`) or denies (`false`) access.
 	pub allow: bool,
 
+	/// Device type: `"a"` (all), `"c"` (char), or `"b"` (block).
 	#[serde(rename = "type", skip_serializing_if = "Option::is_none")]
 	pub device_type: Option<String>,
 
+	/// Device major number; absent means "all majors".
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub major: Option<i64>,
 
+	/// Device minor number; absent means "all minors".
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub minor: Option<i64>,
 
+	/// Access bits as any combination of `r` (read), `w` (write), `m` (mknod).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub access: Option<String>,
 }
@@ -269,30 +328,39 @@ pub struct LinuxDeviceCgroup {
 /// Process rlimit entry.
 #[derive(Serialize)]
 pub struct Ulimit {
+	/// Resource name without the `RLIMIT_` prefix (e.g. `"nofile"`, `"nproc"`).
 	#[serde(rename = "type")]
 	pub ulimit_type: String,
+	/// Soft limit (the value enforced until raised toward `hard`).
 	pub soft: u64,
+	/// Hard limit (the ceiling the soft limit may be raised to).
 	pub hard: u64,
 }
 
 /// Container healthcheck configuration (same structure as Docker).
 #[derive(Serialize, Default)]
 pub struct HealthConfig {
+	/// Probe command; `["CMD", ...]`, `["CMD-SHELL", "<cmd>"]`, or `["NONE"]`.
 	#[serde(rename = "Test", skip_serializing_if = "Option::is_none")]
 	pub test: Option<Vec<String>>,
 
+	/// Time between probes, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "Interval", skip_serializing_if = "Option::is_none")]
 	pub interval: Option<i64>,
 
+	/// Per-probe timeout, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "Timeout", skip_serializing_if = "Option::is_none")]
 	pub timeout: Option<i64>,
 
+	/// Consecutive failures before the container is marked unhealthy.
 	#[serde(rename = "Retries", skip_serializing_if = "Option::is_none")]
 	pub retries: Option<i64>,
 
+	/// Grace period before failures count, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "StartPeriod", skip_serializing_if = "Option::is_none")]
 	pub start_period: Option<i64>,
 
+	/// Probe interval during the start period, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "StartInterval", skip_serializing_if = "Option::is_none")]
 	pub start_interval: Option<i64>,
 }
@@ -355,9 +423,11 @@ pub struct StartupHealthCheck {
 /// Container log driver configuration.
 #[derive(Serialize)]
 pub struct LogConfig {
+	/// Log driver name (e.g. `"json-file"`, `"journald"`, `"k8s-file"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
+	/// Driver-specific options (e.g. `max-size`, `max-file`).
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub options: HashMap<String, String>,
 }
@@ -365,20 +435,28 @@ pub struct LogConfig {
 /// Linux OCI device specification.
 #[derive(Serialize)]
 pub struct LinuxDevice {
+	/// Device node path inside the container (or a CDI device name).
 	pub path: String,
 
+	/// Device type: `"c"` (char), `"b"` (block), `"p"` (FIFO), or `"u"`
+	/// (unbuffered char).
 	#[serde(rename = "type")]
 	pub device_type: String,
 
+	/// Device major number.
 	pub major: i64,
+	/// Device minor number.
 	pub minor: i64,
 
+	/// File mode (permission bits) of the created device node.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file_mode: Option<u32>,
 
+	/// Owner UID of the device node.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub uid: Option<u32>,
 
+	/// Owner GID of the device node.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gid: Option<u32>,
 }

--- a/internal/libpod/types/exec.rs
+++ b/internal/libpod/types/exec.rs
@@ -5,30 +5,39 @@ use serde::{Deserialize, Serialize};
 /// Request body for `POST /libpod/containers/{name}/exec`.
 #[derive(Serialize, Default)]
 pub struct ExecCreateConfig {
+	/// Command and arguments to run, as an argv vector (not shell-parsed).
 	#[serde(rename = "Cmd", skip_serializing_if = "Option::is_none")]
 	pub cmd: Option<Vec<String>>,
 
+	/// Whether to attach to the exec process's stdout.
 	#[serde(rename = "AttachStdout", skip_serializing_if = "Option::is_none")]
 	pub attach_stdout: Option<bool>,
 
+	/// Whether to attach to the exec process's stderr.
 	#[serde(rename = "AttachStderr", skip_serializing_if = "Option::is_none")]
 	pub attach_stderr: Option<bool>,
 
+	/// Whether to attach to the exec process's stdin.
 	#[serde(rename = "AttachStdin", skip_serializing_if = "Option::is_none")]
 	pub attach_stdin: Option<bool>,
 
+	/// Whether to allocate a pseudo-TTY for the exec process.
 	#[serde(rename = "Tty", skip_serializing_if = "Option::is_none")]
 	pub tty: Option<bool>,
 
+	/// User (and optionally group) to run the exec process as (`user[:group]`).
 	#[serde(rename = "User", skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
 
+	/// Whether to run the exec process with extended (privileged) permissions.
 	#[serde(rename = "Privileged", skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
 
+	/// Working directory inside the container for the exec process.
 	#[serde(rename = "WorkingDir", skip_serializing_if = "Option::is_none")]
 	pub working_dir: Option<String>,
 
+	/// Environment variables for the exec process, each entry `KEY=VALUE`.
 	#[serde(rename = "Env", skip_serializing_if = "Option::is_none")]
 	pub env: Option<Vec<String>>,
 }
@@ -36,6 +45,7 @@ pub struct ExecCreateConfig {
 /// Response from `POST /libpod/containers/{name}/exec`.
 #[derive(Deserialize)]
 pub struct ExecCreateResponse {
+	/// Exec session ID, used to start and inspect the session.
 	#[serde(rename = "Id")]
 	pub id: String,
 }
@@ -43,9 +53,12 @@ pub struct ExecCreateResponse {
 /// Request body for `POST /libpod/exec/{id}/start`.
 #[derive(Serialize)]
 pub struct ExecStartConfig {
+	/// Whether to start the exec session detached rather than streaming output.
 	#[serde(rename = "Detach")]
 	pub detach: bool,
 
+	/// Whether the exec session was created with a TTY; selects raw vs.
+	/// multiplexed stream framing on the start response.
 	#[serde(rename = "Tty")]
 	pub tty: bool,
 }
@@ -53,6 +66,7 @@ pub struct ExecStartConfig {
 /// Response from `GET /libpod/exec/{id}/json`.
 #[derive(Deserialize, Default)]
 pub struct ExecInspect {
+	/// Exit code of the finished exec process; `None` while it is still running.
 	#[serde(rename = "ExitCode")]
 	pub exit_code: Option<i64>,
 }

--- a/internal/libpod/types/image.rs
+++ b/internal/libpod/types/image.rs
@@ -5,9 +5,13 @@ use serde::Deserialize;
 /// Streaming JSON line emitted during image pull (`POST /libpod/images/pull`).
 #[derive(Deserialize, Default)]
 pub struct ImagePullProgress {
+	/// Progress text for this line. Mutually exclusive with `error`: on a normal
+	/// line this is populated and `error` is empty.
 	#[serde(default)]
 	pub stream: String,
 
+	/// Error message for this line. Mutually exclusive with `stream`: when the
+	/// pull fails this is populated and `stream` is empty.
 	#[serde(default)]
 	pub error: String,
 }
@@ -15,23 +19,29 @@ pub struct ImagePullProgress {
 /// Streaming JSON line emitted during image build (`POST /libpod/build`).
 #[derive(Deserialize, Default)]
 pub struct BuildOutput {
+	/// Build log text for this line. Populated on normal output lines; mutually
+	/// exclusive with `error`, which is set instead when the build fails.
 	#[serde(default)]
 	pub stream: String,
 
+	/// Error message for this line; present only when the build fails.
 	pub error: Option<String>,
 
+	/// Structured error detail accompanying `error`, when the daemon provides it.
 	pub error_detail: Option<BuildErrorDetail>,
 }
 
 /// Error detail sub-object in build output.
 #[derive(Deserialize)]
 pub struct BuildErrorDetail {
+	/// Human-readable error message.
 	pub message: Option<String>,
 }
 
 /// Response from `GET /libpod/images/{name}/json`.
 #[derive(Deserialize, Default)]
 pub struct ImageInspect {
+	/// Image ID (`sha256:...` content digest of the image config).
 	#[serde(rename = "Id", default)]
 	pub id: String,
 	/// Registry digest references (`repo@sha256:...`) for the image, when it was

--- a/internal/libpod/types/network.rs
+++ b/internal/libpod/types/network.rs
@@ -7,32 +7,45 @@ use serde::Serialize;
 /// Request body for `POST /libpod/networks/create`.
 #[derive(Serialize, Default)]
 pub struct NetworkCreateRequest {
+	/// Network name.
 	pub name: String,
 
+	/// Network driver (e.g. `bridge`, `macvlan`); the daemon default is used
+	/// when omitted.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
+	/// Whether the network is internal (no external/outbound connectivity).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub internal: Option<bool>,
 
+	/// Whether standalone containers may attach to the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attachable: Option<bool>,
 
+	/// Whether the built-in DNS resolver is enabled for the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub dns_enabled: Option<bool>,
 
+	/// Whether IPv6 is enabled for the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipv6_enabled: Option<bool>,
 
+	/// Network labels (key/value), including compose project/network labels.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub labels: HashMap<String, String>,
 
+	/// Driver-specific options passed to the network driver (e.g. `mtu`,
+	/// `com.docker.network.bridge.*`). Distinct from `ipam_options`.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub options: HashMap<String, String>,
 
+	/// Options passed to the IPAM (IP address management) driver, e.g. the IPAM
+	/// `driver` choice. Distinct from the driver-level `options`.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub ipam_options: HashMap<String, String>,
 
+	/// Subnet/gateway definitions for the network; empty lets Podman auto-assign.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub subnets: Vec<Subnet>,
 }
@@ -40,12 +53,15 @@ pub struct NetworkCreateRequest {
 /// Subnet specification for network creation.
 #[derive(Serialize, Default)]
 pub struct Subnet {
+	/// Subnet in CIDR notation (e.g. `10.89.0.0/24`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub subnet: Option<String>,
 
+	/// Gateway IP address for the subnet; auto-assigned when omitted.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gateway: Option<String>,
 
+	/// Range of addresses within the subnet available for dynamic assignment.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub lease_range: Option<LeaseRange>,
 }
@@ -53,9 +69,11 @@ pub struct Subnet {
 /// Lease range for a subnet.
 #[derive(Serialize)]
 pub struct LeaseRange {
+	/// First IP address (inclusive) in the assignable range.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub start_ip: Option<String>,
 
+	/// Last IP address (inclusive) in the assignable range.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub end_ip: Option<String>,
 }

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -15,7 +15,9 @@ use crate::libpod::error::PodmanError;
 /// A single framed chunk from a multiplexed container log or exec stream.
 #[derive(Debug)]
 pub enum LogOutput {
+	/// Payload demuxed from the stdout stream (frame stream type 1).
 	StdOut { message: Bytes },
+	/// Payload demuxed from the stderr stream (frame stream type 2).
 	StdErr { message: Bytes },
 }
 

--- a/internal/libpod/types/volume.rs
+++ b/internal/libpod/types/volume.rs
@@ -7,9 +7,11 @@ use serde::Serialize;
 /// Request body for `POST /libpod/volumes/create`.
 #[derive(Serialize, Default)]
 pub struct VolumeCreateOptions {
+	/// Volume name; omitted to let Podman generate an anonymous-volume name.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
 
+	/// Volume driver (e.g. `local`); the daemon default is used when omitted.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
@@ -17,9 +19,12 @@ pub struct VolumeCreateOptions {
 	// Go field name (case-insensitively): the driver-options map is `Options`, not
 	// `driver_opts`. Without this rename volume driver_opts (NFS/CIFS/tmpfs) are
 	// silently dropped while name/driver/labels still match case-insensitively.
+	/// Driver-specific options (e.g. `type`, `device`, `o` for NFS/CIFS/tmpfs
+	/// mounts). Serialized as `Options` to match Podman's wire field (see above).
 	#[serde(rename = "Options", skip_serializing_if = "HashMap::is_empty", default)]
 	pub driver_opts: HashMap<String, String>,
 
+	/// Volume labels (key/value), including compose project/volume labels.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub labels: HashMap<String, String>,
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -63,6 +63,12 @@ fn run_to_exit() {
 	}
 }
 
+/// Orchestrate one CLI invocation: parse args, then short-circuit the commands
+/// that need neither a compose file nor (for some) Podman — `completions`,
+/// `update`, `ls`, and `config`. Otherwise resolve and parse the compose
+/// file(s), settle the project name and base directory (validating the name at
+/// the trust boundary), acquire the per-project lock, and dispatch the
+/// remaining commands.
 async fn run() -> podup::Result<()> {
 	init_tracing();
 	let cli = parse_cli();

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -6,6 +6,10 @@ use std::collections::BTreeMap;
 use crate::compose::types::{Command, RestartPolicy, VolumeMount, VolumeType};
 use crate::ports::ParsedPort;
 
+/// Render a parsed port into a Quadlet `PublishPort=` value
+/// (`[host_ip:][host_port:]container[/proto]`). A missing or `0` host port is
+/// omitted so Podman picks one; the protocol suffix is only added when it is not
+/// the default `tcp`.
 pub(super) fn render_publish_port(p: &ParsedPort) -> String {
 	let mut s = String::new();
 	if !p.host_ip.is_empty() {
@@ -26,6 +30,11 @@ pub(super) fn render_publish_port(p: &ParsedPort) -> String {
 	s
 }
 
+/// Render a volume mount into a Quadlet `Volume=` value. A source naming a
+/// declared volume gets a `.volume` suffix (so Quadlet wires it to the generated
+/// unit); an undeclared source passes through verbatim. An empty source renders
+/// as just the target. Long-form `read_only`, SELinux relabel (`z`/`Z`), bind
+/// propagation, and `nocopy` opts are folded into the trailing `:opt,opt` field.
 pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> String {
 	match vol {
 		VolumeMount::Short(s) => {
@@ -170,6 +179,8 @@ fn quote_exec_arg(arg: &str) -> String {
 	}
 }
 
+/// Map a compose `restart:` policy onto a systemd `Restart=` value.
+/// `unless-stopped` has no systemd equivalent and is treated as `always`.
 pub(super) fn render_restart(restart: &RestartPolicy) -> String {
 	match restart {
 		RestartPolicy::No => "no".to_string(),
@@ -179,6 +190,8 @@ pub(super) fn render_restart(restart: &RestartPolicy) -> String {
 	}
 }
 
+/// Sort a map of optional-valued entries by key into a stable `Vec`, so the
+/// generated unit is byte-deterministic regardless of `HashMap` iteration order.
 pub(super) fn sorted_pairs(
 	map: std::collections::HashMap<String, Option<String>>,
 ) -> Vec<(String, Option<String>)> {
@@ -186,6 +199,9 @@ pub(super) fn sorted_pairs(
 	sorted.into_iter().collect()
 }
 
+/// Sort a map of string-valued entries (labels, sysctls, …) by key into a stable
+/// `Vec`, so the generated unit is byte-deterministic regardless of `HashMap`
+/// iteration order.
 pub(super) fn sorted_label_pairs(
 	map: std::collections::HashMap<String, String>,
 ) -> Vec<(String, String)> {
@@ -231,6 +247,7 @@ pub(super) struct Section {
 }
 
 impl Section {
+	/// Start an empty section with the given `[name]` header.
 	pub(super) fn new(name: &'static str) -> Self {
 		Section {
 			name,
@@ -238,14 +255,19 @@ impl Section {
 		}
 	}
 
+	/// Append a `Key=Value` line, sanitizing the value (control characters
+	/// stripped) so a hostile compose field cannot inject extra unit directives.
 	pub(super) fn add(&mut self, key: &str, value: String) {
 		self.lines.push(format!("{key}={}", sanitize_value(&value)));
 	}
 
+	/// True when no lines have been added; lets the caller skip emitting an empty
+	/// section.
 	pub(super) fn is_empty(&self) -> bool {
 		self.lines.is_empty()
 	}
 
+	/// Render the section as `[name]` followed by its lines, each newline-terminated.
 	pub(super) fn render(&self) -> String {
 		let mut s = format!("[{}]\n", self.name);
 		for line in &self.lines {

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -4,6 +4,11 @@ use crate::compose::types::NetworkConfig;
 
 use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
 
+/// Build the `.network` unit for one declared network. Emits a single `[Network]`
+/// section (NetworkName, then driver/internal/IPv6/IPAM/options/labels), always
+/// appending the `podup.project` ownership label. No `[Install]` section is
+/// written: `.network` units are pulled in as dependencies of the `.container`
+/// units that reference them.
 pub(crate) fn network_unit(
 	name: &str,
 	project: &str,

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -4,6 +4,11 @@ use crate::compose::types::VolumeConfig;
 
 use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
 
+/// Build the `.volume` unit for one declared named volume. Emits a single
+/// `[Volume]` section (VolumeName, then driver/driver-opts/labels), always
+/// appending the `podup.project` ownership label. No `[Install]` section is
+/// written: `.volume` units are pulled in as dependencies of the `.container`
+/// units that reference them.
 pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfig>) -> QuadletUnit {
 	let mut vol = Section::new("Volume");
 	// A custom `name:` overrides Podman's resource name; Quadlet uses the literal

--- a/internal/size.rs
+++ b/internal/size.rs
@@ -84,7 +84,11 @@ pub fn parse_duration_secs(s: &str) -> Option<u64> {
 	Some(secs as u64)
 }
 
-/// Parse a duration into nanoseconds (used by Docker healthcheck APIs).
+/// Parse a duration like `5s`, `200ms`, `1m`, `1h` into nanoseconds (used by
+/// Docker healthcheck APIs).
+///
+/// Returns `None` for non-finite (`NaN`/`inf`), negative, or out-of-`i64`-range
+/// results instead of saturating or wrapping the cast.
 pub fn parse_duration_nanos(s: &str) -> Option<i64> {
 	let trimmed = s.trim();
 	if trimmed.is_empty() {

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -115,6 +115,11 @@ fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> 
 	buf
 }
 
+/// Apply a parsed `Modifier` to `var`, implementing compose's
+/// `${VAR:-default}` / `${VAR-default}` / `${VAR:+alt}` / `${VAR+alt}` /
+/// `${VAR:?err}` / `${VAR?err}` substitution semantics (the `:` forms treat an
+/// empty value like unset). `Modifier::None` returns the value or an empty
+/// string; the `Error*` variants fail when the condition is unmet.
 pub(super) fn resolve_modifier(
 	var: String,
 	modifier: Modifier,


### PR DESCRIPTION
## What

I filled the doc-comment gaps across `internal/` flagged in #579, judged against our style standard: every public item carries a doc comment stating its contract (errors, invariants, **units**, side effects), not a restatement of the signature.

## Changes

- **Real defect fixed** — `engine/health.rs`: the doc block describing `wait_healthy` was glued above `wait_services_healthy`, so rustdoc rendered the wrong function's docs and `wait_healthy` had none. Moved it to the function it describes.
- **libpod wire types** — documented fields with their units/format where it's a correctness hazard: `HealthConfig` timing = nanoseconds, `LinuxMemory` = bytes, `shm_size` = bytes, `stop_timeout` = seconds, throttle rates = bytes/s or iops by field. Verified each unit against how the value is produced/consumed; converted the serde wire-rename rationale comments from `//` to `///`.
- **compose types** — every `Service` field (compose key, unit/default, precedence: `scale` vs `deploy.replicas`, top-level `cpus`/`mem` over `deploy.resources`, `restart` vs `deploy.restart_policy`, `pull_policy` values), plus `SecretConfig`/`ConfigConfig`/`ModelConfig`/`ComposeFile` and the `develop` watch types.
- **engine / quadlet / crate root** — `build_resource_limits`/`build_ulimits`, `parse_device`, the quadlet `unit`/`render` helpers, and the public module surface in `lib.rs`.
- **doc-build hygiene** — fixed stale/broken intra-doc links surfaced by rustdoc (so docs build clean under `-D warnings`) and corrected the `include.rs` module header that omitted `models` from the merged-fields list.

## Scope

Documentation only — no behavior change.

## Verification

- `cargo fmt --check` — clean
- `cargo doc --no-deps --document-private-items` under `RUSTDOCFLAGS=-D warnings` — clean
- `cargo check --all-targets` — clean
- `cargo test --lib` — 836 passing

Closes #579