### PR TITLE
fix(timeouts-hang): resolve verified timeouts-hang sweep findings

### DIFF
--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -103,12 +103,20 @@ pub(crate) async fn dispatch(
 		} => {
 			engine.start(file, &services).await?;
 			if wait {
-				let fut = engine.wait_services_healthy(file, &services);
 				match wait_timeout {
-					Some(secs) => tokio::time::timeout(std::time::Duration::from_secs(secs), fut)
-						.await
-						.map_err(|_| podup::ComposeError::WaitTimeout { secs })??,
-					None => fut.await?,
+					// `--wait-timeout` both extends the per-service poll budget (so a
+					// short healthcheck plan does not give up early) and caps the
+					// whole wait, so exhaustion surfaces as a clear WaitTimeout rather
+					// than a misleading per-container health-check timeout.
+					Some(secs) => {
+						let budget = std::time::Duration::from_secs(secs);
+						let fut =
+							engine.wait_services_healthy_within(file, &services, Some(budget));
+						tokio::time::timeout(budget, fut)
+							.await
+							.map_err(|_| podup::ComposeError::WaitTimeout { secs })??;
+					}
+					None => engine.wait_services_healthy(file, &services).await?,
 				}
 			}
 		}

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -1,14 +1,64 @@
 //! Image push to a registry (docker compose `push`).
 
-use futures_util::StreamExt;
+use std::time::Duration;
+
+use futures_util::{Stream, StreamExt};
 use tracing::{info, warn};
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImagePullProgress;
-use crate::libpod::{urlencoded, API_PREFIX};
+use crate::libpod::{urlencoded, PodmanError, API_PREFIX};
 
 use super::super::Engine;
+
+/// Maximum time to wait for the next progress line from a push body stream
+/// before treating the registry as unresponsive.
+///
+/// The client `READ_TIMEOUT` only bounds the request head, not this streamed
+/// body, so without a per-line deadline a push to an unreachable/wedged registry
+/// would block indefinitely while draining the response. Generous so a slow but
+/// progressing upload is never aborted.
+const PUSH_STALL_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Drain a push progress stream, surfacing a mid-stream `error` line and bounding
+/// each read by `stall` so an unresponsive registry fails with a clear timeout
+/// instead of hanging. Generic over the stream so it is unit-tested without a
+/// live socket.
+async fn drain_push_stream<S>(mut stream: S, image: &str, stall: Duration) -> Result<()>
+where
+	S: Stream<Item = std::result::Result<ImagePullProgress, PodmanError>> + Unpin,
+{
+	let mut stream_error: Option<String> = None;
+	loop {
+		match tokio::time::timeout(stall, stream.next()).await {
+			Ok(Some(Ok(progress))) => {
+				if !progress.stream.is_empty() {
+					info!("{}", progress.stream.trim_end());
+				}
+				if !progress.error.is_empty() {
+					stream_error = Some(progress.error.clone());
+				}
+			}
+			Ok(Some(Err(e))) => stream_error = Some(e.to_string()),
+			Ok(None) => break,
+			Err(_elapsed) => {
+				return Err(ComposeError::Build(format!(
+					"push {image}: no progress from the registry for {}s; aborting \
+					 (registry unreachable or unresponsive)",
+					stall.as_secs()
+				)));
+			}
+		}
+	}
+	match stream_error {
+		Some(err) => Err(ComposeError::Build(format!("push {image}: {err}"))),
+		None => {
+			info!("pushed {image}");
+			Ok(())
+		}
+	}
+}
 
 /// Options for [`Engine::push`], mirroring `docker compose push` (plus a Podman
 /// `--tls-verify` escape hatch for insecure/local registries).
@@ -71,27 +121,56 @@ impl Engine {
 			.post_empty_stream(&path)
 			.await
 			.map_err(ComposeError::Podman)?;
-		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
-		let mut stream_error: Option<String> = None;
-		while let Some(result) = stream.next().await {
-			match result {
-				Ok(progress) => {
-					if !progress.stream.is_empty() {
-						info!("{}", progress.stream.trim_end());
-					}
-					if !progress.error.is_empty() {
-						stream_error = Some(progress.error.clone());
-					}
-				}
-				Err(e) => stream_error = Some(e.to_string()),
-			}
+		let stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
+		drain_push_stream(stream, image, PUSH_STALL_TIMEOUT).await
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{drain_push_stream, ImagePullProgress};
+	use crate::error::ComposeError;
+	use crate::libpod::PodmanError;
+	use futures_util::StreamExt;
+	use std::time::Duration;
+
+	fn progress(stream: &str, error: &str) -> ImagePullProgress {
+		ImagePullProgress {
+			stream: stream.to_string(),
+			error: error.to_string(),
 		}
-		match stream_error {
-			Some(err) => Err(ComposeError::Build(format!("push {image}: {err}"))),
-			None => {
-				info!("pushed {image}");
-				Ok(())
-			}
-		}
+	}
+
+	#[tokio::test]
+	async fn drain_ok_when_stream_completes_cleanly() {
+		let items = vec![Ok(progress("pushing", "")), Ok(progress("done", ""))];
+		let stream = futures_util::stream::iter(items);
+		drain_push_stream(stream, "img", Duration::from_secs(5))
+			.await
+			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn drain_surfaces_mid_stream_error_line() {
+		let items = vec![Ok(progress("", "denied: unauthorized"))];
+		let stream = futures_util::stream::iter(items);
+		let err = drain_push_stream(stream, "img", Duration::from_secs(5))
+			.await
+			.unwrap_err();
+		assert!(matches!(err, ComposeError::Build(m) if m.contains("denied: unauthorized")));
+	}
+
+	#[tokio::test]
+	async fn drain_times_out_on_an_unresponsive_stream() {
+		// A stream that yields one line then never another stands in for a registry
+		// that accepts the request then stalls — the per-line deadline must fire.
+		let first = futures_util::stream::iter(vec![Ok(progress("pushing", ""))]);
+		let stream = first.chain(futures_util::stream::pending::<
+			std::result::Result<ImagePullProgress, PodmanError>,
+		>());
+		let err = drain_push_stream(stream, "img", Duration::from_millis(20))
+			.await
+			.unwrap_err();
+		assert!(matches!(err, ComposeError::Build(m) if m.contains("no progress")));
 	}
 }

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -92,6 +92,30 @@ fn health_poll_plan(
 	(poll_secs, iterations)
 }
 
+/// Poll iterations to actually run, given the healthcheck poll-plan and an
+/// optional `--wait-timeout`.
+///
+/// `--wait-timeout` must be able to *extend* the wait, not merely cap it: a
+/// healthcheck with a short `interval × retries` budget would otherwise time
+/// out long before a generous `--wait-timeout` elapsed. So when a wait-timeout
+/// is given we run at least enough iterations to cover it (plus a small margin),
+/// letting the outer `--wait-timeout` deadline — not the poll plan — decide when
+/// to give up. Without a wait-timeout the poll plan governs unchanged. Pure so
+/// the budget arithmetic is unit-tested without a live socket.
+fn effective_iterations(poll_secs: u64, plan_iters: u64, wait_timeout: Option<Duration>) -> u64 {
+	match wait_timeout {
+		Some(wt) => {
+			let poll = poll_secs.max(1);
+			// +2 so the inner loop outlasts the outer deadline, ensuring an
+			// exhausted wait surfaces as the `--wait-timeout` error rather than a
+			// spurious health-check-timeout that fired one poll early.
+			let wt_iters = wt.as_secs().div_ceil(poll) + 2;
+			plan_iters.max(wt_iters)
+		}
+		None => plan_iters,
+	}
+}
+
 impl Engine {
 	/// Wait until every targeted service's first replica is healthy (`up
 	/// --wait`). A service with no effective healthcheck is treated as ready
@@ -100,6 +124,22 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],
+	) -> Result<()> {
+		self.wait_services_healthy_within(file, target_services, None)
+			.await
+	}
+
+	/// As [`wait_services_healthy`](Self::wait_services_healthy), but a
+	/// `Some(wait_timeout)` extends each service's poll budget to cover the
+	/// supplied `--wait-timeout` (rather than only capping it). The caller still
+	/// wraps the whole wait in a hard `--wait-timeout` deadline, which becomes the
+	/// authoritative limit; this just stops the per-service poll plan from giving
+	/// up early and reporting a misleading health-check timeout.
+	pub async fn wait_services_healthy_within(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		wait_timeout: Option<Duration>,
 	) -> Result<()> {
 		// Poll services concurrently: each `wait_healthy` is its own poll loop, so
 		// total `--wait` latency is the slowest service, not the sum of all.
@@ -111,7 +151,7 @@ impl Engine {
 			})
 			.map(|(name, service)| {
 				let container = self.first_replica_name(name, service);
-				async move { self.wait_healthy(&container, service).await }
+				async move { self.wait_healthy(&container, service, wait_timeout).await }
 			});
 		futures_util::future::try_join_all(waits).await?;
 		Ok(())
@@ -128,13 +168,21 @@ impl Engine {
 	/// those declared in compose. If the container has no effective healthcheck at
 	/// all (none in the image or compose), it can never report `healthy`, so the
 	/// wait short-circuits as satisfied rather than blocking until timeout.
-	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
+	pub(super) async fn wait_healthy(
+		&self,
+		container_name: &str,
+		service: &Service,
+		wait_timeout: Option<Duration>,
+	) -> Result<()> {
 		let hc = service.healthcheck.as_ref();
-		let (poll_secs, iterations) = health_poll_plan(
+		let (poll_secs, plan_iters) = health_poll_plan(
 			hc.and_then(|h| h.interval.as_deref()),
 			hc.and_then(|h| h.start_period.as_deref()),
 			hc.and_then(|h| h.retries),
 		);
+		// `--wait-timeout` extends the poll budget so it, not the (often shorter)
+		// healthcheck interval×retries plan, decides when the wait gives up.
+		let iterations = effective_iterations(poll_secs, plan_iters, wait_timeout);
 
 		// One inspect decides the short-circuits: already healthy, or no effective
 		// healthcheck at all (image or compose) — in which case a server-side
@@ -247,6 +295,30 @@ mod tests {
 		// An interval below 1s falls back to the 2s default (no busy-poll).
 		let (poll, _) = super::health_poll_plan(Some("500ms"), None, Some(5));
 		assert_eq!(poll, 2);
+	}
+
+	// --- effective_iterations (--wait-timeout budget, #891) ------------------
+
+	#[test]
+	fn effective_iterations_without_wait_timeout_uses_plan() {
+		// No --wait-timeout: the healthcheck poll plan governs unchanged.
+		assert_eq!(super::effective_iterations(2, 30, None), 30);
+	}
+
+	#[test]
+	fn effective_iterations_extends_to_cover_wait_timeout() {
+		// A short plan (interval 10s × 1 retry = 1 iter) must be extended so a
+		// generous --wait-timeout actually elapses: 120s / 10s + 2 margin = 14.
+		let iters = super::effective_iterations(10, 1, Some(Duration::from_secs(120)));
+		assert_eq!(iters, 14);
+	}
+
+	#[test]
+	fn effective_iterations_keeps_larger_plan() {
+		// When the poll plan already outlasts --wait-timeout, the plan wins so the
+		// healthcheck's own budget is never shortened.
+		let iters = super::effective_iterations(2, 100, Some(Duration::from_secs(10)));
+		assert_eq!(iters, 100);
 	}
 
 	// --- wait_healthy gating (service_healthy) -------------------------------

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -8,6 +8,7 @@ use tracing::info;
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
+use super::targets::{stop_deadline, stop_timeout_param};
 use super::{filter_services, RunOptions};
 use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
@@ -28,6 +29,60 @@ impl Engine {
 			Err(e) if e.is_status(304) || e.is_status(404) => {
 				tracing::debug!("{container}: {done} skipped ({e})");
 				Ok(())
+			}
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
+	}
+
+	/// Stop one container, escalating to an explicit `SIGKILL` if the libpod
+	/// `stop` call does not complete within the grace window.
+	///
+	/// libpod normally `SIGKILL`s a container itself once the grace period lapses,
+	/// so a healthy stop returns inside [`stop_deadline`]. If the call instead
+	/// stalls (a daemon that accepts the request then never replies, or a
+	/// container the server fails to reap), the bounded wait surfaces a timeout
+	/// and we send `kill?signal=SIGKILL` so podup never depends solely on the
+	/// server honouring `?t`. 304/404 are idempotent no-ops, as in
+	/// [`run_lifecycle_op`](Self::run_lifecycle_op).
+	async fn stop_container(&self, container: &str, grace: i32) -> Result<()> {
+		let path = format!(
+			"{API_PREFIX}/containers/{}/stop?t={}",
+			crate::libpod::urlencoded(container),
+			stop_timeout_param(grace),
+		);
+		match self
+			.client
+			.post_empty_ok_within(&path, stop_deadline(grace))
+			.await
+		{
+			Ok(()) => {
+				info!("stopped {container}");
+				Ok(())
+			}
+			Err(e) if e.is_status(304) || e.is_status(404) => {
+				tracing::debug!("{container}: stop skipped ({e})");
+				Ok(())
+			}
+			Err(e) if e.is_timeout() => {
+				tracing::warn!(
+					"{container}: stop did not complete within the grace window; escalating to SIGKILL"
+				);
+				let kill_path = format!(
+					"{API_PREFIX}/containers/{}/kill?signal=SIGKILL",
+					crate::libpod::urlencoded(container),
+				);
+				match self.client.post_empty_ok(&kill_path).await {
+					Ok(()) => {
+						info!("killed {container} (SIGKILL after stop timeout)");
+						Ok(())
+					}
+					// Already gone / not running between the timeout and the kill.
+					Err(e) if e.is_status(404) || e.is_status(409) => {
+						tracing::debug!("{container}: SIGKILL skipped ({e})");
+						Ok(())
+					}
+					Err(e) => Err(ComposeError::Podman(e)),
+				}
 			}
 			Err(e) => Err(ComposeError::Podman(e)),
 		}
@@ -61,8 +116,9 @@ impl Engine {
 				// Single atomic restart (no visible stopped window) instead of a
 				// stop+start round-trip.
 				let restart_path = format!(
-					"{API_PREFIX}/containers/{}/restart?t={grace}",
+					"{API_PREFIX}/containers/{}/restart?t={}",
 					crate::libpod::urlencoded(&container_name),
+					stop_timeout_param(grace),
 				);
 				self.run_lifecycle_op(&restart_path, &container_name, "restarted")
 					.await?;
@@ -76,8 +132,9 @@ impl Engine {
 					for dep_container in self.live_replica_names(dep_name, dep_service).await? {
 						let grace = self.grace_period_secs(dep_service);
 						let restart_path = format!(
-							"{API_PREFIX}/containers/{}/restart?t={grace}",
+							"{API_PREFIX}/containers/{}/restart?t={}",
 							crate::libpod::urlencoded(&dep_container),
+							stop_timeout_param(grace),
 						);
 						if let Err(e) = self.client.post_empty_ok(&restart_path).await {
 							tracing::warn!("cascade restart of {dep_name} failed: {e}");
@@ -141,12 +198,7 @@ impl Engine {
 			let service = &file.services[name];
 			for container_name in self.live_replica_names(name, service).await? {
 				let grace = self.grace_period_secs(service);
-				let path = format!(
-					"{API_PREFIX}/containers/{}/stop?t={grace}",
-					crate::libpod::urlencoded(&container_name),
-				);
-				self.run_lifecycle_op(&path, &container_name, "stopped")
-					.await?;
+				self.stop_container(&container_name, grace).await?;
 			}
 		}
 		Ok(())

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -12,6 +12,7 @@ use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
+pub use targets::validate_stop_timeout;
 use targets::{expand_targets, filter_services, in_started_set};
 
 use super::container::config_hash;
@@ -292,7 +293,7 @@ impl Engine {
 						);
 						Ok(())
 					} else {
-						self.wait_healthy(&dep_container, dep_service).await
+						self.wait_healthy(&dep_container, dep_service, None).await
 					}
 				}
 				ServiceCondition::ServiceCompletedSuccessfully => {
@@ -411,11 +412,19 @@ impl Engine {
 				}
 
 				let grace = self.grace_period_secs(service);
+				// Bound the stop by the grace window so a container ignoring SIGTERM
+				// does not pin recreation for the full client READ_TIMEOUT; the
+				// force-remove below SIGKILLs it regardless.
 				let stop_path = format!(
-					"{API_PREFIX}/containers/{}/stop?t={grace}",
+					"{API_PREFIX}/containers/{}/stop?t={}",
 					crate::libpod::urlencoded(&container_name),
+					targets::stop_timeout_param(grace),
 				);
-				if let Err(e) = self.client.post_empty_ok(&stop_path).await {
+				if let Err(e) = self
+					.client
+					.post_empty_ok_within(&stop_path, targets::stop_deadline(grace))
+					.await
+				{
 					tracing::warn!("could not stop {container_name}: {e}");
 				}
 

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -10,6 +10,8 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
+use super::targets::{stop_deadline, stop_timeout_param};
+
 /// The default ceiling on a service's replica count.
 const DEFAULT_MAX_REPLICAS: u32 = 256;
 
@@ -127,11 +129,18 @@ impl Engine {
 
 	/// Stop (best-effort) then force-remove a container by name.
 	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32) {
+		// Bound the stop by the grace window: the force-remove below SIGKILLs the
+		// container, so a stop that stalls past the grace must not pin us for the
+		// full client READ_TIMEOUT before we fall through to it.
 		let stop_path = format!(
-			"{API_PREFIX}/containers/{}/stop?t={grace}",
-			urlencoded(name)
+			"{API_PREFIX}/containers/{}/stop?t={}",
+			urlencoded(name),
+			stop_timeout_param(grace),
 		);
-		let _ = self.client.post_empty_ok(&stop_path).await;
+		let _ = self
+			.client
+			.post_empty_ok_within(&stop_path, stop_deadline(grace))
+			.await;
 		let rm_path = format!("{API_PREFIX}/containers/{}?force=true", urlencoded(name));
 		if let Err(e) = self.client.delete_ok(&rm_path).await {
 			tracing::debug!("scale-down rm {name}: {e}");

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -2,9 +2,18 @@
 //! target-list filtering, and `depends_on` expansion.
 
 use std::collections::HashSet;
+use std::time::Duration;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
+
+/// Extra wall-clock slack, beyond the grace period, before podup gives up on a
+/// stalled libpod `stop` and escalates to a client-side `SIGKILL`. Podman stops
+/// a container by sending `SIGTERM`, waiting the grace window, then `SIGKILL`
+/// itself — so a healthy stop returns at most ~`grace` seconds in. The buffer
+/// absorbs daemon/reap latency so a slow-but-working stop is never escalated;
+/// anything past it means the libpod call is wedged and we kill independently.
+const STOP_GRACE_BUFFER_SECS: u64 = 30;
 
 /// The per-service shutdown grace from `stop_grace_period` (default 10s).
 pub(super) fn service_grace_period_secs(service: &Service) -> i32 {
@@ -14,6 +23,41 @@ pub(super) fn service_grace_period_secs(service: &Service) -> i32 {
 		.and_then(crate::size::parse_duration_secs)
 		.and_then(|s| i32::try_from(s).ok())
 		.unwrap_or(10)
+}
+
+/// Validate a CLI `-t/--timeout` value at the trust boundary.
+///
+/// `-1` (docker's "wait indefinitely") and any non-negative second count are
+/// accepted; anything below `-1` is rejected with [`ComposeError::InvalidTimeout`]
+/// so it never reaches libpod as a `?t=<negative>` that surfaces a raw `HTTP 400`.
+/// Pure so the boundary check is unit-tested without a live socket.
+pub fn validate_stop_timeout(timeout: Option<i32>) -> Result<Option<i32>> {
+	match timeout {
+		Some(t) if t < -1 => Err(ComposeError::InvalidTimeout(t)),
+		other => Ok(other),
+	}
+}
+
+/// The libpod `?t=` value for a grace period. A non-negative grace passes through;
+/// `-1` ("wait indefinitely") maps to the largest value libpod accepts so podman
+/// does not escalate to `SIGKILL` on its own, matching `docker stop -t -1`. Pure.
+pub(super) fn stop_timeout_param(grace: i32) -> i64 {
+	if grace < 0 {
+		i64::from(i32::MAX)
+	} else {
+		i64::from(grace)
+	}
+}
+
+/// Client-side deadline for a `stop` call: the grace window plus
+/// [`STOP_GRACE_BUFFER_SECS`]. `-1` ("wait indefinitely") yields `None`, leaving
+/// the call uncapped like `docker stop -t -1`. Pure so the policy is unit-tested.
+pub(super) fn stop_deadline(grace: i32) -> Option<Duration> {
+	if grace < 0 {
+		None
+	} else {
+		Some(Duration::from_secs(grace as u64 + STOP_GRACE_BUFFER_SECS))
+	}
 }
 
 impl crate::engine::Engine {
@@ -97,9 +141,72 @@ pub(super) fn in_started_set(target_set: &Option<HashSet<String>>, name: &str) -
 
 #[cfg(test)]
 mod tests {
-	use super::{expand_targets, filter_services, in_started_set, service_grace_period_secs};
+	use super::{
+		expand_targets, filter_services, in_started_set, service_grace_period_secs, stop_deadline,
+		stop_timeout_param, validate_stop_timeout, STOP_GRACE_BUFFER_SECS,
+	};
 	use crate::compose::types::{ComposeFile, Service};
+	use crate::error::ComposeError;
 	use std::collections::HashSet;
+	use std::time::Duration;
+
+	// --- validate_stop_timeout (#778) ---
+
+	#[test]
+	fn validate_stop_timeout_accepts_none_zero_and_positive() {
+		assert_eq!(validate_stop_timeout(None).unwrap(), None);
+		assert_eq!(validate_stop_timeout(Some(0)).unwrap(), Some(0));
+		assert_eq!(validate_stop_timeout(Some(30)).unwrap(), Some(30));
+	}
+
+	#[test]
+	fn validate_stop_timeout_accepts_minus_one_infinite() {
+		// -1 is docker's "wait indefinitely" sentinel and must pass through.
+		assert_eq!(validate_stop_timeout(Some(-1)).unwrap(), Some(-1));
+	}
+
+	#[test]
+	fn validate_stop_timeout_rejects_below_minus_one() {
+		// A value below -1 is rejected here rather than leaking a raw libpod 400.
+		let err = validate_stop_timeout(Some(-2)).unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidTimeout(-2)));
+		assert!(validate_stop_timeout(Some(-100)).is_err());
+	}
+
+	// --- stop_timeout_param (#778) ---
+
+	#[test]
+	fn stop_timeout_param_passes_through_non_negative() {
+		assert_eq!(stop_timeout_param(0), 0);
+		assert_eq!(stop_timeout_param(10), 10);
+	}
+
+	#[test]
+	fn stop_timeout_param_maps_infinite_to_max() {
+		// -1 (infinite) maps to the largest value libpod accepts so podman never
+		// escalates to SIGKILL on its own, matching `docker stop -t -1`.
+		assert_eq!(stop_timeout_param(-1), i64::from(i32::MAX));
+	}
+
+	// --- stop_deadline (#719) ---
+
+	#[test]
+	fn stop_deadline_is_grace_plus_buffer() {
+		assert_eq!(
+			stop_deadline(10),
+			Some(Duration::from_secs(10 + STOP_GRACE_BUFFER_SECS))
+		);
+		assert_eq!(
+			stop_deadline(0),
+			Some(Duration::from_secs(STOP_GRACE_BUFFER_SECS))
+		);
+	}
+
+	#[test]
+	fn stop_deadline_infinite_is_none() {
+		// -1 leaves the stop uncapped (docker `stop -t -1` parity).
+		assert_eq!(stop_deadline(-1), None);
+	}
 
 	// --- service_grace_period_secs ---
 

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -10,7 +10,7 @@ mod image;
 pub use build::{BuildOptions, PullOptions, PushOptions};
 pub use copy::CpOptions;
 pub use image::resolve_image_digests;
-pub use lifecycle::{RunOptions, RunOverrides};
+pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
 pub use query::{ExecOptions, ImagesOptions, LogsOptions, PsOptions};
 mod container_config;

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -72,6 +72,11 @@ pub enum ComposeError {
 	},
 	/// `start --wait --wait-timeout` elapsed before services became healthy.
 	WaitTimeout { secs: u64 },
+	/// The `-t/--timeout` shutdown grace was given an unusable value (a number
+	/// below `-1`). `-1` means "wait indefinitely" (docker parity) and any
+	/// non-negative value is a second count; everything else is rejected here
+	/// rather than forwarded to libpod as a raw `HTTP 400`.
+	InvalidTimeout(i32),
 }
 
 impl fmt::Display for ComposeError {
@@ -135,6 +140,10 @@ impl fmt::Display for ComposeError {
 			Self::WaitTimeout { secs } => write!(
 				f,
 				"timed out after {secs}s waiting for services to become healthy"
+			),
+			Self::InvalidTimeout(secs) => write!(
+				f,
+				"invalid --timeout {secs}: use -1 to wait indefinitely or a non-negative number of seconds"
 			),
 		}
 	}
@@ -269,6 +278,10 @@ mod tests {
 			(
 				"timed out after 30s waiting for services to become healthy",
 				ComposeError::WaitTimeout { secs: 30 },
+			),
+			(
+				"invalid --timeout -5: use -1 to wait indefinitely or a non-negative number of seconds",
+				ComposeError::InvalidTimeout(-5),
 			),
 		];
 		for (expected_prefix, err) in cases {

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -46,8 +46,9 @@ pub use compose::{
 /// through.
 pub use engine::{
 	is_safe_project_name, list_projects, resolve_image_digests, retain_active_profiles,
-	BuildOptions, CpOptions, Engine, ExecOptions, ImagesOptions, LogsOptions, LsOptions,
-	ProjectLock, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, VolumesOptions,
+	validate_stop_timeout, BuildOptions, CpOptions, Engine, ExecOptions, ImagesOptions,
+	LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions, PushOptions, RunOptions,
+	RunOverrides, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -365,6 +365,30 @@ impl Client {
 		Self::check_status(status, &body)
 	}
 
+	/// `POST` with empty body → ignore response body (expect 2xx or 304), bounded
+	/// by a caller-chosen deadline rather than the default [`READ_TIMEOUT`].
+	///
+	/// `deadline` of `Some` caps both the response-head wait and the body read so a
+	/// `stop` on a container that is slow to die (or a wedged libpod call) returns a
+	/// timeout error after the grace window instead of pinning the CLI for the full
+	/// `READ_TIMEOUT`; `None` leaves it uncapped (docker `stop -t -1` parity). The
+	/// caller decides whether a resulting [`PodmanError::is_timeout`] warrants a
+	/// client-side `SIGKILL`/force-remove escalation.
+	pub async fn post_empty_ok_within(
+		&self,
+		path: &str,
+		deadline: Option<std::time::Duration>,
+	) -> Result<()> {
+		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let resp = self.send(req, deadline).await?;
+		let (status, body) = Self::read_body(resp, deadline).await?;
+		// 304 Not Modified is fine for idempotent ops
+		if status == StatusCode::NOT_MODIFIED {
+			return Ok(());
+		}
+		Self::check_status(status, &body)
+	}
+
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -366,13 +366,13 @@ impl Client {
 	}
 
 	/// `POST` with empty body → ignore response body (expect 2xx or 304), bounded
-	/// by a caller-chosen deadline rather than the default [`READ_TIMEOUT`].
+	/// by a caller-chosen deadline rather than the default `READ_TIMEOUT`.
 	///
 	/// `deadline` of `Some` caps both the response-head wait and the body read so a
 	/// `stop` on a container that is slow to die (or a wedged libpod call) returns a
 	/// timeout error after the grace window instead of pinning the CLI for the full
 	/// `READ_TIMEOUT`; `None` leaves it uncapped (docker `stop -t -1` parity). The
-	/// caller decides whether a resulting [`PodmanError::is_timeout`] warrants a
+	/// caller decides whether a resulting `PodmanError::is_timeout` warrants a
 	/// client-side `SIGKILL`/force-remove escalation.
 	pub async fn post_empty_ok_within(
 		&self,

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -99,6 +99,14 @@ impl PodmanError {
 		matches!(self, Self::Api { status, .. } if *status == code)
 	}
 
+	/// True if this is a client-side timeout (the request was aborted because the
+	/// socket never responded within the deadline). These carry a synthetic
+	/// status `0` and a `timed out` message; lifecycle callers use this to
+	/// escalate a wedged `stop` to an explicit `SIGKILL`.
+	pub(crate) fn is_timeout(&self) -> bool {
+		matches!(self, Self::Api { status: 0, message } if message.contains("timed out"))
+	}
+
 	/// True if this API error reports that the resource already exists: an HTTP
 	/// 409 conflict, or an HTTP 500 whose message says so. Podman's libpod
 	/// volume-create endpoint returns 500 (not 409) for a duplicate name, so an
@@ -172,6 +180,29 @@ mod tests {
 		assert!(e.is_status(404));
 		assert!(!e.is_status(200));
 		assert!(!e.is_status(500));
+	}
+
+	#[test]
+	fn is_timeout_matches_synthetic_timeout_error() {
+		// Client-side timeouts carry status 0 and a "timed out" message; lifecycle
+		// stop escalation keys off this.
+		assert!(PodmanError::Api {
+			status: 0,
+			message: "timed out after 40s waiting for the Podman socket to respond".into(),
+		}
+		.is_timeout());
+		// A real HTTP error (non-zero status) is not a timeout.
+		assert!(!PodmanError::Api {
+			status: 500,
+			message: "boom".into(),
+		}
+		.is_timeout());
+		// A status-0 error without the timeout marker is not a timeout.
+		assert!(!PodmanError::Api {
+			status: 0,
+			message: "invalid API path".into(),
+		}
+		.is_timeout());
 	}
 
 	#[test]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -212,6 +212,9 @@ async fn run() -> podup::Result<()> {
 		| Commands::Restart { timeout, .. } => *timeout,
 		_ => None,
 	};
+	// Reject a `-t/--timeout` below -1 here, at the trust boundary, with a clear
+	// message instead of forwarding it to libpod as a raw `?t=<negative>` 400.
+	let stop_timeout = podup::validate_stop_timeout(stop_timeout)?;
 	// `--scale SERVICE=N` (on `up`) and the `scale` subcommand both feed the
 	// engine's replica overrides so `resolve_replicas` reports the target count.
 	let scale_overrides: std::collections::HashMap<String, u32> = match &cli.command {


### PR DESCRIPTION
I fixed the verified findings from the timeouts/hang sweep: cases where podup could block far longer than it should (or indefinitely) on a stalled libpod call, plus a `-t/--timeout` boundary gap. Each fix keeps the happy path unchanged and only kicks in when a call outlives its intended window. All new logic is covered by pure unit / stream tests (the container suite was not touched).

## Fixed

- bound stop with a grace-derived client deadline and escalate to SIGKILL so a container ignoring SIGTERM can no longer pin the CLI for the full READ_TIMEOUT (Closes #719)
- validate `-t/--timeout` at the boundary: reject values below -1 with a friendly error instead of leaking a raw libpod HTTP 400, and treat -1 as "wait indefinitely" for docker parity (Closes #778)
- bound the push progress-stream drain with a per-line stall deadline so a push to an unreachable/unresponsive registry fails fast instead of hanging (Closes #779)
- let `--wait-timeout` actually govern (extend) the `start --wait` health-poll budget, and surface the correct WaitTimeout message on exhaustion rather than a misleading per-container health-check timeout (Closes #891)

## Deferred

- #720 (exec with a nonexistent named user) — the fix depends on the exact exec-start failure mode in Podman (whether the hijacked multiplexed stream stalls or returns a delayed non-2xx body), which I cannot reproduce without running the container integration suite. A blind change here risks masking legitimate exec errors, so I am deferring it for empirical verification.

## Verification

- `cargo build` — ok
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --lib` — 888 passed; plus parse/substitute/size/ports/env_file/quadlet/project_name_safety/secret_safety/cli_aliases/cli_diagnostics suites green
- container integration suite deliberately not run
