### PR TITLE
fix(cli): let top --format parse after the service args

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -299,8 +299,10 @@ pub(crate) enum Commands {
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,
-		/// Show only these services.
-		#[arg(trailing_var_arg = true)]
+		/// Show only these services. Unlike the other service-list commands, `top`
+		/// takes a plain positional (not `trailing_var_arg`) so `--format` parses
+		/// in any position (`top web --format json` as well as `top --format json
+		/// web`); service names are never hyphen-prefixed, so nothing is lost.
 		services: Vec<String>,
 	},
 	/// Stream Podman events for this project's containers.


### PR DESCRIPTION
Follow-up to #599. `podup top web --format json` errored `service '--format' not found` because `top`'s services were a `trailing_var_arg`, which swallowed the flag. `top` is the only service-list command that also carries a flag, so it now uses a plain positional and `--format` parses in any position.

## Verified (Podman 5.4.2)
```
podup top web --format json   -> JSON   (was: error)
podup top --format json web   -> JSON
podup top / podup top web     -> table
```