### PR TITLE
chore: set max_line_length in .editorconfig for scaffold parity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
+max_line_length = 120
 
 [*.{yml,yaml,json}]
 indent_style = space


### PR DESCRIPTION
Adds `max_line_length = 120` to `[*]`, matching the org scaffold (`template-repository`) and `apt`. podup's `.editorconfig` was the only thing the now-closed #584 carried that #588 dropped; this brings it over without #584's Markdown-on-tabs regression.