### PR TITLE
fix(engine): repeat the stats `containers` param instead of comma-joining

### DIFF
--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -11,22 +11,22 @@ use crate::libpod::{parse_json_lines, urlencoded, API_PREFIX};
 
 use super::Engine;
 
-/// Build the `&containers=<a,b,c>` query fragment scoping a stats request to the
-/// `wanted` containers, or an empty string when none are wanted (which falls
-/// back to the daemon default). Names are sorted for a stable URL and each is
-/// URL-encoded; the comma separators are intentionally left literal.
+/// Build the query fragment scoping a stats request to the `wanted` containers,
+/// or an empty string when none are wanted (which falls back to the daemon
+/// default). libpod's `/containers/stats` expects the `containers` parameter
+/// **repeated** once per container (`&containers=a&containers=b`), not a single
+/// comma-joined value — a comma-joined list is parsed as one container name and
+/// 404s. Names are sorted for a stable URL and each is URL-encoded.
 fn containers_query(wanted: &HashSet<String>) -> String {
 	if wanted.is_empty() {
 		return String::new();
 	}
 	let mut names: Vec<&String> = wanted.iter().collect();
 	names.sort();
-	let joined = names
+	names
 		.iter()
-		.map(|n| urlencoded(n))
-		.collect::<Vec<_>>()
-		.join(",");
-	format!("&containers={joined}")
+		.map(|n| format!("&containers={}", urlencoded(n)))
+		.collect::<String>()
 }
 
 /// Deserialize a map field, treating an explicit JSON `null` as the default
@@ -257,13 +257,15 @@ mod tests {
 	}
 
 	#[test]
-	fn containers_query_is_sorted_and_scoped() {
+	fn containers_query_repeats_param_per_container() {
+		// libpod wants `containers` repeated, not comma-joined — a comma-joined
+		// list is read as a single container name and 404s.
 		let mut wanted = HashSet::new();
 		wanted.insert("proj-web-1".to_string());
 		wanted.insert("proj-db-1".to_string());
 		assert_eq!(
 			containers_query(&wanted),
-			"&containers=proj-db-1,proj-web-1"
+			"&containers=proj-db-1&containers=proj-web-1"
 		);
 	}
 


### PR DESCRIPTION
## Problem (#591)
`podup stats` always failed on Podman 5:
```
HTTP 404: unable to look up container v591-api,v591-web: no such container
```
libpod's `/containers/stats` wants `containers` **repeated** per container; podup comma-joined them into one value, parsed as a single container name.

## Fix
Emit `&containers=a&containers=b` instead of `&containers=a,b`. Updated the unit test that had encoded the comma-joined form (it asserted an input the daemon never accepts — the fixture enshrined the bug).

## Verified
Probed the real libpod socket: repeated form returns `Stats`, comma/array forms 404. Built and run against Podman 5.4.2:
```
NAME       CPU %   MEM USAGE / LIMIT   ...
v591-api   0.25%   48.0KiB / 60.7GiB
v591-web   0.26%   48.0KiB / 60.7GiB
```

Closes #591