### PR TITLE
fix(cli): validate port command protocol and private-port

### DIFF
--- a/internal/engine/query/inspect_util.rs
+++ b/internal/engine/query/inspect_util.rs
@@ -42,20 +42,63 @@ pub(super) fn select_replica(
 /// Resolve the `(port, proto)` for `port` from a `PORT` or `PORT/proto` argument,
 /// the `/proto` suffix overriding the `--protocol` flag — matching
 /// `docker compose port`. Pure so the parsing is unit-tested.
-pub(super) fn parse_port_proto<'a>(
-	private_port: &'a str,
-	proto_flag: &'a str,
-) -> Result<(u16, &'a str)> {
-	let (port, proto) = match private_port.split_once('/') {
+///
+/// The private port is parsed strictly like docker's port spec: only a canonical
+/// decimal `1..=65535` is accepted, so a leading `+`/`-`, leading zeros
+/// (`080`), surrounding whitespace, or any trailing junk (`80/tcp/extra`) are
+/// rejected rather than silently coerced. The protocol is validated to
+/// `tcp`/`udp` (case-insensitive) and normalised to lowercase so it matches the
+/// lowercase keys Podman reports — an unknown or empty protocol errors clearly
+/// instead of yielding an empty, exit-0 "no mapping" result.
+pub(super) fn parse_port_proto(
+	private_port: &str,
+	proto_flag: &str,
+) -> Result<(u16, &'static str)> {
+	let (port_str, proto_str) = match private_port.split_once('/') {
 		Some((p, pr)) => (p, pr),
 		None => (private_port, proto_flag),
 	};
-	let port: u16 = port.parse().map_err(|_| {
+	let port = parse_strict_port(port_str, private_port)?;
+	let proto = normalise_proto(proto_str)?;
+	Ok((port, proto))
+}
+
+/// Parse a private port strictly: a canonical decimal in `1..=65535`. Rejects an
+/// empty string, a leading sign (`+80`/`-80`), leading zeros (`080`), embedded
+/// whitespace, and any non-digit (so trailing junk cannot slip through).
+fn parse_strict_port(port_str: &str, private_port: &str) -> Result<u16> {
+	let invalid = || {
 		ComposeError::InvalidPort(format!(
 			"port '{private_port}' is not a valid PORT or PORT/proto"
 		))
-	})?;
-	Ok((port, proto))
+	};
+	if port_str.is_empty() || !port_str.bytes().all(|b| b.is_ascii_digit()) {
+		return Err(invalid());
+	}
+	// Reject non-canonical leading zeros (e.g. `080`); a bare `0` is caught below.
+	if port_str.len() > 1 && port_str.starts_with('0') {
+		return Err(invalid());
+	}
+	let port: u16 = port_str.parse().map_err(|_| invalid())?;
+	if port == 0 {
+		return Err(invalid());
+	}
+	Ok(port)
+}
+
+/// Validate and normalise a protocol to `tcp`/`udp` (case-insensitive). Returns a
+/// lowercase `&'static str` so it matches the keys Podman reports; anything else
+/// (including an empty string) is a clear error.
+fn normalise_proto(proto: &str) -> Result<&'static str> {
+	if proto.eq_ignore_ascii_case("tcp") {
+		Ok("tcp")
+	} else if proto.eq_ignore_ascii_case("udp") {
+		Ok("udp")
+	} else {
+		Err(ComposeError::InvalidPort(format!(
+			"protocol '{proto}' is not valid (expected 'tcp' or 'udp')"
+		)))
+	}
 }
 
 /// Deduplicate a list of strings, preserving first-seen order. Used so `top web
@@ -256,6 +299,35 @@ mod tests {
 	fn non_numeric_port_is_rejected() {
 		assert!(parse_port_proto("http", "tcp").is_err());
 		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
+	}
+
+	#[test]
+	fn protocol_flag_is_case_insensitive() {
+		assert_eq!(parse_port_proto("80", "TCP").unwrap(), (80, "tcp"));
+		assert_eq!(parse_port_proto("80", "Udp").unwrap(), (80, "udp"));
+		assert_eq!(parse_port_proto("53/UDP", "tcp").unwrap(), (53, "udp"));
+	}
+
+	#[test]
+	fn unknown_or_empty_protocol_is_rejected() {
+		// Previously these silently produced an empty, exit-0 "no mapping".
+		assert!(parse_port_proto("80", "sctp").is_err());
+		assert!(parse_port_proto("80", "").is_err());
+		assert!(parse_port_proto("80/sctp", "tcp").is_err());
+	}
+
+	#[test]
+	fn non_canonical_private_port_is_rejected() {
+		// Leading sign, leading zeros, whitespace, and trailing junk must all
+		// error rather than being coerced or silently mis-handled.
+		assert!(parse_port_proto("+80", "tcp").is_err());
+		assert!(parse_port_proto("-80", "tcp").is_err());
+		assert!(parse_port_proto("080", "tcp").is_err());
+		assert!(parse_port_proto(" 80", "tcp").is_err());
+		assert!(parse_port_proto("80 ", "tcp").is_err());
+		assert!(parse_port_proto("80/tcp/extra", "tcp").is_err());
+		assert!(parse_port_proto("0", "tcp").is_err());
+		assert!(parse_port_proto("65536", "tcp").is_err());
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

The `port` subcommand parsed both of its value arguments leniently, so a few malformed inputs printed nothing and exited 0 — indistinguishable from a genuinely unmapped port.

### #852 — `--protocol` not validated
`--protocol` was forwarded verbatim into the lookup key. Uppercase `TCP` never matched Podman's lowercase `80/tcp` keys, and bogus values like `sctp` or an empty string silently produced an empty, exit-0 result. The protocol is now validated to `tcp`/`udp` (case-insensitive) and normalised to lowercase, erroring clearly on anything else.

### #853 — private port parsed leniently
The private port went straight through `u16::parse`, which accepts a leading `+`/`-` and leading zeros (`+80`, `080`); and a `PORT/proto` argument with trailing junk (`80/tcp/extra`) was never rejected. It is now parsed strictly to a canonical decimal `1..=65535`, like docker's port spec, with trailing junk caught by the protocol check.

## Live verification (rootless Podman 5.4.2)

```
port web 80                  -> 0.0.0.0:8099   [exit 0]
port web 80 --protocol TCP   -> 0.0.0.0:8099   [exit 0]   (case-insensitive)
port web 80 --protocol sctp  -> error          [exit 1]
port web 80 --protocol ''    -> error          [exit 1]
port web +80                 -> error          [exit 1]
port web 080                 -> error          [exit 1]
port web 80/tcp/extra        -> error          [exit 1]
```

## Tests

Added unit tests covering case-insensitive/normalised protocols, rejected unknown/empty protocols, and rejected non-canonical private ports (leading sign, leading zeros, whitespace, trailing junk, `0`, out-of-range).

Closes #852
Closes #853
