### PR TITLE
feat(compose): forward-compat unknown buckets for nested option blocks

### DIFF
--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -92,6 +92,78 @@ fn nested_unknown_keys(file: &ComposeFile, out: &mut Vec<String>) {
 				out,
 			);
 		}
+		// Per-attachment network options.
+		for net in def.networks.names() {
+			if let Some(cfg) = def.networks.config_for(&net) {
+				push_unknown(
+					&format!("service '{service}' networks.{net}"),
+					&cfg.unknown,
+					out,
+				);
+			}
+		}
+		// Long-form volume mount option blocks.
+		for mount in &def.volumes {
+			if let crate::compose::types::VolumeMount::Long {
+				bind,
+				volume,
+				tmpfs,
+				..
+			} = mount
+			{
+				let target = mount.target();
+				if let Some(b) = bind {
+					push_unknown(
+						&format!("service '{service}' volume '{target}' bind"),
+						&b.unknown,
+						out,
+					);
+				}
+				if let Some(v) = volume {
+					push_unknown(
+						&format!("service '{service}' volume '{target}' volume"),
+						&v.unknown,
+						out,
+					);
+					if let Some(dc) = &v.driver_config {
+						push_unknown(
+							&format!("service '{service}' volume '{target}' driver_config"),
+							&dc.unknown,
+							out,
+						);
+					}
+				}
+				if let Some(t) = tmpfs {
+					push_unknown(
+						&format!("service '{service}' volume '{target}' tmpfs"),
+						&t.unknown,
+						out,
+					);
+				}
+			}
+		}
+		// deploy.resources.limits / reservations and their device reservations.
+		if let Some(resources) = def.deploy.as_ref().and_then(|d| d.resources.as_ref()) {
+			for (label, spec) in [
+				("limits", &resources.limits),
+				("reservations", &resources.reservations),
+			] {
+				if let Some(spec) = spec {
+					push_unknown(
+						&format!("service '{service}' deploy.resources.{label}"),
+						&spec.unknown,
+						out,
+					);
+					for (i, dev) in spec.devices.iter().enumerate() {
+						push_unknown(
+							&format!("service '{service}' deploy.resources.{label}.devices[{i}]"),
+							&dev.unknown,
+							out,
+						);
+					}
+				}
+			}
+		}
 	}
 	for (name, model) in &file.models {
 		push_unknown(&format!("model '{name}'"), &model.unknown, out);

--- a/internal/compose/diagnostics/tests.rs
+++ b/internal/compose/diagnostics/tests.rs
@@ -407,3 +407,24 @@ fn warns_on_typo_inside_provider_and_models() {
 		"got: {msgs:?}"
 	);
 }
+
+#[test]
+fn warns_on_unknown_nested_volume_network_resource_keys() {
+	// Unknown keys inside long-form volume option blocks, per-network attachment
+	// config, and deploy.resources are surfaced (forward-compat), not dropped.
+	let msgs = diagnostics_for(
+		"services:\n  web:\n    image: nginx\n    networks:\n      net1:\n        bogus_net: 1\n    volumes:\n      - type: bind\n        source: ./x\n        target: /x\n        bind:\n          bogus_bind: 2\n    deploy:\n      resources:\n        limits:\n          bogus_limit: 3\nnetworks:\n  net1:\n",
+	);
+	assert!(
+		msgs.iter().any(|m| m.contains("bogus_net")),
+		"got: {msgs:?}"
+	);
+	assert!(
+		msgs.iter().any(|m| m.contains("bogus_bind")),
+		"got: {msgs:?}"
+	);
+	assert!(
+		msgs.iter().any(|m| m.contains("bogus_limit")),
+		"got: {msgs:?}"
+	);
+}

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -78,6 +78,10 @@ pub struct ResourceSpec {
 	/// Device reservations such as GPUs.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub devices: Vec<DeviceReservation>,
+	/// Unknown keys preserved verbatim for round-tripping and forward-compat
+	/// diagnostics.
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +106,10 @@ pub struct DeviceReservation {
 	/// Driver-specific options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub options: HashMap<String, String>,
+	/// Unknown keys preserved verbatim for round-tripping and forward-compat
+	/// diagnostics.
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// `count: all` or `count: N`.

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -72,6 +72,10 @@ pub struct ServiceNetworkConfig {
 	/// Name of the interface created inside the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub interface_name: Option<String>,
+	/// Unknown keys preserved verbatim for round-tripping and forward-compat
+	/// diagnostics.
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// Named network definition in the top-level `networks:` block.

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -38,6 +38,14 @@ pub struct BindOptions {
 	/// SELinux relabeling option (`z` shared or `Z` private).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub selinux: Option<String>,
+	/// Recursive bind-mount mode (compose `bind.recursive`:
+	/// `enabled`/`disabled`/`writable`/`readonly`). Parsed for fidelity.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub recursive: Option<String>,
+	/// Unknown keys preserved verbatim for round-tripping and forward-compat
+	/// diagnostics, so a future `bind.*` option is surfaced, not silently dropped.
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// Sub-options for a `volume`-type mount — nocopy flag and optional driver config.
@@ -55,6 +63,10 @@ pub struct VolumeOptions {
 	/// Path within the volume to mount instead of its root.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub subpath: Option<String>,
+	/// Unknown keys preserved verbatim for round-tripping and forward-compat
+	/// diagnostics.
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// Driver name and key-value options nested under `VolumeOptions`.
@@ -66,6 +78,10 @@ pub struct DriverConfig {
 	/// Driver-specific options.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub options: HashMap<String, String>,
+	/// Unknown keys preserved verbatim for round-tripping and forward-compat
+	/// diagnostics.
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// Sub-options for a `tmpfs`-type mount — size and mode.
@@ -77,6 +93,10 @@ pub struct TmpfsOptions {
 	/// File mode of the tmpfs mount.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mode: Option<u32>,
+	/// Unknown keys preserved verbatim for round-tripping and forward-compat
+	/// diagnostics.
+	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
 /// A volume mount entry — either a short-form string or a long-form typed block.

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -211,6 +211,7 @@ mod tests {
 				propagation: Some("rshared".into()),
 				create_host_path: None,
 				selinux: None,
+				..Default::default()
 			}),
 			volume: None,
 			tmpfs: None,
@@ -316,6 +317,7 @@ mod tests {
 			tmpfs: Some(TmpfsOptions {
 				size: Some(65536),
 				mode: Some(0o700),
+				..Default::default()
 			}),
 			consistency: None,
 		}]);
@@ -349,6 +351,7 @@ mod tests {
 				propagation: None,
 				create_host_path: Some(true),
 				selinux: None,
+				..Default::default()
 			}),
 			volume: None,
 			tmpfs: None,

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -450,6 +450,7 @@ mod tests {
 			tmpfs: Some(TmpfsOptions {
 				size: Some(4096),
 				mode: Some(0o700),
+				..Default::default()
 			}),
 			consistency: None,
 		};


### PR DESCRIPTION
Added flatten `unknown` buckets to BindOptions/VolumeOptions/DriverConfig/TmpfsOptions/ServiceNetworkConfig/ResourceSpec/DeviceReservation and wired them into `nested_unknown_keys`, so unknown keys in volume option blocks, per-network attachments, and deploy.resources warn instead of silently dropping. Also modeled `bind.recursive`.

Verified: `bogus_net`/`bogus_bind`/`bogus_limit` now warn; `bind.recursive: enabled` parses into the field.

Closes #633