### PR TITLE
fix(compose): apply active profiles to config output

### DIFF
--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -19,6 +19,7 @@ mod lifecycle;
 mod lock;
 mod network;
 mod profiles;
+pub use profiles::retain_active_profiles;
 mod projects;
 pub use projects::{list_projects, LsOptions};
 mod query;

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -2,7 +2,18 @@
 
 use std::collections::HashSet;
 
-use crate::compose::types::Service;
+use crate::compose::types::{ComposeFile, Service};
+
+/// Remove services excluded by the active profile set, in place.
+///
+/// Mirrors what `up` actually starts (a per-service profile match, with no
+/// implicit activation of a profiled `depends_on` target), so `config` presents
+/// the same service set the runtime would bring up. `active` is the CLI
+/// `--profile` list, falling back to `COMPOSE_PROFILES`.
+pub fn retain_active_profiles(file: &mut ComposeFile, active: &[String]) {
+	let set = active_profiles_set(active);
+	file.services.retain(|_, svc| service_in_profiles(svc, &set));
+}
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.
 pub(super) fn active_profiles_set(active: &[String]) -> HashSet<String> {
@@ -105,5 +116,28 @@ mod tests {
 		};
 		let active: HashSet<String> = ["prod".to_string()].into();
 		assert!(service_in_profiles(&svc, &active));
+	}
+
+	#[test]
+	fn retain_active_profiles_keeps_unprofiled_and_active() {
+		let yaml = "services:\n  \
+			web:\n    image: x\n  \
+			debugger:\n    image: x\n    profiles: [debug]\n  \
+			db:\n    image: x\n    profiles: [prod]\n";
+		// With `debug` active: the unprofiled `web` and the `debug` service stay,
+		// the `prod`-only `db` is dropped — exactly what `up --profile debug` runs.
+		let mut file = crate::parse_str(yaml).unwrap();
+		retain_active_profiles(&mut file, &["debug".to_string()]);
+		assert!(file.services.contains_key("web"));
+		assert!(file.services.contains_key("debugger"));
+		assert!(!file.services.contains_key("db"));
+
+		// With no active profiles, every profiled service is dropped.
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert!(file.services.contains_key("web"));
+		assert_eq!(file.services.len(), 1);
 	}
 }

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -12,7 +12,8 @@ use crate::compose::types::{ComposeFile, Service};
 /// `--profile` list, falling back to `COMPOSE_PROFILES`.
 pub fn retain_active_profiles(file: &mut ComposeFile, active: &[String]) {
 	let set = active_profiles_set(active);
-	file.services.retain(|_, svc| service_in_profiles(svc, &set));
+	file.services
+		.retain(|_, svc| service_in_profiles(svc, &set));
 }
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -43,9 +43,9 @@ pub use compose::{
 /// project-name/listing helpers — the surface a CLI drives compose operations
 /// through.
 pub use engine::{
-	is_safe_project_name, list_projects, resolve_image_digests, BuildOptions, CpOptions, Engine,
-	ExecOptions, ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions,
-	PushOptions, RunOptions, RunOverrides, VolumesOptions,
+	is_safe_project_name, list_projects, resolve_image_digests, retain_active_profiles,
+	BuildOptions, CpOptions, Engine, ExecOptions, ImagesOptions, LogsOptions, LsOptions,
+	ProjectLock, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -150,12 +150,14 @@ async fn run() -> podup::Result<()> {
 		};
 		// `--resolve-image-digests` pins each image to its registry digest, which
 		// needs a Podman connection to inspect images.
-		let resolved = if *resolve_image_digests {
+		let mut resolved = if *resolve_image_digests {
 			let client = podup::podman::connect(cli.socket.as_deref())?;
 			podup::resolve_image_digests(&client, &parsed).await?
 		} else {
 			parsed
 		};
+		// Honor active profiles so `config` prints the same services `up` starts.
+		podup::retain_active_profiles(&mut resolved, &cli.profile);
 		return startup::render_config(&resolved, format, *services, *quiet);
 	}
 


### PR DESCRIPTION
## What
`podup config` (and `config --services`) ignored `--profile` / `COMPOSE_PROFILES` — filtering lived only in the `up` path, so `config` printed every service while `up` started a profile-filtered set. The two disagreed.

## Change
Expose `retain_active_profiles` and apply it to the resolved file before rendering, mirroring exactly what `up` starts (a per-service profile match, no implicit activation of a profiled `depends_on` target).

## Tests
Unit coverage for the new filter: an active profile keeps unprofiled + matching services and drops the rest; no active profiles drops every profiled service.

Closes #688