### PR TITLE
polish(cli): ps PORTS header, port PORT/proto + --protocol, wait-timeout label

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -353,10 +353,10 @@ pub(crate) enum Commands {
 	Port {
 		/// Service name.
 		service: String,
-		/// Private port number.
-		private_port: u16,
+		/// Private port, e.g. `80` or `80/tcp` (a `/proto` suffix overrides --protocol).
+		private_port: String,
 		/// Protocol (tcp or udp).
-		#[arg(long, default_value = "tcp")]
+		#[arg(long, visible_alias = "protocol", default_value = "tcp")]
 		proto: String,
 		/// Index of the container when the service has multiple replicas (1-based).
 		#[arg(long)]

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -105,11 +105,7 @@ pub(crate) async fn dispatch(
 				match wait_timeout {
 					Some(secs) => tokio::time::timeout(std::time::Duration::from_secs(secs), fut)
 						.await
-						.map_err(|_| {
-							podup::ComposeError::Unsupported(
-								"start --wait timed out before services became healthy".into(),
-							)
-						})??,
+						.map_err(|_| podup::ComposeError::WaitTimeout { secs })??,
 					None => fut.await?,
 				}
 			}
@@ -296,7 +292,7 @@ pub(crate) async fn dispatch(
 			index,
 		} => {
 			engine
-				.port_with_index(file, &service, private_port, &proto, index)
+				.port_with_index(file, &service, &private_port, &proto, index)
 				.await?
 		}
 		Commands::Volumes {

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -85,7 +85,7 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		service_name: &str,
-		private_port: u16,
+		private_port: &str,
 		proto: &str,
 	) -> Result<()> {
 		self.port_with_index(file, service_name, private_port, proto, None)
@@ -98,10 +98,12 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		service_name: &str,
-		private_port: u16,
+		private_port: &str,
 		proto: &str,
 		index: Option<u32>,
 	) -> Result<()> {
+		let (port, proto) = parse_port_proto(private_port, proto)?;
+
 		let service = file
 			.services
 			.get(service_name)
@@ -118,7 +120,7 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 
-		let key = format!("{private_port}/{proto}");
+		let key = format!("{port}/{proto}");
 		let binding = info
 			.network_settings
 			.and_then(|ns| ns.ports.get(&key).cloned().flatten())
@@ -337,5 +339,42 @@ impl Engine {
 		}
 
 		Ok(())
+	}
+}
+
+/// Resolve the `(port, proto)` for `port` from a `PORT` or `PORT/proto` argument,
+/// the `/proto` suffix overriding the `--protocol` flag — matching
+/// `docker compose port`. Pure so the parsing is unit-tested.
+fn parse_port_proto<'a>(private_port: &'a str, proto_flag: &'a str) -> Result<(u16, &'a str)> {
+	let (port, proto) = match private_port.split_once('/') {
+		Some((p, pr)) => (p, pr),
+		None => (private_port, proto_flag),
+	};
+	let port: u16 = port.parse().map_err(|_| {
+		ComposeError::InvalidPort(format!(
+			"port '{private_port}' is not a valid PORT or PORT/proto"
+		))
+	})?;
+	Ok((port, proto))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse_port_proto;
+
+	#[test]
+	fn bare_port_uses_flag_proto() {
+		assert_eq!(parse_port_proto("80", "tcp").unwrap(), (80, "tcp"));
+	}
+
+	#[test]
+	fn suffix_overrides_flag_proto() {
+		assert_eq!(parse_port_proto("53/udp", "tcp").unwrap(), (53, "udp"));
+	}
+
+	#[test]
+	fn non_numeric_port_is_rejected() {
+		assert!(parse_port_proto("http", "tcp").is_err());
+		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -181,7 +181,7 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!("{:<40} {:<30} {:<20}", "NAME", "IMAGE", "STATUS");
+		println!("{:<40} {:<30} {:<20} PORTS", "NAME", "IMAGE", "STATUS");
 		for c in &containers {
 			let ports = format_ports(&c.ports);
 			println!(

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -70,6 +70,8 @@ pub enum ComposeError {
 		replicas: usize,
 		max: u32,
 	},
+	/// `start --wait --wait-timeout` elapsed before services became healthy.
+	WaitTimeout { secs: u64 },
 }
 
 impl fmt::Display for ComposeError {
@@ -129,6 +131,10 @@ impl fmt::Display for ComposeError {
 				f,
 				"service '{service}' requests {replicas} replicas, which exceeds the limit of \
 				 {max}; lower the count or raise the limit with PODUP_MAX_REPLICAS"
+			),
+			Self::WaitTimeout { secs } => write!(
+				f,
+				"timed out after {secs}s waiting for services to become healthy"
 			),
 		}
 	}
@@ -259,6 +265,10 @@ mod tests {
 					replicas: 100_000,
 					max: 256,
 				},
+			),
+			(
+				"timed out after 30s waiting for services to become healthy",
+				ComposeError::WaitTimeout { secs: 30 },
 			),
 		];
 		for (expected_prefix, err) in cases {

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -141,7 +141,7 @@ async fn engine_port_returns_binding() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.port(&file, "web", 80, "tcp").await.unwrap();
+	engine.port(&file, "web", "80", "tcp").await.unwrap();
 	engine.down(&file).await.unwrap();
 }
 
@@ -301,14 +301,14 @@ async fn port_scaled_service_targets_first_replica() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.port(&file, "worker", 80, "tcp").await.unwrap();
+	engine.port(&file, "worker", "80", "tcp").await.unwrap();
 	// --index targets a valid replica; an out-of-range index errors.
 	engine
-		.port_with_index(&file, "worker", 80, "tcp", Some(2))
+		.port_with_index(&file, "worker", "80", "tcp", Some(2))
 		.await
 		.unwrap();
 	let bad = engine
-		.port_with_index(&file, "worker", 80, "tcp", Some(9))
+		.port_with_index(&file, "worker", "80", "tcp", Some(9))
 		.await;
 	assert!(
 		matches!(bad, Err(podup::ComposeError::ServiceNotFound(_))),


### PR DESCRIPTION
## What
Three docker-parity CLI nits from testing 1.5.2:
- `ps` printed published ports in an unlabelled column → add a `PORTS` header.
- `port` required a bare numeric port and only spelled the flag `--proto` → accept `PORT/proto` (suffix overrides the flag) and add `--protocol` as a visible alias.
- `start --wait-timeout` surfaced the timeout via `ComposeError::Unsupported` ("unsupported feature:") → dedicated `WaitTimeout` error with a clear message.

(The fourth item in #693 — silent-success output — is deferred to the colour/output work in #703.)

## Tests
`parse_port_proto` (bare port uses flag proto; `/proto` suffix overrides; non-numeric rejected) and the `WaitTimeout` display.

Closes #693