### PR TITLE
fix(engine): consistent idempotent exit codes for lifecycle commands

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -13,6 +13,26 @@ use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
 
 impl Engine {
+	/// Run a lifecycle POST against one container with a consistent outcome:
+	/// success logs `{done} {container}`; "already in the desired state" (304)
+	/// and "no such container" (404) are idempotent no-ops; any other failure is
+	/// a real error that propagates (setting a non-zero exit) instead of being
+	/// swallowed into a warning. Shared by stop/start/restart/kill/pause/unpause
+	/// so they all behave the same.
+	async fn run_lifecycle_op(&self, path: &str, container: &str, done: &str) -> Result<()> {
+		match self.client.post_empty_ok(path).await {
+			Ok(()) => {
+				info!("{done} {container}");
+				Ok(())
+			}
+			Err(e) if e.is_status(304) || e.is_status(404) => {
+				tracing::debug!("{container}: {done} skipped ({e})");
+				Ok(())
+			}
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
+	}
+
 	/// Restart the named service (or all services). Dependents with a `restart` condition in `depends_on` are also restarted.
 	pub async fn restart(&self, file: &ComposeFile, service_name: Option<&str>) -> Result<()> {
 		let targets: Vec<String> = service_name
@@ -44,12 +64,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/restart?t={grace}",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&restart_path)
-					.await
-					.map_err(ComposeError::Podman)?;
-
-				info!("restarted {container_name}");
+				self.run_lifecycle_op(&restart_path, &container_name, "restarted")
+					.await?;
 			}
 
 			if no_deps {
@@ -129,11 +145,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/stop?t={grace}",
 					crate::libpod::urlencoded(&container_name),
 				);
-				if let Err(e) = self.client.post_empty_ok(&path).await {
-					tracing::warn!("could not stop {container_name}: {e}");
-				} else {
-					info!("stopped {container_name}");
-				}
+				self.run_lifecycle_op(&path, &container_name, "stopped")
+					.await?;
 			}
 		}
 		Ok(())
@@ -154,11 +167,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/start",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("started {container_name}");
+				self.run_lifecycle_op(&path, &container_name, "started")
+					.await?;
 			}
 		}
 		Ok(())
@@ -184,11 +194,8 @@ impl Engine {
 					crate::libpod::urlencoded(&container_name),
 					crate::libpod::urlencoded(signal),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("sent {signal} to {container_name}");
+				self.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
+					.await?;
 			}
 		}
 		Ok(())
@@ -253,11 +260,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/pause",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("paused {container_name}");
+				self.run_lifecycle_op(&path, &container_name, "paused")
+					.await?;
 			}
 		}
 		Ok(())
@@ -277,11 +281,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/unpause",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("unpaused {container_name}");
+				self.run_lifecycle_op(&path, &container_name, "unpaused")
+					.await?;
 			}
 		}
 		Ok(())


### PR DESCRIPTION
## Problem (#598)
`stop`/`start`/`restart`/`kill`/`pause`/`unpause` handled failure inconsistently: `stop` warned and exited 0 even on a real error (masking it), while the others propagated every error — including the harmless "already in that state" (304) and "no such container" (404).

## Fix
A shared `run_lifecycle_op` maps the libpod response consistently:
- **304** (already in the desired state) and **404** (no such container) → idempotent no-op, exit 0.
- any other failure → real error, propagated (non-zero exit) instead of swallowed.

## Verified (Podman 5.4.2, probed the real status codes)
```
start (already running)  -> exit 0   (was 1; 304 is idempotent now)
stop  (already stopped)  -> exit 0   (304)
restart / kill / pause   -> consistent
```
`stop` no longer swallows a genuine podman error into a warning. (`pause` on an already-paused container still exits non-zero — podman returns 500 "already paused" there, not 304, so podup faithfully surfaces it.)

Closes #598