### PR TITLE
fix(watch): resolve verified watch sweep findings

### DIFF
--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -41,7 +41,7 @@ pub struct WatchRule {
 }
 
 /// Action triggered by a `develop.watch` rule: `sync`, `rebuild`, `restart`, `sync+restart`, or `sync+exec`.
-#[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum WatchAction {
 	/// `sync` — copy changed files from `path` into the container at `target`.
 	#[default]
@@ -54,6 +54,38 @@ pub enum WatchAction {
 	SyncAndRestart,
 	/// `sync+exec` — sync changed files, then run the rule's `exec` command in the container.
 	SyncAndExec,
+}
+
+impl WatchAction {
+	/// The lowercase compose token for this action (the inverse of the custom
+	/// [`Deserialize`]). Kept in sync with the parser so `config` output
+	/// round-trips back through podup.
+	pub fn as_token(&self) -> &'static str {
+		match self {
+			WatchAction::Sync => "sync",
+			WatchAction::Rebuild => "rebuild",
+			WatchAction::Restart => "restart",
+			WatchAction::SyncAndRestart => "sync+restart",
+			WatchAction::SyncAndExec => "sync+exec",
+		}
+	}
+
+	/// True for actions whose semantics require a `target` (the sync family).
+	/// `rebuild`/`restart` operate on the whole container and need no target.
+	pub fn requires_target(&self) -> bool {
+		matches!(
+			self,
+			WatchAction::Sync | WatchAction::SyncAndRestart | WatchAction::SyncAndExec
+		)
+	}
+}
+
+impl Serialize for WatchAction {
+	fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+		// Emit the lowercase compose token (not the PascalCase variant name) so
+		// `config` output is re-ingestible by the custom `Deserialize` below.
+		s.serialize_str(self.as_token())
+	}
 }
 
 impl<'de> Deserialize<'de> for WatchAction {
@@ -120,5 +152,52 @@ mod tests {
 	#[test]
 	fn watch_action_unknown_is_error() {
 		assert!(serde_yaml::from_str::<WatchAction>("\"deploy\"").is_err());
+	}
+
+	#[test]
+	fn watch_action_serializes_lowercase_token() {
+		// `config` must emit the compose token, not the PascalCase variant name.
+		assert_eq!(
+			serde_yaml::to_string(&WatchAction::Sync).unwrap().trim(),
+			"sync"
+		);
+		assert_eq!(
+			serde_yaml::to_string(&WatchAction::SyncAndRestart)
+				.unwrap()
+				.trim(),
+			"sync+restart"
+		);
+		assert_eq!(
+			serde_yaml::to_string(&WatchAction::SyncAndExec)
+				.unwrap()
+				.trim(),
+			"sync+exec"
+		);
+	}
+
+	#[test]
+	fn watch_action_round_trips_through_config() {
+		// Every variant must survive a serialize -> deserialize round-trip so
+		// `config` output feeds back into podup unchanged.
+		for action in [
+			WatchAction::Sync,
+			WatchAction::Rebuild,
+			WatchAction::Restart,
+			WatchAction::SyncAndRestart,
+			WatchAction::SyncAndExec,
+		] {
+			let rendered = serde_yaml::to_string(&action).unwrap();
+			let parsed: WatchAction = serde_yaml::from_str(&rendered).unwrap();
+			assert_eq!(parsed, action);
+		}
+	}
+
+	#[test]
+	fn watch_action_requires_target_matches_sync_family() {
+		assert!(WatchAction::Sync.requires_target());
+		assert!(WatchAction::SyncAndRestart.requires_target());
+		assert!(WatchAction::SyncAndExec.requires_target());
+		assert!(!WatchAction::Rebuild.requires_target());
+		assert!(!WatchAction::Restart.requires_target());
 	}
 }

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -9,8 +9,10 @@
 //! - `sync+restart` — sync first, then restart
 //! - `sync+exec` — sync, then run the rule's `exec` command inside the container
 
+mod placement;
 mod sync;
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -25,6 +27,10 @@ use tracing::{debug, info, warn};
 use crate::compose::types::{ComposeFile, WatchAction, WatchRule};
 use crate::error::{ComposeError, Result};
 
+use placement::{
+	is_dispatch_event, mark_dir_ensured, mkdir_p_argv, plan_sync_placement, validate_sync_target,
+	SyncPlacement,
+};
 use sync::{build_sync_tar, is_ignored, is_included};
 
 use super::Engine;
@@ -46,68 +52,6 @@ struct RuleEntry {
 	abs_path: PathBuf,
 }
 
-/// Where a changed host path lands inside the container for a `sync` action:
-/// the archive entry name and the directory the tar is extracted at.
-struct SyncPlacement {
-	/// Archive path the changed entry occupies inside the tar.
-	entry_name: String,
-	/// Container directory the archive is PUT (extracted) at.
-	dest_dir: String,
-}
-
-/// Map a changed host path to its container archive placement, matching
-/// docker-compose `watch` semantics.
-///
-/// `root` is the watch rule's absolute host path, `changed` the path that
-/// actually changed (equal to `root` for a single-file rule, a descendant for a
-/// directory rule), and `target` the rule's container target.
-///
-/// For a directory rule the changed entry keeps its path relative to `root`
-/// (subdirectories preserved) and is extracted under `target` treated as a
-/// directory. For a single-file rule the entry is stored under
-/// `basename(target)` and extracted into `target`'s parent, so a renaming
-/// target is honoured.
-fn plan_sync_placement(root: &Path, changed: &Path, target: &str) -> SyncPlacement {
-	if root.is_dir() {
-		// Directory rule: preserve the changed file's subpath under `target`,
-		// which is treated as a directory.
-		let rel = changed.strip_prefix(root).unwrap_or(changed);
-		let entry_name = rel.to_string_lossy().into_owned();
-		let dest_dir = target.trim_end_matches('/').to_string();
-		let dest_dir = if dest_dir.is_empty() {
-			"/".to_string()
-		} else {
-			dest_dir
-		};
-		SyncPlacement {
-			entry_name,
-			dest_dir,
-		}
-	} else {
-		// Single-file rule: store under the target basename so a renaming target
-		// is honoured, and extract into the target's parent directory.
-		let target_path = Path::new(target);
-		let entry_name = target_path
-			.file_name()
-			.map(|n| n.to_string_lossy().into_owned())
-			.or_else(|| {
-				changed
-					.file_name()
-					.map(|n| n.to_string_lossy().into_owned())
-			})
-			.unwrap_or_default();
-		let dest_dir = target_path
-			.parent()
-			.map(|p| p.to_string_lossy().into_owned())
-			.filter(|s| !s.is_empty())
-			.unwrap_or_else(|| "/".to_string());
-		SyncPlacement {
-			entry_name,
-			dest_dir,
-		}
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Public watch command
 // ---------------------------------------------------------------------------
@@ -120,6 +64,7 @@ impl Engine {
 		for (name, service) in &file.services {
 			if let Some(dev) = &service.develop {
 				for rule in &dev.watch {
+					validate_sync_target(rule)?;
 					let abs = self.base_dir.join(&rule.path);
 					rule_entries.push(RuleEntry {
 						service_name: name.clone(),
@@ -132,9 +77,16 @@ impl Engine {
 		}
 
 		if rule_entries.is_empty() {
-			info!("no develop.watch rules found");
-			return Ok(());
+			// docker compose watch errors when nothing is configured; match that
+			// instead of silently exiting 0.
+			return Err(ComposeError::Watch(
+				"no develop.watch rules configured".into(),
+			));
 		}
+
+		// Track which (container, dest) directories have been ensured so the
+		// best-effort `mkdir -p` exec runs once per target rather than per event.
+		let mut ensured: HashSet<(String, String)> = HashSet::new();
 
 		for entry in &rule_entries {
 			if entry.rule.initial_sync {
@@ -146,6 +98,7 @@ impl Engine {
 							&entry.abs_path,
 							&entry.abs_path,
 							target,
+							&mut ensured,
 						)
 						.await
 					{
@@ -197,6 +150,13 @@ impl Engine {
 				_ = tokio::signal::ctrl_c() => break,
 			};
 
+			// Ignore Access/Other events: only create/modify/remove/rename drive a
+			// sync, matching docker compose and avoiding the read-triggered
+			// self-feedback loop.
+			if !is_dispatch_event(&event.kind) {
+				continue;
+			}
+
 			let mut paths = event.paths;
 			let deadline = tokio::time::Instant::now() + debounce;
 			// Coalesce events within the debounce window, but stop accumulating once
@@ -204,7 +164,11 @@ impl Engine {
 			// bound; the remaining events fall into the next batch.
 			while paths.len() < WATCH_MAX_BATCH_PATHS {
 				match tokio::time::timeout_at(deadline, rx.recv()).await {
-					Ok(Some(Ok(e))) => paths.extend(e.paths),
+					Ok(Some(Ok(e))) => {
+						if is_dispatch_event(&e.kind) {
+							paths.extend(e.paths);
+						}
+					}
 					_ => break,
 				}
 			}
@@ -248,7 +212,7 @@ impl Engine {
 
 					debug!("dispatch {:?} for {}", entry.rule.action, path.display());
 
-					if let Err(e) = self.dispatch_action(file, path, entry).await {
+					if let Err(e) = self.dispatch_action(file, path, entry, &mut ensured).await {
 						warn!("watch action failed: {e}");
 					}
 
@@ -265,12 +229,19 @@ impl Engine {
 		file: &ComposeFile,
 		path: &Path,
 		entry: &RuleEntry,
+		ensured: &mut HashSet<(String, String)>,
 	) -> Result<()> {
 		match &entry.rule.action {
 			WatchAction::Sync => {
 				if let Some(target) = &entry.rule.target {
-					self.sync_to_container(&entry.container_name, &entry.abs_path, path, target)
-						.await?;
+					self.sync_to_container(
+						&entry.container_name,
+						&entry.abs_path,
+						path,
+						target,
+						ensured,
+					)
+					.await?;
 				}
 			}
 			WatchAction::Rebuild => {
@@ -281,15 +252,27 @@ impl Engine {
 			}
 			WatchAction::SyncAndRestart => {
 				if let Some(target) = &entry.rule.target {
-					self.sync_to_container(&entry.container_name, &entry.abs_path, path, target)
-						.await?;
+					self.sync_to_container(
+						&entry.container_name,
+						&entry.abs_path,
+						path,
+						target,
+						ensured,
+					)
+					.await?;
 				}
 				self.watch_restart(&entry.container_name).await?;
 			}
 			WatchAction::SyncAndExec => {
 				if let Some(target) = &entry.rule.target {
-					self.sync_to_container(&entry.container_name, &entry.abs_path, path, target)
-						.await?;
+					self.sync_to_container(
+						&entry.container_name,
+						&entry.abs_path,
+						path,
+						target,
+						ensured,
+					)
+					.await?;
 				}
 				if let Some(exec) = &entry.rule.exec {
 					self.watch_exec(&entry.container_name, exec.command.clone())
@@ -310,6 +293,7 @@ impl Engine {
 		root: &Path,
 		changed: &Path,
 		target: &str,
+		ensured: &mut HashSet<(String, String)>,
 	) -> Result<()> {
 		let SyncPlacement {
 			entry_name,
@@ -320,13 +304,11 @@ impl Engine {
 		// docker compose watch creates the sync target directory when it is
 		// missing; match that so a sync to a not-yet-existing path works instead
 		// of failing the archive PUT. Best-effort: if mkdir is unavailable the
-		// PUT below still surfaces the real error.
-		let _ = self
-			.watch_exec(
-				container,
-				vec!["mkdir".into(), "-p".into(), dest_dir.clone()],
-			)
-			.await;
+		// PUT below still surfaces the real error. Run it once per (container,
+		// dest) so repeated syncs to the same target skip the redundant exec.
+		if mark_dir_ensured(ensured, container, &dest_dir) {
+			let _ = self.watch_exec(container, mkdir_p_argv(&dest_dir)).await;
+		}
 
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
@@ -435,7 +417,9 @@ impl Engine {
 		src: &Path,
 		target: &str,
 	) -> Result<()> {
-		self.sync_to_container(container, src, src, target).await
+		let mut ensured = HashSet::new();
+		self.sync_to_container(container, src, src, target, &mut ensured)
+			.await
 	}
 
 	/// Test seam: run the watch restart action against `container_name`.
@@ -493,77 +477,5 @@ impl Engine {
 			}
 		}
 		Ok(out)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Unit tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-	use super::plan_sync_placement;
-	use std::fs;
-	use tempfile::tempdir;
-
-	#[test]
-	fn placement_directory_rule_preserves_subpath() {
-		// A directory rule: a change to <root>/sub/b.txt must keep the `sub/`
-		// subpath under the target directory.
-		let dir = tempdir().unwrap();
-		fs::create_dir(dir.path().join("sub")).unwrap();
-		let changed = dir.path().join("sub/b.txt");
-		fs::write(&changed, b"b").unwrap();
-
-		let p = plan_sync_placement(dir.path(), &changed, "/app");
-		assert_eq!(p.entry_name, "sub/b.txt");
-		assert_eq!(p.dest_dir, "/app");
-	}
-
-	#[test]
-	fn placement_directory_rule_trailing_slash_target() {
-		let dir = tempdir().unwrap();
-		let changed = dir.path().join("a.txt");
-		fs::write(&changed, b"a").unwrap();
-
-		let p = plan_sync_placement(dir.path(), &changed, "/app/");
-		assert_eq!(p.entry_name, "a.txt");
-		assert_eq!(p.dest_dir, "/app");
-	}
-
-	#[test]
-	fn placement_single_file_rule_honours_renaming_target() {
-		// A single-file rule whose target renames the file must store the entry
-		// under the target basename and extract into the target's parent.
-		let dir = tempdir().unwrap();
-		let src = dir.path().join("settings.yml");
-		fs::write(&src, b"k: v").unwrap();
-
-		let p = plan_sync_placement(&src, &src, "/app/config.yml");
-		assert_eq!(p.entry_name, "config.yml");
-		assert_eq!(p.dest_dir, "/app");
-	}
-
-	#[test]
-	fn placement_single_file_rule_same_basename() {
-		// The existing same-basename case still lands the file at the target.
-		let dir = tempdir().unwrap();
-		let src = dir.path().join("app.txt");
-		fs::write(&src, b"x").unwrap();
-
-		let p = plan_sync_placement(&src, &src, "/newdir/app.txt");
-		assert_eq!(p.entry_name, "app.txt");
-		assert_eq!(p.dest_dir, "/newdir");
-	}
-
-	#[test]
-	fn placement_single_file_rule_target_at_root() {
-		let dir = tempdir().unwrap();
-		let src = dir.path().join("app.txt");
-		fs::write(&src, b"x").unwrap();
-
-		let p = plan_sync_placement(&src, &src, "/app.txt");
-		assert_eq!(p.entry_name, "app.txt");
-		assert_eq!(p.dest_dir, "/");
 	}
 }

--- a/internal/engine/watch/placement.rs
+++ b/internal/engine/watch/placement.rs
@@ -1,0 +1,265 @@
+//! Pure host-path → container placement and watch-event helpers.
+//!
+//! These functions hold the side-effect-free decisions of the watch engine:
+//! mapping a changed host path to its container archive placement, filtering
+//! which notify events drive a sync, validating that sync rules carry a target,
+//! and bookkeeping for the per-target `mkdir`. Keeping them here lets the
+//! dispatch loop in [`super`] stay focused on I/O.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::compose::types::WatchRule;
+use crate::error::{ComposeError, Result};
+
+/// Where a changed host path lands inside the container for a `sync` action:
+/// the archive entry name and the directory the tar is extracted at.
+pub(super) struct SyncPlacement {
+	/// Archive path the changed entry occupies inside the tar.
+	pub(super) entry_name: String,
+	/// Container directory the archive is PUT (extracted) at.
+	pub(super) dest_dir: String,
+}
+
+/// Map a changed host path to its container archive placement, matching
+/// docker-compose `watch` semantics.
+///
+/// `root` is the watch rule's absolute host path, `changed` the path that
+/// actually changed (equal to `root` for a single-file rule, a descendant for a
+/// directory rule), and `target` the rule's container target.
+///
+/// For a directory rule the changed entry keeps its path relative to `root`
+/// (subdirectories preserved) and is extracted under `target` treated as a
+/// directory. For a single-file rule the entry is stored under
+/// `basename(target)` and extracted into `target`'s parent, so a renaming
+/// target is honoured.
+pub(super) fn plan_sync_placement(root: &Path, changed: &Path, target: &str) -> SyncPlacement {
+	if root.is_dir() {
+		// Directory rule: preserve the changed file's subpath under `target`,
+		// which is treated as a directory.
+		let rel = changed.strip_prefix(root).unwrap_or(changed);
+		let entry_name = rel.to_string_lossy().into_owned();
+		let dest_dir = target.trim_end_matches('/').to_string();
+		let dest_dir = if dest_dir.is_empty() {
+			"/".to_string()
+		} else {
+			dest_dir
+		};
+		SyncPlacement {
+			entry_name,
+			dest_dir,
+		}
+	} else {
+		// Single-file rule: store under the target basename so a renaming target
+		// is honoured, and extract into the target's parent directory.
+		let target_path = Path::new(target);
+		let entry_name = target_path
+			.file_name()
+			.map(|n| n.to_string_lossy().into_owned())
+			.or_else(|| {
+				changed
+					.file_name()
+					.map(|n| n.to_string_lossy().into_owned())
+			})
+			.unwrap_or_default();
+		let dest_dir = target_path
+			.parent()
+			.map(|p| p.to_string_lossy().into_owned())
+			.filter(|s| !s.is_empty())
+			.unwrap_or_else(|| "/".to_string());
+		SyncPlacement {
+			entry_name,
+			dest_dir,
+		}
+	}
+}
+
+/// True when a notify event should drive a watch action.
+///
+/// docker-compose `watch` only reacts to write/create/remove/rename changes. The
+/// vendored notify inotify backend also emits `Access` events (it sets
+/// `WatchMask::OPEN`), so merely opening/reading a watched file would otherwise
+/// fire a sync — and the sync's own read of the source re-opens the path,
+/// generating fresh `Access` events that feed back into another sync. Filtering
+/// to create/modify/remove (rename is a `Modify(Name(..))`) matches compose
+/// semantics and breaks that feedback loop.
+pub(super) fn is_dispatch_event(kind: &notify::EventKind) -> bool {
+	use notify::EventKind;
+	matches!(
+		kind,
+		EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+	)
+}
+
+/// Reject a watch rule whose action needs a `target` but has none. docker
+/// compose treats a sync rule without a target as a configuration error rather
+/// than silently performing no sync.
+pub(super) fn validate_sync_target(rule: &WatchRule) -> Result<()> {
+	if rule.action.requires_target() && rule.target.is_none() {
+		return Err(ComposeError::Watch(format!(
+			"watch rule for '{}' uses a sync action ({}) but has no target",
+			rule.path,
+			rule.action.as_token()
+		)));
+	}
+	Ok(())
+}
+
+/// Best-effort `mkdir -p` argv for creating a sync target directory. The `--`
+/// terminates options so a target beginning with `-` (e.g. `-m0777`) is treated
+/// as a path, not parsed as a flag by busybox `mkdir`.
+pub(super) fn mkdir_p_argv(dest_dir: &str) -> Vec<String> {
+	vec![
+		"mkdir".into(),
+		"-p".into(),
+		"--".into(),
+		dest_dir.to_string(),
+	]
+}
+
+/// Record that `(container, dest)` has had its directory ensured, returning
+/// `true` the first time (the caller should then issue the `mkdir`) and `false`
+/// thereafter so the per-event `mkdir` exec is issued at most once per target.
+pub(super) fn mark_dir_ensured(
+	ensured: &mut HashSet<(String, String)>,
+	container: &str,
+	dest: &str,
+) -> bool {
+	ensured.insert((container.to_string(), dest.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::{
+		is_dispatch_event, mark_dir_ensured, mkdir_p_argv, plan_sync_placement,
+		validate_sync_target,
+	};
+	use crate::compose::types::{WatchAction, WatchRule};
+	use std::collections::HashSet;
+	use std::fs;
+	use tempfile::tempdir;
+
+	fn rule(action: WatchAction, target: Option<&str>) -> WatchRule {
+		WatchRule {
+			path: "src".into(),
+			action,
+			target: target.map(str::to_string),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn dispatch_event_filters_access_and_other() {
+		use notify::event::{AccessKind, CreateKind, ModifyKind, RemoveKind};
+		use notify::EventKind;
+		assert!(is_dispatch_event(&EventKind::Create(CreateKind::File)));
+		assert!(is_dispatch_event(&EventKind::Modify(ModifyKind::Any)));
+		assert!(is_dispatch_event(&EventKind::Remove(RemoveKind::File)));
+		// Access (read/open) and Other/Any must not trigger a sync.
+		assert!(!is_dispatch_event(&EventKind::Access(AccessKind::Open(
+			notify::event::AccessMode::Read
+		))));
+		assert!(!is_dispatch_event(&EventKind::Access(AccessKind::Any)));
+		assert!(!is_dispatch_event(&EventKind::Other));
+		assert!(!is_dispatch_event(&EventKind::Any));
+	}
+
+	#[test]
+	fn validate_sync_target_rejects_targetless_sync() {
+		assert!(validate_sync_target(&rule(WatchAction::Sync, None)).is_err());
+		assert!(validate_sync_target(&rule(WatchAction::SyncAndRestart, None)).is_err());
+		assert!(validate_sync_target(&rule(WatchAction::SyncAndExec, None)).is_err());
+	}
+
+	#[test]
+	fn validate_sync_target_accepts_target_and_whole_container_actions() {
+		assert!(validate_sync_target(&rule(WatchAction::Sync, Some("/app"))).is_ok());
+		// rebuild/restart need no target.
+		assert!(validate_sync_target(&rule(WatchAction::Rebuild, None)).is_ok());
+		assert!(validate_sync_target(&rule(WatchAction::Restart, None)).is_ok());
+	}
+
+	#[test]
+	fn mkdir_argv_terminates_options_for_leading_dash_target() {
+		// A target beginning with `-` must be passed as a path, not a flag.
+		assert_eq!(mkdir_p_argv("-m0777"), vec!["mkdir", "-p", "--", "-m0777"]);
+		assert_eq!(mkdir_p_argv("/app"), vec!["mkdir", "-p", "--", "/app"]);
+	}
+
+	#[test]
+	fn mark_dir_ensured_only_first_time_per_target() {
+		let mut ensured: HashSet<(String, String)> = HashSet::new();
+		// First time for a (container, dest) returns true (issue the mkdir)...
+		assert!(mark_dir_ensured(&mut ensured, "c1", "/app"));
+		// ...and subsequent calls for the same pair return false (skip it).
+		assert!(!mark_dir_ensured(&mut ensured, "c1", "/app"));
+		// A different container or dest is ensured independently.
+		assert!(mark_dir_ensured(&mut ensured, "c2", "/app"));
+		assert!(mark_dir_ensured(&mut ensured, "c1", "/other"));
+	}
+
+	#[test]
+	fn placement_directory_rule_preserves_subpath() {
+		// A directory rule: a change to <root>/sub/b.txt must keep the `sub/`
+		// subpath under the target directory.
+		let dir = tempdir().unwrap();
+		fs::create_dir(dir.path().join("sub")).unwrap();
+		let changed = dir.path().join("sub/b.txt");
+		fs::write(&changed, b"b").unwrap();
+
+		let p = plan_sync_placement(dir.path(), &changed, "/app");
+		assert_eq!(p.entry_name, "sub/b.txt");
+		assert_eq!(p.dest_dir, "/app");
+	}
+
+	#[test]
+	fn placement_directory_rule_trailing_slash_target() {
+		let dir = tempdir().unwrap();
+		let changed = dir.path().join("a.txt");
+		fs::write(&changed, b"a").unwrap();
+
+		let p = plan_sync_placement(dir.path(), &changed, "/app/");
+		assert_eq!(p.entry_name, "a.txt");
+		assert_eq!(p.dest_dir, "/app");
+	}
+
+	#[test]
+	fn placement_single_file_rule_honours_renaming_target() {
+		// A single-file rule whose target renames the file must store the entry
+		// under the target basename and extract into the target's parent.
+		let dir = tempdir().unwrap();
+		let src = dir.path().join("settings.yml");
+		fs::write(&src, b"k: v").unwrap();
+
+		let p = plan_sync_placement(&src, &src, "/app/config.yml");
+		assert_eq!(p.entry_name, "config.yml");
+		assert_eq!(p.dest_dir, "/app");
+	}
+
+	#[test]
+	fn placement_single_file_rule_same_basename() {
+		// The existing same-basename case still lands the file at the target.
+		let dir = tempdir().unwrap();
+		let src = dir.path().join("app.txt");
+		fs::write(&src, b"x").unwrap();
+
+		let p = plan_sync_placement(&src, &src, "/newdir/app.txt");
+		assert_eq!(p.entry_name, "app.txt");
+		assert_eq!(p.dest_dir, "/newdir");
+	}
+
+	#[test]
+	fn placement_single_file_rule_target_at_root() {
+		let dir = tempdir().unwrap();
+		let src = dir.path().join("app.txt");
+		fs::write(&src, b"x").unwrap();
+
+		let p = plan_sync_placement(&src, &src, "/app.txt");
+		assert_eq!(p.entry_name, "app.txt");
+		assert_eq!(p.dest_dir, "/");
+	}
+}


### PR DESCRIPTION
I swept the `watch` subsystem against docker compose watch semantics and fixed the verified findings. Each change is covered by parse/unit tests; no container integration tests are touched.

- watch dispatches on every notify event with no EventKind filter (read-triggered syncs + self-feedback loop) (Closes #725)
- config renders watch action in PascalCase (Sync/Rebuild), which its custom Deserialize rejects (Closes #805)
- sync rule with no target is a silent no-op instead of a config error (Closes #806)
- every sync unconditionally runs an in-container mkdir -p before the archive PUT (per-event waste) (Closes #924)
- leading-dash watch target injected as mkdir flag (arg confusion) (Closes #925)
- watch with no develop.watch rules exits 0 (diverges from docker compose) (Closes #926)

I also split the pure placement/event helpers and their tests out of `internal/engine/watch/mod.rs` into a new `placement.rs` so both files stay within the file-size limit.
