### PR TITLE
test: cover BlkioRateDevice::rate_value and GpuSpec::to_count edge cases

### DIFF
--- a/internal/compose/types/resources.rs
+++ b/internal/compose/types/resources.rs
@@ -117,3 +117,38 @@ impl GpuSpec {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn rate(v: serde_yaml::Value) -> BlkioRateDevice {
+		BlkioRateDevice {
+			path: "/dev/sda".into(),
+			rate: v,
+		}
+	}
+
+	#[test]
+	fn rate_value_parses_number_and_size_string() {
+		assert_eq!(rate(serde_yaml::Value::from(1048576)).rate_value(), 1048576);
+		assert_eq!(rate(serde_yaml::Value::from("1mb")).rate_value(), 1_048_576);
+	}
+
+	#[test]
+	fn rate_value_coerces_invalid_inputs_to_zero() {
+		// An unparseable size string, and a non-number/non-string node, both fall
+		// back to 0 rather than erroring or panicking.
+		assert_eq!(rate(serde_yaml::Value::from("not-a-size")).rate_value(), 0);
+		assert_eq!(rate(serde_yaml::Value::Bool(true)).rate_value(), 0);
+		assert_eq!(rate(serde_yaml::Value::Null).rate_value(), 0);
+	}
+
+	#[test]
+	fn gpu_to_count_covers_every_variant() {
+		assert_eq!(GpuSpec::Named("all".into()).to_count(), -1);
+		assert_eq!(GpuSpec::Count(2).to_count(), 2);
+		// The device-list form is treated as "all" (-1); previously untested.
+		assert_eq!(GpuSpec::Devices(vec![]).to_count(), -1);
+	}
+}


### PR DESCRIPTION
Adds the two cleanly-testable gaps from #631: `rate_value`'s invalid-string→0 / non-number→0 fallbacks, and `GpuSpec::Devices→-1`.

The other three gaps in #631 are impractical to test on this platform: the non-unix lock no-op is `#[cfg(unix)]`-excluded (can't exercise the Windows path on Linux CI's unit run), and the MAX_STREAM_BUF real-branch + alias-amplification fuzz invariant need a 256 MiB+ streamed hyper body / a fuzz harness respectively — covered today by the mirror `cap_check` and the heuristic. I'll note that on the issue rather than over-claim.

Refs #631