### PR TITLE
fix(engine): up implicitly starts a profiled depends_on target

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -20,7 +20,7 @@ use targets::{expand_targets, filter_services, in_started_set, validate_targets}
 use super::container::config_hash;
 
 use super::network::resolve_network_name;
-use super::profiles::{active_profiles_set, service_in_profiles};
+use super::profiles::{active_profiles_set, enabled_profile_services};
 use super::Engine;
 
 /// Options for [`Engine::run`].
@@ -146,6 +146,11 @@ impl Engine {
 		async {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
+			// Which services this `up`/`create` should start. A profiled service
+			// that an active service depends on is implicitly activated here —
+			// the same set `config` reports — so `up` never leaves a started
+			// service with an unsatisfied (never-created) dependency.
+			let enabled = enabled_profile_services(file, &active, target_services);
 
 			// Validate every `--scale SERVICE=N` override against the file before
 			// doing any work: an override naming a service the compose file does
@@ -210,7 +215,7 @@ impl Engine {
 					self.up_one_service(
 						name,
 						file,
-						&active,
+						&enabled,
 						&target_set,
 						&present,
 						&existing_hash,
@@ -259,7 +264,7 @@ impl Engine {
 		&self,
 		name: &str,
 		file: &ComposeFile,
-		active: &HashSet<String>,
+		enabled: &HashSet<String>,
 		target_set: &Option<HashSet<String>>,
 		present: &HashSet<String>,
 		existing_hash: &HashMap<String, String>,
@@ -274,7 +279,7 @@ impl Engine {
 		}
 		let service = &file.services[name];
 
-		if !service_in_profiles(service, active) {
+		if !enabled.contains(name) {
 			tracing::debug!("skipping {name}: no active profile match");
 			return Ok(());
 		}
@@ -305,7 +310,7 @@ impl Engine {
 				Some(s) => s,
 				None => continue,
 			};
-			if !service_in_profiles(dep_service, active) {
+			if !enabled.contains(&dep) {
 				continue;
 			}
 			// Scaled dep has no base-named container; wait on its first replica.

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -24,6 +24,29 @@ pub fn retain_active_profiles_with_targets(
 	targets: &[String],
 ) {
 	let set = active_profiles_set(active);
+	let enabled = enabled_profile_services(file, &set, targets);
+	file.services.retain(|name, _| enabled.contains(name));
+}
+
+/// The set of service names that should run under the active profile set.
+///
+/// A service is enabled when it is unprofiled, matches an active profile (or the
+/// `*` wildcard), or is explicitly named in `targets` (naming a service on the
+/// command line activates its profile). Implicit activation then pulls in the
+/// transitive `depends_on` targets of every enabled service — even profiled
+/// ones whose profile is inactive — so a started service never depends on a
+/// service that was filtered out. Mirrors docker compose, which activates a
+/// profiled service that is depended on by a started one.
+///
+/// This is the single source of truth for "which services does an `up`/`config`
+/// with these profiles touch": [`retain_active_profiles_with_targets`] uses it
+/// to prune the config, and the `up`/`create` lifecycle path uses it to decide
+/// which services to actually start — so the two never disagree.
+pub(crate) fn enabled_profile_services(
+	file: &ComposeFile,
+	active: &HashSet<String>,
+	targets: &[String],
+) -> HashSet<String> {
 	let named: HashSet<&str> = targets.iter().map(|s| s.as_str()).collect();
 
 	// Directly enabled: an unprofiled service, a profile match (or `*`), or a
@@ -31,14 +54,13 @@ pub fn retain_active_profiles_with_targets(
 	let mut enabled: HashSet<String> = file
 		.services
 		.iter()
-		.filter(|(name, svc)| service_in_profiles(svc, &set) || named.contains(name.as_str()))
+		.filter(|(name, svc)| service_in_profiles(svc, active) || named.contains(name.as_str()))
 		.map(|(name, _)| name.clone())
 		.collect();
 
 	// Implicit activation: pull in profiled `depends_on` targets of enabled
 	// services, transitively, so a retained service never references a dropped
-	// dependency. Mirrors docker compose, which enables a profiled service that
-	// is depended on by a started one.
+	// dependency.
 	let mut stack: Vec<String> = enabled.iter().cloned().collect();
 	while let Some(name) = stack.pop() {
 		if let Some(svc) = file.services.get(&name) {
@@ -50,7 +72,7 @@ pub fn retain_active_profiles_with_targets(
 		}
 	}
 
-	file.services.retain(|name, _| enabled.contains(name));
+	enabled
 }
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.
@@ -251,6 +273,41 @@ mod tests {
 		});
 		assert!(file.services.contains_key("db"));
 		assert!(!file.services.contains_key("extra"));
+	}
+
+	#[test]
+	fn enabled_set_activates_profiled_dependency_for_up() {
+		// The `up`/`create` lifecycle path consults this set directly. `app`
+		// (unprofiled, started) depends on `db` (profiles: [storage]). With no
+		// profile active, `db` must be in the enabled set so `up` actually
+		// creates it — otherwise `app` runs with an unsatisfied dependency.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n";
+		let file = crate::parse_str(yaml).unwrap();
+		let active: HashSet<String> = HashSet::new();
+		let enabled = enabled_profile_services(&file, &active, &[]);
+		assert!(enabled.contains("app"));
+		assert!(
+			enabled.contains("db"),
+			"profiled depends_on target is in the started set"
+		);
+	}
+
+	#[test]
+	fn enabled_set_excludes_unrelated_profiled_service() {
+		// Only dependencies are pulled in — an unrelated profiled service stays
+		// out of the started set, so `up` does not over-activate it.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n  \
+			extra:\n    image: x\n    profiles: [other]\n";
+		let file = crate::parse_str(yaml).unwrap();
+		let active: HashSet<String> = HashSet::new();
+		let enabled = enabled_profile_services(&file, &active, &[]);
+		assert!(enabled.contains("app"));
+		assert!(enabled.contains("db"));
+		assert!(!enabled.contains("extra"));
 	}
 
 	#[test]


### PR DESCRIPTION
## What

`podup up -d` (no profile) for a compose file where an unprofiled service
depends on a profiled one created only the unprofiled service. The profiled
`depends_on` target was silently skipped (rc=0, no warning), so the started
service ran with an unsatisfied dependency. `config` already retained that
profiled dependency, but the `up`/`create` lifecycle path re-filtered services
through the raw profile check and dropped it again — the two disagreed.

Docker compose implicitly activates a profiled service that is depended on by a
started one, and now podup does too.

## How

I pulled the implicit-activation logic out of `retain_active_profiles_with_targets`
into a shared `enabled_profile_services` — the single source of truth for which
services a given profile set touches. Both `config` (via the retain helper) and
the `up`/`create` lifecycle path now consult it, so they can no longer diverge.
The `depends_on` readiness wait keys off the same set, so the implicitly-started
dependency is waited on instead of skipped.

Only dependencies are pulled in; an unrelated profiled service stays out, so
`up` does not over-activate.

## Tests

- New unit tests for `enabled_profile_services`: a profiled `depends_on` target
  is in the started set; an unrelated profiled service is not.
- Live repro on rootless Podman 5.4.2 with `app` (no profile) `depends_on: [db]`
  where `db` has `profiles: [storage]`: `up -d` now creates BOTH `app` and `db`,
  and a third unrelated profiled service is left out.

Closes #777
