### PR TITLE
chore: drop the apt-refresh dispatch from the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,20 +353,3 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --locked
-
-      - name: Refresh the Glyndor apt repository
-        env:
-          GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
-        run: |
-          # Tell the central apt repo (Glyndor/apt) to rebuild with this new
-          # release. Optional: only fires when an APT_DISPATCH_TOKEN with
-          # contents:write on Glyndor/apt is configured; otherwise the apt repo
-          # picks up the release on its daily schedule.
-          if [ -z "$GH_TOKEN" ]; then
-            echo "APT_DISPATCH_TOKEN not set — Glyndor/apt will refresh on its schedule."
-            exit 0
-          fi
-          gh api -X POST repos/Glyndor/apt/dispatches \
-            -f event_type=product-released \
-            -F "client_payload[product]=podup" \
-            || echo "::warning::apt dispatch failed; the daily schedule will refresh it."


### PR DESCRIPTION
## What

Remove the "Refresh the Glyndor apt repository" step from `release.yml`.

## Why

`Glyndor/apt` no longer listens for a `repository_dispatch` (Glyndor/apt#20) — it rebuilds on its daily schedule and on demand. This step was already a no-op without an `APT_DISPATCH_TOKEN` (a write credential on apt, which was never provisioned), so removing it drops dead code and the need for podup to ever hold any credential on apt. A new podup release is picked up by apt's next daily build.

Replaces the now-closed #585.