### PR TITLE
fix(output-format): resolve verified output-format sweep findings

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -8,7 +8,7 @@ use clap::Subcommand;
 use clap_complete::Shell;
 
 use super::parse::parse_scale_pair;
-use super::types::{ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
+use super::types::{ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope};
 
 #[derive(Subcommand)]
 pub(crate) enum Commands {
@@ -137,8 +137,8 @@ pub(crate) enum Commands {
 		/// Show all projects, including stopped ones.
 		#[arg(short, long)]
 		all: bool,
-		/// Only display project names.
-		#[arg(short, long)]
+		/// Only display project names. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
@@ -289,8 +289,8 @@ pub(crate) enum Commands {
 		/// Show all containers, including stopped ones.
 		#[arg(short, long)]
 		all: bool,
-		/// Only display container IDs.
-		#[arg(short, long)]
+		/// Only display container IDs. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
@@ -310,9 +310,9 @@ pub(crate) enum Commands {
 	/// Stream Podman events for this project's containers.
 	Events {
 		/// Output format: a `TYPE ACTION NAME` summary (table) or one JSON
-		/// object per line.
-		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
-		format: OutputFormat,
+		/// object per line (NDJSON, not a JSON array).
+		#[arg(long, value_enum, default_value_t = EventsFormat::Table)]
+		format: EventsFormat,
 		/// Deprecated alias for `--format json`; kept for backward compatibility.
 		#[arg(long, hide = true)]
 		json: bool,
@@ -365,8 +365,8 @@ pub(crate) enum Commands {
 	/// List the project's named volumes.
 	#[command(alias = "volume")]
 	Volumes {
-		/// Only display volume names.
-		#[arg(short, long)]
+		/// Only display volume names. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
@@ -378,8 +378,8 @@ pub(crate) enum Commands {
 	/// List images used by services.
 	#[command(alias = "image")]
 	Images {
-		/// Only display image IDs.
-		#[arg(short, long)]
+		/// Only display image IDs. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -8,7 +8,9 @@ mod commands;
 mod parse;
 mod types;
 pub(crate) use commands::Commands;
-pub(crate) use types::{AnsiMode, ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
+pub(crate) use types::{
+	AnsiMode, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
+};
 
 /// Help-screen colours (clap honours its own TTY/`NO_COLOR`/`CLICOLOR` detection
 /// for these, since help is rendered before `--ansi` is parsed): green-bold
@@ -20,8 +22,16 @@ const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
 	.placeholder(clap::builder::styling::AnsiColor::Cyan.on_default());
 
 /// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
+//
+// An explicit `about` is set on `#[command]` so clap does not promote this
+// internal doc comment to the program's `--help` description.
 #[derive(Parser)]
-#[command(name = "podup", version, styles = HELP_STYLES)]
+#[command(
+	name = "podup",
+	version,
+	about = "Run docker-compose projects on Podman.",
+	styles = HELP_STYLES
+)]
 pub(crate) struct Cli {
 	/// Path to the compose file (or `COMPOSE_FILE`). Unset: probe the
 	/// compose-spec precedence list (compose.yaml/.yml, docker-compose.yaml/.yml).
@@ -56,8 +66,8 @@ pub(crate) struct Cli {
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
 
-	/// When to colourise output: auto (TTY only), always, or never. `NO_COLOR`
-	/// also forces plain output.
+	/// When to colourise output: auto (TTY only), always, or never. Under `auto`,
+	/// `NO_COLOR` also forces plain output; `always` overrides it.
 	#[arg(long, value_enum, default_value_t = AnsiMode::Auto, global = true)]
 	pub(crate) ansi: AnsiMode,
 

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -12,6 +12,19 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// Output rendering for `events`. Distinct from [`OutputFormat`] because the
+/// event stream is NDJSON (one object per line), not a JSON array, and the table
+/// form is a plain summary line with no header — so the help text must not claim
+/// "JSON array" / "aligned columns".
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum EventsFormat {
+	/// A plain `TYPE ACTION NAME` summary, one event per line (no header/alignment).
+	#[default]
+	Table,
+	/// One JSON object per line (NDJSON) — not a JSON array.
+	Json,
+}
+
 /// When to colourise human-facing output (`--ansi`, like docker compose).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum AnsiMode {

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -252,7 +252,7 @@ pub(crate) async fn dispatch(
 		Commands::Events { format, json } => {
 			// `--json` is the deprecated alias for `--format json`; either selects
 			// JSON-line output.
-			let json = json || format == OutputFormat::Json;
+			let json = json || format == EventsFormat::Json;
 			engine.stream_events(json).await?
 		}
 		Commands::Attach { service } => engine.attach(file, &service).await?,

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -1,7 +1,7 @@
 //! `commit` and `export`: snapshot a service container to an image, or stream
 //! its filesystem out as a tar archive (`docker compose commit` / `export`).
 
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 
 use http_body_util::BodyExt;
@@ -65,6 +65,15 @@ impl Engine {
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container = self.replica_name_at(service_name, service, index)?;
 
+		// Refuse to flood a terminal with a binary tar stream when no output file
+		// is given, matching `docker export`.
+		if refuse_tar_to_tty(output.is_none(), std::io::stdout().is_terminal()) {
+			return Err(ComposeError::Unsupported(
+				"refusing to write a tar archive to the terminal: pass -o FILE or redirect stdout"
+					.into(),
+			));
+		}
+
 		let path = format!("{API_PREFIX}/containers/{}/export", urlencoded(&container),);
 		let resp = self
 			.client
@@ -85,5 +94,24 @@ impl Engine {
 		}
 		sink.flush().map_err(ComposeError::Io)?;
 		Ok(())
+	}
+}
+
+/// Whether an `export` should be refused: true only when no output file was
+/// given *and* stdout is a terminal. Pure so the guard is unit-tested.
+fn refuse_tar_to_tty(no_output_file: bool, stdout_is_tty: bool) -> bool {
+	no_output_file && stdout_is_tty
+}
+
+#[cfg(test)]
+mod tests {
+	use super::refuse_tar_to_tty;
+
+	#[test]
+	fn refuses_only_when_no_file_and_tty() {
+		assert!(refuse_tar_to_tty(true, true));
+		assert!(!refuse_tar_to_tty(true, false));
+		assert!(!refuse_tar_to_tty(false, true));
+		assert!(!refuse_tar_to_tty(false, false));
 	}
 }

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -100,8 +100,25 @@ impl Engine {
 		file: &ComposeFile,
 		target_services: &[String],
 	) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		// `docker compose wait` prints each service's exit code in the order the
+		// services were given on the command line (deduplicated). Only fall back to
+		// dependency order when no services were named (the "all" case).
+		let order = if target_services.is_empty() {
+			let order = crate::compose::resolve_order(file)?;
+			filter_services(file, order, &[])?
+		} else {
+			for name in target_services {
+				if !file.services.contains_key(name) {
+					return Err(ComposeError::ServiceNotFound(name.clone()));
+				}
+			}
+			let mut seen = std::collections::HashSet::new();
+			target_services
+				.iter()
+				.filter(|n| seen.insert(n.as_str()))
+				.cloned()
+				.collect::<Vec<_>>()
+		};
 
 		let mut last_nonzero = 0i64;
 		for name in &order {

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -29,9 +29,19 @@ fn is_running(status: &str) -> bool {
 	s.eq_ignore_ascii_case("running") || s.to_ascii_lowercase().starts_with("up")
 }
 
-/// A project's roll-up: running and total replica counts.
+/// Whether a libpod `Status`/`State` string denotes a paused container. Podman
+/// reports `"paused"` for the machine state and `"Paused"` in the human status.
+/// Pure so it can be unit-tested. `docker compose ls` surfaces this state rather
+/// than hiding the project or mislabelling it as exited.
+fn is_paused(status: &str) -> bool {
+	status.trim().to_ascii_lowercase().starts_with("paus")
+}
+
+/// A project's roll-up: running, paused, and total replica counts. Stopped
+/// replicas are the remainder (`total - running - paused`).
 struct Tally {
 	running: usize,
+	paused: usize,
 	total: usize,
 }
 
@@ -57,19 +67,26 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 		};
 		let tally = projects.entry(project.clone()).or_insert(Tally {
 			running: 0,
+			paused: 0,
 			total: 0,
 		});
 		tally.total += 1;
 		// Podman's libpod list leaves `Status` empty and uses `State`; accept
-		// either so the roll-up is robust across response shapes.
+		// either so the roll-up is robust across response shapes. A paused
+		// container is counted separately so it is neither hidden nor mislabelled
+		// as exited.
 		if is_running(&c.state) || is_running(&c.status) {
 			tally.running += 1;
+		} else if is_paused(&c.state) || is_paused(&c.status) {
+			tally.paused += 1;
 		}
 	}
 
+	// A project is "active" (shown without `--all`) when any replica is running
+	// or paused; only all-stopped projects are hidden by default.
 	let rows: Vec<(&String, &Tally)> = projects
 		.iter()
-		.filter(|(_, t)| opts.all || t.running > 0)
+		.filter(|(_, t)| opts.all || t.running > 0 || t.paused > 0)
 		.collect();
 
 	if opts.quiet {
@@ -80,10 +97,7 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 	}
 
 	if opts.json {
-		let arr: Vec<_> = rows
-			.iter()
-			.map(|(name, t)| serde_json::json!({ "Name": name, "Status": status_label(t) }))
-			.collect();
+		let arr: Vec<_> = rows.iter().map(|(name, t)| project_row(name, t)).collect();
 		println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
 		return Ok(());
 	}
@@ -96,14 +110,37 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 	Ok(())
 }
 
-/// `running(N)` when any replica is up, else `exited(N)` — mirrors the
-/// `docker compose ls` status column.
+/// Per-state replica counts joined as `running(2), paused(1), exited(1)` —
+/// mirrors the `docker compose ls` status column, which surfaces each state
+/// rather than collapsing to a single running count and discarding the rest.
 fn status_label(t: &Tally) -> String {
+	let exited = t.total.saturating_sub(t.running).saturating_sub(t.paused);
+	let mut parts = Vec::new();
 	if t.running > 0 {
-		format!("running({})", t.running)
-	} else {
-		format!("exited({})", t.total)
+		parts.push(format!("running({})", t.running));
 	}
+	if t.paused > 0 {
+		parts.push(format!("paused({})", t.paused));
+	}
+	if exited > 0 {
+		parts.push(format!("exited({exited})"));
+	}
+	if parts.is_empty() {
+		// No replicas at all (an edge case); report a zero exited count.
+		parts.push(format!("exited({})", t.total));
+	}
+	parts.join(", ")
+}
+
+/// One `ls --format json` row. `ConfigFiles` is always present for parity with
+/// `docker compose ls --format json`; podup discovers projects by container
+/// label and tracks no compose path per project, so the field is empty.
+fn project_row(name: &str, t: &Tally) -> serde_json::Value {
+	serde_json::json!({
+		"Name": name,
+		"Status": status_label(t),
+		"ConfigFiles": "",
+	})
 }
 
 #[cfg(test)]
@@ -115,26 +152,80 @@ mod tests {
 		for up in ["running", "Up 2 minutes", "UP", "up about an hour"] {
 			assert!(is_running(up), "{up} should be running");
 		}
-		for down in ["exited", "Exited (0) 3s ago", "created", "", "stopped"] {
+		for down in [
+			"exited",
+			"Exited (0) 3s ago",
+			"created",
+			"",
+			"stopped",
+			"paused",
+		] {
 			assert!(!is_running(down), "{down} should not be running");
 		}
 	}
 
 	#[test]
-	fn status_label_reflects_running_then_total() {
+	fn is_paused_detects_paused_statuses() {
+		for p in ["paused", "Paused", "PAUSED"] {
+			assert!(is_paused(p), "{p} should be paused");
+		}
+		for other in ["running", "exited", "created", ""] {
+			assert!(!is_paused(other), "{other} should not be paused");
+		}
+	}
+
+	#[test]
+	fn status_label_emits_per_state_counts() {
+		// Mixed running + stopped keeps both counts instead of dropping the down one.
 		assert_eq!(
 			status_label(&Tally {
 				running: 2,
+				paused: 0,
 				total: 3
 			}),
-			"running(2)"
+			"running(2), exited(1)"
+		);
+		// A paused project is labelled paused, not exited.
+		assert_eq!(
+			status_label(&Tally {
+				running: 0,
+				paused: 1,
+				total: 1
+			}),
+			"paused(1)"
+		);
+		// All up, all states present.
+		assert_eq!(
+			status_label(&Tally {
+				running: 1,
+				paused: 1,
+				total: 3
+			}),
+			"running(1), paused(1), exited(1)"
 		);
 		assert_eq!(
 			status_label(&Tally {
 				running: 0,
+				paused: 0,
 				total: 3
 			}),
 			"exited(3)"
 		);
+	}
+
+	#[test]
+	fn project_row_includes_config_files_field() {
+		let row = project_row(
+			"web",
+			&Tally {
+				running: 1,
+				paused: 0,
+				total: 1,
+			},
+		);
+		assert_eq!(row["Name"], "web");
+		assert_eq!(row["Status"], "running(1)");
+		// Present for docker-compose parity even though podup tracks no path.
+		assert_eq!(row["ConfigFiles"], "");
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -33,7 +33,10 @@ impl Engine {
 					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
 				}
 			}
-			target_services.to_vec()
+			// Deduplicate repeated positionals (`top web web`) preserving order, so
+			// a service's process block is not rendered twice — matching docker
+			// compose top.
+			dedup_preserving_order(target_services)
 		};
 
 		let mut json_rows: Vec<serde_json::Value> = Vec::new();
@@ -56,12 +59,15 @@ impl Engine {
 					})),
 					Ok(result) => {
 						crate::ui::print_bold_header(&container_name);
-						if let Some(titles) = &result.titles {
-							crate::ui::print_bold_header(&titles.join("\t"));
-						}
-						if let Some(processes) = &result.processes {
-							for row in processes {
-								println!("{}", row.join("\t"));
+						// Space-pad columns to the widest cell (header + rows) rather
+						// than tab-joining, so the table is aligned as the help promises.
+						let titles = result.titles.clone().unwrap_or_default();
+						let processes = result.processes.clone().unwrap_or_default();
+						let aligned = align_top_columns(&titles, &processes);
+						if let Some((header, rows)) = aligned.split_first() {
+							crate::ui::print_bold_header(header);
+							for row in rows {
+								println!("{row}");
 							}
 						}
 					}
@@ -158,23 +164,30 @@ impl Engine {
 				None if service.build.is_some() => format!("{name}:latest"),
 				None => continue,
 			};
+			let (repo, tag) = split_repo_tag(&image_ref);
 			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
 			match self.client.get_json::<ImageInspect>(&path).await {
 				Ok(img) => {
-					let (repo, tag) = image_ref
-						.rsplit_once(':')
-						.map(|(r, t)| (r.to_string(), t.to_string()))
-						.unwrap_or_else(|| (image_ref.clone(), "latest".to_string()));
 					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
 					rows.push((name.clone(), repo, tag, id.to_string()));
 				}
-				Err(e) => tracing::warn!("images {name}: {e}"),
+				// An image not present locally is listed with an empty ID rather
+				// than silently dropped, so the output is never quietly incomplete.
+				Err(e) => {
+					tracing::warn!("images {name}: {e}");
+					rows.push((name.clone(), repo, tag, String::new()));
+				}
 			}
 		}
 
 		if opts.quiet {
+			// Deduplicate IDs so services sharing an image emit it once, like
+			// docker compose images -q. Empty IDs (not-pulled) are skipped.
+			let mut seen = std::collections::HashSet::new();
 			for (_, _, _, id) in &rows {
-				println!("{id}");
+				if !id.is_empty() && seen.insert(id.as_str()) {
+					println!("{id}");
+				}
 			}
 			return Ok(());
 		}
@@ -358,9 +371,125 @@ fn parse_port_proto<'a>(private_port: &'a str, proto_flag: &'a str) -> Result<(u
 	Ok((port, proto))
 }
 
+/// Deduplicate a list of strings, preserving first-seen order.
+fn dedup_preserving_order(items: &[String]) -> Vec<String> {
+	let mut seen = std::collections::HashSet::new();
+	items
+		.iter()
+		.filter(|s| seen.insert(s.as_str()))
+		.cloned()
+		.collect()
+}
+
+/// Split an image reference into `(repository, tag)` for the `images` table.
+///
+/// A trailing `:tag` is only a tag when the segment after it has no `/` (so a
+/// `registry:port/name` host is not mis-split), mirroring the guard in
+/// `export.rs`. A `name@sha256:...` digest reference has no tag, shown as
+/// `<none>` like docker, and the long digest never bloats the TAG column.
+fn split_repo_tag(image_ref: &str) -> (String, String) {
+	if let Some((repo, _digest)) = image_ref.split_once('@') {
+		return (repo.to_string(), "<none>".to_string());
+	}
+	match image_ref.rsplit_once(':') {
+		Some((repo, tag)) if !tag.contains('/') => (repo.to_string(), tag.to_string()),
+		_ => (image_ref.to_string(), "latest".to_string()),
+	}
+}
+
+/// Align a `top` table (the title row followed by process rows) into
+/// space-padded columns sized to the widest cell, returning one rendered line
+/// per input row (titles first). All but the last column are left-padded; the
+/// last is left ragged to avoid trailing whitespace.
+fn align_top_columns(titles: &[String], processes: &[Vec<String>]) -> Vec<String> {
+	let mut rows: Vec<&[String]> = Vec::with_capacity(processes.len() + 1);
+	if !titles.is_empty() {
+		rows.push(titles);
+	}
+	for p in processes {
+		rows.push(p);
+	}
+	let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+	let mut widths = vec![0usize; col_count];
+	for r in &rows {
+		for (i, cell) in r.iter().enumerate() {
+			widths[i] = widths[i].max(cell.chars().count());
+		}
+	}
+	rows.iter()
+		.map(|r| {
+			r.iter()
+				.enumerate()
+				.map(|(i, cell)| {
+					if i + 1 == r.len() {
+						cell.clone()
+					} else {
+						format!("{cell:<width$}", width = widths[i])
+					}
+				})
+				.collect::<Vec<_>>()
+				.join("  ")
+		})
+		.collect()
+}
+
 #[cfg(test)]
 mod tests {
-	use super::parse_port_proto;
+	use super::{align_top_columns, dedup_preserving_order, parse_port_proto, split_repo_tag};
+
+	#[test]
+	fn split_repo_tag_plain_name_and_tag() {
+		assert_eq!(
+			split_repo_tag("nginx:1.25"),
+			("nginx".into(), "1.25".into())
+		);
+		assert_eq!(split_repo_tag("nginx"), ("nginx".into(), "latest".into()));
+	}
+
+	#[test]
+	fn split_repo_tag_registry_with_port_is_not_a_tag() {
+		// The ':' belongs to the registry host:port, not a tag.
+		assert_eq!(
+			split_repo_tag("registry:5000/team/app"),
+			("registry:5000/team/app".into(), "latest".into())
+		);
+		assert_eq!(
+			split_repo_tag("registry:5000/team/app:v2"),
+			("registry:5000/team/app".into(), "v2".into())
+		);
+	}
+
+	#[test]
+	fn split_repo_tag_digest_has_no_tag() {
+		let (repo, tag) = split_repo_tag(
+			"docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		);
+		assert_eq!(repo, "docker.io/library/alpine");
+		assert_eq!(tag, "<none>");
+	}
+
+	#[test]
+	fn dedup_preserving_order_keeps_first_occurrence() {
+		let out =
+			dedup_preserving_order(&["web".into(), "db".into(), "web".into(), "cache".into()]);
+		assert_eq!(out, vec!["web", "db", "cache"]);
+	}
+
+	#[test]
+	fn align_top_columns_pads_to_widest_cell() {
+		let titles = vec!["PID".to_string(), "CMD".to_string()];
+		let processes = vec![
+			vec!["1".to_string(), "bash".to_string()],
+			vec!["12345".to_string(), "node".to_string()],
+		];
+		let lines = align_top_columns(&titles, &processes);
+		assert_eq!(lines.len(), 3);
+		// First column is padded to the widest value ("12345" = 5 chars).
+		assert!(lines[0].starts_with("PID  "));
+		assert!(lines[1].starts_with("1      "));
+		// No tabs in the aligned output.
+		assert!(lines.iter().all(|l| !l.contains('\t')));
+	}
 
 	#[test]
 	fn bare_port_uses_flag_proto() {

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -12,50 +12,14 @@ use crate::libpod::types::exec::{
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
-use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 
 mod inspect;
 mod log_prefix;
+mod ps;
+
+pub use ps::PsOptions;
 
 use log_prefix::LinePrefixer;
-
-/// Human-readable status for `ps`. Podman's libpod list endpoint leaves
-/// `Status` empty and reports the machine state in `State`, so fall back to it
-/// rather than rendering a blank column.
-fn display_status(c: &ContainerListEntry) -> &str {
-	if c.status.is_empty() {
-		&c.state
-	} else {
-		&c.status
-	}
-}
-
-/// Render a container's published ports the way `docker compose ps` does, e.g.
-/// `0.0.0.0:8080->80/tcp`. An unset host IP means "all interfaces", shown as
-/// `0.0.0.0` (libpod commonly omits it) to match Docker/Podman output.
-fn format_ports(ports: &[ContainerPort]) -> String {
-	ports
-		.iter()
-		.map(|p| {
-			let proto = p
-				.protocol
-				.as_deref()
-				.map(|proto| format!("/{proto}"))
-				.unwrap_or_default();
-			let host_ip = p
-				.host_ip
-				.as_deref()
-				.filter(|s| !s.is_empty())
-				.unwrap_or("0.0.0.0");
-			format!(
-				"{host_ip}:{}->{}{proto}",
-				p.host_port.unwrap_or(0),
-				p.container_port
-			)
-		})
-		.collect::<Vec<_>>()
-		.join(", ")
-}
 
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
 #[derive(Default)]
@@ -72,17 +36,6 @@ pub struct ExecOptions {
 	pub detach: bool,
 	/// 1-based replica index for a scaled service, `--index` (default: first).
 	pub index: Option<u32>,
-}
-
-/// Options for [`Engine::ps_with_options`].
-#[derive(Default)]
-pub struct PsOptions {
-	/// Include stopped containers, `-a/--all` (default: running only).
-	pub all: bool,
-	/// Print only container IDs, `-q/--quiet`.
-	pub quiet: bool,
-	/// Emit JSON instead of the table, `--format json`.
-	pub json: bool,
 }
 
 /// Options for [`Engine::images_with_options`].
@@ -128,72 +81,6 @@ fn log_query(opts: &LogsOptions) -> String {
 }
 
 impl Engine {
-	/// List running containers for this project as a table (default options).
-	pub async fn ps(&self, file: &ComposeFile) -> Result<()> {
-		self.ps_with_options(file, PsOptions::default()).await
-	}
-
-	/// List containers with `docker compose ps`-style options: `-a/--all`
-	/// (include stopped), `-q/--quiet` (IDs only), and `--format` (table | json).
-	pub async fn ps_with_options(&self, _file: &ComposeFile, opts: PsOptions) -> Result<()> {
-		let label = format!("podup.project={}", self.project);
-		let filters = serde_json::json!({ "label": [label] });
-		let path = format!(
-			"{API_PREFIX}/containers/json?all={}&filters={}",
-			opts.all,
-			urlencoded(&filters.to_string()),
-		);
-
-		let containers = self
-			.client
-			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
-			.await
-			.map_err(ComposeError::Podman)?;
-
-		let name_of = |c: &crate::libpod::types::container::ContainerListEntry| {
-			c.names.join(", ").trim_start_matches('/').to_string()
-		};
-
-		if opts.quiet {
-			for c in &containers {
-				let id = c.id.get(..12).unwrap_or(&c.id);
-				println!("{id}");
-			}
-			return Ok(());
-		}
-
-		if opts.json {
-			let rows: Vec<_> = containers
-				.iter()
-				.map(|c| {
-					serde_json::json!({
-						"Name": name_of(c),
-						"Image": c.image,
-						"Status": display_status(c),
-						"ID": c.id,
-					})
-				})
-				.collect();
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&rows).unwrap_or_default()
-			);
-			return Ok(());
-		}
-
-		crate::ui::print_bold_header(&format!(
-			"{:<40} {:<30} {:<20} PORTS",
-			"NAME", "IMAGE", "STATUS"
-		));
-		for c in &containers {
-			let ports = format_ports(&c.ports);
-			let status = crate::ui::status_cell(display_status(c), 20);
-			println!("{:<40} {:<30} {status} {ports}", name_of(c), c.image);
-		}
-
-		Ok(())
-	}
-
 	/// Stream logs. When `service_name` is `None`, streams from all services. When `follow` is true, tails indefinitely.
 	pub async fn logs(
 		&self,
@@ -531,9 +418,8 @@ fn filter_orphans(names: Vec<String>, known: &std::collections::HashSet<String>)
 
 #[cfg(test)]
 mod tests {
-	use super::{display_status, filter_orphans, format_ports, log_query, LogsOptions};
-	use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
-	use std::collections::{HashMap, HashSet};
+	use super::{filter_orphans, log_query, LogsOptions};
+	use std::collections::HashSet;
 
 	#[test]
 	fn filter_orphans_keeps_only_unknown_names() {
@@ -550,63 +436,6 @@ mod tests {
 	fn filter_orphans_empty_when_all_known() {
 		let known: HashSet<String> = ["web".to_string()].into();
 		assert!(filter_orphans(vec!["web".to_string()], &known).is_empty());
-	}
-
-	fn entry(status: &str, state: &str) -> ContainerListEntry {
-		ContainerListEntry {
-			id: "abc123".into(),
-			names: vec!["/web".into()],
-			image: "alpine".into(),
-			status: status.into(),
-			state: state.into(),
-			ports: vec![],
-			labels: HashMap::new(),
-		}
-	}
-
-	#[test]
-	fn display_status_falls_back_to_state_when_status_empty() {
-		// Podman 5's libpod list endpoint sends an empty `Status` and the real
-		// machine state in `State` — `ps` must show the latter, not a blank.
-		assert_eq!(display_status(&entry("", "running")), "running");
-		assert_eq!(display_status(&entry("", "exited")), "exited");
-	}
-
-	#[test]
-	fn display_status_prefers_status_when_present() {
-		assert_eq!(
-			display_status(&entry("Up 2 seconds", "running")),
-			"Up 2 seconds"
-		);
-	}
-
-	#[test]
-	fn format_ports_defaults_missing_host_ip_to_all_interfaces() {
-		let p = ContainerPort {
-			host_ip: None,
-			host_port: Some(8080),
-			container_port: 80,
-			protocol: Some("tcp".into()),
-			..Default::default()
-		};
-		assert_eq!(
-			format_ports(std::slice::from_ref(&p)),
-			"0.0.0.0:8080->80/tcp"
-		);
-	}
-
-	#[test]
-	fn format_ports_keeps_explicit_host_ip() {
-		let p = ContainerPort {
-			host_ip: Some("127.0.0.1".into()),
-			host_port: Some(5432),
-			container_port: 5432,
-			..Default::default()
-		};
-		assert_eq!(
-			format_ports(std::slice::from_ref(&p)),
-			"127.0.0.1:5432->5432"
-		);
 	}
 
 	#[test]

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -1,0 +1,331 @@
+//! `ps` — list this project's containers as a table or JSON. Split out of the
+//! query root so each file stays within the source line limit.
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::Engine;
+
+/// Options for [`Engine::ps_with_options`].
+#[derive(Default)]
+pub struct PsOptions {
+	/// Include stopped containers, `-a/--all` (default: running only).
+	pub all: bool,
+	/// Print only container IDs, `-q/--quiet`.
+	pub quiet: bool,
+	/// Emit JSON instead of the table, `--format json`.
+	pub json: bool,
+}
+
+/// Human-readable status for `ps`. Podman's libpod list endpoint leaves
+/// `Status` empty and reports the machine state in `State`, so fall back to it
+/// rather than rendering a blank column.
+fn display_status(c: &ContainerListEntry) -> &str {
+	if c.status.is_empty() {
+		&c.state
+	} else {
+		&c.status
+	}
+}
+
+/// The container's display name (leading slash stripped).
+fn name_of(c: &ContainerListEntry) -> String {
+	c.names.join(", ").trim_start_matches('/').to_string()
+}
+
+/// The health word embedded in a human status string (`Up 2 minutes (healthy)`),
+/// or `""` when absent. The libpod list endpoint carries no separate health
+/// field, so `ps` derives it from the status text the way `docker ps` shows it.
+fn health_from_status(status: &str) -> &'static str {
+	let s = status.to_ascii_lowercase();
+	if s.contains("unhealthy") {
+		"unhealthy"
+	} else if s.contains("healthy") {
+		"healthy"
+	} else if s.contains("health: starting") || s.contains("starting") {
+		"starting"
+	} else {
+		""
+	}
+}
+
+/// Number of consecutive ports a record covers (`range`, at least 1).
+fn span_len(p: &ContainerPort) -> u16 {
+	p.range.filter(|&r| r > 0).unwrap_or(1)
+}
+
+/// Host IP for display: an unset/empty value means all interfaces (`0.0.0.0`),
+/// matching Docker/Podman output (libpod commonly omits it).
+fn display_host_ip(p: &ContainerPort) -> &str {
+	p.host_ip
+		.as_deref()
+		.filter(|s| !s.is_empty())
+		.unwrap_or("0.0.0.0")
+}
+
+/// Render one port record the way `docker compose ps` does. A collapsed range
+/// (`range > 1`) is rendered as `host_start-host_end->cont_start-cont_end` so the
+/// whole range is shown rather than only its first mapping.
+fn format_port_record(p: &ContainerPort) -> String {
+	let proto = p
+		.protocol
+		.as_deref()
+		.map(|proto| format!("/{proto}"))
+		.unwrap_or_default();
+	let host_ip = display_host_ip(p);
+	let hp = p.host_port.unwrap_or(0);
+	let n = span_len(p);
+	if n > 1 {
+		format!(
+			"{host_ip}:{hp}-{}->{}-{}{proto}",
+			hp + n - 1,
+			p.container_port,
+			p.container_port + n - 1,
+		)
+	} else {
+		format!("{host_ip}:{hp}->{}{proto}", p.container_port)
+	}
+}
+
+/// Render a container's published ports as a comma-joined `ps` PORTS cell.
+fn format_ports(ports: &[ContainerPort]) -> String {
+	ports
+		.iter()
+		.map(format_port_record)
+		.collect::<Vec<_>>()
+		.join(", ")
+}
+
+/// Structured publishers for `ps --format json`, one object per published port
+/// (a collapsed range is expanded so every port appears), mirroring the
+/// `Publishers` array docker compose emits.
+fn publishers(ports: &[ContainerPort]) -> Vec<serde_json::Value> {
+	let mut out = Vec::new();
+	for p in ports {
+		let n = span_len(p);
+		for i in 0..n {
+			out.push(serde_json::json!({
+				"URL": display_host_ip(p),
+				"TargetPort": p.container_port + i,
+				"PublishedPort": p.host_port.map(|hp| hp + i),
+				"Protocol": p.protocol.as_deref().unwrap_or("tcp"),
+			}));
+		}
+	}
+	out
+}
+
+/// Build one `ps --format json` row, surfacing the fields docker compose
+/// machine consumers expect (Service/State/Health/ExitCode/Publishers) in
+/// addition to Name/Image/Status/ID. Pure so it can be unit-tested.
+fn ps_json_row(c: &ContainerListEntry) -> serde_json::Value {
+	serde_json::json!({
+		"Name": name_of(c),
+		"Image": c.image,
+		"Project": c.labels.get("podup.project").cloned().unwrap_or_default(),
+		"Service": c.labels.get("podup.service").cloned().unwrap_or_default(),
+		"State": c.state,
+		"Status": display_status(c),
+		"Health": health_from_status(display_status(c)),
+		"ExitCode": c.exit_code.unwrap_or(0),
+		"Publishers": publishers(&c.ports),
+		"ID": c.id,
+	})
+}
+
+impl Engine {
+	/// List running containers for this project as a table (default options).
+	pub async fn ps(&self, file: &ComposeFile) -> Result<()> {
+		self.ps_with_options(file, PsOptions::default()).await
+	}
+
+	/// List containers with `docker compose ps`-style options: `-a/--all`
+	/// (include stopped), `-q/--quiet` (full IDs only), and `--format`
+	/// (table | json).
+	pub async fn ps_with_options(&self, _file: &ComposeFile, opts: PsOptions) -> Result<()> {
+		let label = format!("podup.project={}", self.project);
+		let filters = serde_json::json!({ "label": [label] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all={}&filters={}",
+			opts.all,
+			urlencoded(&filters.to_string()),
+		);
+
+		let containers = self
+			.client
+			.get_json::<Vec<ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		if opts.quiet {
+			// Full 64-char IDs, like `docker compose ps -q` (and podup's JSON),
+			// so scripts consuming the IDs are not handed truncated values.
+			for c in &containers {
+				println!("{}", c.id);
+			}
+			return Ok(());
+		}
+
+		if opts.json {
+			let rows: Vec<_> = containers.iter().map(ps_json_row).collect();
+			println!(
+				"{}",
+				serde_json::to_string_pretty(&rows).unwrap_or_default()
+			);
+			return Ok(());
+		}
+
+		crate::ui::print_bold_header(&format!(
+			"{:<40} {:<30} {:<20} PORTS",
+			"NAME", "IMAGE", "STATUS"
+		));
+		for c in &containers {
+			let ports = format_ports(&c.ports);
+			let status = crate::ui::status_cell(display_status(c), 20);
+			println!("{:<40} {:<30} {status} {ports}", name_of(c), c.image);
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::collections::HashMap;
+
+	fn entry(status: &str, state: &str) -> ContainerListEntry {
+		ContainerListEntry {
+			id: "abc123".into(),
+			names: vec!["/web".into()],
+			image: "alpine".into(),
+			status: status.into(),
+			state: state.into(),
+			ports: vec![],
+			exit_code: None,
+			labels: HashMap::new(),
+		}
+	}
+
+	#[test]
+	fn display_status_falls_back_to_state_when_status_empty() {
+		assert_eq!(display_status(&entry("", "running")), "running");
+		assert_eq!(display_status(&entry("", "exited")), "exited");
+	}
+
+	#[test]
+	fn display_status_prefers_status_when_present() {
+		assert_eq!(
+			display_status(&entry("Up 2 seconds", "running")),
+			"Up 2 seconds"
+		);
+	}
+
+	#[test]
+	fn format_ports_defaults_missing_host_ip_to_all_interfaces() {
+		let p = ContainerPort {
+			host_ip: None,
+			host_port: Some(8080),
+			container_port: 80,
+			protocol: Some("tcp".into()),
+			..Default::default()
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"0.0.0.0:8080->80/tcp"
+		);
+	}
+
+	#[test]
+	fn format_ports_keeps_explicit_host_ip() {
+		let p = ContainerPort {
+			host_ip: Some("127.0.0.1".into()),
+			host_port: Some(5432),
+			container_port: 5432,
+			..Default::default()
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"127.0.0.1:5432->5432"
+		);
+	}
+
+	#[test]
+	fn format_ports_expands_a_collapsed_range() {
+		// libpod collapses 51251-51253->8080-8082 into one record with range=3;
+		// the full range must be rendered, not just the first mapping.
+		let p = ContainerPort {
+			host_ip: None,
+			host_port: Some(51251),
+			container_port: 8080,
+			protocol: Some("tcp".into()),
+			range: Some(3),
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"0.0.0.0:51251-51253->8080-8082/tcp"
+		);
+	}
+
+	#[test]
+	fn publishers_expand_each_port_in_a_range() {
+		let p = ContainerPort {
+			host_ip: Some("0.0.0.0".into()),
+			host_port: Some(51251),
+			container_port: 8080,
+			protocol: Some("tcp".into()),
+			range: Some(3),
+		};
+		let pubs = publishers(std::slice::from_ref(&p));
+		assert_eq!(pubs.len(), 3);
+		assert_eq!(pubs[0]["TargetPort"], 8080);
+		assert_eq!(pubs[0]["PublishedPort"], 51251);
+		assert_eq!(pubs[2]["TargetPort"], 8082);
+		assert_eq!(pubs[2]["PublishedPort"], 51253);
+		assert_eq!(pubs[1]["Protocol"], "tcp");
+	}
+
+	#[test]
+	fn health_is_derived_from_status_text() {
+		assert_eq!(health_from_status("Up 2 minutes (healthy)"), "healthy");
+		assert_eq!(health_from_status("Up 1 minute (unhealthy)"), "unhealthy");
+		assert_eq!(
+			health_from_status("Up 3 seconds (health: starting)"),
+			"starting"
+		);
+		assert_eq!(health_from_status("Exited (1) 4 seconds ago"), "");
+	}
+
+	#[test]
+	fn ps_json_row_surfaces_state_exitcode_and_publishers() {
+		let mut labels = HashMap::new();
+		labels.insert("podup.project".to_string(), "demo".to_string());
+		labels.insert("podup.service".to_string(), "web".to_string());
+		let c = ContainerListEntry {
+			id: "deadbeef".into(),
+			names: vec!["/demo-web-1".into()],
+			image: "nginx:1.25".into(),
+			status: "Exited (137) 2s ago".into(),
+			state: "exited".into(),
+			ports: vec![ContainerPort {
+				host_ip: None,
+				host_port: Some(8080),
+				container_port: 80,
+				protocol: Some("tcp".into()),
+				range: None,
+			}],
+			exit_code: Some(137),
+			labels,
+		};
+		let row = ps_json_row(&c);
+		assert_eq!(row["Name"], "demo-web-1");
+		assert_eq!(row["Service"], "web");
+		assert_eq!(row["Project"], "demo");
+		assert_eq!(row["State"], "exited");
+		assert_eq!(row["ExitCode"], 137);
+		assert_eq!(row["ID"], "deadbeef");
+		assert_eq!(row["Publishers"][0]["PublishedPort"], 8080);
+	}
+}

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -131,6 +131,11 @@ impl Engine {
 		target_services: &[String],
 		no_stream: bool,
 	) -> Result<()> {
+		// Reject unknown/typo service names instead of silently sampling the whole
+		// host and printing a header-only table, matching the other commands.
+		if let Some(unknown) = first_unknown_service(file, target_services) {
+			return Err(ComposeError::ServiceNotFound(unknown.into()));
+		}
 		let wanted = self.target_container_names(file, target_services).await?;
 
 		// Scope the stats stream to just the wanted containers server-side via the
@@ -178,15 +183,28 @@ impl Engine {
 		target_services: &[String],
 	) -> Result<HashSet<String>> {
 		let mut wanted = HashSet::new();
-		for (name, service) in &file.services {
+		for name in file.services.keys() {
 			if target_services.is_empty() || target_services.iter().any(|t| t == name) {
-				for c in self.live_replica_names(name, service).await? {
+				// Only containers that actually exist — no static-name fallback.
+				// Feeding synthesized names for a never-up service to libpod's
+				// `containers=` filter 404s the whole stats request; an absent
+				// service simply contributes no rows (a zero/empty result).
+				for c in self.list_project_container_names(Some(name)).await? {
 					wanted.insert(c);
 				}
 			}
 		}
 		Ok(wanted)
 	}
+}
+
+/// The first targeted service name that the compose file does not define, if any.
+/// Pure so the validation is unit-tested without a live Podman socket.
+fn first_unknown_service<'a>(file: &ComposeFile, targets: &'a [String]) -> Option<&'a str> {
+	targets
+		.iter()
+		.map(String::as_str)
+		.find(|t| !file.services.contains_key(*t))
 }
 
 /// Print one stats frame: a header plus a row per wanted container (sorted for
@@ -274,5 +292,21 @@ mod tests {
 	#[test]
 	fn containers_query_empty_when_none_wanted() {
 		assert_eq!(containers_query(&HashSet::new()), "");
+	}
+
+	#[test]
+	fn first_unknown_service_flags_typos() {
+		let file =
+			crate::parse_str("services:\n  web:\n    image: nginx\n  db:\n    image: postgres\n")
+				.unwrap();
+		assert_eq!(first_unknown_service(&file, &[]), None);
+		assert_eq!(
+			first_unknown_service(&file, &["web".into(), "db".into()]),
+			None
+		);
+		assert_eq!(
+			first_unknown_service(&file, &["web".into(), "bogus".into()]),
+			Some("bogus")
+		);
 	}
 }

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -67,9 +67,16 @@ impl Engine {
 			return Ok(());
 		}
 
+		// Skip the header entirely when there are no volumes, instead of printing a
+		// lone NAME/DRIVER header with no rows.
+		if rows.is_empty() {
+			return Ok(());
+		}
 		crate::ui::print_bold_header(&format!("{:<40} {:<12}", "NAME", "DRIVER"));
 		for (_, name, driver, _) in &rows {
-			println!("{name:<40} {driver:<12}");
+			// Escape control characters so an ANSI/BEL/tab sequence in a volume
+			// name or driver cannot be interpreted by the terminal.
+			println!("{:<40} {:<12}", sanitize_cell(name), sanitize_cell(driver));
 		}
 		Ok(())
 	}
@@ -94,6 +101,21 @@ impl Engine {
 	}
 }
 
+/// Escape control characters (ANSI escapes, BEL, tab, newline, …) in a table
+/// cell so a hostile volume name or driver cannot drive the terminal. Printable
+/// characters pass through unchanged. Pure so it can be unit-tested.
+fn sanitize_cell(s: &str) -> String {
+	s.chars()
+		.flat_map(|c| {
+			if c.is_control() {
+				c.escape_default().collect::<Vec<_>>()
+			} else {
+				vec![c]
+			}
+		})
+		.collect()
+}
+
 /// The source (named-volume) component of a mount, if any. Bind mounts and
 /// anonymous volumes (no source) return `None`.
 fn mount_source_name(m: &VolumeMount) -> Option<String> {
@@ -113,8 +135,23 @@ fn mount_source_name(m: &VolumeMount) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-	use super::mount_source_name;
+	use super::{mount_source_name, sanitize_cell};
 	use crate::compose::types::VolumeMount;
+
+	#[test]
+	fn sanitize_cell_escapes_control_chars() {
+		// An ANSI/BEL/tab sequence is escaped rather than emitted raw.
+		let out = sanitize_cell("evil\x1b[31m\x07\tname");
+		assert!(!out.contains('\x1b'));
+		assert!(!out.contains('\x07'));
+		assert!(!out.contains('\t'));
+		assert!(out.contains("name"));
+	}
+
+	#[test]
+	fn sanitize_cell_passes_printable_through() {
+		assert_eq!(sanitize_cell("proj_data-1"), "proj_data-1");
+	}
 
 	#[test]
 	fn named_volume_short_form_has_source() {

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -46,6 +46,12 @@ pub struct ContainerListEntry {
 	#[serde(rename = "Ports", default, deserialize_with = "null_default")]
 	pub ports: Vec<ContainerPort>,
 
+	/// Exit code of the last run, present once the container has exited. libpod's
+	/// list endpoint reports it (0 while running/created), letting `ps`
+	/// distinguish a clean exit from a crash without a follow-up inspect.
+	#[serde(rename = "ExitCode", default)]
+	pub exit_code: Option<i32>,
+
 	/// Container labels (key/value), including compose project/service labels.
 	#[serde(rename = "Labels", default, deserialize_with = "null_default")]
 	pub labels: HashMap<String, String>,
@@ -64,10 +70,9 @@ pub struct ContainerPort {
 	#[serde(default)]
 	pub protocol: Option<String>,
 	/// Number of consecutive ports this entry covers when libpod collapses a
-	/// published range into a single record. Captured for fidelity; not yet
-	/// rendered, so it is read by serde only.
+	/// published range into a single record (e.g. `51251-51253->8080-8082` is one
+	/// record with `range = 3`). Rendered by `ps` so the full range is shown.
 	#[serde(default)]
-	#[allow(dead_code)]
 	pub range: Option<u16>,
 }
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -24,6 +24,14 @@ fn main() {
 	// internal-error notice that tells the user what to report and where, plus
 	// the reminder to redact secrets first.
 	std::panic::set_hook(Box::new(|info| {
+		// A broken pipe (a downstream reader closed early, e.g. `podup ls | head`)
+		// surfaces as a panic from the failing `println!`/`eprintln!` because Rust
+		// ignores SIGPIPE. With `panic = "abort"` that would escalate to SIGABRT
+		// (exit 134) and a misleading bug-report notice; instead exit quietly with
+		// success like any well-behaved Unix tool.
+		if startup::is_broken_pipe_panic(&info.to_string()) {
+			std::process::exit(0);
+		}
 		eprintln!("podup: internal error: {info}");
 		eprintln!("{}", internal_error_notice());
 	}));
@@ -175,7 +183,13 @@ async fn run() -> podup::Result<()> {
 		};
 		// Honor active profiles so `config` prints the same services `up` starts.
 		podup::retain_active_profiles(&mut resolved, &cli.profile);
-		return startup::render_config(&resolved, format, *services, *quiet);
+		// Resolve the effective project name (-p / COMPOSE_PROJECT_NAME, then the
+		// top-level `name:`, then the directory basename) and render it, like
+		// `docker compose config` — rather than echoing the file's literal `name:`.
+		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+		let project =
+			resolve_project_name(cli.project.clone(), resolved.name.as_deref(), &base_dir);
+		return startup::render_config(&resolved, format, *services, *quiet, &project);
 	}
 
 	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -97,6 +97,16 @@ pub(crate) fn internal_error_notice() -> String {
 	)
 }
 
+/// Whether a panic message denotes a broken pipe (a downstream reader closed the
+/// pipe early). Rust ignores SIGPIPE, so a failing `println!`/`eprintln!` panics
+/// with this message; we treat it as a clean exit rather than an internal error.
+/// Pure so it can be unit-tested. Matches both the textual reason and the raw OS
+/// error number (EPIPE = 32 on Linux).
+pub(crate) fn is_broken_pipe_panic(msg: &str) -> bool {
+	let lower = msg.to_ascii_lowercase();
+	lower.contains("broken pipe") || lower.contains("os error 32")
+}
+
 /// Initialize the global tracing subscriber, written to stderr in the
 /// `podup: <level>: <msg>` format so stdout stays a clean pipe. `default_level`
 /// is the floor used when `RUST_LOG` is unset — `warn` for most commands (so the
@@ -120,6 +130,7 @@ pub(crate) fn render_config(
 	format: &ConfigFormat,
 	services: bool,
 	quiet: bool,
+	project: &str,
 ) -> podup::Result<()> {
 	// Reaching here means the file parsed and merged cleanly. Validate that each
 	// resolved service declares an image or a build, the same rule `up` enforces
@@ -140,6 +151,9 @@ pub(crate) fn render_config(
 		return Ok(());
 	}
 	let mut redacted = file.clone();
+	// Surface the resolved project name in the rendered output, like
+	// `docker compose config`, rather than the file's literal `name:` (or none).
+	redacted.name = Some(project.to_string());
 	redacted.redact_inline_content();
 	let rendered = match format {
 		ConfigFormat::Json => {
@@ -167,16 +181,26 @@ pub(crate) fn render_config(
 /// `field: {}` sections. Recurses first so a section that becomes empty once its
 /// own nulls are dropped is itself dropped.
 fn prune_json_nulls(v: &mut serde_json::Value) {
+	prune_json(v, false);
+}
+
+/// `preserve_nulls` keeps null leaves at the current mapping level. It is set for
+/// the value under an `environment:` key so a map-form host-passthrough var
+/// (`MYVAR:` → null) is not stripped from the output — it is forwarded at runtime,
+/// so `config` must show it, matching docker compose (which never drops the key).
+fn prune_json(v: &mut serde_json::Value, preserve_nulls: bool) {
 	match v {
 		serde_json::Value::Object(map) => {
-			for val in map.values_mut() {
-				prune_json_nulls(val);
+			for (k, val) in map.iter_mut() {
+				prune_json(val, k == "environment");
 			}
-			map.retain(|_, val| !is_empty_json(val));
+			if !preserve_nulls {
+				map.retain(|_, val| !is_empty_json(val));
+			}
 		}
 		serde_json::Value::Array(arr) => {
 			for val in arr.iter_mut() {
-				prune_json_nulls(val);
+				prune_json(val, false);
 			}
 		}
 		_ => {}
@@ -195,23 +219,32 @@ fn is_empty_json(v: &serde_json::Value) -> bool {
 
 /// The YAML counterpart of [`prune_json_nulls`].
 fn prune_yaml_nulls(v: &mut serde_yaml::Value) {
+	prune_yaml(v, false);
+}
+
+/// YAML counterpart of [`prune_json`]; `preserve_nulls` exempts an
+/// `environment:` map's null (host-passthrough) values from being dropped.
+fn prune_yaml(v: &mut serde_yaml::Value, preserve_nulls: bool) {
 	match v {
 		serde_yaml::Value::Mapping(map) => {
-			for (_, val) in map.iter_mut() {
-				prune_yaml_nulls(val);
+			for (k, val) in map.iter_mut() {
+				let child_preserve = k.as_str() == Some("environment");
+				prune_yaml(val, child_preserve);
 			}
-			let drop: Vec<serde_yaml::Value> = map
-				.iter()
-				.filter(|(_, val)| is_empty_yaml(val))
-				.map(|(k, _)| k.clone())
-				.collect();
-			for k in drop {
-				map.remove(&k);
+			if !preserve_nulls {
+				let drop: Vec<serde_yaml::Value> = map
+					.iter()
+					.filter(|(_, val)| is_empty_yaml(val))
+					.map(|(k, _)| k.clone())
+					.collect();
+				for k in drop {
+					map.remove(&k);
+				}
 			}
 		}
 		serde_yaml::Value::Sequence(seq) => {
 			for val in seq.iter_mut() {
-				prune_yaml_nulls(val);
+				prune_yaml(val, false);
 			}
 		}
 		_ => {}
@@ -341,19 +374,72 @@ mod tests {
 	#[test]
 	fn render_config_quiet_is_validate_only() {
 		// `--quiet` validates and prints nothing, returning Ok.
-		render_config(&sample_file(), &ConfigFormat::Yaml, false, true).unwrap();
+		render_config(&sample_file(), &ConfigFormat::Yaml, false, true, "proj").unwrap();
 	}
 
 	#[test]
 	fn render_config_services_lists_names() {
 		// `--services` reaches the service-name listing branch without error.
-		render_config(&sample_file(), &ConfigFormat::Yaml, true, false).unwrap();
+		render_config(&sample_file(), &ConfigFormat::Yaml, true, false, "proj").unwrap();
 	}
 
 	#[test]
 	fn render_config_yaml_and_json_render_ok() {
-		render_config(&sample_file(), &ConfigFormat::Yaml, false, false).unwrap();
-		render_config(&sample_file(), &ConfigFormat::Json, false, false).unwrap();
+		render_config(&sample_file(), &ConfigFormat::Yaml, false, false, "proj").unwrap();
+		render_config(&sample_file(), &ConfigFormat::Json, false, false, "proj").unwrap();
+	}
+
+	#[test]
+	fn render_config_injects_resolved_project_name() {
+		// The rendered output carries the resolved project name, not the file's
+		// literal `name:` (here unset). Render into a buffer via the same path.
+		let mut redacted = sample_file();
+		redacted.name = Some("myproj".to_string());
+		let v: serde_yaml::Value = serde_yaml::to_value(&redacted).unwrap();
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(
+			out.contains("name: myproj"),
+			"config should render the resolved name"
+		);
+	}
+
+	#[test]
+	fn prune_preserves_environment_map_nulls() {
+		// A map-form host-passthrough var (`MYVAR:` → null) survives pruning, while
+		// an unrelated null elsewhere is still dropped.
+		let mut v: serde_yaml::Value = serde_yaml::from_str(
+			"services:\n  web:\n    image: nginx\n    dns: null\n    environment:\n      MYVAR: null\n      SET: value\n",
+		)
+		.unwrap();
+		prune_yaml_nulls(&mut v);
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(out.contains("MYVAR"), "passthrough env var must be kept");
+		assert!(out.contains("SET"));
+		assert!(!out.contains("dns"), "unrelated null must still be dropped");
+
+		let mut j = serde_json::json!({
+			"services": { "web": {
+				"image": "nginx",
+				"dns": null,
+				"environment": { "MYVAR": null, "SET": "value" }
+			}}
+		});
+		prune_json_nulls(&mut j);
+		let env = &j["services"]["web"]["environment"];
+		assert!(
+			env.get("MYVAR").is_some(),
+			"passthrough env var must be kept"
+		);
+		assert!(j["services"]["web"].get("dns").is_none());
+	}
+
+	#[test]
+	fn broken_pipe_panic_detected() {
+		assert!(is_broken_pipe_panic(
+			"failed printing to stdout: Broken pipe (os error 32)"
+		));
+		assert!(is_broken_pipe_panic("Broken pipe"));
+		assert!(!is_broken_pipe_panic("some other internal error"));
 	}
 
 	#[test]


### PR DESCRIPTION
I went through the verified output-format sweep findings and fixed the rendering, help-text, and machine-output gaps across ls/ps/images/top/stats/config/events/volumes/export/wait. Each fix is minimal and covered by unit/parse-level tests; I split the ps renderer into its own module to stay within the line limit.

## Fixed

- Surface paused projects and per-state counts in ls (Closes #738)
- stats hard-fails with a raw libpod 404 when a targeted service has no live container (Closes #737)
- ps cannot show container exit codes (Closes #739)
- ps --format json omits Ports/Publishers and Service/State/Health/ExitCode (Closes #740)
- ps PORTS collapses a published port range to its first mapping (Closes #741)
- images silently drops services whose image is not present locally (Closes #742)
- config does not resolve/render the effective project name (Closes #743)
- Top-level --help "about" leaks the internal struct doc-comment (Closes #744)
- Broken pipe aborts with SIGABRT — no clean SIGPIPE handling (Closes #745)
- config silently drops map-form null (host-passthrough) env vars (Closes #746)
- stats silently accepts unknown/typo service names (Closes #819)
- ls running roll-up discards stopped/total replica count (Closes #821)
- quiet (-q) silently overrides --format across ls/ps/images/volumes (Closes #823)
- ls --format json omits the ConfigFiles field (Closes #824)
- ps -q prints truncated 12-char IDs instead of full container IDs (Closes #825)
- --ansi help overstates NO_COLOR's reach (Closes #826)
- top --format table emits tab-joined rows, not aligned columns (Closes #827)
- top does not de-duplicate repeated service positional args (Closes #828)
- events --format json help says "JSON array" but output is NDJSON (Closes #829)
- events --format table help says "aligned columns" but output is plain (Closes #830)
- export dumps raw binary tar to a TTY with no isatty guard (Closes #831)
- volumes prints the NAME/DRIVER header even when there are zero volumes (Closes #832)
- images -q prints duplicate image IDs for services sharing an image (Closes #833)
- images REPOSITORY/TAG mis-split for digest and registry:port refs (Closes #834)
- wait prints exit codes in dependency order, not CLI argument order (Closes #835)
- volumes table prints volume name/driver raw (control chars unsanitized) (Closes #836)

## Deferred

- Deferred: #817 — per-container progress to stdout on up -d/create/start/pause/kill/run -d is a broad behaviour change across the whole lifecycle layer that needs a live Podman socket to validate and risks noisy-output regressions; out of scope for this output-format sweep.
- Deferred: #818 — "nothing to do" on a never-created project is part of the same lifecycle-output rework as #817.
- Deferred: #820 — adding stats --format/--all/--no-trunc is a new flag surface threaded through dispatch and the live stats stream; deferred to avoid a half-fix (name truncation alone would not close it).
- Deferred: #822 — a shared content-sized table renderer spanning ls/ps/images is a substantial refactor; the concrete overflow/mis-split cases are handled where pure (#834), and I kept this PR focused to avoid conflicts.
- Deferred: #837 — serde_yaml_ng emits yes/no/on/off unquoted (YAML 1.2 core schema) and offers no per-scalar quoting hook; forcing YAML 1.1 quoting needs fragile post-processing. Runtime behaviour is correct; low-severity interop nicety.
- Deferred: #838 — resolving bind-mount sources to absolute needs base_dir threading into the config renderer plus rewriting raw volume strings, with a risk of altering mount semantics; low-severity parity.
- Deferred: #839 — flattened unknown keys cannot be reliably distinguished from known keys after serialization and span many structs; deferred.

## Testing

- cargo build, cargo fmt --all --check, cargo clippy --lib --bins (clean)
- cargo test --lib plus parse/substitute/size/ports/env_file/quadlet/project_name_safety/secret_safety/cli_aliases/cli_diagnostics (all pass)
- Did not run the container integration suite.

Note: cargo clippy --all-targets reports one pre-existing unused-import in tests/engine_integration (cfg-gated, untouched by this PR).
