### PR TITLE
fix(compose-parse): resolve verified compose-parse sweep findings

### DIFF
--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -11,7 +11,16 @@ use crate::error::{ComposeError, Result};
 const MAX_ALIAS_REFS: usize = 100;
 const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
 
+/// Upper bound on flow-style nesting depth (`[`/`{`). serde_yaml_ng's own
+/// recursion cap eventually rejects pathological nesting, but its tokenizer is
+/// O(n^2) in the depth it scans, so a small file of deeply nested flow
+/// collections (`[[[[…]]]]`) can burn quadratic CPU time before that cap fires.
+/// Real compose files nest only a handful of levels, so this cheap pre-parse
+/// pass bounds the parser's worst-case work without affecting any valid input.
+const MAX_FLOW_DEPTH: usize = 100;
+
 pub(super) fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
+	guard_flow_depth(content)?;
 	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
 	apply_merge_keys(&mut value);
@@ -38,6 +47,36 @@ fn guard_alias_expansion(content: &str) -> Result<()> {
 			"compose document uses {refs} YAML alias references; at most {MAX_ALIAS_REFS} are \
 			 allowed — inline the repeated content instead"
 		)));
+	}
+	Ok(())
+}
+
+/// Reject documents whose flow-style nesting (`[`/`{`) exceeds [`MAX_FLOW_DEPTH`]
+/// before they reach the O(n^2) tokenizer. Brackets inside single/double-quoted
+/// scalars and after a `#` comment are ignored, mirroring [`count_alias_refs`]'s
+/// conservative scan; the count never fully parses YAML, it only bounds work.
+fn guard_flow_depth(content: &str) -> Result<()> {
+	let mut depth: usize = 0;
+	for line in content.lines() {
+		let (mut in_single, mut in_double) = (false, false);
+		for c in line.chars() {
+			match c {
+				'\'' if !in_double => in_single = !in_single,
+				'"' if !in_single => in_double = !in_double,
+				'#' if !in_single && !in_double => break,
+				'[' | '{' if !in_single && !in_double => {
+					depth += 1;
+					if depth > MAX_FLOW_DEPTH {
+						return Err(ComposeError::Unsupported(format!(
+							"compose document nests flow collections more than {MAX_FLOW_DEPTH} \
+							 levels deep; flatten the structure"
+						)));
+					}
+				}
+				']' | '}' if !in_single && !in_double => depth = depth.saturating_sub(1),
+				_ => {}
+			}
+		}
 	}
 	Ok(())
 }
@@ -150,6 +189,32 @@ mod tests {
 		}
 		let err = guard_alias_expansion(&yaml).unwrap_err();
 		assert!(format!("{err}").contains("alias references"));
+	}
+
+	// flow-depth guard
+
+	#[test]
+	fn guard_flow_depth_allows_shallow_nesting() {
+		// A handful of nested flow collections (typical compose) is fine.
+		assert!(guard_flow_depth("a: [[1, 2], [3, 4]]\nb: {x: {y: 1}}\n").is_ok());
+	}
+
+	#[test]
+	fn guard_flow_depth_rejects_pathological_nesting() {
+		let deep = format!(
+			"a: {}{}\n",
+			"[".repeat(MAX_FLOW_DEPTH + 5),
+			"]".repeat(MAX_FLOW_DEPTH + 5)
+		);
+		let err = guard_flow_depth(&deep).unwrap_err();
+		assert!(format!("{err}").contains("flow collections"));
+	}
+
+	#[test]
+	fn guard_flow_depth_ignores_brackets_in_quotes_and_comments() {
+		// Brackets inside quoted scalars or after `#` do not count toward depth.
+		let yaml = format!("cmd: \"{}\"  # {}\n", "[".repeat(200), "{".repeat(200));
+		assert!(guard_flow_depth(&yaml).is_ok());
 	}
 
 	#[test]

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -9,6 +9,7 @@ mod extends;
 mod include;
 mod merge;
 mod order;
+mod validate;
 
 use std::path::{Path, PathBuf};
 
@@ -17,6 +18,12 @@ use crate::substitute;
 use types::{ComposeFile, ServiceNetworks};
 
 pub use order::{resolve_levels, resolve_order};
+pub use validate::validate_config;
+
+/// Whether a compose-file path is the stdin sentinel `-` (`docker compose -f -`).
+fn is_stdin(path: &Path) -> bool {
+	path == Path::new("-")
+}
 
 /// Parse a compose file from disk, applying variable substitution and
 /// resolving `extends:` / `include:` directives.
@@ -41,8 +48,17 @@ pub fn parse_file_with_env_files_interp(
 	env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
-	let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-	let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
+	// `-f -` reads the compose document from stdin (like `docker compose`); there
+	// is no file to canonicalize, so relative paths and `.env` resolve against the
+	// working directory.
+	let (abs, dir) = if is_stdin(path) {
+		let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+		(PathBuf::from("-"), cwd)
+	} else {
+		let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+		let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
+		(abs, dir)
+	};
 	let mut file = parse_file_inner_with_env(&abs, &dir, env_files, interpolate)?;
 
 	let includes = std::mem::take(&mut file.include);
@@ -216,13 +232,17 @@ pub(crate) fn parse_file_inner_with_env(
 	extra_env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
-	let content = crate::filesystem::read_to_string_capped(path).map_err(|e| {
-		if e.kind() == std::io::ErrorKind::NotFound {
-			ComposeError::FileNotFound(path.display().to_string())
-		} else {
-			ComposeError::Io(e)
-		}
-	})?;
+	let content = if is_stdin(path) {
+		crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?
+	} else {
+		crate::filesystem::read_to_string_capped(path).map_err(|e| {
+			if e.kind() == std::io::ErrorKind::NotFound {
+				ComposeError::FileNotFound(path.display().to_string())
+			} else {
+				ComposeError::Io(e)
+			}
+		})?
+	};
 	// `config --no-interpolate` leaves `${VAR}` placeholders literal; otherwise
 	// substitute against the env/.env/env-file variable map.
 	let yaml = if interpolate {
@@ -243,6 +263,14 @@ mod tests {
 	use super::*;
 
 	// parse_str_raw
+
+	#[test]
+	fn is_stdin_matches_only_the_dash_sentinel() {
+		assert!(is_stdin(Path::new("-")));
+		assert!(!is_stdin(Path::new("docker-compose.yml")));
+		assert!(!is_stdin(Path::new("./-")));
+		assert!(!is_stdin(Path::new("a-b")));
+	}
 
 	#[test]
 	fn parse_str_raw_minimal_service() {

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -66,8 +66,13 @@ pub struct ResourcesConfig {
 /// A single resource specification: CPU shares, memory limit, pids limit, and device access.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourceSpec {
-	/// CPU limit expressed in cores (e.g. `"0.5"`).
-	#[serde(skip_serializing_if = "Option::is_none")]
+	/// CPU limit expressed in cores (e.g. `0.5` or `"0.5"`); accepts both the
+	/// unquoted-number and quoted-string spec forms.
+	#[serde(
+		default,
+		deserialize_with = "super::primitives::deserialize_opt_string_or_number",
+		skip_serializing_if = "Option::is_none"
+	)]
 	pub cpus: Option<String>,
 	/// Memory limit as a size string (e.g. `"512M"`).
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/internal/compose/types/primitives.rs
+++ b/internal/compose/types/primitives.rs
@@ -32,6 +32,28 @@ where
 	})
 }
 
+/// Deserialize a field that the compose spec allows as either a YAML number or a
+/// quoted string, normalizing to `Option<String>`. `cpus: 0.5` (number) and
+/// `cpus: "0.5"` (string) both parse; an absent key stays `None`. Used for the
+/// `cpus:` limits, which the spec writes unquoted but podup stores as a string.
+pub(crate) fn deserialize_opt_string_or_number<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	#[derive(Deserialize)]
+	#[serde(untagged)]
+	enum StringOrNumber {
+		Str(String),
+		Int(i64),
+		Float(f64),
+	}
+	Ok(Option::<StringOrNumber>::deserialize(de)?.map(|v| match v {
+		StringOrNumber::Str(s) => s,
+		StringOrNumber::Int(i) => i.to_string(),
+		StringOrNumber::Float(fl) => fl.to_string(),
+	}))
+}
+
 /// Container entrypoint / command — either a shell string or exec list.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
@@ -222,6 +244,38 @@ mod tests {
 	fn command_exec_to_argv_passthrough() {
 		let cmd = Command::Exec(vec!["ls".into()]);
 		assert_eq!(cmd.to_argv(), vec!["ls"]);
+	}
+
+	// string-or-number (cpus)
+
+	#[derive(Deserialize)]
+	struct CpusHolder {
+		#[serde(default, deserialize_with = "deserialize_opt_string_or_number")]
+		cpus: Option<String>,
+	}
+
+	#[test]
+	fn opt_string_or_number_accepts_unquoted_float() {
+		let h: CpusHolder = serde_yaml::from_str("cpus: 0.5\n").unwrap();
+		assert_eq!(h.cpus.as_deref(), Some("0.5"));
+	}
+
+	#[test]
+	fn opt_string_or_number_accepts_quoted_string() {
+		let h: CpusHolder = serde_yaml::from_str("cpus: \"0.5\"\n").unwrap();
+		assert_eq!(h.cpus.as_deref(), Some("0.5"));
+	}
+
+	#[test]
+	fn opt_string_or_number_accepts_integer() {
+		let h: CpusHolder = serde_yaml::from_str("cpus: 2\n").unwrap();
+		assert_eq!(h.cpus.as_deref(), Some("2"));
+	}
+
+	#[test]
+	fn opt_string_or_number_absent_is_none() {
+		let h: CpusHolder = serde_yaml::from_str("other: 1\n").unwrap();
+		assert_eq!(h.cpus, None);
 	}
 
 	// StringOrList

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -294,7 +294,12 @@ pub struct Service {
 	pub cpuset: Option<String>,
 	/// `cpus:` — fractional number of CPUs to allow (e.g. `0.5`); a hard cap
 	/// converted to a CFS quota. Top-level value wins over `deploy.resources`.
-	#[serde(skip_serializing_if = "Option::is_none")]
+	/// Accepts both the unquoted number (`cpus: 0.5`) and the quoted string form.
+	#[serde(
+		default,
+		deserialize_with = "super::primitives::deserialize_opt_string_or_number",
+		skip_serializing_if = "Option::is_none"
+	)]
 	pub cpus: Option<String>,
 	/// `cpu_count:` — number of usable CPUs (Windows containers); not honored on
 	/// Linux/Podman.

--- a/internal/compose/validate.rs
+++ b/internal/compose/validate.rs
@@ -1,0 +1,265 @@
+//! Config-time validation of a fully parsed and merged compose file.
+//!
+//! [`validate_config`] backs the `config` subcommand, applying the same
+//! cross-reference and well-formedness checks `docker compose config` performs
+//! and that the mutating commands would otherwise only surface later (at
+//! `resolve_order` time, when Podman rejects a bad port, or when an undeclared
+//! volume/network reaches the runtime). Running them up front means `config`
+//! reports the divergence at exit non-zero instead of echoing the file verbatim.
+
+use crate::compose::order::resolve_order;
+use crate::compose::types::{ComposeFile, PortMapping, VolumeMount, VolumeType};
+use crate::error::{ComposeError, Result};
+use crate::ports::parse_ports;
+
+/// Validate a parsed compose file the way `docker compose config` does.
+///
+/// Checks, in order: at least one service is defined; every service declares an
+/// `image:` or `build:`; service names use the compose charset; published/target
+/// ports are in range; every referenced named volume and network is declared at
+/// the top level; and the `depends_on` graph is acyclic with no dangling
+/// required dependency. Returns the first violation found.
+pub fn validate_config(file: &ComposeFile) -> Result<()> {
+	// An empty file, a missing `services:` key, or `services: {}` is not a valid
+	// project — `docker compose config` errors with "no service selected".
+	if file.services.is_empty() {
+		return Err(ComposeError::Unsupported(
+			"no services defined in compose file".to_string(),
+		));
+	}
+
+	for (name, svc) in &file.services {
+		validate_service_name(name)?;
+		if svc.image.is_none() && svc.build.is_none() {
+			return Err(ComposeError::NoImageOrBuild(name.clone()));
+		}
+		validate_ports(name, &svc.ports)?;
+		validate_network_refs(name, file, svc)?;
+		validate_volume_refs(name, file, svc)?;
+	}
+
+	// Reject `depends_on` cycles and dangling required dependencies, matching the
+	// mutating commands (which run `resolve_order` before they start anything).
+	resolve_order(file)?;
+	Ok(())
+}
+
+/// Reject a service name that is empty or uses characters outside the compose
+/// charset (`[a-zA-Z0-9._-]`). Spaces and punctuation like `!` are rejected.
+fn validate_service_name(name: &str) -> Result<()> {
+	let ok = !name.is_empty()
+		&& name
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+	if ok {
+		Ok(())
+	} else {
+		Err(ComposeError::Unsupported(format!(
+			"service name {name:?} is invalid: use only ASCII letters, digits, '.', '_', '-'"
+		)))
+	}
+}
+
+/// Range-check every port a service publishes. `parse_ports` rejects values that
+/// do not fit a `u16` (e.g. `99999`); on top of that a container or host port of
+/// `0` is rejected here, since a valid published/target port is `1`–`65535`.
+fn validate_ports(service: &str, ports: &[PortMapping]) -> Result<()> {
+	for parsed in parse_ports(ports)? {
+		if parsed.container_port == 0 || parsed.host_port == Some(0) {
+			return Err(ComposeError::InvalidPort(format!(
+				"service '{service}' has a port of 0; ports must be in 1-65535"
+			)));
+		}
+	}
+	Ok(())
+}
+
+/// Every network a service joins must be declared in the top-level `networks:`
+/// map (the implicit `default` network is synthesized before this runs, so a
+/// bare service still validates). `network_mode:` services declare no networks.
+fn validate_network_refs(
+	service: &str,
+	file: &ComposeFile,
+	svc: &crate::compose::types::Service,
+) -> Result<()> {
+	for net in svc.networks.names() {
+		if !file.networks.contains_key(&net) {
+			return Err(ComposeError::Unsupported(format!(
+				"service '{service}' refers to undefined network '{net}'; declare it under the \
+				 top-level 'networks:' key"
+			)));
+		}
+	}
+	Ok(())
+}
+
+/// Every *named* volume a service mounts must be declared in the top-level
+/// `volumes:` map. Bind mounts (host paths) and anonymous volumes carry no
+/// top-level declaration and are skipped.
+fn validate_volume_refs(
+	service: &str,
+	file: &ComposeFile,
+	svc: &crate::compose::types::Service,
+) -> Result<()> {
+	for mount in &svc.volumes {
+		let named = match mount {
+			VolumeMount::Short(s) => short_named_volume(s),
+			VolumeMount::Long {
+				volume_type: VolumeType::Volume,
+				source: Some(src),
+				..
+			} => Some(src.as_str()),
+			VolumeMount::Long { .. } => None,
+		};
+		if let Some(name) = named {
+			if !file.volumes.contains_key(name) {
+				return Err(ComposeError::Unsupported(format!(
+					"service '{service}' refers to undefined volume '{name}'; declare it under the \
+					 top-level 'volumes:' key"
+				)));
+			}
+		}
+	}
+	Ok(())
+}
+
+/// Extract the named-volume reference from a short-form `source:target[:opts]`
+/// mount, or `None` when it is a host-path bind or an anonymous volume.
+///
+/// Mirrors the engine's own classification: a source starting with `/`, `.` or
+/// `~`, or a Windows drive prefix (`C:`), is a bind, not a named volume; a
+/// single token with no target is an anonymous volume.
+fn short_named_volume(spec: &str) -> Option<&str> {
+	let (src, _rest) = spec.split_once(':')?;
+	if src.is_empty()
+		|| src.starts_with('/')
+		|| src.starts_with('.')
+		|| src.starts_with('~')
+		|| is_windows_drive(src)
+	{
+		return None;
+	}
+	Some(src)
+}
+
+/// Whether `src` is exactly a Windows drive letter (e.g. `C`), meaning the colon
+/// after it is part of a host path rather than the `source:target` separator.
+fn is_windows_drive(src: &str) -> bool {
+	let b = src.as_bytes();
+	b.len() == 1 && b[0].is_ascii_alphabetic()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::parse_str_raw;
+
+	fn file(yaml: &str) -> ComposeFile {
+		parse_str_raw(yaml).unwrap()
+	}
+
+	#[test]
+	fn empty_services_is_rejected() {
+		let err = validate_config(&file("services: {}\n")).unwrap_err();
+		assert!(format!("{err}").contains("no services"));
+		// A file with no `services:` key at all is equally rejected.
+		assert!(validate_config(&ComposeFile::default()).is_err());
+	}
+
+	#[test]
+	fn missing_image_and_build_is_rejected() {
+		let err = validate_config(&file("services:\n  web:\n    ports: ['80:80']\n")).unwrap_err();
+		assert!(matches!(err, ComposeError::NoImageOrBuild(_)));
+	}
+
+	#[test]
+	fn valid_minimal_file_passes() {
+		validate_config(&file("services:\n  web:\n    image: nginx\n")).unwrap();
+	}
+
+	#[test]
+	fn out_of_range_port_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    ports: ['99999:80']\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidPort(_)));
+	}
+
+	#[test]
+	fn zero_port_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    ports: ['0:80']\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidPort(_)));
+	}
+
+	#[test]
+	fn undefined_named_volume_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    volumes: ['data:/x']\n",
+		))
+		.unwrap_err();
+		assert!(format!("{err}").contains("undefined volume 'data'"));
+	}
+
+	#[test]
+	fn declared_named_volume_passes() {
+		validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    volumes: ['data:/x']\nvolumes:\n  data:\n",
+		))
+		.unwrap();
+	}
+
+	#[test]
+	fn bind_and_anonymous_volumes_are_not_flagged() {
+		// Host-path binds and anonymous volumes carry no top-level declaration.
+		validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    volumes:\n      - ./host:/x\n      - /abs:/y\n      - /data\n",
+		))
+		.unwrap();
+	}
+
+	#[test]
+	fn undefined_network_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    networks: [backend]\n",
+		))
+		.unwrap_err();
+		assert!(format!("{err}").contains("undefined network 'backend'"));
+	}
+
+	#[test]
+	fn declared_network_passes() {
+		validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    networks: [backend]\nnetworks:\n  backend:\n",
+		))
+		.unwrap();
+	}
+
+	#[test]
+	fn invalid_service_name_is_rejected() {
+		let err =
+			validate_config(&file("services:\n  'bad name':\n    image: nginx\n")).unwrap_err();
+		assert!(format!("{err}").contains("service name"));
+	}
+
+	#[test]
+	fn dependency_cycle_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::CircularDependency(_)));
+	}
+
+	#[test]
+	fn dangling_required_dependency_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    depends_on: [ghost]\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::ServiceNotFound(_)));
+	}
+}

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -232,18 +232,7 @@ pub(crate) async fn dispatch(
 				)
 				.await?
 		}
-		Commands::Ps { all, quiet, format } => {
-			engine
-				.ps_with_options(
-					file,
-					podup::PsOptions {
-						all,
-						quiet,
-						json: format == OutputFormat::Json,
-					},
-				)
-				.await?
-		}
+		Commands::Ps { .. } => unreachable!("handled before compose parsing"),
 		Commands::Top { format, services } => {
 			engine
 				.top_with_options(file, &services, format == OutputFormat::Json)

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -77,7 +77,20 @@ pub enum ComposeError {
 impl fmt::Display for ComposeError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			Self::Parse(e) => write!(f, "failed to parse compose file: {e}"),
+			// Report only the parser's location, never the raw `serde_yaml`
+			// message: that message embeds the offending scalar verbatim (the file's
+			// own content), which would echo a non-compose file pointed at with `-f`
+			// straight onto stderr. Location (line/column) is enough to find the
+			// problem without leaking the bytes.
+			Self::Parse(e) => match e.location() {
+				Some(loc) => write!(
+					f,
+					"failed to parse compose file at line {}, column {}",
+					loc.line(),
+					loc.column()
+				),
+				None => write!(f, "failed to parse compose file"),
+			},
 			Self::FileNotFound(s) => write!(f, "compose file not found: {s}"),
 			Self::Io(e) => write!(f, "io error: {e}"),
 			Self::Podman(e) => write!(f, "podman error: {e}"),
@@ -180,7 +193,7 @@ mod tests {
 	fn display_covers_all_variants() {
 		let cases: &[(&str, ComposeError)] = &[
 			(
-				"failed to parse compose file:",
+				"failed to parse compose file",
 				ComposeError::Parse(serde_yaml::from_str::<serde_yaml::Value>(":\0").unwrap_err()),
 			),
 			(
@@ -279,6 +292,26 @@ mod tests {
 				std::mem::discriminant(err),
 			);
 		}
+	}
+
+	#[test]
+	fn parse_display_does_not_echo_offending_scalar() {
+		// A type error embeds the offending scalar in the raw serde_yaml message
+		// (`invalid type: string "s3cr3t-token", ...`). The Display must not surface
+		// that content — it points at the location instead, so a non-compose file
+		// pointed at with `-f` cannot leak its bytes onto stderr.
+		#[derive(Debug, serde::Deserialize)]
+		struct OnlyMap {
+			#[allow(dead_code)]
+			services: std::collections::BTreeMap<String, String>,
+		}
+		let err = serde_yaml::from_str::<OnlyMap>("services: s3cr3t-token\n").unwrap_err();
+		let msg = ComposeError::Parse(err).to_string();
+		assert!(
+			!msg.contains("s3cr3t-token"),
+			"parse error must not echo file content, got {msg:?}"
+		);
+		assert!(msg.starts_with("failed to parse compose file"));
 	}
 
 	#[test]

--- a/internal/filesystem.rs
+++ b/internal/filesystem.rs
@@ -23,12 +23,25 @@ fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
 	// the file (or swaps in a symlink) after a size check cannot make podup
 	// read past the cap, because the limit is enforced on the read itself.
 	let file = std::fs::File::open(path)?;
+	read_capped_from(file, max, &path.display().to_string())
+}
+
+/// Read the compose document from standard input, refusing input larger than
+/// [`MAX_FILE_BYTES`]. Backs the `-f -` form (`cat compose.yaml | podup config
+/// -f -`), which `docker compose` supports by reading the file from stdin.
+pub(crate) fn read_stdin_to_string_capped() -> io::Result<String> {
+	read_capped_from(io::stdin().lock(), MAX_FILE_BYTES, "standard input")
+}
+
+/// Read any [`io::Read`] into a `String`, enforcing the `max`-byte cap on the
+/// read itself. `label` names the source for the over-limit error message.
+fn read_capped_from(reader: impl Read, max: u64, label: &str) -> io::Result<String> {
 	let mut buf = String::new();
-	let read = file.take(max + 1).read_to_string(&mut buf)?;
+	let read = reader.take(max + 1).read_to_string(&mut buf)?;
 	if read as u64 > max {
 		return Err(io::Error::new(
 			io::ErrorKind::InvalidData,
-			format!("{} is larger than the {max} byte limit", path.display()),
+			format!("{label} is larger than the {max} byte limit"),
 		));
 	}
 	Ok(buf)
@@ -61,7 +74,22 @@ fn read_capped_with(path: &Path, max: u64) -> io::Result<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-	use super::{read_capped_with, read_to_string_capped_with};
+	use super::{read_capped_from, read_capped_with, read_to_string_capped_with};
+
+	#[test]
+	fn read_capped_from_reads_within_limit() {
+		// The shared reader (used for both files and stdin) returns the content
+		// untouched when it fits under the cap.
+		let out = read_capped_from(std::io::Cursor::new(b"version: 1"), 64, "stdin").unwrap();
+		assert_eq!(out, "version: 1");
+	}
+
+	#[test]
+	fn read_capped_from_rejects_over_limit() {
+		let err = read_capped_from(std::io::Cursor::new(vec![b'x'; 32]), 16, "stdin").unwrap_err();
+		assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+		assert!(err.to_string().contains("stdin"));
+	}
 
 	#[test]
 	fn reads_file_within_limit() {

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -24,6 +24,11 @@ pub(crate) fn write_quadlet(
 	project: &str,
 	output: Option<&Path>,
 ) -> podup::Result<()> {
+	// Validate the dependency graph before emitting any unit. A cyclic `depends_on`
+	// would otherwise produce units with mutual `After=`/`Requires=`, which systemd
+	// cannot order; a dangling required dependency would target a non-existent
+	// `.service`. `resolve_order` rejects both, matching the mutating commands.
+	podup::resolve_order(file)?;
 	let result = podup::quadlet::generate(file, project);
 	if let Some(dup) = result.duplicate_filename() {
 		return Err(std::io::Error::new(
@@ -75,7 +80,7 @@ pub(crate) fn write_quadlet(
 
 #[cfg(test)]
 mod tests {
-	use super::quadlet_platform_advisory;
+	use super::{quadlet_platform_advisory, write_quadlet};
 
 	#[test]
 	fn quadlet_advisory_only_on_non_linux() {
@@ -84,5 +89,18 @@ mod tests {
 			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
 			assert!(msg.contains("systemd"), "advisory names the requirement");
 		}
+	}
+
+	#[test]
+	fn cyclic_depends_on_is_rejected_before_emitting_units() {
+		// A `depends_on` cycle must error rather than emit units with mutual
+		// `After=`/`Requires=`; the check runs before any file I/O so `output: None`
+		// is safe here.
+		let file = podup::parse_str(
+			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
+		)
+		.unwrap();
+		let err = write_quadlet(&file, "proj", None).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
 	}
 }

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -40,6 +40,7 @@ pub mod update;
 pub use compose::{
 	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
 	parse_files_with_env_files_interp, parse_str, parse_str_raw, resolve_levels, resolve_order,
+	validate_config,
 };
 /// The lifecycle `Engine` and its per-command option/override types, plus the
 /// project-name/listing helpers — the surface a CLI drives compose operations

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -79,7 +79,7 @@ fn print_error(e: &podup::ComposeError) {
 
 /// Orchestrate one CLI invocation: parse args, then short-circuit the commands
 /// that need neither a compose file nor (for some) Podman — `completions`,
-/// `update`, `ls`, and `config`. Otherwise resolve and parse the compose
+/// `update`, `ls`, `ps`, and `config`. Otherwise resolve and parse the compose
 /// file(s), settle the project name and base directory (validating the name at
 /// the trust boundary), acquire the per-project lock, and dispatch the
 /// remaining commands.
@@ -147,6 +147,34 @@ async fn run() -> podup::Result<()> {
 		.await;
 	}
 
+	// `ps` filters running containers purely by the project label and ignores the
+	// compose file entirely, so it must list an already-running project even when
+	// that file is missing or unparseable (matching `docker compose ps`). Handle
+	// it before the compose file is parsed: read the compose `name:` for project
+	// precedence when the file parses, but fall back to the directory basename
+	// rather than failing, unlike the commands that depend on the file's contents.
+	if let Commands::Ps { all, quiet, format } = &cli.command {
+		let compose_files = resolve_compose_files(&cli.file);
+		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+		let compose_name = podup::parse_files_with_env_files(&compose_files, &cli.env_file)
+			.ok()
+			.and_then(|f| f.name);
+		let project = resolve_project_name(cli.project.clone(), compose_name.as_deref(), &base_dir);
+		startup::validate_project_name(&project)?;
+		let client = podup::podman::connect(cli.socket.as_deref())?;
+		let engine = podup::Engine::with_base_dir(client, project, base_dir);
+		return engine
+			.ps_with_options(
+				&podup::compose::types::ComposeFile::default(),
+				podup::PsOptions {
+					all: *all,
+					quiet: *quiet,
+					json: *format == OutputFormat::Json,
+				},
+			)
+			.await;
+	}
+
 	let compose_files = resolve_compose_files(&cli.file);
 	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
 
@@ -158,6 +186,12 @@ async fn run() -> podup::Result<()> {
 		resolve_image_digests,
 	} = &cli.command
 	{
+		// Validate the resolved project name in the config path too, at the same
+		// trust boundary the mutating commands use, so `config -p 'bad name!'`
+		// reports the same invalid-name error instead of succeeding.
+		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+		let project = resolve_project_name(cli.project.clone(), file.name.as_deref(), &base_dir);
+		startup::validate_project_name(&project)?;
 		// `--no-interpolate` re-parses with substitution disabled; `file` (already
 		// parsed with interpolation) is used otherwise.
 		let parsed = if *no_interpolate {
@@ -186,12 +220,7 @@ async fn run() -> podup::Result<()> {
 	// quadlet generation). Explicit `-p`/`COMPOSE_PROJECT_NAME` values and the
 	// compose `name:` field are otherwise taken verbatim; rejecting an unsafe
 	// name here fails closed regardless of which command runs next.
-	if !podup::is_safe_project_name(&project) {
-		return Err(podup::ComposeError::Unsupported(format!(
-			"project name {project:?} is not a safe path component: use only ASCII \
-			 letters, digits, '-', '_', '.', not starting with '.', max 128 chars"
-		)));
-	}
+	startup::validate_project_name(&project)?;
 
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -33,6 +33,22 @@ pub(crate) fn is_mutating(command: &Commands) -> bool {
 	)
 }
 
+/// Validate the resolved project name at the trust boundary, before it reaches
+/// any code path that builds a filesystem path from it (staging, lock files,
+/// quadlet generation) or filters containers by it. Shared by the mutating
+/// dispatch path and the read-only `config`/`ps` paths so every command reports
+/// the same invalid-name error.
+pub(crate) fn validate_project_name(project: &str) -> podup::Result<()> {
+	if podup::is_safe_project_name(project) {
+		Ok(())
+	} else {
+		Err(podup::ComposeError::Unsupported(format!(
+			"project name {project:?} is not a safe path component: use only ASCII \
+			 letters, digits, '-', '_', '.', not starting with '.', max 128 chars"
+		)))
+	}
+}
+
 /// Canonical project URL, reused for the bug-report hint on internal errors.
 const REPO_URL: &str = "https://github.com/Glyndor/podup";
 
@@ -121,15 +137,12 @@ pub(crate) fn render_config(
 	services: bool,
 	quiet: bool,
 ) -> podup::Result<()> {
-	// Reaching here means the file parsed and merged cleanly. Validate that each
-	// resolved service declares an image or a build, the same rule `up` enforces
-	// — and do it before the `--quiet`/`--services` short-circuits so
-	// validate-only (`--quiet`) actually validates, matching `docker compose config`.
-	for (name, svc) in &file.services {
-		if svc.image.is_none() && svc.build.is_none() {
-			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
-		}
-	}
+	// Reaching here means the file parsed and merged cleanly. Run the full
+	// config-time validation (non-empty services, image-or-build, service-name
+	// charset, port ranges, undefined volume/network references, and an acyclic
+	// dependency graph) before the `--quiet`/`--services` short-circuits, so
+	// validate-only (`--quiet`) actually validates — matching `docker compose config`.
+	podup::validate_config(file)?;
 	if quiet {
 		return Ok(());
 	}

--- a/tests/parse/basic.rs
+++ b/tests/parse/basic.rs
@@ -411,3 +411,42 @@ services:
 	assert_eq!(svc.cpuset.as_deref(), Some("0-1"));
 	assert_eq!(svc.mem_limit.as_deref(), Some("256m"));
 }
+
+#[test]
+fn cpus_accepts_unquoted_number_and_quoted_string() {
+	// The compose spec writes `cpus: 0.5` unquoted; both the number and the quoted
+	// string form must parse to the same stored value (top-level and deploy).
+	let yaml = r#"
+services:
+  num:
+    image: alpine
+    cpus: 0.5
+  str:
+    image: alpine
+    cpus: "0.5"
+  dep:
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 1.5
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["num"].cpus.as_deref(), Some("0.5"));
+	assert_eq!(file.services["str"].cpus.as_deref(), Some("0.5"));
+	assert_eq!(
+		file.services["dep"]
+			.deploy
+			.as_ref()
+			.unwrap()
+			.resources
+			.as_ref()
+			.unwrap()
+			.limits
+			.as_ref()
+			.unwrap()
+			.cpus
+			.as_deref(),
+		Some("1.5")
+	);
+}


### PR DESCRIPTION
I went through the verified compose-parse sweep findings and fixed each one. They cluster around the `config`/`ps` read-only boundary (where invalid input slipped through at exit 0) plus a few parser-robustness and spec-fidelity gaps. Every fix is minimal and covered by unit/parse tests; I did not run the container integration suite.

## Fixed

- ps parses the compose file even though it queries purely by project label (Closes #796)
- config does not run dependency-graph validation; cycles and dangling depends_on propagate into quadlet (Closes #797)
- `-f -` (read compose from stdin) unsupported, treated as a literal path (Closes #905)
- config does not validate undefined named-volume / network references (Closes #906)
- config layer does not validate the project name (Closes #907)
- config does not validate port ranges or service-name charset (Closes #908)
- empty / service-less compose validates OK (Closes #909)
- numeric `cpus` value rejected (only the quoted-string form was accepted) (Closes #910)
- CPU DoS via deeply nested flow YAML (no work/depth guard) (Closes #911)
- parse error reflects offending file content into stderr (info-leak smell) (Closes #912)

## Notes

- I added a `compose::validate_config` pass that `config` now runs in full (non-empty services, image-or-build, service-name charset, port ranges, undefined volume/network references, and an acyclic dependency graph), matching what `docker compose config` rejects. `generate quadlet` validates the dependency graph too, so a cycle can no longer emit mutual `After=`/`Requires=`.
- `ps` is now handled before the compose file is parsed: it still honours the compose `name:` for project precedence when the file parses cleanly, but falls back to the directory basename rather than failing when the file is missing or malformed.
- The parse-error Display now reports only the parser location (line/column) instead of the raw `serde_yaml` message, which embedded the offending scalar verbatim.

Verification: `cargo build`, `cargo fmt --all --check`, `cargo clippy --lib --bins -- -D warnings` (clean), `cargo test --lib --bins`, and the parse/substitute/size/ports/env_file/quadlet/project_name_safety/secret_safety/cli_aliases/cli_diagnostics suites all pass. I also exercised each fix end-to-end against a freshly built binary. The one pre-existing `clippy --all-targets` warning lives in `tests/engine_integration.rs` (the container suite, outside this change) and is untouched here.
