### PR TITLE
chore(crates): exclude install.ps1 from the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/podup"
 readme = "README.md"
 keywords = ["podman", "compose", "quadlet", "docker-compose", "rootless"]
 categories = ["command-line-utilities", "virtualization", "development-tools"]
-exclude = ["/.github", "/debian", "/deny.toml", "/docs", "/install.sh", "/tests"]
+exclude = ["/.github", "/debian", "/deny.toml", "/docs", "/install.ps1", "/install.sh", "/tests"]
 
 [[bin]]
 name = "podup"


### PR DESCRIPTION
`/install.ps1` wasn't in `Cargo.toml` exclude (only `/install.sh` was), so it shipped in the crate tarball. Added; `cargo package --list` confirms no `install.*` in the package.

Closes #629