### PR TITLE
perf(down): prefetch project containers once instead of per-service

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -390,9 +390,17 @@ impl Engine {
 		let mut order = crate::compose::resolve_order(file)?;
 		order.reverse();
 
+		// Prefetch every project container once and group by service, instead of
+		// one container-list round-trip per service (S+1 → 1 for the ordered pass).
+		let live_by_service = self.list_project_containers_by_service().await?;
+
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
+			let container_names = match live_by_service.get(name) {
+				Some(live) if !live.is_empty() => live.clone(),
+				_ => self.replica_names(name, service),
+			};
+			for container_name in container_names {
 				for hook in &service.pre_stop {
 					if let Err(e) = self.run_lifecycle_hook(&container_name, hook).await {
 						tracing::debug!("pre_stop hook {container_name}: {e}");

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -136,6 +136,39 @@ impl Engine {
 			.collect())
 	}
 
+	/// All live project containers grouped by their `podup.service` label, in a
+	/// single API call. Lets a whole-project command (e.g. `down`) avoid one
+	/// per-service container-list round-trip; callers fall back to the static
+	/// [`Engine::replica_names`] for a service absent from the map.
+	pub(crate) async fn list_project_containers_by_service(
+		&self,
+	) -> Result<std::collections::HashMap<String, Vec<String>>> {
+		let filters = serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut by_service: std::collections::HashMap<String, Vec<String>> =
+			std::collections::HashMap::new();
+		for entry in entries {
+			let Some(service) = entry.labels.get("podup.service") else {
+				continue;
+			};
+			if let Some(raw) = entry.names.first() {
+				by_service
+					.entry(service.clone())
+					.or_default()
+					.push(raw.trim_start_matches('/').to_string());
+			}
+		}
+		Ok(by_service)
+	}
+
 	/// The container names to act on for a service: the ones Podman actually has
 	/// (matched by the `podup.service` label), so lifecycle and query commands
 	/// keep working after a runtime `scale`/`up --scale` that the compose file's


### PR DESCRIPTION
`down` made one container-list call per service (S+1 with the orphan sweep). Added `list_project_containers_by_service` (one labelled list grouped by `podup.service`) and drive the ordered teardown from it. Verified: 3 services → container-list calls drop 4→2, teardown still complete.

Closes #620