### PR TITLE
fix: repair up --build image tag and align integration tests

### DIFF
--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -11,6 +11,9 @@ mod push;
 mod tags;
 pub use pull::PullOptions;
 pub use push::PushOptions;
+/// Shared with the container-create path so an `up`/`create` references the same
+/// image tag the build step produced for a build-only service.
+pub(crate) use tags::primary_build_tag;
 
 use bytes::Bytes;
 use futures_util::StreamExt;
@@ -24,7 +27,7 @@ use crate::libpod::API_PREFIX;
 use crate::size;
 
 use context::{build_context_tar, build_context_tar_with_inline, map_additional_context};
-use tags::{is_remote_context, looks_like_secret, primary_build_tag};
+use tags::{is_remote_context, looks_like_secret};
 
 use super::Engine;
 

--- a/internal/engine/build/tags.rs
+++ b/internal/engine/build/tags.rs
@@ -19,7 +19,7 @@ pub(super) fn is_remote_context(context: &str) -> bool {
 /// compose) so two projects sharing a service name don't overwrite each other's
 /// image. Any remaining `build.tags` are applied as extra tags by
 /// [`super::Engine::apply_extra_tags`].
-pub(super) fn primary_build_tag(
+pub(crate) fn primary_build_tag(
 	project: &str,
 	service_name: &str,
 	image: Option<&str>,

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -52,8 +52,14 @@ impl Engine {
 		let derived_image;
 		let image: &str = if let Some(img) = service.image.as_deref() {
 			img
-		} else if service.build.is_some() {
-			derived_image = format!("{}:latest", service_name);
+		} else if let Some(build) = service.build.as_ref() {
+			// No `image:` — reference the exact tag the build step produced for this
+			// build-only service (project-scoped `{project}-{service}:latest`, or
+			// the first `build.tags` entry). Must stay in lockstep with
+			// `primary_build_tag`, or `up --build` creates the container against a
+			// name no built image carries (HTTP 404: no such image).
+			derived_image =
+				super::build::primary_build_tag(&self.project, service_name, None, build.tags());
 			&derived_image
 		} else {
 			return Err(ComposeError::NoImageOrBuild(service_name.into()));

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -555,8 +555,14 @@ impl Engine {
 			}
 			let image = match &service.image {
 				Some(img) => img.clone(),
-				// A build-only service's image defaults to `{service}:latest`.
-				None if builds_locally => format!("{name}:latest"),
+				// A build-only service's image is the tag the build step produced
+				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
+				None if builds_locally => super::build::primary_build_tag(
+					&self.project,
+					name,
+					None,
+					service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
+				),
 				None => continue,
 			};
 			// Do NOT force: a force-removal cascades to every container using the

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -207,10 +207,14 @@ impl Engine {
 			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
 				continue;
 			}
-			let image_ref = match &service.image {
-				Some(img) => img.clone(),
-				None if service.build.is_some() => format!("{name}:latest"),
-				None => continue,
+			let image_ref = match (&service.image, &service.build) {
+				(Some(img), _) => img.clone(),
+				// A build-only service's image is the tag the build step produced
+				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
+				(None, Some(build)) => {
+					super::super::build::primary_build_tag(&self.project, name, None, build.tags())
+				}
+				(None, None) => continue,
 			};
 			let (repo, tag) = split_repo_tag(&image_ref);
 			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));

--- a/tests/engine_integration/cp_flags.rs
+++ b/tests/engine_integration/cp_flags.rs
@@ -15,8 +15,11 @@ async fn engine_cp_index_out_of_range_errors() {
 	let engine = Engine::new(client, proj.clone());
 	let file = parse_str("services:\n  web:\n    image: alpine:latest\n").unwrap();
 
-	// No --index target replica 9 of a single-replica service: must error rather
-	// than silently fall back to the first container.
+	// Target replica 9 of a single-replica service: must error rather than
+	// silently fall back to the first container. The replica-resolution fix
+	// reports this as a typed `ReplicaIndex` (named service, 1-based index)
+	// instead of a generic `ServiceNotFound`, so the user sees exactly which
+	// index is out of range.
 	let result = engine
 		.cp_with_options(
 			&file,
@@ -29,8 +32,11 @@ async fn engine_cp_index_out_of_range_errors() {
 		)
 		.await;
 	assert!(
-		matches!(result, Err(podup::ComposeError::ServiceNotFound(_))),
-		"out-of-range --index must error, got {result:?}"
+		matches!(
+			result,
+			Err(podup::ComposeError::ReplicaIndex { ref service, index: 9 }) if service == "web"
+		),
+		"out-of-range --index must error with ReplicaIndex, got {result:?}"
 	);
 }
 

--- a/tests/engine_integration/niche.rs
+++ b/tests/engine_integration/niche.rs
@@ -109,11 +109,15 @@ async fn cli_attach_streams_output_until_exit() {
 	let dir = tempdir().unwrap();
 	let proj = format!("t{}-attach", std::process::id());
 	let compose = dir.path().join("docker-compose.yml");
-	// Emits a line then exits shortly after, so attach streams output and the
-	// follow stream closes (attach returns) rather than blocking forever.
+	// `attach` streams LIVE output only (libpod `tail=0`), like `docker attach`:
+	// anything emitted before the client connects is not replayed. So the
+	// container must keep emitting after start, or the test races the attach
+	// connection. It prints a line every second for a few seconds, then exits —
+	// attach connects, catches a live line, and the follow stream closes when the
+	// container stops (attach returns rather than blocking forever).
 	fs::write(
 		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo attached-hi; sleep 1\"]\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"for i in 1 2 3 4 5; do echo attached-hi; sleep 1; done\"]\n",
 	)
 	.unwrap();
 	let c = compose.to_str().unwrap();
@@ -124,7 +128,7 @@ async fn cli_attach_streams_output_until_exit() {
 	assert!(out.status.success(), "attach failed: {:?}", out.stderr);
 	assert!(
 		String::from_utf8_lossy(&out.stdout).contains("attached-hi"),
-		"attach must stream the container's output"
+		"attach must stream the container's live output"
 	);
 }
 

--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -4,20 +4,30 @@ use std::time::Duration;
 use super::*;
 
 #[tokio::test]
-async fn watch_no_develop_rules_returns_immediately() {
+async fn watch_no_develop_rules_errors() {
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,
 	};
 	let proj = proj("wno");
 	let engine = Engine::new(client, proj.clone());
-	// No develop.watch section → watch() returns Ok(()) immediately
+	// No develop.watch section → watch() errors, matching docker compose, which
+	// reports "none of the selected services is configured for watch" rather than
+	// silently exiting 0 (an invocation with nothing to watch is almost always a
+	// misconfiguration the user wants flagged).
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
 	)
 	.unwrap();
 
-	engine.watch(&file).await.unwrap();
+	let err = engine
+		.watch(&file)
+		.await
+		.expect_err("watch with no rules must error");
+	assert!(
+		matches!(err, podup::ComposeError::Watch(_)),
+		"expected a Watch error, got {err:?}"
+	);
 }
 
 #[tokio::test]


### PR DESCRIPTION
After the 22-PR fix sweep I validated `develop` against real Podman 5.4.2 (rootless): the engine_integration suite was 141 passed / 4 failed. This repairs all four — one real code regression, three test alignments — and the whole suite is now green (145 passed) on real Podman.

## 1. `up --build` was broken — real code regression (the important one)

Sweep #780 changed the build-only image tag (no `image:`, has `build:`) from the bare `{service}:latest` to a project-scoped `{project}-{service}:latest`, so two projects sharing a service name no longer clobber each other's image. But only the *build* step moved to the new tag — the container-create path still derived the old bare `web:latest`. So `up --build` built `proj-web:latest` and then tried to create the container from `web:latest`:

```
podman API error (HTTP 404): no such image: web:latest: image not known
```

I route the create path through the same `primary_build_tag` helper the build step uses, so the referenced image is always the exact tag the build produced (and it honours `build.tags[0]` too). While there, I fixed the two other places that still derived the bare name the same way:

- `down --rmi local` — would otherwise try to remove a phantom `web:latest` (404, ignored) and leak the real `proj-web:latest`.
- `compose images` — would mislist a built service as not present locally.

Verified `up --build` then `up` (no build) both work end-to-end against real Podman. No public API change (`cargo semver-checks`: no update required).

## 2. cp out-of-range `--index` — test update

The replica-resolution fix now returns a typed `ReplicaIndex { service, index }` ("service 'web' has no replica 9 (replica indexes are 1-based)") instead of a generic `ServiceNotFound`. That's strictly better — the user sees which index is out of range — so I updated the test to assert the precise error. Still a hard error, no silent fallback to the first container.

## 3. attach streaming — test update (race, not a regression)

`attach` streams *live* output only (libpod `tail=0`, exactly like `docker attach` — pre-attach output is not replayed). The test's container emitted its single line at startup, before `attach` could connect, so it raced and usually lost the line (reliably under load). The container now emits a line per second for a few seconds, so attach deterministically connects and catches a *live* line — still proving streaming works, without weakening the assertion.

## 4. watch with no rules — test update

I checked the docker/compose source: `docker compose watch` with no `develop.watch` configured **errors** ("none of the selected services is configured for watch, consider setting a 'develop' section"), it does not no-op. The watch fix correctly matched that. So the right call is to keep the code erroring and fix the stale test (which still expected `Ok`). Renamed it to `watch_no_develop_rules_errors` and assert the `Watch` error.

## Verification

- `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `test --no-run --all-features`, `doc` (RUSTDOCFLAGS=-D warnings), `semver-checks check-release` — all clean.
- Full engine_integration suite against real Podman 5.4.2: **145 passed, 0 failed**. The 4 previously-failing tests all pass. No leftover `t<pid>-` containers/volumes/networks.
