### PR TITLE
fix(replicas): resolve verified replicas sweep findings

### DIFF
--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -84,7 +84,9 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.replica_name_at(service_name, service, opts.index)?;
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
@@ -130,7 +132,9 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.replica_name_at(service_name, service, opts.index)?;
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		// Match `docker cp` destination semantics. The libpod archive PUT extracts
 		// the tar *at* a directory, so:

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -286,30 +286,42 @@ impl Engine {
 		}
 	}
 
-	/// Resolve the container name for a service replica: the 1-based `--index`
-	/// when given (erroring if out of range), else the first replica. Shared by
-	/// the replica-targeting commands (`exec`, `cp`).
+	/// Resolve the container name for a service replica from the statically
+	/// derived names: the 1-based `--index` when given (erroring if out of
+	/// range), else the first replica.
+	///
+	/// Prefer [`Engine::live_replica_name_at`] for the replica-targeting
+	/// commands (`exec`, `cp`): the static names reflect only the compose
+	/// `scale:`/`deploy.replicas` (plus a `--scale` on the *current* invocation),
+	/// so a later `cp`/`exec` would not see replicas created by a prior
+	/// `up --scale`. This variant stays for callers that cannot await.
 	pub(super) fn replica_name_at(
 		&self,
 		service_name: &str,
 		service: &Service,
 		index: Option<u32>,
 	) -> Result<String> {
-		match index {
-			Some(i) => {
-				// `--index` is 1-based; `0` is an invalid index, not "first replica".
-				let idx = (i as usize).checked_sub(1).ok_or_else(|| {
-					ComposeError::ServiceNotFound(format!(
-						"{service_name} (replica index {i}: indexes are 1-based)"
-					))
-				})?;
-				let names = self.replica_names(service_name, service);
-				names.get(idx).cloned().ok_or_else(|| {
-					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
-				})
-			}
-			None => Ok(self.first_replica_name(service_name, service)),
-		}
+		let names = self.replica_names(service_name, service);
+		let base = self.container_name(service_name, service);
+		resolve_replica_name(service_name, &base, &names, index)
+	}
+
+	/// Resolve the container name for a service replica against the *running*
+	/// scale: the replicas Podman actually has (matched by the `podup.service`
+	/// label), falling back to the statically derived names before anything is
+	/// created. `--index n` therefore targets replica `n` even when it was
+	/// created by an earlier `up --scale`/`scale` rather than the current
+	/// invocation, matching `docker compose cp/exec --index`. Shared by the
+	/// replica-targeting commands (`exec`, `cp`).
+	pub(super) async fn live_replica_name_at(
+		&self,
+		service_name: &str,
+		service: &Service,
+		index: Option<u32>,
+	) -> Result<String> {
+		let names = self.live_replica_names(service_name, service).await?;
+		let base = self.container_name(service_name, service);
+		resolve_replica_name(service_name, &base, &names, index)
 	}
 
 	/// Watch for file changes and apply the service's `develop.watch` rules. Returns an error when the `watch` feature is disabled.
@@ -319,6 +331,72 @@ impl Engine {
 			"watch requires the 'watch' feature".into(),
 		))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Replica resolution helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a replica container name from the set of names that exist for a
+/// service (the running replicas, or the statically derived names before
+/// anything is created) and a 1-based `--index`. Each name is either the
+/// unsuffixed base (the sole replica) or `{base}-{n}`.
+///
+/// `--index n` targets the replica numbered `n` — by name, not by position —
+/// so it stays correct after a runtime `scale`/`up --scale` and regardless of
+/// the order Podman lists containers; `0` is rejected (indexes are 1-based);
+/// `None` picks the lowest-numbered replica. Pure so it is unit-testable
+/// without a Podman socket.
+fn resolve_replica_name(
+	service_name: &str,
+	base: &str,
+	names: &[String],
+	index: Option<u32>,
+) -> Result<String> {
+	match index {
+		Some(0) => Err(ComposeError::ServiceNotFound(format!(
+			"{service_name} (replica index 0: indexes are 1-based)"
+		))),
+		Some(i) => {
+			let suffixed = format!("{base}-{i}");
+			if names.iter().any(|n| n == &suffixed) {
+				return Ok(suffixed);
+			}
+			// A single, unsuffixed replica answers to index 1 only.
+			if i == 1 && names.iter().any(|n| n == base) {
+				return Ok(base.to_string());
+			}
+			Err(ComposeError::ServiceNotFound(format!(
+				"{service_name} (replica index {i})"
+			)))
+		}
+		None => order_replicas(base, names)
+			.into_iter()
+			.next()
+			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into())),
+	}
+}
+
+/// Order replica container names by their 1-based replica number so callers can
+/// pick the lowest-numbered one independently of Podman's listing order. A name
+/// is the unsuffixed base (the sole replica → number 1) or `{base}-{n}`; names
+/// matching neither are dropped.
+fn order_replicas(base: &str, names: &[String]) -> Vec<String> {
+	let prefix = format!("{base}-");
+	let mut numbered: Vec<(usize, String)> = names
+		.iter()
+		.filter_map(|name| {
+			if name == base {
+				Some((1, name.clone()))
+			} else {
+				name.strip_prefix(&prefix)
+					.and_then(|s| s.parse::<usize>().ok())
+					.map(|n| (n, name.clone()))
+			}
+		})
+		.collect();
+	numbered.sort_by_key(|(n, _)| *n);
+	numbered.into_iter().map(|(_, name)| name).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -422,6 +500,84 @@ mod tests {
 		assert_eq!(
 			e.replica_name_at("web", &scaled_service(3), None).unwrap(),
 			"proj-web-1"
+		);
+	}
+
+	fn names(list: &[&str]) -> Vec<String> {
+		list.iter().map(|s| s.to_string()).collect()
+	}
+
+	#[test]
+	fn resolve_replica_targets_running_scale_not_compose_default() {
+		// The regression: a later `cp`/`exec` has no `--scale` (empty overrides),
+		// so the static count is the compose default (1). But the service was
+		// scaled up earlier and three replicas are running — `--index 2` must
+		// address the running `proj-web-2`, not fall back to the base name.
+		let live = names(&["proj-web-1", "proj-web-2", "proj-web-3"]);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(2)).unwrap(),
+			"proj-web-2"
+		);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(3)).unwrap(),
+			"proj-web-3"
+		);
+	}
+
+	#[test]
+	fn resolve_replica_is_order_independent() {
+		// Podman does not guarantee a listing order; `--index n` targets replica
+		// `n` by name, and `None` picks the lowest-numbered replica regardless.
+		let live = names(&["proj-web-3", "proj-web-1", "proj-web-2"]);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(1)).unwrap(),
+			"proj-web-1"
+		);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, None).unwrap(),
+			"proj-web-1"
+		);
+	}
+
+	#[test]
+	fn resolve_replica_out_of_range_against_running_scale() {
+		// Only two replicas running: index 3 is out of range, not a stale base.
+		let live = names(&["proj-web-1", "proj-web-2"]);
+		assert!(resolve_replica_name("web", "proj-web", &live, Some(3)).is_err());
+	}
+
+	#[test]
+	fn resolve_replica_index_zero_is_rejected() {
+		let live = names(&["proj-web-1", "proj-web-2"]);
+		let err = resolve_replica_name("web", "proj-web", &live, Some(0))
+			.expect_err("index 0 must be rejected");
+		assert!(
+			matches!(err, ComposeError::ServiceNotFound(ref m) if m.contains("1-based")),
+			"unexpected error: {err:?}"
+		);
+	}
+
+	#[test]
+	fn resolve_replica_single_unsuffixed_base() {
+		// A single, unsuffixed replica answers to index 1 (and None), never index 2.
+		let live = names(&["proj-web"]);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, None).unwrap(),
+			"proj-web"
+		);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(1)).unwrap(),
+			"proj-web"
+		);
+		assert!(resolve_replica_name("web", "proj-web", &live, Some(2)).is_err());
+	}
+
+	#[test]
+	fn order_replicas_sorts_by_replica_number() {
+		let live = names(&["proj-web-10", "proj-web-2", "proj-web-1"]);
+		assert_eq!(
+			order_replicas("proj-web", &live),
+			names(&["proj-web-1", "proj-web-2", "proj-web-10"])
 		);
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -367,16 +367,9 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = match opts.index {
-			Some(i) => {
-				let names = self.replica_names(service_name, service);
-				let idx = (i as usize).saturating_sub(1);
-				names.get(idx).cloned().ok_or_else(|| {
-					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
-				})?
-			}
-			None => self.first_replica_name(service_name, service),
-		};
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		let exec_cfg = ExecCreateConfig {
 			cmd: Some(cmd),


### PR DESCRIPTION
I fixed the verified `replicas` sweep finding: `cp`/`exec --index` ignored the running scale.

`cp` and `exec` resolved `--index` from the static replica count (the compose `scale:`/`deploy.replicas`, plus any `--scale` on the *current* invocation). A later `podup cp`/`exec` carries no `--scale`, so the count fell back to the compose default (often 1) and `--index 2` targeted the stale base name or was reported out of range — even when `proj-web-2` was running from an earlier `up --scale`. That diverged from `docker compose cp/exec --index`, which resolves against the running scale.

I added `live_replica_name_at`, which resolves the index against the replicas Podman actually has (the `podup.service` label, reusing the existing `live_replica_names`), falling back to the static names before anything is created. Resolution is by replica *number*, not list position, so it is correct regardless of Podman's listing order and after a runtime `scale`. The static `replica_name_at` now delegates to the same pure `resolve_replica_name` helper so the two paths cannot drift, and index 0 is now rejected consistently (previously `exec` silently treated it as the first replica).

Fixed:

- cp/exec `--index` resolves replicas from compose/CLI scale, not the running scale (Closes #795)

I added unit tests covering running-scale resolution, order-independence, out-of-range, index 0, and the single unsuffixed-base case. `cargo build`, `cargo fmt --all`, `cargo clippy --lib --bins -D warnings`, `cargo test --lib`, and the parse/substitute/size/ports/env_file/quadlet/project_name_safety/secret_safety/cli_aliases/cli_diagnostics suites all pass. (The container integration suite was not run.)
