### PR TITLE
feat(quadlet): emit a .build unit for services with a build config

### DIFF
--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -16,7 +16,7 @@ mod unit;
 mod warnings;
 
 use crate::compose::types::ComposeFile;
-use unit::{container_unit, network_unit, volume_unit};
+use unit::{build_unit, container_unit, network_unit, volume_unit};
 
 /// A single generated unit file: its name and full contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,6 +92,11 @@ pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 		.map(|(name, _)| name.as_str())
 		.collect();
 	for (name, service) in &file.services {
+		// Emit a `.build` unit first so the systemd generator builds the image
+		// before the container that references it via `Image=<stem>.build`.
+		if let Some(unit) = build_unit(name, project, service, &mut out.warnings) {
+			out.units.push(unit);
+		}
 		out.units.push(container_unit(
 			name,
 			project,

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -83,19 +83,46 @@ networks:
 }
 
 #[test]
-fn warns_about_unmapped_build_field() {
+fn build_field_emits_a_build_unit() {
 	let yaml = r#"
 services:
   app:
-    build: .
+    build:
+      context: ./src
+      dockerfile: Dockerfile.app
+      target: runtime
     image: app:latest
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	assert!(
-		out.warnings.iter().any(|w| w.contains("build")),
-		"a set build field must produce a warning"
-	);
+	// A `.build` unit is generated (no longer just a warning) and the container
+	// references it so Quadlet builds before running.
+	let build = out
+		.units
+		.iter()
+		.find(|u| u.filename == "app.build")
+		.expect("a build service must emit an app.build unit");
+	assert!(build.contents.contains("[Build]"));
+	assert!(build.contents.contains("ImageTag=app:latest"));
+	assert!(build.contents.contains("SetWorkingDirectory=./src"));
+	assert!(build.contents.contains("File=Dockerfile.app"));
+	assert!(build.contents.contains("Target=runtime"));
+	let container = out
+		.units
+		.iter()
+		.find(|u| u.filename == "app.container")
+		.unwrap();
+	assert!(container.contents.contains("Image=app.build"));
+	assert!(!out.warnings.iter().any(|w| w.contains("build")));
+}
+
+#[test]
+fn inline_dockerfile_build_warns_and_emits_no_build_unit() {
+	let yaml = "services:\n  app:\n    build:\n      dockerfile_inline: \"FROM alpine\"\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "proj");
+	assert!(!out.units.iter().any(|u| u.filename == "app.build"));
+	assert!(out.warnings.iter().any(|w| w.contains("dockerfile_inline")));
 }
 
 #[test]

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -1,0 +1,109 @@
+//! Build the `.build` unit for a service that declares a `build:` block.
+//!
+//! Quadlet's `.build` unit type (a `[Build]` section) tells the systemd
+//! generator to build the image before the `.container` unit that consumes it
+//! runs. The container references the result via `Image=<stem>.build`.
+
+use crate::compose::types::{BuildConfig, Service};
+
+use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+
+/// The `.build` unit file name for a service, e.g. `web.build`. The container
+/// unit points its `Image=` at this so Quadlet builds then runs.
+pub(crate) fn build_unit_filename(name: &str) -> String {
+	format!("{}.build", safe_unit_stem(name))
+}
+
+/// Whether `service` yields a `.build` unit — it declares `build:` and that
+/// build is expressible as Quadlet (an inline Dockerfile is not). Used by the
+/// container unit to decide whether `Image=` should reference the `.build`.
+pub(crate) fn emits_build_unit(service: &Service) -> bool {
+	match &service.build {
+		None => false,
+		Some(BuildConfig::Context(_)) => true,
+		Some(BuildConfig::Config {
+			dockerfile_inline, ..
+		}) => dockerfile_inline.is_none(),
+	}
+}
+
+/// Build the `.build` unit for `service`, or `None` when the service has no
+/// `build:` block or its build can't be expressed as a Quadlet `.build` unit
+/// (an inline Dockerfile, which Quadlet does not support — a warning is pushed).
+///
+/// `ImageTag=` is the service's `image:` when set, else `<project>-<service>`,
+/// so the generated container's `Image=<stem>.build` resolves to a concrete tag.
+pub(crate) fn build_unit(
+	name: &str,
+	project: &str,
+	service: &Service,
+	warnings: &mut Vec<String>,
+) -> Option<QuadletUnit> {
+	let build = service.build.as_ref()?;
+
+	let mut section = Section::new("Build");
+
+	let image_tag = service
+		.image
+		.clone()
+		.unwrap_or_else(|| format!("{project}-{name}"));
+	section.add("ImageTag", image_tag);
+
+	match build {
+		BuildConfig::Context(context) => {
+			section.add("SetWorkingDirectory", context.clone());
+		}
+		BuildConfig::Config {
+			context,
+			dockerfile,
+			dockerfile_inline,
+			args,
+			target,
+			labels,
+			network,
+			..
+		} => {
+			if dockerfile_inline.is_some() {
+				// Quadlet has no inline-Dockerfile equivalent; emitting a `.build`
+				// without the source would build the wrong thing. Skip and warn.
+				warnings.push(format!(
+					"{name}: build.dockerfile_inline has no Quadlet `.build` equivalent; \
+					 no .build unit emitted — build the image first and set `image`"
+				));
+				return None;
+			}
+			section.add(
+				"SetWorkingDirectory",
+				context.clone().unwrap_or_else(|| ".".to_string()),
+			);
+			if let Some(df) = dockerfile {
+				section.add("File", df.clone());
+			}
+			if let Some(t) = target {
+				section.add("Target", t.clone());
+			}
+			if let Some(net) = network {
+				section.add("Network", net.clone());
+			}
+			let mut build_args: Vec<(String, Option<String>)> = args.to_map().into_iter().collect();
+			build_args.sort_by(|a, b| a.0.cmp(&b.0));
+			for (key, val) in build_args {
+				match val {
+					Some(v) => section.add("BuildArg", format!("{key}={v}")),
+					None => section.add("BuildArg", key),
+				}
+			}
+			for (key, val) in sorted_label_pairs(labels.to_map()) {
+				section.add("Label", format!("{key}={val}"));
+			}
+		}
+	}
+
+	// Ownership label, mirroring every other generated unit.
+	section.add("Label", format!("podup.project={project}"));
+
+	Some(QuadletUnit {
+		filename: build_unit_filename(name),
+		contents: section.render(),
+	})
+}

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -53,7 +53,11 @@ pub(crate) fn container_unit(
 			.clone()
 			.unwrap_or_else(|| format!("{project}-{name}")),
 	);
-	if let Some(image) = &service.image {
+	// A service with a buildable `build:` references its `.build` unit, so Quadlet
+	// builds the image before running; otherwise the explicit `image:` is used.
+	if super::build::emits_build_unit(service) {
+		container.add("Image", super::build::build_unit_filename(name));
+	} else if let Some(image) = &service.image {
 		container.add("Image", image.clone());
 	}
 	if let Some(hostname) = &service.hostname {

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -1,11 +1,13 @@
 //! Build the individual `.network`, `.volume` and `.container` units.
 
+mod build;
 mod container;
 mod health;
 mod network;
 mod security;
 mod volume;
 
+pub(super) use build::build_unit;
 pub(super) use container::container_unit;
 pub(super) use network::network_unit;
 pub(super) use volume::volume_unit;

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -231,7 +231,6 @@ configs:
 		let joined = warnings.join("\n");
 
 		for field in [
-			"build",
 			"scale/replicas",
 			"configs",
 			"volumes_from",
@@ -457,19 +456,6 @@ services:
 				"missing warning for {field}; got:\n{joined}"
 			);
 		}
-	}
-
-	#[test]
-	fn build_warning_mentions_dot_build_unit() {
-		// The build warning must point at Quadlet's `.build` unit as the supported
-		// path, not claim there is no equivalent.
-		let yaml = "services:\n  s:\n    image: x\n    build: .\n";
-		let file = parse_str(yaml).unwrap();
-		let joined = generate(&file, "proj").warnings.join("\n");
-		assert!(
-			joined.contains(".build"),
-			"build warning should mention the .build unit; got:\n{joined}"
-		);
 	}
 
 	#[test]

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -9,13 +9,6 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 	let mut warn = |field: &str, detail: &str| {
 		warnings.push(format!("{name}: {field} {detail}"));
 	};
-	if service.build.is_some() {
-		warn(
-			"build",
-			"is not emitted; Quadlet's `.build` unit type is the supported path, \
-			 but podup does not generate one yet — build the image first and set `image`",
-		);
-	}
 	let replicas = service
 		.scale
 		.or(service.deploy.as_ref().and_then(|d| d.replicas));


### PR DESCRIPTION
`generate quadlet` now emits a `<service>.build` unit (`[Build]` with ImageTag/SetWorkingDirectory/File/Target/Network/BuildArg/Label) and points the container's `Image=<stem>.build`, instead of only warning. Podman's own quadlet generator validates it and auto-adds `Requires=/After=<svc>-build.service`. Inline-dockerfile builds have no Quadlet equivalent, so they still warn and emit no unit.

Verified end-to-end with `podman-system-generator -dryrun`.

Closes #622