### PR TITLE
feat(cli): colourise human output (--ansi / NO_COLOR, TTY-aware)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -124,6 +168,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -476,6 +526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +715,8 @@ dependencies = [
 name = "podup"
 version = "1.5.2"
 dependencies = [
+ "anstream",
+ "anstyle",
  "base64",
  "bytes",
  "clap",
@@ -1168,6 +1232,12 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "derive", "env"] }
 clap_complete = { version = "4", optional = true }
+# Terminal colour: anstyle for the styles, anstream to degrade gracefully
+# (auto-strip on non-TTY, honour NO_COLOR/--ansi, enable VT on Windows).
+anstyle = "1"
+anstream = "1"
 indexmap = { version = "2", features = ["serde"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tar = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
-clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "derive", "env"] }
+clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "derive", "env", "color"] }
 clap_complete = { version = "4", optional = true }
 # Terminal colour: anstyle for the styles, anstream to degrade gracefully
 # (auto-strip on non-TTY, honour NO_COLOR/--ansi, enable VT on Windows).

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -8,7 +8,7 @@ mod commands;
 mod parse;
 mod types;
 pub(crate) use commands::Commands;
-pub(crate) use types::{ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
+pub(crate) use types::{AnsiMode, ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
 
 /// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
 #[derive(Parser)]
@@ -46,6 +46,11 @@ pub(crate) struct Cli {
 	/// Extra env file(s) for interpolation (repeatable, later win; process env and `.env` still win).
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
+
+	/// When to colourise output: auto (TTY only), always, or never. `NO_COLOR`
+	/// also forces plain output.
+	#[arg(long, value_enum, default_value_t = AnsiMode::Auto, global = true)]
+	pub(crate) ansi: AnsiMode,
 
 	#[command(subcommand)]
 	pub(crate) command: Commands,

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -10,9 +10,18 @@ mod types;
 pub(crate) use commands::Commands;
 pub(crate) use types::{AnsiMode, ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
 
+/// Help-screen colours (clap honours its own TTY/`NO_COLOR`/`CLICOLOR` detection
+/// for these, since help is rendered before `--ansi` is parsed): green-bold
+/// section headers and usage, cyan-bold flag/command literals, plain placeholders.
+const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
+	.header(clap::builder::styling::AnsiColor::Green.on_default().bold())
+	.usage(clap::builder::styling::AnsiColor::Green.on_default().bold())
+	.literal(clap::builder::styling::AnsiColor::Cyan.on_default().bold())
+	.placeholder(clap::builder::styling::AnsiColor::Cyan.on_default());
+
 /// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
 #[derive(Parser)]
-#[command(name = "podup", version)]
+#[command(name = "podup", version, styles = HELP_STYLES)]
 pub(crate) struct Cli {
 	/// Path to the compose file (or `COMPOSE_FILE`). Unset: probe the
 	/// compose-spec precedence list (compose.yaml/.yml, docker-compose.yaml/.yml).

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -12,6 +12,28 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// When to colourise human-facing output (`--ansi`, like docker compose).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum AnsiMode {
+	/// Colour only when writing to a terminal (and `NO_COLOR` is unset).
+	#[default]
+	Auto,
+	/// Always colour, even when piped or redirected.
+	Always,
+	/// Never colour.
+	Never,
+}
+
+impl From<AnsiMode> for anstream::ColorChoice {
+	fn from(m: AnsiMode) -> Self {
+		match m {
+			AnsiMode::Auto => Self::Auto,
+			AnsiMode::Always => Self::Always,
+			AnsiMode::Never => Self::Never,
+		}
+	}
+}
+
 /// Which images `down --rmi` removes.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub(crate) enum RmiScope {

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -5,7 +5,6 @@
 //! [`Client`], not a full [`Engine`](crate::engine::Engine) bound to one project/compose file.
 
 use std::collections::BTreeMap;
-use std::io::Write;
 
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::ContainerListEntry;
@@ -89,14 +88,7 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 		return Ok(());
 	}
 
-	let hdr = crate::ui::bold();
-	let (on, off) = (hdr.render(), hdr.render_reset());
-	let _ = writeln!(
-		anstream::stdout(),
-		"{on}{:<32} {:<20}{off}",
-		"NAME",
-		"STATUS"
-	);
+	crate::ui::print_bold_header(&format!("{:<32} {:<20}", "NAME", "STATUS"));
 	for (name, t) in &rows {
 		let status = crate::ui::status_cell(&status_label(t), 20);
 		println!("{name:<32} {status}");

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -5,6 +5,7 @@
 //! [`Client`], not a full [`Engine`](crate::engine::Engine) bound to one project/compose file.
 
 use std::collections::BTreeMap;
+use std::io::Write;
 
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::ContainerListEntry;
@@ -88,9 +89,17 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 		return Ok(());
 	}
 
-	println!("{:<32} {:<20}", "NAME", "STATUS");
+	let hdr = crate::ui::bold();
+	let (on, off) = (hdr.render(), hdr.render_reset());
+	let _ = writeln!(
+		anstream::stdout(),
+		"{on}{:<32} {:<20}{off}",
+		"NAME",
+		"STATUS"
+	);
 	for (name, t) in &rows {
-		println!("{:<32} {:<20}", name, status_label(t));
+		let status = crate::ui::status_cell(&status_label(t), 20);
+		println!("{name:<32} {status}");
 	}
 	Ok(())
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -55,9 +55,9 @@ impl Engine {
 						"Processes": result.processes,
 					})),
 					Ok(result) => {
-						println!("{container_name}");
+						crate::ui::print_bold_header(&container_name);
 						if let Some(titles) = &result.titles {
-							println!("{}", titles.join("\t"));
+							crate::ui::print_bold_header(&titles.join("\t"));
 						}
 						if let Some(processes) = &result.processes {
 							for row in processes {
@@ -194,16 +194,10 @@ impl Engine {
 			return Ok(());
 		}
 
-		let hdr = crate::ui::bold();
-		anstream::println!(
-			"{}{:<30} {:<25} {:<15} {:<20}{}",
-			hdr.render(),
-			"SERVICE",
-			"REPOSITORY",
-			"TAG",
-			"IMAGE ID",
-			hdr.render_reset()
-		);
+		crate::ui::print_bold_header(&format!(
+			"{:<30} {:<25} {:<15} {:<20}",
+			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
+		));
 		for (svc, repo, tag, id) in &rows {
 			println!("{svc:<30} {repo:<25} {tag:<15} {id:<20}");
 		}

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -194,9 +194,15 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!(
-			"{:<30} {:<25} {:<15} {:<20}",
-			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
+		let hdr = crate::ui::bold();
+		anstream::println!(
+			"{}{:<30} {:<25} {:<15} {:<20}{}",
+			hdr.render(),
+			"SERVICE",
+			"REPOSITORY",
+			"TAG",
+			"IMAGE ID",
+			hdr.render_reset()
 		);
 		for (svc, repo, tag, id) in &rows {
 			println!("{svc:<30} {repo:<25} {tag:<15} {id:<20}");

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -12,8 +12,17 @@ pub(super) struct LinePrefixer {
 
 impl LinePrefixer {
 	pub(super) fn new(label: &str) -> Self {
+		// Colour the whole prefix with the service's stable colour so aggregated
+		// multi-service output is easy to scan. Gated on stdout being a colour sink
+		// (a raw write anstream does not strip for us).
+		let plain = format!("{label}  | ");
+		let label = crate::ui::paint(
+			crate::ui::service_style(label),
+			&plain,
+			crate::ui::stdout_colored(),
+		);
 		Self {
-			label: format!("{label}  | "),
+			label,
 			pending: Vec::new(),
 		}
 	}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -181,10 +181,10 @@ impl Engine {
 			return Ok(());
 		}
 
-		let hdr = crate::ui::bold();
-		let cols = format!("{:<40} {:<30} {:<20} PORTS", "NAME", "IMAGE", "STATUS");
-		let (on, off) = (hdr.render(), hdr.render_reset());
-		let _ = writeln!(anstream::stdout(), "{on}{cols}{off}");
+		crate::ui::print_bold_header(&format!(
+			"{:<40} {:<30} {:<20} PORTS",
+			"NAME", "IMAGE", "STATUS"
+		));
 		for c in &containers {
 			let ports = format_ports(&c.ports);
 			let status = crate::ui::status_cell(display_status(c), 20);

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -187,12 +187,8 @@ impl Engine {
 		let _ = writeln!(anstream::stdout(), "{on}{cols}{off}");
 		for c in &containers {
 			let ports = format_ports(&c.ports);
-			println!(
-				"{:<40} {:<30} {:<20} {ports}",
-				name_of(c),
-				c.image,
-				display_status(c)
-			);
+			let status = crate::ui::status_cell(display_status(c), 20);
+			println!("{:<40} {:<30} {status} {ports}", name_of(c), c.image);
 		}
 
 		Ok(())

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -181,7 +181,10 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!("{:<40} {:<30} {:<20} PORTS", "NAME", "IMAGE", "STATUS");
+		let hdr = crate::ui::bold();
+		let cols = format!("{:<40} {:<30} {:<20} PORTS", "NAME", "IMAGE", "STATUS");
+		let (on, off) = (hdr.render(), hdr.render_reset());
+		let _ = writeln!(anstream::stdout(), "{on}{cols}{off}");
 		for c in &containers {
 			let ports = format_ports(&c.ports);
 			println!(

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -199,7 +199,7 @@ fn print_frame(report: &StatsReport, wanted: &HashSet<String>) {
 		.collect();
 	rows.sort_by(|a, b| a.name.cmp(&b.name));
 
-	println!("{HEADER}");
+	crate::ui::print_bold_header(HEADER);
 	for s in rows {
 		println!("{}", format_row(s));
 	}

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -67,7 +67,7 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!("{:<40} {:<12}", "NAME", "DRIVER");
+		crate::ui::print_bold_header(&format!("{:<40} {:<12}", "NAME", "DRIVER"));
 		for (_, name, driver, _) in &rows {
 			println!("{name:<40} {driver:<12}");
 		}

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -29,6 +29,8 @@ pub mod quadlet;
 pub mod size;
 /// Docker Compose `${VAR}`/`$VAR` substitution over raw YAML before parsing.
 pub mod substitute;
+/// Terminal colour/styling, honouring `--ansi`, `NO_COLOR`, and TTY detection.
+pub mod ui;
 /// Secure self-update for the `podup` binary (signature-verified release fetch).
 #[cfg(feature = "update")]
 pub mod update;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -53,14 +53,28 @@ fn run_to_exit() {
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
 		#[cfg(feature = "update")]
 		Err(e @ podup::ComposeError::Update(_)) => {
-			eprintln!("podup: error: {e}");
+			print_error(&e);
 			process::exit(podup::update::exit_code(&e));
 		}
 		Err(e) => {
-			eprintln!("podup: error: {e}");
+			print_error(&e);
 			process::exit(1);
 		}
 	}
+}
+
+/// Print a top-level error to stderr with a colour-aware bold-red `error:` label.
+/// anstream strips the styling when stderr is not a terminal or colour is off.
+fn print_error(e: &podup::ComposeError) {
+	use std::io::Write;
+	let style = podup::ui::error_style();
+	let mut err = anstream::stderr();
+	let _ = writeln!(
+		err,
+		"podup: {}error:{} {e}",
+		style.render(),
+		style.render_reset()
+	);
 }
 
 /// Orchestrate one CLI invocation: parse args, then short-circuit the commands
@@ -71,6 +85,9 @@ fn run_to_exit() {
 /// remaining commands.
 async fn run() -> podup::Result<()> {
 	let cli = parse_cli();
+	// Resolve the colour choice before any output (including tracing setup below)
+	// so `--ansi`/`NO_COLOR`/TTY detection apply consistently everywhere.
+	podup::ui::set_color_choice(cli.ansi.into());
 	// `watch` is an interactive, long-running command; surface its per-action
 	// progress (synced/rebuilt/restarted) by defaulting to INFO instead of the
 	// quiet WARN floor. `RUST_LOG` always overrides.

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -53,7 +53,13 @@ where
 		mut writer: Writer<'_>,
 		event: &Event<'_>,
 	) -> std::fmt::Result {
-		write!(writer, "podup: {}: ", level_word(*event.metadata().level()))?;
+		let level = *event.metadata().level();
+		let label = podup::ui::paint(
+			level_style(level),
+			level_word(level),
+			podup::ui::stderr_colored(),
+		);
+		write!(writer, "podup: {label}: ")?;
 		ctx.field_format().format_fields(writer.by_ref(), event)?;
 		writeln!(writer)
 	}
@@ -67,6 +73,18 @@ fn level_word(level: tracing::Level) -> &'static str {
 		tracing::Level::INFO => "info",
 		tracing::Level::DEBUG => "debug",
 		tracing::Level::TRACE => "trace",
+	}
+}
+
+/// The colour for a level's word: bold red (error), bold yellow (warning), green
+/// (info), dim (debug/trace).
+fn level_style(level: tracing::Level) -> anstyle::Style {
+	use anstyle::{AnsiColor, Style};
+	match level {
+		tracing::Level::ERROR => Style::new().bold().fg_color(Some(AnsiColor::Red.into())),
+		tracing::Level::WARN => Style::new().bold().fg_color(Some(AnsiColor::Yellow.into())),
+		tracing::Level::INFO => Style::new().fg_color(Some(AnsiColor::Green.into())),
+		_ => Style::new().dimmed(),
 	}
 }
 
@@ -291,6 +309,19 @@ mod tests {
 		assert_eq!(level_word(tracing::Level::INFO), "info");
 		assert_eq!(level_word(tracing::Level::DEBUG), "debug");
 		assert_eq!(level_word(tracing::Level::TRACE), "trace");
+		// Each severity gets a distinct style; debug/trace share the dim style.
+		assert_ne!(
+			level_style(tracing::Level::ERROR),
+			level_style(tracing::Level::INFO)
+		);
+		assert_ne!(
+			level_style(tracing::Level::WARN),
+			level_style(tracing::Level::ERROR)
+		);
+		assert_eq!(
+			level_style(tracing::Level::DEBUG),
+			level_style(tracing::Level::TRACE)
+		);
 	}
 
 	fn sample_file() -> podup::compose::types::ComposeFile {

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -264,7 +264,16 @@ pub(crate) fn parse_cli() -> Cli {
 			clap::error::ErrorKind::DisplayHelp
 			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
 			| clap::error::ErrorKind::DisplayVersion => {
-				print!("\n{e}\n");
+				// `--help`/`--version` are handled by clap before `--ansi` is parsed,
+				// so colour the rendered text by clap's own styling only when stdout
+				// is a colour sink (TTY + no NO_COLOR); piped output stays plain and
+				// byte-identical to before.
+				let rendered = e.render();
+				if podup::ui::stdout_colored() {
+					print!("\n{}\n", rendered.ansi());
+				} else {
+					print!("\n{rendered}\n");
+				}
 				process::exit(0);
 			}
 			_ => e.exit(),

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -1,0 +1,155 @@
+//! Terminal styling — the single place that decides whether to colour output and
+//! holds the palette, so colour stays consistent and always honours `--ansi`,
+//! `NO_COLOR`, and whether the target stream is a TTY.
+//!
+//! Two kinds of sink exist in podup:
+//! - Sinks written through [`anstream`] (e.g. [`anstream::stdout`]) strip the
+//!   ANSI codes themselves when colour is off, so callers may always emit codes.
+//! - Raw sinks (the tracing writer, the log-prefixer's borrowed stdout) do not
+//!   strip, so those callers gate on `stdout_colored`/`stderr_colored`.
+//!
+//! `set_color_choice` also constructs the auto streams once so anstream enables
+//! virtual-terminal processing on Windows for the rest of the process.
+
+use std::io::IsTerminal;
+
+use anstyle::{AnsiColor, Style};
+
+pub use anstream::ColorChoice;
+
+/// Apply the resolved colour choice process-wide and enable Windows VT once.
+///
+/// anstream's `stdout()`/`stderr()` then honour this choice together with
+/// `NO_COLOR`/`CLICOLOR` and TTY detection.
+pub fn set_color_choice(choice: ColorChoice) {
+	choice.write_global();
+	// Constructing the auto streams enables virtual-terminal processing on
+	// Windows so raw-sink callers can emit ANSI safely; a no-op elsewhere.
+	let _ = anstream::AutoStream::auto(std::io::stdout());
+	let _ = anstream::AutoStream::auto(std::io::stderr());
+}
+
+/// `NO_COLOR` is set to a non-empty value (the no-color.org convention).
+fn no_color() -> bool {
+	std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
+}
+
+/// Whether a stream that is (or isn't) a TTY should be coloured under the global
+/// choice. `Auto` defers to the TTY and `NO_COLOR`.
+fn colored(is_terminal: bool) -> bool {
+	match ColorChoice::global() {
+		ColorChoice::Always | ColorChoice::AlwaysAnsi => true,
+		ColorChoice::Never => false,
+		ColorChoice::Auto => is_terminal && !no_color(),
+	}
+}
+
+/// Whether a raw (non-anstream) write to stdout should embed ANSI codes.
+pub fn stdout_colored() -> bool {
+	colored(std::io::stdout().is_terminal())
+}
+
+/// Whether a raw (non-anstream) write to stderr should embed ANSI codes.
+pub fn stderr_colored() -> bool {
+	colored(std::io::stderr().is_terminal())
+}
+
+/// Bold — table headers and emphasis.
+pub fn bold() -> Style {
+	Style::new().bold()
+}
+
+/// Bold red — the `error:` label.
+pub fn error_style() -> Style {
+	Style::new().bold().fg_color(Some(AnsiColor::Red.into()))
+}
+
+/// Bold yellow — the `warning:` label.
+pub fn warn_style() -> Style {
+	Style::new().bold().fg_color(Some(AnsiColor::Yellow.into()))
+}
+
+/// Wrap `text` in `style` when `enabled`, else return it unchanged. For raw sinks
+/// that do not strip; anstream sinks should pass the codes through directly.
+pub fn paint(style: Style, text: &str, enabled: bool) -> String {
+	if enabled {
+		format!("{}{text}{}", style.render(), style.render_reset())
+	} else {
+		text.to_string()
+	}
+}
+
+/// The distinct colours cycled through for per-service log prefixes.
+const SERVICE_PALETTE: [AnsiColor; 6] = [
+	AnsiColor::Cyan,
+	AnsiColor::Green,
+	AnsiColor::Yellow,
+	AnsiColor::Magenta,
+	AnsiColor::Blue,
+	AnsiColor::BrightRed,
+];
+
+/// Stable palette index for a service name — the same name always maps to the
+/// same colour (FNV-1a over the bytes, modulo the palette size).
+fn palette_index(name: &str) -> usize {
+	let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+	for b in name.bytes() {
+		h ^= u64::from(b);
+		h = h.wrapping_mul(0x0100_0000_01b3);
+	}
+	(h % SERVICE_PALETTE.len() as u64) as usize
+}
+
+/// The stable colour for a service's aggregated-log prefix.
+pub fn service_style(name: &str) -> Style {
+	Style::new().fg_color(Some(SERVICE_PALETTE[palette_index(name)].into()))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn service_colour_is_stable_per_name() {
+		// Same name → same index every call; different names spread across the
+		// palette (not all collapsed to one colour).
+		assert_eq!(palette_index("web"), palette_index("web"));
+		let distinct: std::collections::HashSet<usize> =
+			["web", "db", "cache", "worker", "proxy", "queue"]
+				.iter()
+				.map(|n| palette_index(n))
+				.collect();
+		assert!(distinct.len() > 1, "palette should spread service names");
+		assert!(palette_index("web") < SERVICE_PALETTE.len());
+	}
+
+	#[test]
+	fn paint_gates_on_enabled() {
+		let plain = paint(bold(), "hi", false);
+		assert_eq!(plain, "hi");
+		let coloured = paint(bold(), "hi", true);
+		assert!(coloured.contains("hi"));
+		assert!(coloured.len() > "hi".len(), "enabled paint adds ANSI codes");
+		assert!(coloured.starts_with('\u{1b}'), "starts with an ESC");
+	}
+
+	#[test]
+	fn no_color_env_disables_auto() {
+		// `colored` honours NO_COLOR in Auto regardless of the TTY argument.
+		temp_env::with_var("NO_COLOR", Some("1"), || {
+			ColorChoice::Auto.write_global();
+			assert!(!colored(true));
+		});
+		temp_env::with_var_unset("NO_COLOR", || {
+			ColorChoice::Never.write_global();
+			assert!(!colored(true));
+			ColorChoice::Always.write_global();
+			assert!(colored(false));
+			ColorChoice::Auto.write_global();
+			assert!(colored(true));
+			assert!(!colored(false));
+		});
+		// Restore the default for other tests sharing the process-global choice.
+		ColorChoice::Auto.write_global();
+	}
+}

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -66,14 +66,23 @@ pub fn bold() -> Style {
 	Style::new().bold()
 }
 
+/// Print `cols` as a bold table header through an anstream sink, so the styling
+/// is stripped automatically when colour is off. The single place every list
+/// command renders its header, keeping them consistent.
+pub fn print_bold_header(cols: &str) {
+	use std::io::Write;
+	let s = bold();
+	let _ = writeln!(
+		anstream::stdout(),
+		"{}{cols}{}",
+		s.render(),
+		s.render_reset()
+	);
+}
+
 /// Bold red — the `error:` label.
 pub fn error_style() -> Style {
 	Style::new().bold().fg_color(Some(AnsiColor::Red.into()))
-}
-
-/// Bold yellow — the `warning:` label.
-pub fn warn_style() -> Style {
-	Style::new().bold().fg_color(Some(AnsiColor::Yellow.into()))
 }
 
 /// Wrap `text` in `style` when `enabled`, else return it unchanged. For raw sinks

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -34,14 +34,21 @@ fn no_color() -> bool {
 	std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
 }
 
-/// Whether a stream that is (or isn't) a TTY should be coloured under the global
-/// choice. `Auto` defers to the TTY and `NO_COLOR`.
-fn colored(is_terminal: bool) -> bool {
-	match ColorChoice::global() {
+/// Whether a stream that is (or isn't) a TTY should be coloured under `choice`.
+/// `Auto` defers to the TTY and `NO_COLOR`. Pure (takes the choice as an argument)
+/// so the policy is tested without mutating the process-global choice.
+fn colored_with(choice: ColorChoice, is_terminal: bool) -> bool {
+	match choice {
 		ColorChoice::Always | ColorChoice::AlwaysAnsi => true,
 		ColorChoice::Never => false,
 		ColorChoice::Auto => is_terminal && !no_color(),
 	}
+}
+
+/// Whether a stream that is (or isn't) a TTY should be coloured under the global
+/// choice.
+fn colored(is_terminal: bool) -> bool {
+	colored_with(ColorChoice::global(), is_terminal)
 }
 
 /// Whether a raw (non-anstream) write to stdout should embed ANSI codes.
@@ -79,14 +86,16 @@ pub fn paint(style: Style, text: &str, enabled: bool) -> String {
 	}
 }
 
-/// The distinct colours cycled through for per-service log prefixes.
+/// Identity colours cycled through for per-service log prefixes. Deliberately
+/// excludes red/green/yellow, which are reserved for status/severity meaning, so
+/// a service prefix is never mistaken for an error/ok/warning signal.
 const SERVICE_PALETTE: [AnsiColor; 6] = [
 	AnsiColor::Cyan,
-	AnsiColor::Green,
-	AnsiColor::Yellow,
 	AnsiColor::Magenta,
 	AnsiColor::Blue,
-	AnsiColor::BrightRed,
+	AnsiColor::BrightCyan,
+	AnsiColor::BrightMagenta,
+	AnsiColor::BrightBlue,
 ];
 
 /// Stable palette index for a service name — the same name always maps to the
@@ -103,6 +112,38 @@ fn palette_index(name: &str) -> usize {
 /// The stable colour for a service's aggregated-log prefix.
 pub fn service_style(name: &str) -> Style {
 	Style::new().fg_color(Some(SERVICE_PALETTE[palette_index(name)].into()))
+}
+
+/// The semantic colour for a container status word, or `None` for an unknown one
+/// (left uncoloured). Green = up/healthy, red = exited/dead/unhealthy, yellow =
+/// paused/(re)starting, dim = created. Matches on substrings so it handles both
+/// the bare state (`running`) and Podman's verbose `Status` (`Up 2 minutes`,
+/// `Exited (1)`).
+fn status_style(status: &str) -> Option<Style> {
+	let s = status.to_ascii_lowercase();
+	let colour = if s.contains("unhealthy") || s.contains("exit") || s.contains("dead") {
+		AnsiColor::Red
+	} else if s.contains("running") || s.contains("healthy") || s.starts_with("up") {
+		AnsiColor::Green
+	} else if s.contains("paus") || s.contains("restart") || s.contains("starting") {
+		AnsiColor::Yellow
+	} else if s.contains("created") {
+		return Some(Style::new().dimmed());
+	} else {
+		return None;
+	};
+	Some(Style::new().fg_color(Some(colour.into())))
+}
+
+/// Render a container `status` left-padded to `width`, colourised by its meaning
+/// when stdout is a colour sink. The padding is applied first so the colour codes
+/// (zero display width) never disturb column alignment.
+pub fn status_cell(status: &str, width: usize) -> String {
+	let padded = format!("{status:<width$}");
+	match status_style(status) {
+		Some(style) => paint(style, &padded, stdout_colored()),
+		None => padded,
+	}
 }
 
 #[cfg(test)]
@@ -134,22 +175,38 @@ mod tests {
 	}
 
 	#[test]
-	fn no_color_env_disables_auto() {
-		// `colored` honours NO_COLOR in Auto regardless of the TTY argument.
-		temp_env::with_var("NO_COLOR", Some("1"), || {
-			ColorChoice::Auto.write_global();
-			assert!(!colored(true));
-		});
+	fn colour_choice_resolution() {
+		// Pure resolution — never touches the process-global choice, so it can't
+		// race the production code (LinePrefixer/status_cell) that reads it.
 		temp_env::with_var_unset("NO_COLOR", || {
-			ColorChoice::Never.write_global();
-			assert!(!colored(true));
-			ColorChoice::Always.write_global();
-			assert!(colored(false));
-			ColorChoice::Auto.write_global();
-			assert!(colored(true));
-			assert!(!colored(false));
+			assert!(!colored_with(ColorChoice::Never, true));
+			assert!(colored_with(ColorChoice::Always, false));
+			assert!(colored_with(ColorChoice::Auto, true));
+			assert!(!colored_with(ColorChoice::Auto, false));
 		});
-		// Restore the default for other tests sharing the process-global choice.
-		ColorChoice::Auto.write_global();
+		// NO_COLOR forces plain in Auto, regardless of the TTY.
+		temp_env::with_var("NO_COLOR", Some("1"), || {
+			assert!(!colored_with(ColorChoice::Auto, true));
+			// ...but an explicit `always` still overrides NO_COLOR.
+			assert!(colored_with(ColorChoice::Always, true));
+		});
+	}
+
+	#[test]
+	fn status_style_is_semantic() {
+		assert_ne!(status_style("running"), status_style("exited (1)"));
+		assert_ne!(status_style("unhealthy"), status_style("healthy"));
+		assert!(status_style("Up 2 minutes").is_some());
+		assert!(status_style("paused").is_some());
+		assert!(status_style("created").is_some());
+		assert!(status_style("weird-state").is_none());
+	}
+
+	#[test]
+	fn status_cell_pads_and_keeps_status() {
+		let cell = status_cell("ok", 6);
+		assert!(cell.contains("ok"));
+		// At least the requested width (colour codes, if any, only add length).
+		assert!(cell.len() >= 6);
 	}
 }


### PR DESCRIPTION
## What
podup's human-facing output was plain. Add colour (and bold) so states are easy to scan, with a strict contract: default-on for a TTY, off everywhere else, always disableable.

## Change
A central `ui` module (anstyle + anstream) resolves one process-wide colour choice and a stable per-service palette:
- **Default on a TTY**, auto-stripped when piped/redirected/non-TTY.
- `--ansi auto|always|never` (docker-compose flag) + `NO_COLOR` honoured. Explicit `--ansi always` overrides `NO_COLOR` (the usual `--color=always` convention).
- **Machine output stays plain**: `--json`, `-q`, and `config` are never coloured.
- Decoration only — text reads identically without colour.

Wired surfaces: tracing level word (red error / yellow warning / green info / dim debug), the top-level `error:` label, the aggregated log prefix in a stable per-service colour, and bold `ps`/`images` headers. anstream degrades gracefully on Linux, macOS and Windows (enabling VT there); one implementation, no per-platform code.

## Not in this change (follow-up)
Semantic green/red status in `ps` rows, the `volumes` header, and progress/spinner output (the backlog items in #696).

## Tests
`ui`: per-service colour stability + spread, `paint` gating, and `NO_COLOR`/`--ansi` resolution; `level_style` severity mapping. Smoke-verified: piped output plain, `--ansi always` forces codes, `NO_COLOR` plain in auto, bold header.

Closes #703