### PR TITLE
fix(container-create): resolve verified container-create sweep findings

### DIFF
--- a/internal/engine/container/fields.rs
+++ b/internal/engine/container/fields.rs
@@ -12,18 +12,32 @@ use tracing::warn;
 
 use crate::compose::types::{BlkioConfig, Service};
 use crate::libpod::types::container::{
-	LinuxBlockIO, LinuxDevice, LinuxThrottleDevice, LinuxWeightDevice,
+	LinuxBlockIO, LinuxDevice, LinuxDeviceCgroup, LinuxThrottleDevice, LinuxWeightDevice,
 };
 
 // ---------------------------------------------------------------------------
 // Device helpers
 // ---------------------------------------------------------------------------
 
+/// A parsed compose `devices:` entry: the device node to create plus, when the
+/// entry carried an explicit `:permissions` segment, the cgroup access rule that
+/// restricts it.
+pub(crate) struct ParsedDevice {
+	/// The device node to expose inside the container.
+	pub device: LinuxDevice,
+	/// The cgroup access rule derived from the trailing `:permissions` segment,
+	/// present only when one was given.
+	pub cgroup_rule: Option<LinuxDeviceCgroup>,
+}
+
 /// Parse a compose `devices:` entry (`host:container:permissions`) into a
-/// `LinuxDevice`. The container path defaults to the host path when the
+/// [`ParsedDevice`]. The container path defaults to the host path when the
 /// `:container` segment is absent; major/minor/type are derived by `stat`ing the
-/// host node. Trailing permissions, if present, are ignored here.
-pub(crate) fn parse_device(s: &str) -> LinuxDevice {
+/// host node. A trailing `:permissions` segment (e.g. `r`, `rwm`) is retained as
+/// a `device_cgroup_rule`: the OCI `LinuxDevice` has no access field, so the
+/// restriction must ride alongside as a cgroup rule for the live up path to
+/// honor it consistently with the quadlet backend and docker-compose.
+pub(crate) fn parse_device(s: &str) -> ParsedDevice {
 	let parts: Vec<&str> = s.splitn(3, ':').collect();
 	let host = parts.first().copied().unwrap_or("").to_string();
 	let cont = parts
@@ -31,17 +45,33 @@ pub(crate) fn parse_device(s: &str) -> LinuxDevice {
 		.copied()
 		.map(|c| c.to_string())
 		.unwrap_or_else(|| host.clone());
+	let access = parts
+		.get(2)
+		.copied()
+		.filter(|p| !p.is_empty())
+		.map(str::to_string);
 
 	let (major, minor, device_type) = device_major_minor(&host);
 
-	LinuxDevice {
-		path: cont,
-		device_type,
-		major,
-		minor,
-		file_mode: None,
-		uid: None,
-		gid: None,
+	let cgroup_rule = access.map(|access| LinuxDeviceCgroup {
+		allow: true,
+		device_type: Some(device_type.clone()),
+		major: Some(major),
+		minor: Some(minor),
+		access: Some(access),
+	});
+
+	ParsedDevice {
+		device: LinuxDevice {
+			path: cont,
+			device_type,
+			major,
+			minor,
+			file_mode: None,
+			uid: None,
+			gid: None,
+		},
+		cgroup_rule,
 	}
 }
 
@@ -239,20 +269,42 @@ mod tests {
 
 	#[test]
 	fn parse_device_host_container_perm() {
-		let d = parse_device("/dev/null:/dev/zero:rwm");
-		assert_eq!(d.path, "/dev/zero");
+		let parsed = parse_device("/dev/null:/dev/zero:rwm");
+		assert_eq!(parsed.device.path, "/dev/zero");
+		// The trailing permission segment becomes a cgroup access rule.
+		let rule = parsed.cgroup_rule.expect("perm should yield a cgroup rule");
+		assert!(rule.allow);
+		assert_eq!(rule.access.as_deref(), Some("rwm"));
 	}
 
 	#[test]
 	fn parse_device_same_path_both_sides() {
-		let d = parse_device("/dev/null");
-		assert_eq!(d.path, "/dev/null");
+		let parsed = parse_device("/dev/null");
+		assert_eq!(parsed.device.path, "/dev/null");
+		// No permission segment → no cgroup rule (Podman defaults to rwm).
+		assert!(parsed.cgroup_rule.is_none());
 	}
 
 	#[test]
 	fn parse_device_two_part() {
-		let d = parse_device("/dev/null:/dev/xvda");
-		assert_eq!(d.path, "/dev/xvda");
+		let parsed = parse_device("/dev/null:/dev/xvda");
+		assert_eq!(parsed.device.path, "/dev/xvda");
+		assert!(parsed.cgroup_rule.is_none());
+	}
+
+	#[test]
+	fn parse_device_restricted_perm_is_preserved() {
+		// `devices: ["/dev/sda:/dev/sda:r"]` must keep the read-only restriction
+		// rather than silently becoming rwm on the live up path.
+		let parsed = parse_device("/dev/sda:/dev/sda:r");
+		assert_eq!(parsed.device.path, "/dev/sda");
+		let rule = parsed.cgroup_rule.expect("perm should yield a cgroup rule");
+		assert!(rule.allow);
+		assert_eq!(rule.access.as_deref(), Some("r"));
+		// The rule targets the same node as the device it restricts.
+		assert_eq!(rule.device_type, Some(parsed.device.device_type));
+		assert_eq!(rule.major, Some(parsed.device.major));
+		assert_eq!(rule.minor, Some(parsed.device.minor));
 	}
 
 	// --- blkio ---

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -145,7 +145,19 @@ impl Engine {
 		let ulimits = build_ulimits(service);
 
 		// --- Devices ---
-		let mut devices: Vec<_> = service.devices.iter().map(|s| parse_device(s)).collect();
+		let mut devices: Vec<_> = Vec::with_capacity(service.devices.len());
+		// A device's `:permissions` segment cannot live on the OCI node, so it
+		// rides alongside as a cgroup access rule (mirroring the quadlet backend's
+		// verbatim `AddDevice`). These are merged with the explicit
+		// `device_cgroup_rules` below.
+		let mut device_cgroup_rule: Vec<_> = Vec::new();
+		for raw in &service.devices {
+			let parsed = parse_device(raw);
+			if let Some(rule) = parsed.cgroup_rule {
+				device_cgroup_rule.push(rule);
+			}
+			devices.push(parsed.device);
+		}
 		// CDI device names ride in the same array; Podman pulls them out by path.
 		devices.extend(cdi_devices(service).into_iter().map(cdi_device));
 
@@ -153,16 +165,12 @@ impl Engine {
 		let security = parse_security_opts(service);
 
 		// --- Device cgroup rules (parsed to structured form; skip malformed) ---
-		let device_cgroup_rule = service
-			.device_cgroup_rules
-			.iter()
-			.filter_map(|r| {
-				parse_device_cgroup_rule(r).or_else(|| {
-					tracing::warn!("device_cgroup_rules entry '{r}' is malformed and is ignored");
-					None
-				})
+		device_cgroup_rule.extend(service.device_cgroup_rules.iter().filter_map(|r| {
+			parse_device_cgroup_rule(r).or_else(|| {
+				tracing::warn!("device_cgroup_rules entry '{r}' is malformed and is ignored");
+				None
 			})
-			.collect();
+		}));
 
 		// --- Namespace modes ---
 		let pidns = service.pid.as_deref().map(Namespace::parse);

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -12,7 +12,7 @@ use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
-use targets::{expand_targets, filter_services, in_started_set};
+use targets::{expand_targets, filter_services, in_started_set, validate_targets};
 
 use super::container::config_hash;
 
@@ -144,6 +144,9 @@ impl Engine {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
 
+			// Reject unknown service names before doing any work, so `up`/`create`
+			// of a bogus service errors instead of exiting 0 as a silent no-op.
+			validate_targets(file, target_services)?;
 			let target_set = expand_targets(file, target_services, no_deps);
 
 			// Prefetch the project's containers once (instead of one API call per

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -48,6 +48,21 @@ pub(super) fn filter_services(
 		.collect())
 }
 
+/// Error if any requested target service name is absent from the file.
+///
+/// The up/create path expands targets into a set without checking membership, so
+/// a bogus name would silently match nothing and exit 0. This validates the list
+/// up front — matching docker-compose and the stop/start/kill commands, which
+/// already reject unknown services via [`filter_services`].
+pub(super) fn validate_targets(file: &ComposeFile, target_services: &[String]) -> Result<()> {
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	Ok(())
+}
+
 /// Resolve which services `up` should start given an explicit target list.
 ///
 /// Returns `None` when no targets are given (start everything). Otherwise the
@@ -97,7 +112,10 @@ pub(super) fn in_started_set(target_set: &Option<HashSet<String>>, name: &str) -
 
 #[cfg(test)]
 mod tests {
-	use super::{expand_targets, filter_services, in_started_set, service_grace_period_secs};
+	use super::{
+		expand_targets, filter_services, in_started_set, service_grace_period_secs,
+		validate_targets,
+	};
 	use crate::compose::types::{ComposeFile, Service};
 	use std::collections::HashSet;
 
@@ -175,6 +193,32 @@ mod tests {
 		assert!(matches!(
 			err,
 			crate::error::ComposeError::ServiceNotFound(_)
+		));
+	}
+
+	// --- validate_targets ---
+
+	#[test]
+	fn validate_targets_empty_is_ok() {
+		let file = file_with_services(&["a", "b"]);
+		assert!(validate_targets(&file, &[]).is_ok());
+	}
+
+	#[test]
+	fn validate_targets_known_names_ok() {
+		let file = file_with_services(&["a", "b"]);
+		assert!(validate_targets(&file, &["a".to_string(), "b".to_string()]).is_ok());
+	}
+
+	#[test]
+	fn validate_targets_unknown_name_errors() {
+		// An `up`/`create` for a service the file does not define must error
+		// rather than silently match nothing and exit 0.
+		let file = file_with_services(&["a"]);
+		let err = validate_targets(&file, &["no-such-service".to_string()]).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ServiceNotFound(name) if name == "no-such-service"
 		));
 	}
 


### PR DESCRIPTION
I fixed two verified findings from the container-create sweep. Both keep the live `up`/`create` path aligned with docker-compose and with podup's own quadlet backend.

- error on up/create of unknown service (Closes #807)
- honor device permission suffix (:r/:rw/:m) on the live up path (Closes #808)

For #807 the up/create path expanded the target list without checking that each requested service exists, so a bogus name matched nothing and the command exited 0 as a silent no-op. I added `validate_targets` and call it in `run_up` before expanding targets, so an undefined service now errors with `ServiceNotFound` — matching stop/start/kill and docker-compose.

For #808 `parse_device` dropped the trailing permission segment and the OCI `LinuxDevice` has no access field, so devices were created unrestricted (effectively rwm). I retain the permission and emit it as a `LinuxDeviceCgroup` access rule alongside the node, merged with the explicit `device_cgroup_rules`, so the restriction is preserved as the quadlet backend already does.

Both fixes have unit/parse-level test coverage. Verified with `cargo build`, `cargo fmt`, `cargo clippy --lib --bins -D warnings`, `cargo test --lib`, and the parse-level suites; the container integration suite was not run.
