### PR TITLE
chore(release): 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (1.5.1) unstable; urgency=medium
+
+  * cp: copying a host file to a container under a new name now creates a file
+    with that name, not a directory holding the source — the container
+    destination is stat'd to tell an existing directory (copy in) from a target
+    name (rename on copy), matching `docker cp`. A single-character service name
+    (`c:/path`) is also no longer mistaken for a Windows drive letter on Unix.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 26 Jun 2026 10:31:01 -0500
+
 podup (1.5.0) unstable; urgency=medium
 
   * compose: pass an `env_file` bare key through from the host environment


### PR DESCRIPTION
Patch release 1.5.1 — the two `cp` fixes from the 1.5.0 command sweep (#668 rename-on-copy, #669 single-char service name). Merge → then `release: 1.5.1` (develop→main) → tag `v1.5.1`.