### PR TITLE
fix(build): resolve verified build sweep findings

### DIFF
--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -12,20 +12,35 @@ use flate2::Compression;
 use crate::error::{ComposeError, Result};
 
 /// Append the build context to `tar`, honoring `.dockerignore`.
+///
+/// `skip_names` are context-relative paths to omit even when not ignored (used to
+/// drop the user's `.dockerignore` so it can be rewritten with extra rules).
 fn append_context<W: std::io::Write>(
 	tar: &mut tar::Builder<W>,
 	context: &Path,
 	ignore_patterns: &[String],
+	skip_names: &[&str],
 ) -> Result<()> {
+	// Do not dereference symlinks: a symlink in the context would otherwise pack
+	// the bytes of its (possibly out-of-context) target — e.g. `/etc/hostname` or
+	// an SSH key — into the image. Store the link itself instead, matching the
+	// watch-sync and cp paths.
+	tar.follow_symlinks(false);
 	for abs in super::super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
 		let rel_str = rel.to_string_lossy();
+		if skip_names.iter().any(|n| rel_str == *n) {
+			continue;
+		}
 		if is_ignored(&rel_str, ignore_patterns) {
 			continue;
 		}
-		if abs.is_dir() {
+		// Classify without following symlinks so a symlink-to-dir is stored as a
+		// link rather than walked and dereferenced.
+		let is_dir = abs.symlink_metadata().map(|m| m.is_dir()).unwrap_or(false);
+		if is_dir {
 			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
@@ -76,7 +91,20 @@ pub(super) fn build_context_tar_with_inline(
 	tar.append_data(&mut header, inline_name, inline.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-	append_context(&mut tar, context, &ignore_patterns)?;
+	// Skip the user's `.dockerignore` here; it is rewritten below with an extra
+	// rule excluding the synthesized inline Dockerfile.
+	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"])?;
+
+	// Rewrite `.dockerignore` (merged with any user rules) so a `COPY .` in the
+	// build does not bake the synthesized `.dockerfile-inline` into the image.
+	let dockerignore = inline_dockerignore(context, inline_name);
+	let mut di_header = tar::Header::new_gnu();
+	di_header.set_size(dockerignore.len() as u64);
+	di_header.set_mode(0o644);
+	di_header.set_cksum();
+	tar.append_data(&mut di_header, ".dockerignore", dockerignore.as_bytes())
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+
 	append_extra_files(&mut tar, extra_files)?;
 
 	let gz = tar
@@ -98,7 +126,7 @@ pub(crate) fn build_context_tar(
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	append_context(&mut tar, context, &ignore_patterns)?;
+	append_context(&mut tar, context, &ignore_patterns, &[])?;
 	append_extra_files(&mut tar, extra_files)?;
 
 	let gz = tar
@@ -109,6 +137,21 @@ pub(crate) fn build_context_tar(
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
 	Ok(bytes)
+}
+
+/// Build the `.dockerignore` content for an inline-Dockerfile build: any user
+/// rules plus a final entry excluding the synthesized inline Dockerfile so a
+/// `COPY .` in the build does not capture `.dockerfile-inline`.
+fn inline_dockerignore(context: &Path, inline_name: &str) -> String {
+	let existing =
+		crate::filesystem::read_to_string_capped(context.join(".dockerignore")).unwrap_or_default();
+	let mut out = existing.trim_end_matches(['\n', '\r']).to_string();
+	if !out.is_empty() {
+		out.push('\n');
+	}
+	out.push_str(inline_name);
+	out.push('\n');
+	out
 }
 
 /// Map a compose `additional_contexts` value to the libpod
@@ -465,6 +508,109 @@ mod tests {
 		let (bytes, df_name) = build_context_tar_with_inline(dir.path(), inline, &[]).unwrap();
 		assert_eq!(&bytes[..2], &[0x1f, 0x8b]);
 		assert!(!df_name.is_empty());
+	}
+
+	#[test]
+	fn inline_dockerfile_excluded_via_dockerignore() {
+		use flate2::read::GzDecoder;
+		use std::io::Read;
+
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("app.txt"), b"x").unwrap();
+		let (bytes, _) = build_context_tar_with_inline(dir.path(), "FROM alpine\n", &[]).unwrap();
+
+		let mut raw = Vec::new();
+		GzDecoder::new(bytes.as_slice())
+			.read_to_end(&mut raw)
+			.unwrap();
+		let mut archive = tar::Archive::new(raw.as_slice());
+		let mut di = String::new();
+		for entry in archive.entries().unwrap() {
+			let mut entry = entry.unwrap();
+			if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+				entry.read_to_string(&mut di).unwrap();
+			}
+		}
+		assert!(
+			di.lines().any(|l| l == ".dockerfile-inline"),
+			"inline Dockerfile must be excluded from COPY via .dockerignore: {di:?}"
+		);
+	}
+
+	#[test]
+	fn inline_dockerignore_preserves_user_rules() {
+		use flate2::read::GzDecoder;
+		use std::io::Read;
+
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("app.txt"), b"x").unwrap();
+		fs::write(dir.path().join(".dockerignore"), b"*.log\n").unwrap();
+		let (bytes, _) = build_context_tar_with_inline(dir.path(), "FROM alpine\n", &[]).unwrap();
+
+		let mut raw = Vec::new();
+		GzDecoder::new(bytes.as_slice())
+			.read_to_end(&mut raw)
+			.unwrap();
+		let mut archive = tar::Archive::new(raw.as_slice());
+		// The user's `.dockerignore` must appear exactly once, merged with the
+		// synthesized inline-Dockerfile exclusion.
+		let mut di_entries = 0;
+		let mut di = String::new();
+		for entry in archive.entries().unwrap() {
+			let mut entry = entry.unwrap();
+			if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+				di_entries += 1;
+				entry.read_to_string(&mut di).unwrap();
+			}
+		}
+		assert_eq!(di_entries, 1, "exactly one .dockerignore entry");
+		assert!(di.lines().any(|l| l == "*.log"), "user rule kept: {di:?}");
+		assert!(
+			di.lines().any(|l| l == ".dockerfile-inline"),
+			"inline exclusion added: {di:?}"
+		);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn context_tar_packs_symlink_as_link_not_target() {
+		use flate2::read::GzDecoder;
+		use std::io::Read;
+
+		// A symlink that points outside the context (e.g. to a host secret) must be
+		// stored as a link, never dereferenced into the image.
+		let outside = tempdir().unwrap();
+		fs::write(outside.path().join("secret"), b"TOPSECRET").unwrap();
+
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+		std::os::unix::fs::symlink(outside.path().join("secret"), dir.path().join("leak")).unwrap();
+
+		let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+		let mut raw = Vec::new();
+		GzDecoder::new(bytes.as_slice())
+			.read_to_end(&mut raw)
+			.unwrap();
+		let mut archive = tar::Archive::new(raw.as_slice());
+
+		let mut found = false;
+		for entry in archive.entries().unwrap() {
+			let entry = entry.unwrap();
+			if entry.path().unwrap().to_string_lossy() == "leak" {
+				found = true;
+				assert_eq!(
+					entry.header().entry_type(),
+					tar::EntryType::Symlink,
+					"symlink must be packed as a link"
+				);
+				assert_eq!(
+					entry.header().size().unwrap(),
+					0,
+					"link entry must not carry the target's bytes"
+				);
+			}
+		}
+		assert!(found, "symlink entry must be present in the context tar");
 	}
 
 	#[test]

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,6 +8,7 @@
 mod context;
 mod pull;
 mod push;
+mod tags;
 pub use pull::PullOptions;
 pub use push::PushOptions;
 
@@ -23,6 +24,7 @@ use crate::libpod::API_PREFIX;
 use crate::size;
 
 use context::{build_context_tar, build_context_tar_with_inline, map_additional_context};
+use tags::{is_remote_context, looks_like_secret, primary_build_tag};
 
 use super::Engine;
 
@@ -420,56 +422,9 @@ impl Engine {
 	}
 }
 
-/// A build context is remote when it is a URL or Git reference that Podman
-/// clones server-side, rather than a local directory to tar and upload.
-fn is_remote_context(context: &str) -> bool {
-	context.contains("://") || context.starts_with("git@")
-}
-
-/// Pick the primary image tag for a built service.
-///
-/// Precedence matches compose-go: an explicit `image:` wins; otherwise the
-/// first entry of `build.tags` is used as the primary tag; with neither, the
-/// image is named `{project}-{service}:latest` (project-scoped, like docker
-/// compose) so two projects sharing a service name don't overwrite each other's
-/// image. Any remaining `build.tags` are applied as extra tags by
-/// [`Engine::apply_extra_tags`].
-fn primary_build_tag(
-	project: &str,
-	service_name: &str,
-	image: Option<&str>,
-	tags: &[String],
-) -> String {
-	if let Some(image) = image {
-		return image.to_string();
-	}
-	if let Some(first) = tags.first() {
-		return first.clone();
-	}
-	format!("{project}-{service_name}:latest")
-}
-
-/// True if a build-arg name looks like it carries a secret, so the caller can
-/// warn that build args persist in the image history. Case-insensitive substring
-/// match on common secret tokens, kept conservative to avoid false positives
-/// (e.g. a bare `KEY` is not flagged; `API_KEY`/`PRIVATE_KEY` are).
-fn looks_like_secret(name: &str) -> bool {
-	const MARKERS: [&str; 7] = [
-		"SECRET",
-		"PASSWORD",
-		"PASSWD",
-		"TOKEN",
-		"CREDENTIAL",
-		"API_KEY",
-		"PRIVATE_KEY",
-	];
-	let upper = name.to_ascii_uppercase();
-	MARKERS.iter().any(|m| upper.contains(m))
-}
-
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, looks_like_secret, primary_build_tag, Engine};
+	use super::Engine;
 	use crate::libpod::Client;
 
 	fn engine(base: std::path::PathBuf) -> Engine {
@@ -478,22 +433,6 @@ mod tests {
 
 	fn build_of(file: &crate::compose::types::ComposeFile) -> &crate::compose::types::BuildConfig {
 		file.services["app"].build.as_ref().unwrap()
-	}
-
-	#[test]
-	fn looks_like_secret_flags_sensitive_names_only() {
-		for name in [
-			"DB_PASSWORD",
-			"api_token",
-			"MySecret",
-			"AWS_API_KEY",
-			"private_key",
-		] {
-			assert!(looks_like_secret(name), "{name} should be flagged");
-		}
-		for name in ["VERSION", "BUILD_DATE", "PUBLIC_KEY", "PORT", "RUST_LOG"] {
-			assert!(!looks_like_secret(name), "{name} should not be flagged");
-		}
 	}
 
 	#[test]
@@ -530,51 +469,6 @@ mod tests {
 		let (files, specs) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
 		assert!(files.is_empty());
 		assert!(specs.is_empty());
-	}
-
-	#[test]
-	fn remote_context_detection() {
-		assert!(is_remote_context("https://github.com/user/repo.git"));
-		assert!(is_remote_context("git://example.com/repo.git"));
-		assert!(is_remote_context("git@github.com:user/repo.git"));
-		assert!(!is_remote_context("."));
-		assert!(!is_remote_context("./build"));
-		assert!(!is_remote_context("/abs/path"));
-	}
-
-	#[test]
-	fn primary_tag_prefers_explicit_image() {
-		let tags = vec!["registry/app:1.0".to_string()];
-		assert_eq!(
-			primary_build_tag("proj", "app", Some("myimage:2.0"), &tags),
-			"myimage:2.0"
-		);
-	}
-
-	#[test]
-	fn primary_tag_uses_first_build_tag_when_image_unset() {
-		let tags = vec![
-			"registry/app:1.0".to_string(),
-			"registry/app:latest".to_string(),
-		];
-		assert_eq!(
-			primary_build_tag("proj", "app", None, &tags),
-			"registry/app:1.0"
-		);
-	}
-
-	#[test]
-	fn primary_tag_falls_back_to_project_scoped_latest() {
-		// Build-only services (no `image:`, no `tags`) are namespaced by project so
-		// two projects sharing a service name don't clobber each other's image.
-		assert_eq!(
-			primary_build_tag("proj", "app", None, &[]),
-			"proj-app:latest"
-		);
-		assert_eq!(
-			primary_build_tag("other", "app", None, &[]),
-			"other-app:latest"
-		);
 	}
 
 	#[tokio::test]

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -101,7 +101,12 @@ impl Engine {
 
 		let context_str = build.context().to_string();
 		let remote_context = is_remote_context(&context_str);
-		let tag = primary_build_tag(service_name, service.image.as_deref(), build.tags());
+		let tag = primary_build_tag(
+			&self.project,
+			service_name,
+			service.image.as_deref(),
+			build.tags(),
+		);
 
 		// A Git/URL context is cloned server-side by Podman via the `remote`
 		// query parameter — there is no local directory to tar. Tar-only features
@@ -169,6 +174,13 @@ impl Engine {
 				Some((k, v)) => (k.to_string(), v.to_string()),
 				None => (entry.clone(), std::env::var(entry).unwrap_or_default()),
 			};
+			// A bare `=value` (empty key) is a user typo Podman would silently
+			// ignore; reject it with a clear diagnostic instead.
+			if k.is_empty() {
+				return Err(ComposeError::Build(format!(
+					"invalid --build-arg '{entry}': empty argument name"
+				)));
+			}
 			build_args.insert(k, v);
 		}
 
@@ -212,10 +224,14 @@ impl Engine {
 			}).cloned(),
 			_ => None,
 		};
-		let shmsize = build
-			.shm_size()
-			.and_then(size::parse_memory)
-			.map(|s| s as i32);
+		// Distinguish "absent" from "present but unparseable": a malformed
+		// `shm_size` must be rejected, not silently dropped to the default.
+		let shmsize = match build.shm_size() {
+			Some(raw) => Some(size::parse_memory(raw).ok_or_else(|| {
+				ComposeError::Build(format!("invalid build.shm_size value '{raw}'"))
+			})? as i32),
+			None => None,
+		};
 		let extrahosts_str = build.extra_hosts().join(",");
 		let extrahosts = if extrahosts_str.is_empty() {
 			None
@@ -414,16 +430,23 @@ fn is_remote_context(context: &str) -> bool {
 ///
 /// Precedence matches compose-go: an explicit `image:` wins; otherwise the
 /// first entry of `build.tags` is used as the primary tag; with neither, the
-/// image is named `{service}:latest`. Any remaining `build.tags` are applied
-/// as extra tags by [`Engine::apply_extra_tags`].
-fn primary_build_tag(service_name: &str, image: Option<&str>, tags: &[String]) -> String {
+/// image is named `{project}-{service}:latest` (project-scoped, like docker
+/// compose) so two projects sharing a service name don't overwrite each other's
+/// image. Any remaining `build.tags` are applied as extra tags by
+/// [`Engine::apply_extra_tags`].
+fn primary_build_tag(
+	project: &str,
+	service_name: &str,
+	image: Option<&str>,
+	tags: &[String],
+) -> String {
 	if let Some(image) = image {
 		return image.to_string();
 	}
 	if let Some(first) = tags.first() {
 		return first.clone();
 	}
-	format!("{service_name}:latest")
+	format!("{project}-{service_name}:latest")
 }
 
 /// True if a build-arg name looks like it carries a secret, so the caller can
@@ -523,7 +546,7 @@ mod tests {
 	fn primary_tag_prefers_explicit_image() {
 		let tags = vec!["registry/app:1.0".to_string()];
 		assert_eq!(
-			primary_build_tag("app", Some("myimage:2.0"), &tags),
+			primary_build_tag("proj", "app", Some("myimage:2.0"), &tags),
 			"myimage:2.0"
 		);
 	}
@@ -534,12 +557,71 @@ mod tests {
 			"registry/app:1.0".to_string(),
 			"registry/app:latest".to_string(),
 		];
-		assert_eq!(primary_build_tag("app", None, &tags), "registry/app:1.0");
+		assert_eq!(
+			primary_build_tag("proj", "app", None, &tags),
+			"registry/app:1.0"
+		);
 	}
 
 	#[test]
-	fn primary_tag_falls_back_to_service_latest() {
-		assert_eq!(primary_build_tag("app", None, &[]), "app:latest");
+	fn primary_tag_falls_back_to_project_scoped_latest() {
+		// Build-only services (no `image:`, no `tags`) are namespaced by project so
+		// two projects sharing a service name don't clobber each other's image.
+		assert_eq!(
+			primary_build_tag("proj", "app", None, &[]),
+			"proj-app:latest"
+		);
+		assert_eq!(
+			primary_build_tag("other", "app", None, &[]),
+			"other-app:latest"
+		);
+	}
+
+	#[tokio::test]
+	async fn empty_build_arg_key_is_rejected() {
+		// `--build-arg =value` is a user typo Podman would silently ignore; we
+		// reject it before contacting the daemon.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+		let yaml = "services:\n  app:\n    build:\n      context: .\n";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine(dir.path().to_path_buf());
+		let opts = super::BuildOptions {
+			build_args: vec!["=orphan".to_string()],
+			..Default::default()
+		};
+		let err = e
+			.build_service("app", &file.services["app"], &file, &opts)
+			.await
+			.expect_err("empty build-arg key must be rejected");
+		assert!(
+			err.to_string().contains("build-arg"),
+			"unexpected error: {err}"
+		);
+	}
+
+	#[tokio::test]
+	async fn invalid_shm_size_is_rejected() {
+		// A malformed `build.shm_size` must error rather than silently fall back to
+		// the default shm size.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+		let yaml = "services:\n  app:\n    build:\n      context: .\n      shm_size: \"64mb!\"\n";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine(dir.path().to_path_buf());
+		let err = e
+			.build_service(
+				"app",
+				&file.services["app"],
+				&file,
+				&super::BuildOptions::default(),
+			)
+			.await
+			.expect_err("malformed shm_size must be rejected");
+		assert!(
+			err.to_string().contains("shm_size"),
+			"unexpected error: {err}"
+		);
 	}
 
 	#[test]

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -1,7 +1,7 @@
 //! Image pull from a registry (the non-build half of image acquisition).
 
 use futures_util::StreamExt;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use std::collections::HashSet;
 
@@ -48,6 +48,14 @@ impl Engine {
 		services: &[String],
 		opts: PullOptions,
 	) -> Result<()> {
+		// Reject unknown service names up front, matching `docker compose pull`
+		// (and `logs`), rather than silently doing nothing.
+		for name in services {
+			if !file.services.contains_key(name) {
+				return Err(ComposeError::ServiceNotFound(name.clone()));
+			}
+		}
+
 		// `--include-deps` widens the explicit service list to its transitive
 		// depends_on closure; an empty list already means "every service".
 		let wanted: Option<HashSet<String>> = match (services.is_empty(), opts.include_deps) {
@@ -68,27 +76,34 @@ impl Engine {
 			.map(|(name, s)| async move {
 				// The libpod pull stream reports failure as an in-band progress
 				// line, so `pull_image` returns Ok even when the pull failed;
-				// confirm the image actually landed in local storage.
-				let _ = self.pull_image(s).await;
+				// confirm the image actually landed in local storage. Keep the
+				// real transport error (e.g. socket unreachable) so a failed pull
+				// surfaces the underlying cause rather than a generic message.
+				let pull_err = self.pull_image(s).await.err();
 				let image = s.image.clone().unwrap_or_default();
 				(
 					name.clone(),
 					image.clone(),
 					self.image_present(&image).await,
+					pull_err,
 				)
 			})
 			.collect();
 
 		let results = futures_util::future::join_all(futs).await;
-		for (name, image, present) in results {
+		for (name, image, present, pull_err) in results {
 			if present {
 				continue;
 			}
 			if opts.ignore_failures {
-				tracing::warn!("pull {name} ({image}) failed — ignored");
+				match &pull_err {
+					Some(e) => tracing::warn!("pull {name} ({image}) failed — ignored: {e}"),
+					None => tracing::warn!("pull {name} ({image}) failed — ignored"),
+				}
 			} else {
+				let detail = pull_err.map(|e| format!(": {e}")).unwrap_or_default();
 				return Err(ComposeError::Build(format!(
-					"failed to pull image {image} for service {name}"
+					"failed to pull image {image} for service {name}{detail}"
 				)));
 			}
 		}
@@ -101,10 +116,13 @@ impl Engine {
 			None => return Ok(()),
 		};
 
+		// Progress goes to stderr so it shows at default verbosity (the non-watch
+		// log floor is WARN, so info!/debug! would print nothing) and `--quiet`
+		// actually suppresses it, matching `docker compose pull`.
 		if self.quiet_pull {
 			debug!("pulling {image}");
 		} else {
-			info!("pulling {image}");
+			eprintln!("Pulling {image}");
 		}
 
 		// `up --pull <policy>` overrides the per-service `pull_policy`.
@@ -219,6 +237,24 @@ mod tests {
 			.into_iter()
 			.collect();
 		assert_eq!(got, vec!["db"]);
+	}
+
+	#[tokio::test]
+	async fn pull_unknown_service_is_rejected() {
+		// `pull bogus` must error on the unknown name instead of silently exiting 0.
+		let file = crate::parse_str("services:\n  web:\n    image: a\n").unwrap();
+		let e = crate::engine::Engine::new(
+			crate::libpod::Client::new("/nonexistent.sock"),
+			"proj".into(),
+		);
+		let err = e
+			.pull_services(&file, &["nope".to_string()])
+			.await
+			.expect_err("unknown service must be rejected");
+		assert!(
+			matches!(err, crate::error::ComposeError::ServiceNotFound(_)),
+			"unexpected error: {err:?}"
+		);
 	}
 
 	#[test]

--- a/internal/engine/build/tags.rs
+++ b/internal/engine/build/tags.rs
@@ -1,0 +1,119 @@
+//! Pure helpers for build image tagging and context classification.
+//!
+//! These free functions back [`super::Engine::build_service`]: deciding whether
+//! a build context is remote, choosing the primary image tag, and flagging
+//! build-arg names that look like secrets. They hold no engine state, so they
+//! live here apart from the build orchestration.
+
+/// A build context is remote when it is a URL or Git reference that Podman
+/// clones server-side, rather than a local directory to tar and upload.
+pub(super) fn is_remote_context(context: &str) -> bool {
+	context.contains("://") || context.starts_with("git@")
+}
+
+/// Pick the primary image tag for a built service.
+///
+/// Precedence matches compose-go: an explicit `image:` wins; otherwise the
+/// first entry of `build.tags` is used as the primary tag; with neither, the
+/// image is named `{project}-{service}:latest` (project-scoped, like docker
+/// compose) so two projects sharing a service name don't overwrite each other's
+/// image. Any remaining `build.tags` are applied as extra tags by
+/// [`super::Engine::apply_extra_tags`].
+pub(super) fn primary_build_tag(
+	project: &str,
+	service_name: &str,
+	image: Option<&str>,
+	tags: &[String],
+) -> String {
+	if let Some(image) = image {
+		return image.to_string();
+	}
+	if let Some(first) = tags.first() {
+		return first.clone();
+	}
+	format!("{project}-{service_name}:latest")
+}
+
+/// True if a build-arg name looks like it carries a secret, so the caller can
+/// warn that build args persist in the image history. Case-insensitive substring
+/// match on common secret tokens, kept conservative to avoid false positives
+/// (e.g. a bare `KEY` is not flagged; `API_KEY`/`PRIVATE_KEY` are).
+pub(super) fn looks_like_secret(name: &str) -> bool {
+	const MARKERS: [&str; 7] = [
+		"SECRET",
+		"PASSWORD",
+		"PASSWD",
+		"TOKEN",
+		"CREDENTIAL",
+		"API_KEY",
+		"PRIVATE_KEY",
+	];
+	let upper = name.to_ascii_uppercase();
+	MARKERS.iter().any(|m| upper.contains(m))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{is_remote_context, looks_like_secret, primary_build_tag};
+
+	#[test]
+	fn looks_like_secret_flags_sensitive_names_only() {
+		for name in [
+			"DB_PASSWORD",
+			"api_token",
+			"MySecret",
+			"AWS_API_KEY",
+			"private_key",
+		] {
+			assert!(looks_like_secret(name), "{name} should be flagged");
+		}
+		for name in ["VERSION", "BUILD_DATE", "PUBLIC_KEY", "PORT", "RUST_LOG"] {
+			assert!(!looks_like_secret(name), "{name} should not be flagged");
+		}
+	}
+
+	#[test]
+	fn remote_context_detection() {
+		assert!(is_remote_context("https://github.com/user/repo.git"));
+		assert!(is_remote_context("git://example.com/repo.git"));
+		assert!(is_remote_context("git@github.com:user/repo.git"));
+		assert!(!is_remote_context("."));
+		assert!(!is_remote_context("./build"));
+		assert!(!is_remote_context("/abs/path"));
+	}
+
+	#[test]
+	fn primary_tag_prefers_explicit_image() {
+		let tags = vec!["registry/app:1.0".to_string()];
+		assert_eq!(
+			primary_build_tag("proj", "app", Some("myimage:2.0"), &tags),
+			"myimage:2.0"
+		);
+	}
+
+	#[test]
+	fn primary_tag_uses_first_build_tag_when_image_unset() {
+		let tags = vec![
+			"registry/app:1.0".to_string(),
+			"registry/app:latest".to_string(),
+		];
+		assert_eq!(
+			primary_build_tag("proj", "app", None, &tags),
+			"registry/app:1.0"
+		);
+	}
+
+	#[test]
+	fn primary_tag_falls_back_to_project_scoped_latest() {
+		// Build-only services (no `image:`, no `tags`) are namespaced by project so
+		// two projects sharing a service name don't clobber each other's image.
+		assert_eq!(
+			primary_build_tag("proj", "app", None, &[]),
+			"proj-app:latest"
+		);
+		assert_eq!(
+			primary_build_tag("other", "app", None, &[]),
+			"other-app:latest"
+		);
+	}
+}


### PR DESCRIPTION
This sweep fixes a batch of verified findings in the build subsystem (context tar assembly, image build, and pull). Each fix is minimal and covered by a unit/parse-level test.

## Fixed
- Build context symlinks are dereferenced into the image (host-file disclosure) (Closes #721)
- Inline Dockerfile leaks into image as .dockerfile-inline via COPY . (Closes #892)
- Build-only service (no image:) tagged bare {service}:latest, not project-scoped (Closes #780)
- Malformed --build-arg =value (empty key) silently accepted (Closes #893)
- Invalid build.shm_size value silently dropped (Closes #895)
- pull silently ignores unknown service names (Closes #781)
- pull connection/socket errors masked as generic 'failed to pull image' error (Closes #782)
- pull --quiet is a no-op and pull shows no default progress (Closes #894)

## Verification
- `cargo build`, `cargo fmt --all`, `cargo clippy --lib --bins -D warnings`: clean.
- `cargo test --lib` plus the parse/substitute/size/ports/env_file/quadlet/project_name_safety/secret_safety/cli_aliases/cli_diagnostics suites: all green.
- The container integration suite was not run.

Note: `cargo clippy --all-targets` reports a pre-existing unused-import warning in `tests/engine_integration.rs` that is unrelated to these changes (the file is untouched on this branch).
