### PR TITLE
Release 1.7.0: sync develop into main

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -22,4 +22,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       coverage-threshold: 90

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@1f162c71fdb2fff2a40eba6bf0435b9032584a13 # v1.6.2
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           "$venv_py" .github/scripts/sign.py "${{ matrix.asset }}"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ matrix.asset }}
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,37 @@
+podup (1.7.0) unstable; urgency=medium
+
+  * Safety: `down --rmi all|local` no longer force-removes an in-use image and so
+    can no longer cascade into deleting other projects' containers; `run --name`
+    no longer silently replaces a pre-existing container of the same name; and a
+    duplicated service in `scale`/`up --scale` no longer wipes the service.
+  * Hardening: variable interpolation can no longer inject YAML structure from an
+    env value; a deeply nested `${VAR:-…}` default no longer overflows the stack;
+    build contexts no longer dereference symlinks into the image; Quadlet values
+    are properly escaped; and `kill` signals, `--socket`, port/`--protocol`,
+    `--timeout`, project names and other inputs are validated client-side instead
+    of leaking a raw Podman error.
+  * Correctness: `port`/`exec`/`cp`/`attach` resolve runtime-scaled replicas;
+    service start/stop ordering and `wait` output and exit code are deterministic;
+    profiles are honoured across `pull`/`push`/`start`/`wait`/`images`/`stats`
+    and `generate quadlet`; build-only images are tagged per project (and the
+    resulting `up --build` lookup is fixed); a broken pipe exits cleanly instead
+    of aborting; and `config` validates dependency cycles, undefined volume and
+    network references, port ranges, project and service names.
+  * Performance: independent services within a dependency level now start, stop
+    and restart in parallel.
+  * CLI parity: many missing flags were added, including `ps --services/--filter/
+    --status` and a positional service filter, `commit -m/-a/-p/-c`,
+    `stats --format/--all/--no-trunc`, `up --wait-timeout`, `create --pull/
+    --no-deps`, `ls --filter`, `push -q`, `build --progress/--push`, `run -l`,
+    `events --since/--until/--filter`, `logs --no-color/--no-log-prefix`,
+    `attach --index` and `config --volumes/--images/--profiles/--hash`.
+  * Output: lifecycle commands now print per-container progress and a summary on
+    success (suppressed with `--quiet`); `ls`/`ps`/`images` tables size to their
+    content and truncate long values; and many commands now emit a clear,
+    friendly error instead of a raw Podman HTTP status.
+
+ -- Glyndor <packages@glyndor.net>  Mon, 29 Jun 2026 08:34:19 -0500
+
 podup (1.6.0) unstable; urgency=medium
 
   * Output is now colourised on a terminal and degrades gracefully: a semantic

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -286,6 +286,10 @@ fn config_no_interpolate_skips_required_var_error() {
 /// Passing one on the command line is rejected as a usage error rather than
 /// silently accepted as a no-op — and the rejection happens before any network
 /// access, so the test never reaches GitHub.
+///
+/// Gated on the `update` feature: package-manager builds (Debian/apt) compile
+/// without it, so the `update` subcommand does not exist there.
+#[cfg(feature = "update")]
 #[test]
 fn update_rejects_compose_only_global_flags() {
 	for flag in [


### PR DESCRIPTION
Brings 1.7.0 to main for release: the version bump (#974), the Debian reusable fix (rust-debian v1.6.2 + the `update`-feature test gate, #976), and the routine reusable-workflow Dependabot bumps. All 220 sweep fixes are already on main from #973; this adds the release-prep on top. CI is green on develop including both Debian checks.