### PR TITLE
docs(man): correct EXIT STATUS (2 = usage, 3 = update failure)

### DIFF
--- a/debian/podup.1
+++ b/debian/podup.1
@@ -251,6 +251,9 @@ Success.
 A command failed (for example a parse error or a Podman error).
 .TP
 .B 2
+A usage error (invalid arguments or flags).
+.TP
+.B 3
 \fBupdate\fR failed to verify or install a release.
 .PP
 \fBrun\fR propagates the container's own exit code verbatim, so any other


### PR DESCRIPTION
The man page listed exit `2` as update failure and never mentioned `3`, contradicting the source (`UPDATE_FAILURE_EXIT_CODE = 3`, `2` reserved for clap usage) and the markdown docs. Now: `2` = usage error, `3` = update failed to verify/install.

Closes #615