### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+podup (1.4.0) unstable; urgency=medium
+
+  * engine: render the `ps` STATUS from the libpod `State` (was blank on Podman
+    5) and default a port's host IP to `0.0.0.0`; fix `stats` by repeating the
+    `containers` query parameter instead of comma-joining it; resolve a service
+    to its live replica containers so `stop`/`start`/`restart`/`kill`/`pause`/
+    `unpause`/`top`/`stats` keep working after `scale`; prefix each `logs` line
+    with its container name.
+  * cli: don't abort `completions` on a broken pipe; `config` now prunes unset
+    fields from its output and validates that every service has an image or
+    build; surface `watch` progress by default; add `top --format json`.
+  * lifecycle: consistent exit codes — "already in that state" and "no such
+    container" are idempotent no-ops, any other failure propagates (a real
+    failure is no longer swallowed into a warning).
+  * quadlet: default `ContainerName` to `<project>-<service>`, matching `up`.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 25 Jun 2026 17:31:11 -0500
+
 podup (1.3.0) unstable; urgency=medium
 
   * engine: resolve `volumes_from` service names to container names, pre-create


### PR DESCRIPTION
Release 1.4.0 — the empirical-sweep fixes verified against real Podman 5.4.2.

Bumps Cargo.toml/Cargo.lock and prepends the debian/changelog entry.

Highlights since 1.3.0:
- `ps` STATUS/host-IP, `stats` on Podman 5, scale+lifecycle replica resolution, `logs` prefixes (#600/#601/#602/#604)
- `completions` broken-pipe, `config` prune+validate, lifecycle exit codes, `top --format json` + `watch` progress (#603/#607/#608/#606)
- quadlet `ContainerName=<project>-<service>` (#605)

After this lands on develop, I'll open the develop → main release PR (merge commit) and tag v1.4.0.