### PR TITLE
release: 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
 name = "podup"
 version = "1.5.0"
 dependencies = [
+ "base64",
  "bytes",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ notify = { version = "8", optional = true }
 ureq = { version = "3", default-features = false, features = ["rustls"], optional = true }
 ed25519-dalek = { version = "2", default-features = false, features = ["std"], optional = true }
 sha2 = "0.10"
+base64 = "0.22"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (1.5.1) unstable; urgency=medium
+
+  * cp: copying a host file to a container under a new name now creates a file
+    with that name, not a directory holding the source — the container
+    destination is stat'd to tell an existing directory (copy in) from a target
+    name (rename on copy), matching `docker cp`. A single-character service name
+    (`c:/path`) is also no longer mistaken for a Windows drive letter on Unix.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Fri, 26 Jun 2026 10:31:01 -0500
+
 podup (1.5.0) unstable; urgency=medium
 
   * compose: pass an `env_file` bare key through from the host environment

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -132,16 +132,43 @@ impl Engine {
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container_name = self.replica_name_at(service_name, service, opts.index)?;
 
+		// Match `docker cp` destination semantics. The libpod archive PUT extracts
+		// the tar *at* a directory, so:
+		//  - dest is an existing directory (or ends in `/`)  → copy the source in
+		//    under its own name (PUT to the dest dir);
+		//  - dest is anything else (a new name, or a file)   → rename the source to
+		//    the dest's basename and PUT to the dest's parent.
+		// Without this, `cp file svc:/path/newname` created `newname/` as a
+		// directory holding the source instead of a file named `newname`.
+		let stat_path = format!(
+			"{API_PREFIX}/containers/{}/archive?path={}",
+			urlencoded(&container_name),
+			urlencoded(container_path),
+		);
+		let dest_is_dir = self.client.head_path_is_dir(&stat_path).await? == Some(true);
+
+		let (extract_dir, rename) = if dest_is_dir || container_path.ends_with('/') {
+			(container_path.trim_end_matches('/').to_string(), None)
+		} else {
+			let trimmed = container_path.trim_end_matches('/');
+			let (parent, name) = trimmed.rsplit_once('/').unwrap_or(("", trimmed));
+			let parent = if parent.is_empty() { "/" } else { parent };
+			(parent.to_string(), Some(name.to_string()))
+		};
+
 		let src_buf = src.to_path_buf();
 		let follow = opts.follow_link;
-		let tar_bytes = tokio::task::spawn_blocking(move || pack_path(&src_buf, follow))
-			.await
-			.map_err(|e| ComposeError::Build(e.to_string()))??;
+		let rename_for_pack = rename.clone();
+		let tar_bytes = tokio::task::spawn_blocking(move || {
+			pack_path(&src_buf, follow, rename_for_pack.as_deref())
+		})
+		.await
+		.map_err(|e| ComposeError::Build(e.to_string()))??;
 
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
 			urlencoded(&container_name),
-			urlencoded(container_path),
+			urlencoded(&extract_dir),
 		);
 		self.client
 			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/x-tar")
@@ -165,15 +192,18 @@ fn parse_endpoint(s: &str) -> Option<(&str, &str)> {
 	if svc.is_empty() || path.is_empty() {
 		return None;
 	}
-	// Windows absolute paths like `C:\path` have a single-char drive prefix — treat
-	// those as local paths, not as service endpoints.
+	// On Windows, an absolute path like `C:\path` has a single-char drive prefix —
+	// treat those as local paths, not service endpoints. This must NOT apply on
+	// Unix, where a one-character service name (`c:/path`) is perfectly valid and
+	// would otherwise be rejected as a bogus "drive".
+	#[cfg(windows)]
 	if svc.len() == 1 && svc.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
 		return None;
 	}
 	Some((svc, path))
 }
 
-fn pack_path(src: &Path, follow_link: bool) -> Result<Vec<u8>> {
+fn pack_path(src: &Path, follow_link: bool, name_override: Option<&str>) -> Result<Vec<u8>> {
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 	// `-L/--follow-link`: archive the symlink target's contents instead of the
@@ -181,11 +211,15 @@ fn pack_path(src: &Path, follow_link: bool) -> Result<Vec<u8>> {
 	tar.follow_symlinks(follow_link);
 
 	if src.is_dir() {
-		let name = src.file_name().unwrap_or(std::ffi::OsStr::new("."));
+		// `name_override` renames the copied tree (rename-on-copy); otherwise it
+		// keeps the source's own basename and lands inside the destination dir.
+		let default = src.file_name().unwrap_or(std::ffi::OsStr::new("."));
+		let name: &std::ffi::OsStr = name_override.map(std::ffi::OsStr::new).unwrap_or(default);
 		tar.append_dir_all(name, src)
 			.map_err(|e| ComposeError::Build(e.to_string()))?;
 	} else {
-		let name = src.file_name().unwrap_or(std::ffi::OsStr::new("file"));
+		let default = src.file_name().unwrap_or(std::ffi::OsStr::new("file"));
+		let name: &std::ffi::OsStr = name_override.map(std::ffi::OsStr::new).unwrap_or(default);
 		tar.append_path_with_name(src, name)
 			.map_err(|e| ComposeError::Build(e.to_string()))?;
 	}
@@ -335,9 +369,19 @@ mod tests {
 		assert_eq!(parse_endpoint("-"), None);
 	}
 
+	#[cfg(windows)]
 	#[test]
 	fn parse_windows_drive_letter_is_local() {
 		assert_eq!(parse_endpoint("C:\\Users\\foo"), None);
+	}
+
+	#[cfg(not(windows))]
+	#[test]
+	fn single_char_service_parses_on_unix() {
+		// On Unix a one-character service name is valid; only Windows treats a
+		// single-char prefix as a drive letter.
+		assert_eq!(parse_endpoint("c:/tmp/file"), Some(("c", "/tmp/file")));
+		assert_eq!(parse_endpoint("w:data"), Some(("w", "data")));
 	}
 
 	#[test]
@@ -346,6 +390,7 @@ mod tests {
 		assert_eq!(parse_endpoint("svc:"), None);
 	}
 
+	#[cfg(windows)]
 	#[test]
 	fn parse_windows_drive_letter_forward_slash() {
 		assert_eq!(parse_endpoint("C:/Users/foo"), None);
@@ -372,7 +417,7 @@ mod tests {
 		let dir = tempfile::tempdir().expect("tempdir");
 		let file = dir.path().join("data.txt");
 		std::fs::write(&file, b"hello").expect("write");
-		let result = super::pack_path(&file, false);
+		let result = super::pack_path(&file, false, None);
 		assert!(result.is_ok());
 		let bytes = result.unwrap();
 		assert!(!bytes.is_empty());
@@ -385,7 +430,7 @@ mod tests {
 		std::fs::create_dir(&subdir).expect("mkdir");
 		std::fs::write(subdir.join("a.txt"), b"aaa").expect("write");
 		std::fs::write(subdir.join("b.txt"), b"bbb").expect("write");
-		let result = super::pack_path(&subdir, false);
+		let result = super::pack_path(&subdir, false, None);
 		assert!(result.is_ok());
 		assert!(!result.unwrap().is_empty());
 	}

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -412,6 +412,48 @@ impl Client {
 		Self::check_status(status, &body)
 	}
 
+	/// `HEAD` a container-archive path, returning `Some(is_dir)` when it exists or
+	/// `None` on 404. Reads the `X-Docker-Container-Path-Stat` header (base64 JSON
+	/// carrying a Go file `mode`); the directory bit is `os.ModeDir` (`1 << 31`).
+	/// Lets `cp` tell an existing destination directory (copy into it) from a
+	/// target name (rename on copy), matching `docker cp`.
+	pub async fn head_path_is_dir(&self, path: &str) -> Result<Option<bool>> {
+		use base64::Engine as _;
+
+		let req = Self::build_request(Method::HEAD, path, Full::new(Bytes::new()), None)?;
+		let resp = self.send(req).await?;
+		let status = resp.status();
+		if status == StatusCode::NOT_FOUND {
+			return Ok(None);
+		}
+		let stat = resp
+			.headers()
+			.get("X-Docker-Container-Path-Stat")
+			.and_then(|v| v.to_str().ok())
+			.map(str::to_string);
+		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		if status == StatusCode::NOT_FOUND {
+			return Ok(None);
+		}
+		Self::check_status(status, &body)?;
+		let Some(stat) = stat else {
+			return Ok(Some(false));
+		};
+		let json = base64::engine::general_purpose::STANDARD
+			.decode(stat.as_bytes())
+			.map_err(|e| PodmanError::Api {
+				status: 0,
+				message: format!("malformed container path stat: {e}"),
+			})?;
+		#[derive(serde::Deserialize)]
+		struct Stat {
+			mode: u64,
+		}
+		let parsed: Stat = serde_json::from_slice(&json).map_err(PodmanError::Json)?;
+		// Go's os.ModeDir is the high bit of the 32-bit FileMode.
+		Ok(Some(parsed.mode & (1 << 31) != 0))
+	}
+
 	/// `DELETE` → ignore response body (expect 2xx or 404).
 	pub async fn delete_ok(&self, path: &str) -> Result<()> {
 		let req = Self::build_request(Method::DELETE, path, Full::new(Bytes::new()), None)?;

--- a/tests/engine_integration/cp_flags.rs
+++ b/tests/engine_integration/cp_flags.rs
@@ -82,3 +82,46 @@ async fn engine_cp_follow_link_uploads_target_contents() {
 		"-L must upload the symlink target's contents"
 	);
 }
+
+#[cfg(all(unix, feature = "test-helpers"))]
+#[tokio::test]
+async fn engine_cp_to_container_renames_a_single_file() {
+	// `cp host-file svc:/tmp/newname.txt` must create a FILE named newname.txt,
+	// not a directory holding the source — matching `docker cp` rename-on-copy.
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let src = dir.path().join("src.txt");
+	fs::write(&src, b"renamed-content").unwrap();
+
+	let proj = proj("cpren");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	engine.up(&file).await.unwrap();
+
+	let result = engine
+		.cp(&file, src.to_str().unwrap(), "web:/tmp/renamed.txt")
+		.await;
+	// `test -f` succeeds only for a regular file; a directory (the old bug) fails it.
+	let out = engine
+		.test_exec_capture(
+			&format!("{proj}-web"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"test -f /tmp/renamed.txt && cat /tmp/renamed.txt".into(),
+			],
+		)
+		.await;
+	engine.down(&file).await.unwrap();
+	result.unwrap();
+	assert!(
+		out.unwrap_or_default().contains("renamed-content"),
+		"cp to a new name must create a file with the source's content, not a directory"
+	);
+}


### PR DESCRIPTION
Promote develop → main for 1.5.1 (cp rename-on-copy + single-char service fixes). Tag `v1.5.1` after merge.