### PR TITLE
docs(cli): make run/exec -i/-T help honest about their effect

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -252,10 +252,12 @@ pub(crate) enum Commands {
 		/// Publish an extra port (HOST:CONTAINER[/PROTO]); repeatable.
 		#[arg(short = 'p', long = "publish")]
 		publish: Vec<String>,
-		/// Keep STDIN open (accepted for compatibility; run still streams logs).
+		/// Keep the container's STDIN open (sets `stdin_open`). `run` streams the
+		/// container's output but does not attach a live interactive terminal.
 		#[arg(short, long)]
 		interactive: bool,
-		/// Disable pseudo-TTY allocation (podup never allocates one; accepted for compatibility).
+		/// No effect; accepted only for docker-compose compatibility. podup never
+		/// allocates a pseudo-TTY.
 		#[arg(short = 'T', long = "no-TTY")]
 		no_tty: bool,
 		/// Do not start linked services (depends_on) before running.
@@ -422,7 +424,8 @@ pub(crate) enum Commands {
 		/// Detach: run the command in the background.
 		#[arg(short, long)]
 		detach: bool,
-		/// Disable pseudo-TTY allocation (podup never allocates one; accepted for compatibility).
+		/// No effect; accepted only for docker-compose compatibility. podup never
+		/// allocates a pseudo-TTY.
 		#[arg(short = 'T', long = "no-TTY")]
 		no_tty: bool,
 		/// Index of the container when the service has multiple replicas (1-based).


### PR DESCRIPTION
Clarifies the `-i/--interactive` and `-T/--no-TTY` help so it no longer implies an interactive TTY podup doesn't provide: `-T` is a true no-op (compat only), `-i` keeps STDIN open but doesn't attach a terminal.

Addresses the misleading-no-op-flags part of #634. The other two sub-points are won't-fix (see issue comment): the per-command `-q` overload matches docker compose, and `--json` on mutating verbs has no real demand over exit-code + `ps --format json`.

Closes #634