### PR TITLE
perf(wait): poll services concurrently for up --wait

### DIFF
--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -87,13 +87,19 @@ impl Engine {
 		file: &ComposeFile,
 		target_services: &[String],
 	) -> Result<()> {
-		for (name, service) in &file.services {
-			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
-				continue;
-			}
-			let container = self.first_replica_name(name, service);
-			self.wait_healthy(&container, service).await?;
-		}
+		// Poll services concurrently: each `wait_healthy` is its own poll loop, so
+		// total `--wait` latency is the slowest service, not the sum of all.
+		let waits = file
+			.services
+			.iter()
+			.filter(|(name, _)| {
+				target_services.is_empty() || target_services.iter().any(|t| t == *name)
+			})
+			.map(|(name, service)| {
+				let container = self.first_replica_name(name, service);
+				async move { self.wait_healthy(&container, service).await }
+			});
+		futures_util::future::try_join_all(waits).await?;
 		Ok(())
 	}
 


### PR DESCRIPTION
`up --wait` polled each service's health loop serially (sum of all waits). Now concurrent via try_join_all — latency is the slowest single service. Verified multi-service `up --wait` succeeds.

Addresses the `--wait` part of #632. The other two micro-opts in that issue (config_hash recomputed per replica, build-walk re-stat) are deferred as marginal: config_hash only repeats for replicas>1 (uncommon) and the build-walk re-stat is OS-cached — both need a real signature/threading refactor for a negligible gain.

Refs #632