### PR TITLE
fix(engine): validate object names before the podman call

### DIFF
--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -41,13 +41,10 @@ impl Engine {
 		start: bool,
 	) -> Result<()> {
 		// Reject an invalid container name client-side (podman would otherwise
-		// answer with an opaque HTTP 500 from its name-regex check).
-		if !crate::libpod::is_valid_object_name(container_name) {
-			return Err(ComposeError::Unsupported(format!(
-				"invalid container name {container_name:?}: names must start with an ASCII \
-				 letter or digit and contain only letters, digits, '_', '.', '-'"
-			)));
-		}
+		// answer with an opaque HTTP 500 from its name-regex check). Covers the
+		// ad-hoc `run --name` path too, which never passes through the up-time
+		// preflight in `validate_object_names`.
+		super::names::ensure_valid_object_name("container", service_name, container_name)?;
 
 		let derived_image;
 		let image: &str = if let Some(img) = service.image.as_deref() {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -144,6 +144,11 @@ impl Engine {
 		start: bool,
 	) -> Result<()> {
 		async {
+			// Reject any volume/network/container name Podman's regex would refuse
+			// before issuing a single create, so a bad name surfaces as a clear
+			// client-side error (not an opaque HTTP 500) with nothing created.
+			self.validate_object_names(file)?;
+
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
 			// Which services this `up`/`create` should start. A profiled service

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -52,6 +52,10 @@ impl Engine {
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 
+		// Reject any bad volume/network/container name before creating anything
+		// (the run path pre-creates the project networks below).
+		self.validate_object_names(file)?;
+
 		// Compose `run` brings up the service's `depends_on` services first (and
 		// waits on their conditions), unless `--no-deps` is given. The service
 		// itself is excluded — only its transitive dependencies are started.

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -18,6 +18,7 @@ mod container_config;
 mod health;
 mod lifecycle;
 mod lock;
+mod names;
 mod network;
 mod profiles;
 pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};

--- a/internal/engine/names.rs
+++ b/internal/engine/names.rs
@@ -1,0 +1,160 @@
+//! Client-side validation of the object names podup hands to Podman.
+//!
+//! Podman enforces an object-name regex (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`) on
+//! volumes, networks, and containers, rejecting anything else with an opaque
+//! HTTP 500 ("names must match …"). [`Engine::validate_object_names`] applies
+//! the same check up front — before a single create is issued — so a bad name
+//! (typically an explicit `name:` on a top-level volume/network, or an explicit
+//! `container_name:`) surfaces as a clear error naming the offending object,
+//! and nothing is created.
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::is_valid_object_name;
+
+use super::network::resolve_network_name;
+use super::Engine;
+
+impl Engine {
+	/// Reject any volume, network, or container name that Podman's object-name
+	/// regex would refuse, before issuing a single create. Validates the
+	/// resolved host names podup will actually pass to the API: the
+	/// project-prefixed default or the explicit `name:`/`container_name:`
+	/// override. External resources are looked up, not created, so a bad
+	/// external name surfaces as the clearer "does not exist" error instead.
+	pub(super) fn validate_object_names(&self, file: &ComposeFile) -> Result<()> {
+		validate_object_names(file, &self.project)
+	}
+}
+
+/// Pure form of [`Engine::validate_object_names`], taking the project name
+/// directly so it can be unit-tested without a live engine.
+fn validate_object_names(file: &ComposeFile, project: &str) -> Result<()> {
+	for (key, config) in &file.volumes {
+		if config.as_ref().and_then(|c| c.external).unwrap_or(false) {
+			continue;
+		}
+		let name = config
+			.as_ref()
+			.and_then(|c| c.name.as_deref())
+			.map(str::to_string)
+			.unwrap_or_else(|| format!("{project}_{key}"));
+		ensure_valid_object_name("volume", key, &name)?;
+	}
+
+	for (key, config) in &file.networks {
+		if config.as_ref().and_then(|c| c.external).unwrap_or(false) {
+			continue;
+		}
+		let name = resolve_network_name(key, file, project);
+		ensure_valid_object_name("network", key, &name)?;
+	}
+
+	for (svc_name, service) in &file.services {
+		// Only the base name needs checking: replica suffixes (`-1`, `-2`, …)
+		// append digits and a dash, which never turn a valid base invalid.
+		let name = service
+			.container_name
+			.clone()
+			.unwrap_or_else(|| format!("{project}-{svc_name}"));
+		ensure_valid_object_name("container", svc_name, &name)?;
+	}
+
+	Ok(())
+}
+
+/// Error out (with a message naming the offending object) when `name` is not a
+/// valid Podman object name. `kind` is the resource word ("volume", "network",
+/// "container"); `key` is the compose key it derives from, mentioned only when
+/// it differs from the resolved name so the user can locate the declaration.
+pub(super) fn ensure_valid_object_name(kind: &str, key: &str, name: &str) -> Result<()> {
+	if is_valid_object_name(name) {
+		return Ok(());
+	}
+	let origin = if name == key {
+		String::new()
+	} else {
+		format!(" (from {kind} '{key}')")
+	};
+	Err(ComposeError::Unsupported(format!(
+		"invalid {kind} name {name:?}{origin}: names must start with an ASCII letter or digit \
+		 and contain only letters, digits, '_', '.', '-'"
+	)))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::parse_str_raw;
+
+	fn file(yaml: &str) -> ComposeFile {
+		parse_str_raw(yaml).unwrap()
+	}
+
+	#[test]
+	fn clean_project_passes() {
+		let f =
+			file("services:\n  web:\n    image: nginx\nvolumes:\n  data:\nnetworks:\n  back:\n");
+		validate_object_names(&f, "proj").unwrap();
+	}
+
+	#[test]
+	fn bad_explicit_volume_name_is_rejected() {
+		let f = file(
+			"services:\n  web:\n    image: nginx\nvolumes:\n  badvol:\n    name: \"x@bad name!\"\n",
+		);
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("invalid volume name"), "got: {msg}");
+		assert!(msg.contains("x@bad name!"), "got: {msg}");
+		assert!(msg.contains("badvol"), "got: {msg}");
+	}
+
+	#[test]
+	fn bad_default_volume_name_via_key_is_rejected() {
+		// No explicit `name:`; the bad characters come from the key, so the
+		// resolved name `proj_bad key` is rejected without a redundant origin.
+		let f = file("services:\n  web:\n    image: nginx\nvolumes:\n  bad key:\n");
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		assert!(
+			err.to_string().contains("invalid volume name"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn bad_explicit_network_name_is_rejected() {
+		let f =
+			file("services:\n  web:\n    image: nginx\nnetworks:\n  net:\n    name: \"bad@net\"\n");
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("invalid network name"), "got: {msg}");
+		assert!(msg.contains("bad@net"), "got: {msg}");
+	}
+
+	#[test]
+	fn bad_container_name_is_rejected() {
+		let f = file("services:\n  web:\n    image: nginx\n    container_name: \"bad name!\"\n");
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		assert!(
+			err.to_string().contains("invalid container name"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn external_resources_are_not_name_validated() {
+		// An external resource is looked up by its name, not created, so the
+		// strict create-time regex does not apply here.
+		let f = file(
+			"services:\n  web:\n    image: nginx\nvolumes:\n  ext:\n    external: true\n    name: \"weird:name\"\nnetworks:\n  en:\n    external: true\n    name: \"weird:net\"\n",
+		);
+		validate_object_names(&f, "proj").unwrap();
+	}
+
+	#[test]
+	fn origin_is_omitted_when_name_equals_key() {
+		let err = ensure_valid_object_name("volume", "bad name", "bad name").unwrap_err();
+		assert!(!err.to_string().contains("(from"), "got: {err}");
+	}
+}


### PR DESCRIPTION
## What

An invalid volume or network name — typically an explicit `name:` on a top-level `volumes:`/`networks:` entry — was passed straight to libpod's create call, which answered with an opaque HTTP 500 (`names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*`). Only container names were validated client-side, and only mid-create (after networks/volumes had already been created), so the message was unfriendly and the preflight was not fail-closed.

I added an up-front `validate_object_names` preflight that rejects any volume, network, or container name Podman's regex would refuse, run before the first create on both the `up`/`create` and `run` paths. It validates the resolved host name (the project-prefixed default or the explicit override) and names the offending object, so the error points at the declaration. External resources are skipped — they are looked up, not created, and already surface a clear "does not exist" error. The existing container-name guard now shares the same helper, so the ad-hoc `run --name` path keeps its check.

## Live verification (rootless Podman 5.4.2)

Bad volume name:

```
$ podup up -d
podup: error: unsupported feature: invalid volume name "x@bad name!" (from volume 'badvol'): names must start with an ASCII letter or digit and contain only letters, digits, '_', '.', '-'
# exit 1, no volume and no container created
```

Bad network name errors the same way; a valid project still ups/downs cleanly.

## Tests

Unit tests for the preflight (bad explicit/derived volume name, bad network name, bad container name, external resources skipped, origin suffix). `fmt`/`clippy`/`semver-checks`/`doc`/full lib suite green.

Closes #767
