### PR TITLE
fix(libpod): accept v-prefixed API version + test on-failure wire mapping

### DIFF
--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -438,6 +438,7 @@ const MIN_LIBPOD_API_MAJOR: u64 = 5;
 fn meets_minimum(version: &str) -> bool {
 	version
 		.trim()
+		.trim_start_matches('v')
 		.split('.')
 		.next()
 		.and_then(|major| major.parse::<u64>().ok())
@@ -603,6 +604,9 @@ mod tests {
 		assert!(meets_minimum("5.0.0"));
 		assert!(meets_minimum("5.4.2"));
 		assert!(meets_minimum("6.0.0"));
+		// A leading `v` (some libpod builds report `v5.0.0`) is tolerated.
+		assert!(meets_minimum("v5.0.0"));
+		assert!(!meets_minimum("v4.9.3"));
 		assert!(!meets_minimum("4.9.3"));
 		assert!(!meets_minimum("4.0.0"));
 		assert!(!meets_minimum("3.4.4"));
@@ -615,7 +619,6 @@ mod tests {
 		assert!(!meets_minimum(""));
 		assert!(!meets_minimum("   "));
 		assert!(!meets_minimum("not-a-version"));
-		assert!(!meets_minimum("v5.0.0"));
 		assert!(!meets_minimum(".5"));
 		// Leading/trailing whitespace around a valid version is tolerated.
 		assert!(meets_minimum(" 5.0.0 "));

--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -440,4 +440,15 @@ mod tests {
 		assert!(v.get("health_check_on_failure_action").is_none());
 		assert!(v.get("startupHealthConfig").is_none());
 	}
+
+	#[test]
+	fn on_failure_action_serializes_to_podman_integers() {
+		// Podman assigns each action a non-contiguous integer; a wrong discriminant
+		// would silently mis-drive the container, so pin every variant's wire value.
+		use super::HealthCheckOnFailureAction as A;
+		for (action, wire) in [(A::None, 0), (A::Kill, 2), (A::Restart, 3), (A::Stop, 4)] {
+			let v = serde_json::to_value(action).unwrap();
+			assert_eq!(v, wire, "{action:?} should serialize to {wire}");
+		}
+	}
 }


### PR DESCRIPTION
`meets_minimum` rejected a `v5.0.0` header (parsed `v5` → fail). Strip a leading `v`. Plus a table test pinning HealthCheckOnFailureAction's integers (0/2/3/4).

Closes #637
Closes #623