### PR TITLE
release: 1.4.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
+max_line_length = 120
 
 [*.{yml,yaml,json}]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,16 +5,6 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.rs]
-indent_style = tab
-indent_size = 4
-
-[*.sh]
-indent_style = tab
-indent_size = 4
-
-[*.toml]
 indent_style = tab
 indent_size = 4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,20 +353,3 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --locked
-
-      - name: Refresh the Glyndor apt repository
-        env:
-          GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
-        run: |
-          # Tell the central apt repo (Glyndor/apt) to rebuild with this new
-          # release. Optional: only fires when an APT_DISPATCH_TOKEN with
-          # contents:write on Glyndor/apt is configured; otherwise the apt repo
-          # picks up the release on its daily schedule.
-          if [ -z "$GH_TOKEN" ]; then
-            echo "APT_DISPATCH_TOKEN not set — Glyndor/apt will refresh on its schedule."
-            exit 0
-          fi
-          gh api -X POST repos/Glyndor/apt/dispatches \
-            -f event_type=product-released \
-            -F "client_payload[product]=podup" \
-            || echo "::warning::apt dispatch failed; the daily schedule will refresh it."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+podup (1.4.0) unstable; urgency=medium
+
+  * engine: render the `ps` STATUS from the libpod `State` (was blank on Podman
+    5) and default a port's host IP to `0.0.0.0`; fix `stats` by repeating the
+    `containers` query parameter instead of comma-joining it; resolve a service
+    to its live replica containers so `stop`/`start`/`restart`/`kill`/`pause`/
+    `unpause`/`top`/`stats` keep working after `scale`; prefix each `logs` line
+    with its container name.
+  * cli: don't abort `completions` on a broken pipe; `config` now prunes unset
+    fields from its output and validates that every service has an image or
+    build; surface `watch` progress by default; add `top --format json`.
+  * lifecycle: consistent exit codes — "already in that state" and "no such
+    container" are idempotent no-ops, any other failure propagates (a real
+    failure is no longer swallowed into a warning).
+  * quadlet: default `ContainerName` to `<project>-<service>`, matching `up`.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Thu, 25 Jun 2026 17:31:11 -0500
+
 podup (1.3.0) unstable; urgency=medium
 
   * engine: resolve `volumes_from` service names to container names, pre-create

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,8 @@
 # Command reference
 
-Every `podup` subcommand, its options, and what it does. Run `podup <command>
---help` for the same information at the terminal.
+This page lists every `podup` command, its options, and what it does. Run
+`podup <command> --help` for the same information at the terminal. The
+[global options](#global-options) below apply to every command.
 
 ```
 podup [GLOBAL OPTIONS] <COMMAND> [COMMAND OPTIONS] [SERVICE...]
@@ -9,9 +10,9 @@ podup [GLOBAL OPTIONS] <COMMAND> [COMMAND OPTIONS] [SERVICE...]
 
 ## Global options
 
-These apply to every command and may appear before the subcommand.
+These appear before the subcommand and may also come from the environment.
 
-| Option | Env | Description |
+| Flag | Env | Description |
 |---|---|---|
 | `-f, --file <PATH>` | `COMPOSE_FILE` | Compose file. Repeatable; later files merge over earlier ones. When unset, the compose-spec precedence list is probed: `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml`. |
 | `-p, --project <NAME>` | `COMPOSE_PROJECT_NAME` | Project name, prefixing container/network/volume names. When unset: the top-level `name:`, then the sanitized project-directory basename. |
@@ -24,144 +25,296 @@ These apply to every command and may appear before the subcommand.
 
 ### `up`
 Create and start all services (or only the named ones, plus their transitive
-`depends_on`).
+`depends_on`). Accepts a trailing service list.
 
-| Option | Description |
-|---|---|
-| `-d, --detach` | Run containers in the background. |
-| `--build` | Build images before starting. |
-| `-w, --watch` | After starting, watch for changes per `develop.watch`. |
-| `--remove-orphans` | Remove containers for services no longer in the file. |
-| `--no-recreate` | Leave already-running containers in place. |
-| `--force-recreate` | Recreate containers even if their config is unchanged. |
-| `--no-deps` | Do not start the `depends_on` services of the named services. |
-| `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. |
-| `--pull <policy>` | Pull policy before starting: `always`, `missing`, `never`. |
-| `--no-build` | Do not build images, even for services with a `build:` section. |
-| `--quiet-pull` | Suppress image-pull progress output. |
-| `--wait` | Wait until services are running/healthy before returning. |
-| `--no-start` | Create the containers but do not start them. |
+| Flag | Description | Default |
+|---|---|---|
+| `-d, --detach` | Run containers in the background. | off |
+| `--build` | Build images before starting. | off |
+| `-w, --watch` | After starting, watch for changes per `develop.watch`. | off |
+| `--remove-orphans` | Remove containers for services no longer in the file. | off |
+| `--no-recreate` | Leave already-running containers in place. | off |
+| `--force-recreate` | Recreate containers even if their config is unchanged. | off |
+| `--no-deps` | Do not start the `depends_on` services of the named services. | off |
+| `-t, --timeout <SECS>` | Seconds to wait for a container to stop when recreating. | Podman default |
+| `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. | from file |
+| `--pull <POLICY>` | Pull policy before starting: `always`, `missing`, `never`. | per service |
+| `--no-build` | Do not build images, even for services with a `build:` section. | off |
+| `--quiet-pull` | Suppress image-pull progress output. | off |
+| `--wait` | Wait until services are running/healthy before returning. | off |
+| `--no-start` | Create the containers but do not start them. | off |
+| `--timestamps` | Prefix attached log lines with a timestamp (ignored with `-d`). | off |
+| `-V, --renew-anon-volumes` | Recreate anonymous volumes instead of keeping the previous ones. | off |
+
+```bash
+podup up -d --build
+```
 
 ### `down`
-Stop and remove containers. `-v, --volumes` also removes named volumes declared
-in the compose file; `--remove-orphans` also removes containers for services no
-longer in the file; `--rmi all|local` also removes the service images (`local`
-only those built from a `build:` section).
+Stop and remove containers, networks, and (with `-v`) volumes.
 
-### `start` / `stop` / `restart`
-Start existing stopped containers, stop running ones without removing them, or
-restart them. `start`/`stop`/`restart` accept a trailing service list;
-`restart [SERVICE...]` restarts everything or the named services.
-`restart --no-deps` skips cascade-restarting dependents that declare a
-`depends_on` restart condition.
-
-### `scale <SERVICE=N>...`
-Set the number of running containers for one or more services, creating missing
-replicas and removing surplus ones. A service that publishes a **fixed host
-port** cannot be scaled past one replica (only one container can bind a host
-port) — the command fails fast and tells you to drop the host port (`- "80"`, so
-Podman assigns one per replica), front it with a reverse proxy, or stay at one
-replica.
+| Flag | Description | Default |
+|---|---|---|
+| `-v, --volumes` | Also remove named volumes declared in the compose file. | off |
+| `--remove-orphans` | Remove containers for services no longer in the file. | off |
+| `--rmi <SCOPE>` | Also remove service images: `all`, or `local` (only those built from a `build:` section). | keep images |
+| `-t, --timeout <SECS>` | Seconds to wait for containers to stop before killing them. | Podman default |
 
 ### `create`
 Create the containers for services without starting them (like `up` stopped at
-the create step). `--build` builds images first; `--force-recreate` recreates
-unchanged containers; `--no-recreate` leaves existing ones in place. Accepts a
-trailing service list. A later `up`/`start` runs the created containers.
+the create step). Accepts a trailing service list. A later `up`/`start` runs the
+created containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--build` | Build images before creating containers. | off |
+| `--force-recreate` | Recreate containers even if their config is unchanged. | off |
+| `--no-recreate` | Leave existing containers in place. | off |
+
+### `start`
+Start existing stopped containers. Accepts a trailing service list.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--wait` | Wait until services are running/healthy before returning. | off |
+| `--wait-timeout <SECS>` | Maximum seconds to wait with `--wait` before giving up. | no limit |
+
+### `stop`
+Stop running containers without removing them. Accepts a trailing service list.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-t, --timeout <SECS>` | Seconds to wait for containers to stop before killing them. | Podman default |
+
+### `restart`
+Restart service containers (default: all, or the named ones).
+
+| Flag | Description | Default |
+|---|---|---|
+| `-t, --timeout <SECS>` | Seconds to wait for containers to stop before killing them. | Podman default |
+| `--no-deps` | Do not cascade-restart dependents that declare a `depends_on` restart condition. | off |
 
 ### `build`
 Build or rebuild service images (optionally only the named services).
 
-### `push`
-Push each service's `image:` to its registry (services without an image are
-skipped). Credentials come from `podman login`. `--ignore-push-failures`
-continues after a failure; `--tls-verify false` allows an insecure/HTTP
-registry (omit it to keep Podman's default verification). Accepts a trailing
-service list.
+| Flag | Description | Default |
+|---|---|---|
+| `--no-cache` | Do not use the build cache. | off |
+| `--pull` | Always attempt to pull a newer base image. | off |
+| `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
+| `-q, --quiet` | Suppress the build output. | off |
 
-### `rm`
-Remove stopped service containers. `-f, --force` stops and removes running ones;
-`-v, --volumes` also removes anonymous volumes attached to them.
+## Inspection
 
-### `kill`
-Send a signal to service containers. `-s, --signal <SIG>` sets the signal
-(default `SIGKILL`); `--remove-orphans` then removes containers for services no
-longer in the file.
+### `ps`
+List project containers.
 
-### `pause` / `unpause`
-Pause running service containers, or resume paused ones.
+| Flag | Description | Default |
+|---|---|---|
+| `-a, --all` | Include stopped containers. | running only |
+| `-q, --quiet` | Print container IDs only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
 
-## Running commands
+### `ls`
+List podup compose projects on the host. Needs no compose file.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-a, --all` | Include stopped projects. | running only |
+| `-q, --quiet` | Print project names only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
+
+### `logs [SERVICE...]`
+View container output for the named services (or all).
+
+| Flag | Description | Default |
+|---|---|---|
+| `-f, --follow` | Stream new output. | off |
+| `-n, --tail <N>` | Show the last N lines. | all |
+| `--since <TIME>` | Show logs since a timestamp or relative time (e.g. `10m`). | start |
+| `--until <TIME>` | Show logs before a timestamp or relative time. | end |
+| `-t, --timestamps` | Prefix each line with an RFC3339 timestamp. | off |
+
+### `events`
+Stream Podman events for this project's containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FMT>` | `table` (a `TYPE ACTION NAME` summary) or `json` (one object per line). | `table` |
+
+`--json` is a hidden deprecated alias for `--format json`.
+
+### `top [SERVICE...]`
+Show the running processes of service containers.
+
+### `stats [SERVICE...]`
+Live resource usage (CPU, memory, network, block I/O, PIDs) for service
+containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--no-stream` | Print one snapshot and exit. | stream |
+
+### `port <SERVICE> <PRIVATE_PORT>`
+Print the public binding for a port.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--proto <PROTO>` | `tcp` or `udp`. | `tcp` |
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+
+### `images`
+List images used by services.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-q, --quiet` | Print image IDs only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
+
+### `volumes [SERVICE...]`
+List the project's named volumes (a trailing service list narrows it to volumes
+those services mount).
+
+| Flag | Description | Default |
+|---|---|---|
+| `-q, --quiet` | Print volume names only. | off |
+| `--format <FMT>` | `table` or `json`. | `table` |
+
+## Container operations
 
 ### `run <SERVICE> [COMMAND...]`
 Run a one-off command in a new container for the service.
 
-| Option | Description |
-|---|---|
-| `--rm` | Remove the container after it exits (the default). |
-| `--no-rm` | Keep the one-off container after it exits instead of removing it. |
-| `-d, --detach` | Run in the background. |
-| `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. |
-| `--name <NAME>` | Override the container name. |
-| `-P, --service-ports` | Publish the service's declared ports (off by default). |
-| `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. |
-| `-w, --workdir <PATH>` | Working directory inside the container. |
-| `--entrypoint <CMD>` | Override the image entrypoint. |
-| `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. |
-| `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. |
-| `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). |
-| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). |
-| `--no-deps` | Do not start the `depends_on` services before running. |
+| Flag | Description | Default |
+|---|---|---|
+| `--rm` | Remove the container after it exits. | on |
+| `--no-rm` | Keep the one-off container after it exits. | off |
+| `-d, --detach` | Run in the background. | off |
+| `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. | none |
+| `--name <NAME>` | Override the container name. | generated |
+| `-P, --service-ports` | Publish the service's declared ports. | off |
+| `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. | image default |
+| `-w, --workdir <PATH>` | Working directory inside the container. | image default |
+| `--entrypoint <CMD>` | Override the image entrypoint. | image default |
+| `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
+| `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
+| `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
+| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `--no-deps` | Do not start the `depends_on` services before running. | off |
+
+```bash
+podup run --rm web sh -c 'echo hello'
+```
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
 
+| Flag | Description | Default |
+|---|---|---|
+| `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. | none |
+| `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. | container default |
+| `-w, --workdir <PATH>` | Working directory inside the container. | container default |
+| `--privileged` | Give extended privileges to the command. | off |
+| `-d, --detach` | Run the command in the background. | off |
+| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+
+```bash
+podup exec -u root web sh
+```
+
 ### `cp <SRC> <DST>`
 Copy files between a container and the host. Use `SERVICE:PATH` for the
-container side, e.g. `podup cp web:/app/data ./local`. `--index <N>` targets a
-specific replica (1-based) of a scaled service; `-L/--follow-link` follows
-symlinks in the host source before copying into the container; `-a/--archive` is
-accepted for compatibility (no effect under rootless Podman).
+container side, e.g. `podup cp web:/app/data ./local`.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+| `-L, --follow-link` | Follow symlinks in the host source before copying into the container. | off |
+| `-a, --archive` | Accepted for compatibility (no effect under rootless Podman). | off |
 
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
 container exits or you detach.
 
+### `kill [SERVICE...]`
+Send a signal to service containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-s, --signal <SIG>` | Signal to send. | `SIGKILL` |
+| `--remove-orphans` | Then remove containers for services no longer in the file. | off |
+
+### `rm [SERVICE...]`
+Remove stopped service containers.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-f, --force` | Remove even running containers (stop first). | off |
+| `-v, --volumes` | Also remove anonymous volumes attached to them. | off |
+| `-s, --stop` | Stop the containers (gracefully) before removing them. | off |
+
+### `pause [SERVICE...]` / `unpause [SERVICE...]`
+Pause running service containers, or resume paused ones. `resume` is an alias
+for `unpause`.
+
 ### `wait [SERVICE...]`
 Block until the named service containers (default: all) stop, printing each
 container's exit code as it does.
 
+### `scale <SERVICE=N>...`
+Set the number of running containers for one or more services, creating missing
+replicas and removing surplus ones. A service that publishes a **fixed host
+port** cannot be scaled past one replica — the command fails fast and tells you
+to drop the host port (`- "80"`, so Podman assigns one per replica), front it
+with a reverse proxy, or stay at one replica.
+
 ### `commit <SERVICE> <IMAGE>`
 Commit a service container's current state to a new image reference
-(`repo[:tag]`). `--index <N>` selects a replica (1-based) of a scaled service.
+(`repo[:tag]`).
+
+| Flag | Description | Default |
+|---|---|---|
+| `--index <N>` | Select a replica (1-based) of a scaled service. | 1 |
 
 ### `export <SERVICE>`
-Export a service container's filesystem as a tar archive. By default the archive
-goes to stdout; `-o, --output <FILE>` writes it to a file instead. `--index <N>`
-selects a replica (1-based) of a scaled service.
+Export a service container's filesystem as a tar archive.
 
-## Inspection
+| Flag | Description | Default |
+|---|---|---|
+| `-o, --output <FILE>` | Write to a file instead of stdout. | stdout |
+| `--index <N>` | Select a replica (1-based) of a scaled service. | 1 |
 
-| Command | Description |
-|---|---|
-| `ps` | List project containers. `-a/--all` includes stopped containers, `-q/--quiet` prints container IDs only, `--format table\|json`. |
-| `ls` | List podup compose projects on the host. `-a/--all` includes stopped projects, `-q/--quiet` prints names only, `--format table\|json`. Needs no compose file. |
-| `top` | Show running processes of service containers. |
-| `stats` | Live resource usage (CPU, memory, network, block I/O, PIDs) for service containers. `--no-stream` prints one snapshot; a trailing service list narrows it. |
-| `port <SERVICE> <PRIVATE_PORT>` | Print the public binding for a port. `--proto` sets `tcp`/`udp` (default `tcp`). |
-| `events` | Stream Podman events for this project's containers. `--format json` emits each event as a JSON line instead of a `TYPE ACTION NAME` summary (the deprecated `--json` flag is a hidden alias for it). |
-| `images` | List images used by services. `-q/--quiet` prints image IDs only, `--format table\|json`. |
-| `volumes [SERVICE...]` | List the project's named volumes. `-q/--quiet` prints names only, `--format table\|json`; a trailing service list narrows it to volumes those services mount. |
-| `logs [SERVICE...]` | View container output for the named services (or all). `-f/--follow` streams new output, `-n/--tail <N>` limits to the last N lines, `--since`/`--until` bound by time, `-t/--timestamps` prefixes each line. |
-| `config` | Print the resolved compose file (after substitution, extends, include). `--format yaml\|json`, `--services` lists service names, `-q/--quiet` only validates, `--no-interpolate` leaves `${VAR}` placeholders literal, `--resolve-image-digests` rewrites each service `image:` to its registry digest (`repo@sha256:...`). |
-| `pull` | Pull images for all services. `-q/--quiet` suppresses progress output. |
+## Images
+
+### `pull [SERVICE...]`
+Pull images for the named services, or all services if none are given.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-q, --quiet` | Suppress image-pull progress output. | off |
+| `--ignore-pull-failures` | Continue pulling the remaining services after a failure. | off |
+| `--include-deps` | Also pull images for the named services' `depends_on` services. | off |
+| `--policy <POLICY>` | Pull policy, overriding per-service `pull_policy`: `always`, `missing`, `never`, `newer`, `build`. | per service |
+
+### `push [SERVICE...]`
+Push each service's `image:` to its registry (services without an image are
+skipped). Credentials come from `podman login`.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--ignore-push-failures` | Continue after a failure. | off |
+| `--tls-verify <BOOL>` | Verify the registry TLS cert; `false` allows an insecure/HTTP registry. | Podman default |
 
 ## Generate
 
-### `generate quadlet [-o <DIR>]`
+### `generate quadlet`
 Translate the compose file into Podman Quadlet unit files — one `.container` per
-service plus `.network` and `.volume` units. Without `-o, --output` the units
-print to stdout; warnings about fields with no Quadlet mapping go to stderr.
+service plus `.network` and `.volume` units. `gen` is an alias for `generate`.
+
+| Flag | Description | Default |
+|---|---|---|
+| `-o, --output <DIR>` | Directory to write the unit files into. Omit to print to stdout. | stdout |
 
 ```bash
 podup generate quadlet -o ~/.config/containers/systemd
@@ -186,21 +339,19 @@ The `action` of each rule may be:
 | `sync+restart` | Sync the files, then restart the container. |
 | `sync+exec` | Sync the files, then run the rule's `exec` command in the container. |
 
-## Self-update
+## Maintenance
 
-### `update`
-Replace the running binary with the latest signed release.
+### `config`
+Print the resolved compose file (after substitution, extends, include).
+`convert` is an alias.
 
-| Option | Description |
-|---|---|
-| `--check` | Report whether a newer release exists; install nothing. |
-| `--force` | Reinstall even if the latest release is not newer. |
-
-Verification fails closed: a missing key, bad Ed25519 signature, or SHA-256
-mismatch aborts before the installed binary is touched. See
-[self-update.md](self-update.md) for the trust model.
-
-## Shell completions
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FMT>` | `yaml` or `json`. | `yaml` |
+| `--services` | List service names, one per line. | off |
+| `-q, --quiet` | Only validate; print nothing. | off |
+| `--no-interpolate` | Leave `${VAR}` placeholders literal. | off |
+| `--resolve-image-digests` | Rewrite each service `image:` to its registry digest (`repo@sha256:...`). | off |
 
 ### `completions <SHELL>`
 Print a shell completion script to stdout for `bash`, `zsh`, `fish`,
@@ -212,6 +363,20 @@ podup completions bash > ~/.local/share/bash-completion/completions/podup
 podup completions zsh  > "${fpath[1]}/_podup"
 podup completions fish > ~/.config/fish/completions/podup.fish
 ```
+
+### `update`
+Replace the running binary with the latest signed release.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--check` | Report whether a newer release exists; install nothing. | off |
+| `--force` | Reinstall even if the latest release is not newer. | off |
+
+Verification fails closed: a missing key, bad Ed25519 signature, or SHA-256
+mismatch aborts before the installed binary is touched. See
+[self-update.md](self-update.md) for the trust model.
+
+Run `podup --version` to print the version.
 
 ## Diagnostics
 

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -17,12 +17,21 @@ Requires `debhelper`, `cargo` and `rustc >= 1.85` (the crate's declared
 `rust-version`). The package installs `/usr/bin/podup` and the `podup(1)` man
 page.
 
+The packaged binary is built with the self-update feature **compiled out**:
+`debian/rules` builds with `--no-default-features --features watch,completions`,
+dropping the `update` feature (and its `ureq` + TLS + Ed25519 stack). This is
+why `podup update` on a deb-installed binary refuses outright and points back to
+the package manager — the capability is absent from the binary, not merely
+gated at runtime by a dpkg-ownership check.
+
 ## Prebuilt .deb from releases
 
 Each tagged release attaches a signed `.deb` per architecture —
 `podup_<version>_amd64.deb` and `podup_<version>_arm64.deb` (each with its
-`.sig`, and an entry in the release `SHA256SUMS`) built on Debian sid. Install
-the one matching your architecture directly:
+`.sig`, and an entry in the release `SHA256SUMS`). Each architecture is built
+natively in its own `debian:sid` container (amd64 on an x64 runner, arm64 on an
+arm64 runner — no emulation). Install the one matching your architecture
+directly:
 
 ```bash
 sudo apt install ./podup_<version>_amd64.deb   # or _arm64.deb on aarch64
@@ -77,8 +86,7 @@ publishing. The signing key, keyring builder and repository builder all live in
 the `Glyndor/apt` repo.
 
 > **Debian compatibility note:** the MSRV is 1.85, which Debian trixie ships, so
-> trixie and sid can both build the package. (Earlier releases needed 1.86 via
-> an `idna`/`icu` dependency chain that has since been removed.)
+> trixie and sid can both build the package.
 
 ## What the skeleton covers
 

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -76,15 +76,6 @@ The signing key ships as the `glyndor-archive-keyring` package, so apt owns the
 key file. When the key is rotated or its expiry extended, a new keyring version
 is published and `apt upgrade` installs it — nothing for users to re-run.
 
-### Refreshing after a release
-
-The apt repository rebuilds on a daily schedule and can be triggered manually
-(`gh workflow run publish.yml -R Glyndor/apt`). For an immediate refresh on each
-release, set an `APT_DISPATCH_TOKEN` secret (a token with `contents:write` on
-`Glyndor/apt`); `release.yml` then sends a `repository_dispatch` after
-publishing. The signing key, keyring builder and repository builder all live in
-the `Glyndor/apt` repo.
-
 > **Debian compatibility note:** the MSRV is 1.85, which Debian trixie ships, so
 > trixie and sid can both build the package.
 

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -1,10 +1,19 @@
 # Migrating from Docker Compose to podup
 
-This guide covers what to expect when you switch a `docker-compose.yml` from
-Docker to podup on rootless Podman.  The short answer is: **most files work
-without any changes**.  Read on for the full picture.
+Point podup at an existing `docker-compose.yml` and run it — no rewrite, no new
+file format. The short answer is: **most files work without any changes**.
 
-## What works out of the box
+```sh
+cd my-project          # the directory holding docker-compose.yml
+podup up
+```
+
+podup reads the same `compose.yaml` / `docker-compose.yml` files docker-compose
+does and runs them on rootless Podman. The rest of this guide is the full
+picture: what works unchanged, what behaves differently under Podman, what is
+accepted but has no effect, and what is not yet supported.
+
+## Works out of the box
 
 Every core Compose spec key is supported:
 
@@ -19,15 +28,25 @@ Every core Compose spec key is supported:
 | Dependencies | `depends_on` (with `condition:` — `service_started`, `service_healthy`, `service_completed_successfully`) |
 | Health checks | `healthcheck` (test, interval, timeout, retries, start_period, disable) |
 | Lifecycle hooks | `post_start`, `pre_stop` |
-| Restart policies | `restart`, `deploy.restart_policy` |
+| Restart policies | `restart`, `deploy.restart_policy` (`condition`, `max_attempts`) |
 | Replicas / scale | `deploy.replicas`, `scale:` |
 | Resource limits | `deploy.resources`, `mem_limit`, `cpus`, `cpu_shares`, `cpu_quota`, `pids_limit`, `ulimits`, `blkio_config` |
-| Devices | `devices`, `device_cgroup_rules`, `deploy.resources.reservations.devices` (GPU) |
+| Devices | `devices`, `device_cgroup_rules` |
+| GPU | `deploy.resources.reservations.devices`, `gpus:` — see the note below |
 | Security | `cap_add`, `cap_drop`, `security_opt`, `read_only`, `privileged`, `userns_mode` |
 | Namespaces | `pid`, `ipc`, `uts`, `cgroup`, `shm_size` |
 | Metadata | `labels`, `annotations`, `container_name`, `profiles` |
 | Logging | `logging` (driver + options) |
 | Compose features | `extends`, `include`, YAML anchors, x-extensions, `develop.watch` |
+
+### GPU reservations are host-dependent
+
+`deploy.resources.reservations.devices` and the `gpus:` shorthand are honored,
+but only for **NVIDIA** GPUs, and only when the host exposes them through CDI
+(the NVIDIA Container Toolkit must be installed and the CDI spec generated).
+Reservations for other drivers or capabilities are warned about and skipped.
+This is the common case Podman supports natively — but it depends on the host's
+GPU driver and CDI setup, not on podup alone.
 
 ### External secrets and configs
 
@@ -59,10 +78,33 @@ The secret appears at `/run/secrets/db_password` (configs use the long-form
 fast rather than starting a container without it. Use a top-level `name:` when
 the Podman secret is named differently from the compose reference.
 
-## Rootless Podman differences
+## Behaves differently under rootless Podman
 
-These are Podman behaviours, not podup limitations.  They apply equally to any
-Podman-based tool.
+These are Podman behaviours, not podup limitations — they apply equally to any
+Podman-based tool. Each one is something to expect, with the workaround.
+
+### `network_mode: bridge`
+
+| | |
+|---|---|
+| **What to expect** | docker-compose attaches the container to Docker's predefined shared `bridge` network. Podman reads `--network bridge` as "create a fresh, isolated bridge netns", so the container has outbound connectivity but **cannot reach its project siblings** by name or IP. |
+| **Workaround** | Remove `network_mode: bridge` and let the container join the project's default network, or declare a shared `networks:` entry the services share. podup emits a warning when it sees `network_mode: bridge`. |
+
+```yaml
+# before — siblings unreachable under Podman
+services:
+  web:
+    network_mode: bridge
+
+# after — services share a network and resolve each other by name
+services:
+  web:
+    networks: [app]
+  api:
+    networks: [app]
+networks:
+  app: {}
+```
 
 ### Privileged ports (< 1024)
 
@@ -70,7 +112,7 @@ Rootless containers cannot bind host ports below 1024 unless the kernel allows
 it:
 
 ```bash
-# Allow a single port (temporary, requires root once):
+# Allow ports down to 80 (persists; requires root once):
 sudo sysctl net.ipv4.ip_unprivileged_port_start=80
 
 # Or map through a higher port in your compose file:
@@ -80,14 +122,14 @@ ports:
 
 ### UID/GID mapping
 
-Containers run as your host user's UID inside a user namespace.  If a container
+Containers run as your host user's UID inside a user namespace. If a container
 image writes files with UID 0 (root inside the container), those files appear
-owned by your user on the host.  Bind-mount permissions reflect your host
-user's access.
+owned by your user on the host. Bind-mount permissions reflect your host user's
+access.
 
 ### Volume SELinux labels
 
-On SELinux-enforcing systems, bind mounts require relabeling.  Append `:z`
+On SELinux-enforcing systems, bind mounts require relabeling. Append `:z`
 (shared) or `:Z` (private) to the volume spec:
 
 ```yaml
@@ -98,21 +140,18 @@ volumes:
 ### `network_mode: host`
 
 Attaches the container to your user's network namespace, not a privileged host
-namespace.  Traffic is still limited to your user's capabilities.
+namespace. Traffic is still limited to your user's capabilities.
 
 ### `network_mode: none`
 
-Supported.  The container gets a loopback interface only.
-
-## Deprecated fields (honored with a warning)
+Supported. The container gets a loopback interface only.
 
 ### `mac_address:` at the service level
 
 The Compose spec deprecated the top-level `mac_address` field in favour of
-per-network configuration.  podup still honours it (for backward compatibility)
-and applies it to the primary network, but logs a deprecation warning.
-
-**Migration:** move it under `networks:`:
+per-network configuration. podup still honours it (for backward compatibility)
+and applies it to the primary network, but logs a deprecation warning. Move it
+under `networks:` to silence the warning:
 
 ```yaml
 # before
@@ -128,12 +167,15 @@ services:
         mac_address: "02:42:ac:11:00:02"
 ```
 
-## Swarm-only fields (accepted, no effect)
+## Accepted but has no effect
 
-These fields are part of the Compose spec for Docker Swarm deployments.  They
-are parsed without error so existing compose files validate cleanly, but they
-have no equivalent in single-host rootless Podman.  podup logs a warning for
-each one that is present.
+These fields parse cleanly so existing compose files validate, but podup cannot
+translate them on single-host rootless Podman. **podup emits a warning for each
+one it finds**, so nothing is dropped silently. The list below is a set of
+**examples, not exhaustive** — when in doubt, run `podup up` and read the
+warnings (see [Seeing the warnings](#seeing-the-warnings)).
+
+### Swarm / cluster orchestration
 
 | Field | What it does in Swarm |
 |---|---|
@@ -142,9 +184,41 @@ each one that is present.
 | `deploy.update_config` | Rolling-update parallelism, delay, failure action |
 | `deploy.rollback_config` | Automatic rollback behaviour |
 | `deploy.endpoint_mode` | VIP vs DNS round-robin load balancing |
+| `deploy.restart_policy.delay` / `.window` | No first-class Podman restart delay or attempt-counting window (`condition` and `max_attempts` *are* honored) |
+| port long-form `mode:` (`ingress` / `host`) | Swarm ingress routing |
 
-If you see warnings for these fields, you can safely remove them from your
-compose file when targeting a single-host Podman deployment.
+### BuildKit / buildx-only build options
+
+`build.privileged`, `build.ssh`, `build.ulimits`, `build.isolation`,
+`build.entitlements`, `build.provenance`, `build.sbom` — these have no libpod
+build-API equivalent and are ignored.
+
+### Windows / Hyper-V-only
+
+`cpu_count`, `cpu_percent`, `credential_spec`, `isolation` — no rootless Podman
+equivalent.
+
+### Other parsed-but-ignored fields
+
+| Field | Why it has no effect |
+|---|---|
+| `attach` | podup follows its own attach/detach logic for `up` log streaming |
+| `use_api_socket` | no podup equivalent |
+| `provider:` / top-level `models:` | podup runs no model runner; the service/model is not honored (see [Not yet supported](#not-yet-supported)) |
+| volume long-form `driver_config` | not forwarded to Podman |
+| `networks.*.enable_ipv4` | Podman networks enable IPv4 by default and expose no toggle |
+| `networks.*.ipam.config[].aux_addresses` | not supported by Podman |
+| service `networks.*.gw_priority` | not supported by Podman |
+| `secrets`/`configs` `driver` / `template_driver` (on non-`external` defs) | external secret-store plugins (Vault, AWS SM, …) podup does not invoke; the secret/config is not staged |
+
+## Not yet supported
+
+| Feature | Status |
+|---|---|
+| `env_file.format` values other than `dotenv` | A **warning** is emitted (`format is not honored; podup always parses env files as dotenv`); the file is still read as dotenv |
+| `provider:` / model-runner services (`provider`, top-level `models`) | Modeled and parsed, but **not honored** — a not-honored warning is emitted (these are no rootless-Podman equivalent, *not* "unknown key" errors) |
+| Container naming | A single-replica service is named `<project>-<service>` (e.g. `myapp-web`); docker-compose v2 always appends a `-1` replica index (`myapp-web-1`). Scaled replicas (>1) do get the `-N` suffix. Scripts that reference containers by exact name should account for this. |
+| Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
 
 ## Nothing is dropped silently
 
@@ -156,20 +230,25 @@ a typo or an unmapped feature can't hide. At parse time podup warns about:
 - unknown keys at the top level and inside every modeled object (services and
   their `healthcheck`, `deploy`, `develop.watch`; top-level `networks`,
   `networks.*.ipam`, and `volumes`) — usually a typo such as `enviroment:`;
-- fields it models but cannot honor on rootless Podman: `cpu_count` and
-  `cpu_percent` (Windows/Hyper-V only), `networks.*.enable_ipv4`, and the
-  BuildKit-only `build.privileged`, `build.ulimits`, `build.isolation`,
-  `build.entitlements`, `build.provenance`, `build.sbom`.
+- modeled fields it cannot honor on rootless Podman — the
+  [accepted-but-has-no-effect](#accepted-but-has-no-effect) fields above.
 
 This is what lets a compose file written for a newer Docker or Podman release
 run under podup: unsupported additions surface as warnings instead of vanishing.
 
-The `podup` CLI prints these warnings automatically. If you embed podup as a
-**library**, `parse_file` itself stays quiet — call `podup::collect_diagnostics`
-on the parsed file to obtain the same warnings and surface them to your users.
-
 `extra_hosts` is accepted in both the list (`["host:ip"]`) and mapping
 (`{host: ip}`) forms.
+
+### Seeing the warnings
+
+The `podup` CLI prints these warnings automatically. Run with
+`RUST_LOG=podup=debug` to also see network creation and container lifecycle
+events. See the [`RUST_LOG` reference in `commands.md`](commands.md#environment)
+for the full level table.
+
+If you embed podup as a **library**, `parse_file` itself stays quiet — call
+`podup::collect_diagnostics` on the parsed file to obtain the same warnings and
+surface them to your users.
 
 ## File references and path confinement
 
@@ -182,28 +261,14 @@ intentional divergence from a fully sandboxed parser: do not feed podup a
 compose file from an untrusted source any more than you would `make -f` an
 untrusted Makefile.
 
-## Not yet supported
-
-| Feature | Status |
-|---|---|
-| `env_file.format` values other than `dotenv` | Error is emitted; only the `dotenv` format is accepted |
-| `provider:` / model-runner services (`provider`, top-level `models`) | No rootless Podman equivalent; reported as an unknown key |
-| Container naming | A single-replica service is named `<project>-<service>` (e.g. `myapp-web`); docker-compose v2 always appends a `-1` replica index (`myapp-web-1`). Scaled replicas (>1) do get the `-N` suffix. Scripts that reference containers by exact name should account for this. |
-| Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
-
-## Enabling verbose output
-
-Run with `RUST_LOG=podup=debug` to see network creation, container lifecycle
-events, and the parse-time warnings podup emits for any compose field it cannot
-translate. See the [`RUST_LOG` reference in `commands.md`](commands.md#environment)
-for the full level table.
-
 ## Quick compatibility checklist
 
 Before running `podup up` on an existing compose file:
 
+- [ ] Replace `network_mode: bridge` with a shared `networks:` entry if services need to reach each other.
 - [ ] Remove or remap any host ports below 1024 if running fully rootless.
 - [ ] Add `:Z` to bind mounts on SELinux hosts if containers cannot write to them.
 - [ ] Check for `mac_address:` at the service level — move to `networks:` to silence the warning.
 - [ ] Check for Swarm-only `deploy.*` fields — they are harmless but can be cleaned up.
 - [ ] Verify `env_file` uses dotenv format (key=value lines, `#` comments).
+- [ ] For GPUs, confirm the host has an NVIDIA driver + CDI configured.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -15,12 +15,6 @@ separately in [self-update.md](self-update.md).
   them. Fields that assume more (`privileged`, `oom_kill_disable`,
   `mem_swappiness`, `cpu_rt_*`) are forwarded but warned about, since they are
   reduced or ineffective rootless.
-- The libpod socket is **strictly local**. Only a `unix://` socket path (or an
-  `npipe://` named pipe on Windows) is accepted, whether it comes from
-  `--socket`, `PODMAN_SOCKET`, `DOCKER_HOST`, or auto-detection. Remote schemes
-  (`tcp://`, `ssh://`, `http(s)://`, `fd://`) are **rejected fail-closed** —
-  podup never connects to a remote engine, so the socket boundary is always a
-  local one.
 - podup keeps **no persistent state** of its own outside the Podman objects it
   creates and a per-project advisory lock file under the user's runtime
   directory.
@@ -34,6 +28,15 @@ separately in [self-update.md](self-update.md).
 | Release artifacts (`podup update`, installer) | Untrusted transport | Verified against an embedded Ed25519 key + provenance attestation, fail-closed. |
 | Container filesystem (e.g. `cp` archives) | Untrusted | Tar extraction refuses path-traversal (zip-slip) entries. |
 | Network/TLS to GitHub/crates.io | Untrusted | Integrity comes from signatures, not transport. |
+
+## Connection: the libpod socket is local-only
+
+- The libpod socket is **strictly local**. Only a `unix://` socket path (or an
+  `npipe://` named pipe on Windows) is accepted, whether it comes from
+  `--socket`, `PODMAN_SOCKET`, `DOCKER_HOST`, or auto-detection. Remote schemes
+  (`tcp://`, `ssh://`, `http(s)://`, `fd://`) are **rejected fail-closed** —
+  podup never connects to a remote engine, so the socket boundary is always a
+  local one.
 
 ## Compose files are trusted input
 
@@ -83,6 +86,12 @@ only tighten, never widen, what the launching user already has.
   avoid debug logging where the terminal or log sink is not trusted.
 - podup writes no secret material to its own persistent state.
 
+## Memory safety
+
+The crate forbids `unsafe` by default (`#![deny(unsafe_code)]`). The few
+unavoidable FFI calls (rootless uid/gid lookups, `flock`, `stat`) are isolated,
+individually justified with safety comments, and unit-tested.
+
 ## Supply chain
 
 - Dependencies are pinned in `Cargo.lock`; `cargo deny` enforces a license
@@ -94,11 +103,11 @@ only tighten, never widen, what the launching user already has.
 - The Debian package can be built fully offline from a vendored crate tree, for
   air-gapped/classified environments.
 
-## Memory safety
+## Self-update
 
-The crate forbids `unsafe` by default (`#![deny(unsafe_code)]`). The few
-unavoidable FFI calls (rootless uid/gid lookups, `flock`, `stat`) are isolated,
-individually justified with safety comments, and unit-tested.
+The `podup update` mechanism and its release trust chain — the embedded Ed25519
+keys, the verify-before-install flow, key rotation, and independent/offline
+verification — are documented in [self-update.md](self-update.md).
 
 ## Reporting
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -88,45 +88,16 @@ malicious edit to the constant fails CI. If every key is zeroed, both the binary
 and the installer fail closed and install nothing. The same key signs `podup`,
 `panel`, and `panel-agent` releases (shared `RELEASE_SIGN_KEY`).
 
-### Deriving the public key from the signing secret
-
-To re-derive or rotate it, run locally with the `RELEASE_SIGN_KEY` value (the
-raw 32-byte Ed25519 seed, base64). **Never commit or share the private seed** —
-only its public half:
-
-```bash
-python3 -c '
-import base64, sys
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from cryptography.hazmat.primitives import serialization
-seed = base64.b64decode(sys.argv[1] + "==")
-pub = Ed25519PrivateKey.from_private_bytes(seed).public_key()
-raw = pub.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
-print("install.sh base64 :", base64.b64encode(raw).decode().rstrip("="))
-print("verify.rs bytes   :", ", ".join(str(b) for b in raw))
-' "$RELEASE_SIGN_KEY"
-```
-
-Paste the base64 form into `install.sh` and `install.ps1`, and the byte array
-into `RELEASE_PUBKEYS`.
-
 ### Key rotation
 
 Because each binary accepts up to two keys, the signing key can be rotated
-**without stranding installed binaries** — even if the private key leaks. Run the
-two-release procedure:
+**without stranding installed binaries** — even if the private key leaks. A
+two-release transition first ships the new key alongside the old, so binaries
+already in the field accept the next release and gain the new key; a later
+release then retires the old key once every install has converged on the new
+one.
 
-1. **Transition release.** Add the new key to the rotation slot so the binary
-   embeds `[old, new]` (and add `PODUP_RELEASE_PUBKEY2_B64` / `PubKey2B64` to the
-   installers). Keep `RELEASE_SIGN_KEY` set to the **old** key so `SHA256SUMS` is
-   signed by `old`. Binaries already in the field trust only `old`, so they
-   accept this release and upgrade — gaining `new` in the process.
-2. **Retire release.** Move `new` into slot 0 and zero the rotation slot so the
-   binary embeds `[new]`, and switch the CI `RELEASE_SIGN_KEY` secret to the
-   **new** key. Every binary from step 1 trusts `new`, so all installs converge
-   on the new key and `old` is retired.
-
-During step 1 the leaked `old` key is still accepted for one release — an
+During the transition the old key is still accepted for one release — an
 unavoidable cost of any rotation. The GitHub build-provenance attestation, which
 does not depend on the signing key, still proves origin during the window.
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -1,9 +1,12 @@
 # Self-update security model
 
-`podup update` replaces the running binary with the latest release. The design
-goal is that **the update source is impossible to tamper with**: no attacker —
-even one who controls the network or the download host — can make `podup`
-install a modified binary.
+`podup update` replaces the running binary with the latest release. The default
+run resolves the newest release, verifies it, and installs it; `--check` reports
+whether a newer release exists and then stops, downloading nothing and never
+touching the installed binary; `--force` reinstalls the latest release even when
+it is not newer than the current build. The design goal is that **the update
+source is impossible to tamper with**: no attacker — even one who controls the
+network or the download host — can make `podup` install a modified binary.
 
 ## Trust anchor
 
@@ -24,19 +27,31 @@ relied on for integrity.
 
 1. Resolve the latest release tag from the GitHub API and compare it with the
    compiled-in version (`env!("CARGO_PKG_VERSION")`). Nothing is downloaded if
-   the current build is already newest (unless `--force`).
-2. Download the platform binary, `SHA256SUMS`, and `SHA256SUMS.sig` over HTTPS
-   (rustls + webpki roots; HTTPS-only URLs).
-3. **Verify the Ed25519 signature** of `SHA256SUMS` against the embedded public
-   key. A missing/placeholder key, malformed signature, or bad signature aborts
-   here — nothing is written.
-4. Look up the binary's expected SHA-256 in the now-trusted `SHA256SUMS` and
-   verify the downloaded bytes match.
-5. Atomically replace the running executable (write a sibling temp file, fsync,
-   preserve mode, then `rename`). On Windows the in-use `.exe` is renamed aside
-   first and cleaned up on the next run.
+   the current build is already newest (unless `--force`), and `--check` returns
+   here without downloading anything.
+2. **Refuse a package-manager-managed binary.** If the running executable is
+   owned by a system package manager (e.g. installed from the `.deb`, detected
+   via `dpkg-query`), `podup update` refuses **before downloading anything** and
+   redirects you to the package manager (e.g. `apt upgrade podup`); overwriting
+   the file in place would desync the manager's records. This applies even with
+   `--force`. cargo-install / manual layouts (`~/.cargo/bin`, `/usr/local/bin`)
+   are not package-owned and update normally.
+3. Fetch `SHA256SUMS` and `SHA256SUMS.sig` and **verify the Ed25519 signature**
+   of `SHA256SUMS` against the embedded public key — *before* the binary is
+   downloaded, so a tampered or unsigned release is rejected without first
+   buffering a large attacker-controlled payload. A missing/placeholder key,
+   malformed signature, or bad signature aborts here. The manifest and signature
+   are fetched over HTTPS (rustls + webpki roots; HTTPS-only URLs).
+4. Look up the binary's expected SHA-256 in the now-trusted `SHA256SUMS`,
+   download the platform binary over HTTPS, and verify its bytes match (the
+   digest comparison runs in constant time).
+5. Atomically replace the running executable (write a sibling temp file with
+   `O_EXCL`/`O_NOFOLLOW` at mode `0600`, copy the target's mode while stripping
+   any setuid/setgid/sticky bits, fsync, then `rename`). On Windows the in-use
+   `.exe` is renamed aside first and cleaned up on the next run.
 
-Any failure exits with code `2` and leaves the installed binary untouched.
+Any failure exits with code `3` (distinct from clap's `2` for usage errors and
+from a generic `1`) and leaves the installed binary untouched.
 
 ## install.sh
 

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -296,6 +296,9 @@ pub(crate) enum Commands {
 	},
 	/// Display the running processes of service containers.
 	Top {
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+		format: OutputFormat,
 		/// Show only these services.
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -10,6 +10,7 @@ mod types;
 pub(crate) use commands::Commands;
 pub(crate) use types::{ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
 
+/// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
 #[derive(Parser)]
 #[command(name = "podup", version)]
 pub(crate) struct Cli {

--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -1,8 +1,8 @@
 //! `include:` directive — merging externally included compose files.
 //!
 //! Included files are merged into the parent: services, volumes, networks,
-//! secrets, and configs from the included file are added only if the key does
-//! not already exist in the parent (parent wins on conflict).
+//! secrets, configs, and models from the included file are added only if the
+//! key does not already exist in the parent (parent wins on conflict).
 
 use super::types::ComposeFile;
 

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -280,7 +280,7 @@ impl BuildConfig {
 		}
 	}
 
-	/// `build.additional_contexts` — named extra build contexts (`name -> value`).
+	/// `build.additional_contexts` — named extra build contexts (`name -> source`).
 	pub fn additional_contexts(&self) -> Vec<(String, String)> {
 		match self {
 			BuildConfig::Context(_) => Vec::new(),

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -17,16 +17,23 @@ pub struct DevelopConfig {
 /// A single `develop.watch` rule: a path to watch, an action to take, and optional ignore filters.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct WatchRule {
+	/// Host path watched for changes, resolved relative to the project base directory.
 	pub path: String,
+	/// What to do when a watched file changes.
 	pub action: WatchAction,
+	/// Sync destination inside the container; sync actions are skipped when absent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub target: Option<String>,
+	/// Glob patterns (relative to the base dir) whose matches are excluded from triggering.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ignore: Vec<String>,
+	/// Glob allow-list; when non-empty, only matching paths trigger the rule.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub include: Vec<String>,
+	/// When true, copy `path` to `target` once at startup before watching begins.
 	#[serde(default)]
 	pub initial_sync: bool,
+	/// Command run inside the container for the `sync+exec` action.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub exec: Option<WatchExec>,
 	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
@@ -36,11 +43,16 @@ pub struct WatchRule {
 /// Action triggered by a `develop.watch` rule: `sync`, `rebuild`, `restart`, `sync+restart`, or `sync+exec`.
 #[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
 pub enum WatchAction {
+	/// `sync` — copy changed files from `path` into the container at `target`.
 	#[default]
 	Sync,
+	/// `rebuild` — rebuild the service image and recreate the container.
 	Rebuild,
+	/// `restart` — restart the running container without rebuilding.
 	Restart,
+	/// `sync+restart` — sync changed files, then restart the container.
 	SyncAndRestart,
+	/// `sync+exec` — sync changed files, then run the rule's `exec` command in the container.
 	SyncAndExec,
 }
 
@@ -63,6 +75,7 @@ impl<'de> Deserialize<'de> for WatchAction {
 /// Exec command run as part of a `sync+exec` watch action.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchExec {
+	/// Command and arguments executed in the container (argv form, not shell-parsed).
 	pub command: Vec<String>,
 }
 

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -32,22 +32,31 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct SecretConfig {
+	/// Host file supplying the secret value; mutually exclusive with `content` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
+	/// When true, the secret must already exist in the engine; no value source is provided here.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub external: Option<bool>,
+	/// Engine-side name; overrides the map key, and names the pre-existing secret when `external`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Inline secret value; mutually exclusive with `file` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub content: Option<String>,
+	/// Name of an environment variable supplying the value; mutually exclusive with `file` and `content`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub environment: Option<String>,
+	/// Secret driver name (Swarm-style); parsed for fidelity, not honored by podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Options passed to `driver`.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub driver_opts: HashMap<String, String>,
+	/// Labels attached to the secret.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Driver used to render the secret as a template before delivery.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub template_driver: Option<String>,
 }
@@ -56,22 +65,31 @@ pub struct SecretConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ConfigConfig {
+	/// Host file supplying the config value; mutually exclusive with `content` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
+	/// When true, the config must already exist in the engine; no value source is provided here.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub external: Option<bool>,
+	/// Engine-side name; overrides the map key, and names the pre-existing config when `external`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Inline config value; mutually exclusive with `file` and `environment`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub content: Option<String>,
+	/// Name of an environment variable supplying the value; mutually exclusive with `file` and `content`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub environment: Option<String>,
+	/// Labels attached to the config.
 	#[serde(default)]
 	pub labels: Labels,
+	/// Config driver name (Swarm-style); parsed for fidelity, not honored by podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
+	/// Options passed to `driver`.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub driver_opts: HashMap<String, String>,
+	/// Driver used to render the config as a template before delivery.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub template_driver: Option<String>,
 }
@@ -83,14 +101,19 @@ pub struct ConfigConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ModelConfig {
+	/// OCI reference of the model artifact to pull.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub model: Option<String>,
+	/// Engine-side name; overrides the map key.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Maximum context window, in tokens.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub context_size: Option<u64>,
+	/// Raw flags forwarded to the model runner's inference engine.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub runtime_flags: Vec<String>,
+	/// Extra variables injected into the model runtime environment.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub model_variables: HashMap<String, String>,
 	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
@@ -102,20 +125,28 @@ pub struct ModelConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ComposeFile {
+	/// Top-level `version:`. Deprecated by the Compose Spec; parsed and round-tripped but otherwise ignored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub version: Option<String>,
+	/// Project name; overrides the directory-derived default.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	/// Other Compose files merged into this project before processing.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub include: Vec<IncludeConfig>,
+	/// Service definitions, keyed by service name.
 	#[serde(default)]
 	pub services: IndexMap<String, Service>,
+	/// Named volumes; a `None` value is a default-configured volume (`name:` with no body).
 	#[serde(default)]
 	pub volumes: IndexMap<String, Option<VolumeConfig>>,
+	/// Named networks; a `None` value is a default-configured network (`name:` with no body).
 	#[serde(default)]
 	pub networks: IndexMap<String, Option<NetworkConfig>>,
+	/// Named secrets available to services.
 	#[serde(default)]
 	pub secrets: IndexMap<String, SecretConfig>,
+	/// Named configs available to services.
 	#[serde(default)]
 	pub configs: IndexMap<String, ConfigConfig>,
 	/// Top-level `models:` element (Compose v2.38). Parsed for fidelity; podup

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -22,197 +22,367 @@ use super::{
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct Service {
+	/// `image:` — container image reference (`name[:tag|@digest]`) to run; if
+	/// absent, `build:` must supply one.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image: Option<String>,
+	/// `build:` — build the image from source instead of (or in addition to)
+	/// pulling `image:`; a string shorthand is the build context path.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub build: Option<BuildConfig>,
+	/// `extends:` — inherit configuration from another service (optionally in
+	/// another file); merged before this service's own keys are applied.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub extends: Option<ExtendsConfig>,
+	/// `command:` — overrides the image `CMD`; string (shell-parsed) or list (exec
+	/// form, no shell).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub command: Option<Command>,
+	/// `entrypoint:` — overrides the image `ENTRYPOINT` and resets any image
+	/// `CMD`; string (shell form) or list (exec form).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub entrypoint: Option<Command>,
 
+	/// `ports:` — published host↔container port mappings (`[host:]container[/proto]`
+	/// or long form); exposes the port outside the container network.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ports: Vec<PortMapping>,
+	/// `expose:` — ports made reachable to linked services only, without
+	/// publishing them on the host.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub expose: Vec<String>,
 
+	/// `environment:` — environment variables set in the container; map or
+	/// `KEY=VALUE` list. Takes precedence over `env_file:`.
 	#[serde(default)]
 	pub environment: EnvVars,
+	/// `env_file:` — file(s) of `KEY=VALUE` lines loaded into the environment;
+	/// overridden by `environment:` on key collision.
 	#[serde(default)]
 	pub env_file: EnvFile,
+	/// `volumes:` — bind mounts, named volumes, and anonymous volumes (short
+	/// `src:dst[:opts]` or long form).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub volumes: Vec<VolumeMount>,
+	/// `tmpfs:` — paths mounted as an in-memory tmpfs inside the container; single
+	/// path or list.
 	#[serde(default)]
 	pub tmpfs: StringOrList,
+	/// `volumes_from:` — mount all volumes from another service or container
+	/// (`name[:ro|rw]`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub volumes_from: Vec<String>,
+	/// `configs:` — top-level configs granted to this service, mounted as files
+	/// (default `/<config-name>`) or exposed per the long form.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub configs: Vec<ServiceConfigRef>,
+	/// `secrets:` — top-level secrets granted to this service, mounted under
+	/// `/run/secrets/` (or the long-form target).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub secrets: Vec<ServiceSecretRef>,
 
+	/// `networks:` — networks this service joins, with optional per-network
+	/// aliases/IPs; absent means the project's default network.
 	#[serde(default)]
 	pub networks: ServiceNetworks,
+	/// `hostname:` — the container's own hostname (its `/etc/hostname` and
+	/// in-container `uname -n`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub hostname: Option<String>,
+	/// `domainname:` — the container's NIS/DNS domain (fully-qualified
+	/// hostname suffix).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub domainname: Option<String>,
+	/// `mac_address:` — fixed MAC for the container's primary interface; a
+	/// documented divergence under rootless Podman where it may be ignored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mac_address: Option<String>,
+	/// `links:` — legacy service links (`service[:alias]`) adding hostname
+	/// entries; superseded by shared networks.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub links: Vec<String>,
+	/// `external_links:` — link to containers outside this compose project
+	/// (`container[:alias]`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub external_links: Vec<String>,
+	/// `extra_hosts:` — extra `/etc/hosts` entries (`hostname:ip`); accepts the
+	/// list or mapping YAML forms.
 	#[serde(
 		default,
 		deserialize_with = "super::primitives::deserialize_extra_hosts",
 		skip_serializing_if = "Vec::is_empty"
 	)]
 	pub extra_hosts: Vec<String>,
+	/// `dns:` — custom DNS server IP(s) for name resolution; single value or list.
 	#[serde(default)]
 	pub dns: StringOrList,
+	/// `dns_search:` — DNS search domains appended to unqualified names; single
+	/// value or list.
 	#[serde(default)]
 	pub dns_search: StringOrList,
+	/// `dns_opt:` — resolver options written to `/etc/resolv.conf` (e.g.
+	/// `ndots:2`); single value or list.
 	#[serde(default)]
 	pub dns_opt: StringOrList,
+	/// `network_mode:` — networking namespace mode (`bridge`, `host`, `none`,
+	/// `service:NAME`, `container:NAME`); mutually exclusive with `networks:`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub network_mode: Option<String>,
 
+	/// `depends_on:` — start/stop ordering and optional `condition:`
+	/// (`service_started`/`service_healthy`/`service_completed_successfully`)
+	/// dependencies on other services.
 	#[serde(default)]
 	pub depends_on: DependsOn,
+	/// `healthcheck:` — command and timing that determine container health;
+	/// `disable: true` turns off any image-defined check.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub healthcheck: Option<HealthCheck>,
 
+	/// `restart:` — restart policy (`no`/`always`/`on-failure[:max]`/
+	/// `unless-stopped`). Takes precedence over `deploy.restart_policy` when both
+	/// are set.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart: Option<RestartPolicy>,
+	/// `stop_signal:` — signal sent to stop the container (e.g. `SIGTERM`,
+	/// `SIGINT`); default `SIGTERM`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_signal: Option<String>,
+	/// `stop_grace_period:` — duration string (e.g. `10s`, `1m30s`) to wait after
+	/// `stop_signal` before `SIGKILL`; default `10s`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_grace_period: Option<String>,
+	/// `profiles:` — activation profiles; the service starts only when one of
+	/// these profiles is enabled (no profiles = always enabled).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub profiles: Vec<String>,
+	/// `post_start:` — lifecycle hook commands run inside the container right
+	/// after it starts (Compose v2.30+).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub post_start: Vec<LifecycleHook>,
+	/// `pre_stop:` — lifecycle hook commands run inside the container just before
+	/// it is stopped (Compose v2.30+).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub pre_stop: Vec<LifecycleHook>,
 
+	/// `labels:` — metadata labels applied to the container; map or `key=value`
+	/// list.
 	#[serde(default)]
 	pub labels: Labels,
+	/// `annotations:` — OCI annotations on the container; distinct from `labels:`,
+	/// passed through to the runtime.
 	#[serde(default)]
 	pub annotations: Labels,
+	/// `container_name:` — explicit container name overriding the generated
+	/// `<project>_<service>_<n>`; forbids scaling above 1 replica.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub container_name: Option<String>,
+	/// `user:` — user (and optional `:group`) the process runs as, by name or
+	/// numeric `UID[:GID]`; overrides the image `USER`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
+	/// `working_dir:` — working directory for the process; overrides the image
+	/// `WORKDIR`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub working_dir: Option<String>,
+	/// `group_add:` — additional groups (name or GID) the process joins, beyond
+	/// its primary group.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub group_add: Vec<String>,
+	/// `platform:` — target platform for the image (`os[/arch[/variant]]`, e.g.
+	/// `linux/amd64`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub platform: Option<String>,
 
+	/// `cap_add:` — Linux capabilities to grant on top of the runtime default set
+	/// (e.g. `NET_ADMIN`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub cap_add: Vec<String>,
+	/// `cap_drop:` — Linux capabilities to drop from the default set (`ALL` drops
+	/// every capability).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub cap_drop: Vec<String>,
+	/// `security_opt:` — runtime security options (e.g. `label:...`, `seccomp=...`,
+	/// `no-new-privileges:true`, `apparmor=...`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub security_opt: Vec<String>,
+	/// `read_only:` — when `true`, mounts the container's root filesystem
+	/// read-only (writes only via volumes/tmpfs). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub read_only: Option<bool>,
+	/// `privileged:` — when `true`, grants extended host privileges; has reduced
+	/// effect under rootless Podman. Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
+	/// `init:` — when `true`, runs an init process (PID 1) that reaps zombies and
+	/// forwards signals. Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub init: Option<bool>,
+	/// `tty:` — when `true`, allocates a pseudo-TTY for the container (akin to
+	/// `docker run -t`). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub tty: Option<bool>,
+	/// `stdin_open:` — when `true`, keeps stdin open for the container (akin to
+	/// `docker run -i`). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stdin_open: Option<bool>,
 
+	/// `runtime:` — OCI runtime to execute the container (e.g. `runc`, `crun`);
+	/// default is the engine's configured runtime.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub runtime: Option<String>,
+	/// `shm_size:` — size of `/dev/shm` as a size string (e.g. `512m`, `1g`);
+	/// bytes if unitless.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub shm_size: Option<String>,
+	/// `userns_mode:` — user-namespace mode (e.g. `host`, `keep-id`) controlling
+	/// UID/GID mapping into the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub userns_mode: Option<String>,
+	/// `pid:` — PID namespace to share (e.g. `host`, `container:NAME`,
+	/// `service:NAME`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pid: Option<String>,
+	/// `ipc:` — IPC namespace mode (e.g. `host`, `shareable`, `service:NAME`,
+	/// `container:NAME`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipc: Option<String>,
+	/// `uts:` — UTS namespace mode; `host` shares the host's hostname/domain
+	/// namespace.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub uts: Option<String>,
+	/// `cgroup_parent:` — optional parent cgroup under which the container's
+	/// cgroup is created.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup_parent: Option<String>,
+	/// `cgroup:` — cgroup namespace mode (`host` or `private`) for the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup: Option<String>,
 
+	/// `devices:` — host devices exposed to the container
+	/// (`host[:container[:perms]]`, perms a subset of `rwm`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub devices: Vec<String>,
+	/// `device_cgroup_rules:` — explicit device cgroup allow/deny rules (e.g.
+	/// `c 1:3 mr`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_cgroup_rules: Vec<String>,
+	/// `storage_opt:` — per-container storage driver options (e.g. `size`) passed
+	/// to the graph driver.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub storage_opt: HashMap<String, String>,
 
+	/// `scale:` — number of replica containers to run. Takes precedence over
+	/// `deploy.replicas`; a CLI `--scale` override wins over both.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub scale: Option<u32>,
+	/// `cpu_shares:` — relative CPU weight under contention (default `1024`);
+	/// proportional share, not a hard cap like `cpus:`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_shares: Option<u64>,
+	/// `cpu_quota:` — CFS hard cap in microseconds of CPU time per `cpu_period`;
+	/// `cpus:` is the higher-level equivalent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_quota: Option<i64>,
+	/// `cpu_period:` — CFS scheduler period in microseconds against which
+	/// `cpu_quota` is measured (default `100000`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_period: Option<u64>,
+	/// `cpuset:` — explicit CPUs/cores the container may run on (e.g. `0-3`,
+	/// `0,2`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpuset: Option<String>,
+	/// `cpus:` — fractional number of CPUs to allow (e.g. `0.5`); a hard cap
+	/// converted to a CFS quota. Top-level value wins over `deploy.resources`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpus: Option<String>,
+	/// `cpu_count:` — number of usable CPUs (Windows containers); not honored on
+	/// Linux/Podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_count: Option<i64>,
+	/// `cpu_percent:` — usable percentage of available CPU (Windows containers);
+	/// not honored on Linux/Podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_percent: Option<i64>,
+	/// `cpu_rt_runtime:` — real-time CPU runtime per period in microseconds for
+	/// real-time scheduling.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_rt_runtime: Option<i64>,
+	/// `cpu_rt_period:` — real-time scheduler period in microseconds for
+	/// real-time scheduling.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_rt_period: Option<i64>,
+	/// `mem_limit:` — hard memory cap as a size string (e.g. `512m`, `1g`); bytes
+	/// if unitless. Top-level value wins over `deploy.resources.limits.memory`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_limit: Option<String>,
+	/// `memswap_limit:` — total memory + swap limit as a size string; `-1` allows
+	/// unlimited swap.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub memswap_limit: Option<String>,
+	/// `mem_reservation:` — soft memory limit (size string, e.g. `256m`) enforced
+	/// under host memory pressure; must be below `mem_limit`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_reservation: Option<String>,
+	/// `mem_swappiness:` — swap tendency for the container's memory, `0`–`100`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_swappiness: Option<i64>,
+	/// `pids_limit:` — maximum number of PIDs the container may create; `-1` for
+	/// unlimited. Top-level value wins over `deploy.resources.limits.pids`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pids_limit: Option<i64>,
+	/// `oom_kill_disable:` — when `true`, disables the OOM killer for the
+	/// container; not supported on cgroups v2.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_kill_disable: Option<bool>,
+	/// `oom_score_adj:` — OOM-killer preference (`-1000`..`1000`); higher makes
+	/// the container likelier to be killed first.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_score_adj: Option<i64>,
+	/// `blkio_config:` — block-IO weights and per-device read/write bandwidth and
+	/// IOPS limits.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub blkio_config: Option<BlkioConfig>,
 
+	/// `logging:` — log driver and its options for the container's stdout/stderr.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub logging: Option<LoggingConfig>,
+	/// `sysctls:` — kernel parameters set in the container's namespace (e.g.
+	/// `net.core.somaxconn`); map or list form.
 	#[serde(default)]
 	pub sysctls: Sysctls,
+	/// `ulimits:` — per-resource process limits (e.g. `nofile`) as a single
+	/// value or `{soft, hard}` pair, keyed by limit name.
 	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 	pub ulimits: IndexMap<String, UlimitConfig>,
 
+	/// `label_file:` — file(s) of `key=value` lines loaded as container labels;
+	/// single path or list (Compose v2.32+).
 	#[serde(default)]
 	pub label_file: StringOrList,
 
+	/// `attach:` — when `false`, `up` does not stream this service's logs to the
+	/// console. Default `true`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attach: Option<bool>,
 
+	/// `pull_policy:` — when to pull the image: `always`, `never`, `missing` (the
+	/// default; alias `if_not_present`), `build`, or `newer`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pull_policy: Option<String>,
 
+	/// `deploy:` — deployment config (replicas, resource limits/reservations,
+	/// restart policy); a fallback for top-level `scale`/`cpus`/`mem_limit`/
+	/// `restart` and the source of Swarm-only fields.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub deploy: Option<DeployConfig>,
 
+	/// `develop:` — `watch` rules driving file-sync/rebuild during development.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub develop: Option<DevelopConfig>,
 
+	/// `gpus:` — GPU devices to expose (`all` or a capability/count spec),
+	/// forwarded as CDI device reservations.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gpus: Option<GpuSpec>,
 
@@ -255,10 +425,14 @@ pub struct Service {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct CredentialSpec {
+	/// `config:` — ID of a Compose config object holding the credential spec.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub config: Option<String>,
+	/// `file:` — path to a credential-spec file, relative to the Docker data
+	/// directory.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
+	/// `registry:` — Windows registry value name holding the credential spec.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub registry: Option<String>,
 	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
@@ -271,8 +445,12 @@ pub struct CredentialSpec {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ProviderConfig {
+	/// `type:` — name of the external provider plugin to delegate the service
+	/// lifecycle to.
 	#[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
 	pub provider_type: Option<String>,
+	/// `options:` — free-form provider-specific parameters passed through to the
+	/// plugin.
 	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 	pub options: IndexMap<String, serde_yaml::Value>,
 	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -246,7 +246,11 @@ pub(crate) async fn dispatch(
 				)
 				.await?
 		}
-		Commands::Top { services } => engine.top(file, &services).await?,
+		Commands::Top { format, services } => {
+			engine
+				.top_with_options(file, &services, format == OutputFormat::Json)
+				.await?
+		}
 		Commands::Events { format, json } => {
 			// `--json` is the deprecated alias for `--format json`; either selects
 			// JSON-line output.

--- a/internal/engine/container/fields.rs
+++ b/internal/engine/container/fields.rs
@@ -19,6 +19,10 @@ use crate::libpod::types::container::{
 // Device helpers
 // ---------------------------------------------------------------------------
 
+/// Parse a compose `devices:` entry (`host:container:permissions`) into a
+/// `LinuxDevice`. The container path defaults to the host path when the
+/// `:container` segment is absent; major/minor/type are derived by `stat`ing the
+/// host node. Trailing permissions, if present, are ignored here.
 pub(crate) fn parse_device(s: &str) -> LinuxDevice {
 	let parts: Vec<&str> = s.splitn(3, ':').collect();
 	let host = parts.first().copied().unwrap_or("").to_string();

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -1,7 +1,7 @@
 //! Pure configuration builders for container creation: restart policy, logging,
 //! healthcheck, resource limits, and ulimits.
 //!
-//! Device, blkio, tmpfs, and label-file helpers live in [`super::container::fields`].
+//! Device, blkio, tmpfs, and label-file helpers live in `super::container::fields`.
 
 use crate::compose::types::{
 	Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart, Service,

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -9,6 +9,11 @@ use crate::size;
 // Resource limits
 // ---------------------------------------------------------------------------
 
+/// Build the OCI `LinuxResources` (memory, CPU, pids) for a service, or `None`
+/// when nothing constrains it. Top-level `mem_limit`/`cpus`/`pids_limit` win;
+/// the modern `deploy.resources` block only fills a value the top level left
+/// unset. A Docker `cpus` (nano-CPU) is converted to an OCI quota over a 100ms
+/// period (`nano / 10_000`, default period `100_000`).
 pub(crate) fn build_resource_limits(service: &Service) -> Option<LinuxResources> {
 	use crate::libpod::types::container::{LinuxCPU, LinuxMemory, LinuxPids};
 
@@ -113,6 +118,10 @@ pub(crate) fn build_resource_limits(service: &Service) -> Option<LinuxResources>
 	})
 }
 
+/// Build the validated `Ulimit` list for a service. Unrecognized resource names
+/// are dropped (not forwarded), `-1` means unlimited (`u64::MAX`) while any other
+/// negative value is rejected to `0`, and a soft limit above its hard limit is
+/// clamped down to the hard limit (POSIX requires soft <= hard).
 pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 	service
 		.ulimits

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -79,17 +79,6 @@ fn health_poll_plan(
 }
 
 impl Engine {
-	/// Poll a container until its health status is `healthy` or timeout.
-	///
-	/// Polls at the compose `healthcheck.interval` (default 2 s) for
-	/// `healthcheck.retries` (default 30) probes, plus extra probes covering
-	/// `healthcheck.start_period` so a slow-starting service is not timed out early.
-	///
-	/// The wait is driven by the container's *effective* healthcheck reported by
-	/// the runtime, so healthchecks inherited from the image count too — not just
-	/// those declared in compose. If the container has no effective healthcheck at
-	/// all (none in the image or compose), it can never report `healthy`, so the
-	/// wait short-circuits as satisfied rather than blocking until timeout.
 	/// Wait until every targeted service's first replica is healthy (`up
 	/// --wait`). A service with no effective healthcheck is treated as ready
 	/// once started. All services when `target_services` is empty.
@@ -108,6 +97,17 @@ impl Engine {
 		Ok(())
 	}
 
+	/// Poll a container until its health status is `healthy` or timeout.
+	///
+	/// Polls at the compose `healthcheck.interval` (default 2 s) for
+	/// `healthcheck.retries` (default 30) probes, plus extra probes covering
+	/// `healthcheck.start_period` so a slow-starting service is not timed out early.
+	///
+	/// The wait is driven by the container's *effective* healthcheck reported by
+	/// the runtime, so healthchecks inherited from the image count too — not just
+	/// those declared in compose. If the container has no effective healthcheck at
+	/// all (none in the image or compose), it can never report `healthy`, so the
+	/// wait short-circuits as satisfied rather than blocking until timeout.
 	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
 		let hc = service.healthcheck.as_ref();
 		let (poll_secs, iterations) = health_poll_plan(

--- a/internal/engine/image/digests.rs
+++ b/internal/engine/image/digests.rs
@@ -2,7 +2,7 @@
 //! digest.
 //!
 //! Like `ls`, this is project-agnostic — it needs only a [`Client`] to inspect
-//! images, not a full [`Engine`] — so it lives as a free function.
+//! images, not a full [`Engine`](crate::engine::Engine) — so it lives as a free function.
 
 use crate::compose::types::ComposeFile;
 use crate::error::Result;

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -36,7 +36,7 @@ impl Engine {
 		for name in &names {
 			let service = &file.services[name];
 
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let grace = self.grace_period_secs(service);
 				// Single atomic restart (no visible stopped window) instead of a
 				// stop+start round-trip.
@@ -57,7 +57,7 @@ impl Engine {
 			}
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
-					for dep_container in self.replica_names(dep_name, dep_service) {
+					for dep_container in self.live_replica_names(dep_name, dep_service).await? {
 						let grace = self.grace_period_secs(dep_service);
 						let restart_path = format!(
 							"{API_PREFIX}/containers/{}/restart?t={grace}",
@@ -90,7 +90,7 @@ impl Engine {
 		let mut last_nonzero = 0i64;
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/wait?condition=stopped",
 					crate::libpod::urlencoded(&container_name),
@@ -123,7 +123,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let grace = self.grace_period_secs(service);
 				let path = format!(
 					"{API_PREFIX}/containers/{}/stop?t={grace}",
@@ -149,7 +149,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/start",
 					crate::libpod::urlencoded(&container_name),
@@ -178,7 +178,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/kill?signal={}",
 					crate::libpod::urlencoded(&container_name),
@@ -223,7 +223,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let force_str = if force { "true" } else { "false" };
 				let path = format!(
 					"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
@@ -248,7 +248,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/pause",
 					crate::libpod::urlencoded(&container_name),
@@ -272,7 +272,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/unpause",
 					crate::libpod::urlencoded(&container_name),

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -13,6 +13,26 @@ use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
 
 impl Engine {
+	/// Run a lifecycle POST against one container with a consistent outcome:
+	/// success logs `{done} {container}`; "already in the desired state" (304)
+	/// and "no such container" (404) are idempotent no-ops; any other failure is
+	/// a real error that propagates (setting a non-zero exit) instead of being
+	/// swallowed into a warning. Shared by stop/start/restart/kill/pause/unpause
+	/// so they all behave the same.
+	async fn run_lifecycle_op(&self, path: &str, container: &str, done: &str) -> Result<()> {
+		match self.client.post_empty_ok(path).await {
+			Ok(()) => {
+				info!("{done} {container}");
+				Ok(())
+			}
+			Err(e) if e.is_status(304) || e.is_status(404) => {
+				tracing::debug!("{container}: {done} skipped ({e})");
+				Ok(())
+			}
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
+	}
+
 	/// Restart the named service (or all services). Dependents with a `restart` condition in `depends_on` are also restarted.
 	pub async fn restart(&self, file: &ComposeFile, service_name: Option<&str>) -> Result<()> {
 		let targets: Vec<String> = service_name
@@ -44,12 +64,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/restart?t={grace}",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&restart_path)
-					.await
-					.map_err(ComposeError::Podman)?;
-
-				info!("restarted {container_name}");
+				self.run_lifecycle_op(&restart_path, &container_name, "restarted")
+					.await?;
 			}
 
 			if no_deps {
@@ -129,11 +145,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/stop?t={grace}",
 					crate::libpod::urlencoded(&container_name),
 				);
-				if let Err(e) = self.client.post_empty_ok(&path).await {
-					tracing::warn!("could not stop {container_name}: {e}");
-				} else {
-					info!("stopped {container_name}");
-				}
+				self.run_lifecycle_op(&path, &container_name, "stopped")
+					.await?;
 			}
 		}
 		Ok(())
@@ -154,11 +167,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/start",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("started {container_name}");
+				self.run_lifecycle_op(&path, &container_name, "started")
+					.await?;
 			}
 		}
 		Ok(())
@@ -184,11 +194,8 @@ impl Engine {
 					crate::libpod::urlencoded(&container_name),
 					crate::libpod::urlencoded(signal),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("sent {signal} to {container_name}");
+				self.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
+					.await?;
 			}
 		}
 		Ok(())
@@ -253,11 +260,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/pause",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("paused {container_name}");
+				self.run_lifecycle_op(&path, &container_name, "paused")
+					.await?;
 			}
 		}
 		Ok(())
@@ -277,11 +281,8 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/unpause",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.client
-					.post_empty_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("unpaused {container_name}");
+				self.run_lifecycle_op(&path, &container_name, "unpaused")
+					.await?;
 			}
 		}
 		Ok(())

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -392,7 +392,7 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				for hook in &service.pre_stop {
 					if let Err(e) = self.run_lifecycle_hook(&container_name, hook).await {
 						tracing::debug!("pre_stop hook {container_name}: {e}");

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -135,6 +135,26 @@ impl Engine {
 			.map(|raw| raw.trim_start_matches('/').to_string())
 			.collect())
 	}
+
+	/// The container names to act on for a service: the ones Podman actually has
+	/// (matched by the `podup.service` label), so lifecycle and query commands
+	/// keep working after a runtime `scale`/`up --scale` that the compose file's
+	/// static replica count no longer names. Falls back to the statically-derived
+	/// names when none exist yet (e.g. a service not yet created).
+	pub(crate) async fn live_replica_names(
+		&self,
+		service_name: &str,
+		service: &Service,
+	) -> Result<Vec<String>> {
+		let live = self
+			.list_project_container_names(Some(service_name))
+			.await?;
+		Ok(if live.is_empty() {
+			self.replica_names(service_name, service)
+		} else {
+			live
+		})
+	}
 }
 
 #[cfg(test)]

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -1,6 +1,6 @@
 //! Container orchestration engine.
 //!
-//! Translates a parsed [`ComposeFile`] into Podman API calls via the libpod REST API.
+//! Translates a parsed [`ComposeFile`](crate::compose::types::ComposeFile) into Podman API calls via the libpod REST API.
 
 mod build;
 mod container;

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -13,6 +13,10 @@ use crate::libpod::API_PREFIX;
 use super::Engine;
 
 impl Engine {
+	/// Pre-create every declared (non-external) network before containers start,
+	/// stamping each with the `podup.project` label and applying driver/IPAM/label
+	/// config. External networks are verified to already exist instead. An
+	/// already-exists conflict on re-`up` is treated as success (idempotent).
 	pub(super) async fn create_networks(&self, file: &ComposeFile) -> Result<()> {
 		for (name, config) in &file.networks {
 			let network_name = config
@@ -89,6 +93,11 @@ impl Engine {
 // Free helpers
 // ---------------------------------------------------------------------------
 
+/// Build the `PerNetworkOptions` for one service's attachment to a single
+/// network: aliases, static IPv4/IPv6 and link-local IPs, MAC (per-network, else
+/// `fallback_mac`), driver options (with `priority` folded in), and interface
+/// name. The service name is always prepended as an alias unless already present,
+/// so siblings resolve the service by name (compose DNS contract).
 pub(super) fn build_per_network_options(
 	service_name: &str,
 	cfg: Option<&ServiceNetworkConfig>,
@@ -143,6 +152,12 @@ pub(super) fn build_per_network_options(
 	opts
 }
 
+/// Resolve a service's networking into a netns `Namespace` and per-network
+/// options. An explicit `network_mode` wins and yields a namespace with no
+/// per-network options (`container:`/`service:` reuse another container's netns,
+/// the service form resolved to its target container name). Otherwise each
+/// declared network is mapped to its options and `bridge` netns is used (libpod
+/// requires `netns=bridge` when explicit networks are attached).
 pub(super) fn resolve_network_mode(
 	service_name: &str,
 	service: &Service,

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -2,7 +2,7 @@
 //!
 //! Unlike the other commands this is project-agnostic: it scans every container
 //! carrying a `podup.project` label and groups by project, so it needs only a
-//! [`Client`], not a full [`Engine`] bound to one project/compose file.
+//! [`Client`], not a full [`Engine`](crate::engine::Engine) bound to one project/compose file.
 
 use std::collections::BTreeMap;
 

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -14,6 +14,17 @@ impl Engine {
 	///
 	/// If `target_services` is empty, all services are queried.
 	pub async fn top(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
+		self.top_with_options(file, target_services, false).await
+	}
+
+	/// `top` with `docker compose top`-style options: `--format json` emits a
+	/// structured array of `{Container, Titles, Processes}` instead of the table.
+	pub async fn top_with_options(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		json: bool,
+	) -> Result<()> {
 		let names: Vec<String> = if target_services.is_empty() {
 			file.services.keys().cloned().collect()
 		} else {
@@ -25,6 +36,7 @@ impl Engine {
 			target_services.to_vec()
 		};
 
+		let mut json_rows: Vec<serde_json::Value> = Vec::new();
 		for name in &names {
 			let service = &file.services[name];
 			for container_name in self.live_replica_names(name, service).await? {
@@ -37,6 +49,11 @@ impl Engine {
 					.get_json::<crate::libpod::types::container::TopResponse>(&path)
 					.await
 				{
+					Ok(result) if json => json_rows.push(serde_json::json!({
+						"Container": container_name,
+						"Titles": result.titles,
+						"Processes": result.processes,
+					})),
 					Ok(result) => {
 						println!("{container_name}");
 						if let Some(titles) = &result.titles {
@@ -51,6 +68,12 @@ impl Engine {
 					Err(e) => tracing::warn!("top {container_name}: {e}"),
 				}
 			}
+		}
+		if json {
+			println!(
+				"{}",
+				serde_json::to_string_pretty(&json_rows).unwrap_or_default()
+			);
 		}
 		Ok(())
 	}

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -27,7 +27,7 @@ impl Engine {
 
 		for name in &names {
 			let service = &file.services[name];
-			for container_name in self.replica_names(name, service) {
+			for container_name in self.live_replica_names(name, service).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/top",
 					urlencoded(&container_name),

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -1,0 +1,68 @@
+//! Per-line log prefixing for `docker compose logs`-style multi-service output.
+
+use std::io::Write;
+
+/// Tags each complete log line with `{label} | `, the way `docker compose logs`
+/// labels multi-service output. Bytes arrive as stream frames that may split a
+/// line across frames, so a partial line is buffered until its newline arrives.
+pub(super) struct LinePrefixer {
+	label: String,
+	pending: Vec<u8>,
+}
+
+impl LinePrefixer {
+	pub(super) fn new(label: &str) -> Self {
+		Self {
+			label: format!("{label}  | "),
+			pending: Vec::new(),
+		}
+	}
+
+	/// Buffer `chunk` and write every complete line it now completes.
+	pub(super) fn write(&mut self, out: &mut impl Write, chunk: &[u8]) {
+		self.pending.extend_from_slice(chunk);
+		while let Some(nl) = self.pending.iter().position(|&b| b == b'\n') {
+			let _ = out.write_all(self.label.as_bytes());
+			let _ = out.write_all(&self.pending[..=nl]);
+			self.pending.drain(..=nl);
+		}
+		let _ = out.flush();
+	}
+
+	/// Flush a trailing line that never received a newline (e.g. at stream end).
+	pub(super) fn flush_tail(&mut self, out: &mut impl Write) {
+		if !self.pending.is_empty() {
+			let _ = out.write_all(self.label.as_bytes());
+			let _ = out.write_all(&self.pending);
+			let _ = out.write_all(b"\n");
+			let _ = out.flush();
+			self.pending.clear();
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::LinePrefixer;
+
+	#[test]
+	fn line_prefixer_tags_lines_and_buffers_partials() {
+		let mut p = LinePrefixer::new("web");
+		let mut out: Vec<u8> = Vec::new();
+		p.write(&mut out, b"hello\nwor");
+		// The complete line is tagged; the partial "wor" waits for its newline.
+		assert_eq!(out, b"web  | hello\n");
+		p.write(&mut out, b"ld\n");
+		assert_eq!(out, b"web  | hello\nweb  | world\n");
+	}
+
+	#[test]
+	fn line_prefixer_flush_tail_emits_unterminated_line() {
+		let mut p = LinePrefixer::new("db");
+		let mut out: Vec<u8> = Vec::new();
+		p.write(&mut out, b"partial");
+		assert!(out.is_empty(), "a line with no newline is held back");
+		p.flush_tail(&mut out);
+		assert_eq!(out, b"db  | partial\n");
+	}
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -15,6 +15,9 @@ use super::Engine;
 use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 
 mod inspect;
+mod log_prefix;
+
+use log_prefix::LinePrefixer;
 
 /// Human-readable status for `ps`. Podman's libpod list endpoint leaves
 /// `Status` empty and reports the machine state in `State`, so fall back to it
@@ -279,23 +282,21 @@ impl Engine {
 						// let a sibling future block the thread on the same lock
 						// and deadlock. Each frame still locks once and flushes,
 						// keeping interleaved `logs -f` output prompt.
+						let mut out_pfx = LinePrefixer::new(&container_name);
+						let mut err_pfx = LinePrefixer::new(&container_name);
 						while let Some(msg) = stream.next().await {
 							match msg {
 								Ok(LogOutput::StdOut { message }) => {
-									let mut out = std::io::stdout().lock();
-									let _ =
-										out.write_all(String::from_utf8_lossy(&message).as_bytes());
-									let _ = out.flush();
+									out_pfx.write(&mut std::io::stdout().lock(), &message);
 								}
 								Ok(LogOutput::StdErr { message }) => {
-									let mut err = std::io::stderr().lock();
-									let _ =
-										err.write_all(String::from_utf8_lossy(&message).as_bytes());
-									let _ = err.flush();
+									err_pfx.write(&mut std::io::stderr().lock(), &message);
 								}
 								Err(_) => break,
 							}
 						}
+						out_pfx.flush_tail(&mut std::io::stdout().lock());
+						err_pfx.flush_tail(&mut std::io::stderr().lock());
 					}
 				})
 				.collect();
@@ -324,19 +325,18 @@ impl Engine {
 				// across the await loop would starve concurrent log emissions.
 				// Flush after each frame so `logs -f` still streams promptly.
 				let mut out = std::io::stdout().lock();
+				let mut out_pfx = LinePrefixer::new(&container_name);
+				let mut err_pfx = LinePrefixer::new(&container_name);
 				while let Some(msg) = stream.next().await {
 					match msg.map_err(ComposeError::Podman)? {
-						LogOutput::StdOut { message } => {
-							let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
-							let _ = out.flush();
-						}
+						LogOutput::StdOut { message } => out_pfx.write(&mut out, &message),
 						LogOutput::StdErr { message } => {
-							let mut err = std::io::stderr().lock();
-							let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
-							let _ = err.flush();
+							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
 					}
 				}
+				out_pfx.flush_tail(&mut out);
+				err_pfx.flush_tail(&mut std::io::stderr().lock());
 			}
 		}
 

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -12,8 +12,47 @@ use crate::libpod::types::exec::{
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
+use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 
 mod inspect;
+
+/// Human-readable status for `ps`. Podman's libpod list endpoint leaves
+/// `Status` empty and reports the machine state in `State`, so fall back to it
+/// rather than rendering a blank column.
+fn display_status(c: &ContainerListEntry) -> &str {
+	if c.status.is_empty() {
+		&c.state
+	} else {
+		&c.status
+	}
+}
+
+/// Render a container's published ports the way `docker compose ps` does, e.g.
+/// `0.0.0.0:8080->80/tcp`. An unset host IP means "all interfaces", shown as
+/// `0.0.0.0` (libpod commonly omits it) to match Docker/Podman output.
+fn format_ports(ports: &[ContainerPort]) -> String {
+	ports
+		.iter()
+		.map(|p| {
+			let proto = p
+				.protocol
+				.as_deref()
+				.map(|proto| format!("/{proto}"))
+				.unwrap_or_default();
+			let host_ip = p
+				.host_ip
+				.as_deref()
+				.filter(|s| !s.is_empty())
+				.unwrap_or("0.0.0.0");
+			format!(
+				"{host_ip}:{}->{}{proto}",
+				p.host_port.unwrap_or(0),
+				p.container_port
+			)
+		})
+		.collect::<Vec<_>>()
+		.join(", ")
+}
 
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
 #[derive(Default)]
@@ -127,7 +166,7 @@ impl Engine {
 					serde_json::json!({
 						"Name": name_of(c),
 						"Image": c.image,
-						"Status": c.status,
+						"Status": display_status(c),
 						"ID": c.id,
 					})
 				})
@@ -141,29 +180,12 @@ impl Engine {
 
 		println!("{:<40} {:<30} {:<20}", "NAME", "IMAGE", "STATUS");
 		for c in &containers {
-			let ports = c
-				.ports
-				.iter()
-				.map(|p| {
-					let proto = p
-						.protocol
-						.as_deref()
-						.map(|proto| format!("/{proto}"))
-						.unwrap_or_default();
-					format!(
-						"{}:{}->{}{proto}",
-						p.host_ip.as_deref().unwrap_or(""),
-						p.host_port.unwrap_or(0),
-						p.container_port,
-					)
-				})
-				.collect::<Vec<_>>()
-				.join(", ");
+			let ports = format_ports(&c.ports);
 			println!(
 				"{:<40} {:<30} {:<20} {ports}",
 				name_of(c),
 				c.image,
-				c.status
+				display_status(c)
 			);
 		}
 
@@ -485,7 +507,66 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::{log_query, LogsOptions};
+	use super::{display_status, format_ports, log_query, LogsOptions};
+	use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
+	use std::collections::HashMap;
+
+	fn entry(status: &str, state: &str) -> ContainerListEntry {
+		ContainerListEntry {
+			id: "abc123".into(),
+			names: vec!["/web".into()],
+			image: "alpine".into(),
+			status: status.into(),
+			state: state.into(),
+			ports: vec![],
+			labels: HashMap::new(),
+		}
+	}
+
+	#[test]
+	fn display_status_falls_back_to_state_when_status_empty() {
+		// Podman 5's libpod list endpoint sends an empty `Status` and the real
+		// machine state in `State` — `ps` must show the latter, not a blank.
+		assert_eq!(display_status(&entry("", "running")), "running");
+		assert_eq!(display_status(&entry("", "exited")), "exited");
+	}
+
+	#[test]
+	fn display_status_prefers_status_when_present() {
+		assert_eq!(
+			display_status(&entry("Up 2 seconds", "running")),
+			"Up 2 seconds"
+		);
+	}
+
+	#[test]
+	fn format_ports_defaults_missing_host_ip_to_all_interfaces() {
+		let p = ContainerPort {
+			host_ip: None,
+			host_port: Some(8080),
+			container_port: 80,
+			protocol: Some("tcp".into()),
+			..Default::default()
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"0.0.0.0:8080->80/tcp"
+		);
+	}
+
+	#[test]
+	fn format_ports_keeps_explicit_host_ip() {
+		let p = ContainerPort {
+			host_ip: Some("127.0.0.1".into()),
+			host_port: Some(5432),
+			container_port: 5432,
+			..Default::default()
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"127.0.0.1:5432->5432"
+		);
+	}
 
 	#[test]
 	fn log_query_defaults_to_stdout_stderr_no_follow() {

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -11,22 +11,22 @@ use crate::libpod::{parse_json_lines, urlencoded, API_PREFIX};
 
 use super::Engine;
 
-/// Build the `&containers=<a,b,c>` query fragment scoping a stats request to the
-/// `wanted` containers, or an empty string when none are wanted (which falls
-/// back to the daemon default). Names are sorted for a stable URL and each is
-/// URL-encoded; the comma separators are intentionally left literal.
+/// Build the query fragment scoping a stats request to the `wanted` containers,
+/// or an empty string when none are wanted (which falls back to the daemon
+/// default). libpod's `/containers/stats` expects the `containers` parameter
+/// **repeated** once per container (`&containers=a&containers=b`), not a single
+/// comma-joined value — a comma-joined list is parsed as one container name and
+/// 404s. Names are sorted for a stable URL and each is URL-encoded.
 fn containers_query(wanted: &HashSet<String>) -> String {
 	if wanted.is_empty() {
 		return String::new();
 	}
 	let mut names: Vec<&String> = wanted.iter().collect();
 	names.sort();
-	let joined = names
+	names
 		.iter()
-		.map(|n| urlencoded(n))
-		.collect::<Vec<_>>()
-		.join(",");
-	format!("&containers={joined}")
+		.map(|n| format!("&containers={}", urlencoded(n)))
+		.collect::<String>()
 }
 
 /// Deserialize a map field, treating an explicit JSON `null` as the default
@@ -257,13 +257,15 @@ mod tests {
 	}
 
 	#[test]
-	fn containers_query_is_sorted_and_scoped() {
+	fn containers_query_repeats_param_per_container() {
+		// libpod wants `containers` repeated, not comma-joined — a comma-joined
+		// list is read as a single container name and 404s.
 		let mut wanted = HashSet::new();
 		wanted.insert("proj-web-1".to_string());
 		wanted.insert("proj-db-1".to_string());
 		assert_eq!(
 			containers_query(&wanted),
-			"&containers=proj-db-1,proj-web-1"
+			"&containers=proj-db-1&containers=proj-web-1"
 		);
 	}
 

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -131,7 +131,7 @@ impl Engine {
 		target_services: &[String],
 		no_stream: bool,
 	) -> Result<()> {
-		let wanted = self.target_container_names(file, target_services);
+		let wanted = self.target_container_names(file, target_services).await?;
 
 		// Scope the stats stream to just the wanted containers server-side via the
 		// `containers=` query param, so the daemon does not sample every container
@@ -172,18 +172,20 @@ impl Engine {
 
 	/// The set of container names to report on: every replica of the targeted
 	/// services (all services when `target_services` is empty).
-	fn target_container_names(
+	async fn target_container_names(
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],
-	) -> HashSet<String> {
-		file.services
-			.iter()
-			.filter(|(name, _)| {
-				target_services.is_empty() || target_services.iter().any(|t| t == *name)
-			})
-			.flat_map(|(name, service)| self.replica_names(name, service))
-			.collect()
+	) -> Result<HashSet<String>> {
+		let mut wanted = HashSet::new();
+		for (name, service) in &file.services {
+			if target_services.is_empty() || target_services.iter().any(|t| t == name) {
+				for c in self.live_replica_names(name, service).await? {
+					wanted.insert(c);
+				}
+			}
+		}
+		Ok(wanted)
 	}
 }
 

--- a/internal/engine/volume/mod.rs
+++ b/internal/engine/volume/mod.rs
@@ -20,6 +20,11 @@ mod list;
 pub use list::VolumesOptions;
 
 impl Engine {
+	/// Pre-create every declared (non-external) named volume before containers
+	/// start, stamping each with the `podup.project` label and applying
+	/// driver/driver-opts/label config. External volumes are verified to already
+	/// exist instead. An already-exists conflict on re-`up` is treated as success
+	/// (libpod returns 500, not 409, for an existing volume name).
 	pub(super) async fn create_volumes(&self, file: &ComposeFile) -> Result<()> {
 		for (name, config) in &file.volumes {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);

--- a/internal/engine/watch/sync.rs
+++ b/internal/engine/watch/sync.rs
@@ -63,6 +63,10 @@ pub(super) fn build_sync_tar(src: &Path, entry_name: &Path) -> Result<Vec<u8>> {
 	Ok(bytes)
 }
 
+/// True when `path` matches a watch-rule `ignore` pattern. A pattern ending in
+/// `/` matches `path` by directory prefix; otherwise it matches an exact path or
+/// a leading path segment (the pattern followed by `/`). Matching is anchored at
+/// the start of `path`.
 pub(super) fn is_ignored(path: &str, patterns: &[String]) -> bool {
 	for pat in patterns {
 		if pat.ends_with('/') {
@@ -78,6 +82,10 @@ pub(super) fn is_ignored(path: &str, patterns: &[String]) -> bool {
 	false
 }
 
+/// True when `path` matches a watch-rule `include` pattern. Unlike
+/// [`is_ignored`], a `*.ext` pattern matches by extension suffix, and a bare name
+/// matches not only an exact path or directory prefix but also a trailing path
+/// segment anywhere in `path` (the pattern preceded by `/`).
 pub(super) fn is_included(path: &str, patterns: &[String]) -> bool {
 	for pat in patterns {
 		if pat.starts_with("*.") {

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -9,31 +9,48 @@
 // new `unsafe` block elsewhere fails the build.
 #![deny(unsafe_code)]
 
+/// Compose-file parsing, `extends:`/`include:` resolution, and topological
+/// service ordering.
 pub mod compose;
 pub(crate) mod dotenv;
 pub(crate) mod engine;
+/// `env_file:` loading: KEY=VALUE pairs from a service's declared files.
 pub mod env_file;
 pub(crate) mod error;
 pub(crate) mod filesystem;
 pub(crate) mod libpod;
+/// Podman socket connection helpers.
 pub mod podman;
+/// Port-mapping parser for the docker-compose `ports:` format variants.
 pub mod ports;
+/// Quadlet export: translate a parsed compose file into Podman systemd units.
 pub mod quadlet;
+/// Memory and CPU value parsers shared by the engine and tests.
 pub mod size;
+/// Docker Compose `${VAR}`/`$VAR` substitution over raw YAML before parsing.
 pub mod substitute;
+/// Secure self-update for the `podup` binary (signature-verified release fetch).
 #[cfg(feature = "update")]
 pub mod update;
 
+/// Compose entry points: the parser variants, diagnostics collection, and
+/// service-ordering helpers, re-exported at the crate root for callers.
 pub use compose::{
 	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
 	parse_files_with_env_files_interp, parse_str, parse_str_raw, resolve_levels, resolve_order,
 };
+/// The lifecycle `Engine` and its per-command option/override types, plus the
+/// project-name/listing helpers — the surface a CLI drives compose operations
+/// through.
 pub use engine::{
 	is_safe_project_name, list_projects, resolve_image_digests, BuildOptions, CpOptions, Engine,
 	ExecOptions, ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions,
 	PushOptions, RunOptions, RunOverrides, VolumesOptions,
 };
+/// The crate's error type and `Result` alias, surfaced so callers handle one
+/// error enum across parsing and engine calls.
 pub use error::{ComposeError, Result};
+/// The libpod `Client`, surfaced for callers that talk to Podman directly.
 pub use libpod::Client;
 
 /// Internal parsers exposed only under `test-helpers` for fuzzing and tests.

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -173,7 +173,7 @@ impl Client {
 	/// With `Some(limit)` a stalled body is aborted once `limit` elapses, yielding
 	/// a timeout [`PodmanError`]. With `None` the future is awaited uncapped, for
 	/// endpoints that legitimately block server-side (the caller supplies its own
-	/// outer budget). Split out from [`read_body`] so the timeout policy is
+	/// outer budget). Split out from [`read_body`](Self::read_body) so the timeout policy is
 	/// testable without a live socket.
 	async fn apply_read_timeout<F, T>(
 		read_timeout: Option<std::time::Duration>,
@@ -223,7 +223,7 @@ impl Client {
 	}
 
 	/// For streaming endpoints: return the response on success, otherwise read
-	/// the body and surface it through [`check_status`] so the caller gets the
+	/// the body and surface it through [`check_status`](Self::check_status) so the caller gets the
 	/// parsed Podman error message rather than the raw JSON body.
 	async fn stream_or_err(resp: Response<Incoming>) -> Result<Response<Incoming>> {
 		if resp.status().is_success() {

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -19,15 +19,21 @@ where
 /// Entry in the `GET /libpod/containers/json` response array.
 #[derive(Deserialize)]
 pub struct ContainerListEntry {
+	/// Full 64-hex container ID.
 	#[serde(rename = "Id", default)]
 	pub id: String,
 
+	/// Container names, each leading-slash-prefixed as Podman reports them
+	/// (e.g. `/web`). A container may carry multiple names/aliases.
 	#[serde(rename = "Names", default, deserialize_with = "null_default")]
 	pub names: Vec<String>,
 
+	/// Image reference the container was created from (name:tag or an ID).
 	#[serde(rename = "Image", default)]
 	pub image: String,
 
+	/// Human-readable status string for `ps` display (e.g. `Up 3 minutes`,
+	/// `Exited (0) 5 seconds ago`). Empty on libpod, which reports `State`.
 	#[serde(rename = "Status", default)]
 	pub status: String,
 
@@ -36,9 +42,11 @@ pub struct ContainerListEntry {
 	#[serde(rename = "State", default)]
 	pub state: String,
 
+	/// Published port mappings for the container.
 	#[serde(rename = "Ports", default, deserialize_with = "null_default")]
 	pub ports: Vec<ContainerPort>,
 
+	/// Container labels (key/value), including compose project/service labels.
 	#[serde(rename = "Labels", default, deserialize_with = "null_default")]
 	pub labels: HashMap<String, String>,
 }
@@ -46,8 +54,11 @@ pub struct ContainerListEntry {
 /// Port mapping entry in container list response.
 #[derive(Deserialize, Default)]
 pub struct ContainerPort {
+	/// Host IP the port is bound to; absent when bound to all interfaces.
 	pub host_ip: Option<String>,
+	/// Port on the host the mapping is published to; absent when not published.
 	pub host_port: Option<u16>,
+	/// Port inside the container that traffic is forwarded to.
 	pub container_port: u16,
 	/// Transport protocol of the mapping (`tcp`/`udp`/`sctp`), surfaced in `ps`.
 	#[serde(default)]
@@ -63,12 +74,15 @@ pub struct ContainerPort {
 /// Response from `GET /libpod/containers/{name}/json`.
 #[derive(Deserialize, Default)]
 pub struct ContainerInspect {
+	/// Runtime state (status, exit code, health).
 	#[serde(rename = "State")]
 	pub state: Option<ContainerState>,
 
+	/// Static configuration the container was created with.
 	#[serde(rename = "Config")]
 	pub config: Option<ContainerConfig>,
 
+	/// Runtime network settings, including resolved host port bindings.
 	#[serde(rename = "NetworkSettings")]
 	pub network_settings: Option<NetworkSettings>,
 }
@@ -76,6 +90,7 @@ pub struct ContainerInspect {
 /// Container config sub-object from inspect.
 #[derive(Deserialize, Default)]
 pub struct ContainerConfig {
+	/// Effective healthcheck, if any; absent when the image declares none.
 	#[serde(rename = "Healthcheck")]
 	pub healthcheck: Option<HealthConfig>,
 }
@@ -94,6 +109,9 @@ impl ContainerConfig {
 /// Effective healthcheck config baked into the container (image or compose).
 #[derive(Deserialize, Default)]
 pub struct HealthConfig {
+	/// Healthcheck command in Docker's `Test` form: the first element is the
+	/// mode (`NONE`, `CMD`, or `CMD-SHELL`) and the rest are its arguments.
+	/// `["NONE"]` means the healthcheck is explicitly disabled; empty means none.
 	#[serde(rename = "Test", default, deserialize_with = "null_default")]
 	pub test: Vec<String>,
 }
@@ -112,6 +130,7 @@ pub struct ContainerState {
 	#[serde(rename = "ExitCode")]
 	pub exit_code: Option<i64>,
 
+	/// Aggregated healthcheck state; absent when the container has no healthcheck.
 	#[serde(rename = "Health")]
 	pub health: Option<HealthState>,
 }
@@ -119,6 +138,7 @@ pub struct ContainerState {
 /// Container health state sub-object.
 #[derive(Deserialize)]
 pub struct HealthState {
+	/// Current health status (`healthy`, `unhealthy`, `starting`).
 	#[serde(rename = "Status")]
 	pub status: Option<String>,
 }
@@ -126,6 +146,9 @@ pub struct HealthState {
 /// Network settings sub-object from container inspect.
 #[derive(Deserialize, Default)]
 pub struct NetworkSettings {
+	/// Resolved port bindings keyed by container port spec (`"80/tcp"`). The
+	/// value is the list of host bindings, or `None`/empty when the port is
+	/// exposed but not published.
 	#[serde(rename = "Ports", default)]
 	pub ports: HashMap<String, Option<Vec<HostBinding>>>,
 }
@@ -133,9 +156,11 @@ pub struct NetworkSettings {
 /// Host port binding from container inspect network settings.
 #[derive(Deserialize, Clone)]
 pub struct HostBinding {
+	/// Host IP the port is bound to; empty/absent means all interfaces.
 	#[serde(rename = "HostIp")]
 	pub host_ip: Option<String>,
 
+	/// Host port as a string, as Podman reports it in inspect output.
 	#[serde(rename = "HostPort")]
 	pub host_port: Option<String>,
 }
@@ -143,9 +168,11 @@ pub struct HostBinding {
 /// Response from `GET /libpod/containers/{name}/top`.
 #[derive(Deserialize, Default)]
 pub struct TopResponse {
+	/// Column headers for the process table (e.g. `PID`, `USER`, `COMMAND`).
 	#[serde(rename = "Titles")]
 	pub titles: Option<Vec<String>>,
 
+	/// One row per process; each row's columns align with `titles`.
 	#[serde(rename = "Processes")]
 	pub processes: Option<Vec<Vec<String>>>,
 }

--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -14,27 +14,36 @@ pub use parts::*;
 /// Full container specification sent to `POST /libpod/containers/create`.
 #[derive(Serialize, Default)]
 pub struct SpecGenerator {
+	/// Container name.
 	pub name: String,
+	/// Image reference to run (name:tag or digest).
 	pub image: String,
 
+	/// Command (`CMD`) override; replaces the image's default command.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub command: Option<Vec<String>>,
 
+	/// Entrypoint override; replaces the image's `ENTRYPOINT`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub entrypoint: Option<Vec<String>>,
 
+	/// Environment variables to set in the container.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub env: HashMap<String, String>,
 
+	/// Allocate a pseudo-TTY for the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub terminal: Option<bool>,
 
+	/// Keep stdin open for the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stdin: Option<bool>,
 
+	/// User to run as (`name`, `uid`, `uid:gid`, or `name:group`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
 
+	/// Working directory inside the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub work_dir: Option<String>,
 
@@ -44,135 +53,172 @@ pub struct SpecGenerator {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_signal: Option<i64>,
 
+	/// Graceful stop timeout, in **seconds**, before SIGKILL.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_timeout: Option<u64>,
 
+	/// Container hostname.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub hostname: Option<String>,
 
+	/// Container NIS domain name.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub domainname: Option<String>,
 
 	// Labels and annotations
+	/// Container labels.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub labels: HashMap<String, String>,
 
+	/// OCI annotations attached to the container.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub annotations: HashMap<String, String>,
 
 	// Capabilities and security
+	/// Linux capabilities to add (without the `CAP_` prefix, e.g. `"NET_ADMIN"`).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub cap_add: Vec<String>,
 
+	/// Linux capabilities to drop (without the `CAP_` prefix).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub cap_drop: Vec<String>,
 
+	/// Run the container privileged (disables most isolation).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
 
+	/// Mount the container's root filesystem read-only.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub read_only_filesystem: Option<bool>,
 
-	// Podman's SpecGenerator has no `security_opt` field; the compose list is
-	// decomposed into these dedicated fields. A plain `security_opt` array is
-	// silently ignored, so every option (incl. no-new-privileges/seccomp/apparmor)
-	// would otherwise be dropped.
+	/// SELinux options (compose `security_opt` `label=...`); Podman's
+	/// SpecGenerator has no `security_opt` field, so the compose list is
+	/// decomposed into these dedicated fields. A plain `security_opt` array is
+	/// silently ignored, so every option (incl. no-new-privileges/seccomp/apparmor)
+	/// would otherwise be dropped.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub selinux_opts: Vec<String>,
 
+	/// AppArmor profile name to apply.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub apparmor_profile: Option<String>,
 
+	/// Path to a seccomp profile JSON file (or `"unconfined"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub seccomp_profile_path: Option<String>,
 
+	/// Set the `no_new_privs` flag, preventing privilege escalation.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub no_new_privileges: Option<bool>,
 
+	/// Additional `/proc` and `/sys` paths to mask (hide).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub mask: Vec<String>,
 
+	/// Paths to unmask (un-hide), reversing default masks; `"ALL"` unmasks all.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub unmask: Vec<String>,
 
+	/// Kernel `sysctl` parameters to set for the container.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub sysctl: HashMap<String, String>,
 
 	// Networking
+	/// Ports to expose without publishing; key = port number, value = protocol
+	/// (`"tcp"`/`"udp"`).
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub expose: HashMap<u16, String>,
 
+	/// Published port mappings.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub portmappings: Vec<PortMapping>,
 
+	/// Networks to connect to; key = network name, value = per-connection options.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub networks: HashMap<String, PerNetworkOptions>,
 
+	/// Network namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub netns: Option<Namespace>,
 
-	// Podman's SpecGenerator names this field `hostadd` (there is no `extra_hosts`
-	// key); without the rename every extra_hosts entry is silently dropped.
+	/// Extra `/etc/hosts` entries (`"host:ip"`). Podman's SpecGenerator names this
+	/// field `hostadd` (there is no `extra_hosts` key); without the rename every
+	/// extra_hosts entry is silently dropped.
 	#[serde(rename = "hostadd", skip_serializing_if = "Vec::is_empty", default)]
 	pub extra_hosts: Vec<String>,
 
+	/// Custom DNS server addresses.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub dns_server: Vec<String>,
 
+	/// DNS search domains.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub dns_search: Vec<String>,
 
+	/// DNS resolver options (`/etc/resolv.conf` `options` lines).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub dns_option: Vec<String>,
 
 	// Volumes and mounts
+	/// OCI mounts (bind/tmpfs/...) attached to the container.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub mounts: Vec<Mount>,
 
+	/// Named-volume attachments.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub volumes: Vec<NamedVolume>,
 
+	/// Container names/IDs to inherit volume mounts from.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub volumes_from: Vec<String>,
 
-	// Podman-native secrets (also used for external configs): each references an
-	// existing `podman secret` by name and is mounted into the container.
+	/// Podman-native secrets (also used for external configs): each references an
+	/// existing `podman secret` by name and is mounted into the container.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub secrets: Vec<Secret>,
 
 	// Namespace modes
+	/// User namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub userns: Option<Namespace>,
 
+	/// PID namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pidns: Option<Namespace>,
 
+	/// IPC namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipcns: Option<Namespace>,
 
+	/// UTS namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub utsns: Option<Namespace>,
 
+	/// Cgroup namespace mode.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroupns: Option<Namespace>,
 
+	/// Parent cgroup path under which the container's cgroup is created.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup_parent: Option<String>,
 
 	// Resource limits
+	/// CPU/memory/pids/block-I/O resource limits.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub resource_limits: Option<LinuxResources>,
 
-	// Podman's SpecGenerator names this field `r_limits` (POSIX rlimits); without
-	// the rename every ulimits entry is silently dropped. The per-element shape
-	// (`{type, soft, hard}`) already matches Podman's POSIXRlimit.
+	/// POSIX rlimits. Podman's SpecGenerator names this field `r_limits`; without
+	/// the rename every ulimits entry is silently dropped. The per-element shape
+	/// (`{type, soft, hard}`) already matches Podman's POSIXRlimit.
 	#[serde(rename = "r_limits", skip_serializing_if = "Vec::is_empty", default)]
 	pub ulimits: Vec<Ulimit>,
 
+	/// Size of `/dev/shm`, in **bytes**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub shm_size: Option<i64>,
 
 	// Healthcheck
+	/// Main healthcheck configuration.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub healthconfig: Option<HealthConfig>,
 
@@ -193,59 +239,73 @@ pub struct SpecGenerator {
 	pub startup_health_config: Option<StartupHealthCheck>,
 
 	// Logging
+	/// Log driver configuration.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub log_configuration: Option<LogConfig>,
 
 	// Init process
+	/// Run an init process as PID 1 to reap zombies and forward signals.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub init: Option<bool>,
 
 	// Restart policy
+	/// Restart policy name (`"no"`, `"on-failure"`, `"always"`, `"unless-stopped"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart_policy: Option<String>,
 
+	/// Maximum restart attempts (only meaningful for `on-failure`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart_tries: Option<u64>,
 
-	// Devices. Podman 5.x has no SpecGenerator CDI field; CDI device names (e.g.
-	// `nvidia.com/gpu=all`) are recognized by ExtractCDIDevices from this array by
-	// their qualified path, so they are appended here as `LinuxDevice` entries.
+	/// Device nodes to expose. Podman 5.x has no SpecGenerator CDI field; CDI
+	/// device names (e.g. `nvidia.com/gpu=all`) are recognized by ExtractCDIDevices
+	/// from this array by their qualified path, so they are appended here as
+	/// `LinuxDevice` entries.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub devices: Vec<LinuxDevice>,
 
-	// Podman expects structured cgroup rules ([]LinuxDeviceCgroup), not strings; a
-	// string array would fail to deserialize.
+	/// Cgroup device access rules. Podman expects structured rules
+	/// ([`LinuxDeviceCgroup`]), not strings; a string array would fail to
+	/// deserialize.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub device_cgroup_rule: Vec<LinuxDeviceCgroup>,
 
 	// Groups
+	/// Additional supplementary groups (names or GIDs) for the container process.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub groups: Vec<String>,
 
 	// OOM
+	/// OOM-killer score adjustment, `-1000`..=`1000`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_score_adj: Option<i64>,
 
 	// Runtime
+	/// OCI runtime to use (e.g. `"crun"`, `"runc"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub runtime: Option<String>,
 
-	// Links (deprecated in rootless, accepted but may be ignored)
+	/// Legacy container links (deprecated in rootless, accepted but may be ignored).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub links: Vec<String>,
 
 	// Platform selection
+	/// Target image CPU architecture (e.g. `"amd64"`, `"arm64"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image_arch: Option<String>,
 
+	/// Target image OS (e.g. `"linux"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image_os: Option<String>,
 
 	// Volume image handling
+	/// How image-defined `VOLUME`s are handled (e.g. `"anonymous"`, `"tmpfs"`,
+	/// `"ignore"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image_volume_mode: Option<String>,
 
 	// Storage options
+	/// Storage-driver options for the container's root filesystem.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub storage_opts: HashMap<String, String>,
 }

--- a/internal/libpod/types/container/spec/parts.rs
+++ b/internal/libpod/types/container/spec/parts.rs
@@ -11,14 +11,18 @@ use serde::Serialize;
 /// Port mapping for SpecGenerator.
 #[derive(Serialize, Default)]
 pub struct PortMapping {
+	/// Container-side port to publish.
 	pub container_port: u16,
 
+	/// Host-side port to bind; when absent Podman auto-assigns one.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub host_port: Option<u16>,
 
+	/// Host interface address to bind on; empty means all interfaces.
 	#[serde(skip_serializing_if = "String::is_empty", default)]
 	pub host_ip: String,
 
+	/// Transport protocol (`"tcp"` or `"udp"`).
 	pub protocol: String,
 
 	/// Number of ports to map starting from `container_port` (range mapping).
@@ -33,18 +37,24 @@ pub struct PortMapping {
 /// (a bare name lands under `/run/secrets/`, an absolute path is used as-is).
 #[derive(Serialize, Default)]
 pub struct Secret {
+	/// Name of an existing Podman secret to attach.
 	#[serde(rename = "Source")]
 	pub source: String,
 
+	/// Mount destination: a bare name lands under `/run/secrets/`, an absolute
+	/// path is used as-is.
 	#[serde(rename = "Target", skip_serializing_if = "Option::is_none")]
 	pub target: Option<String>,
 
+	/// Owner UID of the mounted secret file.
 	#[serde(rename = "UID", skip_serializing_if = "Option::is_none")]
 	pub uid: Option<u32>,
 
+	/// Owner GID of the mounted secret file.
 	#[serde(rename = "GID", skip_serializing_if = "Option::is_none")]
 	pub gid: Option<u32>,
 
+	/// File mode (permission bits) of the mounted secret, e.g. `0o400`.
 	#[serde(rename = "Mode", skip_serializing_if = "Option::is_none")]
 	pub mode: Option<u32>,
 }
@@ -52,18 +62,23 @@ pub struct Secret {
 /// Per-network connection options (for SpecGenerator `networks` map).
 #[derive(Serialize, Default)]
 pub struct PerNetworkOptions {
+	/// Additional DNS names the container is reachable by on this network.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub aliases: Vec<String>,
 
+	/// Fixed IP addresses to assign on this network.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub static_ips: Vec<String>,
 
+	/// Fixed MAC address for the container's interface on this network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub static_mac: Option<String>,
 
+	/// Name to give the container's network interface on this network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub interface_name: Option<String>,
 
+	/// Driver-specific per-connection options.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver_opts: Option<HashMap<String, String>>,
 }
@@ -71,8 +86,10 @@ pub struct PerNetworkOptions {
 /// Linux network/pid/ipc/uts/cgroup namespace specification.
 #[derive(Serialize, Clone)]
 pub struct Namespace {
+	/// Namespace mode (e.g. `"host"`, `"private"`, `"container"`, `"none"`).
 	pub nsmode: String,
 
+	/// Mode-dependent target, e.g. the container ID for `nsmode == "container"`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub value: Option<String>,
 }
@@ -111,14 +128,18 @@ impl Namespace {
 /// OCI mount specification for SpecGenerator.
 #[derive(Serialize, Default)]
 pub struct Mount {
+	/// OCI mount type (e.g. `"bind"`, `"tmpfs"`, `"volume"`).
 	#[serde(rename = "type")]
 	pub mount_type: String,
 
+	/// Host source path or tmpfs source; absent for anonymous tmpfs mounts.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub source: Option<String>,
 
+	/// Absolute mount path inside the container.
 	pub destination: String,
 
+	/// OCI mount options (e.g. `"ro"`, `"rbind"`, `"nosuid"`).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub options: Vec<String>,
 }
@@ -126,12 +147,15 @@ pub struct Mount {
 /// Named volume attachment for SpecGenerator (goes in `volumes`, not `mounts`).
 #[derive(Serialize, Default)]
 pub struct NamedVolume {
+	/// Name of the Podman volume to attach.
 	#[serde(rename = "Name")]
 	pub name: String,
 
+	/// Absolute mount path inside the container.
 	#[serde(rename = "Dest")]
 	pub dest: String,
 
+	/// Mount options applied to the volume (e.g. `"ro"`, `"z"`).
 	#[serde(rename = "Options", skip_serializing_if = "Vec::is_empty", default)]
 	pub options: Vec<String>,
 
@@ -143,15 +167,19 @@ pub struct NamedVolume {
 /// Linux OCI resource limits for SpecGenerator.
 #[derive(Serialize, Default)]
 pub struct LinuxResources {
+	/// Memory limits sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub memory: Option<LinuxMemory>,
 
+	/// CPU limits sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu: Option<LinuxCPU>,
 
+	/// Process-count (pids) limit sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pids: Option<LinuxPids>,
 
+	/// Block I/O limits sub-block.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub block_io: Option<LinuxBlockIO>,
 
@@ -163,18 +191,23 @@ pub struct LinuxResources {
 /// Linux memory resource limits.
 #[derive(Serialize, Default)]
 pub struct LinuxMemory {
+	/// Hard memory limit in **bytes** (`-1` disables the limit).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub limit: Option<i64>,
 
+	/// Soft memory reservation (low-water mark) in **bytes**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub reservation: Option<i64>,
 
+	/// Total memory+swap limit in **bytes** (`-1` disables the limit).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub swap: Option<i64>,
 
+	/// Swap tendency, `0`–`100` (kernel `memory.swappiness`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub swappiness: Option<u64>,
 
+	/// When true, disables the OOM killer for the cgroup.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub disable_oom_killer: Option<bool>,
 }
@@ -182,18 +215,24 @@ pub struct LinuxMemory {
 /// Linux CPU resource limits.
 #[derive(Serialize, Default)]
 pub struct LinuxCPU {
+	/// Relative CPU weight (cgroup `cpu.shares`); proportional, not a hard cap.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub shares: Option<u64>,
 
+	/// CPU time the cgroup may use per `period`, in **microseconds**
+	/// (`-1` disables the quota).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub quota: Option<i64>,
 
+	/// CFS scheduling period in **microseconds** that `quota` applies to.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub period: Option<u64>,
 
+	/// Realtime scheduling period in **microseconds**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub realtime_period: Option<u64>,
 
+	/// Realtime runtime allowed per `realtime_period`, in **microseconds**.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub realtime_runtime: Option<i64>,
 
@@ -205,27 +244,34 @@ pub struct LinuxCPU {
 /// Linux pids (process count) limit.
 #[derive(Serialize)]
 pub struct LinuxPids {
+	/// Maximum number of processes the cgroup may spawn (`-1` for unlimited).
 	pub limit: i64,
 }
 
 /// Linux block I/O resource limits.
 #[derive(Serialize, Default)]
 pub struct LinuxBlockIO {
+	/// Default block I/O weight, `10`–`1000` (cgroup `blkio.weight`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub weight: Option<u16>,
 
+	/// Per-device block I/O weight overrides.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub weight_device: Vec<LinuxWeightDevice>,
 
+	/// Per-device read-rate caps; each entry's `rate` is in **bytes per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_read_bps_device: Vec<LinuxThrottleDevice>,
 
+	/// Per-device write-rate caps; each entry's `rate` is in **bytes per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_write_bps_device: Vec<LinuxThrottleDevice>,
 
+	/// Per-device read-rate caps; each entry's `rate` is in **IO ops per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_read_iops_device: Vec<LinuxThrottleDevice>,
 
+	/// Per-device write-rate caps; each entry's `rate` is in **IO ops per second**.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub throttle_write_iops_device: Vec<LinuxThrottleDevice>,
 }
@@ -233,9 +279,12 @@ pub struct LinuxBlockIO {
 /// Block device weight entry.
 #[derive(Serialize)]
 pub struct LinuxWeightDevice {
+	/// Device major number.
 	pub major: i64,
+	/// Device minor number.
 	pub minor: i64,
 
+	/// Block I/O weight for this device, `10`–`1000`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub weight: Option<u16>,
 }
@@ -243,25 +292,35 @@ pub struct LinuxWeightDevice {
 /// Block device I/O throttle entry.
 #[derive(Serialize)]
 pub struct LinuxThrottleDevice {
+	/// Device major number.
 	pub major: i64,
+	/// Device minor number.
 	pub minor: i64,
+	/// Throttle rate for this device. Unit depends on the containing list:
+	/// **bytes per second** in `throttle_*_bps_device`, **IO ops per second**
+	/// in `throttle_*_iops_device`.
 	pub rate: u64,
 }
 
 /// cgroup device access rule (for GPU access via `deploy.resources`).
 #[derive(Serialize)]
 pub struct LinuxDeviceCgroup {
+	/// Whether the rule allows (`true`) or denies (`false`) access.
 	pub allow: bool,
 
+	/// Device type: `"a"` (all), `"c"` (char), or `"b"` (block).
 	#[serde(rename = "type", skip_serializing_if = "Option::is_none")]
 	pub device_type: Option<String>,
 
+	/// Device major number; absent means "all majors".
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub major: Option<i64>,
 
+	/// Device minor number; absent means "all minors".
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub minor: Option<i64>,
 
+	/// Access bits as any combination of `r` (read), `w` (write), `m` (mknod).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub access: Option<String>,
 }
@@ -269,30 +328,39 @@ pub struct LinuxDeviceCgroup {
 /// Process rlimit entry.
 #[derive(Serialize)]
 pub struct Ulimit {
+	/// Resource name without the `RLIMIT_` prefix (e.g. `"nofile"`, `"nproc"`).
 	#[serde(rename = "type")]
 	pub ulimit_type: String,
+	/// Soft limit (the value enforced until raised toward `hard`).
 	pub soft: u64,
+	/// Hard limit (the ceiling the soft limit may be raised to).
 	pub hard: u64,
 }
 
 /// Container healthcheck configuration (same structure as Docker).
 #[derive(Serialize, Default)]
 pub struct HealthConfig {
+	/// Probe command; `["CMD", ...]`, `["CMD-SHELL", "<cmd>"]`, or `["NONE"]`.
 	#[serde(rename = "Test", skip_serializing_if = "Option::is_none")]
 	pub test: Option<Vec<String>>,
 
+	/// Time between probes, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "Interval", skip_serializing_if = "Option::is_none")]
 	pub interval: Option<i64>,
 
+	/// Per-probe timeout, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "Timeout", skip_serializing_if = "Option::is_none")]
 	pub timeout: Option<i64>,
 
+	/// Consecutive failures before the container is marked unhealthy.
 	#[serde(rename = "Retries", skip_serializing_if = "Option::is_none")]
 	pub retries: Option<i64>,
 
+	/// Grace period before failures count, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "StartPeriod", skip_serializing_if = "Option::is_none")]
 	pub start_period: Option<i64>,
 
+	/// Probe interval during the start period, in **nanoseconds** (libpod expects ns).
 	#[serde(rename = "StartInterval", skip_serializing_if = "Option::is_none")]
 	pub start_interval: Option<i64>,
 }
@@ -355,9 +423,11 @@ pub struct StartupHealthCheck {
 /// Container log driver configuration.
 #[derive(Serialize)]
 pub struct LogConfig {
+	/// Log driver name (e.g. `"json-file"`, `"journald"`, `"k8s-file"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
+	/// Driver-specific options (e.g. `max-size`, `max-file`).
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub options: HashMap<String, String>,
 }
@@ -365,20 +435,28 @@ pub struct LogConfig {
 /// Linux OCI device specification.
 #[derive(Serialize)]
 pub struct LinuxDevice {
+	/// Device node path inside the container (or a CDI device name).
 	pub path: String,
 
+	/// Device type: `"c"` (char), `"b"` (block), `"p"` (FIFO), or `"u"`
+	/// (unbuffered char).
 	#[serde(rename = "type")]
 	pub device_type: String,
 
+	/// Device major number.
 	pub major: i64,
+	/// Device minor number.
 	pub minor: i64,
 
+	/// File mode (permission bits) of the created device node.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub file_mode: Option<u32>,
 
+	/// Owner UID of the device node.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub uid: Option<u32>,
 
+	/// Owner GID of the device node.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gid: Option<u32>,
 }

--- a/internal/libpod/types/exec.rs
+++ b/internal/libpod/types/exec.rs
@@ -5,30 +5,39 @@ use serde::{Deserialize, Serialize};
 /// Request body for `POST /libpod/containers/{name}/exec`.
 #[derive(Serialize, Default)]
 pub struct ExecCreateConfig {
+	/// Command and arguments to run, as an argv vector (not shell-parsed).
 	#[serde(rename = "Cmd", skip_serializing_if = "Option::is_none")]
 	pub cmd: Option<Vec<String>>,
 
+	/// Whether to attach to the exec process's stdout.
 	#[serde(rename = "AttachStdout", skip_serializing_if = "Option::is_none")]
 	pub attach_stdout: Option<bool>,
 
+	/// Whether to attach to the exec process's stderr.
 	#[serde(rename = "AttachStderr", skip_serializing_if = "Option::is_none")]
 	pub attach_stderr: Option<bool>,
 
+	/// Whether to attach to the exec process's stdin.
 	#[serde(rename = "AttachStdin", skip_serializing_if = "Option::is_none")]
 	pub attach_stdin: Option<bool>,
 
+	/// Whether to allocate a pseudo-TTY for the exec process.
 	#[serde(rename = "Tty", skip_serializing_if = "Option::is_none")]
 	pub tty: Option<bool>,
 
+	/// User (and optionally group) to run the exec process as (`user[:group]`).
 	#[serde(rename = "User", skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
 
+	/// Whether to run the exec process with extended (privileged) permissions.
 	#[serde(rename = "Privileged", skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
 
+	/// Working directory inside the container for the exec process.
 	#[serde(rename = "WorkingDir", skip_serializing_if = "Option::is_none")]
 	pub working_dir: Option<String>,
 
+	/// Environment variables for the exec process, each entry `KEY=VALUE`.
 	#[serde(rename = "Env", skip_serializing_if = "Option::is_none")]
 	pub env: Option<Vec<String>>,
 }
@@ -36,6 +45,7 @@ pub struct ExecCreateConfig {
 /// Response from `POST /libpod/containers/{name}/exec`.
 #[derive(Deserialize)]
 pub struct ExecCreateResponse {
+	/// Exec session ID, used to start and inspect the session.
 	#[serde(rename = "Id")]
 	pub id: String,
 }
@@ -43,9 +53,12 @@ pub struct ExecCreateResponse {
 /// Request body for `POST /libpod/exec/{id}/start`.
 #[derive(Serialize)]
 pub struct ExecStartConfig {
+	/// Whether to start the exec session detached rather than streaming output.
 	#[serde(rename = "Detach")]
 	pub detach: bool,
 
+	/// Whether the exec session was created with a TTY; selects raw vs.
+	/// multiplexed stream framing on the start response.
 	#[serde(rename = "Tty")]
 	pub tty: bool,
 }
@@ -53,6 +66,7 @@ pub struct ExecStartConfig {
 /// Response from `GET /libpod/exec/{id}/json`.
 #[derive(Deserialize, Default)]
 pub struct ExecInspect {
+	/// Exit code of the finished exec process; `None` while it is still running.
 	#[serde(rename = "ExitCode")]
 	pub exit_code: Option<i64>,
 }

--- a/internal/libpod/types/image.rs
+++ b/internal/libpod/types/image.rs
@@ -5,9 +5,13 @@ use serde::Deserialize;
 /// Streaming JSON line emitted during image pull (`POST /libpod/images/pull`).
 #[derive(Deserialize, Default)]
 pub struct ImagePullProgress {
+	/// Progress text for this line. Mutually exclusive with `error`: on a normal
+	/// line this is populated and `error` is empty.
 	#[serde(default)]
 	pub stream: String,
 
+	/// Error message for this line. Mutually exclusive with `stream`: when the
+	/// pull fails this is populated and `stream` is empty.
 	#[serde(default)]
 	pub error: String,
 }
@@ -15,23 +19,29 @@ pub struct ImagePullProgress {
 /// Streaming JSON line emitted during image build (`POST /libpod/build`).
 #[derive(Deserialize, Default)]
 pub struct BuildOutput {
+	/// Build log text for this line. Populated on normal output lines; mutually
+	/// exclusive with `error`, which is set instead when the build fails.
 	#[serde(default)]
 	pub stream: String,
 
+	/// Error message for this line; present only when the build fails.
 	pub error: Option<String>,
 
+	/// Structured error detail accompanying `error`, when the daemon provides it.
 	pub error_detail: Option<BuildErrorDetail>,
 }
 
 /// Error detail sub-object in build output.
 #[derive(Deserialize)]
 pub struct BuildErrorDetail {
+	/// Human-readable error message.
 	pub message: Option<String>,
 }
 
 /// Response from `GET /libpod/images/{name}/json`.
 #[derive(Deserialize, Default)]
 pub struct ImageInspect {
+	/// Image ID (`sha256:...` content digest of the image config).
 	#[serde(rename = "Id", default)]
 	pub id: String,
 	/// Registry digest references (`repo@sha256:...`) for the image, when it was

--- a/internal/libpod/types/network.rs
+++ b/internal/libpod/types/network.rs
@@ -7,32 +7,45 @@ use serde::Serialize;
 /// Request body for `POST /libpod/networks/create`.
 #[derive(Serialize, Default)]
 pub struct NetworkCreateRequest {
+	/// Network name.
 	pub name: String,
 
+	/// Network driver (e.g. `bridge`, `macvlan`); the daemon default is used
+	/// when omitted.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
+	/// Whether the network is internal (no external/outbound connectivity).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub internal: Option<bool>,
 
+	/// Whether standalone containers may attach to the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attachable: Option<bool>,
 
+	/// Whether the built-in DNS resolver is enabled for the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub dns_enabled: Option<bool>,
 
+	/// Whether IPv6 is enabled for the network.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipv6_enabled: Option<bool>,
 
+	/// Network labels (key/value), including compose project/network labels.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub labels: HashMap<String, String>,
 
+	/// Driver-specific options passed to the network driver (e.g. `mtu`,
+	/// `com.docker.network.bridge.*`). Distinct from `ipam_options`.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub options: HashMap<String, String>,
 
+	/// Options passed to the IPAM (IP address management) driver, e.g. the IPAM
+	/// `driver` choice. Distinct from the driver-level `options`.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub ipam_options: HashMap<String, String>,
 
+	/// Subnet/gateway definitions for the network; empty lets Podman auto-assign.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub subnets: Vec<Subnet>,
 }
@@ -40,12 +53,15 @@ pub struct NetworkCreateRequest {
 /// Subnet specification for network creation.
 #[derive(Serialize, Default)]
 pub struct Subnet {
+	/// Subnet in CIDR notation (e.g. `10.89.0.0/24`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub subnet: Option<String>,
 
+	/// Gateway IP address for the subnet; auto-assigned when omitted.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gateway: Option<String>,
 
+	/// Range of addresses within the subnet available for dynamic assignment.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub lease_range: Option<LeaseRange>,
 }
@@ -53,9 +69,11 @@ pub struct Subnet {
 /// Lease range for a subnet.
 #[derive(Serialize)]
 pub struct LeaseRange {
+	/// First IP address (inclusive) in the assignable range.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub start_ip: Option<String>,
 
+	/// Last IP address (inclusive) in the assignable range.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub end_ip: Option<String>,
 }

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -15,7 +15,9 @@ use crate::libpod::error::PodmanError;
 /// A single framed chunk from a multiplexed container log or exec stream.
 #[derive(Debug)]
 pub enum LogOutput {
+	/// Payload demuxed from the stdout stream (frame stream type 1).
 	StdOut { message: Bytes },
+	/// Payload demuxed from the stderr stream (frame stream type 2).
 	StdErr { message: Bytes },
 }
 

--- a/internal/libpod/types/volume.rs
+++ b/internal/libpod/types/volume.rs
@@ -7,9 +7,11 @@ use serde::Serialize;
 /// Request body for `POST /libpod/volumes/create`.
 #[derive(Serialize, Default)]
 pub struct VolumeCreateOptions {
+	/// Volume name; omitted to let Podman generate an anonymous-volume name.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
 
+	/// Volume driver (e.g. `local`); the daemon default is used when omitted.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
@@ -17,9 +19,12 @@ pub struct VolumeCreateOptions {
 	// Go field name (case-insensitively): the driver-options map is `Options`, not
 	// `driver_opts`. Without this rename volume driver_opts (NFS/CIFS/tmpfs) are
 	// silently dropped while name/driver/labels still match case-insensitively.
+	/// Driver-specific options (e.g. `type`, `device`, `o` for NFS/CIFS/tmpfs
+	/// mounts). Serialized as `Options` to match Podman's wire field (see above).
 	#[serde(rename = "Options", skip_serializing_if = "HashMap::is_empty", default)]
 	pub driver_opts: HashMap<String, String>,
 
+	/// Volume labels (key/value), including compose project/volume labels.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub labels: HashMap<String, String>,
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -79,8 +79,18 @@ async fn run() -> podup::Result<()> {
 	if let Commands::Completions { shell } = cli.command {
 		let mut cmd = Cli::command();
 		let name = cmd.get_name().to_string();
-		clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
-		return Ok(());
+		// Render into a buffer first: clap_complete panics if the writer errors,
+		// which aborts (SIGABRT) when stdout is a closed pipe such as
+		// `podup completions bash | head`. A `Vec` write never fails; then send
+		// it to stdout and treat a broken pipe as a clean exit, like a normal
+		// Unix tool.
+		let mut buf = Vec::new();
+		clap_complete::generate(shell, &mut cmd, name, &mut buf);
+		match std::io::Write::write_all(&mut std::io::stdout(), &buf) {
+			Ok(()) => return Ok(()),
+			Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => return Ok(()),
+			Err(e) => return Err(e.into()),
+		}
 	}
 
 	// `update` operates on the binary itself, not a compose project, so it runs

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -63,6 +63,12 @@ fn run_to_exit() {
 	}
 }
 
+/// Orchestrate one CLI invocation: parse args, then short-circuit the commands
+/// that need neither a compose file nor (for some) Podman — `completions`,
+/// `update`, `ls`, and `config`. Otherwise resolve and parse the compose
+/// file(s), settle the project name and base directory (validating the name at
+/// the trust boundary), acquire the per-project lock, and dispatch the
+/// remaining commands.
 async fn run() -> podup::Result<()> {
 	init_tracing();
 	let cli = parse_cli();

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -70,8 +70,16 @@ fn run_to_exit() {
 /// the trust boundary), acquire the per-project lock, and dispatch the
 /// remaining commands.
 async fn run() -> podup::Result<()> {
-	init_tracing();
 	let cli = parse_cli();
+	// `watch` is an interactive, long-running command; surface its per-action
+	// progress (synced/rebuilt/restarted) by defaulting to INFO instead of the
+	// quiet WARN floor. `RUST_LOG` always overrides.
+	let log_floor = if matches!(cli.command, Commands::Watch) {
+		"info"
+	} else {
+		"warn"
+	};
+	init_tracing(log_floor);
 
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -6,6 +6,10 @@ use std::collections::BTreeMap;
 use crate::compose::types::{Command, RestartPolicy, VolumeMount, VolumeType};
 use crate::ports::ParsedPort;
 
+/// Render a parsed port into a Quadlet `PublishPort=` value
+/// (`[host_ip:][host_port:]container[/proto]`). A missing or `0` host port is
+/// omitted so Podman picks one; the protocol suffix is only added when it is not
+/// the default `tcp`.
 pub(super) fn render_publish_port(p: &ParsedPort) -> String {
 	let mut s = String::new();
 	if !p.host_ip.is_empty() {
@@ -26,6 +30,11 @@ pub(super) fn render_publish_port(p: &ParsedPort) -> String {
 	s
 }
 
+/// Render a volume mount into a Quadlet `Volume=` value. A source naming a
+/// declared volume gets a `.volume` suffix (so Quadlet wires it to the generated
+/// unit); an undeclared source passes through verbatim. An empty source renders
+/// as just the target. Long-form `read_only`, SELinux relabel (`z`/`Z`), bind
+/// propagation, and `nocopy` opts are folded into the trailing `:opt,opt` field.
 pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> String {
 	match vol {
 		VolumeMount::Short(s) => {
@@ -170,6 +179,8 @@ fn quote_exec_arg(arg: &str) -> String {
 	}
 }
 
+/// Map a compose `restart:` policy onto a systemd `Restart=` value.
+/// `unless-stopped` has no systemd equivalent and is treated as `always`.
 pub(super) fn render_restart(restart: &RestartPolicy) -> String {
 	match restart {
 		RestartPolicy::No => "no".to_string(),
@@ -179,6 +190,8 @@ pub(super) fn render_restart(restart: &RestartPolicy) -> String {
 	}
 }
 
+/// Sort a map of optional-valued entries by key into a stable `Vec`, so the
+/// generated unit is byte-deterministic regardless of `HashMap` iteration order.
 pub(super) fn sorted_pairs(
 	map: std::collections::HashMap<String, Option<String>>,
 ) -> Vec<(String, Option<String>)> {
@@ -186,6 +199,9 @@ pub(super) fn sorted_pairs(
 	sorted.into_iter().collect()
 }
 
+/// Sort a map of string-valued entries (labels, sysctls, …) by key into a stable
+/// `Vec`, so the generated unit is byte-deterministic regardless of `HashMap`
+/// iteration order.
 pub(super) fn sorted_label_pairs(
 	map: std::collections::HashMap<String, String>,
 ) -> Vec<(String, String)> {
@@ -231,6 +247,7 @@ pub(super) struct Section {
 }
 
 impl Section {
+	/// Start an empty section with the given `[name]` header.
 	pub(super) fn new(name: &'static str) -> Self {
 		Section {
 			name,
@@ -238,14 +255,19 @@ impl Section {
 		}
 	}
 
+	/// Append a `Key=Value` line, sanitizing the value (control characters
+	/// stripped) so a hostile compose field cannot inject extra unit directives.
 	pub(super) fn add(&mut self, key: &str, value: String) {
 		self.lines.push(format!("{key}={}", sanitize_value(&value)));
 	}
 
+	/// True when no lines have been added; lets the caller skip emitting an empty
+	/// section.
 	pub(super) fn is_empty(&self) -> bool {
 		self.lines.is_empty()
 	}
 
+	/// Render the section as `[name]` followed by its lines, each newline-terminated.
 	pub(super) fn render(&self) -> String {
 		let mut s = format!("[{}]\n", self.name);
 		for line in &self.lines {

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -3,6 +3,17 @@ use crate::parse_str;
 use crate::quadlet::{generate, QuadletOutput, QuadletUnit};
 
 #[test]
+fn container_name_defaults_to_project_prefixed() {
+	// A service with no explicit `container_name:` must default to
+	// `{project}-{service}`, matching how `up` names the running container,
+	// rather than a bare `web` that would collide across projects.
+	let file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
+	let out = generate(&file, "proj");
+	let web = unit_named(&out, "web.container");
+	assert!(web.contents.contains("ContainerName=proj-web"));
+}
+
+#[test]
 fn duplicate_filename_detects_collision() {
 	let mk = |n: &str| QuadletUnit {
 		filename: n.to_string(),

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -41,12 +41,17 @@ pub(crate) fn container_unit(
 	}
 
 	let mut container = Section::new("Container");
+	// Default the container name to `{project}-{service}`, matching how `up`
+	// names containers. Without the project prefix the unit would create a
+	// container called just `web`, colliding with any other project's `web`
+	// service and diverging from the running-stack name. An explicit
+	// `container_name:` still wins.
 	container.add(
 		"ContainerName",
 		service
 			.container_name
 			.clone()
-			.unwrap_or_else(|| name.to_string()),
+			.unwrap_or_else(|| format!("{project}-{name}")),
 	);
 	if let Some(image) = &service.image {
 		container.add("Image", image.clone());

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -4,6 +4,11 @@ use crate::compose::types::NetworkConfig;
 
 use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
 
+/// Build the `.network` unit for one declared network. Emits a single `[Network]`
+/// section (NetworkName, then driver/internal/IPv6/IPAM/options/labels), always
+/// appending the `podup.project` ownership label. No `[Install]` section is
+/// written: `.network` units are pulled in as dependencies of the `.container`
+/// units that reference them.
 pub(crate) fn network_unit(
 	name: &str,
 	project: &str,

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -4,6 +4,11 @@ use crate::compose::types::VolumeConfig;
 
 use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
 
+/// Build the `.volume` unit for one declared named volume. Emits a single
+/// `[Volume]` section (VolumeName, then driver/driver-opts/labels), always
+/// appending the `podup.project` ownership label. No `[Install]` section is
+/// written: `.volume` units are pulled in as dependencies of the `.container`
+/// units that reference them.
 pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfig>) -> QuadletUnit {
 	let mut vol = Section::new("Volume");
 	// A custom `name:` overrides Podman's resource name; Quadlet uses the literal

--- a/internal/size.rs
+++ b/internal/size.rs
@@ -84,7 +84,11 @@ pub fn parse_duration_secs(s: &str) -> Option<u64> {
 	Some(secs as u64)
 }
 
-/// Parse a duration into nanoseconds (used by Docker healthcheck APIs).
+/// Parse a duration like `5s`, `200ms`, `1m`, `1h` into nanoseconds (used by
+/// Docker healthcheck APIs).
+///
+/// Returns `None` for non-finite (`NaN`/`inf`), negative, or out-of-`i64`-range
+/// results instead of saturating or wrapping the cast.
 pub fn parse_duration_nanos(s: &str) -> Option<i64> {
 	let trimmed = s.trim();
 	if trimmed.is_empty() {

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -103,7 +103,15 @@ pub(crate) fn render_config(
 	services: bool,
 	quiet: bool,
 ) -> podup::Result<()> {
-	// Reaching here means the file parsed and merged cleanly.
+	// Reaching here means the file parsed and merged cleanly. Validate that each
+	// resolved service declares an image or a build, the same rule `up` enforces
+	// — and do it before the `--quiet`/`--services` short-circuits so
+	// validate-only (`--quiet`) actually validates, matching `docker compose config`.
+	for (name, svc) in &file.services {
+		if svc.image.is_none() && svc.build.is_none() {
+			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
+		}
+	}
 	if quiet {
 		return Ok(());
 	}
@@ -116,15 +124,88 @@ pub(crate) fn render_config(
 	let mut redacted = file.clone();
 	redacted.redact_inline_content();
 	let rendered = match format {
-		ConfigFormat::Json => serde_json::to_string_pretty(&redacted).map_err(|e| {
-			podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
-		})?,
+		ConfigFormat::Json => {
+			let mut v = serde_json::to_value(&redacted).map_err(|e| {
+				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
+			})?;
+			prune_json_nulls(&mut v);
+			serde_json::to_string_pretty(&v).map_err(|e| {
+				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
+			})?
+		}
 		ConfigFormat::Yaml => {
-			serde_yaml::to_string(&redacted).map_err(podup::ComposeError::Parse)?
+			let mut v: serde_yaml::Value =
+				serde_yaml::to_value(&redacted).map_err(podup::ComposeError::Parse)?;
+			prune_yaml_nulls(&mut v);
+			serde_yaml::to_string(&v).map_err(podup::ComposeError::Parse)?
 		}
 	};
 	println!("{rendered}");
 	Ok(())
+}
+
+/// Drop unset keys from a JSON value so `config` output omits them (like
+/// `docker compose config`) instead of a wall of `field: null` and empty
+/// `field: {}` sections. Recurses first so a section that becomes empty once its
+/// own nulls are dropped is itself dropped.
+fn prune_json_nulls(v: &mut serde_json::Value) {
+	match v {
+		serde_json::Value::Object(map) => {
+			for val in map.values_mut() {
+				prune_json_nulls(val);
+			}
+			map.retain(|_, val| !is_empty_json(val));
+		}
+		serde_json::Value::Array(arr) => {
+			for val in arr.iter_mut() {
+				prune_json_nulls(val);
+			}
+		}
+		_ => {}
+	}
+}
+
+fn is_empty_json(v: &serde_json::Value) -> bool {
+	match v {
+		serde_json::Value::Null => true,
+		serde_json::Value::Object(m) => m.is_empty(),
+		serde_json::Value::Array(a) => a.is_empty(),
+		_ => false,
+	}
+}
+
+/// The YAML counterpart of [`prune_json_nulls`].
+fn prune_yaml_nulls(v: &mut serde_yaml::Value) {
+	match v {
+		serde_yaml::Value::Mapping(map) => {
+			for (_, val) in map.iter_mut() {
+				prune_yaml_nulls(val);
+			}
+			let drop: Vec<serde_yaml::Value> = map
+				.iter()
+				.filter(|(_, val)| is_empty_yaml(val))
+				.map(|(k, _)| k.clone())
+				.collect();
+			for k in drop {
+				map.remove(&k);
+			}
+		}
+		serde_yaml::Value::Sequence(seq) => {
+			for val in seq.iter_mut() {
+				prune_yaml_nulls(val);
+			}
+		}
+		_ => {}
+	}
+}
+
+fn is_empty_yaml(v: &serde_yaml::Value) -> bool {
+	match v {
+		serde_yaml::Value::Null => true,
+		serde_yaml::Value::Mapping(m) => m.is_empty(),
+		serde_yaml::Value::Sequence(s) => s.is_empty(),
+		_ => false,
+	}
 }
 
 /// Build the `run`-only flag overrides from the parsed command. These are kept
@@ -174,6 +255,32 @@ pub(crate) fn parse_cli() -> Cli {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn prune_json_drops_nulls_and_empty_then_collapses() {
+		let mut v = serde_json::json!({
+			"image": "nginx",
+			"environment": null,
+			"ports": [],
+			"labels": {},
+			"deploy": { "replicas": null }
+		});
+		prune_json_nulls(&mut v);
+		// Only the real value survives; null/empty fields and the section that
+		// became empty after its own nulls were dropped are gone.
+		assert_eq!(v, serde_json::json!({ "image": "nginx" }));
+	}
+
+	#[test]
+	fn prune_yaml_drops_nulls_and_empty() {
+		let mut v: serde_yaml::Value =
+			serde_yaml::from_str("image: nginx\ndns: null\nnetworks: {}\n").unwrap();
+		prune_yaml_nulls(&mut v);
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(out.contains("image: nginx"));
+		assert!(!out.contains("dns"));
+		assert!(!out.contains("networks"));
+	}
 
 	#[test]
 	fn level_words_match_user_facing_terms() {

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -79,13 +79,16 @@ pub(crate) fn internal_error_notice() -> String {
 	)
 }
 
-/// Initialize the global tracing subscriber: warnings by default (so the
-/// forward-compat "unknown field" notices are never silently dropped), written
-/// to stderr in the `podup: <level>: <msg>` format so stdout stays a clean pipe.
-pub(crate) fn init_tracing() {
+/// Initialize the global tracing subscriber, written to stderr in the
+/// `podup: <level>: <msg>` format so stdout stays a clean pipe. `default_level`
+/// is the floor used when `RUST_LOG` is unset — `warn` for most commands (so the
+/// forward-compat "unknown field" notices are never silently dropped), `info`
+/// for interactive long-running ones like `watch` that should surface their
+/// per-action progress. `RUST_LOG` always overrides.
+pub(crate) fn init_tracing(default_level: &str) {
 	tracing_subscriber::fmt()
 		.with_env_filter(
-			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level)),
 		)
 		.with_writer(std::io::stderr)
 		.event_format(PodupFormat)

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -115,6 +115,11 @@ fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> 
 	buf
 }
 
+/// Apply a parsed `Modifier` to `var`, implementing compose's
+/// `${VAR:-default}` / `${VAR-default}` / `${VAR:+alt}` / `${VAR+alt}` /
+/// `${VAR:?err}` / `${VAR?err}` substitution semantics (the `:` forms treat an
+/// empty value like unset). `Modifier::None` returns the value or an empty
+/// string; the `Error*` variants fail when the condition is unmet.
 pub(super) fn resolve_modifier(
 	var: String,
 	modifier: Modifier,


### PR DESCRIPTION
Promote develop to main for the 1.4.0 release.

All commits since 1.3.0 — the empirical-sweep fixes (#600-#608, #605) verified against real Podman 5.4.2, plus the editorconfig/docs chores. Merged as a merge commit per the release flow; tag v1.4.0 follows on main.

The README redesign is intentionally NOT included (it lives on its own branch, unmerged).