### PR TITLE
fix(compose): stop falsely warning that attach is ignored

### DIFF
--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -18,12 +18,6 @@ pub(super) fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) 
 				 rootless Podman equivalent and is ignored"
 			));
 		}
-		if def.attach.is_some() {
-			out.push(format!(
-				"service '{service}': attach is not honored; podup follows its own \
-				 attach/detach logic for `up` log streaming"
-			));
-		}
 		if def.credential_spec.is_some() {
 			out.push(format!(
 				"service '{service}': credential_spec is a Windows managed-service-account \

--- a/internal/compose/diagnostics/tests.rs
+++ b/internal/compose/diagnostics/tests.rs
@@ -168,11 +168,13 @@ fn clean_file_produces_no_diagnostics() {
 }
 
 #[test]
-fn warns_on_attach() {
+fn attach_is_honored_no_warning() {
+	// `attach: false` is honored (it suppresses the service's `up` log streaming,
+	// matching Compose), so it must NOT produce an "ignored field" diagnostic.
 	let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    attach: false\n");
 	assert!(
-		msgs.iter().any(|m| m.contains("attach is not honored")),
-		"got: {msgs:?}"
+		!msgs.iter().any(|m| m.contains("attach")),
+		"attach should not be flagged as ignored: {msgs:?}"
 	);
 }
 


### PR DESCRIPTION
podup honors `attach` (inspect.rs filters `up` log streaming by `s.attach`, matching docker compose's 'attach: false → no log collection'), but the diagnostics emitted 'attach is not honored'. Removed the false warning; the test now asserts `attach: false` produces no diagnostic.

Closes #616