### PR TITLE
ci: pin rust-debian reusable back to v1.2.0

### DIFF
--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
     with:
       package-name: podup
       check-vendored: true


### PR DESCRIPTION
The Dependabot bump of rust-debian.yml to v1.6.0 (#955) broke the Debian build (`Syntax error: redirection unexpected` in the reusable's shell step); it was green on v1.2.0. Reverting this single caller to v1.2.0 restores the Debian build. release.yml does not use this reusable, so the release path was unaffected; this only repairs the PR/CI Debian check.