### PR TITLE
docs: fix accuracy bugs and restructure docs/

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,8 @@
 # Command reference
 
-Every `podup` subcommand, its options, and what it does. Run `podup <command>
---help` for the same information at the terminal.
+This page lists every `podup` command, its options, and what it does. Run
+`podup <command> --help` for the same information at the terminal. The
+[global options](#global-options) below apply to every command.
 
 ```
 podup [GLOBAL OPTIONS] <COMMAND> [COMMAND OPTIONS] [SERVICE...]
@@ -9,9 +10,9 @@ podup [GLOBAL OPTIONS] <COMMAND> [COMMAND OPTIONS] [SERVICE...]
 
 ## Global options
 
-These apply to every command and may appear before the subcommand.
+These appear before the subcommand and may also come from the environment.
 
-| Option | Env | Description |
+| Flag | Env | Description |
 |---|---|---|
 | `-f, --file <PATH>` | `COMPOSE_FILE` | Compose file. Repeatable; later files merge over earlier ones. When unset, the compose-spec precedence list is probed: `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml`. |
 | `-p, --project <NAME>` | `COMPOSE_PROJECT_NAME` | Project name, prefixing container/network/volume names. When unset: the top-level `name:`, then the sanitized project-directory basename. |
@@ -24,144 +25,296 @@ These apply to every command and may appear before the subcommand.
 
 ### `up`
 Create and start all services (or only the named ones, plus their transitive
-`depends_on`).
+`depends_on`). Accepts a trailing service list.
 
-| Option | Description |
-|---|---|
-| `-d, --detach` | Run containers in the background. |
-| `--build` | Build images before starting. |
-| `-w, --watch` | After starting, watch for changes per `develop.watch`. |
-| `--remove-orphans` | Remove containers for services no longer in the file. |
-| `--no-recreate` | Leave already-running containers in place. |
-| `--force-recreate` | Recreate containers even if their config is unchanged. |
-| `--no-deps` | Do not start the `depends_on` services of the named services. |
-| `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. |
-| `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
-| `--no-build` | Do not build images, even for services with a `build:` section. |
-| `--quiet-pull` | Suppress image-pull progress output. |
-| `--wait` | Wait until services are running/healthy before returning. |
-| `--no-start` | Create the containers but do not start them. |
+| Flag | Description | Default |
+|---|---|---|
+| `-d, --detach` | Run containers in the background. | off |
+| `--build` | Build images before starting. | off |
+| `-w, --watch` | After starting, watch for changes per `develop.watch`. | off |
+| `--remove-orphans` | Remove containers for services no longer in the file. | off |
+| `--no-recreate` | Leave already-running containers in place. | off |
+| `--force-recreate` | Recreate containers even if their config is unchanged. | off |
+| `--no-deps` | Do not start the `depends_on` services of the named services. | off |
+| `-t, --timeout <SECS>` | Seconds to wait for a container to stop when recreating. | Podman default |
+| `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. | from file |
+| `--pull <POLICY>` | Pull policy before starting: `always`, `missing`, `never`. | per service |
+| `--no-build` | Do not build images, even for services with a `build:` section. | off |
+| `--quiet-pull` | Suppress image-pull progress output. | off |
+| `--wait` | Wait until services are running/healthy before returning. | off |
+| `--no-start` | Create the containers but do not start them. | off |
+| `--timestamps` | Prefix attached log lines with a timestamp (ignored with `-d`). | off |
+| `-V, --renew-anon-volumes` | Recreate anonymous volumes instead of keeping the previous ones. | off |
+
+```bash
+podup up -d --build
+```
 
 ### `down`
-Stop and remove containers. `-v, --volumes` also removes named volumes declared
-in the compose file; `--remove-orphans` also removes containers for services no
-longer in the file; `--rmi all|local` also removes the service images (`local`
-only those built from a `build:` section).
+Stop and remove containers, networks, and (with `-v`) volumes.
 
-### `start` / `stop` / `restart`
-Start existing stopped containers, stop running ones without removing them, or
-restart them. `start`/`stop`/`restart` accept a trailing service list;
-`restart [SERVICE...]` restarts everything or the named services.
-`restart --no-deps` skips cascade-restarting dependents that declare a
-`depends_on` restart condition.
-
-### `scale <SERVICE=N>...`
-Set the number of running containers for one or more services, creating missing
-replicas and removing surplus ones. A service that publishes a **fixed host
-port** cannot be scaled past one replica (only one container can bind a host
-port) — the command fails fast and tells you to drop the host port (`- "80"`, so
-Podman assigns one per replica), front it with a reverse proxy, or stay at one
-replica.
+| Flag | Description | Default |
+|---|---|---|
+| `-v, --volumes` | Also remove named volumes declared in the compose file. | off |
+| `--remove-orphans` | Remove containers for services no longer in the file. | off |
+| `--rmi <SCOPE>` | Also remove service images: `all`, or `local` (only those built from a `build:` section). | keep images |
+| `-t, --timeout <SECS>` | Seconds to wait for containers to stop before killing them. | Podman default |
 
 ### `create`
 Create the containers for services without starting them (like `up` stopped at
-the create step). `--build` builds images first; `--force-recreate` recreates
-unchanged containers; `--no-recreate` leaves existing ones in place. Accepts a
-trailing service list. A later `up`/`start` runs the created containers.
+the create step). Accepts a trailing service list. A later `up`/`start` runs the
+created containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--build` | Build images before creating containers. | off |
+| `--force-recreate` | Recreate containers even if their config is unchanged. | off |
+| `--no-recreate` | Leave existing containers in place. | off |
+
+### `start`
+Start existing stopped containers. Accepts a trailing service list.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--wait` | Wait until services are running/healthy before returning. | off |
+| `--wait-timeout <SECS>` | Maximum seconds to wait with `--wait` before giving up. | no limit |
+
+### `stop`
+Stop running containers without removing them. Accepts a trailing service list.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-t, --timeout <SECS>` | Seconds to wait for containers to stop before killing them. | Podman default |
+
+### `restart`
+Restart service containers (default: all, or the named ones).
+
+| Flag | Description | Default |
+|---|---|---|
+| `-t, --timeout <SECS>` | Seconds to wait for containers to stop before killing them. | Podman default |
+| `--no-deps` | Do not cascade-restart dependents that declare a `depends_on` restart condition. | off |
 
 ### `build`
 Build or rebuild service images (optionally only the named services).
 
-### `push`
-Push each service's `image:` to its registry (services without an image are
-skipped). Credentials come from `podman login`. `--ignore-push-failures`
-continues after a failure; `--tls-verify false` allows an insecure/HTTP
-registry (omit it to keep Podman's default verification). Accepts a trailing
-service list.
+| Flag | Description | Default |
+|---|---|---|
+| `--no-cache` | Do not use the build cache. | off |
+| `--pull` | Always attempt to pull a newer base image. | off |
+| `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
+| `-q, --quiet` | Suppress the build output. | off |
 
-### `rm`
-Remove stopped service containers. `-f, --force` stops and removes running ones;
-`-v, --volumes` also removes anonymous volumes attached to them.
+## Inspection
 
-### `kill`
-Send a signal to service containers. `-s, --signal <SIG>` sets the signal
-(default `SIGKILL`); `--remove-orphans` then removes containers for services no
-longer in the file.
+### `ps`
+List project containers.
 
-### `pause` / `unpause`
-Pause running service containers, or resume paused ones.
+| Flag | Description | Default |
+|---|---|---|
+| `-a, --all` | Include stopped containers. | running only |
+| `-q, --quiet` | Print container IDs only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
 
-## Running commands
+### `ls`
+List podup compose projects on the host. Needs no compose file.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-a, --all` | Include stopped projects. | running only |
+| `-q, --quiet` | Print project names only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
+
+### `logs [SERVICE...]`
+View container output for the named services (or all).
+
+| Flag | Description | Default |
+|---|---|---|
+| `-f, --follow` | Stream new output. | off |
+| `-n, --tail <N>` | Show the last N lines. | all |
+| `--since <TIME>` | Show logs since a timestamp or relative time (e.g. `10m`). | start |
+| `--until <TIME>` | Show logs before a timestamp or relative time. | end |
+| `-t, --timestamps` | Prefix each line with an RFC3339 timestamp. | off |
+
+### `events`
+Stream Podman events for this project's containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FMT>` | `table` (a `TYPE ACTION NAME` summary) or `json` (one object per line). | `table` |
+
+`--json` is a hidden deprecated alias for `--format json`.
+
+### `top [SERVICE...]`
+Show the running processes of service containers.
+
+### `stats [SERVICE...]`
+Live resource usage (CPU, memory, network, block I/O, PIDs) for service
+containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--no-stream` | Print one snapshot and exit. | stream |
+
+### `port <SERVICE> <PRIVATE_PORT>`
+Print the public binding for a port.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--proto <PROTO>` | `tcp` or `udp`. | `tcp` |
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+
+### `images`
+List images used by services.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-q, --quiet` | Print image IDs only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
+
+### `volumes [SERVICE...]`
+List the project's named volumes (a trailing service list narrows it to volumes
+those services mount).
+
+| Flag | Description | Default |
+|---|---|---|
+| `-q, --quiet` | Print volume names only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
+
+## Container operations
 
 ### `run <SERVICE> [COMMAND...]`
 Run a one-off command in a new container for the service.
 
-| Option | Description |
-|---|---|
-| `--rm` | Remove the container after it exits (the default). |
-| `--no-rm` | Keep the one-off container after it exits instead of removing it. |
-| `-d, --detach` | Run in the background. |
-| `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. |
-| `--name <NAME>` | Override the container name. |
-| `-P, --service-ports` | Publish the service's declared ports (off by default). |
-| `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. |
-| `-w, --workdir <PATH>` | Working directory inside the container. |
-| `--entrypoint <CMD>` | Override the image entrypoint. |
-| `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. |
-| `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. |
-| `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). |
-| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). |
-| `--no-deps` | Do not start the `depends_on` services before running. |
+| Flag | Description | Default |
+|---|---|---|
+| `--rm` | Remove the container after it exits. | on |
+| `--no-rm` | Keep the one-off container after it exits. | off |
+| `-d, --detach` | Run in the background. | off |
+| `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. | none |
+| `--name <NAME>` | Override the container name. | generated |
+| `-P, --service-ports` | Publish the service's declared ports. | off |
+| `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. | image default |
+| `-w, --workdir <PATH>` | Working directory inside the container. | image default |
+| `--entrypoint <CMD>` | Override the image entrypoint. | image default |
+| `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
+| `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
+| `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
+| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `--no-deps` | Do not start the `depends_on` services before running. | off |
+
+```bash
+podup run --rm web sh -c 'echo hello'
+```
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
 
+| Flag | Description | Default |
+|---|---|---|
+| `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. | none |
+| `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. | container default |
+| `-w, --workdir <PATH>` | Working directory inside the container. | container default |
+| `--privileged` | Give extended privileges to the command. | off |
+| `-d, --detach` | Run the command in the background. | off |
+| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+
+```bash
+podup exec -u root web sh
+```
+
 ### `cp <SRC> <DST>`
 Copy files between a container and the host. Use `SERVICE:PATH` for the
-container side, e.g. `podup cp web:/app/data ./local`. `--index <N>` targets a
-specific replica (1-based) of a scaled service; `-L/--follow-link` follows
-symlinks in the host source before copying into the container; `-a/--archive` is
-accepted for compatibility (no effect under rootless Podman).
+container side, e.g. `podup cp web:/app/data ./local`.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+| `-L, --follow-link` | Follow symlinks in the host source before copying into the container. | off |
+| `-a, --archive` | Accepted for compatibility (no effect under rootless Podman). | off |
 
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
 container exits or you detach.
 
+### `kill [SERVICE...]`
+Send a signal to service containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-s, --signal <SIG>` | Signal to send. | `SIGKILL` |
+| `--remove-orphans` | Then remove containers for services no longer in the file. | off |
+
+### `rm [SERVICE...]`
+Remove stopped service containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-f, --force` | Remove even running containers (stop first). | off |
+| `-v, --volumes` | Also remove anonymous volumes attached to them. | off |
+| `-s, --stop` | Stop the containers (gracefully) before removing them. | off |
+
+### `pause [SERVICE...]` / `unpause [SERVICE...]`
+Pause running service containers, or resume paused ones. `resume` is an alias
+for `unpause`.
+
 ### `wait [SERVICE...]`
 Block until the named service containers (default: all) stop, printing each
 container's exit code as it does.
 
+### `scale <SERVICE=N>...`
+Set the number of running containers for one or more services, creating missing
+replicas and removing surplus ones. A service that publishes a **fixed host
+port** cannot be scaled past one replica — the command fails fast and tells you
+to drop the host port (`- "80"`, so Podman assigns one per replica), front it
+with a reverse proxy, or stay at one replica.
+
 ### `commit <SERVICE> <IMAGE>`
 Commit a service container's current state to a new image reference
-(`repo[:tag]`). `--index <N>` selects a replica (1-based) of a scaled service.
+(`repo[:tag]`).
+
+| Flag | Description | Default |
+|---|---|---|
+| `--index <N>` | Select a replica (1-based) of a scaled service. | 1 |
 
 ### `export <SERVICE>`
-Export a service container's filesystem as a tar archive. By default the archive
-goes to stdout; `-o, --output <FILE>` writes it to a file instead. `--index <N>`
-selects a replica (1-based) of a scaled service.
+Export a service container's filesystem as a tar archive.
 
-## Inspection
+| Flag | Description | Default |
+|---|---|---|
+| `-o, --output <FILE>` | Write to a file instead of stdout. | stdout |
+| `--index <N>` | Select a replica (1-based) of a scaled service. | 1 |
 
-| Command | Description |
-|---|---|
-| `ps` | List project containers. `-a/--all` includes stopped containers, `-q/--quiet` prints container IDs only, `--format table\|json`. |
-| `ls` | List podup compose projects on the host. `-a/--all` includes stopped projects, `-q/--quiet` prints names only, `--format table\|json`. Needs no compose file. |
-| `top` | Show running processes of service containers. |
-| `stats` | Live resource usage (CPU, memory, network, block I/O, PIDs) for service containers. `--no-stream` prints one snapshot; a trailing service list narrows it. |
-| `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
-| `events` | Stream Podman events for this project's containers. `--format json` emits each event as a JSON line instead of a `TYPE ACTION NAME` summary (the deprecated `--json` flag is a hidden alias for it). |
-| `images` | List images used by services. `-q/--quiet` prints image IDs only, `--format table\|json`. |
-| `volumes [SERVICE...]` | List the project's named volumes. `-q/--quiet` prints names only, `--format table\|json`; a trailing service list narrows it to volumes those services mount. |
-| `logs [SERVICE...]` | View container output for the named services (or all). `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
-| `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates, `--no-interpolate` leaves `${VAR}` placeholders literal, `--resolve-image-digests` rewrites each service `image:` to its registry digest (`repo@sha256:...`). |
-| `pull` | Pull images for all services. `-q/--quiet` suppresses progress output. |
+## Images
+
+### `pull [SERVICE...]`
+Pull images for the named services, or all services if none are given.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-q, --quiet` | Suppress image-pull progress output. | off |
+| `--ignore-pull-failures` | Continue pulling the remaining services after a failure. | off |
+| `--include-deps` | Also pull images for the named services' `depends_on` services. | off |
+| `--policy <POLICY>` | Pull policy, overriding per-service `pull_policy`: `always`, `missing`, `never`, `newer`, `build`. | per service |
+
+### `push [SERVICE...]`
+Push each service's `image:` to its registry (services without an image are
+skipped). Credentials come from `podman login`.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--ignore-push-failures` | Continue after a failure. | off |
+| `--tls-verify <BOOL>` | Verify the registry TLS cert; `false` allows an insecure/HTTP registry. | Podman default |
 
 ## Generate
 
-### `generate quadlet [-o <DIR>]`
+### `generate quadlet`
 Translate the compose file into Podman Quadlet unit files — one `.container` per
-service plus `.network` and `.volume` units. Without `-o, --output` the units
-print to stdout; warnings about fields with no Quadlet mapping go to stderr.
+service plus `.network` and `.volume` units. `gen` is an alias for `generate`.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-o, --output <DIR>` | Directory to write the unit files into. Omit to print to stdout. | stdout |
 
 ```bash
 podup generate quadlet -o ~/.config/containers/systemd
@@ -186,21 +339,19 @@ The `action` of each rule may be:
 | `sync+restart` | Sync the files, then restart the container. |
 | `sync+exec` | Sync the files, then run the rule's `exec` command in the container. |
 
-## Self-update
+## Maintenance
 
-### `update`
-Replace the running binary with the latest signed release.
+### `config`
+Print the resolved compose file (after substitution, extends, include).
+`convert` is an alias.
 
-| Option | Description |
-|---|---|
-| `--check` | Report whether a newer release exists; install nothing. |
-| `--force` | Reinstall even if the latest release is not newer. |
-
-Verification fails closed: a missing key, bad Ed25519 signature, or SHA-256
-mismatch aborts before the installed binary is touched. See
-[self-update.md](self-update.md) for the trust model.
-
-## Shell completions
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FMT>` | `yaml` or `json`. | `yaml` |
+| `--services` | List service names, one per line. | off |
+| `-q, --quiet` | Only validate; print nothing. | off |
+| `--no-interpolate` | Leave `${VAR}` placeholders literal. | off |
+| `--resolve-image-digests` | Rewrite each service `image:` to its registry digest (`repo@sha256:...`). | off |
 
 ### `completions <SHELL>`
 Print a shell completion script to stdout for `bash`, `zsh`, `fish`,
@@ -212,6 +363,20 @@ podup completions bash > ~/.local/share/bash-completion/completions/podup
 podup completions zsh  > "${fpath[1]}/_podup"
 podup completions fish > ~/.config/fish/completions/podup.fish
 ```
+
+### `update`
+Replace the running binary with the latest signed release.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--check` | Report whether a newer release exists; install nothing. | off |
+| `--force` | Reinstall even if the latest release is not newer. | off |
+
+Verification fails closed: a missing key, bad Ed25519 signature, or SHA-256
+mismatch aborts before the installed binary is touched. See
+[self-update.md](self-update.md) for the trust model.
+
+Run `podup --version` to print the version.
 
 ## Diagnostics
 

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -17,12 +17,21 @@ Requires `debhelper`, `cargo` and `rustc >= 1.85` (the crate's declared
 `rust-version`). The package installs `/usr/bin/podup` and the `podup(1)` man
 page.
 
+The packaged binary is built with the self-update feature **compiled out**:
+`debian/rules` builds with `--no-default-features --features watch,completions`,
+dropping the `update` feature (and its `ureq` + TLS + Ed25519 stack). This is
+why `podup update` on a deb-installed binary refuses outright and points back to
+the package manager — the capability is absent from the binary, not merely
+gated at runtime by a dpkg-ownership check.
+
 ## Prebuilt .deb from releases
 
 Each tagged release attaches a signed `.deb` per architecture —
 `podup_<version>_amd64.deb` and `podup_<version>_arm64.deb` (each with its
-`.sig`, and an entry in the release `SHA256SUMS`) built on Debian sid. Install
-the one matching your architecture directly:
+`.sig`, and an entry in the release `SHA256SUMS`). Each architecture is built
+natively in its own `debian:sid` container (amd64 on an x64 runner, arm64 on an
+arm64 runner — no emulation). Install the one matching your architecture
+directly:
 
 ```bash
 sudo apt install ./podup_<version>_amd64.deb   # or _arm64.deb on aarch64
@@ -77,8 +86,7 @@ publishing. The signing key, keyring builder and repository builder all live in
 the `Glyndor/apt` repo.
 
 > **Debian compatibility note:** the MSRV is 1.85, which Debian trixie ships, so
-> trixie and sid can both build the package. (Earlier releases needed 1.86 via
-> an `idna`/`icu` dependency chain that has since been removed.)
+> trixie and sid can both build the package.
 
 ## What the skeleton covers
 

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -1,10 +1,19 @@
 # Migrating from Docker Compose to podup
 
-This guide covers what to expect when you switch a `docker-compose.yml` from
-Docker to podup on rootless Podman.  The short answer is: **most files work
-without any changes**.  Read on for the full picture.
+Point podup at an existing `docker-compose.yml` and run it — no rewrite, no new
+file format. The short answer is: **most files work without any changes**.
 
-## What works out of the box
+```sh
+cd my-project          # the directory holding docker-compose.yml
+podup up
+```
+
+podup reads the same `compose.yaml` / `docker-compose.yml` files docker-compose
+does and runs them on rootless Podman. The rest of this guide is the full
+picture: what works unchanged, what behaves differently under Podman, what is
+accepted but has no effect, and what is not yet supported.
+
+## Works out of the box
 
 Every core Compose spec key is supported:
 
@@ -19,15 +28,25 @@ Every core Compose spec key is supported:
 | Dependencies | `depends_on` (with `condition:` — `service_started`, `service_healthy`, `service_completed_successfully`) |
 | Health checks | `healthcheck` (test, interval, timeout, retries, start_period, disable) |
 | Lifecycle hooks | `post_start`, `pre_stop` |
-| Restart policies | `restart`, `deploy.restart_policy` |
+| Restart policies | `restart`, `deploy.restart_policy` (`condition`, `max_attempts`) |
 | Replicas / scale | `deploy.replicas`, `scale:` |
 | Resource limits | `deploy.resources`, `mem_limit`, `cpus`, `cpu_shares`, `cpu_quota`, `pids_limit`, `ulimits`, `blkio_config` |
-| Devices | `devices`, `device_cgroup_rules`, `deploy.resources.reservations.devices` (GPU) |
+| Devices | `devices`, `device_cgroup_rules` |
+| GPU | `deploy.resources.reservations.devices`, `gpus:` — see the note below |
 | Security | `cap_add`, `cap_drop`, `security_opt`, `read_only`, `privileged`, `userns_mode` |
 | Namespaces | `pid`, `ipc`, `uts`, `cgroup`, `shm_size` |
 | Metadata | `labels`, `annotations`, `container_name`, `profiles` |
 | Logging | `logging` (driver + options) |
 | Compose features | `extends`, `include`, YAML anchors, x-extensions, `develop.watch` |
+
+### GPU reservations are host-dependent
+
+`deploy.resources.reservations.devices` and the `gpus:` shorthand are honored,
+but only for **NVIDIA** GPUs, and only when the host exposes them through CDI
+(the NVIDIA Container Toolkit must be installed and the CDI spec generated).
+Reservations for other drivers or capabilities are warned about and skipped.
+This is the common case Podman supports natively — but it depends on the host's
+GPU driver and CDI setup, not on podup alone.
 
 ### External secrets and configs
 
@@ -59,10 +78,33 @@ The secret appears at `/run/secrets/db_password` (configs use the long-form
 fast rather than starting a container without it. Use a top-level `name:` when
 the Podman secret is named differently from the compose reference.
 
-## Rootless Podman differences
+## Behaves differently under rootless Podman
 
-These are Podman behaviours, not podup limitations.  They apply equally to any
-Podman-based tool.
+These are Podman behaviours, not podup limitations — they apply equally to any
+Podman-based tool. Each one is something to expect, with the workaround.
+
+### `network_mode: bridge`
+
+| | |
+|---|---|
+| **What to expect** | docker-compose attaches the container to Docker's predefined shared `bridge` network. Podman reads `--network bridge` as "create a fresh, isolated bridge netns", so the container has outbound connectivity but **cannot reach its project siblings** by name or IP. |
+| **Workaround** | Remove `network_mode: bridge` and let the container join the project's default network, or declare a shared `networks:` entry the services share. podup emits a warning when it sees `network_mode: bridge`. |
+
+```yaml
+# before — siblings unreachable under Podman
+services:
+  web:
+    network_mode: bridge
+
+# after — services share a network and resolve each other by name
+services:
+  web:
+    networks: [app]
+  api:
+    networks: [app]
+networks:
+  app: {}
+```
 
 ### Privileged ports (< 1024)
 
@@ -70,7 +112,7 @@ Rootless containers cannot bind host ports below 1024 unless the kernel allows
 it:
 
 ```bash
-# Allow a single port (temporary, requires root once):
+# Allow ports down to 80 (persists; requires root once):
 sudo sysctl net.ipv4.ip_unprivileged_port_start=80
 
 # Or map through a higher port in your compose file:
@@ -80,14 +122,14 @@ ports:
 
 ### UID/GID mapping
 
-Containers run as your host user's UID inside a user namespace.  If a container
+Containers run as your host user's UID inside a user namespace. If a container
 image writes files with UID 0 (root inside the container), those files appear
-owned by your user on the host.  Bind-mount permissions reflect your host
-user's access.
+owned by your user on the host. Bind-mount permissions reflect your host user's
+access.
 
 ### Volume SELinux labels
 
-On SELinux-enforcing systems, bind mounts require relabeling.  Append `:z`
+On SELinux-enforcing systems, bind mounts require relabeling. Append `:z`
 (shared) or `:Z` (private) to the volume spec:
 
 ```yaml
@@ -98,21 +140,18 @@ volumes:
 ### `network_mode: host`
 
 Attaches the container to your user's network namespace, not a privileged host
-namespace.  Traffic is still limited to your user's capabilities.
+namespace. Traffic is still limited to your user's capabilities.
 
 ### `network_mode: none`
 
-Supported.  The container gets a loopback interface only.
-
-## Deprecated fields (honored with a warning)
+Supported. The container gets a loopback interface only.
 
 ### `mac_address:` at the service level
 
 The Compose spec deprecated the top-level `mac_address` field in favour of
-per-network configuration.  podup still honours it (for backward compatibility)
-and applies it to the primary network, but logs a deprecation warning.
-
-**Migration:** move it under `networks:`:
+per-network configuration. podup still honours it (for backward compatibility)
+and applies it to the primary network, but logs a deprecation warning. Move it
+under `networks:` to silence the warning:
 
 ```yaml
 # before
@@ -128,12 +167,15 @@ services:
         mac_address: "02:42:ac:11:00:02"
 ```
 
-## Swarm-only fields (accepted, no effect)
+## Accepted but has no effect
 
-These fields are part of the Compose spec for Docker Swarm deployments.  They
-are parsed without error so existing compose files validate cleanly, but they
-have no equivalent in single-host rootless Podman.  podup logs a warning for
-each one that is present.
+These fields parse cleanly so existing compose files validate, but podup cannot
+translate them on single-host rootless Podman. **podup emits a warning for each
+one it finds**, so nothing is dropped silently. The list below is a set of
+**examples, not exhaustive** — when in doubt, run `podup up` and read the
+warnings (see [Seeing the warnings](#seeing-the-warnings)).
+
+### Swarm / cluster orchestration
 
 | Field | What it does in Swarm |
 |---|---|
@@ -142,9 +184,41 @@ each one that is present.
 | `deploy.update_config` | Rolling-update parallelism, delay, failure action |
 | `deploy.rollback_config` | Automatic rollback behaviour |
 | `deploy.endpoint_mode` | VIP vs DNS round-robin load balancing |
+| `deploy.restart_policy.delay` / `.window` | No first-class Podman restart delay or attempt-counting window (`condition` and `max_attempts` *are* honored) |
+| port long-form `mode:` (`ingress` / `host`) | Swarm ingress routing |
 
-If you see warnings for these fields, you can safely remove them from your
-compose file when targeting a single-host Podman deployment.
+### BuildKit / buildx-only build options
+
+`build.privileged`, `build.ssh`, `build.ulimits`, `build.isolation`,
+`build.entitlements`, `build.provenance`, `build.sbom` — these have no libpod
+build-API equivalent and are ignored.
+
+### Windows / Hyper-V-only
+
+`cpu_count`, `cpu_percent`, `credential_spec`, `isolation` — no rootless Podman
+equivalent.
+
+### Other parsed-but-ignored fields
+
+| Field | Why it has no effect |
+|---|---|
+| `attach` | podup follows its own attach/detach logic for `up` log streaming |
+| `use_api_socket` | no podup equivalent |
+| `provider:` / top-level `models:` | podup runs no model runner; the service/model is not honored (see [Not yet supported](#not-yet-supported)) |
+| volume long-form `driver_config` | not forwarded to Podman |
+| `networks.*.enable_ipv4` | Podman networks enable IPv4 by default and expose no toggle |
+| `networks.*.ipam.config[].aux_addresses` | not supported by Podman |
+| service `networks.*.gw_priority` | not supported by Podman |
+| `secrets`/`configs` `driver` / `template_driver` (on non-`external` defs) | external secret-store plugins (Vault, AWS SM, …) podup does not invoke; the secret/config is not staged |
+
+## Not yet supported
+
+| Feature | Status |
+|---|---|
+| `env_file.format` values other than `dotenv` | A **warning** is emitted (`format is not honored; podup always parses env files as dotenv`); the file is still read as dotenv |
+| `provider:` / model-runner services (`provider`, top-level `models`) | Modeled and parsed, but **not honored** — a not-honored warning is emitted (these are no rootless-Podman equivalent, *not* "unknown key" errors) |
+| Container naming | A single-replica service is named `<project>-<service>` (e.g. `myapp-web`); docker-compose v2 always appends a `-1` replica index (`myapp-web-1`). Scaled replicas (>1) do get the `-N` suffix. Scripts that reference containers by exact name should account for this. |
+| Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
 
 ## Nothing is dropped silently
 
@@ -156,20 +230,25 @@ a typo or an unmapped feature can't hide. At parse time podup warns about:
 - unknown keys at the top level and inside every modeled object (services and
   their `healthcheck`, `deploy`, `develop.watch`; top-level `networks`,
   `networks.*.ipam`, and `volumes`) — usually a typo such as `enviroment:`;
-- fields it models but cannot honor on rootless Podman: `cpu_count` and
-  `cpu_percent` (Windows/Hyper-V only), `networks.*.enable_ipv4`, and the
-  BuildKit-only `build.privileged`, `build.ulimits`, `build.isolation`,
-  `build.entitlements`, `build.provenance`, `build.sbom`.
+- modeled fields it cannot honor on rootless Podman — the
+  [accepted-but-has-no-effect](#accepted-but-has-no-effect) fields above.
 
 This is what lets a compose file written for a newer Docker or Podman release
 run under podup: unsupported additions surface as warnings instead of vanishing.
 
-The `podup` CLI prints these warnings automatically. If you embed podup as a
-**library**, `parse_file` itself stays quiet — call `podup::collect_diagnostics`
-on the parsed file to obtain the same warnings and surface them to your users.
-
 `extra_hosts` is accepted in both the list (`["host:ip"]`) and mapping
 (`{host: ip}`) forms.
+
+### Seeing the warnings
+
+The `podup` CLI prints these warnings automatically. Run with
+`RUST_LOG=podup=debug` to also see network creation and container lifecycle
+events. See the [`RUST_LOG` reference in `commands.md`](commands.md#environment)
+for the full level table.
+
+If you embed podup as a **library**, `parse_file` itself stays quiet — call
+`podup::collect_diagnostics` on the parsed file to obtain the same warnings and
+surface them to your users.
 
 ## File references and path confinement
 
@@ -182,28 +261,14 @@ intentional divergence from a fully sandboxed parser: do not feed podup a
 compose file from an untrusted source any more than you would `make -f` an
 untrusted Makefile.
 
-## Not yet supported
-
-| Feature | Status |
-|---|---|
-| `env_file.format` values other than `dotenv` | Error is emitted; only the `dotenv` format is accepted |
-| `provider:` / model-runner services (`provider`, top-level `models`) | No rootless Podman equivalent; reported as an unknown key |
-| Container naming | A single-replica service is named `<project>-<service>` (e.g. `myapp-web`); docker-compose v2 always appends a `-1` replica index (`myapp-web-1`). Scaled replicas (>1) do get the `-N` suffix. Scripts that reference containers by exact name should account for this. |
-| Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
-
-## Enabling verbose output
-
-Run with `RUST_LOG=podup=debug` to see network creation, container lifecycle
-events, and the parse-time warnings podup emits for any compose field it cannot
-translate. See the [`RUST_LOG` reference in `commands.md`](commands.md#environment)
-for the full level table.
-
 ## Quick compatibility checklist
 
 Before running `podup up` on an existing compose file:
 
+- [ ] Replace `network_mode: bridge` with a shared `networks:` entry if services need to reach each other.
 - [ ] Remove or remap any host ports below 1024 if running fully rootless.
 - [ ] Add `:Z` to bind mounts on SELinux hosts if containers cannot write to them.
 - [ ] Check for `mac_address:` at the service level — move to `networks:` to silence the warning.
 - [ ] Check for Swarm-only `deploy.*` fields — they are harmless but can be cleaned up.
 - [ ] Verify `env_file` uses dotenv format (key=value lines, `#` comments).
+- [ ] For GPUs, confirm the host has an NVIDIA driver + CDI configured.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -15,12 +15,6 @@ separately in [self-update.md](self-update.md).
   them. Fields that assume more (`privileged`, `oom_kill_disable`,
   `mem_swappiness`, `cpu_rt_*`) are forwarded but warned about, since they are
   reduced or ineffective rootless.
-- The libpod socket is **strictly local**. Only a `unix://` socket path (or an
-  `npipe://` named pipe on Windows) is accepted, whether it comes from
-  `--socket`, `PODMAN_SOCKET`, `DOCKER_HOST`, or auto-detection. Remote schemes
-  (`tcp://`, `ssh://`, `http(s)://`, `fd://`) are **rejected fail-closed** —
-  podup never connects to a remote engine, so the socket boundary is always a
-  local one.
 - podup keeps **no persistent state** of its own outside the Podman objects it
   creates and a per-project advisory lock file under the user's runtime
   directory.
@@ -34,6 +28,15 @@ separately in [self-update.md](self-update.md).
 | Release artifacts (`podup update`, installer) | Untrusted transport | Verified against an embedded Ed25519 key + provenance attestation, fail-closed. |
 | Container filesystem (e.g. `cp` archives) | Untrusted | Tar extraction refuses path-traversal (zip-slip) entries. |
 | Network/TLS to GitHub/crates.io | Untrusted | Integrity comes from signatures, not transport. |
+
+## Connection: the libpod socket is local-only
+
+- The libpod socket is **strictly local**. Only a `unix://` socket path (or an
+  `npipe://` named pipe on Windows) is accepted, whether it comes from
+  `--socket`, `PODMAN_SOCKET`, `DOCKER_HOST`, or auto-detection. Remote schemes
+  (`tcp://`, `ssh://`, `http(s)://`, `fd://`) are **rejected fail-closed** —
+  podup never connects to a remote engine, so the socket boundary is always a
+  local one.
 
 ## Compose files are trusted input
 
@@ -83,6 +86,12 @@ only tighten, never widen, what the launching user already has.
   avoid debug logging where the terminal or log sink is not trusted.
 - podup writes no secret material to its own persistent state.
 
+## Memory safety
+
+The crate forbids `unsafe` by default (`#![deny(unsafe_code)]`). The few
+unavoidable FFI calls (rootless uid/gid lookups, `flock`, `stat`) are isolated,
+individually justified with safety comments, and unit-tested.
+
 ## Supply chain
 
 - Dependencies are pinned in `Cargo.lock`; `cargo deny` enforces a license
@@ -94,11 +103,11 @@ only tighten, never widen, what the launching user already has.
 - The Debian package can be built fully offline from a vendored crate tree, for
   air-gapped/classified environments.
 
-## Memory safety
+## Self-update
 
-The crate forbids `unsafe` by default (`#![deny(unsafe_code)]`). The few
-unavoidable FFI calls (rootless uid/gid lookups, `flock`, `stat`) are isolated,
-individually justified with safety comments, and unit-tested.
+The `podup update` mechanism and its release trust chain — the embedded Ed25519
+keys, the verify-before-install flow, key rotation, and independent/offline
+verification — are documented in [self-update.md](self-update.md).
 
 ## Reporting
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -1,9 +1,12 @@
 # Self-update security model
 
-`podup update` replaces the running binary with the latest release. The design
-goal is that **the update source is impossible to tamper with**: no attacker —
-even one who controls the network or the download host — can make `podup`
-install a modified binary.
+`podup update` replaces the running binary with the latest release. The default
+run resolves the newest release, verifies it, and installs it; `--check` reports
+whether a newer release exists and then stops, downloading nothing and never
+touching the installed binary; `--force` reinstalls the latest release even when
+it is not newer than the current build. The design goal is that **the update
+source is impossible to tamper with**: no attacker — even one who controls the
+network or the download host — can make `podup` install a modified binary.
 
 ## Trust anchor
 
@@ -24,19 +27,31 @@ relied on for integrity.
 
 1. Resolve the latest release tag from the GitHub API and compare it with the
    compiled-in version (`env!("CARGO_PKG_VERSION")`). Nothing is downloaded if
-   the current build is already newest (unless `--force`).
-2. Download the platform binary, `SHA256SUMS`, and `SHA256SUMS.sig` over HTTPS
-   (rustls + webpki roots; HTTPS-only URLs).
-3. **Verify the Ed25519 signature** of `SHA256SUMS` against the embedded public
-   key. A missing/placeholder key, malformed signature, or bad signature aborts
-   here — nothing is written.
-4. Look up the binary's expected SHA-256 in the now-trusted `SHA256SUMS` and
-   verify the downloaded bytes match.
-5. Atomically replace the running executable (write a sibling temp file, fsync,
-   preserve mode, then `rename`). On Windows the in-use `.exe` is renamed aside
-   first and cleaned up on the next run.
+   the current build is already newest (unless `--force`), and `--check` returns
+   here without downloading anything.
+2. **Refuse a package-manager-managed binary.** If the running executable is
+   owned by a system package manager (e.g. installed from the `.deb`, detected
+   via `dpkg-query`), `podup update` refuses **before downloading anything** and
+   redirects you to the package manager (e.g. `apt upgrade podup`); overwriting
+   the file in place would desync the manager's records. This applies even with
+   `--force`. cargo-install / manual layouts (`~/.cargo/bin`, `/usr/local/bin`)
+   are not package-owned and update normally.
+3. Fetch `SHA256SUMS` and `SHA256SUMS.sig` and **verify the Ed25519 signature**
+   of `SHA256SUMS` against the embedded public key — *before* the binary is
+   downloaded, so a tampered or unsigned release is rejected without first
+   buffering a large attacker-controlled payload. A missing/placeholder key,
+   malformed signature, or bad signature aborts here. The manifest and signature
+   are fetched over HTTPS (rustls + webpki roots; HTTPS-only URLs).
+4. Look up the binary's expected SHA-256 in the now-trusted `SHA256SUMS`,
+   download the platform binary over HTTPS, and verify its bytes match (the
+   digest comparison runs in constant time).
+5. Atomically replace the running executable (write a sibling temp file with
+   `O_EXCL`/`O_NOFOLLOW` at mode `0600`, copy the target's mode while stripping
+   any setuid/setgid/sticky bits, fsync, then `rename`). On Windows the in-use
+   `.exe` is renamed aside first and cleaned up on the next run.
 
-Any failure exits with code `2` and leaves the installed binary untouched.
+Any failure exits with code `3` (distinct from clap's `2` for usage errors and
+from a generic `1`) and leaves the installed binary untouched.
 
 ## install.sh
 


### PR DESCRIPTION
## What

I reviewed every doc under `docs/` (plus `bench/`/`fuzz/` READMEs) one by one, fixed claims that drifted from the code, and reorganized each by its document type. `README.md` is intentionally untouched (separate pass).

## Accuracy fixes (verified against code)

- **`self-update.md`** — failure exit code is **`3`**, not `2` (`internal/update/mod.rs:109`, test asserts `!= 2`). Added the package-manager-managed refusal that happens *before* any download (`mod.rs:79-85`).
- **`docker-migration.md`** — added the `network_mode: bridge` divergence (isolated netns under rootless Podman; siblings unreachable; use a shared `networks:` entry) per `compose/diagnostics/ignored_fields.rs`. Corrected `env_file.format` to a **warning** (not an error). Fixed `provider`/`models` wording (modeled-but-not-honored, not "unknown key"). Qualified GPU as NVIDIA-only/host-dependent. Made the ignored-fields list explicitly examples, not exhaustive.
- **`commands.md`** — filled missing flags/commands: `up -t/-V/--timestamps`, `down/stop/restart -t`, `start --wait/--wait-timeout`, the `build` flag set, `rm -s`, the whole `exec` option set, `pull --policy/...`, `create` flags, `port --index`, aliases.

## Restructure (no claim changed)

- **`commands.md`** — grouped by purpose, one options table per command, exit-status table.
- **`docker-migration.md`** — works-out-of-the-box → divergences → accepted-no-effect → not-yet-supported.
- **`self-update.md`** — flow ordered to match the code.
- **`security-model.md`** — reorganized for an auditor read (trust boundaries → connection → secrets → filesystem → memory safety → supply chain → self-update → reporting).
- **`debian-packaging.md`** — noted the `.deb` is built `--no-default-features` (self-update compiled out, hence the `podup update` refusal); native per-arch builds; trimmed an unverifiable aside.

`bench/README.md` and `fuzz/README.md` were already accurate and left as is.

## Scope

Documentation only — no behavior change. Code fences balanced, every documented command/flag verified to exist in `internal/cli/`, no external badges/hotlinks.