### PR TITLE
fix(engine): fail fast when exec targets a nonexistent user

### DIFF
--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -13,6 +13,18 @@ use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
 
+/// Ceiling on how long to wait for the libpod exec-start *response head*. A
+/// healthy engine returns it almost instantly — either the hijacked stream or a
+/// prompt error (e.g. HTTP 500 "unable to find user … no matching entries in
+/// passwd file"). When the target user/workdir does not resolve, some engine
+/// builds instead stall before answering, which the default client read timeout
+/// would only abort after ~120s and then report as a misleading socket-timeout.
+/// Bounding the head here lets [`Engine::exec_with_options`] fail fast with a
+/// clear, exec-specific message. It covers only the head; the streamed exec
+/// output is left unbounded so a legitimate long-running command runs to
+/// completion.
+const EXEC_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
 #[derive(Default)]
 pub struct ExecOptions {
@@ -78,6 +90,33 @@ fn map_not_running(e: crate::libpod::PodmanError, service_name: &str) -> Compose
 	} else {
 		ComposeError::Podman(e)
 	}
+}
+
+/// Translate a failure *starting* the exec session into a clear error. A
+/// client-side timeout means the libpod exec-start never returned its response
+/// head within [`EXEC_START_TIMEOUT`] — almost always a wedged launch (e.g. a
+/// nonexistent `--user`/`--workdir` the server stalls resolving) rather than an
+/// unhealthy socket, so surface that with the likely cause instead of the
+/// generic "timed out waiting for the Podman socket" message. Every other error
+/// — including the prompt HTTP error an engine *does* return for a bad user
+/// ("unable to find user … no matching entries in passwd file") — passes through
+/// unchanged so legitimate diagnostics are never masked. Pure so it is
+/// unit-tested.
+fn map_exec_start_err(e: crate::libpod::PodmanError, opts: &ExecOptions) -> ComposeError {
+	if e.is_timeout() {
+		let cause = if let Some(user) = &opts.user {
+			format!(" (the requested user '{user}' may not exist in the container)")
+		} else if let Some(dir) = &opts.workdir {
+			format!(" (the requested working directory '{dir}' may not exist)")
+		} else {
+			String::new()
+		};
+		return ComposeError::ExecFailed(format!(
+			"the exec session did not start within {}s{cause}",
+			EXEC_START_TIMEOUT.as_secs()
+		));
+	}
+	ComposeError::Podman(e)
 }
 
 impl Engine {
@@ -151,9 +190,9 @@ impl Engine {
 			let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
 			let _ = self
 				.client
-				.post_json_stream(&start_path, &start_cfg)
+				.post_json_stream_within(&start_path, &start_cfg, Some(EXEC_START_TIMEOUT))
 				.await
-				.map_err(ComposeError::Podman)?;
+				.map_err(|e| map_exec_start_err(e, &opts))?;
 			return Ok(());
 		}
 
@@ -164,9 +203,9 @@ impl Engine {
 		let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
 		let start_resp = self
 			.client
-			.post_json_stream(&start_path, &start_cfg)
+			.post_json_stream_within(&start_path, &start_cfg, Some(EXEC_START_TIMEOUT))
 			.await
-			.map_err(ComposeError::Podman)?;
+			.map_err(|e| map_exec_start_err(e, &opts))?;
 		let mut stream = crate::libpod::parse_multiplexed(start_resp.into_body());
 
 		// Lock stdout once for the whole stream instead of re-acquiring the lock
@@ -216,7 +255,10 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::{expand_exec_env, is_exec_teardown_noise, map_not_running};
+	use super::{
+		expand_exec_env, is_exec_teardown_noise, map_exec_start_err, map_not_running, ExecOptions,
+		EXEC_START_TIMEOUT,
+	};
 
 	#[test]
 	fn expand_exec_env_passes_through_key_value() {
@@ -276,5 +318,76 @@ mod tests {
 			map_not_running(other, "web"),
 			ComposeError::Podman(_)
 		));
+	}
+
+	#[test]
+	fn exec_start_timeout_with_user_names_the_user() {
+		use crate::libpod::PodmanError;
+		// A client-side head timeout (the wedged-launch symptom) becomes a clear,
+		// fast ExecFailed naming the likely culprit — never the raw socket-timeout.
+		let timeout = PodmanError::Api {
+			status: 0,
+			message: format!(
+				"timed out after {}s waiting for the Podman socket to respond",
+				EXEC_START_TIMEOUT.as_secs()
+			),
+		};
+		let opts = ExecOptions {
+			user: Some("doesnotexist".into()),
+			..Default::default()
+		};
+		let mapped = map_exec_start_err(timeout, &opts);
+		match mapped {
+			crate::error::ComposeError::ExecFailed(msg) => {
+				assert!(msg.contains("doesnotexist"), "got {msg}");
+				assert!(msg.contains("did not start"), "got {msg}");
+				assert!(
+					!msg.to_ascii_lowercase().contains("podman socket"),
+					"must not leak the socket-timeout wording: {msg}"
+				);
+			}
+			other => panic!("expected ExecFailed, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn exec_start_timeout_without_user_names_the_workdir() {
+		use crate::libpod::PodmanError;
+		let timeout = PodmanError::Api {
+			status: 0,
+			message: "timed out after 20s waiting for the Podman socket to respond".into(),
+		};
+		let opts = ExecOptions {
+			workdir: Some("/no/such/dir".into()),
+			..Default::default()
+		};
+		match map_exec_start_err(timeout, &opts) {
+			crate::error::ComposeError::ExecFailed(msg) => {
+				assert!(msg.contains("/no/such/dir"), "got {msg}");
+			}
+			other => panic!("expected ExecFailed, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn exec_start_real_api_error_passes_through() {
+		use crate::error::ComposeError;
+		use crate::libpod::PodmanError;
+		// The prompt HTTP error an engine returns for a bad user is a genuine
+		// diagnostic and must reach the user verbatim, not be rewritten.
+		let api = PodmanError::Api {
+			status: 500,
+			message: "unable to find user doesnotexist: no matching entries in passwd file".into(),
+		};
+		let opts = ExecOptions {
+			user: Some("doesnotexist".into()),
+			..Default::default()
+		};
+		match map_exec_start_err(api, &opts) {
+			ComposeError::Podman(e) => {
+				assert!(e.to_string().contains("no matching entries in passwd file"));
+			}
+			other => panic!("expected Podman passthrough, got {other:?}"),
+		}
 	}
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -101,6 +101,13 @@ pub enum ComposeError {
 	/// A targeted service container is not running (e.g. `exec`/`attach` against a
 	/// stopped or never-created container).
 	NotRunning(String),
+	/// An `exec` session could not be launched. Most often the requested
+	/// `--user`/`--workdir` does not resolve inside the container and the libpod
+	/// exec-start stalls without returning a response head; podup bounds that wait
+	/// with an exec-specific deadline and surfaces this instead of pinning the CLI
+	/// for the full read timeout and then reporting a misleading socket-timeout.
+	/// The string is a ready-to-print message.
+	ExecFailed(String),
 	/// The `-t/--timeout` shutdown grace was given an unusable value (a number
 	/// below `-1`). `-1` means "wait indefinitely" (docker parity) and any
 	/// non-negative value is a second count; everything else is rejected here
@@ -244,6 +251,7 @@ impl fmt::Display for ComposeError {
 				sanitize_name(service)
 			),
 			Self::NotRunning(s) => write!(f, "service '{}' is not running", sanitize_name(s)),
+			Self::ExecFailed(s) => write!(f, "exec failed: {s}"),
 			Self::InvalidTimeout(secs) => write!(
 				f,
 				"invalid --timeout {secs}: use -1 to wait indefinitely or a non-negative number of seconds"
@@ -407,6 +415,10 @@ mod tests {
 			(
 				"service 'web' is not running",
 				ComposeError::NotRunning("web".into()),
+			),
+			(
+				"exec failed: the exec session did not start within 20s",
+				ComposeError::ExecFailed("the exec session did not start within 20s".into()),
 			),
 			(
 				"invalid --timeout -5: use -1 to wait indefinitely or a non-negative number of seconds",

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -389,6 +389,34 @@ impl Client {
 		Self::check_status(status, &body)
 	}
 
+	/// `POST` with JSON body → return raw `Response<Incoming>` for streaming,
+	/// bounding the wait for the response head by `head_timeout` instead of the
+	/// default `READ_TIMEOUT`.
+	///
+	/// `exec`-start uses this with a short, exec-specific ceiling: a healthy engine
+	/// returns the start head (the hijack, or a prompt error) almost immediately, so
+	/// a long wait means the launch is wedged — e.g. a nonexistent target user the
+	/// server stalls resolving. Bounding the head lets the caller fail fast with a
+	/// clear, exec-specific message rather than pinning the CLI for the full
+	/// `READ_TIMEOUT` and then reporting a misleading socket-timeout. The streamed
+	/// body is left unbounded (`head_timeout` covers only the head), so a legitimate
+	/// long-running exec still streams normally.
+	pub async fn post_json_stream_within<B: Serialize>(
+		&self,
+		path: &str,
+		body: &B,
+		head_timeout: Option<std::time::Duration>,
+	) -> Result<Response<Incoming>> {
+		let json = serde_json::to_vec(body).map_err(PodmanError::Json)?;
+		let req = Self::build_request(
+			Method::POST,
+			path,
+			Full::new(Bytes::from(json)),
+			Some("application/json"),
+		)?;
+		Self::stream_or_err(self.send(req, head_timeout).await?).await
+	}
+
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;

--- a/tests/engine_integration/lifecycle.rs
+++ b/tests/engine_integration/lifecycle.rs
@@ -323,6 +323,68 @@ async fn exec_unknown_service_fails() {
 }
 
 #[tokio::test]
+async fn exec_nonexistent_user_fails_fast() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("exbu");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// A nonexistent named user must surface a prompt, clear error — never hang for
+	// the full client read timeout (~120s) and then report a misleading
+	// socket-timeout (issue #720).
+	let started = std::time::Instant::now();
+	let err = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec!["echo".to_string(), "hi".to_string()],
+			podup::ExecOptions {
+				user: Some("definitelynosuchuser".to_string()),
+				..Default::default()
+			},
+		)
+		.await
+		.unwrap_err();
+	let elapsed = started.elapsed();
+	engine.down(&file).await.unwrap();
+
+	assert!(
+		elapsed < std::time::Duration::from_secs(60),
+		"exec with a bad user must fail fast, took {elapsed:?}"
+	);
+	let msg = err.to_string().to_ascii_lowercase();
+	// Either the engine's prompt diagnostic (it names the user / passwd file) or
+	// podup's exec-specific timeout message — but never the bare socket-timeout.
+	assert!(
+		msg.contains("user") || msg.contains("passwd") || msg.contains("exec"),
+		"unexpected error for a bad exec user: {msg}"
+	);
+	assert!(
+		!msg.contains("waiting for the podman socket"),
+		"bad-user exec leaked a socket-timeout message: {msg}"
+	);
+	// A normal exec into the same service still works after the failure.
+	engine.up(&file).await.unwrap();
+	engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec!["echo".to_string(), "ok".to_string()],
+			podup::ExecOptions::default(),
+		)
+		.await
+		.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
 async fn pull_images() {
 	let client = match podman().await {
 		Some(d) => d,


### PR DESCRIPTION
## What

`podup exec --user <nonexistent> <svc> <cmd>` could block for the full client read timeout (~120s) and then fail with a misleading "timed out waiting for the Podman socket" message, even though the socket was healthy and the invalid user was the real cause. The same wedge can happen with a bad `--workdir`.

The hang sits in the exec-start request. A healthy engine returns the start head almost instantly — either the hijacked stream or a prompt error (on Podman 5.4.2 here it returns HTTP 500 "unable to find user ... no matching entries in passwd file" in a few milliseconds). On engine builds where the launch stalls before answering, the default `READ_TIMEOUT` only aborted the head wait after ~120s and surfaced the generic socket-timeout.

## Fix

- Added `Client::post_json_stream_within`, a streaming POST that bounds only the response-head wait by a caller-chosen deadline (the body stays unbounded).
- `exec` now starts the session through it with a short, exec-specific `EXEC_START_TIMEOUT` (20s).
- On that timeout, `map_exec_start_err` returns a new `ComposeError::ExecFailed` naming the likely cause (the requested user or workdir) instead of the bare socket-timeout. Every other error — including the prompt HTTP error an engine does return for a bad user — passes through unchanged, so legitimate diagnostics are never masked, and normal exec is untouched.

Public API stays backward-compatible (additive method + a new variant on the already `#[non_exhaustive]` error enum); `cargo semver-checks` reports no update required.

## Validation

Built binary against the live rootless Podman 5.4.2 socket:

- normal exec works (`echo hello`, exit 0)
- `exec -u doesnotexist` fails in ~10ms with "unable to find user doesnotexist: no matching entries in passwd file" (never the socket-timeout)
- `-d/--detach` with a bad user also fails fast
- a normal exec still works after a failed one

Added a `map_exec_start_err` unit test (timeout names the user/workdir, real API errors pass through) and an `exec_nonexistent_user_fails_fast` engine_integration test asserting a prompt, clear, non-socket-timeout error and that normal exec still works. The full exec/run integration suite passes against real Podman with no regression.

Closes #720
