### PR TITLE
perf(watch): rebuild/restart each container once per debounce batch

### DIFF
--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -209,6 +209,12 @@ impl Engine {
 				}
 			}
 
+			// A debounce batch may hold many files that map to the same whole-
+			// container action; rebuild/restart each container at most once per
+			// batch. Sync-type actions stay per-file (each changed file is synced).
+			let mut done: std::collections::HashSet<(u8, String)> =
+				std::collections::HashSet::new();
+
 			'outer: for path in &paths {
 				for entry in &rule_entries {
 					if !path.starts_with(&entry.abs_path) {
@@ -224,6 +230,20 @@ impl Engine {
 					if !entry.rule.include.is_empty() && !is_included(&rel_str, &entry.rule.include)
 					{
 						continue;
+					}
+
+					// Collapse repeated rebuild/restart of the same container within
+					// this batch into one; the action's effect is whole-container, so
+					// a second run is pure waste.
+					let dedup_key = match &entry.rule.action {
+						WatchAction::Rebuild => Some((0, entry.service_name.clone())),
+						WatchAction::Restart => Some((1, entry.container_name.clone())),
+						_ => None,
+					};
+					if let Some(key) = dedup_key {
+						if !done.insert(key) {
+							continue 'outer;
+						}
 					}
 
 					debug!("dispatch {:?} for {}", entry.rule.action, path.display());


### PR DESCRIPTION
Within a debounce batch, N files matching the same Rebuild/Restart rule re-ran the full whole-container action N times. Dedup Rebuild (by service) and Restart (by container) per batch; Sync-type actions stay per-file.

Closes #621