### PR TITLE
ci: bump rust-debian reusable to v1.6.1 (Debian build fix)

### DIFF
--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@b9caae5da914c4c7cb4c18b0ee3da8e9a1344988 # v1.6.1
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@1f162c71fdb2fff2a40eba6bf0435b9032584a13 # v1.6.2
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@b9caae5da914c4c7cb4c18b0ee3da8e9a1344988 # v1.6.1
     with:
       package-name: podup
       check-vendored: true

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -286,6 +286,10 @@ fn config_no_interpolate_skips_required_var_error() {
 /// Passing one on the command line is rejected as a usage error rather than
 /// silently accepted as a no-op — and the rejection happens before any network
 /// access, so the test never reaches GitHub.
+///
+/// Gated on the `update` feature: package-manager builds (Debian/apt) compile
+/// without it, so the `update` subcommand does not exist there.
+#[cfg(feature = "update")]
 #[test]
 fn update_rejects_compose_only_global_flags() {
 	for flag in [


### PR DESCRIPTION
v1.6.0 of the rust-debian reusable broke the Debian build (`Syntax error: redirection unexpected` — a bash here-string under dash in the offline build step). I fixed it upstream in Glyndor/.github (v1.6.1, POSIX `set --`) and this bumps the pin from v1.6.0 to v1.6.1, restoring the Debian build.