### PR TITLE
fix(cli): don't abort completions on a broken pipe

### DIFF
--- a/internal/main.rs
+++ b/internal/main.rs
@@ -79,8 +79,18 @@ async fn run() -> podup::Result<()> {
 	if let Commands::Completions { shell } = cli.command {
 		let mut cmd = Cli::command();
 		let name = cmd.get_name().to_string();
-		clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
-		return Ok(());
+		// Render into a buffer first: clap_complete panics if the writer errors,
+		// which aborts (SIGABRT) when stdout is a closed pipe such as
+		// `podup completions bash | head`. A `Vec` write never fails; then send
+		// it to stdout and treat a broken pipe as a clean exit, like a normal
+		// Unix tool.
+		let mut buf = Vec::new();
+		clap_complete::generate(shell, &mut cmd, name, &mut buf);
+		match std::io::Write::write_all(&mut std::io::stdout(), &buf) {
+			Ok(()) => return Ok(()),
+			Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => return Ok(()),
+			Err(e) => return Err(e.into()),
+		}
 	}
 
 	// `update` operates on the binary itself, not a compose project, so it runs


### PR DESCRIPTION
## Problem (#597)
`podup completions bash | head` aborted with SIGABRT (exit 134): `clap_complete::generate` panics when its writer errors, and a reader that closes the pipe early makes the stdout write fail.

## Fix
Render the completion script into a `Vec` (which never fails to write), then write it to stdout and treat `BrokenPipe` as a clean exit — standard Unix-tool behaviour.

## Verified (Podman not needed)
```
podup completions bash | head -1   -> exit 0   (was 134)
podup completions zsh  | head -1   -> exit 0
podup completions bash > /dev/null -> exit 0   (output unchanged)
```

Closes #597