### PR TITLE
Merge develop into main: 1.6.0 sweep fixes (220 findings)

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -337,6 +337,16 @@ pub(crate) enum Commands {
 		/// Replica index (1-based) of a scaled service.
 		#[arg(long)]
 		index: Option<u32>,
+		/// Pause the container during commit for a consistent snapshot
+		/// (default on; `--pause=false` to snapshot a live container).
+		#[arg(
+			long,
+			default_value_t = true,
+			action = clap::ArgAction::Set,
+			num_args = 0..=1,
+			default_missing_value = "true",
+		)]
+		pause: bool,
 	},
 	/// Export a service container's filesystem as a tar archive.
 	Export {

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -27,7 +27,7 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		remove_orphans: bool,
 		/// Do not recreate containers that are already running.
-		#[arg(long)]
+		#[arg(long, conflicts_with = "force_recreate")]
 		no_recreate: bool,
 		/// Recreate containers even if their configuration is unchanged.
 		#[arg(long)]
@@ -117,7 +117,7 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		force_recreate: bool,
 		/// Do not recreate containers that already exist.
-		#[arg(long)]
+		#[arg(long, conflicts_with = "force_recreate")]
 		no_recreate: bool,
 		/// Create only these services.
 		#[arg(trailing_var_arg = true)]

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 #[cfg(feature = "completions")]
 use clap_complete::Shell;
 
-use super::parse::parse_scale_pair;
+use super::parse::{parse_pull_policy, parse_scale_pair, parse_timeout};
 use super::types::{ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope};
 
 #[derive(Subcommand)]
@@ -18,7 +18,7 @@ pub(crate) enum Commands {
 		#[arg(short, long)]
 		detach: bool,
 		/// Build images before starting containers.
-		#[arg(long)]
+		#[arg(long, conflicts_with = "no_build")]
 		build: bool,
 		/// Watch and sync/rebuild/restart per develop.watch rules.
 		#[arg(short, long)]
@@ -36,13 +36,13 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		no_deps: bool,
 		/// Seconds to wait for a container to stop when recreating.
-		#[arg(short = 't', long)]
+		#[arg(short = 't', long, allow_hyphen_values = true, value_parser = parse_timeout)]
 		timeout: Option<i32>,
 		/// Override the replica count for a service: SERVICE=N (repeatable).
 		#[arg(long, value_parser = parse_scale_pair)]
 		scale: Vec<(String, u32)>,
-		/// Pull policy before starting: always, missing, never.
-		#[arg(long)]
+		/// Pull policy before starting: always, missing, never, newer, build.
+		#[arg(long, value_parser = parse_pull_policy)]
 		pull: Option<String>,
 		/// Do not build images, even for services with a build section.
 		#[arg(long)]
@@ -53,6 +53,9 @@ pub(crate) enum Commands {
 		/// Wait until services are running/healthy before returning.
 		#[arg(long)]
 		wait: bool,
+		/// Maximum seconds to wait with --wait before giving up.
+		#[arg(long, requires = "wait")]
+		wait_timeout: Option<u64>,
 		/// Create containers but do not start them.
 		#[arg(long)]
 		no_start: bool,
@@ -78,7 +81,7 @@ pub(crate) enum Commands {
 		#[arg(long, value_enum)]
 		rmi: Option<RmiScope>,
 		/// Seconds to wait for containers to stop before killing them.
-		#[arg(short = 't', long)]
+		#[arg(short = 't', long, allow_hyphen_values = true, value_parser = parse_timeout)]
 		timeout: Option<i32>,
 	},
 	/// Start existing stopped containers.
@@ -87,7 +90,7 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		wait: bool,
 		/// Maximum seconds to wait with --wait before giving up.
-		#[arg(long)]
+		#[arg(long, requires = "wait")]
 		wait_timeout: Option<u64>,
 		/// Start only these services.
 		#[arg(trailing_var_arg = true)]
@@ -96,7 +99,7 @@ pub(crate) enum Commands {
 	/// Stop running containers without removing them.
 	Stop {
 		/// Seconds to wait for containers to stop before killing them.
-		#[arg(short = 't', long)]
+		#[arg(short = 't', long, allow_hyphen_values = true, value_parser = parse_timeout)]
 		timeout: Option<i32>,
 		/// Stop only these services.
 		#[arg(trailing_var_arg = true)]
@@ -119,8 +122,13 @@ pub(crate) enum Commands {
 		/// Do not recreate containers that already exist.
 		#[arg(long, conflicts_with = "force_recreate")]
 		no_recreate: bool,
+		/// Pull policy before creating: always, missing, never, newer, build.
+		#[arg(long, value_parser = parse_pull_policy)]
+		pull: Option<String>,
+		/// Do not create linked services (depends_on) of the named services.
+		#[arg(long)]
+		no_deps: bool,
 		/// Create only these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Display a live stream of container resource usage.
@@ -140,6 +148,10 @@ pub(crate) enum Commands {
 		/// Only display project names. Mutually exclusive with `--format`.
 		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
+		/// Filter projects by predicate: name=<NAME> or status=<running|exited>
+		/// (repeatable).
+		#[arg(long)]
+		filter: Vec<String>,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,
@@ -152,8 +164,10 @@ pub(crate) enum Commands {
 		/// Verify the registry TLS cert (false for insecure/HTTP; default on).
 		#[arg(long)]
 		tls_verify: Option<bool>,
+		/// Suppress the push progress output.
+		#[arg(short, long)]
+		quiet: bool,
 		/// Push only these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Build or rebuild service images.
@@ -167,11 +181,17 @@ pub(crate) enum Commands {
 		/// Set build-time variables (KEY=VAL); may be repeated.
 		#[arg(long = "build-arg")]
 		build_arg: Vec<String>,
+		/// Set the build progress output style (auto, plain, tty); accepted for
+		/// docker-compose compatibility.
+		#[arg(long)]
+		progress: Option<String>,
+		/// Push each built image to its registry after a successful build.
+		#[arg(long)]
+		push: bool,
 		/// Suppress the build output.
 		#[arg(short, long)]
 		quiet: bool,
 		/// Build only these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Remove stopped service containers.
@@ -199,7 +219,6 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		remove_orphans: bool,
 		/// Signal only these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Pause running service containers.
@@ -263,6 +282,9 @@ pub(crate) enum Commands {
 		/// Do not start linked services (depends_on) before running.
 		#[arg(long)]
 		no_deps: bool,
+		/// Add a label to the one-off container (KEY=VAL); may be repeated.
+		#[arg(short = 'l', long = "label")]
+		label: Vec<String>,
 		/// Command (and arguments) to run.
 		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
 		cmd: Vec<String>,
@@ -292,9 +314,21 @@ pub(crate) enum Commands {
 		/// Only display container IDs. Mutually exclusive with `--format`.
 		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
+		/// Print the service names, one per line, instead of the container table.
+		#[arg(long = "services")]
+		services_only: bool,
+		/// Filter containers by predicate: status=<running|exited> or
+		/// name=<NAME> (repeatable).
+		#[arg(long)]
+		filter: Vec<String>,
+		/// Filter by container status (running, exited, ...); repeatable.
+		#[arg(long)]
+		status: Vec<String>,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,
+		/// Show only these services.
+		services: Vec<String>,
 	},
 	/// Display the running processes of service containers.
 	Top {
@@ -313,19 +347,41 @@ pub(crate) enum Commands {
 		/// object per line (NDJSON, not a JSON array).
 		#[arg(long, value_enum, default_value_t = EventsFormat::Table)]
 		format: EventsFormat,
+		/// Only stream events at or after this timestamp/relative time.
+		#[arg(long)]
+		since: Option<String>,
+		/// Only stream events up to this timestamp/relative time.
+		#[arg(long)]
+		until: Option<String>,
+		/// Filter events by predicate (KEY=VALUE, e.g. event=start); repeatable.
+		#[arg(long)]
+		filter: Vec<String>,
 		/// Deprecated alias for `--format json`; kept for backward compatibility.
-		#[arg(long, hide = true)]
+		/// Cannot be combined with an explicit `--format`.
+		#[arg(long, hide = true, conflicts_with = "format")]
 		json: bool,
 	},
 	/// Attach to a service container's output (stdout/stderr).
 	Attach {
 		/// Service whose container to attach to.
 		service: String,
+		/// Index of the container when the service has multiple replicas (1-based).
+		#[arg(long)]
+		index: Option<u32>,
+		/// Do not attach STDIN (accepted for docker-compose compatibility; podup
+		/// attaches output only).
+		#[arg(long)]
+		no_stdin: bool,
+		/// Proxy received signals to the process (accepted for compatibility).
+		#[arg(long)]
+		sig_proxy: Option<bool>,
+		/// Override the detach key sequence (accepted for compatibility).
+		#[arg(long)]
+		detach_keys: Option<String>,
 	},
 	/// Block until service containers stop, printing each exit code.
 	Wait {
 		/// Wait on these services (default: all).
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Commit a service container to a new image.
@@ -334,12 +390,22 @@ pub(crate) enum Commands {
 		service: String,
 		/// Target image reference (repo[:tag]).
 		image: String,
+		/// Commit message for the new image.
+		#[arg(short, long)]
+		message: Option<String>,
+		/// Author of the new image (e.g. "Name <email>").
+		#[arg(short, long)]
+		author: Option<String>,
+		/// Apply a Dockerfile instruction to the committed image (repeatable).
+		#[arg(short = 'c', long = "change")]
+		change: Vec<String>,
 		/// Replica index (1-based) of a scaled service.
 		#[arg(long)]
 		index: Option<u32>,
 		/// Pause the container during commit for a consistent snapshot
 		/// (default on; `--pause=false` to snapshot a live container).
 		#[arg(
+			short,
 			long,
 			default_value_t = true,
 			action = clap::ArgAction::Set,
@@ -382,7 +448,6 @@ pub(crate) enum Commands {
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,
 		/// Show only volumes mounted by these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// List images used by services.
@@ -394,6 +459,8 @@ pub(crate) enum Commands {
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,
+		/// Show images for these services only.
+		services: Vec<String>,
 	},
 	/// View output from containers.
 	#[command(alias = "log")]
@@ -413,6 +480,12 @@ pub(crate) enum Commands {
 		/// Prefix each line with an RFC3339 timestamp.
 		#[arg(short = 't', long)]
 		timestamps: bool,
+		/// Produce monochrome output (no colour in the service-name prefix).
+		#[arg(long)]
+		no_color: bool,
+		/// Do not print the service-name prefix on each line.
+		#[arg(long)]
+		no_log_prefix: bool,
 		/// Show logs for these services (default: all).
 		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
@@ -459,16 +532,15 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		include_deps: bool,
 		/// Pull policy: always, missing, never, newer, build (overrides per-service pull_policy).
-		#[arg(long)]
+		#[arg(long, value_parser = parse_pull_policy)]
 		policy: Option<String>,
 		/// Only pull images for these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// Restart services.
 	Restart {
 		/// Seconds to wait for containers to stop before killing them.
-		#[arg(short = 't', long)]
+		#[arg(short = 't', long, allow_hyphen_values = true, value_parser = parse_timeout)]
 		timeout: Option<i32>,
 		/// Do not restart dependent services (depends_on with a restart condition).
 		#[arg(long)]
@@ -486,21 +558,49 @@ pub(crate) enum Commands {
 		/// Print only the service names, one per line.
 		#[arg(long)]
 		services: bool,
+		/// Print only the named volumes, one per line.
+		#[arg(long)]
+		volumes: bool,
+		/// Print only the service image references, one per line.
+		#[arg(long)]
+		images: bool,
+		/// Print only the profile names, one per line.
+		#[arg(long)]
+		profiles: bool,
+		/// Print the config hash of all services, or of the given comma-separated
+		/// services ("*" for all).
+		#[arg(long)]
+		hash: Option<String>,
 		/// Only validate the configuration; print nothing.
 		#[arg(short, long)]
 		quiet: bool,
 		/// Leave ${VAR} placeholders literal instead of interpolating them.
 		#[arg(long)]
 		no_interpolate: bool,
+		/// Accepted for docker-compose compatibility; podup output is already
+		/// normalized.
+		#[arg(long)]
+		no_normalize: bool,
 		/// Rewrite each service image to its registry digest (repo@sha256:...).
 		#[arg(long)]
 		resolve_image_digests: bool,
 	},
 	/// Generate declarative artifacts from the compose file.
-	#[command(alias = "gen")]
+	#[command(
+		alias = "gen",
+		subcommand_required = true,
+		arg_required_else_help = true
+	)]
 	Generate {
 		#[command(subcommand)]
 		kind: GenerateCommands,
+	},
+	/// Print help for podup, or for a specific command.
+	Help {
+		/// Command to show help for. Extra tokens, `-h`/`--help`, and a leading
+		/// `--` are tolerated; only the first command name is used.
+		#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+		commands: Vec<String>,
 	},
 	/// Watch for file changes and sync/rebuild/restart as configured by develop.watch.
 	Watch,

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -136,8 +136,16 @@ pub(crate) enum Commands {
 		/// Disable streaming; print a single snapshot and exit.
 		#[arg(long)]
 		no_stream: bool,
+		/// Include non-running containers as zeroed rows.
+		#[arg(short, long)]
+		all: bool,
+		/// Do not truncate long container names in the table.
+		#[arg(long)]
+		no_trunc: bool,
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+		format: OutputFormat,
 		/// Show only these services.
-		#[arg(trailing_var_arg = true)]
 		services: Vec<String>,
 	},
 	/// List podup compose projects on the host.

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -8,7 +8,7 @@ use clap::Subcommand;
 use clap_complete::Shell;
 
 use super::parse::parse_scale_pair;
-use super::types::{ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
+use super::types::{ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope};
 
 #[derive(Subcommand)]
 pub(crate) enum Commands {
@@ -137,8 +137,8 @@ pub(crate) enum Commands {
 		/// Show all projects, including stopped ones.
 		#[arg(short, long)]
 		all: bool,
-		/// Only display project names.
-		#[arg(short, long)]
+		/// Only display project names. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
@@ -289,8 +289,8 @@ pub(crate) enum Commands {
 		/// Show all containers, including stopped ones.
 		#[arg(short, long)]
 		all: bool,
-		/// Only display container IDs.
-		#[arg(short, long)]
+		/// Only display container IDs. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
@@ -310,9 +310,9 @@ pub(crate) enum Commands {
 	/// Stream Podman events for this project's containers.
 	Events {
 		/// Output format: a `TYPE ACTION NAME` summary (table) or one JSON
-		/// object per line.
-		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
-		format: OutputFormat,
+		/// object per line (NDJSON, not a JSON array).
+		#[arg(long, value_enum, default_value_t = EventsFormat::Table)]
+		format: EventsFormat,
 		/// Deprecated alias for `--format json`; kept for backward compatibility.
 		#[arg(long, hide = true)]
 		json: bool,
@@ -365,8 +365,8 @@ pub(crate) enum Commands {
 	/// List the project's named volumes.
 	#[command(alias = "volume")]
 	Volumes {
-		/// Only display volume names.
-		#[arg(short, long)]
+		/// Only display volume names. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
@@ -378,8 +378,8 @@ pub(crate) enum Commands {
 	/// List images used by services.
 	#[command(alias = "image")]
 	Images {
-		/// Only display image IDs.
-		#[arg(short, long)]
+		/// Only display image IDs. Mutually exclusive with `--format`.
+		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -63,6 +63,7 @@ pub(crate) struct Cli {
 	pub(crate) project_directory: Option<PathBuf>,
 
 	/// Extra env file(s) for interpolation (repeatable, later win; process env and `.env` still win).
+	/// With `run`, they also seed the one-off container's environment (below `environment:`/`-e`).
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
 

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -30,7 +30,12 @@ const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
 	name = "podup",
 	version,
 	about = "Run docker-compose projects on Podman.",
-	styles = HELP_STYLES
+	styles = HELP_STYLES,
+	// No subcommand prints help and exits non-zero (like docker compose), and the
+	// built-in `help` is replaced by an explicit `Help` variant that tolerates
+	// extra tokens, `-h`/`--help`, and a leading `--`.
+	arg_required_else_help = true,
+	disable_help_subcommand = true
 )]
 pub(crate) struct Cli {
 	/// Path to the compose file (or `COMPOSE_FILE`). Unset: probe the
@@ -67,8 +72,8 @@ pub(crate) struct Cli {
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
 
-	/// When to colourise output: auto (TTY only), always, or never. Under `auto`,
-	/// `NO_COLOR` also forces plain output; `always` overrides it.
+	/// When to colourise output: auto (TTY only), always, or never. With `auto`,
+	/// `NO_COLOR` also forces plain output; `--ansi always` overrides `NO_COLOR`.
 	#[arg(long, value_enum, default_value_t = AnsiMode::Auto, global = true)]
 	pub(crate) ansi: AnsiMode,
 

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -8,7 +8,9 @@ mod commands;
 mod parse;
 mod types;
 pub(crate) use commands::Commands;
-pub(crate) use types::{AnsiMode, ConfigFormat, GenerateCommands, OutputFormat, RmiScope};
+pub(crate) use types::{
+	AnsiMode, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
+};
 
 /// Help-screen colours (clap honours its own TTY/`NO_COLOR`/`CLICOLOR` detection
 /// for these, since help is rendered before `--ansi` is parsed): green-bold
@@ -20,8 +22,16 @@ const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
 	.placeholder(clap::builder::styling::AnsiColor::Cyan.on_default());
 
 /// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
+//
+// An explicit `about` is set on `#[command]` so clap does not promote this
+// internal doc comment to the program's `--help` description.
 #[derive(Parser)]
-#[command(name = "podup", version, styles = HELP_STYLES)]
+#[command(
+	name = "podup",
+	version,
+	about = "Run docker-compose projects on Podman.",
+	styles = HELP_STYLES
+)]
 pub(crate) struct Cli {
 	/// Path to the compose file (or `COMPOSE_FILE`). Unset: probe the
 	/// compose-spec precedence list (compose.yaml/.yml, docker-compose.yaml/.yml).
@@ -56,8 +66,8 @@ pub(crate) struct Cli {
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,
 
-	/// When to colourise output: auto (TTY only), always, or never. `NO_COLOR`
-	/// also forces plain output.
+	/// When to colourise output: auto (TTY only), always, or never. Under `auto`,
+	/// `NO_COLOR` also forces plain output; `always` overrides it.
 	#[arg(long, value_enum, default_value_t = AnsiMode::Auto, global = true)]
 	pub(crate) ansi: AnsiMode,
 

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -30,9 +30,40 @@ pub(crate) fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
 	Ok((service.to_string(), replicas))
 }
 
+/// Pull-policy values podup accepts for `up --pull` / `pull --policy`. `always`,
+/// `missing`, `never`, and `build` mirror `docker compose`; `newer` is Podman's
+/// extension.
+const PULL_POLICIES: [&str; 5] = ["always", "missing", "never", "newer", "build"];
+
+/// Validate a `--pull` / `--policy` value at parse time, rejecting unknown values
+/// with a clear message instead of silently defaulting to `missing` at runtime.
+pub(crate) fn parse_pull_policy(value: &str) -> Result<String, String> {
+	if PULL_POLICIES.contains(&value) {
+		Ok(value.to_string())
+	} else {
+		Err(format!(
+			"invalid pull policy `{value}` (expected one of: {})",
+			PULL_POLICIES.join(", ")
+		))
+	}
+}
+
+/// Parse a `-t/--timeout` shutdown-grace value, rejecting negatives with a clear
+/// range error rather than forwarding `-5` to Podman or letting clap report a
+/// confusing "unexpected argument" for the space form.
+pub(crate) fn parse_timeout(value: &str) -> Result<i32, String> {
+	let secs: i32 = value
+		.parse()
+		.map_err(|_| format!("timeout `{value}` must be an integer number of seconds"))?;
+	if secs < 0 {
+		return Err(format!("timeout `{value}` must be zero or greater"));
+	}
+	Ok(secs)
+}
+
 #[cfg(test)]
 mod tests {
-	use super::parse_scale_pair;
+	use super::{parse_pull_policy, parse_scale_pair, parse_timeout};
 
 	#[test]
 	fn parse_scale_pair_accepts_valid() {
@@ -49,5 +80,34 @@ mod tests {
 		] {
 			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
 		}
+	}
+
+	#[test]
+	fn parse_pull_policy_accepts_known_values() {
+		for ok in ["always", "missing", "never", "newer", "build"] {
+			assert_eq!(parse_pull_policy(ok), Ok(ok.to_string()));
+		}
+	}
+
+	#[test]
+	fn parse_pull_policy_rejects_unknown_values() {
+		for bad in ["bogus", "Always", "if_not_present", ""] {
+			assert!(
+				parse_pull_policy(bad).is_err(),
+				"`{bad}` should be rejected"
+			);
+		}
+	}
+
+	#[test]
+	fn parse_timeout_accepts_zero_and_positive() {
+		assert_eq!(parse_timeout("0"), Ok(0));
+		assert_eq!(parse_timeout("30"), Ok(30));
+	}
+
+	#[test]
+	fn parse_timeout_rejects_negative_and_non_numeric() {
+		assert!(parse_timeout("-5").is_err());
+		assert!(parse_timeout("abc").is_err());
 	}
 }

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -3,13 +3,21 @@
 /// Parse a `SERVICE=N` scale argument into a `(service, replicas)` pair.
 ///
 /// Rejects a missing `=`, an empty service name, a non-numeric count, and `N=0`
-/// (use `down`/`stop` to remove a service, not `scale=0`).
+/// (use `down`/`stop` to remove a service, not `scale=0`). The count must be a
+/// run of plain ASCII digits: a leading sign such as `+3` (which `u32::FromStr`
+/// would otherwise accept) is rejected so the input contract stays consistent
+/// with the already-rejected `-1`/`x`/`0x10` forms.
 pub(crate) fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
 	let (service, count) = value
 		.split_once('=')
 		.ok_or_else(|| format!("expected SERVICE=N, got `{value}`"))?;
 	if service.is_empty() {
 		return Err(format!("missing service name in `{value}`"));
+	}
+	if count.is_empty() || !count.bytes().all(|b| b.is_ascii_digit()) {
+		return Err(format!(
+			"replica count in `{value}` must be a non-negative integer"
+		));
 	}
 	let replicas: u32 = count
 		.parse()
@@ -33,7 +41,12 @@ mod tests {
 
 	#[test]
 	fn parse_scale_pair_rejects_bad_input() {
-		for bad in ["web", "=3", "web=", "web=x", "web=0", "web=-1"] {
+		// `web=+3` is rejected like the other malformed counts: `u32::FromStr`
+		// tolerates a leading '+', so the explicit all-digits guard is what keeps
+		// the contract consistent.
+		for bad in [
+			"web", "=3", "web=", "web=x", "web=0", "web=-1", "web=+3", "web=0x10", "web= 3",
+		] {
 			assert!(parse_scale_pair(bad).is_err(), "`{bad}` should be rejected");
 		}
 	}

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -12,6 +12,19 @@ pub(crate) enum OutputFormat {
 	Json,
 }
 
+/// Output rendering for `events`. Distinct from [`OutputFormat`] because the
+/// event stream is NDJSON (one object per line), not a JSON array, and the table
+/// form is a plain summary line with no header — so the help text must not claim
+/// "JSON array" / "aligned columns".
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum EventsFormat {
+	/// A plain `TYPE ACTION NAME` summary, one event per line (no header/alignment).
+	#[default]
+	Table,
+	/// One JSON object per line (NDJSON) — not a JSON array.
+	Json,
+}
+
 /// When to colourise human-facing output (`--ansi`, like docker compose).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum AnsiMode {

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -13,6 +13,14 @@ use crate::error::{ComposeError, Result};
 const MAX_ALIAS_REFS: usize = 100;
 const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
 
+/// Upper bound on flow-style nesting depth (`[`/`{`). serde_yaml_ng's own
+/// recursion cap eventually rejects pathological nesting, but its tokenizer is
+/// O(n^2) in the depth it scans, so a small file of deeply nested flow
+/// collections (`[[[[…]]]]`) can burn quadratic CPU time before that cap fires.
+/// Real compose files nest only a handful of levels, so this cheap pre-parse
+/// pass bounds the parser's worst-case work without affecting any valid input.
+const MAX_FLOW_DEPTH: usize = 100;
+
 pub(super) fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
 	deserialize_with_merge_interp(content, None)
 }
@@ -31,6 +39,7 @@ pub(super) fn deserialize_with_merge_interp(
 	content: &str,
 	vars: Option<&HashMap<String, String>>,
 ) -> Result<ComposeFile> {
+	guard_flow_depth(content)?;
 	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
 	if let Some(vars) = vars {
@@ -124,6 +133,36 @@ fn guard_alias_expansion(content: &str) -> Result<()> {
 			"compose document uses {refs} YAML alias references; at most {MAX_ALIAS_REFS} are \
 			 allowed — inline the repeated content instead"
 		)));
+	}
+	Ok(())
+}
+
+/// Reject documents whose flow-style nesting (`[`/`{`) exceeds [`MAX_FLOW_DEPTH`]
+/// before they reach the O(n^2) tokenizer. Brackets inside single/double-quoted
+/// scalars and after a `#` comment are ignored, mirroring [`count_alias_refs`]'s
+/// conservative scan; the count never fully parses YAML, it only bounds work.
+fn guard_flow_depth(content: &str) -> Result<()> {
+	let mut depth: usize = 0;
+	for line in content.lines() {
+		let (mut in_single, mut in_double) = (false, false);
+		for c in line.chars() {
+			match c {
+				'\'' if !in_double => in_single = !in_single,
+				'"' if !in_single => in_double = !in_double,
+				'#' if !in_single && !in_double => break,
+				'[' | '{' if !in_single && !in_double => {
+					depth += 1;
+					if depth > MAX_FLOW_DEPTH {
+						return Err(ComposeError::Unsupported(format!(
+							"compose document nests flow collections more than {MAX_FLOW_DEPTH} \
+							 levels deep; flatten the structure"
+						)));
+					}
+				}
+				']' | '}' if !in_single && !in_double => depth = depth.saturating_sub(1),
+				_ => {}
+			}
+		}
 	}
 	Ok(())
 }
@@ -302,6 +341,32 @@ mod tests {
 		}
 		let err = guard_alias_expansion(&yaml).unwrap_err();
 		assert!(format!("{err}").contains("alias references"));
+	}
+
+	// flow-depth guard
+
+	#[test]
+	fn guard_flow_depth_allows_shallow_nesting() {
+		// A handful of nested flow collections (typical compose) is fine.
+		assert!(guard_flow_depth("a: [[1, 2], [3, 4]]\nb: {x: {y: 1}}\n").is_ok());
+	}
+
+	#[test]
+	fn guard_flow_depth_rejects_pathological_nesting() {
+		let deep = format!(
+			"a: {}{}\n",
+			"[".repeat(MAX_FLOW_DEPTH + 5),
+			"]".repeat(MAX_FLOW_DEPTH + 5)
+		);
+		let err = guard_flow_depth(&deep).unwrap_err();
+		assert!(format!("{err}").contains("flow collections"));
+	}
+
+	#[test]
+	fn guard_flow_depth_ignores_brackets_in_quotes_and_comments() {
+		// Brackets inside quoted scalars or after `#` do not count toward depth.
+		let yaml = format!("cmd: \"{}\"  # {}\n", "[".repeat(200), "{".repeat(200));
+		assert!(guard_flow_depth(&yaml).is_ok());
 	}
 
 	#[test]

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
@@ -12,11 +14,95 @@ const MAX_ALIAS_REFS: usize = 100;
 const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
 
 pub(super) fn deserialize_with_merge(content: &str) -> Result<ComposeFile> {
+	deserialize_with_merge_interp(content, None)
+}
+
+/// Parse `content` into a [`ComposeFile`], optionally interpolating `${VAR}`
+/// references at the scalar level once the YAML document has been parsed.
+///
+/// Interpolating *after* parsing (rather than on the raw text) is deliberate:
+/// the resolved value of a variable is stored verbatim into the existing scalar
+/// node, so an env value containing newlines or YAML syntax is treated as data,
+/// never as document structure (no key/`privileged: true` injection), an
+/// unset/empty variable always yields an in-place empty string (it cannot drop a
+/// key or trigger a "mapping values are not allowed" parse error), and multiline
+/// or backslash-bearing values are not re-interpreted by the YAML parser.
+pub(super) fn deserialize_with_merge_interp(
+	content: &str,
+	vars: Option<&HashMap<String, String>>,
+) -> Result<ComposeFile> {
 	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
+	if let Some(vars) = vars {
+		interpolate_value(&mut value, vars)?;
+	}
 	apply_merge_keys(&mut value);
 	let file: ComposeFile = serde_yaml::from_value(value)?;
 	Ok(file)
+}
+
+/// Recursively interpolate every string scalar of a parsed YAML `value`.
+///
+/// Mapping values and sequence items are coerced through [`interpolate_scalar`]
+/// (so an interpolated numeric/boolean keeps its YAML type, matching
+/// docker-compose's typed fields); mapping keys are interpolated as plain text.
+fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, String>) -> Result<()> {
+	match value {
+		serde_yaml::Value::String(s) if s.contains('$') => {
+			*value = interpolate_scalar(s, vars)?;
+		}
+		serde_yaml::Value::Sequence(seq) => {
+			for item in seq.iter_mut() {
+				interpolate_value(item, vars)?;
+			}
+		}
+		serde_yaml::Value::Mapping(map) => {
+			let taken = std::mem::take(map);
+			let mut rebuilt = serde_yaml::Mapping::with_capacity(taken.len());
+			for (key, mut val) in taken {
+				let key = interpolate_key(key, vars)?;
+				interpolate_value(&mut val, vars)?;
+				rebuilt.insert(key, val);
+			}
+			*map = rebuilt;
+		}
+		_ => {}
+	}
+	Ok(())
+}
+
+/// Interpolate a single string scalar and recover its YAML type.
+///
+/// An empty expansion stays an empty string (it must never collapse to `null`
+/// and drop the owning key). Otherwise the resolved text is re-read as a YAML
+/// scalar so `${N}` in a numeric position becomes a number and `${B}` a boolean,
+/// matching docker-compose. Crucially, only *scalar* re-parses are adopted: a
+/// result that parses into a mapping or sequence (an injected
+/// `root\n  privileged: true`, or a trailing-colon `repo:`) is kept verbatim as
+/// a string, so an attacker-influenced value can never introduce structure.
+fn interpolate_scalar(s: &str, vars: &HashMap<String, String>) -> Result<serde_yaml::Value> {
+	let resolved = crate::substitute::substitute(s, vars)?;
+	if resolved.is_empty() {
+		return Ok(serde_yaml::Value::String(String::new()));
+	}
+	match serde_yaml::from_str::<serde_yaml::Value>(&resolved) {
+		Ok(v @ (serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_))) => Ok(v),
+		_ => Ok(serde_yaml::Value::String(resolved)),
+	}
+}
+
+/// Interpolate a mapping key. Keys stay strings (a key is never coerced to a
+/// number/boolean) so the document shape is preserved.
+fn interpolate_key(
+	key: serde_yaml::Value,
+	vars: &HashMap<String, String>,
+) -> Result<serde_yaml::Value> {
+	match key {
+		serde_yaml::Value::String(s) if s.contains('$') => Ok(serde_yaml::Value::String(
+			crate::substitute::substitute(&s, vars)?,
+		)),
+		other => Ok(other),
+	}
 }
 
 /// Reject YAML documents whose alias use could amplify into an out-of-memory
@@ -120,6 +206,72 @@ fn apply_merge_keys(value: &mut serde_yaml::Value) {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+		pairs
+			.iter()
+			.map(|(k, v)| (k.to_string(), v.to_string()))
+			.collect()
+	}
+
+	// scalar-level interpolation (post-parse)
+
+	#[test]
+	fn interpolation_cannot_inject_yaml_structure() {
+		// A value carrying an embedded newline + YAML must NOT introduce new keys:
+		// post-parse interpolation stores it verbatim into the existing scalar.
+		let v = vars(&[("U", "root\n    privileged: true")]);
+		let yaml = "services:\n  app:\n    image: nginx\n    user: ${U}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&v)).unwrap();
+		let svc = &file.services["app"];
+		assert_eq!(svc.user.as_deref(), Some("root\n    privileged: true"));
+		// The injected `privileged: true` is data, not structure.
+		assert_eq!(svc.privileged, None);
+	}
+
+	#[test]
+	fn empty_interpolation_in_unquoted_scalar_keeps_key_and_is_empty() {
+		// `repo:${TAG}` with TAG unset becomes `repo:` (no YAML parse error) and a
+		// bare `${TAG}` value becomes an empty string rather than dropping the key.
+		let yaml = "services:\n  app:\n    image: repo:${TAG}\n    user: ${TAG}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&vars(&[]))).unwrap();
+		let svc = &file.services["app"];
+		assert_eq!(svc.image.as_deref(), Some("repo:"));
+		assert_eq!(svc.user.as_deref(), Some(""));
+	}
+
+	#[test]
+	fn interpolated_multiline_and_backslash_values_preserved_verbatim() {
+		// A resolved value with real newlines/backslashes is stored byte-for-byte;
+		// it is not re-folded or re-escaped by the YAML parser.
+		let v = vars(&[("MSG", "line1\nline2\\x")]);
+		let yaml = "services:\n  app:\n    image: nginx\n    user: ${MSG}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&v)).unwrap();
+		assert_eq!(
+			file.services["app"].user.as_deref(),
+			Some("line1\nline2\\x")
+		);
+	}
+
+	#[test]
+	fn interpolated_scalar_recovers_numeric_and_boolean_type() {
+		// `${N}` in a numeric/boolean position keeps its YAML type, matching
+		// docker-compose's typed fields.
+		let v = vars(&[("P", "true"), ("CPU", "512")]);
+		let yaml =
+			"services:\n  app:\n    image: nginx\n    privileged: ${P}\n    cpu_shares: ${CPU}\n";
+		let file = deserialize_with_merge_interp(yaml, Some(&v)).unwrap();
+		assert_eq!(file.services["app"].privileged, Some(true));
+		assert_eq!(file.services["app"].cpu_shares, Some(512));
+	}
+
+	#[test]
+	fn no_interpolation_when_vars_is_none() {
+		// `config --no-interpolate` path: placeholders stay literal.
+		let yaml = "services:\n  app:\n    image: repo:${TAG}\n";
+		let file = deserialize_with_merge(yaml).unwrap();
+		assert_eq!(file.services["app"].image.as_deref(), Some("repo:${TAG}"));
+	}
 
 	// alias-expansion guard
 

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -9,6 +9,7 @@ mod extends;
 mod include;
 mod merge;
 mod order;
+mod validate;
 
 use std::path::{Path, PathBuf};
 
@@ -128,6 +129,13 @@ pub fn parse_files_with_env_files_interp(
 		merge_override(&mut merged, other);
 	}
 	normalize_default_network(&mut merged);
+	// Semantic validation runs only on the interpolated file: `--no-interpolate`
+	// leaves literal `${VAR}` placeholders that cannot be reference- or
+	// range-checked. This makes `config`, `up`, and `generate` reject the same
+	// contradictory files docker-compose does, at config time.
+	if interpolate {
+		validate::validate(&merged)?;
+	}
 	for warning in diagnostics::collect(&merged) {
 		tracing::warn!("{warning}");
 	}

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -202,8 +202,7 @@ fn merge_override(target: &mut ComposeFile, other: ComposeFile) {
 /// use [`parse_file`] for that.
 pub fn parse_str(content: &str) -> Result<ComposeFile> {
 	let vars = substitute::build_vars(Path::new("."));
-	let substituted = substitute::substitute(content, &vars)?;
-	let mut file = merge::deserialize_with_merge(&substituted)?;
+	let mut file = merge::deserialize_with_merge_interp(content, Some(&vars))?;
 	extends::resolve_extends_same_file(&mut file)?;
 	Ok(file)
 }
@@ -232,18 +231,19 @@ pub(crate) fn parse_file_inner_with_env(
 		}
 	})?;
 	// `config --no-interpolate` leaves `${VAR}` placeholders literal; otherwise
-	// substitute against the env/.env/env-file variable map.
-	let yaml = if interpolate {
+	// interpolate against the env/.env/env-file variable map. Interpolation runs
+	// on the parsed YAML scalars (see `deserialize_with_merge_interp`), not the
+	// raw text, so resolved values cannot alter the document structure.
+	if interpolate {
 		let vars = if extra_env_files.is_empty() {
 			substitute::build_vars(dir)
 		} else {
 			substitute::build_vars_with_env_files_strict(dir, extra_env_files)?
 		};
-		substitute::substitute(&content, &vars)?
+		merge::deserialize_with_merge_interp(&content, Some(&vars))
 	} else {
-		content
-	};
-	merge::deserialize_with_merge(&yaml)
+		merge::deserialize_with_merge(&content)
+	}
 }
 
 #[cfg(test)]

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -237,7 +237,7 @@ pub(crate) fn parse_file_inner_with_env(
 		let vars = if extra_env_files.is_empty() {
 			substitute::build_vars(dir)
 		} else {
-			substitute::build_vars_with_env_files(dir, extra_env_files)
+			substitute::build_vars_with_env_files_strict(dir, extra_env_files)?
 		};
 		substitute::substitute(&content, &vars)?
 	} else {

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -18,6 +18,12 @@ use crate::substitute;
 use types::{ComposeFile, ServiceNetworks};
 
 pub use order::{resolve_levels, resolve_order};
+pub use validate::validate_config;
+
+/// Whether a compose-file path is the stdin sentinel `-` (`docker compose -f -`).
+fn is_stdin(path: &Path) -> bool {
+	path == Path::new("-")
+}
 
 /// Parse a compose file from disk, applying variable substitution and
 /// resolving `extends:` / `include:` directives.
@@ -42,8 +48,17 @@ pub fn parse_file_with_env_files_interp(
 	env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
-	let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-	let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
+	// `-f -` reads the compose document from stdin (like `docker compose`); there
+	// is no file to canonicalize, so relative paths and `.env` resolve against the
+	// working directory.
+	let (abs, dir) = if is_stdin(path) {
+		let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+		(PathBuf::from("-"), cwd)
+	} else {
+		let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+		let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
+		(abs, dir)
+	};
 	let mut file = parse_file_inner_with_env(&abs, &dir, env_files, interpolate)?;
 
 	let includes = std::mem::take(&mut file.include);
@@ -223,13 +238,17 @@ pub(crate) fn parse_file_inner_with_env(
 	extra_env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
-	let content = crate::filesystem::read_to_string_capped(path).map_err(|e| {
-		if e.kind() == std::io::ErrorKind::NotFound {
-			ComposeError::FileNotFound(path.display().to_string())
-		} else {
-			ComposeError::Io(e)
-		}
-	})?;
+	let content = if is_stdin(path) {
+		crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?
+	} else {
+		crate::filesystem::read_to_string_capped(path).map_err(|e| {
+			if e.kind() == std::io::ErrorKind::NotFound {
+				ComposeError::FileNotFound(path.display().to_string())
+			} else {
+				ComposeError::Io(e)
+			}
+		})?
+	};
 	// `config --no-interpolate` leaves `${VAR}` placeholders literal; otherwise
 	// interpolate against the env/.env/env-file variable map. Interpolation runs
 	// on the parsed YAML scalars (see `deserialize_with_merge_interp`), not the
@@ -251,6 +270,14 @@ mod tests {
 	use super::*;
 
 	// parse_str_raw
+
+	#[test]
+	fn is_stdin_matches_only_the_dash_sentinel() {
+		assert!(is_stdin(Path::new("-")));
+		assert!(!is_stdin(Path::new("docker-compose.yml")));
+		assert!(!is_stdin(Path::new("./-")));
+		assert!(!is_stdin(Path::new("a-b")));
+	}
 
 	#[test]
 	fn parse_str_raw_minimal_service() {

--- a/internal/compose/order.rs
+++ b/internal/compose/order.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
@@ -30,25 +31,27 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 		}
 	}
 
-	// Seed the queue from `services` (compose-file order) rather than iterating
-	// the `in_degree` HashMap, whose order is randomised per run. This keeps the
-	// resolved order deterministic for independent services, so dependent
-	// commands (e.g. best-effort `kill`) behave reproducibly.
-	let mut queue: std::collections::VecDeque<&str> = services
+	// A min-heap (lexicographically smallest name first) keeps the order
+	// deterministic: the in-degree map is a `HashMap`, so seeding/extending the
+	// frontier from its iteration order would otherwise be per-run random. This
+	// mirrors the per-level `sort_unstable` in `resolve_levels`, so independent
+	// (in-degree-0) services resolve in a stable order — which `wait` relies on
+	// for a reproducible exit code and output ordering.
+	let mut queue: BinaryHeap<Reverse<&str>> = in_degree
 		.iter()
-		.copied()
-		.filter(|s| in_degree.get(s) == Some(&0))
+		.filter(|(_, &deg)| deg == 0)
+		.map(|(&s, _)| Reverse(s))
 		.collect();
 
 	let mut order = Vec::new();
-	while let Some(node) = queue.pop_front() {
+	while let Some(Reverse(node)) = queue.pop() {
 		order.push(node.to_string());
 		let neighbors: Vec<&str> = graph.get(node).map_or(&[][..], |v| v.as_slice()).to_vec();
 		for neighbor in neighbors {
 			if let Some(deg) = in_degree.get_mut(neighbor) {
 				*deg -= 1;
 				if *deg == 0 {
-					queue.push_back(neighbor);
+					queue.push(Reverse(neighbor));
 				}
 			}
 		}
@@ -147,6 +150,37 @@ mod tests {
 	}
 
 	#[test]
+	fn resolve_order_is_deterministic_for_independent_services() {
+		// Independent (in-degree-0) services must resolve in a stable,
+		// lexicographic order regardless of the HashMap iteration order, so
+		// `wait`'s exit code and printed order are reproducible across runs.
+		let yaml = "services:\n  c:\n    image: x\n  a:\n    image: y\n  b:\n    image: z\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let order = resolve_order(&file).unwrap();
+		assert_eq!(
+			order,
+			vec!["a".to_string(), "b".to_string(), "c".to_string()]
+		);
+		// Re-resolving yields the identical order.
+		for _ in 0..16 {
+			assert_eq!(resolve_order(&file).unwrap(), order);
+		}
+	}
+
+	#[test]
+	fn resolve_order_dependents_are_deterministic() {
+		// Two dependents of the same dependency come out in stable lexicographic
+		// order, not whatever the graph's adjacency iteration happens to be.
+		let yaml = "services:\n  db:\n    image: x\n  zeb:\n    image: y\n    depends_on: [db]\n  api:\n    image: z\n    depends_on: [db]\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let order = resolve_order(&file).unwrap();
+		assert_eq!(
+			order,
+			vec!["db".to_string(), "api".to_string(), "zeb".to_string()]
+		);
+	}
+
+	#[test]
 	fn resolve_order_dep_before_dependent() {
 		let yaml = "services:\n  web:\n    image: nginx\n    depends_on: [db]\n  db:\n    image: postgres\n";
 		let file = parse_str_raw(yaml).unwrap();
@@ -154,23 +188,6 @@ mod tests {
 		let db_pos = order.iter().position(|s| s == "db").unwrap();
 		let web_pos = order.iter().position(|s| s == "web").unwrap();
 		assert!(db_pos < web_pos, "db must start before web");
-	}
-
-	#[test]
-	fn resolve_order_is_deterministic_for_independent_services() {
-		// Independent services must resolve in a stable (compose-file) order on
-		// every call, so best-effort consumers like `kill` behave reproducibly
-		// rather than depending on HashMap iteration order.
-		let yaml = "services:\n  a:\n    image: x\n  b:\n    image: y\n  c:\n    image: z\n";
-		let file = parse_str_raw(yaml).unwrap();
-		let first = resolve_order(&file).unwrap();
-		assert_eq!(
-			first,
-			vec!["a".to_string(), "b".to_string(), "c".to_string()]
-		);
-		for _ in 0..16 {
-			assert_eq!(resolve_order(&file).unwrap(), first);
-		}
 	}
 
 	#[test]

--- a/internal/compose/order.rs
+++ b/internal/compose/order.rs
@@ -30,10 +30,14 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 		}
 	}
 
-	let mut queue: std::collections::VecDeque<&str> = in_degree
+	// Seed the queue from `services` (compose-file order) rather than iterating
+	// the `in_degree` HashMap, whose order is randomised per run. This keeps the
+	// resolved order deterministic for independent services, so dependent
+	// commands (e.g. best-effort `kill`) behave reproducibly.
+	let mut queue: std::collections::VecDeque<&str> = services
 		.iter()
-		.filter(|(_, &deg)| deg == 0)
-		.map(|(&s, _)| s)
+		.copied()
+		.filter(|s| in_degree.get(s) == Some(&0))
 		.collect();
 
 	let mut order = Vec::new();
@@ -150,6 +154,23 @@ mod tests {
 		let db_pos = order.iter().position(|s| s == "db").unwrap();
 		let web_pos = order.iter().position(|s| s == "web").unwrap();
 		assert!(db_pos < web_pos, "db must start before web");
+	}
+
+	#[test]
+	fn resolve_order_is_deterministic_for_independent_services() {
+		// Independent services must resolve in a stable (compose-file) order on
+		// every call, so best-effort consumers like `kill` behave reproducibly
+		// rather than depending on HashMap iteration order.
+		let yaml = "services:\n  a:\n    image: x\n  b:\n    image: y\n  c:\n    image: z\n";
+		let file = parse_str_raw(yaml).unwrap();
+		let first = resolve_order(&file).unwrap();
+		assert_eq!(
+			first,
+			vec!["a".to_string(), "b".to_string(), "c".to_string()]
+		);
+		for _ in 0..16 {
+			assert_eq!(resolve_order(&file).unwrap(), first);
+		}
 	}
 
 	#[test]

--- a/internal/compose/order.rs
+++ b/internal/compose/order.rs
@@ -58,12 +58,26 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 	}
 
 	if order.len() != services.len() {
-		return Err(ComposeError::CircularDependency(
-			"cycle detected in depends_on".into(),
-		));
+		return Err(ComposeError::CircularDependency(cycle_message(&in_degree)));
 	}
 
 	Ok(order)
+}
+
+/// Build the user-facing circular-dependency message naming the services still
+/// holding a nonzero in-degree after Kahn's algorithm — exactly the nodes that
+/// form (or feed into) the cycle. Sorted for a deterministic message.
+fn cycle_message(in_degree: &HashMap<&str, usize>) -> String {
+	let mut involved: Vec<&str> = in_degree
+		.iter()
+		.filter(|(_, &deg)| deg > 0)
+		.map(|(&s, _)| s)
+		.collect();
+	involved.sort_unstable();
+	format!(
+		"circular dependency among services: {}",
+		involved.join(", ")
+	)
 }
 
 /// Group services into dependency levels (Kahn's algorithm, layered).
@@ -124,9 +138,7 @@ pub fn resolve_levels(file: &ComposeFile) -> Result<Vec<Vec<String>>> {
 	}
 
 	if processed != services.len() {
-		return Err(ComposeError::CircularDependency(
-			"cycle detected in depends_on".into(),
-		));
+		return Err(ComposeError::CircularDependency(cycle_message(&in_degree)));
 	}
 
 	Ok(levels)
@@ -194,7 +206,22 @@ mod tests {
 	fn resolve_order_cycle_is_error() {
 		let yaml = "services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n";
 		let file = parse_str_raw(yaml).unwrap();
-		assert!(resolve_order(&file).is_err());
+		let err = resolve_order(&file).unwrap_err();
+		// The message names the services in the cycle and is not the old redundant
+		// "circular dependency detected: cycle detected in depends_on".
+		let msg = err.to_string();
+		assert!(
+			msg.contains("circular dependency among services"),
+			"got {msg:?}"
+		);
+		assert!(
+			msg.contains('a') && msg.contains('b'),
+			"names the cycle: {msg:?}"
+		);
+		assert!(
+			!msg.contains("cycle detected in depends_on"),
+			"no redundancy: {msg:?}"
+		);
 	}
 
 	#[test]
@@ -229,7 +256,16 @@ mod tests {
 	fn resolve_levels_cycle_is_error() {
 		let yaml = "services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n";
 		let file = parse_str_raw(yaml).unwrap();
-		assert!(resolve_levels(&file).is_err());
+		let err = resolve_levels(&file).unwrap_err();
+		let msg = err.to_string();
+		assert!(
+			msg.contains("circular dependency among services"),
+			"got {msg:?}"
+		);
+		assert!(
+			msg.contains('a') && msg.contains('b'),
+			"names the cycle: {msg:?}"
+		);
 	}
 
 	#[test]

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -66,8 +66,13 @@ pub struct ResourcesConfig {
 /// A single resource specification: CPU shares, memory limit, pids limit, and device access.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourceSpec {
-	/// CPU limit expressed in cores (e.g. `"0.5"`).
-	#[serde(skip_serializing_if = "Option::is_none")]
+	/// CPU limit expressed in cores (e.g. `0.5` or `"0.5"`); accepts both the
+	/// unquoted-number and quoted-string spec forms.
+	#[serde(
+		default,
+		deserialize_with = "super::primitives::deserialize_opt_string_or_number",
+		skip_serializing_if = "Option::is_none"
+	)]
 	pub cpus: Option<String>,
 	/// Memory limit as a size string (e.g. `"512M"`).
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -41,7 +41,7 @@ pub struct WatchRule {
 }
 
 /// Action triggered by a `develop.watch` rule: `sync`, `rebuild`, `restart`, `sync+restart`, or `sync+exec`.
-#[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum WatchAction {
 	/// `sync` — copy changed files from `path` into the container at `target`.
 	#[default]
@@ -54,6 +54,38 @@ pub enum WatchAction {
 	SyncAndRestart,
 	/// `sync+exec` — sync changed files, then run the rule's `exec` command in the container.
 	SyncAndExec,
+}
+
+impl WatchAction {
+	/// The lowercase compose token for this action (the inverse of the custom
+	/// [`Deserialize`]). Kept in sync with the parser so `config` output
+	/// round-trips back through podup.
+	pub fn as_token(&self) -> &'static str {
+		match self {
+			WatchAction::Sync => "sync",
+			WatchAction::Rebuild => "rebuild",
+			WatchAction::Restart => "restart",
+			WatchAction::SyncAndRestart => "sync+restart",
+			WatchAction::SyncAndExec => "sync+exec",
+		}
+	}
+
+	/// True for actions whose semantics require a `target` (the sync family).
+	/// `rebuild`/`restart` operate on the whole container and need no target.
+	pub fn requires_target(&self) -> bool {
+		matches!(
+			self,
+			WatchAction::Sync | WatchAction::SyncAndRestart | WatchAction::SyncAndExec
+		)
+	}
+}
+
+impl Serialize for WatchAction {
+	fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+		// Emit the lowercase compose token (not the PascalCase variant name) so
+		// `config` output is re-ingestible by the custom `Deserialize` below.
+		s.serialize_str(self.as_token())
+	}
 }
 
 impl<'de> Deserialize<'de> for WatchAction {
@@ -120,5 +152,52 @@ mod tests {
 	#[test]
 	fn watch_action_unknown_is_error() {
 		assert!(serde_yaml::from_str::<WatchAction>("\"deploy\"").is_err());
+	}
+
+	#[test]
+	fn watch_action_serializes_lowercase_token() {
+		// `config` must emit the compose token, not the PascalCase variant name.
+		assert_eq!(
+			serde_yaml::to_string(&WatchAction::Sync).unwrap().trim(),
+			"sync"
+		);
+		assert_eq!(
+			serde_yaml::to_string(&WatchAction::SyncAndRestart)
+				.unwrap()
+				.trim(),
+			"sync+restart"
+		);
+		assert_eq!(
+			serde_yaml::to_string(&WatchAction::SyncAndExec)
+				.unwrap()
+				.trim(),
+			"sync+exec"
+		);
+	}
+
+	#[test]
+	fn watch_action_round_trips_through_config() {
+		// Every variant must survive a serialize -> deserialize round-trip so
+		// `config` output feeds back into podup unchanged.
+		for action in [
+			WatchAction::Sync,
+			WatchAction::Rebuild,
+			WatchAction::Restart,
+			WatchAction::SyncAndRestart,
+			WatchAction::SyncAndExec,
+		] {
+			let rendered = serde_yaml::to_string(&action).unwrap();
+			let parsed: WatchAction = serde_yaml::from_str(&rendered).unwrap();
+			assert_eq!(parsed, action);
+		}
+	}
+
+	#[test]
+	fn watch_action_requires_target_matches_sync_family() {
+		assert!(WatchAction::Sync.requires_target());
+		assert!(WatchAction::SyncAndRestart.requires_target());
+		assert!(WatchAction::SyncAndExec.requires_target());
+		assert!(!WatchAction::Rebuild.requires_target());
+		assert!(!WatchAction::Restart.requires_target());
 	}
 }

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -181,6 +181,54 @@ impl ComposeFile {
 			}
 		}
 	}
+
+	/// Drop every captured unknown key that the diagnostics pass reports as
+	/// "ignored", so a rendered `config` reflects only what podup actually
+	/// applies. Compose-spec `x-*` extension keys are kept — they are valid and
+	/// round-tripped — but a typo or an unmapped key is removed rather than
+	/// echoed back, which is what makes re-feeding the output stop re-triggering
+	/// the same warning. Mirrors the levels walked by the diagnostics collector.
+	pub fn strip_ignored_unknown_keys(&mut self) {
+		retain_extension_keys(&mut self.extensions);
+		for model in self.models.values_mut() {
+			retain_extension_keys(&mut model.unknown);
+		}
+		for net in self.networks.values_mut().flatten() {
+			retain_extension_keys(&mut net.unknown);
+			if let Some(ipam) = net.ipam.as_mut() {
+				retain_extension_keys(&mut ipam.unknown);
+			}
+		}
+		for vol in self.volumes.values_mut().flatten() {
+			retain_extension_keys(&mut vol.unknown);
+		}
+		for svc in self.services.values_mut() {
+			retain_extension_keys(&mut svc.unknown);
+			if let Some(hc) = svc.healthcheck.as_mut() {
+				retain_extension_keys(&mut hc.unknown);
+			}
+			if let Some(deploy) = svc.deploy.as_mut() {
+				retain_extension_keys(&mut deploy.unknown);
+			}
+			if let Some(develop) = svc.develop.as_mut() {
+				for rule in &mut develop.watch {
+					retain_extension_keys(&mut rule.unknown);
+				}
+			}
+			if let Some(cred) = svc.credential_spec.as_mut() {
+				retain_extension_keys(&mut cred.unknown);
+			}
+			if let Some(provider) = svc.provider.as_mut() {
+				retain_extension_keys(&mut provider.unknown);
+			}
+		}
+	}
+}
+
+/// Keep only Compose-spec `x-*` extension keys in a captured-unknowns map,
+/// discarding the keys the diagnostics pass warns are ignored.
+fn retain_extension_keys(map: &mut IndexMap<String, serde_yaml::Value>) {
+	map.retain(|k, _| k.starts_with("x-"));
 }
 
 #[cfg(test)]
@@ -239,5 +287,47 @@ secrets:
 		let rendered = serde_yaml::to_string(&file).unwrap();
 		assert!(!rendered.contains("hunter2-do-not-leak"));
 		assert!(rendered.contains("<redacted>"));
+	}
+
+	#[test]
+	fn strip_ignored_unknown_keys_drops_non_extension_at_every_level() {
+		// Unknown keys at the top level, in a service, a service sub-object
+		// (deploy), a network, and a volume are all dropped, while `x-*` extension
+		// keys at any level survive — so the rendered config agrees with the
+		// diagnostics that flagged the rest as ignored.
+		let yaml = r#"
+bogus_top: 1
+x-keep-top: ok
+services:
+  web:
+    image: nginx
+    bogus_svc: 2
+    x-keep-svc: ok
+    deploy:
+      bogus_deploy: 3
+networks:
+  netA:
+    bogus_net: 4
+volumes:
+  volA:
+    bogus_vol: 5
+"#;
+		let mut file = parse_str(yaml).unwrap();
+		file.strip_ignored_unknown_keys();
+		let out = serde_yaml::to_string(&file).unwrap();
+		for dropped in [
+			"bogus_top",
+			"bogus_svc",
+			"bogus_deploy",
+			"bogus_net",
+			"bogus_vol",
+		] {
+			assert!(
+				!out.contains(dropped),
+				"{dropped} should be stripped: {out}"
+			);
+		}
+		assert!(out.contains("x-keep-top"), "top x- kept: {out}");
+		assert!(out.contains("x-keep-svc"), "svc x- kept: {out}");
 	}
 }

--- a/internal/compose/types/ports.rs
+++ b/internal/compose/types/ports.rs
@@ -10,13 +10,18 @@ use serde::{Deserialize, Serialize};
 ///
 /// The spec allows `published: 8080` (integer) or `published: "8080"` (string),
 /// and also string ranges like `"8080-8090"` for port range mappings.
+///
+/// The numeric form is held as a `u32` rather than a `u16` so an out-of-range
+/// value (e.g. `published: 99999`) deserializes and is then reported as a clear
+/// `InvalidPort` error by [`crate::ports`], instead of leaking serde's generic
+/// "data did not match any variant of untagged enum" message to the user.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringOrU16 {
 	/// String form, e.g. a quoted port or range like `"8080-8090"`.
 	String(String),
-	/// Numeric port form.
-	Number(u16),
+	/// Numeric port form (range-checked downstream, not at the type level).
+	Number(u32),
 }
 
 impl StringOrU16 {

--- a/internal/compose/types/primitives.rs
+++ b/internal/compose/types/primitives.rs
@@ -32,6 +32,28 @@ where
 	})
 }
 
+/// Deserialize a field that the compose spec allows as either a YAML number or a
+/// quoted string, normalizing to `Option<String>`. `cpus: 0.5` (number) and
+/// `cpus: "0.5"` (string) both parse; an absent key stays `None`. Used for the
+/// `cpus:` limits, which the spec writes unquoted but podup stores as a string.
+pub(crate) fn deserialize_opt_string_or_number<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	#[derive(Deserialize)]
+	#[serde(untagged)]
+	enum StringOrNumber {
+		Str(String),
+		Int(i64),
+		Float(f64),
+	}
+	Ok(Option::<StringOrNumber>::deserialize(de)?.map(|v| match v {
+		StringOrNumber::Str(s) => s,
+		StringOrNumber::Int(i) => i.to_string(),
+		StringOrNumber::Float(fl) => fl.to_string(),
+	}))
+}
+
 /// Container entrypoint / command — either a shell string or exec list.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
@@ -222,6 +244,38 @@ mod tests {
 	fn command_exec_to_argv_passthrough() {
 		let cmd = Command::Exec(vec!["ls".into()]);
 		assert_eq!(cmd.to_argv(), vec!["ls"]);
+	}
+
+	// string-or-number (cpus)
+
+	#[derive(Deserialize)]
+	struct CpusHolder {
+		#[serde(default, deserialize_with = "deserialize_opt_string_or_number")]
+		cpus: Option<String>,
+	}
+
+	#[test]
+	fn opt_string_or_number_accepts_unquoted_float() {
+		let h: CpusHolder = serde_yaml::from_str("cpus: 0.5\n").unwrap();
+		assert_eq!(h.cpus.as_deref(), Some("0.5"));
+	}
+
+	#[test]
+	fn opt_string_or_number_accepts_quoted_string() {
+		let h: CpusHolder = serde_yaml::from_str("cpus: \"0.5\"\n").unwrap();
+		assert_eq!(h.cpus.as_deref(), Some("0.5"));
+	}
+
+	#[test]
+	fn opt_string_or_number_accepts_integer() {
+		let h: CpusHolder = serde_yaml::from_str("cpus: 2\n").unwrap();
+		assert_eq!(h.cpus.as_deref(), Some("2"));
+	}
+
+	#[test]
+	fn opt_string_or_number_absent_is_none() {
+		let h: CpusHolder = serde_yaml::from_str("other: 1\n").unwrap();
+		assert_eq!(h.cpus, None);
 	}
 
 	// StringOrList

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -294,7 +294,12 @@ pub struct Service {
 	pub cpuset: Option<String>,
 	/// `cpus:` — fractional number of CPUs to allow (e.g. `0.5`); a hard cap
 	/// converted to a CFS quota. Top-level value wins over `deploy.resources`.
-	#[serde(skip_serializing_if = "Option::is_none")]
+	/// Accepts both the unquoted number (`cpus: 0.5`) and the quoted string form.
+	#[serde(
+		default,
+		deserialize_with = "super::primitives::deserialize_opt_string_or_number",
+		skip_serializing_if = "Option::is_none"
+	)]
 	pub cpus: Option<String>,
 	/// `cpu_count:` — number of usable CPUs (Windows containers); not honored on
 	/// Linux/Podman.

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -74,9 +74,55 @@ pub struct TmpfsOptions {
 	/// Size of the tmpfs mount in bytes.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub size: Option<u64>,
-	/// File mode of the tmpfs mount.
-	#[serde(skip_serializing_if = "Option::is_none")]
+	/// File mode of the tmpfs mount, stored as the actual permission bits.
+	///
+	/// A leading-zero string (`0700`) or an explicit `0o700` is interpreted as
+	/// octal — the conventional Unix file-mode notation — rather than erroring or
+	/// being silently re-interpreted; invalid input is a clear error.
+	#[serde(
+		default,
+		deserialize_with = "deserialize_octal_mode",
+		skip_serializing_if = "Option::is_none"
+	)]
 	pub mode: Option<u32>,
+}
+
+/// Deserialize a tmpfs `mode` as octal-aware permission bits.
+///
+/// YAML numeric scalars are already decoded by the parser (`0o700` → 448), so an
+/// integer node is taken as the actual permission bits. A string node — which is
+/// how a leading-zero literal like `0700` reaches us (and what previously failed
+/// with an opaque untagged error) — is parsed as octal, accepting an optional
+/// `0o` prefix and rejecting non-octal digits with a clear message.
+fn deserialize_octal_mode<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	use serde::de::Error;
+
+	#[derive(Deserialize)]
+	#[serde(untagged)]
+	enum Raw {
+		Int(u32),
+		Str(String),
+	}
+
+	match Option::<Raw>::deserialize(deserializer)? {
+		None => Ok(None),
+		Some(Raw::Int(bits)) => Ok(Some(bits)),
+		Some(Raw::Str(s)) => {
+			let trimmed = s.trim();
+			let digits = trimmed
+				.strip_prefix("0o")
+				.or_else(|| trimmed.strip_prefix("0O"))
+				.unwrap_or(trimmed);
+			u32::from_str_radix(digits, 8).map(Some).map_err(|_| {
+				D::Error::custom(format!(
+					"invalid tmpfs mode {s:?}: use octal notation like 0700 or 0o700"
+				))
+			})
+		}
+	}
 }
 
 /// A volume mount entry — either a short-form string or a long-form typed block.
@@ -248,6 +294,34 @@ impl ServiceSecretRef {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	// TmpfsOptions::mode octal parsing
+
+	#[test]
+	fn tmpfs_mode_octal_string_is_parsed_as_octal() {
+		// A leading-zero literal reaches us as a string and must parse as octal
+		// (0700 → 448 permission bits) instead of failing opaquely.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: \"0700\"\n").unwrap();
+		assert_eq!(opts.mode, Some(0o700));
+		// An explicit 0o prefix in a string also works.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: \"0o755\"\n").unwrap();
+		assert_eq!(opts.mode, Some(0o755));
+	}
+
+	#[test]
+	fn tmpfs_mode_octal_yaml_literal_is_preserved_as_bits() {
+		// A YAML `0o700` scalar is decoded to 448 by the parser; we keep those
+		// actual permission bits so the renderer's octal format round-trips.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: 0o700\n").unwrap();
+		assert_eq!(opts.mode, Some(0o700));
+	}
+
+	#[test]
+	fn tmpfs_mode_invalid_octal_is_clear_error() {
+		// A non-octal string is rejected with a clear error, not silently coerced.
+		let err = serde_yaml::from_str::<TmpfsOptions>("mode: \"0o9\"\n").unwrap_err();
+		assert!(err.to_string().contains("tmpfs mode"), "got: {err}");
+	}
 
 	// VolumeMount::target
 

--- a/internal/compose/validate.rs
+++ b/internal/compose/validate.rs
@@ -1,0 +1,208 @@
+//! Semantic validation of a resolved compose file.
+//!
+//! Parsing only checks that the YAML deserializes; it never rejects a file that
+//! is syntactically valid but semantically contradictory (e.g. a service that
+//! declares both `network_mode` and `networks`, or a reference to a network that
+//! was never defined). docker-compose errors on these at config time; podup used
+//! to accept them and then silently pick one interpretation, with the live
+//! engine and the Quadlet exporter diverging on which one. This pass closes that
+//! gap by failing fast with a clear message, so `config`, `up`, and `generate`
+//! all agree and no surface silently drops or mistranslates the configuration.
+
+use super::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::ports::parse_ports;
+
+/// Validate the semantic consistency of a resolved compose file. Returns the
+/// first error found, matching docker-compose's fail-at-config-time behaviour.
+///
+/// Run only on the interpolated file: with `--no-interpolate` the values may
+/// still contain literal `${VAR}` placeholders, which cannot be meaningfully
+/// range- or reference-checked.
+pub(super) fn validate(file: &ComposeFile) -> Result<()> {
+	validate_services(file)?;
+	validate_networks(file)?;
+	Ok(())
+}
+
+/// Per-service checks: the `network_mode`/`networks` mutual exclusion, every
+/// network reference resolving to a declared (or external) network, and that the
+/// `ports:` entries parse and are in range.
+fn validate_services(file: &ComposeFile) -> Result<()> {
+	for (name, service) in &file.services {
+		let attached = service.networks.names();
+		if service.network_mode.is_some() {
+			// docker-compose: "network_mode" and "networks" cannot be combined.
+			// The live engine silently honours network_mode and drops the declared
+			// networks; Quadlet emits both, producing a contradictory unit.
+			if !attached.is_empty() {
+				return Err(ComposeError::Unsupported(format!(
+					"service '{name}' sets both 'network_mode' and 'networks', which are \
+					 mutually exclusive; keep one"
+				)));
+			}
+		} else {
+			// Every referenced network must be declared at the top level (or be the
+			// synthesized `default`). An undefined reference is a config error in
+			// docker-compose; podup otherwise prefixes it on the engine path while
+			// the Quadlet exporter emits the raw name, a cross-project attach risk.
+			for net in &attached {
+				// `default` is the implicit project network docker-compose always
+				// provides, so an explicit reference to it is valid even without a
+				// top-level entry; everything else must be declared.
+				if net != "default" && !file.networks.contains_key(net) {
+					return Err(ComposeError::Unsupported(format!(
+						"service '{name}' refers to undefined network '{net}'; declare it \
+						 under the top-level 'networks:' or mark it external"
+					)));
+				}
+			}
+		}
+
+		// Surface a malformed/out-of-range port at config time rather than letting
+		// it slip through to a podman create error at run time.
+		parse_ports(&service.ports)?;
+	}
+	Ok(())
+}
+
+/// Top-level network checks: an `external: true` network must not also carry
+/// creation-time attributes (driver, IPAM, internal, …), which podman cannot
+/// apply to a pre-existing network and docker-compose rejects.
+fn validate_networks(file: &ComposeFile) -> Result<()> {
+	for (name, cfg) in &file.networks {
+		let Some(cfg) = cfg else { continue };
+		if cfg.external != Some(true) {
+			continue;
+		}
+		let mut conflicts = Vec::new();
+		if cfg.driver.is_some() {
+			conflicts.push("driver");
+		}
+		if !cfg.driver_opts.is_empty() {
+			conflicts.push("driver_opts");
+		}
+		if cfg.internal.is_some() {
+			conflicts.push("internal");
+		}
+		if cfg.attachable.is_some() {
+			conflicts.push("attachable");
+		}
+		if cfg.enable_ipv6.is_some() {
+			conflicts.push("enable_ipv6");
+		}
+		if cfg.enable_ipv4.is_some() {
+			conflicts.push("enable_ipv4");
+		}
+		if cfg.ipam.is_some() {
+			conflicts.push("ipam");
+		}
+		if !conflicts.is_empty() {
+			return Err(ComposeError::Unsupported(format!(
+				"network '{name}' is external but also sets {}; an external network is \
+				 used as-is and these attributes cannot be applied to it",
+				conflicts.join(", ")
+			)));
+		}
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::compose::types::ComposeFile;
+	use crate::parse_str;
+
+	fn validate_str(yaml: &str) -> crate::error::Result<()> {
+		let mut file: ComposeFile = parse_str(yaml).unwrap();
+		// Mirror the CLI: synthesize the implicit default network before validating
+		// so a bare service is not flagged as referencing an undefined network.
+		crate::compose::normalize_default_network(&mut file);
+		super::validate(&file)
+	}
+
+	#[test]
+	fn network_mode_with_networks_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    network_mode: host\n    networks: [front]\nnetworks:\n  front:\n";
+		let err = validate_str(yaml).unwrap_err();
+		assert!(err.to_string().contains("mutually exclusive"), "got: {err}");
+	}
+
+	#[test]
+	fn network_mode_alone_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    network_mode: host\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn undefined_network_reference_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [missing]\n";
+		let err = validate_str(yaml).unwrap_err();
+		assert!(
+			err.to_string().contains("undefined network 'missing'"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn declared_network_reference_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [front]\nnetworks:\n  front:\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn bare_service_default_network_is_accepted() {
+		// No networks declared at all: the synthesized `default` must satisfy the
+		// reference check, not trip it.
+		let yaml = "services:\n  web:\n    image: x\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn explicit_default_network_reference_is_accepted() {
+		// `default` is the implicit project network; referencing it without a
+		// top-level entry must not be flagged as undefined.
+		let yaml = "services:\n  web:\n    image: x\n    networks: [default]\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn external_network_with_internal_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n    internal: true\n";
+		let err = validate_str(yaml).unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("external"), "got: {msg}");
+		assert!(msg.contains("internal"), "got: {msg}");
+	}
+
+	#[test]
+	fn external_network_with_ipam_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n    ipam:\n      config:\n        - subnet: 10.0.0.0/24\n";
+		let err = validate_str(yaml).unwrap_err();
+		assert!(err.to_string().contains("ipam"), "got: {err}");
+	}
+
+	#[test]
+	fn plain_external_network_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn external_network_with_name_only_is_accepted() {
+		let yaml = "services:\n  web:\n    image: x\n    networks: [ext]\nnetworks:\n  ext:\n    external: true\n    name: shared_net\n";
+		assert!(validate_str(yaml).is_ok());
+	}
+
+	#[test]
+	fn out_of_range_short_port_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    ports: ['99999:80']\n";
+		assert!(validate_str(yaml).is_err());
+	}
+
+	#[test]
+	fn invalid_port_protocol_is_rejected() {
+		let yaml = "services:\n  web:\n    image: x\n    ports: ['80/banana']\n";
+		assert!(validate_str(yaml).is_err());
+	}
+}

--- a/internal/compose/validate.rs
+++ b/internal/compose/validate.rs
@@ -1,17 +1,163 @@
-//! Semantic validation of a resolved compose file.
+//! Validation of a fully parsed and merged compose file.
 //!
-//! Parsing only checks that the YAML deserializes; it never rejects a file that
-//! is syntactically valid but semantically contradictory (e.g. a service that
-//! declares both `network_mode` and `networks`, or a reference to a network that
-//! was never defined). docker-compose errors on these at config time; podup used
-//! to accept them and then silently pick one interpretation, with the live
-//! engine and the Quadlet exporter diverging on which one. This pass closes that
-//! gap by failing fast with a clear message, so `config`, `up`, and `generate`
-//! all agree and no surface silently drops or mistranslates the configuration.
+//! Two entry points live here. [`validate_config`] backs the `config` subcommand,
+//! applying the same cross-reference and well-formedness checks
+//! `docker compose config` performs and that the mutating commands would
+//! otherwise only surface later (at `resolve_order` time, when Podman rejects a
+//! bad port, or when an undeclared volume/network reaches the runtime). Running
+//! them up front means `config` reports the divergence at exit non-zero instead
+//! of echoing the file verbatim.
+//!
+//! [`validate`] is the semantic consistency pass run automatically after parsing
+//! and merging: it rejects files that deserialize cleanly but are semantically
+//! contradictory (e.g. a service that declares both `network_mode` and
+//! `networks`, or an `external: true` network that also sets creation-time
+//! attributes). docker-compose errors on these at config time; podup used to
+//! accept them and then silently pick one interpretation, with the live engine
+//! and the Quadlet exporter diverging on which one. Failing fast here keeps
+//! `config`, `up`, and `generate` in agreement.
 
-use super::types::ComposeFile;
+use crate::compose::order::resolve_order;
+use crate::compose::types::{ComposeFile, PortMapping, VolumeMount, VolumeType};
 use crate::error::{ComposeError, Result};
 use crate::ports::parse_ports;
+
+/// Validate a parsed compose file the way `docker compose config` does.
+///
+/// Checks, in order: at least one service is defined; every service declares an
+/// `image:` or `build:`; service names use the compose charset; published/target
+/// ports are in range; every referenced named volume and network is declared at
+/// the top level; and the `depends_on` graph is acyclic with no dangling
+/// required dependency. Returns the first violation found.
+pub fn validate_config(file: &ComposeFile) -> Result<()> {
+	// An empty file, a missing `services:` key, or `services: {}` is not a valid
+	// project — `docker compose config` errors with "no service selected".
+	if file.services.is_empty() {
+		return Err(ComposeError::Unsupported(
+			"no services defined in compose file".to_string(),
+		));
+	}
+
+	for (name, svc) in &file.services {
+		validate_service_name(name)?;
+		if svc.image.is_none() && svc.build.is_none() {
+			return Err(ComposeError::NoImageOrBuild(name.clone()));
+		}
+		validate_ports(name, &svc.ports)?;
+		validate_network_refs(name, file, svc)?;
+		validate_volume_refs(name, file, svc)?;
+	}
+
+	// Reject `depends_on` cycles and dangling required dependencies, matching the
+	// mutating commands (which run `resolve_order` before they start anything).
+	resolve_order(file)?;
+	Ok(())
+}
+
+/// Reject a service name that is empty or uses characters outside the compose
+/// charset (`[a-zA-Z0-9._-]`). Spaces and punctuation like `!` are rejected.
+fn validate_service_name(name: &str) -> Result<()> {
+	let ok = !name.is_empty()
+		&& name
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+	if ok {
+		Ok(())
+	} else {
+		Err(ComposeError::Unsupported(format!(
+			"service name {name:?} is invalid: use only ASCII letters, digits, '.', '_', '-'"
+		)))
+	}
+}
+
+/// Range-check every port a service publishes. `parse_ports` rejects values that
+/// do not fit a `u16` (e.g. `99999`); on top of that a container or host port of
+/// `0` is rejected here, since a valid published/target port is `1`–`65535`.
+fn validate_ports(service: &str, ports: &[PortMapping]) -> Result<()> {
+	for parsed in parse_ports(ports)? {
+		if parsed.container_port == 0 || parsed.host_port == Some(0) {
+			return Err(ComposeError::InvalidPort(format!(
+				"service '{service}' has a port of 0; ports must be in 1-65535"
+			)));
+		}
+	}
+	Ok(())
+}
+
+/// Every network a service joins must be declared in the top-level `networks:`
+/// map (the implicit `default` network is synthesized before this runs, so a
+/// bare service still validates). `network_mode:` services declare no networks.
+fn validate_network_refs(
+	service: &str,
+	file: &ComposeFile,
+	svc: &crate::compose::types::Service,
+) -> Result<()> {
+	for net in svc.networks.names() {
+		if !file.networks.contains_key(&net) {
+			return Err(ComposeError::Unsupported(format!(
+				"service '{service}' refers to undefined network '{net}'; declare it under the \
+				 top-level 'networks:' key"
+			)));
+		}
+	}
+	Ok(())
+}
+
+/// Every *named* volume a service mounts must be declared in the top-level
+/// `volumes:` map. Bind mounts (host paths) and anonymous volumes carry no
+/// top-level declaration and are skipped.
+fn validate_volume_refs(
+	service: &str,
+	file: &ComposeFile,
+	svc: &crate::compose::types::Service,
+) -> Result<()> {
+	for mount in &svc.volumes {
+		let named = match mount {
+			VolumeMount::Short(s) => short_named_volume(s),
+			VolumeMount::Long {
+				volume_type: VolumeType::Volume,
+				source: Some(src),
+				..
+			} => Some(src.as_str()),
+			VolumeMount::Long { .. } => None,
+		};
+		if let Some(name) = named {
+			if !file.volumes.contains_key(name) {
+				return Err(ComposeError::Unsupported(format!(
+					"service '{service}' refers to undefined volume '{name}'; declare it under the \
+					 top-level 'volumes:' key"
+				)));
+			}
+		}
+	}
+	Ok(())
+}
+
+/// Extract the named-volume reference from a short-form `source:target[:opts]`
+/// mount, or `None` when it is a host-path bind or an anonymous volume.
+///
+/// Mirrors the engine's own classification: a source starting with `/`, `.` or
+/// `~`, or a Windows drive prefix (`C:`), is a bind, not a named volume; a
+/// single token with no target is an anonymous volume.
+fn short_named_volume(spec: &str) -> Option<&str> {
+	let (src, _rest) = spec.split_once(':')?;
+	if src.is_empty()
+		|| src.starts_with('/')
+		|| src.starts_with('.')
+		|| src.starts_with('~')
+		|| is_windows_drive(src)
+	{
+		return None;
+	}
+	Some(src)
+}
+
+/// Whether `src` is exactly a Windows drive letter (e.g. `C`), meaning the colon
+/// after it is part of a host path rather than the `source:target` separator.
+fn is_windows_drive(src: &str) -> bool {
+	let b = src.as_bytes();
+	b.len() == 1 && b[0].is_ascii_alphabetic()
+}
 
 /// Validate the semantic consistency of a resolved compose file. Returns the
 /// first error found, matching docker-compose's fail-at-config-time behaviour.
@@ -110,8 +256,12 @@ fn validate_networks(file: &ComposeFile) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-	use crate::compose::types::ComposeFile;
-	use crate::parse_str;
+	use super::*;
+	use crate::{parse_str, parse_str_raw};
+
+	fn file(yaml: &str) -> ComposeFile {
+		parse_str_raw(yaml).unwrap()
+	}
 
 	fn validate_str(yaml: &str) -> crate::error::Result<()> {
 		let mut file: ComposeFile = parse_str(yaml).unwrap();
@@ -120,6 +270,115 @@ mod tests {
 		crate::compose::normalize_default_network(&mut file);
 		super::validate(&file)
 	}
+
+	// validate_config (the `config` subcommand)
+
+	#[test]
+	fn empty_services_is_rejected() {
+		let err = validate_config(&file("services: {}\n")).unwrap_err();
+		assert!(format!("{err}").contains("no services"));
+		// A file with no `services:` key at all is equally rejected.
+		assert!(validate_config(&ComposeFile::default()).is_err());
+	}
+
+	#[test]
+	fn missing_image_and_build_is_rejected() {
+		let err = validate_config(&file("services:\n  web:\n    ports: ['80:80']\n")).unwrap_err();
+		assert!(matches!(err, ComposeError::NoImageOrBuild(_)));
+	}
+
+	#[test]
+	fn valid_minimal_file_passes() {
+		validate_config(&file("services:\n  web:\n    image: nginx\n")).unwrap();
+	}
+
+	#[test]
+	fn out_of_range_port_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    ports: ['99999:80']\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidPort(_)));
+	}
+
+	#[test]
+	fn zero_port_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    ports: ['0:80']\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidPort(_)));
+	}
+
+	#[test]
+	fn undefined_named_volume_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    volumes: ['data:/x']\n",
+		))
+		.unwrap_err();
+		assert!(format!("{err}").contains("undefined volume 'data'"));
+	}
+
+	#[test]
+	fn declared_named_volume_passes() {
+		validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    volumes: ['data:/x']\nvolumes:\n  data:\n",
+		))
+		.unwrap();
+	}
+
+	#[test]
+	fn bind_and_anonymous_volumes_are_not_flagged() {
+		// Host-path binds and anonymous volumes carry no top-level declaration.
+		validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    volumes:\n      - ./host:/x\n      - /abs:/y\n      - /data\n",
+		))
+		.unwrap();
+	}
+
+	#[test]
+	fn undefined_network_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    networks: [backend]\n",
+		))
+		.unwrap_err();
+		assert!(format!("{err}").contains("undefined network 'backend'"));
+	}
+
+	#[test]
+	fn declared_network_passes() {
+		validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    networks: [backend]\nnetworks:\n  backend:\n",
+		))
+		.unwrap();
+	}
+
+	#[test]
+	fn invalid_service_name_is_rejected() {
+		let err =
+			validate_config(&file("services:\n  'bad name':\n    image: nginx\n")).unwrap_err();
+		assert!(format!("{err}").contains("service name"));
+	}
+
+	#[test]
+	fn dependency_cycle_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::CircularDependency(_)));
+	}
+
+	#[test]
+	fn dangling_required_dependency_is_rejected() {
+		let err = validate_config(&file(
+			"services:\n  web:\n    image: nginx\n    depends_on: [ghost]\n",
+		))
+		.unwrap_err();
+		assert!(matches!(err, ComposeError::ServiceNotFound(_)));
+	}
+
+	// validate (the post-parse semantic pass)
 
 	#[test]
 	fn network_mode_with_networks_is_rejected() {

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -45,6 +45,7 @@ pub(crate) async fn dispatch(
 			no_build: _,
 			quiet_pull: _,
 			wait,
+			wait_timeout,
 			no_start,
 			timestamps,
 			renew_anon_volumes: _,
@@ -85,7 +86,14 @@ pub(crate) async fn dispatch(
 				)
 				.await?;
 			if wait {
-				engine.wait_services_healthy(file, &services).await?;
+				// `--wait-timeout` bounds the health wait, like `start --wait`.
+				let fut = engine.wait_services_healthy(file, &services);
+				match wait_timeout {
+					Some(secs) => tokio::time::timeout(std::time::Duration::from_secs(secs), fut)
+						.await
+						.map_err(|_| podup::ComposeError::WaitTimeout { secs })??,
+					None => fut.await?,
+				}
 			}
 			if watch {
 				engine.watch(file).await?;
@@ -147,19 +155,34 @@ pub(crate) async fn dispatch(
 			build,
 			force_recreate,
 			no_recreate,
+			// `--pull` is applied via the engine's pull-policy override, set in
+			// `main` (see `with_up_overrides`).
+			pull: _,
+			no_deps,
 			services,
 		} => {
 			if build {
 				engine.build_all(file, &services).await?;
 			}
 			engine
-				.create_with_options(file, profile, &services, no_recreate, force_recreate, false)
+				.create_with_options(
+					file,
+					profile,
+					&services,
+					no_recreate,
+					force_recreate,
+					no_deps,
+				)
 				.await?
 		}
 		Commands::Build {
 			no_cache,
 			pull,
 			build_arg,
+			// `--progress` selects a progress renderer in docker compose; accepted
+			// for compatibility but has no effect on podup's tracing output.
+			progress: _,
+			push,
 			quiet,
 			services,
 		} => {
@@ -175,7 +198,13 @@ pub(crate) async fn dispatch(
 						quiet,
 					},
 				)
-				.await?
+				.await?;
+			// `--push` pushes each freshly built image to its registry.
+			if push {
+				engine
+					.push_with_quiet(file, &services, podup::PushOptions::default(), quiet)
+					.await?;
+			}
 		}
 		Commands::Rm {
 			force,
@@ -231,6 +260,7 @@ pub(crate) async fn dispatch(
 			interactive: _,
 			no_tty: _,
 			no_deps: _,
+			label: _,
 			cmd,
 		} => {
 			engine
@@ -276,13 +306,34 @@ pub(crate) async fn dispatch(
 				.top_with_options(file, &services, format == OutputFormat::Json)
 				.await?
 		}
-		Commands::Events { format, json } => {
-			// `--json` is the deprecated alias for `--format json`; either selects
-			// JSON-line output.
+		Commands::Events {
+			format,
+			since,
+			until,
+			filter,
+			json,
+		} => {
+			// `--json` is the deprecated alias for `--format json` (and conflicts
+			// with an explicit `--format`); either selects JSON-line output.
 			let json = json || format == EventsFormat::Json;
-			engine.stream_events(json).await?
+			engine
+				.stream_events_with_options(
+					json,
+					&podup::EventsOptions {
+						since,
+						until,
+						filters: filter,
+					},
+				)
+				.await?
 		}
-		Commands::Attach { service } => engine.attach(file, &service).await?,
+		Commands::Attach {
+			service,
+			index,
+			no_stdin: _,
+			sig_proxy: _,
+			detach_keys: _,
+		} => engine.attach_with_index(file, &service, index).await?,
 		Commands::Wait { services } => {
 			let file = &profile_filtered(file, profile, &services);
 			engine.wait_services(file, &services).await?
@@ -290,11 +341,25 @@ pub(crate) async fn dispatch(
 		Commands::Commit {
 			service,
 			image,
-			index,
+			message,
+			author,
 			pause,
+			change,
+			index,
 		} => {
 			engine
-				.commit_with_pause(file, &service, &image, index, pause)
+				.commit_with_options(
+					file,
+					&service,
+					&image,
+					index,
+					podup::CommitOptions {
+						message,
+						author,
+						pause: Some(pause),
+						changes: change,
+					},
+				)
 				.await?
 		}
 		Commands::Export {
@@ -309,17 +374,19 @@ pub(crate) async fn dispatch(
 		Commands::Push {
 			ignore_push_failures,
 			tls_verify,
+			quiet,
 			services,
 		} => {
 			let file = &profile_filtered(file, profile, &services);
 			engine
-				.push(
+				.push_with_quiet(
 					file,
 					&services,
 					podup::PushOptions {
 						ignore_failures: ignore_push_failures,
 						tls_verify,
 					},
+					quiet,
 				)
 				.await?
 		}
@@ -349,11 +416,16 @@ pub(crate) async fn dispatch(
 				)
 				.await?
 		}
-		Commands::Images { quiet, format } => {
-			let file = &profile_filtered(file, profile, &[]);
+		Commands::Images {
+			quiet,
+			format,
+			services,
+		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
-				.images_with_options(
+				.images_with_services(
 					file,
+					&services,
 					podup::ImagesOptions {
 						quiet,
 						json: format == OutputFormat::Json,
@@ -367,10 +439,12 @@ pub(crate) async fn dispatch(
 			since,
 			until,
 			timestamps,
+			no_color,
+			no_log_prefix,
 			services,
 		} => {
 			engine
-				.logs_with_options(
+				.logs_with_display(
 					file,
 					&services,
 					podup::LogsOptions {
@@ -379,6 +453,10 @@ pub(crate) async fn dispatch(
 						since,
 						until,
 						timestamps,
+					},
+					podup::LogsDisplay {
+						no_color,
+						no_log_prefix,
 					},
 				)
 				.await?
@@ -442,6 +520,7 @@ pub(crate) async fn dispatch(
 		Commands::Config { .. } => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(file).await?,
+		Commands::Help { .. } => unreachable!("handled before compose parsing"),
 		Commands::Ls { .. } => unreachable!("handled before compose parsing"),
 		#[cfg(feature = "update")]
 		Commands::Update { .. } => unreachable!("handled before compose parsing"),

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -266,18 +266,7 @@ pub(crate) async fn dispatch(
 				)
 				.await?
 		}
-		Commands::Ps { all, quiet, format } => {
-			engine
-				.ps_with_options(
-					file,
-					podup::PsOptions {
-						all,
-						quiet,
-						json: format == OutputFormat::Json,
-					},
-				)
-				.await?
-		}
+		Commands::Ps { .. } => unreachable!("handled before compose parsing"),
 		Commands::Top { format, services } => {
 			engine
 				.top_with_options(file, &services, format == OutputFormat::Json)

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -118,12 +118,20 @@ pub(crate) async fn dispatch(
 			let file = &profile_filtered(file, profile, &services);
 			engine.start(file, &services).await?;
 			if wait {
-				let fut = engine.wait_services_healthy(file, &services);
 				match wait_timeout {
-					Some(secs) => tokio::time::timeout(std::time::Duration::from_secs(secs), fut)
-						.await
-						.map_err(|_| podup::ComposeError::WaitTimeout { secs })??,
-					None => fut.await?,
+					// `--wait-timeout` both extends the per-service poll budget (so a
+					// short healthcheck plan does not give up early) and caps the
+					// whole wait, so exhaustion surfaces as a clear WaitTimeout rather
+					// than a misleading per-container health-check timeout.
+					Some(secs) => {
+						let budget = std::time::Duration::from_secs(secs);
+						let fut =
+							engine.wait_services_healthy_within(file, &services, Some(budget));
+						tokio::time::timeout(budget, fut)
+							.await
+							.map_err(|_| podup::ComposeError::WaitTimeout { secs })??;
+					}
+					None => engine.wait_services_healthy(file, &services).await?,
 				}
 			}
 		}

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -9,6 +9,20 @@ use podup::Engine;
 
 use crate::cli::*;
 
+/// Clone the compose file keeping only services in an active profile, plus any
+/// named on the command line (which activates their profile). Used by the
+/// per-service subcommands so they target exactly the set `up`/`create` would
+/// bring up — never a service hidden behind an inactive profile.
+fn profile_filtered(
+	file: &podup::compose::types::ComposeFile,
+	profile: &[String],
+	targets: &[String],
+) -> podup::compose::types::ComposeFile {
+	let mut filtered = file.clone();
+	podup::retain_active_profiles_with_targets(&mut filtered, profile, targets);
+	filtered
+}
+
 /// Run the command against an already-built engine and parsed compose file.
 pub(crate) async fn dispatch(
 	engine: &Engine,
@@ -101,6 +115,7 @@ pub(crate) async fn dispatch(
 			wait_timeout,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine.start(file, &services).await?;
 			if wait {
 				let fut = engine.wait_services_healthy(file, &services);
@@ -115,7 +130,10 @@ pub(crate) async fn dispatch(
 		Commands::Stop {
 			services,
 			timeout: _,
-		} => engine.stop(file, &services).await?,
+		} => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.stop(file, &services).await?
+		}
 		Commands::Scale { pairs } => engine.scale(file, &pairs).await?,
 		Commands::Create {
 			build,
@@ -137,6 +155,7 @@ pub(crate) async fn dispatch(
 			quiet,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.build_all_with_options(
 					file,
@@ -170,13 +189,20 @@ pub(crate) async fn dispatch(
 			remove_orphans,
 			services,
 		} => {
-			engine.kill(file, &services, &signal).await?;
+			let filtered = profile_filtered(file, profile, &services);
+			engine.kill(&filtered, &services, &signal).await?;
 			if remove_orphans {
 				engine.remove_orphans(file).await?;
 			}
 		}
-		Commands::Pause { services } => engine.pause(file, &services).await?,
-		Commands::Unpause { services } => engine.unpause(file, &services).await?,
+		Commands::Pause { services } => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.pause(file, &services).await?
+		}
+		Commands::Unpause { services } => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.unpause(file, &services).await?
+		}
 		Commands::Run {
 			service,
 			rm: _,
@@ -256,7 +282,10 @@ pub(crate) async fn dispatch(
 			engine.stream_events(json).await?
 		}
 		Commands::Attach { service } => engine.attach(file, &service).await?,
-		Commands::Wait { services } => engine.wait_services(file, &services).await?,
+		Commands::Wait { services } => {
+			let file = &profile_filtered(file, profile, &services);
+			engine.wait_services(file, &services).await?
+		}
 		Commands::Commit {
 			service,
 			image,
@@ -276,6 +305,7 @@ pub(crate) async fn dispatch(
 			tls_verify,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.push(
 					file,
@@ -314,6 +344,7 @@ pub(crate) async fn dispatch(
 				.await?
 		}
 		Commands::Images { quiet, format } => {
+			let file = &profile_filtered(file, profile, &[]);
 			engine
 				.images_with_options(
 					file,
@@ -380,6 +411,7 @@ pub(crate) async fn dispatch(
 			policy: _,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.pull_services_with_options(
 					file,
@@ -396,6 +428,7 @@ pub(crate) async fn dispatch(
 			no_deps,
 			services,
 		} => {
+			let file = &profile_filtered(file, profile, &services);
 			engine
 				.restart_with_options(file, &services, no_deps)
 				.await?

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -278,7 +278,7 @@ pub(crate) async fn dispatch(
 		Commands::Events { format, json } => {
 			// `--json` is the deprecated alias for `--format json`; either selects
 			// JSON-line output.
-			let json = json || format == OutputFormat::Json;
+			let json = json || format == EventsFormat::Json;
 			engine.stream_events(json).await?
 		}
 		Commands::Attach { service } => engine.attach(file, &service).await?,

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -5,7 +5,7 @@
 //! fields); `Config`/`Generate`/`Ls`/`Update`/`Completions` are handled earlier
 //! in `main` and reached here only as `unreachable!` guards.
 
-use podup::Engine;
+use podup::{Engine, StatsOptions};
 
 use crate::cli::*;
 
@@ -369,8 +369,14 @@ pub(crate) async fn dispatch(
 		} => engine.export(file, &service, output, index).await?,
 		Commands::Stats {
 			no_stream,
+			all,
+			no_trunc,
+			format,
 			services,
-		} => engine.stats(file, &services, no_stream).await?,
+		} => {
+			let opts = StatsOptions::new(no_stream, all, no_trunc, format == OutputFormat::Json);
+			engine.stats_with_options(file, &services, opts).await?
+		}
 		Commands::Push {
 			ignore_push_failures,
 			tls_verify,

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -290,7 +290,12 @@ pub(crate) async fn dispatch(
 			service,
 			image,
 			index,
-		} => engine.commit(file, &service, &image, index).await?,
+			pause,
+		} => {
+			engine
+				.commit_with_pause(file, &service, &image, index, pause)
+				.await?
+		}
 		Commands::Export {
 			service,
 			output,

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -185,7 +185,11 @@ pub(crate) async fn dispatch(
 		} => {
 			// `-s/--stop` gracefully stops the targets first so they can be
 			// removed without `--force`.
+			// A paused container cannot be stopped (Podman rejects it with a raw
+			// state error), so resume it first — matching `docker compose rm
+			// -s`. `unpause` is idempotent, so this is a no-op when not paused.
 			if stop {
+				engine.unpause(file, &services).await?;
 				engine.stop(file, &services).await?;
 			}
 			engine

--- a/internal/dotenv.rs
+++ b/internal/dotenv.rs
@@ -6,11 +6,34 @@
 //! unquoted values, and the standard double-quote escape sequences. Callers
 //! decide duplicate-key precedence by the order pairs are returned in.
 
-/// Parse dotenv `content` into ordered `(key, value)` pairs.
+/// Parse dotenv `content` into ordered `(key, value)` pairs (lenient).
 ///
 /// Pairs are returned in file order; a later duplicate key appears after an
-/// earlier one, leaving the precedence decision to the caller.
+/// earlier one, leaving the precedence decision to the caller. This variant is
+/// used for the optional default `.env`: it never fails, so an unterminated
+/// quoted value degrades to consuming the rest of the file (historical
+/// behaviour) rather than erroring.
 pub fn parse(content: &str) -> Vec<(String, String)> {
+	// `strict = false` can never produce an error.
+	parse_inner(content, false).unwrap_or_default()
+}
+
+/// Like [`parse`] but rejects malformed input.
+///
+/// Used for explicitly requested env files (`--env-file`, a service `env_file:`)
+/// where a typo'd or truncated file must fail loudly rather than silently drop
+/// variables — matching docker compose, which hard-errors on an unterminated
+/// quoted value.
+pub fn parse_strict(content: &str) -> crate::error::Result<Vec<(String, String)>> {
+	parse_inner(content, true)
+}
+
+fn parse_inner(content: &str, strict: bool) -> crate::error::Result<Vec<(String, String)>> {
+	// Strip a leading UTF-8 BOM so the first key is not captured as
+	// `\u{feff}KEY` (which would silently lose that variable). Matches
+	// docker/godotenv, which drop a leading BOM before parsing.
+	let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+
 	let mut out = Vec::new();
 	let mut lines = content.lines();
 
@@ -41,21 +64,28 @@ pub fn parse(content: &str) -> Vec<(String, String)> {
 		if key.is_empty() {
 			continue;
 		}
-		let value = parse_value(line[eq + 1..].trim_start(), &mut lines);
+		let value = parse_value(line[eq + 1..].trim_start(), &mut lines, key, strict)?;
 		out.push((key.to_string(), value));
 	}
 
-	out
+	Ok(out)
 }
 
 /// Parse the value portion of an assignment, consuming continuation lines for
-/// a quoted value that does not close on the first line.
-fn parse_value(rest: &str, lines: &mut std::str::Lines) -> String {
+/// a quoted value that does not close on the first line. In `strict` mode a
+/// quote that never closes is a hard error instead of swallowing the rest of
+/// the file (which would silently drop every following key).
+fn parse_value(
+	rest: &str,
+	lines: &mut std::str::Lines,
+	key: &str,
+	strict: bool,
+) -> crate::error::Result<String> {
 	match rest.chars().next() {
 		Some(quote @ ('"' | '\'')) => {
 			let body = &rest[quote.len_utf8()..];
 			if let Some(end) = find_closing(body, quote) {
-				return unescape(&body[..end], quote);
+				return Ok(unescape(&body[..end], quote));
 			}
 			// Unterminated on this line: a multi-line quoted value.
 			let mut buf = String::from(body);
@@ -63,13 +93,18 @@ fn parse_value(rest: &str, lines: &mut std::str::Lines) -> String {
 				buf.push('\n');
 				if let Some(end) = find_closing(next, quote) {
 					buf.push_str(&next[..end]);
-					return unescape(&buf, quote);
+					return Ok(unescape(&buf, quote));
 				}
 				buf.push_str(next);
 			}
-			unescape(&buf, quote)
+			if strict {
+				return Err(crate::error::ComposeError::EnvFile(format!(
+					"unterminated quoted value for key '{key}'"
+				)));
+			}
+			Ok(unescape(&buf, quote))
 		}
-		_ => strip_inline_comment(rest).trim_end().to_string(),
+		_ => Ok(strip_inline_comment(rest).trim_end().to_string()),
 	}
 }
 
@@ -260,6 +295,51 @@ mod tests {
 	fn multiline_single_quoted_value() {
 		let m = map("FOO='line1\nline2'\n");
 		assert_eq!(m["FOO"], "line1\nline2");
+	}
+
+	#[test]
+	fn strips_leading_utf8_bom() {
+		// A file saved as UTF-8-with-BOM must not capture the first key as
+		// `\u{feff}FOO`; the BOM is stripped so FOO resolves normally.
+		let m = map("\u{feff}FOO=bar\nBAZ=qux\n");
+		assert_eq!(m.get("FOO").map(String::as_str), Some("bar"));
+		assert_eq!(m.get("BAZ").map(String::as_str), Some("qux"));
+		assert!(!m.keys().any(|k| k.starts_with('\u{feff}')));
+	}
+
+	#[test]
+	fn parse_strict_strips_leading_bom() {
+		let pairs = super::parse_strict("\u{feff}FOO=bar\n").unwrap();
+		assert_eq!(pairs, vec![("FOO".to_string(), "bar".to_string())]);
+	}
+
+	#[test]
+	fn parse_strict_errors_on_unterminated_quote() {
+		// An unterminated quote would otherwise absorb every following key into
+		// one value, silently dropping them. Strict parsing rejects it.
+		let err = super::parse_strict("A=\"oops\nB=keep\n").unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("unterminated"), "got: {msg}");
+		assert!(msg.contains('A'), "should name the offending key: {msg}");
+	}
+
+	#[test]
+	fn parse_strict_ok_on_terminated_multiline() {
+		// A properly closed multi-line value still parses in strict mode and the
+		// following key survives.
+		let pairs = super::parse_strict("FOO=\"line one\nline two\"\nBAR=after\n").unwrap();
+		let m: std::collections::HashMap<_, _> = pairs.into_iter().collect();
+		assert_eq!(m["FOO"], "line one\nline two");
+		assert_eq!(m["BAR"], "after");
+	}
+
+	#[test]
+	fn lenient_parse_does_not_error_on_unterminated_quote() {
+		// The lenient `.env` path never errors: it degrades to consuming the rest
+		// of the file (historical behaviour) rather than failing.
+		let pairs = parse("A=\"oops\nB=keep\n");
+		assert_eq!(pairs.len(), 1);
+		assert_eq!(pairs[0].0, "A");
 	}
 
 	#[test]

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -12,20 +12,35 @@ use flate2::Compression;
 use crate::error::{ComposeError, Result};
 
 /// Append the build context to `tar`, honoring `.dockerignore`.
+///
+/// `skip_names` are context-relative paths to omit even when not ignored (used to
+/// drop the user's `.dockerignore` so it can be rewritten with extra rules).
 fn append_context<W: std::io::Write>(
 	tar: &mut tar::Builder<W>,
 	context: &Path,
 	ignore_patterns: &[String],
+	skip_names: &[&str],
 ) -> Result<()> {
+	// Do not dereference symlinks: a symlink in the context would otherwise pack
+	// the bytes of its (possibly out-of-context) target — e.g. `/etc/hostname` or
+	// an SSH key — into the image. Store the link itself instead, matching the
+	// watch-sync and cp paths.
+	tar.follow_symlinks(false);
 	for abs in super::super::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
 		let rel_str = rel.to_string_lossy();
+		if skip_names.iter().any(|n| rel_str == *n) {
+			continue;
+		}
 		if is_ignored(&rel_str, ignore_patterns) {
 			continue;
 		}
-		if abs.is_dir() {
+		// Classify without following symlinks so a symlink-to-dir is stored as a
+		// link rather than walked and dereferenced.
+		let is_dir = abs.symlink_metadata().map(|m| m.is_dir()).unwrap_or(false);
+		if is_dir {
 			tar.append_dir(rel, &abs)
 				.map_err(|e| ComposeError::Build(e.to_string()))?;
 		} else {
@@ -76,7 +91,20 @@ pub(super) fn build_context_tar_with_inline(
 	tar.append_data(&mut header, inline_name, inline.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-	append_context(&mut tar, context, &ignore_patterns)?;
+	// Skip the user's `.dockerignore` here; it is rewritten below with an extra
+	// rule excluding the synthesized inline Dockerfile.
+	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"])?;
+
+	// Rewrite `.dockerignore` (merged with any user rules) so a `COPY .` in the
+	// build does not bake the synthesized `.dockerfile-inline` into the image.
+	let dockerignore = inline_dockerignore(context, inline_name);
+	let mut di_header = tar::Header::new_gnu();
+	di_header.set_size(dockerignore.len() as u64);
+	di_header.set_mode(0o644);
+	di_header.set_cksum();
+	tar.append_data(&mut di_header, ".dockerignore", dockerignore.as_bytes())
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+
 	append_extra_files(&mut tar, extra_files)?;
 
 	let gz = tar
@@ -98,7 +126,7 @@ pub(crate) fn build_context_tar(
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	append_context(&mut tar, context, &ignore_patterns)?;
+	append_context(&mut tar, context, &ignore_patterns, &[])?;
 	append_extra_files(&mut tar, extra_files)?;
 
 	let gz = tar
@@ -109,6 +137,21 @@ pub(crate) fn build_context_tar(
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
 	Ok(bytes)
+}
+
+/// Build the `.dockerignore` content for an inline-Dockerfile build: any user
+/// rules plus a final entry excluding the synthesized inline Dockerfile so a
+/// `COPY .` in the build does not capture `.dockerfile-inline`.
+fn inline_dockerignore(context: &Path, inline_name: &str) -> String {
+	let existing =
+		crate::filesystem::read_to_string_capped(context.join(".dockerignore")).unwrap_or_default();
+	let mut out = existing.trim_end_matches(['\n', '\r']).to_string();
+	if !out.is_empty() {
+		out.push('\n');
+	}
+	out.push_str(inline_name);
+	out.push('\n');
+	out
 }
 
 /// Map a compose `additional_contexts` value to the libpod
@@ -465,6 +508,109 @@ mod tests {
 		let (bytes, df_name) = build_context_tar_with_inline(dir.path(), inline, &[]).unwrap();
 		assert_eq!(&bytes[..2], &[0x1f, 0x8b]);
 		assert!(!df_name.is_empty());
+	}
+
+	#[test]
+	fn inline_dockerfile_excluded_via_dockerignore() {
+		use flate2::read::GzDecoder;
+		use std::io::Read;
+
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("app.txt"), b"x").unwrap();
+		let (bytes, _) = build_context_tar_with_inline(dir.path(), "FROM alpine\n", &[]).unwrap();
+
+		let mut raw = Vec::new();
+		GzDecoder::new(bytes.as_slice())
+			.read_to_end(&mut raw)
+			.unwrap();
+		let mut archive = tar::Archive::new(raw.as_slice());
+		let mut di = String::new();
+		for entry in archive.entries().unwrap() {
+			let mut entry = entry.unwrap();
+			if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+				entry.read_to_string(&mut di).unwrap();
+			}
+		}
+		assert!(
+			di.lines().any(|l| l == ".dockerfile-inline"),
+			"inline Dockerfile must be excluded from COPY via .dockerignore: {di:?}"
+		);
+	}
+
+	#[test]
+	fn inline_dockerignore_preserves_user_rules() {
+		use flate2::read::GzDecoder;
+		use std::io::Read;
+
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("app.txt"), b"x").unwrap();
+		fs::write(dir.path().join(".dockerignore"), b"*.log\n").unwrap();
+		let (bytes, _) = build_context_tar_with_inline(dir.path(), "FROM alpine\n", &[]).unwrap();
+
+		let mut raw = Vec::new();
+		GzDecoder::new(bytes.as_slice())
+			.read_to_end(&mut raw)
+			.unwrap();
+		let mut archive = tar::Archive::new(raw.as_slice());
+		// The user's `.dockerignore` must appear exactly once, merged with the
+		// synthesized inline-Dockerfile exclusion.
+		let mut di_entries = 0;
+		let mut di = String::new();
+		for entry in archive.entries().unwrap() {
+			let mut entry = entry.unwrap();
+			if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+				di_entries += 1;
+				entry.read_to_string(&mut di).unwrap();
+			}
+		}
+		assert_eq!(di_entries, 1, "exactly one .dockerignore entry");
+		assert!(di.lines().any(|l| l == "*.log"), "user rule kept: {di:?}");
+		assert!(
+			di.lines().any(|l| l == ".dockerfile-inline"),
+			"inline exclusion added: {di:?}"
+		);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn context_tar_packs_symlink_as_link_not_target() {
+		use flate2::read::GzDecoder;
+		use std::io::Read;
+
+		// A symlink that points outside the context (e.g. to a host secret) must be
+		// stored as a link, never dereferenced into the image.
+		let outside = tempdir().unwrap();
+		fs::write(outside.path().join("secret"), b"TOPSECRET").unwrap();
+
+		let dir = tempdir().unwrap();
+		fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+		std::os::unix::fs::symlink(outside.path().join("secret"), dir.path().join("leak")).unwrap();
+
+		let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+		let mut raw = Vec::new();
+		GzDecoder::new(bytes.as_slice())
+			.read_to_end(&mut raw)
+			.unwrap();
+		let mut archive = tar::Archive::new(raw.as_slice());
+
+		let mut found = false;
+		for entry in archive.entries().unwrap() {
+			let entry = entry.unwrap();
+			if entry.path().unwrap().to_string_lossy() == "leak" {
+				found = true;
+				assert_eq!(
+					entry.header().entry_type(),
+					tar::EntryType::Symlink,
+					"symlink must be packed as a link"
+				);
+				assert_eq!(
+					entry.header().size().unwrap(),
+					0,
+					"link entry must not carry the target's bytes"
+				);
+			}
+		}
+		assert!(found, "symlink entry must be present in the context tar");
 	}
 
 	#[test]

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,6 +8,7 @@
 mod context;
 mod pull;
 mod push;
+mod tags;
 pub use pull::PullOptions;
 pub use push::PushOptions;
 
@@ -23,6 +24,7 @@ use crate::libpod::API_PREFIX;
 use crate::size;
 
 use context::{build_context_tar, build_context_tar_with_inline, map_additional_context};
+use tags::{is_remote_context, looks_like_secret, primary_build_tag};
 
 use super::Engine;
 
@@ -101,7 +103,12 @@ impl Engine {
 
 		let context_str = build.context().to_string();
 		let remote_context = is_remote_context(&context_str);
-		let tag = primary_build_tag(service_name, service.image.as_deref(), build.tags());
+		let tag = primary_build_tag(
+			&self.project,
+			service_name,
+			service.image.as_deref(),
+			build.tags(),
+		);
 
 		// A Git/URL context is cloned server-side by Podman via the `remote`
 		// query parameter — there is no local directory to tar. Tar-only features
@@ -169,6 +176,13 @@ impl Engine {
 				Some((k, v)) => (k.to_string(), v.to_string()),
 				None => (entry.clone(), std::env::var(entry).unwrap_or_default()),
 			};
+			// A bare `=value` (empty key) is a user typo Podman would silently
+			// ignore; reject it with a clear diagnostic instead.
+			if k.is_empty() {
+				return Err(ComposeError::Build(format!(
+					"invalid --build-arg '{entry}': empty argument name"
+				)));
+			}
 			build_args.insert(k, v);
 		}
 
@@ -212,10 +226,14 @@ impl Engine {
 			}).cloned(),
 			_ => None,
 		};
-		let shmsize = build
-			.shm_size()
-			.and_then(size::parse_memory)
-			.map(|s| s as i32);
+		// Distinguish "absent" from "present but unparseable": a malformed
+		// `shm_size` must be rejected, not silently dropped to the default.
+		let shmsize = match build.shm_size() {
+			Some(raw) => Some(size::parse_memory(raw).ok_or_else(|| {
+				ComposeError::Build(format!("invalid build.shm_size value '{raw}'"))
+			})? as i32),
+			None => None,
+		};
 		let extrahosts_str = build.extra_hosts().join(",");
 		let extrahosts = if extrahosts_str.is_empty() {
 			None
@@ -404,49 +422,9 @@ impl Engine {
 	}
 }
 
-/// A build context is remote when it is a URL or Git reference that Podman
-/// clones server-side, rather than a local directory to tar and upload.
-fn is_remote_context(context: &str) -> bool {
-	context.contains("://") || context.starts_with("git@")
-}
-
-/// Pick the primary image tag for a built service.
-///
-/// Precedence matches compose-go: an explicit `image:` wins; otherwise the
-/// first entry of `build.tags` is used as the primary tag; with neither, the
-/// image is named `{service}:latest`. Any remaining `build.tags` are applied
-/// as extra tags by [`Engine::apply_extra_tags`].
-fn primary_build_tag(service_name: &str, image: Option<&str>, tags: &[String]) -> String {
-	if let Some(image) = image {
-		return image.to_string();
-	}
-	if let Some(first) = tags.first() {
-		return first.clone();
-	}
-	format!("{service_name}:latest")
-}
-
-/// True if a build-arg name looks like it carries a secret, so the caller can
-/// warn that build args persist in the image history. Case-insensitive substring
-/// match on common secret tokens, kept conservative to avoid false positives
-/// (e.g. a bare `KEY` is not flagged; `API_KEY`/`PRIVATE_KEY` are).
-fn looks_like_secret(name: &str) -> bool {
-	const MARKERS: [&str; 7] = [
-		"SECRET",
-		"PASSWORD",
-		"PASSWD",
-		"TOKEN",
-		"CREDENTIAL",
-		"API_KEY",
-		"PRIVATE_KEY",
-	];
-	let upper = name.to_ascii_uppercase();
-	MARKERS.iter().any(|m| upper.contains(m))
-}
-
 #[cfg(test)]
 mod tests {
-	use super::{is_remote_context, looks_like_secret, primary_build_tag, Engine};
+	use super::Engine;
 	use crate::libpod::Client;
 
 	fn engine(base: std::path::PathBuf) -> Engine {
@@ -455,22 +433,6 @@ mod tests {
 
 	fn build_of(file: &crate::compose::types::ComposeFile) -> &crate::compose::types::BuildConfig {
 		file.services["app"].build.as_ref().unwrap()
-	}
-
-	#[test]
-	fn looks_like_secret_flags_sensitive_names_only() {
-		for name in [
-			"DB_PASSWORD",
-			"api_token",
-			"MySecret",
-			"AWS_API_KEY",
-			"private_key",
-		] {
-			assert!(looks_like_secret(name), "{name} should be flagged");
-		}
-		for name in ["VERSION", "BUILD_DATE", "PUBLIC_KEY", "PORT", "RUST_LOG"] {
-			assert!(!looks_like_secret(name), "{name} should not be flagged");
-		}
 	}
 
 	#[test]
@@ -509,37 +471,51 @@ mod tests {
 		assert!(specs.is_empty());
 	}
 
-	#[test]
-	fn remote_context_detection() {
-		assert!(is_remote_context("https://github.com/user/repo.git"));
-		assert!(is_remote_context("git://example.com/repo.git"));
-		assert!(is_remote_context("git@github.com:user/repo.git"));
-		assert!(!is_remote_context("."));
-		assert!(!is_remote_context("./build"));
-		assert!(!is_remote_context("/abs/path"));
-	}
-
-	#[test]
-	fn primary_tag_prefers_explicit_image() {
-		let tags = vec!["registry/app:1.0".to_string()];
-		assert_eq!(
-			primary_build_tag("app", Some("myimage:2.0"), &tags),
-			"myimage:2.0"
+	#[tokio::test]
+	async fn empty_build_arg_key_is_rejected() {
+		// `--build-arg =value` is a user typo Podman would silently ignore; we
+		// reject it before contacting the daemon.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+		let yaml = "services:\n  app:\n    build:\n      context: .\n";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine(dir.path().to_path_buf());
+		let opts = super::BuildOptions {
+			build_args: vec!["=orphan".to_string()],
+			..Default::default()
+		};
+		let err = e
+			.build_service("app", &file.services["app"], &file, &opts)
+			.await
+			.expect_err("empty build-arg key must be rejected");
+		assert!(
+			err.to_string().contains("build-arg"),
+			"unexpected error: {err}"
 		);
 	}
 
-	#[test]
-	fn primary_tag_uses_first_build_tag_when_image_unset() {
-		let tags = vec![
-			"registry/app:1.0".to_string(),
-			"registry/app:latest".to_string(),
-		];
-		assert_eq!(primary_build_tag("app", None, &tags), "registry/app:1.0");
-	}
-
-	#[test]
-	fn primary_tag_falls_back_to_service_latest() {
-		assert_eq!(primary_build_tag("app", None, &[]), "app:latest");
+	#[tokio::test]
+	async fn invalid_shm_size_is_rejected() {
+		// A malformed `build.shm_size` must error rather than silently fall back to
+		// the default shm size.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+		let yaml = "services:\n  app:\n    build:\n      context: .\n      shm_size: \"64mb!\"\n";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine(dir.path().to_path_buf());
+		let err = e
+			.build_service(
+				"app",
+				&file.services["app"],
+				&file,
+				&super::BuildOptions::default(),
+			)
+			.await
+			.expect_err("malformed shm_size must be rejected");
+		assert!(
+			err.to_string().contains("shm_size"),
+			"unexpected error: {err}"
+		);
 	}
 
 	#[test]

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -125,6 +125,16 @@ impl Engine {
 			(Vec::new(), df, Vec::new())
 		} else {
 			let context_path = self.base_dir.join(&context_str);
+			// Fail fast with the service name and the resolved context path if the
+			// directory is missing/unreadable, instead of a bare "io error: No such
+			// file or directory" once the context walk hits it.
+			if let Err(e) = std::fs::metadata(&context_path) {
+				return Err(ComposeError::BuildContext {
+					service: service_name.to_string(),
+					path: context_path.display().to_string(),
+					source: e,
+				});
+			}
 			info!("building {tag} from {}", context_path.display());
 
 			// Resolve `build.secrets` to in-tar files before building the context:

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -11,6 +11,9 @@ mod push;
 mod tags;
 pub use pull::PullOptions;
 pub use push::PushOptions;
+/// Shared with the container-create path so an `up`/`create` references the same
+/// image tag the build step produced for a build-only service.
+pub(crate) use tags::primary_build_tag;
 
 use bytes::Bytes;
 use futures_util::StreamExt;
@@ -24,7 +27,7 @@ use crate::libpod::API_PREFIX;
 use crate::size;
 
 use context::{build_context_tar, build_context_tar_with_inline, map_additional_context};
-use tags::{is_remote_context, looks_like_secret, primary_build_tag};
+use tags::{is_remote_context, looks_like_secret};
 
 use super::Engine;
 

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -1,7 +1,7 @@
 //! Image pull from a registry (the non-build half of image acquisition).
 
 use futures_util::StreamExt;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use std::collections::HashSet;
 
@@ -48,6 +48,14 @@ impl Engine {
 		services: &[String],
 		opts: PullOptions,
 	) -> Result<()> {
+		// Reject unknown service names up front, matching `docker compose pull`
+		// (and `logs`), rather than silently doing nothing.
+		for name in services {
+			if !file.services.contains_key(name) {
+				return Err(ComposeError::ServiceNotFound(name.clone()));
+			}
+		}
+
 		// `--include-deps` widens the explicit service list to its transitive
 		// depends_on closure; an empty list already means "every service".
 		let wanted: Option<HashSet<String>> = match (services.is_empty(), opts.include_deps) {
@@ -68,27 +76,34 @@ impl Engine {
 			.map(|(name, s)| async move {
 				// The libpod pull stream reports failure as an in-band progress
 				// line, so `pull_image` returns Ok even when the pull failed;
-				// confirm the image actually landed in local storage.
-				let _ = self.pull_image(s).await;
+				// confirm the image actually landed in local storage. Keep the
+				// real transport error (e.g. socket unreachable) so a failed pull
+				// surfaces the underlying cause rather than a generic message.
+				let pull_err = self.pull_image(s).await.err();
 				let image = s.image.clone().unwrap_or_default();
 				(
 					name.clone(),
 					image.clone(),
 					self.image_present(&image).await,
+					pull_err,
 				)
 			})
 			.collect();
 
 		let results = futures_util::future::join_all(futs).await;
-		for (name, image, present) in results {
+		for (name, image, present, pull_err) in results {
 			if present {
 				continue;
 			}
 			if opts.ignore_failures {
-				tracing::warn!("pull {name} ({image}) failed — ignored");
+				match &pull_err {
+					Some(e) => tracing::warn!("pull {name} ({image}) failed — ignored: {e}"),
+					None => tracing::warn!("pull {name} ({image}) failed — ignored"),
+				}
 			} else {
+				let detail = pull_err.map(|e| format!(": {e}")).unwrap_or_default();
 				return Err(ComposeError::Build(format!(
-					"failed to pull image {image} for service {name}"
+					"failed to pull image {image} for service {name}{detail}"
 				)));
 			}
 		}
@@ -101,10 +116,13 @@ impl Engine {
 			None => return Ok(()),
 		};
 
+		// Progress goes to stderr so it shows at default verbosity (the non-watch
+		// log floor is WARN, so info!/debug! would print nothing) and `--quiet`
+		// actually suppresses it, matching `docker compose pull`.
 		if self.quiet_pull {
 			debug!("pulling {image}");
 		} else {
-			info!("pulling {image}");
+			eprintln!("Pulling {image}");
 		}
 
 		// `up --pull <policy>` overrides the per-service `pull_policy`.
@@ -219,6 +237,24 @@ mod tests {
 			.into_iter()
 			.collect();
 		assert_eq!(got, vec!["db"]);
+	}
+
+	#[tokio::test]
+	async fn pull_unknown_service_is_rejected() {
+		// `pull bogus` must error on the unknown name instead of silently exiting 0.
+		let file = crate::parse_str("services:\n  web:\n    image: a\n").unwrap();
+		let e = crate::engine::Engine::new(
+			crate::libpod::Client::new("/nonexistent.sock"),
+			"proj".into(),
+		);
+		let err = e
+			.pull_services(&file, &["nope".to_string()])
+			.await
+			.expect_err("unknown service must be rejected");
+		assert!(
+			matches!(err, crate::error::ComposeError::ServiceNotFound(_)),
+			"unexpected error: {err:?}"
+		);
 	}
 
 	#[test]

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -132,7 +132,7 @@ impl Engine {
 			.or(service.pull_policy.as_deref());
 		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
 			warn!(
-				"unknown pull_policy '{}', defaulting to 'missing'",
+				"unknown pull policy '{}', defaulting to 'missing'",
 				requested.unwrap_or_default()
 			);
 			"missing"

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -23,9 +23,15 @@ const PUSH_STALL_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Drain a push progress stream, surfacing a mid-stream `error` line and bounding
 /// each read by `stall` so an unresponsive registry fails with a clear timeout
-/// instead of hanging. Generic over the stream so it is unit-tested without a
-/// live socket.
-async fn drain_push_stream<S>(mut stream: S, image: &str, stall: Duration) -> Result<()>
+/// instead of hanging. `quiet` (`-q/--quiet`) suppresses the per-line progress
+/// and the final "pushed" line. Generic over the stream so it is unit-tested
+/// without a live socket.
+async fn drain_push_stream<S>(
+	mut stream: S,
+	image: &str,
+	quiet: bool,
+	stall: Duration,
+) -> Result<()>
 where
 	S: Stream<Item = std::result::Result<ImagePullProgress, PodmanError>> + Unpin,
 {
@@ -33,7 +39,7 @@ where
 	loop {
 		match tokio::time::timeout(stall, stream.next()).await {
 			Ok(Some(Ok(progress))) => {
-				if !progress.stream.is_empty() {
+				if !progress.stream.is_empty() && !quiet {
 					info!("{}", progress.stream.trim_end());
 				}
 				if !progress.error.is_empty() {
@@ -54,7 +60,11 @@ where
 	match stream_error {
 		Some(err) => Err(ComposeError::Build(format!("push {image}: {err}"))),
 		None => {
-			info!("pushed {image}");
+			if quiet {
+				tracing::debug!("pushed {image}");
+			} else {
+				info!("pushed {image}");
+			}
 			Ok(())
 		}
 	}
@@ -81,6 +91,20 @@ impl Engine {
 		target_services: &[String],
 		opts: PushOptions,
 	) -> Result<()> {
+		self.push_with_quiet(file, target_services, opts, false)
+			.await
+	}
+
+	/// Push each service's image like [`Engine::push`], with `quiet` (`-q/--quiet`)
+	/// suppressing the per-image progress output. Kept off the frozen
+	/// [`PushOptions`] struct so the 1.0 library API stays stable.
+	pub async fn push_with_quiet(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: PushOptions,
+		quiet: bool,
+	) -> Result<()> {
 		for svc in target_services {
 			if !file.services.contains_key(svc) {
 				return Err(ComposeError::ServiceNotFound(svc.clone()));
@@ -95,7 +119,7 @@ impl Engine {
 				tracing::debug!("{name}: no image to push, skipping");
 				continue;
 			};
-			if let Err(e) = self.push_image(image, &opts).await {
+			if let Err(e) = self.push_image(image, &opts, quiet).await {
 				if opts.ignore_failures {
 					warn!("push {image} failed (ignored): {e}");
 				} else {
@@ -108,8 +132,12 @@ impl Engine {
 
 	/// Push a single image ref and drain its progress stream, surfacing a
 	/// mid-stream `error` line as a failure.
-	async fn push_image(&self, image: &str, opts: &PushOptions) -> Result<()> {
-		info!("pushing {image}");
+	async fn push_image(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<()> {
+		if quiet {
+			tracing::debug!("pushing {image}");
+		} else {
+			info!("pushing {image}");
+		}
 		let mut query = format!("destination={}", urlencoded(image));
 		if let Some(tls) = opts.tls_verify {
 			query.push_str(&format!("&tlsVerify={tls}"));
@@ -122,7 +150,7 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
-		drain_push_stream(stream, image, PUSH_STALL_TIMEOUT).await
+		drain_push_stream(stream, image, quiet, PUSH_STALL_TIMEOUT).await
 	}
 }
 
@@ -145,7 +173,7 @@ mod tests {
 	async fn drain_ok_when_stream_completes_cleanly() {
 		let items = vec![Ok(progress("pushing", "")), Ok(progress("done", ""))];
 		let stream = futures_util::stream::iter(items);
-		drain_push_stream(stream, "img", Duration::from_secs(5))
+		drain_push_stream(stream, "img", false, Duration::from_secs(5))
 			.await
 			.unwrap();
 	}
@@ -154,7 +182,7 @@ mod tests {
 	async fn drain_surfaces_mid_stream_error_line() {
 		let items = vec![Ok(progress("", "denied: unauthorized"))];
 		let stream = futures_util::stream::iter(items);
-		let err = drain_push_stream(stream, "img", Duration::from_secs(5))
+		let err = drain_push_stream(stream, "img", false, Duration::from_secs(5))
 			.await
 			.unwrap_err();
 		assert!(matches!(err, ComposeError::Build(m) if m.contains("denied: unauthorized")));
@@ -168,7 +196,7 @@ mod tests {
 		let stream = first.chain(futures_util::stream::pending::<
 			std::result::Result<ImagePullProgress, PodmanError>,
 		>());
-		let err = drain_push_stream(stream, "img", Duration::from_millis(20))
+		let err = drain_push_stream(stream, "img", false, Duration::from_millis(20))
 			.await
 			.unwrap_err();
 		assert!(matches!(err, ComposeError::Build(m) if m.contains("no progress")));

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -1,14 +1,64 @@
 //! Image push to a registry (docker compose `push`).
 
-use futures_util::StreamExt;
+use std::time::Duration;
+
+use futures_util::{Stream, StreamExt};
 use tracing::{info, warn};
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImagePullProgress;
-use crate::libpod::{urlencoded, API_PREFIX};
+use crate::libpod::{urlencoded, PodmanError, API_PREFIX};
 
 use super::super::Engine;
+
+/// Maximum time to wait for the next progress line from a push body stream
+/// before treating the registry as unresponsive.
+///
+/// The client `READ_TIMEOUT` only bounds the request head, not this streamed
+/// body, so without a per-line deadline a push to an unreachable/wedged registry
+/// would block indefinitely while draining the response. Generous so a slow but
+/// progressing upload is never aborted.
+const PUSH_STALL_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Drain a push progress stream, surfacing a mid-stream `error` line and bounding
+/// each read by `stall` so an unresponsive registry fails with a clear timeout
+/// instead of hanging. Generic over the stream so it is unit-tested without a
+/// live socket.
+async fn drain_push_stream<S>(mut stream: S, image: &str, stall: Duration) -> Result<()>
+where
+	S: Stream<Item = std::result::Result<ImagePullProgress, PodmanError>> + Unpin,
+{
+	let mut stream_error: Option<String> = None;
+	loop {
+		match tokio::time::timeout(stall, stream.next()).await {
+			Ok(Some(Ok(progress))) => {
+				if !progress.stream.is_empty() {
+					info!("{}", progress.stream.trim_end());
+				}
+				if !progress.error.is_empty() {
+					stream_error = Some(progress.error.clone());
+				}
+			}
+			Ok(Some(Err(e))) => stream_error = Some(e.to_string()),
+			Ok(None) => break,
+			Err(_elapsed) => {
+				return Err(ComposeError::Build(format!(
+					"push {image}: no progress from the registry for {}s; aborting \
+					 (registry unreachable or unresponsive)",
+					stall.as_secs()
+				)));
+			}
+		}
+	}
+	match stream_error {
+		Some(err) => Err(ComposeError::Build(format!("push {image}: {err}"))),
+		None => {
+			info!("pushed {image}");
+			Ok(())
+		}
+	}
+}
 
 /// Options for [`Engine::push`], mirroring `docker compose push` (plus a Podman
 /// `--tls-verify` escape hatch for insecure/local registries).
@@ -71,27 +121,56 @@ impl Engine {
 			.post_empty_stream(&path)
 			.await
 			.map_err(ComposeError::Podman)?;
-		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
-		let mut stream_error: Option<String> = None;
-		while let Some(result) = stream.next().await {
-			match result {
-				Ok(progress) => {
-					if !progress.stream.is_empty() {
-						info!("{}", progress.stream.trim_end());
-					}
-					if !progress.error.is_empty() {
-						stream_error = Some(progress.error.clone());
-					}
-				}
-				Err(e) => stream_error = Some(e.to_string()),
-			}
+		let stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
+		drain_push_stream(stream, image, PUSH_STALL_TIMEOUT).await
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{drain_push_stream, ImagePullProgress};
+	use crate::error::ComposeError;
+	use crate::libpod::PodmanError;
+	use futures_util::StreamExt;
+	use std::time::Duration;
+
+	fn progress(stream: &str, error: &str) -> ImagePullProgress {
+		ImagePullProgress {
+			stream: stream.to_string(),
+			error: error.to_string(),
 		}
-		match stream_error {
-			Some(err) => Err(ComposeError::Build(format!("push {image}: {err}"))),
-			None => {
-				info!("pushed {image}");
-				Ok(())
-			}
-		}
+	}
+
+	#[tokio::test]
+	async fn drain_ok_when_stream_completes_cleanly() {
+		let items = vec![Ok(progress("pushing", "")), Ok(progress("done", ""))];
+		let stream = futures_util::stream::iter(items);
+		drain_push_stream(stream, "img", Duration::from_secs(5))
+			.await
+			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn drain_surfaces_mid_stream_error_line() {
+		let items = vec![Ok(progress("", "denied: unauthorized"))];
+		let stream = futures_util::stream::iter(items);
+		let err = drain_push_stream(stream, "img", Duration::from_secs(5))
+			.await
+			.unwrap_err();
+		assert!(matches!(err, ComposeError::Build(m) if m.contains("denied: unauthorized")));
+	}
+
+	#[tokio::test]
+	async fn drain_times_out_on_an_unresponsive_stream() {
+		// A stream that yields one line then never another stands in for a registry
+		// that accepts the request then stalls — the per-line deadline must fire.
+		let first = futures_util::stream::iter(vec![Ok(progress("pushing", ""))]);
+		let stream = first.chain(futures_util::stream::pending::<
+			std::result::Result<ImagePullProgress, PodmanError>,
+		>());
+		let err = drain_push_stream(stream, "img", Duration::from_millis(20))
+			.await
+			.unwrap_err();
+		assert!(matches!(err, ComposeError::Build(m) if m.contains("no progress")));
 	}
 }

--- a/internal/engine/build/tags.rs
+++ b/internal/engine/build/tags.rs
@@ -19,7 +19,7 @@ pub(super) fn is_remote_context(context: &str) -> bool {
 /// compose) so two projects sharing a service name don't overwrite each other's
 /// image. Any remaining `build.tags` are applied as extra tags by
 /// [`super::Engine::apply_extra_tags`].
-pub(super) fn primary_build_tag(
+pub(crate) fn primary_build_tag(
 	project: &str,
 	service_name: &str,
 	image: Option<&str>,

--- a/internal/engine/build/tags.rs
+++ b/internal/engine/build/tags.rs
@@ -1,0 +1,119 @@
+//! Pure helpers for build image tagging and context classification.
+//!
+//! These free functions back [`super::Engine::build_service`]: deciding whether
+//! a build context is remote, choosing the primary image tag, and flagging
+//! build-arg names that look like secrets. They hold no engine state, so they
+//! live here apart from the build orchestration.
+
+/// A build context is remote when it is a URL or Git reference that Podman
+/// clones server-side, rather than a local directory to tar and upload.
+pub(super) fn is_remote_context(context: &str) -> bool {
+	context.contains("://") || context.starts_with("git@")
+}
+
+/// Pick the primary image tag for a built service.
+///
+/// Precedence matches compose-go: an explicit `image:` wins; otherwise the
+/// first entry of `build.tags` is used as the primary tag; with neither, the
+/// image is named `{project}-{service}:latest` (project-scoped, like docker
+/// compose) so two projects sharing a service name don't overwrite each other's
+/// image. Any remaining `build.tags` are applied as extra tags by
+/// [`super::Engine::apply_extra_tags`].
+pub(super) fn primary_build_tag(
+	project: &str,
+	service_name: &str,
+	image: Option<&str>,
+	tags: &[String],
+) -> String {
+	if let Some(image) = image {
+		return image.to_string();
+	}
+	if let Some(first) = tags.first() {
+		return first.clone();
+	}
+	format!("{project}-{service_name}:latest")
+}
+
+/// True if a build-arg name looks like it carries a secret, so the caller can
+/// warn that build args persist in the image history. Case-insensitive substring
+/// match on common secret tokens, kept conservative to avoid false positives
+/// (e.g. a bare `KEY` is not flagged; `API_KEY`/`PRIVATE_KEY` are).
+pub(super) fn looks_like_secret(name: &str) -> bool {
+	const MARKERS: [&str; 7] = [
+		"SECRET",
+		"PASSWORD",
+		"PASSWD",
+		"TOKEN",
+		"CREDENTIAL",
+		"API_KEY",
+		"PRIVATE_KEY",
+	];
+	let upper = name.to_ascii_uppercase();
+	MARKERS.iter().any(|m| upper.contains(m))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{is_remote_context, looks_like_secret, primary_build_tag};
+
+	#[test]
+	fn looks_like_secret_flags_sensitive_names_only() {
+		for name in [
+			"DB_PASSWORD",
+			"api_token",
+			"MySecret",
+			"AWS_API_KEY",
+			"private_key",
+		] {
+			assert!(looks_like_secret(name), "{name} should be flagged");
+		}
+		for name in ["VERSION", "BUILD_DATE", "PUBLIC_KEY", "PORT", "RUST_LOG"] {
+			assert!(!looks_like_secret(name), "{name} should not be flagged");
+		}
+	}
+
+	#[test]
+	fn remote_context_detection() {
+		assert!(is_remote_context("https://github.com/user/repo.git"));
+		assert!(is_remote_context("git://example.com/repo.git"));
+		assert!(is_remote_context("git@github.com:user/repo.git"));
+		assert!(!is_remote_context("."));
+		assert!(!is_remote_context("./build"));
+		assert!(!is_remote_context("/abs/path"));
+	}
+
+	#[test]
+	fn primary_tag_prefers_explicit_image() {
+		let tags = vec!["registry/app:1.0".to_string()];
+		assert_eq!(
+			primary_build_tag("proj", "app", Some("myimage:2.0"), &tags),
+			"myimage:2.0"
+		);
+	}
+
+	#[test]
+	fn primary_tag_uses_first_build_tag_when_image_unset() {
+		let tags = vec![
+			"registry/app:1.0".to_string(),
+			"registry/app:latest".to_string(),
+		];
+		assert_eq!(
+			primary_build_tag("proj", "app", None, &tags),
+			"registry/app:1.0"
+		);
+	}
+
+	#[test]
+	fn primary_tag_falls_back_to_project_scoped_latest() {
+		// Build-only services (no `image:`, no `tags`) are namespaced by project so
+		// two projects sharing a service name don't clobber each other's image.
+		assert_eq!(
+			primary_build_tag("proj", "app", None, &[]),
+			"proj-app:latest"
+		);
+		assert_eq!(
+			primary_build_tag("other", "app", None, &[]),
+			"other-app:latest"
+		);
+	}
+}

--- a/internal/engine/container/fields.rs
+++ b/internal/engine/container/fields.rs
@@ -12,18 +12,32 @@ use tracing::warn;
 
 use crate::compose::types::{BlkioConfig, Service};
 use crate::libpod::types::container::{
-	LinuxBlockIO, LinuxDevice, LinuxThrottleDevice, LinuxWeightDevice,
+	LinuxBlockIO, LinuxDevice, LinuxDeviceCgroup, LinuxThrottleDevice, LinuxWeightDevice,
 };
 
 // ---------------------------------------------------------------------------
 // Device helpers
 // ---------------------------------------------------------------------------
 
+/// A parsed compose `devices:` entry: the device node to create plus, when the
+/// entry carried an explicit `:permissions` segment, the cgroup access rule that
+/// restricts it.
+pub(crate) struct ParsedDevice {
+	/// The device node to expose inside the container.
+	pub device: LinuxDevice,
+	/// The cgroup access rule derived from the trailing `:permissions` segment,
+	/// present only when one was given.
+	pub cgroup_rule: Option<LinuxDeviceCgroup>,
+}
+
 /// Parse a compose `devices:` entry (`host:container:permissions`) into a
-/// `LinuxDevice`. The container path defaults to the host path when the
+/// [`ParsedDevice`]. The container path defaults to the host path when the
 /// `:container` segment is absent; major/minor/type are derived by `stat`ing the
-/// host node. Trailing permissions, if present, are ignored here.
-pub(crate) fn parse_device(s: &str) -> LinuxDevice {
+/// host node. A trailing `:permissions` segment (e.g. `r`, `rwm`) is retained as
+/// a `device_cgroup_rule`: the OCI `LinuxDevice` has no access field, so the
+/// restriction must ride alongside as a cgroup rule for the live up path to
+/// honor it consistently with the quadlet backend and docker-compose.
+pub(crate) fn parse_device(s: &str) -> ParsedDevice {
 	let parts: Vec<&str> = s.splitn(3, ':').collect();
 	let host = parts.first().copied().unwrap_or("").to_string();
 	let cont = parts
@@ -31,17 +45,33 @@ pub(crate) fn parse_device(s: &str) -> LinuxDevice {
 		.copied()
 		.map(|c| c.to_string())
 		.unwrap_or_else(|| host.clone());
+	let access = parts
+		.get(2)
+		.copied()
+		.filter(|p| !p.is_empty())
+		.map(str::to_string);
 
 	let (major, minor, device_type) = device_major_minor(&host);
 
-	LinuxDevice {
-		path: cont,
-		device_type,
-		major,
-		minor,
-		file_mode: None,
-		uid: None,
-		gid: None,
+	let cgroup_rule = access.map(|access| LinuxDeviceCgroup {
+		allow: true,
+		device_type: Some(device_type.clone()),
+		major: Some(major),
+		minor: Some(minor),
+		access: Some(access),
+	});
+
+	ParsedDevice {
+		device: LinuxDevice {
+			path: cont,
+			device_type,
+			major,
+			minor,
+			file_mode: None,
+			uid: None,
+			gid: None,
+		},
+		cgroup_rule,
 	}
 }
 
@@ -239,20 +269,42 @@ mod tests {
 
 	#[test]
 	fn parse_device_host_container_perm() {
-		let d = parse_device("/dev/null:/dev/zero:rwm");
-		assert_eq!(d.path, "/dev/zero");
+		let parsed = parse_device("/dev/null:/dev/zero:rwm");
+		assert_eq!(parsed.device.path, "/dev/zero");
+		// The trailing permission segment becomes a cgroup access rule.
+		let rule = parsed.cgroup_rule.expect("perm should yield a cgroup rule");
+		assert!(rule.allow);
+		assert_eq!(rule.access.as_deref(), Some("rwm"));
 	}
 
 	#[test]
 	fn parse_device_same_path_both_sides() {
-		let d = parse_device("/dev/null");
-		assert_eq!(d.path, "/dev/null");
+		let parsed = parse_device("/dev/null");
+		assert_eq!(parsed.device.path, "/dev/null");
+		// No permission segment → no cgroup rule (Podman defaults to rwm).
+		assert!(parsed.cgroup_rule.is_none());
 	}
 
 	#[test]
 	fn parse_device_two_part() {
-		let d = parse_device("/dev/null:/dev/xvda");
-		assert_eq!(d.path, "/dev/xvda");
+		let parsed = parse_device("/dev/null:/dev/xvda");
+		assert_eq!(parsed.device.path, "/dev/xvda");
+		assert!(parsed.cgroup_rule.is_none());
+	}
+
+	#[test]
+	fn parse_device_restricted_perm_is_preserved() {
+		// `devices: ["/dev/sda:/dev/sda:r"]` must keep the read-only restriction
+		// rather than silently becoming rwm on the live up path.
+		let parsed = parse_device("/dev/sda:/dev/sda:r");
+		assert_eq!(parsed.device.path, "/dev/sda");
+		let rule = parsed.cgroup_rule.expect("perm should yield a cgroup rule");
+		assert!(rule.allow);
+		assert_eq!(rule.access.as_deref(), Some("r"));
+		// The rule targets the same node as the device it restricts.
+		assert_eq!(rule.device_type, Some(parsed.device.device_type));
+		assert_eq!(rule.major, Some(parsed.device.major));
+		assert_eq!(rule.minor, Some(parsed.device.minor));
 	}
 
 	// --- blkio ---

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -145,7 +145,19 @@ impl Engine {
 		let ulimits = build_ulimits(service);
 
 		// --- Devices ---
-		let mut devices: Vec<_> = service.devices.iter().map(|s| parse_device(s)).collect();
+		let mut devices: Vec<_> = Vec::with_capacity(service.devices.len());
+		// A device's `:permissions` segment cannot live on the OCI node, so it
+		// rides alongside as a cgroup access rule (mirroring the quadlet backend's
+		// verbatim `AddDevice`). These are merged with the explicit
+		// `device_cgroup_rules` below.
+		let mut device_cgroup_rule: Vec<_> = Vec::new();
+		for raw in &service.devices {
+			let parsed = parse_device(raw);
+			if let Some(rule) = parsed.cgroup_rule {
+				device_cgroup_rule.push(rule);
+			}
+			devices.push(parsed.device);
+		}
 		// CDI device names ride in the same array; Podman pulls them out by path.
 		devices.extend(cdi_devices(service).into_iter().map(cdi_device));
 
@@ -153,16 +165,12 @@ impl Engine {
 		let security = parse_security_opts(service);
 
 		// --- Device cgroup rules (parsed to structured form; skip malformed) ---
-		let device_cgroup_rule = service
-			.device_cgroup_rules
-			.iter()
-			.filter_map(|r| {
-				parse_device_cgroup_rule(r).or_else(|| {
-					tracing::warn!("device_cgroup_rules entry '{r}' is malformed and is ignored");
-					None
-				})
+		device_cgroup_rule.extend(service.device_cgroup_rules.iter().filter_map(|r| {
+			parse_device_cgroup_rule(r).or_else(|| {
+				tracing::warn!("device_cgroup_rules entry '{r}' is malformed and is ignored");
+				None
 			})
-			.collect();
+		}));
 
 		// --- Namespace modes ---
 		let pidns = service.pid.as_deref().map(Namespace::parse);

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -40,6 +40,15 @@ impl Engine {
 		file: &ComposeFile,
 		start: bool,
 	) -> Result<()> {
+		// Reject an invalid container name client-side (podman would otherwise
+		// answer with an opaque HTTP 500 from its name-regex check).
+		if !crate::libpod::is_valid_object_name(container_name) {
+			return Err(ComposeError::Unsupported(format!(
+				"invalid container name {container_name:?}: names must start with an ASCII \
+				 letter or digit and contain only letters, digits, '_', '.', '-'"
+			)));
+		}
+
 		let derived_image;
 		let image: &str = if let Some(img) = service.image.as_deref() {
 			img

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -52,8 +52,14 @@ impl Engine {
 		let derived_image;
 		let image: &str = if let Some(img) = service.image.as_deref() {
 			img
-		} else if service.build.is_some() {
-			derived_image = format!("{}:latest", service_name);
+		} else if let Some(build) = service.build.as_ref() {
+			// No `image:` — reference the exact tag the build step produced for this
+			// build-only service (project-scoped `{project}-{service}:latest`, or
+			// the first `build.tags` entry). Must stay in lockstep with
+			// `primary_build_tag`, or `up --build` creates the container against a
+			// name no built image carries (HTTP 404: no such image).
+			derived_image =
+				super::build::primary_build_tag(&self.project, service_name, None, build.tags());
 			&derived_image
 		} else {
 			return Err(ComposeError::NoImageOrBuild(service_name.into()));

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -86,7 +86,7 @@ impl Engine {
 		// Map each named-volume reference to the actual volume name created by
 		// create_volumes (project-prefixed, custom `name:`, or external).
 		for nv in &mut named_volumes {
-			nv.name = self.resolved_volume_name(&nv.name, file);
+			nv.name = self.resolved_volume_name(&nv.name, file)?;
 		}
 
 		// --- Port mappings ---
@@ -311,9 +311,10 @@ impl Engine {
 
 	/// Resolve a service's named-volume reference to the actual volume name
 	/// that `create_volumes` produced: a custom `name:`, the raw name for an
-	/// external volume, or the `{project}_{name}` form. References not declared
-	/// in the top-level `volumes:` map (anonymous/implicit) are left unchanged.
-	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> String {
+	/// external volume, or the `{project}_{name}` form. An empty reference is an
+	/// anonymous volume and is left unchanged; a non-empty reference that is not
+	/// declared under the top-level `volumes:` map is rejected (compose-spec).
+	fn resolved_volume_name(&self, reference: &str, file: &ComposeFile) -> Result<String> {
 		resolve_volume_name(reference, &self.project, file)
 	}
 }

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -9,20 +9,36 @@ use crate::error::{ComposeError, Result};
 
 /// Resolve a named-volume reference to the volume name `create_volumes`
 /// produced: a custom `name:`, the raw name for an external volume, or the
-/// `{project}_{name}` form. References not declared in the top-level `volumes:`
-/// map (anonymous/implicit) are returned unchanged.
-pub(super) fn resolve_volume_name(reference: &str, project: &str, file: &ComposeFile) -> String {
+/// `{project}_{name}` form.
+///
+/// An empty reference is an anonymous volume (an image `VOLUME` directive or a
+/// colon-less short-form mount); it carries no name, so Podman assigns one and
+/// it is returned unchanged. A non-empty reference that is *not* declared under
+/// the top-level `volumes:` map is rejected, matching the compose-spec: leaving
+/// it unprefixed would make Podman auto-create a bare, unlabelled global volume
+/// that escapes project namespacing and is never reclaimed by `down -v`.
+pub(super) fn resolve_volume_name(
+	reference: &str,
+	project: &str,
+	file: &ComposeFile,
+) -> Result<String> {
+	if reference.is_empty() {
+		return Ok(String::new());
+	}
 	match file.volumes.get(reference) {
-		Some(cfg) => {
+		Some(cfg) => Ok(
 			if let Some(name) = cfg.as_ref().and_then(|c| c.name.as_deref()) {
 				name.to_string()
 			} else if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
 				reference.to_string()
 			} else {
 				format!("{project}_{reference}")
-			}
-		}
-		None => reference.to_string(),
+			},
+		),
+		None => Err(ComposeError::Unsupported(format!(
+			"service refers to undefined volume \"{reference}\"; declare it under the \
+			 top-level `volumes:` key, or use a bind mount or anonymous volume instead"
+		))),
 	}
 }
 
@@ -487,11 +503,18 @@ mod tests {
 			"services:\n  s:\n    image: x\nvolumes:\n  data:\n  ext:\n    external: true\n  custom:\n    name: my-vol\n",
 		)
 		.unwrap();
-		assert_eq!(resolve_volume_name("data", "proj", &f), "proj_data");
-		assert_eq!(resolve_volume_name("ext", "proj", &f), "ext");
-		assert_eq!(resolve_volume_name("custom", "proj", &f), "my-vol");
-		// Not declared in top-level volumes -> left as-is.
-		assert_eq!(resolve_volume_name("anon", "proj", &f), "anon");
+		assert_eq!(
+			resolve_volume_name("data", "proj", &f).unwrap(),
+			"proj_data"
+		);
+		assert_eq!(resolve_volume_name("ext", "proj", &f).unwrap(), "ext");
+		assert_eq!(resolve_volume_name("custom", "proj", &f).unwrap(), "my-vol");
+		// An empty reference is an anonymous volume: no name to resolve.
+		assert_eq!(resolve_volume_name("", "proj", &f).unwrap(), "");
+		// A non-empty reference not declared under top-level `volumes:` is
+		// rejected rather than escaping into a bare, unprefixed global volume.
+		let err = resolve_volume_name("missing", "proj", &f).unwrap_err();
+		assert!(err.to_string().contains("missing"), "got: {err}");
 	}
 
 	#[test]

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -50,7 +50,23 @@ pub(super) fn build_restart_policy(service: &Service) -> (Option<String>, Option
 				"unless-stopped"
 			}
 		};
-		return (Some(name.to_string()), drp.max_attempts.map(|n| n as u64));
+		// Podman only honours a retry cap (`RestartRetries`) when the policy is
+		// `on-failure`. Under any other policy the cap is silently dropped by the
+		// backend, which would turn a bounded "restart at most N times" spec into an
+		// unbounded restart. Only forward `max_attempts` for `on-failure`, and warn
+		// if the user set one under a condition where it cannot take effect.
+		let tries = if name == "on-failure" {
+			drp.max_attempts.map(|n| n as u64)
+		} else {
+			if drp.max_attempts.is_some() {
+				tracing::warn!(
+					"deploy.restart_policy.max_attempts is ignored unless condition \
+					 is 'on-failure' (current condition resolves to '{name}')"
+				);
+			}
+			None
+		};
+		return (Some(name.to_string()), tries);
 	}
 	(None, None)
 }
@@ -231,6 +247,78 @@ mod tests {
 		});
 		let (name, _) = build_restart_policy(&svc);
 		assert_eq!(name.as_deref(), Some("always"));
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_any_drops_max_attempts() {
+		// `condition: any` maps to `always`; Podman ignores a retry cap under
+		// `always`, so we must not forward max_attempts (it would otherwise read
+		// as an honoured bound that the backend silently discards).
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy {
+				condition: Some("any".into()),
+				max_attempts: Some(3),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+		let (name, tries) = build_restart_policy(&svc);
+		assert_eq!(name.as_deref(), Some("always"));
+		assert!(tries.is_none());
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_none_drops_max_attempts() {
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy {
+				condition: Some("none".into()),
+				max_attempts: Some(4),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+		let (name, tries) = build_restart_policy(&svc);
+		assert_eq!(name.as_deref(), Some("no"));
+		assert!(tries.is_none());
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_unrecognized_condition_drops_max_attempts() {
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy {
+				condition: Some("on-success".into()),
+				max_attempts: Some(2),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+		let (name, tries) = build_restart_policy(&svc);
+		assert_eq!(name.as_deref(), Some("unless-stopped"));
+		assert!(tries.is_none());
+	}
+
+	#[test]
+	fn restart_policy_from_deploy_on_failure_keeps_max_attempts() {
+		// The one condition that honours the cap must still forward it.
+		use crate::compose::types::{DeployConfig, DeployRestartPolicy};
+		let mut svc = default_service();
+		svc.deploy = Some(DeployConfig {
+			restart_policy: Some(DeployRestartPolicy {
+				condition: Some("on-failure".into()),
+				max_attempts: Some(3),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+		let (name, tries) = build_restart_policy(&svc);
+		assert_eq!(name.as_deref(), Some("on-failure"));
+		assert_eq!(tries, Some(3));
 	}
 
 	// --- log config ---

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -84,7 +84,9 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.replica_name_at(service_name, service, opts.index)?;
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
@@ -130,7 +132,9 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.replica_name_at(service_name, service, opts.index)?;
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		// Match `docker cp` destination semantics. The libpod archive PUT extracts
 		// the tar *at* a directory, so:

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -3,8 +3,6 @@
 use std::path::Path;
 
 use bytes::Bytes;
-use flate2::write::GzEncoder;
-use flate2::Compression;
 use http_body_util::{BodyExt, Limited};
 
 use crate::compose::types::ComposeFile;
@@ -13,6 +11,10 @@ use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
 
 use super::Engine;
+
+mod archive;
+
+use archive::{extract_archive, pack_path};
 
 /// Upper bound on a container→host `cp` archive buffered in memory. Without it a
 /// hostile or huge container path would OOM the CLI. Generous (covers ordinary
@@ -54,6 +56,12 @@ impl Engine {
 		dst: &str,
 		opts: CpOptions,
 	) -> Result<()> {
+		// Reject the explicitly-unsupported endpoint forms (`-` for stdin/stdout,
+		// and a `SERVICE:` with an empty container path) with a clear message
+		// before they silently fall through to a local file literally named `-`
+		// or `SERVICE:`.
+		check_endpoint(src)?;
+		check_endpoint(dst)?;
 		match (parse_endpoint(src), parse_endpoint(dst)) {
 			(Some((service, container_path)), None) => {
 				self.cp_from_container(file, service, container_path, Path::new(dst), &opts)
@@ -160,6 +168,31 @@ impl Engine {
 			(parent.to_string(), Some(name.to_string()))
 		};
 
+		// Validate the extraction directory exists and is itself a directory before
+		// PUTting the archive. Without this, libpod silently auto-creates a missing
+		// parent chain (diverging from docker/podman `cp`, which error with "no such
+		// directory"); and when a path component is a regular file the archive PUT
+		// never gets a response, blocking the full READ_TIMEOUT window instead of
+		// failing fast.
+		let extract_stat_path = format!(
+			"{API_PREFIX}/containers/{}/archive?path={}",
+			urlencoded(&container_name),
+			urlencoded(&extract_dir),
+		);
+		match self.client.head_path_is_dir(&extract_stat_path).await? {
+			Some(true) => {}
+			Some(false) => {
+				return Err(ComposeError::Copy(format!(
+					"cp: not a directory: {extract_dir}"
+				)));
+			}
+			None => {
+				return Err(ComposeError::Copy(format!(
+					"cp: no such directory: {extract_dir}"
+				)));
+			}
+		}
+
 		let src_buf = src.to_path_buf();
 		let follow = opts.follow_link;
 		let rename_for_pack = rename.clone();
@@ -187,6 +220,36 @@ impl Engine {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Reject the `cp` endpoint forms podup explicitly does not support, with a
+/// clear diagnostic rather than letting them fall through to a local path that
+/// happens to be named `-` or `SERVICE:`.
+///
+/// - `-` (stdin/stdout streaming) is not implemented.
+/// - `SERVICE:` (a colon with an empty container path) is a malformed reference.
+///
+/// A plain local path (no colon, or a colon that is part of an ordinary host
+/// path / Windows drive) is left to [`parse_endpoint`].
+fn check_endpoint(s: &str) -> Result<()> {
+	if s == "-" {
+		return Err(ComposeError::Unsupported(
+			"cp: stdin/stdout ('-') is not supported".into(),
+		));
+	}
+	if let Some((svc, path)) = s.split_once(':') {
+		// A Windows drive letter (`C:\...`) is a local path, not a service ref.
+		#[cfg(windows)]
+		if svc.len() == 1 && svc.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+			return Ok(());
+		}
+		if !svc.is_empty() && path.is_empty() {
+			return Err(ComposeError::Copy(format!(
+				"cp: empty container path in '{s}' (expected SERVICE:PATH)"
+			)));
+		}
+	}
+	Ok(())
+}
+
 fn parse_endpoint(s: &str) -> Option<(&str, &str)> {
 	if s == "-" {
 		return None;
@@ -206,205 +269,6 @@ fn parse_endpoint(s: &str) -> Option<(&str, &str)> {
 	}
 	Some((svc, path))
 }
-
-fn pack_path(src: &Path, follow_link: bool, name_override: Option<&str>) -> Result<Vec<u8>> {
-	let encoder = GzEncoder::new(Vec::new(), Compression::default());
-	let mut tar = tar::Builder::new(encoder);
-	// `-L/--follow-link`: archive the symlink target's contents instead of the
-	// link itself.
-	tar.follow_symlinks(follow_link);
-
-	if src.is_dir() {
-		// `name_override` renames the copied tree (rename-on-copy); otherwise it
-		// keeps the source's own basename and lands inside the destination dir.
-		let default = src.file_name().unwrap_or(std::ffi::OsStr::new("."));
-		let name: &std::ffi::OsStr = name_override.map(std::ffi::OsStr::new).unwrap_or(default);
-		tar.append_dir_all(name, src)
-			.map_err(|e| ComposeError::Build(e.to_string()))?;
-	} else {
-		let default = src.file_name().unwrap_or(std::ffi::OsStr::new("file"));
-		let name: &std::ffi::OsStr = name_override.map(std::ffi::OsStr::new).unwrap_or(default);
-		tar.append_path_with_name(src, name)
-			.map_err(|e| ComposeError::Build(e.to_string()))?;
-	}
-
-	let gz = tar
-		.into_inner()
-		.map_err(|e| ComposeError::Build(e.to_string()))?;
-	gz.finish().map_err(|e| ComposeError::Build(e.to_string()))
-}
-
-/// Route a container archive to the host destination.
-///
-/// docker/podman `cp` semantics for a container→host extraction:
-/// - `dst` is an existing directory: the archive is extracted into it (a source
-///   directory lands under its own name).
-/// - `dst` does not exist and the source is a single regular file: its
-///   **content** is written to exactly `dst` — the daemon-supplied entry name is
-///   ignored, so a hostile image cannot choose the on-host filename (e.g. drop a
-///   `.bashrc`/`authorized_keys` into the destination directory).
-/// - `dst` does not exist and the source is a directory: `dst` is created and the
-///   source's *contents* are copied into it (matching `docker cp`).
-fn extract_archive(tar_bytes: &[u8], dst: &Path) -> Result<()> {
-	if dst.is_dir() {
-		return extract_tar_guarded(tar_bytes, dst);
-	}
-	if !archive_contains_dir(tar_bytes)? {
-		// A single regular file (or, defensively, a name-only archive) is written
-		// to exactly `dst`; `write_single_entry_to` still rejects a multi-entry
-		// archive against a file destination.
-		return write_single_entry_to(tar_bytes, dst);
-	}
-	// Directory source into a non-existent destination: create it and copy the
-	// source's contents in. The libpod archive is tarred under the source's
-	// basename, so extract through the zip-slip guard, then collapse that single
-	// wrapper level to leave the contents directly under `dst`.
-	std::fs::create_dir_all(dst).map_err(ComposeError::Io)?;
-	extract_tar_guarded(tar_bytes, dst)?;
-	flatten_single_wrapper_dir(dst)
-}
-
-/// True if any entry in `tar_bytes` is a directory — the signal that the source
-/// of a container→host copy was a directory (libpod tars it under its basename),
-/// as opposed to a single file.
-fn archive_contains_dir(tar_bytes: &[u8]) -> Result<bool> {
-	let cursor = std::io::Cursor::new(tar_bytes);
-	let mut archive = tar::Archive::new(cursor);
-	for entry in archive.entries().map_err(ComposeError::Io)? {
-		let entry = entry.map_err(ComposeError::Io)?;
-		if entry.header().entry_type() == tar::EntryType::Directory {
-			return Ok(true);
-		}
-	}
-	Ok(false)
-}
-
-/// Lift the contents of a single wrapper directory up into `dst`.
-///
-/// The libpod archive for `cp container:/srcdir` is tarred under the source's
-/// basename (`srcdir/...`). When that lands in a freshly-created `dst`, docker
-/// puts the source's *contents* directly in `dst`, so collapse the lone wrapper
-/// level. A no-op unless `dst` holds exactly one entry and it is a directory.
-fn flatten_single_wrapper_dir(dst: &Path) -> Result<()> {
-	let mut children: Vec<std::path::PathBuf> = std::fs::read_dir(dst)
-		.map_err(ComposeError::Io)?
-		.filter_map(|e| e.ok().map(|e| e.path()))
-		.collect();
-	if children.len() != 1 || !children[0].is_dir() {
-		return Ok(());
-	}
-	let wrapper = children.remove(0);
-	for entry in std::fs::read_dir(&wrapper).map_err(ComposeError::Io)? {
-		let from = entry.map_err(ComposeError::Io)?.path();
-		let name = from
-			.file_name()
-			.ok_or_else(|| ComposeError::Build("cp: archive entry has no name".into()))?;
-		std::fs::rename(&from, dst.join(name)).map_err(ComposeError::Io)?;
-	}
-	std::fs::remove_dir(&wrapper).map_err(ComposeError::Io)?;
-	Ok(())
-}
-
-/// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
-/// entry whose path would escape it (zip-slip) and stripping group/other-write
-/// and setuid/setgid/sticky bits the (untrusted) container set on each entry.
-///
-/// Extract entry-by-entry rather than `archive.unpack`: a malicious or
-/// compromised container can craft tar entries whose paths contain `..` or are
-/// absolute, escaping `dst_dir` and overwriting host files. `unpack_in` refuses
-/// such entries, returning `Ok(false)`; we turn that into a hard error so the
-/// copy fails loudly instead of silently skipping data. Pure and synchronous so
-/// the guard can be unit-tested without a container.
-fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
-	let cursor = std::io::Cursor::new(tar_bytes);
-	let mut archive = tar::Archive::new(cursor);
-	for entry in archive.entries().map_err(ComposeError::Io)? {
-		let mut entry = entry.map_err(ComposeError::Io)?;
-		let rel = entry.path().map(|p| p.into_owned()).ok();
-		let mode = entry.header().mode().ok();
-		if !entry.unpack_in(dst_dir).map_err(ComposeError::Io)? {
-			let p = entry
-				.path()
-				.map(|p| p.display().to_string())
-				.unwrap_or_else(|_| "<unprintable>".into());
-			return Err(ComposeError::Build(format!(
-				"cp: refusing archive entry that escapes destination: {p}"
-			)));
-		}
-		if let (Some(rel), Some(mode)) = (rel, mode) {
-			sanitize_extracted_mode(&dst_dir.join(rel), mode);
-		}
-	}
-	Ok(())
-}
-
-/// Write the single regular-file entry of `tar_bytes` to exactly `dst`,
-/// honouring the user's destination filename rather than the daemon's. Errors
-/// if the archive is empty, holds more than one entry, or the entry is not a
-/// regular file (those cases only make sense against a directory destination).
-fn write_single_entry_to(tar_bytes: &[u8], dst: &Path) -> Result<()> {
-	use std::io::Read;
-
-	if let Some(parent) = dst.parent() {
-		if !parent.as_os_str().is_empty() && !parent.exists() {
-			std::fs::create_dir_all(parent).map_err(ComposeError::Io)?;
-		}
-	}
-
-	let cursor = std::io::Cursor::new(tar_bytes);
-	let mut archive = tar::Archive::new(cursor);
-	let mut written = false;
-	for entry in archive.entries().map_err(ComposeError::Io)? {
-		let mut entry = entry.map_err(ComposeError::Io)?;
-		if entry.header().entry_type() != tar::EntryType::Regular {
-			return Err(ComposeError::Unsupported(format!(
-				"cp: destination {} is not a directory but the source is not a single file",
-				dst.display()
-			)));
-		}
-		if written {
-			return Err(ComposeError::Unsupported(format!(
-				"cp: destination {} is not a directory but the source has multiple entries",
-				dst.display()
-			)));
-		}
-		let mode = entry.header().mode().ok();
-		let mut buf = Vec::new();
-		entry.read_to_end(&mut buf).map_err(ComposeError::Io)?;
-		std::fs::write(dst, &buf).map_err(ComposeError::Io)?;
-		if let Some(mode) = mode {
-			sanitize_extracted_mode(dst, mode);
-		}
-		written = true;
-	}
-	if !written {
-		return Err(ComposeError::Build(
-			"cp: container archive was empty".into(),
-		));
-	}
-	Ok(())
-}
-
-/// Strip group/other-write and setuid/setgid/sticky bits from a file extracted
-/// from an untrusted container, keeping the owner and read/execute bits. No-op
-/// on non-files (e.g. symlinks) and on non-unix platforms.
-#[cfg(unix)]
-fn sanitize_extracted_mode(path: &Path, mode: u32) {
-	use std::os::unix::fs::PermissionsExt;
-	let Ok(meta) = std::fs::symlink_metadata(path) else {
-		return;
-	};
-	if !meta.is_file() {
-		return;
-	}
-	let masked = mode & 0o7777 & !0o022 & !0o7000;
-	if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(masked)) {
-		tracing::warn!("cp: could not set permissions on {}: {e}", path.display());
-	}
-}
-
-#[cfg(not(unix))]
-fn sanitize_extracted_mode(_path: &Path, _mode: u32) {}
 
 // ---------------------------------------------------------------------------
 // Unit tests
@@ -473,222 +337,26 @@ mod tests {
 	}
 
 	#[test]
-	fn pack_path_single_file() {
-		let dir = tempfile::tempdir().expect("tempdir");
-		let file = dir.path().join("data.txt");
-		std::fs::write(&file, b"hello").expect("write");
-		let result = super::pack_path(&file, false, None);
-		assert!(result.is_ok());
-		let bytes = result.unwrap();
-		assert!(!bytes.is_empty());
+	fn check_endpoint_rejects_dash() {
+		let err = super::check_endpoint("-").unwrap_err();
+		assert!(format!("{err}").contains("stdin/stdout"), "got: {err}");
 	}
 
 	#[test]
-	fn pack_path_directory() {
-		let dir = tempfile::tempdir().expect("tempdir");
-		let subdir = dir.path().join("mydir");
-		std::fs::create_dir(&subdir).expect("mkdir");
-		std::fs::write(subdir.join("a.txt"), b"aaa").expect("write");
-		std::fs::write(subdir.join("b.txt"), b"bbb").expect("write");
-		let result = super::pack_path(&subdir, false, None);
-		assert!(result.is_ok());
-		assert!(!result.unwrap().is_empty());
-	}
-
-	/// Build an uncompressed tar archive with a single entry at `path`. The name
-	/// is written straight into the GNU header so a hostile `..` path can be
-	/// forged (the safe `set_path`/`append_data` helpers reject `..`).
-	fn tar_bytes_with(path: &str, data: &[u8]) -> Vec<u8> {
-		let mut header = tar::Header::new_gnu();
-		header.set_size(data.len() as u64);
-		header.set_mode(0o644);
-		header.set_entry_type(tar::EntryType::Regular);
-		let name = path.as_bytes();
-		header.as_gnu_mut().expect("gnu header").name[..name.len()].copy_from_slice(name);
-		header.set_cksum();
-		let mut builder = tar::Builder::new(Vec::new());
-		builder.append(&header, data).expect("append");
-		builder.into_inner().expect("finish")
-	}
-
-	#[test]
-	fn extract_tar_guarded_writes_benign_entry() {
-		let dir = tempfile::tempdir().expect("tempdir");
-		let bytes = tar_bytes_with("hello.txt", b"hi");
-		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
-		assert_eq!(
-			std::fs::read(dir.path().join("hello.txt")).expect("read"),
-			b"hi"
-		);
-	}
-
-	#[test]
-	fn extract_archive_to_file_honors_user_filename() {
-		// dst is NOT a dir: the single entry's content must land at exactly `dst`,
-		// ignoring the daemon-supplied entry name (a hostile image must not pick
-		// the on-host filename).
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("myname.txt");
-		let bytes = tar_bytes_with("evil-name", b"payload");
-		super::extract_archive(&bytes, &dst).expect("extract");
-		assert_eq!(std::fs::read(&dst).expect("read"), b"payload");
+	fn check_endpoint_rejects_empty_container_path() {
+		let err = super::check_endpoint("web:").unwrap_err();
 		assert!(
-			!dir.path().join("evil-name").exists(),
-			"daemon entry name must not be used as the on-host filename"
+			format!("{err}").contains("empty container path"),
+			"got: {err}"
 		);
 	}
 
 	#[test]
-	fn extract_archive_to_file_rejects_multiple_entries() {
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("out.txt");
-		let mut builder = tar::Builder::new(Vec::new());
-		for n in ["a.txt", "b.txt"] {
-			let mut h = tar::Header::new_gnu();
-			h.set_size(1);
-			h.set_mode(0o644);
-			h.set_entry_type(tar::EntryType::Regular);
-			h.set_path(n).expect("path");
-			h.set_cksum();
-			builder.append(&h, &b"x"[..]).expect("append");
-		}
-		let bytes = builder.into_inner().expect("finish");
-		assert!(super::extract_archive(&bytes, &dst).is_err());
-	}
-
-	/// Build a directory archive shaped like libpod's `cp container:/srcdir`:
-	/// a wrapper directory entry plus its children, all under the basename.
-	fn tar_dir_with(wrapper: &str, files: &[(&str, &[u8])]) -> Vec<u8> {
-		let mut builder = tar::Builder::new(Vec::new());
-		let mut d = tar::Header::new_gnu();
-		d.set_size(0);
-		d.set_mode(0o755);
-		d.set_entry_type(tar::EntryType::Directory);
-		d.set_path(format!("{wrapper}/")).expect("path");
-		d.set_cksum();
-		builder.append(&d, std::io::empty()).expect("dir");
-		for (name, data) in files {
-			let mut h = tar::Header::new_gnu();
-			h.set_size(data.len() as u64);
-			h.set_mode(0o644);
-			h.set_entry_type(tar::EntryType::Regular);
-			h.set_path(format!("{wrapper}/{name}")).expect("path");
-			h.set_cksum();
-			builder.append(&h, *data).expect("file");
-		}
-		builder.into_inner().expect("finish")
-	}
-
-	#[test]
-	fn extract_dir_into_missing_dest_creates_and_flattens() {
-		// dst does not exist and the source is a directory: dst is created and the
-		// source's *contents* land directly in it (the wrapper level is collapsed),
-		// matching `docker cp`.
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("newdir");
-		let bytes = tar_dir_with("srcdir", &[("a.txt", b"aaa"), ("b.txt", b"bbb")]);
-		super::extract_archive(&bytes, &dst).expect("extract");
-		assert!(dst.is_dir());
-		assert_eq!(std::fs::read(dst.join("a.txt")).expect("read"), b"aaa");
-		assert_eq!(std::fs::read(dst.join("b.txt")).expect("read"), b"bbb");
-		assert!(
-			!dst.join("srcdir").exists(),
-			"the wrapper directory level must be collapsed"
-		);
-	}
-
-	#[test]
-	fn extract_single_file_into_missing_dest_still_writes_exact_name() {
-		// The single-file path is unchanged: content at exactly `dst`.
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("renamed.txt");
-		let bytes = tar_bytes_with("original.txt", b"data");
-		super::extract_archive(&bytes, &dst).expect("extract");
-		assert_eq!(std::fs::read(&dst).expect("read"), b"data");
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn extract_strips_group_other_write_and_special_bits() {
-		use std::os::unix::fs::PermissionsExt;
-		let dir = tempfile::tempdir().expect("tempdir");
-		// World-writable + setuid entry from an untrusted container.
-		let mut h = tar::Header::new_gnu();
-		h.set_size(2);
-		h.set_mode(0o4777);
-		h.set_entry_type(tar::EntryType::Regular);
-		h.set_path("f").expect("path");
-		h.set_cksum();
-		let mut builder = tar::Builder::new(Vec::new());
-		builder.append(&h, &b"hi"[..]).expect("append");
-		let bytes = builder.into_inner().expect("finish");
-		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
-		let mode = std::fs::metadata(dir.path().join("f"))
-			.expect("meta")
-			.permissions()
-			.mode() & 0o7777;
-		assert_eq!(mode & 0o022, 0, "group/other write must be stripped");
-		assert_eq!(mode & 0o7000, 0, "setuid/setgid/sticky must be stripped");
-	}
-
-	#[test]
-	fn extract_tar_guarded_rejects_parent_traversal() {
-		// A compromised container can return a tar whose entry escapes the
-		// destination via `..`; the guard must refuse it and write nothing.
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("dest");
-		std::fs::create_dir(&dst).expect("mkdir");
-		let bytes = tar_bytes_with("../evil.txt", b"pwned");
-		let err = super::extract_tar_guarded(&bytes, &dst).unwrap_err();
-		assert!(
-			format!("{err}").contains("escapes destination"),
-			"expected a zip-slip refusal, got: {err}"
-		);
-		assert!(
-			!dir.path().join("evil.txt").exists(),
-			"traversal entry must not be written outside the destination"
-		);
-	}
-
-	#[test]
-	fn extract_archive_to_file_rejects_empty_archive() {
-		// An empty tar (no entries) against a file destination is an error: there
-		// is nothing to write to `dst`.
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("out.txt");
-		let bytes = tar::Builder::new(Vec::new()).into_inner().expect("finish");
-		let err = super::extract_archive(&bytes, &dst).unwrap_err();
-		assert!(format!("{err}").contains("empty"), "got: {err}");
-	}
-
-	#[test]
-	fn extract_archive_dir_source_creates_non_existent_dest() {
-		// A directory source against a non-existent destination creates the
-		// destination directory (matching `docker cp`) rather than erroring,
-		// regardless of the destination's name.
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("out.txt");
-		let mut h = tar::Header::new_gnu();
-		h.set_size(0);
-		h.set_mode(0o755);
-		h.set_entry_type(tar::EntryType::Directory);
-		h.set_path("subdir/").expect("path");
-		h.set_cksum();
-		let mut builder = tar::Builder::new(Vec::new());
-		builder.append(&h, std::io::empty()).expect("append");
-		let bytes = builder.into_inner().expect("finish");
-		super::extract_archive(&bytes, &dst).expect("extract");
-		assert!(dst.is_dir());
-	}
-
-	#[test]
-	fn extract_archive_to_file_creates_missing_parent() {
-		// The destination's parent directory is created on demand so a fresh
-		// `cp svc:/f ./new/dir/f` works without a pre-existing tree.
-		let dir = tempfile::tempdir().expect("tempdir");
-		let dst = dir.path().join("new").join("nested").join("file.txt");
-		let bytes = tar_bytes_with("ignored-name", b"data");
-		super::extract_archive(&bytes, &dst).expect("extract");
-		assert_eq!(std::fs::read(&dst).expect("read"), b"data");
+	fn check_endpoint_allows_normal_forms() {
+		// A plain local path, a proper SERVICE:PATH, and a relative host path are
+		// all fine (validation only rejects `-` and `SERVICE:`).
+		assert!(super::check_endpoint("/tmp/file").is_ok());
+		assert!(super::check_endpoint("web:/app/data").is_ok());
+		assert!(super::check_endpoint("./local").is_ok());
 	}
 }

--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -289,6 +289,19 @@ mod tests {
 		assert!(!result.unwrap().is_empty());
 	}
 
+	#[test]
+	fn pack_path_missing_source_is_a_cp_error() {
+		// A missing host source on `cp` must read as a cp error, not a build error.
+		let missing = std::path::Path::new("/nonexistent-host-source-xyz");
+		let err = super::pack_path(missing, false, None).unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("cp error"), "wrong category: {msg:?}");
+		assert!(
+			!msg.contains("build error"),
+			"must not be a build error: {msg:?}"
+		);
+	}
+
 	/// Build an uncompressed tar archive with a single entry at `path`. The name
 	/// is written straight into the GNU header so a hostile `..` path can be
 	/// forged (the safe `set_path`/`append_data` helpers reject `..`).

--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -1,0 +1,527 @@
+//! Tar packing and extraction for `cp`.
+//!
+//! The pure, container-free half of `cp`: it moves bytes between the host
+//! filesystem and a tar stream and carries the security hardening — the
+//! zip-slip guard, the extracted-mode sanitization and the docker/podman
+//! destination semantics. Kept synchronous so the guards can be unit-tested
+//! without a container.
+
+use std::path::Path;
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+
+use crate::error::{ComposeError, Result};
+
+pub(super) fn pack_path(
+	src: &Path,
+	follow_link: bool,
+	name_override: Option<&str>,
+) -> Result<Vec<u8>> {
+	let encoder = GzEncoder::new(Vec::new(), Compression::default());
+	let mut tar = tar::Builder::new(encoder);
+	// `-L/--follow-link`: archive the symlink target's contents instead of the
+	// link itself.
+	tar.follow_symlinks(follow_link);
+
+	if src.is_dir() {
+		// `name_override` renames the copied tree (rename-on-copy); otherwise it
+		// keeps the source's own basename and lands inside the destination dir.
+		let default = src.file_name().unwrap_or(std::ffi::OsStr::new("."));
+		let name: &std::ffi::OsStr = name_override.map(std::ffi::OsStr::new).unwrap_or(default);
+		tar.append_dir_all(name, src)
+			.map_err(|e| ComposeError::Copy(format!("cp: {e}")))?;
+	} else {
+		let default = src.file_name().unwrap_or(std::ffi::OsStr::new("file"));
+		let name: &std::ffi::OsStr = name_override.map(std::ffi::OsStr::new).unwrap_or(default);
+		tar.append_path_with_name(src, name)
+			.map_err(|e| ComposeError::Copy(format!("cp: {e}")))?;
+	}
+
+	let gz = tar
+		.into_inner()
+		.map_err(|e| ComposeError::Copy(format!("cp: {e}")))?;
+	gz.finish()
+		.map_err(|e| ComposeError::Copy(format!("cp: {e}")))
+}
+
+/// Route a container archive to the host destination.
+///
+/// docker/podman `cp` semantics for a container→host extraction:
+/// - `dst` is an existing directory: the archive is extracted into it (a source
+///   directory lands under its own name).
+/// - `dst` does not exist and the source is a single regular file: its
+///   **content** is written to exactly `dst` — the daemon-supplied entry name is
+///   ignored, so a hostile image cannot choose the on-host filename (e.g. drop a
+///   `.bashrc`/`authorized_keys` into the destination directory).
+/// - `dst` does not exist and the source is a directory: `dst` is created and the
+///   source's *contents* are copied into it (matching `docker cp`).
+pub(super) fn extract_archive(tar_bytes: &[u8], dst: &Path) -> Result<()> {
+	if dst.is_dir() {
+		return extract_tar_guarded(tar_bytes, dst);
+	}
+	// `dst` is not an existing directory.
+	if !archive_contains_dir(tar_bytes)? {
+		// A single regular file (or, defensively, a name-only archive). docker/podman
+		// `cp` require the destination's parent to exist and refuse a trailing-slash
+		// (directory) destination that does not exist, rather than auto-creating it.
+		if has_trailing_separator(dst) {
+			return Err(ComposeError::Copy(format!(
+				"cp: no such directory: {}",
+				dst.display()
+			)));
+		}
+		if let Some(parent) = dst.parent() {
+			if !parent.as_os_str().is_empty() && !parent.exists() {
+				return Err(ComposeError::Copy(format!(
+					"cp: no such directory: {}",
+					parent.display()
+				)));
+			}
+		}
+		// The single entry's content is written to exactly `dst`;
+		// `write_single_entry_to` still rejects a multi-entry archive here.
+		return write_single_entry_to(tar_bytes, dst);
+	}
+	// Directory source. A destination that already exists as a non-directory is a
+	// clear error (docker `cp` cannot copy a directory onto a file), rather than
+	// letting `create_dir_all` surface a misleading "File exists".
+	if dst.exists() {
+		return Err(ComposeError::Copy(format!(
+			"cp: cannot copy a directory onto the existing file {}",
+			dst.display()
+		)));
+	}
+	if let Some(parent) = dst.parent() {
+		if !parent.as_os_str().is_empty() && !parent.exists() {
+			return Err(ComposeError::Copy(format!(
+				"cp: no such directory: {}",
+				parent.display()
+			)));
+		}
+	}
+	// Directory source into a non-existent destination: create it and copy the
+	// source's contents in. The libpod archive is tarred under the source's
+	// basename, so extract through the zip-slip guard, then collapse that single
+	// wrapper level to leave the contents directly under `dst`.
+	std::fs::create_dir_all(dst).map_err(ComposeError::Io)?;
+	extract_tar_guarded(tar_bytes, dst)?;
+	flatten_single_wrapper_dir(dst)
+}
+
+/// True when the destination path was written with a trailing path separator
+/// (e.g. `./newdir/`), which `docker cp` treats as an explicit *directory*
+/// destination — it must already exist.
+fn has_trailing_separator(p: &Path) -> bool {
+	p.as_os_str()
+		.to_string_lossy()
+		.chars()
+		.last()
+		.is_some_and(std::path::is_separator)
+}
+
+/// True if any entry in `tar_bytes` is a directory — the signal that the source
+/// of a container→host copy was a directory (libpod tars it under its basename),
+/// as opposed to a single file.
+fn archive_contains_dir(tar_bytes: &[u8]) -> Result<bool> {
+	let cursor = std::io::Cursor::new(tar_bytes);
+	let mut archive = tar::Archive::new(cursor);
+	for entry in archive.entries().map_err(ComposeError::Io)? {
+		let entry = entry.map_err(ComposeError::Io)?;
+		if entry.header().entry_type() == tar::EntryType::Directory {
+			return Ok(true);
+		}
+	}
+	Ok(false)
+}
+
+/// Lift the contents of a single wrapper directory up into `dst`.
+///
+/// The libpod archive for `cp container:/srcdir` is tarred under the source's
+/// basename (`srcdir/...`). When that lands in a freshly-created `dst`, docker
+/// puts the source's *contents* directly in `dst`, so collapse the lone wrapper
+/// level. A no-op unless `dst` holds exactly one entry and it is a directory.
+fn flatten_single_wrapper_dir(dst: &Path) -> Result<()> {
+	let mut children: Vec<std::path::PathBuf> = std::fs::read_dir(dst)
+		.map_err(ComposeError::Io)?
+		.filter_map(|e| e.ok().map(|e| e.path()))
+		.collect();
+	if children.len() != 1 || !children[0].is_dir() {
+		return Ok(());
+	}
+	let wrapper = children.remove(0);
+	for entry in std::fs::read_dir(&wrapper).map_err(ComposeError::Io)? {
+		let from = entry.map_err(ComposeError::Io)?.path();
+		let name = from
+			.file_name()
+			.ok_or_else(|| ComposeError::Build("cp: archive entry has no name".into()))?;
+		std::fs::rename(&from, dst.join(name)).map_err(ComposeError::Io)?;
+	}
+	std::fs::remove_dir(&wrapper).map_err(ComposeError::Io)?;
+	Ok(())
+}
+
+/// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
+/// entry whose path would escape it (zip-slip) and stripping group/other-write
+/// and setuid/setgid/sticky bits the (untrusted) container set on each entry.
+///
+/// Extract entry-by-entry rather than `archive.unpack`: a malicious or
+/// compromised container can craft tar entries whose paths contain `..` or are
+/// absolute, escaping `dst_dir` and overwriting host files. `unpack_in` refuses
+/// such entries, returning `Ok(false)`; we turn that into a hard error so the
+/// copy fails loudly instead of silently skipping data. Pure and synchronous so
+/// the guard can be unit-tested without a container.
+fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
+	let cursor = std::io::Cursor::new(tar_bytes);
+	let mut archive = tar::Archive::new(cursor);
+	for entry in archive.entries().map_err(ComposeError::Io)? {
+		let mut entry = entry.map_err(ComposeError::Io)?;
+		let rel = entry.path().map(|p| p.into_owned()).ok();
+		let mode = entry.header().mode().ok();
+		if !entry.unpack_in(dst_dir).map_err(ComposeError::Io)? {
+			let p = entry
+				.path()
+				.map(|p| p.display().to_string())
+				.unwrap_or_else(|_| "<unprintable>".into());
+			return Err(ComposeError::Build(format!(
+				"cp: refusing archive entry that escapes destination: {p}"
+			)));
+		}
+		if let (Some(rel), Some(mode)) = (rel, mode) {
+			sanitize_extracted_mode(&dst_dir.join(rel), mode);
+		}
+	}
+	Ok(())
+}
+
+/// Write the single regular-file entry of `tar_bytes` to exactly `dst`,
+/// honouring the user's destination filename rather than the daemon's. Errors
+/// if the archive is empty, holds more than one entry, or the entry is not a
+/// regular file (those cases only make sense against a directory destination).
+fn write_single_entry_to(tar_bytes: &[u8], dst: &Path) -> Result<()> {
+	use std::io::Read;
+
+	// The caller (`extract_archive`) has already validated that `dst`'s parent
+	// directory exists; matching docker/podman `cp`, a missing parent is an error
+	// rather than being auto-created here.
+
+	let cursor = std::io::Cursor::new(tar_bytes);
+	let mut archive = tar::Archive::new(cursor);
+	let mut written = false;
+	for entry in archive.entries().map_err(ComposeError::Io)? {
+		let mut entry = entry.map_err(ComposeError::Io)?;
+		if entry.header().entry_type() != tar::EntryType::Regular {
+			return Err(ComposeError::Unsupported(format!(
+				"cp: destination {} is not a directory but the source is not a single file",
+				dst.display()
+			)));
+		}
+		if written {
+			return Err(ComposeError::Unsupported(format!(
+				"cp: destination {} is not a directory but the source has multiple entries",
+				dst.display()
+			)));
+		}
+		let mode = entry.header().mode().ok();
+		let mut buf = Vec::new();
+		entry.read_to_end(&mut buf).map_err(ComposeError::Io)?;
+		std::fs::write(dst, &buf).map_err(ComposeError::Io)?;
+		if let Some(mode) = mode {
+			sanitize_extracted_mode(dst, mode);
+		}
+		written = true;
+	}
+	if !written {
+		return Err(ComposeError::Build(
+			"cp: container archive was empty".into(),
+		));
+	}
+	Ok(())
+}
+
+/// Strip group/other-write and setuid/setgid/sticky bits from a file extracted
+/// from an untrusted container, keeping the owner and read/execute bits. No-op
+/// on non-files (e.g. symlinks) and on non-unix platforms.
+#[cfg(unix)]
+fn sanitize_extracted_mode(path: &Path, mode: u32) {
+	use std::os::unix::fs::PermissionsExt;
+	let Ok(meta) = std::fs::symlink_metadata(path) else {
+		return;
+	};
+	if !meta.is_file() {
+		return;
+	}
+	let masked = mode & 0o7777 & !0o022 & !0o7000;
+	if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(masked)) {
+		tracing::warn!("cp: could not set permissions on {}: {e}", path.display());
+	}
+}
+
+#[cfg(not(unix))]
+fn sanitize_extracted_mode(_path: &Path, _mode: u32) {}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn pack_path_single_file() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let file = dir.path().join("data.txt");
+		std::fs::write(&file, b"hello").expect("write");
+		let result = super::pack_path(&file, false, None);
+		assert!(result.is_ok());
+		let bytes = result.unwrap();
+		assert!(!bytes.is_empty());
+	}
+
+	#[test]
+	fn pack_path_directory() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let subdir = dir.path().join("mydir");
+		std::fs::create_dir(&subdir).expect("mkdir");
+		std::fs::write(subdir.join("a.txt"), b"aaa").expect("write");
+		std::fs::write(subdir.join("b.txt"), b"bbb").expect("write");
+		let result = super::pack_path(&subdir, false, None);
+		assert!(result.is_ok());
+		assert!(!result.unwrap().is_empty());
+	}
+
+	/// Build an uncompressed tar archive with a single entry at `path`. The name
+	/// is written straight into the GNU header so a hostile `..` path can be
+	/// forged (the safe `set_path`/`append_data` helpers reject `..`).
+	fn tar_bytes_with(path: &str, data: &[u8]) -> Vec<u8> {
+		let mut header = tar::Header::new_gnu();
+		header.set_size(data.len() as u64);
+		header.set_mode(0o644);
+		header.set_entry_type(tar::EntryType::Regular);
+		let name = path.as_bytes();
+		header.as_gnu_mut().expect("gnu header").name[..name.len()].copy_from_slice(name);
+		header.set_cksum();
+		let mut builder = tar::Builder::new(Vec::new());
+		builder.append(&header, data).expect("append");
+		builder.into_inner().expect("finish")
+	}
+
+	#[test]
+	fn extract_tar_guarded_writes_benign_entry() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let bytes = tar_bytes_with("hello.txt", b"hi");
+		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
+		assert_eq!(
+			std::fs::read(dir.path().join("hello.txt")).expect("read"),
+			b"hi"
+		);
+	}
+
+	#[test]
+	fn extract_archive_to_file_honors_user_filename() {
+		// dst is NOT a dir: the single entry's content must land at exactly `dst`,
+		// ignoring the daemon-supplied entry name (a hostile image must not pick
+		// the on-host filename).
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("myname.txt");
+		let bytes = tar_bytes_with("evil-name", b"payload");
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert_eq!(std::fs::read(&dst).expect("read"), b"payload");
+		assert!(
+			!dir.path().join("evil-name").exists(),
+			"daemon entry name must not be used as the on-host filename"
+		);
+	}
+
+	#[test]
+	fn extract_archive_to_file_rejects_multiple_entries() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("out.txt");
+		let mut builder = tar::Builder::new(Vec::new());
+		for n in ["a.txt", "b.txt"] {
+			let mut h = tar::Header::new_gnu();
+			h.set_size(1);
+			h.set_mode(0o644);
+			h.set_entry_type(tar::EntryType::Regular);
+			h.set_path(n).expect("path");
+			h.set_cksum();
+			builder.append(&h, &b"x"[..]).expect("append");
+		}
+		let bytes = builder.into_inner().expect("finish");
+		assert!(super::extract_archive(&bytes, &dst).is_err());
+	}
+
+	/// Build a directory archive shaped like libpod's `cp container:/srcdir`:
+	/// a wrapper directory entry plus its children, all under the basename.
+	fn tar_dir_with(wrapper: &str, files: &[(&str, &[u8])]) -> Vec<u8> {
+		let mut builder = tar::Builder::new(Vec::new());
+		let mut d = tar::Header::new_gnu();
+		d.set_size(0);
+		d.set_mode(0o755);
+		d.set_entry_type(tar::EntryType::Directory);
+		d.set_path(format!("{wrapper}/")).expect("path");
+		d.set_cksum();
+		builder.append(&d, std::io::empty()).expect("dir");
+		for (name, data) in files {
+			let mut h = tar::Header::new_gnu();
+			h.set_size(data.len() as u64);
+			h.set_mode(0o644);
+			h.set_entry_type(tar::EntryType::Regular);
+			h.set_path(format!("{wrapper}/{name}")).expect("path");
+			h.set_cksum();
+			builder.append(&h, *data).expect("file");
+		}
+		builder.into_inner().expect("finish")
+	}
+
+	#[test]
+	fn extract_dir_into_missing_dest_creates_and_flattens() {
+		// dst does not exist and the source is a directory: dst is created and the
+		// source's *contents* land directly in it (the wrapper level is collapsed),
+		// matching `docker cp`.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("newdir");
+		let bytes = tar_dir_with("srcdir", &[("a.txt", b"aaa"), ("b.txt", b"bbb")]);
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert!(dst.is_dir());
+		assert_eq!(std::fs::read(dst.join("a.txt")).expect("read"), b"aaa");
+		assert_eq!(std::fs::read(dst.join("b.txt")).expect("read"), b"bbb");
+		assert!(
+			!dst.join("srcdir").exists(),
+			"the wrapper directory level must be collapsed"
+		);
+	}
+
+	#[test]
+	fn extract_single_file_into_missing_dest_still_writes_exact_name() {
+		// The single-file path is unchanged: content at exactly `dst`.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("renamed.txt");
+		let bytes = tar_bytes_with("original.txt", b"data");
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert_eq!(std::fs::read(&dst).expect("read"), b"data");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn extract_strips_group_other_write_and_special_bits() {
+		use std::os::unix::fs::PermissionsExt;
+		let dir = tempfile::tempdir().expect("tempdir");
+		// World-writable + setuid entry from an untrusted container.
+		let mut h = tar::Header::new_gnu();
+		h.set_size(2);
+		h.set_mode(0o4777);
+		h.set_entry_type(tar::EntryType::Regular);
+		h.set_path("f").expect("path");
+		h.set_cksum();
+		let mut builder = tar::Builder::new(Vec::new());
+		builder.append(&h, &b"hi"[..]).expect("append");
+		let bytes = builder.into_inner().expect("finish");
+		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
+		let mode = std::fs::metadata(dir.path().join("f"))
+			.expect("meta")
+			.permissions()
+			.mode() & 0o7777;
+		assert_eq!(mode & 0o022, 0, "group/other write must be stripped");
+		assert_eq!(mode & 0o7000, 0, "setuid/setgid/sticky must be stripped");
+	}
+
+	#[test]
+	fn extract_tar_guarded_rejects_parent_traversal() {
+		// A compromised container can return a tar whose entry escapes the
+		// destination via `..`; the guard must refuse it and write nothing.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("dest");
+		std::fs::create_dir(&dst).expect("mkdir");
+		let bytes = tar_bytes_with("../evil.txt", b"pwned");
+		let err = super::extract_tar_guarded(&bytes, &dst).unwrap_err();
+		assert!(
+			format!("{err}").contains("escapes destination"),
+			"expected a zip-slip refusal, got: {err}"
+		);
+		assert!(
+			!dir.path().join("evil.txt").exists(),
+			"traversal entry must not be written outside the destination"
+		);
+	}
+
+	#[test]
+	fn extract_archive_to_file_rejects_empty_archive() {
+		// An empty tar (no entries) against a file destination is an error: there
+		// is nothing to write to `dst`.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("out.txt");
+		let bytes = tar::Builder::new(Vec::new()).into_inner().expect("finish");
+		let err = super::extract_archive(&bytes, &dst).unwrap_err();
+		assert!(format!("{err}").contains("empty"), "got: {err}");
+	}
+
+	#[test]
+	fn extract_archive_dir_source_creates_non_existent_dest() {
+		// A directory source against a non-existent destination creates the
+		// destination directory (matching `docker cp`) rather than erroring,
+		// regardless of the destination's name.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("out.txt");
+		let mut h = tar::Header::new_gnu();
+		h.set_size(0);
+		h.set_mode(0o755);
+		h.set_entry_type(tar::EntryType::Directory);
+		h.set_path("subdir/").expect("path");
+		h.set_cksum();
+		let mut builder = tar::Builder::new(Vec::new());
+		builder.append(&h, std::io::empty()).expect("append");
+		let bytes = builder.into_inner().expect("finish");
+		super::extract_archive(&bytes, &dst).expect("extract");
+		assert!(dst.is_dir());
+	}
+
+	#[test]
+	fn extract_archive_to_file_errors_on_missing_parent() {
+		// docker/podman `cp` error when the destination's parent directory does not
+		// exist, rather than silently creating the whole chain.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("new").join("nested").join("file.txt");
+		let bytes = tar_bytes_with("ignored-name", b"data");
+		let err = super::extract_archive(&bytes, &dst).unwrap_err();
+		assert!(format!("{err}").contains("no such directory"), "got: {err}");
+		assert!(!dst.exists(), "nothing must be created on a missing parent");
+		assert!(
+			!dst.parent().unwrap().exists(),
+			"the parent chain must not be created"
+		);
+	}
+
+	#[test]
+	fn extract_archive_to_trailing_slash_missing_dir_errors() {
+		// A trailing-slash destination names a directory; when it does not exist,
+		// `cp` errors instead of hitting a misleading "Is a directory" (EISDIR).
+		let dir = tempfile::tempdir().expect("tempdir");
+		// Keep the trailing separator on the path string.
+		let dst = std::path::PathBuf::from(format!("{}/newdir/", dir.path().display()));
+		let bytes = tar_bytes_with("hostname", b"data");
+		let err = super::extract_archive(&bytes, &dst).unwrap_err();
+		assert!(format!("{err}").contains("no such directory"), "got: {err}");
+		assert!(!dst.exists(), "nothing must be created");
+	}
+
+	#[test]
+	fn extract_archive_dir_source_onto_existing_file_errors() {
+		// A directory source whose destination already exists as a regular file is
+		// a clear error, not a misleading "File exists" (EEXIST); the file is left
+		// untouched.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let dst = dir.path().join("existing");
+		std::fs::write(&dst, b"keep").expect("write");
+		let bytes = tar_dir_with("srcdir", &[("a.txt", b"aaa")]);
+		let err = super::extract_archive(&bytes, &dst).unwrap_err();
+		assert!(
+			format!("{err}").contains("cannot copy a directory"),
+			"got: {err}"
+		);
+		assert_eq!(
+			std::fs::read(&dst).expect("read"),
+			b"keep",
+			"the existing file must be left untouched"
+		);
+	}
+}

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -9,18 +9,41 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::Engine;
 
+/// Options for [`Engine::stream_events`], mirroring `docker compose events`
+/// (`--since`, `--until`, `--filter`).
+#[derive(Debug, Clone, Default)]
+pub struct EventsOptions {
+	/// Only events at or after this timestamp/relative time (`--since`).
+	pub since: Option<String>,
+	/// Only events up to this timestamp/relative time (`--until`).
+	pub until: Option<String>,
+	/// Extra `KEY=VALUE` event filters (`--filter`, e.g. `event=start`).
+	pub filters: Vec<String>,
+}
+
 impl Engine {
 	/// Stream events for this project's containers until interrupted. With
 	/// `json`, each event is printed as a compact JSON line; otherwise as
 	/// `TYPE ACTION NAME`.
 	pub async fn stream_events(&self, json: bool) -> Result<()> {
-		let filters = serde_json::json!({
-			"label": [format!("podup.project={}", self.project)],
-		});
-		let path = format!(
+		self.stream_events_with_options(json, &EventsOptions::default())
+			.await
+	}
+
+	/// [`Engine::stream_events`] with `docker compose events`-style `--since`,
+	/// `--until`, and `--filter` options.
+	pub async fn stream_events_with_options(&self, json: bool, opts: &EventsOptions) -> Result<()> {
+		let filters = build_event_filters(&self.project, &opts.filters);
+		let mut path = format!(
 			"{API_PREFIX}/events?stream=true&filters={}",
 			urlencoded(&filters.to_string()),
 		);
+		if let Some(since) = &opts.since {
+			path.push_str(&format!("&since={}", urlencoded(since)));
+		}
+		if let Some(until) = &opts.until {
+			path.push_str(&format!("&until={}", urlencoded(until)));
+		}
 		let resp = self
 			.client
 			.get_stream(&path)
@@ -35,6 +58,33 @@ impl Engine {
 		}
 		Ok(())
 	}
+}
+
+/// Build the libpod events `filters` object: always scope to this project's
+/// `podup.project` label, then merge each user `KEY=VALUE` predicate (appending
+/// to that key's value array). A predicate with no `=` is skipped. Pure so the
+/// merge is unit-tested.
+fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
+	use serde_json::{Map, Value};
+	let mut map: Map<String, Value> = Map::new();
+	map.insert(
+		"label".to_string(),
+		Value::Array(vec![Value::String(format!("podup.project={project}"))]),
+	);
+	for f in user_filters {
+		let Some((key, value)) = f.split_once('=') else {
+			tracing::warn!("events: ignoring malformed filter '{f}' (expected KEY=VALUE)");
+			continue;
+		};
+		match map
+			.entry(key.to_string())
+			.or_insert_with(|| Value::Array(Vec::new()))
+		{
+			Value::Array(arr) => arr.push(Value::String(value.to_string())),
+			other => *other = Value::Array(vec![Value::String(value.to_string())]),
+		}
+	}
+	Value::Object(map)
 }
 
 /// Render one event. `json` emits the raw object as a compact line; otherwise a
@@ -61,8 +111,35 @@ fn format_event(value: &Value, json: bool) -> String {
 
 #[cfg(test)]
 mod tests {
-	use super::format_event;
+	use super::{build_event_filters, format_event};
 	use serde_json::json;
+
+	#[test]
+	fn build_event_filters_scopes_to_project_label() {
+		let f = build_event_filters("demo", &[]);
+		assert_eq!(f, json!({ "label": ["podup.project=demo"] }));
+	}
+
+	#[test]
+	fn build_event_filters_merges_user_predicates() {
+		let f = build_event_filters(
+			"demo",
+			&[
+				"event=start".to_string(),
+				"event=die".to_string(),
+				"type=container".to_string(),
+				"bogus".to_string(),
+			],
+		);
+		assert_eq!(
+			f,
+			json!({
+				"label": ["podup.project=demo"],
+				"event": ["start", "die"],
+				"type": ["container"],
+			})
+		);
+	}
 
 	#[test]
 	fn formats_docker_compat_shape() {

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -92,6 +92,30 @@ fn health_poll_plan(
 	(poll_secs, iterations)
 }
 
+/// Poll iterations to actually run, given the healthcheck poll-plan and an
+/// optional `--wait-timeout`.
+///
+/// `--wait-timeout` must be able to *extend* the wait, not merely cap it: a
+/// healthcheck with a short `interval × retries` budget would otherwise time
+/// out long before a generous `--wait-timeout` elapsed. So when a wait-timeout
+/// is given we run at least enough iterations to cover it (plus a small margin),
+/// letting the outer `--wait-timeout` deadline — not the poll plan — decide when
+/// to give up. Without a wait-timeout the poll plan governs unchanged. Pure so
+/// the budget arithmetic is unit-tested without a live socket.
+fn effective_iterations(poll_secs: u64, plan_iters: u64, wait_timeout: Option<Duration>) -> u64 {
+	match wait_timeout {
+		Some(wt) => {
+			let poll = poll_secs.max(1);
+			// +2 so the inner loop outlasts the outer deadline, ensuring an
+			// exhausted wait surfaces as the `--wait-timeout` error rather than a
+			// spurious health-check-timeout that fired one poll early.
+			let wt_iters = wt.as_secs().div_ceil(poll) + 2;
+			plan_iters.max(wt_iters)
+		}
+		None => plan_iters,
+	}
+}
+
 impl Engine {
 	/// Wait until every targeted service's first replica is healthy (`up
 	/// --wait`). A service with no effective healthcheck is treated as ready
@@ -100,6 +124,22 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],
+	) -> Result<()> {
+		self.wait_services_healthy_within(file, target_services, None)
+			.await
+	}
+
+	/// As [`wait_services_healthy`](Self::wait_services_healthy), but a
+	/// `Some(wait_timeout)` extends each service's poll budget to cover the
+	/// supplied `--wait-timeout` (rather than only capping it). The caller still
+	/// wraps the whole wait in a hard `--wait-timeout` deadline, which becomes the
+	/// authoritative limit; this just stops the per-service poll plan from giving
+	/// up early and reporting a misleading health-check timeout.
+	pub async fn wait_services_healthy_within(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		wait_timeout: Option<Duration>,
 	) -> Result<()> {
 		// Poll services concurrently: each `wait_healthy` is its own poll loop, so
 		// total `--wait` latency is the slowest service, not the sum of all.
@@ -111,7 +151,7 @@ impl Engine {
 			})
 			.map(|(name, service)| {
 				let container = self.first_replica_name(name, service);
-				async move { self.wait_healthy(&container, service).await }
+				async move { self.wait_healthy(&container, service, wait_timeout).await }
 			});
 		futures_util::future::try_join_all(waits).await?;
 		Ok(())
@@ -128,13 +168,21 @@ impl Engine {
 	/// those declared in compose. If the container has no effective healthcheck at
 	/// all (none in the image or compose), it can never report `healthy`, so the
 	/// wait short-circuits as satisfied rather than blocking until timeout.
-	pub(super) async fn wait_healthy(&self, container_name: &str, service: &Service) -> Result<()> {
+	pub(super) async fn wait_healthy(
+		&self,
+		container_name: &str,
+		service: &Service,
+		wait_timeout: Option<Duration>,
+	) -> Result<()> {
 		let hc = service.healthcheck.as_ref();
-		let (poll_secs, iterations) = health_poll_plan(
+		let (poll_secs, plan_iters) = health_poll_plan(
 			hc.and_then(|h| h.interval.as_deref()),
 			hc.and_then(|h| h.start_period.as_deref()),
 			hc.and_then(|h| h.retries),
 		);
+		// `--wait-timeout` extends the poll budget so it, not the (often shorter)
+		// healthcheck interval×retries plan, decides when the wait gives up.
+		let iterations = effective_iterations(poll_secs, plan_iters, wait_timeout);
 
 		// One inspect decides the short-circuits: already healthy, or no effective
 		// healthcheck at all (image or compose) — in which case a server-side
@@ -247,6 +295,30 @@ mod tests {
 		// An interval below 1s falls back to the 2s default (no busy-poll).
 		let (poll, _) = super::health_poll_plan(Some("500ms"), None, Some(5));
 		assert_eq!(poll, 2);
+	}
+
+	// --- effective_iterations (--wait-timeout budget, #891) ------------------
+
+	#[test]
+	fn effective_iterations_without_wait_timeout_uses_plan() {
+		// No --wait-timeout: the healthcheck poll plan governs unchanged.
+		assert_eq!(super::effective_iterations(2, 30, None), 30);
+	}
+
+	#[test]
+	fn effective_iterations_extends_to_cover_wait_timeout() {
+		// A short plan (interval 10s × 1 retry = 1 iter) must be extended so a
+		// generous --wait-timeout actually elapses: 120s / 10s + 2 margin = 14.
+		let iters = super::effective_iterations(10, 1, Some(Duration::from_secs(120)));
+		assert_eq!(iters, 14);
+	}
+
+	#[test]
+	fn effective_iterations_keeps_larger_plan() {
+		// When the poll plan already outlasts --wait-timeout, the plan wins so the
+		// healthcheck's own budget is never shortened.
+		let iters = super::effective_iterations(2, 100, Some(Duration::from_secs(10)));
+		assert_eq!(iters, 100);
 	}
 
 	// --- wait_healthy gating (service_healthy) -------------------------------

--- a/internal/engine/image/digests.rs
+++ b/internal/engine/image/digests.rs
@@ -5,7 +5,7 @@
 //! images, not a full [`Engine`](crate::engine::Engine) — so it lives as a free function.
 
 use crate::compose::types::ComposeFile;
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, Client, API_PREFIX};
 
@@ -28,9 +28,16 @@ pub async fn resolve_image_digests(client: &Client, file: &ComposeFile) -> Resul
 					 (service {name}); left unchanged"
 				),
 			},
-			Err(e) => tracing::warn!(
-				"config --resolve-image-digests: cannot inspect {image} (service {name}): {e}"
-			),
+			// A backend failure (unreachable socket, HTTP 500) must be a hard
+			// error: emitting the original UNPINNED config with exit 0 would let a
+			// script that relies on digest pinning silently get unpinned images.
+			// A genuinely-absent image (404) is reported the same way: the user
+			// asked to pin and we could not.
+			Err(e) => {
+				return Err(ComposeError::Build(format!(
+					"config --resolve-image-digests: cannot inspect {image} (service {name}): {e}"
+				)))
+			}
 		}
 	}
 	Ok(out)

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -1,7 +1,7 @@
 //! `commit` and `export`: snapshot a service container to an image, or stream
 //! its filesystem out as a tar archive (`docker compose commit` / `export`).
 
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 
 use http_body_util::BodyExt;
@@ -65,6 +65,15 @@ impl Engine {
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container = self.replica_name_at(service_name, service, index)?;
 
+		// Refuse to flood a terminal with a binary tar stream when no output file
+		// is given, matching `docker export`.
+		if refuse_tar_to_tty(output.is_none(), std::io::stdout().is_terminal()) {
+			return Err(ComposeError::Unsupported(
+				"refusing to write a tar archive to the terminal: pass -o FILE or redirect stdout"
+					.into(),
+			));
+		}
+
 		let path = format!("{API_PREFIX}/containers/{}/export", urlencoded(&container),);
 		let resp = self
 			.client
@@ -85,5 +94,24 @@ impl Engine {
 		}
 		sink.flush().map_err(ComposeError::Io)?;
 		Ok(())
+	}
+}
+
+/// Whether an `export` should be refused: true only when no output file was
+/// given *and* stdout is a terminal. Pure so the guard is unit-tested.
+fn refuse_tar_to_tty(no_output_file: bool, stdout_is_tty: bool) -> bool {
+	no_output_file && stdout_is_tty
+}
+
+#[cfg(test)]
+mod tests {
+	use super::refuse_tar_to_tty;
+
+	#[test]
+	fn refuses_only_when_no_file_and_tty() {
+		assert!(refuse_tar_to_tty(true, true));
+		assert!(!refuse_tar_to_tty(true, false));
+		assert!(!refuse_tar_to_tty(false, true));
+		assert!(!refuse_tar_to_tty(false, false));
 	}
 }

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -191,12 +191,33 @@ impl Engine {
 		while let Some(frame) = body.frame().await {
 			let frame = frame.map_err(|e| ComposeError::Build(format!("export stream: {e}")))?;
 			if let Ok(data) = frame.into_data() {
-				sink.write_all(&data).map_err(|e| io_to_err(&output, e))?;
+				if let Err(e) = sink.write_all(&data) {
+					// A downstream reader that closed early (`podup export svc | head`)
+					// surfaces as a broken pipe; stop quietly and successfully like any
+					// well-behaved Unix tool instead of printing an error and exiting 1.
+					if is_stdout_broken_pipe(to_stdout, &e) {
+						return Ok(());
+					}
+					return Err(io_to_err(&output, e));
+				}
 			}
 		}
-		sink.flush().map_err(|e| io_to_err(&output, e))?;
+		if let Err(e) = sink.flush() {
+			if is_stdout_broken_pipe(to_stdout, &e) {
+				return Ok(());
+			}
+			return Err(io_to_err(&output, e));
+		}
 		Ok(())
 	}
+}
+
+/// Whether a write error is a broken pipe on the stdout sink — a downstream
+/// reader closed early. A broken pipe never applies to a `-o FILE` sink, so it
+/// only short-circuits to a clean exit when streaming to stdout. Pure so it is
+/// unit-tested.
+fn is_stdout_broken_pipe(to_stdout: bool, e: &std::io::Error) -> bool {
+	to_stdout && e.kind() == std::io::ErrorKind::BrokenPipe
 }
 
 /// Map a write error to one that names the `-o` output path when present, so the
@@ -266,5 +287,21 @@ mod tests {
 		assert!(!refuse_tar_to_tty(true, false));
 		assert!(!refuse_tar_to_tty(false, true));
 		assert!(!refuse_tar_to_tty(false, false));
+	}
+
+	#[test]
+	fn stdout_broken_pipe_is_a_clean_stop_only_on_stdout() {
+		use super::is_stdout_broken_pipe;
+		use std::io::{Error, ErrorKind};
+		let epipe = || Error::from(ErrorKind::BrokenPipe);
+		// A broken pipe while streaming to stdout (`| head`) is a clean stop.
+		assert!(is_stdout_broken_pipe(true, &epipe()));
+		// The same error against a `-o FILE` sink is a real failure to report.
+		assert!(!is_stdout_broken_pipe(false, &epipe()));
+		// Any other write error on stdout is still a real failure.
+		assert!(!is_stdout_broken_pipe(
+			true,
+			&Error::from(ErrorKind::PermissionDenied)
+		));
 	}
 }

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -12,6 +12,22 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::super::Engine;
 
+/// Options for [`Engine::commit_with_options`], mirroring `docker compose commit`
+/// (`-m/--message`, `-a/--author`, `-p/--pause`, `-c/--change`). Kept off the
+/// frozen `commit` signature so the 1.0 library API stays stable.
+#[derive(Debug, Clone, Default)]
+pub struct CommitOptions {
+	/// Commit message recorded on the new image (`-m/--message`).
+	pub message: Option<String>,
+	/// Author recorded on the new image (`-a/--author`).
+	pub author: Option<String>,
+	/// Pause the container during the commit (`-p/--pause`); `None` leaves
+	/// Podman's default (pause on).
+	pub pause: Option<bool>,
+	/// Dockerfile instructions to apply to the committed image (`-c/--change`).
+	pub changes: Vec<String>,
+}
+
 /// Split a `commit` image reference into `(repo, tag)`, defaulting the tag to
 /// `latest`. Rejects an empty reference or an empty repository (`""` or `:tag`),
 /// which podman would otherwise accept and turn into a dangling `<none>` image.
@@ -77,6 +93,29 @@ impl Engine {
 		index: Option<u32>,
 		pause: bool,
 	) -> Result<()> {
+		self.commit_with_options(
+			file,
+			service_name,
+			image,
+			index,
+			CommitOptions {
+				pause: Some(pause),
+				..Default::default()
+			},
+		)
+		.await
+	}
+
+	/// Commit a service container with `docker compose commit`-style options
+	/// (message, author, pause, change).
+	pub async fn commit_with_options(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		image: &str,
+		index: Option<u32>,
+		opts: CommitOptions,
+	) -> Result<()> {
 		let service = file
 			.services
 			.get(service_name)
@@ -84,7 +123,18 @@ impl Engine {
 		let container = self.replica_name_at(service_name, service, index)?;
 
 		let (repo, tag) = split_image_ref(image)?;
-		let path = commit_path(&container, repo, tag, pause);
+		// `None` leaves Podman's default (pause on), matching `docker commit`.
+		let pause = opts.pause.unwrap_or(true);
+		let mut path = commit_path(&container, repo, tag, pause);
+		if let Some(message) = &opts.message {
+			path.push_str(&format!("&comment={}", urlencoded(message)));
+		}
+		if let Some(author) = &opts.author {
+			path.push_str(&format!("&author={}", urlencoded(author)));
+		}
+		for change in &opts.changes {
+			path.push_str(&format!("&changes={}", urlencoded(change)));
+		}
 		self.client
 			.post_empty_ok(&path)
 			.await
@@ -125,12 +175,17 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 
-		let mut sink: Box<dyn Write> = match &output {
-			Some(p) => Box::new(std::fs::File::create(p).map_err(|e| ComposeError::IoPath {
+		// `-o -` streams to stdout (the coreutils/docker dash convention) rather
+		// than creating a file literally named `-`.
+		let to_stdout = output.is_none() || output.as_deref() == Some(std::path::Path::new("-"));
+		let mut sink: Box<dyn Write> = if to_stdout {
+			Box::new(std::io::stdout().lock())
+		} else {
+			let p = output.as_ref().unwrap();
+			Box::new(std::fs::File::create(p).map_err(|e| ComposeError::IoPath {
 				path: p.display().to_string(),
 				source: e,
-			})?),
-			None => Box::new(std::io::stdout().lock()),
+			})?)
 		};
 		let mut body = resp.into_body();
 		while let Some(frame) = body.frame().await {

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -12,14 +12,29 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::super::Engine;
 
-/// Split an `image` reference into `(repo, tag)`. A ':' after the last '/' is a
-/// tag; otherwise it is part of a registry `host:port` and the whole string is
-/// the repo. An omitted tag defaults to `latest`.
-fn split_image_ref(image: &str) -> (&str, &str) {
-	match image.rsplit_once(':') {
+/// Split a `commit` image reference into `(repo, tag)`, defaulting the tag to
+/// `latest`. Rejects an empty reference or an empty repository (`""` or `:tag`),
+/// which podman would otherwise accept and turn into a dangling `<none>` image.
+/// Pure so it is unit-tested.
+fn split_image_ref(image: &str) -> Result<(&str, &str)> {
+	let (repo, tag) = match image.rsplit_once(':') {
+		// A ':' after the last '/' is a tag; otherwise it's part of a registry
+		// host:port and the whole string is the repo.
 		Some((r, t)) if !t.contains('/') => (r, t),
 		_ => (image, "latest"),
+	};
+	if repo.is_empty() {
+		return Err(ComposeError::Unsupported(format!(
+			"invalid image reference {image:?}: a non-empty repository name is required \
+			 (e.g. myimage or myimage:tag)"
+		)));
 	}
+	if tag.is_empty() {
+		return Err(ComposeError::Unsupported(format!(
+			"invalid image reference {image:?}: the tag after ':' must not be empty"
+		)));
+	}
+	Ok((repo, tag))
 }
 
 /// Build the libpod `/commit` request path. `pause` quiesces the container
@@ -68,7 +83,7 @@ impl Engine {
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container = self.replica_name_at(service_name, service, index)?;
 
-		let (repo, tag) = split_image_ref(image);
+		let (repo, tag) = split_image_ref(image)?;
 		let path = commit_path(&container, repo, tag, pause);
 		self.client
 			.post_empty_ok(&path)
@@ -111,18 +126,33 @@ impl Engine {
 			.map_err(ComposeError::Podman)?;
 
 		let mut sink: Box<dyn Write> = match &output {
-			Some(p) => Box::new(std::fs::File::create(p).map_err(ComposeError::Io)?),
+			Some(p) => Box::new(std::fs::File::create(p).map_err(|e| ComposeError::IoPath {
+				path: p.display().to_string(),
+				source: e,
+			})?),
 			None => Box::new(std::io::stdout().lock()),
 		};
 		let mut body = resp.into_body();
 		while let Some(frame) = body.frame().await {
 			let frame = frame.map_err(|e| ComposeError::Build(format!("export stream: {e}")))?;
 			if let Ok(data) = frame.into_data() {
-				sink.write_all(&data).map_err(ComposeError::Io)?;
+				sink.write_all(&data).map_err(|e| io_to_err(&output, e))?;
 			}
 		}
-		sink.flush().map_err(ComposeError::Io)?;
+		sink.flush().map_err(|e| io_to_err(&output, e))?;
 		Ok(())
+	}
+}
+
+/// Map a write error to one that names the `-o` output path when present, so the
+/// user learns which destination failed.
+fn io_to_err(output: &Option<PathBuf>, e: std::io::Error) -> ComposeError {
+	match output {
+		Some(p) => ComposeError::IoPath {
+			path: p.display().to_string(),
+			source: e,
+		},
+		None => ComposeError::Io(e),
 	}
 }
 
@@ -137,19 +167,29 @@ mod tests {
 	use super::{commit_path, refuse_tar_to_tty, split_image_ref};
 
 	#[test]
-	fn image_ref_splits_repo_and_tag() {
-		assert_eq!(split_image_ref("myrepo:v1"), ("myrepo", "v1"));
-		// No tag defaults to latest.
-		assert_eq!(split_image_ref("myrepo"), ("myrepo", "latest"));
-		// A registry host:port is not a tag.
+	fn split_image_ref_defaults_tag() {
+		assert_eq!(split_image_ref("myimage").unwrap(), ("myimage", "latest"));
+		assert_eq!(split_image_ref("myimage:1.0").unwrap(), ("myimage", "1.0"));
+	}
+
+	#[test]
+	fn split_image_ref_keeps_registry_port() {
+		// A ':' that is part of a registry host:port is not a tag.
 		assert_eq!(
-			split_image_ref("localhost:5000/app"),
-			("localhost:5000/app", "latest")
+			split_image_ref("registry:5000/app").unwrap(),
+			("registry:5000/app", "latest")
 		);
 		assert_eq!(
-			split_image_ref("localhost:5000/app:v2"),
+			split_image_ref("localhost:5000/app:v2").unwrap(),
 			("localhost:5000/app", "v2")
 		);
+	}
+
+	#[test]
+	fn split_image_ref_rejects_empty_and_empty_repo() {
+		assert!(split_image_ref("").is_err());
+		assert!(split_image_ref(":tag").is_err());
+		assert!(split_image_ref("repo:").is_err());
 	}
 
 	#[test]

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -12,10 +12,33 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::super::Engine;
 
+/// Split an `image` reference into `(repo, tag)`. A ':' after the last '/' is a
+/// tag; otherwise it is part of a registry `host:port` and the whole string is
+/// the repo. An omitted tag defaults to `latest`.
+fn split_image_ref(image: &str) -> (&str, &str) {
+	match image.rsplit_once(':') {
+		Some((r, t)) if !t.contains('/') => (r, t),
+		_ => (image, "latest"),
+	}
+}
+
+/// Build the libpod `/commit` request path. `pause` quiesces the container
+/// during the snapshot (docker default) for a consistent filesystem.
+fn commit_path(container: &str, repo: &str, tag: &str, pause: bool) -> String {
+	format!(
+		"{API_PREFIX}/commit?container={}&repo={}&tag={}&pause={pause}",
+		urlencoded(container),
+		urlencoded(repo),
+		urlencoded(tag),
+	)
+}
+
 impl Engine {
-	/// Commit a service container to a new image (`docker compose commit`).
-	/// Targets the given replica (`index`, 1-based) or the first one. `image`
-	/// is `repo[:tag]`; an omitted tag defaults to `latest`.
+	/// Commit a service container to a new image (`docker compose commit`),
+	/// pausing the container during the snapshot for a consistent filesystem
+	/// (docker default). Equivalent to [`Engine::commit_with_pause`] with
+	/// `pause = true`. Targets the given replica (`index`, 1-based) or the first
+	/// one. `image` is `repo[:tag]`; an omitted tag defaults to `latest`.
 	pub async fn commit(
 		&self,
 		file: &ComposeFile,
@@ -23,24 +46,30 @@ impl Engine {
 		image: &str,
 		index: Option<u32>,
 	) -> Result<()> {
+		self.commit_with_pause(file, service_name, image, index, true)
+			.await
+	}
+
+	/// Commit a service container to a new image (`docker compose commit`).
+	/// Targets the given replica (`index`, 1-based) or the first one. `image`
+	/// is `repo[:tag]`; an omitted tag defaults to `latest`. `pause` quiesces the
+	/// container during the snapshot for a consistent filesystem (docker default).
+	pub async fn commit_with_pause(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		image: &str,
+		index: Option<u32>,
+		pause: bool,
+	) -> Result<()> {
 		let service = file
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		let container = self.replica_name_at(service_name, service, index)?;
 
-		let (repo, tag) = match image.rsplit_once(':') {
-			// A ':' after the last '/' is a tag; otherwise it's part of a registry
-			// host:port and the whole string is the repo.
-			Some((r, t)) if !t.contains('/') => (r, t),
-			_ => (image, "latest"),
-		};
-		let path = format!(
-			"{API_PREFIX}/commit?container={}&repo={}&tag={}",
-			urlencoded(&container),
-			urlencoded(repo),
-			urlencoded(tag),
-		);
+		let (repo, tag) = split_image_ref(image);
+		let path = commit_path(&container, repo, tag, pause);
 		self.client
 			.post_empty_ok(&path)
 			.await
@@ -105,7 +134,36 @@ fn refuse_tar_to_tty(no_output_file: bool, stdout_is_tty: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-	use super::refuse_tar_to_tty;
+	use super::{commit_path, refuse_tar_to_tty, split_image_ref};
+
+	#[test]
+	fn image_ref_splits_repo_and_tag() {
+		assert_eq!(split_image_ref("myrepo:v1"), ("myrepo", "v1"));
+		// No tag defaults to latest.
+		assert_eq!(split_image_ref("myrepo"), ("myrepo", "latest"));
+		// A registry host:port is not a tag.
+		assert_eq!(
+			split_image_ref("localhost:5000/app"),
+			("localhost:5000/app", "latest")
+		);
+		assert_eq!(
+			split_image_ref("localhost:5000/app:v2"),
+			("localhost:5000/app", "v2")
+		);
+	}
+
+	#[test]
+	fn commit_path_includes_pause_flag() {
+		// Pausing (docker default) yields a consistent snapshot.
+		let paused = commit_path("proj_web_1", "repo", "latest", true);
+		assert!(paused.contains("container=proj_web_1"));
+		assert!(paused.contains("repo=repo"));
+		assert!(paused.contains("tag=latest"));
+		assert!(paused.contains("pause=true"));
+		// Opting out keeps the container live during commit.
+		let live = commit_path("proj_web_1", "repo", "latest", false);
+		assert!(live.contains("pause=false"));
+	}
 
 	#[test]
 	fn refuses_only_when_no_file_and_tty() {

--- a/internal/engine/image/mod.rs
+++ b/internal/engine/image/mod.rs
@@ -5,3 +5,4 @@ mod digests;
 mod export;
 
 pub use digests::resolve_image_digests;
+pub use export::CommitOptions;

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -220,8 +220,14 @@ impl Engine {
 
 		let mut last_nonzero = 0i64;
 		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
+			// Only wait on containers Podman actually has. The static-name fallback
+			// would POST `/wait` to a never-created predicted name and surface a raw
+			// HTTP 404; docker compose treats "nothing to wait on" as an idempotent
+			// no-op, so a defined-but-never-created service is simply skipped (#758).
+			for container_name in self
+				.list_project_container_names(Some(name.as_str()))
+				.await?
+			{
 				let path = format!(
 					"{API_PREFIX}/containers/{}/wait?condition=stopped",
 					crate::libpod::urlencoded(&container_name),
@@ -254,9 +260,23 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let grace = self.grace_period_secs(service);
-				self.stop_container(&container_name, grace).await?;
+			let grace = self.grace_period_secs(service);
+			// Enumerate only the containers Podman actually has (no static-name
+			// fallback): a defined-but-never-created service is a quiet no-op
+			// rather than a phantom stop. Report "stopped" solely for containers
+			// that were actually running/paused — stopping a Created/Exited one is
+			// a harmless no-op and must not claim it stopped (#876), matching
+			// docker compose, which acts only on running containers.
+			for container in self.live_service_containers(name).await? {
+				if super::scale::state_is_active(&container.state) {
+					self.stop_container(&container.name, grace).await?;
+				} else {
+					tracing::debug!(
+						"{}: not running ({}) — stop is a no-op",
+						container.name,
+						container.state
+					);
+				}
 			}
 		}
 		Ok(())

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,5 +1,6 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
+use std::collections::HashMap;
 use std::io::Write;
 
 use futures_util::StreamExt;
@@ -341,6 +342,8 @@ impl Engine {
 			interactive,
 			no_deps,
 		} = self.run_overrides.clone();
+		// `--env-file` is global, so it rides on the engine (not `RunOverrides`).
+		let env_files = self.run_env_files.clone();
 		let service = file
 			.services
 			.get(service_name)
@@ -391,15 +394,21 @@ impl Engine {
 				.volumes
 				.push(crate::compose::types::VolumeMount::Short(v));
 		}
-		if !env_overrides.is_empty() {
-			let mut env_list: Vec<String> = {
-				let map = run_service.environment.to_map();
-				map.into_iter()
-					.map(|(k, v)| v.map_or(k.clone(), |v| format!("{k}={v}")))
-					.collect()
-			};
-			env_list.extend(env_overrides);
-			run_service.environment = crate::compose::types::EnvVars::List(env_list);
+		// Layer the run container's environment by precedence, matching
+		// `docker compose run --env-file`: global `--env-file` contents are the
+		// lowest layer, the service's own `environment:` overrides them, and `-e`
+		// overrides win over both.
+		let env_file_vars = if env_files.is_empty() {
+			HashMap::new()
+		} else {
+			crate::env_file::load_env_files(&env_files, &self.base_dir)?
+		};
+		if !env_file_vars.is_empty() || !env_overrides.is_empty() {
+			run_service.environment = crate::compose::types::EnvVars::List(merge_run_environment(
+				env_file_vars,
+				run_service.environment.to_map(),
+				env_overrides,
+			));
 		}
 		run_service.restart = None;
 		// Compose `run` does not publish the service's ports unless
@@ -496,5 +505,81 @@ impl Engine {
 		}
 
 		Ok(())
+	}
+}
+
+/// Layer the three `run` environment sources into the final `KEY=VALUE` / `KEY`
+/// list by precedence (`--env-file` < service `environment:` < `-e`), matching
+/// `docker compose run --env-file`. `-e` overrides are appended last so a later
+/// duplicate wins downstream, mirroring the previous `-e`-only handling.
+fn merge_run_environment(
+	env_file_vars: HashMap<String, String>,
+	service_env: HashMap<String, Option<String>>,
+	env_overrides: Vec<String>,
+) -> Vec<String> {
+	// `--env-file` is the base layer; the service's `environment:` overrides it.
+	let mut map: HashMap<String, Option<String>> = env_file_vars
+		.into_iter()
+		.map(|(k, v)| (k, Some(v)))
+		.collect();
+	for (k, v) in service_env {
+		map.insert(k, v);
+	}
+	let mut env_list: Vec<String> = map
+		.into_iter()
+		.map(|(k, v)| v.map_or_else(|| k.clone(), |v| format!("{k}={v}")))
+		.collect();
+	// `-e` overrides win over everything else.
+	env_list.extend(env_overrides);
+	env_list
+}
+
+#[cfg(test)]
+mod tests {
+	use super::merge_run_environment;
+	use std::collections::HashMap;
+
+	fn lookup<'a>(list: &'a [String], key: &str) -> Option<&'a str> {
+		// Mirror downstream "later duplicate wins" semantics.
+		list.iter().rev().find_map(|e| match e.split_once('=') {
+			Some((k, v)) if k == key => Some(v),
+			_ => None,
+		})
+	}
+
+	#[test]
+	fn env_file_seeds_environment() {
+		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
+		let list = merge_run_environment(file, HashMap::new(), Vec::new());
+		assert_eq!(lookup(&list, "FOO"), Some("from-file"));
+	}
+
+	#[test]
+	fn service_environment_overrides_env_file() {
+		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
+		let service: HashMap<String, Option<String>> =
+			[("FOO".to_string(), Some("from-service".to_string()))].into();
+		let list = merge_run_environment(file, service, Vec::new());
+		assert_eq!(lookup(&list, "FOO"), Some("from-service"));
+	}
+
+	#[test]
+	fn dash_e_override_wins_over_all() {
+		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
+		let service: HashMap<String, Option<String>> =
+			[("FOO".to_string(), Some("from-service".to_string()))].into();
+		let list = merge_run_environment(file, service, vec!["FOO=from-cli".to_string()]);
+		assert_eq!(lookup(&list, "FOO"), Some("from-cli"));
+	}
+
+	#[test]
+	fn distinct_keys_from_each_layer_are_kept() {
+		let file: HashMap<String, String> = [("A".to_string(), "a".to_string())].into();
+		let service: HashMap<String, Option<String>> =
+			[("B".to_string(), Some("b".to_string()))].into();
+		let list = merge_run_environment(file, service, vec!["C=c".to_string()]);
+		assert_eq!(lookup(&list, "A"), Some("a"));
+		assert_eq!(lookup(&list, "B"), Some("b"));
+		assert_eq!(lookup(&list, "C"), Some("c"));
 	}
 }

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -465,4 +465,18 @@ impl Engine {
 		}
 		Ok(())
 	}
+
+	/// True when a container with this exact name exists (any project). Used to
+	/// refuse clobbering a pre-existing container on `run --name`.
+	pub(super) async fn container_exists(&self, name: &str) -> Result<bool> {
+		let path = format!(
+			"{API_PREFIX}/containers/{}/json",
+			crate::libpod::urlencoded(name),
+		);
+		match self.client.get_json::<serde_json::Value>(&path).await {
+			Ok(_) => Ok(true),
+			Err(e) if e.is_status(404) => Ok(false),
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
+	}
 }

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -100,8 +100,25 @@ impl Engine {
 		file: &ComposeFile,
 		target_services: &[String],
 	) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		// `docker compose wait` prints each service's exit code in the order the
+		// services were given on the command line (deduplicated). Only fall back to
+		// dependency order when no services were named (the "all" case).
+		let order = if target_services.is_empty() {
+			let order = crate::compose::resolve_order(file)?;
+			filter_services(file, order, &[])?
+		} else {
+			for name in target_services {
+				if !file.services.contains_key(name) {
+					return Err(ComposeError::ServiceNotFound(name.clone()));
+				}
+			}
+			let mut seen = std::collections::HashSet::new();
+			target_services
+				.iter()
+				.filter(|n| seen.insert(n.as_str()))
+				.cloned()
+				.collect::<Vec<_>>()
+		};
 
 		let mut last_nonzero = 0i64;
 		for name in &order {

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,13 +1,14 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
-use std::collections::HashSet;
-
 use tracing::info;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
 use super::filter_services;
+use super::parallel::{
+	filter_levels, first_error, join_bounded, restart_service_set, retain_levels,
+};
 use super::targets::{stop_deadline, stop_timeout_param};
 use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
@@ -19,7 +20,12 @@ impl Engine {
 	/// a real error that propagates (setting a non-zero exit) instead of being
 	/// swallowed into a warning. Shared by stop/start/restart/kill/pause/unpause
 	/// so they all behave the same.
-	async fn run_lifecycle_op(&self, path: &str, container: &str, done: &str) -> Result<()> {
+	pub(super) async fn run_lifecycle_op(
+		&self,
+		path: &str,
+		container: &str,
+		done: &str,
+	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				info!("{done} {container}");
@@ -38,7 +44,12 @@ impl Engine {
 	/// idempotent no-op. Podman rejects `pause`/`unpause` with a 409/500 when the
 	/// container is not in the expected state; docker compose treats those as
 	/// no-ops, so re-pausing or unpausing a not-paused container is harmless.
-	async fn run_idempotent_state_op(&self, path: &str, container: &str, done: &str) -> Result<()> {
+	pub(super) async fn run_idempotent_state_op(
+		&self,
+		path: &str,
+		container: &str,
+		done: &str,
+	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				info!("{done} {container}");
@@ -62,7 +73,7 @@ impl Engine {
 	/// and we send `kill?signal=SIGKILL` so podup never depends solely on the
 	/// server honouring `?t`. 304/404 are idempotent no-ops, as in
 	/// [`run_lifecycle_op`](Self::run_lifecycle_op).
-	async fn stop_container(&self, container: &str, grace: i32) -> Result<()> {
+	pub(super) async fn stop_container(&self, container: &str, grace: i32) -> Result<()> {
 		let path = format!(
 			"{API_PREFIX}/containers/{}/stop?t={}",
 			crate::libpod::urlencoded(container),
@@ -123,64 +134,35 @@ impl Engine {
 		target_services: &[String],
 		no_deps: bool,
 	) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let names = filter_services(file, order, target_services)?;
+		// Reject unknown target names up front, like the other commands.
+		super::targets::validate_targets(file, target_services)?;
+		// The services to restart: the targets plus their restart-cascade
+		// dependents (one hop, unless `--no-deps`). `targets` is kept only to
+		// label cascade-restarts distinctly in the logs.
+		let (restart_set, targets) = restart_service_set(file, target_services, no_deps);
 
-		// Containers already restarted, so a service that is both an explicit
-		// target and a restart-dependent of another target is restarted once.
-		let mut restarted: HashSet<String> = HashSet::new();
-		// Attempt every container and surface the first error at the end rather
-		// than aborting mid-batch and leaving later replicas/services unrestarted.
+		// Walk dependency levels in order — a dependency restarts before its
+		// dependents — but restart every service *within* a level concurrently.
+		let levels = retain_levels(crate::compose::resolve_levels(file)?, |n| {
+			restart_set.contains(n)
+		});
+
+		// Attempt every service and surface the first error (in service order) at
+		// the end rather than aborting mid-batch and leaving later services
+		// unrestarted.
 		let mut first_err: Option<ComposeError> = None;
-
-		for name in &names {
-			let service = &file.services[name];
-
-			for container_name in self.live_replica_names(name, service).await? {
-				if !restarted.insert(container_name.clone()) {
-					continue;
-				}
-				let grace = self.grace_period_secs(service);
-				// Single atomic restart (no visible stopped window) instead of a
-				// stop+start round-trip.
-				let restart_path = format!(
-					"{API_PREFIX}/containers/{}/restart?t={}",
-					crate::libpod::urlencoded(&container_name),
-					stop_timeout_param(grace),
-				);
-				if let Err(e) = self
-					.run_lifecycle_op(&restart_path, &container_name, "restarted")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
-			}
-
-			if no_deps {
-				continue;
-			}
-			for (dep_name, dep_service) in &file.services {
-				if dep_service.depends_on.restart_for(name) {
-					for dep_container in self.live_replica_names(dep_name, dep_service).await? {
-						if !restarted.insert(dep_container.clone()) {
-							continue;
-						}
-						let grace = self.grace_period_secs(dep_service);
-						let restart_path = format!(
-							"{API_PREFIX}/containers/{}/restart?t={}",
-							crate::libpod::urlencoded(&dep_container),
-							stop_timeout_param(grace),
-						);
-						// Same 304/404 idempotency as the main path: a never-created
-						// dependency must not spew a spurious cascade warning.
-						if let Err(e) = self
-							.run_lifecycle_op(&restart_path, &dep_container, "cascade-restarted")
-							.await
-						{
-							first_err.get_or_insert(e);
-						}
-					}
-				}
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				let service = &file.services[name];
+				let done = if targets.contains(name) {
+					"restarted"
+				} else {
+					"cascade-restarted"
+				};
+				self.restart_one_service(name, service, done)
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 
@@ -254,29 +236,25 @@ impl Engine {
 	/// Services are stopped in reverse dependency order. If `target_services`
 	/// is empty, all services in the compose file are stopped.
 	pub async fn stop(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let mut order = crate::compose::resolve_order(file)?;
-		order.reverse();
-		let order = filter_services(file, order, target_services)?;
+		// Stop in reverse dependency order (dependents before their dependencies),
+		// one level at a time, but stop every service within a level concurrently
+		// so independent grace periods overlap instead of summing (#757).
+		let mut levels = crate::compose::resolve_levels(file)?;
+		levels.reverse();
+		let levels = filter_levels(file, levels, target_services)?;
 
-		for name in &order {
-			let service = &file.services[name];
-			let grace = self.grace_period_secs(service);
-			// Enumerate only the containers Podman actually has (no static-name
-			// fallback): a defined-but-never-created service is a quiet no-op
-			// rather than a phantom stop. Report "stopped" solely for containers
-			// that were actually running/paused — stopping a Created/Exited one is
-			// a harmless no-op and must not claim it stopped (#876), matching
-			// docker compose, which acts only on running containers.
-			for container in self.live_service_containers(name).await? {
-				if super::scale::state_is_active(&container.state) {
-					self.stop_container(&container.name, grace).await?;
-				} else {
-					tracing::debug!(
-						"{}: not running ({}) — stop is a no-op",
-						container.name,
-						container.state
-					);
-				}
+		// Enumerate only the containers Podman actually has (no static-name
+		// fallback): a defined-but-never-created service is a quiet no-op rather
+		// than a phantom stop. Report "stopped" solely for containers actually
+		// running/paused — stopping a Created/Exited one is a harmless no-op and
+		// must not claim it stopped (#876), matching docker compose.
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				let grace = self.grace_period_secs(&file.services[name]);
+				self.stop_one_service(name, grace)
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				return Err(e);
 			}
 		}
 		Ok(())
@@ -287,42 +265,31 @@ impl Engine {
 	/// Services are started in dependency order. If `target_services` is empty,
 	/// all services in the compose file are started.
 	pub async fn start(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		// Start in dependency order, one level at a time, but start every service
+		// within a level concurrently (#757).
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
 		// Only act on containers Podman actually has. Acting on the static
-		// fallback names (`live_replica_names`) would POST `/start` to containers
-		// that were never created, 404 (swallowed as a no-op), and exit 0
-		// silently — masking that the project was never created. Attempt every
-		// live container and aggregate errors rather than aborting on the first.
-		let mut any_live = false;
+		// fallback names would POST `/start` to containers that were never
+		// created, 404 (swallowed as a no-op), and exit 0 silently — masking that
+		// the project was never created. Attempt every live container and
+		// aggregate errors rather than aborting on the first.
+		let any_live = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let live = self
-				.list_project_container_names(Some(name.as_str()))
-				.await?;
-			if live.is_empty() {
-				continue;
-			}
-			any_live = true;
-			for container_name in live {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/start",
-					crate::libpod::urlencoded(&container_name),
-				);
-				if let Err(e) = self
-					.run_lifecycle_op(&path, &container_name, "started")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
+		for level in &levels {
+			let futs = level
+				.iter()
+				.map(|name| self.start_one_service(name, &any_live));
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 
 		if let Some(e) = first_err {
 			return Err(e);
 		}
-		if !any_live {
+		if !any_live.load(std::sync::atomic::Ordering::Relaxed) {
 			eprintln!("podup: no containers to start (project not created)");
 		}
 		Ok(())
@@ -341,19 +308,15 @@ impl Engine {
 		// issuing any request — libpod would silently treat `signal=` as SIGKILL.
 		super::signal::validate_signal(signal)?;
 
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/kill?signal={}",
-					crate::libpod::urlencoded(&container_name),
-					crate::libpod::urlencoded(signal),
-				);
-				self.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
-					.await?;
+		for level in &levels {
+			let futs = level
+				.iter()
+				.map(|name| self.kill_one_service(name, &file.services[name], signal));
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				return Err(e);
 			}
 		}
 		Ok(())
@@ -382,39 +345,19 @@ impl Engine {
 		force: bool,
 		remove_volumes: bool,
 	) -> Result<()> {
-		let mut order = crate::compose::resolve_order(file)?;
-		order.reverse();
-		let order = filter_services(file, order, target_services)?;
+		// Remove in reverse dependency order, one level at a time, with the
+		// per-service removals in a level running concurrently (#757).
+		let mut levels = crate::compose::resolve_levels(file)?;
+		levels.reverse();
+		let levels = filter_levels(file, levels, target_services)?;
 
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let force_str = if force { "true" } else { "false" };
-				let path = format!(
-					"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
-					crate::libpod::urlencoded(&container_name),
-				);
-				match self.client.delete_existed(&path).await {
-					// Only report a removal that actually happened — a phantom
-					// (never-created) container 404s and must not be logged as
-					// "removed".
-					Ok(true) => info!("removed {container_name}"),
-					Ok(false) => {}
-					// Without `--force`, a running container 409s. docker compose rm
-					// skips running containers rather than aborting the batch, so
-					// warn and keep going (later stopped containers still get
-					// removed). The "Remove stopped service containers" help text
-					// already promises this.
-					Err(e) if !force && e.is_status(409) => {
-						tracing::warn!(
-							"{container_name} is running — skipping (pass -f to force removal)"
-						);
-					}
-					Err(e) => {
-						first_err.get_or_insert(ComposeError::Podman(e));
-					}
-				}
+		for level in &levels {
+			let futs = level
+				.iter()
+				.map(|name| self.rm_one_service(name, &file.services[name], force, remove_volumes));
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 		if let Some(e) = first_err {
@@ -427,26 +370,20 @@ impl Engine {
 	///
 	/// If `target_services` is empty, all services are paused.
 	pub async fn pause(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
 		// Idempotent + best-effort: re-pausing an already-paused (or stopped)
-		// container is a no-op, and one state-mismatched container must not abort
-		// the batch and leave the rest in an inconsistent partial state.
+		// container is a no-op, and one state-mismatched service must not abort the
+		// batch and leave the rest in an inconsistent partial state. Services in a
+		// level are paused concurrently (#757).
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/pause",
-					crate::libpod::urlencoded(&container_name),
-				);
-				if let Err(e) = self
-					.run_idempotent_state_op(&path, &container_name, "paused")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				self.idempotent_state_service(name, &file.services[name], "pause", "paused")
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 		if let Some(e) = first_err {
@@ -459,25 +396,19 @@ impl Engine {
 	///
 	/// If `target_services` is empty, all services are unpaused.
 	pub async fn unpause(&self, file: &ComposeFile, target_services: &[String]) -> Result<()> {
-		let order = crate::compose::resolve_order(file)?;
-		let order = filter_services(file, order, target_services)?;
+		let levels = crate::compose::resolve_levels(file)?;
+		let levels = filter_levels(file, levels, target_services)?;
 
 		// Idempotent + best-effort, mirroring `pause`: unpausing a not-paused
 		// container is a no-op, and a single mismatch must not abort the batch.
+		// Services in a level are unpaused concurrently (#757).
 		let mut first_err: Option<ComposeError> = None;
-		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/unpause",
-					crate::libpod::urlencoded(&container_name),
-				);
-				if let Err(e) = self
-					.run_idempotent_state_op(&path, &container_name, "unpaused")
-					.await
-				{
-					first_err.get_or_insert(e);
-				}
+		for level in &levels {
+			let futs = level.iter().map(|name| {
+				self.idempotent_state_service(name, &file.services[name], "unpause", "unpaused")
+			});
+			if let Some(e) = first_error(join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 		if let Some(e) = first_err {

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,7 +1,5 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
-use tracing::info;
-
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
@@ -15,7 +13,8 @@ use crate::libpod::API_PREFIX;
 
 impl Engine {
 	/// Run a lifecycle POST against one container with a consistent outcome:
-	/// success logs `{done} {container}`; "already in the desired state" (304)
+	/// success prints a `Container {container}  {done}` progress line; "already
+	/// in the desired state" (304)
 	/// and "no such container" (404) are idempotent no-ops; any other failure is
 	/// a real error that propagates (setting a non-zero exit) instead of being
 	/// swallowed into a warning. Shared by stop/start/restart/kill/pause/unpause
@@ -28,7 +27,7 @@ impl Engine {
 	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
-				info!("{done} {container}");
+				crate::ui::progress_line("Container", container, done);
 				Ok(())
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
@@ -52,7 +51,7 @@ impl Engine {
 	) -> Result<()> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
-				info!("{done} {container}");
+				crate::ui::progress_line("Container", container, done);
 				Ok(())
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_state_conflict() => {
@@ -85,7 +84,7 @@ impl Engine {
 			.await
 		{
 			Ok(()) => {
-				info!("stopped {container}");
+				crate::ui::progress_line("Container", container, "Stopped");
 				Ok(())
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) => {
@@ -102,7 +101,11 @@ impl Engine {
 				);
 				match self.client.post_empty_ok(&kill_path).await {
 					Ok(()) => {
-						info!("killed {container} (SIGKILL after stop timeout)");
+						crate::ui::progress_line(
+							"Container",
+							container,
+							"Killed (after stop timeout)",
+						);
 						Ok(())
 					}
 					// Already gone / not running between the timeout and the kill.
@@ -155,9 +158,9 @@ impl Engine {
 			let futs = level.iter().map(|name| {
 				let service = &file.services[name];
 				let done = if targets.contains(name) {
-					"restarted"
+					"Restarted"
 				} else {
-					"cascade-restarted"
+					"Restarted (dependency)"
 				};
 				self.restart_one_service(name, service, done)
 			});
@@ -290,7 +293,7 @@ impl Engine {
 			return Err(e);
 		}
 		if !any_live.load(std::sync::atomic::Ordering::Relaxed) {
-			eprintln!("podup: no containers to start (project not created)");
+			crate::ui::progress_note("no containers to start (project not created)");
 		}
 		Ok(())
 	}
@@ -380,7 +383,7 @@ impl Engine {
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(name, &file.services[name], "pause", "paused")
+				self.idempotent_state_service(name, &file.services[name], "pause", "Paused")
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -405,7 +408,7 @@ impl Engine {
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(name, &file.services[name], "unpause", "unpaused")
+				self.idempotent_state_service(name, &file.services[name], "unpause", "Unpaused")
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -9,6 +9,7 @@ use tracing::info;
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
+use super::targets::{stop_deadline, stop_timeout_param};
 use super::{filter_services, RunOptions};
 use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
@@ -29,6 +30,60 @@ impl Engine {
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
 				Ok(())
+			}
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
+	}
+
+	/// Stop one container, escalating to an explicit `SIGKILL` if the libpod
+	/// `stop` call does not complete within the grace window.
+	///
+	/// libpod normally `SIGKILL`s a container itself once the grace period lapses,
+	/// so a healthy stop returns inside [`stop_deadline`]. If the call instead
+	/// stalls (a daemon that accepts the request then never replies, or a
+	/// container the server fails to reap), the bounded wait surfaces a timeout
+	/// and we send `kill?signal=SIGKILL` so podup never depends solely on the
+	/// server honouring `?t`. 304/404 are idempotent no-ops, as in
+	/// [`run_lifecycle_op`](Self::run_lifecycle_op).
+	async fn stop_container(&self, container: &str, grace: i32) -> Result<()> {
+		let path = format!(
+			"{API_PREFIX}/containers/{}/stop?t={}",
+			crate::libpod::urlencoded(container),
+			stop_timeout_param(grace),
+		);
+		match self
+			.client
+			.post_empty_ok_within(&path, stop_deadline(grace))
+			.await
+		{
+			Ok(()) => {
+				info!("stopped {container}");
+				Ok(())
+			}
+			Err(e) if e.is_status(304) || e.is_status(404) => {
+				tracing::debug!("{container}: stop skipped ({e})");
+				Ok(())
+			}
+			Err(e) if e.is_timeout() => {
+				tracing::warn!(
+					"{container}: stop did not complete within the grace window; escalating to SIGKILL"
+				);
+				let kill_path = format!(
+					"{API_PREFIX}/containers/{}/kill?signal=SIGKILL",
+					crate::libpod::urlencoded(container),
+				);
+				match self.client.post_empty_ok(&kill_path).await {
+					Ok(()) => {
+						info!("killed {container} (SIGKILL after stop timeout)");
+						Ok(())
+					}
+					// Already gone / not running between the timeout and the kill.
+					Err(e) if e.is_status(404) || e.is_status(409) => {
+						tracing::debug!("{container}: SIGKILL skipped ({e})");
+						Ok(())
+					}
+					Err(e) => Err(ComposeError::Podman(e)),
+				}
 			}
 			Err(e) => Err(ComposeError::Podman(e)),
 		}
@@ -62,8 +117,9 @@ impl Engine {
 				// Single atomic restart (no visible stopped window) instead of a
 				// stop+start round-trip.
 				let restart_path = format!(
-					"{API_PREFIX}/containers/{}/restart?t={grace}",
+					"{API_PREFIX}/containers/{}/restart?t={}",
 					crate::libpod::urlencoded(&container_name),
+					stop_timeout_param(grace),
 				);
 				self.run_lifecycle_op(&restart_path, &container_name, "restarted")
 					.await?;
@@ -77,8 +133,9 @@ impl Engine {
 					for dep_container in self.live_replica_names(dep_name, dep_service).await? {
 						let grace = self.grace_period_secs(dep_service);
 						let restart_path = format!(
-							"{API_PREFIX}/containers/{}/restart?t={grace}",
+							"{API_PREFIX}/containers/{}/restart?t={}",
 							crate::libpod::urlencoded(&dep_container),
+							stop_timeout_param(grace),
 						);
 						if let Err(e) = self.client.post_empty_ok(&restart_path).await {
 							tracing::warn!("cascade restart of {dep_name} failed: {e}");
@@ -159,12 +216,7 @@ impl Engine {
 			let service = &file.services[name];
 			for container_name in self.live_replica_names(name, service).await? {
 				let grace = self.grace_period_secs(service);
-				let path = format!(
-					"{API_PREFIX}/containers/{}/stop?t={grace}",
-					crate::libpod::urlencoded(&container_name),
-				);
-				self.run_lifecycle_op(&path, &container_name, "stopped")
-					.await?;
+				self.stop_container(&container_name, grace).await?;
 			}
 		}
 		Ok(())

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -1,16 +1,14 @@
 //! Lifecycle sub-commands: restart, stop, start, kill, rm, pause, unpause, run.
 
-use std::collections::HashMap;
-use std::io::Write;
+use std::collections::HashSet;
 
-use futures_util::StreamExt;
 use tracing::info;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
+use super::filter_services;
 use super::targets::{stop_deadline, stop_timeout_param};
-use super::{filter_services, RunOptions};
 use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
 
@@ -28,6 +26,25 @@ impl Engine {
 				Ok(())
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
+				tracing::debug!("{container}: {done} skipped ({e})");
+				Ok(())
+			}
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
+	}
+
+	/// Like [`Self::run_lifecycle_op`] but also treats a "container state
+	/// improper" error (already paused / not paused / not running) as an
+	/// idempotent no-op. Podman rejects `pause`/`unpause` with a 409/500 when the
+	/// container is not in the expected state; docker compose treats those as
+	/// no-ops, so re-pausing or unpausing a not-paused container is harmless.
+	async fn run_idempotent_state_op(&self, path: &str, container: &str, done: &str) -> Result<()> {
+		match self.client.post_empty_ok(path).await {
+			Ok(()) => {
+				info!("{done} {container}");
+				Ok(())
+			}
+			Err(e) if e.is_status(304) || e.is_status(404) || e.is_state_conflict() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
 				Ok(())
 			}
@@ -109,10 +126,20 @@ impl Engine {
 		let order = crate::compose::resolve_order(file)?;
 		let names = filter_services(file, order, target_services)?;
 
+		// Containers already restarted, so a service that is both an explicit
+		// target and a restart-dependent of another target is restarted once.
+		let mut restarted: HashSet<String> = HashSet::new();
+		// Attempt every container and surface the first error at the end rather
+		// than aborting mid-batch and leaving later replicas/services unrestarted.
+		let mut first_err: Option<ComposeError> = None;
+
 		for name in &names {
 			let service = &file.services[name];
 
 			for container_name in self.live_replica_names(name, service).await? {
+				if !restarted.insert(container_name.clone()) {
+					continue;
+				}
 				let grace = self.grace_period_secs(service);
 				// Single atomic restart (no visible stopped window) instead of a
 				// stop+start round-trip.
@@ -121,8 +148,12 @@ impl Engine {
 					crate::libpod::urlencoded(&container_name),
 					stop_timeout_param(grace),
 				);
-				self.run_lifecycle_op(&restart_path, &container_name, "restarted")
-					.await?;
+				if let Err(e) = self
+					.run_lifecycle_op(&restart_path, &container_name, "restarted")
+					.await
+				{
+					first_err.get_or_insert(e);
+				}
 			}
 
 			if no_deps {
@@ -131,22 +162,31 @@ impl Engine {
 			for (dep_name, dep_service) in &file.services {
 				if dep_service.depends_on.restart_for(name) {
 					for dep_container in self.live_replica_names(dep_name, dep_service).await? {
+						if !restarted.insert(dep_container.clone()) {
+							continue;
+						}
 						let grace = self.grace_period_secs(dep_service);
 						let restart_path = format!(
 							"{API_PREFIX}/containers/{}/restart?t={}",
 							crate::libpod::urlencoded(&dep_container),
 							stop_timeout_param(grace),
 						);
-						if let Err(e) = self.client.post_empty_ok(&restart_path).await {
-							tracing::warn!("cascade restart of {dep_name} failed: {e}");
-						} else {
-							info!("cascade-restarted {dep_container} (depends_on.restart)");
+						// Same 304/404 idempotency as the main path: a never-created
+						// dependency must not spew a spurious cascade warning.
+						if let Err(e) = self
+							.run_lifecycle_op(&restart_path, &dep_container, "cascade-restarted")
+							.await
+						{
+							first_err.get_or_insert(e);
 						}
 					}
 				}
 			}
 		}
 
+		if let Some(e) = first_err {
+			return Err(e);
+		}
 		Ok(())
 	}
 
@@ -230,16 +270,40 @@ impl Engine {
 		let order = crate::compose::resolve_order(file)?;
 		let order = filter_services(file, order, target_services)?;
 
+		// Only act on containers Podman actually has. Acting on the static
+		// fallback names (`live_replica_names`) would POST `/start` to containers
+		// that were never created, 404 (swallowed as a no-op), and exit 0
+		// silently — masking that the project was never created. Attempt every
+		// live container and aggregate errors rather than aborting on the first.
+		let mut any_live = false;
+		let mut first_err: Option<ComposeError> = None;
 		for name in &order {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
+			let live = self
+				.list_project_container_names(Some(name.as_str()))
+				.await?;
+			if live.is_empty() {
+				continue;
+			}
+			any_live = true;
+			for container_name in live {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/start",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.run_lifecycle_op(&path, &container_name, "started")
-					.await?;
+				if let Err(e) = self
+					.run_lifecycle_op(&path, &container_name, "started")
+					.await
+				{
+					first_err.get_or_insert(e);
+				}
 			}
+		}
+
+		if let Some(e) = first_err {
+			return Err(e);
+		}
+		if !any_live {
+			eprintln!("podup: no containers to start (project not created)");
 		}
 		Ok(())
 	}
@@ -302,6 +366,7 @@ impl Engine {
 		order.reverse();
 		let order = filter_services(file, order, target_services)?;
 
+		let mut first_err: Option<ComposeError> = None;
 		for name in &order {
 			let service = &file.services[name];
 			for container_name in self.live_replica_names(name, service).await? {
@@ -310,15 +375,30 @@ impl Engine {
 					"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
 					crate::libpod::urlencoded(&container_name),
 				);
-				// `delete_ok` treats 404 as success (already gone), so any error
-				// here is a real failure — propagate it (non-zero exit) instead of
-				// swallowing it into a warning, matching the other lifecycle ops.
-				self.client
-					.delete_ok(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
-				info!("removed {container_name}");
+				match self.client.delete_existed(&path).await {
+					// Only report a removal that actually happened — a phantom
+					// (never-created) container 404s and must not be logged as
+					// "removed".
+					Ok(true) => info!("removed {container_name}"),
+					Ok(false) => {}
+					// Without `--force`, a running container 409s. docker compose rm
+					// skips running containers rather than aborting the batch, so
+					// warn and keep going (later stopped containers still get
+					// removed). The "Remove stopped service containers" help text
+					// already promises this.
+					Err(e) if !force && e.is_status(409) => {
+						tracing::warn!(
+							"{container_name} is running — skipping (pass -f to force removal)"
+						);
+					}
+					Err(e) => {
+						first_err.get_or_insert(ComposeError::Podman(e));
+					}
+				}
 			}
+		}
+		if let Some(e) = first_err {
+			return Err(e);
 		}
 		Ok(())
 	}
@@ -330,6 +410,10 @@ impl Engine {
 		let order = crate::compose::resolve_order(file)?;
 		let order = filter_services(file, order, target_services)?;
 
+		// Idempotent + best-effort: re-pausing an already-paused (or stopped)
+		// container is a no-op, and one state-mismatched container must not abort
+		// the batch and leave the rest in an inconsistent partial state.
+		let mut first_err: Option<ComposeError> = None;
 		for name in &order {
 			let service = &file.services[name];
 			for container_name in self.live_replica_names(name, service).await? {
@@ -337,9 +421,16 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/pause",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.run_lifecycle_op(&path, &container_name, "paused")
-					.await?;
+				if let Err(e) = self
+					.run_idempotent_state_op(&path, &container_name, "paused")
+					.await
+				{
+					first_err.get_or_insert(e);
+				}
 			}
+		}
+		if let Some(e) = first_err {
+			return Err(e);
 		}
 		Ok(())
 	}
@@ -351,6 +442,9 @@ impl Engine {
 		let order = crate::compose::resolve_order(file)?;
 		let order = filter_services(file, order, target_services)?;
 
+		// Idempotent + best-effort, mirroring `pause`: unpausing a not-paused
+		// container is a no-op, and a single mismatch must not abort the batch.
+		let mut first_err: Option<ComposeError> = None;
 		for name in &order {
 			let service = &file.services[name];
 			for container_name in self.live_replica_names(name, service).await? {
@@ -358,280 +452,17 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/unpause",
 					crate::libpod::urlencoded(&container_name),
 				);
-				self.run_lifecycle_op(&path, &container_name, "unpaused")
-					.await?;
-			}
-		}
-		Ok(())
-	}
-
-	/// Run a one-off command in a new container for a service.
-	///
-	/// The container is started, its output streamed, and it is removed when done
-	/// (unless `opts.rm` is false). Non-zero exit codes surface as `ComposeError::RunExited`.
-	pub async fn run(
-		&self,
-		file: &ComposeFile,
-		service_name: &str,
-		opts: RunOptions,
-	) -> Result<()> {
-		let RunOptions {
-			cmd,
-			rm,
-			detach,
-			env_overrides,
-			name_override,
-			service_ports,
-		} = opts;
-		// CLI-only run flags arrive via the engine builder (see `RunOverrides`),
-		// keeping the public `RunOptions` API frozen at 1.0.
-		let super::RunOverrides {
-			user,
-			workdir,
-			entrypoint,
-			volumes,
-			publish,
-			interactive,
-			no_deps,
-		} = self.run_overrides.clone();
-		// `--env-file` is global, so it rides on the engine (not `RunOverrides`).
-		let env_files = self.run_env_files.clone();
-		let service = file
-			.services
-			.get(service_name)
-			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-
-		// Compose `run` brings up the service's `depends_on` services first (and
-		// waits on their conditions), unless `--no-deps` is given. The service
-		// itself is excluded — only its transitive dependencies are started.
-		if !no_deps {
-			let deps: Vec<String> = super::expand_targets(file, &[service_name.to_string()], false)
-				.map(|set| set.into_iter().filter(|n| n != service_name).collect())
-				.unwrap_or_default();
-			if !deps.is_empty() {
-				self.up_with_options(file, true, &[], &deps, false, false, false)
-					.await?;
-			}
-		}
-
-		let run_name = name_override.unwrap_or_else(|| {
-			format!("{}-{service_name}-run-{}", self.project, std::process::id())
-		});
-
-		let mut run_service = service.clone();
-		if !cmd.is_empty() {
-			run_service.command = Some(crate::compose::types::Command::Exec(cmd));
-		}
-		// `--entrypoint` overrides the image/service entrypoint with a single
-		// executable token (compose/`docker run` semantics); any `cmd` becomes
-		// its arguments.
-		if let Some(ep) = entrypoint {
-			run_service.entrypoint = Some(crate::compose::types::Command::Exec(vec![ep]));
-		}
-		if let Some(u) = user {
-			run_service.user = Some(u);
-		}
-		if let Some(w) = workdir {
-			run_service.working_dir = Some(w);
-		}
-		// `-i/--interactive` keeps STDIN open on the spec; `run` still streams
-		// logs rather than attaching a live terminal.
-		if interactive {
-			run_service.stdin_open = Some(true);
-		}
-		// Ad-hoc `-v/--volume` mounts append to the service's own mounts in
-		// compose short form, parsed downstream like compose file entries.
-		for v in volumes {
-			run_service
-				.volumes
-				.push(crate::compose::types::VolumeMount::Short(v));
-		}
-		// Layer the run container's environment by precedence, matching
-		// `docker compose run --env-file`: global `--env-file` contents are the
-		// lowest layer, the service's own `environment:` overrides them, and `-e`
-		// overrides win over both.
-		let env_file_vars = if env_files.is_empty() {
-			HashMap::new()
-		} else {
-			crate::env_file::load_env_files(&env_files, &self.base_dir)?
-		};
-		if !env_file_vars.is_empty() || !env_overrides.is_empty() {
-			run_service.environment = crate::compose::types::EnvVars::List(merge_run_environment(
-				env_file_vars,
-				run_service.environment.to_map(),
-				env_overrides,
-			));
-		}
-		run_service.restart = None;
-		// Compose `run` does not publish the service's ports unless
-		// `--service-ports` is given; otherwise a one-off run would collide
-		// with the long-running service's host-port bindings.
-		if !service_ports {
-			run_service.ports.clear();
-		}
-		// Explicit `-p/--publish` ports are always bound, even without
-		// `--service-ports`, matching `docker compose run -p`.
-		for p in publish {
-			run_service
-				.ports
-				.push(crate::compose::types::PortMapping::Short(p));
-		}
-		// Force non-TTY so Podman uses multiplexed log framing that
-		// parse_multiplexed can decode. TTY mode sends raw bytes without
-		// the 8-byte header, which would produce garbled output.
-		run_service.tty = None;
-
-		// Ensure the project networks exist (compose `run` brings them up like
-		// `up` does); the service may reference the synthesized `default`
-		// network, which is created here as `{project}_default`.
-		self.create_networks(file).await?;
-		// Inline secrets/configs are created up front (no longer in the
-		// per-container build path), so materialise them here too before the run
-		// container is created.
-		self.create_inline_secrets(file).await?;
-
-		self.create_and_start(&run_name, service_name, &run_service, file, true)
-			.await?;
-
-		if detach {
-			info!("started run container {run_name}");
-			return Ok(());
-		}
-
-		let logs_path = format!(
-			"{API_PREFIX}/containers/{}/logs?follow=true&stdout=true&stderr=true",
-			crate::libpod::urlencoded(&run_name),
-		);
-		let logs_resp = self
-			.client
-			.get_stream(&logs_path)
-			.await
-			.map_err(ComposeError::Podman)?;
-		let mut log_stream = crate::libpod::parse_multiplexed(logs_resp.into_body());
-
-		// Lock stdout once for the whole stream instead of re-acquiring the lock
-		// (and issuing a syscall) per frame; stdout is ours exclusively on this
-		// path. stderr is locked per frame because the tracing subscriber also
-		// writes there: holding its lock across the await loop would starve
-		// concurrent log emissions. Flush after each frame so `run` streams
-		// promptly.
-		let mut out = std::io::stdout().lock();
-		while let Some(msg) = log_stream.next().await {
-			match msg.map_err(ComposeError::Podman)? {
-				crate::libpod::LogOutput::StdOut { message } => {
-					let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
-					let _ = out.flush();
-				}
-				crate::libpod::LogOutput::StdErr { message } => {
-					let mut err = std::io::stderr().lock();
-					let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
-					let _ = err.flush();
+				if let Err(e) = self
+					.run_idempotent_state_op(&path, &container_name, "unpaused")
+					.await
+				{
+					first_err.get_or_insert(e);
 				}
 			}
 		}
-
-		let wait_path = format!(
-			"{API_PREFIX}/containers/{}/wait?condition=stopped",
-			crate::libpod::urlencoded(&run_name),
-		);
-		// Capture the wait result before cleanup so a failed wait is surfaced as an
-		// error rather than masked as a successful (exit 0) run.
-		let wait_result = self
-			.client
-			.post_empty_json_unbounded::<i64>(&wait_path)
-			.await;
-
-		if rm {
-			let rm_path = format!(
-				"{API_PREFIX}/containers/{}?force=true",
-				crate::libpod::urlencoded(&run_name),
-			);
-			if let Err(e) = self.client.delete_ok(&rm_path).await {
-				tracing::debug!("run cleanup delete {run_name}: {e}");
-			}
+		if let Some(e) = first_err {
+			return Err(e);
 		}
-
-		let exit_code = wait_result.map_err(ComposeError::Podman)?;
-		if exit_code != 0 {
-			return Err(crate::error::ComposeError::RunExited(exit_code));
-		}
-
 		Ok(())
-	}
-}
-
-/// Layer the three `run` environment sources into the final `KEY=VALUE` / `KEY`
-/// list by precedence (`--env-file` < service `environment:` < `-e`), matching
-/// `docker compose run --env-file`. `-e` overrides are appended last so a later
-/// duplicate wins downstream, mirroring the previous `-e`-only handling.
-fn merge_run_environment(
-	env_file_vars: HashMap<String, String>,
-	service_env: HashMap<String, Option<String>>,
-	env_overrides: Vec<String>,
-) -> Vec<String> {
-	// `--env-file` is the base layer; the service's `environment:` overrides it.
-	let mut map: HashMap<String, Option<String>> = env_file_vars
-		.into_iter()
-		.map(|(k, v)| (k, Some(v)))
-		.collect();
-	for (k, v) in service_env {
-		map.insert(k, v);
-	}
-	let mut env_list: Vec<String> = map
-		.into_iter()
-		.map(|(k, v)| v.map_or_else(|| k.clone(), |v| format!("{k}={v}")))
-		.collect();
-	// `-e` overrides win over everything else.
-	env_list.extend(env_overrides);
-	env_list
-}
-
-#[cfg(test)]
-mod tests {
-	use super::merge_run_environment;
-	use std::collections::HashMap;
-
-	fn lookup<'a>(list: &'a [String], key: &str) -> Option<&'a str> {
-		// Mirror downstream "later duplicate wins" semantics.
-		list.iter().rev().find_map(|e| match e.split_once('=') {
-			Some((k, v)) if k == key => Some(v),
-			_ => None,
-		})
-	}
-
-	#[test]
-	fn env_file_seeds_environment() {
-		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
-		let list = merge_run_environment(file, HashMap::new(), Vec::new());
-		assert_eq!(lookup(&list, "FOO"), Some("from-file"));
-	}
-
-	#[test]
-	fn service_environment_overrides_env_file() {
-		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
-		let service: HashMap<String, Option<String>> =
-			[("FOO".to_string(), Some("from-service".to_string()))].into();
-		let list = merge_run_environment(file, service, Vec::new());
-		assert_eq!(lookup(&list, "FOO"), Some("from-service"));
-	}
-
-	#[test]
-	fn dash_e_override_wins_over_all() {
-		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
-		let service: HashMap<String, Option<String>> =
-			[("FOO".to_string(), Some("from-service".to_string()))].into();
-		let list = merge_run_environment(file, service, vec!["FOO=from-cli".to_string()]);
-		assert_eq!(lookup(&list, "FOO"), Some("from-cli"));
-	}
-
-	#[test]
-	fn distinct_keys_from_each_layer_are_kept() {
-		let file: HashMap<String, String> = [("A".to_string(), "a".to_string())].into();
-		let service: HashMap<String, Option<String>> =
-			[("B".to_string(), Some("b".to_string()))].into();
-		let list = merge_run_environment(file, service, vec!["C=c".to_string()]);
-		assert_eq!(lookup(&list, "A"), Some("a"));
-		assert_eq!(lookup(&list, "B"), Some("b"));
-		assert_eq!(lookup(&list, "C"), Some("c"));
 	}
 }

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -25,7 +25,7 @@ impl Engine {
 				info!("{done} {container}");
 				Ok(())
 			}
-			Err(e) if e.is_status(304) || e.is_status(404) => {
+			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
 				Ok(())
 			}
@@ -183,6 +183,10 @@ impl Engine {
 		target_services: &[String],
 		signal: &str,
 	) -> Result<()> {
+		// Reject an empty/whitespace-only or otherwise invalid signal before
+		// issuing any request — libpod would silently treat `signal=` as SIGKILL.
+		super::signal::validate_signal(signal)?;
+
 		let order = crate::compose::resolve_order(file)?;
 		let order = filter_services(file, order, target_services)?;
 

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -1,0 +1,164 @@
+//! Label-scoped teardown: `down` with no compose file present.
+//!
+//! [`Engine::down_with_options`] walks the parsed service graph, so it needs a
+//! compose file. `docker compose -p NAME down` must also tear a *running*
+//! project down purely from its `podup.project` label when that file is absent
+//! (e.g. it was deleted, or you only have the project name). This module reaps
+//! every labelled container, network, named volume and internal secret without
+//! reading a single service definition.
+
+use tracing::info;
+
+use crate::compose::types::ComposeFile;
+use crate::error::Result;
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::Engine;
+
+/// Shutdown grace (seconds) for the label-only teardown, used when the CLI
+/// `-t/--timeout` override is unset. There is no service definition to read a
+/// `stop_grace_period` from, so this falls back to docker compose's default.
+const DEFAULT_STOP_GRACE_SECS: i32 = 10;
+
+impl Engine {
+	/// Tear a project down purely from its `podup.project` label, with no compose
+	/// file: stop and force-remove every labelled container (and, with
+	/// `remove_volumes`, their anonymous volumes), then sweep the project's
+	/// networks, named volumes and internal secrets by label.
+	///
+	/// Mirrors `docker compose -p NAME down` against a running project whose
+	/// compose file is absent. Unlike [`Engine::down_with_options`], which works
+	/// through the parsed service graph, this enumerates everything by label, so
+	/// it reaps all of the project's resources regardless of whether a file would
+	/// parse. Best-effort throughout: a missing resource (404) is an idempotent
+	/// no-op and an individual delete failure is logged, not fatal.
+	pub async fn down_by_label(&self, remove_volumes: bool) -> Result<()> {
+		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);
+		for container_name in self.list_project_container_names(None).await? {
+			let stop_path = format!(
+				"{API_PREFIX}/containers/{}/stop?t={}",
+				urlencoded(&container_name),
+				super::targets::stop_timeout_param(grace),
+			);
+			// A 404 (already gone) is an idempotent no-op, like the network/volume
+			// arms below; the force-remove that follows SIGKILLs a stubborn one.
+			if let Err(e) = self
+				.client
+				.post_empty_ok_within(&stop_path, super::targets::stop_deadline(grace))
+				.await
+			{
+				if !e.is_status(404) {
+					tracing::warn!("could not stop {container_name}: {e}");
+				}
+			}
+
+			let rm_path = super::container_rm_path(&container_name, remove_volumes);
+			match self.client.delete_ok(&rm_path).await {
+				Ok(()) => info!("removed {container_name}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
+			}
+		}
+
+		// Networks, named volumes and internal secrets are all reaped by label.
+		self.remove_project_networks_by_label().await;
+		if remove_volumes {
+			self.remove_project_volumes_by_label().await;
+		}
+		// An empty file carries no declared secrets/configs, so this falls straight
+		// through to the by-label orphan sweep that already backs `down`.
+		self.remove_internal_secrets(&ComposeFile::default())
+			.await?;
+		Ok(())
+	}
+
+	/// Remove every network carrying this project's `podup.project` label — the
+	/// implicit `<project>_default`, a network whose compose key changed, or any
+	/// project network when no file is present. Only podup-labelled networks
+	/// match, so a user's external network is never touched. Best-effort: a list
+	/// failure leaves networks in place rather than aborting teardown.
+	///
+	/// Shared by [`Engine::down_with_options`] and [`Engine::down_by_label`].
+	pub(super) async fn remove_project_networks_by_label(&self) {
+		let net_filters =
+			serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
+		let list_path = format!(
+			"{API_PREFIX}/networks/json?filters={}",
+			urlencoded(&net_filters.to_string()),
+		);
+		let Ok(nets) = self
+			.client
+			.get_json::<Vec<serde_json::Value>>(&list_path)
+			.await
+		else {
+			return;
+		};
+		for net in nets {
+			let Some(net_name) = net.get("name").and_then(|n| n.as_str()) else {
+				continue;
+			};
+			let del = format!("{API_PREFIX}/networks/{}", urlencoded(net_name));
+			match self.client.delete_ok(&del).await {
+				Ok(_) => info!("removed network {net_name}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove network {net_name}: {e}"),
+			}
+		}
+	}
+
+	/// Remove every named volume carrying this project's `podup.project` label.
+	/// libpod's `/volumes/json` is fetched in full and filtered client-side by
+	/// the label (mirroring the secret sweep) so only podup-created volumes are
+	/// deleted — a user's hand-made or external volume is never touched.
+	/// Best-effort: a list failure leaves volumes in place.
+	pub(super) async fn remove_project_volumes_by_label(&self) {
+		let path = format!("{API_PREFIX}/volumes/json");
+		let Ok(vols) = self.client.get_json::<Vec<serde_json::Value>>(&path).await else {
+			return;
+		};
+		for vol in vols {
+			if !volume_owned_by(&vol, &self.project) {
+				continue;
+			}
+			let Some(name) = vol.get("Name").and_then(|n| n.as_str()) else {
+				continue;
+			};
+			let del = format!("{API_PREFIX}/volumes/{}", urlencoded(name));
+			match self.client.delete_ok(&del).await {
+				Ok(_) => info!("removed volume {name}"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) => tracing::warn!("could not remove volume {name}: {e}"),
+			}
+		}
+	}
+}
+
+/// Whether a `/volumes/json` entry carries the `podup.project=<project>` label,
+/// i.e. it is a volume podup created for this project. Pure so the ownership
+/// check is unit-tested without a live Podman socket.
+fn volume_owned_by(vol: &serde_json::Value, project: &str) -> bool {
+	vol.get("Labels")
+		.and_then(|l| l.get("podup.project"))
+		.and_then(|v| v.as_str())
+		== Some(project)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::volume_owned_by;
+
+	#[test]
+	fn volume_owned_by_matches_project_label() {
+		let vol = serde_json::json!({
+			"Name": "proj_data",
+			"Labels": { "podup.project": "proj", "extra": "1" },
+		});
+		assert!(volume_owned_by(&vol, "proj"));
+		// A different project's volume, or one podup never labelled, is not ours.
+		assert!(!volume_owned_by(&vol, "other"));
+		let unlabelled = serde_json::json!({ "Name": "loose", "Labels": {} });
+		assert!(!volume_owned_by(&unlabelled, "proj"));
+		let no_labels = serde_json::json!({ "Name": "loose" });
+		assert!(!volume_owned_by(&no_labels, "proj"));
+	}
+}

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -7,8 +7,6 @@
 //! every labelled container, network, named volume and internal secret without
 //! reading a single service definition.
 
-use tracing::info;
-
 use crate::compose::types::ComposeFile;
 use crate::error::Result;
 use crate::libpod::{urlencoded, API_PREFIX};
@@ -54,7 +52,7 @@ impl Engine {
 
 			let rm_path = super::container_rm_path(&container_name, remove_volumes);
 			match self.client.delete_ok(&rm_path).await {
-				Ok(()) => info!("removed {container_name}"),
+				Ok(()) => crate::ui::progress_line("Container", &container_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
 			}
@@ -99,7 +97,7 @@ impl Engine {
 			};
 			let del = format!("{API_PREFIX}/networks/{}", urlencoded(net_name));
 			match self.client.delete_ok(&del).await {
-				Ok(_) => info!("removed network {net_name}"),
+				Ok(_) => crate::ui::progress_line("Network", net_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove network {net_name}: {e}"),
 			}
@@ -125,7 +123,7 @@ impl Engine {
 			};
 			let del = format!("{API_PREFIX}/volumes/{}", urlencoded(name));
 			match self.client.delete_ok(&del).await {
-				Ok(_) => info!("removed volume {name}"),
+				Ok(_) => crate::ui::progress_line("Volume", name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove volume {name}: {e}"),
 			}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -1,6 +1,7 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
 mod commands;
+mod run;
 mod scale;
 mod signal;
 mod targets;
@@ -459,30 +460,35 @@ impl Engine {
 					crate::libpod::urlencoded(&container_name),
 					targets::stop_timeout_param(grace),
 				);
+				// A 404 (container already gone, or a profile-gated service that was
+				// never created) is an idempotent no-op here, exactly as the network
+				// and volume removal arms below treat it — not a warning.
 				if let Err(e) = self
 					.client
 					.post_empty_ok_within(&stop_path, targets::stop_deadline(grace))
 					.await
 				{
-					tracing::warn!("could not stop {container_name}: {e}");
+					if !e.is_status(404) {
+						tracing::warn!("could not stop {container_name}: {e}");
+					}
 				}
 
 				let rm_path = container_rm_path(&container_name, remove_volumes);
-				if let Err(e) = self.client.delete_ok(&rm_path).await {
-					tracing::warn!("could not remove {container_name}: {e}");
-				} else {
-					info!("removed {container_name}");
+				match self.client.delete_ok(&rm_path).await {
+					Ok(()) => info!("removed {container_name}"),
+					Err(e) if e.is_status(404) => {}
+					Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
 				}
 			}
 		}
 
-		// A prior `up --scale`/`scale` may have created replicas the compose
-		// file's default count no longer names; sweep any remaining project
-		// containers by label so teardown is always complete.
-		let grace = self.stop_timeout.unwrap_or(10);
-		for name in self.list_project_container_names(None).await? {
-			self.stop_and_remove(&name, grace, remove_volumes).await;
-		}
+		// Scaled replicas (`up --scale`/`scale`) carry the `podup.service` label
+		// of a service still in the file, so the ordered pass above already swept
+		// them via `live_by_service`. Orphan containers of services *removed* from
+		// the file are deliberately NOT touched here: docker compose only reaps
+		// them under `--remove-orphans`, which the dispatch layer handles via
+		// `remove_orphans` before teardown. Removing them unconditionally here
+		// made that flag a no-op.
 
 		for (key, config) in &file.networks {
 			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
@@ -577,13 +583,18 @@ impl Engine {
 				None if builds_locally => format!("{name}:latest"),
 				None => continue,
 			};
-			let path = format!(
-				"{API_PREFIX}/images/{}?force=true",
-				crate::libpod::urlencoded(&image),
-			);
+			// Do NOT force: a force-removal cascades to every container using the
+			// image — including ones owned by other compose projects that share it
+			// (e.g. two stacks both on `nginx:latest`). docker compose leaves an
+			// in-use image in place, so an "in use" conflict is a skip, not a
+			// failure.
+			let path = format!("{API_PREFIX}/images/{}", crate::libpod::urlencoded(&image),);
 			match self.client.delete_ok(&path).await {
 				Ok(_) => info!("removed image {image}"),
 				Err(e) if e.is_status(404) => {}
+				Err(e) if e.is_image_in_use() => {
+					info!("image {image} is still in use — skipping removal")
+				}
 				Err(e) => tracing::warn!("could not remove image {image}: {e}"),
 			}
 		}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -146,6 +146,16 @@ impl Engine {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
 
+			// Validate every `--scale SERVICE=N` override against the file before
+			// doing any work: an override naming a service the compose file does
+			// not define is a user error, not a silent no-op (the standalone
+			// `scale` subcommand already rejects it, so the `up` path must too).
+			for svc in self.scale_overrides.keys() {
+				if !file.services.contains_key(svc) {
+					return Err(crate::error::ComposeError::ServiceNotFound(svc.clone()));
+				}
+			}
+
 			// Reject unknown service names before doing any work, so `up`/`create`
 			// of a bogus service errors instead of exiting 0 as a silent no-op.
 			validate_targets(file, target_services)?;
@@ -209,6 +219,27 @@ impl Engine {
 					)
 				});
 				futures_util::future::try_join_all(started).await?;
+			}
+
+			// Reconcile surplus replicas for every service carrying an active
+			// `--scale` override. Replica naming is unsuffixed for one replica and
+			// suffixed (`svc-N`) for many, so scaling a service *down* on the `up`
+			// path would otherwise leave the old higher-numbered containers running
+			// (e.g. `up --scale web=3` then `up --scale web=1`). The overrides are a
+			// last-wins map, so create (above) and this prune always agree on one
+			// target count. Keyed off live container names inside
+			// `remove_surplus_replicas`, this is the same reconciliation the `scale`
+			// subcommand relies on.
+			for (svc, &target) in &self.scale_overrides {
+				let Some(service) = file.services.get(svc) else {
+					continue;
+				};
+				if let Some(set) = &target_set {
+					if !set.contains(svc) {
+						continue;
+					}
+				}
+				self.remove_surplus_replicas(svc, service, target).await?;
 			}
 
 			Ok(())
@@ -340,6 +371,10 @@ impl Engine {
 		// one container can bind it. Fail fast with guidance instead of letting
 		// replicas 2..N die mid-up with `address already in use`.
 		scale::check_scale_port_conflict(name, service, replicas)?;
+		// A service pinning an explicit container_name cannot be scaled past one
+		// replica without violating its fixed-name contract; reject it rather
+		// than inventing `name-1`, `name-2`, … (docker compose refuses this too).
+		scale::check_fixed_name_scale(name, service, replicas)?;
 
 		let new_hash = config_hash(service, file)?;
 

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -1,6 +1,7 @@
 //! Service lifecycle commands: up, down, start, stop, restart, kill, rm, pause, unpause, run.
 
 mod commands;
+mod down_label;
 mod run;
 mod scale;
 mod signal;
@@ -512,32 +513,7 @@ impl Engine {
 		// network whose compose key changed — mirroring the container sweep so
 		// teardown is complete regardless of how the file was parsed. Only
 		// podup-labelled networks match, so external networks are never touched.
-		let net_filters =
-			serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
-		let list_path = format!(
-			"{API_PREFIX}/networks/json?filters={}",
-			crate::libpod::urlencoded(&net_filters.to_string()),
-		);
-		if let Ok(nets) = self
-			.client
-			.get_json::<Vec<serde_json::Value>>(&list_path)
-			.await
-		{
-			for net in nets {
-				let Some(net_name) = net.get("name").and_then(|n| n.as_str()) else {
-					continue;
-				};
-				let del = format!(
-					"{API_PREFIX}/networks/{}",
-					crate::libpod::urlencoded(net_name)
-				);
-				match self.client.delete_ok(&del).await {
-					Ok(_) => info!("removed network {net_name}"),
-					Err(e) if e.is_status(404) => {}
-					Err(e) => tracing::warn!("could not remove network {net_name}: {e}"),
-				}
-			}
-		}
+		self.remove_project_networks_by_label().await;
 
 		if remove_volumes {
 			for (key, config) in &file.volumes {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod scale;
+mod signal;
 mod targets;
 
 use std::collections::{HashMap, HashSet};

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod down_label;
+mod parallel;
 mod run;
 mod scale;
 mod signal;

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -441,13 +441,19 @@ impl Engine {
 
 		for name in &order {
 			let service = &file.services[name];
-			let container_names = match live_by_service.get(name) {
-				Some(live) if !live.is_empty() => live.clone(),
-				_ => self.replica_names(name, service),
+			// Act only on containers Podman actually has. A defined-but-never-
+			// created service (or one already torn down) has no live containers,
+			// so skip it rather than synthesizing predicted names and POSTing
+			// stop/rm to them — those 404 and, pre-fix, leaked warnings. docker
+			// compose enumerates by label and treats "nothing there" as a quiet
+			// idempotent no-op (#758).
+			let Some(container_names) = live_by_service.get(name).filter(|live| !live.is_empty())
+			else {
+				continue;
 			};
 			for container_name in container_names {
 				for hook in &service.pre_stop {
-					if let Err(e) = self.run_lifecycle_hook(&container_name, hook).await {
+					if let Err(e) = self.run_lifecycle_hook(container_name, hook).await {
 						tracing::debug!("pre_stop hook {container_name}: {e}");
 					}
 				}
@@ -458,7 +464,7 @@ impl Engine {
 				// force-remove below SIGKILLs it regardless.
 				let stop_path = format!(
 					"{API_PREFIX}/containers/{}/stop?t={}",
-					crate::libpod::urlencoded(&container_name),
+					crate::libpod::urlencoded(container_name),
 					targets::stop_timeout_param(grace),
 				);
 				// A 404 (container already gone, or a profile-gated service that was
@@ -474,7 +480,7 @@ impl Engine {
 					}
 				}
 
-				let rm_path = container_rm_path(&container_name, remove_volumes);
+				let rm_path = container_rm_path(container_name, remove_volumes);
 				match self.client.delete_ok(&rm_path).await {
 					Ok(()) => info!("removed {container_name}"),
 					Err(e) if e.is_status(404) => {}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -10,8 +10,6 @@ mod targets;
 
 use std::collections::{HashMap, HashSet};
 
-use tracing::info;
-
 use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
@@ -389,11 +387,16 @@ impl Engine {
 			};
 			if !force_recreate {
 				if no_recreate && present.contains(&container_name) {
-					info!("{container_name} already exists — skipping recreate");
+					tracing::debug!("{container_name} already exists — skipping recreate");
 					// `create` leaves an existing container as-is; `up` ensures it runs.
 					if start {
 						self.ensure_started(&container_name).await;
 					}
+					crate::ui::progress_line(
+						"Container",
+						&container_name,
+						if start { "Running" } else { "Exists" },
+					);
 					continue;
 				}
 				// Services with a build section are rebuilt on every up, so
@@ -401,18 +404,24 @@ impl Engine {
 				// image even when the compose config is unchanged.
 				if service.build.is_none() && existing_hash.get(&container_name) == Some(&new_hash)
 				{
-					info!("{container_name} is up to date — skipping recreate");
+					tracing::debug!("{container_name} is up to date — skipping recreate");
 					if start {
 						self.ensure_started(&container_name).await;
 					}
+					crate::ui::progress_line(
+						"Container",
+						&container_name,
+						if start { "Running" } else { "Exists" },
+					);
 					continue;
 				}
 			}
 			self.create_and_start(&container_name, name, service, file, start)
 				.await?;
-			info!(
-				"{} {container_name}",
-				if start { "started" } else { "created" }
+			crate::ui::progress_line(
+				"Container",
+				&container_name,
+				if start { "Started" } else { "Created" },
 			);
 
 			// `post_start` hooks run inside a running container, so only on `up`.
@@ -483,7 +492,7 @@ impl Engine {
 
 				let rm_path = container_rm_path(container_name, remove_volumes);
 				match self.client.delete_ok(&rm_path).await {
-					Ok(()) => info!("removed {container_name}"),
+					Ok(()) => crate::ui::progress_line("Container", container_name, "Removed"),
 					Err(e) if e.is_status(404) => {}
 					Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
 				}
@@ -509,7 +518,7 @@ impl Engine {
 				crate::libpod::urlencoded(&network_name),
 			);
 			match self.client.delete_ok(&net_path).await {
-				Ok(_) => info!("removed network {network_name}"),
+				Ok(_) => crate::ui::progress_line("Network", &network_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) => tracing::warn!("could not remove network {network_name}: {e}"),
 			}
@@ -538,7 +547,7 @@ impl Engine {
 					crate::libpod::urlencoded(&volume_name),
 				);
 				match self.client.delete_ok(&vol_path).await {
-					Ok(_) => info!("removed volume {volume_name}"),
+					Ok(_) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
 					Err(e) if e.is_status(404) => {}
 					Err(e) => tracing::warn!("could not remove volume {volume_name}: {e}"),
 				}
@@ -579,10 +588,10 @@ impl Engine {
 			// failure.
 			let path = format!("{API_PREFIX}/images/{}", crate::libpod::urlencoded(&image),);
 			match self.client.delete_ok(&path).await {
-				Ok(_) => info!("removed image {image}"),
+				Ok(_) => crate::ui::progress_line("Image", &image, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) if e.is_image_in_use() => {
-					info!("image {image} is still in use — skipping removal")
+					tracing::debug!("image {image} is still in use — skipping removal")
 				}
 				Err(e) => tracing::warn!("could not remove image {image}: {e}"),
 			}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -420,10 +420,7 @@ impl Engine {
 					tracing::warn!("could not stop {container_name}: {e}");
 				}
 
-				let rm_path = format!(
-					"{API_PREFIX}/containers/{}?force=true",
-					crate::libpod::urlencoded(&container_name),
-				);
+				let rm_path = container_rm_path(&container_name, remove_volumes);
 				if let Err(e) = self.client.delete_ok(&rm_path).await {
 					tracing::warn!("could not remove {container_name}: {e}");
 				} else {
@@ -437,7 +434,7 @@ impl Engine {
 		// containers by label so teardown is always complete.
 		let grace = self.stop_timeout.unwrap_or(10);
 		for name in self.list_project_container_names(None).await? {
-			self.stop_and_remove(&name, grace).await;
+			self.stop_and_remove(&name, grace, remove_volumes).await;
 		}
 
 		for (key, config) in &file.networks {
@@ -544,5 +541,50 @@ impl Engine {
 			}
 		}
 		Ok(())
+	}
+}
+
+/// Build the libpod container-removal path. `force` always terminates a running
+/// container; with `remove_volumes` it also reclaims the anonymous volumes the
+/// container owns (`podman rm -v` / `docker compose down -v` semantics). That is
+/// the only way image `VOLUME` directives and short-form anonymous volumes get
+/// removed: podup never names or labels them, so they cannot be enumerated and
+/// deleted the way declared top-level volumes are.
+pub(super) fn container_rm_path(name: &str, remove_volumes: bool) -> String {
+	let with_volumes = if remove_volumes { "&v=true" } else { "" };
+	format!(
+		"{API_PREFIX}/containers/{}?force=true{with_volumes}",
+		crate::libpod::urlencoded(name),
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::container_rm_path;
+
+	#[test]
+	fn rm_path_omits_volume_flag_by_default() {
+		// A plain `down` (or scale-down) must not drop volumes.
+		let path = container_rm_path("proj-web-1", false);
+		assert!(path.ends_with("/proj-web-1?force=true"), "got: {path}");
+		assert!(!path.contains("v=true"), "got: {path}");
+	}
+
+	#[test]
+	fn rm_path_requests_anonymous_volume_removal() {
+		// `down -v` must pass `v=true` so podman reclaims the container's
+		// anonymous (image VOLUME / short-form) volumes.
+		let path = container_rm_path("proj-web-1", true);
+		assert!(path.contains("force=true"), "got: {path}");
+		assert!(path.contains("&v=true"), "got: {path}");
+	}
+
+	#[test]
+	fn rm_path_url_encodes_container_name() {
+		// Names are URL-encoded so a slash in a container name cannot alter the
+		// request path.
+		let path = container_rm_path("weird/name", true);
+		assert!(!path.contains("weird/name"), "got: {path}");
+		assert!(path.contains("weird%2Fname"), "got: {path}");
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -13,7 +13,7 @@ use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
-use targets::{expand_targets, filter_services, in_started_set};
+use targets::{expand_targets, filter_services, in_started_set, validate_targets};
 
 use super::container::config_hash;
 
@@ -145,6 +145,9 @@ impl Engine {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
 
+			// Reject unknown service names before doing any work, so `up`/`create`
+			// of a bogus service errors instead of exiting 0 as a silent no-op.
+			validate_targets(file, target_services)?;
 			let target_set = expand_targets(file, target_services, no_deps);
 
 			// Prefetch the project's containers once (instead of one API call per

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -555,8 +555,14 @@ impl Engine {
 			}
 			let image = match &service.image {
 				Some(img) => img.clone(),
-				// A build-only service's image defaults to `{service}:latest`.
-				None if builds_locally => format!("{name}:latest"),
+				// A build-only service's image is the tag the build step produced
+				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
+				None if builds_locally => super::build::primary_build_tag(
+					&self.project,
+					name,
+					None,
+					service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
+				),
 				None => continue,
 			};
 			// Do NOT force: a force-removal cascades to every container using the

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -13,6 +13,7 @@ use crate::compose::types::{ComposeFile, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
+pub use targets::validate_stop_timeout;
 use targets::{expand_targets, filter_services, in_started_set, validate_targets};
 
 use super::container::config_hash;
@@ -296,7 +297,7 @@ impl Engine {
 						);
 						Ok(())
 					} else {
-						self.wait_healthy(&dep_container, dep_service).await
+						self.wait_healthy(&dep_container, dep_service, None).await
 					}
 				}
 				ServiceCondition::ServiceCompletedSuccessfully => {
@@ -415,11 +416,19 @@ impl Engine {
 				}
 
 				let grace = self.grace_period_secs(service);
+				// Bound the stop by the grace window so a container ignoring SIGTERM
+				// does not pin recreation for the full client READ_TIMEOUT; the
+				// force-remove below SIGKILLs it regardless.
 				let stop_path = format!(
-					"{API_PREFIX}/containers/{}/stop?t={grace}",
+					"{API_PREFIX}/containers/{}/stop?t={}",
 					crate::libpod::urlencoded(&container_name),
+					targets::stop_timeout_param(grace),
 				);
-				if let Err(e) = self.client.post_empty_ok(&stop_path).await {
+				if let Err(e) = self
+					.client
+					.post_empty_ok_within(&stop_path, targets::stop_deadline(grace))
+					.await
+				{
 					tracing::warn!("could not stop {container_name}: {e}");
 				}
 

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -1,0 +1,412 @@
+//! Intra-level parallelism for the lifecycle commands.
+//!
+//! The order resolver groups services into dependency *levels*
+//! ([`crate::compose::resolve_levels`]): every service in one level has its
+//! `depends_on` satisfied by an earlier level, so services *within* a level have
+//! no ordering between them and can be acted on concurrently. The whole-project
+//! lifecycle commands (stop/start/restart/kill/rm/pause/unpause) walk the levels
+//! in order — preserving the cross-level dependency ordering — but dispatch each
+//! level's per-service operations in parallel instead of strictly serially, so a
+//! restart/stop of many independent services no longer serializes every grace
+//! period (#757). This mirrors what the `up`/`create` path already does.
+
+use std::collections::HashSet;
+
+use tracing::info;
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::engine::Engine;
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::targets::stop_timeout_param;
+
+/// Upper bound on the number of same-level services a lifecycle command acts on
+/// concurrently. Services within a dependency level have no ordering between
+/// them, so they run in parallel; the cap keeps a very wide compose file from
+/// opening an unbounded number of simultaneous libpod connections at once.
+const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
+
+/// Run a batch of independent per-service futures concurrently, bounded by
+/// [`MAX_LIFECYCLE_CONCURRENCY`], and return their results in the *input* order
+/// (not completion order) so error selection and reporting stay deterministic
+/// regardless of which service happens to finish first.
+pub(super) async fn join_bounded<F>(futs: impl IntoIterator<Item = F>) -> Vec<Result<()>>
+where
+	F: std::future::Future<Output = Result<()>>,
+{
+	use futures_util::stream::StreamExt;
+	let mut indexed: Vec<(usize, Result<()>)> = futures_util::stream::iter(
+		futs.into_iter()
+			.enumerate()
+			.map(|(i, fut)| async move { (i, fut.await) }),
+	)
+	.buffer_unordered(MAX_LIFECYCLE_CONCURRENCY)
+	.collect()
+	.await;
+	indexed.sort_by_key(|(i, _)| *i);
+	indexed.into_iter().map(|(_, r)| r).collect()
+}
+
+/// Reduce a level's per-service results to the first error in service order, so
+/// one failing service is still reported clearly while the rest of the level is
+/// allowed to complete.
+pub(super) fn first_error(results: Vec<Result<()>>) -> Option<ComposeError> {
+	results.into_iter().find_map(Result::err)
+}
+
+/// Filter each dependency level down to `target_services`, dropping levels that
+/// end up empty. An empty target list keeps every level. Returns an error if any
+/// requested name is not in the file, matching [`super::targets::filter_services`]
+/// (and docker compose's "no such service").
+pub(super) fn filter_levels(
+	file: &ComposeFile,
+	levels: Vec<Vec<String>>,
+	target_services: &[String],
+) -> Result<Vec<Vec<String>>> {
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	if target_services.is_empty() {
+		return Ok(levels);
+	}
+	let set: HashSet<&str> = target_services.iter().map(|s| s.as_str()).collect();
+	Ok(retain_levels(levels, |n| set.contains(n)))
+}
+
+/// Keep only the level entries matching `keep`, dropping levels left empty.
+pub(super) fn retain_levels(
+	levels: Vec<Vec<String>>,
+	keep: impl Fn(&str) -> bool,
+) -> Vec<Vec<String>> {
+	levels
+		.into_iter()
+		.map(|level| {
+			level
+				.into_iter()
+				.filter(|n| keep(n.as_str()))
+				.collect::<Vec<_>>()
+		})
+		.filter(|level| !level.is_empty())
+		.collect()
+}
+
+/// Compute the set of services a `restart` should act on, plus the explicit
+/// target subset (used only to label cascade-restarts distinctly in the logs).
+///
+/// With no targets every service is restarted. With targets, the set is the
+/// targets plus — unless `no_deps` — every service whose `depends_on` carries a
+/// `restart: true` condition pointing at one of the targets (one hop, matching
+/// the previous serial implementation).
+pub(super) fn restart_service_set(
+	file: &ComposeFile,
+	target_services: &[String],
+	no_deps: bool,
+) -> (HashSet<String>, HashSet<String>) {
+	if target_services.is_empty() {
+		let all: HashSet<String> = file.services.keys().cloned().collect();
+		return (all.clone(), all);
+	}
+	let targets: HashSet<String> = target_services.iter().cloned().collect();
+	let mut full = targets.clone();
+	if !no_deps {
+		for (dep_name, dep_service) in &file.services {
+			if targets
+				.iter()
+				.any(|t| dep_service.depends_on.restart_for(t))
+			{
+				full.insert(dep_name.clone());
+			}
+		}
+	}
+	(full, targets)
+}
+
+impl Engine {
+	/// Stop a single service's live containers (only those actually running), as
+	/// one unit of work in a concurrent level. See [`Engine::stop`].
+	pub(super) async fn stop_one_service(&self, service_name: &str, grace: i32) -> Result<()> {
+		for container in self.live_service_containers(service_name).await? {
+			if super::scale::state_is_active(&container.state) {
+				self.stop_container(&container.name, grace).await?;
+			} else {
+				tracing::debug!(
+					"{}: not running ({}) — stop is a no-op",
+					container.name,
+					container.state
+				);
+			}
+		}
+		Ok(())
+	}
+
+	/// Start a single service's live containers, recording in `any_live` whether
+	/// the service had any container to act on. See [`Engine::start`].
+	pub(super) async fn start_one_service(
+		&self,
+		service_name: &str,
+		any_live: &std::sync::atomic::AtomicBool,
+	) -> Result<()> {
+		let live = self
+			.list_project_container_names(Some(service_name))
+			.await?;
+		if live.is_empty() {
+			return Ok(());
+		}
+		any_live.store(true, std::sync::atomic::Ordering::Relaxed);
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in live {
+			let path = format!(
+				"{API_PREFIX}/containers/{}/start",
+				urlencoded(&container_name),
+			);
+			if let Err(e) = self
+				.run_lifecycle_op(&path, &container_name, "started")
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Restart a single service's live containers. `done` is the log verb
+	/// (`restarted` for a direct target, `cascade-restarted` for a dependent).
+	pub(super) async fn restart_one_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		done: &str,
+	) -> Result<()> {
+		let grace = self.grace_period_secs(service);
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			// Single atomic restart (no visible stopped window) instead of a
+			// stop+start round-trip.
+			let restart_path = format!(
+				"{API_PREFIX}/containers/{}/restart?t={}",
+				urlencoded(&container_name),
+				stop_timeout_param(grace),
+			);
+			if let Err(e) = self
+				.run_lifecycle_op(&restart_path, &container_name, done)
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Send `signal` to a single service's live containers. See [`Engine::kill`].
+	pub(super) async fn kill_one_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		signal: &str,
+	) -> Result<()> {
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			let path = format!(
+				"{API_PREFIX}/containers/{}/kill?signal={}",
+				urlencoded(&container_name),
+				urlencoded(signal),
+			);
+			if let Err(e) = self
+				.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Remove a single service's containers. See [`Engine::rm_with_options`].
+	pub(super) async fn rm_one_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		force: bool,
+		remove_volumes: bool,
+	) -> Result<()> {
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			let force_str = if force { "true" } else { "false" };
+			let path = format!(
+				"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
+				urlencoded(&container_name),
+			);
+			match self.client.delete_existed(&path).await {
+				// Only report a removal that actually happened — a phantom
+				// (never-created) container 404s and must not be logged as
+				// "removed".
+				Ok(true) => info!("removed {container_name}"),
+				Ok(false) => {}
+				// Without `--force`, a running container 409s. docker compose rm
+				// skips running containers rather than aborting, so warn and keep
+				// going (later stopped containers still get removed).
+				Err(e) if !force && e.is_status(409) => {
+					tracing::warn!(
+						"{container_name} is running — skipping (pass -f to force removal)"
+					);
+				}
+				Err(e) => {
+					first_err.get_or_insert(ComposeError::Podman(e));
+				}
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Pause or unpause a single service's live containers, treating a state
+	/// mismatch as an idempotent no-op. `endpoint` is `pause`/`unpause`.
+	pub(super) async fn idempotent_state_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		endpoint: &str,
+		done: &str,
+	) -> Result<()> {
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in self.live_replica_names(service_name, service).await? {
+			let path = format!(
+				"{API_PREFIX}/containers/{}/{endpoint}",
+				urlencoded(&container_name),
+			);
+			if let Err(e) = self
+				.run_idempotent_state_op(&path, &container_name, done)
+				.await
+			{
+				first_err.get_or_insert(e);
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::error::ComposeError;
+
+	fn levels(input: &[&[&str]]) -> Vec<Vec<String>> {
+		input
+			.iter()
+			.map(|lvl| lvl.iter().map(|s| s.to_string()).collect())
+			.collect()
+	}
+
+	fn file_with(services: &[&str]) -> ComposeFile {
+		let mut file = ComposeFile::default();
+		for &s in services {
+			file.services.insert(s.to_string(), Service::default());
+		}
+		file
+	}
+
+	#[tokio::test]
+	async fn join_bounded_preserves_input_order() {
+		// Futures finish out of order (later index resolves first) but the
+		// collected results are returned in input order.
+		let futs = (0..5usize).map(|i| async move {
+			// Smaller i yields later via more yields, so completion order != input.
+			for _ in 0..(5 - i) {
+				tokio::task::yield_now().await;
+			}
+			if i == 2 {
+				Err(ComposeError::ServiceNotFound(format!("svc{i}")))
+			} else {
+				Ok(())
+			}
+		});
+		let results = join_bounded(futs).await;
+		assert_eq!(results.len(), 5);
+		// Only index 2 is an error, proving order is preserved.
+		for (i, r) in results.iter().enumerate() {
+			assert_eq!(r.is_err(), i == 2, "index {i}");
+		}
+	}
+
+	#[test]
+	fn first_error_returns_first_in_order() {
+		let results = vec![
+			Ok(()),
+			Err(ComposeError::ServiceNotFound("a".into())),
+			Err(ComposeError::ServiceNotFound("b".into())),
+		];
+		let err = first_error(results).unwrap();
+		assert!(matches!(err, ComposeError::ServiceNotFound(n) if n == "a"));
+	}
+
+	#[test]
+	fn first_error_none_when_all_ok() {
+		assert!(first_error(vec![Ok(()), Ok(())]).is_none());
+	}
+
+	#[test]
+	fn filter_levels_empty_targets_keeps_all() {
+		let file = file_with(&["a", "b", "c"]);
+		let lv = levels(&[&["a", "b"], &["c"]]);
+		let out = filter_levels(&file, lv.clone(), &[]).unwrap();
+		assert_eq!(out, lv);
+	}
+
+	#[test]
+	fn filter_levels_drops_empty_levels() {
+		let file = file_with(&["a", "b", "c"]);
+		let lv = levels(&[&["a", "b"], &["c"]]);
+		let out = filter_levels(&file, lv, &["c".into()]).unwrap();
+		assert_eq!(out, levels(&[&["c"]]));
+	}
+
+	#[test]
+	fn filter_levels_unknown_target_errors() {
+		let file = file_with(&["a"]);
+		let lv = levels(&[&["a"]]);
+		let err = filter_levels(&file, lv, &["z".into()]).unwrap_err();
+		assert!(matches!(err, ComposeError::ServiceNotFound(n) if n == "z"));
+	}
+
+	#[test]
+	fn retain_levels_filters_and_drops() {
+		let lv = levels(&[&["a", "b"], &["c"]]);
+		let keep: HashSet<&str> = ["a", "c"].into_iter().collect();
+		let out = retain_levels(lv, |n| keep.contains(n));
+		assert_eq!(out, levels(&[&["a"], &["c"]]));
+	}
+
+	#[test]
+	fn restart_service_set_empty_targets_is_all() {
+		let file = file_with(&["a", "b"]);
+		let (full, targets) = restart_service_set(&file, &[], false);
+		assert_eq!(full, targets);
+		assert_eq!(full.len(), 2);
+		assert!(full.contains("a") && full.contains("b"));
+	}
+
+	#[test]
+	fn restart_service_set_includes_cascade_dependents() {
+		// web depends_on db with restart: true → restarting db cascades to web.
+		let file = crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      db:\n        condition: service_started\n        restart: true\n",
+		)
+		.unwrap();
+		let (full, targets) = restart_service_set(&file, &["db".into()], false);
+		assert!(targets.contains("db") && targets.len() == 1);
+		assert!(full.contains("db") && full.contains("web"));
+	}
+
+	#[test]
+	fn restart_service_set_no_deps_excludes_cascade() {
+		let file = crate::parse_str(
+			"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      db:\n        condition: service_started\n        restart: true\n",
+		)
+		.unwrap();
+		let (full, _) = restart_service_set(&file, &["db".into()], true);
+		assert!(full.contains("db"));
+		assert!(!full.contains("web"));
+	}
+}

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -12,8 +12,6 @@
 
 use std::collections::HashSet;
 
-use tracing::info;
-
 use crate::compose::types::{ComposeFile, Service};
 use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
@@ -163,7 +161,7 @@ impl Engine {
 				urlencoded(&container_name),
 			);
 			if let Err(e) = self
-				.run_lifecycle_op(&path, &container_name, "started")
+				.run_lifecycle_op(&path, &container_name, "Started")
 				.await
 			{
 				first_err.get_or_insert(e);
@@ -215,7 +213,7 @@ impl Engine {
 				urlencoded(signal),
 			);
 			if let Err(e) = self
-				.run_lifecycle_op(&path, &container_name, &format!("sent {signal} to"))
+				.run_lifecycle_op(&path, &container_name, "Killed")
 				.await
 			{
 				first_err.get_or_insert(e);
@@ -243,7 +241,7 @@ impl Engine {
 				// Only report a removal that actually happened — a phantom
 				// (never-created) container 404s and must not be logged as
 				// "removed".
-				Ok(true) => info!("removed {container_name}"),
+				Ok(true) => crate::ui::progress_line("Container", &container_name, "Removed"),
 				Ok(false) => {}
 				// Without `--force`, a running container 409s. docker compose rm
 				// skips running containers rather than aborting, so warn and keep

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -1,0 +1,287 @@
+//! One-off `run` command: start a throwaway container for a service, stream its
+//! output, and remove it when done.
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use futures_util::StreamExt;
+use tracing::info;
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+
+use super::RunOptions;
+use crate::engine::Engine;
+use crate::libpod::API_PREFIX;
+
+impl Engine {
+	/// Run a one-off command in a new container for a service.
+	///
+	/// The container is started, its output streamed, and it is removed when done
+	/// (unless `opts.rm` is false). Non-zero exit codes surface as `ComposeError::RunExited`.
+	pub async fn run(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		opts: RunOptions,
+	) -> Result<()> {
+		let RunOptions {
+			cmd,
+			rm,
+			detach,
+			env_overrides,
+			name_override,
+			service_ports,
+		} = opts;
+		// CLI-only run flags arrive via the engine builder (see `RunOverrides`),
+		// keeping the public `RunOptions` API frozen at 1.0.
+		let super::RunOverrides {
+			user,
+			workdir,
+			entrypoint,
+			volumes,
+			publish,
+			interactive,
+			no_deps,
+		} = self.run_overrides.clone();
+		// `--env-file` is global, so it rides on the engine (not `RunOverrides`).
+		let env_files = self.run_env_files.clone();
+		let service = file
+			.services
+			.get(service_name)
+			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
+
+		// Compose `run` brings up the service's `depends_on` services first (and
+		// waits on their conditions), unless `--no-deps` is given. The service
+		// itself is excluded — only its transitive dependencies are started.
+		if !no_deps {
+			let deps: Vec<String> = super::expand_targets(file, &[service_name.to_string()], false)
+				.map(|set| set.into_iter().filter(|n| n != service_name).collect())
+				.unwrap_or_default();
+			if !deps.is_empty() {
+				self.up_with_options(file, true, &[], &deps, false, false, false)
+					.await?;
+			}
+		}
+
+		let run_name = name_override.unwrap_or_else(|| {
+			format!("{}-{service_name}-run-{}", self.project, std::process::id())
+		});
+
+		let mut run_service = service.clone();
+		if !cmd.is_empty() {
+			run_service.command = Some(crate::compose::types::Command::Exec(cmd));
+		}
+		// `--entrypoint` overrides the image/service entrypoint with a single
+		// executable token (compose/`docker run` semantics); any `cmd` becomes
+		// its arguments.
+		if let Some(ep) = entrypoint {
+			run_service.entrypoint = Some(crate::compose::types::Command::Exec(vec![ep]));
+		}
+		if let Some(u) = user {
+			run_service.user = Some(u);
+		}
+		if let Some(w) = workdir {
+			run_service.working_dir = Some(w);
+		}
+		// `-i/--interactive` keeps STDIN open on the spec; `run` still streams
+		// logs rather than attaching a live terminal.
+		if interactive {
+			run_service.stdin_open = Some(true);
+		}
+		// Ad-hoc `-v/--volume` mounts append to the service's own mounts in
+		// compose short form, parsed downstream like compose file entries.
+		for v in volumes {
+			run_service
+				.volumes
+				.push(crate::compose::types::VolumeMount::Short(v));
+		}
+		// Layer the run container's environment by precedence, matching
+		// `docker compose run --env-file`: global `--env-file` contents are the
+		// lowest layer, the service's own `environment:` overrides them, and `-e`
+		// overrides win over both.
+		let env_file_vars = if env_files.is_empty() {
+			HashMap::new()
+		} else {
+			crate::env_file::load_env_files(&env_files, &self.base_dir)?
+		};
+		if !env_file_vars.is_empty() || !env_overrides.is_empty() {
+			run_service.environment = crate::compose::types::EnvVars::List(merge_run_environment(
+				env_file_vars,
+				run_service.environment.to_map(),
+				env_overrides,
+			));
+		}
+		run_service.restart = None;
+		// Compose `run` does not publish the service's ports unless
+		// `--service-ports` is given; otherwise a one-off run would collide
+		// with the long-running service's host-port bindings.
+		if !service_ports {
+			run_service.ports.clear();
+		}
+		// Explicit `-p/--publish` ports are always bound, even without
+		// `--service-ports`, matching `docker compose run -p`.
+		for p in publish {
+			run_service
+				.ports
+				.push(crate::compose::types::PortMapping::Short(p));
+		}
+		// Force non-TTY so Podman uses multiplexed log framing that
+		// parse_multiplexed can decode. TTY mode sends raw bytes without
+		// the 8-byte header, which would produce garbled output.
+		run_service.tty = None;
+
+		// Ensure the project networks exist (compose `run` brings them up like
+		// `up` does); the service may reference the synthesized `default`
+		// network, which is created here as `{project}_default`.
+		self.create_networks(file).await?;
+		// Inline secrets/configs are created up front (no longer in the
+		// per-container build path), so materialise them here too before the run
+		// container is created.
+		self.create_inline_secrets(file).await?;
+
+		self.create_and_start(&run_name, service_name, &run_service, file, true)
+			.await?;
+
+		if detach {
+			info!("started run container {run_name}");
+			return Ok(());
+		}
+
+		let logs_path = format!(
+			"{API_PREFIX}/containers/{}/logs?follow=true&stdout=true&stderr=true",
+			crate::libpod::urlencoded(&run_name),
+		);
+		let logs_resp = self
+			.client
+			.get_stream(&logs_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut log_stream = crate::libpod::parse_multiplexed(logs_resp.into_body());
+
+		// Lock stdout once for the whole stream instead of re-acquiring the lock
+		// (and issuing a syscall) per frame; stdout is ours exclusively on this
+		// path. stderr is locked per frame because the tracing subscriber also
+		// writes there: holding its lock across the await loop would starve
+		// concurrent log emissions. Flush after each frame so `run` streams
+		// promptly.
+		let mut out = std::io::stdout().lock();
+		while let Some(msg) = log_stream.next().await {
+			match msg.map_err(ComposeError::Podman)? {
+				crate::libpod::LogOutput::StdOut { message } => {
+					let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
+					let _ = out.flush();
+				}
+				crate::libpod::LogOutput::StdErr { message } => {
+					let mut err = std::io::stderr().lock();
+					let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
+					let _ = err.flush();
+				}
+			}
+		}
+
+		let wait_path = format!(
+			"{API_PREFIX}/containers/{}/wait?condition=stopped",
+			crate::libpod::urlencoded(&run_name),
+		);
+		// Capture the wait result before cleanup so a failed wait is surfaced as an
+		// error rather than masked as a successful (exit 0) run.
+		let wait_result = self
+			.client
+			.post_empty_json_unbounded::<i64>(&wait_path)
+			.await;
+
+		if rm {
+			let rm_path = format!(
+				"{API_PREFIX}/containers/{}?force=true",
+				crate::libpod::urlencoded(&run_name),
+			);
+			if let Err(e) = self.client.delete_ok(&rm_path).await {
+				tracing::debug!("run cleanup delete {run_name}: {e}");
+			}
+		}
+
+		let exit_code = wait_result.map_err(ComposeError::Podman)?;
+		if exit_code != 0 {
+			return Err(crate::error::ComposeError::RunExited(exit_code));
+		}
+
+		Ok(())
+	}
+}
+
+/// Layer the three `run` environment sources into the final `KEY=VALUE` / `KEY`
+/// list by precedence (`--env-file` < service `environment:` < `-e`), matching
+/// `docker compose run --env-file`. `-e` overrides are appended last so a later
+/// duplicate wins downstream, mirroring the previous `-e`-only handling.
+fn merge_run_environment(
+	env_file_vars: HashMap<String, String>,
+	service_env: HashMap<String, Option<String>>,
+	env_overrides: Vec<String>,
+) -> Vec<String> {
+	// `--env-file` is the base layer; the service's `environment:` overrides it.
+	let mut map: HashMap<String, Option<String>> = env_file_vars
+		.into_iter()
+		.map(|(k, v)| (k, Some(v)))
+		.collect();
+	for (k, v) in service_env {
+		map.insert(k, v);
+	}
+	let mut env_list: Vec<String> = map
+		.into_iter()
+		.map(|(k, v)| v.map_or_else(|| k.clone(), |v| format!("{k}={v}")))
+		.collect();
+	// `-e` overrides win over everything else.
+	env_list.extend(env_overrides);
+	env_list
+}
+
+#[cfg(test)]
+mod tests {
+	use super::merge_run_environment;
+	use std::collections::HashMap;
+
+	fn lookup<'a>(list: &'a [String], key: &str) -> Option<&'a str> {
+		// Mirror downstream "later duplicate wins" semantics.
+		list.iter().rev().find_map(|e| match e.split_once('=') {
+			Some((k, v)) if k == key => Some(v),
+			_ => None,
+		})
+	}
+
+	#[test]
+	fn env_file_seeds_environment() {
+		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
+		let list = merge_run_environment(file, HashMap::new(), Vec::new());
+		assert_eq!(lookup(&list, "FOO"), Some("from-file"));
+	}
+
+	#[test]
+	fn service_environment_overrides_env_file() {
+		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
+		let service: HashMap<String, Option<String>> =
+			[("FOO".to_string(), Some("from-service".to_string()))].into();
+		let list = merge_run_environment(file, service, Vec::new());
+		assert_eq!(lookup(&list, "FOO"), Some("from-service"));
+	}
+
+	#[test]
+	fn dash_e_override_wins_over_all() {
+		let file: HashMap<String, String> = [("FOO".to_string(), "from-file".to_string())].into();
+		let service: HashMap<String, Option<String>> =
+			[("FOO".to_string(), Some("from-service".to_string()))].into();
+		let list = merge_run_environment(file, service, vec!["FOO=from-cli".to_string()]);
+		assert_eq!(lookup(&list, "FOO"), Some("from-cli"));
+	}
+
+	#[test]
+	fn distinct_keys_from_each_layer_are_kept() {
+		let file: HashMap<String, String> = [("A".to_string(), "a".to_string())].into();
+		let service: HashMap<String, Option<String>> =
+			[("B".to_string(), Some("b".to_string()))].into();
+		let list = merge_run_environment(file, service, vec!["C=c".to_string()]);
+		assert_eq!(lookup(&list, "A"), Some("a"));
+		assert_eq!(lookup(&list, "B"), Some("b"));
+		assert_eq!(lookup(&list, "C"), Some("c"));
+	}
+}

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -64,6 +64,13 @@ impl Engine {
 			}
 		}
 
+		// A user-supplied `--name` is taken verbatim (no project prefix), so it can
+		// collide with an arbitrary pre-existing container. docker compose errors on
+		// such a conflict; podup must NOT force-remove the unrelated container (the
+		// idempotent recreate in `create_and_start` would otherwise delete it). The
+		// auto-generated default name carries the PID and is unique, so it never
+		// needs this guard.
+		let user_named = name_override.is_some();
 		let run_name = name_override.unwrap_or_else(|| {
 			format!("{}-{service_name}-run-{}", self.project, std::process::id())
 		});
@@ -140,68 +147,96 @@ impl Engine {
 		// container is created.
 		self.create_inline_secrets(file).await?;
 
-		self.create_and_start(&run_name, service_name, &run_service, file, true)
-			.await?;
+		// Refuse to clobber a pre-existing container of the same name (data-loss
+		// footgun): `create_and_start` would force-remove it. Only the verbatim
+		// user-supplied name can collide with something we don't own.
+		if user_named && self.container_exists(&run_name).await? {
+			return Err(ComposeError::Unsupported(format!(
+				"the container name \"{run_name}\" is already in use; remove the existing \
+				 container or choose a different --name"
+			)));
+		}
+
+		let rm_path = format!(
+			"{API_PREFIX}/containers/{}?force=true",
+			crate::libpod::urlencoded(&run_name),
+		);
+
+		// On a start failure (bad --workdir/--user/--entrypoint), the container is
+		// created but never starts; with --rm, remove it here so repeated failures
+		// don't accumulate orphaned 'Created' containers.
+		if let Err(e) = self
+			.create_and_start(&run_name, service_name, &run_service, file, true)
+			.await
+		{
+			if rm {
+				let _ = self.client.delete_ok(&rm_path).await;
+			}
+			return Err(e);
+		}
 
 		if detach {
 			info!("started run container {run_name}");
 			return Ok(());
 		}
 
-		let logs_path = format!(
-			"{API_PREFIX}/containers/{}/logs?follow=true&stdout=true&stderr=true",
-			crate::libpod::urlencoded(&run_name),
-		);
-		let logs_resp = self
-			.client
-			.get_stream(&logs_path)
-			.await
-			.map_err(ComposeError::Podman)?;
-		let mut log_stream = crate::libpod::parse_multiplexed(logs_resp.into_body());
-
-		// Lock stdout once for the whole stream instead of re-acquiring the lock
-		// (and issuing a syscall) per frame; stdout is ours exclusively on this
-		// path. stderr is locked per frame because the tracing subscriber also
-		// writes there: holding its lock across the await loop would starve
-		// concurrent log emissions. Flush after each frame so `run` streams
-		// promptly.
-		let mut out = std::io::stdout().lock();
-		while let Some(msg) = log_stream.next().await {
-			match msg.map_err(ComposeError::Podman)? {
-				crate::libpod::LogOutput::StdOut { message } => {
-					let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
-					let _ = out.flush();
-				}
-				crate::libpod::LogOutput::StdErr { message } => {
-					let mut err = std::io::stderr().lock();
-					let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
-					let _ = err.flush();
-				}
-			}
-		}
-
-		let wait_path = format!(
-			"{API_PREFIX}/containers/{}/wait?condition=stopped",
-			crate::libpod::urlencoded(&run_name),
-		);
-		// Capture the wait result before cleanup so a failed wait is surfaced as an
-		// error rather than masked as a successful (exit 0) run.
-		let wait_result = self
-			.client
-			.post_empty_json_unbounded::<i64>(&wait_path)
-			.await;
-
-		if rm {
-			let rm_path = format!(
-				"{API_PREFIX}/containers/{}?force=true",
+		// Stream logs and wait for the exit code. Any failure on this path also
+		// triggers the --rm cleanup below, so a failed stream/wait never leaks the
+		// running container either. The wait result is captured before cleanup so a
+		// failed wait surfaces as an error rather than masked as a successful run.
+		let outcome: Result<i64> = async {
+			let logs_path = format!(
+				"{API_PREFIX}/containers/{}/logs?follow=true&stdout=true&stderr=true",
 				crate::libpod::urlencoded(&run_name),
 			);
+			let logs_resp = self
+				.client
+				.get_stream(&logs_path)
+				.await
+				.map_err(ComposeError::Podman)?;
+			let mut log_stream = crate::libpod::parse_multiplexed(logs_resp.into_body());
+
+			// Lock stdout once for the whole stream instead of re-acquiring the lock
+			// (and issuing a syscall) per frame; stdout is ours exclusively on this
+			// path. stderr is locked per frame because the tracing subscriber also
+			// writes there: holding its lock across the await loop would starve
+			// concurrent log emissions. Flush after each frame so `run` streams
+			// promptly.
+			{
+				let mut out = std::io::stdout().lock();
+				while let Some(msg) = log_stream.next().await {
+					match msg.map_err(ComposeError::Podman)? {
+						crate::libpod::LogOutput::StdOut { message } => {
+							let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
+							let _ = out.flush();
+						}
+						crate::libpod::LogOutput::StdErr { message } => {
+							let mut err = std::io::stderr().lock();
+							let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
+							let _ = err.flush();
+						}
+					}
+				}
+			}
+
+			let wait_path = format!(
+				"{API_PREFIX}/containers/{}/wait?condition=stopped",
+				crate::libpod::urlencoded(&run_name),
+			);
+			self.client
+				.post_empty_json_unbounded::<i64>(&wait_path)
+				.await
+				.map_err(ComposeError::Podman)
+		}
+		.await;
+
+		if rm {
 			if let Err(e) = self.client.delete_ok(&rm_path).await {
 				tracing::debug!("run cleanup delete {run_name}: {e}");
 			}
 		}
 
-		let exit_code = wait_result.map_err(ComposeError::Podman)?;
+		let exit_code = outcome?;
 		if exit_code != 0 {
 			return Err(crate::error::ComposeError::RunExited(exit_code));
 		}

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use futures_util::StreamExt;
-use tracing::info;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
@@ -190,7 +189,10 @@ impl Engine {
 		}
 
 		if detach {
-			info!("started run container {run_name}");
+			// Echo the started container's name to stdout (gated by progress
+			// output), so scripts capturing stdout get an id like
+			// `docker compose run -d`.
+			crate::ui::result_line(&run_name);
 			return Ok(());
 		}
 

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -44,8 +44,10 @@ impl Engine {
 			interactive,
 			no_deps,
 		} = self.run_overrides.clone();
-		// `--env-file` is global, so it rides on the engine (not `RunOverrides`).
+		// `--env-file` and `-l/--label` are carried on the engine (not
+		// `RunOverrides`) to keep the public struct frozen.
 		let env_files = self.run_env_files.clone();
+		let labels = self.run_labels.clone();
 		let service = file
 			.services
 			.get(service_name)
@@ -102,6 +104,18 @@ impl Engine {
 			run_service
 				.volumes
 				.push(crate::compose::types::VolumeMount::Short(v));
+		}
+		// `-l/--label` adds ad-hoc labels to the one-off container, merged over the
+		// service's own labels in compose `KEY=VALUE` list form.
+		if !labels.is_empty() {
+			let mut list: Vec<String> = run_service
+				.labels
+				.to_map()
+				.into_iter()
+				.map(|(k, v)| if v.is_empty() { k } else { format!("{k}={v}") })
+				.collect();
+			list.extend(labels);
+			run_service.labels = crate::compose::types::Labels::List(list);
 		}
 		// Layer the run container's environment by precedence, matching
 		// `docker compose run --env-file`: global `--env-file` contents are the

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -3,8 +3,6 @@
 
 use std::collections::HashSet;
 
-use tracing::info;
-
 use crate::compose::types::{ComposeFile, Service};
 use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
@@ -192,7 +190,7 @@ impl Engine {
 		if let Err(e) = self.client.delete_ok(&rm_path).await {
 			tracing::debug!("scale-down rm {name}: {e}");
 		} else {
-			info!("removed {name}");
+			crate::ui::progress_line("Container", name, "Removed");
 		}
 	}
 

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -12,6 +12,25 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::targets::{stop_deadline, stop_timeout_param};
 
+/// A live project container: the name to act on plus its machine-readable
+/// state, as reported by the libpod container-list endpoint. Returned by
+/// [`Engine::live_service_containers`] so callers can act on (and report) only
+/// containers in the right state.
+pub(crate) struct LiveContainer {
+	/// Container name with the leading slash stripped.
+	pub name: String,
+	/// Machine-readable state (`running`, `created`, `exited`, `paused`, …).
+	pub state: String,
+}
+
+/// Whether a container in this state is currently active — i.e. `stop` would
+/// actually transition it. A `running` or `paused` container is stopped; a
+/// `created`/`exited`/`dead`/… one is already not running, so stopping it is a
+/// no-op that must not be reported as "stopped" (#876). Pure for unit testing.
+pub(crate) fn state_is_active(state: &str) -> bool {
+	matches!(state, "running" | "paused")
+}
+
 /// The default ceiling on a service's replica count.
 const DEFAULT_MAX_REPLICAS: u32 = 256;
 
@@ -238,6 +257,45 @@ impl Engine {
 		Ok(by_service)
 	}
 
+	/// The live containers of a service (matched by the `podup.service` label),
+	/// each paired with its machine-readable state (`running`, `created`,
+	/// `exited`, `paused`, …). Unlike [`Self::live_replica_names`] this does NOT
+	/// fall back to statically-predicted names: a service with no live container
+	/// yields an empty vec, so a lifecycle op (stop/wait/…) on a defined-but-
+	/// never-created service is a quiet no-op instead of POSTing to a phantom
+	/// name and surfacing a raw 404 (#758). The state lets `stop` report
+	/// "stopped" only for containers that were actually running (#876).
+	pub(crate) async fn live_service_containers(
+		&self,
+		service_name: &str,
+	) -> Result<Vec<LiveContainer>> {
+		let filters = serde_json::json!({
+			"label": [
+				format!("podup.project={}", self.project),
+				format!("podup.service={service_name}"),
+			],
+		});
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		Ok(entries
+			.into_iter()
+			.filter_map(|e| {
+				let state = e.state;
+				e.names.into_iter().next().map(|raw| LiveContainer {
+					name: raw.trim_start_matches('/').to_string(),
+					state,
+				})
+			})
+			.collect())
+	}
+
 	/// The container names to act on for a service: the ones Podman actually has
 	/// (matched by the `podup.service` label), so lifecycle and query commands
 	/// keep working after a runtime `scale`/`up --scale` that the compose file's
@@ -262,9 +320,23 @@ impl Engine {
 #[cfg(test)]
 mod tests {
 	use super::{
-		check_fixed_name_scale, check_replica_limit, check_scale_port_conflict,
+		check_fixed_name_scale, check_replica_limit, check_scale_port_conflict, state_is_active,
 		DEFAULT_MAX_REPLICAS,
 	};
+
+	#[test]
+	fn state_is_active_only_for_running_and_paused() {
+		// `stop` actually transitions only a running or paused container; for any
+		// other state it is a no-op that must not be reported as "stopped" (#876).
+		assert!(state_is_active("running"));
+		assert!(state_is_active("paused"));
+		assert!(!state_is_active("created"));
+		assert!(!state_is_active("exited"));
+		assert!(!state_is_active("stopped"));
+		assert!(!state_is_active("dead"));
+		assert!(!state_is_active("configured"));
+		assert!(!state_is_active(""));
+	}
 
 	#[test]
 	fn replica_limit_default_and_env_override() {

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -10,6 +10,8 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
+use super::targets::{stop_deadline, stop_timeout_param};
+
 /// The default ceiling on a service's replica count.
 const DEFAULT_MAX_REPLICAS: u32 = 256;
 
@@ -132,11 +134,18 @@ impl Engine {
 	/// (`podman rm -v`), so a label-based teardown sweep does not leave image
 	/// `VOLUME`/anonymous volumes behind.
 	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32, remove_volumes: bool) {
+		// Bound the stop by the grace window: the force-remove below SIGKILLs the
+		// container, so a stop that stalls past the grace must not pin us for the
+		// full client READ_TIMEOUT before we fall through to it.
 		let stop_path = format!(
-			"{API_PREFIX}/containers/{}/stop?t={grace}",
-			urlencoded(name)
+			"{API_PREFIX}/containers/{}/stop?t={}",
+			urlencoded(name),
+			stop_timeout_param(grace),
 		);
-		let _ = self.client.post_empty_ok(&stop_path).await;
+		let _ = self
+			.client
+			.post_empty_ok_within(&stop_path, stop_deadline(grace))
+			.await;
 		let rm_path = super::container_rm_path(name, remove_volumes);
 		if let Err(e) = self.client.delete_ok(&rm_path).await {
 			tracing::debug!("scale-down rm {name}: {e}");

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -119,20 +119,25 @@ impl Engine {
 			.await?
 		{
 			if !desired.contains(&name) {
-				self.stop_and_remove(&name, grace).await;
+				// Scaling down removes surplus replicas but keeps their data
+				// volumes (only `down -v` reclaims volumes).
+				self.stop_and_remove(&name, grace, false).await;
 			}
 		}
 		Ok(())
 	}
 
-	/// Stop (best-effort) then force-remove a container by name.
-	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32) {
+	/// Stop (best-effort) then force-remove a container by name. With
+	/// `remove_volumes`, the container's anonymous volumes are reclaimed too
+	/// (`podman rm -v`), so a label-based teardown sweep does not leave image
+	/// `VOLUME`/anonymous volumes behind.
+	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32, remove_volumes: bool) {
 		let stop_path = format!(
 			"{API_PREFIX}/containers/{}/stop?t={grace}",
 			urlencoded(name)
 		);
 		let _ = self.client.post_empty_ok(&stop_path).await;
-		let rm_path = format!("{API_PREFIX}/containers/{}?force=true", urlencoded(name));
+		let rm_path = super::container_rm_path(name, remove_volumes);
 		if let Err(e) = self.client.delete_ok(&rm_path).await {
 			tracing::debug!("scale-down rm {name}: {e}");
 		} else {

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -71,6 +71,25 @@ pub(super) fn check_scale_port_conflict(
 	})
 }
 
+/// Reject scaling a service that pins an explicit `container_name` above one
+/// replica. A fixed container name can only ever name a single container, so
+/// inventing `name-1`, `name-2`, … would break the fixed-name contract; docker
+/// compose refuses this too, so podup fails fast with the same guidance.
+pub(super) fn check_fixed_name_scale(
+	service_name: &str,
+	service: &Service,
+	replicas: usize,
+) -> Result<()> {
+	if replicas > 1 && service.container_name.is_some() {
+		return Err(ComposeError::Unsupported(format!(
+			"service '{service_name}' sets a fixed container_name but is scaled to {replicas} \
+			 replicas; a fixed container_name can name only one container. Remove container_name \
+			 to scale, or keep the service at a single replica."
+		)));
+	}
+	Ok(())
+}
+
 impl Engine {
 	/// Set the number of running containers for the named services (docker
 	/// `compose scale SERVICE=N`). Creates missing replicas and removes any
@@ -82,28 +101,28 @@ impl Engine {
 				return Err(ComposeError::ServiceNotFound(svc.clone()));
 			}
 		}
-		// Fail fast on an over-limit count or a fixed host port before touching
-		// any container.
+		// Fail fast on an over-limit count, a fixed host port, or a fixed
+		// container_name before touching any container.
 		for (svc, target) in pairs {
 			check_replica_limit(svc, *target as usize)?;
 			check_scale_port_conflict(svc, &file.services[svc], *target as usize)?;
+			check_fixed_name_scale(svc, &file.services[svc], *target as usize)?;
 		}
-		// Scale up: create only the missing replicas of the named services
-		// (no_recreate keeps existing ones; no_deps leaves dependencies alone).
+		// Create the missing replicas and prune any surplus. Both halves run on
+		// the shared `up` path, which reconciles every service carrying an active
+		// `--scale` override against the last-wins target (so duplicate pairs such
+		// as `svc=1 svc=3` can no longer drive create and prune to disagree).
 		let targets: Vec<String> = pairs.iter().map(|(s, _)| s.clone()).collect();
 		self.up_with_options(file, true, &[], &targets, true, false, true)
 			.await?;
-		// Scale down: remove replicas beyond the target count.
-		for (svc, target) in pairs {
-			self.remove_surplus_replicas(svc, &file.services[svc], *target)
-				.await?;
-		}
 		Ok(())
 	}
 
 	/// Remove the containers of `service_name` whose names fall outside the
 	/// desired `target`-replica set (the scale-down half of reconciliation).
-	async fn remove_surplus_replicas(
+	/// Surplus containers are stopped and removed concurrently so a large
+	/// scale-down costs roughly one grace period rather than one per replica.
+	pub(super) async fn remove_surplus_replicas(
 		&self,
 		service_name: &str,
 		service: &Service,
@@ -116,16 +135,20 @@ impl Engine {
 			(1..=target).map(|i| format!("{base}-{i}")).collect()
 		};
 		let grace = self.grace_period_secs(service);
-		for name in self
+		let surplus: Vec<String> = self
 			.list_project_container_names(Some(service_name))
 			.await?
-		{
-			if !desired.contains(&name) {
-				// Scaling down removes surplus replicas but keeps their data
-				// volumes (only `down -v` reclaims volumes).
-				self.stop_and_remove(&name, grace, false).await;
-			}
-		}
+			.into_iter()
+			.filter(|name| !desired.contains(name))
+			.collect();
+		// Scaling down removes surplus replicas but keeps their data volumes
+		// (only `down -v` reclaims volumes).
+		futures_util::future::join_all(
+			surplus
+				.iter()
+				.map(|name| self.stop_and_remove(name, grace, false)),
+		)
+		.await;
 		Ok(())
 	}
 
@@ -238,7 +261,10 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::{check_replica_limit, check_scale_port_conflict, DEFAULT_MAX_REPLICAS};
+	use super::{
+		check_fixed_name_scale, check_replica_limit, check_scale_port_conflict,
+		DEFAULT_MAX_REPLICAS,
+	};
 
 	#[test]
 	fn replica_limit_default_and_env_override() {
@@ -304,5 +330,25 @@ mod tests {
 	fn scaled_no_ports_is_allowed() {
 		let svc = service("services:\n  worker:\n    image: x\n");
 		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
+	}
+
+	#[test]
+	fn fixed_container_name_single_replica_is_allowed() {
+		let svc = service("services:\n  app:\n    image: x\n    container_name: myapp\n");
+		assert!(check_fixed_name_scale("app", &svc, 1).is_ok());
+	}
+
+	#[test]
+	fn fixed_container_name_scaled_above_one_is_rejected() {
+		let svc = service("services:\n  app:\n    image: x\n    container_name: myapp\n");
+		let err = check_fixed_name_scale("app", &svc, 3).unwrap_err();
+		assert!(matches!(err, crate::error::ComposeError::Unsupported(_)));
+		assert!(err.to_string().contains("container_name"));
+	}
+
+	#[test]
+	fn unnamed_service_scales_freely() {
+		let svc = service("services:\n  app:\n    image: x\n");
+		assert!(check_fixed_name_scale("app", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/lifecycle/signal.rs
+++ b/internal/engine/lifecycle/signal.rs
@@ -1,0 +1,122 @@
+//! Validation for `kill -s/--signal` values.
+//!
+//! `kill` forwards the requested signal to libpod as a `signal=` query
+//! parameter. An empty (or whitespace-only) value renders as `signal=`, which
+//! libpod silently treats as the default SIGKILL — so an unset shell variable
+//! passed via `-s "$SIG"` would destroy every targeted container with no
+//! warning. To match `docker compose`'s up-front validation, the signal is
+//! checked here before any request is issued.
+
+use crate::error::{ComposeError, Result};
+
+/// Signal names podup accepts for `kill -s`, matched case-insensitively and
+/// with the `SIG` prefix optional. Covers the standard POSIX signals plus the
+/// common Linux additions Podman understands.
+const KNOWN_SIGNALS: &[&str] = &[
+	"ABRT", "ALRM", "BUS", "CHLD", "CLD", "CONT", "EMT", "FPE", "HUP", "ILL", "INT", "IO", "IOT",
+	"KILL", "LOST", "PIPE", "POLL", "PROF", "PWR", "QUIT", "RTMAX", "RTMIN", "SEGV", "STKFLT",
+	"STOP", "SYS", "TERM", "TRAP", "TSTP", "TTIN", "TTOU", "UNUSED", "URG", "USR1", "USR2",
+	"VTALRM", "WINCH", "XCPU", "XFSZ",
+];
+
+/// Validate a `kill` signal before it is forwarded to libpod.
+///
+/// Accepts a numeric signal in `1..=64` or a known signal name (case-insensitive,
+/// with or without the `SIG` prefix). Rejects an empty/whitespace-only value and
+/// any unrecognised name/number with [`ComposeError::InvalidSignal`], rather than
+/// letting it default to SIGKILL on the libpod side.
+pub(crate) fn validate_signal(signal: &str) -> Result<()> {
+	let trimmed = signal.trim();
+	if trimmed.is_empty() {
+		return Err(ComposeError::InvalidSignal(
+			"signal must not be empty".into(),
+		));
+	}
+	// A bare number is a raw signal number; restrict it to the valid range.
+	if trimmed.chars().all(|c| c.is_ascii_digit()) {
+		return match trimmed.parse::<u32>() {
+			Ok(n) if (1..=64).contains(&n) => Ok(()),
+			_ => Err(ComposeError::InvalidSignal(signal.into())),
+		};
+	}
+	let upper = trimmed.to_ascii_uppercase();
+	let name = upper.strip_prefix("SIG").unwrap_or(&upper);
+	if KNOWN_SIGNALS.contains(&name) {
+		Ok(())
+	} else {
+		Err(ComposeError::InvalidSignal(signal.into()))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::validate_signal;
+	use crate::error::ComposeError;
+
+	#[test]
+	fn accepts_common_signal_names() {
+		for s in ["SIGKILL", "SIGTERM", "SIGHUP", "SIGINT", "SIGUSR1"] {
+			assert!(validate_signal(s).is_ok(), "{s} should be accepted");
+		}
+	}
+
+	#[test]
+	fn accepts_names_without_sig_prefix_case_insensitive() {
+		assert!(validate_signal("TERM").is_ok());
+		assert!(validate_signal("term").is_ok());
+		assert!(validate_signal("Kill").is_ok());
+	}
+
+	#[test]
+	fn accepts_numeric_signals_in_range() {
+		assert!(validate_signal("9").is_ok());
+		assert!(validate_signal("15").is_ok());
+		assert!(validate_signal("1").is_ok());
+		assert!(validate_signal("64").is_ok());
+	}
+
+	#[test]
+	fn rejects_empty_signal() {
+		// The core bug: an empty signal must not be forwarded (it would default
+		// to SIGKILL on the libpod side).
+		let err = validate_signal("").unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidSignal(_)));
+		assert!(err.to_string().contains("invalid signal"));
+	}
+
+	#[test]
+	fn rejects_whitespace_only_signal() {
+		assert!(matches!(
+			validate_signal("   ").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+	}
+
+	#[test]
+	fn rejects_out_of_range_and_zero_numbers() {
+		assert!(matches!(
+			validate_signal("0").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+		assert!(matches!(
+			validate_signal("65").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+		assert!(matches!(
+			validate_signal("9999").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+	}
+
+	#[test]
+	fn rejects_unknown_signal_names() {
+		assert!(matches!(
+			validate_signal("SIGBOGUS").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+		assert!(matches!(
+			validate_signal("not-a-signal").unwrap_err(),
+			ComposeError::InvalidSignal(_)
+		));
+	}
+}

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -2,9 +2,18 @@
 //! target-list filtering, and `depends_on` expansion.
 
 use std::collections::HashSet;
+use std::time::Duration;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
+
+/// Extra wall-clock slack, beyond the grace period, before podup gives up on a
+/// stalled libpod `stop` and escalates to a client-side `SIGKILL`. Podman stops
+/// a container by sending `SIGTERM`, waiting the grace window, then `SIGKILL`
+/// itself — so a healthy stop returns at most ~`grace` seconds in. The buffer
+/// absorbs daemon/reap latency so a slow-but-working stop is never escalated;
+/// anything past it means the libpod call is wedged and we kill independently.
+const STOP_GRACE_BUFFER_SECS: u64 = 30;
 
 /// The per-service shutdown grace from `stop_grace_period` (default 10s).
 pub(super) fn service_grace_period_secs(service: &Service) -> i32 {
@@ -14,6 +23,41 @@ pub(super) fn service_grace_period_secs(service: &Service) -> i32 {
 		.and_then(crate::size::parse_duration_secs)
 		.and_then(|s| i32::try_from(s).ok())
 		.unwrap_or(10)
+}
+
+/// Validate a CLI `-t/--timeout` value at the trust boundary.
+///
+/// `-1` (docker's "wait indefinitely") and any non-negative second count are
+/// accepted; anything below `-1` is rejected with [`ComposeError::InvalidTimeout`]
+/// so it never reaches libpod as a `?t=<negative>` that surfaces a raw `HTTP 400`.
+/// Pure so the boundary check is unit-tested without a live socket.
+pub fn validate_stop_timeout(timeout: Option<i32>) -> Result<Option<i32>> {
+	match timeout {
+		Some(t) if t < -1 => Err(ComposeError::InvalidTimeout(t)),
+		other => Ok(other),
+	}
+}
+
+/// The libpod `?t=` value for a grace period. A non-negative grace passes through;
+/// `-1` ("wait indefinitely") maps to the largest value libpod accepts so podman
+/// does not escalate to `SIGKILL` on its own, matching `docker stop -t -1`. Pure.
+pub(super) fn stop_timeout_param(grace: i32) -> i64 {
+	if grace < 0 {
+		i64::from(i32::MAX)
+	} else {
+		i64::from(grace)
+	}
+}
+
+/// Client-side deadline for a `stop` call: the grace window plus
+/// [`STOP_GRACE_BUFFER_SECS`]. `-1` ("wait indefinitely") yields `None`, leaving
+/// the call uncapped like `docker stop -t -1`. Pure so the policy is unit-tested.
+pub(super) fn stop_deadline(grace: i32) -> Option<Duration> {
+	if grace < 0 {
+		None
+	} else {
+		Some(Duration::from_secs(grace as u64 + STOP_GRACE_BUFFER_SECS))
+	}
 }
 
 impl crate::engine::Engine {
@@ -113,11 +157,71 @@ pub(super) fn in_started_set(target_set: &Option<HashSet<String>>, name: &str) -
 #[cfg(test)]
 mod tests {
 	use super::{
-		expand_targets, filter_services, in_started_set, service_grace_period_secs,
-		validate_targets,
+		expand_targets, filter_services, in_started_set, service_grace_period_secs, stop_deadline,
+		stop_timeout_param, validate_stop_timeout, validate_targets, STOP_GRACE_BUFFER_SECS,
 	};
 	use crate::compose::types::{ComposeFile, Service};
+	use crate::error::ComposeError;
 	use std::collections::HashSet;
+	use std::time::Duration;
+
+	// --- validate_stop_timeout (#778) ---
+
+	#[test]
+	fn validate_stop_timeout_accepts_none_zero_and_positive() {
+		assert_eq!(validate_stop_timeout(None).unwrap(), None);
+		assert_eq!(validate_stop_timeout(Some(0)).unwrap(), Some(0));
+		assert_eq!(validate_stop_timeout(Some(30)).unwrap(), Some(30));
+	}
+
+	#[test]
+	fn validate_stop_timeout_accepts_minus_one_infinite() {
+		// -1 is docker's "wait indefinitely" sentinel and must pass through.
+		assert_eq!(validate_stop_timeout(Some(-1)).unwrap(), Some(-1));
+	}
+
+	#[test]
+	fn validate_stop_timeout_rejects_below_minus_one() {
+		// A value below -1 is rejected here rather than leaking a raw libpod 400.
+		let err = validate_stop_timeout(Some(-2)).unwrap_err();
+		assert!(matches!(err, ComposeError::InvalidTimeout(-2)));
+		assert!(validate_stop_timeout(Some(-100)).is_err());
+	}
+
+	// --- stop_timeout_param (#778) ---
+
+	#[test]
+	fn stop_timeout_param_passes_through_non_negative() {
+		assert_eq!(stop_timeout_param(0), 0);
+		assert_eq!(stop_timeout_param(10), 10);
+	}
+
+	#[test]
+	fn stop_timeout_param_maps_infinite_to_max() {
+		// -1 (infinite) maps to the largest value libpod accepts so podman never
+		// escalates to SIGKILL on its own, matching `docker stop -t -1`.
+		assert_eq!(stop_timeout_param(-1), i64::from(i32::MAX));
+	}
+
+	// --- stop_deadline (#719) ---
+
+	#[test]
+	fn stop_deadline_is_grace_plus_buffer() {
+		assert_eq!(
+			stop_deadline(10),
+			Some(Duration::from_secs(10 + STOP_GRACE_BUFFER_SECS))
+		);
+		assert_eq!(
+			stop_deadline(0),
+			Some(Duration::from_secs(STOP_GRACE_BUFFER_SECS))
+		);
+	}
+
+	#[test]
+	fn stop_deadline_infinite_is_none() {
+		// -1 leaves the stop uncapped (docker `stop -t -1` parity).
+		assert_eq!(stop_deadline(-1), None);
+	}
 
 	// --- service_grace_period_secs ---
 

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -48,6 +48,21 @@ pub(super) fn filter_services(
 		.collect())
 }
 
+/// Error if any requested target service name is absent from the file.
+///
+/// The up/create path expands targets into a set without checking membership, so
+/// a bogus name would silently match nothing and exit 0. This validates the list
+/// up front — matching docker-compose and the stop/start/kill commands, which
+/// already reject unknown services via [`filter_services`].
+pub(super) fn validate_targets(file: &ComposeFile, target_services: &[String]) -> Result<()> {
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	Ok(())
+}
+
 /// Resolve which services `up` should start given an explicit target list.
 ///
 /// Returns `None` when no targets are given (start everything). Otherwise the
@@ -97,7 +112,10 @@ pub(super) fn in_started_set(target_set: &Option<HashSet<String>>, name: &str) -
 
 #[cfg(test)]
 mod tests {
-	use super::{expand_targets, filter_services, in_started_set, service_grace_period_secs};
+	use super::{
+		expand_targets, filter_services, in_started_set, service_grace_period_secs,
+		validate_targets,
+	};
 	use crate::compose::types::{ComposeFile, Service};
 	use std::collections::HashSet;
 
@@ -175,6 +193,32 @@ mod tests {
 		assert!(matches!(
 			err,
 			crate::error::ComposeError::ServiceNotFound(_)
+		));
+	}
+
+	// --- validate_targets ---
+
+	#[test]
+	fn validate_targets_empty_is_ok() {
+		let file = file_with_services(&["a", "b"]);
+		assert!(validate_targets(&file, &[]).is_ok());
+	}
+
+	#[test]
+	fn validate_targets_known_names_ok() {
+		let file = file_with_services(&["a", "b"]);
+		assert!(validate_targets(&file, &["a".to_string(), "b".to_string()]).is_ok());
+	}
+
+	#[test]
+	fn validate_targets_unknown_name_errors() {
+		// An `up`/`create` for a service the file does not define must error
+		// rather than silently match nothing and exit 0.
+		let file = file_with_services(&["a"]);
+		let err = validate_targets(&file, &["no-such-service".to_string()]).unwrap_err();
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::ServiceNotFound(name) if name == "no-such-service"
 		));
 	}
 

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -107,11 +107,15 @@ pub(super) fn validate_targets(file: &ComposeFile, target_services: &[String]) -
 	Ok(())
 }
 
-/// Resolve which services `up` should start given an explicit target list.
+/// Resolve which services `up`/`create` should start given an explicit target
+/// list.
 ///
-/// Returns `None` when no targets are given (start everything). Otherwise the
-/// set contains the targets plus, unless `no_deps` is set, their transitive
-/// `depends_on` services.
+/// Returns `None` when no targets are given (start everything). Otherwise the set
+/// contains the targets plus, unless `no_deps` is set, their transitive
+/// `depends_on` services. Callers must validate `target_services` up front via
+/// [`validate_targets`] so a typo'd/unknown name fails loudly instead of being
+/// silently skipped — mirroring [`filter_services`] (and docker compose's "no
+/// such service").
 pub(super) fn expand_targets(
 	file: &ComposeFile,
 	target_services: &[String],

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -6,13 +6,14 @@ mod build;
 mod container;
 mod copy;
 mod events;
+pub use events::EventsOptions;
 mod image;
 pub use build::{BuildOptions, PullOptions, PushOptions};
 pub use copy::CpOptions;
-pub use image::resolve_image_digests;
+pub use image::{resolve_image_digests, CommitOptions};
 pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
-pub use query::{ExecOptions, ImagesOptions, LogsOptions, PsOptions};
+pub use query::{ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsFilterOptions, PsOptions};
 mod container_config;
 mod health;
 mod lifecycle;
@@ -21,7 +22,7 @@ mod network;
 mod profiles;
 pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};
 mod projects;
-pub use projects::{list_projects, LsOptions};
+pub use projects::{list_projects, list_projects_filtered, LsOptions};
 mod query;
 mod secrets;
 mod staging;
@@ -77,6 +78,10 @@ pub struct Engine {
 	/// to `base_dir`; empty by default. Kept off the frozen public
 	/// [`lifecycle::RunOverrides`] struct so the library API stays stable.
 	pub(super) run_env_files: Vec<String>,
+	/// CLI `docker compose run -l/--label KEY=VAL` ad-hoc labels for the one-off
+	/// `run` container; empty by default. Kept off the frozen public
+	/// [`lifecycle::RunOverrides`] struct so the library API stays stable.
+	pub(super) run_labels: Vec<String>,
 	/// CLI `up -V/--renew-anon-volumes`: when recreating a container, also remove
 	/// its old anonymous volumes instead of leaving them orphaned.
 	pub(super) renew_anon_volumes: bool,
@@ -96,6 +101,7 @@ impl Engine {
 			quiet_pull: false,
 			run_overrides: lifecycle::RunOverrides::default(),
 			run_env_files: Vec::new(),
+			run_labels: Vec::new(),
 			renew_anon_volumes: false,
 		}
 	}
@@ -113,6 +119,7 @@ impl Engine {
 			quiet_pull: false,
 			run_overrides: lifecycle::RunOverrides::default(),
 			run_env_files: Vec::new(),
+			run_labels: Vec::new(),
 			renew_anon_volumes: false,
 		}
 	}
@@ -159,6 +166,13 @@ impl Engine {
 	/// [`Engine::run`]. Resolved relative to the engine's base dir.
 	pub fn with_run_env_files(mut self, env_files: Vec<String>) -> Self {
 		self.run_env_files = env_files;
+		self
+	}
+
+	/// Set the CLI `docker compose run -l/--label KEY=VAL` ad-hoc labels for the
+	/// one-off `run` container. Builder-style; consumed by [`Engine::run`].
+	pub fn with_run_labels(mut self, labels: Vec<String>) -> Self {
+		self.run_labels = labels;
 		self
 	}
 

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -10,7 +10,7 @@ mod image;
 pub use build::{BuildOptions, PullOptions, PushOptions};
 pub use copy::CpOptions;
 pub use image::resolve_image_digests;
-pub use lifecycle::{RunOptions, RunOverrides};
+pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
 pub use query::{ExecOptions, ImagesOptions, LogsOptions, PsOptions};
 mod container_config;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -286,30 +286,42 @@ impl Engine {
 		}
 	}
 
-	/// Resolve the container name for a service replica: the 1-based `--index`
-	/// when given (erroring if out of range), else the first replica. Shared by
-	/// the replica-targeting commands (`exec`, `cp`).
+	/// Resolve the container name for a service replica from the statically
+	/// derived names: the 1-based `--index` when given (erroring if out of
+	/// range), else the first replica.
+	///
+	/// Prefer [`Engine::live_replica_name_at`] for the replica-targeting
+	/// commands (`exec`, `cp`): the static names reflect only the compose
+	/// `scale:`/`deploy.replicas` (plus a `--scale` on the *current* invocation),
+	/// so a later `cp`/`exec` would not see replicas created by a prior
+	/// `up --scale`. This variant stays for callers that cannot await.
 	pub(super) fn replica_name_at(
 		&self,
 		service_name: &str,
 		service: &Service,
 		index: Option<u32>,
 	) -> Result<String> {
-		match index {
-			Some(i) => {
-				// `--index` is 1-based; `0` is an invalid index, not "first replica".
-				let idx = (i as usize).checked_sub(1).ok_or_else(|| {
-					ComposeError::ServiceNotFound(format!(
-						"{service_name} (replica index {i}: indexes are 1-based)"
-					))
-				})?;
-				let names = self.replica_names(service_name, service);
-				names.get(idx).cloned().ok_or_else(|| {
-					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
-				})
-			}
-			None => Ok(self.first_replica_name(service_name, service)),
-		}
+		let names = self.replica_names(service_name, service);
+		let base = self.container_name(service_name, service);
+		resolve_replica_name(service_name, &base, &names, index)
+	}
+
+	/// Resolve the container name for a service replica against the *running*
+	/// scale: the replicas Podman actually has (matched by the `podup.service`
+	/// label), falling back to the statically derived names before anything is
+	/// created. `--index n` therefore targets replica `n` even when it was
+	/// created by an earlier `up --scale`/`scale` rather than the current
+	/// invocation, matching `docker compose cp/exec --index`. Shared by the
+	/// replica-targeting commands (`exec`, `cp`).
+	pub(super) async fn live_replica_name_at(
+		&self,
+		service_name: &str,
+		service: &Service,
+		index: Option<u32>,
+	) -> Result<String> {
+		let names = self.live_replica_names(service_name, service).await?;
+		let base = self.container_name(service_name, service);
+		resolve_replica_name(service_name, &base, &names, index)
 	}
 
 	/// Watch for file changes and apply the service's `develop.watch` rules. Returns an error when the `watch` feature is disabled.
@@ -319,6 +331,72 @@ impl Engine {
 			"watch requires the 'watch' feature".into(),
 		))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Replica resolution helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a replica container name from the set of names that exist for a
+/// service (the running replicas, or the statically derived names before
+/// anything is created) and a 1-based `--index`. Each name is either the
+/// unsuffixed base (the sole replica) or `{base}-{n}`.
+///
+/// `--index n` targets the replica numbered `n` — by name, not by position —
+/// so it stays correct after a runtime `scale`/`up --scale` and regardless of
+/// the order Podman lists containers; `0` is rejected (indexes are 1-based);
+/// `None` picks the lowest-numbered replica. Pure so it is unit-testable
+/// without a Podman socket.
+fn resolve_replica_name(
+	service_name: &str,
+	base: &str,
+	names: &[String],
+	index: Option<u32>,
+) -> Result<String> {
+	match index {
+		Some(0) => Err(ComposeError::ServiceNotFound(format!(
+			"{service_name} (replica index 0: indexes are 1-based)"
+		))),
+		Some(i) => {
+			let suffixed = format!("{base}-{i}");
+			if names.iter().any(|n| n == &suffixed) {
+				return Ok(suffixed);
+			}
+			// A single, unsuffixed replica answers to index 1 only.
+			if i == 1 && names.iter().any(|n| n == base) {
+				return Ok(base.to_string());
+			}
+			Err(ComposeError::ServiceNotFound(format!(
+				"{service_name} (replica index {i})"
+			)))
+		}
+		None => order_replicas(base, names)
+			.into_iter()
+			.next()
+			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into())),
+	}
+}
+
+/// Order replica container names by their 1-based replica number so callers can
+/// pick the lowest-numbered one independently of Podman's listing order. A name
+/// is the unsuffixed base (the sole replica → number 1) or `{base}-{n}`; names
+/// matching neither are dropped.
+fn order_replicas(base: &str, names: &[String]) -> Vec<String> {
+	let prefix = format!("{base}-");
+	let mut numbered: Vec<(usize, String)> = names
+		.iter()
+		.filter_map(|name| {
+			if name == base {
+				Some((1, name.clone()))
+			} else {
+				name.strip_prefix(&prefix)
+					.and_then(|s| s.parse::<usize>().ok())
+					.map(|n| (n, name.clone()))
+			}
+		})
+		.collect();
+	numbered.sort_by_key(|(n, _)| *n);
+	numbered.into_iter().map(|(_, name)| name).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -422,6 +500,84 @@ mod tests {
 		assert_eq!(
 			e.replica_name_at("web", &scaled_service(3), None).unwrap(),
 			"proj-web-1"
+		);
+	}
+
+	fn names(list: &[&str]) -> Vec<String> {
+		list.iter().map(|s| s.to_string()).collect()
+	}
+
+	#[test]
+	fn resolve_replica_targets_running_scale_not_compose_default() {
+		// The regression: a later `cp`/`exec` has no `--scale` (empty overrides),
+		// so the static count is the compose default (1). But the service was
+		// scaled up earlier and three replicas are running — `--index 2` must
+		// address the running `proj-web-2`, not fall back to the base name.
+		let live = names(&["proj-web-1", "proj-web-2", "proj-web-3"]);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(2)).unwrap(),
+			"proj-web-2"
+		);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(3)).unwrap(),
+			"proj-web-3"
+		);
+	}
+
+	#[test]
+	fn resolve_replica_is_order_independent() {
+		// Podman does not guarantee a listing order; `--index n` targets replica
+		// `n` by name, and `None` picks the lowest-numbered replica regardless.
+		let live = names(&["proj-web-3", "proj-web-1", "proj-web-2"]);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(1)).unwrap(),
+			"proj-web-1"
+		);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, None).unwrap(),
+			"proj-web-1"
+		);
+	}
+
+	#[test]
+	fn resolve_replica_out_of_range_against_running_scale() {
+		// Only two replicas running: index 3 is out of range, not a stale base.
+		let live = names(&["proj-web-1", "proj-web-2"]);
+		assert!(resolve_replica_name("web", "proj-web", &live, Some(3)).is_err());
+	}
+
+	#[test]
+	fn resolve_replica_index_zero_is_rejected() {
+		let live = names(&["proj-web-1", "proj-web-2"]);
+		let err = resolve_replica_name("web", "proj-web", &live, Some(0))
+			.expect_err("index 0 must be rejected");
+		assert!(
+			matches!(err, ComposeError::ServiceNotFound(ref m) if m.contains("1-based")),
+			"unexpected error: {err:?}"
+		);
+	}
+
+	#[test]
+	fn resolve_replica_single_unsuffixed_base() {
+		// A single, unsuffixed replica answers to index 1 (and None), never index 2.
+		let live = names(&["proj-web"]);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, None).unwrap(),
+			"proj-web"
+		);
+		assert_eq!(
+			resolve_replica_name("web", "proj-web", &live, Some(1)).unwrap(),
+			"proj-web"
+		);
+		assert!(resolve_replica_name("web", "proj-web", &live, Some(2)).is_err());
+	}
+
+	#[test]
+	fn order_replicas_sorts_by_replica_number() {
+		let live = names(&["proj-web-10", "proj-web-2", "proj-web-1"]);
+		assert_eq!(
+			order_replicas("proj-web", &live),
+			names(&["proj-web-1", "proj-web-2", "proj-web-10"])
 		);
 	}
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -371,9 +371,10 @@ fn resolve_replica_name(
 	index: Option<u32>,
 ) -> Result<String> {
 	match index {
-		Some(0) => Err(ComposeError::ServiceNotFound(format!(
-			"{service_name} (replica index 0: indexes are 1-based)"
-		))),
+		Some(0) => Err(ComposeError::ReplicaIndex {
+			service: service_name.to_string(),
+			index: 0,
+		}),
 		Some(i) => {
 			let suffixed = format!("{base}-{i}");
 			if names.iter().any(|n| n == &suffixed) {
@@ -383,9 +384,10 @@ fn resolve_replica_name(
 			if i == 1 && names.iter().any(|n| n == base) {
 				return Ok(base.to_string());
 			}
-			Err(ComposeError::ServiceNotFound(format!(
-				"{service_name} (replica index {i})"
-			)))
+			Err(ComposeError::ReplicaIndex {
+				service: service_name.to_string(),
+				index: i,
+			})
 		}
 		None => order_replicas(base, names)
 			.into_iter()
@@ -473,8 +475,14 @@ mod tests {
 			.replica_name_at("web", &svc, Some(0))
 			.expect_err("index 0 must be rejected");
 		assert!(
-			matches!(err, ComposeError::ServiceNotFound(ref m) if m.contains("1-based")),
+			matches!(err, ComposeError::ReplicaIndex { index: 0, ref service } if service == "web"),
 			"unexpected error: {err:?}"
+		);
+		// The index hint renders outside the quoted service name.
+		let msg = err.to_string();
+		assert!(
+			msg.contains("'web'") && msg.contains("1-based"),
+			"got {msg:?}"
 		);
 	}
 
@@ -569,7 +577,7 @@ mod tests {
 		let err = resolve_replica_name("web", "proj-web", &live, Some(0))
 			.expect_err("index 0 must be rejected");
 		assert!(
-			matches!(err, ComposeError::ServiceNotFound(ref m) if m.contains("1-based")),
+			matches!(err, ComposeError::ReplicaIndex { index: 0, ref service } if service == "web"),
 			"unexpected error: {err:?}"
 		);
 	}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -28,6 +28,7 @@ mod secrets;
 mod staging;
 mod stats;
 pub use staging::is_safe_project_name;
+pub use stats::StatsOptions;
 mod volume;
 pub use volume::VolumesOptions;
 mod volume_mounts;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -71,6 +71,12 @@ pub struct Engine {
 	/// CLI `run`-only flag overrides (user/workdir/entrypoint/volume/publish/
 	/// interactive/no-deps); empty by default.
 	pub(super) run_overrides: lifecycle::RunOverrides,
+	/// Global `--env-file` paths that double as `docker compose run --env-file`:
+	/// their contents seed a one-off `run` container's environment at the lowest
+	/// precedence (env-file < service `environment:` < `-e`). Resolved relative
+	/// to `base_dir`; empty by default. Kept off the frozen public
+	/// [`lifecycle::RunOverrides`] struct so the library API stays stable.
+	pub(super) run_env_files: Vec<String>,
 	/// CLI `up -V/--renew-anon-volumes`: when recreating a container, also remove
 	/// its old anonymous volumes instead of leaving them orphaned.
 	pub(super) renew_anon_volumes: bool,
@@ -89,6 +95,7 @@ impl Engine {
 			no_build: false,
 			quiet_pull: false,
 			run_overrides: lifecycle::RunOverrides::default(),
+			run_env_files: Vec::new(),
 			renew_anon_volumes: false,
 		}
 	}
@@ -105,6 +112,7 @@ impl Engine {
 			no_build: false,
 			quiet_pull: false,
 			run_overrides: lifecycle::RunOverrides::default(),
+			run_env_files: Vec::new(),
 			renew_anon_volumes: false,
 		}
 	}
@@ -142,6 +150,15 @@ impl Engine {
 	/// --no-deps`). Builder-style; consumed by [`Engine::run`].
 	pub fn with_run_overrides(mut self, overrides: RunOverrides) -> Self {
 		self.run_overrides = overrides;
+		self
+	}
+
+	/// Set the global `--env-file` paths that also seed a one-off `run`
+	/// container's environment (`docker compose run --env-file`: env-file <
+	/// service `environment:` < `-e`). Builder-style; consumed by
+	/// [`Engine::run`]. Resolved relative to the engine's base dir.
+	pub fn with_run_env_files(mut self, env_files: Vec<String>) -> Self {
+		self.run_env_files = env_files;
 		self
 	}
 

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -19,7 +19,7 @@ mod lifecycle;
 mod lock;
 mod network;
 mod profiles;
-pub use profiles::retain_active_profiles;
+pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};
 mod projects;
 pub use projects::{list_projects, LsOptions};
 mod query;

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -6,14 +6,51 @@ use crate::compose::types::{ComposeFile, Service};
 
 /// Remove services excluded by the active profile set, in place.
 ///
-/// Mirrors what `up` actually starts (a per-service profile match, with no
-/// implicit activation of a profiled `depends_on` target), so `config` presents
-/// the same service set the runtime would bring up. `active` is the CLI
-/// `--profile` list, falling back to `COMPOSE_PROFILES`.
+/// `active` is the CLI `--profile` list, falling back to `COMPOSE_PROFILES`.
+/// A profiled service that is a transitive `depends_on` target of a retained
+/// service is implicitly enabled, matching docker compose — so the output never
+/// carries a dangling dependency reference.
 pub fn retain_active_profiles(file: &mut ComposeFile, active: &[String]) {
+	retain_active_profiles_with_targets(file, active, &[]);
+}
+
+/// Like [`retain_active_profiles`], but also keeps any service named in
+/// `targets` even when its profile is inactive: naming a service on the command
+/// line activates its profile (docker compose), so per-service subcommands
+/// (`start`, `stop`, `build`, `push`, `pull`, …) can still address it.
+pub fn retain_active_profiles_with_targets(
+	file: &mut ComposeFile,
+	active: &[String],
+	targets: &[String],
+) {
 	let set = active_profiles_set(active);
-	file.services
-		.retain(|_, svc| service_in_profiles(svc, &set));
+	let named: HashSet<&str> = targets.iter().map(|s| s.as_str()).collect();
+
+	// Directly enabled: an unprofiled service, a profile match (or `*`), or a
+	// service explicitly named on the command line.
+	let mut enabled: HashSet<String> = file
+		.services
+		.iter()
+		.filter(|(name, svc)| service_in_profiles(svc, &set) || named.contains(name.as_str()))
+		.map(|(name, _)| name.clone())
+		.collect();
+
+	// Implicit activation: pull in profiled `depends_on` targets of enabled
+	// services, transitively, so a retained service never references a dropped
+	// dependency. Mirrors docker compose, which enables a profiled service that
+	// is depended on by a started one.
+	let mut stack: Vec<String> = enabled.iter().cloned().collect();
+	while let Some(name) = stack.pop() {
+		if let Some(svc) = file.services.get(&name) {
+			for dep in svc.depends_on.service_names() {
+				if file.services.contains_key(&dep) && enabled.insert(dep.clone()) {
+					stack.push(dep);
+				}
+			}
+		}
+	}
+
+	file.services.retain(|name, _| enabled.contains(name));
 }
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.
@@ -34,9 +71,14 @@ pub(super) fn active_profiles_set(active: &[String]) -> HashSet<String> {
 
 /// True if the service should be started given the active profile set.
 ///
-/// Services with no profiles always start.
+/// Services with no profiles always start. A literal `*` in the active set is a
+/// wildcard that enables every profiled service (docker compose's
+/// "enable all profiles").
 pub(super) fn service_in_profiles(service: &Service, active: &HashSet<String>) -> bool {
 	if service.profiles.is_empty() {
+		return true;
+	}
+	if active.contains("*") {
 		return true;
 	}
 	service.profiles.iter().any(|p| active.contains(p))
@@ -140,5 +182,89 @@ mod tests {
 		});
 		assert!(file.services.contains_key("web"));
 		assert_eq!(file.services.len(), 1);
+	}
+
+	#[test]
+	fn wildcard_enables_all_profiles() {
+		// `--profile '*'` enables every profiled service, matching docker compose.
+		let svc = Service {
+			profiles: vec!["debug".to_string()],
+			..Default::default()
+		};
+		let active: HashSet<String> = ["*".to_string()].into();
+		assert!(service_in_profiles(&svc, &active));
+
+		let yaml = "services:\n  \
+			web:\n    image: x\n  \
+			debugger:\n    image: x\n    profiles: [debug]\n  \
+			db:\n    image: x\n    profiles: [prod]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		retain_active_profiles(&mut file, &["*".to_string()]);
+		assert_eq!(file.services.len(), 3);
+	}
+
+	#[test]
+	fn implicit_activation_keeps_profiled_dependency() {
+		// `app` (active) depends on `db` (profiles: [storage]). With no profile
+		// active, `db` is implicitly enabled so `app` keeps a satisfiable dep —
+		// no dangling reference, matching docker compose.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert!(file.services.contains_key("app"));
+		assert!(
+			file.services.contains_key("db"),
+			"profiled depends_on target is implicitly activated"
+		);
+	}
+
+	#[test]
+	fn implicit_activation_is_transitive() {
+		// app -> db -> storage, where both db and storage are profiled. Enabling
+		// app must pull in the whole transitive dependency chain.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [p]\n    depends_on: [storage]\n  \
+			storage:\n    image: x\n    profiles: [q]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert_eq!(file.services.len(), 3);
+	}
+
+	#[test]
+	fn unrelated_profiled_service_still_dropped() {
+		// Implicit activation only reaches dependencies — an unrelated profiled
+		// service is still removed.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n  \
+			extra:\n    image: x\n    profiles: [other]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles(&mut file, &[]);
+		});
+		assert!(file.services.contains_key("db"));
+		assert!(!file.services.contains_key("extra"));
+	}
+
+	#[test]
+	fn named_target_keeps_inactive_profile_service() {
+		// Naming a profiled service on the command line activates its profile, so
+		// per-service subcommands can still address it.
+		let yaml = "services:\n  \
+			web:\n    image: x\n  \
+			debugger:\n    image: x\n    profiles: [debug]\n";
+		let mut file = crate::parse_str(yaml).unwrap();
+		temp_env::with_var_unset("COMPOSE_PROFILES", || {
+			retain_active_profiles_with_targets(&mut file, &[], &["debugger".to_string()]);
+		});
+		assert!(file.services.contains_key("web"));
+		assert!(file.services.contains_key("debugger"));
 	}
 }

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -29,9 +29,19 @@ fn is_running(status: &str) -> bool {
 	s.eq_ignore_ascii_case("running") || s.to_ascii_lowercase().starts_with("up")
 }
 
-/// A project's roll-up: running and total replica counts.
+/// Whether a libpod `Status`/`State` string denotes a paused container. Podman
+/// reports `"paused"` for the machine state and `"Paused"` in the human status.
+/// Pure so it can be unit-tested. `docker compose ls` surfaces this state rather
+/// than hiding the project or mislabelling it as exited.
+fn is_paused(status: &str) -> bool {
+	status.trim().to_ascii_lowercase().starts_with("paus")
+}
+
+/// A project's roll-up: running, paused, and total replica counts. Stopped
+/// replicas are the remainder (`total - running - paused`).
 struct Tally {
 	running: usize,
+	paused: usize,
 	total: usize,
 }
 
@@ -57,19 +67,26 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 		};
 		let tally = projects.entry(project.clone()).or_insert(Tally {
 			running: 0,
+			paused: 0,
 			total: 0,
 		});
 		tally.total += 1;
 		// Podman's libpod list leaves `Status` empty and uses `State`; accept
-		// either so the roll-up is robust across response shapes.
+		// either so the roll-up is robust across response shapes. A paused
+		// container is counted separately so it is neither hidden nor mislabelled
+		// as exited.
 		if is_running(&c.state) || is_running(&c.status) {
 			tally.running += 1;
+		} else if is_paused(&c.state) || is_paused(&c.status) {
+			tally.paused += 1;
 		}
 	}
 
+	// A project is "active" (shown without `--all`) when any replica is running
+	// or paused; only all-stopped projects are hidden by default.
 	let rows: Vec<(&String, &Tally)> = projects
 		.iter()
-		.filter(|(_, t)| opts.all || t.running > 0)
+		.filter(|(_, t)| opts.all || t.running > 0 || t.paused > 0)
 		.collect();
 
 	if opts.quiet {
@@ -80,10 +97,7 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 	}
 
 	if opts.json {
-		let arr: Vec<_> = rows
-			.iter()
-			.map(|(name, t)| serde_json::json!({ "Name": name, "Status": status_label(t) }))
-			.collect();
+		let arr: Vec<_> = rows.iter().map(|(name, t)| project_row(name, t)).collect();
 		println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
 		return Ok(());
 	}
@@ -96,14 +110,37 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 	Ok(())
 }
 
-/// `running(N)` when any replica is up, else `exited(N)` — mirrors the
-/// `docker compose ls` status column.
+/// Per-state replica counts joined as `running(2), paused(1), exited(1)` —
+/// mirrors the `docker compose ls` status column, which surfaces each state
+/// rather than collapsing to a single running count and discarding the rest.
 fn status_label(t: &Tally) -> String {
+	let exited = t.total.saturating_sub(t.running).saturating_sub(t.paused);
+	let mut parts = Vec::new();
 	if t.running > 0 {
-		format!("running({})", t.running)
-	} else {
-		format!("exited({})", t.total)
+		parts.push(format!("running({})", t.running));
 	}
+	if t.paused > 0 {
+		parts.push(format!("paused({})", t.paused));
+	}
+	if exited > 0 {
+		parts.push(format!("exited({exited})"));
+	}
+	if parts.is_empty() {
+		// No replicas at all (an edge case); report a zero exited count.
+		parts.push(format!("exited({})", t.total));
+	}
+	parts.join(", ")
+}
+
+/// One `ls --format json` row. `ConfigFiles` is always present for parity with
+/// `docker compose ls --format json`; podup discovers projects by container
+/// label and tracks no compose path per project, so the field is empty.
+fn project_row(name: &str, t: &Tally) -> serde_json::Value {
+	serde_json::json!({
+		"Name": name,
+		"Status": status_label(t),
+		"ConfigFiles": "",
+	})
 }
 
 #[cfg(test)]
@@ -115,26 +152,80 @@ mod tests {
 		for up in ["running", "Up 2 minutes", "UP", "up about an hour"] {
 			assert!(is_running(up), "{up} should be running");
 		}
-		for down in ["exited", "Exited (0) 3s ago", "created", "", "stopped"] {
+		for down in [
+			"exited",
+			"Exited (0) 3s ago",
+			"created",
+			"",
+			"stopped",
+			"paused",
+		] {
 			assert!(!is_running(down), "{down} should not be running");
 		}
 	}
 
 	#[test]
-	fn status_label_reflects_running_then_total() {
+	fn is_paused_detects_paused_statuses() {
+		for p in ["paused", "Paused", "PAUSED"] {
+			assert!(is_paused(p), "{p} should be paused");
+		}
+		for other in ["running", "exited", "created", ""] {
+			assert!(!is_paused(other), "{other} should not be paused");
+		}
+	}
+
+	#[test]
+	fn status_label_emits_per_state_counts() {
+		// Mixed running + stopped keeps both counts instead of dropping the down one.
 		assert_eq!(
 			status_label(&Tally {
 				running: 2,
+				paused: 0,
 				total: 3
 			}),
-			"running(2)"
+			"running(2), exited(1)"
+		);
+		// A paused project is labelled paused, not exited.
+		assert_eq!(
+			status_label(&Tally {
+				running: 0,
+				paused: 1,
+				total: 1
+			}),
+			"paused(1)"
+		);
+		// All up, all states present.
+		assert_eq!(
+			status_label(&Tally {
+				running: 1,
+				paused: 1,
+				total: 3
+			}),
+			"running(1), paused(1), exited(1)"
 		);
 		assert_eq!(
 			status_label(&Tally {
 				running: 0,
+				paused: 0,
 				total: 3
 			}),
 			"exited(3)"
 		);
+	}
+
+	#[test]
+	fn project_row_includes_config_files_field() {
+		let row = project_row(
+			"web",
+			&Tally {
+				running: 1,
+				paused: 0,
+				total: 1,
+			},
+		);
+		assert_eq!(row["Name"], "web");
+		assert_eq!(row["Status"], "running(1)");
+		// Present for docker-compose parity even though podup tracks no path.
+		assert_eq!(row["ConfigFiles"], "");
 	}
 }

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -143,11 +143,13 @@ pub async fn list_projects_filtered(
 		return Ok(());
 	}
 
-	crate::ui::print_bold_header(&format!("{:<32} {:<20}", "NAME", "STATUS"));
+	let mut table = crate::ui::Table::new(&["NAME", "STATUS"])
+		.cap(0, 48)
+		.status_col(1);
 	for (name, t) in &rows {
-		let status = crate::ui::status_cell(&status_label(t), 20);
-		println!("{name:<32} {status}");
+		table.push(vec![name.to_string(), status_label(t)]);
 	}
+	table.print();
 	Ok(())
 }
 

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -21,6 +21,29 @@ pub struct LsOptions {
 	pub json: bool,
 }
 
+/// Split `ls --filter KEY=VALUE` predicates into name, status, and unknown
+/// buckets. Pure so it is unit-tested.
+fn split_ls_filters(filters: &[String]) -> (Vec<String>, Vec<String>, Vec<String>) {
+	let (mut names, mut status, mut unknown) = (Vec::new(), Vec::new(), Vec::new());
+	for f in filters {
+		match f.split_once('=') {
+			Some(("name", v)) => names.push(v.to_string()),
+			Some(("status", v)) => status.push(v.to_ascii_lowercase()),
+			_ => unknown.push(f.clone()),
+		}
+	}
+	(names, status, unknown)
+}
+
+/// Whether a project row passes the parsed name/status filters. `running` is the
+/// project's roll-up running flag. Pure so it is unit-tested.
+fn ls_row_matches(name: &str, running: bool, names: &[String], status: &[String]) -> bool {
+	let name_ok = names.is_empty() || names.iter().any(|n| name.contains(n.as_str()));
+	let status_word = if running { "running" } else { "exited" };
+	let status_ok = status.is_empty() || status.iter().any(|s| s == status_word);
+	name_ok && status_ok
+}
+
 /// Whether a libpod `Status` string denotes a running container. Podman reports
 /// `"running"` (or a human `"Up …"`) for live containers and `"exited"`/`"Exited
 /// …"`/`"created"` otherwise. Pure so it can be unit-tested.
@@ -48,11 +71,23 @@ struct Tally {
 /// List podup projects on the host (`docker compose ls`). Groups every
 /// `podup.project`-labelled container by project; by default shows only
 /// projects with at least one running container (`all` includes stopped ones).
+/// For the `--filter name=/status=` predicates use [`list_projects_filtered`].
 pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
-	let filters = serde_json::json!({ "label": ["podup.project"] });
+	list_projects_filtered(client, opts, &[]).await
+}
+
+/// List podup projects (`docker compose ls`) narrowed by `--filter` predicates
+/// (`name=<NAME>`, `status=<running|exited>`). The `filters` slice is kept off
+/// the frozen [`LsOptions`] struct so the 1.0 library API stays stable.
+pub async fn list_projects_filtered(
+	client: &Client,
+	opts: LsOptions,
+	filters: &[String],
+) -> Result<()> {
+	let label_filters = serde_json::json!({ "label": ["podup.project"] });
 	let path = format!(
 		"{API_PREFIX}/containers/json?all=true&filters={}",
-		urlencoded(&filters.to_string()),
+		urlencoded(&label_filters.to_string()),
 	);
 	let containers = client
 		.get_json::<Vec<ContainerListEntry>>(&path)
@@ -82,11 +117,17 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 		}
 	}
 
+	let (name_filter, status_filter, unknown) = split_ls_filters(filters);
+	for u in &unknown {
+		tracing::warn!("ls: ignoring unsupported filter '{u}'");
+	}
 	// A project is "active" (shown without `--all`) when any replica is running
-	// or paused; only all-stopped projects are hidden by default.
+	// or paused; only all-stopped projects are hidden by default. The `--filter`
+	// name=/status= predicates further narrow the shown rows.
 	let rows: Vec<(&String, &Tally)> = projects
 		.iter()
 		.filter(|(_, t)| opts.all || t.running > 0 || t.paused > 0)
+		.filter(|(name, t)| ls_row_matches(name, t.running > 0, &name_filter, &status_filter))
 		.collect();
 
 	if opts.quiet {
@@ -162,6 +203,31 @@ mod tests {
 		] {
 			assert!(!is_running(down), "{down} should not be running");
 		}
+	}
+
+	#[test]
+	fn split_ls_filters_buckets_and_flags_unknown() {
+		let (names, status, unknown) = split_ls_filters(&[
+			"name=web".to_string(),
+			"status=RUNNING".to_string(),
+			"bogus=1".to_string(),
+		]);
+		assert_eq!(names, vec!["web".to_string()]);
+		assert_eq!(status, vec!["running".to_string()]);
+		assert_eq!(unknown, vec!["bogus=1".to_string()]);
+	}
+
+	#[test]
+	fn ls_row_matches_applies_name_and_status() {
+		// No filters → always matches.
+		assert!(ls_row_matches("app", true, &[], &[]));
+		// name substring.
+		assert!(ls_row_matches("myapp", true, &["app".to_string()], &[]));
+		assert!(!ls_row_matches("other", true, &["app".to_string()], &[]));
+		// status word.
+		assert!(ls_row_matches("app", true, &[], &["running".to_string()]));
+		assert!(!ls_row_matches("app", false, &[], &["running".to_string()]));
+		assert!(ls_row_matches("app", false, &[], &["exited".to_string()]));
 	}
 
 	#[test]

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -13,6 +13,18 @@ use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
 
+/// Ceiling on how long to wait for the libpod exec-start *response head*. A
+/// healthy engine returns it almost instantly — either the hijacked stream or a
+/// prompt error (e.g. HTTP 500 "unable to find user … no matching entries in
+/// passwd file"). When the target user/workdir does not resolve, some engine
+/// builds instead stall before answering, which the default client read timeout
+/// would only abort after ~120s and then report as a misleading socket-timeout.
+/// Bounding the head here lets [`Engine::exec_with_options`] fail fast with a
+/// clear, exec-specific message. It covers only the head; the streamed exec
+/// output is left unbounded so a legitimate long-running command runs to
+/// completion.
+const EXEC_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
 #[derive(Default)]
 pub struct ExecOptions {
@@ -78,6 +90,33 @@ fn map_not_running(e: crate::libpod::PodmanError, service_name: &str) -> Compose
 	} else {
 		ComposeError::Podman(e)
 	}
+}
+
+/// Translate a failure *starting* the exec session into a clear error. A
+/// client-side timeout means the libpod exec-start never returned its response
+/// head within [`EXEC_START_TIMEOUT`] — almost always a wedged launch (e.g. a
+/// nonexistent `--user`/`--workdir` the server stalls resolving) rather than an
+/// unhealthy socket, so surface that with the likely cause instead of the
+/// generic "timed out waiting for the Podman socket" message. Every other error
+/// — including the prompt HTTP error an engine *does* return for a bad user
+/// ("unable to find user … no matching entries in passwd file") — passes through
+/// unchanged so legitimate diagnostics are never masked. Pure so it is
+/// unit-tested.
+fn map_exec_start_err(e: crate::libpod::PodmanError, opts: &ExecOptions) -> ComposeError {
+	if e.is_timeout() {
+		let cause = if let Some(user) = &opts.user {
+			format!(" (the requested user '{user}' may not exist in the container)")
+		} else if let Some(dir) = &opts.workdir {
+			format!(" (the requested working directory '{dir}' may not exist)")
+		} else {
+			String::new()
+		};
+		return ComposeError::ExecFailed(format!(
+			"the exec session did not start within {}s{cause}",
+			EXEC_START_TIMEOUT.as_secs()
+		));
+	}
+	ComposeError::Podman(e)
 }
 
 impl Engine {
@@ -151,9 +190,9 @@ impl Engine {
 			let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
 			let _ = self
 				.client
-				.post_json_stream(&start_path, &start_cfg)
+				.post_json_stream_within(&start_path, &start_cfg, Some(EXEC_START_TIMEOUT))
 				.await
-				.map_err(ComposeError::Podman)?;
+				.map_err(|e| map_exec_start_err(e, &opts))?;
 			return Ok(());
 		}
 
@@ -164,9 +203,9 @@ impl Engine {
 		let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
 		let start_resp = self
 			.client
-			.post_json_stream(&start_path, &start_cfg)
+			.post_json_stream_within(&start_path, &start_cfg, Some(EXEC_START_TIMEOUT))
 			.await
-			.map_err(ComposeError::Podman)?;
+			.map_err(|e| map_exec_start_err(e, &opts))?;
 		let mut stream = crate::libpod::parse_multiplexed(start_resp.into_body());
 
 		// Lock stdout once for the whole stream instead of re-acquiring the lock
@@ -216,7 +255,10 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::{expand_exec_env, is_exec_teardown_noise, map_not_running};
+	use super::{
+		expand_exec_env, is_exec_teardown_noise, map_exec_start_err, map_not_running, ExecOptions,
+		EXEC_START_TIMEOUT,
+	};
 
 	#[test]
 	fn expand_exec_env_passes_through_key_value() {
@@ -276,5 +318,76 @@ mod tests {
 			map_not_running(other, "web"),
 			ComposeError::Podman(_)
 		));
+	}
+
+	#[test]
+	fn exec_start_timeout_with_user_names_the_user() {
+		use crate::libpod::PodmanError;
+		// A client-side head timeout (the wedged-launch symptom) becomes a clear,
+		// fast ExecFailed naming the likely culprit — never the raw socket-timeout.
+		let timeout = PodmanError::Api {
+			status: 0,
+			message: format!(
+				"timed out after {}s waiting for the Podman socket to respond",
+				EXEC_START_TIMEOUT.as_secs()
+			),
+		};
+		let opts = ExecOptions {
+			user: Some("doesnotexist".into()),
+			..Default::default()
+		};
+		let mapped = map_exec_start_err(timeout, &opts);
+		match mapped {
+			crate::error::ComposeError::ExecFailed(msg) => {
+				assert!(msg.contains("doesnotexist"), "got {msg}");
+				assert!(msg.contains("did not start"), "got {msg}");
+				assert!(
+					!msg.to_ascii_lowercase().contains("podman socket"),
+					"must not leak the socket-timeout wording: {msg}"
+				);
+			}
+			other => panic!("expected ExecFailed, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn exec_start_timeout_without_user_names_the_workdir() {
+		use crate::libpod::PodmanError;
+		let timeout = PodmanError::Api {
+			status: 0,
+			message: "timed out after 20s waiting for the Podman socket to respond".into(),
+		};
+		let opts = ExecOptions {
+			workdir: Some("/no/such/dir".into()),
+			..Default::default()
+		};
+		match map_exec_start_err(timeout, &opts) {
+			crate::error::ComposeError::ExecFailed(msg) => {
+				assert!(msg.contains("/no/such/dir"), "got {msg}");
+			}
+			other => panic!("expected ExecFailed, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn exec_start_real_api_error_passes_through() {
+		use crate::error::ComposeError;
+		use crate::libpod::PodmanError;
+		// The prompt HTTP error an engine returns for a bad user is a genuine
+		// diagnostic and must reach the user verbatim, not be rewritten.
+		let api = PodmanError::Api {
+			status: 500,
+			message: "unable to find user doesnotexist: no matching entries in passwd file".into(),
+		};
+		let opts = ExecOptions {
+			user: Some("doesnotexist".into()),
+			..Default::default()
+		};
+		match map_exec_start_err(api, &opts) {
+			ComposeError::Podman(e) => {
+				assert!(e.to_string().contains("no matching entries in passwd file"));
+			}
+			other => panic!("expected Podman passthrough, got {other:?}"),
+		}
 	}
 }

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -1,0 +1,225 @@
+//! `exec` command: run a command inside a service container.
+
+use std::io::Write;
+
+use futures_util::StreamExt;
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::exec::{
+	ExecCreateConfig, ExecCreateResponse, ExecInspect, ExecStartConfig,
+};
+use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
+
+use super::Engine;
+
+/// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
+#[derive(Default)]
+pub struct ExecOptions {
+	/// Extra environment variables (`KEY=VAL`), `-e/--env`.
+	pub env: Vec<String>,
+	/// Run as this user, `-u/--user`.
+	pub user: Option<String>,
+	/// Working directory inside the container, `-w/--workdir`.
+	pub workdir: Option<String>,
+	/// Run with extended privileges, `--privileged`.
+	pub privileged: bool,
+	/// Detach: start the exec and return without streaming output, `-d/--detach`.
+	pub detach: bool,
+	/// 1-based replica index for a scaled service, `--index` (default: first).
+	pub index: Option<u32>,
+}
+
+/// Build the exec environment list, expanding a bare `KEY` (no `=`) from podup's
+/// own environment the way docker-compose does. A `KEY=VALUE` entry passes
+/// through unchanged; a value-less `KEY` is replaced with `KEY=<host value>` and
+/// dropped entirely when the variable is unset (libpod rejects a bare key with
+/// HTTP 400). Pure so it is unit-tested without a container.
+fn expand_exec_env(env: &[String]) -> Vec<String> {
+	env.iter()
+		.filter_map(|e| {
+			if e.contains('=') {
+				Some(e.clone())
+			} else {
+				std::env::var(e).ok().map(|v| format!("{e}={v}"))
+			}
+		})
+		.collect()
+}
+
+/// True for the in-band stream-teardown line Podman/conmon emits on the exec
+/// stderr channel when an exec launch fails (e.g. a bad `--workdir`/`--user`):
+/// a secondary `read unixpacket ... connection reset by peer` frame that adds
+/// nothing to the real diagnostic. Matching is deliberately narrow so ordinary
+/// program output is never suppressed.
+fn is_exec_teardown_noise(line: &str) -> bool {
+	line.contains("unixpacket") && line.contains("connection reset by peer")
+}
+
+impl Engine {
+	/// Run a command in the first replica of the named service with default
+	/// options. Exits with the command's exit code.
+	pub async fn exec(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		cmd: Vec<String>,
+	) -> Result<()> {
+		self.exec_with_options(file, service_name, cmd, ExecOptions::default())
+			.await
+	}
+
+	/// Run a command in a service container with `docker compose exec`-style
+	/// overrides (env, user, workdir, privileged, detach, replica index).
+	pub async fn exec_with_options(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		cmd: Vec<String>,
+		opts: ExecOptions,
+	) -> Result<()> {
+		// An empty command would be forwarded as an empty `cmd` and surface a raw
+		// podman HTTP 500; reject it up front with a clear message.
+		if cmd.is_empty() {
+			return Err(ComposeError::Unsupported(
+				"exec: a command is required".into(),
+			));
+		}
+		let service = file
+			.services
+			.get(service_name)
+			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
+		// Resolve the target replica through the shared helper so `--index 0` (and
+		// out-of-range indexes) are rejected consistently with `cp`/`port`/etc.,
+		// rather than aliasing index 0 to the first replica.
+		let container_name = self.replica_name_at(service_name, service, opts.index)?;
+
+		let env = expand_exec_env(&opts.env);
+		let exec_cfg = ExecCreateConfig {
+			cmd: Some(cmd),
+			attach_stdout: Some(true),
+			attach_stderr: Some(true),
+			user: opts.user.clone(),
+			working_dir: opts.workdir.clone(),
+			privileged: opts.privileged.then_some(true),
+			env: (!env.is_empty()).then_some(env),
+			..Default::default()
+		};
+		let create_path = format!(
+			"{API_PREFIX}/containers/{}/exec",
+			urlencoded(&container_name),
+		);
+		let resp: ExecCreateResponse = self
+			.client
+			.post_json(&create_path, &exec_cfg)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let exec_id = resp.id;
+
+		// `-d/--detach`: start the exec and return without streaming output or
+		// waiting for the exit code. The server returns immediately, so the
+		// response body is dropped.
+		if opts.detach {
+			let start_cfg = ExecStartConfig {
+				detach: true,
+				tty: false,
+			};
+			let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
+			let _ = self
+				.client
+				.post_json_stream(&start_path, &start_cfg)
+				.await
+				.map_err(ComposeError::Podman)?;
+			return Ok(());
+		}
+
+		let start_cfg = ExecStartConfig {
+			detach: false,
+			tty: false,
+		};
+		let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
+		let start_resp = self
+			.client
+			.post_json_stream(&start_path, &start_cfg)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let mut stream = crate::libpod::parse_multiplexed(start_resp.into_body());
+
+		// Lock stdout once for the whole stream instead of re-acquiring the lock
+		// (and issuing a syscall) per frame; stdout is ours exclusively on this
+		// path. stderr is locked per frame because the tracing subscriber also
+		// writes there: holding its lock across the await loop would starve
+		// concurrent log emissions. Flush after each frame so exec streams
+		// promptly.
+		{
+			let mut out = std::io::stdout().lock();
+			while let Some(msg) = stream.next().await {
+				match msg.map_err(ComposeError::Podman)? {
+					LogOutput::StdOut { message } => {
+						let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
+						let _ = out.flush();
+					}
+					LogOutput::StdErr { message } => {
+						let text = String::from_utf8_lossy(&message);
+						// Drop the spurious connection-reset teardown frame an OCI
+						// exec launch-failure emits, so only the real diagnostic shows.
+						if is_exec_teardown_noise(&text) {
+							continue;
+						}
+						let mut err = std::io::stderr().lock();
+						let _ = err.write_all(text.as_bytes());
+						let _ = err.flush();
+					}
+				}
+			}
+		}
+
+		let inspect_path = format!("{API_PREFIX}/exec/{}/json", urlencoded(&exec_id));
+		let inspect: ExecInspect = self
+			.client
+			.get_json(&inspect_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		if let Some(code) = inspect.exit_code {
+			if code != 0 {
+				return Err(ComposeError::RunExited(code));
+			}
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{expand_exec_env, is_exec_teardown_noise};
+
+	#[test]
+	fn expand_exec_env_passes_through_key_value() {
+		let out = expand_exec_env(&["FOO=bar".to_string(), "BAZ=qux".to_string()]);
+		assert_eq!(out, vec!["FOO=bar".to_string(), "BAZ=qux".to_string()]);
+	}
+
+	#[test]
+	fn expand_exec_env_resolves_bare_key_from_host() {
+		// A bare `KEY` takes its value from podup's own environment; an unset bare
+		// key is dropped (libpod rejects a value-less env entry).
+		std::env::set_var("PODUP_TEST_EXEC_ENV", "from-host");
+		let out = expand_exec_env(&[
+			"PODUP_TEST_EXEC_ENV".to_string(),
+			"PODUP_TEST_EXEC_UNSET_ENV".to_string(),
+		]);
+		std::env::remove_var("PODUP_TEST_EXEC_ENV");
+		assert_eq!(out, vec!["PODUP_TEST_EXEC_ENV=from-host".to_string()]);
+	}
+
+	#[test]
+	fn teardown_noise_matches_only_connection_reset_frame() {
+		assert!(is_exec_teardown_noise(
+			"read unixpacket @->/run/...: read: connection reset by peer"
+		));
+		// Ordinary program output is never suppressed.
+		assert!(!is_exec_teardown_noise("connection reset by peer"));
+		assert!(!is_exec_teardown_noise("hello world"));
+	}
+}

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -56,6 +56,30 @@ fn is_exec_teardown_noise(line: &str) -> bool {
 	line.contains("unixpacket") && line.contains("connection reset by peer")
 }
 
+/// Map a libpod error from an `exec` target into a friendly
+/// [`ComposeError::NotRunning`] when it means the container is absent (404) or
+/// stopped ("can only create exec sessions on running containers"), so the user
+/// sees "service X is not running" instead of a raw HTTP 404/500. Any other
+/// failure passes through unchanged. Pure so it is unit-tested.
+fn map_not_running(e: crate::libpod::PodmanError, service_name: &str) -> ComposeError {
+	let not_running = e.is_status(404)
+		|| matches!(
+			&e,
+			crate::libpod::PodmanError::Api { message, .. }
+				if {
+					let m = message.to_ascii_lowercase();
+					m.contains("can only create exec sessions on running containers")
+						|| m.contains("is not running")
+						|| m.contains("no such container")
+				}
+		);
+	if not_running {
+		ComposeError::NotRunning(service_name.to_string())
+	} else {
+		ComposeError::Podman(e)
+	}
+}
+
 impl Engine {
 	/// Run a command in the first replica of the named service with default
 	/// options. Exits with the command's exit code.
@@ -113,7 +137,7 @@ impl Engine {
 			.client
 			.post_json(&create_path, &exec_cfg)
 			.await
-			.map_err(ComposeError::Podman)?;
+			.map_err(|e| map_not_running(e, service_name))?;
 		let exec_id = resp.id;
 
 		// `-d/--detach`: start the exec and return without streaming output or
@@ -192,7 +216,7 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-	use super::{expand_exec_env, is_exec_teardown_noise};
+	use super::{expand_exec_env, is_exec_teardown_noise, map_not_running};
 
 	#[test]
 	fn expand_exec_env_passes_through_key_value() {
@@ -221,5 +245,36 @@ mod tests {
 		// Ordinary program output is never suppressed.
 		assert!(!is_exec_teardown_noise("connection reset by peer"));
 		assert!(!is_exec_teardown_noise("hello world"));
+	}
+
+	#[test]
+	fn map_not_running_maps_404_and_stopped() {
+		use crate::error::ComposeError;
+		use crate::libpod::PodmanError;
+		let e404 = PodmanError::Api {
+			status: 404,
+			message: "no such container: web".into(),
+		};
+		assert!(matches!(
+			map_not_running(e404, "web"),
+			ComposeError::NotRunning(s) if s == "web"
+		));
+		let e500 = PodmanError::Api {
+			status: 500,
+			message: "can only create exec sessions on running containers".into(),
+		};
+		assert!(matches!(
+			map_not_running(e500, "web"),
+			ComposeError::NotRunning(_)
+		));
+		// An unrelated error passes through unchanged.
+		let other = PodmanError::Api {
+			status: 500,
+			message: "disk full".into(),
+		};
+		assert!(matches!(
+			map_not_running(other, "web"),
+			ComposeError::Podman(_)
+		));
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -207,10 +207,14 @@ impl Engine {
 			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
 				continue;
 			}
-			let image_ref = match &service.image {
-				Some(img) => img.clone(),
-				None if service.build.is_some() => format!("{name}:latest"),
-				None => continue,
+			let image_ref = match (&service.image, &service.build) {
+				(Some(img), _) => img.clone(),
+				// A build-only service's image is the tag the build step produced
+				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
+				(None, Some(build)) => {
+					super::super::build::primary_build_tag(&self.project, name, None, build.tags())
+				}
+				(None, None) => continue,
 			};
 			let (repo, tag) = split_repo_tag(&image_ref);
 			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -33,7 +33,10 @@ impl Engine {
 					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
 				}
 			}
-			target_services.to_vec()
+			// Deduplicate repeated positionals (`top web web`) preserving order, so
+			// a service's process block is not rendered twice — matching docker
+			// compose top.
+			dedup_preserving_order(target_services)
 		};
 
 		let mut json_rows: Vec<serde_json::Value> = Vec::new();
@@ -56,12 +59,15 @@ impl Engine {
 					})),
 					Ok(result) => {
 						crate::ui::print_bold_header(&container_name);
-						if let Some(titles) = &result.titles {
-							crate::ui::print_bold_header(&titles.join("\t"));
-						}
-						if let Some(processes) = &result.processes {
-							for row in processes {
-								println!("{}", row.join("\t"));
+						// Space-pad columns to the widest cell (header + rows) rather
+						// than tab-joining, so the table is aligned as the help promises.
+						let titles = result.titles.clone().unwrap_or_default();
+						let processes = result.processes.clone().unwrap_or_default();
+						let aligned = align_top_columns(&titles, &processes);
+						if let Some((header, rows)) = aligned.split_first() {
+							crate::ui::print_bold_header(header);
+							for row in rows {
+								println!("{row}");
 							}
 						}
 					}
@@ -158,23 +164,30 @@ impl Engine {
 				None if service.build.is_some() => format!("{name}:latest"),
 				None => continue,
 			};
+			let (repo, tag) = split_repo_tag(&image_ref);
 			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
 			match self.client.get_json::<ImageInspect>(&path).await {
 				Ok(img) => {
-					let (repo, tag) = image_ref
-						.rsplit_once(':')
-						.map(|(r, t)| (r.to_string(), t.to_string()))
-						.unwrap_or_else(|| (image_ref.clone(), "latest".to_string()));
 					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
 					rows.push((name.clone(), repo, tag, id.to_string()));
 				}
-				Err(e) => tracing::warn!("images {name}: {e}"),
+				// An image not present locally is listed with an empty ID rather
+				// than silently dropped, so the output is never quietly incomplete.
+				Err(e) => {
+					tracing::warn!("images {name}: {e}");
+					rows.push((name.clone(), repo, tag, String::new()));
+				}
 			}
 		}
 
 		if opts.quiet {
+			// Deduplicate IDs so services sharing an image emit it once, like
+			// docker compose images -q. Empty IDs (not-pulled) are skipped.
+			let mut seen = std::collections::HashSet::new();
 			for (_, _, _, id) in &rows {
-				println!("{id}");
+				if !id.is_empty() && seen.insert(id.as_str()) {
+					println!("{id}");
+				}
 			}
 			return Ok(());
 		}
@@ -358,9 +371,125 @@ fn parse_port_proto<'a>(private_port: &'a str, proto_flag: &'a str) -> Result<(u
 	Ok((port, proto))
 }
 
+/// Deduplicate a list of strings, preserving first-seen order.
+fn dedup_preserving_order(items: &[String]) -> Vec<String> {
+	let mut seen = std::collections::HashSet::new();
+	items
+		.iter()
+		.filter(|s| seen.insert(s.as_str()))
+		.cloned()
+		.collect()
+}
+
+/// Split an image reference into `(repository, tag)` for the `images` table.
+///
+/// A trailing `:tag` is only a tag when the segment after it has no `/` (so a
+/// `registry:port/name` host is not mis-split), mirroring the guard in
+/// `export.rs`. A `name@sha256:...` digest reference has no tag, shown as
+/// `<none>` like docker, and the long digest never bloats the TAG column.
+fn split_repo_tag(image_ref: &str) -> (String, String) {
+	if let Some((repo, _digest)) = image_ref.split_once('@') {
+		return (repo.to_string(), "<none>".to_string());
+	}
+	match image_ref.rsplit_once(':') {
+		Some((repo, tag)) if !tag.contains('/') => (repo.to_string(), tag.to_string()),
+		_ => (image_ref.to_string(), "latest".to_string()),
+	}
+}
+
+/// Align a `top` table (the title row followed by process rows) into
+/// space-padded columns sized to the widest cell, returning one rendered line
+/// per input row (titles first). All but the last column are left-padded; the
+/// last is left ragged to avoid trailing whitespace.
+fn align_top_columns(titles: &[String], processes: &[Vec<String>]) -> Vec<String> {
+	let mut rows: Vec<&[String]> = Vec::with_capacity(processes.len() + 1);
+	if !titles.is_empty() {
+		rows.push(titles);
+	}
+	for p in processes {
+		rows.push(p);
+	}
+	let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+	let mut widths = vec![0usize; col_count];
+	for r in &rows {
+		for (i, cell) in r.iter().enumerate() {
+			widths[i] = widths[i].max(cell.chars().count());
+		}
+	}
+	rows.iter()
+		.map(|r| {
+			r.iter()
+				.enumerate()
+				.map(|(i, cell)| {
+					if i + 1 == r.len() {
+						cell.clone()
+					} else {
+						format!("{cell:<width$}", width = widths[i])
+					}
+				})
+				.collect::<Vec<_>>()
+				.join("  ")
+		})
+		.collect()
+}
+
 #[cfg(test)]
 mod tests {
-	use super::parse_port_proto;
+	use super::{align_top_columns, dedup_preserving_order, parse_port_proto, split_repo_tag};
+
+	#[test]
+	fn split_repo_tag_plain_name_and_tag() {
+		assert_eq!(
+			split_repo_tag("nginx:1.25"),
+			("nginx".into(), "1.25".into())
+		);
+		assert_eq!(split_repo_tag("nginx"), ("nginx".into(), "latest".into()));
+	}
+
+	#[test]
+	fn split_repo_tag_registry_with_port_is_not_a_tag() {
+		// The ':' belongs to the registry host:port, not a tag.
+		assert_eq!(
+			split_repo_tag("registry:5000/team/app"),
+			("registry:5000/team/app".into(), "latest".into())
+		);
+		assert_eq!(
+			split_repo_tag("registry:5000/team/app:v2"),
+			("registry:5000/team/app".into(), "v2".into())
+		);
+	}
+
+	#[test]
+	fn split_repo_tag_digest_has_no_tag() {
+		let (repo, tag) = split_repo_tag(
+			"docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		);
+		assert_eq!(repo, "docker.io/library/alpine");
+		assert_eq!(tag, "<none>");
+	}
+
+	#[test]
+	fn dedup_preserving_order_keeps_first_occurrence() {
+		let out =
+			dedup_preserving_order(&["web".into(), "db".into(), "web".into(), "cache".into()]);
+		assert_eq!(out, vec!["web", "db", "cache"]);
+	}
+
+	#[test]
+	fn align_top_columns_pads_to_widest_cell() {
+		let titles = vec!["PID".to_string(), "CMD".to_string()];
+		let processes = vec![
+			vec!["1".to_string(), "bash".to_string()],
+			vec!["12345".to_string(), "node".to_string()],
+		];
+		let lines = align_top_columns(&titles, &processes);
+		assert_eq!(lines.len(), 3);
+		// First column is padded to the widest value ("12345" = 5 chars).
+		assert!(lines[0].starts_with("PID  "));
+		assert!(lines[1].starts_with("1      "));
+		// No tabs in the aligned output.
+		assert!(lines.iter().all(|l| !l.contains('\t')));
+	}
 
 	#[test]
 	fn bare_port_uses_flag_proto() {

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -7,6 +7,10 @@ use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
+use super::inspect_util::{
+	align_top_columns, dedup_preserving_order, is_running_status, parse_port_proto, select_replica,
+	split_repo_tag,
+};
 use super::Engine;
 
 impl Engine {
@@ -114,17 +118,33 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| crate::error::ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self.replica_name_at(service_name, service, index)?;
+		// Resolve against the containers Podman actually has, not the static
+		// compose replica count: a service scaled purely via CLI `--scale` has no
+		// `scale:` in the file, so the static count is 1 and would target the
+		// never-created un-indexed base name. `live_replica_names` falls back to
+		// the static names only when nothing is running yet.
+		let live = self.live_replica_names(service_name, service).await?;
+		let container_name = select_replica(live, service_name, index)?;
 
 		let path = format!(
 			"{API_PREFIX}/containers/{}/json",
 			urlencoded(&container_name),
 		);
-		let info = self
+		let info = match self
 			.client
 			.get_json::<crate::libpod::types::container::ContainerInspect>(&path)
 			.await
-			.map_err(ComposeError::Podman)?;
+		{
+			Ok(info) => info,
+			// Translate a missing container into a friendly not-found rather than
+			// surfacing a raw podman 404.
+			Err(e) if e.is_status(404) => {
+				return Err(crate::error::ComposeError::ServiceNotFound(format!(
+					"{service_name} (no running container '{container_name}')"
+				)));
+			}
+			Err(e) => return Err(ComposeError::Podman(e)),
+		};
 
 		let key = format!("{port}/{proto}");
 		let binding = info
@@ -374,194 +394,5 @@ impl Engine {
 		}
 
 		Ok(())
-	}
-}
-
-/// Resolve the `(port, proto)` for `port` from a `PORT` or `PORT/proto` argument,
-/// the `/proto` suffix overriding the `--protocol` flag — matching
-/// `docker compose port`. Pure so the parsing is unit-tested.
-fn parse_port_proto<'a>(private_port: &'a str, proto_flag: &'a str) -> Result<(u16, &'a str)> {
-	let (port, proto) = match private_port.split_once('/') {
-		Some((p, pr)) => (p, pr),
-		None => (private_port, proto_flag),
-	};
-	let port: u16 = port.parse().map_err(|_| {
-		ComposeError::InvalidPort(format!(
-			"port '{private_port}' is not a valid PORT or PORT/proto"
-		))
-	})?;
-	Ok((port, proto))
-}
-
-/// Deduplicate a list of strings, preserving first-seen order. Used so `top web
-/// web` queries and prints each service once, matching `docker compose top`.
-fn dedup_preserving_order(items: &[String]) -> Vec<String> {
-	let mut seen = std::collections::HashSet::new();
-	items
-		.iter()
-		.filter(|s| seen.insert(s.as_str()))
-		.cloned()
-		.collect()
-}
-
-/// Whether a libpod container `Status` string denotes a running container.
-/// `docker compose attach` only attaches to a running container; anything else
-/// (exited, created, paused, empty/unknown) must fail closed.
-fn is_running_status(status: &str) -> bool {
-	status.eq_ignore_ascii_case("running")
-}
-
-/// Split an image reference into `(repository, tag)` for the `images` table.
-///
-/// A trailing `:tag` is only a tag when the segment after it has no `/` (so a
-/// `registry:port/name` host is not mis-split), mirroring the guard in
-/// `export.rs`. A `name@sha256:...` digest reference has no tag, shown as
-/// `<none>` like docker, and the long digest never bloats the TAG column.
-fn split_repo_tag(image_ref: &str) -> (String, String) {
-	if let Some((repo, _digest)) = image_ref.split_once('@') {
-		return (repo.to_string(), "<none>".to_string());
-	}
-	match image_ref.rsplit_once(':') {
-		Some((repo, tag)) if !tag.contains('/') => (repo.to_string(), tag.to_string()),
-		_ => (image_ref.to_string(), "latest".to_string()),
-	}
-}
-
-/// Align a `top` table (the title row followed by process rows) into
-/// space-padded columns sized to the widest cell, returning one rendered line
-/// per input row (titles first). All but the last column are left-padded; the
-/// last is left ragged to avoid trailing whitespace.
-fn align_top_columns(titles: &[String], processes: &[Vec<String>]) -> Vec<String> {
-	let mut rows: Vec<&[String]> = Vec::with_capacity(processes.len() + 1);
-	if !titles.is_empty() {
-		rows.push(titles);
-	}
-	for p in processes {
-		rows.push(p);
-	}
-	let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
-	let mut widths = vec![0usize; col_count];
-	for r in &rows {
-		for (i, cell) in r.iter().enumerate() {
-			widths[i] = widths[i].max(cell.chars().count());
-		}
-	}
-	rows.iter()
-		.map(|r| {
-			r.iter()
-				.enumerate()
-				.map(|(i, cell)| {
-					if i + 1 == r.len() {
-						cell.clone()
-					} else {
-						format!("{cell:<width$}", width = widths[i])
-					}
-				})
-				.collect::<Vec<_>>()
-				.join("  ")
-		})
-		.collect()
-}
-
-#[cfg(test)]
-mod tests {
-	use super::{
-		align_top_columns, dedup_preserving_order, is_running_status, parse_port_proto,
-		split_repo_tag,
-	};
-
-	#[test]
-	fn split_repo_tag_plain_name_and_tag() {
-		assert_eq!(
-			split_repo_tag("nginx:1.25"),
-			("nginx".into(), "1.25".into())
-		);
-		assert_eq!(split_repo_tag("nginx"), ("nginx".into(), "latest".into()));
-	}
-
-	#[test]
-	fn split_repo_tag_registry_with_port_is_not_a_tag() {
-		// The ':' belongs to the registry host:port, not a tag.
-		assert_eq!(
-			split_repo_tag("registry:5000/team/app"),
-			("registry:5000/team/app".into(), "latest".into())
-		);
-		assert_eq!(
-			split_repo_tag("registry:5000/team/app:v2"),
-			("registry:5000/team/app".into(), "v2".into())
-		);
-	}
-
-	#[test]
-	fn split_repo_tag_digest_has_no_tag() {
-		let (repo, tag) = split_repo_tag(
-			"docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-		);
-		assert_eq!(repo, "docker.io/library/alpine");
-		assert_eq!(tag, "<none>");
-	}
-
-	#[test]
-	fn dedup_preserving_order_keeps_first_occurrence() {
-		let out =
-			dedup_preserving_order(&["web".into(), "db".into(), "web".into(), "cache".into()]);
-		assert_eq!(out, vec!["web", "db", "cache"]);
-	}
-
-	#[test]
-	fn align_top_columns_pads_to_widest_cell() {
-		let titles = vec!["PID".to_string(), "CMD".to_string()];
-		let processes = vec![
-			vec!["1".to_string(), "bash".to_string()],
-			vec!["12345".to_string(), "node".to_string()],
-		];
-		let lines = align_top_columns(&titles, &processes);
-		assert_eq!(lines.len(), 3);
-		// First column is padded to the widest value ("12345" = 5 chars).
-		assert!(lines[0].starts_with("PID  "));
-		assert!(lines[1].starts_with("1      "));
-		// No tabs in the aligned output.
-		assert!(lines.iter().all(|l| !l.contains('\t')));
-	}
-
-	#[test]
-	fn bare_port_uses_flag_proto() {
-		assert_eq!(parse_port_proto("80", "tcp").unwrap(), (80, "tcp"));
-	}
-
-	#[test]
-	fn suffix_overrides_flag_proto() {
-		assert_eq!(parse_port_proto("53/udp", "tcp").unwrap(), (53, "udp"));
-	}
-
-	#[test]
-	fn non_numeric_port_is_rejected() {
-		assert!(parse_port_proto("http", "tcp").is_err());
-		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
-	}
-
-	#[test]
-	fn dedup_keeps_first_occurrence_order() {
-		let input = ["web".to_string(), "web".to_string(), "db".to_string()];
-		assert_eq!(dedup_preserving_order(&input), vec!["web", "db"]);
-		let input = [
-			"a".to_string(),
-			"b".to_string(),
-			"a".to_string(),
-			"c".to_string(),
-			"b".to_string(),
-		];
-		assert_eq!(dedup_preserving_order(&input), vec!["a", "b", "c"]);
-	}
-
-	#[test]
-	fn running_status_detected_case_insensitively() {
-		assert!(is_running_status("running"));
-		assert!(is_running_status("Running"));
-		// Anything else is not attachable.
-		assert!(!is_running_status("exited"));
-		assert!(!is_running_status("created"));
-		assert!(!is_running_status("paused"));
-		assert!(!is_running_status(""));
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -247,7 +247,19 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container = self.first_replica_name(service_name, service);
+		// Resolve against the containers Podman actually has so a service scaled at
+		// runtime (`up --scale=3` → `…-1`/`…-2`/`…-3`) attaches to a real replica
+		// instead of the unsuffixed base name, which would 404. Pick the
+		// lowest-numbered live container for a stable choice.
+		let mut live = self
+			.list_project_container_names(Some(service_name))
+			.await?;
+		live.sort();
+		let container = live.into_iter().next().ok_or_else(|| {
+			ComposeError::Unsupported(format!(
+				"attach: no running container for service '{service_name}'"
+			))
+		})?;
 		let is_tty = service.tty.unwrap_or(false);
 
 		// `docker compose attach` errors when the target is not running. Without
@@ -273,8 +285,9 @@ impl Engine {
 		}
 
 		let path = format!(
-			"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
+			"{API_PREFIX}/containers/{}/logs?{}",
 			urlencoded(&container),
+			attach_log_query(),
 		);
 		let resp = self
 			.client
@@ -394,5 +407,25 @@ impl Engine {
 		}
 
 		Ok(())
+	}
+}
+
+/// Query string for `attach`: a live-only stdout/stderr stream. `tail=0`
+/// suppresses the historical log backlog so attach shows live output (matching
+/// `docker compose attach`) instead of replaying the container's whole history.
+fn attach_log_query() -> &'static str {
+	"stdout=true&stderr=true&follow=true&tail=0"
+}
+
+#[cfg(test)]
+mod tests {
+	use super::attach_log_query;
+
+	#[test]
+	fn attach_query_suppresses_log_backlog() {
+		// `tail=0` means attach streams live output only, not the full history.
+		let q = attach_log_query();
+		assert!(q.contains("follow=true"), "got: {q}");
+		assert!(q.contains("tail=0"), "got: {q}");
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -75,7 +75,14 @@ impl Engine {
 							}
 						}
 					}
-					Err(e) => tracing::warn!("top {container_name}: {e}"),
+					// A not-created container (404) is tolerated; any other failure
+					// (e.g. a stopped container's HTTP 500, or an unreachable socket)
+					// is a real error that must surface with a non-zero exit instead
+					// of being swallowed into a warning.
+					Err(e) if e.is_status(404) => {
+						tracing::debug!("top {container_name}: {e}")
+					}
+					Err(e) => return Err(ComposeError::Podman(e)),
 				}
 			}
 		}
@@ -191,12 +198,16 @@ impl Engine {
 					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
 					rows.push((name.clone(), repo, tag, id.to_string()));
 				}
-				// An image not present locally is listed with an empty ID rather
-				// than silently dropped, so the output is never quietly incomplete.
-				Err(e) => {
-					tracing::warn!("images {name}: {e}");
+				// A 404 means the image is simply not present locally — list it with
+				// an empty ID rather than silently dropping it, matching docker
+				// compose. Any other error (a connection failure / unreachable
+				// socket, or an HTTP 500) is a real failure that must propagate with
+				// a non-zero exit rather than printing an empty table and exiting 0.
+				Err(e) if e.is_status(404) => {
+					tracing::debug!("images {name}: not present ({e})");
 					rows.push((name.clone(), repo, tag, String::new()));
 				}
+				Err(e) => return Err(ComposeError::Podman(e)),
 			}
 		}
 
@@ -289,11 +300,17 @@ impl Engine {
 			urlencoded(&container),
 			attach_log_query(),
 		);
-		let resp = self
-			.client
-			.get_stream(&path)
-			.await
-			.map_err(ComposeError::Podman)?;
+		// A service that exists in the compose file but has no created container
+		// answers 404 here; surface a friendly "service X is not running" instead
+		// of leaking a raw libpod HTTP 404, mirroring the ServiceNotFound a service
+		// absent from compose gets.
+		let resp = match self.client.get_stream(&path).await {
+			Ok(r) => r,
+			Err(e) if e.is_status(404) => {
+				return Err(ComposeError::NotRunning(service_name.into()))
+			}
+			Err(e) => return Err(ComposeError::Podman(e)),
+		};
 		let mut stream = if is_tty {
 			crate::libpod::parse_raw(resp.into_body())
 		} else {

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -34,8 +34,8 @@ impl Engine {
 				}
 			}
 			// Deduplicate repeated positionals (`top web web`) preserving order, so
-			// a service's process block is not rendered twice — matching docker
-			// compose top.
+			// a service's process block is not rendered twice and we avoid redundant
+			// `/top` API calls — matching docker compose top.
 			dedup_preserving_order(target_services)
 		};
 
@@ -230,6 +230,28 @@ impl Engine {
 		let container = self.first_replica_name(service_name, service);
 		let is_tty = service.tty.unwrap_or(false);
 
+		// `docker compose attach` errors when the target is not running. Without
+		// this check the libpod logs endpoint replays the *entire* history of a
+		// stopped container and then ends the stream, so `attach` would print the
+		// whole log and exit 0. Inspect the state first and fail closed otherwise.
+		let inspect_path = format!("{API_PREFIX}/containers/{}/json", urlencoded(&container));
+		let info = self
+			.client
+			.get_json::<crate::libpod::types::container::ContainerInspect>(&inspect_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		let status = info.state.and_then(|s| s.status).unwrap_or_default();
+		if !is_running_status(&status) {
+			let shown = if status.is_empty() {
+				"unknown"
+			} else {
+				&status
+			};
+			return Err(ComposeError::Unsupported(format!(
+				"cannot attach to {container}: container is not running (state: {shown})"
+			)));
+		}
+
 		let path = format!(
 			"{API_PREFIX}/containers/{}/logs?stdout=true&stderr=true&follow=true",
 			urlencoded(&container),
@@ -371,7 +393,8 @@ fn parse_port_proto<'a>(private_port: &'a str, proto_flag: &'a str) -> Result<(u
 	Ok((port, proto))
 }
 
-/// Deduplicate a list of strings, preserving first-seen order.
+/// Deduplicate a list of strings, preserving first-seen order. Used so `top web
+/// web` queries and prints each service once, matching `docker compose top`.
 fn dedup_preserving_order(items: &[String]) -> Vec<String> {
 	let mut seen = std::collections::HashSet::new();
 	items
@@ -379,6 +402,13 @@ fn dedup_preserving_order(items: &[String]) -> Vec<String> {
 		.filter(|s| seen.insert(s.as_str()))
 		.cloned()
 		.collect()
+}
+
+/// Whether a libpod container `Status` string denotes a running container.
+/// `docker compose attach` only attaches to a running container; anything else
+/// (exited, created, paused, empty/unknown) must fail closed.
+fn is_running_status(status: &str) -> bool {
+	status.eq_ignore_ascii_case("running")
 }
 
 /// Split an image reference into `(repository, tag)` for the `images` table.
@@ -435,7 +465,10 @@ fn align_top_columns(titles: &[String], processes: &[Vec<String>]) -> Vec<String
 
 #[cfg(test)]
 mod tests {
-	use super::{align_top_columns, dedup_preserving_order, parse_port_proto, split_repo_tag};
+	use super::{
+		align_top_columns, dedup_preserving_order, is_running_status, parse_port_proto,
+		split_repo_tag,
+	};
 
 	#[test]
 	fn split_repo_tag_plain_name_and_tag() {
@@ -505,5 +538,30 @@ mod tests {
 	fn non_numeric_port_is_rejected() {
 		assert!(parse_port_proto("http", "tcp").is_err());
 		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
+	}
+
+	#[test]
+	fn dedup_keeps_first_occurrence_order() {
+		let input = ["web".to_string(), "web".to_string(), "db".to_string()];
+		assert_eq!(dedup_preserving_order(&input), vec!["web", "db"]);
+		let input = [
+			"a".to_string(),
+			"b".to_string(),
+			"a".to_string(),
+			"c".to_string(),
+			"b".to_string(),
+		];
+		assert_eq!(dedup_preserving_order(&input), vec!["a", "b", "c"]);
+	}
+
+	#[test]
+	fn running_status_detected_case_insensitively() {
+		assert!(is_running_status("running"));
+		assert!(is_running_status("Running"));
+		// Anything else is not attachable.
+		assert!(!is_running_status("exited"));
+		assert!(!is_running_status("created"));
+		assert!(!is_running_status("paused"));
+		assert!(!is_running_status(""));
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -263,13 +263,14 @@ impl Engine {
 			return Ok(());
 		}
 
-		crate::ui::print_bold_header(&format!(
-			"{:<30} {:<25} {:<15} {:<20}",
-			"SERVICE", "REPOSITORY", "TAG", "IMAGE ID"
-		));
+		let mut table = crate::ui::Table::new(&["SERVICE", "REPOSITORY", "TAG", "IMAGE ID"])
+			.cap(0, 48)
+			.cap(1, 48)
+			.cap(2, 24);
 		for (svc, repo, tag, id) in &rows {
-			println!("{svc:<30} {repo:<25} {tag:<15} {id:<20}");
+			table.push(vec![svc.clone(), repo.clone(), tag.clone(), id.clone()]);
 		}
+		table.print();
 		Ok(())
 	}
 

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -177,15 +177,36 @@ impl Engine {
 	}
 
 	/// List service images with `docker compose images`-style options:
-	/// `-q/--quiet` (IDs only) and `--format` (table | json).
+	/// `-q/--quiet` (IDs only) and `--format` (table | json), across all services.
+	/// To restrict to specific services use [`Engine::images_with_services`].
 	pub async fn images_with_options(
 		&self,
 		file: &ComposeFile,
 		opts: super::ImagesOptions,
 	) -> Result<()> {
+		self.images_with_services(file, &[], opts).await
+	}
+
+	/// List service images like [`Engine::images_with_options`]. When
+	/// `target_services` is non-empty, only those services are listed (an unknown
+	/// name is an error), matching `docker compose images [SERVICE...]`.
+	pub async fn images_with_services(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: super::ImagesOptions,
+	) -> Result<()> {
+		for name in target_services {
+			if !file.services.contains_key(name) {
+				return Err(ComposeError::ServiceNotFound(name.clone()));
+			}
+		}
 		// Collect rows first so quiet/json modes can render without the header.
 		let mut rows: Vec<(String, String, String, String)> = Vec::new();
 		for (name, service) in &file.services {
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
+				continue;
+			}
 			let image_ref = match &service.image {
 				Some(img) => img.clone(),
 				None if service.build.is_some() => format!("{name}:latest"),
@@ -254,23 +275,46 @@ impl Engine {
 	/// stdout/stderr with no prefix, until the container stops. podup never
 	/// attaches STDIN (it allocates no TTY), so this is output-only.
 	pub async fn attach(&self, file: &ComposeFile, service_name: &str) -> Result<()> {
+		self.attach_with_index(file, service_name, None).await
+	}
+
+	/// Like [`Engine::attach`] but targets a specific replica via `--index`
+	/// (1-based); `None` uses the first replica. This is what lets `attach` reach
+	/// a scaled service's later replicas.
+	pub async fn attach_with_index(
+		&self,
+		file: &ComposeFile,
+		service_name: &str,
+		index: Option<u32>,
+	) -> Result<()> {
 		let service = file
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 		// Resolve against the containers Podman actually has so a service scaled at
 		// runtime (`up --scale=3` → `…-1`/`…-2`/`…-3`) attaches to a real replica
-		// instead of the unsuffixed base name, which would 404. Pick the
+		// instead of the unsuffixed base name, which would 404. `--index`
+		// (1-based) selects a specific live replica; `None` picks the
 		// lowest-numbered live container for a stable choice.
 		let mut live = self
 			.list_project_container_names(Some(service_name))
 			.await?;
 		live.sort();
-		let container = live.into_iter().next().ok_or_else(|| {
-			ComposeError::Unsupported(format!(
-				"attach: no running container for service '{service_name}'"
-			))
-		})?;
+		let container = match index {
+			Some(i) => {
+				let idx = (i as usize).checked_sub(1).ok_or_else(|| {
+					ComposeError::Unsupported(format!("attach: --index must be >= 1 (got {i})"))
+				})?;
+				live.into_iter().nth(idx).ok_or_else(|| {
+					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
+				})?
+			}
+			None => live.into_iter().next().ok_or_else(|| {
+				ComposeError::Unsupported(format!(
+					"attach: no running container for service '{service_name}'"
+				))
+			})?,
+		};
 		let is_tty = service.tty.unwrap_or(false);
 
 		// `docker compose attach` errors when the target is not running. Without

--- a/internal/engine/query/inspect_util.rs
+++ b/internal/engine/query/inspect_util.rs
@@ -1,0 +1,285 @@
+//! Pure helpers for `inspect`: replica/port selection, image-ref
+//! splitting, and process-table formatting. Kept free of the live Podman
+//! client so each is unit-tested in isolation.
+
+use crate::error::{ComposeError, Result};
+
+/// Pick a service's target replica container from its live container names.
+///
+/// Names are ordered by their trailing `-N` suffix (numerically, so `svc-10`
+/// sorts after `svc-2`); an unsuffixed single-replica name sorts first. `index`
+/// is the 1-based `--index`; `None` selects the first replica. Pure so the
+/// indexing is unit-tested without a live Podman socket.
+pub(super) fn select_replica(
+	mut names: Vec<String>,
+	service_name: &str,
+	index: Option<u32>,
+) -> Result<String> {
+	names.sort_by_key(|n| {
+		n.rsplit_once('-')
+			.and_then(|(_, suffix)| suffix.parse::<u64>().ok())
+			.unwrap_or(0)
+	});
+	match index {
+		Some(i) => {
+			// `--index` is 1-based; `0` is invalid, not "first replica".
+			let idx = (i as usize).checked_sub(1).ok_or_else(|| {
+				ComposeError::ServiceNotFound(format!(
+					"{service_name} (replica index {i}: indexes are 1-based)"
+				))
+			})?;
+			names.get(idx).cloned().ok_or_else(|| {
+				ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
+			})
+		}
+		None => names
+			.into_iter()
+			.next()
+			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into())),
+	}
+}
+
+/// Resolve the `(port, proto)` for `port` from a `PORT` or `PORT/proto` argument,
+/// the `/proto` suffix overriding the `--protocol` flag — matching
+/// `docker compose port`. Pure so the parsing is unit-tested.
+pub(super) fn parse_port_proto<'a>(
+	private_port: &'a str,
+	proto_flag: &'a str,
+) -> Result<(u16, &'a str)> {
+	let (port, proto) = match private_port.split_once('/') {
+		Some((p, pr)) => (p, pr),
+		None => (private_port, proto_flag),
+	};
+	let port: u16 = port.parse().map_err(|_| {
+		ComposeError::InvalidPort(format!(
+			"port '{private_port}' is not a valid PORT or PORT/proto"
+		))
+	})?;
+	Ok((port, proto))
+}
+
+/// Deduplicate a list of strings, preserving first-seen order. Used so `top web
+/// web` queries and prints each service once, matching `docker compose top`.
+pub(super) fn dedup_preserving_order(items: &[String]) -> Vec<String> {
+	let mut seen = std::collections::HashSet::new();
+	items
+		.iter()
+		.filter(|s| seen.insert(s.as_str()))
+		.cloned()
+		.collect()
+}
+
+/// Whether a libpod container `Status` string denotes a running container.
+/// `docker compose attach` only attaches to a running container; anything else
+/// (exited, created, paused, empty/unknown) must fail closed.
+pub(super) fn is_running_status(status: &str) -> bool {
+	status.eq_ignore_ascii_case("running")
+}
+
+/// Split an image reference into `(repository, tag)` for the `images` table.
+///
+/// A trailing `:tag` is only a tag when the segment after it has no `/` (so a
+/// `registry:port/name` host is not mis-split), mirroring the guard in
+/// `export.rs`. A `name@sha256:...` digest reference has no tag, shown as
+/// `<none>` like docker, and the long digest never bloats the TAG column.
+pub(super) fn split_repo_tag(image_ref: &str) -> (String, String) {
+	if let Some((repo, _digest)) = image_ref.split_once('@') {
+		return (repo.to_string(), "<none>".to_string());
+	}
+	match image_ref.rsplit_once(':') {
+		Some((repo, tag)) if !tag.contains('/') => (repo.to_string(), tag.to_string()),
+		_ => (image_ref.to_string(), "latest".to_string()),
+	}
+}
+
+/// Align a `top` table (the title row followed by process rows) into
+/// space-padded columns sized to the widest cell, returning one rendered line
+/// per input row (titles first). All but the last column are left-padded; the
+/// last is left ragged to avoid trailing whitespace.
+pub(super) fn align_top_columns(titles: &[String], processes: &[Vec<String>]) -> Vec<String> {
+	let mut rows: Vec<&[String]> = Vec::with_capacity(processes.len() + 1);
+	if !titles.is_empty() {
+		rows.push(titles);
+	}
+	for p in processes {
+		rows.push(p);
+	}
+	let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+	let mut widths = vec![0usize; col_count];
+	for r in &rows {
+		for (i, cell) in r.iter().enumerate() {
+			widths[i] = widths[i].max(cell.chars().count());
+		}
+	}
+	rows.iter()
+		.map(|r| {
+			r.iter()
+				.enumerate()
+				.map(|(i, cell)| {
+					if i + 1 == r.len() {
+						cell.clone()
+					} else {
+						format!("{cell:<width$}", width = widths[i])
+					}
+				})
+				.collect::<Vec<_>>()
+				.join("  ")
+		})
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{
+		align_top_columns, dedup_preserving_order, is_running_status, parse_port_proto,
+		select_replica, split_repo_tag,
+	};
+
+	#[test]
+	fn select_replica_none_picks_first_by_suffix() {
+		// Live names come back in arbitrary API order; the first replica is the
+		// lowest-suffixed one regardless.
+		let names = vec![
+			"proj-web-3".into(),
+			"proj-web-1".into(),
+			"proj-web-2".into(),
+		];
+		assert_eq!(select_replica(names, "web", None).unwrap(), "proj-web-1");
+	}
+
+	#[test]
+	fn select_replica_orders_suffix_numerically() {
+		// `-10` must sort after `-2`, not lexicographically before it.
+		let names = vec![
+			"proj-web-10".into(),
+			"proj-web-2".into(),
+			"proj-web-1".into(),
+		];
+		assert_eq!(
+			select_replica(names, "web", Some(3)).unwrap(),
+			"proj-web-10"
+		);
+	}
+
+	#[test]
+	fn select_replica_index_targets_nth() {
+		let names = vec!["proj-web-1".into(), "proj-web-2".into()];
+		assert_eq!(
+			select_replica(names.clone(), "web", Some(2)).unwrap(),
+			"proj-web-2"
+		);
+	}
+
+	#[test]
+	fn select_replica_unsuffixed_single() {
+		let names = vec!["proj-web".into()];
+		assert_eq!(select_replica(names, "web", None).unwrap(), "proj-web");
+	}
+
+	#[test]
+	fn select_replica_rejects_index_zero_and_out_of_range() {
+		let names = vec!["proj-web-1".into(), "proj-web-2".into()];
+		assert!(select_replica(names.clone(), "web", Some(0)).is_err());
+		assert!(select_replica(names, "web", Some(5)).is_err());
+	}
+
+	#[test]
+	fn select_replica_empty_is_not_found() {
+		assert!(select_replica(vec![], "web", None).is_err());
+	}
+
+	#[test]
+	fn split_repo_tag_plain_name_and_tag() {
+		assert_eq!(
+			split_repo_tag("nginx:1.25"),
+			("nginx".into(), "1.25".into())
+		);
+		assert_eq!(split_repo_tag("nginx"), ("nginx".into(), "latest".into()));
+	}
+
+	#[test]
+	fn split_repo_tag_registry_with_port_is_not_a_tag() {
+		// The ':' belongs to the registry host:port, not a tag.
+		assert_eq!(
+			split_repo_tag("registry:5000/team/app"),
+			("registry:5000/team/app".into(), "latest".into())
+		);
+		assert_eq!(
+			split_repo_tag("registry:5000/team/app:v2"),
+			("registry:5000/team/app".into(), "v2".into())
+		);
+	}
+
+	#[test]
+	fn split_repo_tag_digest_has_no_tag() {
+		let (repo, tag) = split_repo_tag(
+			"docker.io/library/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		);
+		assert_eq!(repo, "docker.io/library/alpine");
+		assert_eq!(tag, "<none>");
+	}
+
+	#[test]
+	fn dedup_preserving_order_keeps_first_occurrence() {
+		let out =
+			dedup_preserving_order(&["web".into(), "db".into(), "web".into(), "cache".into()]);
+		assert_eq!(out, vec!["web", "db", "cache"]);
+	}
+
+	#[test]
+	fn align_top_columns_pads_to_widest_cell() {
+		let titles = vec!["PID".to_string(), "CMD".to_string()];
+		let processes = vec![
+			vec!["1".to_string(), "bash".to_string()],
+			vec!["12345".to_string(), "node".to_string()],
+		];
+		let lines = align_top_columns(&titles, &processes);
+		assert_eq!(lines.len(), 3);
+		// First column is padded to the widest value ("12345" = 5 chars).
+		assert!(lines[0].starts_with("PID  "));
+		assert!(lines[1].starts_with("1      "));
+		// No tabs in the aligned output.
+		assert!(lines.iter().all(|l| !l.contains('\t')));
+	}
+
+	#[test]
+	fn bare_port_uses_flag_proto() {
+		assert_eq!(parse_port_proto("80", "tcp").unwrap(), (80, "tcp"));
+	}
+
+	#[test]
+	fn suffix_overrides_flag_proto() {
+		assert_eq!(parse_port_proto("53/udp", "tcp").unwrap(), (53, "udp"));
+	}
+
+	#[test]
+	fn non_numeric_port_is_rejected() {
+		assert!(parse_port_proto("http", "tcp").is_err());
+		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
+	}
+
+	#[test]
+	fn dedup_keeps_first_occurrence_order() {
+		let input = ["web".to_string(), "web".to_string(), "db".to_string()];
+		assert_eq!(dedup_preserving_order(&input), vec!["web", "db"]);
+		let input = [
+			"a".to_string(),
+			"b".to_string(),
+			"a".to_string(),
+			"c".to_string(),
+			"b".to_string(),
+		];
+		assert_eq!(dedup_preserving_order(&input), vec!["a", "b", "c"]);
+	}
+
+	#[test]
+	fn running_status_detected_case_insensitively() {
+		assert!(is_running_status("running"));
+		assert!(is_running_status("Running"));
+		// Anything else is not attachable.
+		assert!(!is_running_status("exited"));
+		assert!(!is_running_status("created"));
+		assert!(!is_running_status("paused"));
+		assert!(!is_running_status(""));
+	}
+}

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -11,15 +11,25 @@ pub(super) struct LinePrefixer {
 }
 
 impl LinePrefixer {
-	pub(super) fn new(label: &str) -> Self {
+	/// Build a prefixer for `label`. `prefix` gates whether any `{label} | ` is
+	/// emitted at all (`logs --no-log-prefix`); `allow_color` gates the colour of
+	/// the prefix (`logs --no-color`), still subject to stdout being a colour sink.
+	pub(super) fn new(label: &str, prefix: bool, allow_color: bool) -> Self {
+		// `--no-log-prefix`: emit the bare line with no `{label} | ` tag.
+		if !prefix {
+			return Self {
+				label: String::new(),
+				pending: Vec::new(),
+			};
+		}
 		// Colour the whole prefix with the service's stable colour so aggregated
 		// multi-service output is easy to scan. Gated on stdout being a colour sink
-		// (a raw write anstream does not strip for us).
+		// (a raw write anstream does not strip for us) and on `--no-color`.
 		let plain = format!("{label}  | ");
 		let label = crate::ui::paint(
 			crate::ui::service_style(label),
 			&plain,
-			crate::ui::stdout_colored(),
+			allow_color && crate::ui::stdout_colored(),
 		);
 		Self {
 			label,
@@ -56,7 +66,7 @@ mod tests {
 
 	#[test]
 	fn line_prefixer_tags_lines_and_buffers_partials() {
-		let mut p = LinePrefixer::new("web");
+		let mut p = LinePrefixer::new("web", true, false);
 		let mut out: Vec<u8> = Vec::new();
 		p.write(&mut out, b"hello\nwor");
 		// The complete line is tagged; the partial "wor" waits for its newline.
@@ -67,11 +77,23 @@ mod tests {
 
 	#[test]
 	fn line_prefixer_flush_tail_emits_unterminated_line() {
-		let mut p = LinePrefixer::new("db");
+		let mut p = LinePrefixer::new("db", true, false);
 		let mut out: Vec<u8> = Vec::new();
 		p.write(&mut out, b"partial");
 		assert!(out.is_empty(), "a line with no newline is held back");
 		p.flush_tail(&mut out);
 		assert_eq!(out, b"db  | partial\n");
+	}
+
+	#[test]
+	fn line_prefixer_no_prefix_emits_bare_lines() {
+		// `--no-log-prefix`: lines pass through with no `{label} | ` tag.
+		let mut p = LinePrefixer::new("web", false, false);
+		let mut out: Vec<u8> = Vec::new();
+		p.write(&mut out, b"hello\n");
+		assert_eq!(out, b"hello\n");
+		p.write(&mut out, b"tail");
+		p.flush_tail(&mut out);
+		assert_eq!(out, b"hello\ntail\n");
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -1,18 +1,14 @@
 //! Query and observation commands: ps, logs, exec, pull, remove_orphans.
 
-use std::io::Write;
-
 use futures_util::StreamExt;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
-use crate::libpod::types::exec::{
-	ExecCreateConfig, ExecCreateResponse, ExecInspect, ExecStartConfig,
-};
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
 
+mod exec;
 mod inspect;
 mod inspect_util;
 mod log_prefix;
@@ -20,24 +16,8 @@ mod ps;
 
 pub use ps::PsOptions;
 
+pub use exec::ExecOptions;
 use log_prefix::LinePrefixer;
-
-/// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
-#[derive(Default)]
-pub struct ExecOptions {
-	/// Extra environment variables (`KEY=VAL`), `-e/--env`.
-	pub env: Vec<String>,
-	/// Run as this user, `-u/--user`.
-	pub user: Option<String>,
-	/// Working directory inside the container, `-w/--workdir`.
-	pub workdir: Option<String>,
-	/// Run with extended privileges, `--privileged`.
-	pub privileged: bool,
-	/// Detach: start the exec and return without streaming output, `-d/--detach`.
-	pub detach: bool,
-	/// 1-based replica index for a scaled service, `--index` (default: first).
-	pub index: Option<u32>,
-}
 
 /// Options for [`Engine::images_with_options`].
 #[derive(Default)]
@@ -224,123 +204,6 @@ impl Engine {
 				}
 				out_pfx.flush_tail(&mut out);
 				err_pfx.flush_tail(&mut std::io::stderr().lock());
-			}
-		}
-
-		Ok(())
-	}
-
-	/// Run a command in the first replica of the named service with default
-	/// options. Exits with the command's exit code.
-	pub async fn exec(
-		&self,
-		file: &ComposeFile,
-		service_name: &str,
-		cmd: Vec<String>,
-	) -> Result<()> {
-		self.exec_with_options(file, service_name, cmd, ExecOptions::default())
-			.await
-	}
-
-	/// Run a command in a service container with `docker compose exec`-style
-	/// overrides (env, user, workdir, privileged, detach, replica index).
-	pub async fn exec_with_options(
-		&self,
-		file: &ComposeFile,
-		service_name: &str,
-		cmd: Vec<String>,
-		opts: ExecOptions,
-	) -> Result<()> {
-		let service = file
-			.services
-			.get(service_name)
-			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = self
-			.live_replica_name_at(service_name, service, opts.index)
-			.await?;
-
-		let exec_cfg = ExecCreateConfig {
-			cmd: Some(cmd),
-			attach_stdout: Some(true),
-			attach_stderr: Some(true),
-			user: opts.user.clone(),
-			working_dir: opts.workdir.clone(),
-			privileged: opts.privileged.then_some(true),
-			env: (!opts.env.is_empty()).then(|| opts.env.clone()),
-			..Default::default()
-		};
-		let create_path = format!(
-			"{API_PREFIX}/containers/{}/exec",
-			urlencoded(&container_name),
-		);
-		let resp: ExecCreateResponse = self
-			.client
-			.post_json(&create_path, &exec_cfg)
-			.await
-			.map_err(ComposeError::Podman)?;
-		let exec_id = resp.id;
-
-		// `-d/--detach`: start the exec and return without streaming output or
-		// waiting for the exit code. The server returns immediately, so the
-		// response body is dropped.
-		if opts.detach {
-			let start_cfg = ExecStartConfig {
-				detach: true,
-				tty: false,
-			};
-			let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
-			let _ = self
-				.client
-				.post_json_stream(&start_path, &start_cfg)
-				.await
-				.map_err(ComposeError::Podman)?;
-			return Ok(());
-		}
-
-		let start_cfg = ExecStartConfig {
-			detach: false,
-			tty: false,
-		};
-		let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(&exec_id));
-		let start_resp = self
-			.client
-			.post_json_stream(&start_path, &start_cfg)
-			.await
-			.map_err(ComposeError::Podman)?;
-		let mut stream = crate::libpod::parse_multiplexed(start_resp.into_body());
-
-		// Lock stdout once for the whole stream instead of re-acquiring the lock
-		// (and issuing a syscall) per frame; stdout is ours exclusively on this
-		// path. stderr is locked per frame because the tracing subscriber also
-		// writes there: holding its lock across the await loop would starve
-		// concurrent log emissions. Flush after each frame so exec streams
-		// promptly.
-		{
-			let mut out = std::io::stdout().lock();
-			while let Some(msg) = stream.next().await {
-				match msg.map_err(ComposeError::Podman)? {
-					LogOutput::StdOut { message } => {
-						let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
-						let _ = out.flush();
-					}
-					LogOutput::StdErr { message } => {
-						let mut err = std::io::stderr().lock();
-						let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
-						let _ = err.flush();
-					}
-				}
-			}
-		}
-
-		let inspect_path = format!("{API_PREFIX}/exec/{}/json", urlencoded(&exec_id));
-		let inspect: ExecInspect = self
-			.client
-			.get_json(&inspect_path)
-			.await
-			.map_err(ComposeError::Podman)?;
-		if let Some(code) = inspect.exit_code {
-			if code != 0 {
-				return Err(ComposeError::RunExited(code));
 			}
 		}
 

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -14,6 +14,7 @@ use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 use super::Engine;
 
 mod inspect;
+mod inspect_util;
 mod log_prefix;
 mod ps;
 

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -12,50 +12,14 @@ use crate::libpod::types::exec::{
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::Engine;
-use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 
 mod inspect;
 mod log_prefix;
+mod ps;
+
+pub use ps::PsOptions;
 
 use log_prefix::LinePrefixer;
-
-/// Human-readable status for `ps`. Podman's libpod list endpoint leaves
-/// `Status` empty and reports the machine state in `State`, so fall back to it
-/// rather than rendering a blank column.
-fn display_status(c: &ContainerListEntry) -> &str {
-	if c.status.is_empty() {
-		&c.state
-	} else {
-		&c.status
-	}
-}
-
-/// Render a container's published ports the way `docker compose ps` does, e.g.
-/// `0.0.0.0:8080->80/tcp`. An unset host IP means "all interfaces", shown as
-/// `0.0.0.0` (libpod commonly omits it) to match Docker/Podman output.
-fn format_ports(ports: &[ContainerPort]) -> String {
-	ports
-		.iter()
-		.map(|p| {
-			let proto = p
-				.protocol
-				.as_deref()
-				.map(|proto| format!("/{proto}"))
-				.unwrap_or_default();
-			let host_ip = p
-				.host_ip
-				.as_deref()
-				.filter(|s| !s.is_empty())
-				.unwrap_or("0.0.0.0");
-			format!(
-				"{host_ip}:{}->{}{proto}",
-				p.host_port.unwrap_or(0),
-				p.container_port
-			)
-		})
-		.collect::<Vec<_>>()
-		.join(", ")
-}
 
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
 #[derive(Default)]
@@ -72,17 +36,6 @@ pub struct ExecOptions {
 	pub detach: bool,
 	/// 1-based replica index for a scaled service, `--index` (default: first).
 	pub index: Option<u32>,
-}
-
-/// Options for [`Engine::ps_with_options`].
-#[derive(Default)]
-pub struct PsOptions {
-	/// Include stopped containers, `-a/--all` (default: running only).
-	pub all: bool,
-	/// Print only container IDs, `-q/--quiet`.
-	pub quiet: bool,
-	/// Emit JSON instead of the table, `--format json`.
-	pub json: bool,
 }
 
 /// Options for [`Engine::images_with_options`].
@@ -128,72 +81,6 @@ fn log_query(opts: &LogsOptions) -> String {
 }
 
 impl Engine {
-	/// List running containers for this project as a table (default options).
-	pub async fn ps(&self, file: &ComposeFile) -> Result<()> {
-		self.ps_with_options(file, PsOptions::default()).await
-	}
-
-	/// List containers with `docker compose ps`-style options: `-a/--all`
-	/// (include stopped), `-q/--quiet` (IDs only), and `--format` (table | json).
-	pub async fn ps_with_options(&self, _file: &ComposeFile, opts: PsOptions) -> Result<()> {
-		let label = format!("podup.project={}", self.project);
-		let filters = serde_json::json!({ "label": [label] });
-		let path = format!(
-			"{API_PREFIX}/containers/json?all={}&filters={}",
-			opts.all,
-			urlencoded(&filters.to_string()),
-		);
-
-		let containers = self
-			.client
-			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
-			.await
-			.map_err(ComposeError::Podman)?;
-
-		let name_of = |c: &crate::libpod::types::container::ContainerListEntry| {
-			c.names.join(", ").trim_start_matches('/').to_string()
-		};
-
-		if opts.quiet {
-			for c in &containers {
-				let id = c.id.get(..12).unwrap_or(&c.id);
-				println!("{id}");
-			}
-			return Ok(());
-		}
-
-		if opts.json {
-			let rows: Vec<_> = containers
-				.iter()
-				.map(|c| {
-					serde_json::json!({
-						"Name": name_of(c),
-						"Image": c.image,
-						"Status": display_status(c),
-						"ID": c.id,
-					})
-				})
-				.collect();
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&rows).unwrap_or_default()
-			);
-			return Ok(());
-		}
-
-		crate::ui::print_bold_header(&format!(
-			"{:<40} {:<30} {:<20} PORTS",
-			"NAME", "IMAGE", "STATUS"
-		));
-		for c in &containers {
-			let ports = format_ports(&c.ports);
-			let status = crate::ui::status_cell(display_status(c), 20);
-			println!("{:<40} {:<30} {status} {ports}", name_of(c), c.image);
-		}
-
-		Ok(())
-	}
-
 	/// Stream logs. When `service_name` is `None`, streams from all services. When `follow` is true, tails indefinitely.
 	pub async fn logs(
 		&self,
@@ -524,9 +411,8 @@ fn filter_orphans(names: Vec<String>, known: &std::collections::HashSet<String>)
 
 #[cfg(test)]
 mod tests {
-	use super::{display_status, filter_orphans, format_ports, log_query, LogsOptions};
-	use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
-	use std::collections::{HashMap, HashSet};
+	use super::{filter_orphans, log_query, LogsOptions};
+	use std::collections::HashSet;
 
 	#[test]
 	fn filter_orphans_keeps_only_unknown_names() {
@@ -543,63 +429,6 @@ mod tests {
 	fn filter_orphans_empty_when_all_known() {
 		let known: HashSet<String> = ["web".to_string()].into();
 		assert!(filter_orphans(vec!["web".to_string()], &known).is_empty());
-	}
-
-	fn entry(status: &str, state: &str) -> ContainerListEntry {
-		ContainerListEntry {
-			id: "abc123".into(),
-			names: vec!["/web".into()],
-			image: "alpine".into(),
-			status: status.into(),
-			state: state.into(),
-			ports: vec![],
-			labels: HashMap::new(),
-		}
-	}
-
-	#[test]
-	fn display_status_falls_back_to_state_when_status_empty() {
-		// Podman 5's libpod list endpoint sends an empty `Status` and the real
-		// machine state in `State` — `ps` must show the latter, not a blank.
-		assert_eq!(display_status(&entry("", "running")), "running");
-		assert_eq!(display_status(&entry("", "exited")), "exited");
-	}
-
-	#[test]
-	fn display_status_prefers_status_when_present() {
-		assert_eq!(
-			display_status(&entry("Up 2 seconds", "running")),
-			"Up 2 seconds"
-		);
-	}
-
-	#[test]
-	fn format_ports_defaults_missing_host_ip_to_all_interfaces() {
-		let p = ContainerPort {
-			host_ip: None,
-			host_port: Some(8080),
-			container_port: 80,
-			protocol: Some("tcp".into()),
-			..Default::default()
-		};
-		assert_eq!(
-			format_ports(std::slice::from_ref(&p)),
-			"0.0.0.0:8080->80/tcp"
-		);
-	}
-
-	#[test]
-	fn format_ports_keeps_explicit_host_ip() {
-		let p = ContainerPort {
-			host_ip: Some("127.0.0.1".into()),
-			host_port: Some(5432),
-			container_port: 5432,
-			..Default::default()
-		};
-		assert_eq!(
-			format_ports(std::slice::from_ref(&p)),
-			"127.0.0.1:5432->5432"
-		);
 	}
 
 	#[test]

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -14,7 +14,7 @@ mod inspect_util;
 mod log_prefix;
 mod ps;
 
-pub use ps::PsOptions;
+pub use ps::{PsFilterOptions, PsOptions};
 
 pub use exec::ExecOptions;
 use log_prefix::LinePrefixer;
@@ -41,6 +41,17 @@ pub struct LogsOptions {
 	pub until: Option<String>,
 	/// Prefix each line with an RFC3339 timestamp, `-t/--timestamps`.
 	pub timestamps: bool,
+}
+
+/// Prefix-display options for [`Engine::logs_with_display`] (`docker compose
+/// logs --no-color` / `--no-log-prefix`). Kept off the frozen [`LogsOptions`]
+/// struct so the 1.0 library API stays stable.
+#[derive(Default)]
+pub struct LogsDisplay {
+	/// Produce monochrome output (no colour in the prefix), `--no-color`.
+	pub no_color: bool,
+	/// Do not print the `{service} | ` prefix, `--no-log-prefix`.
+	pub no_log_prefix: bool,
 }
 
 /// Validate the `--tail`/`--since`/`--until` values client-side so a typo is
@@ -164,7 +175,8 @@ impl Engine {
 	}
 
 	/// Stream logs with `docker compose logs` options (`--tail`, `--since`,
-	/// `--until`, `--timestamps`, `--follow`).
+	/// `--until`, `--timestamps`, `--follow`). For the `--no-color`/
+	/// `--no-log-prefix` prefix-display options use [`Engine::logs_with_display`].
 	///
 	/// When `target_services` is empty, logs from every service are streamed;
 	/// otherwise only the named services (an unknown name is an error).
@@ -174,8 +186,28 @@ impl Engine {
 		target_services: &[String],
 		opts: LogsOptions,
 	) -> Result<()> {
+		self.logs_with_display(file, target_services, opts, LogsDisplay::default())
+			.await
+	}
+
+	/// Stream logs with `docker compose logs` options plus the prefix-display
+	/// controls (`--no-color`, `--no-log-prefix`).
+	///
+	/// When `target_services` is empty, logs from every service are streamed;
+	/// otherwise only the named services (an unknown name is an error).
+	pub async fn logs_with_display(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: LogsOptions,
+		display: LogsDisplay,
+	) -> Result<()> {
 		validate_log_filters(&opts)?;
 		let follow = opts.follow;
+		// `--no-log-prefix` drops the `{service} | ` tag; `--no-color` forces a
+		// monochrome prefix even on a colour-capable stdout.
+		let prefix = !display.no_log_prefix;
+		let allow_color = !display.no_color;
 		let query = log_query(&opts);
 		for svc in target_services {
 			if !file.services.contains_key(svc) {
@@ -230,8 +262,8 @@ impl Engine {
 						// let a sibling future block the thread on the same lock
 						// and deadlock. Each frame still locks once and flushes,
 						// keeping interleaved `logs -f` output prompt.
-						let mut out_pfx = LinePrefixer::new(&container_name);
-						let mut err_pfx = LinePrefixer::new(&container_name);
+						let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
+						let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 						while let Some(msg) = stream.next().await {
 							match msg {
 								Ok(LogOutput::StdOut { message }) => {
@@ -279,8 +311,8 @@ impl Engine {
 				// across the await loop would starve concurrent log emissions.
 				// Flush after each frame so `logs -f` still streams promptly.
 				let mut out = std::io::stdout().lock();
-				let mut out_pfx = LinePrefixer::new(&container_name);
-				let mut err_pfx = LinePrefixer::new(&container_name);
+				let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
+				let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 				while let Some(msg) = stream.next().await {
 					match msg {
 						Ok(LogOutput::StdOut { message }) => out_pfx.write(&mut out, &message),

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -43,6 +43,86 @@ pub struct LogsOptions {
 	pub timestamps: bool,
 }
 
+/// Validate the `--tail`/`--since`/`--until` values client-side so a typo is
+/// rejected with a clear local message instead of a raw podman HTTP 400. `tail`
+/// must be `all` or a non-negative integer; `since`/`until` must be a Unix
+/// timestamp or a Go-style duration (e.g. `10m`, `1h30m`) or an RFC3339-ish
+/// timestamp. Pure so it is unit-tested.
+fn validate_log_filters(opts: &LogsOptions) -> Result<()> {
+	if let Some(tail) = &opts.tail {
+		if tail != "all" && tail.parse::<u64>().is_err() {
+			return Err(ComposeError::Unsupported(format!(
+				"invalid --tail value {tail:?}: expected a non-negative integer or 'all'"
+			)));
+		}
+	}
+	for (flag, value) in [("--since", &opts.since), ("--until", &opts.until)] {
+		if let Some(v) = value {
+			if !is_valid_log_time(v) {
+				return Err(ComposeError::Unsupported(format!(
+					"invalid {flag} value {v:?}: expected a duration (e.g. 10m, 1h30m), a Unix \
+					 timestamp, or an RFC3339 time"
+				)));
+			}
+		}
+	}
+	Ok(())
+}
+
+/// Whether a `--since`/`--until` value is a plausible duration, Unix timestamp,
+/// or timestamp string. Conservative: rejects obvious garbage (`abc`) while
+/// accepting the forms podman understands.
+fn is_valid_log_time(v: &str) -> bool {
+	if v.is_empty() {
+		return false;
+	}
+	// Unix timestamp (optionally fractional).
+	if v.parse::<f64>().is_ok() {
+		return true;
+	}
+	// Go-style duration: digit-run + unit, repeated (e.g. 1h30m, 90s, 500ms).
+	if is_go_duration(v) {
+		return true;
+	}
+	// Timestamp-ish: starts with a 4-digit year and contains only the characters
+	// an RFC3339/date string uses. The server does the precise parse; this just
+	// blocks free-form garbage.
+	let bytes = v.as_bytes();
+	bytes.len() >= 4
+		&& bytes[..4].iter().all(u8::is_ascii_digit)
+		&& v.chars().all(|c| {
+			c.is_ascii_digit() || matches!(c, '-' | ':' | 't' | 'T' | 'z' | 'Z' | '.' | '+' | ' ')
+		})
+}
+
+/// Match a Go-style duration: one or more `<number><unit>` segments, units one
+/// of `ns,us,µs,ms,s,m,h`.
+fn is_go_duration(v: &str) -> bool {
+	let mut rest = v.strip_prefix('-').unwrap_or(v);
+	if rest.is_empty() {
+		return false;
+	}
+	let mut segments = 0;
+	while !rest.is_empty() {
+		let digits = rest.trim_start_matches(|c: char| c.is_ascii_digit() || c == '.');
+		if digits.len() == rest.len() {
+			// No digits consumed → not a duration segment.
+			return false;
+		}
+		rest = digits;
+		let unit_len = ["ms", "ns", "us", "µs", "s", "m", "h"]
+			.into_iter()
+			.find(|u| rest.starts_with(u))
+			.map(str::len);
+		match unit_len {
+			Some(n) => rest = &rest[n..],
+			None => return false,
+		}
+		segments += 1;
+	}
+	segments > 0
+}
+
 /// Build the libpod `containers/{}/logs` query string from the options.
 fn log_query(opts: &LogsOptions) -> String {
 	let mut q = format!(
@@ -94,6 +174,7 @@ impl Engine {
 		target_services: &[String],
 		opts: LogsOptions,
 	) -> Result<()> {
+		validate_log_filters(&opts)?;
 		let follow = opts.follow;
 		let query = log_query(&opts);
 		for svc in target_services {
@@ -174,11 +255,17 @@ impl Engine {
 					"{API_PREFIX}/containers/{}/logs?{query}",
 					urlencoded(&container_name),
 				);
-				let resp = self
-					.client
-					.get_stream(&path)
-					.await
-					.map_err(ComposeError::Podman)?;
+				// Tolerate a missing/not-yet-created container the way the
+				// multi-follow path does: warn and move on so the logs of the
+				// services that *do* exist are still shown, instead of aborting the
+				// whole command on the first 404.
+				let resp = match self.client.get_stream(&path).await {
+					Ok(r) => r,
+					Err(e) => {
+						tracing::warn!("logs {container_name}: {e}");
+						continue;
+					}
+				};
 				let mut stream = if is_tty {
 					crate::libpod::parse_raw(resp.into_body())
 				} else {
@@ -195,11 +282,12 @@ impl Engine {
 				let mut out_pfx = LinePrefixer::new(&container_name);
 				let mut err_pfx = LinePrefixer::new(&container_name);
 				while let Some(msg) = stream.next().await {
-					match msg.map_err(ComposeError::Podman)? {
-						LogOutput::StdOut { message } => out_pfx.write(&mut out, &message),
-						LogOutput::StdErr { message } => {
+					match msg {
+						Ok(LogOutput::StdOut { message }) => out_pfx.write(&mut out, &message),
+						Ok(LogOutput::StdErr { message }) => {
 							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
+						Err(_) => break,
 					}
 				}
 				out_pfx.flush_tail(&mut out);
@@ -275,7 +363,7 @@ fn filter_orphans(names: Vec<String>, known: &std::collections::HashSet<String>)
 
 #[cfg(test)]
 mod tests {
-	use super::{filter_orphans, log_query, LogsOptions};
+	use super::{filter_orphans, is_valid_log_time, log_query, validate_log_filters, LogsOptions};
 	use std::collections::HashSet;
 
 	#[test]
@@ -316,5 +404,54 @@ mod tests {
 		assert!(q.contains("&since=10m"));
 		// `:` is percent-encoded in the query value.
 		assert!(q.contains("&until=2024-01-01T00%3A00%3A00"));
+	}
+
+	#[test]
+	fn validate_log_filters_accepts_good_values() {
+		assert!(validate_log_filters(&LogsOptions {
+			tail: Some("all".into()),
+			since: Some("10m".into()),
+			until: Some("2024-01-01T00:00:00Z".into()),
+			..Default::default()
+		})
+		.is_ok());
+		assert!(validate_log_filters(&LogsOptions {
+			tail: Some("100".into()),
+			since: Some("1700000000".into()),
+			..Default::default()
+		})
+		.is_ok());
+		assert!(validate_log_filters(&LogsOptions::default()).is_ok());
+	}
+
+	#[test]
+	fn validate_log_filters_rejects_bad_tail_and_time() {
+		assert!(validate_log_filters(&LogsOptions {
+			tail: Some("abc".into()),
+			..Default::default()
+		})
+		.is_err());
+		assert!(validate_log_filters(&LogsOptions {
+			since: Some("yesterday".into()),
+			..Default::default()
+		})
+		.is_err());
+		assert!(validate_log_filters(&LogsOptions {
+			until: Some("not-a-time".into()),
+			..Default::default()
+		})
+		.is_err());
+	}
+
+	#[test]
+	fn is_valid_log_time_classifies_forms() {
+		assert!(is_valid_log_time("10m"));
+		assert!(is_valid_log_time("1h30m"));
+		assert!(is_valid_log_time("500ms"));
+		assert!(is_valid_log_time("1700000000"));
+		assert!(is_valid_log_time("2024-01-02T03:04:05Z"));
+		assert!(!is_valid_log_time("abc"));
+		assert!(!is_valid_log_time(""));
+		assert!(!is_valid_log_time("10x"));
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -367,16 +367,9 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		let container_name = match opts.index {
-			Some(i) => {
-				let names = self.replica_names(service_name, service);
-				let idx = (i as usize).saturating_sub(1);
-				names.get(idx).cloned().ok_or_else(|| {
-					ComposeError::ServiceNotFound(format!("{service_name} (replica index {i})"))
-				})?
-			}
-			None => self.first_replica_name(service_name, service),
-		};
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		let exec_cfg = ExecCreateConfig {
 			cmd: Some(cmd),

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -8,7 +8,7 @@ use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::Engine;
 
-/// Options for [`Engine::ps_with_options`].
+/// Options for [`Engine::ps_with_options`], mirroring `docker compose ps`.
 #[derive(Default)]
 pub struct PsOptions {
 	/// Include stopped containers, `-a/--all` (default: running only).
@@ -17,6 +17,21 @@ pub struct PsOptions {
 	pub quiet: bool,
 	/// Emit JSON instead of the table, `--format json`.
 	pub json: bool,
+}
+
+/// Service/status/name filters for [`Engine::ps_filtered`] (`docker compose ps`
+/// `--services`, `[SERVICE...]`, `--status`, `--filter`). Kept off the frozen
+/// [`PsOptions`] struct so the 1.0 library API stays stable.
+#[derive(Default)]
+pub struct PsFilterOptions {
+	/// Print the service names instead of the container table, `--services`.
+	pub services_only: bool,
+	/// Restrict to these services' containers (positional `SERVICE` filter).
+	pub services: Vec<String>,
+	/// Status filters, `--status` (e.g. running, exited); OR-combined.
+	pub status: Vec<String>,
+	/// Generic `KEY=VALUE` predicates, `--filter` (supports status= and name=).
+	pub filters: Vec<String>,
 }
 
 /// Human-readable status for `ps`. Podman's libpod list endpoint leaves
@@ -33,6 +48,37 @@ fn display_status(c: &ContainerListEntry) -> &str {
 /// The container's display name (leading slash stripped).
 fn name_of(c: &ContainerListEntry) -> String {
 	c.names.join(", ").trim_start_matches('/').to_string()
+}
+
+/// Whether a container status/state word satisfies a `--status`/`status=` filter.
+/// Each wanted value matches case-insensitively as a prefix of the status word
+/// (so `running` matches `running` and `up`-style strings via the state). An
+/// empty `wanted` matches everything. Pure so the predicate is unit-tested.
+fn status_matches(status: &str, wanted: &[String]) -> bool {
+	if wanted.is_empty() {
+		return true;
+	}
+	let s = status.trim().to_ascii_lowercase();
+	wanted.iter().any(|w| {
+		let w = w.trim().to_ascii_lowercase();
+		!w.is_empty() && (s == w || s.starts_with(&w))
+	})
+}
+
+/// Split `--filter KEY=VALUE` predicates into the supported buckets: extra
+/// `status=` values are folded into the status filter, `name=` values into the
+/// name-substring filter, and anything else is returned as `unknown` so the
+/// caller can warn. Pure so it is unit-tested.
+fn split_ps_filters(filters: &[String]) -> (Vec<String>, Vec<String>, Vec<String>) {
+	let (mut status, mut names, mut unknown) = (Vec::new(), Vec::new(), Vec::new());
+	for f in filters {
+		match f.split_once('=') {
+			Some(("status", v)) => status.push(v.to_string()),
+			Some(("name", v)) => names.push(v.to_string()),
+			_ => unknown.push(f.clone()),
+		}
+	}
+	(status, names, unknown)
 }
 
 /// The health word embedded in a human status string (`Up 2 minutes (healthy)`),
@@ -141,10 +187,65 @@ impl Engine {
 		self.ps_with_options(file, PsOptions::default()).await
 	}
 
+	/// List containers with `docker compose ps`-style options (`-a/--all`,
+	/// `-q/--quiet`, `--format`). For the `--services`/`[SERVICE...]`/`--status`/
+	/// `--filter` predicates use [`Engine::ps_filtered`].
+	pub async fn ps_with_options(&self, file: &ComposeFile, opts: PsOptions) -> Result<()> {
+		self.ps_filtered(file, opts, PsFilterOptions::default())
+			.await
+	}
+
 	/// List containers with `docker compose ps`-style options: `-a/--all`
-	/// (include stopped), `-q/--quiet` (full IDs only), and `--format`
-	/// (table | json).
-	pub async fn ps_with_options(&self, _file: &ComposeFile, opts: PsOptions) -> Result<()> {
+	/// (include stopped), `-q/--quiet` (full IDs only), `--format`
+	/// (table | json), `--services` (service-name list), a positional `SERVICE`
+	/// filter, and `--status`/`--filter` predicates.
+	pub async fn ps_filtered(
+		&self,
+		file: &ComposeFile,
+		opts: PsOptions,
+		filters: PsFilterOptions,
+	) -> Result<()> {
+		for name in &filters.services {
+			if !file.services.contains_key(name) {
+				return Err(ComposeError::ServiceNotFound(name.clone()));
+			}
+		}
+
+		// `--services` lists the (optionally filtered) configured service names,
+		// one per line, instead of the container table.
+		if filters.services_only {
+			for name in file.services.keys() {
+				if filters.services.is_empty() || filters.services.iter().any(|s| s == name) {
+					println!("{name}");
+				}
+			}
+			return Ok(());
+		}
+
+		// Fold `--status` and any `status=`/`name=` from `--filter` together;
+		// warn on unsupported `--filter` keys rather than silently ignoring them.
+		let (mut status_filter, name_filter, unknown) = split_ps_filters(&filters.filters);
+		for u in &unknown {
+			tracing::warn!("ps: ignoring unsupported filter '{u}'");
+		}
+		status_filter.extend(filters.status.iter().cloned());
+
+		// A positional `SERVICE` filter restricts to those services' container
+		// names (across replicas).
+		let allowed_names: Option<std::collections::HashSet<String>> =
+			if filters.services.is_empty() {
+				None
+			} else {
+				Some(
+					filters
+						.services
+						.iter()
+						.filter_map(|n| file.services.get(n).map(|s| (n, s)))
+						.flat_map(|(n, s)| self.replica_names(n, s))
+						.collect(),
+				)
+			};
+
 		let label = format!("podup.project={}", self.project);
 		let filters = serde_json::json!({ "label": [label] });
 		let path = format!(
@@ -153,11 +254,25 @@ impl Engine {
 			urlencoded(&filters.to_string()),
 		);
 
-		let containers = self
+		let all_containers = self
 			.client
 			.get_json::<Vec<ContainerListEntry>>(&path)
 			.await
 			.map_err(ComposeError::Podman)?;
+
+		let containers: Vec<ContainerListEntry> = all_containers
+			.into_iter()
+			.filter(|c| {
+				let name = name_of(c);
+				allowed_names.as_ref().is_none_or(|set| {
+					c.names
+						.iter()
+						.any(|n| set.contains(n.trim_start_matches('/')))
+				}) && (status_matches(&c.state, &status_filter)
+					|| status_matches(&c.status, &status_filter))
+					&& (name_filter.is_empty() || name_filter.iter().any(|nf| name.contains(nf)))
+			})
+			.collect();
 
 		if opts.quiet {
 			// Full 64-char IDs, like `docker compose ps -q` (and podup's JSON),
@@ -207,6 +322,33 @@ mod tests {
 			exit_code: None,
 			labels: HashMap::new(),
 		}
+	}
+
+	#[test]
+	fn status_matches_empty_filter_matches_all() {
+		assert!(status_matches("running", &[]));
+		assert!(status_matches("exited", &[]));
+	}
+
+	#[test]
+	fn status_matches_is_case_insensitive_prefix() {
+		assert!(status_matches("running", &["RUNNING".to_string()]));
+		assert!(status_matches("exited", &["exit".to_string()]));
+		assert!(!status_matches("running", &["exited".to_string()]));
+		// An empty wanted value never matches.
+		assert!(!status_matches("running", &["".to_string()]));
+	}
+
+	#[test]
+	fn split_ps_filters_buckets_known_keys_and_flags_unknown() {
+		let (status, names, unknown) = split_ps_filters(&[
+			"status=running".to_string(),
+			"name=web".to_string(),
+			"label=foo".to_string(),
+		]);
+		assert_eq!(status, vec!["running".to_string()]);
+		assert_eq!(names, vec!["web".to_string()]);
+		assert_eq!(unknown, vec!["label=foo".to_string()]);
 	}
 
 	#[test]

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -292,15 +292,19 @@ impl Engine {
 			return Ok(());
 		}
 
-		crate::ui::print_bold_header(&format!(
-			"{:<40} {:<30} {:<20} PORTS",
-			"NAME", "IMAGE", "STATUS"
-		));
+		let mut table = crate::ui::Table::new(&["NAME", "IMAGE", "STATUS", "PORTS"])
+			.cap(0, 48)
+			.cap(1, 48)
+			.status_col(2);
 		for c in &containers {
-			let ports = format_ports(&c.ports);
-			let status = crate::ui::status_cell(display_status(c), 20);
-			println!("{:<40} {:<30} {status} {ports}", name_of(c), c.image);
+			table.push(vec![
+				name_of(c),
+				c.image.clone(),
+				display_status(c).to_string(),
+				format_ports(&c.ports),
+			]);
 		}
+		table.print();
 
 		Ok(())
 	}

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -1,0 +1,331 @@
+//! `ps` — list this project's containers as a table or JSON. Split out of the
+//! query root so each file stays within the source line limit.
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::Engine;
+
+/// Options for [`Engine::ps_with_options`].
+#[derive(Default)]
+pub struct PsOptions {
+	/// Include stopped containers, `-a/--all` (default: running only).
+	pub all: bool,
+	/// Print only container IDs, `-q/--quiet`.
+	pub quiet: bool,
+	/// Emit JSON instead of the table, `--format json`.
+	pub json: bool,
+}
+
+/// Human-readable status for `ps`. Podman's libpod list endpoint leaves
+/// `Status` empty and reports the machine state in `State`, so fall back to it
+/// rather than rendering a blank column.
+fn display_status(c: &ContainerListEntry) -> &str {
+	if c.status.is_empty() {
+		&c.state
+	} else {
+		&c.status
+	}
+}
+
+/// The container's display name (leading slash stripped).
+fn name_of(c: &ContainerListEntry) -> String {
+	c.names.join(", ").trim_start_matches('/').to_string()
+}
+
+/// The health word embedded in a human status string (`Up 2 minutes (healthy)`),
+/// or `""` when absent. The libpod list endpoint carries no separate health
+/// field, so `ps` derives it from the status text the way `docker ps` shows it.
+fn health_from_status(status: &str) -> &'static str {
+	let s = status.to_ascii_lowercase();
+	if s.contains("unhealthy") {
+		"unhealthy"
+	} else if s.contains("healthy") {
+		"healthy"
+	} else if s.contains("health: starting") || s.contains("starting") {
+		"starting"
+	} else {
+		""
+	}
+}
+
+/// Number of consecutive ports a record covers (`range`, at least 1).
+fn span_len(p: &ContainerPort) -> u16 {
+	p.range.filter(|&r| r > 0).unwrap_or(1)
+}
+
+/// Host IP for display: an unset/empty value means all interfaces (`0.0.0.0`),
+/// matching Docker/Podman output (libpod commonly omits it).
+fn display_host_ip(p: &ContainerPort) -> &str {
+	p.host_ip
+		.as_deref()
+		.filter(|s| !s.is_empty())
+		.unwrap_or("0.0.0.0")
+}
+
+/// Render one port record the way `docker compose ps` does. A collapsed range
+/// (`range > 1`) is rendered as `host_start-host_end->cont_start-cont_end` so the
+/// whole range is shown rather than only its first mapping.
+fn format_port_record(p: &ContainerPort) -> String {
+	let proto = p
+		.protocol
+		.as_deref()
+		.map(|proto| format!("/{proto}"))
+		.unwrap_or_default();
+	let host_ip = display_host_ip(p);
+	let hp = p.host_port.unwrap_or(0);
+	let n = span_len(p);
+	if n > 1 {
+		format!(
+			"{host_ip}:{hp}-{}->{}-{}{proto}",
+			hp + n - 1,
+			p.container_port,
+			p.container_port + n - 1,
+		)
+	} else {
+		format!("{host_ip}:{hp}->{}{proto}", p.container_port)
+	}
+}
+
+/// Render a container's published ports as a comma-joined `ps` PORTS cell.
+fn format_ports(ports: &[ContainerPort]) -> String {
+	ports
+		.iter()
+		.map(format_port_record)
+		.collect::<Vec<_>>()
+		.join(", ")
+}
+
+/// Structured publishers for `ps --format json`, one object per published port
+/// (a collapsed range is expanded so every port appears), mirroring the
+/// `Publishers` array docker compose emits.
+fn publishers(ports: &[ContainerPort]) -> Vec<serde_json::Value> {
+	let mut out = Vec::new();
+	for p in ports {
+		let n = span_len(p);
+		for i in 0..n {
+			out.push(serde_json::json!({
+				"URL": display_host_ip(p),
+				"TargetPort": p.container_port + i,
+				"PublishedPort": p.host_port.map(|hp| hp + i),
+				"Protocol": p.protocol.as_deref().unwrap_or("tcp"),
+			}));
+		}
+	}
+	out
+}
+
+/// Build one `ps --format json` row, surfacing the fields docker compose
+/// machine consumers expect (Service/State/Health/ExitCode/Publishers) in
+/// addition to Name/Image/Status/ID. Pure so it can be unit-tested.
+fn ps_json_row(c: &ContainerListEntry) -> serde_json::Value {
+	serde_json::json!({
+		"Name": name_of(c),
+		"Image": c.image,
+		"Project": c.labels.get("podup.project").cloned().unwrap_or_default(),
+		"Service": c.labels.get("podup.service").cloned().unwrap_or_default(),
+		"State": c.state,
+		"Status": display_status(c),
+		"Health": health_from_status(display_status(c)),
+		"ExitCode": c.exit_code.unwrap_or(0),
+		"Publishers": publishers(&c.ports),
+		"ID": c.id,
+	})
+}
+
+impl Engine {
+	/// List running containers for this project as a table (default options).
+	pub async fn ps(&self, file: &ComposeFile) -> Result<()> {
+		self.ps_with_options(file, PsOptions::default()).await
+	}
+
+	/// List containers with `docker compose ps`-style options: `-a/--all`
+	/// (include stopped), `-q/--quiet` (full IDs only), and `--format`
+	/// (table | json).
+	pub async fn ps_with_options(&self, _file: &ComposeFile, opts: PsOptions) -> Result<()> {
+		let label = format!("podup.project={}", self.project);
+		let filters = serde_json::json!({ "label": [label] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all={}&filters={}",
+			opts.all,
+			urlencoded(&filters.to_string()),
+		);
+
+		let containers = self
+			.client
+			.get_json::<Vec<ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		if opts.quiet {
+			// Full 64-char IDs, like `docker compose ps -q` (and podup's JSON),
+			// so scripts consuming the IDs are not handed truncated values.
+			for c in &containers {
+				println!("{}", c.id);
+			}
+			return Ok(());
+		}
+
+		if opts.json {
+			let rows: Vec<_> = containers.iter().map(ps_json_row).collect();
+			println!(
+				"{}",
+				serde_json::to_string_pretty(&rows).unwrap_or_default()
+			);
+			return Ok(());
+		}
+
+		crate::ui::print_bold_header(&format!(
+			"{:<40} {:<30} {:<20} PORTS",
+			"NAME", "IMAGE", "STATUS"
+		));
+		for c in &containers {
+			let ports = format_ports(&c.ports);
+			let status = crate::ui::status_cell(display_status(c), 20);
+			println!("{:<40} {:<30} {status} {ports}", name_of(c), c.image);
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::collections::HashMap;
+
+	fn entry(status: &str, state: &str) -> ContainerListEntry {
+		ContainerListEntry {
+			id: "abc123".into(),
+			names: vec!["/web".into()],
+			image: "alpine".into(),
+			status: status.into(),
+			state: state.into(),
+			ports: vec![],
+			exit_code: None,
+			labels: HashMap::new(),
+		}
+	}
+
+	#[test]
+	fn display_status_falls_back_to_state_when_status_empty() {
+		assert_eq!(display_status(&entry("", "running")), "running");
+		assert_eq!(display_status(&entry("", "exited")), "exited");
+	}
+
+	#[test]
+	fn display_status_prefers_status_when_present() {
+		assert_eq!(
+			display_status(&entry("Up 2 seconds", "running")),
+			"Up 2 seconds"
+		);
+	}
+
+	#[test]
+	fn format_ports_defaults_missing_host_ip_to_all_interfaces() {
+		let p = ContainerPort {
+			host_ip: None,
+			host_port: Some(8080),
+			container_port: 80,
+			protocol: Some("tcp".into()),
+			..Default::default()
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"0.0.0.0:8080->80/tcp"
+		);
+	}
+
+	#[test]
+	fn format_ports_keeps_explicit_host_ip() {
+		let p = ContainerPort {
+			host_ip: Some("127.0.0.1".into()),
+			host_port: Some(5432),
+			container_port: 5432,
+			..Default::default()
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"127.0.0.1:5432->5432"
+		);
+	}
+
+	#[test]
+	fn format_ports_expands_a_collapsed_range() {
+		// libpod collapses 51251-51253->8080-8082 into one record with range=3;
+		// the full range must be rendered, not just the first mapping.
+		let p = ContainerPort {
+			host_ip: None,
+			host_port: Some(51251),
+			container_port: 8080,
+			protocol: Some("tcp".into()),
+			range: Some(3),
+		};
+		assert_eq!(
+			format_ports(std::slice::from_ref(&p)),
+			"0.0.0.0:51251-51253->8080-8082/tcp"
+		);
+	}
+
+	#[test]
+	fn publishers_expand_each_port_in_a_range() {
+		let p = ContainerPort {
+			host_ip: Some("0.0.0.0".into()),
+			host_port: Some(51251),
+			container_port: 8080,
+			protocol: Some("tcp".into()),
+			range: Some(3),
+		};
+		let pubs = publishers(std::slice::from_ref(&p));
+		assert_eq!(pubs.len(), 3);
+		assert_eq!(pubs[0]["TargetPort"], 8080);
+		assert_eq!(pubs[0]["PublishedPort"], 51251);
+		assert_eq!(pubs[2]["TargetPort"], 8082);
+		assert_eq!(pubs[2]["PublishedPort"], 51253);
+		assert_eq!(pubs[1]["Protocol"], "tcp");
+	}
+
+	#[test]
+	fn health_is_derived_from_status_text() {
+		assert_eq!(health_from_status("Up 2 minutes (healthy)"), "healthy");
+		assert_eq!(health_from_status("Up 1 minute (unhealthy)"), "unhealthy");
+		assert_eq!(
+			health_from_status("Up 3 seconds (health: starting)"),
+			"starting"
+		);
+		assert_eq!(health_from_status("Exited (1) 4 seconds ago"), "");
+	}
+
+	#[test]
+	fn ps_json_row_surfaces_state_exitcode_and_publishers() {
+		let mut labels = HashMap::new();
+		labels.insert("podup.project".to_string(), "demo".to_string());
+		labels.insert("podup.service".to_string(), "web".to_string());
+		let c = ContainerListEntry {
+			id: "deadbeef".into(),
+			names: vec!["/demo-web-1".into()],
+			image: "nginx:1.25".into(),
+			status: "Exited (137) 2s ago".into(),
+			state: "exited".into(),
+			ports: vec![ContainerPort {
+				host_ip: None,
+				host_port: Some(8080),
+				container_port: 80,
+				protocol: Some("tcp".into()),
+				range: None,
+			}],
+			exit_code: Some(137),
+			labels,
+		};
+		let row = ps_json_row(&c);
+		assert_eq!(row["Name"], "demo-web-1");
+		assert_eq!(row["Service"], "web");
+		assert_eq!(row["Project"], "demo");
+		assert_eq!(row["State"], "exited");
+		assert_eq!(row["ExitCode"], 137);
+		assert_eq!(row["ID"], "deadbeef");
+		assert_eq!(row["Publishers"][0]["PublishedPort"], 8080);
+	}
+}

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -20,15 +20,22 @@ use std::path::PathBuf;
 use std::path::Path;
 
 /// Whether `name` is safe to use as a single path component and container
-/// name prefix: non-empty, bounded, ASCII alphanumeric plus `-`/`_`/`.`,
-/// not starting with a dot (rejects `.`, `..` and hidden directories).
+/// name prefix. Matches docker-compose's project-name rule `^[a-z0-9][a-z0-9_-]*$`:
+/// non-empty, bounded, lowercase ASCII letters/digits/`-`/`_` only, and a first
+/// character that is a letter or digit. This rejects a leading separator
+/// (`-rf`, `--all`, `_x` — a latent flag-injection vector for forwarding paths),
+/// uppercase, dots (`.`, `..`, hidden directories, `bad.` trailing-dot names),
+/// and all-separator names.
 pub fn is_safe_project_name(name: &str) -> bool {
-	!name.is_empty()
-		&& name.len() <= 128
-		&& !name.starts_with('.')
-		&& name
-			.chars()
-			.all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+	if name.is_empty() || name.len() > 128 {
+		return false;
+	}
+	let mut chars = name.chars();
+	let first = chars.next().expect("name is non-empty");
+	if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+		return false;
+	}
+	chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '_'))
 }
 
 /// Per-user staging base for inline secret/config content.
@@ -159,7 +166,9 @@ mod name_tests {
 
 	#[test]
 	fn safe_project_names_accepted() {
-		for name in ["web", "my-app", "my_app", "app.v2", "A1"] {
+		// Matches docker-compose `^[a-z0-9][a-z0-9_-]*$`: lowercase letters/digits,
+		// `-`/`_`, first char a letter or digit.
+		for name in ["web", "my-app", "my_app", "appv2", "a1", "1app", "x"] {
 			assert!(is_safe_project_name(name), "{name:?} must be accepted");
 		}
 	}
@@ -176,6 +185,15 @@ mod name_tests {
 			"../x",
 			"a b",
 			"a\0b",
+			// docker-compose rejects these too; previously accepted by podup.
+			"-rf",    // leading dash (flag-injection vector)
+			"--all",  // leading dash
+			"---",    // all-dash
+			"_x",     // leading underscore
+			"App",    // uppercase
+			"MYAPP",  // uppercase
+			"app.v2", // dot
+			"bad.",   // trailing dot
 			long.as_str(),
 		] {
 			assert!(!is_safe_project_name(name), "{name:?} must be rejected");

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -7,9 +7,45 @@ use serde::Deserialize;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
+use crate::libpod::types::container::ContainerListEntry;
 use crate::libpod::{parse_json_lines, urlencoded, API_PREFIX};
 
 use super::Engine;
+
+/// Options for [`Engine::stats_with_options`], mirroring `docker compose stats`
+/// and the table-shaping flags the other list commands expose. Kept off the
+/// frozen [`Engine::stats`] signature so the 1.0 library API stays stable.
+#[derive(Default)]
+pub struct StatsOptions {
+	/// Disable streaming; print a single snapshot and exit, `--no-stream`.
+	pub no_stream: bool,
+	/// Include non-running containers as zeroed rows, `-a/--all`.
+	pub all: bool,
+	/// Emit JSON instead of the table, `--format json`.
+	pub json: bool,
+	/// Disable container-name truncation in the table, `--no-trunc`.
+	pub no_trunc: bool,
+}
+
+impl StatsOptions {
+	/// Build options from the four CLI flags, in `--no-stream`/`--all`/
+	/// `--no-trunc`/`--format json` order. A terse constructor so the CLI keeps
+	/// the field names (all `pub`) available for clarity while the dispatch site
+	/// stays compact.
+	pub fn new(no_stream: bool, all: bool, no_trunc: bool, json: bool) -> Self {
+		Self {
+			no_stream,
+			all,
+			no_trunc,
+			json,
+		}
+	}
+}
+
+/// Width of the table NAME column; long names are truncated to this width (with
+/// a trailing ellipsis) unless `--no-trunc` is given, so a long container name
+/// no longer overflows and shifts every following column. Matches [`HEADER`].
+const NAME_WIDTH: usize = 32;
 
 /// Build the query fragment scoping a stats request to the `wanted` containers,
 /// or an empty string when none are wanted (which falls back to the daemon
@@ -41,14 +77,14 @@ where
 }
 
 /// One frame of the libpod `/containers/stats` response.
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 struct StatsReport {
 	#[serde(rename = "Stats", default)]
 	stats: Vec<ContainerStat>,
 }
 
 /// Per-container resource sample within a [`StatsReport`].
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Clone)]
 struct ContainerStat {
 	#[serde(rename = "Name", default)]
 	name: String,
@@ -74,7 +110,7 @@ struct ContainerStat {
 }
 
 /// Per-interface network counters.
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Clone)]
 struct NetStat {
 	#[serde(rename = "RxBytes", default)]
 	rx: u64,
@@ -98,15 +134,33 @@ fn format_bytes(bytes: u64) -> String {
 	}
 }
 
-/// Format one stats row into the table layout. Pure for testing.
-fn format_row(s: &ContainerStat) -> String {
-	let (rx, tx) = s
-		.network
+/// Sum a container's per-interface network counters into one `(rx, tx)` pair.
+fn net_totals(s: &ContainerStat) -> (u64, u64) {
+	s.network
 		.values()
-		.fold((0u64, 0u64), |(rx, tx), n| (rx + n.rx, tx + n.tx));
+		.fold((0u64, 0u64), |(rx, tx), n| (rx + n.rx, tx + n.tx))
+}
+
+/// The NAME cell for the table: the full name when `no_trunc`, otherwise
+/// truncated to [`NAME_WIDTH`] with a trailing ellipsis so a long name keeps the
+/// row aligned. Counts characters (not bytes) so multi-byte names truncate
+/// safely. Pure for testing.
+fn truncate_name(name: &str, no_trunc: bool) -> String {
+	if no_trunc || name.chars().count() <= NAME_WIDTH {
+		return name.to_string();
+	}
+	let head: String = name.chars().take(NAME_WIDTH - 1).collect();
+	format!("{head}…")
+}
+
+/// Format one stats row into the table layout. With `no_trunc` a long name is
+/// left intact (and may overflow its column); otherwise it is truncated to
+/// [`NAME_WIDTH`]. Pure for testing.
+fn format_row(s: &ContainerStat, no_trunc: bool) -> String {
+	let (rx, tx) = net_totals(s);
 	format!(
-		"{:<32} {:>7.2}% {:>10} / {:<10} {:>6.2}% {:>9} / {:<9} {:>9} / {:<9} {:>5}",
-		s.name,
+		"{:<NAME_WIDTH$} {:>7.2}% {:>10} / {:<10} {:>6.2}% {:>9} / {:<9} {:>9} / {:<9} {:>5}",
+		truncate_name(&s.name, no_trunc),
 		s.cpu,
 		format_bytes(s.mem_usage),
 		format_bytes(s.mem_limit),
@@ -117,6 +171,25 @@ fn format_row(s: &ContainerStat) -> String {
 		format_bytes(s.block_out),
 		s.pids,
 	)
+}
+
+/// Build one `stats --format json` row with numeric values (raw bytes/percent),
+/// so machine consumers get exact figures rather than the table's rounded,
+/// human-formatted cells. Pure so it can be unit-tested.
+fn stat_json_row(s: &ContainerStat) -> serde_json::Value {
+	let (rx, tx) = net_totals(s);
+	serde_json::json!({
+		"Name": s.name,
+		"CPUPerc": s.cpu,
+		"MemUsage": s.mem_usage,
+		"MemLimit": s.mem_limit,
+		"MemPerc": s.mem_perc,
+		"NetInput": rx,
+		"NetOutput": tx,
+		"BlockInput": s.block_in,
+		"BlockOutput": s.block_out,
+		"PIDs": s.pids,
+	})
 }
 
 const HEADER: &str = "NAME                                 CPU %       MEM USAGE / LIMIT        MEM %    NET I/O             BLOCK I/O           PIDS";
@@ -131,27 +204,74 @@ impl Engine {
 		target_services: &[String],
 		no_stream: bool,
 	) -> Result<()> {
+		self.stats_with_options(
+			file,
+			target_services,
+			StatsOptions {
+				no_stream,
+				..StatsOptions::default()
+			},
+		)
+		.await
+	}
+
+	/// Stream resource usage with `docker compose stats`-style options:
+	/// `--no-stream` (single snapshot), `-a/--all` (include non-running
+	/// containers as zeroed rows), `--format` (table | json), and `--no-trunc`
+	/// (keep full container names). `target_services` narrows to specific
+	/// services.
+	pub async fn stats_with_options(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: StatsOptions,
+	) -> Result<()> {
 		// Reject unknown/typo service names instead of silently sampling the whole
 		// host and printing a header-only table, matching the other commands.
 		if let Some(unknown) = first_unknown_service(file, target_services) {
 			return Err(ComposeError::ServiceNotFound(unknown.into()));
 		}
-		let wanted = self.target_container_names(file, target_services).await?;
+		let targets = self.target_containers(file, target_services).await?;
 
-		// Scope the stats stream to just the wanted containers server-side via the
+		// Only running containers carry live samples, so scope the libpod
+		// `containers=` filter to them: a stopped/created container fed to that
+		// filter 404s the whole request. Non-running rows are synthesized locally
+		// (as zeros) when `--all` is set.
+		let running: HashSet<String> = targets
+			.iter()
+			.filter(|t| t.running)
+			.map(|t| t.name.clone())
+			.collect();
+		let stopped: Vec<String> = if opts.all {
+			targets
+				.iter()
+				.filter(|t| !t.running)
+				.map(|t| t.name.clone())
+				.collect()
+		} else {
+			Vec::new()
+		};
+
+		// Scope the stats stream to just the running containers server-side via the
 		// `containers=` query param, so the daemon does not sample every container
-		// on the host (the response is still filtered locally by `wanted`).
-		let containers = containers_query(&wanted);
+		// on the host (the response is still filtered locally by `running`).
+		let containers = containers_query(&running);
 
-		if no_stream {
-			let report: StatsReport = self
-				.client
-				.get_json(&format!(
-					"{API_PREFIX}/containers/stats?stream=false{containers}"
-				))
-				.await
-				.map_err(ComposeError::Podman)?;
-			print_frame(&report, &wanted);
+		if opts.no_stream || running.is_empty() {
+			// Nothing running means nothing to sample (and an empty `containers=`
+			// filter would otherwise fall back to the whole host) — skip the call
+			// and render an empty/`--all`-only frame.
+			let report = if running.is_empty() {
+				StatsReport::default()
+			} else {
+				self.client
+					.get_json(&format!(
+						"{API_PREFIX}/containers/stats?stream=false{containers}"
+					))
+					.await
+					.map_err(ComposeError::Podman)?
+			};
+			print_frame(&report, &running, &stopped, &opts);
 			return Ok(());
 		}
 
@@ -165,7 +285,7 @@ impl Engine {
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
 		while let Some(frame) = frames.next().await {
 			match frame {
-				Ok(report) => print_frame(&report, &wanted),
+				Ok(report) => print_frame(&report, &running, &stopped, &opts),
 				Err(e) => {
 					tracing::debug!("stats stream ended: {e}");
 					break;
@@ -175,27 +295,58 @@ impl Engine {
 		Ok(())
 	}
 
-	/// The set of container names to report on: every replica of the targeted
-	/// services (all services when `target_services` is empty).
-	async fn target_container_names(
+	/// The containers to report on — every existing replica of the targeted
+	/// services (all services when `target_services` is empty), paired with
+	/// whether each is currently running. Only containers that actually exist are
+	/// returned (no static-name fallback): an absent service simply contributes
+	/// no rows.
+	async fn target_containers(
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],
-	) -> Result<HashSet<String>> {
-		let mut wanted = HashSet::new();
-		for name in file.services.keys() {
-			if target_services.is_empty() || target_services.iter().any(|t| t == name) {
-				// Only containers that actually exist — no static-name fallback.
-				// Feeding synthesized names for a never-up service to libpod's
-				// `containers=` filter 404s the whole stats request; an absent
-				// service simply contributes no rows (a zero/empty result).
-				for c in self.list_project_container_names(Some(name)).await? {
-					wanted.insert(c);
-				}
+	) -> Result<Vec<TargetContainer>> {
+		let filters = serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		let mut out = Vec::new();
+		for e in entries {
+			let service = e
+				.labels
+				.get("podup.service")
+				.map(String::as_str)
+				.unwrap_or("");
+			// Skip containers whose service the compose file no longer defines, and
+			// honour a positional `SERVICE` filter.
+			if !file.services.contains_key(service) {
+				continue;
+			}
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == service) {
+				continue;
+			}
+			if let Some(raw) = e.names.first() {
+				out.push(TargetContainer {
+					name: raw.trim_start_matches('/').to_string(),
+					running: e.state == "running",
+				});
 			}
 		}
-		Ok(wanted)
+		Ok(out)
 	}
+}
+
+/// A project container considered for `stats`, with its run state so non-running
+/// containers can be folded in (as zeroed rows) only under `--all`.
+struct TargetContainer {
+	name: String,
+	running: bool,
 }
 
 /// The first targeted service name that the compose file does not define, if any.
@@ -207,19 +358,52 @@ fn first_unknown_service<'a>(file: &ComposeFile, targets: &'a [String]) -> Optio
 		.find(|t| !file.services.contains_key(*t))
 }
 
-/// Print one stats frame: a header plus a row per wanted container (sorted for
-/// stable output). Frames are separated by a blank line.
-fn print_frame(report: &StatsReport, wanted: &HashSet<String>) {
-	let mut rows: Vec<&ContainerStat> = report
+/// Assemble the rows for one frame: the live samples for `running` containers
+/// plus synthesized zero rows for each `stopped` container (already empty when
+/// `--all` is off), sorted by name for stable output.
+fn frame_rows(
+	report: &StatsReport,
+	running: &HashSet<String>,
+	stopped: &[String],
+) -> Vec<ContainerStat> {
+	let mut rows: Vec<ContainerStat> = report
 		.stats
 		.iter()
-		.filter(|s| wanted.contains(&s.name))
+		.filter(|s| running.contains(&s.name))
+		.cloned()
 		.collect();
+	for name in stopped {
+		rows.push(ContainerStat {
+			name: name.clone(),
+			..ContainerStat::default()
+		});
+	}
 	rows.sort_by(|a, b| a.name.cmp(&b.name));
+	rows
+}
+
+/// Print one stats frame: the table (a bold header plus one row per container)
+/// or a JSON array when `--format json`. Table frames end with a blank line.
+fn print_frame(
+	report: &StatsReport,
+	running: &HashSet<String>,
+	stopped: &[String],
+	opts: &StatsOptions,
+) {
+	let rows = frame_rows(report, running, stopped);
+
+	if opts.json {
+		let json: Vec<_> = rows.iter().map(stat_json_row).collect();
+		println!(
+			"{}",
+			serde_json::to_string_pretty(&json).unwrap_or_default()
+		);
+		return;
+	}
 
 	crate::ui::print_bold_header(HEADER);
-	for s in rows {
-		println!("{}", format_row(s));
+	for s in &rows {
+		println!("{}", format_row(s, opts.no_trunc));
 	}
 	println!();
 }
@@ -252,11 +436,104 @@ mod tests {
 			pids: 3,
 			network,
 		};
-		let row = format_row(&s);
+		let row = format_row(&s, false);
 		assert!(row.contains("proj-web"));
 		assert!(row.contains("12.50%"));
 		assert!(row.contains("1.0MiB"));
 		assert!(row.contains('3'));
+	}
+
+	#[test]
+	fn truncate_name_shortens_long_names_with_ellipsis() {
+		let short = "proj-web-1";
+		assert_eq!(truncate_name(short, false), short);
+		// Exactly the column width is kept verbatim.
+		let exact = "a".repeat(NAME_WIDTH);
+		assert_eq!(truncate_name(&exact, false), exact);
+		// One over the width is truncated to width-1 chars plus an ellipsis.
+		let long = "a".repeat(NAME_WIDTH + 10);
+		let cut = truncate_name(&long, false);
+		assert_eq!(cut.chars().count(), NAME_WIDTH);
+		assert!(cut.ends_with('…'));
+		// `--no-trunc` keeps the full name regardless of length.
+		assert_eq!(truncate_name(&long, true), long);
+	}
+
+	#[test]
+	fn format_row_truncates_long_name_but_no_trunc_keeps_it() {
+		let s = ContainerStat {
+			name: "really-long-project-web-container-name-1".into(),
+			..Default::default()
+		};
+		// Default: the long name is truncated (ellipsis present, full name gone).
+		let row = format_row(&s, false);
+		assert!(row.contains('…'));
+		assert!(!row.contains(&s.name));
+		// `--no-trunc`: the full name survives intact.
+		let row_full = format_row(&s, true);
+		assert!(row_full.contains(&s.name));
+	}
+
+	#[test]
+	fn stat_json_row_emits_numeric_fields() {
+		let mut network = HashMap::new();
+		network.insert("eth0".to_string(), NetStat { rx: 100, tx: 200 });
+		let s = ContainerStat {
+			name: "proj-db-1".into(),
+			cpu: 5.5,
+			mem_usage: 2048,
+			mem_limit: 4096,
+			mem_perc: 50.0,
+			block_in: 1,
+			block_out: 2,
+			pids: 7,
+			network,
+		};
+		let row = stat_json_row(&s);
+		assert_eq!(row["Name"], "proj-db-1");
+		assert_eq!(row["CPUPerc"], 5.5);
+		assert_eq!(row["MemUsage"], 2048);
+		assert_eq!(row["MemLimit"], 4096);
+		assert_eq!(row["NetInput"], 100);
+		assert_eq!(row["NetOutput"], 200);
+		assert_eq!(row["PIDs"], 7);
+	}
+
+	#[test]
+	fn frame_rows_keeps_running_and_adds_stopped_zeros_sorted() {
+		let report = StatsReport {
+			stats: vec![
+				ContainerStat {
+					name: "proj-web-1".into(),
+					cpu: 1.0,
+					..Default::default()
+				},
+				// Not in `running` → must be dropped (stale daemon sample).
+				ContainerStat {
+					name: "other".into(),
+					..Default::default()
+				},
+			],
+		};
+		let mut running = HashSet::new();
+		running.insert("proj-web-1".to_string());
+		let stopped = vec!["proj-db-1".to_string()];
+		let rows = frame_rows(&report, &running, &stopped);
+		// Sorted: db (stopped) before web (running); the unrelated sample is gone.
+		assert_eq!(rows.len(), 2);
+		assert_eq!(rows[0].name, "proj-db-1");
+		assert_eq!(rows[0].cpu, 0.0);
+		assert_eq!(rows[1].name, "proj-web-1");
+		assert_eq!(rows[1].cpu, 1.0);
+	}
+
+	#[test]
+	fn frame_rows_without_all_has_no_stopped_rows() {
+		let report = StatsReport::default();
+		let running = HashSet::new();
+		// `--all` off → caller passes an empty `stopped` slice → no rows.
+		let rows = frame_rows(&report, &running, &[]);
+		assert!(rows.is_empty());
 	}
 
 	#[test]

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -131,6 +131,11 @@ impl Engine {
 		target_services: &[String],
 		no_stream: bool,
 	) -> Result<()> {
+		// Reject unknown/typo service names instead of silently sampling the whole
+		// host and printing a header-only table, matching the other commands.
+		if let Some(unknown) = first_unknown_service(file, target_services) {
+			return Err(ComposeError::ServiceNotFound(unknown.into()));
+		}
 		let wanted = self.target_container_names(file, target_services).await?;
 
 		// Scope the stats stream to just the wanted containers server-side via the
@@ -178,15 +183,28 @@ impl Engine {
 		target_services: &[String],
 	) -> Result<HashSet<String>> {
 		let mut wanted = HashSet::new();
-		for (name, service) in &file.services {
+		for name in file.services.keys() {
 			if target_services.is_empty() || target_services.iter().any(|t| t == name) {
-				for c in self.live_replica_names(name, service).await? {
+				// Only containers that actually exist — no static-name fallback.
+				// Feeding synthesized names for a never-up service to libpod's
+				// `containers=` filter 404s the whole stats request; an absent
+				// service simply contributes no rows (a zero/empty result).
+				for c in self.list_project_container_names(Some(name)).await? {
 					wanted.insert(c);
 				}
 			}
 		}
 		Ok(wanted)
 	}
+}
+
+/// The first targeted service name that the compose file does not define, if any.
+/// Pure so the validation is unit-tested without a live Podman socket.
+fn first_unknown_service<'a>(file: &ComposeFile, targets: &'a [String]) -> Option<&'a str> {
+	targets
+		.iter()
+		.map(String::as_str)
+		.find(|t| !file.services.contains_key(*t))
 }
 
 /// Print one stats frame: a header plus a row per wanted container (sorted for
@@ -274,5 +292,21 @@ mod tests {
 	#[test]
 	fn containers_query_empty_when_none_wanted() {
 		assert_eq!(containers_query(&HashSet::new()), "");
+	}
+
+	#[test]
+	fn first_unknown_service_flags_typos() {
+		let file =
+			crate::parse_str("services:\n  web:\n    image: nginx\n  db:\n    image: postgres\n")
+				.unwrap();
+		assert_eq!(first_unknown_service(&file, &[]), None);
+		assert_eq!(
+			first_unknown_service(&file, &["web".into(), "db".into()]),
+			None
+		);
+		assert_eq!(
+			first_unknown_service(&file, &["web".into(), "bogus".into()]),
+			Some("bogus")
+		);
 	}
 }

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -67,9 +67,16 @@ impl Engine {
 			return Ok(());
 		}
 
+		// Skip the header entirely when there are no volumes, instead of printing a
+		// lone NAME/DRIVER header with no rows.
+		if rows.is_empty() {
+			return Ok(());
+		}
 		crate::ui::print_bold_header(&format!("{:<40} {:<12}", "NAME", "DRIVER"));
 		for (_, name, driver, _) in &rows {
-			println!("{name:<40} {driver:<12}");
+			// Escape control characters so an ANSI/BEL/tab sequence in a volume
+			// name or driver cannot be interpreted by the terminal.
+			println!("{:<40} {:<12}", sanitize_cell(name), sanitize_cell(driver));
 		}
 		Ok(())
 	}
@@ -94,6 +101,21 @@ impl Engine {
 	}
 }
 
+/// Escape control characters (ANSI escapes, BEL, tab, newline, …) in a table
+/// cell so a hostile volume name or driver cannot drive the terminal. Printable
+/// characters pass through unchanged. Pure so it can be unit-tested.
+fn sanitize_cell(s: &str) -> String {
+	s.chars()
+		.flat_map(|c| {
+			if c.is_control() {
+				c.escape_default().collect::<Vec<_>>()
+			} else {
+				vec![c]
+			}
+		})
+		.collect()
+}
+
 /// The source (named-volume) component of a mount, if any. Bind mounts and
 /// anonymous volumes (no source) return `None`.
 fn mount_source_name(m: &VolumeMount) -> Option<String> {
@@ -113,8 +135,23 @@ fn mount_source_name(m: &VolumeMount) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-	use super::mount_source_name;
+	use super::{mount_source_name, sanitize_cell};
 	use crate::compose::types::VolumeMount;
+
+	#[test]
+	fn sanitize_cell_escapes_control_chars() {
+		// An ANSI/BEL/tab sequence is escaped rather than emitted raw.
+		let out = sanitize_cell("evil\x1b[31m\x07\tname");
+		assert!(!out.contains('\x1b'));
+		assert!(!out.contains('\x07'));
+		assert!(!out.contains('\t'));
+		assert!(out.contains("name"));
+	}
+
+	#[test]
+	fn sanitize_cell_passes_printable_through() {
+		assert_eq!(sanitize_cell("proj_data-1"), "proj_data-1");
+	}
 
 	#[test]
 	fn named_volume_short_form_has_source() {

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -30,6 +30,13 @@ impl Engine {
 		services: &[String],
 		opts: VolumesOptions,
 	) -> Result<()> {
+		// Reject an unknown service name (docker compose errors with "no such
+		// service") instead of silently filtering it out and printing nothing.
+		for s in services {
+			if !file.services.contains_key(s) {
+				return Err(crate::error::ComposeError::ServiceNotFound(s.clone()));
+			}
+		}
 		let keys = self.selected_volume_keys(file, services);
 
 		// (declared key, resolved on-host name, driver, external)

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -36,7 +36,23 @@ pub(crate) fn build_mounts_all(
 				if let Some((m, n)) = parse_volume_string(s) {
 					match n {
 						Some(nv) => named.push(nv),
-						None => mounts.push(m.unwrap()),
+						None => {
+							let m = m.unwrap();
+							// Short-form binds imply `create_host_path` (compose-spec),
+							// so create a missing host source directory before mounting.
+							// Otherwise `up` aborts with a raw podman HTTP 500 statfs
+							// error that leaks the absolute host path. Resolve exactly
+							// like the mount source so the directory is created at the
+							// path actually bind-mounted (relative anchored to the
+							// project dir, leading `~` expanded).
+							if let Some(src) = m.source.as_deref() {
+								let abs = super::container::resolve_bind_source(src, base_dir);
+								if let Err(e) = std::fs::create_dir_all(&abs) {
+									tracing::warn!("create_host_path: failed to create {abs}: {e}");
+								}
+							}
+							mounts.push(m);
+						}
 					}
 				}
 			}
@@ -356,6 +372,25 @@ mod tests {
 		}]);
 		build_mounts_all(&svc, dir.path(), &[], &[]);
 		assert!(dir.path().join(rel).exists());
+	}
+
+	#[test]
+	fn short_form_bind_creates_missing_host_path() {
+		// A short-form bind whose relative source is missing must have its host
+		// directory created (compose-spec implies create_host_path for short
+		// syntax), anchored to the project base dir — not left to fail with a raw
+		// podman statfs 500.
+		let dir = tempfile::tempdir().unwrap();
+		let rel = "missing-dir";
+		let svc = svc_with_volumes(vec![VolumeMount::Short(format!("./{rel}:/app/data"))]);
+		let (mounts, named) = build_mounts_all(&svc, dir.path(), &[], &[]);
+		assert!(named.is_empty());
+		assert_eq!(mounts.len(), 1);
+		assert_eq!(mounts[0].mount_type, "bind");
+		assert!(
+			dir.path().join(rel).is_dir(),
+			"short-form bind source directory should be created"
+		);
 	}
 
 	#[test]

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -18,6 +18,21 @@ pub(super) fn parse_volume_string(s: &str) -> Option<(Option<Mount>, Option<Name
 		.map(|o| o.trim().to_string())
 		.filter(|o| !o.is_empty())
 		.collect();
+	// A colon-less entry (`/data`, `cache`) is a single in-container target, not
+	// a `src:dst` pair: per the compose-spec it provisions an anonymous volume at
+	// that path. Without this, `is_bind_source("/data")` is true and the leading
+	// slash would be mistaken for a host bind, mounting the host's `/data`.
+	if !spec_has_separator(s) {
+		return Some((
+			None,
+			Some(NamedVolume {
+				name: String::new(),
+				dest: dst.to_string(),
+				options: opts,
+				sub_path: None,
+			}),
+		));
+	}
 	if is_bind_source(src) {
 		Some((
 			Some(Mount {
@@ -60,6 +75,14 @@ fn is_bind_source(src: &str) -> bool {
 		|| src.starts_with('.')
 		|| src.starts_with('~')
 		|| has_windows_drive_prefix(src)
+}
+
+/// Whether a short-form spec carries a `src:dst` separator, i.e. at least one
+/// colon outside a leading Windows drive prefix. A spec with none is a single
+/// in-container path (anonymous volume) rather than a `src:dst` pair.
+fn spec_has_separator(s: &str) -> bool {
+	let scan_from = if has_windows_drive_prefix(s) { 2 } else { 0 };
+	s.bytes().skip(scan_from).any(|b| b == b':')
 }
 
 /// Split a short-form volume spec into `(src, dst, opts)`. Colons separate the
@@ -150,8 +173,42 @@ pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOp
 
 #[cfg(test)]
 mod tests {
-	use super::{extend_bind_opts_str, is_bind_source, map_selinux_option, split_volume_spec};
+	use super::{
+		extend_bind_opts_str, is_bind_source, map_selinux_option, parse_volume_string,
+		split_volume_spec,
+	};
 	use crate::compose::types::BindOptions;
+
+	#[test]
+	fn colon_less_path_is_anonymous_volume_not_bind() {
+		// `- /data` (no `src:dst`) is a single in-container target: an anonymous
+		// volume, not a host bind of `/data`.
+		let (mount, named) = parse_volume_string("/data").unwrap();
+		assert!(mount.is_none(), "must not be a bind mount");
+		let nv = named.expect("expected an anonymous named volume");
+		assert_eq!(nv.name, "", "anonymous volume carries no name");
+		assert_eq!(nv.dest, "/data");
+	}
+
+	#[test]
+	fn colon_less_relative_token_is_anonymous_volume() {
+		// A bare token with no separator is still a single target, so it produces
+		// an anonymous volume rather than being read as a host bind.
+		let (mount, named) = parse_volume_string("cache").unwrap();
+		assert!(mount.is_none());
+		assert_eq!(named.unwrap().dest, "cache");
+	}
+
+	#[test]
+	fn explicit_pair_still_binds_host_path() {
+		// An explicit `src:dst` with a host-path source is still a bind mount.
+		let (mount, named) = parse_volume_string("/host:/data").unwrap();
+		assert!(named.is_none());
+		let m = mount.expect("expected a bind mount");
+		assert_eq!(m.mount_type, "bind");
+		assert_eq!(m.source.as_deref(), Some("/host"));
+		assert_eq!(m.destination, "/data");
+	}
 
 	#[test]
 	fn selinux_shared_maps_to_lowercase_z() {

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -9,8 +9,10 @@
 //! - `sync+restart` — sync first, then restart
 //! - `sync+exec` — sync, then run the rule's `exec` command inside the container
 
+mod placement;
 mod sync;
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -25,6 +27,10 @@ use tracing::{debug, info, warn};
 use crate::compose::types::{ComposeFile, WatchAction, WatchRule};
 use crate::error::{ComposeError, Result};
 
+use placement::{
+	is_dispatch_event, mark_dir_ensured, mkdir_p_argv, plan_sync_placement, validate_sync_target,
+	SyncPlacement,
+};
 use sync::{build_sync_tar, is_ignored, is_included};
 
 use super::Engine;
@@ -46,68 +52,6 @@ struct RuleEntry {
 	abs_path: PathBuf,
 }
 
-/// Where a changed host path lands inside the container for a `sync` action:
-/// the archive entry name and the directory the tar is extracted at.
-struct SyncPlacement {
-	/// Archive path the changed entry occupies inside the tar.
-	entry_name: String,
-	/// Container directory the archive is PUT (extracted) at.
-	dest_dir: String,
-}
-
-/// Map a changed host path to its container archive placement, matching
-/// docker-compose `watch` semantics.
-///
-/// `root` is the watch rule's absolute host path, `changed` the path that
-/// actually changed (equal to `root` for a single-file rule, a descendant for a
-/// directory rule), and `target` the rule's container target.
-///
-/// For a directory rule the changed entry keeps its path relative to `root`
-/// (subdirectories preserved) and is extracted under `target` treated as a
-/// directory. For a single-file rule the entry is stored under
-/// `basename(target)` and extracted into `target`'s parent, so a renaming
-/// target is honoured.
-fn plan_sync_placement(root: &Path, changed: &Path, target: &str) -> SyncPlacement {
-	if root.is_dir() {
-		// Directory rule: preserve the changed file's subpath under `target`,
-		// which is treated as a directory.
-		let rel = changed.strip_prefix(root).unwrap_or(changed);
-		let entry_name = rel.to_string_lossy().into_owned();
-		let dest_dir = target.trim_end_matches('/').to_string();
-		let dest_dir = if dest_dir.is_empty() {
-			"/".to_string()
-		} else {
-			dest_dir
-		};
-		SyncPlacement {
-			entry_name,
-			dest_dir,
-		}
-	} else {
-		// Single-file rule: store under the target basename so a renaming target
-		// is honoured, and extract into the target's parent directory.
-		let target_path = Path::new(target);
-		let entry_name = target_path
-			.file_name()
-			.map(|n| n.to_string_lossy().into_owned())
-			.or_else(|| {
-				changed
-					.file_name()
-					.map(|n| n.to_string_lossy().into_owned())
-			})
-			.unwrap_or_default();
-		let dest_dir = target_path
-			.parent()
-			.map(|p| p.to_string_lossy().into_owned())
-			.filter(|s| !s.is_empty())
-			.unwrap_or_else(|| "/".to_string());
-		SyncPlacement {
-			entry_name,
-			dest_dir,
-		}
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Public watch command
 // ---------------------------------------------------------------------------
@@ -120,6 +64,7 @@ impl Engine {
 		for (name, service) in &file.services {
 			if let Some(dev) = &service.develop {
 				for rule in &dev.watch {
+					validate_sync_target(rule)?;
 					let abs = self.base_dir.join(&rule.path);
 					rule_entries.push(RuleEntry {
 						service_name: name.clone(),
@@ -132,9 +77,16 @@ impl Engine {
 		}
 
 		if rule_entries.is_empty() {
-			info!("no develop.watch rules found");
-			return Ok(());
+			// docker compose watch errors when nothing is configured; match that
+			// instead of silently exiting 0.
+			return Err(ComposeError::Watch(
+				"no develop.watch rules configured".into(),
+			));
 		}
+
+		// Track which (container, dest) directories have been ensured so the
+		// best-effort `mkdir -p` exec runs once per target rather than per event.
+		let mut ensured: HashSet<(String, String)> = HashSet::new();
 
 		for entry in &rule_entries {
 			if entry.rule.initial_sync {
@@ -146,6 +98,7 @@ impl Engine {
 							&entry.abs_path,
 							&entry.abs_path,
 							target,
+							&mut ensured,
 						)
 						.await
 					{
@@ -197,6 +150,13 @@ impl Engine {
 				_ = tokio::signal::ctrl_c() => break,
 			};
 
+			// Ignore Access/Other events: only create/modify/remove/rename drive a
+			// sync, matching docker compose and avoiding the read-triggered
+			// self-feedback loop.
+			if !is_dispatch_event(&event.kind) {
+				continue;
+			}
+
 			let mut paths = event.paths;
 			let deadline = tokio::time::Instant::now() + debounce;
 			// Coalesce events within the debounce window, but stop accumulating once
@@ -204,7 +164,11 @@ impl Engine {
 			// bound; the remaining events fall into the next batch.
 			while paths.len() < WATCH_MAX_BATCH_PATHS {
 				match tokio::time::timeout_at(deadline, rx.recv()).await {
-					Ok(Some(Ok(e))) => paths.extend(e.paths),
+					Ok(Some(Ok(e))) => {
+						if is_dispatch_event(&e.kind) {
+							paths.extend(e.paths);
+						}
+					}
 					_ => break,
 				}
 			}
@@ -248,7 +212,7 @@ impl Engine {
 
 					debug!("dispatch {:?} for {}", entry.rule.action, path.display());
 
-					if let Err(e) = self.dispatch_action(file, path, entry).await {
+					if let Err(e) = self.dispatch_action(file, path, entry, &mut ensured).await {
 						warn!("watch action failed: {e}");
 					}
 
@@ -265,12 +229,19 @@ impl Engine {
 		file: &ComposeFile,
 		path: &Path,
 		entry: &RuleEntry,
+		ensured: &mut HashSet<(String, String)>,
 	) -> Result<()> {
 		match &entry.rule.action {
 			WatchAction::Sync => {
 				if let Some(target) = &entry.rule.target {
-					self.sync_to_container(&entry.container_name, &entry.abs_path, path, target)
-						.await?;
+					self.sync_to_container(
+						&entry.container_name,
+						&entry.abs_path,
+						path,
+						target,
+						ensured,
+					)
+					.await?;
 				}
 			}
 			WatchAction::Rebuild => {
@@ -281,15 +252,27 @@ impl Engine {
 			}
 			WatchAction::SyncAndRestart => {
 				if let Some(target) = &entry.rule.target {
-					self.sync_to_container(&entry.container_name, &entry.abs_path, path, target)
-						.await?;
+					self.sync_to_container(
+						&entry.container_name,
+						&entry.abs_path,
+						path,
+						target,
+						ensured,
+					)
+					.await?;
 				}
 				self.watch_restart(&entry.container_name).await?;
 			}
 			WatchAction::SyncAndExec => {
 				if let Some(target) = &entry.rule.target {
-					self.sync_to_container(&entry.container_name, &entry.abs_path, path, target)
-						.await?;
+					self.sync_to_container(
+						&entry.container_name,
+						&entry.abs_path,
+						path,
+						target,
+						ensured,
+					)
+					.await?;
 				}
 				if let Some(exec) = &entry.rule.exec {
 					self.watch_exec(&entry.container_name, exec.command.clone())
@@ -310,6 +293,7 @@ impl Engine {
 		root: &Path,
 		changed: &Path,
 		target: &str,
+		ensured: &mut HashSet<(String, String)>,
 	) -> Result<()> {
 		let SyncPlacement {
 			entry_name,
@@ -320,13 +304,11 @@ impl Engine {
 		// docker compose watch creates the sync target directory when it is
 		// missing; match that so a sync to a not-yet-existing path works instead
 		// of failing the archive PUT. Best-effort: if mkdir is unavailable the
-		// PUT below still surfaces the real error.
-		let _ = self
-			.watch_exec(
-				container,
-				vec!["mkdir".into(), "-p".into(), dest_dir.clone()],
-			)
-			.await;
+		// PUT below still surfaces the real error. Run it once per (container,
+		// dest) so repeated syncs to the same target skip the redundant exec.
+		if mark_dir_ensured(ensured, container, &dest_dir) {
+			let _ = self.watch_exec(container, mkdir_p_argv(&dest_dir)).await;
+		}
 
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
@@ -435,7 +417,9 @@ impl Engine {
 		src: &Path,
 		target: &str,
 	) -> Result<()> {
-		self.sync_to_container(container, src, src, target).await
+		let mut ensured = HashSet::new();
+		self.sync_to_container(container, src, src, target, &mut ensured)
+			.await
 	}
 
 	/// Test seam: run the watch restart action against `container_name`.
@@ -493,77 +477,5 @@ impl Engine {
 			}
 		}
 		Ok(out)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Unit tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-	use super::plan_sync_placement;
-	use std::fs;
-	use tempfile::tempdir;
-
-	#[test]
-	fn placement_directory_rule_preserves_subpath() {
-		// A directory rule: a change to <root>/sub/b.txt must keep the `sub/`
-		// subpath under the target directory.
-		let dir = tempdir().unwrap();
-		fs::create_dir(dir.path().join("sub")).unwrap();
-		let changed = dir.path().join("sub/b.txt");
-		fs::write(&changed, b"b").unwrap();
-
-		let p = plan_sync_placement(dir.path(), &changed, "/app");
-		assert_eq!(p.entry_name, "sub/b.txt");
-		assert_eq!(p.dest_dir, "/app");
-	}
-
-	#[test]
-	fn placement_directory_rule_trailing_slash_target() {
-		let dir = tempdir().unwrap();
-		let changed = dir.path().join("a.txt");
-		fs::write(&changed, b"a").unwrap();
-
-		let p = plan_sync_placement(dir.path(), &changed, "/app/");
-		assert_eq!(p.entry_name, "a.txt");
-		assert_eq!(p.dest_dir, "/app");
-	}
-
-	#[test]
-	fn placement_single_file_rule_honours_renaming_target() {
-		// A single-file rule whose target renames the file must store the entry
-		// under the target basename and extract into the target's parent.
-		let dir = tempdir().unwrap();
-		let src = dir.path().join("settings.yml");
-		fs::write(&src, b"k: v").unwrap();
-
-		let p = plan_sync_placement(&src, &src, "/app/config.yml");
-		assert_eq!(p.entry_name, "config.yml");
-		assert_eq!(p.dest_dir, "/app");
-	}
-
-	#[test]
-	fn placement_single_file_rule_same_basename() {
-		// The existing same-basename case still lands the file at the target.
-		let dir = tempdir().unwrap();
-		let src = dir.path().join("app.txt");
-		fs::write(&src, b"x").unwrap();
-
-		let p = plan_sync_placement(&src, &src, "/newdir/app.txt");
-		assert_eq!(p.entry_name, "app.txt");
-		assert_eq!(p.dest_dir, "/newdir");
-	}
-
-	#[test]
-	fn placement_single_file_rule_target_at_root() {
-		let dir = tempdir().unwrap();
-		let src = dir.path().join("app.txt");
-		fs::write(&src, b"x").unwrap();
-
-		let p = plan_sync_placement(&src, &src, "/app.txt");
-		assert_eq!(p.entry_name, "app.txt");
-		assert_eq!(p.dest_dir, "/");
 	}
 }

--- a/internal/engine/watch/placement.rs
+++ b/internal/engine/watch/placement.rs
@@ -1,0 +1,265 @@
+//! Pure host-path → container placement and watch-event helpers.
+//!
+//! These functions hold the side-effect-free decisions of the watch engine:
+//! mapping a changed host path to its container archive placement, filtering
+//! which notify events drive a sync, validating that sync rules carry a target,
+//! and bookkeeping for the per-target `mkdir`. Keeping them here lets the
+//! dispatch loop in [`super`] stay focused on I/O.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::compose::types::WatchRule;
+use crate::error::{ComposeError, Result};
+
+/// Where a changed host path lands inside the container for a `sync` action:
+/// the archive entry name and the directory the tar is extracted at.
+pub(super) struct SyncPlacement {
+	/// Archive path the changed entry occupies inside the tar.
+	pub(super) entry_name: String,
+	/// Container directory the archive is PUT (extracted) at.
+	pub(super) dest_dir: String,
+}
+
+/// Map a changed host path to its container archive placement, matching
+/// docker-compose `watch` semantics.
+///
+/// `root` is the watch rule's absolute host path, `changed` the path that
+/// actually changed (equal to `root` for a single-file rule, a descendant for a
+/// directory rule), and `target` the rule's container target.
+///
+/// For a directory rule the changed entry keeps its path relative to `root`
+/// (subdirectories preserved) and is extracted under `target` treated as a
+/// directory. For a single-file rule the entry is stored under
+/// `basename(target)` and extracted into `target`'s parent, so a renaming
+/// target is honoured.
+pub(super) fn plan_sync_placement(root: &Path, changed: &Path, target: &str) -> SyncPlacement {
+	if root.is_dir() {
+		// Directory rule: preserve the changed file's subpath under `target`,
+		// which is treated as a directory.
+		let rel = changed.strip_prefix(root).unwrap_or(changed);
+		let entry_name = rel.to_string_lossy().into_owned();
+		let dest_dir = target.trim_end_matches('/').to_string();
+		let dest_dir = if dest_dir.is_empty() {
+			"/".to_string()
+		} else {
+			dest_dir
+		};
+		SyncPlacement {
+			entry_name,
+			dest_dir,
+		}
+	} else {
+		// Single-file rule: store under the target basename so a renaming target
+		// is honoured, and extract into the target's parent directory.
+		let target_path = Path::new(target);
+		let entry_name = target_path
+			.file_name()
+			.map(|n| n.to_string_lossy().into_owned())
+			.or_else(|| {
+				changed
+					.file_name()
+					.map(|n| n.to_string_lossy().into_owned())
+			})
+			.unwrap_or_default();
+		let dest_dir = target_path
+			.parent()
+			.map(|p| p.to_string_lossy().into_owned())
+			.filter(|s| !s.is_empty())
+			.unwrap_or_else(|| "/".to_string());
+		SyncPlacement {
+			entry_name,
+			dest_dir,
+		}
+	}
+}
+
+/// True when a notify event should drive a watch action.
+///
+/// docker-compose `watch` only reacts to write/create/remove/rename changes. The
+/// vendored notify inotify backend also emits `Access` events (it sets
+/// `WatchMask::OPEN`), so merely opening/reading a watched file would otherwise
+/// fire a sync — and the sync's own read of the source re-opens the path,
+/// generating fresh `Access` events that feed back into another sync. Filtering
+/// to create/modify/remove (rename is a `Modify(Name(..))`) matches compose
+/// semantics and breaks that feedback loop.
+pub(super) fn is_dispatch_event(kind: &notify::EventKind) -> bool {
+	use notify::EventKind;
+	matches!(
+		kind,
+		EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+	)
+}
+
+/// Reject a watch rule whose action needs a `target` but has none. docker
+/// compose treats a sync rule without a target as a configuration error rather
+/// than silently performing no sync.
+pub(super) fn validate_sync_target(rule: &WatchRule) -> Result<()> {
+	if rule.action.requires_target() && rule.target.is_none() {
+		return Err(ComposeError::Watch(format!(
+			"watch rule for '{}' uses a sync action ({}) but has no target",
+			rule.path,
+			rule.action.as_token()
+		)));
+	}
+	Ok(())
+}
+
+/// Best-effort `mkdir -p` argv for creating a sync target directory. The `--`
+/// terminates options so a target beginning with `-` (e.g. `-m0777`) is treated
+/// as a path, not parsed as a flag by busybox `mkdir`.
+pub(super) fn mkdir_p_argv(dest_dir: &str) -> Vec<String> {
+	vec![
+		"mkdir".into(),
+		"-p".into(),
+		"--".into(),
+		dest_dir.to_string(),
+	]
+}
+
+/// Record that `(container, dest)` has had its directory ensured, returning
+/// `true` the first time (the caller should then issue the `mkdir`) and `false`
+/// thereafter so the per-event `mkdir` exec is issued at most once per target.
+pub(super) fn mark_dir_ensured(
+	ensured: &mut HashSet<(String, String)>,
+	container: &str,
+	dest: &str,
+) -> bool {
+	ensured.insert((container.to_string(), dest.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::{
+		is_dispatch_event, mark_dir_ensured, mkdir_p_argv, plan_sync_placement,
+		validate_sync_target,
+	};
+	use crate::compose::types::{WatchAction, WatchRule};
+	use std::collections::HashSet;
+	use std::fs;
+	use tempfile::tempdir;
+
+	fn rule(action: WatchAction, target: Option<&str>) -> WatchRule {
+		WatchRule {
+			path: "src".into(),
+			action,
+			target: target.map(str::to_string),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn dispatch_event_filters_access_and_other() {
+		use notify::event::{AccessKind, CreateKind, ModifyKind, RemoveKind};
+		use notify::EventKind;
+		assert!(is_dispatch_event(&EventKind::Create(CreateKind::File)));
+		assert!(is_dispatch_event(&EventKind::Modify(ModifyKind::Any)));
+		assert!(is_dispatch_event(&EventKind::Remove(RemoveKind::File)));
+		// Access (read/open) and Other/Any must not trigger a sync.
+		assert!(!is_dispatch_event(&EventKind::Access(AccessKind::Open(
+			notify::event::AccessMode::Read
+		))));
+		assert!(!is_dispatch_event(&EventKind::Access(AccessKind::Any)));
+		assert!(!is_dispatch_event(&EventKind::Other));
+		assert!(!is_dispatch_event(&EventKind::Any));
+	}
+
+	#[test]
+	fn validate_sync_target_rejects_targetless_sync() {
+		assert!(validate_sync_target(&rule(WatchAction::Sync, None)).is_err());
+		assert!(validate_sync_target(&rule(WatchAction::SyncAndRestart, None)).is_err());
+		assert!(validate_sync_target(&rule(WatchAction::SyncAndExec, None)).is_err());
+	}
+
+	#[test]
+	fn validate_sync_target_accepts_target_and_whole_container_actions() {
+		assert!(validate_sync_target(&rule(WatchAction::Sync, Some("/app"))).is_ok());
+		// rebuild/restart need no target.
+		assert!(validate_sync_target(&rule(WatchAction::Rebuild, None)).is_ok());
+		assert!(validate_sync_target(&rule(WatchAction::Restart, None)).is_ok());
+	}
+
+	#[test]
+	fn mkdir_argv_terminates_options_for_leading_dash_target() {
+		// A target beginning with `-` must be passed as a path, not a flag.
+		assert_eq!(mkdir_p_argv("-m0777"), vec!["mkdir", "-p", "--", "-m0777"]);
+		assert_eq!(mkdir_p_argv("/app"), vec!["mkdir", "-p", "--", "/app"]);
+	}
+
+	#[test]
+	fn mark_dir_ensured_only_first_time_per_target() {
+		let mut ensured: HashSet<(String, String)> = HashSet::new();
+		// First time for a (container, dest) returns true (issue the mkdir)...
+		assert!(mark_dir_ensured(&mut ensured, "c1", "/app"));
+		// ...and subsequent calls for the same pair return false (skip it).
+		assert!(!mark_dir_ensured(&mut ensured, "c1", "/app"));
+		// A different container or dest is ensured independently.
+		assert!(mark_dir_ensured(&mut ensured, "c2", "/app"));
+		assert!(mark_dir_ensured(&mut ensured, "c1", "/other"));
+	}
+
+	#[test]
+	fn placement_directory_rule_preserves_subpath() {
+		// A directory rule: a change to <root>/sub/b.txt must keep the `sub/`
+		// subpath under the target directory.
+		let dir = tempdir().unwrap();
+		fs::create_dir(dir.path().join("sub")).unwrap();
+		let changed = dir.path().join("sub/b.txt");
+		fs::write(&changed, b"b").unwrap();
+
+		let p = plan_sync_placement(dir.path(), &changed, "/app");
+		assert_eq!(p.entry_name, "sub/b.txt");
+		assert_eq!(p.dest_dir, "/app");
+	}
+
+	#[test]
+	fn placement_directory_rule_trailing_slash_target() {
+		let dir = tempdir().unwrap();
+		let changed = dir.path().join("a.txt");
+		fs::write(&changed, b"a").unwrap();
+
+		let p = plan_sync_placement(dir.path(), &changed, "/app/");
+		assert_eq!(p.entry_name, "a.txt");
+		assert_eq!(p.dest_dir, "/app");
+	}
+
+	#[test]
+	fn placement_single_file_rule_honours_renaming_target() {
+		// A single-file rule whose target renames the file must store the entry
+		// under the target basename and extract into the target's parent.
+		let dir = tempdir().unwrap();
+		let src = dir.path().join("settings.yml");
+		fs::write(&src, b"k: v").unwrap();
+
+		let p = plan_sync_placement(&src, &src, "/app/config.yml");
+		assert_eq!(p.entry_name, "config.yml");
+		assert_eq!(p.dest_dir, "/app");
+	}
+
+	#[test]
+	fn placement_single_file_rule_same_basename() {
+		// The existing same-basename case still lands the file at the target.
+		let dir = tempdir().unwrap();
+		let src = dir.path().join("app.txt");
+		fs::write(&src, b"x").unwrap();
+
+		let p = plan_sync_placement(&src, &src, "/newdir/app.txt");
+		assert_eq!(p.entry_name, "app.txt");
+		assert_eq!(p.dest_dir, "/newdir");
+	}
+
+	#[test]
+	fn placement_single_file_rule_target_at_root() {
+		let dir = tempdir().unwrap();
+		let src = dir.path().join("app.txt");
+		fs::write(&src, b"x").unwrap();
+
+		let p = plan_sync_placement(&src, &src, "/app.txt");
+		assert_eq!(p.entry_name, "app.txt");
+		assert_eq!(p.dest_dir, "/");
+	}
+}

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -64,7 +64,10 @@ pub fn load_env_file_entries(
 			Err(e) => return Err(ComposeError::Io(e)),
 		};
 
-		for (key, value) in crate::dotenv::parse(&content) {
+		// A service `env_file:` is explicitly requested, so a malformed entry
+		// (e.g. an unterminated quoted value that would otherwise swallow the
+		// following keys) is a hard error rather than silent data loss.
+		for (key, value) in crate::dotenv::parse_strict(&content)? {
 			result.insert(key, value);
 		}
 	}
@@ -188,6 +191,26 @@ mod tests {
 			required: Some(false),
 			format: Some("json".into()),
 		}];
+		let m = load_env_file_entries(&entries, dir.path()).unwrap();
+		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("bar"));
+	}
+
+	#[test]
+	fn unterminated_quote_is_an_error() {
+		// A never-closed quote would otherwise absorb every following key; an
+		// explicitly requested env_file must fail loudly instead.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "A=\"oops\nB=keep\n").unwrap();
+		let entries = vec![EnvFileEntry::Path(".env".into())];
+		let err = load_env_file_entries(&entries, dir.path()).unwrap_err();
+		assert!(matches!(err, ComposeError::EnvFile(_)), "got {err:?}");
+	}
+
+	#[test]
+	fn strips_leading_bom_first_key_kept() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join(".env"), "\u{feff}FOO=bar\n").unwrap();
+		let entries = vec![EnvFileEntry::Path(".env".into())];
 		let m = load_env_file_entries(&entries, dir.path()).unwrap();
 		assert_eq!(m.get("FOO").map(|s| s.as_str()), Some("bar"));
 	}

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -80,6 +80,27 @@ pub enum ComposeError {
 	},
 	/// `start --wait --wait-timeout` elapsed before services became healthy.
 	WaitTimeout { secs: u64 },
+	/// A replica index (`--index`) does not name a replica of the service (zero,
+	/// or beyond the replica count). Kept distinct from [`Self::ServiceNotFound`]
+	/// so the index hint renders outside the quoted service name.
+	ReplicaIndex { service: String, index: u32 },
+	/// A filesystem operation failed against a known path; carries the path so the
+	/// message can name the offending file (Rust's `File::create`/`open` errors
+	/// drop it).
+	IoPath {
+		path: String,
+		source: std::io::Error,
+	},
+	/// A service's build context could not be accessed; names the service and the
+	/// resolved context path instead of a bare `io error`.
+	BuildContext {
+		service: String,
+		path: String,
+		source: std::io::Error,
+	},
+	/// A targeted service container is not running (e.g. `exec`/`attach` against a
+	/// stopped or never-created container).
+	NotRunning(String),
 	/// The `-t/--timeout` shutdown grace was given an unusable value (a number
 	/// below `-1`). `-1` means "wait indefinitely" (docker parity) and any
 	/// non-negative value is a second count; everything else is rejected here
@@ -90,6 +111,28 @@ pub enum ComposeError {
 	/// entry such as an unterminated quoted value. The string is a ready-to-print
 	/// message.
 	EnvFile(String),
+}
+
+/// Escape control characters (tabs, newlines, ESC, …) in an interpolated,
+/// possibly-untrusted name before it reaches a terminal, so a crafted
+/// service/container name cannot emit raw escape sequences. Printable characters
+/// (including non-ASCII) pass through unchanged; only borrows when nothing needs
+/// escaping.
+fn sanitize_name(s: &str) -> std::borrow::Cow<'_, str> {
+	if s.chars().any(char::is_control) {
+		s.chars()
+			.flat_map(|c| {
+				if c.is_control() {
+					c.escape_default().collect::<Vec<_>>()
+				} else {
+					vec![c]
+				}
+			})
+			.collect::<String>()
+			.into()
+	} else {
+		std::borrow::Cow::Borrowed(s)
+	}
 }
 
 impl fmt::Display for ComposeError {
@@ -109,19 +152,31 @@ impl fmt::Display for ComposeError {
 				),
 				None => write!(f, "failed to parse compose file"),
 			},
-			Self::FileNotFound(s) => write!(f, "compose file not found: {s}"),
+			Self::FileNotFound(s) => write!(f, "compose file not found: {}", sanitize_name(s)),
 			Self::Io(e) => write!(f, "io error: {e}"),
 			Self::Podman(e) => write!(f, "podman error: {e}"),
-			Self::ServiceNotFound(s) => write!(f, "service '{s}' not found"),
-			Self::CircularDependency(s) => write!(f, "circular dependency detected: {s}"),
-			Self::NoImageOrBuild(s) => write!(f, "service '{s}' has no image or build config"),
+			Self::ServiceNotFound(s) => write!(f, "service '{}' not found", sanitize_name(s)),
+			Self::CircularDependency(s) => write!(f, "{s}"),
+			Self::NoImageOrBuild(s) => {
+				write!(
+					f,
+					"service '{}' has no image or build config",
+					sanitize_name(s)
+				)
+			}
 			Self::RequiredVarNotSet { var, msg } => {
 				write!(f, "required variable '{var}' is not set: {msg}")
 			}
 			Self::InvalidSubstitution(s) => {
 				write!(f, "invalid variable substitution: {s}")
 			}
-			Self::HealthCheckTimeout(s) => write!(f, "health check timeout for container '{s}'"),
+			Self::HealthCheckTimeout(s) => {
+				write!(
+					f,
+					"health check timeout for container '{}'",
+					sanitize_name(s)
+				)
+			}
 			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),
 			Self::InvalidSignal(s) => write!(f, "invalid signal: {s}"),
 			Self::Build(s) => write!(f, "build error: {s}"),
@@ -154,7 +209,8 @@ impl fmt::Display for ComposeError {
 			}
 			Self::WaitServiceExited { container, code } => write!(
 				f,
-				"container '{container}' exited with code {code} while waiting for it to be ready"
+				"container '{}' exited with code {code} while waiting for it to be ready",
+				sanitize_name(container)
 			),
 			Self::ReplicaLimitExceeded {
 				service,
@@ -169,6 +225,25 @@ impl fmt::Display for ComposeError {
 				f,
 				"timed out after {secs}s waiting for services to become healthy"
 			),
+			Self::ReplicaIndex { service, index } => write!(
+				f,
+				"service '{}' has no replica {index} (replica indexes are 1-based)",
+				sanitize_name(service)
+			),
+			Self::IoPath { path, source } => {
+				write!(f, "io error: {}: {source}", sanitize_name(path))
+			}
+			Self::BuildContext {
+				service,
+				path,
+				source,
+			} => write!(
+				f,
+				"build context '{}' for service '{}': {source}",
+				sanitize_name(path),
+				sanitize_name(service)
+			),
+			Self::NotRunning(s) => write!(f, "service '{}' is not running", sanitize_name(s)),
 			Self::InvalidTimeout(secs) => write!(
 				f,
 				"invalid --timeout {secs}: use -1 to wait indefinitely or a non-negative number of seconds"
@@ -184,6 +259,7 @@ impl std::error::Error for ComposeError {
 			Self::Parse(e) => Some(e),
 			Self::Io(e) => Some(e),
 			Self::Podman(e) => Some(e),
+			Self::IoPath { source, .. } | Self::BuildContext { source, .. } => Some(source),
 			_ => None,
 		}
 	}
@@ -230,10 +306,7 @@ mod tests {
 				"service 's' not found",
 				ComposeError::ServiceNotFound("s".into()),
 			),
-			(
-				"circular dependency detected: c",
-				ComposeError::CircularDependency("c".into()),
-			),
+			("c", ComposeError::CircularDependency("c".into())),
 			(
 				"service 'svc' has no image or build config",
 				ComposeError::NoImageOrBuild("svc".into()),
@@ -310,6 +383,32 @@ mod tests {
 				ComposeError::WaitTimeout { secs: 30 },
 			),
 			(
+				"service 'web' has no replica 99 (replica indexes are 1-based)",
+				ComposeError::ReplicaIndex {
+					service: "web".into(),
+					index: 99,
+				},
+			),
+			(
+				"io error: /out/x.tar:",
+				ComposeError::IoPath {
+					path: "/out/x.tar".into(),
+					source: std::io::Error::other("boom"),
+				},
+			),
+			(
+				"build context './ctx' for service 'web':",
+				ComposeError::BuildContext {
+					service: "web".into(),
+					path: "./ctx".into(),
+					source: std::io::Error::other("boom"),
+				},
+			),
+			(
+				"service 'web' is not running",
+				ComposeError::NotRunning("web".into()),
+			),
+			(
 				"invalid --timeout -5: use -1 to wait indefinitely or a non-negative number of seconds",
 				ComposeError::InvalidTimeout(-5),
 			),
@@ -364,6 +463,33 @@ mod tests {
 		assert!(podman.source().is_some());
 		let svc = ComposeError::ServiceNotFound("s".into());
 		assert!(svc.source().is_none());
+	}
+
+	#[test]
+	fn service_name_control_chars_are_escaped_in_display() {
+		// A crafted name carrying an ESC sequence and newline must not reach the
+		// terminal raw: the control bytes are escaped, the quotes preserved.
+		let err = ComposeError::ServiceNotFound("we\x1b[31mb\n".into());
+		let msg = err.to_string();
+		assert!(!msg.contains('\x1b'), "ESC must be escaped: {msg:?}");
+		assert!(!msg.contains('\n'), "newline must be escaped: {msg:?}");
+		assert!(
+			msg.contains("\\u{1b}") && msg.contains("\\n"),
+			"got {msg:?}"
+		);
+	}
+
+	#[test]
+	fn replica_index_hint_is_outside_the_quoted_name() {
+		// The hint must render after the closing quote, not inside the service name.
+		let err = ComposeError::ReplicaIndex {
+			service: "web".into(),
+			index: 0,
+		};
+		let msg = err.to_string();
+		assert!(msg.contains("'web'"), "service name stays clean: {msg:?}");
+		assert!(!msg.contains("'web "), "hint leaked into the name: {msg:?}");
+		assert!(msg.contains("1-based"));
 	}
 
 	#[test]

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -35,6 +35,10 @@ pub enum ComposeError {
 	HealthCheckTimeout(String),
 	/// A `ports:` entry could not be parsed.
 	InvalidPort(String),
+	/// A `kill` signal is empty, malformed, or not a recognised signal
+	/// name/number. Forwarding it verbatim would let libpod silently default to
+	/// SIGKILL, so it is rejected up front.
+	InvalidSignal(String),
 	/// Image build failed (context assembly or the Podman build step).
 	Build(String),
 	/// `extends:` could not be resolved (missing file/service or a cycle).
@@ -92,6 +96,7 @@ impl fmt::Display for ComposeError {
 			}
 			Self::HealthCheckTimeout(s) => write!(f, "health check timeout for container '{s}'"),
 			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),
+			Self::InvalidSignal(s) => write!(f, "invalid signal: {s}"),
 			Self::Build(s) => write!(f, "build error: {s}"),
 			Self::Extends(s) => write!(f, "extends error: {s}"),
 			Self::Include(s) => write!(f, "include error: {s}"),

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -91,7 +91,20 @@ pub enum ComposeError {
 impl fmt::Display for ComposeError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			Self::Parse(e) => write!(f, "failed to parse compose file: {e}"),
+			// Report only the parser's location, never the raw `serde_yaml`
+			// message: that message embeds the offending scalar verbatim (the file's
+			// own content), which would echo a non-compose file pointed at with `-f`
+			// straight onto stderr. Location (line/column) is enough to find the
+			// problem without leaking the bytes.
+			Self::Parse(e) => match e.location() {
+				Some(loc) => write!(
+					f,
+					"failed to parse compose file at line {}, column {}",
+					loc.line(),
+					loc.column()
+				),
+				None => write!(f, "failed to parse compose file"),
+			},
 			Self::FileNotFound(s) => write!(f, "compose file not found: {s}"),
 			Self::Io(e) => write!(f, "io error: {e}"),
 			Self::Podman(e) => write!(f, "podman error: {e}"),
@@ -200,7 +213,7 @@ mod tests {
 	fn display_covers_all_variants() {
 		let cases: &[(&str, ComposeError)] = &[
 			(
-				"failed to parse compose file:",
+				"failed to parse compose file",
 				ComposeError::Parse(serde_yaml::from_str::<serde_yaml::Value>(":\0").unwrap_err()),
 			),
 			(
@@ -307,6 +320,26 @@ mod tests {
 				std::mem::discriminant(err),
 			);
 		}
+	}
+
+	#[test]
+	fn parse_display_does_not_echo_offending_scalar() {
+		// A type error embeds the offending scalar in the raw serde_yaml message
+		// (`invalid type: string "s3cr3t-token", ...`). The Display must not surface
+		// that content — it points at the location instead, so a non-compose file
+		// pointed at with `-f` cannot leak its bytes onto stderr.
+		#[derive(Debug, serde::Deserialize)]
+		struct OnlyMap {
+			#[allow(dead_code)]
+			services: std::collections::BTreeMap<String, String>,
+		}
+		let err = serde_yaml::from_str::<OnlyMap>("services: s3cr3t-token\n").unwrap_err();
+		let msg = ComposeError::Parse(err).to_string();
+		assert!(
+			!msg.contains("s3cr3t-token"),
+			"parse error must not echo file content, got {msg:?}"
+		);
+		assert!(msg.starts_with("failed to parse compose file"));
 	}
 
 	#[test]

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -101,6 +101,13 @@ pub enum ComposeError {
 	/// A targeted service container is not running (e.g. `exec`/`attach` against a
 	/// stopped or never-created container).
 	NotRunning(String),
+	/// An `exec` session could not be launched. Most often the requested
+	/// `--user`/`--workdir` does not resolve inside the container and the libpod
+	/// exec-start stalls without returning a response head; podup bounds that wait
+	/// with an exec-specific deadline and surfaces this instead of pinning the CLI
+	/// for the full read timeout and then reporting a misleading socket-timeout.
+	/// The string is a ready-to-print message.
+	ExecFailed(String),
 	/// The `-t/--timeout` shutdown grace was given an unusable value (a number
 	/// below `-1`). `-1` means "wait indefinitely" (docker parity) and any
 	/// non-negative value is a second count; everything else is rejected here
@@ -244,6 +251,7 @@ impl fmt::Display for ComposeError {
 				sanitize_name(service)
 			),
 			Self::NotRunning(s) => write!(f, "service '{}' is not running", sanitize_name(s)),
+			Self::ExecFailed(s) => write!(f, "exec failed: {s}"),
 			Self::InvalidTimeout(secs) => write!(
 				f,
 				"invalid --timeout {secs}: use -1 to wait indefinitely or a non-negative number of seconds"
@@ -407,6 +415,10 @@ mod tests {
 			(
 				"service 'web' is not running",
 				ComposeError::NotRunning("web".into()),
+			),
+			(
+				"exec failed: the exec session did not start within 20s",
+				ComposeError::ExecFailed("the exec session did not start within 20s".into()),
 			),
 			(
 				"invalid --timeout -5: use -1 to wait indefinitely or a non-negative number of seconds",

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -76,6 +76,11 @@ pub enum ComposeError {
 	},
 	/// `start --wait --wait-timeout` elapsed before services became healthy.
 	WaitTimeout { secs: u64 },
+	/// An explicitly requested env file (`--env-file` or a service `env_file:`)
+	/// could not be read or parsed — a missing/unreadable path or a malformed
+	/// entry such as an unterminated quoted value. The string is a ready-to-print
+	/// message.
+	EnvFile(String),
 }
 
 impl fmt::Display for ComposeError {
@@ -141,6 +146,7 @@ impl fmt::Display for ComposeError {
 				f,
 				"timed out after {secs}s waiting for services to become healthy"
 			),
+			Self::EnvFile(s) => write!(f, "{s}"),
 		}
 	}
 }
@@ -274,6 +280,10 @@ mod tests {
 			(
 				"timed out after 30s waiting for services to become healthy",
 				ComposeError::WaitTimeout { secs: 30 },
+			),
+			(
+				"env file not found: app.env",
+				ComposeError::EnvFile("env file not found: app.env".into()),
 			),
 		];
 		for (expected_prefix, err) in cases {

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -76,6 +76,11 @@ pub enum ComposeError {
 	},
 	/// `start --wait --wait-timeout` elapsed before services became healthy.
 	WaitTimeout { secs: u64 },
+	/// The `-t/--timeout` shutdown grace was given an unusable value (a number
+	/// below `-1`). `-1` means "wait indefinitely" (docker parity) and any
+	/// non-negative value is a second count; everything else is rejected here
+	/// rather than forwarded to libpod as a raw `HTTP 400`.
+	InvalidTimeout(i32),
 	/// An explicitly requested env file (`--env-file` or a service `env_file:`)
 	/// could not be read or parsed — a missing/unreadable path or a malformed
 	/// entry such as an unterminated quoted value. The string is a ready-to-print
@@ -145,6 +150,10 @@ impl fmt::Display for ComposeError {
 			Self::WaitTimeout { secs } => write!(
 				f,
 				"timed out after {secs}s waiting for services to become healthy"
+			),
+			Self::InvalidTimeout(secs) => write!(
+				f,
+				"invalid --timeout {secs}: use -1 to wait indefinitely or a non-negative number of seconds"
 			),
 			Self::EnvFile(s) => write!(f, "{s}"),
 		}
@@ -280,6 +289,10 @@ mod tests {
 			(
 				"timed out after 30s waiting for services to become healthy",
 				ComposeError::WaitTimeout { secs: 30 },
+			),
+			(
+				"invalid --timeout -5: use -1 to wait indefinitely or a non-negative number of seconds",
+				ComposeError::InvalidTimeout(-5),
 			),
 			(
 				"env file not found: app.env",

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -41,6 +41,10 @@ pub enum ComposeError {
 	InvalidSignal(String),
 	/// Image build failed (context assembly or the Podman build step).
 	Build(String),
+	/// A `cp` (copy between a container and the host) operation failed — a missing
+	/// destination directory, a non-directory path component, an unsupported
+	/// endpoint, or a host-side packing/extraction error.
+	Copy(String),
 	/// `extends:` could not be resolved (missing file/service or a cycle).
 	Extends(String),
 	/// `include:` could not be resolved or merged.
@@ -121,6 +125,7 @@ impl fmt::Display for ComposeError {
 			Self::InvalidPort(s) => write!(f, "invalid port mapping: {s}"),
 			Self::InvalidSignal(s) => write!(f, "invalid signal: {s}"),
 			Self::Build(s) => write!(f, "build error: {s}"),
+			Self::Copy(s) => write!(f, "cp error: {s}"),
 			Self::Extends(s) => write!(f, "extends error: {s}"),
 			Self::Include(s) => write!(f, "include error: {s}"),
 			Self::Watch(s) => write!(f, "watch error: {s}"),
@@ -260,6 +265,7 @@ mod tests {
 				ComposeError::InvalidSubstitution("bad".into()),
 			),
 			("build error: b", ComposeError::Build("b".into())),
+			("cp error: c", ComposeError::Copy("c".into())),
 			("extends error: e", ComposeError::Extends("e".into())),
 			("include error: i", ComposeError::Include("i".into())),
 			("watch error: w", ComposeError::Watch("w".into())),

--- a/internal/filesystem.rs
+++ b/internal/filesystem.rs
@@ -23,12 +23,25 @@ fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
 	// the file (or swaps in a symlink) after a size check cannot make podup
 	// read past the cap, because the limit is enforced on the read itself.
 	let file = std::fs::File::open(path)?;
+	read_capped_from(file, max, &path.display().to_string())
+}
+
+/// Read the compose document from standard input, refusing input larger than
+/// [`MAX_FILE_BYTES`]. Backs the `-f -` form (`cat compose.yaml | podup config
+/// -f -`), which `docker compose` supports by reading the file from stdin.
+pub(crate) fn read_stdin_to_string_capped() -> io::Result<String> {
+	read_capped_from(io::stdin().lock(), MAX_FILE_BYTES, "standard input")
+}
+
+/// Read any [`io::Read`] into a `String`, enforcing the `max`-byte cap on the
+/// read itself. `label` names the source for the over-limit error message.
+fn read_capped_from(reader: impl Read, max: u64, label: &str) -> io::Result<String> {
 	let mut buf = String::new();
-	let read = file.take(max + 1).read_to_string(&mut buf)?;
+	let read = reader.take(max + 1).read_to_string(&mut buf)?;
 	if read as u64 > max {
 		return Err(io::Error::new(
 			io::ErrorKind::InvalidData,
-			format!("{} is larger than the {max} byte limit", path.display()),
+			format!("{label} is larger than the {max} byte limit"),
 		));
 	}
 	Ok(buf)
@@ -61,7 +74,22 @@ fn read_capped_with(path: &Path, max: u64) -> io::Result<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-	use super::{read_capped_with, read_to_string_capped_with};
+	use super::{read_capped_from, read_capped_with, read_to_string_capped_with};
+
+	#[test]
+	fn read_capped_from_reads_within_limit() {
+		// The shared reader (used for both files and stdin) returns the content
+		// untouched when it fits under the cap.
+		let out = read_capped_from(std::io::Cursor::new(b"version: 1"), 64, "stdin").unwrap();
+		assert_eq!(out, "version: 1");
+	}
+
+	#[test]
+	fn read_capped_from_rejects_over_limit() {
+		let err = read_capped_from(std::io::Cursor::new(vec![b'x'; 32]), 16, "stdin").unwrap_err();
+		assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+		assert!(err.to_string().contains("stdin"));
+	}
 
 	#[test]
 	fn reads_file_within_limit() {

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -1,7 +1,10 @@
 //! The `generate quadlet` command: turn the compose file into Quadlet units and
 //! either write them to a directory or print them to stdout.
 
+use std::io::Write;
 use std::path::Path;
+
+use podup::compose::types::ComposeFile;
 
 /// Quadlet units are systemd unit files; they only run on Linux hosts (where
 /// systemd consumes them from `~/.config/containers/systemd/`). Generating them
@@ -16,6 +19,55 @@ fn quadlet_platform_advisory(os: &str) -> Option<String> {
 	})
 }
 
+/// Validate the compose file before emitting Quadlet units, applying the same
+/// rules `up`/`create`/`config` enforce so `generate quadlet` is not more
+/// permissive than the commands that actually run the stack. Rejecting here keeps
+/// the generator from emitting structurally invalid units (a `.container` with
+/// no `Image=`, an out-of-range `PublishPort=`, a `--memory` flag with a
+/// malformed size) or a systemd ordering cycle.
+fn validate_for_quadlet(file: &ComposeFile) -> podup::Result<()> {
+	// `depends_on` cycles would emit mutually `After=`/`Requires=` units that
+	// systemd rejects as an ordering cycle; reject them as `up`/`create` do.
+	// A missing dependency is *not* fatal here: an `After=` may legitimately
+	// reference a unit managed outside this project.
+	if let Err(e @ podup::ComposeError::CircularDependency(_)) = podup::compose::resolve_order(file)
+	{
+		return Err(e);
+	}
+	for (name, svc) in &file.services {
+		// Every service must declare an image or a build, the same rule
+		// `config`/`up` enforce; without it the unit would have no `Image=`.
+		if svc.image.is_none() && svc.build.is_none() {
+			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
+		}
+		// Reject malformed/out-of-range ports instead of re-emitting them as an
+		// invalid `PublishPort=`.
+		podup::ports::parse_ports(&svc.ports)?;
+		// Reject a malformed memory limit rather than passing it through to a
+		// `--memory` flag systemd/Podman would choke on.
+		if let Some(mem) = &svc.mem_limit {
+			if podup::size::parse_memory(mem).is_none() {
+				return Err(podup::ComposeError::Unsupported(format!(
+					"service '{name}': mem_limit '{mem}' is not a valid memory size"
+				)));
+			}
+		}
+	}
+	Ok(())
+}
+
+/// Write to stdout, treating a closed pipe (e.g. `podup generate quadlet | head`)
+/// as a clean exit instead of a panic. With `panic = "abort"` the panic from a
+/// raw `println!` on `EPIPE` aborts the process (exit 134) with a spurious
+/// "internal error" message; a Unix tool should just stop quietly.
+fn write_stdout(buf: &str) -> podup::Result<()> {
+	match std::io::stdout().write_all(buf.as_bytes()) {
+		Ok(()) => Ok(()),
+		Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+		Err(e) => Err(e.into()),
+	}
+}
+
 /// Generate Quadlet units from the compose file and either write them to a
 /// directory or print them to stdout. Warnings about unmapped fields go to
 /// stderr so stdout stays clean for piping.
@@ -24,6 +76,9 @@ pub(crate) fn write_quadlet(
 	project: &str,
 	output: Option<&Path>,
 ) -> podup::Result<()> {
+	// Reject configs the running commands would reject, before emitting anything.
+	validate_for_quadlet(file)?;
+
 	let result = podup::quadlet::generate(file, project);
 	if let Some(dup) = result.duplicate_filename() {
 		return Err(std::io::Error::new(
@@ -44,6 +99,7 @@ pub(crate) fn write_quadlet(
 	match output {
 		Some(dir) => {
 			std::fs::create_dir_all(dir)?;
+			let mut progress = String::new();
 			for unit in &result.units {
 				// Defense in depth: the unit stem is already sanitized in the
 				// library, but never write a unit whose name is anything but a
@@ -59,15 +115,18 @@ pub(crate) fn write_quadlet(
 				}
 				let path = dir.join(&unit.filename);
 				std::fs::write(&path, &unit.contents)?;
-				println!("wrote {}", path.display());
+				progress.push_str(&format!("wrote {}\n", path.display()));
 			}
+			write_stdout(&progress)?;
 		}
 		None => {
+			let mut out = String::new();
 			for unit in &result.units {
-				println!("# {}", unit.filename);
-				print!("{}", unit.contents);
-				println!();
+				out.push_str(&format!("# {}\n", unit.filename));
+				out.push_str(&unit.contents);
+				out.push('\n');
 			}
+			write_stdout(&out)?;
 		}
 	}
 	Ok(())
@@ -75,7 +134,8 @@ pub(crate) fn write_quadlet(
 
 #[cfg(test)]
 mod tests {
-	use super::quadlet_platform_advisory;
+	use super::{quadlet_platform_advisory, validate_for_quadlet};
+	use podup::parse_str;
 
 	#[test]
 	fn quadlet_advisory_only_on_non_linux() {
@@ -84,5 +144,53 @@ mod tests {
 			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
 			assert!(msg.contains("systemd"), "advisory names the requirement");
 		}
+	}
+
+	#[test]
+	fn valid_compose_passes_validation() {
+		let file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
+		assert!(validate_for_quadlet(&file).is_ok());
+	}
+
+	#[test]
+	fn service_without_image_or_build_is_rejected() {
+		// `generate quadlet` must reject the same config `config`/`up` reject
+		// rather than emit a `[Container]` with no `Image=`.
+		let file = parse_str("services:\n  web:\n    ports:\n      - \"8080:80\"\n").unwrap();
+		let err = validate_for_quadlet(&file).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::NoImageOrBuild(_)));
+	}
+
+	#[test]
+	fn out_of_range_port_is_rejected() {
+		// A port above u16 must error, not be re-emitted as an invalid PublishPort.
+		let file = parse_str("services:\n  web:\n    image: x\n    ports:\n      - \"70000:80\"\n")
+			.unwrap();
+		assert!(validate_for_quadlet(&file).is_err());
+	}
+
+	#[test]
+	fn malformed_mem_limit_is_rejected() {
+		let file = parse_str("services:\n  web:\n    image: x\n    mem_limit: abc\n").unwrap();
+		let err = validate_for_quadlet(&file).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::Unsupported(_)));
+	}
+
+	#[test]
+	fn dependency_cycle_is_rejected() {
+		// A `depends_on` cycle would emit a systemd ordering cycle; reject it like
+		// `up`/`create` do.
+		let yaml = "services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: x\n    depends_on: [a]\n";
+		let file = parse_str(yaml).unwrap();
+		let err = validate_for_quadlet(&file).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
+	}
+
+	#[test]
+	fn missing_dependency_is_not_fatal() {
+		// An `After=` referencing an externally-managed unit is allowed; only
+		// cycles are rejected.
+		let file = parse_str("services:\n  web:\n    image: x\n    depends_on: [db]\n").unwrap();
+		assert!(validate_for_quadlet(&file).is_ok());
 	}
 }

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -134,7 +134,7 @@ pub(crate) fn write_quadlet(
 
 #[cfg(test)]
 mod tests {
-	use super::{quadlet_platform_advisory, validate_for_quadlet};
+	use super::{quadlet_platform_advisory, validate_for_quadlet, write_quadlet};
 	use podup::parse_str;
 
 	#[test]
@@ -144,6 +144,19 @@ mod tests {
 			let msg = quadlet_platform_advisory(os).expect("non-linux host warns");
 			assert!(msg.contains("systemd"), "advisory names the requirement");
 		}
+	}
+
+	#[test]
+	fn cyclic_depends_on_is_rejected_before_emitting_units() {
+		// A `depends_on` cycle must error rather than emit units with mutual
+		// `After=`/`Requires=`; the check runs before any file I/O so `output: None`
+		// is safe here.
+		let file = podup::parse_str(
+			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
+		)
+		.unwrap();
+		let err = write_quadlet(&file, "proj", None).unwrap_err();
+		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
 	}
 
 	#[test]

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -46,9 +46,10 @@ pub use compose::{
 /// project-name/listing helpers — the surface a CLI drives compose operations
 /// through.
 pub use engine::{
-	is_safe_project_name, list_projects, resolve_image_digests, retain_active_profiles,
-	retain_active_profiles_with_targets, validate_stop_timeout, BuildOptions, CpOptions, Engine,
-	ExecOptions, ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions,
+	is_safe_project_name, list_projects, list_projects_filtered, resolve_image_digests,
+	retain_active_profiles, retain_active_profiles_with_targets, validate_stop_timeout,
+	BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions, ImagesOptions,
+	LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsFilterOptions, PsOptions, PullOptions,
 	PushOptions, RunOptions, RunOverrides, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -50,7 +50,7 @@ pub use engine::{
 	retain_active_profiles, retain_active_profiles_with_targets, validate_stop_timeout,
 	BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions, ImagesOptions,
 	LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsFilterOptions, PsOptions, PullOptions,
-	PushOptions, RunOptions, RunOverrides, VolumesOptions,
+	PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -40,6 +40,7 @@ pub mod update;
 pub use compose::{
 	collect_diagnostics, parse_file, parse_file_with_env_files, parse_files_with_env_files,
 	parse_files_with_env_files_interp, parse_str, parse_str_raw, resolve_levels, resolve_order,
+	validate_config,
 };
 /// The lifecycle `Engine` and its per-command option/override types, plus the
 /// project-name/listing helpers — the surface a CLI drives compose operations

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -46,9 +46,9 @@ pub use compose::{
 /// through.
 pub use engine::{
 	is_safe_project_name, list_projects, resolve_image_digests, retain_active_profiles,
-	retain_active_profiles_with_targets, BuildOptions, CpOptions, Engine, ExecOptions,
-	ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions, PushOptions,
-	RunOptions, RunOverrides, VolumesOptions,
+	retain_active_profiles_with_targets, validate_stop_timeout, BuildOptions, CpOptions, Engine,
+	ExecOptions, ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions,
+	PushOptions, RunOptions, RunOverrides, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -46,8 +46,9 @@ pub use compose::{
 /// through.
 pub use engine::{
 	is_safe_project_name, list_projects, resolve_image_digests, retain_active_profiles,
-	BuildOptions, CpOptions, Engine, ExecOptions, ImagesOptions, LogsOptions, LsOptions,
-	ProjectLock, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, VolumesOptions,
+	retain_active_profiles_with_targets, BuildOptions, CpOptions, Engine, ExecOptions,
+	ImagesOptions, LogsOptions, LsOptions, ProjectLock, PsOptions, PullOptions, PushOptions,
+	RunOptions, RunOverrides, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/libpod/client/encode.rs
+++ b/internal/libpod/client/encode.rs
@@ -28,9 +28,42 @@ pub(crate) fn urlencoded(s: &str) -> String {
 	out
 }
 
+/// Whether `name` matches podman's object-name pattern
+/// (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`): a leading ASCII alphanumeric followed by
+/// alphanumerics, `_`, `.`, or `-`. Used to reject an invalid container/network/
+/// volume name client-side with a clear message instead of deferring to an
+/// opaque podman HTTP 500. Pure so it is unit-tested.
+pub(crate) fn is_valid_object_name(name: &str) -> bool {
+	let mut chars = name.chars();
+	match chars.next() {
+		Some(c) if c.is_ascii_alphanumeric() => {}
+		_ => return false,
+	}
+	chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
+}
+
 #[cfg(test)]
 mod tests {
-	use super::urlencoded;
+	use super::{is_valid_object_name, urlencoded};
+
+	#[test]
+	fn valid_object_names_accepted() {
+		assert!(is_valid_object_name("web"));
+		assert!(is_valid_object_name("proj-web-1"));
+		assert!(is_valid_object_name("a.b_c-1"));
+		assert!(is_valid_object_name("0abc"));
+	}
+
+	#[test]
+	fn invalid_object_names_rejected() {
+		assert!(!is_valid_object_name(""));
+		assert!(!is_valid_object_name("-leading-dash"));
+		assert!(!is_valid_object_name(".leading-dot"));
+		assert!(!is_valid_object_name("has space"));
+		assert!(!is_valid_object_name("has/slash"));
+		assert!(!is_valid_object_name("tab\tname"));
+		assert!(!is_valid_object_name("emoji😀"));
+	}
 
 	#[test]
 	fn unreserved_chars_pass_through() {

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -15,7 +15,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::error::PodmanError;
 
 mod encode;
-pub(crate) use encode::urlencoded;
+pub(crate) use encode::{is_valid_object_name, urlencoded};
 
 type BoxBody = Full<Bytes>;
 

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -365,6 +365,30 @@ impl Client {
 		Self::check_status(status, &body)
 	}
 
+	/// `POST` with empty body → ignore response body (expect 2xx or 304), bounded
+	/// by a caller-chosen deadline rather than the default `READ_TIMEOUT`.
+	///
+	/// `deadline` of `Some` caps both the response-head wait and the body read so a
+	/// `stop` on a container that is slow to die (or a wedged libpod call) returns a
+	/// timeout error after the grace window instead of pinning the CLI for the full
+	/// `READ_TIMEOUT`; `None` leaves it uncapped (docker `stop -t -1` parity). The
+	/// caller decides whether a resulting `PodmanError::is_timeout` warrants a
+	/// client-side `SIGKILL`/force-remove escalation.
+	pub async fn post_empty_ok_within(
+		&self,
+		path: &str,
+		deadline: Option<std::time::Duration>,
+	) -> Result<()> {
+		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let resp = self.send(req, deadline).await?;
+		let (status, body) = Self::read_body(resp, deadline).await?;
+		// 304 Not Modified is fine for idempotent ops
+		if status == StatusCode::NOT_MODIFIED {
+			return Ok(());
+		}
+		Self::check_status(status, &body)
+	}
+
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -389,6 +389,34 @@ impl Client {
 		Self::check_status(status, &body)
 	}
 
+	/// `POST` with JSON body → return raw `Response<Incoming>` for streaming,
+	/// bounding the wait for the response head by `head_timeout` instead of the
+	/// default `READ_TIMEOUT`.
+	///
+	/// `exec`-start uses this with a short, exec-specific ceiling: a healthy engine
+	/// returns the start head (the hijack, or a prompt error) almost immediately, so
+	/// a long wait means the launch is wedged — e.g. a nonexistent target user the
+	/// server stalls resolving. Bounding the head lets the caller fail fast with a
+	/// clear, exec-specific message rather than pinning the CLI for the full
+	/// `READ_TIMEOUT` and then reporting a misleading socket-timeout. The streamed
+	/// body is left unbounded (`head_timeout` covers only the head), so a legitimate
+	/// long-running exec still streams normally.
+	pub async fn post_json_stream_within<B: Serialize>(
+		&self,
+		path: &str,
+		body: &B,
+		head_timeout: Option<std::time::Duration>,
+	) -> Result<Response<Incoming>> {
+		let json = serde_json::to_vec(body).map_err(PodmanError::Json)?;
+		let req = Self::build_request(
+			Method::POST,
+			path,
+			Full::new(Bytes::from(json)),
+			Some("application/json"),
+		)?;
+		Self::stream_or_err(self.send(req, head_timeout).await?).await
+	}
+
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -501,15 +501,25 @@ impl Client {
 		Ok(Some(parsed.mode & (1 << 31) != 0))
 	}
 
-	/// `DELETE` → ignore response body (expect 2xx or 404).
-	pub async fn delete_ok(&self, path: &str) -> Result<()> {
+	/// `DELETE` → `Ok(true)` if the resource existed and was removed, `Ok(false)`
+	/// on a 404 (nothing to delete). Lets a caller tell a real deletion from a
+	/// no-op, so it can avoid reporting a phantom "removed" for a container that
+	/// never existed.
+	pub async fn delete_existed(&self, path: &str) -> Result<bool> {
 		let req = Self::build_request(Method::DELETE, path, Full::new(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		if status == StatusCode::NOT_FOUND {
-			return Ok(());
+			return Ok(false);
 		}
-		Self::check_status(status, &body)
+		Self::check_status(status, &body)?;
+		Ok(true)
+	}
+
+	/// `DELETE` → ignore response body (expect 2xx or 404). A 404 is an
+	/// idempotent no-op; see [`Self::delete_existed`] when the distinction matters.
+	pub async fn delete_ok(&self, path: &str) -> Result<()> {
+		self.delete_existed(path).await.map(|_| ())
 	}
 }
 

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -56,7 +56,7 @@ fn conflict_hint(message: &str) -> Option<&'static str> {
 		Some("the container is already paused")
 	} else if m.contains("not paused") {
 		Some("the container is not paused")
-	} else if m.contains("not running") {
+	} else if m.contains("not running") || m.contains("can only kill running") {
 		Some("the container is not running")
 	} else {
 		None
@@ -99,6 +99,20 @@ impl PodmanError {
 		matches!(self, Self::Api { status, .. } if *status == code)
 	}
 
+	/// True if this is the libpod 409 returned when `kill` targets a container
+	/// that is not running ("can only kill running containers …"). `docker
+	/// compose kill` is best-effort across all targets, so this is treated as an
+	/// idempotent no-op rather than a fatal error that aborts the loop. The
+	/// message is unique to the kill endpoint, so matching it cannot mask another
+	/// op's 409.
+	pub(crate) fn is_kill_of_stopped(&self) -> bool {
+		matches!(
+			self,
+			Self::Api { status: 409, message }
+				if message.to_ascii_lowercase().contains("can only kill running")
+		)
+	}
+
 	/// True if this API error reports that the resource already exists: an HTTP
 	/// 409 conflict, or an HTTP 500 whose message says so. Podman's libpod
 	/// volume-create endpoint returns 500 (not 409) for a duplicate name, so an
@@ -134,6 +148,39 @@ mod tests {
 			conflict_hint("cannot kill container abc: container abc is not running")
 				.unwrap()
 				.contains("not running")
+		);
+		// libpod's kill-of-stopped 409 message ("can only kill running
+		// containers …") gets the same friendly "not running" hint.
+		assert!(conflict_hint(
+			"can only kill running containers. abc is in state exited: container state improper"
+		)
+		.unwrap()
+		.contains("not running"));
+	}
+
+	#[test]
+	fn is_kill_of_stopped_matches_only_the_kill_409() {
+		let stopped = PodmanError::Api {
+			status: 409,
+			message: "can only kill running containers. abc is in state exited: \
+				container state improper"
+				.into(),
+		};
+		assert!(stopped.is_kill_of_stopped());
+		// A different 409 (e.g. already-paused) must not be swallowed by kill.
+		let paused = PodmanError::Api {
+			status: 409,
+			message: "container abc is already paused".into(),
+		};
+		assert!(!paused.is_kill_of_stopped());
+		// Wrong status, even with a matching message, is not a kill-of-stopped.
+		let other = PodmanError::Api {
+			status: 500,
+			message: "can only kill running containers".into(),
+		};
+		assert!(!other.is_kill_of_stopped());
+		assert!(
+			!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_kill_of_stopped()
 		);
 	}
 

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -99,6 +99,14 @@ impl PodmanError {
 		matches!(self, Self::Api { status, .. } if *status == code)
 	}
 
+	/// True if this is a client-side timeout (the request was aborted because the
+	/// socket never responded within the deadline). These carry a synthetic
+	/// status `0` and a `timed out` message; lifecycle callers use this to
+	/// escalate a wedged `stop` to an explicit `SIGKILL`.
+	pub(crate) fn is_timeout(&self) -> bool {
+		matches!(self, Self::Api { status: 0, message } if message.contains("timed out"))
+	}
+
 	/// True if this is the libpod 409 returned when `kill` targets a container
 	/// that is not running ("can only kill running containers …"). `docker
 	/// compose kill` is best-effort across all targets, so this is treated as an
@@ -219,6 +227,29 @@ mod tests {
 		assert!(e.is_status(404));
 		assert!(!e.is_status(200));
 		assert!(!e.is_status(500));
+	}
+
+	#[test]
+	fn is_timeout_matches_synthetic_timeout_error() {
+		// Client-side timeouts carry status 0 and a "timed out" message; lifecycle
+		// stop escalation keys off this.
+		assert!(PodmanError::Api {
+			status: 0,
+			message: "timed out after 40s waiting for the Podman socket to respond".into(),
+		}
+		.is_timeout());
+		// A real HTTP error (non-zero status) is not a timeout.
+		assert!(!PodmanError::Api {
+			status: 500,
+			message: "boom".into(),
+		}
+		.is_timeout());
+		// A status-0 error without the timeout marker is not a timeout.
+		assert!(!PodmanError::Api {
+			status: 0,
+			message: "invalid API path".into(),
+		}
+		.is_timeout());
 	}
 
 	#[test]

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -135,6 +135,43 @@ impl PodmanError {
 			_ => false,
 		}
 	}
+
+	/// True if this API error reports the target image is still referenced by a
+	/// container. A non-force `down --rmi` must skip such an image (matching
+	/// docker compose) instead of force-removing it and cascading the deletion of
+	/// every dependent container — including ones owned by other projects. Podman
+	/// returns this as a 409 conflict, or on some versions a 500 whose message
+	/// names the in-use cause.
+	pub(crate) fn is_image_in_use(&self) -> bool {
+		match self {
+			Self::Api { status: 409, .. } => true,
+			Self::Api {
+				status: 500,
+				message,
+			} => {
+				let m = message.to_ascii_lowercase();
+				m.contains("in use") || m.contains("being used") || m.contains("used by")
+			}
+			_ => false,
+		}
+	}
+
+	/// True if this API error reports a container is in the wrong state for the
+	/// attempted lifecycle op (already paused, not paused, not running). Podman
+	/// returns these as a 409/500 with a "container state improper" cause. Lets
+	/// `pause`/`unpause` stay idempotent no-ops, matching docker compose.
+	pub(crate) fn is_state_conflict(&self) -> bool {
+		match self {
+			Self::Api { status, message } if *status == 409 || *status == 500 => {
+				let m = message.to_ascii_lowercase();
+				m.contains("state improper")
+					|| m.contains("already paused")
+					|| m.contains("not paused")
+					|| m.contains("not running")
+			}
+			_ => false,
+		}
+	}
 }
 
 #[cfg(test)]
@@ -273,6 +310,63 @@ mod tests {
 			message: "volume with name p_v already exists: volume already exists".into(),
 		}
 		.is_already_exists());
+	}
+
+	#[test]
+	fn image_in_use_accepts_409_and_500_with_message() {
+		// A 409 on image delete is always an in-use conflict.
+		assert!(PodmanError::Api {
+			status: 409,
+			message: "image is in use by 1 container".into(),
+		}
+		.is_image_in_use());
+		// Some Podman versions report it as a 500 naming the cause.
+		assert!(PodmanError::Api {
+			status: 500,
+			message: "image used by a container: image in use".into(),
+		}
+		.is_image_in_use());
+		// An unrelated 500 still propagates.
+		assert!(!PodmanError::Api {
+			status: 500,
+			message: "internal error".into(),
+		}
+		.is_image_in_use());
+		assert!(!PodmanError::Api {
+			status: 404,
+			message: "no such image".into(),
+		}
+		.is_image_in_use());
+	}
+
+	#[test]
+	fn state_conflict_recognises_pause_unpause_mismatches() {
+		for msg in [
+			"container abc is already paused: container state improper",
+			"container abc is not paused: container state improper",
+			"cannot pause container abc: container abc is not running",
+			"unpausing container: container state improper",
+		] {
+			assert!(
+				PodmanError::Api {
+					status: 500,
+					message: msg.into(),
+				}
+				.is_state_conflict(),
+				"should treat {msg:?} as a state conflict"
+			);
+		}
+		// A genuine failure is not a state conflict.
+		assert!(!PodmanError::Api {
+			status: 500,
+			message: "internal error".into(),
+		}
+		.is_state_conflict());
+		assert!(!PodmanError::Api {
+			status: 404,
+			message: "no such container".into(),
+		}
+		.is_state_conflict());
 	}
 
 	#[test]

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -51,13 +51,35 @@ impl fmt::Display for PodmanError {
 fn conflict_hint(message: &str) -> Option<&'static str> {
 	let m = message.to_ascii_lowercase();
 	if m.contains("without force") || (m.contains("cannot remove") && m.contains("running")) {
-		Some("the container is running — stop it first, or pass `-f` to force removal")
+		// Podman's removal refusal wording is the same for a running and a paused
+		// container ("running or paused containers cannot be removed without
+		// force"); the state is only in the leading "as it is paused/running"
+		// clause. Match that so a paused container is not mislabelled as running.
+		if m.contains("is paused") {
+			Some("the container is paused — unpause it first, or pass `-f` to force removal")
+		} else {
+			Some("the container is running — stop it first, or pass `-f` to force removal")
+		}
 	} else if m.contains("already paused") {
 		Some("the container is already paused")
 	} else if m.contains("not paused") {
 		Some("the container is not paused")
-	} else if m.contains("not running") || m.contains("can only kill running") {
+	} else if m.contains("not running")
+		|| m.contains("can only kill running containers")
+		|| m.contains("can only create exec sessions on running containers")
+	{
+		// kill/exec against a stopped container, plus the generic "not running".
 		Some("the container is not running")
+	} else if m.contains("already running") {
+		Some("the container is already running")
+	} else if m.contains("must be in created or stopped state")
+		|| (m.contains("unable to start") && m.contains("state"))
+	{
+		// start of a container that is not in a startable state (e.g. paused).
+		Some("the container cannot be started in its current state")
+	} else if m.contains("container state improper") {
+		// restart/other ops that podman rejects with the generic state message.
+		Some("the container is not in a valid state for this operation")
 	} else {
 		None
 	}
@@ -227,6 +249,41 @@ mod tests {
 		assert!(
 			!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_kill_of_stopped()
 		);
+	}
+
+	#[test]
+	fn conflict_hint_paused_rm_is_not_labelled_running() {
+		// Podman's removal refusal for a *paused* container shares the "without
+		// force" wording; the hint must say paused, not running.
+		let paused = "cannot remove container abc as it is paused - running or paused containers \
+			cannot be removed without force: container state improper";
+		let hint = conflict_hint(paused).unwrap();
+		assert!(hint.contains("paused"), "got {hint:?}");
+		assert!(!hint.contains("running"), "must not say running: {hint:?}");
+		assert!(hint.contains("-f"));
+	}
+
+	#[test]
+	fn conflict_hint_covers_kill_exec_and_start() {
+		// kill a stopped container.
+		assert!(
+			conflict_hint("can only kill running containers. abc is in state exited")
+				.unwrap()
+				.contains("not running")
+		);
+		// exec into a stopped container.
+		assert!(conflict_hint(
+			"can only create exec sessions on running containers: container state improper"
+		)
+		.unwrap()
+		.contains("not running"));
+		// start a container that is not startable.
+		assert!(conflict_hint(
+			"unable to start container abc: container must be in Created or Stopped state to be \
+			 started"
+		)
+		.unwrap()
+		.contains("cannot be started"));
 	}
 
 	#[test]

--- a/internal/libpod/mod.rs
+++ b/internal/libpod/mod.rs
@@ -22,7 +22,7 @@ pub mod types;
 /// exception and deliberately omits this prefix.
 pub(crate) const API_PREFIX: &str = "/v5.0.0/libpod";
 
-pub(crate) use client::urlencoded;
 pub use client::Client;
+pub(crate) use client::{is_valid_object_name, urlencoded};
 pub use error::PodmanError;
 pub use types::stream::{parse_json_lines, parse_multiplexed, parse_raw, LogOutput};

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -46,6 +46,12 @@ pub struct ContainerListEntry {
 	#[serde(rename = "Ports", default, deserialize_with = "null_default")]
 	pub ports: Vec<ContainerPort>,
 
+	/// Exit code of the last run, present once the container has exited. libpod's
+	/// list endpoint reports it (0 while running/created), letting `ps`
+	/// distinguish a clean exit from a crash without a follow-up inspect.
+	#[serde(rename = "ExitCode", default)]
+	pub exit_code: Option<i32>,
+
 	/// Container labels (key/value), including compose project/service labels.
 	#[serde(rename = "Labels", default, deserialize_with = "null_default")]
 	pub labels: HashMap<String, String>,
@@ -64,10 +70,9 @@ pub struct ContainerPort {
 	#[serde(default)]
 	pub protocol: Option<String>,
 	/// Number of consecutive ports this entry covers when libpod collapses a
-	/// published range into a single record. Captured for fidelity; not yet
-	/// rendered, so it is read by serde only.
+	/// published range into a single record (e.g. `51251-51253->8080-8082` is one
+	/// record with `range = 3`). Rendered by `ps` so the full range is shown.
 	#[serde(default)]
-	#[allow(dead_code)]
 	pub range: Option<u16>,
 }
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -66,8 +66,36 @@ fn run_to_exit() {
 		}
 		Err(e) => {
 			print_error(&e);
-			process::exit(1);
+			// A `run`/`exec` whose command cannot be launched arrives as a Podman
+			// (OCI/crun) error; map it onto docker's conventional codes (127 not
+			// found, 126 not executable) instead of the generic exit 1.
+			let code = match &e {
+				podup::ComposeError::Podman(_) => command_failure_exit_code(&e.to_string()),
+				_ => 1,
+			};
+			process::exit(code);
 		}
+	}
+}
+
+/// Map a failed launch onto docker's conventional exit codes by inspecting the
+/// OCI/crun error text: a "command not found" failure → 127, a
+/// "not executable"/"permission denied"/"exec format error" failure → 126,
+/// anything else → 1. Pure string inspection so it is unit-testable.
+fn command_failure_exit_code(msg: &str) -> i32 {
+	let m = msg.to_ascii_lowercase();
+	let not_found = m.contains("executable file not found")
+		|| m.contains("not found in $path")
+		|| (m.contains("oci runtime") && m.contains("no such file"));
+	let not_executable = m.contains("exec format error")
+		|| m.contains("not executable")
+		|| (m.contains("oci runtime") && m.contains("permission denied"));
+	if not_found {
+		127
+	} else if not_executable {
+		126
+	} else {
+		1
 	}
 }
 
@@ -343,6 +371,41 @@ async fn run() -> podup::Result<()> {
 	};
 
 	dispatch::dispatch(&engine, &file, cli.command, &cli.profile).await
+}
+
+#[cfg(test)]
+mod exit_code_tests {
+	use super::command_failure_exit_code;
+
+	#[test]
+	fn not_found_maps_to_127() {
+		assert_eq!(
+			command_failure_exit_code(
+				"podman error: crun: executable file `foo` not found in $PATH: \
+				 No such file or directory: OCI runtime command not found error"
+			),
+			127
+		);
+		assert_eq!(
+			command_failure_exit_code("OCI runtime error: ...: no such file or directory"),
+			127
+		);
+	}
+
+	#[test]
+	fn not_executable_maps_to_126() {
+		assert_eq!(
+			command_failure_exit_code("OCI runtime error: permission denied"),
+			126
+		);
+		assert_eq!(command_failure_exit_code("exec format error"), 126);
+	}
+
+	#[test]
+	fn unrelated_errors_map_to_1() {
+		assert_eq!(command_failure_exit_code("some other failure"), 1);
+		assert_eq!(command_failure_exit_code("container is restarting"), 1);
+	}
 }
 
 /// Compose-only global value-flags that `update` parses (they are declared

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -274,6 +274,7 @@ async fn run() -> podup::Result<()> {
 		.with_scale_overrides(scale_overrides)
 		.with_up_overrides(pull_override, no_build, quiet_pull)
 		.with_run_overrides(startup::run_overrides_for(&cli.command))
+		.with_run_env_files(cli.env_file.clone())
 		.with_renew_anon_volumes(renew_anon_volumes);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -132,6 +132,15 @@ fn command_failure_exit_code(msg: &str) -> i32 {
 	}
 }
 
+/// Whether a `down` invocation should tear the project down purely by its
+/// `podup.project` label: the command is `down`, an explicit project name was
+/// given (`-p` / `COMPOSE_PROJECT_NAME`), and no compose file resolves on disk.
+/// Matches `docker compose -p NAME down` against a running project whose compose
+/// file is absent. Pure so it is unit-testable without a Podman daemon.
+fn down_by_label_path(command: &Commands, project: Option<&str>, compose_present: bool) -> bool {
+	matches!(command, Commands::Down { .. }) && project.is_some() && !compose_present
+}
+
 /// Print a top-level error to stderr with a colour-aware bold-red `error:` label.
 /// anstream strips the styling when stderr is not a terminal or colour is off.
 fn print_error(e: &podup::ComposeError) {
@@ -309,6 +318,48 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
+
+	// `down -p NAME` must tear a running project down purely from its
+	// `podup.project` label when no compose file is present — matching `docker
+	// compose -p NAME down`. The startup flow otherwise parses the compose file
+	// before dispatch, so a label-only teardown by project name fails on the
+	// missing file. Handle it here, before that parse, but only when an explicit
+	// project name was given and no file resolves, so a stray `down` in an empty
+	// directory still errors rather than guessing a project from the basename.
+	if down_by_label_path(
+		&cli.command,
+		cli.project.as_deref(),
+		compose_files.iter().any(|p| p.is_file()),
+	) {
+		if let Commands::Down {
+			volumes,
+			rmi,
+			timeout,
+			..
+		} = &cli.command
+		{
+			let project = cli.project.clone().expect("checked by down_by_label_path");
+			startup::validate_project_name(&project)?;
+			// `--rmi` removes the images of the file's services, which cannot be
+			// resolved without a file; warn rather than silently dropping it.
+			if rmi.is_some() {
+				tracing::warn!(
+					"--rmi has no effect without a compose file; containers, networks and \
+					 volumes are still removed by project label"
+				);
+			}
+			let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+			let stop_timeout = podup::validate_stop_timeout(*timeout)?;
+			let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+			let engine = podup::Engine::with_base_dir(client, project, base_dir)
+				.with_stop_timeout(stop_timeout);
+			// `down` is mutating, so serialize it against concurrent runs as the
+			// normal teardown path does.
+			let _lock = engine.lock_project()?;
+			return engine.down_by_label(*volumes).await;
+		}
+	}
+
 	// `config --no-interpolate` must skip interpolation *entirely*: parsing with
 	// interpolation enabled would evaluate a required-var `${VAR:?msg}` and fail
 	// before we ever reached the no-interpolate branch. Detect it up front so the
@@ -468,6 +519,42 @@ async fn run() -> podup::Result<()> {
 	};
 
 	dispatch::dispatch(&engine, &file, cli.command, &cli.profile).await
+}
+
+#[cfg(test)]
+mod down_by_label_tests {
+	use super::down_by_label_path;
+	use crate::cli::Commands;
+
+	fn down() -> Commands {
+		Commands::Down {
+			volumes: false,
+			remove_orphans: false,
+			rmi: None,
+			timeout: None,
+		}
+	}
+
+	#[test]
+	fn down_with_project_and_no_file_takes_label_path() {
+		// `down -p NAME` with no compose file present is the label-only teardown.
+		assert!(down_by_label_path(&down(), Some("proj"), false));
+	}
+
+	#[test]
+	fn down_without_project_or_with_file_does_not() {
+		// Without an explicit project name there is nothing to scope the teardown to,
+		// and when a file is present the normal compose-parse path handles `down`.
+		assert!(!down_by_label_path(&down(), None, false));
+		assert!(!down_by_label_path(&down(), Some("proj"), true));
+	}
+
+	#[test]
+	fn other_commands_never_take_the_down_label_path() {
+		// Only `down` is routed by label here; another command with `-p` and no file
+		// must not be diverted.
+		assert!(!down_by_label_path(&Commands::Watch, Some("proj"), false));
+	}
 }
 
 #[cfg(test)]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -123,6 +123,22 @@ async fn run() -> podup::Result<()> {
 	// filesystem work is blocking; keep it off the async path entirely.
 	#[cfg(feature = "update")]
 	if let Commands::Update { check, force } = cli.command {
+		// The compose-only global value-flags (--socket/--profile/--env-file/
+		// --project-directory) never reach the binary-only self-update, so accepting
+		// them silently is a misleading no-op. Reject any that were passed on the
+		// command line (env-sourced values are left alone — they are not a misuse).
+		if let Some(flag) = misused_update_global() {
+			use clap::CommandFactory;
+			Cli::command()
+				.error(
+					clap::error::ErrorKind::ArgumentConflict,
+					format!(
+						"`{flag}` has no effect on `update`, which replaces the podup \
+						 binary itself rather than acting on a compose project"
+					),
+				)
+				.exit();
+		}
 		let opts = podup::update::UpdateOptions {
 			check_only: check,
 			force,
@@ -257,4 +273,79 @@ async fn run() -> podup::Result<()> {
 	};
 
 	dispatch::dispatch(&engine, &file, cli.command, &cli.profile).await
+}
+
+/// Compose-only global value-flags that `update` parses (they are declared
+/// `global` on [`Cli`]) but cannot act on, since self-update rewrites the binary
+/// itself rather than a compose project. Each entry is `(arg-id, user-facing
+/// spelling)`.
+#[cfg(feature = "update")]
+const UPDATE_IRRELEVANT_GLOBALS: &[(&str, &str)] = &[
+	("socket", "--socket"),
+	("profile", "--profile"),
+	("project_directory", "--project-directory"),
+	("env_file", "--env-file"),
+];
+
+/// Return the first compose-only global flag that was supplied on the command
+/// line for an `update` invocation, or `None` if none were. Re-parses the
+/// already-validated argv to inspect value sources; env-sourced and default
+/// values are deliberately ignored, so an exported `PODMAN_SOCKET` does not
+/// break `podup update`.
+#[cfg(feature = "update")]
+fn misused_update_global() -> Option<&'static str> {
+	use clap::CommandFactory;
+	// Parsing already succeeded once in `parse_cli`, so this re-parse cannot fail.
+	let matches = Cli::command().try_get_matches().ok()?;
+	first_misused_global(&matches)
+}
+
+/// Core of [`misused_update_global`], split out so it can be tested against
+/// matches built from a fixed argv. A global flag can surface on the root
+/// matches or on the `update` subcommand matches depending on its position
+/// relative to the subcommand, so both are checked.
+#[cfg(feature = "update")]
+fn first_misused_global(matches: &clap::ArgMatches) -> Option<&'static str> {
+	use clap::parser::ValueSource;
+	let update = matches.subcommand_matches("update");
+	UPDATE_IRRELEVANT_GLOBALS.iter().find_map(|(id, flag)| {
+		let from_cli = |m: &clap::ArgMatches| m.value_source(id) == Some(ValueSource::CommandLine);
+		(from_cli(matches) || update.is_some_and(from_cli)).then_some(*flag)
+	})
+}
+
+#[cfg(all(test, feature = "update"))]
+mod tests {
+	use super::*;
+	use clap::CommandFactory;
+
+	fn matches_for(args: &[&str]) -> clap::ArgMatches {
+		Cli::command()
+			.try_get_matches_from(args)
+			.expect("args parse")
+	}
+
+	#[test]
+	fn update_flags_compose_globals_before_subcommand_are_rejected() {
+		let m = matches_for(&[
+			"podup",
+			"--socket",
+			"unix:///tmp/x.sock",
+			"update",
+			"--check",
+		]);
+		assert_eq!(first_misused_global(&m), Some("--socket"));
+	}
+
+	#[test]
+	fn update_flags_compose_globals_after_subcommand_are_rejected() {
+		let m = matches_for(&["podup", "update", "--project-directory", "/tmp"]);
+		assert_eq!(first_misused_global(&m), Some("--project-directory"));
+	}
+
+	#[test]
+	fn update_without_compose_globals_is_accepted() {
+		let m = matches_for(&["podup", "update", "--check", "--force"]);
+		assert_eq!(first_misused_global(&m), None);
+	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -24,6 +24,14 @@ fn main() {
 	// internal-error notice that tells the user what to report and where, plus
 	// the reminder to redact secrets first.
 	std::panic::set_hook(Box::new(|info| {
+		// A broken pipe (a downstream reader closed early, e.g. `podup ls | head`)
+		// surfaces as a panic from the failing `println!`/`eprintln!` because Rust
+		// ignores SIGPIPE. With `panic = "abort"` that would escalate to SIGABRT
+		// (exit 134) and a misleading bug-report notice; instead exit quietly with
+		// success like any well-behaved Unix tool.
+		if startup::is_broken_pipe_panic(&info.to_string()) {
+			std::process::exit(0);
+		}
 		eprintln!("podup: internal error: {info}");
 		eprintln!("{}", internal_error_notice());
 	}));
@@ -191,7 +199,13 @@ async fn run() -> podup::Result<()> {
 		};
 		// Honor active profiles so `config` prints the same services `up` starts.
 		podup::retain_active_profiles(&mut resolved, &cli.profile);
-		return startup::render_config(&resolved, format, *services, *quiet);
+		// Resolve the effective project name (-p / COMPOSE_PROJECT_NAME, then the
+		// top-level `name:`, then the directory basename) and render it, like
+		// `docker compose config` — rather than echoing the file's literal `name:`.
+		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+		let project =
+			resolve_project_name(cli.project.clone(), resolved.name.as_deref(), &base_dir);
+		return startup::render_config(&resolved, format, *services, *quiet, &project);
 	}
 
 	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -87,7 +87,7 @@ fn print_error(e: &podup::ComposeError) {
 
 /// Orchestrate one CLI invocation: parse args, then short-circuit the commands
 /// that need neither a compose file nor (for some) Podman — `completions`,
-/// `update`, `ls`, and `config`. Otherwise resolve and parse the compose
+/// `update`, `ls`, `ps`, and `config`. Otherwise resolve and parse the compose
 /// file(s), settle the project name and base directory (validating the name at
 /// the trust boundary), acquire the per-project lock, and dispatch the
 /// remaining commands.
@@ -171,6 +171,34 @@ async fn run() -> podup::Result<()> {
 		.await;
 	}
 
+	// `ps` filters running containers purely by the project label and ignores the
+	// compose file entirely, so it must list an already-running project even when
+	// that file is missing or unparseable (matching `docker compose ps`). Handle
+	// it before the compose file is parsed: read the compose `name:` for project
+	// precedence when the file parses, but fall back to the directory basename
+	// rather than failing, unlike the commands that depend on the file's contents.
+	if let Commands::Ps { all, quiet, format } = &cli.command {
+		let compose_files = resolve_compose_files(&cli.file);
+		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+		let compose_name = podup::parse_files_with_env_files(&compose_files, &cli.env_file)
+			.ok()
+			.and_then(|f| f.name);
+		let project = resolve_project_name(cli.project.clone(), compose_name.as_deref(), &base_dir);
+		startup::validate_project_name(&project)?;
+		let client = podup::podman::connect(cli.socket.as_deref())?;
+		let engine = podup::Engine::with_base_dir(client, project, base_dir);
+		return engine
+			.ps_with_options(
+				&podup::compose::types::ComposeFile::default(),
+				podup::PsOptions {
+					all: *all,
+					quiet: *quiet,
+					json: *format == OutputFormat::Json,
+				},
+			)
+			.await;
+	}
+
 	let compose_files = resolve_compose_files(&cli.file);
 	// `config --no-interpolate` must skip interpolation *entirely*: parsing with
 	// interpolation enabled would evaluate a required-var `${VAR:?msg}` and fail
@@ -204,6 +232,13 @@ async fn run() -> podup::Result<()> {
 		..
 	} = &cli.command
 	{
+		// Validate the resolved project name in the config path too, at the same
+		// trust boundary the mutating commands use, so `config -p 'bad name!'`
+		// reports the same invalid-name error instead of succeeding. The config
+		// path returns early below, so without this it would never be checked.
+		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+		let project = resolve_project_name(cli.project.clone(), file.name.as_deref(), &base_dir);
+		startup::validate_project_name(&project)?;
 		// `file` is already parsed with the correct interpolation setting above.
 		let parsed = file;
 		// `--resolve-image-digests` pins each image to its registry digest, which
@@ -233,13 +268,7 @@ async fn run() -> podup::Result<()> {
 	// quadlet generation). Explicit `-p`/`COMPOSE_PROJECT_NAME` values and the
 	// compose `name:` field are otherwise taken verbatim; rejecting an unsafe
 	// name here fails closed regardless of which command runs next.
-	if !podup::is_safe_project_name(&project) {
-		return Err(podup::ComposeError::Unsupported(format!(
-			"project name {project:?} is not a safe path component: use lowercase ASCII \
-			 letters, digits, '-', '_', starting with a letter or digit, max 128 chars \
-			 (docker-compose rule ^[a-z0-9][a-z0-9_-]*$)"
-		)));
-	}
+	startup::validate_project_name(&project)?;
 
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -247,7 +247,12 @@ async fn run() -> podup::Result<()> {
 		kind: GenerateCommands::Quadlet { output },
 	} = &cli.command
 	{
-		return write_quadlet(&file, &project, output.as_deref());
+		// Honor active profiles so `generate quadlet` emits the same services
+		// `up` would start, instead of also emitting units for inactive-profile
+		// services (which would make `--profile` a no-op on this subcommand).
+		let mut filtered = file.clone();
+		podup::retain_active_profiles(&mut filtered, &cli.profile);
+		return write_quadlet(&filtered, &project, output.as_deref());
 	}
 
 	let client = podup::podman::connect(cli.socket.as_deref())?;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -17,7 +17,7 @@ mod startup;
 use cli::*;
 use generate::write_quadlet;
 use resolve::*;
-use startup::{init_tracing, internal_error_notice, is_mutating, parse_cli};
+use startup::{init_tracing, internal_error_notice, is_label_only, is_mutating, parse_cli};
 
 fn main() {
 	// Replace the default panic output (a raw Rust backtrace) with a `podup:`
@@ -172,7 +172,18 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
-	let file = podup::parse_files_with_env_files(&compose_files, &cli.env_file)?;
+	// `events` and `ps` are scoped purely by the `podup.project` label and never
+	// read service definitions, so — like `docker compose -p NAME events`/`ps` —
+	// they must work against a running project even when no compose file is
+	// present. Tolerate a missing file for these label-only commands by falling
+	// back to an empty compose model; any other parse error (a malformed file
+	// that *does* exist, a missing env file) still surfaces.
+	let label_only = is_label_only(&cli.command);
+	let file = if label_only && !compose_files.iter().any(|p| p.is_file()) {
+		podup::compose::types::ComposeFile::default()
+	} else {
+		podup::parse_files_with_env_files(&compose_files, &cli.env_file)?
+	};
 
 	if let Commands::Config {
 		format,
@@ -218,8 +229,9 @@ async fn run() -> podup::Result<()> {
 	// name here fails closed regardless of which command runs next.
 	if !podup::is_safe_project_name(&project) {
 		return Err(podup::ComposeError::Unsupported(format!(
-			"project name {project:?} is not a safe path component: use only ASCII \
-			 letters, digits, '-', '_', '.', not starting with '.', max 128 chars"
+			"project name {project:?} is not a safe path component: use lowercase ASCII \
+			 letters, digits, '-', '_', starting with a letter or digit, max 128 chars \
+			 (docker-compose rule ^[a-z0-9][a-z0-9_-]*$)"
 		)));
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -166,6 +166,12 @@ async fn run() -> podup::Result<()> {
 	// Resolve the colour choice before any output (including tracing setup below)
 	// so `--ansi`/`NO_COLOR`/TTY detection apply consistently everywhere.
 	podup::ui::set_color_choice(cli.ansi.into());
+	// Enable user-facing lifecycle progress for the CLI: per-container
+	// Started/Stopped/Removed lines on stderr (and the `run -d` id on stdout),
+	// matching docker compose. The library leaves this off so embedders stay
+	// silent. Only the lifecycle commands emit it, so enabling it globally here
+	// is inert for read-only/machine-output commands.
+	podup::ui::set_progress(true);
 	// `watch` is an interactive, long-running command; surface its per-action
 	// progress (synced/rebuilt/restarted) by defaulting to INFO instead of the
 	// quiet WARN floor. `RUST_LOG` always overrides.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -172,6 +172,17 @@ async fn run() -> podup::Result<()> {
 	}
 
 	let compose_files = resolve_compose_files(&cli.file);
+	// `config --no-interpolate` must skip interpolation *entirely*: parsing with
+	// interpolation enabled would evaluate a required-var `${VAR:?msg}` and fail
+	// before we ever reached the no-interpolate branch. Detect it up front so the
+	// file is parsed only once, with interpolation disabled.
+	let no_interpolate = matches!(
+		&cli.command,
+		Commands::Config {
+			no_interpolate: true,
+			..
+		}
+	);
 	// `events` and `ps` are scoped purely by the `podup.project` label and never
 	// read service definitions, so — like `docker compose -p NAME events`/`ps` —
 	// they must work against a running project even when no compose file is
@@ -182,24 +193,19 @@ async fn run() -> podup::Result<()> {
 	let file = if label_only && !compose_files.iter().any(|p| p.is_file()) {
 		podup::compose::types::ComposeFile::default()
 	} else {
-		podup::parse_files_with_env_files(&compose_files, &cli.env_file)?
+		podup::parse_files_with_env_files_interp(&compose_files, &cli.env_file, !no_interpolate)?
 	};
 
 	if let Commands::Config {
 		format,
 		services,
 		quiet,
-		no_interpolate,
 		resolve_image_digests,
+		..
 	} = &cli.command
 	{
-		// `--no-interpolate` re-parses with substitution disabled; `file` (already
-		// parsed with interpolation) is used otherwise.
-		let parsed = if *no_interpolate {
-			podup::parse_files_with_env_files_interp(&compose_files, &cli.env_file, false)?
-		} else {
-			file
-		};
+		// `file` is already parsed with the correct interpolation setting above.
+		let parsed = file;
 		// `--resolve-image-digests` pins each image to its registry digest, which
 		// needs a Podman connection to inspect images.
 		let mut resolved = if *resolve_image_digests {

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -78,6 +78,39 @@ fn run_to_exit() {
 	}
 }
 
+/// Resolve the Podman socket: an explicit `--socket` / `PODMAN_SOCKET` value
+/// wins (clap already folds the env var into `cli.socket`); otherwise fall back
+/// to `DOCKER_HOST` for Docker compatibility. A remote scheme on either is
+/// rejected by [`podup::podman::connect`], so `DOCKER_HOST=tcp://…` fails closed
+/// rather than being silently ignored.
+fn resolve_socket(cli_socket: Option<&str>) -> Option<String> {
+	cli_socket
+		.map(str::to_string)
+		.or_else(|| std::env::var("DOCKER_HOST").ok().filter(|s| !s.is_empty()))
+}
+
+/// Render help for `help [COMMAND]`, framed and colour-aware to match clap's own
+/// `--help`. Help-flag tokens (`-h`/`--help`) and a leading `--` are tolerated;
+/// the first remaining token selects the subcommand (an unknown one falls back
+/// to the top-level help).
+fn print_command_help(commands: &[String]) -> podup::Result<()> {
+	use clap::CommandFactory;
+	let mut cmd = Cli::command();
+	let target = commands
+		.iter()
+		.find(|t| !matches!(t.as_str(), "-h" | "--help" | "--"));
+	let rendered = match target.and_then(|name| cmd.find_subcommand_mut(name)) {
+		Some(sub) => sub.render_long_help(),
+		None => cmd.render_long_help(),
+	};
+	if podup::ui::stdout_colored() {
+		print!("\n{}\n", rendered.ansi());
+	} else {
+		print!("\n{rendered}\n");
+	}
+	Ok(())
+}
+
 /// Map a failed launch onto docker's conventional exit codes by inspecting the
 /// OCI/crun error text: a "command not found" failure → 127, a
 /// "not executable"/"permission denied"/"exec format error" failure → 126,
@@ -134,6 +167,13 @@ async fn run() -> podup::Result<()> {
 	};
 	init_tracing(log_floor);
 
+	// `help [COMMAND]` is served from the static CLI definition. Unlike clap's
+	// built-in help subcommand it tolerates extra tokens, `-h`/`--help`, and a
+	// leading `--`, and never errors with "unrecognized subcommand".
+	if let Commands::Help { commands } = &cli.command {
+		return print_command_help(commands);
+	}
+
 	// `completions` derives entirely from the static CLI definition; it neither
 	// parses a compose file nor contacts Podman. Print to stdout for piping.
 	#[cfg(feature = "completions")]
@@ -184,17 +224,39 @@ async fn run() -> podup::Result<()> {
 			.map_err(|e| podup::ComposeError::Update(format!("update task failed: {e}")))?;
 	}
 
+	// An explicit `--project-directory` must exist and be a directory before any
+	// command relies on it (staging, lock files, quadlet output, base-dir
+	// resolution); validate it once, at the trust boundary, for every command.
+	validate_project_directory(cli.project_directory.as_deref())?;
+
 	// `ls` discovers projects across the host by container label; it needs a
 	// Podman connection but no compose file, so handle it before parsing one.
-	if let Commands::Ls { all, quiet, format } = &cli.command {
-		let client = podup::podman::connect(cli.socket.as_deref())?;
-		return podup::list_projects(
+	if let Commands::Ls {
+		all,
+		quiet,
+		filter,
+		format,
+	} = &cli.command
+	{
+		// `ls` is project-agnostic and short-circuits before compose parsing, so
+		// validate the global `--env-file` paths it would otherwise silently
+		// ignore (the other paths validate them while parsing).
+		for ef in &cli.env_file {
+			if !std::path::Path::new(ef).is_file() {
+				return Err(podup::ComposeError::Unsupported(format!(
+					"--env-file {ef} does not exist or is not a file"
+				)));
+			}
+		}
+		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+		return podup::list_projects_filtered(
 			&client,
 			podup::LsOptions {
 				all: *all,
 				quiet: *quiet,
 				json: *format == OutputFormat::Json,
 			},
+			filter,
 		)
 		.await;
 	}
@@ -205,23 +267,42 @@ async fn run() -> podup::Result<()> {
 	// it before the compose file is parsed: read the compose `name:` for project
 	// precedence when the file parses, but fall back to the directory basename
 	// rather than failing, unlike the commands that depend on the file's contents.
-	if let Commands::Ps { all, quiet, format } = &cli.command {
+	if let Commands::Ps {
+		all,
+		quiet,
+		services_only,
+		filter,
+		status,
+		format,
+		services,
+	} = &cli.command
+	{
 		let compose_files = resolve_compose_files(&cli.file);
 		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
-		let compose_name = podup::parse_files_with_env_files(&compose_files, &cli.env_file)
-			.ok()
-			.and_then(|f| f.name);
+		// Parse the compose file when it is present and valid so `--services` and a
+		// positional `SERVICE` filter can resolve service names and replicas;
+		// otherwise fall back to an empty model (and the directory basename for the
+		// project name) rather than failing, matching `docker compose ps`.
+		let parsed = podup::parse_files_with_env_files(&compose_files, &cli.env_file).ok();
+		let compose_name = parsed.as_ref().and_then(|f| f.name.clone());
+		let file = parsed.unwrap_or_default();
 		let project = resolve_project_name(cli.project.clone(), compose_name.as_deref(), &base_dir);
 		startup::validate_project_name(&project)?;
-		let client = podup::podman::connect(cli.socket.as_deref())?;
+		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 		let engine = podup::Engine::with_base_dir(client, project, base_dir);
 		return engine
-			.ps_with_options(
-				&podup::compose::types::ComposeFile::default(),
+			.ps_filtered(
+				&file,
 				podup::PsOptions {
 					all: *all,
 					quiet: *quiet,
 					json: *format == OutputFormat::Json,
+				},
+				podup::PsFilterOptions {
+					services_only: *services_only,
+					services: services.clone(),
+					status: status.clone(),
+					filters: filter.clone(),
 				},
 			)
 			.await;
@@ -255,6 +336,10 @@ async fn run() -> podup::Result<()> {
 	if let Commands::Config {
 		format,
 		services,
+		volumes,
+		images,
+		profiles,
+		hash,
 		quiet,
 		resolve_image_digests,
 		..
@@ -272,20 +357,30 @@ async fn run() -> podup::Result<()> {
 		// `--resolve-image-digests` pins each image to its registry digest, which
 		// needs a Podman connection to inspect images.
 		let mut resolved = if *resolve_image_digests {
-			let client = podup::podman::connect(cli.socket.as_deref())?;
+			let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 			podup::resolve_image_digests(&client, &parsed).await?
 		} else {
 			parsed
 		};
 		// Honor active profiles so `config` prints the same services `up` starts.
 		podup::retain_active_profiles(&mut resolved, &cli.profile);
-		// Resolve the effective project name (-p / COMPOSE_PROJECT_NAME, then the
-		// top-level `name:`, then the directory basename) and render it, like
-		// `docker compose config` — rather than echoing the file's literal `name:`.
-		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
-		let project =
-			resolve_project_name(cli.project.clone(), resolved.name.as_deref(), &base_dir);
-		return startup::render_config(&resolved, format, *services, *quiet, &project);
+		// Render the resolved project name (already settled above from -p /
+		// COMPOSE_PROJECT_NAME, the top-level `name:`, then the directory
+		// basename), like `docker compose config`, rather than echoing the file's
+		// literal `name:`.
+		return startup::render_config(
+			&resolved,
+			format,
+			&startup::ConfigOutput {
+				services: *services,
+				volumes: *volumes,
+				images: *images,
+				profiles: *profiles,
+				hash: hash.clone(),
+				quiet: *quiet,
+			},
+			&project,
+		);
 	}
 
 	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
@@ -312,7 +407,7 @@ async fn run() -> podup::Result<()> {
 		return write_quadlet(&filtered, &project, output.as_deref());
 	}
 
-	let client = podup::podman::connect(cli.socket.as_deref())?;
+	let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 	// The `-t/--timeout` shutdown-grace override applies to every command that
 	// stops containers (up recreate, down, stop, restart).
 	let stop_timeout = match &cli.command {
@@ -341,6 +436,7 @@ async fn run() -> podup::Result<()> {
 			..
 		} => (pull.clone(), *no_build, *quiet_pull),
 		Commands::Pull { quiet, policy, .. } => (policy.clone(), false, *quiet),
+		Commands::Create { pull, .. } => (pull.clone(), false, false),
 		_ => (None, false, false),
 	};
 	// `up -V/--renew-anon-volumes`: recreate anonymous volumes on container
@@ -358,6 +454,7 @@ async fn run() -> podup::Result<()> {
 		.with_up_overrides(pull_override, no_build, quiet_pull)
 		.with_run_overrides(startup::run_overrides_for(&cli.command))
 		.with_run_env_files(cli.env_file.clone())
+		.with_run_labels(startup::run_labels_for(&cli.command))
 		.with_renew_anon_volumes(renew_anon_volumes);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -437,6 +437,7 @@ async fn run() -> podup::Result<()> {
 				quiet: *quiet,
 			},
 			&project,
+			&base_dir,
 		);
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -260,6 +260,9 @@ async fn run() -> podup::Result<()> {
 		| Commands::Restart { timeout, .. } => *timeout,
 		_ => None,
 	};
+	// Reject a `-t/--timeout` below -1 here, at the trust boundary, with a clear
+	// message instead of forwarding it to libpod as a raw `?t=<negative>` 400.
+	let stop_timeout = podup::validate_stop_timeout(stop_timeout)?;
 	// `--scale SERVICE=N` (on `up`) and the `scale` subcommand both feed the
 	// engine's replica overrides so `resolve_replicas` reports the target count.
 	let scale_overrides: std::collections::HashMap<String, u32> = match &cli.command {

--- a/internal/ports.rs
+++ b/internal/ports.rs
@@ -62,14 +62,18 @@ fn parse_one(mapping: &PortMapping) -> Result<Vec<ParsedPort>> {
 			..
 		} => {
 			let proto = protocol.clone().unwrap_or_else(|| "tcp".into());
+			validate_protocol(&proto, &format!("{target}/{proto}"))?;
 			let hip = host_ip.clone().unwrap_or_default();
 			let host_port = published
 				.as_ref()
 				.map(|p| match p {
-					StringOrU16::Number(n) => Ok(*n),
-					StringOrU16::String(s) => s.parse::<u16>().map_err(|_| {
-						ComposeError::InvalidPort(format!("invalid published port: {s}"))
-					}),
+					StringOrU16::Number(n) => port_in_range(*n, &n.to_string()),
+					StringOrU16::String(s) => {
+						let n: u32 = s.parse().map_err(|_| {
+							ComposeError::InvalidPort(format!("invalid published port: {s}"))
+						})?;
+						port_in_range(n, s)
+					}
 				})
 				.transpose()?;
 			Ok(vec![ParsedPort {
@@ -99,6 +103,7 @@ fn parse_short(s: &str) -> Result<Vec<ParsedPort>> {
 	} else {
 		(s, "tcp".to_string())
 	};
+	validate_protocol(&proto, s)?;
 
 	// IPv6 form: `[::1]:host:container` or `[::1]:container`.
 	if let Some(rest) = rest.strip_prefix('[') {
@@ -181,8 +186,7 @@ fn parse_with_ip(ip: &str, after: &str, proto: &str, full: &str) -> Result<Vec<P
 			})
 			.collect())
 	} else {
-		let cp: u16 = after
-			.parse()
+		let cp = parse_port_num(after)
 			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {full}")))?;
 		Ok(vec![ParsedPort {
 			container_port: cp,
@@ -225,16 +229,44 @@ fn expand_single_host_port(
 
 pub(crate) const MAX_PORT_RANGE: usize = 1024;
 
+/// The set of transport protocols podman accepts for a published port. A value
+/// outside this set is rejected at config time rather than passed verbatim to
+/// podman, which would only surface as an opaque create-time error.
+const VALID_PROTOCOLS: [&str; 3] = ["tcp", "udp", "sctp"];
+
+/// Validate a port's protocol suffix against the `tcp`/`udp`/`sctp` allow-list.
+fn validate_protocol(proto: &str, full: &str) -> Result<()> {
+	if VALID_PROTOCOLS.contains(&proto) {
+		Ok(())
+	} else {
+		Err(ComposeError::InvalidPort(format!(
+			"unsupported protocol '{proto}' in '{full}'; use tcp, udp, or sctp"
+		)))
+	}
+}
+
+/// Range-check a numeric port and narrow it to `u16`. Surfaces an out-of-range
+/// value (e.g. `99999`) as a clear config error so the short and long port forms
+/// fail the same way instead of overflowing or leaking a serde enum message.
+fn port_in_range(n: u32, label: &str) -> Result<u16> {
+	u16::try_from(n)
+		.map_err(|_| ComposeError::InvalidPort(format!("port out of range (1-65535): {label}")))
+}
+
+/// Parse a single port number, range-checked against 1-65535.
+fn parse_port_num(s: &str) -> Result<u16> {
+	let n: u32 = s
+		.parse()
+		.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
+	port_in_range(n, s)
+}
+
 /// Expand `start-end` or a single port string.
 fn expand_port_range(s: &str) -> Result<Vec<u16>> {
 	let s = s.trim();
 	if let Some(idx) = s.find('-') {
-		let start: u16 = s[..idx]
-			.parse()
-			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
-		let end: u16 = s[idx + 1..]
-			.parse()
-			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
+		let start = parse_port_num(&s[..idx])?;
+		let end = parse_port_num(&s[idx + 1..])?;
 		if start > end {
 			return Err(ComposeError::InvalidPort(format!(
 				"start > end in range: {s}"
@@ -248,10 +280,7 @@ fn expand_port_range(s: &str) -> Result<Vec<u16>> {
 		}
 		Ok((start..=end).collect())
 	} else {
-		let p: u16 = s
-			.parse()
-			.map_err(|_| ComposeError::InvalidPort(format!("bad port: {s}")))?;
-		Ok(vec![p])
+		Ok(vec![parse_port_num(s)?])
 	}
 }
 
@@ -382,6 +411,56 @@ mod tests {
 	#[test]
 	fn invalid_port_string_is_error() {
 		assert!(parse_ports(&[short("abc")]).is_err());
+	}
+
+	#[test]
+	fn invalid_protocol_suffix_is_rejected() {
+		// A protocol outside tcp/udp/sctp is a config error, not something to pass
+		// verbatim to podman.
+		let err = parse_ports(&[short("80/banana")]).unwrap_err();
+		assert!(err.to_string().contains("banana"), "got: {err}");
+		assert!(parse_ports(&[short("53/udp")]).is_ok());
+		assert!(parse_ports(&[short("9/sctp")]).is_ok());
+	}
+
+	#[test]
+	fn out_of_range_short_port_reports_range() {
+		// 99999 overflows the 1-65535 port space; surface a clear range error
+		// rather than a generic parse failure.
+		let err = parse_ports(&[short("99999:80")]).unwrap_err();
+		assert!(err.to_string().contains("out of range"), "got: {err}");
+	}
+
+	#[test]
+	fn out_of_range_long_published_reports_range() {
+		// The numeric long form deserializes (u32) and is range-checked here, so the
+		// user sees the same clear message as the short form instead of a serde
+		// untagged-enum error.
+		let mapping = PortMapping::Long {
+			target: 80,
+			published: Some(StringOrU16::Number(99999)),
+			protocol: None,
+			host_ip: None,
+			mode: None,
+			app_protocol: None,
+			name: None,
+		};
+		let err = parse_ports(&[mapping]).unwrap_err();
+		assert!(err.to_string().contains("out of range"), "got: {err}");
+	}
+
+	#[test]
+	fn long_form_invalid_protocol_is_rejected() {
+		let mapping = PortMapping::Long {
+			target: 80,
+			published: Some(StringOrU16::Number(8080)),
+			protocol: Some("banana".to_string()),
+			host_ip: None,
+			mode: None,
+			app_protocol: None,
+			name: None,
+		};
+		assert!(parse_ports(&[mapping]).is_err());
 	}
 
 	#[test]

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -71,6 +71,20 @@ pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 			continue;
 		}
 		out.units.push(network_unit(name, project, cfg.as_ref()));
+		// `podman network create` (and therefore Quadlet) exposes no key for IPAM
+		// options beyond the IPAM driver, so `ipam.options` cannot be emitted. The
+		// live engine forwards them via the libpod API directly, so warn rather than
+		// let `generate` silently diverge from `up`.
+		if let Some(c) = cfg {
+			if let Some(ipam) = &c.ipam {
+				if !ipam.options.is_empty() {
+					out.warnings.push(format!(
+						"network '{name}': ipam.options have no Quadlet key and are not emitted; \
+						 the live engine forwards them but `generate` cannot"
+					));
+				}
+			}
+		}
 	}
 	for (name, cfg) in &file.volumes {
 		if cfg.as_ref().is_some_and(|c| c.external == Some(true)) {

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -117,6 +117,7 @@ pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 			service,
 			&declared_volumes,
 			&declared_networks,
+			&file.secrets,
 			&mut out.warnings,
 		));
 	}

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -31,16 +31,17 @@ pub(super) fn render_publish_port(p: &ParsedPort) -> String {
 }
 
 /// Render a volume mount into a Quadlet `Volume=` value. A source naming a
-/// declared volume gets a `.volume` suffix (so Quadlet wires it to the generated
-/// unit); an undeclared source passes through verbatim. An empty source renders
-/// as just the target. Long-form `read_only`, SELinux relabel (`z`/`Z`), bind
-/// propagation, and `nocopy` opts are folded into the trailing `:opt,opt` field.
-pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> String {
+/// declared volume gets a project-prefixed `.volume` suffix (so Quadlet wires it
+/// to the generated unit, whose file name is also project-prefixed); an
+/// undeclared source passes through verbatim. An empty source renders as just the
+/// target. Long-form `read_only`, SELinux relabel (`z`/`Z`), bind propagation,
+/// and `nocopy` opts are folded into the trailing `:opt,opt` field.
+pub(super) fn render_volume(vol: &VolumeMount, project: &str, declared_volumes: &[&str]) -> String {
 	match vol {
 		VolumeMount::Short(s) => {
 			let parts: Vec<&str> = s.splitn(3, ':').collect();
 			if parts.len() >= 2 && declared_volumes.contains(&parts[0]) {
-				let mut out = format!("{}.volume:{}", parts[0], parts[1]);
+				let mut out = format!("{}.volume:{}", unit_stem(project, parts[0]), parts[1]);
 				if let Some(opts) = parts.get(2) {
 					out.push(':');
 					out.push_str(opts);
@@ -60,7 +61,7 @@ pub(super) fn render_volume(vol: &VolumeMount, declared_volumes: &[&str]) -> Str
 		} => {
 			let src = source.clone().unwrap_or_default();
 			let src = if declared_volumes.contains(&src.as_str()) {
-				format!("{src}.volume")
+				format!("{}.volume", unit_stem(project, &src))
 			} else {
 				src
 			};
@@ -218,11 +219,69 @@ pub(super) fn sanitize_value(value: &str) -> String {
 	value.chars().filter(|c| !c.is_control()).collect()
 }
 
+/// Keys whose value Quadlet/systemd splits on whitespace (a `KEY=VALUE` option
+/// list): an unquoted space would split a single value into a truncated value
+/// plus bogus extra entries, so such values are quoted when they contain
+/// whitespace.
+fn key_is_word_split(key: &str) -> bool {
+	matches!(key, "Environment" | "Label" | "Annotation" | "Sysctl")
+}
+
+/// Keys whose value is an argument line we render (and quote) ourselves
+/// (`PodmanArgs`, `Exec`, `Entrypoint`); systemd must keep splitting these on
+/// whitespace, so they are passed through with only control characters stripped.
+fn key_is_arg_line(key: &str) -> bool {
+	matches!(key, "PodmanArgs" | "Exec" | "Entrypoint")
+}
+
+/// Escape a value for a single-line systemd `Key=Value` entry.
+///
+/// On top of [`sanitize_value`] (control characters stripped so a value can
+/// never inject a second directive) this makes the value byte-faithful to the
+/// compose source the way docker-compose treats it:
+///
+/// * systemd specifiers (`%h`, `%U`, …) are passed through literally by doubling
+///   `%` to `%%`, instead of being expanded at unit-activation time;
+/// * a value ending in a backslash — which would otherwise fold the next
+///   physical line (and the directive on it) into this value — is quoted and the
+///   backslash escaped, closing the line-continuation hole;
+/// * for word-split keys (`Environment`, `Label`, …) a value containing
+///   whitespace is double-quoted so systemd keeps it as one value rather than
+///   splitting it into bogus extra entries.
+///
+/// Argument-line keys keep their own rendering (they encode whitespace splitting
+/// deliberately) and only have control characters stripped.
+pub(super) fn escape_unit_value(key: &str, value: &str) -> String {
+	let stripped = sanitize_value(value);
+	if key_is_arg_line(key) {
+		return stripped;
+	}
+	let escaped = stripped.replace('%', "%%");
+	let needs_quote = (key_is_word_split(key) && escaped.contains(char::is_whitespace))
+		|| escaped.ends_with('\\')
+		|| escaped.starts_with('"');
+	if needs_quote {
+		format!("\"{}\"", escaped.replace('\\', "\\\\").replace('"', "\\\""))
+	} else {
+		escaped
+	}
+}
+
+/// Build the project-prefixed unit-file stem for a resource, e.g. service `web`
+/// in project `proj` → `proj-web`. Generated unit files share a single systemd
+/// directory across projects, so the stem (and every in-unit cross-reference to
+/// it) carries the project name — matching the project-scoped resource names
+/// inside the units — so two projects' `web` services do not clobber each other.
+pub(super) fn unit_stem(project: &str, name: &str) -> String {
+	safe_unit_stem(&format!("{project}-{name}"))
+}
+
 /// Reduce a compose key to a safe single path-component stem for a unit file
 /// name. Keeps ASCII alphanumerics and `-`/`_`/`.`; replaces anything else
 /// (path separators, control characters) with `_`, and guarantees the result
-/// is non-empty and does not start with a dot, so it can never escape the
-/// output directory or resolve to `.`/`..`.
+/// is non-empty and starts with neither a dot nor a dash, so it can never escape
+/// the output directory, resolve to `.`/`..`, or be mistaken for a command-line
+/// flag by downstream tooling that globs the generated file names.
 pub(super) fn safe_unit_stem(name: &str) -> String {
 	let mut stem: String = name
 		.chars()
@@ -234,7 +293,7 @@ pub(super) fn safe_unit_stem(name: &str) -> String {
 			}
 		})
 		.collect();
-	if stem.is_empty() || stem.starts_with('.') {
+	if stem.is_empty() || stem.starts_with('.') || stem.starts_with('-') {
 		stem.insert(0, '_');
 	}
 	stem
@@ -255,10 +314,14 @@ impl Section {
 		}
 	}
 
-	/// Append a `Key=Value` line, sanitizing the value (control characters
-	/// stripped) so a hostile compose field cannot inject extra unit directives.
+	/// Append a `Key=Value` line, escaping the value for systemd unit syntax
+	/// (control characters stripped, specifiers passed through literally,
+	/// whitespace/line-continuation hazards quoted) so a hostile or merely
+	/// awkward compose field cannot inject extra directives, split a value, or
+	/// swallow the following line. See [`escape_unit_value`].
 	pub(super) fn add(&mut self, key: &str, value: String) {
-		self.lines.push(format!("{key}={}", sanitize_value(&value)));
+		self.lines
+			.push(format!("{key}={}", escape_unit_value(key, &value)));
 	}
 
 	/// True when no lines have been added; lets the caller skip emitting an empty
@@ -389,12 +452,16 @@ mod tests {
 
 	#[test]
 	fn render_volume_short_declared_uses_dot_volume_with_options() {
-		let out = render_volume(&VolumeMount::Short("data:/app:ro".into()), &["data"]);
-		// A declared named volume becomes `<name>.volume:<target>:<opts>`.
-		assert_eq!(out, "data.volume:/app:ro");
+		let out = render_volume(
+			&VolumeMount::Short("data:/app:ro".into()),
+			"proj",
+			&["data"],
+		);
+		// A declared named volume becomes `<project>-<name>.volume:<target>:<opts>`.
+		assert_eq!(out, "proj-data.volume:/app:ro");
 		// An undeclared source is passed through verbatim.
 		assert_eq!(
-			render_volume(&VolumeMount::Short("./host:/app".into()), &["data"]),
+			render_volume(&VolumeMount::Short("./host:/app".into()), "proj", &["data"]),
 			"./host:/app"
 		);
 	}
@@ -415,10 +482,11 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		};
-		// Declared → `.volume` suffix; ro + nocopy folded into the options field.
+		// Declared → project-prefixed `.volume` suffix; ro + nocopy folded into
+		// the options field.
 		assert_eq!(
-			render_volume(&nocopy, &["vol"]),
-			"vol.volume:/data:ro,nocopy"
+			render_volume(&nocopy, "proj", &["vol"]),
+			"proj-vol.volume:/data:ro,nocopy"
 		);
 
 		// An empty source renders as just the target (anonymous mount).
@@ -432,7 +500,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		};
-		assert_eq!(render_volume(&anon, &[]), "/scratch");
+		assert_eq!(render_volume(&anon, "proj", &[]), "/scratch");
 	}
 
 	// --- render_tmpfs_mount ---
@@ -473,5 +541,74 @@ mod tests {
 
 		// A non-tmpfs mount returns None so the caller emits a normal Volume=.
 		assert!(render_tmpfs_mount(&VolumeMount::Short("a:/b".into())).is_none());
+	}
+
+	// --- escape_unit_value (bug: incomplete systemd value escaping) ---
+
+	#[test]
+	fn escape_word_split_value_with_whitespace_is_quoted() {
+		// An Environment value with whitespace must be quoted so systemd keeps it
+		// as one value instead of splitting it into bogus extra entries.
+		assert_eq!(
+			escape_unit_value("Environment", "JAVA_OPTS=-Xmx512m -Xms256m"),
+			"\"JAVA_OPTS=-Xmx512m -Xms256m\""
+		);
+		// A Label is word-split too.
+		assert_eq!(
+			escape_unit_value("Label", "note=hello world"),
+			"\"note=hello world\""
+		);
+		// A scalar key that is not word-split keeps whitespace unquoted.
+		assert_eq!(
+			escape_unit_value("Description", "web (podup)"),
+			"web (podup)"
+		);
+	}
+
+	#[test]
+	fn escape_trailing_backslash_is_quoted_and_escaped() {
+		// A value ending in a backslash would otherwise continue onto — and
+		// swallow — the next directive line; it must be quoted and escaped.
+		let out = escape_unit_value("Environment", "WINPATH=C:\\tmp\\");
+		assert!(!out.ends_with('\\') || out.ends_with("\\\""));
+		assert_eq!(out, "\"WINPATH=C:\\\\tmp\\\\\"");
+	}
+
+	#[test]
+	fn escape_percent_is_doubled_for_literal() {
+		// systemd specifiers like %h must be passed through literally, not
+		// expanded at unit-activation time, matching docker-compose semantics.
+		assert_eq!(escape_unit_value("Environment", "HOME=%h"), "HOME=%%h");
+		assert_eq!(escape_unit_value("Image", "img%U"), "img%%U");
+	}
+
+	#[test]
+	fn escape_arg_line_keys_are_left_intact() {
+		// PodmanArgs/Exec/Entrypoint encode their own whitespace splitting and
+		// must not be quoted or have `%` doubled.
+		assert_eq!(
+			escape_unit_value("PodmanArgs", "--security-opt apparmor=foo"),
+			"--security-opt apparmor=foo"
+		);
+		assert_eq!(
+			escape_unit_value("Exec", "sh -c \"echo %s\""),
+			"sh -c \"echo %s\""
+		);
+	}
+
+	#[test]
+	fn safe_unit_stem_strips_leading_dash() {
+		// A name starting with `-`/`--` must not yield a file name beginning with
+		// a dash (a globbing/flag-injection hazard for downstream tooling).
+		assert_eq!(safe_unit_stem("--foo"), "_--foo");
+		assert_eq!(safe_unit_stem("-x"), "_-x");
+		assert!(!safe_unit_stem("--foo").starts_with('-'));
+	}
+
+	#[test]
+	fn unit_stem_is_project_prefixed() {
+		assert_eq!(unit_stem("proj", "web"), "proj-web");
+		// A leading dash in the project still cannot produce a dash-leading stem.
+		assert!(!unit_stem("-p", "web").starts_with('-'));
 	}
 }

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -29,7 +29,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "app.container").contents;
+	let c = &unit_named(&out, "proj-app.container").contents;
 	assert!(c.contains("HostName=app-host"));
 	// `user: "1000:1000"` splits into separate User=/Group= keys.
 	assert!(c.contains("User=1000"));
@@ -62,7 +62,9 @@ fn restart_policies_map_to_systemd() {
 		let file = parse_str(&yaml).unwrap();
 		let out = generate(&file, "p");
 		assert!(
-			unit_named(&out, "s.container").contents.contains(expected),
+			unit_named(&out, "p-s.container")
+				.contents
+				.contains(expected),
 			"{policy} -> {expected}"
 		);
 	}
@@ -83,10 +85,10 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "web.container").contents;
-	assert!(c.contains("After=cache.service"));
-	assert!(c.contains("Wants=cache.service"));
-	assert!(!c.contains("Requires=cache.service"));
+	let c = &unit_named(&out, "proj-web.container").contents;
+	assert!(c.contains("After=proj-cache.service"));
+	assert!(c.contains("Wants=proj-cache.service"));
+	assert!(!c.contains("Requires=proj-cache.service"));
 }
 
 #[test]
@@ -129,7 +131,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "app.container").contents;
+	let c = &unit_named(&out, "p-app.container").contents;
 	for needle in [
 		"ContainerName=custom",
 		"EnvironmentFile=./app.env",
@@ -137,7 +139,6 @@ services:
 		"Sysctl=net.core.somaxconn=1024",
 		"Ulimit=nofile=1024:2048",
 		"ShmSize=64m",
-		"Memory=512m",
 		"PidsLimit=100",
 		"UserNS=keep-id",
 		"StopSignal=SIGTERM",
@@ -147,6 +148,7 @@ services:
 		"AddHost=db:10.0.0.2",
 		"Annotation=run.oci.keep=1",
 		"Network=host",
+		"PodmanArgs=--memory=512m",
 		"HealthCmd=curl -f http://localhost",
 		"HealthInterval=5s",
 		"HealthRetries=3",
@@ -167,7 +169,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PublishPort=80"));
 	assert!(!c.contains("PublishPort=:80"));
 }
@@ -177,7 +179,7 @@ fn user_with_gid_splits_into_user_and_group() {
 	let yaml = "services:\n  s:\n    image: x\n    user: \"1000:2000\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("User=1000"));
 	assert!(c.contains("Group=2000"));
 	assert!(!c.contains("User=1000:2000"));
@@ -202,7 +204,7 @@ secrets:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Secret=tok"));
 	assert!(c.contains("Secret=cred,target=/run/cred,uid=100"));
 	assert!(!out.warnings.iter().any(|w| w.contains("secrets")));
@@ -240,7 +242,7 @@ networks:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	for needle in [
 		"GroupAdd=audio",
 		"ExposeHostPort=8080",
@@ -251,17 +253,18 @@ networks:
 		"LogDriver=journald",
 		"LogOpt=tag=mytag",
 		"NetworkAlias=web-alias",
-		"Memory=256m",
+		"PodmanArgs=--memory=256m",
 	] {
 		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
 	}
 }
 
 #[test]
-fn memory_and_apparmor_render_as_native_keys() {
-	// `Memory=` and `AppArmor=` are valid native [Container] keys in current
-	// podman-systemd.unit(5); they must be emitted directly, not routed through
-	// `PodmanArgs=`.
+fn memory_and_apparmor_render_as_podman_args() {
+	// `Memory=` and `AppArmor=` are not recognised [Container] keys in
+	// podman-systemd.unit(5) (Quadlet drops the whole unit at daemon-reload), so
+	// they must route through `PodmanArgs=` like the CPU limits, not be emitted as
+	// native keys.
 	let yaml = r#"
 services:
   s:
@@ -272,19 +275,19 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
-	assert!(c.contains("Memory=512m"), "missing native Memory= in:\n{c}");
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
-		c.contains("AppArmor=my-profile"),
-		"missing native AppArmor= in:\n{c}"
+		c.contains("PodmanArgs=--memory=512m"),
+		"mem_limit must route through PodmanArgs in:\n{c}"
 	);
-	for forbidden in [
-		"PodmanArgs=--memory=",
-		"PodmanArgs=--security-opt apparmor=",
-	] {
+	assert!(
+		c.contains("PodmanArgs=--security-opt apparmor=my-profile"),
+		"apparmor must route through PodmanArgs in:\n{c}"
+	);
+	for forbidden in ["Memory=512m", "AppArmor=my-profile"] {
 		assert!(
 			!c.contains(forbidden),
-			"memory/apparmor must use the native key, not `{forbidden}` in:\n{c}"
+			"memory/apparmor must not use an unrecognised native key `{forbidden}` in:\n{c}"
 		);
 	}
 }
@@ -305,7 +308,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	for expected in [
 		"PodmanArgs=--cpus=1.5",
 		"PodmanArgs=--cpuset-cpus=0,1",
@@ -332,7 +335,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("PodmanArgs=--cpus=2"),
 		"missing deploy cpus PodmanArgs in:\n{c}"
@@ -356,7 +359,7 @@ networks:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("IP=10.5.0.7"), "missing IP= in:\n{c}");
 	assert!(c.contains("IP6=2001:db8::7"), "missing IP6= in:\n{c}");
 }
@@ -368,7 +371,7 @@ fn network_mode_none_maps_to_network_none() {
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: none\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Network=none"), "missing Network=none in:\n{c}");
 	assert!(
 		!out.warnings.iter().any(|w| w.contains("network_mode")),
@@ -389,7 +392,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("SecurityLabelFileType=usr_t"), "in:\n{c}");
 	assert!(c.contains("SecurityLabelNested=true"), "in:\n{c}");
 	assert!(
@@ -413,7 +416,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Restart=on-failure"), "in:\n{c}");
 	assert!(c.contains("StartLimitBurst=4"), "in:\n{c}");
 	assert!(c.contains("StartLimitIntervalSec=120"), "in:\n{c}");
@@ -424,7 +427,7 @@ fn deploy_restart_condition_none_maps_to_no() {
 	let yaml = "services:\n  s:\n    image: x\n    deploy:\n      restart_policy:\n        condition: none\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	assert!(unit_named(&out, "s.container")
+	assert!(unit_named(&out, "p-s.container")
 		.contents
 		.contains("Restart=no"));
 }
@@ -442,7 +445,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PidsLimit=256"), "missing PidsLimit in:\n{c}");
 }
 
@@ -463,7 +466,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Tmpfs=/cache:size=64000000,mode=755"),
 		"tmpfs not rendered as Tmpfs= with options in:\n{c}"

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -420,19 +420,67 @@ services:
 }
 
 #[test]
-fn network_mode_service_and_container_map_to_dot_container() {
-	// `network_mode: service:X` / `container:X` reuse another container's netns,
-	// which Quadlet expresses as `Network={X}.container`.
-	for (mode, target) in [("service:db", "db"), ("container:sidecar", "sidecar")] {
-		let yaml = format!("services:\n  s:\n    image: x\n    network_mode: \"{mode}\"\n");
-		let file = parse_str(&yaml).unwrap();
-		let out = generate(&file, "p");
-		let c = &unit_named(&out, "s.container").contents;
-		assert!(
-			c.contains(&format!("Network={target}.container")),
-			"{mode} must map to Network={target}.container; got:\n{c}"
-		);
-	}
+fn network_mode_service_maps_to_dot_container() {
+	// `network_mode: service:X` reuses a sibling service's netns, which Quadlet
+	// expresses as the `Network={X}.container` unit dependency.
+	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:db\"\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("Network=db.container"),
+		"service:db must map to Network=db.container; got:\n{c}"
+	);
+}
+
+#[test]
+fn network_mode_container_maps_to_join_form() {
+	// `network_mode: container:X` joins an *existing* container's netns by id/name
+	// via podman's `Network=container:X`; it is not a `.container` unit dependency
+	// (that would name a non-existent unit and fail to start).
+	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"container:sidecar\"\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert!(
+		c.contains("Network=container:sidecar"),
+		"container:sidecar must map to the join form; got:\n{c}"
+	);
+	assert!(
+		!c.contains("sidecar.container"),
+		"container: must not emit a .container unit dependency; got:\n{c}"
+	);
+}
+
+#[test]
+fn duplicate_network_aliases_are_emitted_once() {
+	// A repeated alias must not produce duplicate `NetworkAlias=` lines, which
+	// podman may reject at container create.
+	let yaml = "services:\n  s:\n    image: x\n    networks:\n      front:\n        aliases: [dup, dup, uniq]\nnetworks:\n  front:\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	let c = &unit_named(&out, "s.container").contents;
+	assert_eq!(
+		c.matches("NetworkAlias=dup").count(),
+		1,
+		"duplicate alias must be emitted once; got:\n{c}"
+	);
+	assert_eq!(c.matches("NetworkAlias=uniq").count(), 1, "in:\n{c}");
+}
+
+#[test]
+fn ipam_options_warn_because_quadlet_cannot_emit_them() {
+	// The live engine forwards `ipam.options` via the libpod API, but podman
+	// network create / Quadlet expose no key for them, so `generate` warns instead
+	// of silently diverging.
+	let yaml = "networks:\n  net:\n    ipam:\n      options:\n        foo: bar\nservices:\n  s:\n    image: x\n    networks: [net]\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate(&file, "p");
+	assert!(
+		out.warnings.iter().any(|w| w.contains("ipam.options")),
+		"expected an ipam.options warning; got: {:?}",
+		out.warnings
+	);
 }
 
 #[test]

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -9,7 +9,7 @@ fn container_name_defaults_to_project_prefixed() {
 	// rather than a bare `web` that would collide across projects.
 	let file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
 	let out = generate(&file, "proj");
-	let web = unit_named(&out, "web.container");
+	let web = unit_named(&out, "proj-web.container");
 	assert!(web.contents.contains("ContainerName=proj-web"));
 }
 
@@ -57,7 +57,7 @@ networks:
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
 
-	let web = unit_named(&out, "web.container");
+	let web = unit_named(&out, "proj-web.container");
 	assert!(web.contents.contains("Image=nginx:1.27"));
 	assert!(web.contents.contains("ContainerName=web"));
 	assert!(web.contents.contains("PublishPort=8080:80"));
@@ -66,18 +66,20 @@ networks:
 	let b = web.contents.find("Environment=B_KEY=two").unwrap();
 	assert!(a < b, "environment keys must be sorted");
 	// Declared named volume is tied to its .volume unit.
-	assert!(web.contents.contains("Volume=data.volume:/var/lib/data"));
-	assert!(web.contents.contains("Network=frontend.network"));
+	assert!(web
+		.contents
+		.contains("Volume=proj-data.volume:/var/lib/data"));
+	assert!(web.contents.contains("Network=proj-frontend.network"));
 	// unless-stopped maps to systemd Restart=always.
 	assert!(web.contents.contains("Restart=always"));
-	assert!(web.contents.contains("After=db.service"));
+	assert!(web.contents.contains("After=proj-db.service"));
 	assert!(web.contents.contains("WantedBy=default.target"));
 
-	unit_named(&out, "db.container");
-	assert!(unit_named(&out, "data.volume")
+	unit_named(&out, "proj-db.container");
+	assert!(unit_named(&out, "proj-data.volume")
 		.contents
 		.contains("VolumeName=proj_data"));
-	assert!(unit_named(&out, "frontend.network")
+	assert!(unit_named(&out, "proj-frontend.network")
 		.contents
 		.contains("NetworkName=proj_frontend"));
 }
@@ -100,7 +102,7 @@ services:
 	let build = out
 		.units
 		.iter()
-		.find(|u| u.filename == "app.build")
+		.find(|u| u.filename == "proj-app.build")
 		.expect("a build service must emit an app.build unit");
 	assert!(build.contents.contains("[Build]"));
 	assert!(build.contents.contains("ImageTag=app:latest"));
@@ -110,9 +112,9 @@ services:
 	let container = out
 		.units
 		.iter()
-		.find(|u| u.filename == "app.container")
+		.find(|u| u.filename == "proj-app.container")
 		.unwrap();
-	assert!(container.contents.contains("Image=app.build"));
+	assert!(container.contents.contains("Image=proj-app.build"));
 	assert!(!out.warnings.iter().any(|w| w.contains("build")));
 }
 
@@ -121,7 +123,7 @@ fn inline_dockerfile_build_warns_and_emits_no_build_unit() {
 	let yaml = "services:\n  app:\n    build:\n      dockerfile_inline: \"FROM alpine\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	assert!(!out.units.iter().any(|u| u.filename == "app.build"));
+	assert!(!out.units.iter().any(|u| u.filename == "proj-app.build"));
 	assert!(out.warnings.iter().any(|w| w.contains("dockerfile_inline")));
 }
 
@@ -136,7 +138,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let web = unit_named(&out, "web.container");
+	let web = unit_named(&out, "proj-web.container");
 	assert!(web
 		.contents
 		.contains("Volume=./html:/usr/share/nginx/html:ro"));
@@ -158,8 +160,8 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "db.container").contents;
-	assert!(c.contains("Volume=pgdata.volume:/var/lib/postgresql/data:ro"));
+	let c = &unit_named(&out, "proj-db.container").contents;
+	assert!(c.contains("Volume=proj-pgdata.volume:/var/lib/postgresql/data:ro"));
 }
 
 #[test]
@@ -207,7 +209,7 @@ fn newline_in_value_cannot_inject_unit_directives() {
 		"services:\n  web:\n    image: x\n    environment:\n      EVIL: \"a\\nExecStartPre=/bin/rm -rf /\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let c = &unit_named(&out, "web.container").contents;
+	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(
 		!c.lines().any(|l| l.starts_with("ExecStartPre")),
 		"a newline in a value must not inject a directive line:\n{c}"
@@ -234,12 +236,15 @@ volumes:
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
 	// No unit is generated for external resources.
-	assert!(!out.units.iter().any(|u| u.filename == "extnet.network"));
-	assert!(!out.units.iter().any(|u| u.filename == "extvol.volume"));
+	assert!(!out
+		.units
+		.iter()
+		.any(|u| u.filename == "proj-extnet.network"));
+	assert!(!out.units.iter().any(|u| u.filename == "proj-extvol.volume"));
 	// The container references them by their existing name, not `.network`/`.volume`.
-	let c = &unit_named(&out, "web.container").contents;
+	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(c.contains("Network=extnet"));
-	assert!(!c.contains("Network=extnet.network"));
+	assert!(!c.contains("Network=proj-extnet.network"));
 	assert!(c.contains("Volume=extvol:/data"));
 	assert!(!c.contains("extvol.volume"));
 }
@@ -260,7 +265,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Volume=/host/data:/data:z,rshared"),
 		"selinux/propagation must be preserved; got:\n{c}"
@@ -288,12 +293,12 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let net = &unit_named(&out, "net.network").contents;
+	let net = &unit_named(&out, "p-net.network").contents;
 	assert!(net.contains("Driver=bridge"));
 	assert!(net.contains("Internal=true"));
 	assert!(net.contains("IPv6=true"));
 	assert!(net.contains("Label=tier=net"));
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(vol.contains("Driver=local"));
 	assert!(vol.contains("Label=tier=vol"));
 }
@@ -319,7 +324,7 @@ networks:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let net = &unit_named(&out, "net.network").contents;
+	let net = &unit_named(&out, "p-net.network").contents;
 	// A custom name overrides the project-prefixed default.
 	assert!(net.contains("NetworkName=custom-net"), "in:\n{net}");
 	assert!(!net.contains("NetworkName=p_net"), "in:\n{net}");
@@ -354,7 +359,7 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(vol.contains("VolumeName=custom-vol"), "in:\n{vol}");
 	assert!(!vol.contains("VolumeName=p_vol"), "in:\n{vol}");
 	// `local` driver opts map to dedicated keys; `o` is a single mount-option
@@ -382,7 +387,7 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("HealthInterval=5s"), "in:\n{c}");
 	assert!(
 		!c.contains("HealthStartupInterval"),
@@ -410,26 +415,27 @@ services:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
-	let web = &unit_named(&out, "web.container").contents;
-	assert!(web.contains("After=db_1.service"), "in:\n{web}");
-	assert!(web.contains("Requires=db_1.service"), "in:\n{web}");
+	let web = &unit_named(&out, "proj-web.container").contents;
+	assert!(web.contains("After=proj-db_1.service"), "in:\n{web}");
+	assert!(web.contains("Requires=proj-db_1.service"), "in:\n{web}");
 	// The raw, unsanitized name must not leak into the ordering directives.
 	assert!(!web.contains("db:1.service"), "in:\n{web}");
 	// The dependency's own unit really is named with the sanitized stem.
-	unit_named(&out, "db_1.container");
+	unit_named(&out, "proj-db_1.container");
 }
 
 #[test]
 fn network_mode_service_maps_to_dot_container() {
 	// `network_mode: service:X` reuses a sibling service's netns, which Quadlet
-	// expresses as the `Network={X}.container` unit dependency.
+	// expresses as the `Network={X}.container` unit dependency. Generated unit
+	// stems are project-prefixed, so the dependency is `p-db.container`.
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:db\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
-		c.contains("Network=db.container"),
-		"service:db must map to Network=db.container; got:\n{c}"
+		c.contains("Network=p-db.container"),
+		"service:db must map to Network=p-db.container; got:\n{c}"
 	);
 }
 
@@ -441,7 +447,7 @@ fn network_mode_container_maps_to_join_form() {
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"container:sidecar\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Network=container:sidecar"),
 		"container:sidecar must map to the join form; got:\n{c}"
@@ -459,7 +465,7 @@ fn duplicate_network_aliases_are_emitted_once() {
 	let yaml = "services:\n  s:\n    image: x\n    networks:\n      front:\n        aliases: [dup, dup, uniq]\nnetworks:\n  front:\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert_eq!(
 		c.matches("NetworkAlias=dup").count(),
 		1,
@@ -488,8 +494,8 @@ fn network_mode_service_target_is_sanitized() {
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:web:1\"\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
-	assert!(c.contains("Network=web_1.container"), "in:\n{c}");
+	let c = &unit_named(&out, "p-s.container").contents;
+	assert!(c.contains("Network=p-web_1.container"), "in:\n{c}");
 }
 
 #[test]
@@ -505,8 +511,8 @@ volumes:
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let net = &unit_named(&out, "net.network").contents;
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let net = &unit_named(&out, "p-net.network").contents;
+	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(
 		!net.contains("[Install]") && !net.contains("WantedBy"),
 		".network must carry no [Install]; got:\n{net}"
@@ -516,7 +522,7 @@ volumes:
 		".volume must carry no [Install]; got:\n{vol}"
 	);
 	// The container unit still carries its [Install].
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("[Install]") && c.contains("WantedBy=default.target"));
 }
 
@@ -525,7 +531,7 @@ fn privileged_maps_to_podman_arg() {
 	let yaml = "services:\n  s:\n    image: x\n    privileged: true\n";
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "p");
-	let c = &unit_named(&out, "s.container").contents;
+	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PodmanArgs=--privileged"), "in:\n{c}");
 	assert!(
 		!out.warnings.iter().any(|w| w.contains("privileged")),
@@ -551,7 +557,7 @@ volumes:
 	let file = parse_str(yaml).unwrap();
 	let out = generate(&file, "proj");
 
-	let c = &unit_named(&out, "web.container").contents;
+	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(
 		c.contains("Label=podup.project=proj"),
 		"container missing project ownership label in:\n{c}"
@@ -561,7 +567,7 @@ volumes:
 		"container missing service ownership label in:\n{c}"
 	);
 
-	let net = &unit_named(&out, "net.network").contents;
+	let net = &unit_named(&out, "proj-net.network").contents;
 	assert!(
 		net.contains("Label=podup.project=proj"),
 		"network missing project ownership label in:\n{net}"
@@ -572,7 +578,7 @@ volumes:
 		"network must not carry a service label in:\n{net}"
 	);
 
-	let vol = &unit_named(&out, "vol.volume").contents;
+	let vol = &unit_named(&out, "proj-vol.volume").contents;
 	assert!(
 		vol.contains("Label=podup.project=proj"),
 		"volume missing project ownership label in:\n{vol}"

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -6,12 +6,14 @@
 
 use crate::compose::types::{BuildConfig, Service};
 
-use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
-/// The `.build` unit file name for a service, e.g. `web.build`. The container
-/// unit points its `Image=` at this so Quadlet builds then runs.
-pub(crate) fn build_unit_filename(name: &str) -> String {
-	format!("{}.build", safe_unit_stem(name))
+/// The `.build` unit file name for a service, e.g. `proj-web.build`. The
+/// container unit points its `Image=` at this so Quadlet builds then runs; the
+/// stem is project-prefixed so two projects' build units do not clobber each
+/// other in the shared systemd directory.
+pub(crate) fn build_unit_filename(project: &str, name: &str) -> String {
+	format!("{}.build", unit_stem(project, name))
 }
 
 /// Whether `service` yields a `.build` unit — it declares `build:` and that
@@ -88,9 +90,12 @@ pub(crate) fn build_unit(
 			let mut build_args: Vec<(String, Option<String>)> = args.to_map().into_iter().collect();
 			build_args.sort_by(|a, b| a.0.cmp(&b.0));
 			for (key, val) in build_args {
+				// `BuildArg=` is not a recognised [Build] Quadlet key (Quadlet would
+				// drop the whole unit at daemon-reload), so route build args through
+				// PodmanArgs= as `--build-arg`, like the container CPU/memory limits.
 				match val {
-					Some(v) => section.add("BuildArg", format!("{key}={v}")),
-					None => section.add("BuildArg", key),
+					Some(v) => section.add("PodmanArgs", format!("--build-arg {key}={v}")),
+					None => section.add("PodmanArgs", format!("--build-arg {key}")),
 				}
 			}
 			for (key, val) in sorted_label_pairs(labels.to_map()) {
@@ -103,7 +108,7 @@ pub(crate) fn build_unit(
 	section.add("Label", format!("podup.project={project}"));
 
 	Some(QuadletUnit {
-		filename: build_unit_filename(name),
+		filename: build_unit_filename(project, name),
 		contents: section.render(),
 	})
 }

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -246,19 +246,20 @@ pub(crate) fn container_unit(
 		}
 	}
 	// `network_mode: host`/`none` map to `Network=host`/`Network=none`.
-	// `service:X`/`container:X` reuse another container's netns, which Quadlet
-	// expresses as `Network={X}.container` (the `.container` special case);
-	// other modes (bridge:, custom, …) have no key and are reported by
-	// collect_warnings.
+	// `service:X` reuses a *sibling service's* netns, which Quadlet expresses as
+	// `Network={X}.container` (the `.container` unit dependency). `container:X`
+	// reuses an *existing* container's netns by id/name and maps to podman's
+	// `Network=container:X` join form — not a `.container` unit, which would name
+	// a non-existent dependency and fail to start. Other modes (bridge:, custom,
+	// …) have no key and are reported by collect_warnings.
 	match service.network_mode.as_deref() {
 		Some("host") => container.add("Network", "host".to_string()),
 		Some("none") => container.add("Network", "none".to_string()),
 		Some(m) => {
-			if let Some(target) = m
-				.strip_prefix("service:")
-				.or_else(|| m.strip_prefix("container:"))
-			{
+			if let Some(target) = m.strip_prefix("service:") {
 				container.add("Network", format!("{}.container", safe_unit_stem(target)));
+			} else if let Some(target) = m.strip_prefix("container:") {
+				container.add("Network", format!("container:{target}"));
 			}
 		}
 		None => {}
@@ -274,11 +275,17 @@ pub(crate) fn container_unit(
 	// scoping); a second one is reported by collect_warnings.
 	let mut static_ip: Option<&str> = None;
 	let mut static_ip6: Option<&str> = None;
+	// Emit each alias at most once: a repeated alias (within a network or across
+	// networks) would produce duplicate `NetworkAlias=` lines, which podman may
+	// reject at container create.
+	let mut seen_aliases = std::collections::HashSet::new();
 	for net in service.networks.names() {
 		if let Some(cfg) = service.networks.config_for(&net) {
 			if let Some(aliases) = &cfg.aliases {
 				for alias in aliases {
-					container.add("NetworkAlias", alias.clone());
+					if seen_aliases.insert(alias.clone()) {
+						container.add("NetworkAlias", alias.clone());
+					}
 				}
 			}
 			if static_ip.is_none() {

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -1,14 +1,16 @@
 //! Build the `.container` unit for a service.
 
-use crate::compose::types::{PortMapping, RestartPolicy, Service};
+use indexmap::IndexMap;
+
+use crate::compose::types::{RestartPolicy, SecretConfig, Service};
 use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
 use super::health::render_healthcheck;
-use super::security::{map_security_opt, render_secret};
+use super::security::{is_inline_secret, map_security_opt, render_secret};
 use super::{
 	collect_warnings, render_command, render_publish_port, render_restart, render_tmpfs_mount,
-	render_volume, safe_unit_stem, sorted_label_pairs, sorted_pairs, QuadletUnit, Section,
+	render_volume, sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit, Section,
 };
 
 /// Build the `.container` unit for one compose `service`.
@@ -23,15 +25,16 @@ pub(crate) fn container_unit(
 	service: &Service,
 	declared_volumes: &[&str],
 	declared_networks: &[&str],
+	secrets: &IndexMap<String, SecretConfig>,
 	warnings: &mut Vec<String>,
 ) -> QuadletUnit {
 	let mut unit = Section::new("Unit");
 	unit.add("Description", format!("{name} (podup)"));
 	for dep in service.depends_on.service_names() {
-		// The dependency's generated unit is named `{safe_unit_stem(dep)}.container`,
-		// so its service is `{safe_unit_stem(dep)}.service`; reference that, not the
+		// The dependency's generated unit is named `{unit_stem(project, dep)}.container`,
+		// so its service is `{unit_stem(project, dep)}.service`; reference that, not the
 		// raw compose key, or the ordering would target a non-existent unit.
-		let dep_service = format!("{}.service", safe_unit_stem(&dep));
+		let dep_service = format!("{}.service", unit_stem(project, &dep));
 		unit.add("After", dep_service.clone());
 		if service.depends_on.required_for(&dep) {
 			unit.add("Requires", dep_service);
@@ -56,7 +59,7 @@ pub(crate) fn container_unit(
 	// A service with a buildable `build:` references its `.build` unit, so Quadlet
 	// builds the image before running; otherwise the explicit `image:` is used.
 	if super::build::emits_build_unit(service) {
-		container.add("Image", super::build::build_unit_filename(name));
+		container.add("Image", super::build::build_unit_filename(project, name));
 	} else if let Some(image) = &service.image {
 		container.add("Image", image.clone());
 	}
@@ -90,19 +93,13 @@ pub(crate) fn container_unit(
 		container.add("RunInit", "true".to_string());
 	}
 
-	match parse_ports(&service.ports) {
-		Ok(ports) => {
-			for p in ports {
-				container.add("PublishPort", render_publish_port(&p));
-			}
-		}
-		Err(_) => {
-			// Fall back to the raw short forms so nothing is dropped.
-			for port in &service.ports {
-				if let PortMapping::Short(s) = port {
-					container.add("PublishPort", s.clone());
-				}
-			}
+	// Ports are validated (range, format) before generation, so parsing succeeds
+	// here. A malformed/out-of-range mapping is rejected at the command boundary
+	// rather than re-emitted verbatim as an invalid `PublishPort=` — emitting the
+	// raw string would produce a unit Quadlet/Podman would reject anyway.
+	if let Ok(ports) = parse_ports(&service.ports) {
+		for p in ports {
+			container.add("PublishPort", render_publish_port(&p));
 		}
 	}
 
@@ -119,7 +116,7 @@ pub(crate) fn container_unit(
 		if let Some(t) = render_tmpfs_mount(vol) {
 			container.add("Tmpfs", t);
 		} else {
-			container.add("Volume", render_volume(vol, declared_volumes));
+			container.add("Volume", render_volume(vol, project, declared_volumes));
 		}
 	}
 	for net in service.networks.names() {
@@ -127,7 +124,7 @@ pub(crate) fn container_unit(
 		// unit; an external network is referenced by its existing name directly,
 		// since no unit is emitted for it.
 		if declared_networks.contains(&net.as_str()) {
-			container.add("Network", format!("{net}.network"));
+			container.add("Network", format!("{}.network", unit_stem(project, &net)));
 		} else {
 			container.add("Network", net.clone());
 		}
@@ -194,9 +191,11 @@ pub(crate) fn container_unit(
 		container.add("ShmSize", shm.clone());
 	}
 	if let Some(mem) = &service.mem_limit {
-		// `Memory=` is a native [Container] key in current podman-systemd.unit(5);
-		// emit it directly rather than as a raw podman flag.
-		container.add("Memory", mem.clone());
+		// `Memory=` is not a recognised [Container] Quadlet key (Quadlet would drop
+		// the whole unit at daemon-reload), so route the limit through PodmanArgs=
+		// as `--memory`, like the CPU limits. The value is validated as a size
+		// before generation, so it is a well-formed limit here.
+		container.add("PodmanArgs", format!("--memory={mem}"));
 	}
 	// CPU limits have no native [Container] Quadlet key (unlike Memory=/
 	// PidsLimit=), so they go through PodmanArgs=.
@@ -257,7 +256,10 @@ pub(crate) fn container_unit(
 		Some("none") => container.add("Network", "none".to_string()),
 		Some(m) => {
 			if let Some(target) = m.strip_prefix("service:") {
-				container.add("Network", format!("{}.container", safe_unit_stem(target)));
+				container.add(
+					"Network",
+					format!("{}.container", unit_stem(project, target)),
+				);
 			} else if let Some(target) = m.strip_prefix("container:") {
 				container.add("Network", format!("container:{target}"));
 			}
@@ -325,11 +327,24 @@ pub(crate) fn container_unit(
 			.and_then(|r| r.limits.as_ref())
 			.and_then(|l| l.memory.as_ref())
 		{
-			container.add("Memory", mem.clone());
+			container.add("PodmanArgs", format!("--memory={mem}"));
 		}
 	}
 	for secret in &service.secrets {
-		container.add("Secret", render_secret(secret));
+		// An inline (`content:`/`environment:`) secret is created by `up` under the
+		// project-scoped name `{project}_secret_{name}`; reference that here so the
+		// generated unit points at the secret `up` would create, not an unscoped
+		// (possibly colliding or non-existent) host secret. Quadlet does not create
+		// the secret itself, so warn the operator to provision it first.
+		let source = secret.source();
+		if is_inline_secret(secrets.get(source)) {
+			warnings.push(format!(
+				"{name}: inline secret {source:?} is referenced but Quadlet does not \
+				 create it; provision the project-scoped secret \"{project}_secret_{source}\" \
+				 first (e.g. via `podup up`)"
+			));
+		}
+		container.add("Secret", render_secret(secret, project, secrets));
 	}
 	render_healthcheck(name, service, &mut container, warnings);
 
@@ -378,7 +393,7 @@ pub(crate) fn container_unit(
 	contents.push_str("\n[Install]\nWantedBy=default.target\n");
 
 	QuadletUnit {
-		filename: format!("{}.container", safe_unit_stem(name)),
+		filename: format!("{}.container", unit_stem(project, name)),
 		contents,
 	}
 }

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -16,7 +16,7 @@ pub(super) use volume::volume_unit;
 // `QuadletUnit` type, re-exported so the unit submodules import them from here.
 use super::render::{
 	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
-	safe_unit_stem, sorted_label_pairs, sorted_pairs, Section,
+	sorted_label_pairs, sorted_pairs, unit_stem, Section,
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -2,7 +2,7 @@
 
 use crate::compose::types::NetworkConfig;
 
-use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
 /// Build the `.network` unit for one declared network. Emits a single `[Network]`
 /// section (NetworkName, then driver/internal/IPv6/IPAM/options/labels), always
@@ -67,7 +67,7 @@ pub(crate) fn network_unit(
 	// them. Only `.container` units carry [Install].
 	let contents = net.render();
 	QuadletUnit {
-		filename: format!("{}.network", safe_unit_stem(name)),
+		filename: format!("{}.network", unit_stem(project, name)),
 		contents,
 	}
 }

--- a/internal/quadlet/unit/security.rs
+++ b/internal/quadlet/unit/security.rs
@@ -1,6 +1,8 @@
 //! Render service `secrets:` and `security_opt:` onto their Quadlet keys.
 
-use crate::compose::types::ServiceSecretRef;
+use indexmap::IndexMap;
+
+use crate::compose::types::{SecretConfig, ServiceSecretRef};
 
 use super::Section;
 
@@ -13,13 +15,44 @@ pub(super) fn secret_field(value: &str) -> String {
 		.collect()
 }
 
+/// Whether a top-level secret definition is an inline `content:`/`environment:`
+/// source — the kind `up` materialises as a project-scoped native Podman secret.
+/// `external:` wins (never created by podup) and a bare `file:`/empty def is a
+/// bind/host source kept under its compose name.
+pub(super) fn is_inline_secret(def: Option<&SecretConfig>) -> bool {
+	def.is_some_and(|d| {
+		d.external != Some(true) && (d.content.is_some() || d.environment.is_some())
+	})
+}
+
+/// Resolve the `Secret=` source name for a service secret reference. An inline
+/// secret resolves to the project-scoped name `{project}_secret_{name}` that
+/// `up` creates (via `plan::scoped_name`), so generated units reference the same
+/// secret `up` would; any other secret keeps its compose source name.
+fn secret_source_name(
+	project: &str,
+	source: &str,
+	secrets: &IndexMap<String, SecretConfig>,
+) -> String {
+	if is_inline_secret(secrets.get(source)) {
+		format!("{project}_secret_{source}")
+	} else {
+		source.to_string()
+	}
+}
+
 /// Render a service `secrets:` entry into a Quadlet `Secret=` value
-/// (`name[,target=,uid=,gid=,mode=]`).
-pub(super) fn render_secret(secret: &ServiceSecretRef) -> String {
+/// (`name[,target=,uid=,gid=,mode=]`), resolving inline secrets to their
+/// project-scoped name so the reference matches what `up` creates.
+pub(super) fn render_secret(
+	secret: &ServiceSecretRef,
+	project: &str,
+	secrets: &IndexMap<String, SecretConfig>,
+) -> String {
 	match secret {
 		// Sanitize the short-form name too: `Secret=` is an option list, so a
 		// `,`/`=` in the name would inject extra options (same guard as Long).
-		ServiceSecretRef::Short(name) => secret_field(name),
+		ServiceSecretRef::Short(name) => secret_field(&secret_source_name(project, name, secrets)),
 		ServiceSecretRef::Long {
 			source,
 			target,
@@ -30,7 +63,7 @@ pub(super) fn render_secret(secret: &ServiceSecretRef) -> String {
 			// `Secret=` is a comma-separated `key=value` option list, so a `,`
 			// or `=` embedded in any field would inject extra options. Strip
 			// those (and control chars) from each value at the boundary.
-			let mut s = secret_field(source);
+			let mut s = secret_field(&secret_source_name(project, source, secrets));
 			if let Some(t) = target {
 				s.push_str(&format!(",target={}", secret_field(t)));
 			}
@@ -66,9 +99,10 @@ pub(super) fn map_security_opt(
 		.strip_prefix("apparmor=")
 		.or_else(|| opt.strip_prefix("apparmor:"))
 	{
-		// `AppArmor=` is a native [Container] key in current podman-systemd.unit(5);
-		// emit it directly rather than as a raw `--security-opt apparmor=` flag.
-		container.add("AppArmor", profile.to_string());
+		// `AppArmor=` is not a recognised [Container] Quadlet key (Quadlet would
+		// drop the whole unit at daemon-reload), so route it through PodmanArgs= as
+		// `--security-opt apparmor=<profile>`, like the other escape-hatch flags.
+		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
 	} else if let Some(label) = opt.strip_prefix("label=") {
 		if label == "disable" {
 			container.add("SecurityLabelDisable", "true".to_string());
@@ -98,8 +132,15 @@ pub(super) fn map_security_opt(
 
 #[cfg(test)]
 mod tests {
-	use super::{map_security_opt, render_secret, secret_field, Section};
-	use crate::compose::types::ServiceSecretRef;
+	use super::{is_inline_secret, map_security_opt, render_secret, secret_field, Section};
+	use crate::compose::types::{SecretConfig, ServiceSecretRef};
+	use indexmap::IndexMap;
+
+	/// Render a secret with no top-level definitions in scope (so no inline
+	/// scoping applies).
+	fn render_bare(secret: &ServiceSecretRef) -> String {
+		render_secret(secret, "proj", &IndexMap::new())
+	}
 
 	/// Render a fresh `[Container]` section after applying one `security_opt`,
 	/// returning `(rendered_body, warnings)`.
@@ -120,7 +161,7 @@ mod tests {
 	fn render_secret_short_form_sanitizes_name() {
 		// A short-form name with a `,`/`=` would inject extra `Secret=` options.
 		let s = ServiceSecretRef::Short("tok,uid=0".into());
-		assert_eq!(render_secret(&s), "tokuid0");
+		assert_eq!(render_bare(&s), "tokuid0");
 	}
 
 	#[test]
@@ -134,7 +175,7 @@ mod tests {
 			mode: Some(0o440),
 		};
 		assert_eq!(
-			render_secret(&s),
+			render_bare(&s),
 			"tok,target=/run/tok,uid=1000,gid=1000,mode=440"
 		);
 	}
@@ -149,7 +190,7 @@ mod tests {
 			gid: None,
 			mode: None,
 		};
-		let out = render_secret(&s);
+		let out = render_bare(&s);
 		// The injected `,uid=0` must be flattened into the target value, not a
 		// separate option: exactly one comma (the legitimate `,target=`).
 		assert_eq!(out.matches(',').count(), 1);
@@ -177,13 +218,57 @@ mod tests {
 		assert!(map_one("seccomp=/etc/seccomp.json")
 			.0
 			.contains("SeccompProfile=/etc/seccomp.json"));
-		// Both `apparmor=` and `apparmor:` map to the native AppArmor key.
+		// `AppArmor=` is not a recognised Quadlet key, so both `apparmor=` and
+		// `apparmor:` route through PodmanArgs= as a `--security-opt` flag.
 		assert!(map_one("apparmor=docker-default")
 			.0
-			.contains("AppArmor=docker-default"));
+			.contains("PodmanArgs=--security-opt apparmor=docker-default"));
 		assert!(map_one("apparmor:unconfined")
 			.0
-			.contains("AppArmor=unconfined"));
+			.contains("PodmanArgs=--security-opt apparmor=unconfined"));
+	}
+
+	#[test]
+	fn inline_secret_resolves_to_project_scoped_name() {
+		// An inline (`content:`) secret must reference the project-scoped name
+		// `up` creates, not the bare compose name.
+		let mut defs = IndexMap::new();
+		defs.insert(
+			"tok".to_string(),
+			SecretConfig {
+				content: Some("s3cr3t".into()),
+				..Default::default()
+			},
+		);
+		assert!(is_inline_secret(defs.get("tok")));
+		let s = ServiceSecretRef::Short("tok".into());
+		assert_eq!(render_secret(&s, "proj", &defs), "proj_secret_tok");
+
+		// A file-based secret keeps its compose name (it is a host source, not a
+		// project-scoped native secret).
+		let mut file_defs = IndexMap::new();
+		file_defs.insert(
+			"tok".to_string(),
+			SecretConfig {
+				file: Some("./tok.txt".into()),
+				..Default::default()
+			},
+		);
+		assert!(!is_inline_secret(file_defs.get("tok")));
+		assert_eq!(render_secret(&s, "proj", &file_defs), "tok");
+
+		// An external secret is referenced by its existing name, never scoped.
+		let mut ext_defs = IndexMap::new();
+		ext_defs.insert(
+			"tok".to_string(),
+			SecretConfig {
+				external: Some(true),
+				content: Some("ignored".into()),
+				..Default::default()
+			},
+		);
+		assert!(!is_inline_secret(ext_defs.get("tok")));
+		assert_eq!(render_secret(&s, "proj", &ext_defs), "tok");
 	}
 
 	#[test]

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -2,7 +2,7 @@
 
 use crate::compose::types::VolumeConfig;
 
-use super::{safe_unit_stem, sorted_label_pairs, QuadletUnit, Section};
+use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
 /// Build the `.volume` unit for one declared named volume. Emits a single
 /// `[Volume]` section (VolumeName, then driver/driver-opts/labels), always
@@ -45,7 +45,7 @@ pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfi
 	// them. Only `.container` units carry [Install].
 	let contents = vol.render();
 	QuadletUnit {
-		filename: format!("{}.volume", safe_unit_stem(name)),
+		filename: format!("{}.volume", unit_stem(project, name)),
 		contents,
 	}
 }

--- a/internal/resolve.rs
+++ b/internal/resolve.rs
@@ -2,6 +2,24 @@
 
 use std::path::{Path, PathBuf};
 
+use podup::ComposeError;
+
+/// Validate an explicit `--project-directory`: it must exist and be a directory.
+/// A `None` (unset) directory is always fine — it is derived from the compose
+/// file's location. Matches `docker compose`, which errors on a missing working
+/// directory instead of silently accepting it.
+pub(crate) fn validate_project_directory(dir: Option<&Path>) -> podup::Result<()> {
+	if let Some(dir) = dir {
+		if !dir.is_dir() {
+			return Err(ComposeError::Unsupported(format!(
+				"--project-directory {} does not exist or is not a directory",
+				dir.display()
+			)));
+		}
+	}
+	Ok(())
+}
+
 /// Compose-spec file-name precedence, highest first.
 const COMPOSE_FILE_CANDIDATES: [&str; 4] = [
 	"compose.yaml",
@@ -104,8 +122,27 @@ pub(crate) fn sanitize_project_name(raw: &str) -> String {
 mod tests {
 	use super::{
 		resolve_base_dir, resolve_compose_files, resolve_project_name, sanitize_project_name,
+		validate_project_directory,
 	};
 	use std::path::{Path, PathBuf};
+
+	#[test]
+	fn validate_project_directory_accepts_none_and_existing_dir() {
+		validate_project_directory(None).unwrap();
+		let dir = std::env::temp_dir();
+		validate_project_directory(Some(&dir)).unwrap();
+	}
+
+	#[test]
+	fn validate_project_directory_rejects_missing_and_file() {
+		let missing = std::env::temp_dir().join(format!("podup-pd-{}-nope", std::process::id()));
+		assert!(validate_project_directory(Some(&missing)).is_err());
+
+		let file = std::env::temp_dir().join(format!("podup-pd-{}.tmp", std::process::id()));
+		std::fs::write(&file, b"x").unwrap();
+		assert!(validate_project_directory(Some(&file)).is_err());
+		let _ = std::fs::remove_file(&file);
+	}
 
 	#[test]
 	fn explicit_compose_files_win() {

--- a/internal/size.rs
+++ b/internal/size.rs
@@ -81,6 +81,11 @@ pub fn parse_duration_secs(s: &str) -> Option<u64> {
 		"h" => num * 3600.0,
 		_ => return None,
 	};
+	// Reject non-finite or out-of-range results rather than saturating the cast
+	// (e.g. `1e24s` would otherwise become u64::MAX and emit a garbage timeout).
+	if !secs.is_finite() || secs < 0.0 || secs > u64::MAX as f64 {
+		return None;
+	}
 	Some(secs as u64)
 }
 
@@ -255,6 +260,14 @@ mod tests {
 	#[test]
 	fn duration_secs_unknown_suffix_is_none() {
 		assert_eq!(parse_duration_secs("5d"), None);
+	}
+
+	#[test]
+	fn duration_secs_out_of_range_is_none() {
+		// A value whose seconds product exceeds u64::MAX must return None rather
+		// than saturating the cast to u64::MAX.
+		assert_eq!(parse_duration_secs("1e24"), None);
+		assert_eq!(parse_duration_secs("1e24h"), None);
 	}
 
 	// parse_duration_nanos

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -97,6 +97,16 @@ pub(crate) fn internal_error_notice() -> String {
 	)
 }
 
+/// Whether a panic message denotes a broken pipe (a downstream reader closed the
+/// pipe early). Rust ignores SIGPIPE, so a failing `println!`/`eprintln!` panics
+/// with this message; we treat it as a clean exit rather than an internal error.
+/// Pure so it can be unit-tested. Matches both the textual reason and the raw OS
+/// error number (EPIPE = 32 on Linux).
+pub(crate) fn is_broken_pipe_panic(msg: &str) -> bool {
+	let lower = msg.to_ascii_lowercase();
+	lower.contains("broken pipe") || lower.contains("os error 32")
+}
+
 /// Initialize the global tracing subscriber, written to stderr in the
 /// `podup: <level>: <msg>` format so stdout stays a clean pipe. `default_level`
 /// is the floor used when `RUST_LOG` is unset — `warn` for most commands (so the
@@ -120,6 +130,7 @@ pub(crate) fn render_config(
 	format: &ConfigFormat,
 	services: bool,
 	quiet: bool,
+	project: &str,
 ) -> podup::Result<()> {
 	// Reaching here means the file parsed and merged cleanly. Validate that each
 	// resolved service declares an image or a build, the same rule `up` enforces
@@ -140,6 +151,9 @@ pub(crate) fn render_config(
 		return Ok(());
 	}
 	let mut redacted = file.clone();
+	// Surface the resolved project name in the rendered output, like
+	// `docker compose config`, rather than the file's literal `name:` (or none).
+	redacted.name = Some(project.to_string());
 	redacted.redact_inline_content();
 	let rendered = match format {
 		ConfigFormat::Json => {
@@ -167,16 +181,26 @@ pub(crate) fn render_config(
 /// `field: {}` sections. Recurses first so a section that becomes empty once its
 /// own nulls are dropped is itself dropped.
 fn prune_json_nulls(v: &mut serde_json::Value) {
+	prune_json(v, false);
+}
+
+/// `preserve_nulls` keeps null leaves at the current mapping level. It is set for
+/// the value under an `environment:` key so a map-form host-passthrough var
+/// (`MYVAR:` → null) is not stripped from the output — it is forwarded at runtime,
+/// so `config` must show it, matching docker compose (which never drops the key).
+fn prune_json(v: &mut serde_json::Value, preserve_nulls: bool) {
 	match v {
 		serde_json::Value::Object(map) => {
-			for val in map.values_mut() {
-				prune_json_nulls(val);
+			for (k, val) in map.iter_mut() {
+				prune_json(val, k == "environment");
 			}
-			map.retain(|_, val| !is_empty_json(val));
+			if !preserve_nulls {
+				map.retain(|_, val| !is_empty_json(val));
+			}
 		}
 		serde_json::Value::Array(arr) => {
 			for val in arr.iter_mut() {
-				prune_json_nulls(val);
+				prune_json(val, false);
 			}
 		}
 		_ => {}
@@ -195,23 +219,32 @@ fn is_empty_json(v: &serde_json::Value) -> bool {
 
 /// The YAML counterpart of [`prune_json_nulls`].
 fn prune_yaml_nulls(v: &mut serde_yaml::Value) {
+	prune_yaml(v, false);
+}
+
+/// YAML counterpart of [`prune_json`]; `preserve_nulls` exempts an
+/// `environment:` map's null (host-passthrough) values from being dropped.
+fn prune_yaml(v: &mut serde_yaml::Value, preserve_nulls: bool) {
 	match v {
 		serde_yaml::Value::Mapping(map) => {
-			for (_, val) in map.iter_mut() {
-				prune_yaml_nulls(val);
+			for (k, val) in map.iter_mut() {
+				let child_preserve = k.as_str() == Some("environment");
+				prune_yaml(val, child_preserve);
 			}
-			let drop: Vec<serde_yaml::Value> = map
-				.iter()
-				.filter(|(_, val)| is_empty_yaml(val))
-				.map(|(k, _)| k.clone())
-				.collect();
-			for k in drop {
-				map.remove(&k);
+			if !preserve_nulls {
+				let drop: Vec<serde_yaml::Value> = map
+					.iter()
+					.filter(|(_, val)| is_empty_yaml(val))
+					.map(|(k, _)| k.clone())
+					.collect();
+				for k in drop {
+					map.remove(&k);
+				}
 			}
 		}
 		serde_yaml::Value::Sequence(seq) => {
 			for val in seq.iter_mut() {
-				prune_yaml_nulls(val);
+				prune_yaml(val, false);
 			}
 		}
 		_ => {}
@@ -341,19 +374,72 @@ mod tests {
 	#[test]
 	fn render_config_quiet_is_validate_only() {
 		// `--quiet` validates and prints nothing, returning Ok.
-		render_config(&sample_file(), &ConfigFormat::Yaml, false, true).unwrap();
+		render_config(&sample_file(), &ConfigFormat::Yaml, false, true, "proj").unwrap();
 	}
 
 	#[test]
 	fn render_config_services_lists_names() {
 		// `--services` reaches the service-name listing branch without error.
-		render_config(&sample_file(), &ConfigFormat::Yaml, true, false).unwrap();
+		render_config(&sample_file(), &ConfigFormat::Yaml, true, false, "proj").unwrap();
 	}
 
 	#[test]
 	fn render_config_yaml_and_json_render_ok() {
-		render_config(&sample_file(), &ConfigFormat::Yaml, false, false).unwrap();
-		render_config(&sample_file(), &ConfigFormat::Json, false, false).unwrap();
+		render_config(&sample_file(), &ConfigFormat::Yaml, false, false, "proj").unwrap();
+		render_config(&sample_file(), &ConfigFormat::Json, false, false, "proj").unwrap();
+	}
+
+	#[test]
+	fn render_config_injects_resolved_project_name() {
+		// The rendered output carries the resolved project name, not the file's
+		// literal `name:` (here unset). Render into a buffer via the same path.
+		let mut redacted = sample_file();
+		redacted.name = Some("myproj".to_string());
+		let v: serde_yaml::Value = serde_yaml::to_value(&redacted).unwrap();
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(
+			out.contains("name: myproj"),
+			"config should render the resolved name"
+		);
+	}
+
+	#[test]
+	fn prune_preserves_environment_map_nulls() {
+		// A map-form host-passthrough var (`MYVAR:` → null) survives pruning, while
+		// an unrelated null elsewhere is still dropped.
+		let mut v: serde_yaml::Value = serde_yaml::from_str(
+			"services:\n  web:\n    image: nginx\n    dns: null\n    environment:\n      MYVAR: null\n      SET: value\n",
+		)
+		.unwrap();
+		prune_yaml_nulls(&mut v);
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(out.contains("MYVAR"), "passthrough env var must be kept");
+		assert!(out.contains("SET"));
+		assert!(!out.contains("dns"), "unrelated null must still be dropped");
+
+		let mut j = serde_json::json!({
+			"services": { "web": {
+				"image": "nginx",
+				"dns": null,
+				"environment": { "MYVAR": null, "SET": "value" }
+			}}
+		});
+		prune_json_nulls(&mut j);
+		let env = &j["services"]["web"]["environment"];
+		assert!(
+			env.get("MYVAR").is_some(),
+			"passthrough env var must be kept"
+		);
+		assert!(j["services"]["web"].get("dns").is_none());
+	}
+
+	#[test]
+	fn broken_pipe_panic_detected() {
+		assert!(is_broken_pipe_panic(
+			"failed printing to stdout: Broken pipe (os error 32)"
+		));
+		assert!(is_broken_pipe_panic("Broken pipe"));
+		assert!(!is_broken_pipe_panic("some other internal error"));
 	}
 
 	#[test]

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -148,6 +148,10 @@ pub(crate) fn render_config(
 		if svc.image.is_none() && svc.build.is_none() {
 			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
 		}
+		// Reject malformed/out-of-range port mappings (e.g. `70000:80`) here too,
+		// so `config` validates them rather than accepting a mapping `up` and
+		// `generate quadlet` would reject.
+		podup::ports::parse_ports(&svc.ports)?;
 	}
 	if quiet {
 		return Ok(());

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -33,6 +33,22 @@ pub(crate) fn is_mutating(command: &Commands) -> bool {
 	)
 }
 
+/// Validate the resolved project name at the trust boundary, before it reaches
+/// any code path that builds a filesystem path from it (staging, lock files,
+/// quadlet generation) or filters containers by it. Shared by the mutating
+/// dispatch path and the read-only `config`/`ps` paths so every command reports
+/// the same invalid-name error.
+pub(crate) fn validate_project_name(project: &str) -> podup::Result<()> {
+	if podup::is_safe_project_name(project) {
+		Ok(())
+	} else {
+		Err(podup::ComposeError::Unsupported(format!(
+			"project name {project:?} is not a safe path component: use only ASCII \
+			 letters, digits, '-', '_', '.', not starting with '.', max 128 chars"
+		)))
+	}
+}
+
 /// Whether a command is scoped purely by the `podup.project` label and never
 /// reads service definitions, so it can run against a project with no compose
 /// file present — matching `docker compose -p NAME events`/`ps`. These commands
@@ -140,19 +156,12 @@ pub(crate) fn render_config(
 	quiet: bool,
 	project: &str,
 ) -> podup::Result<()> {
-	// Reaching here means the file parsed and merged cleanly. Validate that each
-	// resolved service declares an image or a build, the same rule `up` enforces
-	// — and do it before the `--quiet`/`--services` short-circuits so
-	// validate-only (`--quiet`) actually validates, matching `docker compose config`.
-	for (name, svc) in &file.services {
-		if svc.image.is_none() && svc.build.is_none() {
-			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
-		}
-		// Reject malformed/out-of-range port mappings (e.g. `70000:80`) here too,
-		// so `config` validates them rather than accepting a mapping `up` and
-		// `generate quadlet` would reject.
-		podup::ports::parse_ports(&svc.ports)?;
-	}
+	// Reaching here means the file parsed and merged cleanly. Run the full
+	// config-time validation (non-empty services, image-or-build, service-name
+	// charset, port ranges, undefined volume/network references, and an acyclic
+	// dependency graph) before the `--quiet`/`--services` short-circuits, so
+	// validate-only (`--quiet`) actually validates — matching `docker compose config`.
+	podup::validate_config(file)?;
 	if quiet {
 		return Ok(());
 	}

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -33,6 +33,14 @@ pub(crate) fn is_mutating(command: &Commands) -> bool {
 	)
 }
 
+/// Whether a command is scoped purely by the `podup.project` label and never
+/// reads service definitions, so it can run against a project with no compose
+/// file present — matching `docker compose -p NAME events`/`ps`. These commands
+/// tolerate a missing compose file at startup instead of erroring `FileNotFound`.
+pub(crate) fn is_label_only(command: &Commands) -> bool {
+	matches!(command, Commands::Events { .. } | Commands::Ps { .. })
+}
+
 /// Canonical project URL, reused for the bug-report hint on internal errors.
 const REPO_URL: &str = "https://github.com/Glyndor/podup";
 
@@ -317,6 +325,27 @@ pub(crate) fn parse_cli() -> Cli {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn label_only_covers_ps_and_events() {
+		use crate::cli::{EventsFormat, OutputFormat};
+		// `ps` and `events` are scoped purely by the project label, so they are
+		// label-only and may run without a compose file.
+		assert!(is_label_only(&Commands::Ps {
+			all: false,
+			quiet: false,
+			format: OutputFormat::Table,
+		}));
+		assert!(is_label_only(&Commands::Events {
+			format: EventsFormat::Table,
+			json: false,
+		}));
+		// A command that reads service definitions is not label-only.
+		assert!(!is_label_only(&Commands::Top {
+			format: OutputFormat::Table,
+			services: vec![],
+		}));
+	}
 
 	#[test]
 	fn prune_json_drops_nulls_and_empty_then_collapses() {

--- a/internal/startup.rs
+++ b/internal/startup.rs
@@ -414,6 +414,17 @@ mod tests {
 	}
 
 	#[test]
+	fn render_config_rejects_depends_on_cycle() {
+		// A `depends_on` cycle must be reported at config time, not deferred to up.
+		let file = podup::parse_str(
+			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
+		)
+		.unwrap();
+		let err = render_config(&file, &ConfigFormat::Yaml, false, true, "proj").unwrap_err();
+		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
+	}
+
+	#[test]
 	fn render_config_quiet_is_validate_only() {
 		// `--quiet` validates and prints nothing, returning Ok.
 		render_config(&sample_file(), &ConfigFormat::Yaml, false, true, "proj").unwrap();

--- a/internal/startup/config_normalize.rs
+++ b/internal/startup/config_normalize.rs
@@ -1,0 +1,239 @@
+//! Output-fidelity normalizers for the `config` render path: resolving relative
+//! bind-mount sources to absolute paths, and quoting YAML 1.1 boolean-like
+//! scalars. Split out of `config_render` so each file stays within the source
+//! line limit. None of this changes runtime behaviour — it only shapes the
+//! rendered `config` output to match `docker compose config`.
+
+use std::path::{Component, Path, PathBuf};
+
+use podup::compose::types::{ComposeFile, VolumeMount, VolumeType};
+
+/// Rewrite each service's relative bind-mount source to an absolute path,
+/// resolved against the project directory (matching `docker compose config`).
+/// Only `.`-prefixed host paths are resolved — absolute paths, `~`, named
+/// volumes, and Windows drive paths are left untouched, mirroring how the engine
+/// classifies a short-form source. Mount semantics are unchanged; this only
+/// affects the rendered output's source field.
+pub(super) fn resolve_bind_sources(file: &mut ComposeFile, base_dir: &Path) {
+	for svc in file.services.values_mut() {
+		for mount in &mut svc.volumes {
+			match mount {
+				VolumeMount::Short(s) => {
+					if let Some(rewritten) = rewrite_short_bind(s, base_dir) {
+						*s = rewritten;
+					}
+				}
+				VolumeMount::Long {
+					volume_type: VolumeType::Bind,
+					source: Some(src),
+					..
+				} => {
+					if let Some(abs) = absolute_bind_source(src, base_dir) {
+						*src = abs;
+					}
+				}
+				VolumeMount::Long { .. } => {}
+			}
+		}
+	}
+}
+
+/// Resolve the source of a short-form `source:target[:options]` bind mount,
+/// returning the rewritten spec when the source is a relative host path. A spec
+/// with no `:` separator is a single in-container target (anonymous volume), and
+/// a non-`.` source is absolute or a named volume — both are left as-is.
+fn rewrite_short_bind(spec: &str, base_dir: &Path) -> Option<String> {
+	let (src, rest) = spec.split_once(':')?;
+	let abs = absolute_bind_source(src, base_dir)?;
+	Some(format!("{abs}:{rest}"))
+}
+
+/// Resolve a relative (`.`-prefixed) bind source to a lexically-normalized
+/// absolute path against `base_dir`; return `None` for anything else.
+fn absolute_bind_source(src: &str, base_dir: &Path) -> Option<String> {
+	if !src.starts_with('.') {
+		return None;
+	}
+	let joined = base_dir.join(src);
+	let absolute = if joined.is_absolute() {
+		joined
+	} else {
+		std::env::current_dir().unwrap_or_default().join(joined)
+	};
+	Some(normalize_lexically(&absolute))
+}
+
+/// Lexically clean a path: drop `.` components and collapse `..` against the
+/// preceding normal component, without touching the filesystem (the path need
+/// not exist, and symlinks must not be resolved). Matches docker compose, which
+/// produces a cleaned absolute source rather than a canonicalized one.
+fn normalize_lexically(path: &Path) -> String {
+	let mut out: Vec<Component> = Vec::new();
+	for comp in path.components() {
+		match comp {
+			Component::CurDir => {}
+			Component::ParentDir => {
+				if matches!(out.last(), Some(Component::Normal(_))) {
+					out.pop();
+				} else {
+					out.push(comp);
+				}
+			}
+			other => out.push(other),
+		}
+	}
+	let mut pb = PathBuf::new();
+	for c in out {
+		pb.push(c.as_os_str());
+	}
+	pb.to_string_lossy().into_owned()
+}
+
+/// Quote any plain (unquoted) YAML scalar value that a strict YAML 1.1 reader
+/// would misparse as a boolean (`yes`/`no`/`on`/`off`/`y`/`n`/`true`/`false`),
+/// leaving already-quoted scalars, keys, and everything else untouched. Works on
+/// serde_yaml_ng's block output, where each scalar value sits after a `: `
+/// mapping separator or a `- ` sequence marker on its own line.
+pub(super) fn quote_yaml11_booleans(yaml: &str) -> String {
+	let lines: Vec<String> = yaml.lines().map(requote_bool_line).collect();
+	let mut joined = lines.join("\n");
+	// `lines()` drops the trailing newline serde_yaml emits; restore it.
+	if yaml.ends_with('\n') {
+		joined.push('\n');
+	}
+	joined
+}
+
+/// Quote the scalar value on a single block-YAML line if it is an unquoted YAML
+/// 1.1 boolean token; otherwise return the line unchanged.
+fn requote_bool_line(line: &str) -> String {
+	let Some((prefix, value)) = split_block_scalar(line) else {
+		return line.to_string();
+	};
+	if is_quoted(value) || !looks_like_yaml11_bool(value) {
+		return line.to_string();
+	}
+	format!("{prefix}'{value}'")
+}
+
+/// Split a block-YAML line into `(prefix, value)` where `prefix` ends with the
+/// `: ` mapping separator or the `- ` sequence marker. Returns `None` for lines
+/// that carry no inline scalar value (nested keys, blank lines).
+fn split_block_scalar(line: &str) -> Option<(&str, &str)> {
+	// A mapping entry: the value follows the first `: `. An unquoted scalar value
+	// never contains `: ` (serde_yaml would quote it), so the first occurrence is
+	// the separator.
+	if let Some(idx) = line.find(": ") {
+		let (prefix, value) = line.split_at(idx + 2);
+		if !value.is_empty() {
+			return Some((prefix, value));
+		}
+	}
+	// A scalar sequence item: `<indent>- value`.
+	let rest = line.trim_start().strip_prefix("- ")?;
+	if rest.is_empty() {
+		return None;
+	}
+	let prefix_len = line.len() - rest.len();
+	Some((&line[..prefix_len], rest))
+}
+
+/// Whether a scalar is already quoted (single or double), so it must be left
+/// as-is rather than re-quoted.
+fn is_quoted(s: &str) -> bool {
+	s.starts_with('\'') || s.starts_with('"')
+}
+
+/// Whether a scalar matches a YAML 1.1 boolean token (case-insensitive) that a
+/// 1.1 reader would resolve to true/false. The YAML 1.2 core schema serde_yaml
+/// emits leaves these as plain strings.
+fn looks_like_yaml11_bool(s: &str) -> bool {
+	matches!(
+		s.to_ascii_lowercase().as_str(),
+		"y" | "yes" | "n" | "no" | "true" | "false" | "on" | "off"
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn yaml11_bool_detection_is_case_insensitive_and_scoped() {
+		for tok in [
+			"yes", "Yes", "YES", "no", "on", "OFF", "y", "N", "true", "False",
+		] {
+			assert!(looks_like_yaml11_bool(tok), "{tok} should match");
+		}
+		for tok in ["hello", "yess", "0", "onoff", "", "nullish"] {
+			assert!(!looks_like_yaml11_bool(tok), "{tok} should not match");
+		}
+	}
+
+	#[test]
+	fn quote_yaml11_booleans_quotes_only_plain_bool_scalars() {
+		// `yes`/`off` are quoted; an already-quoted `'null'`, a normal string, a
+		// nested key, and a non-bool value are all left exactly as serde_yaml wrote
+		// them. A `: ` inside a quoted value must not trip the splitter.
+		let input = "environment:\n  FROM_A: yes\n  FROM_B: off\n  FROM_C: 'null'\n  NORMAL: hello\n  COLON: 'a: b'\nports:\n- on\n- '8080:80'\n";
+		let out = quote_yaml11_booleans(input);
+		assert!(out.contains("FROM_A: 'yes'"), "got: {out}");
+		assert!(out.contains("FROM_B: 'off'"), "got: {out}");
+		assert!(out.contains("FROM_C: 'null'"), "double-quoting: {out}");
+		assert!(out.contains("NORMAL: hello"), "got: {out}");
+		assert!(out.contains("COLON: 'a: b'"), "got: {out}");
+		assert!(out.contains("- 'on'"), "sequence bool item: {out}");
+		assert!(out.contains("- '8080:80'"), "got: {out}");
+		// The trailing newline is preserved.
+		assert!(out.ends_with('\n'));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn short_bind_source_resolves_relative_only() {
+		let base = Path::new("/home/user/proj");
+		// A relative `.`-prefixed source is resolved against the project dir, keeping
+		// the target and options intact.
+		assert_eq!(
+			rewrite_short_bind("./data:/data:ro", base).as_deref(),
+			Some("/home/user/proj/data:/data:ro")
+		);
+		// `..` collapses lexically.
+		assert_eq!(
+			rewrite_short_bind("../shared:/s", base).as_deref(),
+			Some("/home/user/shared:/s")
+		);
+		// Absolute sources, named volumes, and `~` are left untouched.
+		assert!(rewrite_short_bind("/abs:/data", base).is_none());
+		assert!(rewrite_short_bind("named:/data", base).is_none());
+		assert!(rewrite_short_bind("~/x:/data", base).is_none());
+		// A colon-less spec (anonymous volume target) is not a bind.
+		assert!(rewrite_short_bind("/data", base).is_none());
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn resolve_bind_sources_rewrites_short_and_long_binds() {
+		let mut file = podup::parse_str(
+			"services:\n  web:\n    image: nginx\n    volumes:\n      - ./data:/data:ro\n      - type: bind\n        source: ./logs\n        target: /logs\n      - named:/cache\n",
+		)
+		.unwrap();
+		resolve_bind_sources(&mut file, Path::new("/srv/app"));
+		let mounts = &file.services["web"].volumes;
+		match &mounts[0] {
+			VolumeMount::Short(s) => assert_eq!(s, "/srv/app/data:/data:ro"),
+			other => panic!("expected short, got {other:?}"),
+		}
+		match &mounts[1] {
+			VolumeMount::Long { source, .. } => {
+				assert_eq!(source.as_deref(), Some("/srv/app/logs"))
+			}
+			other => panic!("expected long bind, got {other:?}"),
+		}
+		// The named volume is untouched.
+		match &mounts[2] {
+			VolumeMount::Short(s) => assert_eq!(s, "named:/cache"),
+			other => panic!("expected short, got {other:?}"),
+		}
+	}
+}

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -1,0 +1,423 @@
+//! `config` rendering: validate-only, list projections (`--services`,
+//! `--volumes`, `--images`, `--profiles`, `--hash`), and the resolved compose
+//! file in YAML/JSON with unset keys pruned and inline secrets redacted. Split
+//! out of `startup` so each file stays within the source line limit.
+
+use sha2::{Digest, Sha256};
+
+use crate::cli::ConfigFormat;
+
+/// Output selectors for `config`, mirroring the mutually-exclusive `docker
+/// compose config` list modes. The first set selector wins, in the order
+/// services, volumes, images, profiles, hash.
+#[derive(Default)]
+pub(crate) struct ConfigOutput {
+	/// `--services`: print the service names.
+	pub services: bool,
+	/// `--volumes`: print the named-volume keys.
+	pub volumes: bool,
+	/// `--images`: print each service's image reference.
+	pub images: bool,
+	/// `--profiles`: print the declared profile names.
+	pub profiles: bool,
+	/// `--hash`: print the config hash of all services ("*") or a comma-separated
+	/// subset.
+	pub hash: Option<String>,
+	/// `--quiet`: validate only, print nothing.
+	pub quiet: bool,
+}
+
+/// Render `config`: validate-only (`--quiet`), a list projection (`--services`,
+/// `--volumes`, `--images`, `--profiles`, `--hash`), or the resolved compose file
+/// in YAML/JSON with inline secret content redacted.
+pub(crate) fn render_config(
+	file: &podup::compose::types::ComposeFile,
+	format: &ConfigFormat,
+	out: &ConfigOutput,
+	project: &str,
+) -> podup::Result<()> {
+	// Reaching here means the file parsed and merged cleanly. Run the full
+	// config-time validation (non-empty services, image-or-build, service-name
+	// charset, port ranges, undefined volume/network references, and an acyclic
+	// dependency graph) before the `--quiet`/projection short-circuits, so
+	// validate-only (`--quiet`) actually validates — matching `docker compose config`.
+	podup::validate_config(file)?;
+	if out.quiet {
+		return Ok(());
+	}
+	if out.services {
+		for name in file.services.keys() {
+			println!("{name}");
+		}
+		return Ok(());
+	}
+	if out.volumes {
+		for name in file.volumes.keys() {
+			println!("{name}");
+		}
+		return Ok(());
+	}
+	if out.images {
+		for (name, svc) in &file.services {
+			let image = svc
+				.image
+				.clone()
+				.unwrap_or_else(|| format!("{name}:latest"));
+			println!("{image}");
+		}
+		return Ok(());
+	}
+	if out.profiles {
+		let mut profiles: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+		for svc in file.services.values() {
+			for p in &svc.profiles {
+				profiles.insert(p.as_str());
+			}
+		}
+		for p in profiles {
+			println!("{p}");
+		}
+		return Ok(());
+	}
+	if let Some(selector) = &out.hash {
+		return render_config_hash(file, selector);
+	}
+	let mut redacted = file.clone();
+	// Surface the resolved project name in the rendered output, like
+	// `docker compose config`, rather than the file's literal `name:` (or none).
+	redacted.name = Some(project.to_string());
+	redacted.redact_inline_content();
+	let rendered = match format {
+		ConfigFormat::Json => {
+			let mut v = serde_json::to_value(&redacted).map_err(|e| {
+				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
+			})?;
+			prune_json_nulls(&mut v);
+			serde_json::to_string_pretty(&v).map_err(|e| {
+				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
+			})?
+		}
+		ConfigFormat::Yaml => {
+			let mut v: serde_yaml::Value =
+				serde_yaml::to_value(&redacted).map_err(podup::ComposeError::Parse)?;
+			prune_yaml_nulls(&mut v);
+			serde_yaml::to_string(&v).map_err(podup::ComposeError::Parse)?
+		}
+	};
+	println!("{rendered}");
+	Ok(())
+}
+
+/// SHA-256 of a service's resolved configuration, hex-encoded. Used by
+/// `config --hash` so a deploy pipeline can detect a changed service. Pure so it
+/// is unit-tested.
+fn service_config_hash(svc: &podup::compose::types::Service) -> String {
+	let json = serde_json::to_vec(svc).unwrap_or_default();
+	Sha256::digest(&json)
+		.iter()
+		.map(|b| format!("{b:02x}"))
+		.collect()
+}
+
+/// `config --hash`: print `SERVICE HASH` for all services ("*") or the given
+/// comma-separated subset (an unknown service name is an error).
+fn render_config_hash(
+	file: &podup::compose::types::ComposeFile,
+	selector: &str,
+) -> podup::Result<()> {
+	let names: Vec<String> = if selector == "*" {
+		file.services.keys().cloned().collect()
+	} else {
+		selector
+			.split(',')
+			.map(|s| s.trim().to_string())
+			.filter(|s| !s.is_empty())
+			.collect()
+	};
+	for name in names {
+		let svc = file
+			.services
+			.get(&name)
+			.ok_or_else(|| podup::ComposeError::ServiceNotFound(name.clone()))?;
+		println!("{name} {}", service_config_hash(svc));
+	}
+	Ok(())
+}
+
+/// Drop unset keys from a JSON value so `config` output omits them (like
+/// `docker compose config`) instead of a wall of `field: null` and empty
+/// `field: {}` sections. Recurses first so a section that becomes empty once its
+/// own nulls are dropped is itself dropped.
+fn prune_json_nulls(v: &mut serde_json::Value) {
+	prune_json(v, false);
+}
+
+/// `preserve_nulls` keeps null leaves at the current mapping level. It is set for
+/// the value under an `environment:` key so a map-form host-passthrough var
+/// (`MYVAR:` → null) is not stripped from the output — it is forwarded at runtime,
+/// so `config` must show it, matching docker compose (which never drops the key).
+fn prune_json(v: &mut serde_json::Value, preserve_nulls: bool) {
+	match v {
+		serde_json::Value::Object(map) => {
+			for (k, val) in map.iter_mut() {
+				prune_json(val, k == "environment");
+			}
+			if !preserve_nulls {
+				map.retain(|_, val| !is_empty_json(val));
+			}
+		}
+		serde_json::Value::Array(arr) => {
+			for val in arr.iter_mut() {
+				prune_json(val, false);
+			}
+		}
+		_ => {}
+	}
+}
+
+fn is_empty_json(v: &serde_json::Value) -> bool {
+	match v {
+		serde_json::Value::Null => true,
+		serde_json::Value::Object(m) => m.is_empty(),
+		// An empty array is kept: an explicit `command: []`/`entrypoint: []`
+		// overrides the image's value, so dropping it would change meaning.
+		_ => false,
+	}
+}
+
+/// The YAML counterpart of [`prune_json_nulls`].
+fn prune_yaml_nulls(v: &mut serde_yaml::Value) {
+	prune_yaml(v, false);
+}
+
+/// YAML counterpart of [`prune_json`]; `preserve_nulls` exempts an
+/// `environment:` map's null (host-passthrough) values from being dropped.
+fn prune_yaml(v: &mut serde_yaml::Value, preserve_nulls: bool) {
+	match v {
+		serde_yaml::Value::Mapping(map) => {
+			for (k, val) in map.iter_mut() {
+				let child_preserve = k.as_str() == Some("environment");
+				prune_yaml(val, child_preserve);
+			}
+			if !preserve_nulls {
+				let drop: Vec<serde_yaml::Value> = map
+					.iter()
+					.filter(|(_, val)| is_empty_yaml(val))
+					.map(|(k, _)| k.clone())
+					.collect();
+				for k in drop {
+					map.remove(&k);
+				}
+			}
+		}
+		serde_yaml::Value::Sequence(seq) => {
+			for val in seq.iter_mut() {
+				prune_yaml(val, false);
+			}
+		}
+		_ => {}
+	}
+}
+
+fn is_empty_yaml(v: &serde_yaml::Value) -> bool {
+	match v {
+		serde_yaml::Value::Null => true,
+		serde_yaml::Value::Mapping(m) => m.is_empty(),
+		// Keep empty sequences: an explicit `command: []`/`entrypoint: []`
+		// overrides the image's value, so dropping it would change meaning.
+		_ => false,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn sample_file() -> podup::compose::types::ComposeFile {
+		podup::parse_str("services:\n  web:\n    image: nginx\n  db:\n    image: postgres\n")
+			.unwrap()
+	}
+
+	#[test]
+	fn prune_json_drops_nulls_and_empty_then_collapses() {
+		let mut v = serde_json::json!({
+			"image": "nginx",
+			"environment": null,
+			"command": [],
+			"labels": {},
+			"deploy": { "replicas": null }
+		});
+		prune_json_nulls(&mut v);
+		// null fields and the section emptied by its own nulls are gone, but an
+		// explicit empty array (`command: []`) survives — it overrides the image.
+		assert_eq!(v, serde_json::json!({ "image": "nginx", "command": [] }));
+	}
+
+	#[test]
+	fn prune_yaml_drops_nulls_and_empty() {
+		let mut v: serde_yaml::Value =
+			serde_yaml::from_str("image: nginx\ndns: null\nnetworks: {}\n").unwrap();
+		prune_yaml_nulls(&mut v);
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(out.contains("image: nginx"));
+		assert!(!out.contains("dns"));
+		assert!(!out.contains("networks"));
+	}
+
+	#[test]
+	fn render_config_rejects_depends_on_cycle() {
+		// A `depends_on` cycle must be reported at config time, not deferred to up.
+		let file = podup::parse_str(
+			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
+		)
+		.unwrap();
+		let err = render_config(
+			&file,
+			&ConfigFormat::Yaml,
+			&ConfigOutput {
+				quiet: true,
+				..Default::default()
+			},
+			"proj",
+		)
+		.unwrap_err();
+		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
+	}
+
+	#[test]
+	fn render_config_quiet_is_validate_only() {
+		// `--quiet` validates and prints nothing, returning Ok.
+		render_config(
+			&sample_file(),
+			&ConfigFormat::Yaml,
+			&ConfigOutput {
+				quiet: true,
+				..Default::default()
+			},
+			"proj",
+		)
+		.unwrap();
+	}
+
+	#[test]
+	fn render_config_services_lists_names() {
+		// `--services` reaches the service-name listing branch without error.
+		render_config(
+			&sample_file(),
+			&ConfigFormat::Yaml,
+			&ConfigOutput {
+				services: true,
+				..Default::default()
+			},
+			"proj",
+		)
+		.unwrap();
+	}
+
+	#[test]
+	fn render_config_projection_modes_render_ok() {
+		// Each list-projection selector reaches its branch without error.
+		for out in [
+			ConfigOutput {
+				volumes: true,
+				..Default::default()
+			},
+			ConfigOutput {
+				images: true,
+				..Default::default()
+			},
+			ConfigOutput {
+				profiles: true,
+				..Default::default()
+			},
+			ConfigOutput {
+				hash: Some("*".to_string()),
+				..Default::default()
+			},
+		] {
+			render_config(&sample_file(), &ConfigFormat::Yaml, &out, "proj").unwrap();
+		}
+	}
+
+	#[test]
+	fn render_config_hash_rejects_unknown_service() {
+		let out = ConfigOutput {
+			hash: Some("nope".to_string()),
+			..Default::default()
+		};
+		assert!(render_config(&sample_file(), &ConfigFormat::Yaml, &out, "proj").is_err());
+	}
+
+	#[test]
+	fn service_config_hash_is_stable_and_distinct() {
+		let file = sample_file();
+		let web = service_config_hash(&file.services["web"]);
+		let db = service_config_hash(&file.services["db"]);
+		// Stable for the same input, and distinct across different services.
+		assert_eq!(web, service_config_hash(&file.services["web"]));
+		assert_ne!(web, db);
+		assert_eq!(web.len(), 64, "sha-256 hex is 64 chars");
+	}
+
+	#[test]
+	fn render_config_yaml_and_json_render_ok() {
+		render_config(
+			&sample_file(),
+			&ConfigFormat::Yaml,
+			&ConfigOutput::default(),
+			"proj",
+		)
+		.unwrap();
+		render_config(
+			&sample_file(),
+			&ConfigFormat::Json,
+			&ConfigOutput::default(),
+			"proj",
+		)
+		.unwrap();
+	}
+
+	#[test]
+	fn render_config_injects_resolved_project_name() {
+		// The rendered output carries the resolved project name, not the file's
+		// literal `name:` (here unset). Render into a buffer via the same path.
+		let mut redacted = sample_file();
+		redacted.name = Some("myproj".to_string());
+		let v: serde_yaml::Value = serde_yaml::to_value(&redacted).unwrap();
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(
+			out.contains("name: myproj"),
+			"config should render the resolved name"
+		);
+	}
+
+	#[test]
+	fn prune_preserves_environment_map_nulls() {
+		// A map-form host-passthrough var (`MYVAR:` -> null) survives pruning, while
+		// an unrelated null elsewhere is still dropped.
+		let mut v: serde_yaml::Value = serde_yaml::from_str(
+			"services:\n  web:\n    image: nginx\n    dns: null\n    environment:\n      MYVAR: null\n      SET: value\n",
+		)
+		.unwrap();
+		prune_yaml_nulls(&mut v);
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(out.contains("MYVAR"), "passthrough env var must be kept");
+		assert!(out.contains("SET"));
+		assert!(!out.contains("dns"), "unrelated null must still be dropped");
+
+		let mut j = serde_json::json!({
+			"services": { "web": {
+				"image": "nginx",
+				"dns": null,
+				"environment": { "MYVAR": null, "SET": "value" }
+			}}
+		});
+		prune_json_nulls(&mut j);
+		let env = &j["services"]["web"]["environment"];
+		assert!(
+			env.get("MYVAR").is_some(),
+			"passthrough env var must be kept"
+		);
+		assert!(j["services"]["web"].get("dns").is_none());
+	}
+}

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -3,8 +3,11 @@
 //! file in YAML/JSON with unset keys pruned and inline secrets redacted. Split
 //! out of `startup` so each file stays within the source line limit.
 
+use std::path::Path;
+
 use sha2::{Digest, Sha256};
 
+use super::config_normalize::{quote_yaml11_booleans, resolve_bind_sources};
 use crate::cli::ConfigFormat;
 
 /// Output selectors for `config`, mirroring the mutually-exclusive `docker
@@ -35,6 +38,7 @@ pub(crate) fn render_config(
 	format: &ConfigFormat,
 	out: &ConfigOutput,
 	project: &str,
+	base_dir: &Path,
 ) -> podup::Result<()> {
 	// Reaching here means the file parsed and merged cleanly. Run the full
 	// config-time validation (non-empty services, image-or-build, service-name
@@ -86,6 +90,14 @@ pub(crate) fn render_config(
 	// Surface the resolved project name in the rendered output, like
 	// `docker compose config`, rather than the file's literal `name:` (or none).
 	redacted.name = Some(project.to_string());
+	// Don't echo keys the diagnostics pass warned were ignored: the rendered
+	// config should reflect what podup actually applies, and re-feeding it must
+	// not re-trigger the same warning. `x-*` extensions are kept.
+	redacted.strip_ignored_unknown_keys();
+	// Resolve relative bind-mount sources to absolute paths against the project
+	// directory, like `docker compose config`. Runtime mounting is unaffected —
+	// this only normalizes the rendered output.
+	resolve_bind_sources(&mut redacted, base_dir);
 	redacted.redact_inline_content();
 	let rendered = match format {
 		ConfigFormat::Json => {
@@ -101,7 +113,12 @@ pub(crate) fn render_config(
 			let mut v: serde_yaml::Value =
 				serde_yaml::to_value(&redacted).map_err(podup::ComposeError::Parse)?;
 			prune_yaml_nulls(&mut v);
-			serde_yaml::to_string(&v).map_err(podup::ComposeError::Parse)?
+			let yaml = serde_yaml::to_string(&v).map_err(podup::ComposeError::Parse)?;
+			// serde_yaml_ng emits YAML 1.2, where `yes`/`no`/`on`/`off` are plain
+			// strings and stay unquoted. A strict YAML 1.1 reader (docker compose's
+			// emitter among them) would misread those as booleans, so quote any
+			// string scalar that looks like a YAML 1.1 boolean to match.
+			quote_yaml11_booleans(&yaml)
 		}
 	};
 	println!("{rendered}");
@@ -279,6 +296,7 @@ mod tests {
 				..Default::default()
 			},
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap_err();
 		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
@@ -295,6 +313,7 @@ mod tests {
 				..Default::default()
 			},
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 	}
@@ -310,6 +329,7 @@ mod tests {
 				..Default::default()
 			},
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 	}
@@ -335,7 +355,14 @@ mod tests {
 				..Default::default()
 			},
 		] {
-			render_config(&sample_file(), &ConfigFormat::Yaml, &out, "proj").unwrap();
+			render_config(
+				&sample_file(),
+				&ConfigFormat::Yaml,
+				&out,
+				"proj",
+				Path::new("/proj"),
+			)
+			.unwrap();
 		}
 	}
 
@@ -345,7 +372,14 @@ mod tests {
 			hash: Some("nope".to_string()),
 			..Default::default()
 		};
-		assert!(render_config(&sample_file(), &ConfigFormat::Yaml, &out, "proj").is_err());
+		assert!(render_config(
+			&sample_file(),
+			&ConfigFormat::Yaml,
+			&out,
+			"proj",
+			Path::new("/proj")
+		)
+		.is_err());
 	}
 
 	#[test]
@@ -366,6 +400,7 @@ mod tests {
 			&ConfigFormat::Yaml,
 			&ConfigOutput::default(),
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 		render_config(
@@ -373,6 +408,7 @@ mod tests {
 			&ConfigFormat::Json,
 			&ConfigOutput::default(),
 			"proj",
+			Path::new("/proj"),
 		)
 		.unwrap();
 	}
@@ -419,5 +455,31 @@ mod tests {
 			"passthrough env var must be kept"
 		);
 		assert!(j["services"]["web"].get("dns").is_none());
+	}
+
+	#[test]
+	fn render_config_strips_ignored_unknown_keys() {
+		// An unknown (non-`x-`) top-level and service key is dropped from the
+		// rendered output, while a valid `x-` extension is round-tripped. Rendered
+		// via the YAML path through a clone so the public method is exercised.
+		let mut file = podup::parse_str(
+			"x-anchors: keep\nbogus_top: 1\nservices:\n  web:\n    image: nginx\n    bogus_svc: 2\n",
+		)
+		.unwrap();
+		file.strip_ignored_unknown_keys();
+		let v: serde_yaml::Value = serde_yaml::to_value(&file).unwrap();
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(
+			!out.contains("bogus_top"),
+			"ignored top key re-emitted: {out}"
+		);
+		assert!(
+			!out.contains("bogus_svc"),
+			"ignored svc key re-emitted: {out}"
+		);
+		assert!(
+			out.contains("x-anchors"),
+			"x- extension must survive: {out}"
+		);
 	}
 }

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::cli::{Cli, Commands};
 
+mod config_normalize;
 mod config_render;
 pub(crate) use config_render::{render_config, ConfigOutput};
 

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -10,7 +10,10 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
-use crate::cli::{Cli, Commands, ConfigFormat};
+use crate::cli::{Cli, Commands};
+
+mod config_render;
+pub(crate) use config_render::{render_config, ConfigOutput};
 
 /// Whether a command creates, destroys, or changes the state of containers and
 /// so must hold the exclusive project lock.
@@ -147,141 +150,6 @@ pub(crate) fn init_tracing(default_level: &str) {
 		.init();
 }
 
-/// Render `config`: validate-only (`--quiet`), service-name list (`--services`),
-/// or the resolved compose file in YAML/JSON with inline secret content redacted.
-pub(crate) fn render_config(
-	file: &podup::compose::types::ComposeFile,
-	format: &ConfigFormat,
-	services: bool,
-	quiet: bool,
-	project: &str,
-) -> podup::Result<()> {
-	// Reaching here means the file parsed and merged cleanly. Run the full
-	// config-time validation (non-empty services, image-or-build, service-name
-	// charset, port ranges, undefined volume/network references, and an acyclic
-	// dependency graph) before the `--quiet`/`--services` short-circuits, so
-	// validate-only (`--quiet`) actually validates — matching `docker compose config`.
-	podup::validate_config(file)?;
-	if quiet {
-		return Ok(());
-	}
-	if services {
-		for name in file.services.keys() {
-			println!("{name}");
-		}
-		return Ok(());
-	}
-	let mut redacted = file.clone();
-	// Surface the resolved project name in the rendered output, like
-	// `docker compose config`, rather than the file's literal `name:` (or none).
-	redacted.name = Some(project.to_string());
-	redacted.redact_inline_content();
-	let rendered = match format {
-		ConfigFormat::Json => {
-			let mut v = serde_json::to_value(&redacted).map_err(|e| {
-				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
-			})?;
-			prune_json_nulls(&mut v);
-			serde_json::to_string_pretty(&v).map_err(|e| {
-				podup::ComposeError::Unsupported(format!("failed to render config as JSON: {e}"))
-			})?
-		}
-		ConfigFormat::Yaml => {
-			let mut v: serde_yaml::Value =
-				serde_yaml::to_value(&redacted).map_err(podup::ComposeError::Parse)?;
-			prune_yaml_nulls(&mut v);
-			serde_yaml::to_string(&v).map_err(podup::ComposeError::Parse)?
-		}
-	};
-	println!("{rendered}");
-	Ok(())
-}
-
-/// Drop unset keys from a JSON value so `config` output omits them (like
-/// `docker compose config`) instead of a wall of `field: null` and empty
-/// `field: {}` sections. Recurses first so a section that becomes empty once its
-/// own nulls are dropped is itself dropped.
-fn prune_json_nulls(v: &mut serde_json::Value) {
-	prune_json(v, false);
-}
-
-/// `preserve_nulls` keeps null leaves at the current mapping level. It is set for
-/// the value under an `environment:` key so a map-form host-passthrough var
-/// (`MYVAR:` → null) is not stripped from the output — it is forwarded at runtime,
-/// so `config` must show it, matching docker compose (which never drops the key).
-fn prune_json(v: &mut serde_json::Value, preserve_nulls: bool) {
-	match v {
-		serde_json::Value::Object(map) => {
-			for (k, val) in map.iter_mut() {
-				prune_json(val, k == "environment");
-			}
-			if !preserve_nulls {
-				map.retain(|_, val| !is_empty_json(val));
-			}
-		}
-		serde_json::Value::Array(arr) => {
-			for val in arr.iter_mut() {
-				prune_json(val, false);
-			}
-		}
-		_ => {}
-	}
-}
-
-fn is_empty_json(v: &serde_json::Value) -> bool {
-	match v {
-		serde_json::Value::Null => true,
-		serde_json::Value::Object(m) => m.is_empty(),
-		// An empty array is kept: an explicit `command: []`/`entrypoint: []`
-		// overrides the image's value, so dropping it would change meaning.
-		_ => false,
-	}
-}
-
-/// The YAML counterpart of [`prune_json_nulls`].
-fn prune_yaml_nulls(v: &mut serde_yaml::Value) {
-	prune_yaml(v, false);
-}
-
-/// YAML counterpart of [`prune_json`]; `preserve_nulls` exempts an
-/// `environment:` map's null (host-passthrough) values from being dropped.
-fn prune_yaml(v: &mut serde_yaml::Value, preserve_nulls: bool) {
-	match v {
-		serde_yaml::Value::Mapping(map) => {
-			for (k, val) in map.iter_mut() {
-				let child_preserve = k.as_str() == Some("environment");
-				prune_yaml(val, child_preserve);
-			}
-			if !preserve_nulls {
-				let drop: Vec<serde_yaml::Value> = map
-					.iter()
-					.filter(|(_, val)| is_empty_yaml(val))
-					.map(|(k, _)| k.clone())
-					.collect();
-				for k in drop {
-					map.remove(&k);
-				}
-			}
-		}
-		serde_yaml::Value::Sequence(seq) => {
-			for val in seq.iter_mut() {
-				prune_yaml(val, false);
-			}
-		}
-		_ => {}
-	}
-}
-
-fn is_empty_yaml(v: &serde_yaml::Value) -> bool {
-	match v {
-		serde_yaml::Value::Null => true,
-		serde_yaml::Value::Mapping(m) => m.is_empty(),
-		// Keep empty sequences: an explicit `command: []`/`entrypoint: []`
-		// overrides the image's value, so dropping it would change meaning.
-		_ => false,
-	}
-}
-
 /// Build the `run`-only flag overrides from the parsed command. These are kept
 /// off the frozen public `RunOptions` API and threaded through the engine
 /// builder instead (`Engine::with_run_overrides`).
@@ -309,15 +177,24 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 	}
 }
 
+/// Extract the `docker compose run -l/--label KEY=VAL` ad-hoc labels for the
+/// engine builder ([`podup::Engine::with_run_labels`]). Carried on the engine
+/// rather than the frozen `RunOverrides` struct so the 1.0 library API stays
+/// stable, mirroring `run_overrides_for`.
+pub(crate) fn run_labels_for(command: &Commands) -> Vec<String> {
+	match command {
+		Commands::Run { label, .. } => label.clone(),
+		_ => Vec::new(),
+	}
+}
+
 /// Parse the CLI, framing `--help`/`--version` output with a blank line top and
 /// bottom (clap trims template edges, so wrap the rendered text here).
 pub(crate) fn parse_cli() -> Cli {
 	match Cli::try_parse() {
 		Ok(cli) => cli,
 		Err(e) => match e.kind() {
-			clap::error::ErrorKind::DisplayHelp
-			| clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
-			| clap::error::ErrorKind::DisplayVersion => {
+			clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
 				// `--help`/`--version` are handled by clap before `--ansi` is parsed,
 				// so colour the rendered text by clap's own styling only when stdout
 				// is a colour sink (TTY + no NO_COLOR); piped output stays plain and
@@ -329,6 +206,14 @@ pub(crate) fn parse_cli() -> Cli {
 					print!("\n{rendered}\n");
 				}
 				process::exit(0);
+			}
+			clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+				// No subcommand (top level) or a required nested subcommand (e.g.
+				// `generate`) was given: print the help to stderr and exit non-zero,
+				// like docker compose, so a script sees the error instead of a silent
+				// success. `podup help` (the explicit Help variant) still exits 0.
+				eprint!("\n{}\n", e.render());
+				process::exit(2);
 			}
 			_ => e.exit(),
 		},
@@ -347,10 +232,17 @@ mod tests {
 		assert!(is_label_only(&Commands::Ps {
 			all: false,
 			quiet: false,
+			services_only: false,
+			filter: vec![],
+			status: vec![],
 			format: OutputFormat::Table,
+			services: vec![],
 		}));
 		assert!(is_label_only(&Commands::Events {
 			format: EventsFormat::Table,
+			since: None,
+			until: None,
+			filter: vec![],
 			json: false,
 		}));
 		// A command that reads service definitions is not label-only.
@@ -358,32 +250,6 @@ mod tests {
 			format: OutputFormat::Table,
 			services: vec![],
 		}));
-	}
-
-	#[test]
-	fn prune_json_drops_nulls_and_empty_then_collapses() {
-		let mut v = serde_json::json!({
-			"image": "nginx",
-			"environment": null,
-			"command": [],
-			"labels": {},
-			"deploy": { "replicas": null }
-		});
-		prune_json_nulls(&mut v);
-		// null fields and the section emptied by its own nulls are gone, but an
-		// explicit empty array (`command: []`) survives — it overrides the image.
-		assert_eq!(v, serde_json::json!({ "image": "nginx", "command": [] }));
-	}
-
-	#[test]
-	fn prune_yaml_drops_nulls_and_empty() {
-		let mut v: serde_yaml::Value =
-			serde_yaml::from_str("image: nginx\ndns: null\nnetworks: {}\n").unwrap();
-		prune_yaml_nulls(&mut v);
-		let out = serde_yaml::to_string(&v).unwrap();
-		assert!(out.contains("image: nginx"));
-		assert!(!out.contains("dns"));
-		assert!(!out.contains("networks"));
 	}
 
 	#[test]
@@ -406,84 +272,6 @@ mod tests {
 			level_style(tracing::Level::DEBUG),
 			level_style(tracing::Level::TRACE)
 		);
-	}
-
-	fn sample_file() -> podup::compose::types::ComposeFile {
-		podup::parse_str("services:\n  web:\n    image: nginx\n  db:\n    image: postgres\n")
-			.unwrap()
-	}
-
-	#[test]
-	fn render_config_rejects_depends_on_cycle() {
-		// A `depends_on` cycle must be reported at config time, not deferred to up.
-		let file = podup::parse_str(
-			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
-		)
-		.unwrap();
-		let err = render_config(&file, &ConfigFormat::Yaml, false, true, "proj").unwrap_err();
-		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
-	}
-
-	#[test]
-	fn render_config_quiet_is_validate_only() {
-		// `--quiet` validates and prints nothing, returning Ok.
-		render_config(&sample_file(), &ConfigFormat::Yaml, false, true, "proj").unwrap();
-	}
-
-	#[test]
-	fn render_config_services_lists_names() {
-		// `--services` reaches the service-name listing branch without error.
-		render_config(&sample_file(), &ConfigFormat::Yaml, true, false, "proj").unwrap();
-	}
-
-	#[test]
-	fn render_config_yaml_and_json_render_ok() {
-		render_config(&sample_file(), &ConfigFormat::Yaml, false, false, "proj").unwrap();
-		render_config(&sample_file(), &ConfigFormat::Json, false, false, "proj").unwrap();
-	}
-
-	#[test]
-	fn render_config_injects_resolved_project_name() {
-		// The rendered output carries the resolved project name, not the file's
-		// literal `name:` (here unset). Render into a buffer via the same path.
-		let mut redacted = sample_file();
-		redacted.name = Some("myproj".to_string());
-		let v: serde_yaml::Value = serde_yaml::to_value(&redacted).unwrap();
-		let out = serde_yaml::to_string(&v).unwrap();
-		assert!(
-			out.contains("name: myproj"),
-			"config should render the resolved name"
-		);
-	}
-
-	#[test]
-	fn prune_preserves_environment_map_nulls() {
-		// A map-form host-passthrough var (`MYVAR:` → null) survives pruning, while
-		// an unrelated null elsewhere is still dropped.
-		let mut v: serde_yaml::Value = serde_yaml::from_str(
-			"services:\n  web:\n    image: nginx\n    dns: null\n    environment:\n      MYVAR: null\n      SET: value\n",
-		)
-		.unwrap();
-		prune_yaml_nulls(&mut v);
-		let out = serde_yaml::to_string(&v).unwrap();
-		assert!(out.contains("MYVAR"), "passthrough env var must be kept");
-		assert!(out.contains("SET"));
-		assert!(!out.contains("dns"), "unrelated null must still be dropped");
-
-		let mut j = serde_json::json!({
-			"services": { "web": {
-				"image": "nginx",
-				"dns": null,
-				"environment": { "MYVAR": null, "SET": "value" }
-			}}
-		});
-		prune_json_nulls(&mut j);
-		let env = &j["services"]["web"]["environment"];
-		assert!(
-			env.get("MYVAR").is_some(),
-			"passthrough env var must be kept"
-		);
-		assert!(j["services"]["web"].get("dns").is_none());
 	}
 
 	#[test]

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -1,6 +1,7 @@
 //! Docker Compose variable substitution.
 //!
-//! Applies `${VAR}` / `$VAR` substitution to raw YAML text before parsing.
+//! Applies `${VAR}` / `$VAR` substitution to individual scalar values of a
+//! parsed compose document (compose-spec value-level interpolation).
 //! Handles all compose-spec modifier forms: `:-`, `-`, `:+`, `+`, `:?`, `?`.
 
 mod parse;
@@ -8,9 +9,14 @@ mod parse;
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 
 use parse::{collect_var_name, is_var_start, parse_braced_var, resolve_modifier};
+
+/// Maximum nesting depth for interpolated default/alternate values
+/// (`${A:-${A:-…}}`). Real compose files nest a handful of levels at most; this
+/// cap turns a pathological chain into a clean error instead of a stack overflow.
+const MAX_INTERP_DEPTH: usize = 64;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -21,6 +27,22 @@ use parse::{collect_var_name, is_var_start, parse_braced_var, resolve_modifier};
 /// `vars` should contain both the process environment and the `.env` file
 /// entries (process environment takes precedence).
 pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String> {
+	substitute_depth(input, vars, 0)
+}
+
+/// Inner substitution carrying the current nesting `depth` so recursive
+/// interpolation of modifier defaults/alternates (`${A:-${B}}`) is bounded.
+pub(super) fn substitute_depth(
+	input: &str,
+	vars: &HashMap<String, String>,
+	depth: usize,
+) -> Result<String> {
+	if depth > MAX_INTERP_DEPTH {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"interpolation nesting too deep (more than {MAX_INTERP_DEPTH} levels)"
+		)));
+	}
+
 	let mut out = String::with_capacity(input.len());
 	let mut chars = input.chars().peekable();
 
@@ -41,12 +63,21 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String>
 			Some('{') => {
 				chars.next();
 				let (var, modifier) = parse_braced_var(&mut chars)?;
-				let value = resolve_modifier(var, modifier, vars)?;
+				let value = resolve_modifier(var, modifier, vars, depth)?;
 				out.push_str(&value);
 			}
 			Some(c) if is_var_start(*c) => {
 				let var = collect_var_name(&mut chars);
-				let value = vars.get(&var).cloned().unwrap_or_default();
+				let value = match vars.get(&var) {
+					Some(v) => v.clone(),
+					None => {
+						// Match docker compose v2: warn before defaulting to blank.
+						tracing::warn!(
+							"The {var} variable is not set. Defaulting to a blank string."
+						);
+						String::new()
+					}
+				};
 				out.push_str(&value);
 			}
 			Some(_) => {
@@ -388,6 +419,53 @@ mod tests {
 		assert_eq!(
 			substitute("${FOO:-${BAR}}/tail", &vars(&[("BAR", "b")])).unwrap(),
 			"b/tail"
+		);
+	}
+
+	// Malformed / pathological references
+
+	#[test]
+	fn empty_name_is_error() {
+		assert!(substitute("${}", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn digit_leading_name_is_error() {
+		assert!(substitute("${1BAD}", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn unterminated_modifier_is_error() {
+		// The missing `}` must error rather than consume the rest of the input.
+		assert!(substitute("${TAG:-latest\nmore", &vars(&[])).is_err());
+	}
+
+	#[test]
+	fn deeply_nested_defaults_error_instead_of_overflowing() {
+		// A pathological `${A:-${A:-…}}` chain (all default branches taken, A unset)
+		// returns a clean error past the depth cap rather than overflowing the stack.
+		let depth = MAX_INTERP_DEPTH + 50;
+		let mut s = String::new();
+		for _ in 0..depth {
+			s.push_str("${A:-");
+		}
+		s.push('x');
+		for _ in 0..depth {
+			s.push('}');
+		}
+		let err = substitute(&s, &vars(&[])).expect_err("over-deep nesting must error");
+		assert!(matches!(
+			err,
+			crate::error::ComposeError::InvalidSubstitution(_)
+		));
+	}
+
+	#[test]
+	fn moderate_nesting_still_resolves() {
+		// Well within the cap, nested defaults resolve normally.
+		assert_eq!(
+			substitute("${A:-${B:-${C:-deep}}}", &vars(&[])).unwrap(),
+			"deep"
 		);
 	}
 

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -154,6 +154,18 @@ pub fn build_vars_with_env_files_strict(
 	build_vars_with_env_files_inner(dir, extra, true)
 }
 
+/// The first control character in `value` that is never legitimate in an
+/// env-file value, or `None` if there is none. Tab, newline and carriage return
+/// are allowed — dotenv escapes (`\t`, `\n`, `\r`) and multi-line quoted values
+/// produce them legitimately, and post-parse interpolation stores them verbatim
+/// as scalar data. Everything else in the C0/C1 ranges (NUL, ESC, …) is
+/// rejected. Pure so it is unit-tested.
+fn first_disallowed_control_char(value: &str) -> Option<char> {
+	value
+		.chars()
+		.find(|&c| c.is_control() && !matches!(c, '\t' | '\n' | '\r'))
+}
+
 fn build_vars_with_env_files_inner(
 	dir: &Path,
 	extra: &[String],
@@ -189,6 +201,24 @@ fn build_vars_with_env_files_inner(
 			crate::dotenv::parse(&content)
 		};
 		for (key, value) in pairs {
+			// A disallowed control character (e.g. NUL) in a value would be
+			// interpolated verbatim into a compose scalar, where it is meaningless
+			// at best and corrupts the container's config at worst. Reject it here,
+			// at load time, with an error that names the originating env file and
+			// key — instead of letting it surface later as a compose-file parse
+			// error at a meaningless post-substitution offset. Only the explicit
+			// (strict) `--env-file`/`env_file:` path errors; the lenient `.env`
+			// fallback keeps its historical pass-through behaviour.
+			if strict {
+				if let Some(bad) = first_disallowed_control_char(&value) {
+					return Err(crate::error::ComposeError::EnvFile(format!(
+						"env file {}: value of '{key}' contains a disallowed control \
+						 character ({}); remove it before use",
+						abs.display(),
+						bad.escape_default(),
+					)));
+				}
+			}
 			file_vars.insert(key, value);
 		}
 	}
@@ -643,5 +673,55 @@ mod tests {
 		// silently skipped rather than failing.
 		let vars = build_vars_with_env_files(dir.path(), &["absent.env".to_string()]);
 		assert!(!vars.contains_key("FROM_EXTRA"));
+	}
+
+	#[test]
+	fn first_disallowed_control_char_allows_tab_newline_cr() {
+		// Legitimate dotenv escapes / multi-line values must pass.
+		assert_eq!(first_disallowed_control_char("plain value"), None);
+		assert_eq!(first_disallowed_control_char("a\tb\nc\rd"), None);
+		// NUL, ESC and other C0/C1 controls are rejected.
+		assert_eq!(first_disallowed_control_char("a\0b"), Some('\0'));
+		assert_eq!(first_disallowed_control_char("x\x1by"), Some('\x1b'));
+	}
+
+	#[test]
+	fn strict_build_vars_errors_on_control_char_value_naming_file_and_key() {
+		let dir = tempfile::tempdir().unwrap();
+		// A NUL in an env-file value is rejected at load time, before any compose
+		// parse, with an error that names the originating env file and key — not a
+		// misattributed parse offset into the post-substitution document (#885).
+		std::fs::write(dir.path().join("bad.env"), "SECRET=ab\0cd\n").unwrap();
+		let err =
+			build_vars_with_env_files_strict(dir.path(), &["bad.env".to_string()]).unwrap_err();
+		assert!(
+			matches!(err, crate::error::ComposeError::EnvFile(_)),
+			"expected EnvFile error, got {err:?}"
+		);
+		let msg = err.to_string();
+		assert!(msg.contains("bad.env"), "names the env file: {msg}");
+		assert!(msg.contains("SECRET"), "names the offending key: {msg}");
+		assert!(
+			msg.contains("control"),
+			"explains the control-char cause: {msg}"
+		);
+	}
+
+	#[test]
+	fn strict_build_vars_allows_multiline_and_tab_values() {
+		let dir = tempfile::tempdir().unwrap();
+		// A multi-line quoted value (real newline) and a `\t` escape are legitimate
+		// and must not be rejected by the control-char guard.
+		std::fs::write(
+			dir.path().join("ok.env"),
+			"MULTI=\"line one\nline two\"\nTABBED=\"a\\tb\"\n",
+		)
+		.unwrap();
+		let vars = build_vars_with_env_files_strict(dir.path(), &["ok.env".to_string()]).unwrap();
+		assert_eq!(
+			vars.get("MULTI").map(String::as_str),
+			Some("line one\nline two")
+		);
+		assert_eq!(vars.get("TABBED").map(String::as_str), Some("a\tb"));
 	}
 }

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -100,9 +100,36 @@ pub fn build_vars(dir: &Path) -> HashMap<String, String> {
 /// the default `.env` (which is therefore not loaded), and among several files
 /// the **last** one wins. With no explicit files this is just [`build_vars`]
 /// (process env + `.env`). Process env always takes precedence over file values.
+///
+/// A missing, unreadable, or malformed `--env-file` is silently skipped here
+/// (legacy lenient behaviour). This signature is part of the published library
+/// API and is kept for backward compatibility; the CLI drives
+/// [`build_vars_with_env_files_strict`], which fails loudly on a bad file.
 pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String, String> {
+	// `strict = false` can never produce an error.
+	build_vars_with_env_files_inner(dir, extra, false).unwrap_or_default()
+}
+
+/// Like [`build_vars_with_env_files`] but rejects a bad `--env-file`.
+///
+/// An explicitly-passed `--env-file` that is missing, unreadable, or malformed
+/// is a hard error (matching docker compose, which fails on a not-found env
+/// file) rather than being silently skipped — a typo'd path must not fall back
+/// to process-env/defaults and exit 0.
+pub fn build_vars_with_env_files_strict(
+	dir: &Path,
+	extra: &[String],
+) -> Result<HashMap<String, String>> {
+	build_vars_with_env_files_inner(dir, extra, true)
+}
+
+fn build_vars_with_env_files_inner(
+	dir: &Path,
+	extra: &[String],
+	strict: bool,
+) -> Result<HashMap<String, String>> {
 	if extra.is_empty() {
-		return build_vars(dir);
+		return Ok(build_vars(dir));
 	}
 
 	// Explicit `--env-file`s replace `.env`; a later file overrides an earlier one.
@@ -113,10 +140,24 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 		} else {
 			dir.join(path)
 		};
-		let Ok(content) = crate::filesystem::read_to_string_capped(&abs) else {
-			continue;
+		let content = match crate::filesystem::read_to_string_capped(&abs) {
+			Ok(content) => content,
+			Err(e) => {
+				if strict {
+					return Err(crate::error::ComposeError::EnvFile(format!(
+						"env file not found: {} ({e})",
+						abs.display()
+					)));
+				}
+				continue;
+			}
 		};
-		for (key, value) in crate::dotenv::parse(&content) {
+		let pairs = if strict {
+			crate::dotenv::parse_strict(&content)?
+		} else {
+			crate::dotenv::parse(&content)
+		};
+		for (key, value) in pairs {
 			file_vars.insert(key, value);
 		}
 	}
@@ -126,7 +167,7 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 	for (k, v) in file_vars {
 		vars.entry(k).or_insert(v);
 	}
-	vars
+	Ok(vars)
 }
 
 // ---------------------------------------------------------------------------
@@ -440,7 +481,8 @@ mod tests {
 		)
 		.unwrap();
 
-		let vars = build_vars_with_env_files(dir.path(), &["extra.env".to_string()]);
+		let vars =
+			build_vars_with_env_files_strict(dir.path(), &["extra.env".to_string()]).unwrap();
 		assert_eq!(vars.get("FROM_DOTENV"), None);
 		assert_eq!(vars.get("FROM_EXTRA").map(String::as_str), Some("more"));
 		assert_eq!(
@@ -456,8 +498,11 @@ mod tests {
 		std::fs::write(dir.path().join("a.env"), "FROM_A=a\nSHARED=a\n").unwrap();
 		std::fs::write(dir.path().join("b.env"), "FROM_B=b\nSHARED=b\n").unwrap();
 
-		let vars =
-			build_vars_with_env_files(dir.path(), &["a.env".to_string(), "b.env".to_string()]);
+		let vars = build_vars_with_env_files_strict(
+			dir.path(),
+			&["a.env".to_string(), "b.env".to_string()],
+		)
+		.unwrap();
 		assert_eq!(vars.get("FROM_A").map(String::as_str), Some("a"));
 		assert_eq!(vars.get("FROM_B").map(String::as_str), Some("b"));
 		assert_eq!(vars.get("SHARED").map(String::as_str), Some("b"));
@@ -473,7 +518,7 @@ mod tests {
 		)
 		.unwrap();
 
-		let vars = build_vars_with_env_files(dir.path(), &["x.env".to_string()]);
+		let vars = build_vars_with_env_files_strict(dir.path(), &["x.env".to_string()]).unwrap();
 		assert_eq!(
 			vars.get("PODUP_ENVFILE_PROCESS_WINS").map(String::as_str),
 			Some("from-process")
@@ -486,14 +531,38 @@ mod tests {
 		let dir = tempfile::tempdir().unwrap();
 		// With no `--env-file`, `.env` is loaded as before.
 		std::fs::write(dir.path().join(".env"), "FROM_DOTENV=base\n").unwrap();
-		let vars = build_vars_with_env_files(dir.path(), &[]);
+		let vars = build_vars_with_env_files_strict(dir.path(), &[]).unwrap();
 		assert_eq!(vars.get("FROM_DOTENV").map(String::as_str), Some("base"));
 	}
 
 	#[test]
-	fn build_vars_with_env_files_skips_missing_extra_file() {
+	fn strict_build_vars_errors_on_missing_extra_file() {
 		let dir = tempfile::tempdir().unwrap();
-		// A missing extra file is silently skipped rather than erroring.
+		// An explicitly-passed `--env-file` that does not exist is a hard error
+		// (docker compose parity), not a silent fall-back to defaults.
+		let err =
+			build_vars_with_env_files_strict(dir.path(), &["absent.env".to_string()]).unwrap_err();
+		assert!(
+			matches!(err, crate::error::ComposeError::EnvFile(_)),
+			"expected EnvFile error, got {err:?}"
+		);
+		assert!(err.to_string().contains("env file not found"));
+	}
+
+	#[test]
+	fn strict_build_vars_errors_on_unterminated_quote() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("bad.env"), "A=\"oops\nB=keep\n").unwrap();
+		let err =
+			build_vars_with_env_files_strict(dir.path(), &["bad.env".to_string()]).unwrap_err();
+		assert!(matches!(err, crate::error::ComposeError::EnvFile(_)));
+	}
+
+	#[test]
+	fn lenient_build_vars_skips_missing_extra_file() {
+		let dir = tempfile::tempdir().unwrap();
+		// The backward-compatible shim never errors: a missing extra file is
+		// silently skipped rather than failing.
 		let vars = build_vars_with_env_files(dir.path(), &["absent.env".to_string()]);
 		assert!(!vars.contains_key("FROM_EXTRA"));
 	}

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -49,15 +49,25 @@ pub(super) enum Modifier {
 /// Parse the content inside `${…}`.  The opening `{` has already been consumed.
 ///
 /// The variable name is collected with [`is_var_char`] (matching the unbraced
-/// `$VAR` path and the compose-spec grammar). After the name, only a modifier
-/// delimiter (`}`, `:`, `-`, `+`, `?`) or end-of-input may follow; any other
-/// trailing character (a space in `${FOO BAR}`, a dot in `${FOO.BAR}`, …) makes
-/// the reference malformed and is rejected rather than folded into the lookup
-/// key.
+/// `$VAR` path and the compose-spec grammar). It must be non-empty and start
+/// with `[A-Za-z_]`; `${}` and `${1BAD}` are rejected as malformed rather than
+/// resolved to an empty string. After the name, only a modifier delimiter
+/// (`}`, `:`, `-`, `+`, `?`) or end-of-input may follow; any other trailing
+/// character (a space in `${FOO BAR}`, a dot in `${FOO.BAR}`, …) makes the
+/// reference malformed and is rejected rather than folded into the lookup key.
 pub(super) fn parse_braced_var(
 	chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
 ) -> Result<(String, Modifier)> {
 	let name = collect_var_name(chars);
+
+	// The name must be a valid identifier: non-empty and starting with a letter
+	// or `_`. `collect_var_name` accepts digits (they are valid *within* a name),
+	// so an empty name or a digit-leading name only fails here.
+	if name.is_empty() || !name.starts_with(is_var_start) {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"invalid variable name {name:?} in '${{…}}': names must start with a letter or '_'"
+		)));
+	}
 
 	match chars.peek() {
 		None => Ok((name, Modifier::None)),
@@ -71,31 +81,31 @@ pub(super) fn parse_braced_var(
 			let modifier = match chars.peek() {
 				Some('-') => {
 					chars.next();
-					Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars))
+					Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)?)
 				}
 				Some('+') => {
 					chars.next();
-					Modifier::AltIfSetAndNonEmpty(collect_until_close(chars))
+					Modifier::AltIfSetAndNonEmpty(collect_until_close(chars)?)
 				}
 				Some('?') => {
 					chars.next();
-					Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars))
+					Modifier::ErrorIfUnsetOrEmpty(collect_until_close(chars)?)
 				}
-				_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)),
+				_ => Modifier::DefaultIfUnsetOrEmpty(collect_until_close(chars)?),
 			};
 			Ok((name, modifier))
 		}
 		Some('-') => {
 			chars.next();
-			Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars))))
+			Ok((name, Modifier::DefaultIfUnset(collect_until_close(chars)?)))
 		}
 		Some('+') => {
 			chars.next();
-			Ok((name, Modifier::AltIfSet(collect_until_close(chars))))
+			Ok((name, Modifier::AltIfSet(collect_until_close(chars)?)))
 		}
 		Some('?') => {
 			chars.next();
-			Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars))))
+			Ok((name, Modifier::ErrorIfUnset(collect_until_close(chars)?)))
 		}
 		Some(&c) => Err(ComposeError::InvalidSubstitution(format!(
 			"unexpected character {c:?} in variable name '${{{name}…}}'"
@@ -107,7 +117,12 @@ pub(super) fn parse_braced_var(
 /// balancing nested braces so an inner `${…}` is captured whole. For
 /// `${FOO:-${BAR}}` the default is `${BAR}` (not `${BAR`), enabling nested
 /// interpolation in [`resolve_modifier`].
-fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
+///
+/// If the input ends before the matching `}` is reached the reference is
+/// unterminated (e.g. `${TAG:-latest` with no closing brace), which would
+/// otherwise silently swallow the rest of the document as the modifier value;
+/// that is reported as [`ComposeError::InvalidSubstitution`] instead.
+fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> Result<String> {
 	let mut buf = String::new();
 	let mut depth = 0u32;
 	for c in chars.by_ref() {
@@ -116,7 +131,7 @@ fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> 
 				depth += 1;
 				buf.push(c);
 			}
-			'}' if depth == 0 => break,
+			'}' if depth == 0 => return Ok(buf),
 			'}' => {
 				depth -= 1;
 				buf.push(c);
@@ -124,7 +139,9 @@ fn collect_until_close(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> 
 			_ => buf.push(c),
 		}
 	}
-	buf
+	Err(ComposeError::InvalidSubstitution(
+		"unterminated variable substitution: missing closing '}'".to_string(),
+	))
 }
 
 /// Apply a parsed `Modifier` to `var`, implementing compose's
@@ -136,31 +153,42 @@ pub(super) fn resolve_modifier(
 	var: String,
 	modifier: Modifier,
 	vars: &HashMap<String, String>,
+	depth: usize,
 ) -> Result<String> {
 	let value = vars.get(&var);
 
 	match modifier {
-		Modifier::None => Ok(value.cloned().unwrap_or_default()),
+		Modifier::None => match value {
+			Some(v) => Ok(v.clone()),
+			None => {
+				// Match docker compose v2, which warns on stderr before defaulting an
+				// unreferenced variable to the empty string, so config typos surface.
+				tracing::warn!("The {var} variable is not set. Defaulting to a blank string.");
+				Ok(String::new())
+			}
+		},
 
 		// Default/alt values are themselves interpolated (compose allows nesting,
-		// e.g. `${FOO:-${BAR}}`), but only when actually used.
+		// e.g. `${FOO:-${BAR}}`), but only when actually used. `depth` bounds that
+		// recursion so a pathological `${A:-${A:-…}}` chain returns an error rather
+		// than overflowing the stack.
 		Modifier::DefaultIfUnsetOrEmpty(default) => match value {
 			Some(v) if !v.is_empty() => Ok(v.clone()),
-			_ => super::substitute(&default, vars),
+			_ => super::substitute_depth(&default, vars, depth + 1),
 		},
 
 		Modifier::DefaultIfUnset(default) => match value {
 			Some(v) => Ok(v.clone()),
-			None => super::substitute(&default, vars),
+			None => super::substitute_depth(&default, vars, depth + 1),
 		},
 
 		Modifier::AltIfSetAndNonEmpty(alt) => match value {
-			Some(v) if !v.is_empty() => super::substitute(&alt, vars),
+			Some(v) if !v.is_empty() => super::substitute_depth(&alt, vars, depth + 1),
 			_ => Ok(String::new()),
 		},
 
 		Modifier::AltIfSet(alt) => match value {
-			Some(_) => super::substitute(&alt, vars),
+			Some(_) => super::substitute_depth(&alt, vars, depth + 1),
 			None => Ok(String::new()),
 		},
 
@@ -317,17 +345,60 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn parse_braced_var_rejects_empty_name() {
+		// `${}` has no name and must be rejected, not resolved to an empty string.
+		let mut it = peekable("}");
+		let err = parse_braced_var(&mut it).expect_err("empty name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
+	#[test]
+	fn parse_braced_var_rejects_digit_leading_name() {
+		// `${1BAD}` is not a valid identifier (must start with a letter or `_`).
+		let mut it = peekable("1BAD}");
+		let err = parse_braced_var(&mut it).expect_err("digit-leading name must be rejected");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
+	#[test]
+	fn parse_braced_var_underscore_name_is_valid() {
+		// A leading underscore is a valid identifier start.
+		let mut it = peekable("_FOO}");
+		let (name, modifier) = parse_braced_var(&mut it).unwrap();
+		assert_eq!(name, "_FOO");
+		assert!(matches!(modifier, Modifier::None));
+	}
+
+	#[test]
+	fn parse_unterminated_modifier_is_error() {
+		// `${TAG:-latest` (no closing `}`) must not swallow the rest of the input as
+		// the default value — it is reported as a malformed substitution.
+		let mut it = peekable("TAG:-latest\nmore: data\n");
+		let err = parse_braced_var(&mut it).expect_err("missing close brace must error");
+		assert!(
+			matches!(err, ComposeError::InvalidSubstitution(_)),
+			"{err:?}"
+		);
+	}
+
 	// --- resolve_modifier ---
 
 	#[test]
 	fn resolve_none_uses_value_or_empty() {
 		let v = vars(&[("A", "1")]);
 		assert_eq!(
-			resolve_modifier("A".into(), Modifier::None, &v).unwrap(),
+			resolve_modifier("A".into(), Modifier::None, &v, 0).unwrap(),
 			"1"
 		);
 		assert_eq!(
-			resolve_modifier("MISSING".into(), Modifier::None, &v).unwrap(),
+			resolve_modifier("MISSING".into(), Modifier::None, &v, 0).unwrap(),
 			""
 		);
 	}
@@ -336,20 +407,35 @@ mod tests {
 	fn resolve_default_if_unset_or_empty() {
 		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
 		let m = || Modifier::DefaultIfUnsetOrEmpty("def".into());
-		assert_eq!(resolve_modifier("EMPTY".into(), m(), &v).unwrap(), "def");
-		assert_eq!(resolve_modifier("MISSING".into(), m(), &v).unwrap(), "def");
-		assert_eq!(resolve_modifier("SET".into(), m(), &v).unwrap(), "x");
+		assert_eq!(resolve_modifier("EMPTY".into(), m(), &v, 0).unwrap(), "def");
+		assert_eq!(
+			resolve_modifier("MISSING".into(), m(), &v, 0).unwrap(),
+			"def"
+		);
+		assert_eq!(resolve_modifier("SET".into(), m(), &v, 0).unwrap(), "x");
 	}
 
 	#[test]
 	fn resolve_default_if_unset_keeps_empty_value() {
 		let v = vars(&[("EMPTY", "")]);
 		assert_eq!(
-			resolve_modifier("EMPTY".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			resolve_modifier(
+				"EMPTY".into(),
+				Modifier::DefaultIfUnset("def".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			""
 		);
 		assert_eq!(
-			resolve_modifier("MISSING".into(), Modifier::DefaultIfUnset("def".into()), &v).unwrap(),
+			resolve_modifier(
+				"MISSING".into(),
+				Modifier::DefaultIfUnset("def".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			"def"
 		);
 	}
@@ -358,24 +444,31 @@ mod tests {
 	fn resolve_alt_forms() {
 		let v = vars(&[("EMPTY", ""), ("SET", "x")]);
 		assert_eq!(
-			resolve_modifier("SET".into(), Modifier::AltIfSetAndNonEmpty("a".into()), &v).unwrap(),
+			resolve_modifier(
+				"SET".into(),
+				Modifier::AltIfSetAndNonEmpty("a".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			"a"
 		);
 		assert_eq!(
 			resolve_modifier(
 				"EMPTY".into(),
 				Modifier::AltIfSetAndNonEmpty("a".into()),
-				&v
+				&v,
+				0
 			)
 			.unwrap(),
 			""
 		);
 		assert_eq!(
-			resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
 			"a"
 		);
 		assert_eq!(
-			resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v).unwrap(),
+			resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
 			""
 		);
 	}
@@ -386,18 +479,25 @@ mod tests {
 		assert!(resolve_modifier(
 			"EMPTY".into(),
 			Modifier::ErrorIfUnsetOrEmpty("e".into()),
-			&v
+			&v,
+			0
 		)
 		.is_err());
 		assert_eq!(
-			resolve_modifier("SET".into(), Modifier::ErrorIfUnsetOrEmpty("e".into()), &v).unwrap(),
+			resolve_modifier(
+				"SET".into(),
+				Modifier::ErrorIfUnsetOrEmpty("e".into()),
+				&v,
+				0
+			)
+			.unwrap(),
 			"x"
 		);
 		assert!(
-			resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v).is_err()
+			resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).is_err()
 		);
 		assert_eq!(
-			resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v).unwrap(),
+			resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).unwrap(),
 			""
 		);
 	}

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -17,6 +17,9 @@ use anstyle::{AnsiColor, Style};
 
 pub use anstream::ColorChoice;
 
+mod table;
+pub use table::{fit_cell, Table};
+
 /// Apply the resolved colour choice process-wide and enable Windows VT once.
 ///
 /// anstream's `stdout()`/`stderr()` then honour this choice together with

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -61,6 +61,68 @@ pub fn stderr_colored() -> bool {
 	colored(std::io::stderr().is_terminal())
 }
 
+/// Process-wide switch for user-facing lifecycle progress output. Off by default
+/// so the library (consumed by other crates) stays silent unless asked; the CLI
+/// turns it on for the human-facing lifecycle commands. Progress is written to
+/// stderr (matching docker compose) so stdout stays a clean pipe for scripting
+/// and machine/JSON output.
+static PROGRESS_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Enable or disable user-facing lifecycle progress output process-wide. The CLI
+/// enables it for the lifecycle commands; embedders that want podup silent leave
+/// it off (the default).
+pub fn set_progress(enabled: bool) {
+	PROGRESS_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether user-facing lifecycle progress output is currently enabled.
+pub fn progress_enabled() -> bool {
+	PROGRESS_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Emit a concise per-resource lifecycle progress line to stderr, mirroring
+/// docker compose's `Container <name>  <Action>` progress stream (which also
+/// goes to stderr). `kind` is the resource noun (`Container`, `Network`,
+/// `Volume`, `Image`); `action` is the past-tense verb (`Started`, `Removed`,
+/// …), tinted green on a colour sink. A no-op unless [`set_progress`] enabled
+/// progress output, so stdout consumers and machine output are never polluted.
+pub fn progress_line(kind: &str, name: &str, action: &str) {
+	use std::io::Write;
+	if !progress_enabled() {
+		return;
+	}
+	let style = Style::new().fg_color(Some(AnsiColor::Green.into()));
+	// anstream::stderr strips the ANSI codes itself when colour is off.
+	let _ = writeln!(
+		anstream::stderr(),
+		" {kind} {name}  {}{action}{}",
+		style.render(),
+		style.render_reset()
+	);
+}
+
+/// Emit a plain user-facing progress note to stderr (e.g. a "nothing to do"
+/// line). A no-op unless [`set_progress`] enabled progress output.
+pub fn progress_note(msg: &str) {
+	use std::io::Write;
+	if !progress_enabled() {
+		return;
+	}
+	let _ = writeln!(anstream::stderr(), "{msg}");
+}
+
+/// Print a result line to stdout — used by `run -d` to echo the started
+/// container's name so scripts capturing stdout get the id, matching
+/// `docker compose run -d`. A no-op unless [`set_progress`] enabled progress
+/// output, so embedders and machine paths stay silent.
+pub fn result_line(msg: &str) {
+	use std::io::Write;
+	if !progress_enabled() {
+		return;
+	}
+	let _ = writeln!(anstream::stdout(), "{msg}");
+}
+
 /// Bold — table headers and emphasis.
 pub fn bold() -> Style {
 	Style::new().bold()
@@ -209,6 +271,18 @@ mod tests {
 		assert!(status_style("paused").is_some());
 		assert!(status_style("created").is_some());
 		assert!(status_style("weird-state").is_none());
+	}
+
+	#[test]
+	fn progress_toggle_is_observable() {
+		// Off by default-or-restored; toggling flips the observable state. Restore
+		// afterwards so the process-global flag does not leak into other tests.
+		let prev = progress_enabled();
+		set_progress(false);
+		assert!(!progress_enabled());
+		set_progress(true);
+		assert!(progress_enabled());
+		set_progress(prev);
 	}
 
 	#[test]

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -1,0 +1,244 @@
+//! Content-sized, truncating table rendering shared by the list commands
+//! (`ls`, `ps`, `images`). Each column sizes to its widest cell (bounded by an
+//! optional per-column cap, so a pathologically long value truncates with an
+//! ellipsis instead of shoving every later column off its header), the way
+//! `docker compose` lays out its tables. The trailing column is emitted raw
+//! (never padded). The `--quiet` and `--format json` paths bypass this entirely.
+
+/// Appended to a truncated cell to signal elision.
+const ELLIPSIS: char = '…';
+
+/// Fit `cell` into exactly `width` display columns: when it overflows, keep the
+/// leading `width - 1` chars and append an ellipsis; otherwise left-pad with
+/// spaces. Counts `char`s (not bytes) so multi-byte cells truncate on a char
+/// boundary and stay aligned. A `width` of 0 returns the cell unchanged — used
+/// for the trailing column, which is never padded or truncated.
+pub fn fit_cell(cell: &str, width: usize) -> String {
+	if width == 0 {
+		return cell.to_string();
+	}
+	let len = cell.chars().count();
+	if len <= width {
+		return format!("{cell:<width$}");
+	}
+	let mut out: String = cell.chars().take(width - 1).collect();
+	out.push(ELLIPSIS);
+	out
+}
+
+/// A list-command table whose columns size to their content (capped, so a
+/// pathologically long cell truncates with an ellipsis rather than pushing every
+/// later column past its header). The trailing column is emitted raw.
+#[derive(Default)]
+pub struct Table {
+	headers: Vec<String>,
+	/// Per-column max width; `None` sizes the column to its content unbounded.
+	caps: Vec<Option<usize>>,
+	/// The column (if any) whose cells are colourised by container status.
+	status_col: Option<usize>,
+	rows: Vec<Vec<String>>,
+}
+
+impl Table {
+	/// Start a table with the given column `headers`. Columns are uncapped (size
+	/// to content) until bounded with [`Table::cap`].
+	pub fn new(headers: &[&str]) -> Self {
+		Self {
+			headers: headers.iter().map(|h| (*h).to_string()).collect(),
+			caps: vec![None; headers.len()],
+			status_col: None,
+			rows: Vec::new(),
+		}
+	}
+
+	/// Cap column `col` at `max` display columns; wider cells truncate with an
+	/// ellipsis. The cap never shrinks a column below its header width.
+	pub fn cap(mut self, col: usize, max: usize) -> Self {
+		if let Some(slot) = self.caps.get_mut(col) {
+			*slot = Some(max);
+		}
+		self
+	}
+
+	/// Mark column `col` as the status column, so its cells are colourised by
+	/// meaning (green = up/healthy, red = exited/unhealthy, …) when stdout is a
+	/// colour sink.
+	pub fn status_col(mut self, col: usize) -> Self {
+		self.status_col = Some(col);
+		self
+	}
+
+	/// Append one data row. The cell count should match the header count; missing
+	/// cells render blank and extra cells are ignored.
+	pub fn push(&mut self, cells: Vec<String>) {
+		self.rows.push(cells);
+	}
+
+	/// Content-sized width of each column: the widest of the header and its cells,
+	/// bounded by the column cap (but never below the header width).
+	fn widths(&self) -> Vec<usize> {
+		self.headers
+			.iter()
+			.enumerate()
+			.map(|(col, header)| {
+				let header_w = header.chars().count();
+				let content = self
+					.rows
+					.iter()
+					.filter_map(|r| r.get(col))
+					.map(|c| c.chars().count())
+					.max()
+					.unwrap_or(0);
+				let mut w = header_w.max(content);
+				if let Some(cap) = self.caps[col] {
+					w = w.min(cap.max(header_w));
+				}
+				w
+			})
+			.collect()
+	}
+
+	/// Format one row's cells against the precomputed `widths`. The trailing
+	/// column is emitted raw; when `colour` the status column is tinted by its
+	/// meaning (the padding is applied first so the zero-width ANSI codes never
+	/// disturb alignment).
+	fn format_row(&self, cells: &[String], widths: &[usize], colour: bool) -> String {
+		let last = self.headers.len().saturating_sub(1);
+		(0..self.headers.len())
+			.map(|i| {
+				let cell = cells.get(i).map(String::as_str).unwrap_or("");
+				let w = if i == last { 0 } else { widths[i] };
+				let padded = fit_cell(cell, w);
+				if colour && Some(i) == self.status_col {
+					if let Some(style) = super::status_style(cell) {
+						return super::paint(style, &padded, true);
+					}
+				}
+				padded
+			})
+			.collect::<Vec<_>>()
+			.join(" ")
+	}
+
+	/// Render the table as plain (uncoloured) lines: the header first, then one
+	/// line per row, columns aligned and over-cap cells truncated. Pure — used by
+	/// the unit tests and shared with [`Table::print`].
+	pub fn render(&self) -> Vec<String> {
+		let widths = self.widths();
+		let mut out = Vec::with_capacity(self.rows.len() + 1);
+		out.push(self.format_row(&self.headers, &widths, false));
+		for row in &self.rows {
+			out.push(self.format_row(row, &widths, false));
+		}
+		out
+	}
+
+	/// Print the table to stdout: a bold header followed by the rows, with the
+	/// status column (if any) colourised when stdout is a colour sink.
+	pub fn print(&self) {
+		let widths = self.widths();
+		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
+		let colour = self.status_col.is_some() && super::stdout_colored();
+		for row in &self.rows {
+			println!("{}", self.format_row(row, &widths, colour));
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn fit_cell_pads_short_values_to_width() {
+		assert_eq!(fit_cell("web", 6), "web   ");
+		// Exactly the width is kept verbatim (padded to itself).
+		assert_eq!(fit_cell("alpine", 6), "alpine");
+	}
+
+	#[test]
+	fn fit_cell_truncates_with_an_ellipsis() {
+		// One over the width: keep width-1 chars plus the ellipsis (display width
+		// stays == width).
+		let out = fit_cell("docker.io/library/alpine", 10);
+		assert_eq!(out.chars().count(), 10);
+		assert!(out.ends_with(ELLIPSIS));
+		assert!(out.starts_with("docker.io"));
+	}
+
+	#[test]
+	fn fit_cell_counts_chars_not_bytes() {
+		// Multi-byte cell truncated on a char boundary, no panic, width honoured.
+		let out = fit_cell("café-service-name", 6);
+		assert_eq!(out.chars().count(), 6);
+		assert!(out.ends_with(ELLIPSIS));
+	}
+
+	#[test]
+	fn fit_cell_width_zero_returns_cell_unchanged() {
+		assert_eq!(fit_cell("anything-at-all", 0), "anything-at-all");
+		assert_eq!(fit_cell("", 0), "");
+	}
+
+	#[test]
+	fn columns_size_to_their_widest_cell() {
+		let mut t = Table::new(&["NAME", "STATUS"]);
+		t.push(vec!["a-very-long-project-name".into(), "running(1)".into()]);
+		t.push(vec!["x".into(), "exited(1)".into()]);
+		let lines = t.render();
+		// Header NAME column is padded to the widest name (24 chars), so STATUS
+		// starts at the same offset on every line.
+		let name_w = "a-very-long-project-name".chars().count();
+		assert!(lines[0].starts_with(&format!("{:<width$} ", "NAME", width = name_w)));
+		assert!(lines[2].starts_with(&format!("{:<width$} ", "x", width = name_w)));
+		// Short content does not blow the column out to a fixed width.
+		assert_eq!(name_w, 24);
+	}
+
+	#[test]
+	fn over_cap_cells_truncate_and_stay_aligned() {
+		let mut t = Table::new(&["NAME", "STATUS"]).cap(0, 10).status_col(1);
+		t.push(vec!["this-name-is-far-too-long".into(), "running".into()]);
+		t.push(vec!["short".into(), "exited".into()]);
+		let lines = t.render();
+		// Every line's first column occupies exactly the cap (10) before the gap,
+		// so STATUS lands in the same place; the long name carries the ellipsis.
+		for line in &lines {
+			assert_eq!(
+				line.chars().nth(10),
+				Some(' '),
+				"gap at the cap on {line:?}"
+			);
+		}
+		assert!(lines[1].contains(ELLIPSIS));
+	}
+
+	#[test]
+	fn cap_never_shrinks_below_the_header() {
+		// A cap smaller than the header keeps the header intact (no truncation).
+		let mut t = Table::new(&["REPOSITORY"]).cap(0, 3);
+		t.push(vec!["x".into()]);
+		let lines = t.render();
+		assert_eq!(lines[0], "REPOSITORY");
+	}
+
+	#[test]
+	fn trailing_column_is_emitted_raw() {
+		// The last column is neither padded nor truncated (no later column to
+		// misalign), even when much longer than its header.
+		let mut t = Table::new(&["NAME", "PORTS"]).cap(0, 8);
+		let ports = "0.0.0.0:8080->80/tcp, 0.0.0.0:8443->443/tcp";
+		t.push(vec!["web".into(), ports.into()]);
+		let lines = t.render();
+		assert!(lines[1].ends_with(ports));
+	}
+
+	#[test]
+	fn missing_cells_render_blank() {
+		let mut t = Table::new(&["A", "B"]);
+		t.push(vec!["only-a".into()]);
+		let lines = t.render();
+		// No panic; the absent B cell is blank (the line is the padded A plus a gap).
+		assert!(lines[1].starts_with("only-a"));
+	}
+}

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -44,42 +44,6 @@ pub fn require_platform_asset() -> crate::Result<&'static str> {
 	})
 }
 
-/// Name of the system package manager that owns the running binary, if any.
-///
-/// Self-update replaces the executable in place, which would corrupt a package
-/// manager's record of the installed file. When the running binary is tracked
-/// by such a manager the caller refuses and redirects the user to it.
-///
-/// Only `dpkg`/`apt` is detected, on Linux. cargo-install layouts
-/// (`~/.cargo/bin`, `/usr/local/bin`) are not owned by `dpkg` and update
-/// normally. A missing `dpkg-query`, or a path no package owns, returns `None`.
-#[cfg(target_os = "linux")]
-pub fn managing_package_manager() -> Option<&'static str> {
-	let exe = std::env::current_exe().ok()?;
-	let path = std::fs::canonicalize(&exe).unwrap_or(exe);
-	let output = std::process::Command::new("dpkg-query")
-		.arg("-S")
-		.arg(&path)
-		.output()
-		.ok()?;
-	output.status.success().then_some("apt")
-}
-
-/// Non-Linux platforms have no supported package-manager-managed install yet.
-#[cfg(not(target_os = "linux"))]
-pub fn managing_package_manager() -> Option<&'static str> {
-	None
-}
-
-/// Error returned when the running binary is managed by package manager `pm`.
-pub fn package_managed_error(pm: &str) -> ComposeError {
-	ComposeError::Update(format!(
-		"this podup was installed by {pm}; update it with your package manager \
-		 (e.g. `apt upgrade podup`) rather than `podup update`, which would break \
-		 the package's record of the file"
-	))
-}
-
 /// Replace the currently running executable with `new_bytes`. Returns the path
 /// that was updated. The caller MUST have verified `new_bytes` first.
 pub fn install_binary(new_bytes: &[u8]) -> crate::Result<PathBuf> {
@@ -414,25 +378,6 @@ mod tests {
 			(None, Err(_)) => {}
 			_ => panic!("platform_asset and require_platform_asset disagree"),
 		}
-	}
-
-	#[test]
-	fn package_managed_error_names_the_manager() {
-		let e = package_managed_error("apt");
-		match e {
-			ComposeError::Update(msg) => {
-				assert!(msg.contains("apt"));
-				assert!(msg.contains("podup update"));
-			}
-			_ => panic!("expected an Update error"),
-		}
-	}
-
-	#[test]
-	fn test_binary_is_not_package_managed() {
-		// The test runner binary lives under target/, which no package owns, so
-		// detection must not false-positive and block updates for normal builds.
-		assert_eq!(managing_package_manager(), None);
 	}
 
 	#[test]

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -10,6 +10,7 @@
 
 mod github;
 mod install;
+mod pkg;
 mod verify;
 
 pub use github::{GitHubSource, REPO};
@@ -46,7 +47,7 @@ pub fn run_with(
 	current: &str,
 	opts: UpdateOptions,
 ) -> crate::Result<()> {
-	run_with_guard(source, current, opts, install::managing_package_manager())
+	run_with_guard(source, current, opts, pkg::managing_package_manager())
 }
 
 /// [`run_with`] with the package-manager guard injected, so the refusal branch
@@ -79,7 +80,7 @@ fn run_with_guard(
 	// Refuse to self-replace a package-manager-managed binary (even with
 	// --force): overwriting it would desync the package manager's records.
 	if let Some(pm) = managed_by {
-		return Err(install::package_managed_error(pm));
+		return Err(pkg::package_managed_error(pm));
 	}
 
 	let asset = install::require_platform_asset()?;

--- a/internal/update/pkg.rs
+++ b/internal/update/pkg.rs
@@ -1,0 +1,147 @@
+//! Detect whether the running binary is owned by a system package manager.
+//!
+//! Self-update replaces the executable in place, which would corrupt a package
+//! manager's record of the installed file. When the running binary is tracked by
+//! such a manager the caller refuses and redirects the user to it.
+
+#[cfg(target_os = "linux")]
+use std::path::Path;
+
+use crate::ComposeError;
+
+/// Name of the system package manager that owns the running binary, if any.
+///
+/// Only `dpkg`/`apt` is detected, on Linux. cargo-install layouts
+/// (`~/.cargo/bin`, `/usr/local/bin`) are not owned by `dpkg` and update
+/// normally. A path no package owns returns `None`.
+#[cfg(target_os = "linux")]
+pub fn managing_package_manager() -> Option<&'static str> {
+	let exe = std::env::current_exe().ok()?;
+	let path = std::fs::canonicalize(&exe).unwrap_or(exe);
+	dpkg_owns(&path).then_some("apt")
+}
+
+/// Whether dpkg's database records `path` as belonging to an installed package.
+///
+/// The primary check is `dpkg-query -S <path>`. Crucially this must not *fail
+/// open*: if the helper cannot be spawned (missing, not executable, or denied)
+/// we do not assume the file is unmanaged — that would let self-update clobber an
+/// apt-owned binary and desync the dpkg database. Instead we fall back to reading
+/// dpkg's on-disk file lists directly. A host with no dpkg database at all
+/// (`/var/lib/dpkg/info` absent — e.g. Fedora or a cargo-install) is genuinely
+/// not Debian-managed, so both paths report `false` and update proceeds.
+#[cfg(target_os = "linux")]
+fn dpkg_owns(path: &Path) -> bool {
+	match std::process::Command::new("dpkg-query")
+		.arg("-S")
+		.arg(path)
+		.output()
+	{
+		// dpkg-query ran to completion: trust its verdict (success == owned).
+		Ok(output) => output.status.success(),
+		// dpkg-query could not be spawned. Don't fail open — consult dpkg's
+		// own file lists, which exist only on a Debian-family system.
+		Err(_) => dpkg_lists_contain(path),
+	}
+}
+
+/// Fallback ownership check: scan dpkg's installed-file manifests
+/// (`/var/lib/dpkg/info/*.list`) for an exact line matching `path`.
+#[cfg(target_os = "linux")]
+fn dpkg_lists_contain(path: &Path) -> bool {
+	dpkg_lists_contain_in(Path::new("/var/lib/dpkg/info"), path)
+}
+
+/// Core of [`dpkg_lists_contain`], parameterised on the info directory so it can
+/// be tested against a fixture without a real dpkg database. Returns `false`
+/// when the directory is absent (not a Debian host).
+#[cfg(target_os = "linux")]
+fn dpkg_lists_contain_in(info_dir: &Path, path: &Path) -> bool {
+	let Ok(entries) = std::fs::read_dir(info_dir) else {
+		return false; // no dpkg database → not Debian-managed
+	};
+	let needle = path.to_string_lossy();
+	for entry in entries.flatten() {
+		let p = entry.path();
+		if p.extension().and_then(|e| e.to_str()) != Some("list") {
+			continue;
+		}
+		if let Ok(contents) = std::fs::read_to_string(&p) {
+			if contents.lines().any(|line| line == needle) {
+				return true;
+			}
+		}
+	}
+	false
+}
+
+/// Non-Linux platforms have no supported package-manager-managed install yet.
+#[cfg(not(target_os = "linux"))]
+pub fn managing_package_manager() -> Option<&'static str> {
+	None
+}
+
+/// Error returned when the running binary is managed by package manager `pm`.
+pub fn package_managed_error(pm: &str) -> ComposeError {
+	ComposeError::Update(format!(
+		"this podup was installed by {pm}; update it with your package manager \
+		 (e.g. `apt upgrade podup`) rather than `podup update`, which would break \
+		 the package's record of the file"
+	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn package_managed_error_names_the_manager() {
+		let e = package_managed_error("apt");
+		match e {
+			ComposeError::Update(msg) => {
+				assert!(msg.contains("apt"));
+				assert!(msg.contains("podup update"));
+			}
+			_ => panic!("expected an Update error"),
+		}
+	}
+
+	#[test]
+	fn test_binary_is_not_package_managed() {
+		// The test runner binary lives under target/, which no package owns, so
+		// detection must not false-positive and block updates for normal builds.
+		assert_eq!(managing_package_manager(), None);
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn dpkg_lists_fallback_matches_an_owned_path() {
+		// Simulate dpkg's info dir: a `.list` file naming the binary's path means
+		// the file is package-managed and self-update must refuse.
+		let dir = tempfile::tempdir().unwrap();
+		let owned = Path::new("/usr/bin/podup");
+		std::fs::write(
+			dir.path().join("podup.list"),
+			"/.\n/usr/bin\n/usr/bin/podup\n",
+		)
+		.unwrap();
+		// A non-`.list` file with the same name must be ignored.
+		std::fs::write(dir.path().join("other.md5sums"), "/usr/bin/podup\n").unwrap();
+
+		assert!(dpkg_lists_contain_in(dir.path(), owned));
+		assert!(!dpkg_lists_contain_in(
+			dir.path(),
+			Path::new("/usr/bin/somethingelse")
+		));
+	}
+
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn dpkg_lists_fallback_is_false_without_a_database() {
+		// No dpkg info directory (e.g. Fedora, cargo-install): genuinely not
+		// Debian-managed, so the fallback reports unowned and update proceeds.
+		let dir = tempfile::tempdir().unwrap();
+		let absent = dir.path().join("no-such-info-dir");
+		assert!(!dpkg_lists_contain_in(&absent, Path::new("/usr/bin/podup")));
+	}
+}

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -178,3 +178,34 @@ fn config_no_interpolate_keeps_placeholders_literal() {
 		"--no-interpolate must keep ${{PODUP_TAG}} literal"
 	);
 }
+
+/// `update` only rewrites the podup binary, so the compose-only global value
+/// flags (--socket/--profile/--env-file/--project-directory) cannot affect it.
+/// Passing one on the command line is rejected as a usage error rather than
+/// silently accepted as a no-op — and the rejection happens before any network
+/// access, so the test never reaches GitHub.
+#[test]
+fn update_rejects_compose_only_global_flags() {
+	for flag in [
+		"--socket=unix:///tmp/nope.sock",
+		"--profile=dev",
+		"--env-file=/tmp/nope.env",
+		"--project-directory=/tmp",
+	] {
+		let output = Command::new(bin())
+			.args([flag, "update", "--check"])
+			.env_remove("PODMAN_SOCKET")
+			.env_remove("COMPOSE_PROFILES")
+			.output()
+			.expect("run podup update with a compose-only flag");
+		assert!(
+			!output.status.success(),
+			"`{flag}` must be rejected for update, got success"
+		);
+		let stderr = String::from_utf8_lossy(&output.stderr);
+		assert!(
+			stderr.contains("no effect on `update`"),
+			"rejection should explain the misuse for {flag}; got stderr:\n{stderr}"
+		);
+	}
+}

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -179,6 +179,75 @@ fn config_no_interpolate_keeps_placeholders_literal() {
 	);
 }
 
+#[test]
+fn config_warns_on_unset_interpolation_variable() {
+	// An unset `${VAR}` interpolates to an empty string but must warn on stderr
+	// (matching docker compose) so a config typo does not pass silently.
+	let dir = std::env::temp_dir().join(format!("podup-unset-warn-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: ${PODUP_UNSET_IMAGE}\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "config"])
+		.env_remove("PODUP_UNSET_IMAGE")
+		.output()
+		.unwrap();
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("PODUP_UNSET_IMAGE") && stderr.contains("not set"),
+		"expected an unset-variable warning on stderr, got: {stderr:?}"
+	);
+}
+
+#[test]
+fn config_no_interpolate_skips_required_var_error() {
+	// `--no-interpolate` must not evaluate a required-var `${VAR:?msg}`: with the
+	// variable unset the command should still succeed and print the placeholder
+	// literally, rather than failing on the required-var check.
+	let dir = std::env::temp_dir().join(format!("podup-noint-req-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: ${MUST_SET:?required}\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	// With interpolation on, the required-var error fails the command.
+	let interp = Command::new(bin())
+		.args(["-f", c, "config"])
+		.env_remove("MUST_SET")
+		.output()
+		.unwrap();
+	assert!(
+		!interp.status.success(),
+		"default config must fail on the required-var"
+	);
+
+	// With --no-interpolate, the file is printed uninterpolated and succeeds.
+	let raw = Command::new(bin())
+		.args(["-f", c, "config", "--no-interpolate"])
+		.env_remove("MUST_SET")
+		.output()
+		.unwrap();
+	assert!(
+		raw.status.success(),
+		"config --no-interpolate must not evaluate the required-var: {:?}",
+		String::from_utf8_lossy(&raw.stderr)
+	);
+	assert!(
+		String::from_utf8_lossy(&raw.stdout).contains("${MUST_SET:?required}"),
+		"--no-interpolate must keep the placeholder literal"
+	);
+}
+
 /// `update` only rewrites the podup binary, so the compose-only global value
 /// flags (--socket/--profile/--env-file/--project-directory) cannot affect it.
 /// Passing one on the command line is rejected as a usage error rather than

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -179,6 +179,39 @@ fn config_no_interpolate_keeps_placeholders_literal() {
 	);
 }
 
+/// `--no-recreate` and `--force-recreate` are mutually exclusive: clap must
+/// reject them together at parse time (exit non-zero) rather than silently
+/// letting force-recreate win, matching docker compose.
+#[test]
+fn up_rejects_no_recreate_with_force_recreate() {
+	let output = Command::new(bin())
+		.args(["up", "--no-recreate", "--force-recreate"])
+		.output()
+		.expect("run up with conflicting flags");
+	assert!(
+		!output.status.success(),
+		"conflicting recreate flags must be rejected"
+	);
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(
+		stderr.contains("cannot be used with") || stderr.contains("conflict"),
+		"expected a clap conflict error; got:\n{stderr}"
+	);
+}
+
+/// The same exclusivity holds for `create`.
+#[test]
+fn create_rejects_no_recreate_with_force_recreate() {
+	let output = Command::new(bin())
+		.args(["create", "--no-recreate", "--force-recreate"])
+		.output()
+		.expect("run create with conflicting flags");
+	assert!(
+		!output.status.success(),
+		"conflicting recreate flags must be rejected"
+	);
+}
+
 #[test]
 fn config_warns_on_unset_interpolation_variable() {
 	// An unset `${VAR}` interpolates to an empty string but must warn on stderr

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -1,0 +1,358 @@
+//! CLI-surface checks for the flag-parity sweep: interspersed flags after a
+//! service positional, value validation, conflicting-flag rejection, the
+//! tolerant `help` handler, non-zero exits for missing subcommands, and the new
+//! per-command flags. These exercise the built binary's argument parsing and
+//! exit codes; none of them contact Podman (they either stop at `--help`, fail
+//! parsing, or reach runtime against a nonexistent socket).
+
+use std::fs;
+use std::process::{Command, Output};
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// True when clap rejected the arguments itself (exit 2 with the `error:`/
+/// `Usage:` banner) rather than parsing and failing later at runtime.
+fn is_clap_usage_error(out: &Output) -> bool {
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	out.status.code() == Some(2) && stderr.contains("error:") && stderr.contains("Usage:")
+}
+
+/// True when clap rejected a value (exit 2 with an `error:` line). Value-parser
+/// errors print the offending value and a `--help` hint but no `Usage:` banner.
+fn is_clap_value_error(out: &Output) -> bool {
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	out.status.code() == Some(2) && stderr.contains("error:")
+}
+
+/// Run podup against a nonexistent socket so a parsed command reaches runtime
+/// (and fails connecting) instead of being rejected by clap.
+fn run_offline(args: &[&str]) -> Output {
+	let mut full = vec!["--socket", "/nonexistent.sock"];
+	full.extend_from_slice(args);
+	Command::new(bin())
+		.args(&full)
+		.output()
+		.expect("run podup offline")
+}
+
+fn help_of(cmd: &str) -> String {
+	let out = Command::new(bin())
+		.args([cmd, "--help"])
+		.output()
+		.expect("run <cmd> --help");
+	assert!(out.status.success(), "`{cmd} --help` failed");
+	String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+// --- #717: flags after a service positional are no longer swallowed ----------
+
+#[test]
+fn flags_after_service_positional_parse() {
+	// Each of these used to capture the trailing flag as a phantom service.
+	for args in [
+		&["pull", "web", "--ignore-pull-failures"][..],
+		&["push", "web", "--ignore-push-failures"][..],
+		&["kill", "web", "-s", "SIGTERM"][..],
+		&["wait", "web", "--help"][..],
+		&["volumes", "web", "--quiet"][..],
+	] {
+		let out = run_offline(args);
+		assert!(
+			!is_clap_usage_error(&out),
+			"`{args:?}` should parse interspersed flags; got:\n{}",
+			String::from_utf8_lossy(&out.stderr)
+		);
+	}
+}
+
+// --- #747: invalid pull policy rejected at parse time ------------------------
+
+#[test]
+fn invalid_pull_policy_is_rejected() {
+	for args in [
+		&["pull", "--policy", "bogus"][..],
+		&["up", "--pull", "nope"][..],
+	] {
+		let out = run_offline(args);
+		assert!(
+			is_clap_value_error(&out),
+			"`{args:?}` should be a parse error; got:\n{}",
+			String::from_utf8_lossy(&out.stderr)
+		);
+	}
+	// A valid value parses.
+	assert!(!is_clap_value_error(&run_offline(&[
+		"pull", "--policy", "always", "web"
+	])));
+}
+
+// --- #840/#843: up --wait-timeout, and it requires --wait -------------------
+
+#[test]
+fn up_has_wait_timeout_that_requires_wait() {
+	assert!(help_of("up").contains("--wait-timeout"));
+	// Without --wait it is a usage error (clap `requires`).
+	assert!(is_clap_usage_error(&run_offline(&[
+		"start",
+		"--wait-timeout",
+		"30"
+	])));
+	assert!(is_clap_usage_error(&run_offline(&[
+		"up",
+		"--wait-timeout",
+		"30"
+	])));
+	// With --wait it parses.
+	assert!(!is_clap_usage_error(&run_offline(&[
+		"up",
+		"--wait",
+		"--wait-timeout",
+		"30"
+	])));
+}
+
+// --- #841: conflicting recreate/build flags are rejected ---------------------
+
+#[test]
+fn conflicting_recreate_and_build_flags_are_rejected() {
+	for args in [
+		&["up", "--no-recreate", "--force-recreate"][..],
+		&["up", "--build", "--no-build"][..],
+		&["create", "--no-recreate", "--force-recreate"][..],
+	] {
+		assert!(
+			is_clap_usage_error(&run_offline(args)),
+			"`{args:?}` should be rejected as conflicting"
+		);
+	}
+}
+
+// --- #842: negative --timeout rejected in both spellings --------------------
+
+#[test]
+fn negative_timeout_is_rejected_consistently() {
+	for args in [
+		&["down", "--timeout=-5"][..],
+		&["down", "-t", "-5"][..],
+		&["stop", "-t", "-1"][..],
+	] {
+		assert!(
+			is_clap_value_error(&run_offline(args)),
+			"`{args:?}` should be a clear range error"
+		);
+	}
+	// Zero and positive are fine.
+	assert!(!is_clap_value_error(&run_offline(&["down", "--timeout=0"])));
+}
+
+// --- #844: create --pull / --no-deps ----------------------------------------
+
+#[test]
+fn create_exposes_pull_and_no_deps() {
+	let h = help_of("create");
+	assert!(h.contains("--no-deps"), "create missing --no-deps:\n{h}");
+	assert!(h.contains("--pull"), "create missing --pull:\n{h}");
+}
+
+// --- #845/#847/#848/#849/#850/#851/#854: new per-command flags in help ------
+
+#[test]
+fn new_command_flags_appear_in_help() {
+	assert!(help_of("ls").contains("--filter"));
+	let push = help_of("push");
+	assert!(push.contains("--quiet"));
+	let build = help_of("build");
+	assert!(build.contains("--push") && build.contains("--progress"));
+	assert!(help_of("run").contains("--label"));
+	let events = help_of("events");
+	assert!(
+		events.contains("--since") && events.contains("--until") && events.contains("--filter")
+	);
+	assert!(help_of("attach").contains("--index"));
+	let logs = help_of("logs");
+	assert!(logs.contains("--no-color") && logs.contains("--no-log-prefix"));
+	let config = help_of("config");
+	for flag in [
+		"--volumes",
+		"--images",
+		"--profiles",
+		"--hash",
+		"--no-normalize",
+	] {
+		assert!(config.contains(flag), "config missing {flag}:\n{config}");
+	}
+}
+
+// --- #855: --ansi help mentions the NO_COLOR override -----------------------
+
+#[test]
+fn ansi_help_text_clarifies_no_color_override() {
+	let out = Command::new(bin()).arg("--help").output().unwrap();
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		stdout.contains("overrides"),
+		"--ansi help should clarify that `always` overrides NO_COLOR:\n{stdout}"
+	);
+}
+
+// --- #857: help tolerates extra args, -h/--help, and -- ---------------------
+
+#[test]
+fn help_subcommand_is_tolerant() {
+	for args in [
+		&["help", "up", "down"][..],
+		&["help", "-h"][..],
+		&["help", "--help"][..],
+		&["help", "--", "up"][..],
+		&["help"][..],
+	] {
+		let out = Command::new(bin())
+			.args(args)
+			.output()
+			.expect("run help variant");
+		assert!(
+			out.status.success(),
+			"`{args:?}` should exit 0; got {:?}\n{}",
+			out.status.code(),
+			String::from_utf8_lossy(&out.stderr)
+		);
+	}
+	// `help up down` shows up's help.
+	let out = Command::new(bin())
+		.args(["help", "up", "down"])
+		.output()
+		.unwrap();
+	assert!(String::from_utf8_lossy(&out.stdout).contains("Create and start"));
+}
+
+// --- #858/#859: missing subcommand exits non-zero ---------------------------
+
+#[test]
+fn missing_subcommand_exits_non_zero() {
+	let none = Command::new(bin())
+		.output()
+		.expect("run podup with no args");
+	assert!(!none.status.success(), "no args must exit non-zero");
+	let gen = Command::new(bin())
+		.arg("generate")
+		.output()
+		.expect("run generate");
+	assert!(
+		!gen.status.success(),
+		"generate with no subcommand must exit non-zero"
+	);
+}
+
+// --- #860: --project-directory must exist -----------------------------------
+
+#[test]
+fn missing_project_directory_is_rejected() {
+	let out = Command::new(bin())
+		.args(["--project-directory", "/no/such/podup/dir", "config"])
+		.output()
+		.expect("run with bad project-directory");
+	assert!(
+		!out.status.success(),
+		"missing project directory must error"
+	);
+	assert!(
+		String::from_utf8_lossy(&out.stderr).contains("project-directory"),
+		"error should name --project-directory:\n{}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+}
+
+// --- #861: deprecated --json conflicts with an explicit --format ------------
+
+#[test]
+fn events_json_conflicts_with_explicit_format() {
+	assert!(is_clap_usage_error(&run_offline(&[
+		"events", "--json", "--format", "json"
+	])));
+	// Each spelling alone still parses.
+	assert!(!is_clap_usage_error(&run_offline(&["events", "--json"])));
+	assert!(!is_clap_usage_error(&run_offline(&[
+		"events", "--format", "json"
+	])));
+}
+
+// --- #863/#862: positional service / dash output reach runtime --------------
+
+#[test]
+fn images_and_export_positionals_parse() {
+	assert!(!is_clap_usage_error(&run_offline(&["images", "web"])));
+	assert!(!is_clap_usage_error(&run_offline(&[
+		"export", "web", "-o", "-"
+	])));
+}
+
+// --- #750: DOCKER_HOST with a remote scheme is rejected (not ignored) -------
+
+#[test]
+fn docker_host_remote_scheme_is_rejected() {
+	let out = Command::new(bin())
+		.arg("ls")
+		.env_remove("PODMAN_SOCKET")
+		.env("DOCKER_HOST", "tcp://127.0.0.1:2375")
+		.output()
+		.expect("run ls with DOCKER_HOST");
+	assert!(!out.status.success(), "remote DOCKER_HOST must error");
+	assert!(
+		String::from_utf8_lossy(&out.stderr).contains("remote Podman"),
+		"DOCKER_HOST=tcp:// should be rejected as remote:\n{}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+}
+
+// --- #856: config list projections render the expected lines ----------------
+
+#[test]
+fn config_projections_render_lists() {
+	let dir = std::env::temp_dir().join(format!("podup-cflags-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("compose.yaml");
+	// `web` is always active; `admin` lives behind the `frontend` profile so the
+	// profile-aware projections are exercised when that profile is activated.
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: nginx:1.27\n  admin:\n    image: busybox:1.36\n    profiles: [frontend]\nvolumes:\n  data: {}\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let volumes = Command::new(bin())
+		.args(["-f", c, "config", "--volumes"])
+		.output()
+		.unwrap();
+	assert!(volumes.status.success());
+	assert!(String::from_utf8_lossy(&volumes.stdout)
+		.lines()
+		.any(|l| l == "data"));
+
+	let images = Command::new(bin())
+		.args(["-f", c, "config", "--images"])
+		.output()
+		.unwrap();
+	assert!(String::from_utf8_lossy(&images.stdout).contains("nginx:1.27"));
+
+	// `--profiles` lists the declared profiles of the active services; activate
+	// `frontend` so `admin` (and its profile) survive profile resolution.
+	let profiles = Command::new(bin())
+		.args(["-f", c, "--profile", "frontend", "config", "--profiles"])
+		.output()
+		.unwrap();
+	assert!(String::from_utf8_lossy(&profiles.stdout)
+		.lines()
+		.any(|l| l == "frontend"));
+
+	let hash = Command::new(bin())
+		.args(["-f", c, "config", "--hash", "*"])
+		.output()
+		.unwrap();
+	assert!(hash.status.success());
+	assert!(String::from_utf8_lossy(&hash.stdout).contains("web "));
+
+	let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -68,3 +68,5 @@ mod cli_lifecycle;
 mod create_ls;
 #[path = "engine_integration/scale.rs"]
 mod scale;
+#[path = "engine_integration/stats_flags.rs"]
+mod stats_flags;

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -66,6 +66,8 @@ mod cli_flags;
 mod cli_lifecycle;
 #[path = "engine_integration/create_ls.rs"]
 mod create_ls;
+#[path = "engine_integration/lifecycle_output.rs"]
+mod lifecycle_output;
 #[path = "engine_integration/scale.rs"]
 mod scale;
 #[path = "engine_integration/stats_flags.rs"]

--- a/tests/engine_integration/cli_lifecycle.rs
+++ b/tests/engine_integration/cli_lifecycle.rs
@@ -334,3 +334,125 @@ async fn cli_kill_subcommand() {
 		.output()
 		.unwrap();
 }
+
+/// #758: `down` on a defined-but-never-created project is a clean, quiet no-op —
+/// it must not synthesize predicted container names and leak a raw 404 / "could
+/// not stop" warning.
+#[tokio::test]
+async fn cli_down_on_never_created_is_quiet_noop() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-dnvr", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	// `down` without a prior `up`: nothing exists, so this must exit 0 cleanly.
+	let down = Command::new(bin())
+		.env("RUST_LOG", "info")
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
+		.output()
+		.unwrap();
+	assert!(
+		down.status.success(),
+		"down on never-created failed: {}",
+		String::from_utf8_lossy(&down.stderr)
+	);
+	let stderr = String::from_utf8_lossy(&down.stderr);
+	assert!(
+		!stderr.contains("404") && !stderr.contains("no such container"),
+		"down leaked a 404 for a never-created project: {stderr}"
+	);
+	assert!(
+		!stderr.contains("could not stop"),
+		"down warned about stopping a phantom container: {stderr}"
+	);
+}
+
+/// #758: `wait` on a defined-but-never-created service returns cleanly instead of
+/// surfacing a raw `podman API error (HTTP 404)`.
+#[tokio::test]
+async fn cli_wait_on_never_created_is_quiet_noop() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-wnvr", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	let wait = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "wait", "web"])
+		.output()
+		.unwrap();
+	assert!(
+		wait.status.success(),
+		"wait on never-created failed: {}",
+		String::from_utf8_lossy(&wait.stderr)
+	);
+	let stderr = String::from_utf8_lossy(&wait.stderr);
+	assert!(
+		!stderr.contains("404"),
+		"wait leaked a 404 for a never-created service: {stderr}"
+	);
+}
+
+/// #876: `stop` on a Created (never-started) container must not claim it was
+/// "stopped" — it is a harmless no-op, so no "stopped" line is logged.
+#[tokio::test]
+async fn cli_stop_on_created_does_not_report_stopped() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-screa", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	// `create` builds the container but never starts it (state = Created).
+	let create = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "create"])
+		.output()
+		.unwrap();
+	assert!(
+		create.status.success(),
+		"create failed: {}",
+		String::from_utf8_lossy(&create.stderr)
+	);
+
+	// `stop` with INFO logging on: a not-running container must not be reported
+	// as "stopped".
+	let stop = Command::new(bin())
+		.env("RUST_LOG", "info")
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "stop"])
+		.output()
+		.unwrap();
+	assert!(
+		stop.status.success(),
+		"stop failed: {}",
+		String::from_utf8_lossy(&stop.stderr)
+	);
+	let stderr = String::from_utf8_lossy(&stop.stderr);
+	assert!(
+		!stderr.contains("stopped"),
+		"stop claimed it stopped a not-running container: {stderr}"
+	);
+
+	Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}

--- a/tests/engine_integration/cp_flags.rs
+++ b/tests/engine_integration/cp_flags.rs
@@ -15,8 +15,11 @@ async fn engine_cp_index_out_of_range_errors() {
 	let engine = Engine::new(client, proj.clone());
 	let file = parse_str("services:\n  web:\n    image: alpine:latest\n").unwrap();
 
-	// No --index target replica 9 of a single-replica service: must error rather
-	// than silently fall back to the first container.
+	// Target replica 9 of a single-replica service: must error rather than
+	// silently fall back to the first container. The replica-resolution fix
+	// reports this as a typed `ReplicaIndex` (named service, 1-based index)
+	// instead of a generic `ServiceNotFound`, so the user sees exactly which
+	// index is out of range.
 	let result = engine
 		.cp_with_options(
 			&file,
@@ -29,8 +32,11 @@ async fn engine_cp_index_out_of_range_errors() {
 		)
 		.await;
 	assert!(
-		matches!(result, Err(podup::ComposeError::ServiceNotFound(_))),
-		"out-of-range --index must error, got {result:?}"
+		matches!(
+			result,
+			Err(podup::ComposeError::ReplicaIndex { ref service, index: 9 }) if service == "web"
+		),
+		"out-of-range --index must error with ReplicaIndex, got {result:?}"
 	);
 }
 

--- a/tests/engine_integration/lifecycle.rs
+++ b/tests/engine_integration/lifecycle.rs
@@ -323,6 +323,68 @@ async fn exec_unknown_service_fails() {
 }
 
 #[tokio::test]
+async fn exec_nonexistent_user_fails_fast() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("exbu");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	// A nonexistent named user must surface a prompt, clear error — never hang for
+	// the full client read timeout (~120s) and then report a misleading
+	// socket-timeout (issue #720).
+	let started = std::time::Instant::now();
+	let err = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec!["echo".to_string(), "hi".to_string()],
+			podup::ExecOptions {
+				user: Some("definitelynosuchuser".to_string()),
+				..Default::default()
+			},
+		)
+		.await
+		.unwrap_err();
+	let elapsed = started.elapsed();
+	engine.down(&file).await.unwrap();
+
+	assert!(
+		elapsed < std::time::Duration::from_secs(60),
+		"exec with a bad user must fail fast, took {elapsed:?}"
+	);
+	let msg = err.to_string().to_ascii_lowercase();
+	// Either the engine's prompt diagnostic (it names the user / passwd file) or
+	// podup's exec-specific timeout message — but never the bare socket-timeout.
+	assert!(
+		msg.contains("user") || msg.contains("passwd") || msg.contains("exec"),
+		"unexpected error for a bad exec user: {msg}"
+	);
+	assert!(
+		!msg.contains("waiting for the podman socket"),
+		"bad-user exec leaked a socket-timeout message: {msg}"
+	);
+	// A normal exec into the same service still works after the failure.
+	engine.up(&file).await.unwrap();
+	engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec!["echo".to_string(), "ok".to_string()],
+			podup::ExecOptions::default(),
+		)
+		.await
+		.unwrap();
+	engine.down(&file).await.unwrap();
+}
+
+#[tokio::test]
 async fn pull_images() {
 	let client = match podman().await {
 		Some(d) => d,

--- a/tests/engine_integration/lifecycle_output.rs
+++ b/tests/engine_integration/lifecycle_output.rs
@@ -1,0 +1,129 @@
+//! #817/#818/#873: the lifecycle commands must report concise per-container
+//! progress on success (docker-compose style), on stderr so stdout stays a
+//! clean pipe — and `run -d` must echo the started container's id on stdout.
+
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// Write a one-service compose file (alpine, `pull_policy: never`, sleeping) and
+/// return its directory + path.
+fn sleeper() -> (tempfile::TempDir, std::path::PathBuf) {
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    pull_policy: never\n    \
+		 command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	(dir, compose)
+}
+
+/// #817/#873: `up -d` prints a per-container `Container <name>  Started` line to
+/// stderr and leaves stdout empty (so scripting/pipes are unaffected); `down`
+/// reports each removal.
+#[tokio::test]
+async fn up_and_down_report_progress_on_stderr_clean_stdout() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let proj = proj("lout-ud");
+	let (_dir, compose) = sleeper();
+	let cf = compose.to_str().unwrap();
+
+	let up = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	assert!(
+		up.status.success(),
+		"up failed: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	let out = String::from_utf8_lossy(&up.stdout);
+	let err = String::from_utf8_lossy(&up.stderr);
+	assert!(
+		out.trim().is_empty(),
+		"up -d must keep stdout clean for scripting, got: {out:?}"
+	);
+	assert!(
+		err.contains(&format!("Container {proj}-web")) && err.contains("Started"),
+		"up -d must report the started container on stderr, got: {err:?}"
+	);
+
+	let down = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+	assert!(
+		down.status.success(),
+		"down failed: {}",
+		String::from_utf8_lossy(&down.stderr)
+	);
+	let derr = String::from_utf8_lossy(&down.stderr);
+	assert!(
+		derr.contains(&format!("Container {proj}-web")) && derr.contains("Removed"),
+		"down must report the removed container on stderr, got: {derr:?}"
+	);
+}
+
+/// #818: `start` on a project that was never created prints a clear
+/// "nothing to do" message (to stderr) and still exits 0.
+#[tokio::test]
+async fn start_on_never_created_reports_nothing_to_do() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let proj = proj("lout-cold");
+	let (_dir, compose) = sleeper();
+
+	let start = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "start"])
+		.output()
+		.unwrap();
+	assert!(
+		start.status.success(),
+		"start failed: {}",
+		String::from_utf8_lossy(&start.stderr)
+	);
+	let err = String::from_utf8_lossy(&start.stderr);
+	assert!(
+		err.contains("no containers to start"),
+		"cold start must report nothing to do, got: {err:?}"
+	);
+}
+
+/// #817: `run -d` echoes the started container's name to stdout (like
+/// `docker compose run -d`), so a script can capture an id.
+#[tokio::test]
+async fn run_detached_echoes_container_name_to_stdout() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let proj = proj("lout-rund");
+	let (_dir, compose) = sleeper();
+	let cf = compose.to_str().unwrap();
+
+	let run = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "run", "-d", "web", "sleep", "30"])
+		.output()
+		.unwrap();
+	assert!(
+		run.status.success(),
+		"run -d failed: {}",
+		String::from_utf8_lossy(&run.stderr)
+	);
+	let out = String::from_utf8_lossy(&run.stdout);
+	assert!(
+		out.contains(&format!("{proj}-web-run-")),
+		"run -d must echo the container name on stdout, got: {out:?}"
+	);
+
+	// Clean up the detached run container plus any project state.
+	let _ = Command::new(bin())
+		.args(["-f", cf, "-p", &proj, "down"])
+		.output();
+}

--- a/tests/engine_integration/niche.rs
+++ b/tests/engine_integration/niche.rs
@@ -109,11 +109,15 @@ async fn cli_attach_streams_output_until_exit() {
 	let dir = tempdir().unwrap();
 	let proj = format!("t{}-attach", std::process::id());
 	let compose = dir.path().join("docker-compose.yml");
-	// Emits a line then exits shortly after, so attach streams output and the
-	// follow stream closes (attach returns) rather than blocking forever.
+	// `attach` streams LIVE output only (libpod `tail=0`), like `docker attach`:
+	// anything emitted before the client connects is not replayed. So the
+	// container must keep emitting after start, or the test races the attach
+	// connection. It prints a line every second for a few seconds, then exits —
+	// attach connects, catches a live line, and the follow stream closes when the
+	// container stops (attach returns rather than blocking forever).
 	fs::write(
 		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo attached-hi; sleep 1\"]\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"for i in 1 2 3 4 5; do echo attached-hi; sleep 1; done\"]\n",
 	)
 	.unwrap();
 	let c = compose.to_str().unwrap();
@@ -124,7 +128,7 @@ async fn cli_attach_streams_output_until_exit() {
 	assert!(out.status.success(), "attach failed: {:?}", out.stderr);
 	assert!(
 		String::from_utf8_lossy(&out.stdout).contains("attached-hi"),
-		"attach must stream the container's output"
+		"attach must stream the container's live output"
 	);
 }
 

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -1,0 +1,102 @@
+//! CLI integration tests for `stats` table-shaping flags (`--all`, `--no-trunc`,
+//! `--format`). Kept in its own submodule so `cli_commands.rs` stays within the
+//! source line limit.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+#[tokio::test]
+async fn cli_stats_flags_truncate_all_and_format() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// A service name long enough that `{proj}-{svc}-1` overflows the 32-char NAME
+	// column, so truncation/`--no-trunc` is observable.
+	let svc = "superlongservicenamethatoverflows";
+	let proj = format!("t{}-stf", std::process::id());
+	fs::write(
+		&compose,
+		format!(
+			"services:\n  {svc}:\n    image: alpine:latest\n    pull_policy: never\n    command: [\"sleep\", \"infinity\"]\n"
+		),
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	// A single-replica service's container is named `{proj}-{svc}` (no `-1`).
+	let full = format!("{proj}-{svc}");
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+
+	// `--no-trunc` shows the full container name; the default table truncates it
+	// (ellipsis present, full name gone).
+	let notrunc = run(c, &proj, &["stats", "--no-stream", "--no-trunc"]);
+	assert!(
+		notrunc.contains(&full),
+		"--no-trunc must show full name: {notrunc}"
+	);
+
+	let truncd = run(c, &proj, &["stats", "--no-stream"]);
+	assert!(
+		truncd.contains('…'),
+		"default table must truncate: {truncd}"
+	);
+	assert!(
+		!truncd.contains(&full),
+		"default must not show full name: {truncd}"
+	);
+
+	// `--format json` emits a JSON array with the full (untruncated) name.
+	let json = run(c, &proj, &["stats", "--no-stream", "--format", "json"]);
+	assert!(
+		json.contains("\"Name\""),
+		"json must have Name field: {json}"
+	);
+	assert!(
+		json.contains("\"CPUPerc\""),
+		"json must have CPUPerc: {json}"
+	);
+	assert!(json.contains(&full), "json must carry full name: {json}");
+
+	// Stop the container: it drops out of the default (running-only) view but
+	// `--all` folds it back in as a zeroed row.
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "stop"])
+		.output()
+		.unwrap();
+	let stopped = run(c, &proj, &["stats", "--no-stream", "--no-trunc"]);
+	assert!(
+		!stopped.contains(&full),
+		"stopped container must be hidden: {stopped}"
+	);
+	let all = run(c, &proj, &["stats", "--no-stream", "--all", "--no-trunc"]);
+	assert!(
+		all.contains(&full),
+		"--all must include stopped container: {all}"
+	);
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+}
+
+/// Run the built `podup` against compose file `c`/project `proj` with `args` and
+/// return its stdout, asserting a clean exit.
+fn run(c: &str, proj: &str, args: &[&str]) -> String {
+	let mut full = vec!["-f", c, "-p", proj];
+	full.extend_from_slice(args);
+	let out = Command::new(bin()).args(&full).output().unwrap();
+	assert!(
+		out.status.success(),
+		"podup {args:?} failed: {:?}",
+		out.stderr
+	);
+	String::from_utf8_lossy(&out.stdout).into_owned()
+}

--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -4,20 +4,30 @@ use std::time::Duration;
 use super::*;
 
 #[tokio::test]
-async fn watch_no_develop_rules_returns_immediately() {
+async fn watch_no_develop_rules_errors() {
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,
 	};
 	let proj = proj("wno");
 	let engine = Engine::new(client, proj.clone());
-	// No develop.watch section → watch() returns Ok(()) immediately
+	// No develop.watch section → watch() errors, matching docker compose, which
+	// reports "none of the selected services is configured for watch" rather than
+	// silently exiting 0 (an invocation with nothing to watch is almost always a
+	// misconfiguration the user wants flagged).
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
 	)
 	.unwrap();
 
-	engine.watch(&file).await.unwrap();
+	let err = engine
+		.watch(&file)
+		.await
+		.expect_err("watch with no rules must error");
+	assert!(
+		matches!(err, podup::ComposeError::Watch(_)),
+		"expected a Watch error, got {err:?}"
+	);
 }
 
 #[tokio::test]

--- a/tests/parse/basic.rs
+++ b/tests/parse/basic.rs
@@ -411,3 +411,42 @@ services:
 	assert_eq!(svc.cpuset.as_deref(), Some("0-1"));
 	assert_eq!(svc.mem_limit.as_deref(), Some("256m"));
 }
+
+#[test]
+fn cpus_accepts_unquoted_number_and_quoted_string() {
+	// The compose spec writes `cpus: 0.5` unquoted; both the number and the quoted
+	// string form must parse to the same stored value (top-level and deploy).
+	let yaml = r#"
+services:
+  num:
+    image: alpine
+    cpus: 0.5
+  str:
+    image: alpine
+    cpus: "0.5"
+  dep:
+    image: alpine
+    deploy:
+      resources:
+        limits:
+          cpus: 1.5
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["num"].cpus.as_deref(), Some("0.5"));
+	assert_eq!(file.services["str"].cpus.as_deref(), Some("0.5"));
+	assert_eq!(
+		file.services["dep"]
+			.deploy
+			.as_ref()
+			.unwrap()
+			.resources
+			.as_ref()
+			.unwrap()
+			.limits
+			.as_ref()
+			.unwrap()
+			.cpus
+			.as_deref(),
+		Some("1.5")
+	);
+}

--- a/tests/project_name_safety.rs
+++ b/tests/project_name_safety.rs
@@ -63,6 +63,35 @@ fn rejects_project_name_from_env() {
 }
 
 #[test]
+fn rejects_leading_dash_project_name() {
+	// A leading dash is a latent flag-injection vector and is rejected by
+	// docker-compose's `^[a-z0-9][a-z0-9_-]*$` rule. `-p=` keeps clap from
+	// treating the value itself as a flag so the boundary check is what fails.
+	let dir = compose_dir();
+	let out = podup()
+		.current_dir(dir.path())
+		.args(["-p=-rf", "generate", "quadlet"])
+		.output()
+		.expect("run podup");
+
+	assert!(!out.status.success(), "leading-dash project name must fail");
+	assert!(String::from_utf8_lossy(&out.stderr).contains("not a safe path component"));
+}
+
+#[test]
+fn rejects_uppercase_project_name() {
+	let dir = compose_dir();
+	let out = podup()
+		.current_dir(dir.path())
+		.args(["-p", "MyApp", "generate", "quadlet"])
+		.output()
+		.expect("run podup");
+
+	assert!(!out.status.success(), "uppercase project name must fail");
+	assert!(String::from_utf8_lossy(&out.stderr).contains("not a safe path component"));
+}
+
+#[test]
 fn accepts_safe_project_name() {
 	let dir = compose_dir();
 	let out = podup()

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -48,16 +48,16 @@ networks:
 	let expected = "\
 [Unit]
 Description=web (podup)
-After=db.service
-Requires=db.service
+After=proj-db.service
+Requires=proj-db.service
 
 [Container]
 ContainerName=web
 Image=nginx:1.27
 PublishPort=8080:80
 Environment=TZ=UTC
-Volume=data.volume:/var/lib/data
-Network=frontend.network
+Volume=proj-data.volume:/var/lib/data
+Network=proj-frontend.network
 Label=podup.project=proj
 Label=podup.service=web
 
@@ -67,7 +67,7 @@ Restart=always
 [Install]
 WantedBy=default.target
 ";
-	assert_eq!(unit(&out, "web.container"), expected);
+	assert_eq!(unit(&out, "proj-web.container"), expected);
 }
 
 #[test]
@@ -85,11 +85,11 @@ networks:
 	let out = generate(&file, "myproj");
 
 	assert_eq!(
-		unit(&out, "cache.volume"),
+		unit(&out, "myproj-cache.volume"),
 		"[Volume]\nVolumeName=myproj_cache\nLabel=podup.project=myproj\n"
 	);
 	assert_eq!(
-		unit(&out, "backend.network"),
+		unit(&out, "myproj-backend.network"),
 		"[Network]\nNetworkName=myproj_backend\nLabel=podup.project=myproj\n"
 	);
 }
@@ -108,15 +108,25 @@ fn cli_writes_units_to_output_dir() {
 	let out_dir = dir.join("units");
 
 	let status = Command::new(bin())
-		.args(["-f", compose.to_str().unwrap(), "generate", "quadlet", "-o"])
+		.args([
+			"-p",
+			"proj",
+			"-f",
+			compose.to_str().unwrap(),
+			"generate",
+			"quadlet",
+			"-o",
+		])
 		.arg(&out_dir)
 		.status()
 		.unwrap();
 	assert!(status.success());
 
-	let web = fs::read_to_string(out_dir.join("web.container")).unwrap();
+	// Unit file names are project-prefixed so multiple projects can share the
+	// systemd directory without clobbering each other.
+	let web = fs::read_to_string(out_dir.join("proj-web.container")).unwrap();
 	assert!(web.contains("Image=nginx"));
-	assert!(fs::read_to_string(out_dir.join("data.volume"))
+	assert!(fs::read_to_string(out_dir.join("proj-data.volume"))
 		.unwrap()
 		.contains("VolumeName="));
 
@@ -132,12 +142,19 @@ fn cli_prints_units_to_stdout() {
 	fs::write(&compose, "services:\n  web:\n    image: nginx\n").unwrap();
 
 	let output = Command::new(bin())
-		.args(["-f", compose.to_str().unwrap(), "generate", "quadlet"])
+		.args([
+			"-p",
+			"proj",
+			"-f",
+			compose.to_str().unwrap(),
+			"generate",
+			"quadlet",
+		])
 		.output()
 		.unwrap();
 	assert!(output.status.success());
 	let stdout = String::from_utf8(output.stdout).unwrap();
-	assert!(stdout.contains("# web.container"));
+	assert!(stdout.contains("# proj-web.container"));
 	assert!(stdout.contains("Image=nginx"));
 
 	let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
This brings the 1.6.0 command/edge/security sweep fixes from develop into main.

I ran an intensive per-command, adversarial and security sweep of 1.6.0 against real Podman 5.4.2, triaged the findings down to 221 verified, distinct bugs (filed #711–#931), and fixed 220 of them across PRs #932–#972. Highlights:

- **Data-loss / safety:** `down --rmi all` no longer force-cascades and destroys other projects' containers; `run --name` no longer silently force-replaces an existing container; duplicate `scale` pairs no longer wipe a service.
- **Injection / robustness:** textual interpolation can no longer inject YAML structure; deeply nested `${VAR:-…}` no longer overflows the stack; build contexts no longer dereference symlinks into the image; quadlet values are properly escaped; CLI flags after a service name are parsed; `kill`/signal and `--socket` inputs are validated.
- **Correctness / parity:** scaled-replica resolution for `port`/`exec`/`cp`; deterministic `wait` ordering and exit codes; profile handling across `pull`/`push`/`start`/`wait`/`images`/`stats`/quadlet; project-scoped build image tags (and the `up --build` regression that surfaced from it); graceful broken-pipe handling; content-sized table rendering; intra-level lifecycle parallelism; success/progress output; `stats --format/--all/--no-trunc`.

Everything was validated against real Podman 5.4.2 — the `engine_integration` suite is 145/145, plus per-fix end-to-end checks. The one remaining finding, #815 (unifying single/multi-replica container naming), is intentionally held: it is a user-visible naming and upgrade-compatibility change for a low-severity bug, so it belongs to a major version, not this batch.
