### PR TITLE
fix(misc): resolve verified misc sweep findings

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -337,6 +337,16 @@ pub(crate) enum Commands {
 		/// Replica index (1-based) of a scaled service.
 		#[arg(long)]
 		index: Option<u32>,
+		/// Pause the container during commit for a consistent snapshot
+		/// (default on; `--pause=false` to snapshot a live container).
+		#[arg(
+			long,
+			default_value_t = true,
+			action = clap::ArgAction::Set,
+			num_args = 0..=1,
+			default_missing_value = "true",
+		)]
+		pause: bool,
 	},
 	/// Export a service container's filesystem as a tar archive.
 	Export {

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -261,7 +261,8 @@ pub(crate) async fn dispatch(
 			service,
 			image,
 			index,
-		} => engine.commit(file, &service, &image, index).await?,
+			pause,
+		} => engine.commit(file, &service, &image, index, pause).await?,
 		Commands::Export {
 			service,
 			output,

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -291,7 +291,11 @@ pub(crate) async fn dispatch(
 			image,
 			index,
 			pause,
-		} => engine.commit(file, &service, &image, index, pause).await?,
+		} => {
+			engine
+				.commit_with_pause(file, &service, &image, index, pause)
+				.await?
+		}
 		Commands::Export {
 			service,
 			output,

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -34,11 +34,27 @@ fn commit_path(container: &str, repo: &str, tag: &str, pause: bool) -> String {
 }
 
 impl Engine {
+	/// Commit a service container to a new image (`docker compose commit`),
+	/// pausing the container during the snapshot for a consistent filesystem
+	/// (docker default). Equivalent to [`Engine::commit_with_pause`] with
+	/// `pause = true`. Targets the given replica (`index`, 1-based) or the first
+	/// one. `image` is `repo[:tag]`; an omitted tag defaults to `latest`.
+	pub async fn commit(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		image: &str,
+		index: Option<u32>,
+	) -> Result<()> {
+		self.commit_with_pause(file, service_name, image, index, true)
+			.await
+	}
+
 	/// Commit a service container to a new image (`docker compose commit`).
 	/// Targets the given replica (`index`, 1-based) or the first one. `image`
 	/// is `repo[:tag]`; an omitted tag defaults to `latest`. `pause` quiesces the
 	/// container during the snapshot for a consistent filesystem (docker default).
-	pub async fn commit(
+	pub async fn commit_with_pause(
 		&self,
 		file: &ComposeFile,
 		service_name: &str,

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -12,16 +12,39 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::super::Engine;
 
+/// Split an `image` reference into `(repo, tag)`. A ':' after the last '/' is a
+/// tag; otherwise it is part of a registry `host:port` and the whole string is
+/// the repo. An omitted tag defaults to `latest`.
+fn split_image_ref(image: &str) -> (&str, &str) {
+	match image.rsplit_once(':') {
+		Some((r, t)) if !t.contains('/') => (r, t),
+		_ => (image, "latest"),
+	}
+}
+
+/// Build the libpod `/commit` request path. `pause` quiesces the container
+/// during the snapshot (docker default) for a consistent filesystem.
+fn commit_path(container: &str, repo: &str, tag: &str, pause: bool) -> String {
+	format!(
+		"{API_PREFIX}/commit?container={}&repo={}&tag={}&pause={pause}",
+		urlencoded(container),
+		urlencoded(repo),
+		urlencoded(tag),
+	)
+}
+
 impl Engine {
 	/// Commit a service container to a new image (`docker compose commit`).
 	/// Targets the given replica (`index`, 1-based) or the first one. `image`
-	/// is `repo[:tag]`; an omitted tag defaults to `latest`.
+	/// is `repo[:tag]`; an omitted tag defaults to `latest`. `pause` quiesces the
+	/// container during the snapshot for a consistent filesystem (docker default).
 	pub async fn commit(
 		&self,
 		file: &ComposeFile,
 		service_name: &str,
 		image: &str,
 		index: Option<u32>,
+		pause: bool,
 	) -> Result<()> {
 		let service = file
 			.services
@@ -29,18 +52,8 @@ impl Engine {
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container = self.replica_name_at(service_name, service, index)?;
 
-		let (repo, tag) = match image.rsplit_once(':') {
-			// A ':' after the last '/' is a tag; otherwise it's part of a registry
-			// host:port and the whole string is the repo.
-			Some((r, t)) if !t.contains('/') => (r, t),
-			_ => (image, "latest"),
-		};
-		let path = format!(
-			"{API_PREFIX}/commit?container={}&repo={}&tag={}",
-			urlencoded(&container),
-			urlencoded(repo),
-			urlencoded(tag),
-		);
+		let (repo, tag) = split_image_ref(image);
+		let path = commit_path(&container, repo, tag, pause);
 		self.client
 			.post_empty_ok(&path)
 			.await
@@ -85,5 +98,39 @@ impl Engine {
 		}
 		sink.flush().map_err(ComposeError::Io)?;
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{commit_path, split_image_ref};
+
+	#[test]
+	fn image_ref_splits_repo_and_tag() {
+		assert_eq!(split_image_ref("myrepo:v1"), ("myrepo", "v1"));
+		// No tag defaults to latest.
+		assert_eq!(split_image_ref("myrepo"), ("myrepo", "latest"));
+		// A registry host:port is not a tag.
+		assert_eq!(
+			split_image_ref("localhost:5000/app"),
+			("localhost:5000/app", "latest")
+		);
+		assert_eq!(
+			split_image_ref("localhost:5000/app:v2"),
+			("localhost:5000/app", "v2")
+		);
+	}
+
+	#[test]
+	fn commit_path_includes_pause_flag() {
+		// Pausing (docker default) yields a consistent snapshot.
+		let paused = commit_path("proj_web_1", "repo", "latest", true);
+		assert!(paused.contains("container=proj_web_1"));
+		assert!(paused.contains("repo=repo"));
+		assert!(paused.contains("tag=latest"));
+		assert!(paused.contains("pause=true"));
+		// Opting out keeps the container live during commit.
+		let live = commit_path("proj_web_1", "repo", "latest", false);
+		assert!(live.contains("pause=false"));
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -33,7 +33,9 @@ impl Engine {
 					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
 				}
 			}
-			target_services.to_vec()
+			// Deduplicate so `top web web` queries and prints `web` once, matching
+			// `docker compose top` and avoiding redundant `/top` API calls.
+			dedup_preserving_order(target_services)
 		};
 
 		let mut json_rows: Vec<serde_json::Value> = Vec::new();
@@ -217,6 +219,28 @@ impl Engine {
 		let container = self.first_replica_name(service_name, service);
 		let is_tty = service.tty.unwrap_or(false);
 
+		// `docker compose attach` errors when the target is not running. Without
+		// this check the libpod logs endpoint replays the *entire* history of a
+		// stopped container and then ends the stream, so `attach` would print the
+		// whole log and exit 0. Inspect the state first and fail closed otherwise.
+		let inspect_path = format!("{API_PREFIX}/containers/{}/json", urlencoded(&container));
+		let info = self
+			.client
+			.get_json::<crate::libpod::types::container::ContainerInspect>(&inspect_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let status = info.state.and_then(|s| s.status).unwrap_or_default();
+		if !is_running_status(&status) {
+			let shown = if status.is_empty() {
+				"unknown"
+			} else {
+				&status
+			};
+			return Err(ComposeError::Unsupported(format!(
+				"cannot attach to {container}: container is not running (state: {shown})"
+			)));
+		}
+
 		let path = format!(
 			"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
 			urlencoded(&container),
@@ -358,9 +382,27 @@ fn parse_port_proto<'a>(private_port: &'a str, proto_flag: &'a str) -> Result<(u
 	Ok((port, proto))
 }
 
+/// Deduplicate `names` while preserving first-seen order. Used so `top web web`
+/// queries and prints each service once, matching `docker compose top`.
+fn dedup_preserving_order(names: &[String]) -> Vec<String> {
+	let mut seen = std::collections::HashSet::new();
+	names
+		.iter()
+		.filter(|n| seen.insert((*n).clone()))
+		.cloned()
+		.collect()
+}
+
+/// Whether a libpod container `Status` string denotes a running container.
+/// `docker compose attach` only attaches to a running container; anything else
+/// (exited, created, paused, empty/unknown) must fail closed.
+fn is_running_status(status: &str) -> bool {
+	status.eq_ignore_ascii_case("running")
+}
+
 #[cfg(test)]
 mod tests {
-	use super::parse_port_proto;
+	use super::{dedup_preserving_order, is_running_status, parse_port_proto};
 
 	#[test]
 	fn bare_port_uses_flag_proto() {
@@ -376,5 +418,30 @@ mod tests {
 	fn non_numeric_port_is_rejected() {
 		assert!(parse_port_proto("http", "tcp").is_err());
 		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
+	}
+
+	#[test]
+	fn dedup_keeps_first_occurrence_order() {
+		let input = ["web".to_string(), "web".to_string(), "db".to_string()];
+		assert_eq!(dedup_preserving_order(&input), vec!["web", "db"]);
+		let input = [
+			"a".to_string(),
+			"b".to_string(),
+			"a".to_string(),
+			"c".to_string(),
+			"b".to_string(),
+		];
+		assert_eq!(dedup_preserving_order(&input), vec!["a", "b", "c"]);
+	}
+
+	#[test]
+	fn running_status_detected_case_insensitively() {
+		assert!(is_running_status("running"));
+		assert!(is_running_status("Running"));
+		// Anything else is not attachable.
+		assert!(!is_running_status("exited"));
+		assert!(!is_running_status("created"));
+		assert!(!is_running_status("paused"));
+		assert!(!is_running_status(""));
 	}
 }

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -20,15 +20,22 @@ use std::path::PathBuf;
 use std::path::Path;
 
 /// Whether `name` is safe to use as a single path component and container
-/// name prefix: non-empty, bounded, ASCII alphanumeric plus `-`/`_`/`.`,
-/// not starting with a dot (rejects `.`, `..` and hidden directories).
+/// name prefix. Matches docker-compose's project-name rule `^[a-z0-9][a-z0-9_-]*$`:
+/// non-empty, bounded, lowercase ASCII letters/digits/`-`/`_` only, and a first
+/// character that is a letter or digit. This rejects a leading separator
+/// (`-rf`, `--all`, `_x` — a latent flag-injection vector for forwarding paths),
+/// uppercase, dots (`.`, `..`, hidden directories, `bad.` trailing-dot names),
+/// and all-separator names.
 pub fn is_safe_project_name(name: &str) -> bool {
-	!name.is_empty()
-		&& name.len() <= 128
-		&& !name.starts_with('.')
-		&& name
-			.chars()
-			.all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+	if name.is_empty() || name.len() > 128 {
+		return false;
+	}
+	let mut chars = name.chars();
+	let first = chars.next().expect("name is non-empty");
+	if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+		return false;
+	}
+	chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '_'))
 }
 
 /// Per-user staging base for inline secret/config content.
@@ -159,7 +166,9 @@ mod name_tests {
 
 	#[test]
 	fn safe_project_names_accepted() {
-		for name in ["web", "my-app", "my_app", "app.v2", "A1"] {
+		// Matches docker-compose `^[a-z0-9][a-z0-9_-]*$`: lowercase letters/digits,
+		// `-`/`_`, first char a letter or digit.
+		for name in ["web", "my-app", "my_app", "appv2", "a1", "1app", "x"] {
 			assert!(is_safe_project_name(name), "{name:?} must be accepted");
 		}
 	}
@@ -176,6 +185,15 @@ mod name_tests {
 			"../x",
 			"a b",
 			"a\0b",
+			// docker-compose rejects these too; previously accepted by podup.
+			"-rf",    // leading dash (flag-injection vector)
+			"--all",  // leading dash
+			"---",    // all-dash
+			"_x",     // leading underscore
+			"App",    // uppercase
+			"MYAPP",  // uppercase
+			"app.v2", // dot
+			"bad.",   // trailing dot
 			long.as_str(),
 		] {
 			assert!(!is_safe_project_name(name), "{name:?} must be rejected");

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -17,7 +17,7 @@ mod startup;
 use cli::*;
 use generate::write_quadlet;
 use resolve::*;
-use startup::{init_tracing, internal_error_notice, is_mutating, parse_cli};
+use startup::{init_tracing, internal_error_notice, is_label_only, is_mutating, parse_cli};
 
 fn main() {
 	// Replace the default panic output (a raw Rust backtrace) with a `podup:`
@@ -148,7 +148,18 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
-	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
+	// `events` and `ps` are scoped purely by the `podup.project` label and never
+	// read service definitions, so — like `docker compose -p NAME events`/`ps` —
+	// they must work against a running project even when no compose file is
+	// present. Tolerate a missing file for these label-only commands by falling
+	// back to an empty compose model; any other parse error (a malformed file
+	// that *does* exist, a missing env file) still surfaces.
+	let label_only = is_label_only(&cli.command);
+	let file = if label_only && !compose_files.iter().any(|p| p.is_file()) {
+		podup::compose::types::ComposeFile::default()
+	} else {
+		podup::parse_files_with_env_files(&compose_files, &cli.env_file)?
+	};
 
 	if let Commands::Config {
 		format,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -199,8 +199,9 @@ async fn run() -> podup::Result<()> {
 	// name here fails closed regardless of which command runs next.
 	if !podup::is_safe_project_name(&project) {
 		return Err(podup::ComposeError::Unsupported(format!(
-			"project name {project:?} is not a safe path component: use only ASCII \
-			 letters, digits, '-', '_', '.', not starting with '.', max 128 chars"
+			"project name {project:?} is not a safe path component: use lowercase ASCII \
+			 letters, digits, '-', '_', starting with a letter or digit, max 128 chars \
+			 (docker-compose rule ^[a-z0-9][a-z0-9_-]*$)"
 		)));
 	}
 

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -33,6 +33,14 @@ pub(crate) fn is_mutating(command: &Commands) -> bool {
 	)
 }
 
+/// Whether a command is scoped purely by the `podup.project` label and never
+/// reads service definitions, so it can run against a project with no compose
+/// file present — matching `docker compose -p NAME events`/`ps`. These commands
+/// tolerate a missing compose file at startup instead of erroring `FileNotFound`.
+pub(crate) fn is_label_only(command: &Commands) -> bool {
+	matches!(command, Commands::Events { .. } | Commands::Ps { .. })
+}
+
 /// Canonical project URL, reused for the bug-report hint on internal errors.
 const REPO_URL: &str = "https://github.com/Glyndor/podup";
 
@@ -284,6 +292,27 @@ pub(crate) fn parse_cli() -> Cli {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn label_only_covers_ps_and_events() {
+		use crate::cli::OutputFormat;
+		// `ps` and `events` are scoped purely by the project label, so they are
+		// label-only and may run without a compose file.
+		assert!(is_label_only(&Commands::Ps {
+			all: false,
+			quiet: false,
+			format: OutputFormat::Table,
+		}));
+		assert!(is_label_only(&Commands::Events {
+			format: OutputFormat::Table,
+			json: false,
+		}));
+		// A command that reads service definitions is not label-only.
+		assert!(!is_label_only(&Commands::Top {
+			format: OutputFormat::Table,
+			services: vec![],
+		}));
+	}
 
 	#[test]
 	fn prune_json_drops_nulls_and_empty_then_collapses() {

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -328,7 +328,7 @@ mod tests {
 
 	#[test]
 	fn label_only_covers_ps_and_events() {
-		use crate::cli::OutputFormat;
+		use crate::cli::{EventsFormat, OutputFormat};
 		// `ps` and `events` are scoped purely by the project label, so they are
 		// label-only and may run without a compose file.
 		assert!(is_label_only(&Commands::Ps {
@@ -337,7 +337,7 @@ mod tests {
 			format: OutputFormat::Table,
 		}));
 		assert!(is_label_only(&Commands::Events {
-			format: OutputFormat::Table,
+			format: EventsFormat::Table,
 			json: false,
 		}));
 		// A command that reads service definitions is not label-only.

--- a/tests/project_name_safety.rs
+++ b/tests/project_name_safety.rs
@@ -63,6 +63,35 @@ fn rejects_project_name_from_env() {
 }
 
 #[test]
+fn rejects_leading_dash_project_name() {
+	// A leading dash is a latent flag-injection vector and is rejected by
+	// docker-compose's `^[a-z0-9][a-z0-9_-]*$` rule. `-p=` keeps clap from
+	// treating the value itself as a flag so the boundary check is what fails.
+	let dir = compose_dir();
+	let out = podup()
+		.current_dir(dir.path())
+		.args(["-p=-rf", "generate", "quadlet"])
+		.output()
+		.expect("run podup");
+
+	assert!(!out.status.success(), "leading-dash project name must fail");
+	assert!(String::from_utf8_lossy(&out.stderr).contains("not a safe path component"));
+}
+
+#[test]
+fn rejects_uppercase_project_name() {
+	let dir = compose_dir();
+	let out = podup()
+		.current_dir(dir.path())
+		.args(["-p", "MyApp", "generate", "quadlet"])
+		.output()
+		.expect("run podup");
+
+	assert!(!out.status.success(), "uppercase project name must fail");
+	assert!(String::from_utf8_lossy(&out.stderr).contains("not a safe path component"));
+}
+
+#[test]
 fn accepts_safe_project_name() {
 	let dir = compose_dir();
 	let out = podup()


### PR DESCRIPTION
## What

A sweep of verified miscellaneous findings, each fixed in its own commit with unit/parse-level coverage. All changes align podup's behaviour with `docker compose`.

## Fixed

- Let `events` and `ps` run without a compose file (Closes #798) — these commands are scoped purely by the `podup.project` label, so I tolerate a missing compose file for them (matching `docker compose -p NAME events`/`ps`); mutating commands still require a real file.
- Enforce docker-compose project-name rule `^[a-z0-9][a-z0-9_-]*$` (Closes #913) — rejects leading-dash (a latent flag-injection vector), all-dash, leading-underscore, uppercase, and trailing-dot names that were previously accepted.
- Pause the container during `commit` by default and add `--pause` (Closes #914) — quiesces a live container for a consistent snapshot, with `--pause=false` to opt out, matching docker's default.
- Deduplicate `top` service args (Closes #915) — `top web web` now queries and prints `web` once instead of twice.
- Error when `attach` targets a stopped container (Closes #916) — inspect state first and fail closed, instead of dumping the full log history and exiting 0.

## Testing

- `cargo build`, `cargo fmt --all`, `cargo clippy --all-targets --features test-helpers -- -D warnings` (clean)
- `cargo test --lib` and the parse/CLI suites (`parse`, `substitute`, `size`, `ports`, `env_file`, `quadlet`, `project_name_safety`, `secret_safety`, `cli_aliases`, `cli_diagnostics`)
- Manually verified the binary: `ps`/`events` run with no compose file; `up` still errors; `MyApp`/`-rf`/`bad.` rejected, `my-app` accepted; `commit --pause` defaults on.
