### PR TITLE
fix(engine): fail --wait when a service exits before becoming ready

### DIFF
--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -31,6 +31,10 @@ enum HealthVerdict {
 	/// The container has no effective healthcheck, so `healthy` is unreachable;
 	/// treat the dependency as satisfied rather than blocking until timeout.
 	NoHealthcheck,
+	/// The container has already exited non-zero. It can never become healthy and
+	/// the service failed to start, so the wait must fail rather than report the
+	/// dependency satisfied. Carries the exit code.
+	Failed(i64),
 	/// Not healthy yet — keep polling.
 	Pending,
 }
@@ -44,6 +48,16 @@ fn classify_health(info: &ContainerInspect) -> HealthVerdict {
 		if let Some(health) = &state.health {
 			if health.status.as_deref() == Some("healthy") {
 				return HealthVerdict::Healthy;
+			}
+		}
+		// A container that has already exited can never become healthy. If it
+		// exited non-zero the service failed to start, so fail the wait instead of
+		// reporting it satisfied (which would mask the failure in `up --wait`/CI).
+		// An exit code of 0 is a one-shot that completed; let it fall through.
+		if state.status.as_deref() == Some("exited") {
+			let code = state.exit_code.unwrap_or(0);
+			if code != 0 {
+				return HealthVerdict::Failed(code);
 			}
 		}
 	}
@@ -140,6 +154,12 @@ impl Engine {
 					"{container_name} has no effective healthcheck; treating service_healthy as satisfied"
 				);
 				return Ok(());
+			}
+			HealthVerdict::Failed(code) => {
+				return Err(ComposeError::WaitServiceExited {
+					container: container_name.to_string(),
+					code,
+				});
 			}
 			HealthVerdict::Pending => {}
 		}
@@ -255,5 +275,23 @@ mod tests {
 			r#"{"State":{"Status":"running","Health":{"Status":"starting"}},"Config":{"Healthcheck":{"Test":["CMD","true"]}}}"#,
 		);
 		assert!(matches!(classify_health(&info), HealthVerdict::Pending));
+	}
+
+	#[test]
+	fn health_exited_nonzero_fails() {
+		// A no-healthcheck service that crashed during the wait must fail, not be
+		// reported satisfied (the `up --wait` masking bug).
+		let info = inspect(r#"{"State":{"Status":"exited","ExitCode":7}}"#);
+		assert!(matches!(classify_health(&info), HealthVerdict::Failed(7)));
+	}
+
+	#[test]
+	fn health_exited_zero_is_satisfied() {
+		// A one-shot that completed cleanly with no healthcheck is still satisfied.
+		let info = inspect(r#"{"State":{"Status":"exited","ExitCode":0}}"#);
+		assert!(matches!(
+			classify_health(&info),
+			HealthVerdict::NoHealthcheck
+		));
 	}
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -59,6 +59,9 @@ pub enum ComposeError {
 		replicas: usize,
 		ports: Vec<u16>,
 	},
+	/// A container being waited on (`up`/`start --wait`, or a `service_healthy`
+	/// dependency) exited non-zero before becoming ready.
+	WaitServiceExited { container: String, code: i64 },
 }
 
 impl fmt::Display for ComposeError {
@@ -106,6 +109,10 @@ impl fmt::Display for ComposeError {
 					 proxy's port\n  - reduce the service to a single replica"
 				)
 			}
+			Self::WaitServiceExited { container, code } => write!(
+				f,
+				"container '{container}' exited with code {code} while waiting for it to be ready"
+			),
 		}
 	}
 }
@@ -219,6 +226,13 @@ mod tests {
 					service: "web".into(),
 					replicas: 3,
 					ports: vec![8080],
+				},
+			),
+			(
+				"container 'web' exited with code 7 while waiting for it to be ready",
+				ComposeError::WaitServiceExited {
+					container: "web".into(),
+					code: 7,
 				},
 			),
 		];

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -119,14 +119,13 @@ pub struct HealthConfig {
 /// Container state sub-object.
 #[derive(Deserialize, Default)]
 pub struct ContainerState {
-	// `status`/`exit_code` round-trip the libpod state for completeness and are
-	// asserted in tests; container completion now blocks on `wait?condition`
-	// (which returns the code directly) rather than reading them here.
-	#[allow(dead_code)]
+	/// Lifecycle status (`running`, `exited`, ...). Read while waiting to detect a
+	/// container that exited before becoming ready.
 	#[serde(rename = "Status")]
 	pub status: Option<String>,
 
-	#[allow(dead_code)]
+	/// Exit code once the container has exited; used to fail `--wait` when a
+	/// no-healthcheck service crashes during the wait.
 	#[serde(rename = "ExitCode")]
 	pub exit_code: Option<i64>,
 


### PR DESCRIPTION
## What
`up --wait` / `start --wait` returned success even when a service with no healthcheck had already exited non-zero: the wait short-circuited a no-healthcheck verdict as satisfied without ever checking the container's exit state, so a crashed startup returned rc=0 and masked failures in CI/automation.

## Change
Classify an already-exited container while waiting: a non-zero exit fails the wait with its code; an exit 0 (a completed one-shot) stays satisfied. The same path backs the `service_healthy` dependency condition, so a dependency that crashes now fails fast too.

## Tests
Added classify-health cases for exited-non-zero (fails) and exited-zero (satisfied); covered the new error variant's message.

Closes #686