### PR TITLE
feat(cli): success + progress output for lifecycle commands

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,7 +1,5 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
-use tracing::info;
-
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
@@ -15,7 +13,8 @@ use crate::libpod::API_PREFIX;
 
 impl Engine {
 	/// Run a lifecycle POST against one container with a consistent outcome:
-	/// success logs `{done} {container}`; "already in the desired state" (304)
+	/// success prints a `Container {container}  {done}` progress line; "already
+	/// in the desired state" (304)
 	/// and "no such container" (404) are idempotent no-ops; any other failure is
 	/// a real error that propagates (setting a non-zero exit) instead of being
 	/// swallowed into a warning. Shared by stop/start/restart/kill/pause/unpause
@@ -28,7 +27,7 @@ impl Engine {
 	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
-				info!("{done} {container}");
+				crate::ui::progress_line("Container", container, done);
 				Ok(())
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
@@ -52,7 +51,7 @@ impl Engine {
 	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
-				info!("{done} {container}");
+				crate::ui::progress_line("Container", container, done);
 				Ok(())
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_state_conflict() => {
@@ -85,7 +84,7 @@ impl Engine {
 			.await
 		{
 			Ok(()) => {
-				info!("stopped {container}");
+				crate::ui::progress_line("Container", container, "Stopped");
 				Ok(())
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) => {
@@ -102,7 +101,11 @@ impl Engine {
 				);
 				match self.client.post_empty_ok(&kill_path).await {
 					Ok(()) => {
-						info!("killed {container} (SIGKILL after stop timeout)");
+						crate::ui::progress_line(
+							"Container",
+							container,
+							"Killed (after stop timeout)",
+						);
 						Ok(())
 					}
 					// Already gone / not running between the timeout and the kill.
@@ -155,9 +158,9 @@ impl Engine {
 			let futs = level.iter().map(|name| {
 				let service = &file.services[name];
 				let done = if targets.contains(name) {
-					"restarted"
+					"Restarted"
 				} else {
-					"cascade-restarted"
+					"Restarted (dependency)"
 				};
 				self.restart_one_service(name, service, done)
 			});
@@ -290,7 +293,7 @@ impl Engine {
 			return Err(e);
 		}
 		if !any_live.load(std::sync::atomic::Ordering::Relaxed) {
-			eprintln!("podup: no containers to start (project not created)");
+			crate::ui::progress_note("no containers to start (project not created)");
 		}
 		Ok(())
 	}
@@ -380,7 +383,7 @@ impl Engine {
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(name, &file.services[name], "pause", "paused")
+				self.idempotent_state_service(name, &file.services[name], "pause", "Paused")
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -405,7 +408,7 @@ impl Engine {
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(name, &file.services[name], "unpause", "unpaused")
+				self.idempotent_state_service(name, &file.services[name], "unpause", "Unpaused")
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -7,8 +7,6 @@
 //! every labelled container, network, named volume and internal secret without
 //! reading a single service definition.
 
-use tracing::info;
-
 use crate::compose::types::ComposeFile;
 use crate::error::Result;
 use crate::libpod::{urlencoded, API_PREFIX};
@@ -54,7 +52,7 @@ impl Engine {
 
 			let rm_path = super::container_rm_path(&container_name, remove_volumes);
 			match self.client.delete_ok(&rm_path).await {
-				Ok(()) => info!("removed {container_name}"),
+				Ok(()) => crate::ui::progress_line("Container", &container_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
 			}
@@ -99,7 +97,7 @@ impl Engine {
 			};
 			let del = format!("{API_PREFIX}/networks/{}", urlencoded(net_name));
 			match self.client.delete_ok(&del).await {
-				Ok(_) => info!("removed network {net_name}"),
+				Ok(_) => crate::ui::progress_line("Network", net_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove network {net_name}: {e}"),
 			}
@@ -125,7 +123,7 @@ impl Engine {
 			};
 			let del = format!("{API_PREFIX}/volumes/{}", urlencoded(name));
 			match self.client.delete_ok(&del).await {
-				Ok(_) => info!("removed volume {name}"),
+				Ok(_) => crate::ui::progress_line("Volume", name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove volume {name}: {e}"),
 			}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -10,8 +10,6 @@ mod targets;
 
 use std::collections::{HashMap, HashSet};
 
-use tracing::info;
-
 use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
@@ -389,11 +387,16 @@ impl Engine {
 			};
 			if !force_recreate {
 				if no_recreate && present.contains(&container_name) {
-					info!("{container_name} already exists — skipping recreate");
+					tracing::debug!("{container_name} already exists — skipping recreate");
 					// `create` leaves an existing container as-is; `up` ensures it runs.
 					if start {
 						self.ensure_started(&container_name).await;
 					}
+					crate::ui::progress_line(
+						"Container",
+						&container_name,
+						if start { "Running" } else { "Exists" },
+					);
 					continue;
 				}
 				// Services with a build section are rebuilt on every up, so
@@ -401,18 +404,24 @@ impl Engine {
 				// image even when the compose config is unchanged.
 				if service.build.is_none() && existing_hash.get(&container_name) == Some(&new_hash)
 				{
-					info!("{container_name} is up to date — skipping recreate");
+					tracing::debug!("{container_name} is up to date — skipping recreate");
 					if start {
 						self.ensure_started(&container_name).await;
 					}
+					crate::ui::progress_line(
+						"Container",
+						&container_name,
+						if start { "Running" } else { "Exists" },
+					);
 					continue;
 				}
 			}
 			self.create_and_start(&container_name, name, service, file, start)
 				.await?;
-			info!(
-				"{} {container_name}",
-				if start { "started" } else { "created" }
+			crate::ui::progress_line(
+				"Container",
+				&container_name,
+				if start { "Started" } else { "Created" },
 			);
 
 			// `post_start` hooks run inside a running container, so only on `up`.
@@ -483,7 +492,7 @@ impl Engine {
 
 				let rm_path = container_rm_path(container_name, remove_volumes);
 				match self.client.delete_ok(&rm_path).await {
-					Ok(()) => info!("removed {container_name}"),
+					Ok(()) => crate::ui::progress_line("Container", container_name, "Removed"),
 					Err(e) if e.is_status(404) => {}
 					Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
 				}
@@ -509,7 +518,7 @@ impl Engine {
 				crate::libpod::urlencoded(&network_name),
 			);
 			match self.client.delete_ok(&net_path).await {
-				Ok(_) => info!("removed network {network_name}"),
+				Ok(_) => crate::ui::progress_line("Network", &network_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove network {network_name}: {e}"),
 			}
@@ -538,7 +547,7 @@ impl Engine {
 					crate::libpod::urlencoded(&volume_name),
 				);
 				match self.client.delete_ok(&vol_path).await {
-					Ok(_) => info!("removed volume {volume_name}"),
+					Ok(_) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
 					Err(e) if e.is_status(404) => {}
 					Err(e) => tracing::warn!("could not remove volume {volume_name}: {e}"),
 				}
@@ -579,10 +588,10 @@ impl Engine {
 			// failure.
 			let path = format!("{API_PREFIX}/images/{}", crate::libpod::urlencoded(&image),);
 			match self.client.delete_ok(&path).await {
-				Ok(_) => info!("removed image {image}"),
+				Ok(_) => crate::ui::progress_line("Image", &image, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) if e.is_image_in_use() => {
-					info!("image {image} is still in use — skipping removal")
+					tracing::debug!("image {image} is still in use — skipping removal")
 				}
 				Err(e) => tracing::warn!("could not remove image {image}: {e}"),
 			}

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -12,8 +12,6 @@
 
 use std::collections::HashSet;
 
-use tracing::info;
-
 use crate::compose::types::{ComposeFile, Service};
 use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
@@ -163,7 +161,7 @@ impl Engine {
 				urlencoded(&container_name),
 			);
 			if let Err(e) = self
-				.run_lifecycle_op(&path, &container_name, "started")
+				.run_lifecycle_op(&path, &container_name, "Started")
 				.await
 			{
 				first_err.get_or_insert(e);
@@ -215,7 +213,7 @@ impl Engine {
 				urlencoded(signal),
 			);
 			if let Err(e) = self
-				.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
+				.run_lifecycle_op(&path, &container_name, "Killed")
 				.await
 			{
 				first_err.get_or_insert(e);
@@ -243,7 +241,7 @@ impl Engine {
 				// Only report a removal that actually happened — a phantom
 				// (never-created) container 404s and must not be logged as
 				// "removed".
-				Ok(true) => info!("removed {container_name}"),
+				Ok(true) => crate::ui::progress_line("Container", &container_name, "Removed"),
 				Ok(false) => {}
 				// Without `--force`, a running container 409s. docker compose rm
 				// skips running containers rather than aborting, so warn and keep

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use futures_util::StreamExt;
-use tracing::info;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
@@ -190,7 +189,10 @@ impl Engine {
 		}
 
 		if detach {
-			info!("started run container {run_name}");
+			// Echo the started container's name to stdout (gated by progress
+			// output), so scripts capturing stdout get an id like
+			// `docker compose run -d`.
+			crate::ui::result_line(&run_name);
 			return Ok(());
 		}
 

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -3,8 +3,6 @@
 
 use std::collections::HashSet;
 
-use tracing::info;
-
 use crate::compose::types::{ComposeFile, Service};
 use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
@@ -192,7 +190,7 @@ impl Engine {
 		if let Err(e) = self.client.delete_ok(&rm_path).await {
 			tracing::debug!("scale-down rm {name}: {e}");
 		} else {
-			info!("removed {name}");
+			crate::ui::progress_line("Container", name, "Removed");
 		}
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -166,6 +166,12 @@ async fn run() -> podup::Result<()> {
 	// Resolve the colour choice before any output (including tracing setup below)
 	// so `--ansi`/`NO_COLOR`/TTY detection apply consistently everywhere.
 	podup::ui::set_color_choice(cli.ansi.into());
+	// Enable user-facing lifecycle progress for the CLI: per-container
+	// Started/Stopped/Removed lines on stderr (and the `run -d` id on stdout),
+	// matching docker compose. The library leaves this off so embedders stay
+	// silent. Only the lifecycle commands emit it, so enabling it globally here
+	// is inert for read-only/machine-output commands.
+	podup::ui::set_progress(true);
 	// `watch` is an interactive, long-running command; surface its per-action
 	// progress (synced/rebuilt/restarted) by defaulting to INFO instead of the
 	// quiet WARN floor. `RUST_LOG` always overrides.

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -61,6 +61,68 @@ pub fn stderr_colored() -> bool {
 	colored(std::io::stderr().is_terminal())
 }
 
+/// Process-wide switch for user-facing lifecycle progress output. Off by default
+/// so the library (consumed by other crates) stays silent unless asked; the CLI
+/// turns it on for the human-facing lifecycle commands. Progress is written to
+/// stderr (matching docker compose) so stdout stays a clean pipe for scripting
+/// and machine/JSON output.
+static PROGRESS_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Enable or disable user-facing lifecycle progress output process-wide. The CLI
+/// enables it for the lifecycle commands; embedders that want podup silent leave
+/// it off (the default).
+pub fn set_progress(enabled: bool) {
+	PROGRESS_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether user-facing lifecycle progress output is currently enabled.
+pub fn progress_enabled() -> bool {
+	PROGRESS_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Emit a concise per-resource lifecycle progress line to stderr, mirroring
+/// docker compose's `Container <name>  <Action>` progress stream (which also
+/// goes to stderr). `kind` is the resource noun (`Container`, `Network`,
+/// `Volume`, `Image`); `action` is the past-tense verb (`Started`, `Removed`,
+/// …), tinted green on a colour sink. A no-op unless [`set_progress`] enabled
+/// progress output, so stdout consumers and machine output are never polluted.
+pub fn progress_line(kind: &str, name: &str, action: &str) {
+	use std::io::Write;
+	if !progress_enabled() {
+		return;
+	}
+	let style = Style::new().fg_color(Some(AnsiColor::Green.into()));
+	// anstream::stderr strips the ANSI codes itself when colour is off.
+	let _ = writeln!(
+		anstream::stderr(),
+		" {kind} {name}  {}{action}{}",
+		style.render(),
+		style.render_reset()
+	);
+}
+
+/// Emit a plain user-facing progress note to stderr (e.g. a "nothing to do"
+/// line). A no-op unless [`set_progress`] enabled progress output.
+pub fn progress_note(msg: &str) {
+	use std::io::Write;
+	if !progress_enabled() {
+		return;
+	}
+	let _ = writeln!(anstream::stderr(), "{msg}");
+}
+
+/// Print a result line to stdout — used by `run -d` to echo the started
+/// container's name so scripts capturing stdout get the id, matching
+/// `docker compose run -d`. A no-op unless [`set_progress`] enabled progress
+/// output, so embedders and machine paths stay silent.
+pub fn result_line(msg: &str) {
+	use std::io::Write;
+	if !progress_enabled() {
+		return;
+	}
+	let _ = writeln!(anstream::stdout(), "{msg}");
+}
+
 /// Bold — table headers and emphasis.
 pub fn bold() -> Style {
 	Style::new().bold()
@@ -209,6 +271,18 @@ mod tests {
 		assert!(status_style("paused").is_some());
 		assert!(status_style("created").is_some());
 		assert!(status_style("weird-state").is_none());
+	}
+
+	#[test]
+	fn progress_toggle_is_observable() {
+		// Off by default-or-restored; toggling flips the observable state. Restore
+		// afterwards so the process-global flag does not leak into other tests.
+		let prev = progress_enabled();
+		set_progress(false);
+		assert!(!progress_enabled());
+		set_progress(true);
+		assert!(progress_enabled());
+		set_progress(prev);
 	}
 
 	#[test]

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -66,6 +66,8 @@ mod cli_flags;
 mod cli_lifecycle;
 #[path = "engine_integration/create_ls.rs"]
 mod create_ls;
+#[path = "engine_integration/lifecycle_output.rs"]
+mod lifecycle_output;
 #[path = "engine_integration/scale.rs"]
 mod scale;
 #[path = "engine_integration/stats_flags.rs"]

--- a/tests/engine_integration/lifecycle_output.rs
+++ b/tests/engine_integration/lifecycle_output.rs
@@ -1,0 +1,129 @@
+//! #817/#818/#873: the lifecycle commands must report concise per-container
+//! progress on success (docker-compose style), on stderr so stdout stays a
+//! clean pipe — and `run -d` must echo the started container's id on stdout.
+
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// Write a one-service compose file (alpine, `pull_policy: never`, sleeping) and
+/// return its directory + path.
+fn sleeper() -> (tempfile::TempDir, std::path::PathBuf) {
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    pull_policy: never\n    \
+		 command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	(dir, compose)
+}
+
+/// #817/#873: `up -d` prints a per-container `Container <name>  Started` line to
+/// stderr and leaves stdout empty (so scripting/pipes are unaffected); `down`
+/// reports each removal.
+#[tokio::test]
+async fn up_and_down_report_progress_on_stderr_clean_stdout() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let proj = proj("lout-ud");
+	let (_dir, compose) = sleeper();
+	let cf = compose.to_str().unwrap();
+
+	let up = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	assert!(
+		up.status.success(),
+		"up failed: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	let out = String::from_utf8_lossy(&up.stdout);
+	let err = String::from_utf8_lossy(&up.stderr);
+	assert!(
+		out.trim().is_empty(),
+		"up -d must keep stdout clean for scripting, got: {out:?}"
+	);
+	assert!(
+		err.contains(&format!("Container {proj}-web")) && err.contains("Started"),
+		"up -d must report the started container on stderr, got: {err:?}"
+	);
+
+	let down = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+	assert!(
+		down.status.success(),
+		"down failed: {}",
+		String::from_utf8_lossy(&down.stderr)
+	);
+	let derr = String::from_utf8_lossy(&down.stderr);
+	assert!(
+		derr.contains(&format!("Container {proj}-web")) && derr.contains("Removed"),
+		"down must report the removed container on stderr, got: {derr:?}"
+	);
+}
+
+/// #818: `start` on a project that was never created prints a clear
+/// "nothing to do" message (to stderr) and still exits 0.
+#[tokio::test]
+async fn start_on_never_created_reports_nothing_to_do() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let proj = proj("lout-cold");
+	let (_dir, compose) = sleeper();
+
+	let start = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "start"])
+		.output()
+		.unwrap();
+	assert!(
+		start.status.success(),
+		"start failed: {}",
+		String::from_utf8_lossy(&start.stderr)
+	);
+	let err = String::from_utf8_lossy(&start.stderr);
+	assert!(
+		err.contains("no containers to start"),
+		"cold start must report nothing to do, got: {err:?}"
+	);
+}
+
+/// #817: `run -d` echoes the started container's name to stdout (like
+/// `docker compose run -d`), so a script can capture an id.
+#[tokio::test]
+async fn run_detached_echoes_container_name_to_stdout() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let proj = proj("lout-rund");
+	let (_dir, compose) = sleeper();
+	let cf = compose.to_str().unwrap();
+
+	let run = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "run", "-d", "web", "sleep", "30"])
+		.output()
+		.unwrap();
+	assert!(
+		run.status.success(),
+		"run -d failed: {}",
+		String::from_utf8_lossy(&run.stderr)
+	);
+	let out = String::from_utf8_lossy(&run.stdout);
+	assert!(
+		out.contains(&format!("{proj}-web-run-")),
+		"run -d must echo the container name on stdout, got: {out:?}"
+	);
+
+	// Clean up the detached run container plus any project state.
+	let _ = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "down"])
+		.output();
+}


### PR DESCRIPTION
## What

The lifecycle commands reported per-container outcomes only through `info!`, which the WARN log floor swallows at default verbosity. So `up -d`, `create`, `start`, `stop`, `restart`, `pause`, `unpause`, `kill`, `rm`, `run -d` and `down` all completed silently — diverging from docker compose, which prints per-container progress. A cold `start` on a never-created project was silent too.

I route the user-facing lifecycle outcomes through a small `ui` progress layer instead of `info!`:

- Concise docker-compose-style lines (`Container <name>  Started/Stopped/Removed/Running/…`, plus `Network`/`Volume`/`Image` for `down`) printed to **stderr**, so stdout stays a clean pipe for scripting and machine output.
- `run -d` echoes the started container's name to **stdout**, like `docker compose run -d`, so scripts capturing stdout get an id.
- A cold `start` now prints a clear `no containers to start` note.

Output is gated by a process-wide switch the CLI turns on and the library leaves off, so embedders stay silent and the public API is unchanged (`cargo semver-checks` clean, no version bump).

## Why it's safe

- Progress never touches stdout (except the intentional `run -d` id), so `--quiet`/pipe/machine paths are unaffected; the lifecycle commands have no JSON mode.
- Not-running/404 paths stay quiet — no false `Stopped`/`Removed` (the #876 guard still holds).
- Added a `ui` unit test and live `lifecycle_output` integration tests; re-ran the lifecycle / cli / run / scale / create suites for regressions.

## Validation

Validated end-to-end on rootless Podman 5.4.2 across up/create/start/stop/restart/pause/unpause/kill/rm/run -d/down, confirming progress on stderr, clean stdout, the `run -d` id, and the cold-start note. No test artifacts left behind.

Closes #817
Closes #818
Closes #873
