### PR TITLE
fix: resolve deferred-safe sweep findings (#870, #885)

### DIFF
--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -1,0 +1,164 @@
+//! Label-scoped teardown: `down` with no compose file present.
+//!
+//! [`Engine::down_with_options`] walks the parsed service graph, so it needs a
+//! compose file. `docker compose -p NAME down` must also tear a *running*
+//! project down purely from its `podup.project` label when that file is absent
+//! (e.g. it was deleted, or you only have the project name). This module reaps
+//! every labelled container, network, named volume and internal secret without
+//! reading a single service definition.
+
+use tracing::info;
+
+use crate::compose::types::ComposeFile;
+use crate::error::Result;
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::Engine;
+
+/// Shutdown grace (seconds) for the label-only teardown, used when the CLI
+/// `-t/--timeout` override is unset. There is no service definition to read a
+/// `stop_grace_period` from, so this falls back to docker compose's default.
+const DEFAULT_STOP_GRACE_SECS: i32 = 10;
+
+impl Engine {
+	/// Tear a project down purely from its `podup.project` label, with no compose
+	/// file: stop and force-remove every labelled container (and, with
+	/// `remove_volumes`, their anonymous volumes), then sweep the project's
+	/// networks, named volumes and internal secrets by label.
+	///
+	/// Mirrors `docker compose -p NAME down` against a running project whose
+	/// compose file is absent. Unlike [`Engine::down_with_options`], which works
+	/// through the parsed service graph, this enumerates everything by label, so
+	/// it reaps all of the project's resources regardless of whether a file would
+	/// parse. Best-effort throughout: a missing resource (404) is an idempotent
+	/// no-op and an individual delete failure is logged, not fatal.
+	pub async fn down_by_label(&self, remove_volumes: bool) -> Result<()> {
+		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);
+		for container_name in self.list_project_container_names(None).await? {
+			let stop_path = format!(
+				"{API_PREFIX}/containers/{}/stop?t={}",
+				urlencoded(&container_name),
+				super::targets::stop_timeout_param(grace),
+			);
+			// A 404 (already gone) is an idempotent no-op, like the network/volume
+			// arms below; the force-remove that follows SIGKILLs a stubborn one.
+			if let Err(e) = self
+				.client
+				.post_empty_ok_within(&stop_path, super::targets::stop_deadline(grace))
+				.await
+			{
+				if !e.is_status(404) {
+					tracing::warn!("could not stop {container_name}: {e}");
+				}
+			}
+
+			let rm_path = super::container_rm_path(&container_name, remove_volumes);
+			match self.client.delete_ok(&rm_path).await {
+				Ok(()) => info!("removed {container_name}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
+			}
+		}
+
+		// Networks, named volumes and internal secrets are all reaped by label.
+		self.remove_project_networks_by_label().await;
+		if remove_volumes {
+			self.remove_project_volumes_by_label().await;
+		}
+		// An empty file carries no declared secrets/configs, so this falls straight
+		// through to the by-label orphan sweep that already backs `down`.
+		self.remove_internal_secrets(&ComposeFile::default())
+			.await?;
+		Ok(())
+	}
+
+	/// Remove every network carrying this project's `podup.project` label — the
+	/// implicit `<project>_default`, a network whose compose key changed, or any
+	/// project network when no file is present. Only podup-labelled networks
+	/// match, so a user's external network is never touched. Best-effort: a list
+	/// failure leaves networks in place rather than aborting teardown.
+	///
+	/// Shared by [`Engine::down_with_options`] and [`Engine::down_by_label`].
+	pub(super) async fn remove_project_networks_by_label(&self) {
+		let net_filters =
+			serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
+		let list_path = format!(
+			"{API_PREFIX}/networks/json?filters={}",
+			urlencoded(&net_filters.to_string()),
+		);
+		let Ok(nets) = self
+			.client
+			.get_json::<Vec<serde_json::Value>>(&list_path)
+			.await
+		else {
+			return;
+		};
+		for net in nets {
+			let Some(net_name) = net.get("name").and_then(|n| n.as_str()) else {
+				continue;
+			};
+			let del = format!("{API_PREFIX}/networks/{}", urlencoded(net_name));
+			match self.client.delete_ok(&del).await {
+				Ok(_) => info!("removed network {net_name}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove network {net_name}: {e}"),
+			}
+		}
+	}
+
+	/// Remove every named volume carrying this project's `podup.project` label.
+	/// libpod's `/volumes/json` is fetched in full and filtered client-side by
+	/// the label (mirroring the secret sweep) so only podup-created volumes are
+	/// deleted — a user's hand-made or external volume is never touched.
+	/// Best-effort: a list failure leaves volumes in place.
+	pub(super) async fn remove_project_volumes_by_label(&self) {
+		let path = format!("{API_PREFIX}/volumes/json");
+		let Ok(vols) = self.client.get_json::<Vec<serde_json::Value>>(&path).await else {
+			return;
+		};
+		for vol in vols {
+			if !volume_owned_by(&vol, &self.project) {
+				continue;
+			}
+			let Some(name) = vol.get("Name").and_then(|n| n.as_str()) else {
+				continue;
+			};
+			let del = format!("{API_PREFIX}/volumes/{}", urlencoded(name));
+			match self.client.delete_ok(&del).await {
+				Ok(_) => info!("removed volume {name}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove volume {name}: {e}"),
+			}
+		}
+	}
+}
+
+/// Whether a `/volumes/json` entry carries the `podup.project=<project>` label,
+/// i.e. it is a volume podup created for this project. Pure so the ownership
+/// check is unit-tested without a live Podman socket.
+fn volume_owned_by(vol: &serde_json::Value, project: &str) -> bool {
+	vol.get("Labels")
+		.and_then(|l| l.get("podup.project"))
+		.and_then(|v| v.as_str())
+		== Some(project)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::volume_owned_by;
+
+	#[test]
+	fn volume_owned_by_matches_project_label() {
+		let vol = serde_json::json!({
+			"Name": "proj_data",
+			"Labels": { "podup.project": "proj", "extra": "1" },
+		});
+		assert!(volume_owned_by(&vol, "proj"));
+		// A different project's volume, or one podup never labelled, is not ours.
+		assert!(!volume_owned_by(&vol, "other"));
+		let unlabelled = serde_json::json!({ "Name": "loose", "Labels": {} });
+		assert!(!volume_owned_by(&unlabelled, "proj"));
+		let no_labels = serde_json::json!({ "Name": "loose" });
+		assert!(!volume_owned_by(&no_labels, "proj"));
+	}
+}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -1,6 +1,7 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
 mod commands;
+mod down_label;
 mod run;
 mod scale;
 mod signal;
@@ -512,32 +513,7 @@ impl Engine {
 		// network whose compose key changed — mirroring the container sweep so
 		// teardown is complete regardless of how the file was parsed. Only
 		// podup-labelled networks match, so external networks are never touched.
-		let net_filters =
-			serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
-		let list_path = format!(
-			"{API_PREFIX}/networks/json?filters={}",
-			crate::libpod::urlencoded(&net_filters.to_string()),
-		);
-		if let Ok(nets) = self
-			.client
-			.get_json::<Vec<serde_json::Value>>(&list_path)
-			.await
-		{
-			for net in nets {
-				let Some(net_name) = net.get("name").and_then(|n| n.as_str()) else {
-					continue;
-				};
-				let del = format!(
-					"{API_PREFIX}/networks/{}",
-					crate::libpod::urlencoded(net_name)
-				);
-				match self.client.delete_ok(&del).await {
-					Ok(_) => info!("removed network {net_name}"),
-					Err(e) if e.is_status(404) => {}
-					Err(e) => tracing::warn!("could not remove network {net_name}: {e}"),
-				}
-			}
-		}
+		self.remove_project_networks_by_label().await;
 
 		if remove_volumes {
 			for (key, config) in &file.volumes {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -132,6 +132,15 @@ fn command_failure_exit_code(msg: &str) -> i32 {
 	}
 }
 
+/// Whether a `down` invocation should tear the project down purely by its
+/// `podup.project` label: the command is `down`, an explicit project name was
+/// given (`-p` / `COMPOSE_PROJECT_NAME`), and no compose file resolves on disk.
+/// Matches `docker compose -p NAME down` against a running project whose compose
+/// file is absent. Pure so it is unit-testable without a Podman daemon.
+fn down_by_label_path(command: &Commands, project: Option<&str>, compose_present: bool) -> bool {
+	matches!(command, Commands::Down { .. }) && project.is_some() && !compose_present
+}
+
 /// Print a top-level error to stderr with a colour-aware bold-red `error:` label.
 /// anstream strips the styling when stderr is not a terminal or colour is off.
 fn print_error(e: &podup::ComposeError) {
@@ -309,6 +318,48 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
+
+	// `down -p NAME` must tear a running project down purely from its
+	// `podup.project` label when no compose file is present — matching `docker
+	// compose -p NAME down`. The startup flow otherwise parses the compose file
+	// before dispatch, so a label-only teardown by project name fails on the
+	// missing file. Handle it here, before that parse, but only when an explicit
+	// project name was given and no file resolves, so a stray `down` in an empty
+	// directory still errors rather than guessing a project from the basename.
+	if down_by_label_path(
+		&cli.command,
+		cli.project.as_deref(),
+		compose_files.iter().any(|p| p.is_file()),
+	) {
+		if let Commands::Down {
+			volumes,
+			rmi,
+			timeout,
+			..
+		} = &cli.command
+		{
+			let project = cli.project.clone().expect("checked by down_by_label_path");
+			startup::validate_project_name(&project)?;
+			// `--rmi` removes the images of the file's services, which cannot be
+			// resolved without a file; warn rather than silently dropping it.
+			if rmi.is_some() {
+				tracing::warn!(
+					"--rmi has no effect without a compose file; containers, networks and \
+					 volumes are still removed by project label"
+				);
+			}
+			let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+			let stop_timeout = podup::validate_stop_timeout(*timeout)?;
+			let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+			let engine = podup::Engine::with_base_dir(client, project, base_dir)
+				.with_stop_timeout(stop_timeout);
+			// `down` is mutating, so serialize it against concurrent runs as the
+			// normal teardown path does.
+			let _lock = engine.lock_project()?;
+			return engine.down_by_label(*volumes).await;
+		}
+	}
+
 	// `config --no-interpolate` must skip interpolation *entirely*: parsing with
 	// interpolation enabled would evaluate a required-var `${VAR:?msg}` and fail
 	// before we ever reached the no-interpolate branch. Detect it up front so the
@@ -468,6 +519,42 @@ async fn run() -> podup::Result<()> {
 	};
 
 	dispatch::dispatch(&engine, &file, cli.command, &cli.profile).await
+}
+
+#[cfg(test)]
+mod down_by_label_tests {
+	use super::down_by_label_path;
+	use crate::cli::Commands;
+
+	fn down() -> Commands {
+		Commands::Down {
+			volumes: false,
+			remove_orphans: false,
+			rmi: None,
+			timeout: None,
+		}
+	}
+
+	#[test]
+	fn down_with_project_and_no_file_takes_label_path() {
+		// `down -p NAME` with no compose file present is the label-only teardown.
+		assert!(down_by_label_path(&down(), Some("proj"), false));
+	}
+
+	#[test]
+	fn down_without_project_or_with_file_does_not() {
+		// Without an explicit project name there is nothing to scope the teardown to,
+		// and when a file is present the normal compose-parse path handles `down`.
+		assert!(!down_by_label_path(&down(), None, false));
+		assert!(!down_by_label_path(&down(), Some("proj"), true));
+	}
+
+	#[test]
+	fn other_commands_never_take_the_down_label_path() {
+		// Only `down` is routed by label here; another command with `-p` and no file
+		// must not be diverted.
+		assert!(!down_by_label_path(&Commands::Watch, Some("proj"), false));
+	}
 }
 
 #[cfg(test)]

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -154,6 +154,18 @@ pub fn build_vars_with_env_files_strict(
 	build_vars_with_env_files_inner(dir, extra, true)
 }
 
+/// The first control character in `value` that is never legitimate in an
+/// env-file value, or `None` if there is none. Tab, newline and carriage return
+/// are allowed — dotenv escapes (`\t`, `\n`, `\r`) and multi-line quoted values
+/// produce them legitimately, and post-parse interpolation stores them verbatim
+/// as scalar data. Everything else in the C0/C1 ranges (NUL, ESC, …) is
+/// rejected. Pure so it is unit-tested.
+fn first_disallowed_control_char(value: &str) -> Option<char> {
+	value
+		.chars()
+		.find(|&c| c.is_control() && !matches!(c, '\t' | '\n' | '\r'))
+}
+
 fn build_vars_with_env_files_inner(
 	dir: &Path,
 	extra: &[String],
@@ -189,6 +201,24 @@ fn build_vars_with_env_files_inner(
 			crate::dotenv::parse(&content)
 		};
 		for (key, value) in pairs {
+			// A disallowed control character (e.g. NUL) in a value would be
+			// interpolated verbatim into a compose scalar, where it is meaningless
+			// at best and corrupts the container's config at worst. Reject it here,
+			// at load time, with an error that names the originating env file and
+			// key — instead of letting it surface later as a compose-file parse
+			// error at a meaningless post-substitution offset. Only the explicit
+			// (strict) `--env-file`/`env_file:` path errors; the lenient `.env`
+			// fallback keeps its historical pass-through behaviour.
+			if strict {
+				if let Some(bad) = first_disallowed_control_char(&value) {
+					return Err(crate::error::ComposeError::EnvFile(format!(
+						"env file {}: value of '{key}' contains a disallowed control \
+						 character ({}); remove it before use",
+						abs.display(),
+						bad.escape_default(),
+					)));
+				}
+			}
 			file_vars.insert(key, value);
 		}
 	}
@@ -643,5 +673,55 @@ mod tests {
 		// silently skipped rather than failing.
 		let vars = build_vars_with_env_files(dir.path(), &["absent.env".to_string()]);
 		assert!(!vars.contains_key("FROM_EXTRA"));
+	}
+
+	#[test]
+	fn first_disallowed_control_char_allows_tab_newline_cr() {
+		// Legitimate dotenv escapes / multi-line values must pass.
+		assert_eq!(first_disallowed_control_char("plain value"), None);
+		assert_eq!(first_disallowed_control_char("a\tb\nc\rd"), None);
+		// NUL, ESC and other C0/C1 controls are rejected.
+		assert_eq!(first_disallowed_control_char("a\0b"), Some('\0'));
+		assert_eq!(first_disallowed_control_char("x\x1by"), Some('\x1b'));
+	}
+
+	#[test]
+	fn strict_build_vars_errors_on_control_char_value_naming_file_and_key() {
+		let dir = tempfile::tempdir().unwrap();
+		// A NUL in an env-file value is rejected at load time, before any compose
+		// parse, with an error that names the originating env file and key — not a
+		// misattributed parse offset into the post-substitution document (#885).
+		std::fs::write(dir.path().join("bad.env"), "SECRET=ab\0cd\n").unwrap();
+		let err =
+			build_vars_with_env_files_strict(dir.path(), &["bad.env".to_string()]).unwrap_err();
+		assert!(
+			matches!(err, crate::error::ComposeError::EnvFile(_)),
+			"expected EnvFile error, got {err:?}"
+		);
+		let msg = err.to_string();
+		assert!(msg.contains("bad.env"), "names the env file: {msg}");
+		assert!(msg.contains("SECRET"), "names the offending key: {msg}");
+		assert!(
+			msg.contains("control"),
+			"explains the control-char cause: {msg}"
+		);
+	}
+
+	#[test]
+	fn strict_build_vars_allows_multiline_and_tab_values() {
+		let dir = tempfile::tempdir().unwrap();
+		// A multi-line quoted value (real newline) and a `\t` escape are legitimate
+		// and must not be rejected by the control-char guard.
+		std::fs::write(
+			dir.path().join("ok.env"),
+			"MULTI=\"line one\nline two\"\nTABBED=\"a\\tb\"\n",
+		)
+		.unwrap();
+		let vars = build_vars_with_env_files_strict(dir.path(), &["ok.env".to_string()]).unwrap();
+		assert_eq!(
+			vars.get("MULTI").map(String::as_str),
+			Some("line one\nline two")
+		);
+		assert_eq!(vars.get("TABBED").map(String::as_str), Some("a\tb"));
 	}
 }


### PR DESCRIPTION
I picked up two deferred sweep findings that are now safe to land.

## `down -p NAME` with no compose file (#870)

`down` parsed the compose file before dispatch, so a label-only teardown by
project name failed with "compose file not found" when no file existed —
diverging from `docker compose -p NAME down`. I added an early label-only path:
when `down` is given an explicit project name (`-p` / `COMPOSE_PROJECT_NAME`)
and no compose file resolves on disk, I build the engine, take the project
lock, and tear the project down purely from its `podup.project` label.

The new `Engine::down_by_label` stops and force-removes every labelled
container (with `-v`, their anonymous volumes too), then sweeps the project's
networks, named volumes and internal secrets by label. I factored the network
label-sweep out of `down_with_options` so both paths share it. Only
podup-labelled resources are touched, so a user's external network/volume is
never removed. `--rmi` warns (images can't be resolved without a file) but
everything else is still reaped. The normal path (file present, or no `-p`) is
unchanged.

## Env-file control-char error attribution (#885)

A control character (e.g. NUL) in a `--env-file` value was interpolated
verbatim into a compose scalar; if it later tripped the parser, the error
pointed at a meaningless offset in the post-substitution document and blamed
the compose file rather than the env file it came from. I now validate
env-file values for disallowed control characters at load time, in the strict
`--env-file` / `env_file:` path, and reject them with an error that names the
originating env file and key. Tab, newline and carriage return stay allowed —
dotenv escapes (\t, \n, \r) and multi-line quoted values produce them
legitimately. The lenient `.env` fallback keeps its historical pass-through
behaviour.

## Notes

- Both fixes carry unit tests that need no live Podman daemon (the label-query
  / dispatch construction for #870, the pure control-char guard plus an
  env-file round-trip for #885).
- No public API change — `cargo semver-checks check-release` reports no semver
  update required.

Closes #870
Closes #885
