### PR TITLE
fix: graceful broken-pipe + config output fidelity

### DIFF
--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -181,6 +181,54 @@ impl ComposeFile {
 			}
 		}
 	}
+
+	/// Drop every captured unknown key that the diagnostics pass reports as
+	/// "ignored", so a rendered `config` reflects only what podup actually
+	/// applies. Compose-spec `x-*` extension keys are kept — they are valid and
+	/// round-tripped — but a typo or an unmapped key is removed rather than
+	/// echoed back, which is what makes re-feeding the output stop re-triggering
+	/// the same warning. Mirrors the levels walked by the diagnostics collector.
+	pub fn strip_ignored_unknown_keys(&mut self) {
+		retain_extension_keys(&mut self.extensions);
+		for model in self.models.values_mut() {
+			retain_extension_keys(&mut model.unknown);
+		}
+		for net in self.networks.values_mut().flatten() {
+			retain_extension_keys(&mut net.unknown);
+			if let Some(ipam) = net.ipam.as_mut() {
+				retain_extension_keys(&mut ipam.unknown);
+			}
+		}
+		for vol in self.volumes.values_mut().flatten() {
+			retain_extension_keys(&mut vol.unknown);
+		}
+		for svc in self.services.values_mut() {
+			retain_extension_keys(&mut svc.unknown);
+			if let Some(hc) = svc.healthcheck.as_mut() {
+				retain_extension_keys(&mut hc.unknown);
+			}
+			if let Some(deploy) = svc.deploy.as_mut() {
+				retain_extension_keys(&mut deploy.unknown);
+			}
+			if let Some(develop) = svc.develop.as_mut() {
+				for rule in &mut develop.watch {
+					retain_extension_keys(&mut rule.unknown);
+				}
+			}
+			if let Some(cred) = svc.credential_spec.as_mut() {
+				retain_extension_keys(&mut cred.unknown);
+			}
+			if let Some(provider) = svc.provider.as_mut() {
+				retain_extension_keys(&mut provider.unknown);
+			}
+		}
+	}
+}
+
+/// Keep only Compose-spec `x-*` extension keys in a captured-unknowns map,
+/// discarding the keys the diagnostics pass warns are ignored.
+fn retain_extension_keys(map: &mut IndexMap<String, serde_yaml::Value>) {
+	map.retain(|k, _| k.starts_with("x-"));
 }
 
 #[cfg(test)]
@@ -239,5 +287,47 @@ secrets:
 		let rendered = serde_yaml::to_string(&file).unwrap();
 		assert!(!rendered.contains("hunter2-do-not-leak"));
 		assert!(rendered.contains("<redacted>"));
+	}
+
+	#[test]
+	fn strip_ignored_unknown_keys_drops_non_extension_at_every_level() {
+		// Unknown keys at the top level, in a service, a service sub-object
+		// (deploy), a network, and a volume are all dropped, while `x-*` extension
+		// keys at any level survive — so the rendered config agrees with the
+		// diagnostics that flagged the rest as ignored.
+		let yaml = r#"
+bogus_top: 1
+x-keep-top: ok
+services:
+  web:
+    image: nginx
+    bogus_svc: 2
+    x-keep-svc: ok
+    deploy:
+      bogus_deploy: 3
+networks:
+  netA:
+    bogus_net: 4
+volumes:
+  volA:
+    bogus_vol: 5
+"#;
+		let mut file = parse_str(yaml).unwrap();
+		file.strip_ignored_unknown_keys();
+		let out = serde_yaml::to_string(&file).unwrap();
+		for dropped in [
+			"bogus_top",
+			"bogus_svc",
+			"bogus_deploy",
+			"bogus_net",
+			"bogus_vol",
+		] {
+			assert!(
+				!out.contains(dropped),
+				"{dropped} should be stripped: {out}"
+			);
+		}
+		assert!(out.contains("x-keep-top"), "top x- kept: {out}");
+		assert!(out.contains("x-keep-svc"), "svc x- kept: {out}");
 	}
 }

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -191,12 +191,33 @@ impl Engine {
 		while let Some(frame) = body.frame().await {
 			let frame = frame.map_err(|e| ComposeError::Build(format!("export stream: {e}")))?;
 			if let Ok(data) = frame.into_data() {
-				sink.write_all(&data).map_err(|e| io_to_err(&output, e))?;
+				if let Err(e) = sink.write_all(&data) {
+					// A downstream reader that closed early (`podup export svc | head`)
+					// surfaces as a broken pipe; stop quietly and successfully like any
+					// well-behaved Unix tool instead of printing an error and exiting 1.
+					if is_stdout_broken_pipe(to_stdout, &e) {
+						return Ok(());
+					}
+					return Err(io_to_err(&output, e));
+				}
 			}
 		}
-		sink.flush().map_err(|e| io_to_err(&output, e))?;
+		if let Err(e) = sink.flush() {
+			if is_stdout_broken_pipe(to_stdout, &e) {
+				return Ok(());
+			}
+			return Err(io_to_err(&output, e));
+		}
 		Ok(())
 	}
+}
+
+/// Whether a write error is a broken pipe on the stdout sink — a downstream
+/// reader closed early. A broken pipe never applies to a `-o FILE` sink, so it
+/// only short-circuits to a clean exit when streaming to stdout. Pure so it is
+/// unit-tested.
+fn is_stdout_broken_pipe(to_stdout: bool, e: &std::io::Error) -> bool {
+	to_stdout && e.kind() == std::io::ErrorKind::BrokenPipe
 }
 
 /// Map a write error to one that names the `-o` output path when present, so the
@@ -266,5 +287,21 @@ mod tests {
 		assert!(!refuse_tar_to_tty(true, false));
 		assert!(!refuse_tar_to_tty(false, true));
 		assert!(!refuse_tar_to_tty(false, false));
+	}
+
+	#[test]
+	fn stdout_broken_pipe_is_a_clean_stop_only_on_stdout() {
+		use super::is_stdout_broken_pipe;
+		use std::io::{Error, ErrorKind};
+		let epipe = || Error::from(ErrorKind::BrokenPipe);
+		// A broken pipe while streaming to stdout (`| head`) is a clean stop.
+		assert!(is_stdout_broken_pipe(true, &epipe()));
+		// The same error against a `-o FILE` sink is a real failure to report.
+		assert!(!is_stdout_broken_pipe(false, &epipe()));
+		// Any other write error on stdout is still a real failure.
+		assert!(!is_stdout_broken_pipe(
+			true,
+			&Error::from(ErrorKind::PermissionDenied)
+		));
 	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -437,6 +437,7 @@ async fn run() -> podup::Result<()> {
 				quiet: *quiet,
 			},
 			&project,
+			&base_dir,
 		);
 	}
 

--- a/internal/startup/config_normalize.rs
+++ b/internal/startup/config_normalize.rs
@@ -188,6 +188,7 @@ mod tests {
 		assert!(out.ends_with('\n'));
 	}
 
+	#[cfg(unix)]
 	#[test]
 	fn short_bind_source_resolves_relative_only() {
 		let base = Path::new("/home/user/proj");
@@ -210,6 +211,7 @@ mod tests {
 		assert!(rewrite_short_bind("/data", base).is_none());
 	}
 
+	#[cfg(unix)]
 	#[test]
 	fn resolve_bind_sources_rewrites_short_and_long_binds() {
 		let mut file = podup::parse_str(

--- a/internal/startup/config_normalize.rs
+++ b/internal/startup/config_normalize.rs
@@ -1,0 +1,237 @@
+//! Output-fidelity normalizers for the `config` render path: resolving relative
+//! bind-mount sources to absolute paths, and quoting YAML 1.1 boolean-like
+//! scalars. Split out of `config_render` so each file stays within the source
+//! line limit. None of this changes runtime behaviour — it only shapes the
+//! rendered `config` output to match `docker compose config`.
+
+use std::path::{Component, Path, PathBuf};
+
+use podup::compose::types::{ComposeFile, VolumeMount, VolumeType};
+
+/// Rewrite each service's relative bind-mount source to an absolute path,
+/// resolved against the project directory (matching `docker compose config`).
+/// Only `.`-prefixed host paths are resolved — absolute paths, `~`, named
+/// volumes, and Windows drive paths are left untouched, mirroring how the engine
+/// classifies a short-form source. Mount semantics are unchanged; this only
+/// affects the rendered output's source field.
+pub(super) fn resolve_bind_sources(file: &mut ComposeFile, base_dir: &Path) {
+	for svc in file.services.values_mut() {
+		for mount in &mut svc.volumes {
+			match mount {
+				VolumeMount::Short(s) => {
+					if let Some(rewritten) = rewrite_short_bind(s, base_dir) {
+						*s = rewritten;
+					}
+				}
+				VolumeMount::Long {
+					volume_type: VolumeType::Bind,
+					source: Some(src),
+					..
+				} => {
+					if let Some(abs) = absolute_bind_source(src, base_dir) {
+						*src = abs;
+					}
+				}
+				VolumeMount::Long { .. } => {}
+			}
+		}
+	}
+}
+
+/// Resolve the source of a short-form `source:target[:options]` bind mount,
+/// returning the rewritten spec when the source is a relative host path. A spec
+/// with no `:` separator is a single in-container target (anonymous volume), and
+/// a non-`.` source is absolute or a named volume — both are left as-is.
+fn rewrite_short_bind(spec: &str, base_dir: &Path) -> Option<String> {
+	let (src, rest) = spec.split_once(':')?;
+	let abs = absolute_bind_source(src, base_dir)?;
+	Some(format!("{abs}:{rest}"))
+}
+
+/// Resolve a relative (`.`-prefixed) bind source to a lexically-normalized
+/// absolute path against `base_dir`; return `None` for anything else.
+fn absolute_bind_source(src: &str, base_dir: &Path) -> Option<String> {
+	if !src.starts_with('.') {
+		return None;
+	}
+	let joined = base_dir.join(src);
+	let absolute = if joined.is_absolute() {
+		joined
+	} else {
+		std::env::current_dir().unwrap_or_default().join(joined)
+	};
+	Some(normalize_lexically(&absolute))
+}
+
+/// Lexically clean a path: drop `.` components and collapse `..` against the
+/// preceding normal component, without touching the filesystem (the path need
+/// not exist, and symlinks must not be resolved). Matches docker compose, which
+/// produces a cleaned absolute source rather than a canonicalized one.
+fn normalize_lexically(path: &Path) -> String {
+	let mut out: Vec<Component> = Vec::new();
+	for comp in path.components() {
+		match comp {
+			Component::CurDir => {}
+			Component::ParentDir => {
+				if matches!(out.last(), Some(Component::Normal(_))) {
+					out.pop();
+				} else {
+					out.push(comp);
+				}
+			}
+			other => out.push(other),
+		}
+	}
+	let mut pb = PathBuf::new();
+	for c in out {
+		pb.push(c.as_os_str());
+	}
+	pb.to_string_lossy().into_owned()
+}
+
+/// Quote any plain (unquoted) YAML scalar value that a strict YAML 1.1 reader
+/// would misparse as a boolean (`yes`/`no`/`on`/`off`/`y`/`n`/`true`/`false`),
+/// leaving already-quoted scalars, keys, and everything else untouched. Works on
+/// serde_yaml_ng's block output, where each scalar value sits after a `: `
+/// mapping separator or a `- ` sequence marker on its own line.
+pub(super) fn quote_yaml11_booleans(yaml: &str) -> String {
+	let lines: Vec<String> = yaml.lines().map(requote_bool_line).collect();
+	let mut joined = lines.join("\n");
+	// `lines()` drops the trailing newline serde_yaml emits; restore it.
+	if yaml.ends_with('\n') {
+		joined.push('\n');
+	}
+	joined
+}
+
+/// Quote the scalar value on a single block-YAML line if it is an unquoted YAML
+/// 1.1 boolean token; otherwise return the line unchanged.
+fn requote_bool_line(line: &str) -> String {
+	let Some((prefix, value)) = split_block_scalar(line) else {
+		return line.to_string();
+	};
+	if is_quoted(value) || !looks_like_yaml11_bool(value) {
+		return line.to_string();
+	}
+	format!("{prefix}'{value}'")
+}
+
+/// Split a block-YAML line into `(prefix, value)` where `prefix` ends with the
+/// `: ` mapping separator or the `- ` sequence marker. Returns `None` for lines
+/// that carry no inline scalar value (nested keys, blank lines).
+fn split_block_scalar(line: &str) -> Option<(&str, &str)> {
+	// A mapping entry: the value follows the first `: `. An unquoted scalar value
+	// never contains `: ` (serde_yaml would quote it), so the first occurrence is
+	// the separator.
+	if let Some(idx) = line.find(": ") {
+		let (prefix, value) = line.split_at(idx + 2);
+		if !value.is_empty() {
+			return Some((prefix, value));
+		}
+	}
+	// A scalar sequence item: `<indent>- value`.
+	let rest = line.trim_start().strip_prefix("- ")?;
+	if rest.is_empty() {
+		return None;
+	}
+	let prefix_len = line.len() - rest.len();
+	Some((&line[..prefix_len], rest))
+}
+
+/// Whether a scalar is already quoted (single or double), so it must be left
+/// as-is rather than re-quoted.
+fn is_quoted(s: &str) -> bool {
+	s.starts_with('\'') || s.starts_with('"')
+}
+
+/// Whether a scalar matches a YAML 1.1 boolean token (case-insensitive) that a
+/// 1.1 reader would resolve to true/false. The YAML 1.2 core schema serde_yaml
+/// emits leaves these as plain strings.
+fn looks_like_yaml11_bool(s: &str) -> bool {
+	matches!(
+		s.to_ascii_lowercase().as_str(),
+		"y" | "yes" | "n" | "no" | "true" | "false" | "on" | "off"
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn yaml11_bool_detection_is_case_insensitive_and_scoped() {
+		for tok in [
+			"yes", "Yes", "YES", "no", "on", "OFF", "y", "N", "true", "False",
+		] {
+			assert!(looks_like_yaml11_bool(tok), "{tok} should match");
+		}
+		for tok in ["hello", "yess", "0", "onoff", "", "nullish"] {
+			assert!(!looks_like_yaml11_bool(tok), "{tok} should not match");
+		}
+	}
+
+	#[test]
+	fn quote_yaml11_booleans_quotes_only_plain_bool_scalars() {
+		// `yes`/`off` are quoted; an already-quoted `'null'`, a normal string, a
+		// nested key, and a non-bool value are all left exactly as serde_yaml wrote
+		// them. A `: ` inside a quoted value must not trip the splitter.
+		let input = "environment:\n  FROM_A: yes\n  FROM_B: off\n  FROM_C: 'null'\n  NORMAL: hello\n  COLON: 'a: b'\nports:\n- on\n- '8080:80'\n";
+		let out = quote_yaml11_booleans(input);
+		assert!(out.contains("FROM_A: 'yes'"), "got: {out}");
+		assert!(out.contains("FROM_B: 'off'"), "got: {out}");
+		assert!(out.contains("FROM_C: 'null'"), "double-quoting: {out}");
+		assert!(out.contains("NORMAL: hello"), "got: {out}");
+		assert!(out.contains("COLON: 'a: b'"), "got: {out}");
+		assert!(out.contains("- 'on'"), "sequence bool item: {out}");
+		assert!(out.contains("- '8080:80'"), "got: {out}");
+		// The trailing newline is preserved.
+		assert!(out.ends_with('\n'));
+	}
+
+	#[test]
+	fn short_bind_source_resolves_relative_only() {
+		let base = Path::new("/home/user/proj");
+		// A relative `.`-prefixed source is resolved against the project dir, keeping
+		// the target and options intact.
+		assert_eq!(
+			rewrite_short_bind("./data:/data:ro", base).as_deref(),
+			Some("/home/user/proj/data:/data:ro")
+		);
+		// `..` collapses lexically.
+		assert_eq!(
+			rewrite_short_bind("../shared:/s", base).as_deref(),
+			Some("/home/user/shared:/s")
+		);
+		// Absolute sources, named volumes, and `~` are left untouched.
+		assert!(rewrite_short_bind("/abs:/data", base).is_none());
+		assert!(rewrite_short_bind("named:/data", base).is_none());
+		assert!(rewrite_short_bind("~/x:/data", base).is_none());
+		// A colon-less spec (anonymous volume target) is not a bind.
+		assert!(rewrite_short_bind("/data", base).is_none());
+	}
+
+	#[test]
+	fn resolve_bind_sources_rewrites_short_and_long_binds() {
+		let mut file = podup::parse_str(
+			"services:\n  web:\n    image: nginx\n    volumes:\n      - ./data:/data:ro\n      - type: bind\n        source: ./logs\n        target: /logs\n      - named:/cache\n",
+		)
+		.unwrap();
+		resolve_bind_sources(&mut file, Path::new("/srv/app"));
+		let mounts = &file.services["web"].volumes;
+		match &mounts[0] {
+			VolumeMount::Short(s) => assert_eq!(s, "/srv/app/data:/data:ro"),
+			other => panic!("expected short, got {other:?}"),
+		}
+		match &mounts[1] {
+			VolumeMount::Long { source, .. } => {
+				assert_eq!(source.as_deref(), Some("/srv/app/logs"))
+			}
+			other => panic!("expected long bind, got {other:?}"),
+		}
+		// The named volume is untouched.
+		match &mounts[2] {
+			VolumeMount::Short(s) => assert_eq!(s, "named:/cache"),
+			other => panic!("expected short, got {other:?}"),
+		}
+	}
+}

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -3,8 +3,11 @@
 //! file in YAML/JSON with unset keys pruned and inline secrets redacted. Split
 //! out of `startup` so each file stays within the source line limit.
 
+use std::path::Path;
+
 use sha2::{Digest, Sha256};
 
+use super::config_normalize::{quote_yaml11_booleans, resolve_bind_sources};
 use crate::cli::ConfigFormat;
 
 /// Output selectors for `config`, mirroring the mutually-exclusive `docker
@@ -35,6 +38,7 @@ pub(crate) fn render_config(
 	format: &ConfigFormat,
 	out: &ConfigOutput,
 	project: &str,
+	base_dir: &Path,
 ) -> podup::Result<()> {
 	// Reaching here means the file parsed and merged cleanly. Run the full
 	// config-time validation (non-empty services, image-or-build, service-name
@@ -86,6 +90,14 @@ pub(crate) fn render_config(
 	// Surface the resolved project name in the rendered output, like
 	// `docker compose config`, rather than the file's literal `name:` (or none).
 	redacted.name = Some(project.to_string());
+	// Don't echo keys the diagnostics pass warned were ignored: the rendered
+	// config should reflect what podup actually applies, and re-feeding it must
+	// not re-trigger the same warning. `x-*` extensions are kept.
+	redacted.strip_ignored_unknown_keys();
+	// Resolve relative bind-mount sources to absolute paths against the project
+	// directory, like `docker compose config`. Runtime mounting is unaffected —
+	// this only normalizes the rendered output.
+	resolve_bind_sources(&mut redacted, base_dir);
 	redacted.redact_inline_content();
 	let rendered = match format {
 		ConfigFormat::Json => {
@@ -101,7 +113,12 @@ pub(crate) fn render_config(
 			let mut v: serde_yaml::Value =
 				serde_yaml::to_value(&redacted).map_err(podup::ComposeError::Parse)?;
 			prune_yaml_nulls(&mut v);
-			serde_yaml::to_string(&v).map_err(podup::ComposeError::Parse)?
+			let yaml = serde_yaml::to_string(&v).map_err(podup::ComposeError::Parse)?;
+			// serde_yaml_ng emits YAML 1.2, where `yes`/`no`/`on`/`off` are plain
+			// strings and stay unquoted. A strict YAML 1.1 reader (docker compose's
+			// emitter among them) would misread those as booleans, so quote any
+			// string scalar that looks like a YAML 1.1 boolean to match.
+			quote_yaml11_booleans(&yaml)
 		}
 	};
 	println!("{rendered}");
@@ -279,6 +296,7 @@ mod tests {
 				..Default::default()
 			},
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap_err();
 		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
@@ -295,6 +313,7 @@ mod tests {
 				..Default::default()
 			},
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 	}
@@ -310,6 +329,7 @@ mod tests {
 				..Default::default()
 			},
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 	}
@@ -335,7 +355,14 @@ mod tests {
 				..Default::default()
 			},
 		] {
-			render_config(&sample_file(), &ConfigFormat::Yaml, &out, "proj").unwrap();
+			render_config(
+				&sample_file(),
+				&ConfigFormat::Yaml,
+				&out,
+				"proj",
+				Path::new("/proj"),
+			)
+			.unwrap();
 		}
 	}
 
@@ -345,7 +372,14 @@ mod tests {
 			hash: Some("nope".to_string()),
 			..Default::default()
 		};
-		assert!(render_config(&sample_file(), &ConfigFormat::Yaml, &out, "proj").is_err());
+		assert!(render_config(
+			&sample_file(),
+			&ConfigFormat::Yaml,
+			&out,
+			"proj",
+			Path::new("/proj")
+		)
+		.is_err());
 	}
 
 	#[test]
@@ -366,6 +400,7 @@ mod tests {
 			&ConfigFormat::Yaml,
 			&ConfigOutput::default(),
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 		render_config(
@@ -373,6 +408,7 @@ mod tests {
 			&ConfigFormat::Json,
 			&ConfigOutput::default(),
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 	}
@@ -419,5 +455,31 @@ mod tests {
 			"passthrough env var must be kept"
 		);
 		assert!(j["services"]["web"].get("dns").is_none());
+	}
+
+	#[test]
+	fn render_config_strips_ignored_unknown_keys() {
+		// An unknown (non-`x-`) top-level and service key is dropped from the
+		// rendered output, while a valid `x-` extension is round-tripped. Rendered
+		// via the YAML path through a clone so the public method is exercised.
+		let mut file = podup::parse_str(
+			"x-anchors: keep\nbogus_top: 1\nservices:\n  web:\n    image: nginx\n    bogus_svc: 2\n",
+		)
+		.unwrap();
+		file.strip_ignored_unknown_keys();
+		let v: serde_yaml::Value = serde_yaml::to_value(&file).unwrap();
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(
+			!out.contains("bogus_top"),
+			"ignored top key re-emitted: {out}"
+		);
+		assert!(
+			!out.contains("bogus_svc"),
+			"ignored svc key re-emitted: {out}"
+		);
+		assert!(
+			out.contains("x-anchors"),
+			"x- extension must survive: {out}"
+		);
 	}
 }

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::cli::{Cli, Commands};
 
+mod config_normalize;
 mod config_render;
 pub(crate) use config_render::{render_config, ConfigOutput};
 


### PR DESCRIPTION
Four bounded fixes to the error-handling and `config` render paths, found during the 1.6.0 sweep against rootless Podman 5.4.2.

## #762 — graceful broken pipe (med)
`podup export svc | head` printed `io error: Broken pipe (os error 32)` and exited 1. A broken pipe on the stdout sink is now a clean, successful stop like any well-behaved Unix tool; a `-o FILE` sink still surfaces a real write error. The print-macro paths (help/attach/general stdout) already exit cleanly via the broken-pipe panic hook, so this finishes the job without resetting SIGPIPE (the crate is `#![deny(unsafe_code)]`).

## #837 — quote YAML 1.1 boolean-like env values (low)
serde_yaml_ng emits YAML 1.2 core schema, where `yes`/`no`/`on`/`off` are plain strings and stay unquoted, so a strict YAML 1.1 reader misreads `FROM_A: yes` as a boolean. `config` now quotes any string scalar that looks like a YAML 1.1 boolean (`yes`/`no`/`on`/`off`/`y`/`n`/`true`/`false`), matching docker compose. Already-quoted scalars and keys are untouched.

## #838 — resolve bind-mount source to absolute (low)
`config` kept a relative bind source (`./data:/data:ro`) verbatim; docker compose resolves it. The render path now resolves `.`-prefixed host paths to a lexically-cleaned absolute path against the project directory. Absolute paths, `~`, named volumes, and Windows drive paths are left as-is, and runtime mount semantics are unchanged — only the rendered output is normalized.

## #839 — stop echoing ignored unknown keys (low)
Unknown (non-`x-`) keys captured for diagnostics were re-emitted by `config`, so re-feeding the output re-triggered the "ignored" warning. They are now stripped from the rendered config at every modeled level, while `x-*` extensions are still round-tripped, so the diagnostics and the output agree.

## Notes
- Split the new render-fidelity helpers into `startup::config_normalize` to keep every file under the source line limit.
- Added unit tests for each fix.
- Validated the broken-pipe fix and the `config` output end-to-end with the built binary on rootless Podman 5.4.2, and re-ran the export/attach/lifecycle/config `engine_integration` suites with no regression.

Closes #762
Closes #837
Closes #838
Closes #839
