### PR TITLE
fix(cli): surface watch progress and add top --format json

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -296,6 +296,9 @@ pub(crate) enum Commands {
 	},
 	/// Display the running processes of service containers.
 	Top {
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+		format: OutputFormat,
 		/// Show only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -246,7 +246,11 @@ pub(crate) async fn dispatch(
 				)
 				.await?
 		}
-		Commands::Top { services } => engine.top(file, &services).await?,
+		Commands::Top { format, services } => {
+			engine
+				.top(file, &services, format == OutputFormat::Json)
+				.await?
+		}
 		Commands::Events { format, json } => {
 			// `--json` is the deprecated alias for `--format json`; either selects
 			// JSON-line output.

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -248,7 +248,7 @@ pub(crate) async fn dispatch(
 		}
 		Commands::Top { format, services } => {
 			engine
-				.top(file, &services, format == OutputFormat::Json)
+				.top_with_options(file, &services, format == OutputFormat::Json)
 				.await?
 		}
 		Commands::Events { format, json } => {

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -13,7 +13,13 @@ impl Engine {
 	/// Display running processes in each service container (`docker compose top`).
 	///
 	/// If `target_services` is empty, all services are queried.
-	pub async fn top(
+	pub async fn top(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
+		self.top_with_options(file, target_services, false).await
+	}
+
+	/// `top` with `docker compose top`-style options: `--format json` emits a
+	/// structured array of `{Container, Titles, Processes}` instead of the table.
+	pub async fn top_with_options(
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -13,7 +13,12 @@ impl Engine {
 	/// Display running processes in each service container (`docker compose top`).
 	///
 	/// If `target_services` is empty, all services are queried.
-	pub async fn top(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
+	pub async fn top(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		json: bool,
+	) -> Result<()> {
 		let names: Vec<String> = if target_services.is_empty() {
 			file.services.keys().cloned().collect()
 		} else {
@@ -25,6 +30,7 @@ impl Engine {
 			target_services.to_vec()
 		};
 
+		let mut json_rows: Vec<serde_json::Value> = Vec::new();
 		for name in &names {
 			let service = &file.services[name];
 			for container_name in self.live_replica_names(name, service).await? {
@@ -37,6 +43,11 @@ impl Engine {
 					.get_json::<crate::libpod::types::container::TopResponse>(&path)
 					.await
 				{
+					Ok(result) if json => json_rows.push(serde_json::json!({
+						"Container": container_name,
+						"Titles": result.titles,
+						"Processes": result.processes,
+					})),
 					Ok(result) => {
 						println!("{container_name}");
 						if let Some(titles) = &result.titles {
@@ -51,6 +62,12 @@ impl Engine {
 					Err(e) => tracing::warn!("top {container_name}: {e}"),
 				}
 			}
+		}
+		if json {
+			println!(
+				"{}",
+				serde_json::to_string_pretty(&json_rows).unwrap_or_default()
+			);
 		}
 		Ok(())
 	}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -70,8 +70,16 @@ fn run_to_exit() {
 /// the trust boundary), acquire the per-project lock, and dispatch the
 /// remaining commands.
 async fn run() -> podup::Result<()> {
-	init_tracing();
 	let cli = parse_cli();
+	// `watch` is an interactive, long-running command; surface its per-action
+	// progress (synced/rebuilt/restarted) by defaulting to INFO instead of the
+	// quiet WARN floor. `RUST_LOG` always overrides.
+	let log_floor = if matches!(cli.command, Commands::Watch) {
+		"info"
+	} else {
+		"warn"
+	};
+	init_tracing(log_floor);
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -79,13 +79,16 @@ pub(crate) fn internal_error_notice() -> String {
 	)
 }
 
-/// Initialize the global tracing subscriber: warnings by default (so the
-/// forward-compat "unknown field" notices are never silently dropped), written
-/// to stderr in the `podup: <level>: <msg>` format so stdout stays a clean pipe.
-pub(crate) fn init_tracing() {
+/// Initialize the global tracing subscriber, written to stderr in the
+/// `podup: <level>: <msg>` format so stdout stays a clean pipe. `default_level`
+/// is the floor used when `RUST_LOG` is unset — `warn` for most commands (so the
+/// forward-compat "unknown field" notices are never silently dropped), `info`
+/// for interactive long-running ones like `watch` that should surface their
+/// per-action progress. `RUST_LOG` always overrides.
+pub(crate) fn init_tracing(default_level: &str) {
 	tracing_subscriber::fmt()
 		.with_env_filter(
-			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level)),
 		)
 		.with_writer(std::io::stderr)
 		.event_format(PodupFormat)

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -97,7 +97,7 @@ async fn engine_top_running_container() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.top(&file, &[], false).await.unwrap();
+	engine.top(&file, &[]).await.unwrap();
 	engine.down(&file).await.unwrap();
 }
 
@@ -257,7 +257,7 @@ async fn top_scaled_service_all_replicas() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.top(&file, &[], false).await.unwrap();
+	engine.top(&file, &[]).await.unwrap();
 	engine.down(&file).await.unwrap();
 }
 

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -97,7 +97,7 @@ async fn engine_top_running_container() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.top(&file, &[]).await.unwrap();
+	engine.top(&file, &[], false).await.unwrap();
 	engine.down(&file).await.unwrap();
 }
 
@@ -257,7 +257,7 @@ async fn top_scaled_service_all_replicas() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.top(&file, &[]).await.unwrap();
+	engine.top(&file, &[], false).await.unwrap();
 	engine.down(&file).await.unwrap();
 }
 


### PR DESCRIPTION
## Problem (#599)
Two CLI output gaps found in the empirical sweep:
1. `podup watch` looked silent — it logs each sync/rebuild/restart at INFO, but the default WARN log floor hid them.
2. `podup top --format json` errored `service '--format' not found` — `top` had no `--format` and its `trailing_var_arg` swallowed the flag as a service name.

## Fix
- Initialize tracing with an **INFO** floor for the interactive `watch` command (every other command keeps WARN; `RUST_LOG` always overrides).
- Add `--format json` to `top` (like ps/ls/images), emitting `[{Container, Titles, Processes}]`.

## Verified (Podman 5.4.2)
```
# watch (no RUST_LOG) now prints:
podup: info: synced …/src/f.txt -> /app

# top --format json:
[ { "Container": "v599c-web", "Processes": [[ "root", "1", … ]] } ]
```
Table `top` output unchanged.

Closes #599