### PR TITLE
fix(observability): trace libpod requests and dropped watch events

### DIFF
--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -162,7 +162,12 @@ impl Engine {
 		let (tx, mut rx) = mpsc::channel::<notify::Result<notify::Event>>(WATCH_CHANNEL_CAP);
 		let mut watcher = RecommendedWatcher::new(
 			move |res| {
-				let _ = tx.try_send(res);
+				// A full bounded channel drops this event; a later event
+				// re-triggers the sync, so no state is lost, but trace the drop
+				// instead of swallowing it silently.
+				if let Err(e) = tx.try_send(res) {
+					debug!("watch event dropped (channel full or closed): {e}");
+				}
 			},
 			notify::Config::default(),
 		)

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -133,6 +133,7 @@ impl Client {
 
 	/// Send a request and return the raw response.
 	async fn send(&self, req: Request<BoxBody>) -> Result<Response<Incoming>> {
+		tracing::debug!("libpod {} {}", req.method(), req.uri().path());
 		let mut sender = tokio::time::timeout(CONNECT_TIMEOUT, self.connect())
 			.await
 			.map_err(|_| PodmanError::Api {


### PR DESCRIPTION
Add a `debug!` at the libpod client `send()` chokepoint (method + path) — verified `RUST_LOG=podup=debug podup ls` now logs `libpod GET /v5.0.0/libpod/containers/json`. And trace the watch event drop on a full channel instead of swallowing it.

Closes #635