### PR TITLE
fix(networks): resolve verified networks sweep findings

### DIFF
--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -9,6 +9,7 @@ mod extends;
 mod include;
 mod merge;
 mod order;
+mod validate;
 
 use std::path::{Path, PathBuf};
 
@@ -128,6 +129,13 @@ pub fn parse_files_with_env_files_interp(
 		merge_override(&mut merged, other);
 	}
 	normalize_default_network(&mut merged);
+	// Semantic validation runs only on the interpolated file: `--no-interpolate`
+	// leaves literal `${VAR}` placeholders that cannot be reference- or
+	// range-checked. This makes `config`, `up`, and `generate` reject the same
+	// contradictory files docker-compose does, at config time.
+	if interpolate {
+		validate::validate(&merged)?;
+	}
 	for warning in diagnostics::collect(&merged) {
 		tracing::warn!("{warning}");
 	}

--- a/internal/compose/types/ports.rs
+++ b/internal/compose/types/ports.rs
@@ -10,13 +10,18 @@ use serde::{Deserialize, Serialize};
 ///
 /// The spec allows `published: 8080` (integer) or `published: "8080"` (string),
 /// and also string ranges like `"8080-8090"` for port range mappings.
+///
+/// The numeric form is held as a `u32` rather than a `u16` so an out-of-range
+/// value (e.g. `published: 99999`) deserializes and is then reported as a clear
+/// `InvalidPort` error by [`crate::ports`], instead of leaking serde's generic
+/// "data did not match any variant of untagged enum" message to the user.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringOrU16 {
 	/// String form, e.g. a quoted port or range like `"8080-8090"`.
 	String(String),
-	/// Numeric port form.
-	Number(u16),
+	/// Numeric port form (range-checked downstream, not at the type level).
+	Number(u32),
 }
 
 impl StringOrU16 {

--- a/internal/compose/validate.rs
+++ b/internal/compose/validate.rs
@@ -1,0 +1,208 @@
+//! Semantic validation of a resolved compose file.
+//!
+//! Parsing only checks that the YAML deserializes; it never rejects a file that
+//! is syntactically valid but semantically contradictory (e.g. a service that
+//! declares both `network_mode` and `networks`, or a reference to a network that
+//! was never defined). docker-compose errors on these at config time; podup used
+//! to accept them and then silently pick one interpretation, with the live
+//! engine and the Quadlet exporter diverging on which one. This pass closes that
+//! gap by failing fast with a clear message, so `config`, `up`, and `generate`
+//! all agree and no surface silently drops or mistranslates the configuration.
+
+use super::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::ports::parse_ports;
+
+/// Validate the semantic consistency of a resolved compose file. Returns the
+/// first error found, matching docker-compose's fail-at-config-time behaviour.
+///
+/// Run only on the interpolated file: with `--no-interpolate` the values may
+/// still contain literal `${VAR}` placeholders, which cannot be meaningfully
+/// range- or reference-checked.
+pub(super) fn validate(file: &ComposeFile) -> Result<()> {
+	validate_services(file)?;
+	validate_networks(file)?;
+	Ok(())
+}
+
+/// Per-service checks: the `network_mode`/`networks` mutual exclusion, every
+/// network reference resolving to a declared (or external) network, and that the
+/// `ports:` entries parse and are in range.
+fn validate_services(file: &ComposeFile) -> Result<()> {
+	for (name, service) in &file.services {
+		let attached = service.networks.names();
+		if service.network_mode.is_some() {
+			// docker-compose: "network_mode" and "networks" cannot be combined.
+			// The live engine silently honours network_mode and drops the declared
+			// networks; Quadlet emits both, producing a contradictory unit.
+			if !attached.is_empty() {
+				return Err(ComposeError::Unsupported(format!(
+					"service '{name}' sets both 'network_mode' and 'networks', which are \
+					 mutually exclusive; keep one"
+				)));
+			}
+		} else {
+			// Every referenced network must be declared at the top level (or be the
+			// synthesized `default`). An undefined reference is a config error in
+			// docker-compose; podup otherwise prefixes it on the engine path while
+			// the Quadlet exporter emits the raw name, a cross-project attach risk.
+			for net in &attached {
+				// `default` is the implicit project network docker-compose always
+				// provides, so an explicit reference to it is valid even without a
+				// top-level entry; everything else must be declared.
+				if net != "default" && !file.networks.contains_key(net) {
+					return Err(ComposeError::Unsupported(format!(
+						"service '{name}' refers to undefined network '{net}'; declare it \
+						 under the top-level 'networks:' or mark it external"
+					)));
+				}
+			}
+		}
+
+		// Surface a malformed/out-of-range port at config time rather than letting
+		// it slip through to a podman create error at run time.
+		parse_ports(&service.ports)?;
+	}
+	Ok(())
+}
+
+/// Top-level network checks: an `external: true` network must not also carry
+/// creation-time attributes (driver, IPAM, internal, …), which podman cannot
+/// apply to a pre-existing network and docker-compose rejects.
+fn validate_networks(file: &ComposeFile) -> Result<()> {
+	for (name, cfg) in &file.networks {
+		let Some(cfg) = cfg else { continue };
+		if cfg.external != Some(true) {
+			continue;
+		}
+		let mut conflicts = Vec::new();
+		if cfg.driver.is_some() {
+			conflicts.push("driver");
+		}
+		if !cfg.driver_opts.is_empty() {
+			conflicts.push("driver_opts");
+		}
+		if cfg.internal.is_some() {
+			conflicts.push("internal");
+		}
+		if cfg.attachable.is_some() {
+			conflicts.push("attachable");
+		}
+		if cfg.enable_ipv6.is_some() {
+			conflicts.push("enable_ipv6");
+		}
+		if cfg.enable_ipv4.is_some() {
+			conflicts.push("enable_ipv4");
+		}
+		if cfg.ipam.is_some() {
+			conflicts.push("ipam");
+		}
+		if !conflicts.is_empty() {
+			return Err(ComposeError::Unsupported(format!(
+				"network '{name}' is external but also sets {}; an external network is \
+				 used as-is and these attributes cannot be applied to it",
+				conflicts.join(", ")
+			)));
+		}
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::compose::types::ComposeFile;
+	use crate::parse_str;
+
+	fn validate_str(yaml: &str) -> crate::error::Result<()> {
+		let mut file: ComposeFile = parse_str(yaml).unwrap();
+		// Mirror the CLI: synthesize the implicit default network before validating
+		// so a bare service is not flagged as referencing an undefined network.
+		crate::compose::normalize_default_network(&mut file);
+		super::validate(&file)
+	}
+
+	#[test]
+	fn network_mode_with_networks_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    network_mode: host\n    networks: [front]\nnetworks:\n  front:\n";
+		let err = validate_str(yaml).unwrap_err();
+		assert!(err.to_string().contains("mutually exclusive"), "got: {err}");
+	}
+
+	#[test]
+	fn network_mode_alone_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    network_mode: host\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn undefined_network_reference_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [missing]\n";
+		let err = validate_str(yaml).unwrap_err();
+		assert!(
+			err.to_string().contains("undefined network 'missing'"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn declared_network_reference_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [front]\nnetworks:\n  front:\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn bare_service_default_network_is_accepted() {
+		// No networks declared at all: the synthesized `default` must satisfy the
+		// reference check, not trip it.
+		let yaml = "services:\n  web:\n    image: x\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn explicit_default_network_reference_is_accepted() {
+		// `default` is the implicit project network; referencing it without a
+		// top-level entry must not be flagged as undefined.
+		let yaml = "services:\n  web:\n    image: x\n    networks: [default]\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn external_network_with_internal_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n    internal: true\n";
+		let err = validate_str(yaml).unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("external"), "got: {msg}");
+		assert!(msg.contains("internal"), "got: {msg}");
+	}
+
+	#[test]
+	fn external_network_with_ipam_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n    ipam:\n      config:\n        - subnet: 10.0.0.0/24\n";
+		let err = validate_str(yaml).unwrap_err();
+		assert!(err.to_string().contains("ipam"), "got: {err}");
+	}
+
+	#[test]
+	fn plain_external_network_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn external_network_with_name_only_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n    name: shared_net\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn out_of_range_short_port_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    ports: ['99999:80']\n";
+		assert!(validate_str(yaml).is_err());
+	}
+
+	#[test]
+	fn invalid_port_protocol_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    ports: ['80/banana']\n";
+		assert!(validate_str(yaml).is_err());
+	}
+}

--- a/internal/ports.rs
+++ b/internal/ports.rs
@@ -62,14 +62,18 @@ fn parse_one(mapping: &PortMapping) -> Result<Vec<ParsedPort>> {
 			..
 		} => {
 			let proto = protocol.clone().unwrap_or_else(|| "tcp".into());
+			validate_protocol(&proto, &format!("{target}/{proto}"))?;
 			let hip = host_ip.clone().unwrap_or_default();
 			let host_port = published
 				.as_ref()
 				.map(|p| match p {
-					StringOrU16::Number(n) => Ok(*n),
-					StringOrU16::String(s) => s.parse::<u16>().map_err(|_| {
-						ComposeError::InvalidPort(format!("invalid published port: {s}"))
-					}),
+					StringOrU16::Number(n) => port_in_range(*n, &n.to_string()),
+					StringOrU16::String(s) => {
+						let n: u32 = s.parse().map_err(|_| {
+							ComposeError::InvalidPort(format!("invalid published port: {s}"))
+						})?;
+						port_in_range(n, s)
+					}
 				})
 				.transpose()?;
 			Ok(vec![ParsedPort {
@@ -99,6 +103,7 @@ fn parse_short(s: &str) -> Result<Vec<ParsedPort>> {
 	} else {
 		(s, "tcp".to_string())
 	};
+	validate_protocol(&proto, s)?;
 
 	// IPv6 form: `[::1]:host:container` or `[::1]:container`.
 	if let Some(rest) = rest.strip_prefix('[') {
@@ -181,8 +186,7 @@ fn parse_with_ip(ip: &str, after: &str, proto: &str, full: &str) -> Result<Vec<P
 			})
 			.collect())
 	} else {
-		let cp: u16 = after
-			.parse()
+		let cp = parse_port_num(after)
 			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {full}")))?;
 		Ok(vec![ParsedPort {
 			container_port: cp,
@@ -225,16 +229,44 @@ fn expand_single_host_port(
 
 pub(crate) const MAX_PORT_RANGE: usize = 1024;
 
+/// The set of transport protocols podman accepts for a published port. A value
+/// outside this set is rejected at config time rather than passed verbatim to
+/// podman, which would only surface as an opaque create-time error.
+const VALID_PROTOCOLS: [&str; 3] = ["tcp", "udp", "sctp"];
+
+/// Validate a port's protocol suffix against the `tcp`/`udp`/`sctp` allow-list.
+fn validate_protocol(proto: &str, full: &str) -> Result<()> {
+	if VALID_PROTOCOLS.contains(&proto) {
+		Ok(())
+	} else {
+		Err(ComposeError::InvalidPort(format!(
+			"unsupported protocol '{proto}' in '{full}'; use tcp, udp, or sctp"
+		)))
+	}
+}
+
+/// Range-check a numeric port and narrow it to `u16`. Surfaces an out-of-range
+/// value (e.g. `99999`) as a clear config error so the short and long port forms
+/// fail the same way instead of overflowing or leaking a serde enum message.
+fn port_in_range(n: u32, label: &str) -> Result<u16> {
+	u16::try_from(n)
+		.map_err(|_| ComposeError::InvalidPort(format!("port out of range (1-65535): {label}")))
+}
+
+/// Parse a single port number, range-checked against 1-65535.
+fn parse_port_num(s: &str) -> Result<u16> {
+	let n: u32 = s
+		.parse()
+		.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
+	port_in_range(n, s)
+}
+
 /// Expand `start-end` or a single port string.
 fn expand_port_range(s: &str) -> Result<Vec<u16>> {
 	let s = s.trim();
 	if let Some(idx) = s.find('-') {
-		let start: u16 = s[..idx]
-			.parse()
-			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
-		let end: u16 = s[idx + 1..]
-			.parse()
-			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
+		let start = parse_port_num(&s[..idx])?;
+		let end = parse_port_num(&s[idx + 1..])?;
 		if start > end {
 			return Err(ComposeError::InvalidPort(format!(
 				"start > end in range: {s}"
@@ -248,10 +280,7 @@ fn expand_port_range(s: &str) -> Result<Vec<u16>> {
 		}
 		Ok((start..=end).collect())
 	} else {
-		let p: u16 = s
-			.parse()
-			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
-		Ok(vec![p])
+		Ok(vec![parse_port_num(s)?])
 	}
 }
 
@@ -382,6 +411,56 @@ mod tests {
 	#[test]
 	fn invalid_port_string_is_error() {
 		assert!(parse_ports(&[short("abc")]).is_err());
+	}
+
+	#[test]
+	fn invalid_protocol_suffix_is_rejected() {
+		// A protocol outside tcp/udp/sctp is a config error, not something to pass
+		// verbatim to podman.
+		let err = parse_ports(&[short("80/banana")]).unwrap_err();
+		assert!(err.to_string().contains("banana"), "got: {err}");
+		assert!(parse_ports(&[short("53/udp")]).is_ok());
+		assert!(parse_ports(&[short("9/sctp")]).is_ok());
+	}
+
+	#[test]
+	fn out_of_range_short_port_reports_range() {
+		// 99999 overflows the 1-65535 port space; surface a clear range error
+		// rather than a generic parse failure.
+		let err = parse_ports(&[short("99999:80")]).unwrap_err();
+		assert!(err.to_string().contains("out of range"), "got: {err}");
+	}
+
+	#[test]
+	fn out_of_range_long_published_reports_range() {
+		// The numeric long form deserializes (u32) and is range-checked here, so the
+		// user sees the same clear message as the short form instead of a serde
+		// untagged-enum error.
+		let mapping = PortMapping::Long {
+			target: 80,
+			published: Some(StringOrU16::Number(99999)),
+			protocol: None,
+			host_ip: None,
+			mode: None,
+			app_protocol: None,
+			name: None,
+		};
+		let err = parse_ports(&[mapping]).unwrap_err();
+		assert!(err.to_string().contains("out of range"), "got: {err}");
+	}
+
+	#[test]
+	fn long_form_invalid_protocol_is_rejected() {
+		let mapping = PortMapping::Long {
+			target: 80,
+			published: Some(StringOrU16::Number(8080)),
+			protocol: Some("banana".to_string()),
+			host_ip: None,
+			mode: None,
+			app_protocol: None,
+			name: None,
+		};
+		assert!(parse_ports(&[mapping]).is_err());
 	}
 
 	#[test]

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -71,6 +71,20 @@ pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 			continue;
 		}
 		out.units.push(network_unit(name, project, cfg.as_ref()));
+		// `podman network create` (and therefore Quadlet) exposes no key for IPAM
+		// options beyond the IPAM driver, so `ipam.options` cannot be emitted. The
+		// live engine forwards them via the libpod API directly, so warn rather than
+		// let `generate` silently diverge from `up`.
+		if let Some(c) = cfg {
+			if let Some(ipam) = &c.ipam {
+				if !ipam.options.is_empty() {
+					out.warnings.push(format!(
+						"network '{name}': ipam.options have no Quadlet key and are not emitted; \
+						 the live engine forwards them but `generate` cannot"
+					));
+				}
+			}
+		}
 	}
 	for (name, cfg) in &file.volumes {
 		if cfg.as_ref().is_some_and(|c| c.external == Some(true)) {

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -420,19 +420,67 @@ services:
 }
 
 #[test]
-fn network_mode_service_and_container_map_to_dot_container() {
-	// `network_mode: service:X` / `container:X` reuse another container's netns,
-	// which Quadlet expresses as `Network={X}.container`.
-	for (mode, target) in [("service:db", "db"), ("container:sidecar", "sidecar")] {
-		let yaml = format!("services:\n  s:\n    image: x\n    network_mode: \"{mode}\"\n");
-		let file = parse_str(&yaml).unwrap();
-		let out = generate(&file, "p");
-		let c = &unit_named(&out, "s.container").contents;
-		assert!(
-			c.contains(&format!("Network={target}.container")),
-			"{mode} must map to Network={target}.container; got:\n{c}"
-		);
-	}
+fn network_mode_service_maps_to_dot_container() {
+	// `network_mode: service:X` reuses a sibling service's netns, which Quadlet
+	// expresses as the `Network={X}.container` unit dependency.
+	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:db\"\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("Network=db.container"),
+		"service:db must map to Network=db.container; got:\n{c}"
+	);
+}
+
+#[test]
+fn network_mode_container_maps_to_join_form() {
+	// `network_mode: container:X` joins an *existing* container's netns by id/name
+	// via podman's `Network=container:X`; it is not a `.container` unit dependency
+	// (that would name a non-existent unit and fail to start).
+	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"container:sidecar\"\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("Network=container:sidecar"),
+		"container:sidecar must map to the join form; got:\n{c}"
+	);
+	assert!(
+		!c.contains("sidecar.container"),
+		"container: must not emit a .container unit dependency; got:\n{c}"
+	);
+}
+
+#[test]
+fn duplicate_network_aliases_are_emitted_once() {
+	// A repeated alias must not produce duplicate `NetworkAlias=` lines, which
+	// podman may reject at container create.
+	let yaml = "services:\n  s:\n    image: x\n    networks:\n      front:\n        aliases: [dup, dup, uniq]\nnetworks:\n  front:\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert_eq!(
+		c.matches("NetworkAlias=dup").count(),
+		1,
+		"duplicate alias must be emitted once; got:\n{c}"
+	);
+	assert_eq!(c.matches("NetworkAlias=uniq").count(), 1, "in:\n{c}");
+}
+
+#[test]
+fn ipam_options_warn_because_quadlet_cannot_emit_them() {
+	// The live engine forwards `ipam.options` via the libpod API, but podman
+	// network create / Quadlet expose no key for them, so `generate` warns instead
+	// of silently diverging.
+	let yaml = "networks:\n  net:\n    ipam:\n      options:\n        foo: bar\nservices:\n  s:\n    image: x\n    networks: [net]\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	assert!(
+		out.warnings.iter().any(|w| w.contains("ipam.options")),
+		"expected an ipam.options warning; got: {:?}",
+		out.warnings
+	);
 }
 
 #[test]

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -246,19 +246,20 @@ pub(crate) fn container_unit(
 		}
 	}
 	// `network_mode: host`/`none` map to `Network=host`/`Network=none`.
-	// `service:X`/`container:X` reuse another container's netns, which Quadlet
-	// expresses as `Network={X}.container` (the `.container` special case);
-	// other modes (bridge:, custom, …) have no key and are reported by
-	// collect_warnings.
+	// `service:X` reuses a *sibling service's* netns, which Quadlet expresses as
+	// `Network={X}.container` (the `.container` unit dependency). `container:X`
+	// reuses an *existing* container's netns by id/name and maps to podman's
+	// `Network=container:X` join form — not a `.container` unit, which would name
+	// a non-existent dependency and fail to start. Other modes (bridge:, custom,
+	// …) have no key and are reported by collect_warnings.
 	match service.network_mode.as_deref() {
 		Some("host") => container.add("Network", "host".to_string()),
 		Some("none") => container.add("Network", "none".to_string()),
 		Some(m) => {
-			if let Some(target) = m
-				.strip_prefix("service:")
-				.or_else(|| m.strip_prefix("container:"))
-			{
+			if let Some(target) = m.strip_prefix("service:") {
 				container.add("Network", format!("{}.container", safe_unit_stem(target)));
+			} else if let Some(target) = m.strip_prefix("container:") {
+				container.add("Network", format!("container:{target}"));
 			}
 		}
 		None => {}
@@ -274,11 +275,17 @@ pub(crate) fn container_unit(
 	// scoping); a second one is reported by collect_warnings.
 	let mut static_ip: Option<&str> = None;
 	let mut static_ip6: Option<&str> = None;
+	// Emit each alias at most once: a repeated alias (within a network or across
+	// networks) would produce duplicate `NetworkAlias=` lines, which podman may
+	// reject at container create.
+	let mut seen_aliases = std::collections::HashSet::new();
 	for net in service.networks.names() {
 		if let Some(cfg) = service.networks.config_for(&net) {
 			if let Some(aliases) = &cfg.aliases {
 				for alias in aliases {
-					container.add("NetworkAlias", alias.clone());
+					if seen_aliases.insert(alias.clone()) {
+						container.add("NetworkAlias", alias.clone());
+					}
 				}
 			}
 			if static_ip.is_none() {


### PR DESCRIPTION
This sweeps the verified `networks` findings. Across these issues podup accepted
configs that docker-compose rejects at config time and then silently diverged
between the live engine and the Quadlet exporter. I added a semantic validation
pass so `config`, `up`, and `generate` agree and fail fast, tightened the port
parser, and corrected the Quadlet network export.

- network_mode + networks accepted together; engine drops the networks, Quadlet emits a contradictory unit (Closes #809)
- reference to an undefined network silently accepted; engine prefixes it, Quadlet emits the raw name (Closes #810)
- Quadlet mistranslates network_mode: container:<id> into a Network=<id>.container unit dependency (Closes #811)
- external: true combined with internal/driver/ipam silently ignores the extra config (Closes #927)
- Quadlet drops ipam.options while the engine forwards them (Closes #928)
- duplicate network aliases emitted verbatim by Quadlet (Closes #929)
- port protocol suffix not validated against the tcp/udp/sctp allow-list (Closes #930)
- inconsistent/cryptic port-range validation (short accepts out-of-range, long leaks a serde enum error) (Closes #931)

Notes on #928: podman network create, and therefore Quadlet, exposes no key for
IPAM options beyond the IPAM driver, so they cannot be emitted into a `.network`
unit. The live engine forwards them via the libpod API directly, so `generate`
now warns about the gap rather than dropping them silently.

Validation runs only on the interpolated file; `--no-interpolate` leaves literal
`${VAR}` placeholders that cannot be range- or reference-checked.

Verified with `cargo build`, `cargo fmt --all`, `cargo clippy --lib --bins -D warnings`
(clean), `cargo test --lib`, and the parse/ports/quadlet/substitute/size/env_file/
project_name_safety/secret_safety/cli_aliases/cli_diagnostics suites. The
container integration suite was not run.
