### PR TITLE
fix(engine): exec resolves running scaled replicas (--index/--scale)

### DIFF
--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -152,10 +152,13 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		// Resolve the target replica through the shared helper so `--index 0` (and
-		// out-of-range indexes) are rejected consistently with `cp`/`port`/etc.,
-		// rather than aliasing index 0 to the first replica.
-		let container_name = self.replica_name_at(service_name, service, opts.index)?;
+		// Resolve the target replica against the *running* containers (matching
+		// `cp`), so `--index N` and a bare `exec` reach a live replica of a service
+		// scaled by an earlier `up --scale`/`scale` — not just the compose static
+		// count. `--index 0`/out-of-range indexes stay rejected consistently.
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		let env = expand_exec_env(&opts.env);
 		let exec_cfg = ExecCreateConfig {

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -43,6 +43,8 @@ mod build_resources;
 mod commands_networking;
 #[path = "engine_integration/cp_flags.rs"]
 mod cp_flags;
+#[path = "engine_integration/exec_flags.rs"]
+mod exec_flags;
 #[path = "engine_integration/health_targeting.rs"]
 mod health_targeting;
 #[path = "engine_integration/lifecycle.rs"]

--- a/tests/engine_integration/exec_flags.rs
+++ b/tests/engine_integration/exec_flags.rs
@@ -1,0 +1,130 @@
+//! `exec` replica-resolution integration tests: a bare `exec` and `exec
+//! --index N` must reach a *running* replica of a service scaled by an earlier
+//! `up --scale`/`scale`, not the compose static count (issue #795). Skip
+//! gracefully when Podman is unreachable.
+use super::*;
+
+#[cfg(feature = "test-helpers")]
+use std::collections::HashMap;
+
+/// Bring up `web` with three replicas, then drive `exec` from a *fresh* engine
+/// whose compose file still declares the default single replica — exactly the
+/// real CLI case where a later `podup exec` knows nothing of the prior
+/// `up --scale`. Before the fix, `exec` resolved the replica count from that
+/// static default (1): a bare `exec` targeted the unsuffixed `web` (which does
+/// not exist once scaled) and `--index 2` was rejected as "no replica 2".
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn engine_exec_reaches_live_scaled_replicas() {
+	let (scaler_client, exec_client) = match (podman().await, podman().await) {
+		(Some(a), Some(b)) => (a, b),
+		_ => return,
+	};
+	let proj = proj("execscale");
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	// Scale to three replicas with a dedicated engine (mirrors `up --scale web=3`).
+	let scaler = Engine::new(scaler_client, proj.clone())
+		.with_scale_overrides(HashMap::from([("web".to_string(), 3)]));
+	scaler.up(&file).await.unwrap();
+
+	// A fresh engine with NO scale override: it sees only the compose default of
+	// one replica, just like a separate `podup exec` invocation would.
+	let engine = Engine::new(exec_client, proj.clone());
+
+	// `--index 2` must reach the *running* web-2. Drop a marker in it via exec,
+	// then read each replica back to prove exactly web-2 was hit.
+	let by_index = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"echo idx2 > /tmp/exec_marker".into(),
+			],
+			podup::ExecOptions {
+				index: Some(2),
+				..Default::default()
+			},
+		)
+		.await;
+
+	// A bare `exec` (no index) must reach the lowest-numbered running replica,
+	// web-1 — not the never-created unsuffixed `web`.
+	let bare = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"echo bare > /tmp/exec_bare".into(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
+
+	// `--index 4` is out of range against the three running replicas.
+	let out_of_range = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec!["true".into()],
+			podup::ExecOptions {
+				index: Some(4),
+				..Default::default()
+			},
+		)
+		.await;
+
+	let marker_in_2 = engine
+		.test_exec_capture(
+			&format!("{proj}-web-2"),
+			vec!["cat".into(), "/tmp/exec_marker".into()],
+		)
+		.await;
+	let marker_in_1 = engine
+		.test_exec_capture(
+			&format!("{proj}-web-1"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"cat /tmp/exec_marker 2>/dev/null || true".into(),
+			],
+		)
+		.await;
+	let bare_in_1 = engine
+		.test_exec_capture(
+			&format!("{proj}-web-1"),
+			vec!["cat".into(), "/tmp/exec_bare".into()],
+		)
+		.await;
+
+	scaler.down(&file).await.unwrap();
+
+	by_index.unwrap();
+	bare.unwrap();
+	assert!(
+		matches!(
+			out_of_range,
+			Err(podup::ComposeError::ReplicaIndex { ref service, index: 4 }) if service == "web"
+		),
+		"out-of-range --index against running scale must error, got {out_of_range:?}"
+	);
+	assert!(
+		marker_in_2.unwrap_or_default().contains("idx2"),
+		"`exec --index 2` must run inside the running web-2"
+	);
+	assert!(
+		!marker_in_1.unwrap_or_default().contains("idx2"),
+		"`exec --index 2` must NOT touch web-1"
+	);
+	assert!(
+		bare_in_1.unwrap_or_default().contains("bare"),
+		"bare `exec` must run inside the lowest-numbered running replica web-1"
+	);
+}


### PR DESCRIPTION
## Summary

`exec` resolved a service's replica set from the compose static count (`scale:`/`deploy.replicas`, defaulting to 1) instead of the containers Podman actually has. After `up -d --scale web=3`, a later `podup exec` knew nothing of that scale:

- `exec --index 2 web hostname` errored `service web has no replica 2`
- `exec web hostname` / `exec --index 1 web hostname` errored `service web is not running` (they targeted the never-created unsuffixed `web`)

`cp` already resolves against the live running replicas via `live_replica_name_at`. I switched `exec` to the same live resolution so `exec --index N` and a bare `exec` reach a running replica of a service scaled by an earlier `up --scale`/`scale`. `--index 0`/out-of-range stay rejected with the typed `ReplicaIndex` error.

No new `--scale` flag: `cp` does not expose one either — both rely purely on live-replica resolution, so this keeps exec/cp at parity.

## Verification

`fmt`/`clippy --all-targets --all-features -D warnings`/`test --no-run --all-features`/`doc`/`semver-checks` (no change required)/`test --lib` all green. New live integration test `engine_exec_reaches_live_scaled_replicas` proves `--index 2` lands in the running `web-2`, a bare `exec` lands in `web-1`, and `--index 4` errors out of range.

Live repro on rootless Podman 5.4.2 after `up -d --scale web=3`:

```
exec --index 2 web hostname  -> 495a3c35867d (web-2)
exec --index 1 web hostname  -> 267cc26cf300 (web-1)
exec web hostname            -> 267cc26cf300 (web-1)
exec --index 3 web hostname  -> f0e978517de9 (web-3)
exec --index 4 web hostname  -> error: service 'web' has no replica 4
```

Closes #795
