### PR TITLE
perf(engine): run independent lifecycle ops within a dependency level in parallel

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,13 +1,14 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
-use std::collections::HashSet;
-
 use tracing::info;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
 use super::filter_services;
+use super::parallel::{
+	filter_levels, first_error, join_bounded, restart_service_set, retain_levels,
+};
 use super::targets::{stop_deadline, stop_timeout_param};
 use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
@@ -19,7 +20,12 @@ impl Engine {
 	/// a real error that propagates (setting a non-zero exit) instead of being
 	/// swallowed into a warning. Shared by stop/start/restart/kill/pause/unpause
 	/// so they all behave the same.
-	async fn run_lifecycle_op(&self, path: &str, container: &str, done: &str) -> Result<()> {
+	pub(super) async fn run_lifecycle_op(
+		&self,
+		path: &str,
+		container: &str,
+		done: &str,
+	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				info!("{done} {container}");
@@ -38,7 +44,12 @@ impl Engine {
 	/// idempotent no-op. Podman rejects `pause`/`unpause` with a 409/500 when the
 	/// container is not in the expected state; docker compose treats those as
 	/// no-ops, so re-pausing or unpausing a not-paused container is harmless.
-	async fn run_idempotent_state_op(&self, path: &str, container: &str, done: &str) -> Result<()> {
+	pub(super) async fn run_idempotent_state_op(
+		&self,
+		path: &str,
+		container: &str,
+		done: &str,
+	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				info!("{done} {container}");
@@ -62,7 +73,7 @@ impl Engine {
 	/// and we send `kill?signal=SIGKILL` so podup never depends solely on the
 	/// server honouring `?t`. 304/404 are idempotent no-ops, as in
 	/// [`run_lifecycle_op`](Self::run_lifecycle_op).
-	async fn stop_container(&self, container: &str, grace: i32) -> Result<()> {
+	pub(super) async fn stop_container(&self, container: &str, grace: i32) -> Result<()> {
 		let path = format!(
 			"{API_PREFIX}/containers/{}/stop?t={}",
 			crate::libpod::urlencoded(container),
@@ -123,64 +134,35 @@ impl Engine {
 		target_services: &[String],
 		no_deps: bool,
 	) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let names = filter_services(file, order, target_services)?;
+		// Reject unknown target names up front, like the other commands.
+		super::targets::validate_targets(file, target_services)?;
+		// The services to restart: the targets plus their restart-cascade
+		// dependents (one hop, unless `--no-deps`). `targets` is kept only to
+		// label cascade-restarts distinctly in the logs.
+		let (restart_set, targets) = restart_service_set(file, target_services, no_deps);
 
-		// Containers already restarted, so a service that is both an explicit
-		// target and a restart-dependent of another target is restarted once.
-		let mut restarted: HashSet<String> = HashSet::new();
-		// Attempt every container and surface the first error at the end rather
-		// than aborting mid-batch and leaving later replicas/services unrestarted.
+		// Walk dependency levels in order — a dependency restarts before its
+		// dependents — but restart every service *within* a level concurrently.
+		let levels = retain_levels(crate::compose::resolve_levels(file)?, |n| {
+			restart_set.contains(n)
+		});
+
+		// Attempt every service and surface the first error (in service order) at
+		// the end rather than aborting mid-batch and leaving later services
+		// unrestarted.
 		let mut first_err: Option<ComposeError> = None;
-
-		for name in &names {
-			let service = &file.services[name];
-
-			for container_name in self.live_replica_names(name, service).await? {
-				if !restarted.insert(container_name.clone()) {
-					continue;
-				}
-				let grace = self.grace_period_secs(service);
-				// Single atomic restart (no visible stopped window) instead of a
-				// stop+start round-trip.
-				let restart_path = format!(
-					"{API_PREFIX}/containers/{}/restart?t={}",
-					crate::libpod::urlencoded(&container_name),
-					stop_timeout_param(grace),
-				);
-				if let Err(e) = self
-					.run_lifecycle_op(&restart_path, &container_name, "restarted")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
-			}
-
-			if no_deps {
-				continue;
-			}
-			for (dep_name, dep_service) in &file.services {
-				if dep_service.depends_on.restart_for(name) {
-					for dep_container in self.live_replica_names(dep_name, dep_service).await? {
-						if !restarted.insert(dep_container.clone()) {
-							continue;
-						}
-						let grace = self.grace_period_secs(dep_service);
-						let restart_path = format!(
-							"{API_PREFIX}/containers/{}/restart?t={}",
-							crate::libpod::urlencoded(&dep_container),
-							stop_timeout_param(grace),
-						);
-						// Same 304/404 idempotency as the main path: a never-created
-						// dependency must not spew a spurious cascade warning.
-						if let Err(e) = self
-							.run_lifecycle_op(&restart_path, &dep_container, "cascade-restarted")
-							.await
-						{
-							first_err.get_or_insert(e);
-						}
-					}
-				}
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				let service = &file.services[name];
+				let done = if targets.contains(name) {
+					"restarted"
+				} else {
+					"cascade-restarted"
+				};
+				self.restart_one_service(name, service, done)
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 
@@ -254,29 +236,25 @@ impl Engine {
 	/// Services are stopped in reverse dependency order. If `target_services`
 	/// is empty, all services in the compose file are stopped.
 	pub async fn stop(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let mut order = crate::compose::resolve_order(file)?;
-		order.reverse();
-		let order = filter_services(file, order, target_services)?;
+		// Stop in reverse dependency order (dependents before their dependencies),
+		// one level at a time, but stop every service within a level concurrently
+		// so independent grace periods overlap instead of summing (#757).
+		let mut levels = crate::compose::resolve_levels(file)?;
+		levels.reverse();
+		let levels = filter_levels(file, levels, target_services)?;
 
-		for name in &order {
-			let service = &file.services[name];
-			let grace = self.grace_period_secs(service);
-			// Enumerate only the containers Podman actually has (no static-name
-			// fallback): a defined-but-never-created service is a quiet no-op
-			// rather than a phantom stop. Report "stopped" solely for containers
-			// that were actually running/paused — stopping a Created/Exited one is
-			// a harmless no-op and must not claim it stopped (#876), matching
-			// docker compose, which acts only on running containers.
-			for container in self.live_service_containers(name).await? {
-				if super::scale::state_is_active(&container.state) {
-					self.stop_container(&container.name, grace).await?;
-				} else {
-					tracing::debug!(
-						"{}: not running ({}) — stop is a no-op",
-						container.name,
-						container.state
-					);
-				}
+		// Enumerate only the containers Podman actually has (no static-name
+		// fallback): a defined-but-never-created service is a quiet no-op rather
+		// than a phantom stop. Report "stopped" solely for containers actually
+		// running/paused — stopping a Created/Exited one is a harmless no-op and
+		// must not claim it stopped (#876), matching docker compose.
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				let grace = self.grace_period_secs(&file.services[name]);
+				self.stop_one_service(name, grace)
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				return Err(e);
 			}
 		}
 		Ok(())
@@ -287,42 +265,31 @@ impl Engine {
 	/// Services are started in dependency order. If `target_services` is empty,
 	/// all services in the compose file are started.
 	pub async fn start(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		// Start in dependency order, one level at a time, but start every service
+		// within a level concurrently (#757).
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
 		// Only act on containers Podman actually has. Acting on the static
-		// fallback names (`live_replica_names`) would POST `/start` to containers
-		// that were never created, 404 (swallowed as a no-op), and exit 0
-		// silently — masking that the project was never created. Attempt every
-		// live container and aggregate errors rather than aborting on the first.
-		let mut any_live = false;
+		// fallback names would POST `/start` to containers that were never
+		// created, 404 (swallowed as a no-op), and exit 0 silently — masking that
+		// the project was never created. Attempt every live container and
+		// aggregate errors rather than aborting on the first.
+		let any_live = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let live = self
-				.list_project_container_names(Some(name.as_str()))
-				.await?;
-			if live.is_empty() {
-				continue;
-			}
-			any_live = true;
-			for container_name in live {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/start",
-					crate::libpod::urlencoded(&container_name),
-				);
-				if let Err(e) = self
-					.run_lifecycle_op(&path, &container_name, "started")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
+		for level in &levels {
+			let futs = level
+				.iter()
+				.map(|name| self.start_one_service(name, &any_live));
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 
 		if let Some(e) = first_err {
 			return Err(e);
 		}
-		if !any_live {
+		if !any_live.load(std::sync::atomic::Ordering::Relaxed) {
 			eprintln!("podup: no containers to start (project not created)");
 		}
 		Ok(())
@@ -341,19 +308,15 @@ impl Engine {
 		// issuing any request — libpod would silently treat `signal=` as SIGKILL.
 		super::signal::validate_signal(signal)?;
 
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/kill?signal={}",
-					crate::libpod::urlencoded(&container_name),
-					crate::libpod::urlencoded(signal),
-				);
-				self.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
-					.await?;
+		for level in &levels {
+			let futs = level
+				.iter()
+				.map(|name| self.kill_one_service(name, &file.services[name], signal));
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				return Err(e);
 			}
 		}
 		Ok(())
@@ -382,39 +345,19 @@ impl Engine {
 		force: bool,
 		remove_volumes: bool,
 	) -> Result<()> {
-		let mut order = crate::compose::resolve_order(file)?;
-		order.reverse();
-		let order = filter_services(file, order, target_services)?;
+		// Remove in reverse dependency order, one level at a time, with the
+		// per-service removals in a level running concurrently (#757).
+		let mut levels = crate::compose::resolve_levels(file)?;
+		levels.reverse();
+		let levels = filter_levels(file, levels, target_services)?;
 
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let force_str = if force { "true" } else { "false" };
-				let path = format!(
-					"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
-					crate::libpod::urlencoded(&container_name),
-				);
-				match self.client.delete_existed(&path).await {
-					// Only report a removal that actually happened — a phantom
-					// (never-created) container 404s and must not be logged as
-					// "removed".
-					Ok(true) => info!("removed {container_name}"),
-					Ok(false) => {}
-					// Without `--force`, a running container 409s. docker compose rm
-					// skips running containers rather than aborting the batch, so
-					// warn and keep going (later stopped containers still get
-					// removed). The "Remove stopped service containers" help text
-					// already promises this.
-					Err(e) if !force && e.is_status(409) => {
-						tracing::warn!(
-							"{container_name} is running — skipping (pass -f to force removal)"
-						);
-					}
-					Err(e) => {
-						first_err.get_or_insert(ComposeError::Podman(e));
-					}
-				}
+		for level in &levels {
+			let futs = level
+				.iter()
+				.map(|name| self.rm_one_service(name, &file.services[name], force, remove_volumes));
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 		if let Some(e) = first_err {
@@ -427,26 +370,20 @@ impl Engine {
 	///
 	/// If `target_services` is empty, all services are paused.
 	pub async fn pause(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
 		// Idempotent + best-effort: re-pausing an already-paused (or stopped)
-		// container is a no-op, and one state-mismatched container must not abort
-		// the batch and leave the rest in an inconsistent partial state.
+		// container is a no-op, and one state-mismatched service must not abort the
+		// batch and leave the rest in an inconsistent partial state. Services in a
+		// level are paused concurrently (#757).
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/pause",
-					crate::libpod::urlencoded(&container_name),
-				);
-				if let Err(e) = self
-					.run_idempotent_state_op(&path, &container_name, "paused")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				self.idempotent_state_service(name, &file.services[name], "pause", "paused")
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 		if let Some(e) = first_err {
@@ -459,25 +396,19 @@ impl Engine {
 	///
 	/// If `target_services` is empty, all services are unpaused.
 	pub async fn unpause(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
 		// Idempotent + best-effort, mirroring `pause`: unpausing a not-paused
 		// container is a no-op, and a single mismatch must not abort the batch.
+		// Services in a level are unpaused concurrently (#757).
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/unpause",
-					crate::libpod::urlencoded(&container_name),
-				);
-				if let Err(e) = self
-					.run_idempotent_state_op(&path, &container_name, "unpaused")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				self.idempotent_state_service(name, &file.services[name], "unpause", "unpaused")
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 		if let Some(e) = first_err {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod down_label;
+mod parallel;
 mod run;
 mod scale;
 mod signal;

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -1,0 +1,412 @@
+//! Intra-level parallelism for the lifecycle commands.
+//!
+//! The order resolver groups services into dependency *levels*
+//! ([`crate::compose::resolve_levels`]): every service in one level has its
+//! `depends_on` satisfied by an earlier level, so services *within* a level have
+//! no ordering between them and can be acted on concurrently. The whole-project
+//! lifecycle commands (stop/start/restart/kill/rm/pause/unpause) walk the levels
+//! in order — preserving the cross-level dependency ordering — but dispatch each
+//! level's per-service operations in parallel instead of strictly serially, so a
+//! restart/stop of many independent services no longer serializes every grace
+//! period (#757). This mirrors what the `up`/`create` path already does.
+
+use std::collections::HashSet;
+
+use tracing::info;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::engine::Engine;
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::targets::stop_timeout_param;
+
+/// Upper bound on the number of same-level services a lifecycle command acts on
+/// concurrently. Services within a dependency level have no ordering between
+/// them, so they run in parallel; the cap keeps a very wide compose file from
+/// opening an unbounded number of simultaneous libpod connections at once.
+const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
+
+/// Run a batch of independent per-service futures concurrently, bounded by
+/// [`MAX_LIFECYCLE_CONCURRENCY`], and return their results in the *input* order
+/// (not completion order) so error selection and reporting stay deterministic
+/// regardless of which service happens to finish first.
+pub(super) async fn join_bounded<F>(futs: impl IntoIterator<Item = F>) -> Vec<Result<()>>
+where
+	F: std::future::Future<Output = Result<()>>,
+{
+	use futures_util::stream::StreamExt;
+	let mut indexed: Vec<(usize, Result<()>)> = futures_util::stream::iter(
+		futs.into_iter()
+			.enumerate()
+			.map(|(i, fut)| async move { (i, fut.await) }),
+	)
+	.buffer_unordered(MAX_LIFECYCLE_CONCURRENCY)
+	.collect()
+	.await;
+	indexed.sort_by_key(|(i, _)| *i);
+	indexed.into_iter().map(|(_, r)| r).collect()
+}
+
+/// Reduce a level's per-service results to the first error in service order, so
+/// one failing service is still reported clearly while the rest of the level is
+/// allowed to complete.
+pub(super) fn first_error(results: Vec<Result<()>>) -> Option<ComposeError> {
+	results.into_iter().find_map(Result::err)
+}
+
+/// Filter each dependency level down to `target_services`, dropping levels that
+/// end up empty. An empty target list keeps every level. Returns an error if any
+/// requested name is not in the file, matching [`super::targets::filter_services`]
+/// (and docker compose's "no such service").
+pub(super) fn filter_levels(
+	file: &ComposeFile,
+	levels: Vec<Vec<String>>,
+	target_services: &[String],
+) -> Result<Vec<Vec<String>>> {
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	if target_services.is_empty() {
+		return Ok(levels);
+	}
+	let set: HashSet<&str> = target_services.iter().map(|s| s.as_str()).collect();
+	Ok(retain_levels(levels, |n| set.contains(n)))
+}
+
+/// Keep only the level entries matching `keep`, dropping levels left empty.
+pub(super) fn retain_levels(
+	levels: Vec<Vec<String>>,
+	keep: impl Fn(&str) -> bool,
+) -> Vec<Vec<String>> {
+	levels
+		.into_iter()
+		.map(|level| {
+			level
+				.into_iter()
+				.filter(|n| keep(n.as_str()))
+				.collect::<Vec<_>>()
+		})
+		.filter(|level| !level.is_empty())
+		.collect()
+}
+
+/// Compute the set of services a `restart` should act on, plus the explicit
+/// target subset (used only to label cascade-restarts distinctly in the logs).
+///
+/// With no targets every service is restarted. With targets, the set is the
+/// targets plus — unless `no_deps` — every service whose `depends_on` carries a
+/// `restart: true` condition pointing at one of the targets (one hop, matching
+/// the previous serial implementation).
+pub(super) fn restart_service_set(
+	file: &ComposeFile,
+	target_services: &[String],
+	no_deps: bool,
+) -> (HashSet<String>, HashSet<String>) {
+	if target_services.is_empty() {
+		let all: HashSet<String> = file.services.keys().cloned().collect();
+		return (all.clone(), all);
+	}
+	let targets: HashSet<String> = target_services.iter().cloned().collect();
+	let mut full = targets.clone();
+	if !no_deps {
+		for (dep_name, dep_service) in &file.services {
+			if targets
+				.iter()
+				.any(|t| dep_service.depends_on.restart_for(t))
+			{
+				full.insert(dep_name.clone());
+			}
+		}
+	}
+	(full, targets)
+}
+
+impl Engine {
+	/// Stop a single service's live containers (only those actually running), as
+	/// one unit of work in a concurrent level. See [`Engine::stop`].
+	pub(super) async fn stop_one_service(&self, service_name: &str, grace: i32) -> Result<()> {
+		for container in self.live_service_containers(service_name).await? {
+			if super::scale::state_is_active(&container.state) {
+				self.stop_container(&container.name, grace).await?;
+			} else {
+				tracing::debug!(
+					"{}: not running ({}) — stop is a no-op",
+					container.name,
+					container.state
+				);
+			}
+		}
+		Ok(())
+	}
+
+	/// Start a single service's live containers, recording in `any_live` whether
+	/// the service had any container to act on. See [`Engine::start`].
+	pub(super) async fn start_one_service(
+		&self,
+		service_name: &str,
+		any_live: &std::sync::atomic::AtomicBool,
+	) -> Result<()> {
+		let live = self
+			.list_project_container_names(Some(service_name))
+			.await?;
+		if live.is_empty() {
+			return Ok(());
+		}
+		any_live.store(true, std::sync::atomic::Ordering::Relaxed);
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in live {
+			let path = format!(
+				"{API_PREFIX}/containers/{}/start",
+				urlencoded(&container_name),
+			);
+			if let Err(e) = self
+				.run_lifecycle_op(&path, &container_name, "started")
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Restart a single service's live containers. `done` is the log verb
+	/// (`restarted` for a direct target, `cascade-restarted` for a dependent).
+	pub(super) async fn restart_one_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		done: &str,
+	) -> Result<()> {
+		let grace = self.grace_period_secs(service);
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			// Single atomic restart (no visible stopped window) instead of a
+			// stop+start round-trip.
+			let restart_path = format!(
+				"{API_PREFIX}/containers/{}/restart?t={}",
+				urlencoded(&container_name),
+				stop_timeout_param(grace),
+			);
+			if let Err(e) = self
+				.run_lifecycle_op(&restart_path, &container_name, done)
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Send `signal` to a single service's live containers. See [`Engine::kill`].
+	pub(super) async fn kill_one_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		signal: &str,
+	) -> Result<()> {
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			let path = format!(
+				"{API_PREFIX}/containers/{}/kill?signal={}",
+				urlencoded(&container_name),
+				urlencoded(signal),
+			);
+			if let Err(e) = self
+				.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Remove a single service's containers. See [`Engine::rm_with_options`].
+	pub(super) async fn rm_one_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		force: bool,
+		remove_volumes: bool,
+	) -> Result<()> {
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			let force_str = if force { "true" } else { "false" };
+			let path = format!(
+				"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
+				urlencoded(&container_name),
+			);
+			match self.client.delete_existed(&path).await {
+				// Only report a removal that actually happened — a phantom
+				// (never-created) container 404s and must not be logged as
+				// "removed".
+				Ok(true) => info!("removed {container_name}"),
+				Ok(false) => {}
+				// Without `--force`, a running container 409s. docker compose rm
+				// skips running containers rather than aborting, so warn and keep
+				// going (later stopped containers still get removed).
+				Err(e) if !force && e.is_status(409) => {
+					tracing::warn!(
+						"{container_name} is running — skipping (pass -f to force removal)"
+					);
+				}
+				Err(e) => {
+					first_err.get_or_insert(ComposeError::Podman(e));
+				}
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Pause or unpause a single service's live containers, treating a state
+	/// mismatch as an idempotent no-op. `endpoint` is `pause`/`unpause`.
+	pub(super) async fn idempotent_state_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		endpoint: &str,
+		done: &str,
+	) -> Result<()> {
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			let path = format!(
+				"{API_PREFIX}/containers/{}/{endpoint}",
+				urlencoded(&container_name),
+			);
+			if let Err(e) = self
+				.run_idempotent_state_op(&path, &container_name, done)
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::error::ComposeError;
+
+	fn levels(input: &[&[&str]]) -> Vec<Vec<String>> {
+		input
+			.iter()
+			.map(|lvl| lvl.iter().map(|s| s.to_string()).collect())
+			.collect()
+	}
+
+	fn file_with(services: &[&str]) -> ComposeFile {
+		let mut file = ComposeFile::default();
+		for &s in services {
+			file.services.insert(s.to_string(), Service::default());
+		}
+		file
+	}
+
+	#[tokio::test]
+	async fn join_bounded_preserves_input_order() {
+		// Futures finish out of order (later index resolves first) but the
+		// collected results are returned in input order.
+		let futs = (0..5usize).map(|i| async move {
+			// Smaller i yields later via more yields, so completion order != input.
+			for _ in 0..(5 - i) {
+				tokio::task::yield_now().await;
+			}
+			if i == 2 {
+				Err(ComposeError::ServiceNotFound(format!("svc{i}")))
+			} else {
+				Ok(())
+			}
+		});
+		let results = join_bounded(futs).await;
+		assert_eq!(results.len(), 5);
+		// Only index 2 is an error, proving order is preserved.
+		for (i, r) in results.iter().enumerate() {
+			assert_eq!(r.is_err(), i == 2, "index {i}");
+		}
+	}
+
+	#[test]
+	fn first_error_returns_first_in_order() {
+		let results = vec![
+			Ok(()),
+			Err(ComposeError::ServiceNotFound("a".into())),
+			Err(ComposeError::ServiceNotFound("b".into())),
+		];
+		let err = first_error(results).unwrap();
+		assert!(matches!(err, ComposeError::ServiceNotFound(n) if n == "a"));
+	}
+
+	#[test]
+	fn first_error_none_when_all_ok() {
+		assert!(first_error(vec![Ok(()), Ok(())]).is_none());
+	}
+
+	#[test]
+	fn filter_levels_empty_targets_keeps_all() {
+		let file = file_with(&["a", "b", "c"]);
+		let lv = levels(&[&["a", "b"], &["c"]]);
+		let out = filter_levels(&file, lv.clone(), &[]).unwrap();
+		assert_eq!(out, lv);
+	}
+
+	#[test]
+	fn filter_levels_drops_empty_levels() {
+		let file = file_with(&["a", "b", "c"]);
+		let lv = levels(&[&["a", "b"], &["c"]]);
+		let out = filter_levels(&file, lv, &["c".into()]).unwrap();
+		assert_eq!(out, levels(&[&["c"]]));
+	}
+
+	#[test]
+	fn filter_levels_unknown_target_errors() {
+		let file = file_with(&["a"]);
+		let lv = levels(&[&["a"]]);
+		let err = filter_levels(&file, lv, &["z".into()]).unwrap_err();
+		assert!(matches!(err, ComposeError::ServiceNotFound(n) if n == "z"));
+	}
+
+	#[test]
+	fn retain_levels_filters_and_drops() {
+		let lv = levels(&[&["a", "b"], &["c"]]);
+		let keep: HashSet<&str> = ["a", "c"].into_iter().collect();
+		let out = retain_levels(lv, |n| keep.contains(n));
+		assert_eq!(out, levels(&[&["a"], &["c"]]));
+	}
+
+	#[test]
+	fn restart_service_set_empty_targets_is_all() {
+		let file = file_with(&["a", "b"]);
+		let (full, targets) = restart_service_set(&file, &[], false);
+		assert_eq!(full, targets);
+		assert_eq!(full.len(), 2);
+		assert!(full.contains("a") && full.contains("b"));
+	}
+
+	#[test]
+	fn restart_service_set_includes_cascade_dependents() {
+		// web depends_on db with restart: true → restarting db cascades to web.
+		let file = crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      db:\n        condition: service_started\n        restart: true\n",
+		)
+		.unwrap();
+		let (full, targets) = restart_service_set(&file, &["db".into()], false);
+		assert!(targets.contains("db") && targets.len() == 1);
+		assert!(full.contains("db") && full.contains("web"));
+	}
+
+	#[test]
+	fn restart_service_set_no_deps_excludes_cascade() {
+		let file = crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      db:\n        condition: service_started\n        restart: true\n",
+		)
+		.unwrap();
+		let (full, _) = restart_service_set(&file, &["db".into()], true);
+		assert!(full.contains("db"));
+		assert!(!full.contains("web"));
+	}
+}


### PR DESCRIPTION
## What

The whole-project lifecycle commands — `stop`, `start`, `restart`, `kill`, `rm`, `pause`, `unpause` — iterated `resolve_order` strictly serially: each operation, *including its full stop grace period*, completed before the next began. Restarting or stopping many independent services therefore serialized every grace window (the wall-clock cost was the sum of all grace periods) instead of overlapping the ones in the same dependency level, which is what docker compose does.

## How

I switched these commands to walk dependency **levels** (`resolve_levels`, already used by the `up`/`create` path) and dispatch each level's per-service operations concurrently, bounded to a sensible fan-out. Within one level there is no `depends_on` relationship between services, so they are safe to run in parallel; the barrier between levels preserves the inter-level ordering (and the reverse-order teardown for `stop`/`rm`).

To keep things faithful and deterministic:

- results are collected in **service order**, so the first reported error is stable regardless of which service finishes first, and one failing service is still surfaced clearly;
- `restart`'s cascade is computed up front as a service set (targets plus their one-hop `restart: true` dependents) and restarted in level order, replacing the old per-container dedup set;
- behavior is identical except speed.

I pulled the intra-level helpers and the per-service op bodies into a new `internal/engine/lifecycle/parallel.rs` module (both touched files stay under the line limit) and added unit tests for ordering, error selection, level filtering, and the restart-set computation.

## Validation

`cargo fmt --check`, `clippy -D warnings`, `test --no-run --all-features`, `doc`, `semver-checks` (no API change), and `test --lib` all pass.

On rootless Podman 5.4.2 I ran the full lifecycle, networking, scale, create and CLI-flag integration suites — no regressions. A four-service same-level stack whose containers ignore `SIGTERM` with a 4s `stop_grace_period` now stops in ~4s instead of ~16s.

Closes #757
