### PR TITLE
fix(update): resolve verified update sweep findings

### DIFF
--- a/internal/main.rs
+++ b/internal/main.rs
@@ -123,6 +123,22 @@ async fn run() -> podup::Result<()> {
 	// filesystem work is blocking; keep it off the async path entirely.
 	#[cfg(feature = "update")]
 	if let Commands::Update { check, force } = cli.command {
+		// The compose-only global value-flags (--socket/--profile/--env-file/
+		// --project-directory) never reach the binary-only self-update, so accepting
+		// them silently is a misleading no-op. Reject any that were passed on the
+		// command line (env-sourced values are left alone — they are not a misuse).
+		if let Some(flag) = misused_update_global() {
+			use clap::CommandFactory;
+			Cli::command()
+				.error(
+					clap::error::ErrorKind::ArgumentConflict,
+					format!(
+						"`{flag}` has no effect on `update`, which replaces the podup \
+						 binary itself rather than acting on a compose project"
+					),
+				)
+				.exit();
+		}
 		let opts = podup::update::UpdateOptions {
 			check_only: check,
 			force,
@@ -257,4 +273,79 @@ async fn run() -> podup::Result<()> {
 	};
 
 	dispatch::dispatch(&engine, &file, cli.command, &cli.profile).await
+}
+
+/// Compose-only global value-flags that `update` parses (they are declared
+/// `global` on [`Cli`]) but cannot act on, since self-update rewrites the binary
+/// itself rather than a compose project. Each entry is `(arg-id, user-facing
+/// spelling)`.
+#[cfg(feature = "update")]
+const UPDATE_IRRELEVANT_GLOBALS: &[(&str, &str)] = &[
+	("socket", "--socket"),
+	("profile", "--profile"),
+	("project_directory", "--project-directory"),
+	("env_file", "--env-file"),
+];
+
+/// Return the first compose-only global flag that was supplied on the command
+/// line for an `update` invocation, or `None` if none were. Re-parses the
+/// already-validated argv to inspect value sources; env-sourced and default
+/// values are deliberately ignored, so an exported `PODMAN_SOCKET` does not
+/// break `podup update`.
+#[cfg(feature = "update")]
+fn misused_update_global() -> Option<&'static str> {
+	use clap::CommandFactory;
+	// Parsing already succeeded once in `parse_cli`, so this re-parse cannot fail.
+	let matches = Cli::command().try_get_matches().ok()?;
+	first_misused_global(&matches)
+}
+
+/// Core of [`misused_update_global`], split out so it can be tested against
+/// matches built from a fixed argv. A global flag can surface on the root
+/// matches or on the `update` subcommand matches depending on its position
+/// relative to the subcommand, so both are checked.
+#[cfg(feature = "update")]
+fn first_misused_global(matches: &clap::ArgMatches) -> Option<&'static str> {
+	use clap::parser::ValueSource;
+	let update = matches.subcommand_matches("update");
+	UPDATE_IRRELEVANT_GLOBALS.iter().find_map(|(id, flag)| {
+		let from_cli = |m: &clap::ArgMatches| m.value_source(id) == Some(ValueSource::CommandLine);
+		(from_cli(matches) || update.is_some_and(from_cli)).then_some(*flag)
+	})
+}
+
+#[cfg(all(test, feature = "update"))]
+mod tests {
+	use super::*;
+	use clap::CommandFactory;
+
+	fn matches_for(args: &[&str]) -> clap::ArgMatches {
+		Cli::command()
+			.try_get_matches_from(args)
+			.expect("args parse")
+	}
+
+	#[test]
+	fn update_flags_compose_globals_before_subcommand_are_rejected() {
+		let m = matches_for(&[
+			"podup",
+			"--socket",
+			"unix:///tmp/x.sock",
+			"update",
+			"--check",
+		]);
+		assert_eq!(first_misused_global(&m), Some("--socket"));
+	}
+
+	#[test]
+	fn update_flags_compose_globals_after_subcommand_are_rejected() {
+		let m = matches_for(&["podup", "update", "--project-directory", "/tmp"]);
+		assert_eq!(first_misused_global(&m), Some("--project-directory"));
+	}
+
+	#[test]
+	fn update_without_compose_globals_is_accepted() {
+		let m = matches_for(&["podup", "update", "--check", "--force"]);
+		assert_eq!(first_misused_global(&m), None);
+	}
 }

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -44,42 +44,6 @@ pub fn require_platform_asset() -> crate::Result<&'static str> {
 	})
 }
 
-/// Name of the system package manager that owns the running binary, if any.
-///
-/// Self-update replaces the executable in place, which would corrupt a package
-/// manager's record of the installed file. When the running binary is tracked
-/// by such a manager the caller refuses and redirects the user to it.
-///
-/// Only `dpkg`/`apt` is detected, on Linux. cargo-install layouts
-/// (`~/.cargo/bin`, `/usr/local/bin`) are not owned by `dpkg` and update
-/// normally. A missing `dpkg-query`, or a path no package owns, returns `None`.
-#[cfg(target_os = "linux")]
-pub fn managing_package_manager() -> Option<&'static str> {
-	let exe = std::env::current_exe().ok()?;
-	let path = std::fs::canonicalize(&exe).unwrap_or(exe);
-	let output = std::process::Command::new("dpkg-query")
-		.arg("-S")
-		.arg(&path)
-		.output()
-		.ok()?;
-	output.status.success().then_some("apt")
-}
-
-/// Non-Linux platforms have no supported package-manager-managed install yet.
-#[cfg(not(target_os = "linux"))]
-pub fn managing_package_manager() -> Option<&'static str> {
-	None
-}
-
-/// Error returned when the running binary is managed by package manager `pm`.
-pub fn package_managed_error(pm: &str) -> ComposeError {
-	ComposeError::Update(format!(
-		"this podup was installed by {pm}; update it with your package manager \
-		 (e.g. `apt upgrade podup`) rather than `podup update`, which would break \
-		 the package's record of the file"
-	))
-}
-
 /// Replace the currently running executable with `new_bytes`. Returns the path
 /// that was updated. The caller MUST have verified `new_bytes` first.
 pub fn install_binary(new_bytes: &[u8]) -> crate::Result<PathBuf> {
@@ -414,25 +378,6 @@ mod tests {
 			(None, Err(_)) => {}
 			_ => panic!("platform_asset and require_platform_asset disagree"),
 		}
-	}
-
-	#[test]
-	fn package_managed_error_names_the_manager() {
-		let e = package_managed_error("apt");
-		match e {
-			ComposeError::Update(msg) => {
-				assert!(msg.contains("apt"));
-				assert!(msg.contains("podup update"));
-			}
-			_ => panic!("expected an Update error"),
-		}
-	}
-
-	#[test]
-	fn test_binary_is_not_package_managed() {
-		// The test runner binary lives under target/, which no package owns, so
-		// detection must not false-positive and block updates for normal builds.
-		assert_eq!(managing_package_manager(), None);
 	}
 
 	#[test]

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -10,6 +10,7 @@
 
 mod github;
 mod install;
+mod pkg;
 mod verify;
 
 pub use github::{GitHubSource, REPO};
@@ -46,7 +47,7 @@ pub fn run_with(
 	current: &str,
 	opts: UpdateOptions,
 ) -> crate::Result<()> {
-	run_with_guard(source, current, opts, install::managing_package_manager())
+	run_with_guard(source, current, opts, pkg::managing_package_manager())
 }
 
 /// [`run_with`] with the package-manager guard injected, so the refusal branch
@@ -79,7 +80,7 @@ fn run_with_guard(
 	// Refuse to self-replace a package-manager-managed binary (even with
 	// --force): overwriting it would desync the package manager's records.
 	if let Some(pm) = managed_by {
-		return Err(install::package_managed_error(pm));
+		return Err(pkg::package_managed_error(pm));
 	}
 
 	let asset = install::require_platform_asset()?;

--- a/internal/update/pkg.rs
+++ b/internal/update/pkg.rs
@@ -1,0 +1,147 @@
+//! Detect whether the running binary is owned by a system package manager.
+//!
+//! Self-update replaces the executable in place, which would corrupt a package
+//! manager's record of the installed file. When the running binary is tracked by
+//! such a manager the caller refuses and redirects the user to it.
+
+#[cfg(target_os = "linux")]
+use std::path::Path;
+
+use crate::ComposeError;
+
+/// Name of the system package manager that owns the running binary, if any.
+///
+/// Only `dpkg`/`apt` is detected, on Linux. cargo-install layouts
+/// (`~/.cargo/bin`, `/usr/local/bin`) are not owned by `dpkg` and update
+/// normally. A path no package owns returns `None`.
+#[cfg(target_os = "linux")]
+pub fn managing_package_manager() -> Option<&'static str> {
+	let exe = std::env::current_exe().ok()?;
+	let path = std::fs::canonicalize(&exe).unwrap_or(exe);
+	dpkg_owns(&path).then_some("apt")
+}
+
+/// Whether dpkg's database records `path` as belonging to an installed package.
+///
+/// The primary check is `dpkg-query -S <path>`. Crucially this must not *fail
+/// open*: if the helper cannot be spawned (missing, not executable, or denied)
+/// we do not assume the file is unmanaged — that would let self-update clobber an
+/// apt-owned binary and desync the dpkg database. Instead we fall back to reading
+/// dpkg's on-disk file lists directly. A host with no dpkg database at all
+/// (`/var/lib/dpkg/info` absent — e.g. Fedora or a cargo-install) is genuinely
+/// not Debian-managed, so both paths report `false` and update proceeds.
+#[cfg(target_os = "linux")]
+fn dpkg_owns(path: &Path) -> bool {
+	match std::process::Command::new("dpkg-query")
+		.arg("-S")
+		.arg(path)
+		.output()
+	{
+		// dpkg-query ran to completion: trust its verdict (success == owned).
+		Ok(output) => output.status.success(),
+		// dpkg-query could not be spawned. Don't fail open — consult dpkg's
+		// own file lists, which exist only on a Debian-family system.
+		Err(_) => dpkg_lists_contain(path),
+	}
+}
+
+/// Fallback ownership check: scan dpkg's installed-file manifests
+/// (`/var/lib/dpkg/info/*.list`) for an exact line matching `path`.
+#[cfg(target_os = "linux")]
+fn dpkg_lists_contain(path: &Path) -> bool {
+	dpkg_lists_contain_in(Path::new("/var/lib/dpkg/info"), path)
+}
+
+/// Core of [`dpkg_lists_contain`], parameterised on the info directory so it can
+/// be tested against a fixture without a real dpkg database. Returns `false`
+/// when the directory is absent (not a Debian host).
+#[cfg(target_os = "linux")]
+fn dpkg_lists_contain_in(info_dir: &Path, path: &Path) -> bool {
+	let Ok(entries) = std::fs::read_dir(info_dir) else {
+		return false; // no dpkg database → not Debian-managed
+	};
+	let needle = path.to_string_lossy();
+	for entry in entries.flatten() {
+		let p = entry.path();
+		if p.extension().and_then(|e| e.to_str()) != Some("list") {
+			continue;
+		}
+		if let Ok(contents) = std::fs::read_to_string(&p) {
+			if contents.lines().any(|line| line == needle) {
+				return true;
+			}
+		}
+	}
+	false
+}
+
+/// Non-Linux platforms have no supported package-manager-managed install yet.
+#[cfg(not(target_os = "linux"))]
+pub fn managing_package_manager() -> Option<&'static str> {
+	None
+}
+
+/// Error returned when the running binary is managed by package manager `pm`.
+pub fn package_managed_error(pm: &str) -> ComposeError {
+	ComposeError::Update(format!(
+		"this podup was installed by {pm}; update it with your package manager \
+		 (e.g. `apt upgrade podup`) rather than `podup update`, which would break \
+		 the package's record of the file"
+	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn package_managed_error_names_the_manager() {
+		let e = package_managed_error("apt");
+		match e {
+			ComposeError::Update(msg) => {
+				assert!(msg.contains("apt"));
+				assert!(msg.contains("podup update"));
+			}
+			_ => panic!("expected an Update error"),
+		}
+	}
+
+	#[test]
+	fn test_binary_is_not_package_managed() {
+		// The test runner binary lives under target/, which no package owns, so
+		// detection must not false-positive and block updates for normal builds.
+		assert_eq!(managing_package_manager(), None);
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn dpkg_lists_fallback_matches_an_owned_path() {
+		// Simulate dpkg's info dir: a `.list` file naming the binary's path means
+		// the file is package-managed and self-update must refuse.
+		let dir = tempfile::tempdir().unwrap();
+		let owned = Path::new("/usr/bin/podup");
+		std::fs::write(
+			dir.path().join("podup.list"),
+			"/.\n/usr/bin\n/usr/bin/podup\n",
+		)
+		.unwrap();
+		// A non-`.list` file with the same name must be ignored.
+		std::fs::write(dir.path().join("other.md5sums"), "/usr/bin/podup\n").unwrap();
+
+		assert!(dpkg_lists_contain_in(dir.path(), owned));
+		assert!(!dpkg_lists_contain_in(
+			dir.path(),
+			Path::new("/usr/bin/somethingelse")
+		));
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn dpkg_lists_fallback_is_false_without_a_database() {
+		// No dpkg info directory (e.g. Fedora, cargo-install): genuinely not
+		// Debian-managed, so the fallback reports unowned and update proceeds.
+		let dir = tempfile::tempdir().unwrap();
+		let absent = dir.path().join("no-such-info-dir");
+		assert!(!dpkg_lists_contain_in(&absent, Path::new("/usr/bin/podup")));
+	}
+}

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -178,3 +178,34 @@ fn config_no_interpolate_keeps_placeholders_literal() {
 		"--no-interpolate must keep ${{PODUP_TAG}} literal"
 	);
 }
+
+/// `update` only rewrites the podup binary, so the compose-only global value
+/// flags (--socket/--profile/--env-file/--project-directory) cannot affect it.
+/// Passing one on the command line is rejected as a usage error rather than
+/// silently accepted as a no-op — and the rejection happens before any network
+/// access, so the test never reaches GitHub.
+#[test]
+fn update_rejects_compose_only_global_flags() {
+	for flag in [
+		"--socket=unix:///tmp/nope.sock",
+		"--profile=dev",
+		"--env-file=/tmp/nope.env",
+		"--project-directory=/tmp",
+	] {
+		let output = Command::new(bin())
+			.args([flag, "update", "--check"])
+			.env_remove("PODMAN_SOCKET")
+			.env_remove("COMPOSE_PROFILES")
+			.output()
+			.expect("run podup update with a compose-only flag");
+		assert!(
+			!output.status.success(),
+			"`{flag}` must be rejected for update, got success"
+		);
+		let stderr = String::from_utf8_lossy(&output.stderr);
+		assert!(
+			stderr.contains("no effect on `update`"),
+			"rejection should explain the misuse for {flag}; got stderr:\n{stderr}"
+		);
+	}
+}


### PR DESCRIPTION
I swept the `update` (self-update) subsystem and fixed two verified findings. Both are scoped to the update flow; no behaviour changes elsewhere.

- Close fail-open hole in the dpkg package-manager guard (Closes #922)
- Reject compose-only global flags on `update` instead of silently ignoring them (Closes #923)

Details:

- #922: the guard mapped any `dpkg-query` spawn failure to "not package-managed", so a missing/unspawnable `dpkg-query` let self-update clobber an apt-owned binary and desync the dpkg database. I now trust only a `dpkg-query` that actually runs, and fall back to scanning dpkg's on-disk file lists when it can't be spawned -- a non-Debian host (no dpkg database) still updates normally. I split the detection into a new `update::pkg` module to stay under the 500-line file limit.
- #923: `--socket`/`--profile`/`--env-file`/`--project-directory` are global, so they parsed and appeared in `update`'s help despite having no effect on a binary-only self-update. I reject them when passed on the command line for `update` (env-sourced values are left alone, so an exported `PODMAN_SOCKET` doesn't break `podup update`).

Both fixes ship with unit and end-to-end tests. Verified locally: `cargo build`, `cargo fmt --all`, `cargo clippy --lib --bin podup -- -D warnings` (clean), and the unit/parse suites all pass. The container integration suite was not run.
