### PR TITLE
chore(crates): improve crates.io metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,11 @@ rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"
 license = "Apache-2.0"
 repository = "https://github.com/Glyndor/podup"
-homepage = "https://github.com/Glyndor/podup"
+homepage = "https://glyndor.net/projects/podup"
+documentation = "https://docs.rs/podup"
 readme = "README.md"
-keywords = ["podman", "compose", "containers", "docker-compose", "rootless"]
-categories = ["command-line-utilities", "virtualization"]
+keywords = ["podman", "compose", "quadlet", "docker-compose", "rootless"]
+categories = ["command-line-utilities", "virtualization", "development-tools"]
 exclude = ["/.github", "/debian", "/deny.toml", "/docs", "/install.sh", "/tests"]
 
 [[bin]]


### PR DESCRIPTION
Reviewed the live crates.io page for podup 1.4.0. The demo GIF and mermaid render fine (crates.io rewrites relative paths), but the metadata had gaps:

- **homepage** pointed at the repository (so crates.io showed no separate Homepage link) → now the project site `glyndor.net/projects/podup`.
- **documentation** was unset (no Documentation link) → `https://docs.rs/podup`.
- **keywords**: swap generic `containers` for `quadlet` (podman/docker-compose already imply containers; quadlet is the distinctive niche podup serves).
- **categories**: add `development-tools`.

Takes effect on the next `cargo publish` (next release).