### PR TITLE
fix(generate-quadlet): resolve verified generate-quadlet sweep findings

### DIFF
--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -74,9 +74,55 @@ pub struct TmpfsOptions {
 	/// Size of the tmpfs mount in bytes.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub size: Option<u64>,
-	/// File mode of the tmpfs mount.
-	#[serde(skip_serializing_if = "Option::is_none")]
+	/// File mode of the tmpfs mount, stored as the actual permission bits.
+	///
+	/// A leading-zero string (`0700`) or an explicit `0o700` is interpreted as
+	/// octal — the conventional Unix file-mode notation — rather than erroring or
+	/// being silently re-interpreted; invalid input is a clear error.
+	#[serde(
+		default,
+		deserialize_with = "deserialize_octal_mode",
+		skip_serializing_if = "Option::is_none"
+	)]
 	pub mode: Option<u32>,
+}
+
+/// Deserialize a tmpfs `mode` as octal-aware permission bits.
+///
+/// YAML numeric scalars are already decoded by the parser (`0o700` → 448), so an
+/// integer node is taken as the actual permission bits. A string node — which is
+/// how a leading-zero literal like `0700` reaches us (and what previously failed
+/// with an opaque untagged error) — is parsed as octal, accepting an optional
+/// `0o` prefix and rejecting non-octal digits with a clear message.
+fn deserialize_octal_mode<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	use serde::de::Error;
+
+	#[derive(Deserialize)]
+	#[serde(untagged)]
+	enum Raw {
+		Int(u32),
+		Str(String),
+	}
+
+	match Option::<Raw>::deserialize(deserializer)? {
+		None => Ok(None),
+		Some(Raw::Int(bits)) => Ok(Some(bits)),
+		Some(Raw::Str(s)) => {
+			let trimmed = s.trim();
+			let digits = trimmed
+				.strip_prefix("0o")
+				.or_else(|| trimmed.strip_prefix("0O"))
+				.unwrap_or(trimmed);
+			u32::from_str_radix(digits, 8).map(Some).map_err(|_| {
+				D::Error::custom(format!(
+					"invalid tmpfs mode {s:?}: use octal notation like 0700 or 0o700"
+				))
+			})
+		}
+	}
 }
 
 /// A volume mount entry — either a short-form string or a long-form typed block.
@@ -248,6 +294,34 @@ impl ServiceSecretRef {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	// TmpfsOptions::mode octal parsing
+
+	#[test]
+	fn tmpfs_mode_octal_string_is_parsed_as_octal() {
+		// A leading-zero literal reaches us as a string and must parse as octal
+		// (0700 → 448 permission bits) instead of failing opaquely.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: \"0700\"\n").unwrap();
+		assert_eq!(opts.mode, Some(0o700));
+		// An explicit 0o prefix in a string also works.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: \"0o755\"\n").unwrap();
+		assert_eq!(opts.mode, Some(0o755));
+	}
+
+	#[test]
+	fn tmpfs_mode_octal_yaml_literal_is_preserved_as_bits() {
+		// A YAML `0o700` scalar is decoded to 448 by the parser; we keep those
+		// actual permission bits so the renderer's octal format round-trips.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: 0o700\n").unwrap();
+		assert_eq!(opts.mode, Some(0o700));
+	}
+
+	#[test]
+	fn tmpfs_mode_invalid_octal_is_clear_error() {
+		// A non-octal string is rejected with a clear error, not silently coerced.
+		let err = serde_yaml::from_str::<TmpfsOptions>("mode: \"0o9\"\n").unwrap_err();
+		assert!(err.to_string().contains("tmpfs mode"), "got: {err}");
+	}
 
 	// VolumeMount::target
 

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -1,7 +1,10 @@
 //! The `generate quadlet` command: turn the compose file into Quadlet units and
 //! either write them to a directory or print them to stdout.
 
+use std::io::Write;
 use std::path::Path;
+
+use podup::compose::types::ComposeFile;
 
 /// Quadlet units are systemd unit files; they only run on Linux hosts (where
 /// systemd consumes them from `~/.config/containers/systemd/`). Generating them
@@ -16,6 +19,55 @@ fn quadlet_platform_advisory(os: &str) -> Option<String> {
 	})
 }
 
+/// Validate the compose file before emitting Quadlet units, applying the same
+/// rules `up`/`create`/`config` enforce so `generate quadlet` is not more
+/// permissive than the commands that actually run the stack. Rejecting here keeps
+/// the generator from emitting structurally invalid units (a `.container` with
+/// no `Image=`, an out-of-range `PublishPort=`, a `--memory` flag with a
+/// malformed size) or a systemd ordering cycle.
+fn validate_for_quadlet(file: &ComposeFile) -> podup::Result<()> {
+	// `depends_on` cycles would emit mutually `After=`/`Requires=` units that
+	// systemd rejects as an ordering cycle; reject them as `up`/`create` do.
+	// A missing dependency is *not* fatal here: an `After=` may legitimately
+	// reference a unit managed outside this project.
+	if let Err(e @ podup::ComposeError::CircularDependency(_)) = podup::compose::resolve_order(file)
+	{
+		return Err(e);
+	}
+	for (name, svc) in &file.services {
+		// Every service must declare an image or a build, the same rule
+		// `config`/`up` enforce; without it the unit would have no `Image=`.
+		if svc.image.is_none() && svc.build.is_none() {
+			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
+		}
+		// Reject malformed/out-of-range ports instead of re-emitting them as an
+		// invalid `PublishPort=`.
+		podup::ports::parse_ports(&svc.ports)?;
+		// Reject a malformed memory limit rather than passing it through to a
+		// `--memory` flag systemd/Podman would choke on.
+		if let Some(mem) = &svc.mem_limit {
+			if podup::size::parse_memory(mem).is_none() {
+				return Err(podup::ComposeError::Unsupported(format!(
+					"service '{name}': mem_limit '{mem}' is not a valid memory size"
+				)));
+			}
+		}
+	}
+	Ok(())
+}
+
+/// Write to stdout, treating a closed pipe (e.g. `podup generate quadlet | head`)
+/// as a clean exit instead of a panic. With `panic = "abort"` the panic from a
+/// raw `println!` on `EPIPE` aborts the process (exit 134) with a spurious
+/// "internal error" message; a Unix tool should just stop quietly.
+fn write_stdout(buf: &str) -> podup::Result<()> {
+	match std::io::stdout().write_all(buf.as_bytes()) {
+		Ok(()) => Ok(()),
+		Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+		Err(e) => Err(e.into()),
+	}
+}
+
 /// Generate Quadlet units from the compose file and either write them to a
 /// directory or print them to stdout. Warnings about unmapped fields go to
 /// stderr so stdout stays clean for piping.
@@ -24,6 +76,9 @@ pub(crate) fn write_quadlet(
 	project: &str,
 	output: Option<&Path>,
 ) -> podup::Result<()> {
+	// Reject configs the running commands would reject, before emitting anything.
+	validate_for_quadlet(file)?;
+
 	let result = podup::quadlet::generate(file, project);
 	if let Some(dup) = result.duplicate_filename() {
 		return Err(std::io::Error::new(
@@ -44,6 +99,7 @@ pub(crate) fn write_quadlet(
 	match output {
 		Some(dir) => {
 			std::fs::create_dir_all(dir)?;
+			let mut progress = String::new();
 			for unit in &result.units {
 				// Defense in depth: the unit stem is already sanitized in the
 				// library, but never write a unit whose name is anything but a
@@ -59,15 +115,18 @@ pub(crate) fn write_quadlet(
 				}
 				let path = dir.join(&unit.filename);
 				std::fs::write(&path, &unit.contents)?;
-				println!("wrote {}", path.display());
+				progress.push_str(&format!("wrote {}\n", path.display()));
 			}
+			write_stdout(&progress)?;
 		}
 		None => {
+			let mut out = String::new();
 			for unit in &result.units {
-				println!("# {}", unit.filename);
-				print!("{}", unit.contents);
-				println!();
+				out.push_str(&format!("# {}\n", unit.filename));
+				out.push_str(&unit.contents);
+				out.push('\n');
 			}
+			write_stdout(&out)?;
 		}
 	}
 	Ok(())
@@ -75,7 +134,8 @@ pub(crate) fn write_quadlet(
 
 #[cfg(test)]
 mod tests {
-	use super::quadlet_platform_advisory;
+	use super::{quadlet_platform_advisory, validate_for_quadlet};
+	use podup::parse_str;
 
 	#[test]
 	fn quadlet_advisory_only_on_non_linux() {
@@ -84,5 +144,53 @@ mod tests {
 			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
 			assert!(msg.contains("systemd"), "advisory names the requirement");
 		}
+	}
+
+	#[test]
+	fn valid_compose_passes_validation() {
+		let file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
+		assert!(validate_for_quadlet(&file).is_ok());
+	}
+
+	#[test]
+	fn service_without_image_or_build_is_rejected() {
+		// `generate quadlet` must reject the same config `config`/`up` reject
+		// rather than emit a `[Container]` with no `Image=`.
+		let file = parse_str("services:\n  web:\n    ports:\n      - \"8080:80\"\n").unwrap();
+		let err = validate_for_quadlet(&file).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::NoImageOrBuild(_)));
+	}
+
+	#[test]
+	fn out_of_range_port_is_rejected() {
+		// A port above u16 must error, not be re-emitted as an invalid PublishPort.
+		let file = parse_str("services:\n  web:\n    image: x\n    ports:\n      - \"70000:80\"\n")
+			.unwrap();
+		assert!(validate_for_quadlet(&file).is_err());
+	}
+
+	#[test]
+	fn malformed_mem_limit_is_rejected() {
+		let file = parse_str("services:\n  web:\n    image: x\n    mem_limit: abc\n").unwrap();
+		let err = validate_for_quadlet(&file).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::Unsupported(_)));
+	}
+
+	#[test]
+	fn dependency_cycle_is_rejected() {
+		// A `depends_on` cycle would emit a systemd ordering cycle; reject it like
+		// `up`/`create` do.
+		let yaml = "services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: x\n    depends_on: [a]\n";
+		let file = parse_str(yaml).unwrap();
+		let err = validate_for_quadlet(&file).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
+	}
+
+	#[test]
+	fn missing_dependency_is_not_fatal() {
+		// An `After=` referencing an externally-managed unit is allowed; only
+		// cycles are rejected.
+		let file = parse_str("services:\n  web:\n    image: x\n    depends_on: [db]\n").unwrap();
+		assert!(validate_for_quadlet(&file).is_ok());
 	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -199,7 +199,12 @@ async fn run() -> podup::Result<()> {
 		kind: GenerateCommands::Quadlet { output },
 	} = &cli.command
 	{
-		return write_quadlet(&file, &project, output.as_deref());
+		// Honor active profiles so `generate quadlet` emits the same services
+		// `up` would start, instead of also emitting units for inactive-profile
+		// services (which would make `--profile` a no-op on this subcommand).
+		let mut filtered = file.clone();
+		podup::retain_active_profiles(&mut filtered, &cli.profile);
+		return write_quadlet(&filtered, &project, output.as_deref());
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -103,6 +103,7 @@ pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 			service,
 			&declared_volumes,
 			&declared_networks,
+			&file.secrets,
 			&mut out.warnings,
 		));
 	}

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -31,16 +31,17 @@ pub(super) fn render_publish_port(p: &ParsedPort) -> String {
 }
 
 /// Render a volume mount into a Quadlet `Volume=` value. A source naming a
-/// declared volume gets a `.volume` suffix (so Quadlet wires it to the generated
-/// unit); an undeclared source passes through verbatim. An empty source renders
-/// as just the target. Long-form `read_only`, SELinux relabel (`z`/`Z`), bind
-/// propagation, and `nocopy` opts are folded into the trailing `:opt,opt` field.
-pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> String {
+/// declared volume gets a project-prefixed `.volume` suffix (so Quadlet wires it
+/// to the generated unit, whose file name is also project-prefixed); an
+/// undeclared source passes through verbatim. An empty source renders as just the
+/// target. Long-form `read_only`, SELinux relabel (`z`/`Z`), bind propagation,
+/// and `nocopy` opts are folded into the trailing `:opt,opt` field.
+pub(super) fn render_volume(vol: &VolumeMount, project: &str, declared_volumes: &[&str]) -> String {
 	match vol {
 		VolumeMount::Short(s) => {
 			let parts: Vec<&str> = s.splitn(3, ':').collect();
 			if parts.len() >= 2 && declared_volumes.contains(&parts[0]) {
-				let mut out = format!("{}.volume:{}", parts[0], parts[1]);
+				let mut out = format!("{}.volume:{}", unit_stem(project, parts[0]), parts[1]);
 				if let Some(opts) = parts.get(2) {
 					out.push(':');
 					out.push_str(opts);
@@ -60,7 +61,7 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 		} => {
 			let src = source.clone().unwrap_or_default();
 			let src = if declared_volumes.contains(&src.as_str()) {
-				format!("{src}.volume")
+				format!("{}.volume", unit_stem(project, &src))
 			} else {
 				src
 			};
@@ -218,11 +219,69 @@ pub(super) fn sanitize_value(value: &str) -> String {
 	value.chars().filter(|c| !c.is_control()).collect()
 }
 
+/// Keys whose value Quadlet/systemd splits on whitespace (a `KEY=VALUE` option
+/// list): an unquoted space would split a single value into a truncated value
+/// plus bogus extra entries, so such values are quoted when they contain
+/// whitespace.
+fn key_is_word_split(key: &str) -> bool {
+	matches!(key, "Environment" | "Label" | "Annotation" | "Sysctl")
+}
+
+/// Keys whose value is an argument line we render (and quote) ourselves
+/// (`PodmanArgs`, `Exec`, `Entrypoint`); systemd must keep splitting these on
+/// whitespace, so they are passed through with only control characters stripped.
+fn key_is_arg_line(key: &str) -> bool {
+	matches!(key, "PodmanArgs" | "Exec" | "Entrypoint")
+}
+
+/// Escape a value for a single-line systemd `Key=Value` entry.
+///
+/// On top of [`sanitize_value`] (control characters stripped so a value can
+/// never inject a second directive) this makes the value byte-faithful to the
+/// compose source the way docker-compose treats it:
+///
+/// * systemd specifiers (`%h`, `%U`, …) are passed through literally by doubling
+///   `%` to `%%`, instead of being expanded at unit-activation time;
+/// * a value ending in a backslash — which would otherwise fold the next
+///   physical line (and the directive on it) into this value — is quoted and the
+///   backslash escaped, closing the line-continuation hole;
+/// * for word-split keys (`Environment`, `Label`, …) a value containing
+///   whitespace is double-quoted so systemd keeps it as one value rather than
+///   splitting it into bogus extra entries.
+///
+/// Argument-line keys keep their own rendering (they encode whitespace splitting
+/// deliberately) and only have control characters stripped.
+pub(super) fn escape_unit_value(key: &str, value: &str) -> String {
+	let stripped = sanitize_value(value);
+	if key_is_arg_line(key) {
+		return stripped;
+	}
+	let escaped = stripped.replace('%', "%%");
+	let needs_quote = (key_is_word_split(key) && escaped.contains(char::is_whitespace))
+		|| escaped.ends_with('\\')
+		|| escaped.starts_with('"');
+	if needs_quote {
+		format!("\"{}\"", escaped.replace('\\', "\\\\").replace('"', "\\\""))
+	} else {
+		escaped
+	}
+}
+
+/// Build the project-prefixed unit-file stem for a resource, e.g. service `web`
+/// in project `proj` → `proj-web`. Generated unit files share a single systemd
+/// directory across projects, so the stem (and every in-unit cross-reference to
+/// it) carries the project name — matching the project-scoped resource names
+/// inside the units — so two projects' `web` services do not clobber each other.
+pub(super) fn unit_stem(project: &str, name: &str) -> String {
+	safe_unit_stem(&format!("{project}-{name}"))
+}
+
 /// Reduce a compose key to a safe single path-component stem for a unit file
 /// name. Keeps ASCII alphanumerics and `-`/`_`/`.`; replaces anything else
 /// (path separators, control characters) with `_`, and guarantees the result
-/// is non-empty and does not start with a dot, so it can never escape the
-/// output directory or resolve to `.`/`..`.
+/// is non-empty and starts with neither a dot nor a dash, so it can never escape
+/// the output directory, resolve to `.`/`..`, or be mistaken for a command-line
+/// flag by downstream tooling that globs the generated file names.
 pub(super) fn safe_unit_stem(name: &str) -> String {
 	let mut stem: String = name
 		.chars()
@@ -234,7 +293,7 @@ pub(super) fn safe_unit_stem(name: &str) -> String {
 			}
 		})
 		.collect();
-	if stem.is_empty() || stem.starts_with('.') {
+	if stem.is_empty() || stem.starts_with('.') || stem.starts_with('-') {
 		stem.insert(0, '_');
 	}
 	stem
@@ -255,10 +314,14 @@ impl Section {
 		}
 	}
 
-	/// Append a `Key=Value` line, sanitizing the value (control characters
-	/// stripped) so a hostile compose field cannot inject extra unit directives.
+	/// Append a `Key=Value` line, escaping the value for systemd unit syntax
+	/// (control characters stripped, specifiers passed through literally,
+	/// whitespace/line-continuation hazards quoted) so a hostile or merely
+	/// awkward compose field cannot inject extra directives, split a value, or
+	/// swallow the following line. See [`escape_unit_value`].
 	pub(super) fn add(&mut self, key: &str, value: String) {
-		self.lines.push(format!("{key}={}", sanitize_value(&value)));
+		self.lines
+			.push(format!("{key}={}", escape_unit_value(key, &value)));
 	}
 
 	/// True when no lines have been added; lets the caller skip emitting an empty
@@ -389,12 +452,16 @@ mod tests {
 
 	#[test]
 	fn render_volume_short_declared_uses_dot_volume_with_options() {
-		let out = render_volume(&VolumeMount::Short("data:/app:ro".into()), &["data"]);
-		// A declared named volume becomes `<name>.volume:<target>:<opts>`.
-		assert_eq!(out, "data.volume:/app:ro");
+		let out = render_volume(
+			&VolumeMount::Short("data:/app:ro".into()),
+			"proj",
+			&["data"],
+		);
+		// A declared named volume becomes `<project>-<name>.volume:<target>:<opts>`.
+		assert_eq!(out, "proj-data.volume:/app:ro");
 		// An undeclared source is passed through verbatim.
 		assert_eq!(
-			render_volume(&VolumeMount::Short("./host:/app".into()), &["data"]),
+			render_volume(&VolumeMount::Short("./host:/app".into()), "proj", &["data"]),
 			"./host:/app"
 		);
 	}
@@ -415,10 +482,11 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		};
-		// Declared → `.volume` suffix; ro + nocopy folded into the options field.
+		// Declared → project-prefixed `.volume` suffix; ro + nocopy folded into
+		// the options field.
 		assert_eq!(
-			render_volume(&nocopy, &["vol"]),
-			"vol.volume:/data:ro,nocopy"
+			render_volume(&nocopy, "proj", &["vol"]),
+			"proj-vol.volume:/data:ro,nocopy"
 		);
 
 		// An empty source renders as just the target (anonymous mount).
@@ -432,7 +500,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		};
-		assert_eq!(render_volume(&anon, &[]), "/scratch");
+		assert_eq!(render_volume(&anon, "proj", &[]), "/scratch");
 	}
 
 	// --- render_tmpfs_mount ---
@@ -473,5 +541,74 @@ mod tests {
 
 		// A non-tmpfs mount returns None so the caller emits a normal Volume=.
 		assert!(render_tmpfs_mount(&VolumeMount::Short("a:/b".into())).is_none());
+	}
+
+	// --- escape_unit_value (bug: incomplete systemd value escaping) ---
+
+	#[test]
+	fn escape_word_split_value_with_whitespace_is_quoted() {
+		// An Environment value with whitespace must be quoted so systemd keeps it
+		// as one value instead of splitting it into bogus extra entries.
+		assert_eq!(
+			escape_unit_value("Environment", "JAVA_OPTS=-Xmx512m -Xms256m"),
+			"\"JAVA_OPTS=-Xmx512m -Xms256m\""
+		);
+		// A Label is word-split too.
+		assert_eq!(
+			escape_unit_value("Label", "note=hello world"),
+			"\"note=hello world\""
+		);
+		// A scalar key that is not word-split keeps whitespace unquoted.
+		assert_eq!(
+			escape_unit_value("Description", "web (podup)"),
+			"web (podup)"
+		);
+	}
+
+	#[test]
+	fn escape_trailing_backslash_is_quoted_and_escaped() {
+		// A value ending in a backslash would otherwise continue onto — and
+		// swallow — the next directive line; it must be quoted and escaped.
+		let out = escape_unit_value("Environment", "WINPATH=C:\\tmp\\");
+		assert!(!out.ends_with('\\') || out.ends_with("\\\""));
+		assert_eq!(out, "\"WINPATH=C:\\\\tmp\\\\\"");
+	}
+
+	#[test]
+	fn escape_percent_is_doubled_for_literal() {
+		// systemd specifiers like %h must be passed through literally, not
+		// expanded at unit-activation time, matching docker-compose semantics.
+		assert_eq!(escape_unit_value("Environment", "HOME=%h"), "HOME=%%h");
+		assert_eq!(escape_unit_value("Image", "img%U"), "img%%U");
+	}
+
+	#[test]
+	fn escape_arg_line_keys_are_left_intact() {
+		// PodmanArgs/Exec/Entrypoint encode their own whitespace splitting and
+		// must not be quoted or have `%` doubled.
+		assert_eq!(
+			escape_unit_value("PodmanArgs", "--security-opt apparmor=foo"),
+			"--security-opt apparmor=foo"
+		);
+		assert_eq!(
+			escape_unit_value("Exec", "sh -c \"echo %s\""),
+			"sh -c \"echo %s\""
+		);
+	}
+
+	#[test]
+	fn safe_unit_stem_strips_leading_dash() {
+		// A name starting with `-`/`--` must not yield a file name beginning with
+		// a dash (a globbing/flag-injection hazard for downstream tooling).
+		assert_eq!(safe_unit_stem("--foo"), "_--foo");
+		assert_eq!(safe_unit_stem("-x"), "_-x");
+		assert!(!safe_unit_stem("--foo").starts_with('-'));
+	}
+
+	#[test]
+	fn unit_stem_is_project_prefixed() {
+		assert_eq!(unit_stem("proj", "web"), "proj-web");
+		// A leading dash in the project still cannot produce a dash-leading stem.
+		assert!(!unit_stem("-p", "web").starts_with('-'));
 	}
 }

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -29,7 +29,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "app.container").contents;
+	let c = &unit_named(&out, "proj-app.container").contents;
 	assert!(c.contains("HostName=app-host"));
 	// `user: "1000:1000"` splits into separate User=/Group= keys.
 	assert!(c.contains("User=1000"));
@@ -62,7 +62,9 @@ fn restart_policies_map_to_systemd() {
 		let file = parse_str(&yaml).unwrap();
 		let out = generate(&file, "p");
 		assert!(
-			unit_named(&out, "s.container").contents.contains(expected),
+			unit_named(&out, "p-s.container")
+				.contents
+				.contains(expected),
 			"{policy} -> {expected}"
 		);
 	}
@@ -83,10 +85,10 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "web.container").contents;
-	assert!(c.contains("After=cache.service"));
-	assert!(c.contains("Wants=cache.service"));
-	assert!(!c.contains("Requires=cache.service"));
+	let c = &unit_named(&out, "proj-web.container").contents;
+	assert!(c.contains("After=proj-cache.service"));
+	assert!(c.contains("Wants=proj-cache.service"));
+	assert!(!c.contains("Requires=proj-cache.service"));
 }
 
 #[test]
@@ -129,7 +131,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "app.container").contents;
+	let c = &unit_named(&out, "p-app.container").contents;
 	for needle in [
 		"ContainerName=custom",
 		"EnvironmentFile=./app.env",
@@ -137,7 +139,6 @@ services:
 		"Sysctl=net.core.somaxconn=1024",
 		"Ulimit=nofile=1024:2048",
 		"ShmSize=64m",
-		"Memory=512m",
 		"PidsLimit=100",
 		"UserNS=keep-id",
 		"StopSignal=SIGTERM",
@@ -147,6 +148,7 @@ services:
 		"AddHost=db:10.0.0.2",
 		"Annotation=run.oci.keep=1",
 		"Network=host",
+		"PodmanArgs=--memory=512m",
 		"HealthCmd=curl -f http://localhost",
 		"HealthInterval=5s",
 		"HealthRetries=3",
@@ -167,7 +169,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PublishPort=80"));
 	assert!(!c.contains("PublishPort=:80"));
 }
@@ -177,7 +179,7 @@ fn user_with_gid_splits_into_user_and_group() {
 	let yaml = "services:\n  s:\n    image: x\n    user: \"1000:2000\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("User=1000"));
 	assert!(c.contains("Group=2000"));
 	assert!(!c.contains("User=1000:2000"));
@@ -202,7 +204,7 @@ secrets:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Secret=tok"));
 	assert!(c.contains("Secret=cred,target=/run/cred,uid=100"));
 	assert!(!out.warnings.iter().any(|w| w.contains("secrets")));
@@ -240,7 +242,7 @@ networks:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	for needle in [
 		"GroupAdd=audio",
 		"ExposeHostPort=8080",
@@ -251,17 +253,18 @@ networks:
 		"LogDriver=journald",
 		"LogOpt=tag=mytag",
 		"NetworkAlias=web-alias",
-		"Memory=256m",
+		"PodmanArgs=--memory=256m",
 	] {
 		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
 	}
 }
 
 #[test]
-fn memory_and_apparmor_render_as_native_keys() {
-	// `Memory=` and `AppArmor=` are valid native [Container] keys in current
-	// podman-systemd.unit(5); they must be emitted directly, not routed through
-	// `PodmanArgs=`.
+fn memory_and_apparmor_render_as_podman_args() {
+	// `Memory=` and `AppArmor=` are not recognised [Container] keys in
+	// podman-systemd.unit(5) (Quadlet drops the whole unit at daemon-reload), so
+	// they must route through `PodmanArgs=` like the CPU limits, not be emitted as
+	// native keys.
 	let yaml = r#"
 services:
   s:
@@ -272,19 +275,19 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
-	assert!(c.contains("Memory=512m"), "missing native Memory= in:\n{c}");
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
-		c.contains("AppArmor=my-profile"),
-		"missing native AppArmor= in:\n{c}"
+		c.contains("PodmanArgs=--memory=512m"),
+		"mem_limit must route through PodmanArgs in:\n{c}"
 	);
-	for forbidden in [
-		"PodmanArgs=--memory=",
-		"PodmanArgs=--security-opt apparmor=",
-	] {
+	assert!(
+		c.contains("PodmanArgs=--security-opt apparmor=my-profile"),
+		"apparmor must route through PodmanArgs in:\n{c}"
+	);
+	for forbidden in ["Memory=512m", "AppArmor=my-profile"] {
 		assert!(
 			!c.contains(forbidden),
-			"memory/apparmor must use the native key, not `{forbidden}` in:\n{c}"
+			"memory/apparmor must not use an unrecognised native key `{forbidden}` in:\n{c}"
 		);
 	}
 }
@@ -305,7 +308,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	for expected in [
 		"PodmanArgs=--cpus=1.5",
 		"PodmanArgs=--cpuset-cpus=0,1",
@@ -332,7 +335,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("PodmanArgs=--cpus=2"),
 		"missing deploy cpus PodmanArgs in:\n{c}"
@@ -356,7 +359,7 @@ networks:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("IP=10.5.0.7"), "missing IP= in:\n{c}");
 	assert!(c.contains("IP6=2001:db8::7"), "missing IP6= in:\n{c}");
 }
@@ -368,7 +371,7 @@ fn network_mode_none_maps_to_network_none() {
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: none\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Network=none"), "missing Network=none in:\n{c}");
 	assert!(
 		!out.warnings.iter().any(|w| w.contains("network_mode")),
@@ -389,7 +392,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("SecurityLabelFileType=usr_t"), "in:\n{c}");
 	assert!(c.contains("SecurityLabelNested=true"), "in:\n{c}");
 	assert!(
@@ -413,7 +416,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Restart=on-failure"), "in:\n{c}");
 	assert!(c.contains("StartLimitBurst=4"), "in:\n{c}");
 	assert!(c.contains("StartLimitIntervalSec=120"), "in:\n{c}");
@@ -424,7 +427,7 @@ fn deploy_restart_condition_none_maps_to_no() {
 	let yaml = "services:\n  s:\n    image: x\n    deploy:\n      restart_policy:\n        condition: none\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	assert!(unit_named(&out, "s.container")
+	assert!(unit_named(&out, "p-s.container")
 		.contents
 		.contains("Restart=no"));
 }
@@ -442,7 +445,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PidsLimit=256"), "missing PidsLimit in:\n{c}");
 }
 
@@ -463,7 +466,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Tmpfs=/cache:size=64000000,mode=755"),
 		"tmpfs not rendered as Tmpfs= with options in:\n{c}"

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -9,7 +9,7 @@ fn container_name_defaults_to_project_prefixed() {
 	// rather than a bare `web` that would collide across projects.
 	let file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
 	let out = generate(&file, "proj");
-	let web = unit_named(&out, "web.container");
+	let web = unit_named(&out, "proj-web.container");
 	assert!(web.contents.contains("ContainerName=proj-web"));
 }
 
@@ -57,7 +57,7 @@ networks:
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
 
-	let web = unit_named(&out, "web.container");
+	let web = unit_named(&out, "proj-web.container");
 	assert!(web.contents.contains("Image=nginx:1.27"));
 	assert!(web.contents.contains("ContainerName=web"));
 	assert!(web.contents.contains("PublishPort=8080:80"));
@@ -66,18 +66,20 @@ networks:
 	let b = web.contents.find("Environment=B_KEY=two").unwrap();
 	assert!(a < b, "environment keys must be sorted");
 	// Declared named volume is tied to its .volume unit.
-	assert!(web.contents.contains("Volume=data.volume:/var/lib/data"));
-	assert!(web.contents.contains("Network=frontend.network"));
+	assert!(web
+		.contents
+		.contains("Volume=proj-data.volume:/var/lib/data"));
+	assert!(web.contents.contains("Network=proj-frontend.network"));
 	// unless-stopped maps to systemd Restart=always.
 	assert!(web.contents.contains("Restart=always"));
-	assert!(web.contents.contains("After=db.service"));
+	assert!(web.contents.contains("After=proj-db.service"));
 	assert!(web.contents.contains("WantedBy=default.target"));
 
-	unit_named(&out, "db.container");
-	assert!(unit_named(&out, "data.volume")
+	unit_named(&out, "proj-db.container");
+	assert!(unit_named(&out, "proj-data.volume")
 		.contents
 		.contains("VolumeName=proj_data"));
-	assert!(unit_named(&out, "frontend.network")
+	assert!(unit_named(&out, "proj-frontend.network")
 		.contents
 		.contains("NetworkName=proj_frontend"));
 }
@@ -100,7 +102,7 @@ services:
 	let build = out
 		.units
 		.iter()
-		.find(|u| u.filename == "app.build")
+		.find(|u| u.filename == "proj-app.build")
 		.expect("a build service must emit an app.build unit");
 	assert!(build.contents.contains("[Build]"));
 	assert!(build.contents.contains("ImageTag=app:latest"));
@@ -110,9 +112,9 @@ services:
 	let container = out
 		.units
 		.iter()
-		.find(|u| u.filename == "app.container")
+		.find(|u| u.filename == "proj-app.container")
 		.unwrap();
-	assert!(container.contents.contains("Image=app.build"));
+	assert!(container.contents.contains("Image=proj-app.build"));
 	assert!(!out.warnings.iter().any(|w| w.contains("build")));
 }
 
@@ -121,7 +123,7 @@ fn inline_dockerfile_build_warns_and_emits_no_build_unit() {
 	let yaml = "services:\n  app:\n    build:\n      dockerfile_inline: \"FROM alpine\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	assert!(!out.units.iter().any(|u| u.filename == "app.build"));
+	assert!(!out.units.iter().any(|u| u.filename == "proj-app.build"));
 	assert!(out.warnings.iter().any(|w| w.contains("dockerfile_inline")));
 }
 
@@ -136,7 +138,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let web = unit_named(&out, "web.container");
+	let web = unit_named(&out, "proj-web.container");
 	assert!(web
 		.contents
 		.contains("Volume=./html:/usr/share/nginx/html:ro"));
@@ -158,8 +160,8 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "db.container").contents;
-	assert!(c.contains("Volume=pgdata.volume:/var/lib/postgresql/data:ro"));
+	let c = &unit_named(&out, "proj-db.container").contents;
+	assert!(c.contains("Volume=proj-pgdata.volume:/var/lib/postgresql/data:ro"));
 }
 
 #[test]
@@ -207,7 +209,7 @@ fn newline_in_value_cannot_inject_unit_directives() {
 		"services:\n  web:\n    image: x\n    environment:\n      EVIL: \"a\\nExecStartPre=/bin/rm -rf /\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "web.container").contents;
+	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(
 		!c.lines().any(|l| l.starts_with("ExecStartPre")),
 		"a newline in a value must not inject a directive line:\n{c}"
@@ -234,12 +236,15 @@ volumes:
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
 	// No unit is generated for external resources.
-	assert!(!out.units.iter().any(|u| u.filename == "extnet.network"));
-	assert!(!out.units.iter().any(|u| u.filename == "extvol.volume"));
+	assert!(!out
+		.units
+		.iter()
+		.any(|u| u.filename == "proj-extnet.network"));
+	assert!(!out.units.iter().any(|u| u.filename == "proj-extvol.volume"));
 	// The container references them by their existing name, not `.network`/`.volume`.
-	let c = &unit_named(&out, "web.container").contents;
+	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(c.contains("Network=extnet"));
-	assert!(!c.contains("Network=extnet.network"));
+	assert!(!c.contains("Network=proj-extnet.network"));
 	assert!(c.contains("Volume=extvol:/data"));
 	assert!(!c.contains("extvol.volume"));
 }
@@ -260,7 +265,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Volume=/host/data:/data:z,rshared"),
 		"selinux/propagation must be preserved; got:\n{c}"
@@ -288,12 +293,12 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let net = &unit_named(&out, "net.network").contents;
+	let net = &unit_named(&out, "p-net.network").contents;
 	assert!(net.contains("Driver=bridge"));
 	assert!(net.contains("Internal=true"));
 	assert!(net.contains("IPv6=true"));
 	assert!(net.contains("Label=tier=net"));
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(vol.contains("Driver=local"));
 	assert!(vol.contains("Label=tier=vol"));
 }
@@ -319,7 +324,7 @@ networks:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let net = &unit_named(&out, "net.network").contents;
+	let net = &unit_named(&out, "p-net.network").contents;
 	// A custom name overrides the project-prefixed default.
 	assert!(net.contains("NetworkName=custom-net"), "in:\n{net}");
 	assert!(!net.contains("NetworkName=p_net"), "in:\n{net}");
@@ -354,7 +359,7 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(vol.contains("VolumeName=custom-vol"), "in:\n{vol}");
 	assert!(!vol.contains("VolumeName=p_vol"), "in:\n{vol}");
 	// `local` driver opts map to dedicated keys; `o` is a single mount-option
@@ -382,7 +387,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("HealthInterval=5s"), "in:\n{c}");
 	assert!(
 		!c.contains("HealthStartupInterval"),
@@ -410,13 +415,13 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let web = &unit_named(&out, "web.container").contents;
-	assert!(web.contains("After=db_1.service"), "in:\n{web}");
-	assert!(web.contains("Requires=db_1.service"), "in:\n{web}");
+	let web = &unit_named(&out, "proj-web.container").contents;
+	assert!(web.contains("After=proj-db_1.service"), "in:\n{web}");
+	assert!(web.contains("Requires=proj-db_1.service"), "in:\n{web}");
 	// The raw, unsanitized name must not leak into the ordering directives.
 	assert!(!web.contains("db:1.service"), "in:\n{web}");
 	// The dependency's own unit really is named with the sanitized stem.
-	unit_named(&out, "db_1.container");
+	unit_named(&out, "proj-db_1.container");
 }
 
 #[test]
@@ -427,10 +432,10 @@ fn network_mode_service_and_container_map_to_dot_container() {
 		let yaml = format!("services:\n  s:\n    image: x\n    network_mode: \"{mode}\"\n");
 		let file = parse_str(&yaml).unwrap();
 		let out = generate(&file, "p");
-		let c = &unit_named(&out, "s.container").contents;
+		let c = &unit_named(&out, "p-s.container").contents;
 		assert!(
-			c.contains(&format!("Network={target}.container")),
-			"{mode} must map to Network={target}.container; got:\n{c}"
+			c.contains(&format!("Network=p-{target}.container")),
+			"{mode} must map to Network=p-{target}.container; got:\n{c}"
 		);
 	}
 }
@@ -440,8 +445,8 @@ fn network_mode_service_target_is_sanitized() {
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:web:1\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
-	assert!(c.contains("Network=web_1.container"), "in:\n{c}");
+	let c = &unit_named(&out, "p-s.container").contents;
+	assert!(c.contains("Network=p-web_1.container"), "in:\n{c}");
 }
 
 #[test]
@@ -457,8 +462,8 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let net = &unit_named(&out, "net.network").contents;
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let net = &unit_named(&out, "p-net.network").contents;
+	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(
 		!net.contains("[Install]") && !net.contains("WantedBy"),
 		".network must carry no [Install]; got:\n{net}"
@@ -468,7 +473,7 @@ volumes:
 		".volume must carry no [Install]; got:\n{vol}"
 	);
 	// The container unit still carries its [Install].
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("[Install]") && c.contains("WantedBy=default.target"));
 }
 
@@ -477,7 +482,7 @@ fn privileged_maps_to_podman_arg() {
 	let yaml = "services:\n  s:\n    image: x\n    privileged: true\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PodmanArgs=--privileged"), "in:\n{c}");
 	assert!(
 		!out.warnings.iter().any(|w| w.contains("privileged")),
@@ -503,7 +508,7 @@ volumes:
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
 
-	let c = &unit_named(&out, "web.container").contents;
+	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(
 		c.contains("Label=podup.project=proj"),
 		"container missing project ownership label in:\n{c}"
@@ -513,7 +518,7 @@ volumes:
 		"container missing service ownership label in:\n{c}"
 	);
 
-	let net = &unit_named(&out, "net.network").contents;
+	let net = &unit_named(&out, "proj-net.network").contents;
 	assert!(
 		net.contains("Label=podup.project=proj"),
 		"network missing project ownership label in:\n{net}"
@@ -524,7 +529,7 @@ volumes:
 		"network must not carry a service label in:\n{net}"
 	);
 
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let vol = &unit_named(&out, "proj-vol.volume").contents;
 	assert!(
 		vol.contains("Label=podup.project=proj"),
 		"volume missing project ownership label in:\n{vol}"

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -6,12 +6,14 @@
 
 use crate::compose::types::{BuildConfig, Service};
 
-use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
-/// The `.build` unit file name for a service, e.g. `web.build`. The container
-/// unit points its `Image=` at this so Quadlet builds then runs.
-pub(crate) fn build_unit_filename(name: &str) -> String {
-	format!("{}.build", safe_unit_stem(name))
+/// The `.build` unit file name for a service, e.g. `proj-web.build`. The
+/// container unit points its `Image=` at this so Quadlet builds then runs; the
+/// stem is project-prefixed so two projects' build units do not clobber each
+/// other in the shared systemd directory.
+pub(crate) fn build_unit_filename(project: &str, name: &str) -> String {
+	format!("{}.build", unit_stem(project, name))
 }
 
 /// Whether `service` yields a `.build` unit — it declares `build:` and that
@@ -88,9 +90,12 @@ pub(crate) fn build_unit(
 			let mut build_args: Vec<(String, Option<String>)> = args.to_map().into_iter().collect();
 			build_args.sort_by(|a, b| a.0.cmp(&b.0));
 			for (key, val) in build_args {
+				// `BuildArg=` is not a recognised [Build] Quadlet key (Quadlet would
+				// drop the whole unit at daemon-reload), so route build args through
+				// PodmanArgs= as `--build-arg`, like the container CPU/memory limits.
 				match val {
-					Some(v) => section.add("BuildArg", format!("{key}={v}")),
-					None => section.add("BuildArg", key),
+					Some(v) => section.add("PodmanArgs", format!("--build-arg {key}={v}")),
+					None => section.add("PodmanArgs", format!("--build-arg {key}")),
 				}
 			}
 			for (key, val) in sorted_label_pairs(labels.to_map()) {
@@ -103,7 +108,7 @@ pub(crate) fn build_unit(
 	section.add("Label", format!("podup.project={project}"));
 
 	Some(QuadletUnit {
-		filename: build_unit_filename(name),
+		filename: build_unit_filename(project, name),
 		contents: section.render(),
 	})
 }

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -1,14 +1,16 @@
 //! Build the `.container` unit for a service.
 
-use crate::compose::types::{PortMapping, RestartPolicy, Service};
+use indexmap::IndexMap;
+
+use crate::compose::types::{RestartPolicy, SecretConfig, Service};
 use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
 use super::health::render_healthcheck;
-use super::security::{map_security_opt, render_secret};
+use super::security::{is_inline_secret, map_security_opt, render_secret};
 use super::{
 	collect_warnings, render_command, render_publish_port, render_restart, render_tmpfs_mount,
-	render_volume, safe_unit_stem, sorted_label_pairs, sorted_pairs, QuadletUnit, Section,
+	render_volume, sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit, Section,
 };
 
 /// Build the `.container` unit for one compose `service`.
@@ -23,15 +25,16 @@ pub(crate) fn container_unit(
 	service: &Service,
 	declared_volumes: &[&str],
 	declared_networks: &[&str],
+	secrets: &IndexMap<String, SecretConfig>,
 	warnings: &mut Vec<String>,
 ) -> QuadletUnit {
 	let mut unit = Section::new("Unit");
 	unit.add("Description", format!("{name} (podup)"));
 	for dep in service.depends_on.service_names() {
-		// The dependency's generated unit is named `{safe_unit_stem(dep)}.container`,
-		// so its service is `{safe_unit_stem(dep)}.service`; reference that, not the
+		// The dependency's generated unit is named `{unit_stem(project, dep)}.container`,
+		// so its service is `{unit_stem(project, dep)}.service`; reference that, not the
 		// raw compose key, or the ordering would target a non-existent unit.
-		let dep_service = format!("{}.service", safe_unit_stem(&dep));
+		let dep_service = format!("{}.service", unit_stem(project, &dep));
 		unit.add("After", dep_service.clone());
 		if service.depends_on.required_for(&dep) {
 			unit.add("Requires", dep_service);
@@ -56,7 +59,7 @@ pub(crate) fn container_unit(
 	// A service with a buildable `build:` references its `.build` unit, so Quadlet
 	// builds the image before running; otherwise the explicit `image:` is used.
 	if super::build::emits_build_unit(service) {
-		container.add("Image", super::build::build_unit_filename(name));
+		container.add("Image", super::build::build_unit_filename(project, name));
 	} else if let Some(image) = &service.image {
 		container.add("Image", image.clone());
 	}
@@ -90,19 +93,13 @@ pub(crate) fn container_unit(
 		container.add("RunInit", "true".to_string());
 	}
 
-	match parse_ports(&service.ports) {
-		Ok(ports) => {
-			for p in ports {
-				container.add("PublishPort", render_publish_port(&p));
-			}
-		}
-		Err(_) => {
-			// Fall back to the raw short forms so nothing is dropped.
-			for port in &service.ports {
-				if let PortMapping::Short(s) = port {
-					container.add("PublishPort", s.clone());
-				}
-			}
+	// Ports are validated (range, format) before generation, so parsing succeeds
+	// here. A malformed/out-of-range mapping is rejected at the command boundary
+	// rather than re-emitted verbatim as an invalid `PublishPort=` — emitting the
+	// raw string would produce a unit Quadlet/Podman would reject anyway.
+	if let Ok(ports) = parse_ports(&service.ports) {
+		for p in ports {
+			container.add("PublishPort", render_publish_port(&p));
 		}
 	}
 
@@ -119,7 +116,7 @@ pub(crate) fn container_unit(
 		if let Some(t) = render_tmpfs_mount(vol) {
 			container.add("Tmpfs", t);
 		} else {
-			container.add("Volume", render_volume(vol, declared_volumes));
+			container.add("Volume", render_volume(vol, project, declared_volumes));
 		}
 	}
 	for net in service.networks.names() {
@@ -127,7 +124,7 @@ pub(crate) fn container_unit(
 		// unit; an external network is referenced by its existing name directly,
 		// since no unit is emitted for it.
 		if declared_networks.contains(&net.as_str()) {
-			container.add("Network", format!("{net}.network"));
+			container.add("Network", format!("{}.network", unit_stem(project, &net)));
 		} else {
 			container.add("Network", net.clone());
 		}
@@ -194,9 +191,11 @@ pub(crate) fn container_unit(
 		container.add("ShmSize", shm.clone());
 	}
 	if let Some(mem) = &service.mem_limit {
-		// `Memory=` is a native [Container] key in current podman-systemd.unit(5);
-		// emit it directly rather than as a raw podman flag.
-		container.add("Memory", mem.clone());
+		// `Memory=` is not a recognised [Container] Quadlet key (Quadlet would drop
+		// the whole unit at daemon-reload), so route the limit through PodmanArgs=
+		// as `--memory`, like the CPU limits. The value is validated as a size
+		// before generation, so it is a well-formed limit here.
+		container.add("PodmanArgs", format!("--memory={mem}"));
 	}
 	// CPU limits have no native [Container] Quadlet key (unlike Memory=/
 	// PidsLimit=), so they go through PodmanArgs=.
@@ -258,7 +257,10 @@ pub(crate) fn container_unit(
 				.strip_prefix("service:")
 				.or_else(|| m.strip_prefix("container:"))
 			{
-				container.add("Network", format!("{}.container", safe_unit_stem(target)));
+				container.add(
+					"Network",
+					format!("{}.container", unit_stem(project, target)),
+				);
 			}
 		}
 		None => {}
@@ -318,11 +320,24 @@ pub(crate) fn container_unit(
 			.and_then(|r| r.limits.as_ref())
 			.and_then(|l| l.memory.as_ref())
 		{
-			container.add("Memory", mem.clone());
+			container.add("PodmanArgs", format!("--memory={mem}"));
 		}
 	}
 	for secret in &service.secrets {
-		container.add("Secret", render_secret(secret));
+		// An inline (`content:`/`environment:`) secret is created by `up` under the
+		// project-scoped name `{project}_secret_{name}`; reference that here so the
+		// generated unit points at the secret `up` would create, not an unscoped
+		// (possibly colliding or non-existent) host secret. Quadlet does not create
+		// the secret itself, so warn the operator to provision it first.
+		let source = secret.source();
+		if is_inline_secret(secrets.get(source)) {
+			warnings.push(format!(
+				"{name}: inline secret {source:?} is referenced but Quadlet does not \
+				 create it; provision the project-scoped secret \"{project}_secret_{source}\" \
+				 first (e.g. via `podup up`)"
+			));
+		}
+		container.add("Secret", render_secret(secret, project, secrets));
 	}
 	render_healthcheck(name, service, &mut container, warnings);
 
@@ -371,7 +386,7 @@ pub(crate) fn container_unit(
 	contents.push_str("\n[Install]\nWantedBy=default.target\n");
 
 	QuadletUnit {
-		filename: format!("{}.container", safe_unit_stem(name)),
+		filename: format!("{}.container", unit_stem(project, name)),
 		contents,
 	}
 }

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -16,7 +16,7 @@ pub(super) use volume::volume_unit;
 // `QuadletUnit` type, re-exported so the unit submodules import them from here.
 use super::render::{
 	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
-	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
+	sorted_label_pairs, sorted_pairs, unit_stem, Section,
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -2,7 +2,7 @@
 
 use crate::compose::types::NetworkConfig;
 
-use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
 /// Build the `.network` unit for one declared network. Emits a single `[Network]`
 /// section (NetworkName, then driver/internal/IPv6/IPAM/options/labels), always
@@ -67,7 +67,7 @@ pub(crate) fn network_unit(
 	// them. Only `.container` units carry [Install].
 	let contents = net.render();
 	QuadletUnit {
-		filename: format!("{}.network", safe_unit_stem(name)),
+		filename: format!("{}.network", unit_stem(project, name)),
 		contents,
 	}
 }

--- a/internal/quadlet/unit/security.rs
+++ b/internal/quadlet/unit/security.rs
@@ -1,6 +1,8 @@
 //! Render service `secrets:` and `security_opt:` onto their Quadlet keys.
 
-use crate::compose::types::ServiceSecretRef;
+use indexmap::IndexMap;
+
+use crate::compose::types::{SecretConfig, ServiceSecretRef};
 
 use super::Section;
 
@@ -13,13 +15,44 @@ pub(super) fn secret_field(value: &str) -> String {
 		.collect()
 }
 
+/// Whether a top-level secret definition is an inline `content:`/`environment:`
+/// source — the kind `up` materialises as a project-scoped native Podman secret.
+/// `external:` wins (never created by podup) and a bare `file:`/empty def is a
+/// bind/host source kept under its compose name.
+pub(super) fn is_inline_secret(def: Option<&SecretConfig>) -> bool {
+	def.is_some_and(|d| {
+		d.external != Some(true) && (d.content.is_some() || d.environment.is_some())
+	})
+}
+
+/// Resolve the `Secret=` source name for a service secret reference. An inline
+/// secret resolves to the project-scoped name `{project}_secret_{name}` that
+/// `up` creates (via `plan::scoped_name`), so generated units reference the same
+/// secret `up` would; any other secret keeps its compose source name.
+fn secret_source_name(
+	project: &str,
+	source: &str,
+	secrets: &IndexMap<String, SecretConfig>,
+) -> String {
+	if is_inline_secret(secrets.get(source)) {
+		format!("{project}_secret_{source}")
+	} else {
+		source.to_string()
+	}
+}
+
 /// Render a service `secrets:` entry into a Quadlet `Secret=` value
-/// (`name[,target=,uid=,gid=,mode=]`).
-pub(super) fn render_secret(secret: &ServiceSecretRef) -> String {
+/// (`name[,target=,uid=,gid=,mode=]`), resolving inline secrets to their
+/// project-scoped name so the reference matches what `up` creates.
+pub(super) fn render_secret(
+	secret: &ServiceSecretRef,
+	project: &str,
+	secrets: &IndexMap<String, SecretConfig>,
+) -> String {
 	match secret {
 		// Sanitize the short-form name too: `Secret=` is an option list, so a
 		// `,`/`=` in the name would inject extra options (same guard as Long).
-		ServiceSecretRef::Short(name) => secret_field(name),
+		ServiceSecretRef::Short(name) => secret_field(&secret_source_name(project, name, secrets)),
 		ServiceSecretRef::Long {
 			source,
 			target,
@@ -30,7 +63,7 @@ pub(super) fn render_secret(secret: &ServiceSecretRef) -> String {
 			// `Secret=` is a comma-separated `key=value` option list, so a `,`
 			// or `=` embedded in any field would inject extra options. Strip
 			// those (and control chars) from each value at the boundary.
-			let mut s = secret_field(source);
+			let mut s = secret_field(&secret_source_name(project, source, secrets));
 			if let Some(t) = target {
 				s.push_str(&format!(",target={}", secret_field(t)));
 			}
@@ -66,9 +99,10 @@ pub(super) fn map_security_opt(
 		.strip_prefix("apparmor=")
 		.or_else(|| opt.strip_prefix("apparmor:"))
 	{
-		// `AppArmor=` is a native [Container] key in current podman-systemd.unit(5);
-		// emit it directly rather than as a raw `--security-opt apparmor=` flag.
-		container.add("AppArmor", profile.to_string());
+		// `AppArmor=` is not a recognised [Container] Quadlet key (Quadlet would
+		// drop the whole unit at daemon-reload), so route it through PodmanArgs= as
+		// `--security-opt apparmor=<profile>`, like the other escape-hatch flags.
+		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
 	} else if let Some(label) = opt.strip_prefix("label=") {
 		if label == "disable" {
 			container.add("SecurityLabelDisable", "true".to_string());
@@ -98,8 +132,15 @@ pub(super) fn map_security_opt(
 
 #[cfg(test)]
 mod tests {
-	use super::{map_security_opt, render_secret, secret_field, Section};
-	use crate::compose::types::ServiceSecretRef;
+	use super::{is_inline_secret, map_security_opt, render_secret, secret_field, Section};
+	use crate::compose::types::{SecretConfig, ServiceSecretRef};
+	use indexmap::IndexMap;
+
+	/// Render a secret with no top-level definitions in scope (so no inline
+	/// scoping applies).
+	fn render_bare(secret: &ServiceSecretRef) -> String {
+		render_secret(secret, "proj", &IndexMap::new())
+	}
 
 	/// Render a fresh `[Container]` section after applying one `security_opt`,
 	/// returning `(rendered_body, warnings)`.
@@ -120,7 +161,7 @@ mod tests {
 	fn render_secret_short_form_sanitizes_name() {
 		// A short-form name with a `,`/`=` would inject extra `Secret=` options.
 		let s = ServiceSecretRef::Short("tok,uid=0".into());
-		assert_eq!(render_secret(&s), "tokuid0");
+		assert_eq!(render_bare(&s), "tokuid0");
 	}
 
 	#[test]
@@ -134,7 +175,7 @@ mod tests {
 			mode: Some(0o440),
 		};
 		assert_eq!(
-			render_secret(&s),
+			render_bare(&s),
 			"tok,target=/run/tok,uid=1000,gid=1000,mode=440"
 		);
 	}
@@ -149,7 +190,7 @@ mod tests {
 			gid: None,
 			mode: None,
 		};
-		let out = render_secret(&s);
+		let out = render_bare(&s);
 		// The injected `,uid=0` must be flattened into the target value, not a
 		// separate option: exactly one comma (the legitimate `,target=`).
 		assert_eq!(out.matches(',').count(), 1);
@@ -177,13 +218,57 @@ mod tests {
 		assert!(map_one("seccomp=/etc/seccomp.json")
 			.0
 			.contains("SeccompProfile=/etc/seccomp.json"));
-		// Both `apparmor=` and `apparmor:` map to the native AppArmor key.
+		// `AppArmor=` is not a recognised Quadlet key, so both `apparmor=` and
+		// `apparmor:` route through PodmanArgs= as a `--security-opt` flag.
 		assert!(map_one("apparmor=docker-default")
 			.0
-			.contains("AppArmor=docker-default"));
+			.contains("PodmanArgs=--security-opt apparmor=docker-default"));
 		assert!(map_one("apparmor:unconfined")
 			.0
-			.contains("AppArmor=unconfined"));
+			.contains("PodmanArgs=--security-opt apparmor=unconfined"));
+	}
+
+	#[test]
+	fn inline_secret_resolves_to_project_scoped_name() {
+		// An inline (`content:`) secret must reference the project-scoped name
+		// `up` creates, not the bare compose name.
+		let mut defs = IndexMap::new();
+		defs.insert(
+			"tok".to_string(),
+			SecretConfig {
+				content: Some("s3cr3t".into()),
+				..Default::default()
+			},
+		);
+		assert!(is_inline_secret(defs.get("tok")));
+		let s = ServiceSecretRef::Short("tok".into());
+		assert_eq!(render_secret(&s, "proj", &defs), "proj_secret_tok");
+
+		// A file-based secret keeps its compose name (it is a host source, not a
+		// project-scoped native secret).
+		let mut file_defs = IndexMap::new();
+		file_defs.insert(
+			"tok".to_string(),
+			SecretConfig {
+				file: Some("./tok.txt".into()),
+				..Default::default()
+			},
+		);
+		assert!(!is_inline_secret(file_defs.get("tok")));
+		assert_eq!(render_secret(&s, "proj", &file_defs), "tok");
+
+		// An external secret is referenced by its existing name, never scoped.
+		let mut ext_defs = IndexMap::new();
+		ext_defs.insert(
+			"tok".to_string(),
+			SecretConfig {
+				external: Some(true),
+				content: Some("ignored".into()),
+				..Default::default()
+			},
+		);
+		assert!(!is_inline_secret(ext_defs.get("tok")));
+		assert_eq!(render_secret(&s, "proj", &ext_defs), "tok");
 	}
 
 	#[test]

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -2,7 +2,7 @@
 
 use crate::compose::types::VolumeConfig;
 
-use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
 /// Build the `.volume` unit for one declared named volume. Emits a single
 /// `[Volume]` section (VolumeName, then driver/driver-opts/labels), always
@@ -45,7 +45,7 @@ pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfi
 	// them. Only `.container` units carry [Install].
 	let contents = vol.render();
 	QuadletUnit {
-		filename: format!("{}.volume", safe_unit_stem(name)),
+		filename: format!("{}.volume", unit_stem(project, name)),
 		contents,
 	}
 }

--- a/internal/size.rs
+++ b/internal/size.rs
@@ -81,6 +81,11 @@ pub fn parse_duration_secs(s: &str) -> Option<u64> {
 		"h" => num * 3600.0,
 		_ => return None,
 	};
+	// Reject non-finite or out-of-range results rather than saturating the cast
+	// (e.g. `1e24s` would otherwise become u64::MAX and emit a garbage timeout).
+	if !secs.is_finite() || secs < 0.0 || secs > u64::MAX as f64 {
+		return None;
+	}
 	Some(secs as u64)
 }
 
@@ -255,6 +260,14 @@ mod tests {
 	#[test]
 	fn duration_secs_unknown_suffix_is_none() {
 		assert_eq!(parse_duration_secs("5d"), None);
+	}
+
+	#[test]
+	fn duration_secs_out_of_range_is_none() {
+		// A value whose seconds product exceeds u64::MAX must return None rather
+		// than saturating the cast to u64::MAX.
+		assert_eq!(parse_duration_secs("1e24"), None);
+		assert_eq!(parse_duration_secs("1e24h"), None);
 	}
 
 	// parse_duration_nanos

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -129,6 +129,10 @@ pub(crate) fn render_config(
 		if svc.image.is_none() && svc.build.is_none() {
 			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
 		}
+		// Reject malformed/out-of-range port mappings (e.g. `70000:80`) here too,
+		// so `config` validates them rather than accepting a mapping `up` and
+		// `generate quadlet` would reject.
+		podup::ports::parse_ports(&svc.ports)?;
 	}
 	if quiet {
 		return Ok(());

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -48,16 +48,16 @@ networks:
 	let expected = "\
 [Unit]
 Description=web (podup)
-After=db.service
-Requires=db.service
+After=proj-db.service
+Requires=proj-db.service
 
 [Container]
 ContainerName=web
 Image=nginx:1.27
 PublishPort=8080:80
 Environment=TZ=UTC
-Volume=data.volume:/var/lib/data
-Network=frontend.network
+Volume=proj-data.volume:/var/lib/data
+Network=proj-frontend.network
 Label=podup.project=proj
 Label=podup.service=web
 
@@ -67,7 +67,7 @@ Restart=always
 [Install]
 WantedBy=default.target
 ";
-	assert_eq!(unit(&out, "web.container"), expected);
+	assert_eq!(unit(&out, "proj-web.container"), expected);
 }
 
 #[test]
@@ -85,11 +85,11 @@ networks:
 	let out = generate(&file, "myproj");
 
 	assert_eq!(
-		unit(&out, "cache.volume"),
+		unit(&out, "myproj-cache.volume"),
 		"[Volume]\nVolumeName=myproj_cache\nLabel=podup.project=myproj\n"
 	);
 	assert_eq!(
-		unit(&out, "backend.network"),
+		unit(&out, "myproj-backend.network"),
 		"[Network]\nNetworkName=myproj_backend\nLabel=podup.project=myproj\n"
 	);
 }
@@ -108,15 +108,25 @@ fn cli_writes_units_to_output_dir() {
 	let out_dir = dir.join("units");
 
 	let status = Command::new(bin())
-		.args(["-f", compose.to_str().unwrap(), "generate", "quadlet", "-o"])
+		.args([
+			"-p",
+			"proj",
+			"-f",
+			compose.to_str().unwrap(),
+			"generate",
+			"quadlet",
+			"-o",
+		])
 		.arg(&out_dir)
 		.status()
 		.unwrap();
 	assert!(status.success());
 
-	let web = fs::read_to_string(out_dir.join("web.container")).unwrap();
+	// Unit file names are project-prefixed so multiple projects can share the
+	// systemd directory without clobbering each other.
+	let web = fs::read_to_string(out_dir.join("proj-web.container")).unwrap();
 	assert!(web.contains("Image=nginx"));
-	assert!(fs::read_to_string(out_dir.join("data.volume"))
+	assert!(fs::read_to_string(out_dir.join("proj-data.volume"))
 		.unwrap()
 		.contains("VolumeName="));
 
@@ -132,12 +142,19 @@ fn cli_prints_units_to_stdout() {
 	fs::write(&compose, "services:\n  web:\n    image: nginx\n").unwrap();
 
 	let output = Command::new(bin())
-		.args(["-f", compose.to_str().unwrap(), "generate", "quadlet"])
+		.args([
+			"-p",
+			"proj",
+			"-f",
+			compose.to_str().unwrap(),
+			"generate",
+			"quadlet",
+		])
 		.output()
 		.unwrap();
 	assert!(output.status.success());
 	let stdout = String::from_utf8(output.stdout).unwrap();
-	assert!(stdout.contains("# web.container"));
+	assert!(stdout.contains("# proj-web.container"));
 	assert!(stdout.contains("Image=nginx"));
 
 	let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
I went through the verified `generate quadlet` findings and fixed every one. The
common thread: the quadlet exporter was emitting units that Quadlet drops at
`systemctl daemon-reload`, was more permissive than `up`/`config`, and had a few
rendering/robustness bugs. Each fix has unit/parse-level coverage; the container
integration suite was not run.

Fixed:

- Route Memory/AppArmor/BuildArg through PodmanArgs= (they are not recognized native keys on Podman 5.4.2) (Closes #723)
- Escape systemd unit values properly: quote whitespace, neutralize trailing backslashes, double `%` so specifiers stay literal (Closes #724)
- Honor active profiles in `generate quadlet` so `--profile` is no longer a no-op (Closes #799)
- Reject a service with no image or build, matching `config`/`up` (Closes #800)
- Reject `depends_on` cycles before emitting an ordering cycle (Closes #801)
- Handle a closed stdout pipe gracefully instead of aborting with exit 134 (Closes #802)
- Resolve inline secrets to the project-scoped `{project}_secret_{name}` and warn the operator (Closes #803)
- Reject out-of-range ports in both `generate quadlet` and `config` instead of emitting an invalid PublishPort (Closes #804)
- Parse tmpfs `mode` as octal-aware permission bits with a clear error on bad input (Closes #917)
- Prefix generated unit file names (and in-unit cross-references) with the project so projects don't clobber each other in the shared systemd dir (Closes #918)
- Neutralize a leading dash in unit file stems (globbing/flag-injection hazard) (Closes #919)
- Reject out-of-range durations instead of saturating to u64::MAX (Closes #920)
- Validate `mem_limit` as a size before emission (Closes #921)

Verification: `cargo build`, `cargo fmt --all`, `cargo clippy` (clean on the
touched code; the only clippy error is a pre-existing unused import in the
off-limits `engine_integration` suite), `cargo test --lib --bins` plus the
parse/quadlet/ports/size/secret_safety/cli suites — all green.
