### PR TITLE
release: 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -94,6 +138,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
 ]
@@ -124,6 +169,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -476,6 +527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +716,8 @@ dependencies = [
 name = "podup"
 version = "1.5.2"
 dependencies = [
+ "anstream",
+ "anstyle",
  "base64",
  "bytes",
  "clap",
@@ -1168,6 +1233,12 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,12 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
-clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "derive", "env"] }
+clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "derive", "env", "color"] }
 clap_complete = { version = "4", optional = true }
+# Terminal colour: anstyle for the styles, anstream to degrade gracefully
+# (auto-strip on non-TTY, honour NO_COLOR/--ansi, enable VT on Windows).
+anstyle = "1"
+anstream = "1"
 indexmap = { version = "2", features = ["serde"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tar = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.5.2"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (1.6.0) unstable; urgency=medium
+
+  * Output is now colourised on a terminal and degrades gracefully: a semantic
+    status colour in `ps`/`ls` (green running, red exited, yellow paused), a
+    stable per-service colour in aggregated logs, bold table and help headers,
+    and red error labels. Control it with `--ansi auto|always|never` or
+    `NO_COLOR`; piped or redirected output stays plain.
+  * `up`/`start --wait` now fails when a service exits before becoming ready
+    instead of reporting success, so a crashed startup no longer passes silently
+    in CI.
+  * `--env-file` now replaces the default `.env` and the last file wins, matching
+    docker compose (previously `.env` and the first file wrongly took precedence).
+  * `config` honours `--profile`/`COMPOSE_PROFILES`, printing the same services
+    `up` would start.
+  * `cp` of a directory from a container to a destination that does not yet exist
+    now creates it and copies the contents in, matching `docker cp`.
+  * `scale`/`deploy.replicas` are capped (default 256, override with
+    `PODUP_MAX_REPLICAS`) so an untrusted compose file cannot drive unbounded
+    container creation.
+  * A Podman socket that accepts a connection but never replies no longer hangs
+    podup — the wait for the response head is now bounded.
+  * Smaller polish: a `PORTS` header in `ps`; `port` accepts the `PORT/proto` form
+    and a `--protocol` alias; a plain hint for podman state-conflict errors; an
+    orphan-containers warning on `up` when `--remove-orphans` is absent; and a
+    warning when a `--build-arg` name looks like a secret.
+
+ -- Glyndor <packages@glyndor.net>  Sun, 28 Jun 2026 10:17:11 -0500
+
 podup (1.5.2) unstable; urgency=medium
 
   * Documentation and CI only — no functional change to the binary. The README is

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -353,10 +353,10 @@ pub(crate) enum Commands {
 	Port {
 		/// Service name.
 		service: String,
-		/// Private port number.
-		private_port: u16,
+		/// Private port, e.g. `80` or `80/tcp` (a `/proto` suffix overrides --protocol).
+		private_port: String,
 		/// Protocol (tcp or udp).
-		#[arg(long, default_value = "tcp")]
+		#[arg(long, visible_alias = "protocol", default_value = "tcp")]
 		proto: String,
 		/// Index of the container when the service has multiple replicas (1-based).
 		#[arg(long)]

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -8,11 +8,20 @@ mod commands;
 mod parse;
 mod types;
 pub(crate) use commands::Commands;
-pub(crate) use types::{ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
+pub(crate) use types::{AnsiMode, ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
+
+/// Help-screen colours (clap honours its own TTY/`NO_COLOR`/`CLICOLOR` detection
+/// for these, since help is rendered before `--ansi` is parsed): green-bold
+/// section headers and usage, cyan-bold flag/command literals, plain placeholders.
+const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
+	.header(clap::builder::styling::AnsiColor::Green.on_default().bold())
+	.usage(clap::builder::styling::AnsiColor::Green.on_default().bold())
+	.literal(clap::builder::styling::AnsiColor::Cyan.on_default().bold())
+	.placeholder(clap::builder::styling::AnsiColor::Cyan.on_default());
 
 /// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
 #[derive(Parser)]
-#[command(name = "podup", version)]
+#[command(name = "podup", version, styles = HELP_STYLES)]
 pub(crate) struct Cli {
 	/// Path to the compose file (or `COMPOSE_FILE`). Unset: probe the
 	/// compose-spec precedence list (compose.yaml/.yml, docker-compose.yaml/.yml).
@@ -46,6 +55,11 @@ pub(crate) struct Cli {
 	/// Extra env file(s) for interpolation (repeatable, later win; process env and `.env` still win).
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
+
+	/// When to colourise output: auto (TTY only), always, or never. `NO_COLOR`
+	/// also forces plain output.
+	#[arg(long, value_enum, default_value_t = AnsiMode::Auto, global = true)]
+	pub(crate) ansi: AnsiMode,
 
 	#[command(subcommand)]
 	pub(crate) command: Commands,

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -12,6 +12,28 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// When to colourise human-facing output (`--ansi`, like docker compose).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum AnsiMode {
+	/// Colour only when writing to a terminal (and `NO_COLOR` is unset).
+	#[default]
+	Auto,
+	/// Always colour, even when piped or redirected.
+	Always,
+	/// Never colour.
+	Never,
+}
+
+impl From<AnsiMode> for anstream::ColorChoice {
+	fn from(m: AnsiMode) -> Self {
+		match m {
+			AnsiMode::Auto => Self::Auto,
+			AnsiMode::Always => Self::Always,
+			AnsiMode::Never => Self::Never,
+		}
+	}
+}
+
 /// Which images `down --rmi` removes.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub(crate) enum RmiScope {

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -107,11 +107,7 @@ pub(crate) async fn dispatch(
 				match wait_timeout {
 					Some(secs) => tokio::time::timeout(std::time::Duration::from_secs(secs), fut)
 						.await
-						.map_err(|_| {
-							podup::ComposeError::Unsupported(
-								"start --wait timed out before services became healthy".into(),
-							)
-						})??,
+						.map_err(|_| podup::ComposeError::WaitTimeout { secs })??,
 					None => fut.await?,
 				}
 			}
@@ -298,7 +294,7 @@ pub(crate) async fn dispatch(
 			index,
 		} => {
 			engine
-				.port_with_index(file, &service, private_port, &proto, index)
+				.port_with_index(file, &service, &private_port, &proto, index)
 				.await?
 		}
 		Commands::Volumes {

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -38,6 +38,8 @@ pub(crate) async fn dispatch(
 		} => {
 			if remove_orphans {
 				engine.remove_orphans(file).await?;
+			} else {
+				engine.warn_orphans(file).await?;
 			}
 			if build {
 				engine.build_all(file, &services).await?;

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -172,6 +172,23 @@ impl Engine {
 			build_args.insert(k, v);
 		}
 
+		// A secret passed as a build arg is recorded in the image history and, if
+		// promoted via `ENV`, the image config — so it can leak. Warn and point at
+		// `build.secrets` (BuildKit `--mount=type=secret`), which does not persist.
+		let mut secretish: Vec<&str> = build_args
+			.keys()
+			.filter(|k| looks_like_secret(k))
+			.map(String::as_str)
+			.collect();
+		if !secretish.is_empty() {
+			secretish.sort_unstable();
+			warn!(
+				"build-arg(s) [{}] look like secrets; build args are stored in the image history \
+				 and can leak. Use build.secrets for sensitive values.",
+				secretish.join(", ")
+			);
+		}
+
 		let mut labels: std::collections::HashMap<String, String> =
 			std::collections::HashMap::new();
 		if let BuildConfig::Config { labels: l, .. } = build {
@@ -409,9 +426,27 @@ fn primary_build_tag(service_name: &str, image: Option<&str>, tags: &[String]) -
 	format!("{service_name}:latest")
 }
 
+/// True if a build-arg name looks like it carries a secret, so the caller can
+/// warn that build args persist in the image history. Case-insensitive substring
+/// match on common secret tokens, kept conservative to avoid false positives
+/// (e.g. a bare `KEY` is not flagged; `API_KEY`/`PRIVATE_KEY` are).
+fn looks_like_secret(name: &str) -> bool {
+	const MARKERS: [&str; 7] = [
+		"SECRET",
+		"PASSWORD",
+		"PASSWD",
+		"TOKEN",
+		"CREDENTIAL",
+		"API_KEY",
+		"PRIVATE_KEY",
+	];
+	let upper = name.to_ascii_uppercase();
+	MARKERS.iter().any(|m| upper.contains(m))
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, primary_build_tag, Engine};
+	use super::{is_remote_context, looks_like_secret, primary_build_tag, Engine};
 	use crate::libpod::Client;
 
 	fn engine(base: std::path::PathBuf) -> Engine {
@@ -420,6 +455,22 @@ mod tests {
 
 	fn build_of(file: &crate::compose::types::ComposeFile) -> &crate::compose::types::BuildConfig {
 		file.services["app"].build.as_ref().unwrap()
+	}
+
+	#[test]
+	fn looks_like_secret_flags_sensitive_names_only() {
+		for name in [
+			"DB_PASSWORD",
+			"api_token",
+			"MySecret",
+			"AWS_API_KEY",
+			"private_key",
+		] {
+			assert!(looks_like_secret(name), "{name} should be flagged");
+		}
+		for name in ["VERSION", "BUILD_DATE", "PUBLIC_KEY", "PORT", "RUST_LOG"] {
+			assert!(!looks_like_secret(name), "{name} should not be flagged");
+		}
 	}
 
 	#[test]

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -232,17 +232,73 @@ fn pack_path(src: &Path, follow_link: bool, name_override: Option<&str>) -> Resu
 
 /// Route a container archive to the host destination.
 ///
-/// docker/podman `cp` semantics: when `dst` is an existing directory the archive
-/// is extracted into it; otherwise `dst` names the target file and the archive
-/// must contain a single regular file, whose **content** is written to exactly
-/// `dst` — the daemon-supplied entry name is ignored. This matters for security:
-/// a hostile image must not be able to choose the on-host filename (e.g. drop a
-/// `.bashrc`/`authorized_keys` into the destination directory).
+/// docker/podman `cp` semantics for a container→host extraction:
+/// - `dst` is an existing directory: the archive is extracted into it (a source
+///   directory lands under its own name).
+/// - `dst` does not exist and the source is a single regular file: its
+///   **content** is written to exactly `dst` — the daemon-supplied entry name is
+///   ignored, so a hostile image cannot choose the on-host filename (e.g. drop a
+///   `.bashrc`/`authorized_keys` into the destination directory).
+/// - `dst` does not exist and the source is a directory: `dst` is created and the
+///   source's *contents* are copied into it (matching `docker cp`).
 fn extract_archive(tar_bytes: &[u8], dst: &Path) -> Result<()> {
 	if dst.is_dir() {
 		return extract_tar_guarded(tar_bytes, dst);
 	}
-	write_single_entry_to(tar_bytes, dst)
+	if !archive_contains_dir(tar_bytes)? {
+		// A single regular file (or, defensively, a name-only archive) is written
+		// to exactly `dst`; `write_single_entry_to` still rejects a multi-entry
+		// archive against a file destination.
+		return write_single_entry_to(tar_bytes, dst);
+	}
+	// Directory source into a non-existent destination: create it and copy the
+	// source's contents in. The libpod archive is tarred under the source's
+	// basename, so extract through the zip-slip guard, then collapse that single
+	// wrapper level to leave the contents directly under `dst`.
+	std::fs::create_dir_all(dst).map_err(ComposeError::Io)?;
+	extract_tar_guarded(tar_bytes, dst)?;
+	flatten_single_wrapper_dir(dst)
+}
+
+/// True if any entry in `tar_bytes` is a directory — the signal that the source
+/// of a container→host copy was a directory (libpod tars it under its basename),
+/// as opposed to a single file.
+fn archive_contains_dir(tar_bytes: &[u8]) -> Result<bool> {
+	let cursor = std::io::Cursor::new(tar_bytes);
+	let mut archive = tar::Archive::new(cursor);
+	for entry in archive.entries().map_err(ComposeError::Io)? {
+		let entry = entry.map_err(ComposeError::Io)?;
+		if entry.header().entry_type() == tar::EntryType::Directory {
+			return Ok(true);
+		}
+	}
+	Ok(false)
+}
+
+/// Lift the contents of a single wrapper directory up into `dst`.
+///
+/// The libpod archive for `cp container:/srcdir` is tarred under the source's
+/// basename (`srcdir/...`). When that lands in a freshly-created `dst`, docker
+/// puts the source's *contents* directly in `dst`, so collapse the lone wrapper
+/// level. A no-op unless `dst` holds exactly one entry and it is a directory.
+fn flatten_single_wrapper_dir(dst: &Path) -> Result<()> {
+	let mut children: Vec<std::path::PathBuf> = std::fs::read_dir(dst)
+		.map_err(ComposeError::Io)?
+		.filter_map(|e| e.ok().map(|e| e.path()))
+		.collect();
+	if children.len() != 1 || !children[0].is_dir() {
+		return Ok(());
+	}
+	let wrapper = children.remove(0);
+	for entry in std::fs::read_dir(&wrapper).map_err(ComposeError::Io)? {
+		let from = entry.map_err(ComposeError::Io)?.path();
+		let name = from
+			.file_name()
+			.ok_or_else(|| ComposeError::Build("cp: archive entry has no name".into()))?;
+		std::fs::rename(&from, dst.join(name)).map_err(ComposeError::Io)?;
+	}
+	std::fs::remove_dir(&wrapper).map_err(ComposeError::Io)?;
+	Ok(())
 }
 
 /// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
@@ -496,6 +552,57 @@ mod tests {
 		assert!(super::extract_archive(&bytes, &dst).is_err());
 	}
 
+	/// Build a directory archive shaped like libpod's `cp container:/srcdir`:
+	/// a wrapper directory entry plus its children, all under the basename.
+	fn tar_dir_with(wrapper: &str, files: &[(&str, &[u8])]) -> Vec<u8> {
+		let mut builder = tar::Builder::new(Vec::new());
+		let mut d = tar::Header::new_gnu();
+		d.set_size(0);
+		d.set_mode(0o755);
+		d.set_entry_type(tar::EntryType::Directory);
+		d.set_path(format!("{wrapper}/")).expect("path");
+		d.set_cksum();
+		builder.append(&d, std::io::empty()).expect("dir");
+		for (name, data) in files {
+			let mut h = tar::Header::new_gnu();
+			h.set_size(data.len() as u64);
+			h.set_mode(0o644);
+			h.set_entry_type(tar::EntryType::Regular);
+			h.set_path(format!("{wrapper}/{name}")).expect("path");
+			h.set_cksum();
+			builder.append(&h, *data).expect("file");
+		}
+		builder.into_inner().expect("finish")
+	}
+
+	#[test]
+	fn extract_dir_into_missing_dest_creates_and_flattens() {
+		// dst does not exist and the source is a directory: dst is created and the
+		// source's *contents* land directly in it (the wrapper level is collapsed),
+		// matching `docker cp`.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("newdir");
+		let bytes = tar_dir_with("srcdir", &[("a.txt", b"aaa"), ("b.txt", b"bbb")]);
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert!(dst.is_dir());
+		assert_eq!(std::fs::read(dst.join("a.txt")).expect("read"), b"aaa");
+		assert_eq!(std::fs::read(dst.join("b.txt")).expect("read"), b"bbb");
+		assert!(
+			!dst.join("srcdir").exists(),
+			"the wrapper directory level must be collapsed"
+		);
+	}
+
+	#[test]
+	fn extract_single_file_into_missing_dest_still_writes_exact_name() {
+		// The single-file path is unchanged: content at exactly `dst`.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("renamed.txt");
+		let bytes = tar_bytes_with("original.txt", b"data");
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert_eq!(std::fs::read(&dst).expect("read"), b"data");
+	}
+
 	#[cfg(unix)]
 	#[test]
 	fn extract_strips_group_other_write_and_special_bits() {
@@ -551,9 +658,10 @@ mod tests {
 	}
 
 	#[test]
-	fn extract_archive_to_file_rejects_non_regular_entry() {
-		// A single directory entry (not a regular file) against a file destination
-		// is rejected — only a directory destination accepts a directory tree.
+	fn extract_archive_dir_source_creates_non_existent_dest() {
+		// A directory source against a non-existent destination creates the
+		// destination directory (matching `docker cp`) rather than erroring,
+		// regardless of the destination's name.
 		let dir = tempfile::tempdir().expect("tempdir");
 		let dst = dir.path().join("out.txt");
 		let mut h = tar::Header::new_gnu();
@@ -565,7 +673,8 @@ mod tests {
 		let mut builder = tar::Builder::new(Vec::new());
 		builder.append(&h, std::io::empty()).expect("append");
 		let bytes = builder.into_inner().expect("finish");
-		assert!(super::extract_archive(&bytes, &dst).is_err());
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert!(dst.is_dir());
 	}
 
 	#[test]

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -31,6 +31,10 @@ enum HealthVerdict {
 	/// The container has no effective healthcheck, so `healthy` is unreachable;
 	/// treat the dependency as satisfied rather than blocking until timeout.
 	NoHealthcheck,
+	/// The container has already exited non-zero. It can never become healthy and
+	/// the service failed to start, so the wait must fail rather than report the
+	/// dependency satisfied. Carries the exit code.
+	Failed(i64),
 	/// Not healthy yet — keep polling.
 	Pending,
 }
@@ -44,6 +48,16 @@ fn classify_health(info: &ContainerInspect) -> HealthVerdict {
 		if let Some(health) = &state.health {
 			if health.status.as_deref() == Some("healthy") {
 				return HealthVerdict::Healthy;
+			}
+		}
+		// A container that has already exited can never become healthy. If it
+		// exited non-zero the service failed to start, so fail the wait instead of
+		// reporting it satisfied (which would mask the failure in `up --wait`/CI).
+		// An exit code of 0 is a one-shot that completed; let it fall through.
+		if state.status.as_deref() == Some("exited") {
+			let code = state.exit_code.unwrap_or(0);
+			if code != 0 {
+				return HealthVerdict::Failed(code);
 			}
 		}
 	}
@@ -140,6 +154,12 @@ impl Engine {
 					"{container_name} has no effective healthcheck; treating service_healthy as satisfied"
 				);
 				return Ok(());
+			}
+			HealthVerdict::Failed(code) => {
+				return Err(ComposeError::WaitServiceExited {
+					container: container_name.to_string(),
+					code,
+				});
 			}
 			HealthVerdict::Pending => {}
 		}
@@ -255,5 +275,23 @@ mod tests {
 			r#"{"State":{"Status":"running","Health":{"Status":"starting"}},"Config":{"Healthcheck":{"Test":["CMD","true"]}}}"#,
 		);
 		assert!(matches!(classify_health(&info), HealthVerdict::Pending));
+	}
+
+	#[test]
+	fn health_exited_nonzero_fails() {
+		// A no-healthcheck service that crashed during the wait must fail, not be
+		// reported satisfied (the `up --wait` masking bug).
+		let info = inspect(r#"{"State":{"Status":"exited","ExitCode":7}}"#);
+		assert!(matches!(classify_health(&info), HealthVerdict::Failed(7)));
+	}
+
+	#[test]
+	fn health_exited_zero_is_satisfied() {
+		// A one-shot that completed cleanly with no healthcheck is still satisfied.
+		let info = inspect(r#"{"State":{"Status":"exited","ExitCode":0}}"#);
+		assert!(matches!(
+			classify_health(&info),
+			HealthVerdict::NoHealthcheck
+		));
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -328,6 +328,9 @@ impl Engine {
 		}
 
 		let replicas = self.resolve_replicas(name, service);
+		// Bound the replica count (covers an untrusted compose `deploy.replicas`/
+		// `scale:` as well as `--scale`) before creating any container.
+		scale::check_replica_limit(name, replicas)?;
 		// A scaled service that publishes a fixed host port cannot start: only
 		// one container can bind it. Fail fast with guidance instead of letting
 		// replicas 2..N die mid-up with `address already in use`.

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -10,6 +10,36 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
+/// The default ceiling on a service's replica count.
+const DEFAULT_MAX_REPLICAS: u32 = 256;
+
+/// The replica ceiling, overridable via the `PODUP_MAX_REPLICAS` environment
+/// variable (a host operator's escape hatch). A missing, unparseable, or zero
+/// override falls back to [`DEFAULT_MAX_REPLICAS`].
+fn max_replicas() -> u32 {
+	std::env::var("PODUP_MAX_REPLICAS")
+		.ok()
+		.and_then(|v| v.parse::<u32>().ok())
+		.filter(|&n| n > 0)
+		.unwrap_or(DEFAULT_MAX_REPLICAS)
+}
+
+/// Reject a replica count beyond the configured ceiling. Guards both the CLI
+/// `scale`/`--scale` path and an untrusted compose `deploy.replicas`/`scale:`
+/// from driving podup into unbounded container creation (a host DoS), since
+/// every command resolves its replica count through this one check.
+pub(super) fn check_replica_limit(service_name: &str, replicas: usize) -> Result<()> {
+	let max = max_replicas();
+	if replicas as u64 > u64::from(max) {
+		return Err(ComposeError::ReplicaLimitExceeded {
+			service: service_name.to_string(),
+			replicas,
+			max,
+		});
+	}
+	Ok(())
+}
+
 /// Reject a scaled service that publishes a fixed host port: only one container
 /// can bind a given host port, so replicas 2..N would fail at runtime with
 /// `address already in use`. A host port of 0/None is runtime-assigned by
@@ -50,8 +80,10 @@ impl Engine {
 				return Err(ComposeError::ServiceNotFound(svc.clone()));
 			}
 		}
-		// Fail fast on a fixed host port before touching any container.
+		// Fail fast on an over-limit count or a fixed host port before touching
+		// any container.
 		for (svc, target) in pairs {
+			check_replica_limit(svc, *target as usize)?;
 			check_scale_port_conflict(svc, &file.services[svc], *target as usize)?;
 		}
 		// Scale up: create only the missing replicas of the named services
@@ -192,7 +224,37 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::check_scale_port_conflict;
+	use super::{check_replica_limit, check_scale_port_conflict, DEFAULT_MAX_REPLICAS};
+
+	#[test]
+	fn replica_limit_default_and_env_override() {
+		// One test owns the shared `PODUP_MAX_REPLICAS` env var for its whole body
+		// so a sibling test running in parallel can never race it.
+		let max = DEFAULT_MAX_REPLICAS as usize;
+
+		// Default ceiling: at-limit allowed, over-limit rejected.
+		std::env::remove_var("PODUP_MAX_REPLICAS");
+		assert!(check_replica_limit("web", 1).is_ok());
+		assert!(check_replica_limit("web", max).is_ok());
+		let err = check_replica_limit("web", max + 1).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ReplicaLimitExceeded { .. }
+		));
+		assert!(check_replica_limit("web", 100_000).is_err());
+
+		// Env override lowers the ceiling.
+		std::env::set_var("PODUP_MAX_REPLICAS", "2");
+		assert!(check_replica_limit("web", 2).is_ok());
+		assert!(check_replica_limit("web", 3).is_err());
+
+		// A zero/garbage override falls back to the default ceiling.
+		std::env::set_var("PODUP_MAX_REPLICAS", "0");
+		assert!(check_replica_limit("web", max).is_ok());
+		std::env::set_var("PODUP_MAX_REPLICAS", "nope");
+		assert!(check_replica_limit("web", max).is_ok());
+		std::env::remove_var("PODUP_MAX_REPLICAS");
+	}
 
 	fn service(yaml: &str) -> crate::compose::types::Service {
 		let file = crate::parse_str(yaml).unwrap();

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -19,6 +19,7 @@ mod lifecycle;
 mod lock;
 mod network;
 mod profiles;
+pub use profiles::retain_active_profiles;
 mod projects;
 pub use projects::{list_projects, LsOptions};
 mod query;

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -2,7 +2,19 @@
 
 use std::collections::HashSet;
 
-use crate::compose::types::Service;
+use crate::compose::types::{ComposeFile, Service};
+
+/// Remove services excluded by the active profile set, in place.
+///
+/// Mirrors what `up` actually starts (a per-service profile match, with no
+/// implicit activation of a profiled `depends_on` target), so `config` presents
+/// the same service set the runtime would bring up. `active` is the CLI
+/// `--profile` list, falling back to `COMPOSE_PROFILES`.
+pub fn retain_active_profiles(file: &mut ComposeFile, active: &[String]) {
+	let set = active_profiles_set(active);
+	file.services
+		.retain(|_, svc| service_in_profiles(svc, &set));
+}
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.
 pub(super) fn active_profiles_set(active: &[String]) -> HashSet<String> {
@@ -105,5 +117,28 @@ mod tests {
 		};
 		let active: HashSet<String> = ["prod".to_string()].into();
 		assert!(service_in_profiles(&svc, &active));
+	}
+
+	#[test]
+	fn retain_active_profiles_keeps_unprofiled_and_active() {
+		let yaml = "services:\n  \
+			web:\n    image: x\n  \
+			debugger:\n    image: x\n    profiles: [debug]\n  \
+			db:\n    image: x\n    profiles: [prod]\n";
+		// With `debug` active: the unprofiled `web` and the `debug` service stay,
+		// the `prod`-only `db` is dropped — exactly what `up --profile debug` runs.
+		let mut file = crate::parse_str(yaml).unwrap();
+		retain_active_profiles(&mut file, &["debug".to_string()]);
+		assert!(file.services.contains_key("web"));
+		assert!(file.services.contains_key("debugger"));
+		assert!(!file.services.contains_key("db"));
+
+		// With no active profiles, every profiled service is dropped.
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert!(file.services.contains_key("web"));
+		assert_eq!(file.services.len(), 1);
 	}
 }

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -88,9 +88,10 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 		return Ok(());
 	}
 
-	println!("{:<32} {:<20}", "NAME", "STATUS");
+	crate::ui::print_bold_header(&format!("{:<32} {:<20}", "NAME", "STATUS"));
 	for (name, t) in &rows {
-		println!("{:<32} {:<20}", name, status_label(t));
+		let status = crate::ui::status_cell(&status_label(t), 20);
+		println!("{name:<32} {status}");
 	}
 	Ok(())
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -85,7 +85,7 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		service_name: &str,
-		private_port: u16,
+		private_port: &str,
 		proto: &str,
 	) -> Result<()> {
 		self.port_with_index(file, service_name, private_port, proto, None)
@@ -98,10 +98,12 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		service_name: &str,
-		private_port: u16,
+		private_port: &str,
 		proto: &str,
 		index: Option<u32>,
 	) -> Result<()> {
+		let (port, proto) = parse_port_proto(private_port, proto)?;
+
 		let service = file
 			.services
 			.get(service_name)
@@ -118,7 +120,7 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 
-		let key = format!("{private_port}/{proto}");
+		let key = format!("{port}/{proto}");
 		let binding = info
 			.network_settings
 			.and_then(|ns| ns.ports.get(&key).cloned().flatten())
@@ -337,5 +339,42 @@ impl Engine {
 		}
 
 		Ok(())
+	}
+}
+
+/// Resolve the `(port, proto)` for `port` from a `PORT` or `PORT/proto` argument,
+/// the `/proto` suffix overriding the `--protocol` flag — matching
+/// `docker compose port`. Pure so the parsing is unit-tested.
+fn parse_port_proto<'a>(private_port: &'a str, proto_flag: &'a str) -> Result<(u16, &'a str)> {
+	let (port, proto) = match private_port.split_once('/') {
+		Some((p, pr)) => (p, pr),
+		None => (private_port, proto_flag),
+	};
+	let port: u16 = port.parse().map_err(|_| {
+		ComposeError::InvalidPort(format!(
+			"port '{private_port}' is not a valid PORT or PORT/proto"
+		))
+	})?;
+	Ok((port, proto))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::parse_port_proto;
+
+	#[test]
+	fn bare_port_uses_flag_proto() {
+		assert_eq!(parse_port_proto("80", "tcp").unwrap(), (80, "tcp"));
+	}
+
+	#[test]
+	fn suffix_overrides_flag_proto() {
+		assert_eq!(parse_port_proto("53/udp", "tcp").unwrap(), (53, "udp"));
+	}
+
+	#[test]
+	fn non_numeric_port_is_rejected() {
+		assert!(parse_port_proto("http", "tcp").is_err());
+		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -55,9 +55,9 @@ impl Engine {
 						"Processes": result.processes,
 					})),
 					Ok(result) => {
-						println!("{container_name}");
+						crate::ui::print_bold_header(&container_name);
 						if let Some(titles) = &result.titles {
-							println!("{}", titles.join("\t"));
+							crate::ui::print_bold_header(&titles.join("\t"));
 						}
 						if let Some(processes) = &result.processes {
 							for row in processes {
@@ -194,10 +194,10 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!(
+		crate::ui::print_bold_header(&format!(
 			"{:<30} {:<25} {:<15} {:<20}",
 			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
-		);
+		));
 		for (svc, repo, tag, id) in &rows {
 			println!("{svc:<30} {repo:<25} {tag:<15} {id:<20}");
 		}

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -12,8 +12,17 @@ pub(super) struct LinePrefixer {
 
 impl LinePrefixer {
 	pub(super) fn new(label: &str) -> Self {
+		// Colour the whole prefix with the service's stable colour so aggregated
+		// multi-service output is easy to scan. Gated on stdout being a colour sink
+		// (a raw write anstream does not strip for us).
+		let plain = format!("{label}  | ");
+		let label = crate::ui::paint(
+			crate::ui::service_style(label),
+			&plain,
+			crate::ui::stdout_colored(),
+		);
 		Self {
-			label: format!("{label}  | "),
+			label,
 			pending: Vec::new(),
 		}
 	}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -181,7 +181,7 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!("{:<40} {:<30} {:<20}", "NAME", "IMAGE", "STATUS");
+		println!("{:<40} {:<30} {:<20} PORTS", "NAME", "IMAGE", "STATUS");
 		for c in &containers {
 			let ports = format_ports(&c.ports);
 			println!(

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -181,15 +181,14 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!("{:<40} {:<30} {:<20} PORTS", "NAME", "IMAGE", "STATUS");
+		crate::ui::print_bold_header(&format!(
+			"{:<40} {:<30} {:<20} PORTS",
+			"NAME", "IMAGE", "STATUS"
+		));
 		for c in &containers {
 			let ports = format_ports(&c.ports);
-			println!(
-				"{:<40} {:<30} {:<20} {ports}",
-				name_of(c),
-				c.image,
-				display_status(c)
-			);
+			let status = crate::ui::status_cell(display_status(c), 20);
+			println!("{:<40} {:<30} {status} {ports}", name_of(c), c.image);
 		}
 
 		Ok(())

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -467,8 +467,9 @@ impl Engine {
 		Ok(())
 	}
 
-	/// Remove containers labelled for this project that are not defined in the current compose file.
-	pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
+	/// Names of this project's containers (by label) that the current compose file
+	/// no longer defines — the orphans, shared by removal and the warning.
+	async fn orphan_container_names(&self, file: &ComposeFile) -> Result<Vec<String>> {
 		let label = format!("podup.project={}", self.project);
 		let filters = serde_json::json!({ "label": [label] });
 		let path = format!(
@@ -488,28 +489,69 @@ impl Engine {
 			.flat_map(|(n, s)| self.replica_names(n, s))
 			.collect();
 
-		for c in running {
-			for raw in &c.names {
-				let name = raw.trim_start_matches('/');
-				if !known.contains(name) {
-					tracing::info!("removing orphan container {name}");
-					let rm_path =
-						format!("{API_PREFIX}/containers/{}?force=true", urlencoded(name));
-					if let Err(e) = self.client.delete_ok(&rm_path).await {
-						tracing::debug!("orphan delete {name}: {e}");
-					}
-				}
+		let names: Vec<String> = running
+			.iter()
+			.flat_map(|c| c.names.iter())
+			.map(|raw| raw.trim_start_matches('/').to_string())
+			.collect();
+		Ok(filter_orphans(names, &known))
+	}
+
+	/// Remove containers labelled for this project that are not defined in the current compose file.
+	pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
+		for name in self.orphan_container_names(file).await? {
+			tracing::info!("removing orphan container {name}");
+			let rm_path = format!("{API_PREFIX}/containers/{}?force=true", urlencoded(&name));
+			if let Err(e) = self.client.delete_ok(&rm_path).await {
+				tracing::debug!("orphan delete {name}: {e}");
 			}
+		}
+		Ok(())
+	}
+
+	/// Warn (without removing) when this project has orphan containers and
+	/// `--remove-orphans` was not given, matching docker compose's `up`.
+	pub async fn warn_orphans(&self, file: &ComposeFile) -> Result<()> {
+		let orphans = self.orphan_container_names(file).await?;
+		if !orphans.is_empty() {
+			eprintln!(
+				"Found orphan container(s) ({}) for this project. If you removed or renamed a \
+				 service in your compose file, run with --remove-orphans to remove them.",
+				orphans.join(", ")
+			);
 		}
 		Ok(())
 	}
 }
 
+/// The subset of `names` not present in `known` (the orphan containers). Pure so
+/// the membership logic is unit-tested without a live Podman socket.
+fn filter_orphans(names: Vec<String>, known: &std::collections::HashSet<String>) -> Vec<String> {
+	names.into_iter().filter(|n| !known.contains(n)).collect()
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{display_status, format_ports, log_query, LogsOptions};
+	use super::{display_status, filter_orphans, format_ports, log_query, LogsOptions};
 	use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
-	use std::collections::HashMap;
+	use std::collections::{HashMap, HashSet};
+
+	#[test]
+	fn filter_orphans_keeps_only_unknown_names() {
+		let known: HashSet<String> = ["web-1".to_string(), "db".to_string()].into();
+		let names = vec![
+			"web-1".to_string(),
+			"db".to_string(),
+			"old-cache".to_string(),
+		];
+		assert_eq!(filter_orphans(names, &known), vec!["old-cache".to_string()]);
+	}
+
+	#[test]
+	fn filter_orphans_empty_when_all_known() {
+		let known: HashSet<String> = ["web".to_string()].into();
+		assert!(filter_orphans(vec!["web".to_string()], &known).is_empty());
+	}
 
 	fn entry(status: &str, state: &str) -> ContainerListEntry {
 		ContainerListEntry {

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -199,7 +199,7 @@ fn print_frame(report: &StatsReport, wanted: &HashSet<String>) {
 		.collect();
 	rows.sort_by(|a, b| a.name.cmp(&b.name));
 
-	println!("{HEADER}");
+	crate::ui::print_bold_header(HEADER);
 	for s in rows {
 		println!("{}", format_row(s));
 	}

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -67,7 +67,7 @@ impl Engine {
 			return Ok(());
 		}
 
-		println!("{:<40} {:<12}", "NAME", "DRIVER");
+		crate::ui::print_bold_header(&format!("{:<40} {:<12}", "NAME", "DRIVER"));
 		for (_, name, driver, _) in &rows {
 			println!("{name:<40} {driver:<12}");
 		}

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -59,6 +59,9 @@ pub enum ComposeError {
 		replicas: usize,
 		ports: Vec<u16>,
 	},
+	/// A container being waited on (`up`/`start --wait`, or a `service_healthy`
+	/// dependency) exited non-zero before becoming ready.
+	WaitServiceExited { container: String, code: i64 },
 }
 
 impl fmt::Display for ComposeError {
@@ -106,6 +109,10 @@ impl fmt::Display for ComposeError {
 					 proxy's port\n  - reduce the service to a single replica"
 				)
 			}
+			Self::WaitServiceExited { container, code } => write!(
+				f,
+				"container '{container}' exited with code {code} while waiting for it to be ready"
+			),
 		}
 	}
 }
@@ -219,6 +226,13 @@ mod tests {
 					service: "web".into(),
 					replicas: 3,
 					ports: vec![8080],
+				},
+			),
+			(
+				"container 'web' exited with code 7 while waiting for it to be ready",
+				ComposeError::WaitServiceExited {
+					container: "web".into(),
+					code: 7,
 				},
 			),
 		];

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -70,6 +70,8 @@ pub enum ComposeError {
 		replicas: usize,
 		max: u32,
 	},
+	/// `start --wait --wait-timeout` elapsed before services became healthy.
+	WaitTimeout { secs: u64 },
 }
 
 impl fmt::Display for ComposeError {
@@ -129,6 +131,10 @@ impl fmt::Display for ComposeError {
 				f,
 				"service '{service}' requests {replicas} replicas, which exceeds the limit of \
 				 {max}; lower the count or raise the limit with PODUP_MAX_REPLICAS"
+			),
+			Self::WaitTimeout { secs } => write!(
+				f,
+				"timed out after {secs}s waiting for services to become healthy"
 			),
 		}
 	}
@@ -259,6 +265,10 @@ mod tests {
 					replicas: 100_000,
 					max: 256,
 				},
+			),
+			(
+				"timed out after 30s waiting for services to become healthy",
+				ComposeError::WaitTimeout { secs: 30 },
 			),
 		];
 		for (expected_prefix, err) in cases {

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -62,6 +62,14 @@ pub enum ComposeError {
 	/// A container being waited on (`up`/`start --wait`, or a `service_healthy`
 	/// dependency) exited non-zero before becoming ready.
 	WaitServiceExited { container: String, code: i64 },
+	/// A service requests more replicas than the configured ceiling, which would
+	/// let an untrusted `deploy.replicas`/`scale:` drive unbounded container
+	/// creation (host DoS).
+	ReplicaLimitExceeded {
+		service: String,
+		replicas: usize,
+		max: u32,
+	},
 }
 
 impl fmt::Display for ComposeError {
@@ -112,6 +120,15 @@ impl fmt::Display for ComposeError {
 			Self::WaitServiceExited { container, code } => write!(
 				f,
 				"container '{container}' exited with code {code} while waiting for it to be ready"
+			),
+			Self::ReplicaLimitExceeded {
+				service,
+				replicas,
+				max,
+			} => write!(
+				f,
+				"service '{service}' requests {replicas} replicas, which exceeds the limit of \
+				 {max}; lower the count or raise the limit with PODUP_MAX_REPLICAS"
 			),
 		}
 	}
@@ -233,6 +250,14 @@ mod tests {
 				ComposeError::WaitServiceExited {
 					container: "web".into(),
 					code: 7,
+				},
+			),
+			(
+				"service 'web' requests 100000 replicas, which exceeds the limit of 256",
+				ComposeError::ReplicaLimitExceeded {
+					service: "web".into(),
+					replicas: 100_000,
+					max: 256,
 				},
 			),
 		];

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -43,9 +43,9 @@ pub use compose::{
 /// project-name/listing helpers — the surface a CLI drives compose operations
 /// through.
 pub use engine::{
-	is_safe_project_name, list_projects, resolve_image_digests, BuildOptions, CpOptions, Engine,
-	ExecOptions, ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions,
-	PushOptions, RunOptions, RunOverrides, VolumesOptions,
+	is_safe_project_name, list_projects, resolve_image_digests, retain_active_profiles,
+	BuildOptions, CpOptions, Engine, ExecOptions, ImagesOptions, LogsOptions, LsOptions,
+	ProjectLock, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -29,6 +29,8 @@ pub mod quadlet;
 pub mod size;
 /// Docker Compose `${VAR}`/`$VAR` substitution over raw YAML before parsing.
 pub mod substitute;
+/// Terminal colour/styling, honouring `--ansi`, `NO_COLOR`, and TTY detection.
+pub mod ui;
 /// Secure self-update for the `podup` binary (signature-verified release fetch).
 #[cfg(feature = "update")]
 pub mod update;

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -132,7 +132,19 @@ impl Client {
 	}
 
 	/// Send a request and return the raw response.
-	async fn send(&self, req: Request<BoxBody>) -> Result<Response<Incoming>> {
+	///
+	/// `response_timeout` bounds how long we wait for the server to return the
+	/// response head. Pass `Some` (the default [`READ_TIMEOUT`]) for ordinary and
+	/// streaming calls, where the head arrives promptly — this stops a socket that
+	/// accepts the connection but never replies from hanging the CLI indefinitely.
+	/// Pass `None` only for endpoints that legitimately block server-side before
+	/// the head (e.g. `wait?condition=stopped`), whose callers impose an outer
+	/// budget.
+	async fn send(
+		&self,
+		req: Request<BoxBody>,
+		response_timeout: Option<std::time::Duration>,
+	) -> Result<Response<Incoming>> {
 		tracing::debug!("libpod {} {}", req.method(), req.uri().path());
 		let mut sender = tokio::time::timeout(CONNECT_TIMEOUT, self.connect())
 			.await
@@ -143,7 +155,14 @@ impl Client {
 					CONNECT_TIMEOUT.as_secs()
 				),
 			})??;
-		sender.send_request(req).await.map_err(PodmanError::Hyper)
+		let request = sender.send_request(req);
+		Self::apply_timeout(
+			response_timeout,
+			"waiting for the Podman socket to respond",
+			request,
+		)
+		.await?
+		.map_err(PodmanError::Hyper)
 	}
 
 	/// Read the full response body into a `Vec<u8>`, capped at
@@ -160,40 +179,44 @@ impl Client {
 	) -> Result<(StatusCode, Vec<u8>)> {
 		let status = resp.status();
 		let read = Limited::new(resp.into_body(), MAX_RESPONSE_BYTES).collect();
-		let collected = Self::apply_read_timeout(read_timeout, read)
-			.await?
-			.map_err(|e| PodmanError::Api {
-				status: 0,
-				message: format!("reading response body: {e}"),
-			})?;
+		let collected = Self::apply_timeout(
+			read_timeout,
+			"reading the response body from the Podman socket",
+			read,
+		)
+		.await?
+		.map_err(|e| PodmanError::Api {
+			status: 0,
+			message: format!("reading response body: {e}"),
+		})?;
 		Ok((status, collected.to_bytes().to_vec()))
 	}
 
-	/// Await `read`, optionally bounded by `read_timeout`.
+	/// Await `fut`, optionally bounded by `timeout`.
 	///
-	/// With `Some(limit)` a stalled body is aborted once `limit` elapses, yielding
-	/// a timeout [`PodmanError`]. With `None` the future is awaited uncapped, for
-	/// endpoints that legitimately block server-side (the caller supplies its own
-	/// outer budget). Split out from [`read_body`](Self::read_body) so the timeout policy is
-	/// testable without a live socket.
-	async fn apply_read_timeout<F, T>(
-		read_timeout: Option<std::time::Duration>,
-		read: F,
+	/// With `Some(limit)` a stalled future is aborted once `limit` elapses, yielding
+	/// a timeout [`PodmanError`] whose message names `phase` (what we were waiting
+	/// on); with `None` it is awaited uncapped, for endpoints that legitimately
+	/// block server-side (the caller supplies its own outer budget). Shared by the
+	/// response-head wait ([`send`](Self::send)) and the body read
+	/// ([`read_body`](Self::read_body)); split out so the policy is testable without
+	/// a live socket.
+	async fn apply_timeout<F, T>(
+		timeout: Option<std::time::Duration>,
+		phase: &str,
+		fut: F,
 	) -> Result<T>
 	where
 		F: std::future::Future<Output = T>,
 	{
-		match read_timeout {
-			Some(limit) => tokio::time::timeout(limit, read)
+		match timeout {
+			Some(limit) => tokio::time::timeout(limit, fut)
 				.await
 				.map_err(|_| PodmanError::Api {
 					status: 0,
-					message: format!(
-						"timed out after {}s reading the response body from the Podman socket",
-						limit.as_secs()
-					),
+					message: format!("timed out after {}s {phase}", limit.as_secs()),
 				}),
-			None => Ok(read.await),
+			None => Ok(fut.await),
 		}
 	}
 
@@ -250,7 +273,7 @@ impl Client {
 	pub async fn ping(&self) -> Result<()> {
 		// Deliberately omits the version prefix: `_ping` is version-independent.
 		let req = Self::build_request(Method::GET, "/libpod/_ping", Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		// Read the version header before the body is consumed below.
 		let reported = resp
 			.headers()
@@ -269,7 +292,7 @@ impl Client {
 	/// `GET` → deserialize JSON response.
 	pub async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
 		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(PodmanError::Json)
@@ -278,7 +301,7 @@ impl Client {
 	/// `GET` → return raw `Response<Incoming>` for streaming.
 	pub async fn get_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
-		Self::stream_or_err(self.send(req).await?).await
+		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with JSON body → deserialize JSON response.
@@ -294,7 +317,7 @@ impl Client {
 			Full::new(Bytes::from(json)),
 			Some("application/json"),
 		)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(PodmanError::Json)
@@ -309,7 +332,7 @@ impl Client {
 			Full::new(Bytes::from(json)),
 			Some("application/json"),
 		)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)
 	}
@@ -327,13 +350,13 @@ impl Client {
 			Full::new(Bytes::from(json)),
 			Some("application/json"),
 		)?;
-		Self::stream_or_err(self.send(req).await?).await
+		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with empty body → ignore response body (expect 2xx or 304).
 	pub async fn post_empty_ok(&self, path: &str) -> Result<()> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		// 304 Not Modified is fine for idempotent ops
 		if status == StatusCode::NOT_MODIFIED {
@@ -345,13 +368,13 @@ impl Client {
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
-		Self::stream_or_err(self.send(req).await?).await
+		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with empty body → deserialize JSON response.
 	pub async fn post_empty_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(PodmanError::Json)
@@ -369,7 +392,7 @@ impl Client {
 	/// [`tokio::time::timeout`]) to stay bounded.
 	pub async fn post_empty_json_unbounded<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, None).await?;
 		let (status, body) = Self::read_body(resp, None).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(PodmanError::Json)
@@ -383,7 +406,7 @@ impl Client {
 		content_type: &str,
 	) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
-		Self::stream_or_err(self.send(req).await?).await
+		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with a raw-bytes body → deserialize JSON response.
@@ -398,7 +421,7 @@ impl Client {
 		content_type: &str,
 	) -> Result<T> {
 		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(PodmanError::Json)
@@ -407,7 +430,7 @@ impl Client {
 	/// `PUT` with raw bytes body → expect 2xx.
 	pub async fn put_bytes_ok(&self, path: &str, bytes: Bytes, content_type: &str) -> Result<()> {
 		let req = Self::build_request(Method::PUT, path, Full::new(bytes), Some(content_type))?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)
 	}
@@ -421,7 +444,7 @@ impl Client {
 		use base64::Engine as _;
 
 		let req = Self::build_request(Method::HEAD, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let status = resp.status();
 		if status == StatusCode::NOT_FOUND {
 			return Ok(None);
@@ -457,7 +480,7 @@ impl Client {
 	/// `DELETE` → ignore response body (expect 2xx or 404).
 	pub async fn delete_ok(&self, path: &str) -> Result<()> {
 		let req = Self::build_request(Method::DELETE, path, Full::new(Bytes::new()), None)?;
-		let resp = self.send(req).await?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		if status == StatusCode::NOT_FOUND {
 			return Ok(());
@@ -595,49 +618,32 @@ mod tests {
 	}
 
 	// ---------------------------------------------------------------------------
-	// read-timeout policy tests
+	// timeout policy tests
 	// ---------------------------------------------------------------------------
 
-	/// A bounded read aborts a future that outlives the limit, surfacing the
-	/// timeout error rather than hanging — the guard for ordinary buffered calls.
+	/// A bounded wait aborts a future that outlives the limit and names the phase
+	/// in the message — the guard that stops a stalled or silent socket (whether
+	/// waiting on the response head or reading a buffered body) from hanging the
+	/// CLI. A never-resolving future stands in for the silent-socket attack.
 	#[tokio::test]
-	async fn apply_read_timeout_some_aborts_slow_read() {
-		let slow = async {
-			tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
-			0u8
-		};
-		let err = Client::apply_read_timeout(Some(std::time::Duration::from_millis(10)), slow)
+	async fn apply_timeout_some_aborts_and_names_phase() {
+		let never: std::future::Pending<u8> = std::future::pending();
+		let d = std::time::Duration::from_millis(10);
+		let msg = Client::apply_timeout(Some(d), "phase-marker", never)
 			.await
-			.unwrap_err();
-		assert!(err.to_string().contains("timed out"));
+			.unwrap_err()
+			.to_string();
+		assert!(msg.contains("timed out") && msg.contains("phase-marker"));
 	}
 
-	/// The unbounded read (the `wait?condition=stopped` path) wraps no timeout: the
-	/// future is awaited directly, so the only bound is the caller's own outer
-	/// budget — never a spurious 120 s abort. Verified by completing well past a
-	/// limit that, applied as `Some`, would have aborted the same future.
+	/// With `None` the future is awaited uncapped (the `wait?condition=stopped`
+	/// path, bounded only by the caller's own outer budget).
 	#[tokio::test]
-	async fn apply_read_timeout_none_outlives_a_bounded_limit() {
-		// Long enough to exceed the bounded-case limit below, short enough to keep
-		// the test fast.
-		let delay = std::time::Duration::from_millis(50);
-		let read = async move {
-			tokio::time::sleep(delay).await;
-			42u8
-		};
-		let value = Client::apply_read_timeout(None, read).await.unwrap();
-		assert_eq!(value, 42);
-
-		// The same delay under a tighter bound aborts — confirming the `None` case
-		// genuinely skips the ceiling rather than racing it.
-		let read = async move {
-			tokio::time::sleep(delay).await;
-			42u8
-		};
-		let err = Client::apply_read_timeout(Some(std::time::Duration::from_millis(1)), read)
+	async fn apply_timeout_none_awaits_uncapped() {
+		let value = Client::apply_timeout(None, "phase-marker", async { 42u8 })
 			.await
-			.unwrap_err();
-		assert!(err.to_string().contains("timed out"));
+			.unwrap();
+		assert_eq!(value, 42);
 	}
 
 	/// The version gate accepts Podman 5.x (and any higher major) and rejects

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -25,9 +25,10 @@ impl fmt::Display for PodmanError {
 			Self::Connect(e) => write!(f, "podman socket connection error: {e}"),
 			Self::Hyper(e) => write!(f, "http error: {e}"),
 			Self::Json(e) => write!(f, "json error: {e}"),
-			Self::Api { status, message } => {
-				write!(f, "podman API error (HTTP {status}): {message}")
-			}
+			Self::Api { status, message } => match conflict_hint(message) {
+				Some(hint) => write!(f, "{hint} (podman: {message})"),
+				None => write!(f, "podman API error (HTTP {status}): {message}"),
+			},
 			Self::IncompatibleApiVersion { reported } => {
 				let reported = if reported.is_empty() {
 					"an unknown version"
@@ -40,6 +41,25 @@ impl fmt::Display for PodmanError {
 				)
 			}
 		}
+	}
+}
+
+/// A short, actionable hint for the common Podman container state-conflict
+/// errors, so the CLI leads with plain guidance instead of the raw HTTP message
+/// (which still follows in parentheses). Returns `None` for anything unrecognised
+/// so the original message is shown verbatim. Pure, so it is unit-tested.
+fn conflict_hint(message: &str) -> Option<&'static str> {
+	let m = message.to_ascii_lowercase();
+	if m.contains("without force") || (m.contains("cannot remove") && m.contains("running")) {
+		Some("the container is running — stop it first, or pass `-f` to force removal")
+	} else if m.contains("already paused") {
+		Some("the container is already paused")
+	} else if m.contains("not paused") {
+		Some("the container is not paused")
+	} else if m.contains("not running") {
+		Some("the container is not running")
+	} else {
+		None
 	}
 }
 
@@ -97,7 +117,51 @@ impl PodmanError {
 
 #[cfg(test)]
 mod tests {
-	use super::PodmanError;
+	use super::{conflict_hint, PodmanError};
+
+	#[test]
+	fn conflict_hint_recognises_common_state_errors() {
+		let rm = "cannot remove container abc as it is running - running or paused containers \
+			cannot be removed without force: container state improper";
+		assert!(conflict_hint(rm).unwrap().contains("-f"));
+		assert!(conflict_hint("container abc is already paused")
+			.unwrap()
+			.contains("already paused"));
+		assert!(conflict_hint("container abc is not paused")
+			.unwrap()
+			.contains("not paused"));
+		assert!(
+			conflict_hint("cannot kill container abc: container abc is not running")
+				.unwrap()
+				.contains("not running")
+		);
+	}
+
+	#[test]
+	fn conflict_hint_none_for_unrecognised() {
+		assert!(conflict_hint("some unrelated error").is_none());
+		assert!(conflict_hint("no such container: abc").is_none());
+	}
+
+	#[test]
+	fn api_error_display_leads_with_hint_and_keeps_message() {
+		let e = PodmanError::Api {
+			status: 409,
+			message: "container abc is already paused".into(),
+		};
+		let s = e.to_string();
+		assert!(s.starts_with("the container is already paused"));
+		assert!(s.contains("podman: container abc is already paused"));
+	}
+
+	#[test]
+	fn api_error_display_raw_when_no_hint() {
+		let e = PodmanError::Api {
+			status: 500,
+			message: "boom".into(),
+		};
+		assert_eq!(e.to_string(), "podman API error (HTTP 500): boom");
+	}
 
 	#[test]
 	fn is_status_matches_code() {

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -119,14 +119,13 @@ pub struct HealthConfig {
 /// Container state sub-object.
 #[derive(Deserialize, Default)]
 pub struct ContainerState {
-	// `status`/`exit_code` round-trip the libpod state for completeness and are
-	// asserted in tests; container completion now blocks on `wait?condition`
-	// (which returns the code directly) rather than reading them here.
-	#[allow(dead_code)]
+	/// Lifecycle status (`running`, `exited`, ...). Read while waiting to detect a
+	/// container that exited before becoming ready.
 	#[serde(rename = "Status")]
 	pub status: Option<String>,
 
-	#[allow(dead_code)]
+	/// Exit code once the container has exited; used to fail `--wait` when a
+	/// no-healthcheck service crashes during the wait.
 	#[serde(rename = "ExitCode")]
 	pub exit_code: Option<i64>,
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -150,12 +150,14 @@ async fn run() -> podup::Result<()> {
 		};
 		// `--resolve-image-digests` pins each image to its registry digest, which
 		// needs a Podman connection to inspect images.
-		let resolved = if *resolve_image_digests {
+		let mut resolved = if *resolve_image_digests {
 			let client = podup::podman::connect(cli.socket.as_deref())?;
 			podup::resolve_image_digests(&client, &parsed).await?
 		} else {
 			parsed
 		};
+		// Honor active profiles so `config` prints the same services `up` starts.
+		podup::retain_active_profiles(&mut resolved, &cli.profile);
 		return startup::render_config(&resolved, format, *services, *quiet);
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -53,14 +53,28 @@ fn run_to_exit() {
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
 		#[cfg(feature = "update")]
 		Err(e @ podup::ComposeError::Update(_)) => {
-			eprintln!("podup: error: {e}");
+			print_error(&e);
 			process::exit(podup::update::exit_code(&e));
 		}
 		Err(e) => {
-			eprintln!("podup: error: {e}");
+			print_error(&e);
 			process::exit(1);
 		}
 	}
+}
+
+/// Print a top-level error to stderr with a colour-aware bold-red `error:` label.
+/// anstream strips the styling when stderr is not a terminal or colour is off.
+fn print_error(e: &podup::ComposeError) {
+	use std::io::Write;
+	let style = podup::ui::error_style();
+	let mut err = anstream::stderr();
+	let _ = writeln!(
+		err,
+		"podup: {}error:{} {e}",
+		style.render(),
+		style.render_reset()
+	);
 }
 
 /// Orchestrate one CLI invocation: parse args, then short-circuit the commands
@@ -71,6 +85,9 @@ fn run_to_exit() {
 /// remaining commands.
 async fn run() -> podup::Result<()> {
 	let cli = parse_cli();
+	// Resolve the colour choice before any output (including tracing setup below)
+	// so `--ansi`/`NO_COLOR`/TTY detection apply consistently everywhere.
+	podup::ui::set_color_choice(cli.ansi.into());
 	// `watch` is an interactive, long-running command; surface its per-action
 	// progress (synced/rebuilt/restarted) by defaulting to INFO instead of the
 	// quiet WARN floor. `RUST_LOG` always overrides.

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -53,7 +53,13 @@ where
 		mut writer: Writer<'_>,
 		event: &Event<'_>,
 	) -> std::fmt::Result {
-		write!(writer, "podup: {}: ", level_word(*event.metadata().level()))?;
+		let level = *event.metadata().level();
+		let label = podup::ui::paint(
+			level_style(level),
+			level_word(level),
+			podup::ui::stderr_colored(),
+		);
+		write!(writer, "podup: {label}: ")?;
 		ctx.field_format().format_fields(writer.by_ref(), event)?;
 		writeln!(writer)
 	}
@@ -67,6 +73,18 @@ fn level_word(level: tracing::Level) -> &'static str {
 		tracing::Level::INFO => "info",
 		tracing::Level::DEBUG => "debug",
 		tracing::Level::TRACE => "trace",
+	}
+}
+
+/// The colour for a level's word: bold red (error), bold yellow (warning), green
+/// (info), dim (debug/trace).
+fn level_style(level: tracing::Level) -> anstyle::Style {
+	use anstyle::{AnsiColor, Style};
+	match level {
+		tracing::Level::ERROR => Style::new().bold().fg_color(Some(AnsiColor::Red.into())),
+		tracing::Level::WARN => Style::new().bold().fg_color(Some(AnsiColor::Yellow.into())),
+		tracing::Level::INFO => Style::new().fg_color(Some(AnsiColor::Green.into())),
+		_ => Style::new().dimmed(),
 	}
 }
 
@@ -246,7 +264,16 @@ pub(crate) fn parse_cli() -> Cli {
 			clap::error::ErrorKind::DisplayHelp
 			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
 			| clap::error::ErrorKind::DisplayVersion => {
-				print!("\n{e}\n");
+				// `--help`/`--version` are handled by clap before `--ansi` is parsed,
+				// so colour the rendered text by clap's own styling only when stdout
+				// is a colour sink (TTY + no NO_COLOR); piped output stays plain and
+				// byte-identical to before.
+				let rendered = e.render();
+				if podup::ui::stdout_colored() {
+					print!("\n{}\n", rendered.ansi());
+				} else {
+					print!("\n{rendered}\n");
+				}
 				process::exit(0);
 			}
 			_ => e.exit(),
@@ -291,6 +318,19 @@ mod tests {
 		assert_eq!(level_word(tracing::Level::INFO), "info");
 		assert_eq!(level_word(tracing::Level::DEBUG), "debug");
 		assert_eq!(level_word(tracing::Level::TRACE), "trace");
+		// Each severity gets a distinct style; debug/trace share the dim style.
+		assert_ne!(
+			level_style(tracing::Level::ERROR),
+			level_style(tracing::Level::INFO)
+		);
+		assert_ne!(
+			level_style(tracing::Level::WARN),
+			level_style(tracing::Level::ERROR)
+		);
+		assert_eq!(
+			level_style(tracing::Level::DEBUG),
+			level_style(tracing::Level::TRACE)
+		);
 	}
 
 	fn sample_file() -> podup::compose::types::ComposeFile {

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -94,11 +94,19 @@ pub fn build_vars(dir: &Path) -> HashMap<String, String> {
 	vars
 }
 
-/// Build vars additionally loading explicit env files (process env + dotenv + extra files).
+/// Build vars, layering explicit `--env-file` files over the process environment.
 ///
-/// Extra files are loaded after dotenv; process env still wins for all keys.
+/// Compose v2 semantics: when one or more `--env-file` are given they *replace*
+/// the default `.env` (which is therefore not loaded), and among several files
+/// the **last** one wins. With no explicit files this is just [`build_vars`]
+/// (process env + `.env`). Process env always takes precedence over file values.
 pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String, String> {
-	let mut vars = build_vars(dir);
+	if extra.is_empty() {
+		return build_vars(dir);
+	}
+
+	// Explicit `--env-file`s replace `.env`; a later file overrides an earlier one.
+	let mut file_vars: HashMap<String, String> = HashMap::new();
 	for path in extra {
 		let abs = if std::path::Path::new(path).is_absolute() {
 			std::path::PathBuf::from(path)
@@ -109,8 +117,14 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 			continue;
 		};
 		for (key, value) in crate::dotenv::parse(&content) {
-			vars.entry(key).or_insert(value);
+			file_vars.insert(key, value);
 		}
+	}
+
+	// Process env wins over every file value.
+	let mut vars: HashMap<String, String> = std::env::vars().collect();
+	for (k, v) in file_vars {
+		vars.entry(k).or_insert(v);
 	}
 	vars
 }
@@ -411,10 +425,10 @@ mod tests {
 	// build_vars_with_env_files
 
 	#[test]
-	fn build_vars_with_env_files_loads_relative_extra_file() {
+	fn env_file_replaces_dotenv() {
 		let dir = tempfile::tempdir().unwrap();
-		// A `.env` provides a base var; the extra file adds another and does NOT
-		// override the dotenv value (process env / earlier sources win via entry).
+		// Compose v2: an explicit `--env-file` replaces the default `.env`, so the
+		// dotenv-only key is absent and the extra file's value wins for a shared key.
 		std::fs::write(
 			dir.path().join(".env"),
 			"FROM_DOTENV=base\nPODUP_TEST_SHARED=dotenv\n",
@@ -427,13 +441,53 @@ mod tests {
 		.unwrap();
 
 		let vars = build_vars_with_env_files(dir.path(), &["extra.env".to_string()]);
-		assert_eq!(vars.get("FROM_DOTENV").map(String::as_str), Some("base"));
+		assert_eq!(vars.get("FROM_DOTENV"), None);
 		assert_eq!(vars.get("FROM_EXTRA").map(String::as_str), Some("more"));
-		// The extra file must not clobber a value an earlier source already set.
 		assert_eq!(
 			vars.get("PODUP_TEST_SHARED").map(String::as_str),
-			Some("dotenv")
+			Some("extra")
 		);
+	}
+
+	#[test]
+	fn later_env_file_wins() {
+		let dir = tempfile::tempdir().unwrap();
+		// Among several `--env-file`s the last one listed wins.
+		std::fs::write(dir.path().join("a.env"), "FROM_A=a\nSHARED=a\n").unwrap();
+		std::fs::write(dir.path().join("b.env"), "FROM_B=b\nSHARED=b\n").unwrap();
+
+		let vars =
+			build_vars_with_env_files(dir.path(), &["a.env".to_string(), "b.env".to_string()]);
+		assert_eq!(vars.get("FROM_A").map(String::as_str), Some("a"));
+		assert_eq!(vars.get("FROM_B").map(String::as_str), Some("b"));
+		assert_eq!(vars.get("SHARED").map(String::as_str), Some("b"));
+	}
+
+	#[test]
+	fn process_env_wins_over_env_file() {
+		let dir = tempfile::tempdir().unwrap();
+		std::env::set_var("PODUP_ENVFILE_PROCESS_WINS", "from-process");
+		std::fs::write(
+			dir.path().join("x.env"),
+			"PODUP_ENVFILE_PROCESS_WINS=from-file\n",
+		)
+		.unwrap();
+
+		let vars = build_vars_with_env_files(dir.path(), &["x.env".to_string()]);
+		assert_eq!(
+			vars.get("PODUP_ENVFILE_PROCESS_WINS").map(String::as_str),
+			Some("from-process")
+		);
+		std::env::remove_var("PODUP_ENVFILE_PROCESS_WINS");
+	}
+
+	#[test]
+	fn no_env_file_loads_dotenv() {
+		let dir = tempfile::tempdir().unwrap();
+		// With no `--env-file`, `.env` is loaded as before.
+		std::fs::write(dir.path().join(".env"), "FROM_DOTENV=base\n").unwrap();
+		let vars = build_vars_with_env_files(dir.path(), &[]);
+		assert_eq!(vars.get("FROM_DOTENV").map(String::as_str), Some("base"));
 	}
 
 	#[test]

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -1,0 +1,221 @@
+//! Terminal styling — the single place that decides whether to colour output and
+//! holds the palette, so colour stays consistent and always honours `--ansi`,
+//! `NO_COLOR`, and whether the target stream is a TTY.
+//!
+//! Two kinds of sink exist in podup:
+//! - Sinks written through [`anstream`] (e.g. [`anstream::stdout`]) strip the
+//!   ANSI codes themselves when colour is off, so callers may always emit codes.
+//! - Raw sinks (the tracing writer, the log-prefixer's borrowed stdout) do not
+//!   strip, so those callers gate on `stdout_colored`/`stderr_colored`.
+//!
+//! `set_color_choice` also constructs the auto streams once so anstream enables
+//! virtual-terminal processing on Windows for the rest of the process.
+
+use std::io::IsTerminal;
+
+use anstyle::{AnsiColor, Style};
+
+pub use anstream::ColorChoice;
+
+/// Apply the resolved colour choice process-wide and enable Windows VT once.
+///
+/// anstream's `stdout()`/`stderr()` then honour this choice together with
+/// `NO_COLOR`/`CLICOLOR` and TTY detection.
+pub fn set_color_choice(choice: ColorChoice) {
+	choice.write_global();
+	// Constructing the auto streams enables virtual-terminal processing on
+	// Windows so raw-sink callers can emit ANSI safely; a no-op elsewhere.
+	let _ = anstream::AutoStream::auto(std::io::stdout());
+	let _ = anstream::AutoStream::auto(std::io::stderr());
+}
+
+/// `NO_COLOR` is set to a non-empty value (the no-color.org convention).
+fn no_color() -> bool {
+	std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
+}
+
+/// Whether a stream that is (or isn't) a TTY should be coloured under `choice`.
+/// `Auto` defers to the TTY and `NO_COLOR`. Pure (takes the choice as an argument)
+/// so the policy is tested without mutating the process-global choice.
+fn colored_with(choice: ColorChoice, is_terminal: bool) -> bool {
+	match choice {
+		ColorChoice::Always | ColorChoice::AlwaysAnsi => true,
+		ColorChoice::Never => false,
+		ColorChoice::Auto => is_terminal && !no_color(),
+	}
+}
+
+/// Whether a stream that is (or isn't) a TTY should be coloured under the global
+/// choice.
+fn colored(is_terminal: bool) -> bool {
+	colored_with(ColorChoice::global(), is_terminal)
+}
+
+/// Whether a raw (non-anstream) write to stdout should embed ANSI codes.
+pub fn stdout_colored() -> bool {
+	colored(std::io::stdout().is_terminal())
+}
+
+/// Whether a raw (non-anstream) write to stderr should embed ANSI codes.
+pub fn stderr_colored() -> bool {
+	colored(std::io::stderr().is_terminal())
+}
+
+/// Bold — table headers and emphasis.
+pub fn bold() -> Style {
+	Style::new().bold()
+}
+
+/// Print `cols` as a bold table header through an anstream sink, so the styling
+/// is stripped automatically when colour is off. The single place every list
+/// command renders its header, keeping them consistent.
+pub fn print_bold_header(cols: &str) {
+	use std::io::Write;
+	let s = bold();
+	let _ = writeln!(
+		anstream::stdout(),
+		"{}{cols}{}",
+		s.render(),
+		s.render_reset()
+	);
+}
+
+/// Bold red — the `error:` label.
+pub fn error_style() -> Style {
+	Style::new().bold().fg_color(Some(AnsiColor::Red.into()))
+}
+
+/// Wrap `text` in `style` when `enabled`, else return it unchanged. For raw sinks
+/// that do not strip; anstream sinks should pass the codes through directly.
+pub fn paint(style: Style, text: &str, enabled: bool) -> String {
+	if enabled {
+		format!("{}{text}{}", style.render(), style.render_reset())
+	} else {
+		text.to_string()
+	}
+}
+
+/// Identity colours cycled through for per-service log prefixes. Deliberately
+/// excludes red/green/yellow, which are reserved for status/severity meaning, so
+/// a service prefix is never mistaken for an error/ok/warning signal.
+const SERVICE_PALETTE: [AnsiColor; 6] = [
+	AnsiColor::Cyan,
+	AnsiColor::Magenta,
+	AnsiColor::Blue,
+	AnsiColor::BrightCyan,
+	AnsiColor::BrightMagenta,
+	AnsiColor::BrightBlue,
+];
+
+/// Stable palette index for a service name — the same name always maps to the
+/// same colour (FNV-1a over the bytes, modulo the palette size).
+fn palette_index(name: &str) -> usize {
+	let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+	for b in name.bytes() {
+		h ^= u64::from(b);
+		h = h.wrapping_mul(0x0100_0000_01b3);
+	}
+	(h % SERVICE_PALETTE.len() as u64) as usize
+}
+
+/// The stable colour for a service's aggregated-log prefix.
+pub fn service_style(name: &str) -> Style {
+	Style::new().fg_color(Some(SERVICE_PALETTE[palette_index(name)].into()))
+}
+
+/// The semantic colour for a container status word, or `None` for an unknown one
+/// (left uncoloured). Green = up/healthy, red = exited/dead/unhealthy, yellow =
+/// paused/(re)starting, dim = created. Matches on substrings so it handles both
+/// the bare state (`running`) and Podman's verbose `Status` (`Up 2 minutes`,
+/// `Exited (1)`).
+fn status_style(status: &str) -> Option<Style> {
+	let s = status.to_ascii_lowercase();
+	let colour = if s.contains("unhealthy") || s.contains("exit") || s.contains("dead") {
+		AnsiColor::Red
+	} else if s.contains("running") || s.contains("healthy") || s.starts_with("up") {
+		AnsiColor::Green
+	} else if s.contains("paus") || s.contains("restart") || s.contains("starting") {
+		AnsiColor::Yellow
+	} else if s.contains("created") {
+		return Some(Style::new().dimmed());
+	} else {
+		return None;
+	};
+	Some(Style::new().fg_color(Some(colour.into())))
+}
+
+/// Render a container `status` left-padded to `width`, colourised by its meaning
+/// when stdout is a colour sink. The padding is applied first so the colour codes
+/// (zero display width) never disturb column alignment.
+pub fn status_cell(status: &str, width: usize) -> String {
+	let padded = format!("{status:<width$}");
+	match status_style(status) {
+		Some(style) => paint(style, &padded, stdout_colored()),
+		None => padded,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn service_colour_is_stable_per_name() {
+		// Same name → same index every call; different names spread across the
+		// palette (not all collapsed to one colour).
+		assert_eq!(palette_index("web"), palette_index("web"));
+		let distinct: std::collections::HashSet<usize> =
+			["web", "db", "cache", "worker", "proxy", "queue"]
+				.iter()
+				.map(|n| palette_index(n))
+				.collect();
+		assert!(distinct.len() > 1, "palette should spread service names");
+		assert!(palette_index("web") < SERVICE_PALETTE.len());
+	}
+
+	#[test]
+	fn paint_gates_on_enabled() {
+		let plain = paint(bold(), "hi", false);
+		assert_eq!(plain, "hi");
+		let coloured = paint(bold(), "hi", true);
+		assert!(coloured.contains("hi"));
+		assert!(coloured.len() > "hi".len(), "enabled paint adds ANSI codes");
+		assert!(coloured.starts_with('\u{1b}'), "starts with an ESC");
+	}
+
+	#[test]
+	fn colour_choice_resolution() {
+		// Pure resolution — never touches the process-global choice, so it can't
+		// race the production code (LinePrefixer/status_cell) that reads it.
+		temp_env::with_var_unset("NO_COLOR", || {
+			assert!(!colored_with(ColorChoice::Never, true));
+			assert!(colored_with(ColorChoice::Always, false));
+			assert!(colored_with(ColorChoice::Auto, true));
+			assert!(!colored_with(ColorChoice::Auto, false));
+		});
+		// NO_COLOR forces plain in Auto, regardless of the TTY.
+		temp_env::with_var("NO_COLOR", Some("1"), || {
+			assert!(!colored_with(ColorChoice::Auto, true));
+			// ...but an explicit `always` still overrides NO_COLOR.
+			assert!(colored_with(ColorChoice::Always, true));
+		});
+	}
+
+	#[test]
+	fn status_style_is_semantic() {
+		assert_ne!(status_style("running"), status_style("exited (1)"));
+		assert_ne!(status_style("unhealthy"), status_style("healthy"));
+		assert!(status_style("Up 2 minutes").is_some());
+		assert!(status_style("paused").is_some());
+		assert!(status_style("created").is_some());
+		assert!(status_style("weird-state").is_none());
+	}
+
+	#[test]
+	fn status_cell_pads_and_keeps_status() {
+		let cell = status_cell("ok", 6);
+		assert!(cell.contains("ok"));
+		// At least the requested width (colour codes, if any, only add length).
+		assert!(cell.len() >= 6);
+	}
+}

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -141,7 +141,7 @@ async fn engine_port_returns_binding() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.port(&file, "web", 80, "tcp").await.unwrap();
+	engine.port(&file, "web", "80", "tcp").await.unwrap();
 	engine.down(&file).await.unwrap();
 }
 
@@ -301,14 +301,14 @@ async fn port_scaled_service_targets_first_replica() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.port(&file, "worker", 80, "tcp").await.unwrap();
+	engine.port(&file, "worker", "80", "tcp").await.unwrap();
 	// --index targets a valid replica; an out-of-range index errors.
 	engine
-		.port_with_index(&file, "worker", 80, "tcp", Some(2))
+		.port_with_index(&file, "worker", "80", "tcp", Some(2))
 		.await
 		.unwrap();
 	let bad = engine
-		.port_with_index(&file, "worker", 80, "tcp", Some(9))
+		.port_with_index(&file, "worker", "80", "tcp", Some(9))
 		.await;
 	assert!(
 		matches!(bad, Err(podup::ComposeError::ServiceNotFound(_))),


### PR DESCRIPTION
Promote develop → main for the 1.6.0 release.

Contents: the 11 fixes/hardening items + colour-output feature from the 1.5.2 end-to-end test sweep (epic #696), plus the version bump (#709).

Notable behaviour changes (in the release notes): `up`/`start --wait` now fails when a service exits during the wait, and `--env-file` replaces `.env` with last-file-wins — both aligning to docker compose.

Release-readiness reviewed: GO (version files consistent, SemVer MINOR correct, MSRV 1.85 unchanged, asset contract intact, new deps musl-safe + SBOM-covered). After merge I tag v1.6.0 to trigger the release workflow.