### PR TITLE
chore(release): 1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+podup (1.5.2) unstable; urgency=medium
+
+  * Documentation and CI only — no functional change to the binary. The README is
+    redesigned as a concise, visual landing page with an apt-first install. The
+    Podman support policy is now stated explicitly: the latest two majors, Podman
+    5.x and 6.x (floor >= 5.0). CI validates the engine against both Podman 5 and
+    6 on every engine change.
+
+ -- Glyndor <75870284+Jaro-c@users.noreply.github.com>  Sat, 27 Jun 2026 12:37:18 -0500
+
 podup (1.5.1) unstable; urgency=medium
 
   * cp: copying a host file to a container under a new name now creates a file


### PR DESCRIPTION
Patch release 1.5.2 — **documentation and CI only, the binary is unchanged from 1.5.1**.

- README redesigned as a concise, visual landing page (apt-first install).
- Podman support window stated explicitly: the latest two majors — **Podman 5.x and 6.x** (floor ≥ 5.0).
- CI validates the engine against both Podman 5 and 6 on every engine change.

Flow: merge here → `release: 1.5.2` (develop→main) → tag `v1.5.2`.