### PR TITLE
fix(engine): graceful no-op and accurate stop reporting for not-created/not-running containers

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -220,8 +220,14 @@ impl Engine {
 
 		let mut last_nonzero = 0i64;
 		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
+			// Only wait on containers Podman actually has. The static-name fallback
+			// would POST `/wait` to a never-created predicted name and surface a raw
+			// HTTP 404; docker compose treats "nothing to wait on" as an idempotent
+			// no-op, so a defined-but-never-created service is simply skipped (#758).
+			for container_name in self
+				.list_project_container_names(Some(name.as_str()))
+				.await?
+			{
 				let path = format!(
 					"{API_PREFIX}/containers/{}/wait?condition=stopped",
 					crate::libpod::urlencoded(&container_name),
@@ -254,9 +260,23 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let grace = self.grace_period_secs(service);
-				self.stop_container(&container_name, grace).await?;
+			let grace = self.grace_period_secs(service);
+			// Enumerate only the containers Podman actually has (no static-name
+			// fallback): a defined-but-never-created service is a quiet no-op
+			// rather than a phantom stop. Report "stopped" solely for containers
+			// that were actually running/paused — stopping a Created/Exited one is
+			// a harmless no-op and must not claim it stopped (#876), matching
+			// docker compose, which acts only on running containers.
+			for container in self.live_service_containers(name).await? {
+				if super::scale::state_is_active(&container.state) {
+					self.stop_container(&container.name, grace).await?;
+				} else {
+					tracing::debug!(
+						"{}: not running ({}) — stop is a no-op",
+						container.name,
+						container.state
+					);
+				}
 			}
 		}
 		Ok(())

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -441,13 +441,19 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			let container_names = match live_by_service.get(name) {
-				Some(live) if !live.is_empty() => live.clone(),
-				_ => self.replica_names(name, service),
+			// Act only on containers Podman actually has. A defined-but-never-
+			// created service (or one already torn down) has no live containers,
+			// so skip it rather than synthesizing predicted names and POSTing
+			// stop/rm to them — those 404 and, pre-fix, leaked warnings. docker
+			// compose enumerates by label and treats "nothing there" as a quiet
+			// idempotent no-op (#758).
+			let Some(container_names) = live_by_service.get(name).filter(|live| !live.is_empty())
+			else {
+				continue;
 			};
 			for container_name in container_names {
 				for hook in &service.pre_stop {
-					if let Err(e) = self.run_lifecycle_hook(&container_name, hook).await {
+					if let Err(e) = self.run_lifecycle_hook(container_name, hook).await {
 						tracing::debug!("pre_stop hook {container_name}: {e}");
 					}
 				}
@@ -458,7 +464,7 @@ impl Engine {
 				// force-remove below SIGKILLs it regardless.
 				let stop_path = format!(
 					"{API_PREFIX}/containers/{}/stop?t={}",
-					crate::libpod::urlencoded(&container_name),
+					crate::libpod::urlencoded(container_name),
 					targets::stop_timeout_param(grace),
 				);
 				// A 404 (container already gone, or a profile-gated service that was
@@ -474,7 +480,7 @@ impl Engine {
 					}
 				}
 
-				let rm_path = container_rm_path(&container_name, remove_volumes);
+				let rm_path = container_rm_path(container_name, remove_volumes);
 				match self.client.delete_ok(&rm_path).await {
 					Ok(()) => info!("removed {container_name}"),
 					Err(e) if e.is_status(404) => {}

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -12,6 +12,25 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::targets::{stop_deadline, stop_timeout_param};
 
+/// A live project container: the name to act on plus its machine-readable
+/// state, as reported by the libpod container-list endpoint. Returned by
+/// [`Engine::live_service_containers`] so callers can act on (and report) only
+/// containers in the right state.
+pub(crate) struct LiveContainer {
+	/// Container name with the leading slash stripped.
+	pub name: String,
+	/// Machine-readable state (`running`, `created`, `exited`, `paused`, …).
+	pub state: String,
+}
+
+/// Whether a container in this state is currently active — i.e. `stop` would
+/// actually transition it. A `running` or `paused` container is stopped; a
+/// `created`/`exited`/`dead`/… one is already not running, so stopping it is a
+/// no-op that must not be reported as "stopped" (#876). Pure for unit testing.
+pub(crate) fn state_is_active(state: &str) -> bool {
+	matches!(state, "running" | "paused")
+}
+
 /// The default ceiling on a service's replica count.
 const DEFAULT_MAX_REPLICAS: u32 = 256;
 
@@ -238,6 +257,45 @@ impl Engine {
 		Ok(by_service)
 	}
 
+	/// The live containers of a service (matched by the `podup.service` label),
+	/// each paired with its machine-readable state (`running`, `created`,
+	/// `exited`, `paused`, …). Unlike [`Self::live_replica_names`] this does NOT
+	/// fall back to statically-predicted names: a service with no live container
+	/// yields an empty vec, so a lifecycle op (stop/wait/…) on a defined-but-
+	/// never-created service is a quiet no-op instead of POSTing to a phantom
+	/// name and surfacing a raw 404 (#758). The state lets `stop` report
+	/// "stopped" only for containers that were actually running (#876).
+	pub(crate) async fn live_service_containers(
+		&self,
+		service_name: &str,
+	) -> Result<Vec<LiveContainer>> {
+		let filters = serde_json::json!({
+			"label": [
+				format!("podup.project={}", self.project),
+				format!("podup.service={service_name}"),
+			],
+		});
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		Ok(entries
+			.into_iter()
+			.filter_map(|e| {
+				let state = e.state;
+				e.names.into_iter().next().map(|raw| LiveContainer {
+					name: raw.trim_start_matches('/').to_string(),
+					state,
+				})
+			})
+			.collect())
+	}
+
 	/// The container names to act on for a service: the ones Podman actually has
 	/// (matched by the `podup.service` label), so lifecycle and query commands
 	/// keep working after a runtime `scale`/`up --scale` that the compose file's
@@ -262,9 +320,23 @@ impl Engine {
 #[cfg(test)]
 mod tests {
 	use super::{
-		check_fixed_name_scale, check_replica_limit, check_scale_port_conflict,
+		check_fixed_name_scale, check_replica_limit, check_scale_port_conflict, state_is_active,
 		DEFAULT_MAX_REPLICAS,
 	};
+
+	#[test]
+	fn state_is_active_only_for_running_and_paused() {
+		// `stop` actually transitions only a running or paused container; for any
+		// other state it is a no-op that must not be reported as "stopped" (#876).
+		assert!(state_is_active("running"));
+		assert!(state_is_active("paused"));
+		assert!(!state_is_active("created"));
+		assert!(!state_is_active("exited"));
+		assert!(!state_is_active("stopped"));
+		assert!(!state_is_active("dead"));
+		assert!(!state_is_active("configured"));
+		assert!(!state_is_active(""));
+	}
 
 	#[test]
 	fn replica_limit_default_and_env_override() {

--- a/tests/engine_integration/cli_lifecycle.rs
+++ b/tests/engine_integration/cli_lifecycle.rs
@@ -334,3 +334,125 @@ async fn cli_kill_subcommand() {
 		.output()
 		.unwrap();
 }
+
+/// #758: `down` on a defined-but-never-created project is a clean, quiet no-op —
+/// it must not synthesize predicted container names and leak a raw 404 / "could
+/// not stop" warning.
+#[tokio::test]
+async fn cli_down_on_never_created_is_quiet_noop() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-dnvr", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	// `down` without a prior `up`: nothing exists, so this must exit 0 cleanly.
+	let down = Command::new(bin())
+		.env("RUST_LOG", "info")
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
+		.output()
+		.unwrap();
+	assert!(
+		down.status.success(),
+		"down on never-created failed: {}",
+		String::from_utf8_lossy(&down.stderr)
+	);
+	let stderr = String::from_utf8_lossy(&down.stderr);
+	assert!(
+		!stderr.contains("404") && !stderr.contains("no such container"),
+		"down leaked a 404 for a never-created project: {stderr}"
+	);
+	assert!(
+		!stderr.contains("could not stop"),
+		"down warned about stopping a phantom container: {stderr}"
+	);
+}
+
+/// #758: `wait` on a defined-but-never-created service returns cleanly instead of
+/// surfacing a raw `podman API error (HTTP 404)`.
+#[tokio::test]
+async fn cli_wait_on_never_created_is_quiet_noop() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-wnvr", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	let wait = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "wait", "web"])
+		.output()
+		.unwrap();
+	assert!(
+		wait.status.success(),
+		"wait on never-created failed: {}",
+		String::from_utf8_lossy(&wait.stderr)
+	);
+	let stderr = String::from_utf8_lossy(&wait.stderr);
+	assert!(
+		!stderr.contains("404"),
+		"wait leaked a 404 for a never-created service: {stderr}"
+	);
+}
+
+/// #876: `stop` on a Created (never-started) container must not claim it was
+/// "stopped" — it is a harmless no-op, so no "stopped" line is logged.
+#[tokio::test]
+async fn cli_stop_on_created_does_not_report_stopped() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-screa", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	// `create` builds the container but never starts it (state = Created).
+	let create = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "create"])
+		.output()
+		.unwrap();
+	assert!(
+		create.status.success(),
+		"create failed: {}",
+		String::from_utf8_lossy(&create.stderr)
+	);
+
+	// `stop` with INFO logging on: a not-running container must not be reported
+	// as "stopped".
+	let stop = Command::new(bin())
+		.env("RUST_LOG", "info")
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "stop"])
+		.output()
+		.unwrap();
+	assert!(
+		stop.status.success(),
+		"stop failed: {}",
+		String::from_utf8_lossy(&stop.stderr)
+	);
+	let stderr = String::from_utf8_lossy(&stop.stderr);
+	assert!(
+		!stderr.contains("stopped"),
+		"stop claimed it stopped a not-running container: {stderr}"
+	);
+
+	Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}


### PR DESCRIPTION
## What

Two errors-messaging fixes for lifecycle/query ops that target predicted-but-never-created containers.

### #758 — quiet no-op instead of a raw 404 (med)
`down`/`wait` (and the shared teardown path) fell back to statically-predicted replica names when a service had no live containers, then POSTed `stop`/`wait` against names that were never created. The resulting podman 404 surfaced as a "could not stop …" warning on `down` and as a raw `podman API error (HTTP 404)` on `wait`.

I now enumerate live containers by the compose label and skip services that have none:
- `wait` uses the live-only name list (`list_project_container_names`), so a defined-but-never-created service is simply skipped.
- `down` skips services with no live containers instead of synthesizing phantom names.

These match docker compose, which enumerates by label and treats "nothing there" as an idempotent no-op. I only dropped the phantom-name fallback — the existing 404/error handling stays, so genuine failures still surface.

### #876 — accurate `stop` reporting (low)
`stop` logged "stopped X" for containers that were never running (Created/Exited), because live enumeration lists those too and the idempotent 304 path is never taken for them. I now inspect each container's state and only report "stopped" for ones that were actually running or paused; a not-running container is a silent no-op.

## Tests
- Unit test for the new `state_is_active` state classifier.
- New CLI integration tests on a live Podman socket: `down`/`wait` on a never-created project exit 0 with no 404/warning, and `stop` on a Created container does not claim it stopped.
- Re-ran the full `engine_integration` suite (149 tests) on rootless Podman 5.4.2 — no regressions. Manually verified the three scenarios end-to-end with the release binary.

Closes #758
Closes #876
