### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.5.2"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (1.6.0) unstable; urgency=medium
+
+  * Output is now colourised on a terminal and degrades gracefully: a semantic
+    status colour in `ps`/`ls` (green running, red exited, yellow paused), a
+    stable per-service colour in aggregated logs, bold table and help headers,
+    and red error labels. Control it with `--ansi auto|always|never` or
+    `NO_COLOR`; piped or redirected output stays plain.
+  * `up`/`start --wait` now fails when a service exits before becoming ready
+    instead of reporting success, so a crashed startup no longer passes silently
+    in CI.
+  * `--env-file` now replaces the default `.env` and the last file wins, matching
+    docker compose (previously `.env` and the first file wrongly took precedence).
+  * `config` honours `--profile`/`COMPOSE_PROFILES`, printing the same services
+    `up` would start.
+  * `cp` of a directory from a container to a destination that does not yet exist
+    now creates it and copies the contents in, matching `docker cp`.
+  * `scale`/`deploy.replicas` are capped (default 256, override with
+    `PODUP_MAX_REPLICAS`) so an untrusted compose file cannot drive unbounded
+    container creation.
+  * A Podman socket that accepts a connection but never replies no longer hangs
+    podup — the wait for the response head is now bounded.
+  * Smaller polish: a `PORTS` header in `ps`; `port` accepts the `PORT/proto` form
+    and a `--protocol` alias; a plain hint for podman state-conflict errors; an
+    orphan-containers warning on `up` when `--remove-orphans` is absent; and a
+    warning when a `--build-arg` name looks like a secret.
+
+ -- Glyndor <packages@glyndor.net>  Sun, 28 Jun 2026 10:17:11 -0500
+
 podup (1.5.2) unstable; urgency=medium
 
   * Documentation and CI only — no functional change to the binary. The README is


### PR DESCRIPTION
Version bump + changelog for 1.6.0: the 11 fixes/hardening items and the colour-output feature from the 1.5.2 end-to-end test sweep (epic #696).

Notable behaviour changes (called out in the release notes): `up`/`start --wait` now fails when a service exits during the wait, and `--env-file` now replaces `.env` with last-file-wins — both aligning to docker compose.

After this lands on develop I'll open the release PR develop → main and tag v1.6.0.