### PR TITLE
fix(migration): warn on network_mode bridge at container-create

### DIFF
--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -175,22 +175,6 @@ pub(super) fn ignored_network_fields(file: &ComposeFile, out: &mut Vec<String>) 
 	}
 }
 
-/// `network_mode: bridge` behaves differently on Docker and Podman. docker-compose
-/// attaches the container to Docker's predefined shared `bridge` network; Podman
-/// reads `--network bridge` as "create a fresh, isolated bridge netns", so the
-/// container has connectivity but cannot reach its project siblings.
-pub(super) fn diverging_network_mode(file: &ComposeFile, out: &mut Vec<String>) {
-	for (service, def) in &file.services {
-		if def.network_mode.as_deref() == Some("bridge") {
-			out.push(format!(
-				"service '{service}': network_mode 'bridge' attaches to a fresh isolated \
-				 bridge under Podman, not Docker's shared default bridge, so project \
-				 siblings are unreachable; declare a shared `networks:` entry instead"
-			));
-		}
-	}
-}
-
 /// `deploy.restart_policy` sub-fields with no Podman restart-policy equivalent.
 /// Only `condition` and `max_attempts` are honored (see container_config); Podman
 /// has no first-class restart delay or attempt-counting window.

--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -12,9 +12,9 @@ use super::types::ComposeFile;
 
 mod ignored_fields;
 use ignored_fields::{
-	diverging_network_mode, ignored_build_fields, ignored_models, ignored_network_fields,
-	ignored_port_fields, ignored_restart_policy_fields, ignored_secret_config_drivers,
-	ignored_service_fields, ignored_service_network_fields, ignored_volume_mount_fields,
+	ignored_build_fields, ignored_models, ignored_network_fields, ignored_port_fields,
+	ignored_restart_policy_fields, ignored_secret_config_drivers, ignored_service_fields,
+	ignored_service_network_fields, ignored_volume_mount_fields,
 };
 
 /// Collect a warning for every parsed-but-unsupported key or field in `file`.
@@ -32,7 +32,6 @@ pub(super) fn collect(file: &ComposeFile) -> Vec<String> {
 	ignored_service_network_fields(file, &mut out);
 	ignored_secret_config_drivers(file, &mut out);
 	ignored_models(file, &mut out);
-	diverging_network_mode(file, &mut out);
 	ignored_restart_policy_fields(file, &mut out);
 	out
 }

--- a/internal/compose/diagnostics/tests.rs
+++ b/internal/compose/diagnostics/tests.rs
@@ -347,16 +347,6 @@ fn warns_on_use_api_socket_not_honored() {
 }
 
 #[test]
-fn warns_on_network_mode_bridge_divergence() {
-	let msgs = diagnostics_for("services:\n  web:\n    image: nginx\n    network_mode: bridge\n");
-	assert!(
-		msgs.iter()
-			.any(|m| m.contains("network_mode 'bridge'") && m.contains("siblings")),
-		"got: {msgs:?}"
-	);
-}
-
-#[test]
 fn warns_on_ipam_aux_addresses() {
 	let msgs = diagnostics_for(
 			"services:\n  web:\n    image: nginx\nnetworks:\n  net:\n    ipam:\n      config:\n        - subnet: 10.0.0.0/24\n          aux_addresses:\n            host1: 10.0.0.5\n",

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -175,6 +175,18 @@ pub(super) fn resolve_network_mode(
 				.unwrap_or_else(|| svc_name.to_string());
 			Namespace::container(cname)
 		} else {
+			if mode == "bridge" {
+				// docker-compose attaches to Docker's shared default `bridge`;
+				// Podman reads `--network bridge` as a fresh isolated bridge netns,
+				// so project siblings are unreachable. Warn here (at container
+				// create) so every path — CLI, library, embedded — surfaces it, not
+				// only the parse-time diagnostics.
+				tracing::warn!(
+					"service '{service_name}': network_mode 'bridge' attaches to a fresh \
+					 isolated bridge under Podman, not Docker's shared default bridge, so \
+					 project siblings are unreachable; declare a shared `networks:` entry instead"
+				);
+			}
 			Namespace::new(mode)
 		};
 		return (Some(ns), HashMap::new());


### PR DESCRIPTION
The `network_mode: bridge` divergence warning was parse-time only (skipped by raw/embedded parse paths). Moved it to `resolve_network_mode` so every path surfaces it once. Verified the warning fires on `up`.

Closes #643