### PR TITLE
fix(compose): pass env_file bare keys through from the host

### DIFF
--- a/internal/dotenv.rs
+++ b/internal/dotenv.rs
@@ -25,9 +25,14 @@ pub fn parse(content: &str) -> Vec<(String, String)> {
 			.unwrap_or(line);
 
 		let Some(eq) = line.find('=') else {
+			// A bare key (no `=`) means "pass the value through from the host
+			// environment" (compose env_file semantics). If the host doesn't
+			// define it, the variable is omitted, not set to an empty string.
 			let key = line.trim();
 			if !key.is_empty() {
-				out.push((key.to_string(), String::new()));
+				if let Ok(val) = std::env::var(key) {
+					out.push((key.to_string(), val));
+				}
 			}
 			continue;
 		};
@@ -205,10 +210,15 @@ mod tests {
 	}
 
 	#[test]
-	fn export_prefix_bare_key_yields_empty_value() {
-		// `export NAME` with no `=` records the key with an empty value.
-		let m = map("export FOO\n");
-		assert_eq!(m.get("FOO").map(String::as_str), Some(""));
+	fn export_prefix_bare_key_passes_through_host() {
+		// `export NAME` with no `=` passes NAME through from the host environment.
+		std::env::set_var("PODUP_DOTENV_EXPORT_BARE", "fromhost");
+		let m = map("export PODUP_DOTENV_EXPORT_BARE\n");
+		assert_eq!(
+			m.get("PODUP_DOTENV_EXPORT_BARE").map(String::as_str),
+			Some("fromhost")
+		);
+		std::env::remove_var("PODUP_DOTENV_EXPORT_BARE");
 	}
 
 	#[test]
@@ -226,8 +236,17 @@ mod tests {
 	}
 
 	#[test]
-	fn bare_key_has_empty_value() {
-		assert_eq!(map("BARE\n")["BARE"], "");
+	fn bare_key_passes_through_or_is_omitted() {
+		// Present in the host → passed through; absent → omitted (not empty string).
+		std::env::set_var("PODUP_DOTENV_BARE_PRESENT", "v");
+		std::env::remove_var("PODUP_DOTENV_BARE_ABSENT");
+		let m = map("PODUP_DOTENV_BARE_PRESENT\nPODUP_DOTENV_BARE_ABSENT\n");
+		assert_eq!(
+			m.get("PODUP_DOTENV_BARE_PRESENT").map(String::as_str),
+			Some("v")
+		);
+		assert!(!m.contains_key("PODUP_DOTENV_BARE_ABSENT"));
+		std::env::remove_var("PODUP_DOTENV_BARE_PRESENT");
 	}
 
 	#[test]

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -124,12 +124,25 @@ mod tests {
 	}
 
 	#[test]
-	fn key_without_equals_has_empty_value() {
+	fn bare_key_passes_through_host_or_is_omitted() {
+		// A bare key (no `=`) takes its value from the host environment; absent
+		// from the host, it is omitted rather than set to an empty string.
+		std::env::set_var("PODUP_ENVFILE_BARE_PRESENT", "h");
+		std::env::remove_var("PODUP_ENVFILE_BARE_ABSENT");
 		let dir = tempfile::tempdir().unwrap();
-		std::fs::write(dir.path().join(".env"), "BARE\n").unwrap();
+		std::fs::write(
+			dir.path().join(".env"),
+			"PODUP_ENVFILE_BARE_PRESENT\nPODUP_ENVFILE_BARE_ABSENT\n",
+		)
+		.unwrap();
 		let entries = vec![EnvFileEntry::Path(".env".into())];
 		let m = load_env_file_entries(&entries, dir.path()).unwrap();
-		assert_eq!(m.get("BARE").map(|s| s.as_str()), Some(""));
+		assert_eq!(
+			m.get("PODUP_ENVFILE_BARE_PRESENT").map(|s| s.as_str()),
+			Some("h")
+		);
+		assert!(!m.contains_key("PODUP_ENVFILE_BARE_ABSENT"));
+		std::env::remove_var("PODUP_ENVFILE_BARE_PRESENT");
 	}
 
 	#[test]

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -343,11 +343,24 @@ mod tests {
 	}
 
 	#[test]
-	fn load_dotenv_key_without_equals_is_empty() {
+	fn load_dotenv_bare_key_is_not_set_to_empty() {
+		// A bare key (no `=`) no longer becomes an empty string. In `.env` it
+		// resolves from the host, but `load_dotenv` already drops host-present
+		// keys (process env wins), so either way a bare key never lands in the map
+		// as `""` — it's host-provided for interpolation or absent.
+		std::env::set_var("PODUP_DOTENV_ENV_PRESENT", "h");
+		std::env::remove_var("PODUP_DOTENV_ENV_ABSENT");
 		let dir = tempfile::tempdir().unwrap();
-		std::fs::write(dir.path().join(".env"), "BARE_KEY\n").unwrap();
+		std::fs::write(
+			dir.path().join(".env"),
+			"PODUP_DOTENV_ENV_PRESENT\nPODUP_DOTENV_ENV_ABSENT\n",
+		)
+		.unwrap();
 		let map = load_dotenv(dir.path());
-		assert_eq!(map.get("BARE_KEY").map(|s| s.as_str()), Some(""));
+		// host-present → dropped (process env wins); host-absent → omitted. Never "".
+		assert!(!map.contains_key("PODUP_DOTENV_ENV_PRESENT"));
+		assert!(!map.contains_key("PODUP_DOTENV_ENV_ABSENT"));
+		std::env::remove_var("PODUP_DOTENV_ENV_PRESENT");
 	}
 
 	#[test]

--- a/tests/env_file/loading.rs
+++ b/tests/env_file/loading.rs
@@ -10,12 +10,14 @@ fn basic_key_value() {
 	writeln!(f).unwrap();
 	writeln!(f, "DB_HOST=localhost").unwrap();
 	writeln!(f, "PORT=5432").unwrap();
-	writeln!(f, "NOVALUE").unwrap();
+	// A bare key takes its value from the host env; unset there, it is omitted.
+	writeln!(f, "PODUP_ENVFILE_LOADING_NOVALUE").unwrap();
+	std::env::remove_var("PODUP_ENVFILE_LOADING_NOVALUE");
 
 	let map = load_env_files(&["app.env".to_string()], dir.path()).unwrap();
 	assert_eq!(map["DB_HOST"], "localhost");
 	assert_eq!(map["PORT"], "5432");
-	assert_eq!(map["NOVALUE"], "");
+	assert!(!map.contains_key("PODUP_ENVFILE_LOADING_NOVALUE"));
 }
 
 #[test]

--- a/tests/substitute/dotenv.rs
+++ b/tests/substitute/dotenv.rs
@@ -9,12 +9,14 @@ fn basic_key_value() {
 	writeln!(f).unwrap();
 	writeln!(f, "KEY=value").unwrap();
 	writeln!(f, "EMPTY=").unwrap();
-	writeln!(f, "NOVALUE").unwrap();
+	// A bare key takes its value from the host env; unset there, it is omitted.
+	writeln!(f, "PODUP_SUBST_DOTENV_NOVALUE").unwrap();
+	std::env::remove_var("PODUP_SUBST_DOTENV_NOVALUE");
 
 	let map = load_dotenv(dir.path());
 	assert_eq!(map.get("KEY").map(|s| s.as_str()), Some("value"));
 	assert_eq!(map.get("EMPTY").map(|s| s.as_str()), Some(""));
-	assert_eq!(map.get("NOVALUE").map(|s| s.as_str()), Some(""));
+	assert!(!map.contains_key("PODUP_SUBST_DOTENV_NOVALUE"));
 	assert!(!map.contains_key("# comment"));
 }
 


### PR DESCRIPTION
A bare key in an `env_file` was forced to `""`. Per docker compose, a bare key takes its value from the host environment, or is omitted if unset — never empty. The shared dotenv parser now resolves bare keys via the host env.

Verified: `env_file` with bare `HOST_PASS` → container gets the host value; absent → omitted; `EXPLICIT=set` unchanged.

Closes #617