### PR TITLE
fix(profiles): resolve verified profiles sweep findings

### DIFF
--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -9,6 +9,20 @@ use podup::Engine;
 
 use crate::cli::*;
 
+/// Clone the compose file keeping only services in an active profile, plus any
+/// named on the command line (which activates their profile). Used by the
+/// per-service subcommands so they target exactly the set `up`/`create` would
+/// bring up — never a service hidden behind an inactive profile.
+fn profile_filtered(
+	file: &podup::compose::types::ComposeFile,
+	profile: &[String],
+	targets: &[String],
+) -> podup::compose::types::ComposeFile {
+	let mut filtered = file.clone();
+	podup::retain_active_profiles_with_targets(&mut filtered, profile, targets);
+	filtered
+}
+
 /// Run the command against an already-built engine and parsed compose file.
 pub(crate) async fn dispatch(
 	engine: &Engine,
@@ -101,6 +115,7 @@ pub(crate) async fn dispatch(
 			wait_timeout,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine.start(file, &services).await?;
 			if wait {
 				let fut = engine.wait_services_healthy(file, &services);
@@ -115,7 +130,10 @@ pub(crate) async fn dispatch(
 		Commands::Stop {
 			services,
 			timeout: _,
-		} => engine.stop(file, &services).await?,
+		} => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.stop(file, &services).await?
+		}
 		Commands::Scale { pairs } => engine.scale(file, &pairs).await?,
 		Commands::Create {
 			build,
@@ -137,6 +155,7 @@ pub(crate) async fn dispatch(
 			quiet,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.build_all_with_options(
 					file,
@@ -170,13 +189,20 @@ pub(crate) async fn dispatch(
 			remove_orphans,
 			services,
 		} => {
-			engine.kill(file, &services, &signal).await?;
+			let filtered = profile_filtered(file, profile, &services);
+			engine.kill(&filtered, &services, &signal).await?;
 			if remove_orphans {
 				engine.remove_orphans(file).await?;
 			}
 		}
-		Commands::Pause { services } => engine.pause(file, &services).await?,
-		Commands::Unpause { services } => engine.unpause(file, &services).await?,
+		Commands::Pause { services } => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.pause(file, &services).await?
+		}
+		Commands::Unpause { services } => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.unpause(file, &services).await?
+		}
 		Commands::Run {
 			service,
 			rm: _,
@@ -256,7 +282,10 @@ pub(crate) async fn dispatch(
 			engine.stream_events(json).await?
 		}
 		Commands::Attach { service } => engine.attach(file, &service).await?,
-		Commands::Wait { services } => engine.wait_services(file, &services).await?,
+		Commands::Wait { services } => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.wait_services(file, &services).await?
+		}
 		Commands::Commit {
 			service,
 			image,
@@ -276,6 +305,7 @@ pub(crate) async fn dispatch(
 			tls_verify,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.push(
 					file,
@@ -314,6 +344,7 @@ pub(crate) async fn dispatch(
 				.await?
 		}
 		Commands::Images { quiet, format } => {
+			let file = &profile_filtered(file, profile, &[]);
 			engine
 				.images_with_options(
 					file,
@@ -380,6 +411,7 @@ pub(crate) async fn dispatch(
 			policy: _,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.pull_services_with_options(
 					file,
@@ -396,6 +428,7 @@ pub(crate) async fn dispatch(
 			no_deps,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.restart_with_options(file, &services, no_deps)
 				.await?

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -19,7 +19,7 @@ mod lifecycle;
 mod lock;
 mod network;
 mod profiles;
-pub use profiles::retain_active_profiles;
+pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};
 mod projects;
 pub use projects::{list_projects, LsOptions};
 mod query;

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -6,14 +6,51 @@ use crate::compose::types::{ComposeFile, Service};
 
 /// Remove services excluded by the active profile set, in place.
 ///
-/// Mirrors what `up` actually starts (a per-service profile match, with no
-/// implicit activation of a profiled `depends_on` target), so `config` presents
-/// the same service set the runtime would bring up. `active` is the CLI
-/// `--profile` list, falling back to `COMPOSE_PROFILES`.
+/// `active` is the CLI `--profile` list, falling back to `COMPOSE_PROFILES`.
+/// A profiled service that is a transitive `depends_on` target of a retained
+/// service is implicitly enabled, matching docker compose — so the output never
+/// carries a dangling dependency reference.
 pub fn retain_active_profiles(file: &mut ComposeFile, active: &[String]) {
+	retain_active_profiles_with_targets(file, active, &[]);
+}
+
+/// Like [`retain_active_profiles`], but also keeps any service named in
+/// `targets` even when its profile is inactive: naming a service on the command
+/// line activates its profile (docker compose), so per-service subcommands
+/// (`start`, `stop`, `build`, `push`, `pull`, …) can still address it.
+pub fn retain_active_profiles_with_targets(
+	file: &mut ComposeFile,
+	active: &[String],
+	targets: &[String],
+) {
 	let set = active_profiles_set(active);
-	file.services
-		.retain(|_, svc| service_in_profiles(svc, &set));
+	let named: HashSet<&str> = targets.iter().map(|s| s.as_str()).collect();
+
+	// Directly enabled: an unprofiled service, a profile match (or `*`), or a
+	// service explicitly named on the command line.
+	let mut enabled: HashSet<String> = file
+		.services
+		.iter()
+		.filter(|(name, svc)| service_in_profiles(svc, &set) || named.contains(name.as_str()))
+		.map(|(name, _)| name.clone())
+		.collect();
+
+	// Implicit activation: pull in profiled `depends_on` targets of enabled
+	// services, transitively, so a retained service never references a dropped
+	// dependency. Mirrors docker compose, which enables a profiled service that
+	// is depended on by a started one.
+	let mut stack: Vec<String> = enabled.iter().cloned().collect();
+	while let Some(name) = stack.pop() {
+		if let Some(svc) = file.services.get(&name) {
+			for dep in svc.depends_on.service_names() {
+				if file.services.contains_key(&dep) && enabled.insert(dep.clone()) {
+					stack.push(dep);
+				}
+			}
+		}
+	}
+
+	file.services.retain(|name, _| enabled.contains(name));
 }
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.
@@ -34,9 +71,14 @@ pub(super) fn active_profiles_set(active: &[String]) -> HashSet<String> {
 
 /// True if the service should be started given the active profile set.
 ///
-/// Services with no profiles always start.
+/// Services with no profiles always start. A literal `*` in the active set is a
+/// wildcard that enables every profiled service (docker compose's
+/// "enable all profiles").
 pub(super) fn service_in_profiles(service: &Service, active: &HashSet<String>) -> bool {
 	if service.profiles.is_empty() {
+		return true;
+	}
+	if active.contains("*") {
 		return true;
 	}
 	service.profiles.iter().any(|p| active.contains(p))
@@ -140,5 +182,89 @@ mod tests {
 		});
 		assert!(file.services.contains_key("web"));
 		assert_eq!(file.services.len(), 1);
+	}
+
+	#[test]
+	fn wildcard_enables_all_profiles() {
+		// `--profile '*'` enables every profiled service, matching docker compose.
+		let svc = Service {
+			profiles: vec!["debug".to_string()],
+			..Default::default()
+		};
+		let active: HashSet<String> = ["*".to_string()].into();
+		assert!(service_in_profiles(&svc, &active));
+
+		let yaml = "services:\n  \
+			web:\n    image: x\n  \
+			debugger:\n    image: x\n    profiles: [debug]\n  \
+			db:\n    image: x\n    profiles: [prod]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		retain_active_profiles(&mut file, &["*".to_string()]);
+		assert_eq!(file.services.len(), 3);
+	}
+
+	#[test]
+	fn implicit_activation_keeps_profiled_dependency() {
+		// `app` (active) depends on `db` (profiles: [storage]). With no profile
+		// active, `db` is implicitly enabled so `app` keeps a satisfiable dep —
+		// no dangling reference, matching docker compose.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert!(file.services.contains_key("app"));
+		assert!(
+			file.services.contains_key("db"),
+			"profiled depends_on target is implicitly activated"
+		);
+	}
+
+	#[test]
+	fn implicit_activation_is_transitive() {
+		// app -> db -> storage, where both db and storage are profiled. Enabling
+		// app must pull in the whole transitive dependency chain.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [p]\n    depends_on: [storage]\n  \
+			storage:\n    image: x\n    profiles: [q]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert_eq!(file.services.len(), 3);
+	}
+
+	#[test]
+	fn unrelated_profiled_service_still_dropped() {
+		// Implicit activation only reaches dependencies — an unrelated profiled
+		// service is still removed.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n  \
+			extra:\n    image: x\n    profiles: [other]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert!(file.services.contains_key("db"));
+		assert!(!file.services.contains_key("extra"));
+	}
+
+	#[test]
+	fn named_target_keeps_inactive_profile_service() {
+		// Naming a profiled service on the command line activates its profile, so
+		// per-service subcommands can still address it.
+		let yaml = "services:\n  \
+			web:\n    image: x\n  \
+			debugger:\n    image: x\n    profiles: [debug]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles_with_targets(&mut file, &[], &["debugger".to_string()]);
+		});
+		assert!(file.services.contains_key("web"));
+		assert!(file.services.contains_key("debugger"));
 	}
 }

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -46,8 +46,9 @@ pub use compose::{
 /// through.
 pub use engine::{
 	is_safe_project_name, list_projects, resolve_image_digests, retain_active_profiles,
-	BuildOptions, CpOptions, Engine, ExecOptions, ImagesOptions, LogsOptions, LsOptions,
-	ProjectLock, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, VolumesOptions,
+	retain_active_profiles_with_targets, BuildOptions, CpOptions, Engine, ExecOptions,
+	ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions, PushOptions,
+	RunOptions, RunOverrides, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.


### PR DESCRIPTION
## Profiles sweep

This is a sweep of verified profile-handling bugs. Profile filtering was applied only in the `config` render path, so most commands operated on the full, unfiltered service set and acted on services hidden behind an inactive profile — services `up`/`create` would never have brought up. I also align profile resolution itself with docker compose (wildcard support and implicit `depends_on` activation).

The per-service subcommands now pre-filter the compose file through the active profile set, keeping any service named on the command line (naming a service activates its profile). `remove_orphans` still sees the full file so profiled services are not mistaken for orphans.

### Fixed

- Lifecycle commands (start/stop/restart/kill/pause/unpause) ignore active profiles (Closes #771)
- push ignores active profiles (Closes #772)
- build ignores compose profiles; --profile is a no-op for build (Closes #773)
- wait ignores active profiles: default wait 404s on profile-gated services (Closes #774)
- images ignores compose profiles (Closes #775)
- pull does not honour profiles (Closes #776)
- Profile filtering ignores depends_on: profiled dependency dropped, leaving dangling references (Closes #777)
- --profile '*' wildcard not supported (enable-all-profiles) (Closes #890)

### Tests

Profile resolution is covered by unit tests in `internal/engine/profiles.rs`: the `*` wildcard, transitive implicit `depends_on` activation, unrelated-profile exclusion, and named-target retention.
