### PR TITLE
fix(volumes): resolve verified volumes sweep findings

### DIFF
--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -86,7 +86,7 @@ impl Engine {
 		// Map each named-volume reference to the actual volume name created by
 		// create_volumes (project-prefixed, custom `name:`, or external).
 		for nv in &mut named_volumes {
-			nv.name = self.resolved_volume_name(&nv.name, file);
+			nv.name = self.resolved_volume_name(&nv.name, file)?;
 		}
 
 		// --- Port mappings ---
@@ -311,9 +311,10 @@ impl Engine {
 
 	/// Resolve a service's named-volume reference to the actual volume name
 	/// that `create_volumes` produced: a custom `name:`, the raw name for an
-	/// external volume, or the `{project}_{name}` form. References not declared
-	/// in the top-level `volumes:` map (anonymous/implicit) are left unchanged.
-	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> String {
+	/// external volume, or the `{project}_{name}` form. An empty reference is an
+	/// anonymous volume and is left unchanged; a non-empty reference that is not
+	/// declared under the top-level `volumes:` map is rejected (compose-spec).
+	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> Result<String> {
 		resolve_volume_name(reference, &self.project, file)
 	}
 }

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -9,20 +9,36 @@ use crate::error::{ComposeError, Result};
 
 /// Resolve a named-volume reference to the volume name `create_volumes`
 /// produced: a custom `name:`, the raw name for an external volume, or the
-/// `{project}_{name}` form. References not declared in the top-level `volumes:`
-/// map (anonymous/implicit) are returned unchanged.
-pub(super) fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> String {
+/// `{project}_{name}` form.
+///
+/// An empty reference is an anonymous volume (an image `VOLUME` directive or a
+/// colon-less short-form mount); it carries no name, so Podman assigns one and
+/// it is returned unchanged. A non-empty reference that is *not* declared under
+/// the top-level `volumes:` map is rejected, matching the compose-spec: leaving
+/// it unprefixed would make Podman auto-create a bare, unlabelled global volume
+/// that escapes project namespacing and is never reclaimed by `down -v`.
+pub(super) fn resolve_volume_name(
+	reference: &str,
+	project: &str,
+	file: &ComposeFile,
+) -> Result<String> {
+	if reference.is_empty() {
+		return Ok(String::new());
+	}
 	match file.volumes.get(reference) {
-		Some(cfg) => {
+		Some(cfg) => Ok(
 			if let Some(name) = cfg.as_ref().and_then(|c| c.name.as_deref()) {
 				name.to_string()
 			} else if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
 				reference.to_string()
 			} else {
 				format!("{project}_{reference}")
-			}
-		}
-		None => reference.to_string(),
+			},
+		),
+		None => Err(ComposeError::Unsupported(format!(
+			"service refers to undefined volume \"{reference}\"; declare it under the \
+			 top-level `volumes:` key, or use a bind mount or anonymous volume instead"
+		))),
 	}
 }
 
@@ -487,11 +503,18 @@ mod tests {
 			"services:\n  s:\n    image: x\nvolumes:\n  data:\n  ext:\n    external: true\n  custom:\n    name: my-vol\n",
 		)
 		.unwrap();
-		assert_eq!(resolve_volume_name("data", "proj", &f), "proj_data");
-		assert_eq!(resolve_volume_name("ext", "proj", &f), "ext");
-		assert_eq!(resolve_volume_name("custom", "proj", &f), "my-vol");
-		// Not declared in top-level volumes -> left as-is.
-		assert_eq!(resolve_volume_name("anon", "proj", &f), "anon");
+		assert_eq!(
+			resolve_volume_name("data", "proj", &f).unwrap(),
+			"proj_data"
+		);
+		assert_eq!(resolve_volume_name("ext", "proj", &f).unwrap(), "ext");
+		assert_eq!(resolve_volume_name("custom", "proj", &f).unwrap(), "my-vol");
+		// An empty reference is an anonymous volume: no name to resolve.
+		assert_eq!(resolve_volume_name("", "proj", &f).unwrap(), "");
+		// A non-empty reference not declared under top-level `volumes:` is
+		// rejected rather than escaping into a bare, unprefixed global volume.
+		let err = resolve_volume_name("missing", "proj", &f).unwrap_err();
+		assert!(err.to_string().contains("missing"), "got: {err}");
 	}
 
 	#[test]

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -419,10 +419,7 @@ impl Engine {
 					tracing::warn!("could not stop {container_name}: {e}");
 				}
 
-				let rm_path = format!(
-					"{API_PREFIX}/containers/{}?force=true",
-					crate::libpod::urlencoded(&container_name),
-				);
+				let rm_path = container_rm_path(&container_name, remove_volumes);
 				if let Err(e) = self.client.delete_ok(&rm_path).await {
 					tracing::warn!("could not remove {container_name}: {e}");
 				} else {
@@ -436,7 +433,7 @@ impl Engine {
 		// containers by label so teardown is always complete.
 		let grace = self.stop_timeout.unwrap_or(10);
 		for name in self.list_project_container_names(None).await? {
-			self.stop_and_remove(&name, grace).await;
+			self.stop_and_remove(&name, grace, remove_volumes).await;
 		}
 
 		for (key, config) in &file.networks {
@@ -543,5 +540,50 @@ impl Engine {
 			}
 		}
 		Ok(())
+	}
+}
+
+/// Build the libpod container-removal path. `force` always terminates a running
+/// container; with `remove_volumes` it also reclaims the anonymous volumes the
+/// container owns (`podman rm -v` / `docker compose down -v` semantics). That is
+/// the only way image `VOLUME` directives and short-form anonymous volumes get
+/// removed: podup never names or labels them, so they cannot be enumerated and
+/// deleted the way declared top-level volumes are.
+pub(super) fn container_rm_path(name: &str, remove_volumes: bool) -> String {
+	let with_volumes = if remove_volumes { "&v=true" } else { "" };
+	format!(
+		"{API_PREFIX}/containers/{}?force=true{with_volumes}",
+		crate::libpod::urlencoded(name),
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::container_rm_path;
+
+	#[test]
+	fn rm_path_omits_volume_flag_by_default() {
+		// A plain `down` (or scale-down) must not drop volumes.
+		let path = container_rm_path("proj-web-1", false);
+		assert!(path.ends_with("/proj-web-1?force=true"), "got: {path}");
+		assert!(!path.contains("v=true"), "got: {path}");
+	}
+
+	#[test]
+	fn rm_path_requests_anonymous_volume_removal() {
+		// `down -v` must pass `v=true` so podman reclaims the container's
+		// anonymous (image VOLUME / short-form) volumes.
+		let path = container_rm_path("proj-web-1", true);
+		assert!(path.contains("force=true"), "got: {path}");
+		assert!(path.contains("&v=true"), "got: {path}");
+	}
+
+	#[test]
+	fn rm_path_url_encodes_container_name() {
+		// Names are URL-encoded so a slash in a container name cannot alter the
+		// request path.
+		let path = container_rm_path("weird/name", true);
+		assert!(!path.contains("weird/name"), "got: {path}");
+		assert!(path.contains("weird%2Fname"), "got: {path}");
 	}
 }

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -119,20 +119,25 @@ impl Engine {
 			.await?
 		{
 			if !desired.contains(&name) {
-				self.stop_and_remove(&name, grace).await;
+				// Scaling down removes surplus replicas but keeps their data
+				// volumes (only `down -v` reclaims volumes).
+				self.stop_and_remove(&name, grace, false).await;
 			}
 		}
 		Ok(())
 	}
 
-	/// Stop (best-effort) then force-remove a container by name.
-	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32) {
+	/// Stop (best-effort) then force-remove a container by name. With
+	/// `remove_volumes`, the container's anonymous volumes are reclaimed too
+	/// (`podman rm -v`), so a label-based teardown sweep does not leave image
+	/// `VOLUME`/anonymous volumes behind.
+	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32, remove_volumes: bool) {
 		let stop_path = format!(
 			"{API_PREFIX}/containers/{}/stop?t={grace}",
 			urlencoded(name)
 		);
 		let _ = self.client.post_empty_ok(&stop_path).await;
-		let rm_path = format!("{API_PREFIX}/containers/{}?force=true", urlencoded(name));
+		let rm_path = super::container_rm_path(name, remove_volumes);
 		if let Err(e) = self.client.delete_ok(&rm_path).await {
 			tracing::debug!("scale-down rm {name}: {e}");
 		} else {

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -36,7 +36,23 @@ pub(crate) fn build_mounts_all(
 				if let Some((m, n)) = parse_volume_string(s) {
 					match n {
 						Some(nv) => named.push(nv),
-						None => mounts.push(m.unwrap()),
+						None => {
+							let m = m.unwrap();
+							// Short-form binds imply `create_host_path` (compose-spec),
+							// so create a missing host source directory before mounting.
+							// Otherwise `up` aborts with a raw podman HTTP 500 statfs
+							// error that leaks the absolute host path. Resolve exactly
+							// like the mount source so the directory is created at the
+							// path actually bind-mounted (relative anchored to the
+							// project dir, leading `~` expanded).
+							if let Some(src) = m.source.as_deref() {
+								let abs = super::container::resolve_bind_source(src, base_dir);
+								if let Err(e) = std::fs::create_dir_all(&abs) {
+									tracing::warn!("create_host_path: failed to create {abs}: {e}");
+								}
+							}
+							mounts.push(m);
+						}
 					}
 				}
 			}
@@ -356,6 +372,25 @@ mod tests {
 		}]);
 		build_mounts_all(&svc, dir.path(), &[], &[]);
 		assert!(dir.path().join(rel).exists());
+	}
+
+	#[test]
+	fn short_form_bind_creates_missing_host_path() {
+		// A short-form bind whose relative source is missing must have its host
+		// directory created (compose-spec implies create_host_path for short
+		// syntax), anchored to the project base dir — not left to fail with a raw
+		// podman statfs 500.
+		let dir = tempfile::tempdir().unwrap();
+		let rel = "missing-dir";
+		let svc = svc_with_volumes(vec![VolumeMount::Short(format!("./{rel}:/app/data"))]);
+		let (mounts, named) = build_mounts_all(&svc, dir.path(), &[], &[]);
+		assert!(named.is_empty());
+		assert_eq!(mounts.len(), 1);
+		assert_eq!(mounts[0].mount_type, "bind");
+		assert!(
+			dir.path().join(rel).is_dir(),
+			"short-form bind source directory should be created"
+		);
 	}
 
 	#[test]

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -18,6 +18,21 @@ pub(super) fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<Name
 		.map(|o| o.trim().to_string())
 		.filter(|o| !o.is_empty())
 		.collect();
+	// A colon-less entry (`/data`, `cache`) is a single in-container target, not
+	// a `src:dst` pair: per the compose-spec it provisions an anonymous volume at
+	// that path. Without this, `is_bind_source("/data")` is true and the leading
+	// slash would be mistaken for a host bind, mounting the host's `/data`.
+	if !spec_has_separator(s) {
+		return Some((
+			None,
+			Some(NamedVolume {
+				name: String::new(),
+				dest: dst.to_string(),
+				options: opts,
+				sub_path: None,
+			}),
+		));
+	}
 	if is_bind_source(src) {
 		Some((
 			Some(Mount {
@@ -60,6 +75,14 @@ fn is_bind_source(src: &str) -> bool {
 		|| src.starts_with('.')
 		|| src.starts_with('~')
 		|| has_windows_drive_prefix(src)
+}
+
+/// Whether a short-form spec carries a `src:dst` separator, i.e. at least one
+/// colon outside a leading Windows drive prefix. A spec with none is a single
+/// in-container path (anonymous volume) rather than a `src:dst` pair.
+fn spec_has_separator(s: &str) -> bool {
+	let scan_from = if has_windows_drive_prefix(s) { 2 } else { 0 };
+	s.bytes().skip(scan_from).any(|b| b == b':')
 }
 
 /// Split a short-form volume spec into `(src, dst, opts)`. Colons separate the
@@ -150,8 +173,42 @@ pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOp
 
 #[cfg(test)]
 mod tests {
-	use super::{extend_bind_opts_str, is_bind_source, map_selinux_option, split_volume_spec};
+	use super::{
+		extend_bind_opts_str, is_bind_source, map_selinux_option, parse_volume_string,
+		split_volume_spec,
+	};
 	use crate::compose::types::BindOptions;
+
+	#[test]
+	fn colon_less_path_is_anonymous_volume_not_bind() {
+		// `- /data` (no `src:dst`) is a single in-container target: an anonymous
+		// volume, not a host bind of `/data`.
+		let (mount, named) = parse_volume_string("/data").unwrap();
+		assert!(mount.is_none(), "must not be a bind mount");
+		let nv = named.expect("expected an anonymous named volume");
+		assert_eq!(nv.name, "", "anonymous volume carries no name");
+		assert_eq!(nv.dest, "/data");
+	}
+
+	#[test]
+	fn colon_less_relative_token_is_anonymous_volume() {
+		// A bare token with no separator is still a single target, so it produces
+		// an anonymous volume rather than being read as a host bind.
+		let (mount, named) = parse_volume_string("cache").unwrap();
+		assert!(mount.is_none());
+		assert_eq!(named.unwrap().dest, "cache");
+	}
+
+	#[test]
+	fn explicit_pair_still_binds_host_path() {
+		// An explicit `src:dst` with a host-path source is still a bind mount.
+		let (mount, named) = parse_volume_string("/host:/data").unwrap();
+		assert!(named.is_none());
+		let m = mount.expect("expected a bind mount");
+		assert_eq!(m.mount_type, "bind");
+		assert_eq!(m.source.as_deref(), Some("/host"));
+		assert_eq!(m.destination, "/data");
+	}
 
 	#[test]
 	fn selinux_shared_maps_to_lowercase_z() {


### PR DESCRIPTION
I swept the volumes subsystem for the verified findings and fixed each one, keeping changes minimal and behaviour aligned with the compose-spec / Docker Compose.

## Fixes

- Undeclared named volume passed through unprefixed, escaping project namespacing (Closes #714)
- Anonymous short-form volume `- /data` parsed as a host bind mount (Closes #729)
- Short-form bind mount with missing source dir not auto-created (raw HTTP 500) (Closes #730)
- `down -v` leaks anonymous/image volumes attached to project containers (Closes #731)

## Notes

- #714: I reject a non-empty named-volume reference that is not declared under the top-level `volumes:` map (matching Docker Compose). Anonymous volumes still pass through untouched.
- #729: a colon-less short-form entry now provisions an anonymous volume at that in-container path instead of being read as a host bind via the leading slash.
- #730: short-form binds now imply `create_host_path`, so a missing host source directory is created (resolved against the project dir) instead of failing with a raw podman statfs 500.
- #731: `down -v` now passes `v=true` to container removal (`podman rm -v` semantics) so anonymous/image VOLUME volumes are reclaimed; scale-down still keeps its volumes.

Each fix has unit/parse-level test coverage. I ran `cargo build`, `cargo fmt --all`, `cargo clippy --lib -D warnings` (clean), and the unit + non-container test suites (all green). The one clippy finding under `--all-targets` is a pre-existing unused import in `tests/engine_integration.rs` on `develop`, unrelated to this change.
