### PR TITLE
fix(signals-kill): resolve verified signals-kill sweep findings

### DIFF
--- a/internal/compose/order.rs
+++ b/internal/compose/order.rs
@@ -30,10 +30,14 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 		}
 	}
 
-	let mut queue: std::collections::VecDeque<&str> = in_degree
+	// Seed the queue from `services` (compose-file order) rather than iterating
+	// the `in_degree` HashMap, whose order is randomised per run. This keeps the
+	// resolved order deterministic for independent services, so dependent
+	// commands (e.g. best-effort `kill`) behave reproducibly.
+	let mut queue: std::collections::VecDeque<&str> = services
 		.iter()
-		.filter(|(_, &deg)| deg == 0)
-		.map(|(&s, _)| s)
+		.copied()
+		.filter(|s| in_degree.get(s) == Some(&0))
 		.collect();
 
 	let mut order = Vec::new();
@@ -150,6 +154,23 @@ mod tests {
 		let db_pos = order.iter().position(|s| s == "db").unwrap();
 		let web_pos = order.iter().position(|s| s == "web").unwrap();
 		assert!(db_pos < web_pos, "db must start before web");
+	}
+
+	#[test]
+	fn resolve_order_is_deterministic_for_independent_services() {
+		// Independent services must resolve in a stable (compose-file) order on
+		// every call, so best-effort consumers like `kill` behave reproducibly
+		// rather than depending on HashMap iteration order.
+		let yaml = "services:\n  a:\n    image: x\n  b:\n    image: y\n  c:\n    image: z\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let first = resolve_order(&file).unwrap();
+		assert_eq!(
+			first,
+			vec!["a".to_string(), "b".to_string(), "c".to_string()]
+		);
+		for _ in 0..16 {
+			assert_eq!(resolve_order(&file).unwrap(), first);
+		}
 	}
 
 	#[test]

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -183,6 +183,10 @@ impl Engine {
 		target_services: &[String],
 		signal: &str,
 	) -> Result<()> {
+		// Reject an empty/whitespace-only or otherwise invalid signal before
+		// issuing any request — libpod would silently treat `signal=` as SIGKILL.
+		super::signal::validate_signal(signal)?;
+
 		let order = crate::compose::resolve_order(file)?;
 		let order = filter_services(file, order, target_services)?;
 

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -25,7 +25,7 @@ impl Engine {
 				info!("{done} {container}");
 				Ok(())
 			}
-			Err(e) if e.is_status(304) || e.is_status(404) => {
+			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
 				Ok(())
 			}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod scale;
+mod signal;
 mod targets;
 
 use std::collections::{HashMap, HashSet};

--- a/internal/engine/lifecycle/signal.rs
+++ b/internal/engine/lifecycle/signal.rs
@@ -1,0 +1,122 @@
+//! Validation for `kill -s/--signal` values.
+//!
+//! `kill` forwards the requested signal to libpod as a `signal=` query
+//! parameter. An empty (or whitespace-only) value renders as `signal=`, which
+//! libpod silently treats as the default SIGKILL — so an unset shell variable
+//! passed via `-s "$SIG"` would destroy every targeted container with no
+//! warning. To match `docker compose`'s up-front validation, the signal is
+//! checked here before any request is issued.
+
+use crate::error::{ComposeError, Result};
+
+/// Signal names podup accepts for `kill -s`, matched case-insensitively and
+/// with the `SIG` prefix optional. Covers the standard POSIX signals plus the
+/// common Linux additions Podman understands.
+const KNOWN_SIGNALS: &[&str] = &[
+	"ABRT", "ALRM", "BUS", "CHLD", "CLD", "CONT", "EMT", "FPE", "HUP", "ILL", "INT", "IO", "IOT",
+	"KILL", "LOST", "PIPE", "POLL", "PROF", "PWR", "QUIT", "RTMAX", "RTMIN", "SEGV", "STKFLT",
+	"STOP", "SYS", "TERM", "TRAP", "TSTP", "TTIN", "TTOU", "UNUSED", "URG", "USR1", "USR2",
+	"VTALRM", "WINCH", "XCPU", "XFSZ",
+];
+
+/// Validate a `kill` signal before it is forwarded to libpod.
+///
+/// Accepts a numeric signal in `1..=64` or a known signal name (case-insensitive,
+/// with or without the `SIG` prefix). Rejects an empty/whitespace-only value and
+/// any unrecognised name/number with [`ComposeError::InvalidSignal`], rather than
+/// letting it default to SIGKILL on the libpod side.
+pub(crate) fn validate_signal(signal: &str) -> Result<()> {
+	let trimmed = signal.trim();
+	if trimmed.is_empty() {
+		return Err(ComposeError::InvalidSignal(
+			"signal must not be empty".into(),
+		));
+	}
+	// A bare number is a raw signal number; restrict it to the valid range.
+	if trimmed.chars().all(|c| c.is_ascii_digit()) {
+		return match trimmed.parse::<u32>() {
+			Ok(n) if (1..=64).contains(&n) => Ok(()),
+			_ => Err(ComposeError::InvalidSignal(signal.into())),
+		};
+	}
+	let upper = trimmed.to_ascii_uppercase();
+	let name = upper.strip_prefix("SIG").unwrap_or(&upper);
+	if KNOWN_SIGNALS.contains(&name) {
+		Ok(())
+	} else {
+		Err(ComposeError::InvalidSignal(signal.into()))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::validate_signal;
+	use crate::error::ComposeError;
+
+	#[test]
+	fn accepts_common_signal_names() {
+		for s in ["SIGKILL", "SIGTERM", "SIGHUP", "SIGINT", "SIGUSR1"] {
+			assert!(validate_signal(s).is_ok(), "{s} should be accepted");
+		}
+	}
+
+	#[test]
+	fn accepts_names_without_sig_prefix_case_insensitive() {
+		assert!(validate_signal("TERM").is_ok());
+		assert!(validate_signal("term").is_ok());
+		assert!(validate_signal("Kill").is_ok());
+	}
+
+	#[test]
+	fn accepts_numeric_signals_in_range() {
+		assert!(validate_signal("9").is_ok());
+		assert!(validate_signal("15").is_ok());
+		assert!(validate_signal("1").is_ok());
+		assert!(validate_signal("64").is_ok());
+	}
+
+	#[test]
+	fn rejects_empty_signal() {
+		// The core bug: an empty signal must not be forwarded (it would default
+		// to SIGKILL on the libpod side).
+		let err = validate_signal("").unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidSignal(_)));
+		assert!(err.to_string().contains("invalid signal"));
+	}
+
+	#[test]
+	fn rejects_whitespace_only_signal() {
+		assert!(matches!(
+			validate_signal("   ").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+	}
+
+	#[test]
+	fn rejects_out_of_range_and_zero_numbers() {
+		assert!(matches!(
+			validate_signal("0").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+		assert!(matches!(
+			validate_signal("65").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+		assert!(matches!(
+			validate_signal("9999").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+	}
+
+	#[test]
+	fn rejects_unknown_signal_names() {
+		assert!(matches!(
+			validate_signal("SIGBOGUS").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+		assert!(matches!(
+			validate_signal("not-a-signal").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+	}
+}

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -35,6 +35,10 @@ pub enum ComposeError {
 	HealthCheckTimeout(String),
 	/// A `ports:` entry could not be parsed.
 	InvalidPort(String),
+	/// A `kill` signal is empty, malformed, or not a recognised signal
+	/// name/number. Forwarding it verbatim would let libpod silently default to
+	/// SIGKILL, so it is rejected up front.
+	InvalidSignal(String),
 	/// Image build failed (context assembly or the Podman build step).
 	Build(String),
 	/// `extends:` could not be resolved (missing file/service or a cycle).
@@ -92,6 +96,7 @@ impl fmt::Display for ComposeError {
 			}
 			Self::HealthCheckTimeout(s) => write!(f, "health check timeout for container '{s}'"),
 			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),
+			Self::InvalidSignal(s) => write!(f, "invalid signal: {s}"),
 			Self::Build(s) => write!(f, "build error: {s}"),
 			Self::Extends(s) => write!(f, "extends error: {s}"),
 			Self::Include(s) => write!(f, "include error: {s}"),

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -56,7 +56,7 @@ fn conflict_hint(message: &str) -> Option<&'static str> {
 		Some("the container is already paused")
 	} else if m.contains("not paused") {
 		Some("the container is not paused")
-	} else if m.contains("not running") {
+	} else if m.contains("not running") || m.contains("can only kill running") {
 		Some("the container is not running")
 	} else {
 		None
@@ -99,6 +99,20 @@ impl PodmanError {
 		matches!(self, Self::Api { status, .. } if *status == code)
 	}
 
+	/// True if this is the libpod 409 returned when `kill` targets a container
+	/// that is not running ("can only kill running containers …"). `docker
+	/// compose kill` is best-effort across all targets, so this is treated as an
+	/// idempotent no-op rather than a fatal error that aborts the loop. The
+	/// message is unique to the kill endpoint, so matching it cannot mask another
+	/// op's 409.
+	pub(crate) fn is_kill_of_stopped(&self) -> bool {
+		matches!(
+			self,
+			Self::Api { status: 409, message }
+				if message.to_ascii_lowercase().contains("can only kill running")
+		)
+	}
+
 	/// True if this API error reports that the resource already exists: an HTTP
 	/// 409 conflict, or an HTTP 500 whose message says so. Podman's libpod
 	/// volume-create endpoint returns 500 (not 409) for a duplicate name, so an
@@ -134,6 +148,39 @@ mod tests {
 			conflict_hint("cannot kill container abc: container abc is not running")
 				.unwrap()
 				.contains("not running")
+		);
+		// libpod's kill-of-stopped 409 message ("can only kill running
+		// containers …") gets the same friendly "not running" hint.
+		assert!(conflict_hint(
+			"can only kill running containers. abc is in state exited: container state improper"
+		)
+		.unwrap()
+		.contains("not running"));
+	}
+
+	#[test]
+	fn is_kill_of_stopped_matches_only_the_kill_409() {
+		let stopped = PodmanError::Api {
+			status: 409,
+			message: "can only kill running containers. abc is in state exited: \
+				container state improper"
+				.into(),
+		};
+		assert!(stopped.is_kill_of_stopped());
+		// A different 409 (e.g. already-paused) must not be swallowed by kill.
+		let paused = PodmanError::Api {
+			status: 409,
+			message: "container abc is already paused".into(),
+		};
+		assert!(!paused.is_kill_of_stopped());
+		// Wrong status, even with a matching message, is not a kill-of-stopped.
+		let other = PodmanError::Api {
+			status: 500,
+			message: "can only kill running containers".into(),
+		};
+		assert!(!other.is_kill_of_stopped());
+		assert!(
+			!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_kill_of_stopped()
 		);
 	}
 


### PR DESCRIPTION
I fixed two `kill`/signal-handling findings from the signals-kill sweep.

## What I changed

- **kill of an already-stopped container no longer aborts the loop or leaks a raw HTTP error (Closes #783).** libpod returns 409 ("can only kill running containers …") for a stopped target; I treat that as an idempotent no-op alongside 304/404 so `kill` stays best-effort across every service/replica like `docker compose kill`. I added a `conflict_hint` branch so any such error that surfaces reads as "the container is not running", and I seed the Kahn queue in `resolve_order` from compose-file order so independent services resolve deterministically.
- **kill with an empty/invalid signal is rejected instead of silently SIGKILL-ing everything (Closes #784).** An empty or whitespace-only `-s` value used to render as `signal=` and default to SIGKILL on the libpod side. I now validate the signal up front (empty, zero/out-of-range numbers, and unknown names are rejected; valid names case-insensitively with optional `SIG` prefix, and numbers 1-64, are accepted).

## Tests

- `validate_signal` unit tests (accept/reject cases, empty + whitespace + bad numbers + unknown names).
- `is_kill_of_stopped` matches only the kill 409 and not other conflicts; `conflict_hint` covers the kill-of-stopped message.
- `resolve_order` determinism test for independent services.

All run under `cargo test --lib` plus the parse-level suites; `cargo build`, `cargo fmt`, and `cargo clippy --lib --bins -D warnings` are clean.
