### PR TITLE
fix(engine): resolve live replicas for lifecycle/query after scale

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -36,7 +36,7 @@ impl Engine {
 		for name in &names {
 			let service = &file.services[name];
 
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let grace = self.grace_period_secs(service);
 				// Single atomic restart (no visible stopped window) instead of a
 				// stop+start round-trip.
@@ -57,7 +57,7 @@ impl Engine {
 			}
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
-					for dep_container in self.replica_names(dep_name, dep_service) {
+					for dep_container in self.live_replica_names(dep_name, dep_service).await? {
 						let grace = self.grace_period_secs(dep_service);
 						let restart_path = format!(
 							"{API_PREFIX}/containers/{}/restart?t={grace}",
@@ -90,7 +90,7 @@ impl Engine {
 		let mut last_nonzero = 0i64;
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/wait?condition=stopped",
 					crate::libpod::urlencoded(&container_name),
@@ -123,7 +123,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let grace = self.grace_period_secs(service);
 				let path = format!(
 					"{API_PREFIX}/containers/{}/stop?t={grace}",
@@ -149,7 +149,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/start",
 					crate::libpod::urlencoded(&container_name),
@@ -178,7 +178,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/kill?signal={}",
 					crate::libpod::urlencoded(&container_name),
@@ -223,7 +223,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let force_str = if force { "true" } else { "false" };
 				let path = format!(
 					"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
@@ -248,7 +248,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/pause",
 					crate::libpod::urlencoded(&container_name),
@@ -272,7 +272,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/unpause",
 					crate::libpod::urlencoded(&container_name),

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -392,7 +392,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				for hook in &service.pre_stop {
 					if let Err(e) = self.run_lifecycle_hook(&container_name, hook).await {
 						tracing::debug!("pre_stop hook {container_name}: {e}");

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -135,6 +135,26 @@ impl Engine {
 			.map(|raw| raw.trim_start_matches('/').to_string())
 			.collect())
 	}
+
+	/// The container names to act on for a service: the ones Podman actually has
+	/// (matched by the `podup.service` label), so lifecycle and query commands
+	/// keep working after a runtime `scale`/`up --scale` that the compose file's
+	/// static replica count no longer names. Falls back to the statically-derived
+	/// names when none exist yet (e.g. a service not yet created).
+	pub(crate) async fn live_replica_names(
+		&self,
+		service_name: &str,
+		service: &Service,
+	) -> Result<Vec<String>> {
+		let live = self
+			.list_project_container_names(Some(service_name))
+			.await?;
+		Ok(if live.is_empty() {
+			self.replica_names(service_name, service)
+		} else {
+			live
+		})
+	}
 }
 
 #[cfg(test)]

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -27,7 +27,7 @@ impl Engine {
 
 		for name in &names {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/top",
 					urlencoded(&container_name),

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -131,7 +131,7 @@ impl Engine {
 		target_services: &[String],
 		no_stream: bool,
 	) -> Result<()> {
-		let wanted = self.target_container_names(file, target_services);
+		let wanted = self.target_container_names(file, target_services).await?;
 
 		// Scope the stats stream to just the wanted containers server-side via the
 		// `containers=` query param, so the daemon does not sample every container
@@ -172,18 +172,20 @@ impl Engine {
 
 	/// The set of container names to report on: every replica of the targeted
 	/// services (all services when `target_services` is empty).
-	fn target_container_names(
+	async fn target_container_names(
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],
-	) -> HashSet<String> {
-		file.services
-			.iter()
-			.filter(|(name, _)| {
-				target_services.is_empty() || target_services.iter().any(|t| t == *name)
-			})
-			.flat_map(|(name, service)| self.replica_names(name, service))
-			.collect()
+	) -> Result<HashSet<String>> {
+		let mut wanted = HashSet::new();
+		for (name, service) in &file.services {
+			if target_services.is_empty() || target_services.iter().any(|t| t == name) {
+				for c in self.live_replica_names(name, service).await? {
+					wanted.insert(c);
+				}
+			}
+		}
+		Ok(wanted)
 	}
 }
 


### PR DESCRIPTION
## Problem (#592)
After a runtime `scale`/`up --scale`, by-service commands broke. The running containers are `svc-1..N` but the targeting commands derived names from the compose file's **static** replica count (`replica_names`, which is 1), so they looked for the unsuffixed `project-svc` and 404'd or warned:
```
$ podup scale api=3 && podup restart api
HTTP 404: no container with name or ID "sweep-api" found
```
Affected `stop`/`start`/`restart`/`kill`/`pause`/`unpause`/`top`/`stats`/`wait`; `down` emitted a spurious `could not stop project-svc` warning before its label sweep.

## Fix
`live_replica_names()` lists the containers Podman actually has for a service (by the `podup.service` label) and falls back to the static names only when none exist yet. The targeting commands route through it; `down` stops the real replicas directly.

## Verified
Built and run against real Podman 5.4.2 — `scale api=3` then:
```
restart api  -> exit 0       (was 404)
top api      -> 3 replicas   (was warning)
stop api     -> 3 stopped    (was 404)
down         -> 3 removed, no warning
```

Closes #592