### PR TITLE
fix(compose): expand nested variables in interpolation defaults

### DIFF
--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -298,6 +298,44 @@ mod tests {
 		);
 	}
 
+	// Nested interpolation inside modifier values (compose-spec allows nesting).
+
+	#[test]
+	fn nested_default_is_interpolated() {
+		// ${FOO:-${BAR}} → BAR's value when FOO is unset.
+		assert_eq!(
+			substitute("${FOO:-${BAR}}", &vars(&[("BAR", "b")])).unwrap(),
+			"b"
+		);
+	}
+
+	#[test]
+	fn nested_chained_default_falls_through() {
+		// ${FOO:-${BAR:-baz}} → literal baz when both FOO and BAR are unset.
+		assert_eq!(
+			substitute("${FOO:-${BAR:-baz}}", &vars(&[])).unwrap(),
+			"baz"
+		);
+	}
+
+	#[test]
+	fn nested_alt_is_interpolated() {
+		// ${FOO:+${BAR}} → BAR's value when FOO is set and non-empty.
+		assert_eq!(
+			substitute("${FOO:+${BAR}}", &vars(&[("FOO", "x"), ("BAR", "b")])).unwrap(),
+			"b"
+		);
+	}
+
+	#[test]
+	fn nested_default_with_trailing_text() {
+		// The balanced-brace scan stops at the matching close, leaving following text.
+		assert_eq!(
+			substitute("${FOO:-${BAR}}/tail", &vars(&[("BAR", "b")])).unwrap(),
+			"b/tail"
+		);
+	}
+
 	// Multiple substitutions in one string
 
 	#[test]

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -103,14 +103,26 @@ pub(super) fn parse_braced_var(
 	}
 }
 
-/// Collect everything until `}` (exclusive), consuming the `}`.
+/// Collect the modifier value up to the matching closing `}` (consumed),
+/// balancing nested braces so an inner `${…}` is captured whole. For
+/// `${FOO:-${BAR}}` the default is `${BAR}` (not `${BAR`), enabling nested
+/// interpolation in [`resolve_modifier`].
 fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
 	let mut buf = String::new();
+	let mut depth = 0u32;
 	for c in chars.by_ref() {
-		if c == '}' {
-			break;
+		match c {
+			'{' => {
+				depth += 1;
+				buf.push(c);
+			}
+			'}' if depth == 0 => break,
+			'}' => {
+				depth -= 1;
+				buf.push(c);
+			}
+			_ => buf.push(c),
 		}
-		buf.push(c);
 	}
 	buf
 }
@@ -130,23 +142,25 @@ pub(super) fn resolve_modifier(
 	match modifier {
 		Modifier::None => Ok(value.cloned().unwrap_or_default()),
 
+		// Default/alt values are themselves interpolated (compose allows nesting,
+		// e.g. `${FOO:-${BAR}}`), but only when actually used.
 		Modifier::DefaultIfUnsetOrEmpty(default) => match value {
 			Some(v) if !v.is_empty() => Ok(v.clone()),
-			_ => Ok(default),
+			_ => super::substitute(&default, vars),
 		},
 
 		Modifier::DefaultIfUnset(default) => match value {
 			Some(v) => Ok(v.clone()),
-			None => Ok(default),
+			None => super::substitute(&default, vars),
 		},
 
 		Modifier::AltIfSetAndNonEmpty(alt) => match value {
-			Some(v) if !v.is_empty() => Ok(alt),
+			Some(v) if !v.is_empty() => super::substitute(&alt, vars),
 			_ => Ok(String::new()),
 		},
 
 		Modifier::AltIfSet(alt) => match value {
-			Some(_) => Ok(alt),
+			Some(_) => super::substitute(&alt, vars),
 			None => Ok(String::new()),
 		},
 


### PR DESCRIPTION
`collect_until_close` stopped at the first `}`, so `${FOO:-${BAR}}` captured `${BAR` literally. Now it balances braces and recursively interpolates the captured default/alt, per the compose-spec.

Verified: `${FOO:-${BAR}}`→BAR; `${FOO:-${BAR:-baz}}`→baz; `${FOO:+${BAR}}`→BAR; empirically via `config`.

Closes #618