### PR TITLE
fix(quadlet): default ContainerName to project-service

### DIFF
--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -3,6 +3,17 @@ use crate::parse_str;
 use crate::quadlet::{generate, QuadletOutput, QuadletUnit};
 
 #[test]
+fn container_name_defaults_to_project_prefixed() {
+	// A service with no explicit `container_name:` must default to
+	// `{project}-{service}`, matching how `up` names the running container,
+	// rather than a bare `web` that would collide across projects.
+	let file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
+	let out = generate(&file, "proj");
+	let web = unit_named(&out, "web.container");
+	assert!(web.contents.contains("ContainerName=proj-web"));
+}
+
+#[test]
 fn duplicate_filename_detects_collision() {
 	let mk = |n: &str| QuadletUnit {
 		filename: n.to_string(),

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -41,12 +41,17 @@ pub(crate) fn container_unit(
 	}
 
 	let mut container = Section::new("Container");
+	// Default the container name to `{project}-{service}`, matching how `up`
+	// names containers. Without the project prefix the unit would create a
+	// container called just `web`, colliding with any other project's `web`
+	// service and diverging from the running-stack name. An explicit
+	// `container_name:` still wins.
 	container.add(
 		"ContainerName",
 		service
 			.container_name
 			.clone()
-			.unwrap_or_else(|| name.to_string()),
+			.unwrap_or_else(|| format!("{project}-{name}")),
 	);
 	if let Some(image) = &service.image {
 		container.add("Image", image.clone());


### PR DESCRIPTION
## Problem (part of #593)
A generated `.container` unit set `ContainerName` to the bare service key (`ContainerName=web`), so the container it creates is named `web` — colliding with any other project's `web` service and diverging from `up`, which names it `project-web`.

## Fix
Default `ContainerName` to `{project}-{service}`, matching `up`. An explicit `container_name:` still wins.

## Verified
`generate quadlet` on project `sweep`:
```
ContainerName=sweep-web    # was: web
```
74 quadlet tests pass, including a new one for the default.

## Out of scope (left on #593)
Prefixing the unit **filenames** (`web.container` → `sweep-web.container`, and the same for `.network`/`.volume`) needs a coordinated rename plus an audit of every cross-unit reference (`After=`/`Requires=`/`Network=`), and Quadlet-resolution verification — its own PR.