### PR TITLE
feat(cli): add stats --format/--all/--no-trunc and truncate long names

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -136,8 +136,16 @@ pub(crate) enum Commands {
 		/// Disable streaming; print a single snapshot and exit.
 		#[arg(long)]
 		no_stream: bool,
+		/// Include non-running containers as zeroed rows.
+		#[arg(short, long)]
+		all: bool,
+		/// Do not truncate long container names in the table.
+		#[arg(long)]
+		no_trunc: bool,
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+		format: OutputFormat,
 		/// Show only these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// List podup compose projects on the host.

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -5,7 +5,7 @@
 //! fields); `Config`/`Generate`/`Ls`/`Update`/`Completions` are handled earlier
 //! in `main` and reached here only as `unreachable!` guards.
 
-use podup::Engine;
+use podup::{Engine, StatsOptions};
 
 use crate::cli::*;
 
@@ -369,8 +369,14 @@ pub(crate) async fn dispatch(
 		} => engine.export(file, &service, output, index).await?,
 		Commands::Stats {
 			no_stream,
+			all,
+			no_trunc,
+			format,
 			services,
-		} => engine.stats(file, &services, no_stream).await?,
+		} => {
+			let opts = StatsOptions::new(no_stream, all, no_trunc, format == OutputFormat::Json);
+			engine.stats_with_options(file, &services, opts).await?
+		}
 		Commands::Push {
 			ignore_push_failures,
 			tls_verify,

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -28,6 +28,7 @@ mod secrets;
 mod staging;
 mod stats;
 pub use staging::is_safe_project_name;
+pub use stats::StatsOptions;
 mod volume;
 pub use volume::VolumesOptions;
 mod volume_mounts;

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -7,9 +7,45 @@ use serde::Deserialize;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::ContainerListEntry;
 use crate::libpod::{parse_json_lines, urlencoded, API_PREFIX};
 
 use super::Engine;
+
+/// Options for [`Engine::stats_with_options`], mirroring `docker compose stats`
+/// and the table-shaping flags the other list commands expose. Kept off the
+/// frozen [`Engine::stats`] signature so the 1.0 library API stays stable.
+#[derive(Default)]
+pub struct StatsOptions {
+	/// Disable streaming; print a single snapshot and exit, `--no-stream`.
+	pub no_stream: bool,
+	/// Include non-running containers as zeroed rows, `-a/--all`.
+	pub all: bool,
+	/// Emit JSON instead of the table, `--format json`.
+	pub json: bool,
+	/// Disable container-name truncation in the table, `--no-trunc`.
+	pub no_trunc: bool,
+}
+
+impl StatsOptions {
+	/// Build options from the four CLI flags, in `--no-stream`/`--all`/
+	/// `--no-trunc`/`--format json` order. A terse constructor so the CLI keeps
+	/// the field names (all `pub`) available for clarity while the dispatch site
+	/// stays compact.
+	pub fn new(no_stream: bool, all: bool, no_trunc: bool, json: bool) -> Self {
+		Self {
+			no_stream,
+			all,
+			no_trunc,
+			json,
+		}
+	}
+}
+
+/// Width of the table NAME column; long names are truncated to this width (with
+/// a trailing ellipsis) unless `--no-trunc` is given, so a long container name
+/// no longer overflows and shifts every following column. Matches [`HEADER`].
+const NAME_WIDTH: usize = 32;
 
 /// Build the query fragment scoping a stats request to the `wanted` containers,
 /// or an empty string when none are wanted (which falls back to the daemon
@@ -41,14 +77,14 @@ where
 }
 
 /// One frame of the libpod `/containers/stats` response.
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 struct StatsReport {
 	#[serde(rename = "Stats", default)]
 	stats: Vec<ContainerStat>,
 }
 
 /// Per-container resource sample within a [`StatsReport`].
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Clone)]
 struct ContainerStat {
 	#[serde(rename = "Name", default)]
 	name: String,
@@ -74,7 +110,7 @@ struct ContainerStat {
 }
 
 /// Per-interface network counters.
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Clone)]
 struct NetStat {
 	#[serde(rename = "RxBytes", default)]
 	rx: u64,
@@ -98,15 +134,33 @@ fn format_bytes(bytes: u64) -> String {
 	}
 }
 
-/// Format one stats row into the table layout. Pure for testing.
-fn format_row(s: &ContainerStat) -> String {
-	let (rx, tx) = s
-		.network
+/// Sum a container's per-interface network counters into one `(rx, tx)` pair.
+fn net_totals(s: &ContainerStat) -> (u64, u64) {
+	s.network
 		.values()
-		.fold((0u64, 0u64), |(rx, tx), n| (rx + n.rx, tx + n.tx));
+		.fold((0u64, 0u64), |(rx, tx), n| (rx + n.rx, tx + n.tx))
+}
+
+/// The NAME cell for the table: the full name when `no_trunc`, otherwise
+/// truncated to [`NAME_WIDTH`] with a trailing ellipsis so a long name keeps the
+/// row aligned. Counts characters (not bytes) so multi-byte names truncate
+/// safely. Pure for testing.
+fn truncate_name(name: &str, no_trunc: bool) -> String {
+	if no_trunc || name.chars().count() <= NAME_WIDTH {
+		return name.to_string();
+	}
+	let head: String = name.chars().take(NAME_WIDTH - 1).collect();
+	format!("{head}…")
+}
+
+/// Format one stats row into the table layout. With `no_trunc` a long name is
+/// left intact (and may overflow its column); otherwise it is truncated to
+/// [`NAME_WIDTH`]. Pure for testing.
+fn format_row(s: &ContainerStat, no_trunc: bool) -> String {
+	let (rx, tx) = net_totals(s);
 	format!(
-		"{:<32} {:>7.2}% {:>10} / {:<10} {:>6.2}% {:>9} / {:<9} {:>9} / {:<9} {:>5}",
-		s.name,
+		"{:<NAME_WIDTH$} {:>7.2}% {:>10} / {:<10} {:>6.2}% {:>9} / {:<9} {:>9} / {:<9} {:>5}",
+		truncate_name(&s.name, no_trunc),
 		s.cpu,
 		format_bytes(s.mem_usage),
 		format_bytes(s.mem_limit),
@@ -117,6 +171,25 @@ fn format_row(s: &ContainerStat) -> String {
 		format_bytes(s.block_out),
 		s.pids,
 	)
+}
+
+/// Build one `stats --format json` row with numeric values (raw bytes/percent),
+/// so machine consumers get exact figures rather than the table's rounded,
+/// human-formatted cells. Pure so it can be unit-tested.
+fn stat_json_row(s: &ContainerStat) -> serde_json::Value {
+	let (rx, tx) = net_totals(s);
+	serde_json::json!({
+		"Name": s.name,
+		"CPUPerc": s.cpu,
+		"MemUsage": s.mem_usage,
+		"MemLimit": s.mem_limit,
+		"MemPerc": s.mem_perc,
+		"NetInput": rx,
+		"NetOutput": tx,
+		"BlockInput": s.block_in,
+		"BlockOutput": s.block_out,
+		"PIDs": s.pids,
+	})
 }
 
 const HEADER: &str = "NAME                                 CPU %       MEM USAGE / LIMIT        MEM %    NET I/O             BLOCK I/O           PIDS";
@@ -131,27 +204,74 @@ impl Engine {
 		target_services: &[String],
 		no_stream: bool,
 	) -> Result<()> {
+		self.stats_with_options(
+			file,
+			target_services,
+			StatsOptions {
+				no_stream,
+				..StatsOptions::default()
+			},
+		)
+		.await
+	}
+
+	/// Stream resource usage with `docker compose stats`-style options:
+	/// `--no-stream` (single snapshot), `-a/--all` (include non-running
+	/// containers as zeroed rows), `--format` (table | json), and `--no-trunc`
+	/// (keep full container names). `target_services` narrows to specific
+	/// services.
+	pub async fn stats_with_options(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: StatsOptions,
+	) -> Result<()> {
 		// Reject unknown/typo service names instead of silently sampling the whole
 		// host and printing a header-only table, matching the other commands.
 		if let Some(unknown) = first_unknown_service(file, target_services) {
 			return Err(ComposeError::ServiceNotFound(unknown.into()));
 		}
-		let wanted = self.target_container_names(file, target_services).await?;
+		let targets = self.target_containers(file, target_services).await?;
 
-		// Scope the stats stream to just the wanted containers server-side via the
+		// Only running containers carry live samples, so scope the libpod
+		// `containers=` filter to them: a stopped/created container fed to that
+		// filter 404s the whole request. Non-running rows are synthesized locally
+		// (as zeros) when `--all` is set.
+		let running: HashSet<String> = targets
+			.iter()
+			.filter(|t| t.running)
+			.map(|t| t.name.clone())
+			.collect();
+		let stopped: Vec<String> = if opts.all {
+			targets
+				.iter()
+				.filter(|t| !t.running)
+				.map(|t| t.name.clone())
+				.collect()
+		} else {
+			Vec::new()
+		};
+
+		// Scope the stats stream to just the running containers server-side via the
 		// `containers=` query param, so the daemon does not sample every container
-		// on the host (the response is still filtered locally by `wanted`).
-		let containers = containers_query(&wanted);
+		// on the host (the response is still filtered locally by `running`).
+		let containers = containers_query(&running);
 
-		if no_stream {
-			let report: StatsReport = self
-				.client
-				.get_json(&format!(
-					"{API_PREFIX}/containers/stats?stream=false{containers}"
-				))
-				.await
-				.map_err(ComposeError::Podman)?;
-			print_frame(&report, &wanted);
+		if opts.no_stream || running.is_empty() {
+			// Nothing running means nothing to sample (and an empty `containers=`
+			// filter would otherwise fall back to the whole host) — skip the call
+			// and render an empty/`--all`-only frame.
+			let report = if running.is_empty() {
+				StatsReport::default()
+			} else {
+				self.client
+					.get_json(&format!(
+						"{API_PREFIX}/containers/stats?stream=false{containers}"
+					))
+					.await
+					.map_err(ComposeError::Podman)?
+			};
+			print_frame(&report, &running, &stopped, &opts);
 			return Ok(());
 		}
 
@@ -165,7 +285,7 @@ impl Engine {
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
 		while let Some(frame) = frames.next().await {
 			match frame {
-				Ok(report) => print_frame(&report, &wanted),
+				Ok(report) => print_frame(&report, &running, &stopped, &opts),
 				Err(e) => {
 					tracing::debug!("stats stream ended: {e}");
 					break;
@@ -175,27 +295,58 @@ impl Engine {
 		Ok(())
 	}
 
-	/// The set of container names to report on: every replica of the targeted
-	/// services (all services when `target_services` is empty).
-	async fn target_container_names(
+	/// The containers to report on — every existing replica of the targeted
+	/// services (all services when `target_services` is empty), paired with
+	/// whether each is currently running. Only containers that actually exist are
+	/// returned (no static-name fallback): an absent service simply contributes
+	/// no rows.
+	async fn target_containers(
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],
-	) -> Result<HashSet<String>> {
-		let mut wanted = HashSet::new();
-		for name in file.services.keys() {
-			if target_services.is_empty() || target_services.iter().any(|t| t == name) {
-				// Only containers that actually exist — no static-name fallback.
-				// Feeding synthesized names for a never-up service to libpod's
-				// `containers=` filter 404s the whole stats request; an absent
-				// service simply contributes no rows (a zero/empty result).
-				for c in self.list_project_container_names(Some(name)).await? {
-					wanted.insert(c);
-				}
+	) -> Result<Vec<TargetContainer>> {
+		let filters = serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		let mut out = Vec::new();
+		for e in entries {
+			let service = e
+				.labels
+				.get("podup.service")
+				.map(String::as_str)
+				.unwrap_or("");
+			// Skip containers whose service the compose file no longer defines, and
+			// honour a positional `SERVICE` filter.
+			if !file.services.contains_key(service) {
+				continue;
+			}
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == service) {
+				continue;
+			}
+			if let Some(raw) = e.names.first() {
+				out.push(TargetContainer {
+					name: raw.trim_start_matches('/').to_string(),
+					running: e.state == "running",
+				});
 			}
 		}
-		Ok(wanted)
+		Ok(out)
 	}
+}
+
+/// A project container considered for `stats`, with its run state so non-running
+/// containers can be folded in (as zeroed rows) only under `--all`.
+struct TargetContainer {
+	name: String,
+	running: bool,
 }
 
 /// The first targeted service name that the compose file does not define, if any.
@@ -207,19 +358,52 @@ fn first_unknown_service<'a>(file: &ComposeFile, targets: &'a [String]) -> Optio
 		.find(|t| !file.services.contains_key(*t))
 }
 
-/// Print one stats frame: a header plus a row per wanted container (sorted for
-/// stable output). Frames are separated by a blank line.
-fn print_frame(report: &StatsReport, wanted: &HashSet<String>) {
-	let mut rows: Vec<&ContainerStat> = report
+/// Assemble the rows for one frame: the live samples for `running` containers
+/// plus synthesized zero rows for each `stopped` container (already empty when
+/// `--all` is off), sorted by name for stable output.
+fn frame_rows(
+	report: &StatsReport,
+	running: &HashSet<String>,
+	stopped: &[String],
+) -> Vec<ContainerStat> {
+	let mut rows: Vec<ContainerStat> = report
 		.stats
 		.iter()
-		.filter(|s| wanted.contains(&s.name))
+		.filter(|s| running.contains(&s.name))
+		.cloned()
 		.collect();
+	for name in stopped {
+		rows.push(ContainerStat {
+			name: name.clone(),
+			..ContainerStat::default()
+		});
+	}
 	rows.sort_by(|a, b| a.name.cmp(&b.name));
+	rows
+}
+
+/// Print one stats frame: the table (a bold header plus one row per container)
+/// or a JSON array when `--format json`. Table frames end with a blank line.
+fn print_frame(
+	report: &StatsReport,
+	running: &HashSet<String>,
+	stopped: &[String],
+	opts: &StatsOptions,
+) {
+	let rows = frame_rows(report, running, stopped);
+
+	if opts.json {
+		let json: Vec<_> = rows.iter().map(stat_json_row).collect();
+		println!(
+			"{}",
+			serde_json::to_string_pretty(&json).unwrap_or_default()
+		);
+		return;
+	}
 
 	crate::ui::print_bold_header(HEADER);
-	for s in rows {
-		println!("{}", format_row(s));
+	for s in &rows {
+		println!("{}", format_row(s, opts.no_trunc));
 	}
 	println!();
 }
@@ -252,11 +436,104 @@ mod tests {
 			pids: 3,
 			network,
 		};
-		let row = format_row(&s);
+		let row = format_row(&s, false);
 		assert!(row.contains("proj-web"));
 		assert!(row.contains("12.50%"));
 		assert!(row.contains("1.0MiB"));
 		assert!(row.contains('3'));
+	}
+
+	#[test]
+	fn truncate_name_shortens_long_names_with_ellipsis() {
+		let short = "proj-web-1";
+		assert_eq!(truncate_name(short, false), short);
+		// Exactly the column width is kept verbatim.
+		let exact = "a".repeat(NAME_WIDTH);
+		assert_eq!(truncate_name(&exact, false), exact);
+		// One over the width is truncated to width-1 chars plus an ellipsis.
+		let long = "a".repeat(NAME_WIDTH + 10);
+		let cut = truncate_name(&long, false);
+		assert_eq!(cut.chars().count(), NAME_WIDTH);
+		assert!(cut.ends_with('…'));
+		// `--no-trunc` keeps the full name regardless of length.
+		assert_eq!(truncate_name(&long, true), long);
+	}
+
+	#[test]
+	fn format_row_truncates_long_name_but_no_trunc_keeps_it() {
+		let s = ContainerStat {
+			name: "really-long-project-web-container-name-1".into(),
+			..Default::default()
+		};
+		// Default: the long name is truncated (ellipsis present, full name gone).
+		let row = format_row(&s, false);
+		assert!(row.contains('…'));
+		assert!(!row.contains(&s.name));
+		// `--no-trunc`: the full name survives intact.
+		let row_full = format_row(&s, true);
+		assert!(row_full.contains(&s.name));
+	}
+
+	#[test]
+	fn stat_json_row_emits_numeric_fields() {
+		let mut network = HashMap::new();
+		network.insert("eth0".to_string(), NetStat { rx: 100, tx: 200 });
+		let s = ContainerStat {
+			name: "proj-db-1".into(),
+			cpu: 5.5,
+			mem_usage: 2048,
+			mem_limit: 4096,
+			mem_perc: 50.0,
+			block_in: 1,
+			block_out: 2,
+			pids: 7,
+			network,
+		};
+		let row = stat_json_row(&s);
+		assert_eq!(row["Name"], "proj-db-1");
+		assert_eq!(row["CPUPerc"], 5.5);
+		assert_eq!(row["MemUsage"], 2048);
+		assert_eq!(row["MemLimit"], 4096);
+		assert_eq!(row["NetInput"], 100);
+		assert_eq!(row["NetOutput"], 200);
+		assert_eq!(row["PIDs"], 7);
+	}
+
+	#[test]
+	fn frame_rows_keeps_running_and_adds_stopped_zeros_sorted() {
+		let report = StatsReport {
+			stats: vec![
+				ContainerStat {
+					name: "proj-web-1".into(),
+					cpu: 1.0,
+					..Default::default()
+				},
+				// Not in `running` → must be dropped (stale daemon sample).
+				ContainerStat {
+					name: "other".into(),
+					..Default::default()
+				},
+			],
+		};
+		let mut running = HashSet::new();
+		running.insert("proj-web-1".to_string());
+		let stopped = vec!["proj-db-1".to_string()];
+		let rows = frame_rows(&report, &running, &stopped);
+		// Sorted: db (stopped) before web (running); the unrelated sample is gone.
+		assert_eq!(rows.len(), 2);
+		assert_eq!(rows[0].name, "proj-db-1");
+		assert_eq!(rows[0].cpu, 0.0);
+		assert_eq!(rows[1].name, "proj-web-1");
+		assert_eq!(rows[1].cpu, 1.0);
+	}
+
+	#[test]
+	fn frame_rows_without_all_has_no_stopped_rows() {
+		let report = StatsReport::default();
+		let running = HashSet::new();
+		// `--all` off → caller passes an empty `stopped` slice → no rows.
+		let rows = frame_rows(&report, &running, &[]);
+		assert!(rows.is_empty());
 	}
 
 	#[test]

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -50,7 +50,7 @@ pub use engine::{
 	retain_active_profiles, retain_active_profiles_with_targets, validate_stop_timeout,
 	BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions, ImagesOptions,
 	LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsFilterOptions, PsOptions, PullOptions,
-	PushOptions, RunOptions, RunOverrides, VolumesOptions,
+	PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -68,3 +68,5 @@ mod cli_lifecycle;
 mod create_ls;
 #[path = "engine_integration/scale.rs"]
 mod scale;
+#[path = "engine_integration/stats_flags.rs"]
+mod stats_flags;

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -1,0 +1,102 @@
+//! CLI integration tests for `stats` table-shaping flags (`--all`, `--no-trunc`,
+//! `--format`). Kept in its own submodule so `cli_commands.rs` stays within the
+//! source line limit.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+#[tokio::test]
+async fn cli_stats_flags_truncate_all_and_format() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// A service name long enough that `{proj}-{svc}-1` overflows the 32-char NAME
+	// column, so truncation/`--no-trunc` is observable.
+	let svc = "superlongservicenamethatoverflows";
+	let proj = format!("t{}-stf", std::process::id());
+	fs::write(
+		&compose,
+		format!(
+			"services:\n  {svc}:\n    image: alpine:latest\n    pull_policy: never\n    command: [\"sleep\", \"infinity\"]\n"
+		),
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	// A single-replica service's container is named `{proj}-{svc}` (no `-1`).
+	let full = format!("{proj}-{svc}");
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+
+	// `--no-trunc` shows the full container name; the default table truncates it
+	// (ellipsis present, full name gone).
+	let notrunc = run(c, &proj, &["stats", "--no-stream", "--no-trunc"]);
+	assert!(
+		notrunc.contains(&full),
+		"--no-trunc must show full name: {notrunc}"
+	);
+
+	let truncd = run(c, &proj, &["stats", "--no-stream"]);
+	assert!(
+		truncd.contains('…'),
+		"default table must truncate: {truncd}"
+	);
+	assert!(
+		!truncd.contains(&full),
+		"default must not show full name: {truncd}"
+	);
+
+	// `--format json` emits a JSON array with the full (untruncated) name.
+	let json = run(c, &proj, &["stats", "--no-stream", "--format", "json"]);
+	assert!(
+		json.contains("\"Name\""),
+		"json must have Name field: {json}"
+	);
+	assert!(
+		json.contains("\"CPUPerc\""),
+		"json must have CPUPerc: {json}"
+	);
+	assert!(json.contains(&full), "json must carry full name: {json}");
+
+	// Stop the container: it drops out of the default (running-only) view but
+	// `--all` folds it back in as a zeroed row.
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "stop"])
+		.output()
+		.unwrap();
+	let stopped = run(c, &proj, &["stats", "--no-stream", "--no-trunc"]);
+	assert!(
+		!stopped.contains(&full),
+		"stopped container must be hidden: {stopped}"
+	);
+	let all = run(c, &proj, &["stats", "--no-stream", "--all", "--no-trunc"]);
+	assert!(
+		all.contains(&full),
+		"--all must include stopped container: {all}"
+	);
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}
+
+/// Run the built `podup` against compose file `c`/project `proj` with `args` and
+/// return its stdout, asserting a clean exit.
+fn run(c: &str, proj: &str, args: &[&str]) -> String {
+	let mut full = vec!["-f", c, "-p", proj];
+	full.extend_from_slice(args);
+	let out = Command::new(bin()).args(&full).output().unwrap();
+	assert!(
+		out.status.success(),
+		"podup {args:?} failed: {:?}",
+		out.stderr
+	);
+	String::from_utf8_lossy(&out.stdout).into_owned()
+}


### PR DESCRIPTION
## What

`stats` only exposed `--no-stream`/`services`, and its table hardcoded a 32-char NAME field with no truncation — a long container name overflowed and shifted every following column (issue #820).

I added the `docker compose stats` parity flags, mirroring the patterns `ps`/`ls` already use:

- **`--format table|json`** — table is the default; `json` emits one object per container with numeric (un-rounded) values for machine consumers.
- **`--all`** — include non-running containers as zeroed rows. The running set is what carries live samples, so stopped rows are synthesized locally (a stopped container fed to libpod's `containers=` filter would otherwise 404 the whole request).
- **`--no-trunc`** — keep full container names; by default the NAME column truncates to 32 chars with a trailing ellipsis so the row stays aligned.

## API compatibility

`Engine::stats` keeps its signature and now wraps a new `Engine::stats_with_options(StatsOptions)` — the same wrapper pattern used elsewhere, so the 1.0 library API stays stable. `cargo semver-checks` reports no change.

## Testing

- New unit tests for `truncate_name`, `stat_json_row`, and `frame_rows` (running + synthesized-stopped rows, sorted).
- New `engine_integration` test exercising `--no-trunc`/default-truncation/`--format json`/`--all` against a real container.
- Validated end-to-end on rootless Podman 5.4.2: default truncates with an ellipsis, `--no-trunc` shows the full name, `--format json` emits the structured array, and a stopped container is hidden by default but shown zeroed under `--all`. Re-ran the existing `stats`/`ps`/`top` integration tests — no regression.

Closes #820
