### PR TITLE
fix(interpolation): resolve verified interpolation sweep findings

### DIFF
--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
@@ -12,11 +14,95 @@ const MAX_ALIAS_REFS: usize = 100;
 const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
 
 pub(super) fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
+	deserialize_with_merge_interp(content, None)
+}
+
+/// Parse `content` into a [`ComposeFile`], optionally interpolating `${VAR}`
+/// references at the scalar level once the YAML document has been parsed.
+///
+/// Interpolating *after* parsing (rather than on the raw text) is deliberate:
+/// the resolved value of a variable is stored verbatim into the existing scalar
+/// node, so an env value containing newlines or YAML syntax is treated as data,
+/// never as document structure (no key/`privileged: true` injection), an
+/// unset/empty variable always yields an in-place empty string (it cannot drop a
+/// key or trigger a "mapping values are not allowed" parse error), and multiline
+/// or backslash-bearing values are not re-interpreted by the YAML parser.
+pub(super) fn deserialize_with_merge_interp(
+	content: &str,
+	vars: Option<&HashMap<String, String>>,
+) -> Result<ComposeFile> {
 	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
+	if let Some(vars) = vars {
+		interpolate_value(&mut value, vars)?;
+	}
 	apply_merge_keys(&mut value);
 	let file: ComposeFile = serde_yaml::from_value(value)?;
 	Ok(file)
+}
+
+/// Recursively interpolate every string scalar of a parsed YAML `value`.
+///
+/// Mapping values and sequence items are coerced through [`interpolate_scalar`]
+/// (so an interpolated numeric/boolean keeps its YAML type, matching
+/// docker-compose's typed fields); mapping keys are interpolated as plain text.
+fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, String>) -> Result<()> {
+	match value {
+		serde_yaml::Value::String(s) if s.contains('$') => {
+			*value = interpolate_scalar(s, vars)?;
+		}
+		serde_yaml::Value::Sequence(seq) => {
+			for item in seq.iter_mut() {
+				interpolate_value(item, vars)?;
+			}
+		}
+		serde_yaml::Value::Mapping(map) => {
+			let taken = std::mem::take(map);
+			let mut rebuilt = serde_yaml::Mapping::with_capacity(taken.len());
+			for (key, mut val) in taken {
+				let key = interpolate_key(key, vars)?;
+				interpolate_value(&mut val, vars)?;
+				rebuilt.insert(key, val);
+			}
+			*map = rebuilt;
+		}
+		_ => {}
+	}
+	Ok(())
+}
+
+/// Interpolate a single string scalar and recover its YAML type.
+///
+/// An empty expansion stays an empty string (it must never collapse to `null`
+/// and drop the owning key). Otherwise the resolved text is re-read as a YAML
+/// scalar so `${N}` in a numeric position becomes a number and `${B}` a boolean,
+/// matching docker-compose. Crucially, only *scalar* re-parses are adopted: a
+/// result that parses into a mapping or sequence (an injected
+/// `root\n  privileged: true`, or a trailing-colon `repo:`) is kept verbatim as
+/// a string, so an attacker-influenced value can never introduce structure.
+fn interpolate_scalar(s: &str, vars: &HashMap<String, String>) -> Result<serde_yaml::Value> {
+	let resolved = crate::substitute::substitute(s, vars)?;
+	if resolved.is_empty() {
+		return Ok(serde_yaml::Value::String(String::new()));
+	}
+	match serde_yaml::from_str::<serde_yaml::Value>(&resolved) {
+		Ok(v @ (serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_))) => Ok(v),
+		_ => Ok(serde_yaml::Value::String(resolved)),
+	}
+}
+
+/// Interpolate a mapping key. Keys stay strings (a key is never coerced to a
+/// number/boolean) so the document shape is preserved.
+fn interpolate_key(
+	key: serde_yaml::Value,
+	vars: &HashMap<String, String>,
+) -> Result<serde_yaml::Value> {
+	match key {
+		serde_yaml::Value::String(s) if s.contains('$') => Ok(serde_yaml::Value::String(
+			crate::substitute::substitute(&s, vars)?,
+		)),
+		other => Ok(other),
+	}
 }
 
 /// Reject YAML documents whose alias use could amplify into an out-of-memory
@@ -120,6 +206,72 @@ fn apply_merge_keys(value: &mut serde_yaml::Value) {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+		pairs
+			.iter()
+			.map(|(k, v)| (k.to_string(), v.to_string()))
+			.collect()
+	}
+
+	// scalar-level interpolation (post-parse)
+
+	#[test]
+	fn interpolation_cannot_inject_yaml_structure() {
+		// A value carrying an embedded newline + YAML must NOT introduce new keys:
+		// post-parse interpolation stores it verbatim into the existing scalar.
+		let v = vars(&[("U", "root\n    privileged: true")]);
+		let yaml = "services:\n  app:\n    image: nginx\n    user: ${U}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&v)).unwrap();
+		let svc = &file.services["app"];
+		assert_eq!(svc.user.as_deref(), Some("root\n    privileged: true"));
+		// The injected `privileged: true` is data, not structure.
+		assert_eq!(svc.privileged, None);
+	}
+
+	#[test]
+	fn empty_interpolation_in_unquoted_scalar_keeps_key_and_is_empty() {
+		// `repo:${TAG}` with TAG unset becomes `repo:` (no YAML parse error) and a
+		// bare `${TAG}` value becomes an empty string rather than dropping the key.
+		let yaml = "services:\n  app:\n    image: repo:${TAG}\n    user: ${TAG}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&vars(&[]))).unwrap();
+		let svc = &file.services["app"];
+		assert_eq!(svc.image.as_deref(), Some("repo:"));
+		assert_eq!(svc.user.as_deref(), Some(""));
+	}
+
+	#[test]
+	fn interpolated_multiline_and_backslash_values_preserved_verbatim() {
+		// A resolved value with real newlines/backslashes is stored byte-for-byte;
+		// it is not re-folded or re-escaped by the YAML parser.
+		let v = vars(&[("MSG", "line1\nline2\\x")]);
+		let yaml = "services:\n  app:\n    image: nginx\n    user: ${MSG}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&v)).unwrap();
+		assert_eq!(
+			file.services["app"].user.as_deref(),
+			Some("line1\nline2\\x")
+		);
+	}
+
+	#[test]
+	fn interpolated_scalar_recovers_numeric_and_boolean_type() {
+		// `${N}` in a numeric/boolean position keeps its YAML type, matching
+		// docker-compose's typed fields.
+		let v = vars(&[("P", "true"), ("CPU", "512")]);
+		let yaml =
+			"services:\n  app:\n    image: nginx\n    privileged: ${P}\n    cpu_shares: ${CPU}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&v)).unwrap();
+		assert_eq!(file.services["app"].privileged, Some(true));
+		assert_eq!(file.services["app"].cpu_shares, Some(512));
+	}
+
+	#[test]
+	fn no_interpolation_when_vars_is_none() {
+		// `config --no-interpolate` path: placeholders stay literal.
+		let yaml = "services:\n  app:\n    image: repo:${TAG}\n";
+		let file = deserialize_with_merge(yaml).unwrap();
+		assert_eq!(file.services["app"].image.as_deref(), Some("repo:${TAG}"));
+	}
 
 	// alias-expansion guard
 

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -194,8 +194,7 @@ fn merge_override(target: &mut ComposeFile, other: ComposeFile) {
 /// use [`parse_file`] for that.
 pub fn parse_str(content: &str) -> Result<ComposeFile> {
 	let vars = substitute::build_vars(Path::new("."));
-	let substituted = substitute::substitute(content, &vars)?;
-	let mut file = merge::deserialize_with_merge(&substituted)?;
+	let mut file = merge::deserialize_with_merge_interp(content, Some(&vars))?;
 	extends::resolve_extends_same_file(&mut file)?;
 	Ok(file)
 }
@@ -224,18 +223,19 @@ pub(crate) fn parse_file_inner_with_env(
 		}
 	})?;
 	// `config --no-interpolate` leaves `${VAR}` placeholders literal; otherwise
-	// substitute against the env/.env/env-file variable map.
-	let yaml = if interpolate {
+	// interpolate against the env/.env/env-file variable map. Interpolation runs
+	// on the parsed YAML scalars (see `deserialize_with_merge_interp`), not the
+	// raw text, so resolved values cannot alter the document structure.
+	if interpolate {
 		let vars = if extra_env_files.is_empty() {
 			substitute::build_vars(dir)
 		} else {
 			substitute::build_vars_with_env_files(dir, extra_env_files)
 		};
-		substitute::substitute(&content, &vars)?
+		merge::deserialize_with_merge_interp(&content, Some(&vars))
 	} else {
-		content
-	};
-	merge::deserialize_with_merge(&yaml)
+		merge::deserialize_with_merge(&content)
+	}
 }
 
 #[cfg(test)]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -148,23 +148,30 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
-	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
+	// `config --no-interpolate` must skip interpolation *entirely*: parsing with
+	// interpolation enabled would evaluate a required-var `${VAR:?msg}` and fail
+	// before we ever reached the no-interpolate branch. Detect it up front so the
+	// file is parsed only once, with interpolation disabled.
+	let no_interpolate = matches!(
+		&cli.command,
+		Commands::Config {
+			no_interpolate: true,
+			..
+		}
+	);
+	let file =
+		podup::parse_files_with_env_files_interp(&compose_files, &cli.env_file, !no_interpolate)?;
 
 	if let Commands::Config {
 		format,
 		services,
 		quiet,
-		no_interpolate,
 		resolve_image_digests,
+		..
 	} = &cli.command
 	{
-		// `--no-interpolate` re-parses with substitution disabled; `file` (already
-		// parsed with interpolation) is used otherwise.
-		let parsed = if *no_interpolate {
-			podup::parse_files_with_env_files_interp(&compose_files, &cli.env_file, false)?
-		} else {
-			file
-		};
+		// `file` is already parsed with the correct interpolation setting above.
+		let parsed = file;
 		// `--resolve-image-digests` pins each image to its registry digest, which
 		// needs a Podman connection to inspect images.
 		let mut resolved = if *resolve_image_digests {

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -1,6 +1,7 @@
 //! Docker Compose variable substitution.
 //!
-//! Applies `${VAR}` / `$VAR` substitution to raw YAML text before parsing.
+//! Applies `${VAR}` / `$VAR` substitution to individual scalar values of a
+//! parsed compose document (compose-spec value-level interpolation).
 //! Handles all compose-spec modifier forms: `:-`, `-`, `:+`, `+`, `:?`, `?`.
 
 mod parse;
@@ -8,9 +9,14 @@ mod parse;
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 
 use parse::{collect_var_name, is_var_start, parse_braced_var, resolve_modifier};
+
+/// Maximum nesting depth for interpolated default/alternate values
+/// (`${A:-${A:-…}}`). Real compose files nest a handful of levels at most; this
+/// cap turns a pathological chain into a clean error instead of a stack overflow.
+const MAX_INTERP_DEPTH: usize = 64;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -21,6 +27,22 @@ use parse::{collect_var_name, is_var_start, parse_braced_var, resolve_modifier};
 /// `vars` should contain both the process environment and the `.env` file
 /// entries (process environment takes precedence).
 pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String> {
+	substitute_depth(input, vars, 0)
+}
+
+/// Inner substitution carrying the current nesting `depth` so recursive
+/// interpolation of modifier defaults/alternates (`${A:-${B}}`) is bounded.
+pub(super) fn substitute_depth(
+	input: &str,
+	vars: &HashMap<String, String>,
+	depth: usize,
+) -> Result<String> {
+	if depth > MAX_INTERP_DEPTH {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"interpolation nesting too deep (more than {MAX_INTERP_DEPTH} levels)"
+		)));
+	}
+
 	let mut out = String::with_capacity(input.len());
 	let mut chars = input.chars().peekable();
 
@@ -41,12 +63,21 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String>
 			Some('{') => {
 				chars.next();
 				let (var, modifier) = parse_braced_var(&mut chars)?;
-				let value = resolve_modifier(var, modifier, vars)?;
+				let value = resolve_modifier(var, modifier, vars, depth)?;
 				out.push_str(&value);
 			}
 			Some(c) if is_var_start(*c) => {
 				let var = collect_var_name(&mut chars);
-				let value = vars.get(&var).cloned().unwrap_or_default();
+				let value = match vars.get(&var) {
+					Some(v) => v.clone(),
+					None => {
+						// Match docker compose v2: warn before defaulting to blank.
+						tracing::warn!(
+							"The {var} variable is not set. Defaulting to a blank string."
+						);
+						String::new()
+					}
+				};
 				out.push_str(&value);
 			}
 			Some(_) => {
@@ -347,6 +378,53 @@ mod tests {
 		assert_eq!(
 			substitute("${FOO:-${BAR}}/tail", &vars(&[("BAR", "b")])).unwrap(),
 			"b/tail"
+		);
+	}
+
+	// Malformed / pathological references
+
+	#[test]
+	fn empty_name_is_error() {
+		assert!(substitute("${}", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn digit_leading_name_is_error() {
+		assert!(substitute("${1BAD}", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn unterminated_modifier_is_error() {
+		// The missing `}` must error rather than consume the rest of the input.
+		assert!(substitute("${TAG:-latest\nmore", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn deeply_nested_defaults_error_instead_of_overflowing() {
+		// A pathological `${A:-${A:-…}}` chain (all default branches taken, A unset)
+		// returns a clean error past the depth cap rather than overflowing the stack.
+		let depth = MAX_INTERP_DEPTH + 50;
+		let mut s = String::new();
+		for _ in 0..depth {
+			s.push_str("${A:-");
+		}
+		s.push('x');
+		for _ in 0..depth {
+			s.push('}');
+		}
+		let err = substitute(&s, &vars(&[])).expect_err("over-deep nesting must error");
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::InvalidSubstitution(_)
+		));
+	}
+
+	#[test]
+	fn moderate_nesting_still_resolves() {
+		// Well within the cap, nested defaults resolve normally.
+		assert_eq!(
+			substitute("${A:-${B:-${C:-deep}}}", &vars(&[])).unwrap(),
+			"deep"
 		);
 	}
 

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -49,15 +49,25 @@ pub(super) enum Modifier {
 /// Parse the content inside `${…}`.  The opening `{` has already been consumed.
 ///
 /// The variable name is collected with [`is_var_char`] (matching the unbraced
-/// `$VAR` path and the compose-spec grammar). After the name, only a modifier
-/// delimiter (`}`, `:`, `-`, `+`, `?`) or end-of-input may follow; any other
-/// trailing character (a space in `${FOO BAR}`, a dot in `${FOO.BAR}`, …) makes
-/// the reference malformed and is rejected rather than folded into the lookup
-/// key.
+/// `$VAR` path and the compose-spec grammar). It must be non-empty and start
+/// with `[A-Za-z_]`; `${}` and `${1BAD}` are rejected as malformed rather than
+/// resolved to an empty string. After the name, only a modifier delimiter
+/// (`}`, `:`, `-`, `+`, `?`) or end-of-input may follow; any other trailing
+/// character (a space in `${FOO BAR}`, a dot in `${FOO.BAR}`, …) makes the
+/// reference malformed and is rejected rather than folded into the lookup key.
 pub(super) fn parse_braced_var(
 	chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
 ) -> Result<(String, Modifier)> {
 	let name = collect_var_name(chars);
+
+	// The name must be a valid identifier: non-empty and starting with a letter
+	// or `_`. `collect_var_name` accepts digits (they are valid *within* a name),
+	// so an empty name or a digit-leading name only fails here.
+	if name.is_empty() || !name.starts_with(is_var_start) {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"invalid variable name {name:?} in '${{…}}': names must start with a letter or '_'"
+		)));
+	}
 
 	match chars.peek() {
 		None => Ok((name, Modifier::None)),
@@ -71,31 +81,31 @@ pub(super) fn parse_braced_var(
 			let modifier = match chars.peek() {
 				Some('-') => {
 					chars.next();
-					Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
+					Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)?)
 				}
 				Some('+') => {
 					chars.next();
-					Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
+					Modifier::AltIfSetAndNonEmpty(collect_until_close(chars)?)
 				}
 				Some('?') => {
 					chars.next();
-					Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
+					Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars)?)
 				}
-				_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)),
+				_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)?),
 			};
 			Ok((name, modifier))
 		}
 		Some('-') => {
 			chars.next();
-			Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))))
+			Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars)?)))
 		}
 		Some('+') => {
 			chars.next();
-			Ok((name, Modifier::AltIfSet(collect_until_close(chars))))
+			Ok((name, Modifier::AltIfSet(collect_until_close(chars)?)))
 		}
 		Some('?') => {
 			chars.next();
-			Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))))
+			Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars)?)))
 		}
 		Some(&c) => Err(ComposeError::InvalidSubstitution(format!(
 			"unexpected character {c:?} in variable name '${{{name}…}}'"
@@ -107,7 +117,12 @@ pub(super) fn parse_braced_var(
 /// balancing nested braces so an inner `${…}` is captured whole. For
 /// `${FOO:-${BAR}}` the default is `${BAR}` (not `${BAR`), enabling nested
 /// interpolation in [`resolve_modifier`].
-fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
+///
+/// If the input ends before the matching `}` is reached the reference is
+/// unterminated (e.g. `${TAG:-latest` with no closing brace), which would
+/// otherwise silently swallow the rest of the document as the modifier value;
+/// that is reported as [`ComposeError::InvalidSubstitution`] instead.
+fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> Result<String> {
 	let mut buf = String::new();
 	let mut depth = 0u32;
 	for c in chars.by_ref() {
@@ -116,7 +131,7 @@ fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> 
 				depth += 1;
 				buf.push(c);
 			}
-			'}' if depth == 0 => break,
+			'}' if depth == 0 => return Ok(buf),
 			'}' => {
 				depth -= 1;
 				buf.push(c);
@@ -124,7 +139,9 @@ fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> 
 			_ => buf.push(c),
 		}
 	}
-	buf
+	Err(ComposeError::InvalidSubstitution(
+		"unterminated variable substitution: missing closing '}'".to_string(),
+	))
 }
 
 /// Apply a parsed `Modifier` to `var`, implementing compose's
@@ -136,31 +153,42 @@ pub(super) fn resolve_modifier(
 	var: String,
 	modifier: Modifier,
 	vars: &HashMap<String, String>,
+	depth: usize,
 ) -> Result<String> {
 	let value = vars.get(&var);
 
 	match modifier {
-		Modifier::None => Ok(value.cloned().unwrap_or_default()),
+		Modifier::None => match value {
+			Some(v) => Ok(v.clone()),
+			None => {
+				// Match docker compose v2, which warns on stderr before defaulting an
+				// unreferenced variable to the empty string, so config typos surface.
+				tracing::warn!("The {var} variable is not set. Defaulting to a blank string.");
+				Ok(String::new())
+			}
+		},
 
 		// Default/alt values are themselves interpolated (compose allows nesting,
-		// e.g. `${FOO:-${BAR}}`), but only when actually used.
+		// e.g. `${FOO:-${BAR}}`), but only when actually used. `depth` bounds that
+		// recursion so a pathological `${A:-${A:-…}}` chain returns an error rather
+		// than overflowing the stack.
 		Modifier::DefaultIfUnsetOrEmpty(default) => match value {
 			Some(v) if !v.is_empty() => Ok(v.clone()),
-			_ => super::substitute(&default, vars),
+			_ => super::substitute_depth(&default, vars, depth + 1),
 		},
 
 		Modifier::DefaultIfUnset(default) => match value {
 			Some(v) => Ok(v.clone()),
-			None => super::substitute(&default, vars),
+			None => super::substitute_depth(&default, vars, depth + 1),
 		},
 
 		Modifier::AltIfSetAndNonEmpty(alt) => match value {
-			Some(v) if !v.is_empty() => super::substitute(&alt, vars),
+			Some(v) if !v.is_empty() => super::substitute_depth(&alt, vars, depth + 1),
 			_ => Ok(String::new()),
 		},
 
 		Modifier::AltIfSet(alt) => match value {
-			Some(_) => super::substitute(&alt, vars),
+			Some(_) => super::substitute_depth(&alt, vars, depth + 1),
 			None => Ok(String::new()),
 		},
 
@@ -317,17 +345,60 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn parse_braced_var_rejects_empty_name() {
+		// `${}` has no name and must be rejected, not resolved to an empty string.
+		let mut it = peekable("}");
+		let err = parse_braced_var(&mut it).expect_err("empty name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
+	#[test]
+	fn parse_braced_var_rejects_digit_leading_name() {
+		// `${1BAD}` is not a valid identifier (must start with a letter or `_`).
+		let mut it = peekable("1BAD}");
+		let err = parse_braced_var(&mut it).expect_err("digit-leading name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
+	#[test]
+	fn parse_braced_var_underscore_name_is_valid() {
+		// A leading underscore is a valid identifier start.
+		let mut it = peekable("_FOO}");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "_FOO");
+		assert!(matches!(modifier, Modifier::None));
+	}
+
+	#[test]
+	fn parse_unterminated_modifier_is_error() {
+		// `${TAG:-latest` (no closing `}`) must not swallow the rest of the input as
+		// the default value — it is reported as a malformed substitution.
+		let mut it = peekable("TAG:-latest\nmore: data\n");
+		let err = parse_braced_var(&mut it).expect_err("missing close brace must error");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
 	// --- resolve_modifier ---
 
 	#[test]
 	fn resolve_none_uses_value_or_empty() {
 		let v = vars(&[("A", "1")]);
 		assert_eq!(
-			resolve_modifier("A".into(), Modifier::None, &v).unwrap(),
+			resolve_modifier("A".into(), Modifier::None, &v, 0).unwrap(),
 			"1"
 		);
 		assert_eq!(
-			resolve_modifier("MISSING".into(), Modifier::None, &v).unwrap(),
+			resolve_modifier("MISSING".into(), Modifier::None, &v, 0).unwrap(),
 			""
 		);
 	}
@@ -336,20 +407,35 @@ mod tests {
 	fn resolve_default_if_unset_or_empty() {
 		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
 		let m = || Modifier::DefaultIfUnsetOrEmpty("def".into());
-		assert_eq!(resolve_modifier("EMPTY".into(), m(), &v).unwrap(), "def");
-		assert_eq!(resolve_modifier("MISSING".into(), m(), &v).unwrap(), "def");
-		assert_eq!(resolve_modifier("SET".into(), m(), &v).unwrap(), "x");
+		assert_eq!(resolve_modifier("EMPTY".into(), m(), &v, 0).unwrap(), "def");
+		assert_eq!(
+			resolve_modifier("MISSING".into(), m(), &v, 0).unwrap(),
+			"def"
+		);
+		assert_eq!(resolve_modifier("SET".into(), m(), &v, 0).unwrap(), "x");
 	}
 
 	#[test]
 	fn resolve_default_if_unset_keeps_empty_value() {
 		let v = vars(&[("EMPTY", "")]);
 		assert_eq!(
-			resolve_modifier("EMPTY".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			resolve_modifier(
+				"EMPTY".into(),
+				Modifier::DefaultIfUnset("def".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			""
 		);
 		assert_eq!(
-			resolve_modifier("MISSING".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			resolve_modifier(
+				"MISSING".into(),
+				Modifier::DefaultIfUnset("def".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			"def"
 		);
 	}
@@ -358,24 +444,31 @@ mod tests {
 	fn resolve_alt_forms() {
 		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
 		assert_eq!(
-			resolve_modifier("SET".into(), Modifier::AltIfSetAndNonEmpty("a".into()), &v).unwrap(),
+			resolve_modifier(
+				"SET".into(),
+				Modifier::AltIfSetAndNonEmpty("a".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			"a"
 		);
 		assert_eq!(
 			resolve_modifier(
 				"EMPTY".into(),
 				Modifier::AltIfSetAndNonEmpty("a".into()),
-				&v
+				&v,
+				0
 			)
 			.unwrap(),
 			""
 		);
 		assert_eq!(
-			resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
 			"a"
 		);
 		assert_eq!(
-			resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
 			""
 		);
 	}
@@ -386,18 +479,25 @@ mod tests {
 		assert!(resolve_modifier(
 			"EMPTY".into(),
 			Modifier::ErrorIfUnsetOrEmpty("e".into()),
-			&v
+			&v,
+			0
 		)
 		.is_err());
 		assert_eq!(
-			resolve_modifier("SET".into(), Modifier::ErrorIfUnsetOrEmpty("e".into()), &v).unwrap(),
+			resolve_modifier(
+				"SET".into(),
+				Modifier::ErrorIfUnsetOrEmpty("e".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			"x"
 		);
 		assert!(
-			resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v).is_err()
+			resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).is_err()
 		);
 		assert_eq!(
-			resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v).unwrap(),
+			resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).unwrap(),
 			""
 		);
 	}

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -178,3 +178,72 @@ fn config_no_interpolate_keeps_placeholders_literal() {
 		"--no-interpolate must keep ${{PODUP_TAG}} literal"
 	);
 }
+
+#[test]
+fn config_warns_on_unset_interpolation_variable() {
+	// An unset `${VAR}` interpolates to an empty string but must warn on stderr
+	// (matching docker compose) so a config typo does not pass silently.
+	let dir = std::env::temp_dir().join(format!("podup-unset-warn-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: ${PODUP_UNSET_IMAGE}\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "config"])
+		.env_remove("PODUP_UNSET_IMAGE")
+		.output()
+		.unwrap();
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("PODUP_UNSET_IMAGE") && stderr.contains("not set"),
+		"expected an unset-variable warning on stderr, got: {stderr:?}"
+	);
+}
+
+#[test]
+fn config_no_interpolate_skips_required_var_error() {
+	// `--no-interpolate` must not evaluate a required-var `${VAR:?msg}`: with the
+	// variable unset the command should still succeed and print the placeholder
+	// literally, rather than failing on the required-var check.
+	let dir = std::env::temp_dir().join(format!("podup-noint-req-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: ${MUST_SET:?required}\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	// With interpolation on, the required-var error fails the command.
+	let interp = Command::new(bin())
+		.args(["-f", c, "config"])
+		.env_remove("MUST_SET")
+		.output()
+		.unwrap();
+	assert!(
+		!interp.status.success(),
+		"default config must fail on the required-var"
+	);
+
+	// With --no-interpolate, the file is printed uninterpolated and succeeds.
+	let raw = Command::new(bin())
+		.args(["-f", c, "config", "--no-interpolate"])
+		.env_remove("MUST_SET")
+		.output()
+		.unwrap();
+	assert!(
+		raw.status.success(),
+		"config --no-interpolate must not evaluate the required-var: {:?}",
+		String::from_utf8_lossy(&raw.stderr)
+	);
+	assert!(
+		String::from_utf8_lossy(&raw.stdout).contains("${MUST_SET:?required}"),
+		"--no-interpolate must keep the placeholder literal"
+	);
+}


### PR DESCRIPTION
I worked through the verified interpolation sweep findings. The headline change is that variable interpolation now runs against the parsed YAML document at the scalar level instead of against the raw text before parsing — this closes a structural-injection hole and fixes a family of empty/multiline corruption bugs in one move. The remaining fixes harden the `${VAR}` reference parser and the `--no-interpolate` path.

## Fixed

- Interpolate at the scalar level after parsing, so resolved env values are data and can never alter document structure (Closes #715)
- Empty/unset interpolation in an unquoted scalar now yields an in-place empty string instead of dropping the key or causing a "mapping values are not allowed" parse error (Closes #732)
- Interpolated multiline/backslash env values are stored verbatim and not re-interpreted by a second YAML pass (Closes #733)
- Cap interpolation nesting depth so deeply nested `${A:-${A:-...}}` chains return a clean error instead of overflowing the stack (Closes #716)
- Warn on stderr when an interpolation variable is unset, matching docker compose v2 (Closes #734)
- Report an error for an unterminated `${VAR:-...}` modifier instead of swallowing the rest of the file (Closes #735)
- `config --no-interpolate` no longer performs an eager interpolated parse, so a required-var `${VAR:?msg}` no longer fails the command (Closes #736)
- Reject empty and digit-leading interpolation variable names (`${}`, `${1BAD}`) instead of expanding them to empty (Closes #816)

## Notes

To preserve docker-compose's typed-field behaviour, a resolved scalar is re-read as YAML so `${N}` in a numeric position stays a number and `${B}` a boolean; only scalar re-parses are adopted — anything that parses into a mapping or sequence is kept verbatim as a string, which is what blocks the injection vector.

## Verification

- `cargo build`, `cargo fmt --all`, `cargo clippy --all-targets --features test-helpers -- -D warnings` clean
- `cargo test --lib` plus the parse/substitute/env_file/quadlet/ports/size/cli_diagnostics/cli_aliases/project_name_safety/secret_safety suites all pass; container integration suites not run
- Added unit and CLI-level tests for every fix above
