### PR TITLE
chore: align .editorconfig with the tabs/spaces standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,28 +1,17 @@
 root = true
 
 [*]
-charset = utf-8
+indent_style = tab
+indent_size = 4
 end_of_line = lf
-insert_final_newline = true
+charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
 
-[*.rs]
-indent_style = tab
-indent_size = 4
-
-[*.sh]
-indent_style = tab
-indent_size = 4
-
-[*.toml]
-indent_style = tab
-indent_size = 4
-
-[*.{yml,yaml,json}]
+[*.{json,yml,yaml}]
 indent_style = space
 indent_size = 2
 
 [*.md]
-indent_style = space
-indent_size = 2
 trim_trailing_whitespace = false


### PR DESCRIPTION
Closes #583.

Aligns `.editorconfig` with the org style standard (tabs width 4 everywhere, spaces for YAML/JSON). The previous file set indentation only per language, so files without a matching section (e.g. .py) had no rule; the [*] default now applies tabs width 4 to everything.