### PR TITLE
fix(engine): prefix log lines with the container name

### DIFF
--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -1,0 +1,68 @@
+//! Per-line log prefixing for `docker compose logs`-style multi-service output.
+
+use std::io::Write;
+
+/// Tags each complete log line with `{label} | `, the way `docker compose logs`
+/// labels multi-service output. Bytes arrive as stream frames that may split a
+/// line across frames, so a partial line is buffered until its newline arrives.
+pub(super) struct LinePrefixer {
+	label: String,
+	pending: Vec<u8>,
+}
+
+impl LinePrefixer {
+	pub(super) fn new(label: &str) -> Self {
+		Self {
+			label: format!("{label}  | "),
+			pending: Vec::new(),
+		}
+	}
+
+	/// Buffer `chunk` and write every complete line it now completes.
+	pub(super) fn write(&mut self, out: &mut impl Write, chunk: &[u8]) {
+		self.pending.extend_from_slice(chunk);
+		while let Some(nl) = self.pending.iter().position(|&b| b == b'\n') {
+			let _ = out.write_all(self.label.as_bytes());
+			let _ = out.write_all(&self.pending[..=nl]);
+			self.pending.drain(..=nl);
+		}
+		let _ = out.flush();
+	}
+
+	/// Flush a trailing line that never received a newline (e.g. at stream end).
+	pub(super) fn flush_tail(&mut self, out: &mut impl Write) {
+		if !self.pending.is_empty() {
+			let _ = out.write_all(self.label.as_bytes());
+			let _ = out.write_all(&self.pending);
+			let _ = out.write_all(b"\n");
+			let _ = out.flush();
+			self.pending.clear();
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::LinePrefixer;
+
+	#[test]
+	fn line_prefixer_tags_lines_and_buffers_partials() {
+		let mut p = LinePrefixer::new("web");
+		let mut out: Vec<u8> = Vec::new();
+		p.write(&mut out, b"hello\nwor");
+		// The complete line is tagged; the partial "wor" waits for its newline.
+		assert_eq!(out, b"web  | hello\n");
+		p.write(&mut out, b"ld\n");
+		assert_eq!(out, b"web  | hello\nweb  | world\n");
+	}
+
+	#[test]
+	fn line_prefixer_flush_tail_emits_unterminated_line() {
+		let mut p = LinePrefixer::new("db");
+		let mut out: Vec<u8> = Vec::new();
+		p.write(&mut out, b"partial");
+		assert!(out.is_empty(), "a line with no newline is held back");
+		p.flush_tail(&mut out);
+		assert_eq!(out, b"db  | partial\n");
+	}
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -54,6 +54,45 @@ fn format_ports(ports: &[ContainerPort]) -> String {
 		.join(", ")
 }
 
+/// Tags each complete log line with `{label} | `, the way `docker compose logs`
+/// labels multi-service output. Bytes arrive as stream frames that may split a
+/// line across frames, so a partial line is buffered until its newline arrives.
+struct LinePrefixer {
+	label: String,
+	pending: Vec<u8>,
+}
+
+impl LinePrefixer {
+	fn new(label: &str) -> Self {
+		Self {
+			label: format!("{label}  | "),
+			pending: Vec::new(),
+		}
+	}
+
+	/// Buffer `chunk` and write every complete line it now completes.
+	fn write(&mut self, out: &mut impl Write, chunk: &[u8]) {
+		self.pending.extend_from_slice(chunk);
+		while let Some(nl) = self.pending.iter().position(|&b| b == b'\n') {
+			let _ = out.write_all(self.label.as_bytes());
+			let _ = out.write_all(&self.pending[..=nl]);
+			self.pending.drain(..=nl);
+		}
+		let _ = out.flush();
+	}
+
+	/// Flush a trailing line that never received a newline (e.g. at stream end).
+	fn flush_tail(&mut self, out: &mut impl Write) {
+		if !self.pending.is_empty() {
+			let _ = out.write_all(self.label.as_bytes());
+			let _ = out.write_all(&self.pending);
+			let _ = out.write_all(b"\n");
+			let _ = out.flush();
+			self.pending.clear();
+		}
+	}
+}
+
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
 #[derive(Default)]
 pub struct ExecOptions {
@@ -279,23 +318,21 @@ impl Engine {
 						// let a sibling future block the thread on the same lock
 						// and deadlock. Each frame still locks once and flushes,
 						// keeping interleaved `logs -f` output prompt.
+						let mut out_pfx = LinePrefixer::new(&container_name);
+						let mut err_pfx = LinePrefixer::new(&container_name);
 						while let Some(msg) = stream.next().await {
 							match msg {
 								Ok(LogOutput::StdOut { message }) => {
-									let mut out = std::io::stdout().lock();
-									let _ =
-										out.write_all(String::from_utf8_lossy(&message).as_bytes());
-									let _ = out.flush();
+									out_pfx.write(&mut std::io::stdout().lock(), &message);
 								}
 								Ok(LogOutput::StdErr { message }) => {
-									let mut err = std::io::stderr().lock();
-									let _ =
-										err.write_all(String::from_utf8_lossy(&message).as_bytes());
-									let _ = err.flush();
+									err_pfx.write(&mut std::io::stderr().lock(), &message);
 								}
 								Err(_) => break,
 							}
 						}
+						out_pfx.flush_tail(&mut std::io::stdout().lock());
+						err_pfx.flush_tail(&mut std::io::stderr().lock());
 					}
 				})
 				.collect();
@@ -324,19 +361,18 @@ impl Engine {
 				// across the await loop would starve concurrent log emissions.
 				// Flush after each frame so `logs -f` still streams promptly.
 				let mut out = std::io::stdout().lock();
+				let mut out_pfx = LinePrefixer::new(&container_name);
+				let mut err_pfx = LinePrefixer::new(&container_name);
 				while let Some(msg) = stream.next().await {
 					match msg.map_err(ComposeError::Podman)? {
-						LogOutput::StdOut { message } => {
-							let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
-							let _ = out.flush();
-						}
+						LogOutput::StdOut { message } => out_pfx.write(&mut out, &message),
 						LogOutput::StdErr { message } => {
-							let mut err = std::io::stderr().lock();
-							let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
-							let _ = err.flush();
+							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
 					}
 				}
+				out_pfx.flush_tail(&mut out);
+				err_pfx.flush_tail(&mut std::io::stderr().lock());
 			}
 		}
 
@@ -507,7 +543,28 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::{display_status, format_ports, log_query, LogsOptions};
+	use super::{display_status, format_ports, log_query, LinePrefixer, LogsOptions};
+
+	#[test]
+	fn line_prefixer_tags_lines_and_buffers_partials() {
+		let mut p = LinePrefixer::new("web");
+		let mut out: Vec<u8> = Vec::new();
+		p.write(&mut out, b"hello\nwor");
+		// The complete line is tagged; the partial "wor" waits for its newline.
+		assert_eq!(out, b"web  | hello\n");
+		p.write(&mut out, b"ld\n");
+		assert_eq!(out, b"web  | hello\nweb  | world\n");
+	}
+
+	#[test]
+	fn line_prefixer_flush_tail_emits_unterminated_line() {
+		let mut p = LinePrefixer::new("db");
+		let mut out: Vec<u8> = Vec::new();
+		p.write(&mut out, b"partial");
+		assert!(out.is_empty(), "a line with no newline is held back");
+		p.flush_tail(&mut out);
+		assert_eq!(out, b"db  | partial\n");
+	}
 	use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 	use std::collections::HashMap;
 

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -15,6 +15,9 @@ use super::Engine;
 use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 
 mod inspect;
+mod log_prefix;
+
+use log_prefix::LinePrefixer;
 
 /// Human-readable status for `ps`. Podman's libpod list endpoint leaves
 /// `Status` empty and reports the machine state in `State`, so fall back to it
@@ -52,45 +55,6 @@ fn format_ports(ports: &[ContainerPort]) -> String {
 		})
 		.collect::<Vec<_>>()
 		.join(", ")
-}
-
-/// Tags each complete log line with `{label} | `, the way `docker compose logs`
-/// labels multi-service output. Bytes arrive as stream frames that may split a
-/// line across frames, so a partial line is buffered until its newline arrives.
-struct LinePrefixer {
-	label: String,
-	pending: Vec<u8>,
-}
-
-impl LinePrefixer {
-	fn new(label: &str) -> Self {
-		Self {
-			label: format!("{label}  | "),
-			pending: Vec::new(),
-		}
-	}
-
-	/// Buffer `chunk` and write every complete line it now completes.
-	fn write(&mut self, out: &mut impl Write, chunk: &[u8]) {
-		self.pending.extend_from_slice(chunk);
-		while let Some(nl) = self.pending.iter().position(|&b| b == b'\n') {
-			let _ = out.write_all(self.label.as_bytes());
-			let _ = out.write_all(&self.pending[..=nl]);
-			self.pending.drain(..=nl);
-		}
-		let _ = out.flush();
-	}
-
-	/// Flush a trailing line that never received a newline (e.g. at stream end).
-	fn flush_tail(&mut self, out: &mut impl Write) {
-		if !self.pending.is_empty() {
-			let _ = out.write_all(self.label.as_bytes());
-			let _ = out.write_all(&self.pending);
-			let _ = out.write_all(b"\n");
-			let _ = out.flush();
-			self.pending.clear();
-		}
-	}
 }
 
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
@@ -543,28 +507,7 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::{display_status, format_ports, log_query, LinePrefixer, LogsOptions};
-
-	#[test]
-	fn line_prefixer_tags_lines_and_buffers_partials() {
-		let mut p = LinePrefixer::new("web");
-		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"hello\nwor");
-		// The complete line is tagged; the partial "wor" waits for its newline.
-		assert_eq!(out, b"web  | hello\n");
-		p.write(&mut out, b"ld\n");
-		assert_eq!(out, b"web  | hello\nweb  | world\n");
-	}
-
-	#[test]
-	fn line_prefixer_flush_tail_emits_unterminated_line() {
-		let mut p = LinePrefixer::new("db");
-		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"partial");
-		assert!(out.is_empty(), "a line with no newline is held back");
-		p.flush_tail(&mut out);
-		assert_eq!(out, b"db  | partial\n");
-	}
+	use super::{display_status, format_ports, log_query, LogsOptions};
 	use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 	use std::collections::HashMap;
 


### PR DESCRIPTION
## Problem (#594)
`podup logs` printed raw output with no service tag — in a multi-service stack you can't tell which service a line came from. `docker compose logs` prefixes each line with the service.

## Fix
`LinePrefixer` buffers stream frames (which may split a line) and tags each complete line with `<container>  | `, applied on both the concurrent `-f` path and the sequential path, with a tail flush for an unterminated final line. stdout/stderr keep separate buffers.

## Verified
Built and run against real Podman 5.4.2 on a two-service stack:
```
v594-alpha  | alpha-1
v594-alpha  | alpha-2
v594-beta   | beta-1
v594-beta   | beta-2
```
Plus unit tests for line tagging, partial-frame buffering and tail flush.

Closes #594