### PR TITLE
docs: move release-key maintainer runbooks out of public docs

### DIFF
--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -76,15 +76,6 @@ The signing key ships as the `glyndor-archive-keyring` package, so apt owns the
 key file. When the key is rotated or its expiry extended, a new keyring version
 is published and `apt upgrade` installs it — nothing for users to re-run.
 
-### Refreshing after a release
-
-The apt repository rebuilds on a daily schedule and can be triggered manually
-(`gh workflow run publish.yml -R Glyndor/apt`). For an immediate refresh on each
-release, set an `APT_DISPATCH_TOKEN` secret (a token with `contents:write` on
-`Glyndor/apt`); `release.yml` then sends a `repository_dispatch` after
-publishing. The signing key, keyring builder and repository builder all live in
-the `Glyndor/apt` repo.
-
 > **Debian compatibility note:** the MSRV is 1.85, which Debian trixie ships, so
 > trixie and sid can both build the package.
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -88,45 +88,16 @@ malicious edit to the constant fails CI. If every key is zeroed, both the binary
 and the installer fail closed and install nothing. The same key signs `podup`,
 `panel`, and `panel-agent` releases (shared `RELEASE_SIGN_KEY`).
 
-### Deriving the public key from the signing secret
-
-To re-derive or rotate it, run locally with the `RELEASE_SIGN_KEY` value (the
-raw 32-byte Ed25519 seed, base64). **Never commit or share the private seed** —
-only its public half:
-
-```bash
-python3 -c '
-import base64, sys
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from cryptography.hazmat.primitives import serialization
-seed = base64.b64decode(sys.argv[1] + "==")
-pub = Ed25519PrivateKey.from_private_bytes(seed).public_key()
-raw = pub.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
-print("install.sh base64 :", base64.b64encode(raw).decode().rstrip("="))
-print("verify.rs bytes   :", ", ".join(str(b) for b in raw))
-' "$RELEASE_SIGN_KEY"
-```
-
-Paste the base64 form into `install.sh` and `install.ps1`, and the byte array
-into `RELEASE_PUBKEYS`.
-
 ### Key rotation
 
 Because each binary accepts up to two keys, the signing key can be rotated
-**without stranding installed binaries** — even if the private key leaks. Run the
-two-release procedure:
+**without stranding installed binaries** — even if the private key leaks. A
+two-release transition first ships the new key alongside the old, so binaries
+already in the field accept the next release and gain the new key; a later
+release then retires the old key once every install has converged on the new
+one.
 
-1. **Transition release.** Add the new key to the rotation slot so the binary
-   embeds `[old, new]` (and add `PODUP_RELEASE_PUBKEY2_B64` / `PubKey2B64` to the
-   installers). Keep `RELEASE_SIGN_KEY` set to the **old** key so `SHA256SUMS` is
-   signed by `old`. Binaries already in the field trust only `old`, so they
-   accept this release and upgrade — gaining `new` in the process.
-2. **Retire release.** Move `new` into slot 0 and zero the rotation slot so the
-   binary embeds `[new]`, and switch the CI `RELEASE_SIGN_KEY` secret to the
-   **new** key. Every binary from step 1 trusts `new`, so all installs converge
-   on the new key and `old` is retired.
-
-During step 1 the leaked `old` key is still accepted for one release — an
+During the transition the old key is still accepted for one release — an
 unavoidable cost of any rotation. The GitHub build-provenance attestation, which
 does not depend on the signing key, still proves origin during the window.
 


### PR DESCRIPTION
## What

The public security docs carried maintainer-only mechanics that don't belong on a public surface:

- `docs/self-update.md` — the public-key derivation script (`RELEASE_SIGN_KEY` → python) and the step-by-step two-release key-rotation procedure (slot edits, CI-secret switch).
- `docs/debian-packaging.md` — the "Refreshing after a release" runbook (`gh workflow run publish.yml`, the `APT_DISPATCH_TOKEN` setup).

Those are operator runbooks, not third-party trust-model content.

## Change

I trimmed both docs to keep only what a third party needs to trust and independently verify a release: the two-key trust anchor, fail-closed verification, rotation that never strands installs, and offline/air-gapped verification. The operator procedures move to the private ops context (no information lost).

Net: +7 −45.