### PR TITLE
fix(engine): cap replica count to bound untrusted-compose host DoS

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -328,6 +328,9 @@ impl Engine {
 		}
 
 		let replicas = self.resolve_replicas(name, service);
+		// Bound the replica count (covers an untrusted compose `deploy.replicas`/
+		// `scale:` as well as `--scale`) before creating any container.
+		scale::check_replica_limit(name, replicas)?;
 		// A scaled service that publishes a fixed host port cannot start: only
 		// one container can bind it. Fail fast with guidance instead of letting
 		// replicas 2..N die mid-up with `address already in use`.

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -10,6 +10,36 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
+/// The default ceiling on a service's replica count.
+const DEFAULT_MAX_REPLICAS: u32 = 256;
+
+/// The replica ceiling, overridable via the `PODUP_MAX_REPLICAS` environment
+/// variable (a host operator's escape hatch). A missing, unparseable, or zero
+/// override falls back to [`DEFAULT_MAX_REPLICAS`].
+fn max_replicas() -> u32 {
+	std::env::var("PODUP_MAX_REPLICAS")
+		.ok()
+		.and_then(|v| v.parse::<u32>().ok())
+		.filter(|&n| n > 0)
+		.unwrap_or(DEFAULT_MAX_REPLICAS)
+}
+
+/// Reject a replica count beyond the configured ceiling. Guards both the CLI
+/// `scale`/`--scale` path and an untrusted compose `deploy.replicas`/`scale:`
+/// from driving podup into unbounded container creation (a host DoS), since
+/// every command resolves its replica count through this one check.
+pub(super) fn check_replica_limit(service_name: &str, replicas: usize) -> Result<()> {
+	let max = max_replicas();
+	if replicas as u64 > u64::from(max) {
+		return Err(ComposeError::ReplicaLimitExceeded {
+			service: service_name.to_string(),
+			replicas,
+			max,
+		});
+	}
+	Ok(())
+}
+
 /// Reject a scaled service that publishes a fixed host port: only one container
 /// can bind a given host port, so replicas 2..N would fail at runtime with
 /// `address already in use`. A host port of 0/None is runtime-assigned by
@@ -50,8 +80,10 @@ impl Engine {
 				return Err(ComposeError::ServiceNotFound(svc.clone()));
 			}
 		}
-		// Fail fast on a fixed host port before touching any container.
+		// Fail fast on an over-limit count or a fixed host port before touching
+		// any container.
 		for (svc, target) in pairs {
+			check_replica_limit(svc, *target as usize)?;
 			check_scale_port_conflict(svc, &file.services[svc], *target as usize)?;
 		}
 		// Scale up: create only the missing replicas of the named services
@@ -192,7 +224,37 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::check_scale_port_conflict;
+	use super::{check_replica_limit, check_scale_port_conflict, DEFAULT_MAX_REPLICAS};
+
+	#[test]
+	fn replica_limit_default_and_env_override() {
+		// One test owns the shared `PODUP_MAX_REPLICAS` env var for its whole body
+		// so a sibling test running in parallel can never race it.
+		let max = DEFAULT_MAX_REPLICAS as usize;
+
+		// Default ceiling: at-limit allowed, over-limit rejected.
+		std::env::remove_var("PODUP_MAX_REPLICAS");
+		assert!(check_replica_limit("web", 1).is_ok());
+		assert!(check_replica_limit("web", max).is_ok());
+		let err = check_replica_limit("web", max + 1).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ReplicaLimitExceeded { .. }
+		));
+		assert!(check_replica_limit("web", 100_000).is_err());
+
+		// Env override lowers the ceiling.
+		std::env::set_var("PODUP_MAX_REPLICAS", "2");
+		assert!(check_replica_limit("web", 2).is_ok());
+		assert!(check_replica_limit("web", 3).is_err());
+
+		// A zero/garbage override falls back to the default ceiling.
+		std::env::set_var("PODUP_MAX_REPLICAS", "0");
+		assert!(check_replica_limit("web", max).is_ok());
+		std::env::set_var("PODUP_MAX_REPLICAS", "nope");
+		assert!(check_replica_limit("web", max).is_ok());
+		std::env::remove_var("PODUP_MAX_REPLICAS");
+	}
 
 	fn service(yaml: &str) -> crate::compose::types::Service {
 		let file = crate::parse_str(yaml).unwrap();

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -62,6 +62,14 @@ pub enum ComposeError {
 	/// A container being waited on (`up`/`start --wait`, or a `service_healthy`
 	/// dependency) exited non-zero before becoming ready.
 	WaitServiceExited { container: String, code: i64 },
+	/// A service requests more replicas than the configured ceiling, which would
+	/// let an untrusted `deploy.replicas`/`scale:` drive unbounded container
+	/// creation (host DoS).
+	ReplicaLimitExceeded {
+		service: String,
+		replicas: usize,
+		max: u32,
+	},
 }
 
 impl fmt::Display for ComposeError {
@@ -112,6 +120,15 @@ impl fmt::Display for ComposeError {
 			Self::WaitServiceExited { container, code } => write!(
 				f,
 				"container '{container}' exited with code {code} while waiting for it to be ready"
+			),
+			Self::ReplicaLimitExceeded {
+				service,
+				replicas,
+				max,
+			} => write!(
+				f,
+				"service '{service}' requests {replicas} replicas, which exceeds the limit of \
+				 {max}; lower the count or raise the limit with PODUP_MAX_REPLICAS"
 			),
 		}
 	}
@@ -233,6 +250,14 @@ mod tests {
 				ComposeError::WaitServiceExited {
 					container: "web".into(),
 					code: 7,
+				},
+			),
+			(
+				"service 'web' requests 100000 replicas, which exceeds the limit of 256",
+				ComposeError::ReplicaLimitExceeded {
+					service: "web".into(),
+					replicas: 100_000,
+					max: 256,
 				},
 			),
 		];


### PR DESCRIPTION
## What
`scale`, `--scale`, and the compose `deploy.replicas`/`scale:` keys had no upper bound, so `scale worker=100000` (or the same value inside a compose file) drove podup into serial per-replica creation. For a consumer that runs `up` on an untrusted compose file that is an input-driven host DoS.

## Change
A single `check_replica_limit` guard that every command funnels through (the up pass and the `scale` fast-path), default ceiling 256, overridable via `PODUP_MAX_REPLICAS` for operators who need more.

## Tests
Boundary (at-limit ok / over-limit rejected), the env override, and the zero/garbage-override fallback; covered the new error variant's message.

Closes #690