### PR TITLE
ci: send the apt dispatch token so the rebuild authenticates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,6 +357,11 @@ jobs:
       - name: Refresh the Glyndor apt repository
         env:
           GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
+          # Shared secret apt checks in the dispatch payload to confirm the
+          # rebuild was requested by a Glyndor product, not just anyone able to
+          # POST a repository_dispatch. Passed via env so it is never expanded
+          # into the command line.
+          DISPATCH_TOKEN: ${{ secrets.GLYNDOR_APT_DISPATCH_TOKEN }}
         run: |
           # Tell the central apt repo (Glyndor/apt) to rebuild with this new
           # release. Optional: only fires when an APT_DISPATCH_TOKEN with
@@ -369,4 +374,5 @@ jobs:
           gh api -X POST repos/Glyndor/apt/dispatches \
             -f event_type=product-released \
             -F "client_payload[product]=podup" \
+            -F "client_payload[token]=$DISPATCH_TOKEN" \
             || echo "::warning::apt dispatch failed; the daily schedule will refresh it."


### PR DESCRIPTION
## What

Add `client_payload[token]` (from `secrets.GLYNDOR_APT_DISPATCH_TOKEN`) to the `repository_dispatch` that the release workflow sends to `Glyndor/apt`.

## Why

`Glyndor/apt` now authenticates the `product-released` dispatch against a shared secret in the payload (Glyndor/apt#19) instead of accepting any dispatch. podup must send that secret or apt will reject the rebuild and the archive only refreshes on its daily schedule. The secret is a selected org secret already scoped to `podup` and `apt`.

## Notes
- Passed via `env:` (`DISPATCH_TOKEN`), never interpolated into the command line.
- The existing `APT_DISPATCH_TOKEN` (the API auth token with `contents:write` on apt) is unchanged — that authenticates the *call*; the new value authenticates the *payload*.
- Must merge together with Glyndor/apt#19 to keep the instant refresh working.