### PR TITLE
fix(quadlet): render tmpfs mode without octal re-encoding

### DIFF
--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -76,9 +76,10 @@ pub struct TmpfsOptions {
 	pub size: Option<u64>,
 	/// File mode of the tmpfs mount, stored as the actual permission bits.
 	///
-	/// A leading-zero string (`0700`) or an explicit `0o700` is interpreted as
-	/// octal — the conventional Unix file-mode notation — rather than erroring or
-	/// being silently re-interpreted; invalid input is a clear error.
+	/// A compose `mode:` is conventionally octal, so every spelling is normalised
+	/// to the same permission bits: a leading-zero string (`0700`), an explicit
+	/// `0o700`, and a bare `700` all yield `0o700` (448). Invalid input is a clear
+	/// error rather than a silent re-interpretation.
 	#[serde(
 		default,
 		deserialize_with = "deserialize_octal_mode",
@@ -89,11 +90,14 @@ pub struct TmpfsOptions {
 
 /// Deserialize a tmpfs `mode` as octal-aware permission bits.
 ///
-/// YAML numeric scalars are already decoded by the parser (`0o700` → 448), so an
-/// integer node is taken as the actual permission bits. A string node — which is
-/// how a leading-zero literal like `0700` reaches us (and what previously failed
-/// with an opaque untagged error) — is parsed as octal, accepting an optional
-/// `0o` prefix and rejecting non-octal digits with a clear message.
+/// A compose `mode:` is conventionally octal, but serde_yaml decodes the spelling
+/// before we see it: a `0o`-prefixed literal arrives as its numeric value
+/// (`0o700` → 448), a leading-zero literal (`0700`) arrives as a string, and a
+/// bare `700` arrives unchanged. We normalise all of them to the actual
+/// permission bits (see [`int_mode_bits`] for the integer case), so the renderer
+/// can octal-encode a single canonical value. A string is parsed as octal,
+/// accepting an optional `0o` prefix and rejecting non-octal digits with a clear
+/// message.
 fn deserialize_octal_mode<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
 where
 	D: serde::Deserializer<'de>,
@@ -109,7 +113,7 @@ where
 
 	match Option::<Raw>::deserialize(deserializer)? {
 		None => Ok(None),
-		Some(Raw::Int(bits)) => Ok(Some(bits)),
+		Some(Raw::Int(n)) => Ok(Some(int_mode_bits(n))),
 		Some(Raw::Str(s)) => {
 			let trimmed = s.trim();
 			let digits = trimmed
@@ -123,6 +127,18 @@ where
 			})
 		}
 	}
+}
+
+/// Interpret a bare YAML integer `mode:` as octal permission bits.
+///
+/// A bare `700` is the octal file-mode the user typed, so its decimal digits are
+/// read as octal (`700` → `0o700` = 448). A digit of `8` or `9` cannot be a real
+/// octal digit, so such a value can only be a `0o` literal that serde_yaml has
+/// already decoded to its numeric value (`0o700` → 448, `0o755` → 493); it is
+/// taken as the actual permission bits verbatim. The same fallback covers an
+/// out-of-range octal reading, so the conversion never panics.
+fn int_mode_bits(n: u32) -> u32 {
+	u32::from_str_radix(&n.to_string(), 8).unwrap_or(n)
 }
 
 /// A volume mount entry — either a short-form string or a long-form typed block.
@@ -321,6 +337,27 @@ mod tests {
 		// A non-octal string is rejected with a clear error, not silently coerced.
 		let err = serde_yaml::from_str::<TmpfsOptions>("mode: \"0o9\"\n").unwrap_err();
 		assert!(err.to_string().contains("tmpfs mode"), "got: {err}");
+	}
+
+	#[test]
+	fn tmpfs_mode_bare_decimal_is_interpreted_as_octal() {
+		// A bare `700` is the octal file-mode the user typed, not a decimal value:
+		// it must yield the same permission bits as `0700`/`0o700` (issue #917)
+		// instead of being octal-encoded a second time at render time.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: 700\n").unwrap();
+		assert_eq!(opts.mode, Some(0o700));
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: 644\n").unwrap();
+		assert_eq!(opts.mode, Some(0o644));
+	}
+
+	#[test]
+	fn int_mode_bits_treats_decoded_0o_literals_as_bits() {
+		// A value carrying an 8/9 digit can only be a `0o` literal serde_yaml
+		// already decoded (`0o755` → 493), so it is taken as the bits verbatim;
+		// a value of valid octal digits is read as the octal the user typed.
+		assert_eq!(int_mode_bits(700), 0o700);
+		assert_eq!(int_mode_bits(0o755), 0o755);
+		assert_eq!(int_mode_bits(0o700), 0o700);
 	}
 
 	// VolumeMount::target

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -543,6 +543,15 @@ mod tests {
 		assert!(render_tmpfs_mount(&VolumeMount::Short("a:/b".into())).is_none());
 	}
 
+	#[test]
+	fn render_tmpfs_mount_bare_decimal_mode_is_not_octal_re_encoded() {
+		// Regression for #917: a long-form tmpfs with a bare `mode: 700` must
+		// render `mode=700`, not `mode=1274` (700 octal-encoded a second time).
+		let yaml = "type: tmpfs\ntarget: /run\ntmpfs:\n  mode: 700\n";
+		let mount: VolumeMount = serde_yaml::from_str(yaml).expect("parse tmpfs mount");
+		assert_eq!(render_tmpfs_mount(&mount).as_deref(), Some("/run:mode=700"));
+	}
+
 	// --- escape_unit_value (bug: incomplete systemd value escaping) ---
 
 	#[test]

--- a/tests/parse/fields/extends_build.rs
+++ b/tests/parse/fields/extends_build.rs
@@ -160,13 +160,15 @@ services:
         target: /run
         tmpfs:
           size: 67108864
-          mode: 1023
+          mode: 1750
 "#;
 	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
 	match v {
 		VolumeMount::Long { tmpfs: Some(t), .. } => {
 			assert_eq!(t.size, Some(67108864));
-			assert_eq!(t.mode, Some(1023));
+			// A bare `mode:` is octal (issue #917): `1750` is `0o1750`, the same
+			// bits `0o1750`/`01750` would yield, not the decimal 1750.
+			assert_eq!(t.mode, Some(0o1750));
 		}
 		_ => panic!("expected tmpfs mount"),
 	}


### PR DESCRIPTION
## What

Long-form tmpfs `mode:` is conventionally octal, but a bare `mode: 700` was
emitted as `Tmpfs=/run:mode=1274` — the decimal `700` got octal-encoded a
second time at render time. `0700`/`0o700` already rendered `mode=700`.

## Why

serde_yaml decodes the spelling before the deserializer sees it: `0o700`
arrives as the integer 448, the leading-zero `0700` arrives as a string, and a
bare `700` arrives unchanged. Only the string form was normalised to octal
permission bits, so the bare integer kept the value 700 and the renderer's
`{:o}` format turned it into `1274`.

## Fix

I normalise a bare integer mode in `deserialize_octal_mode` to the same
permission bits as the other spellings: its decimal digits are read as octal
(`700` -> `0o700`), while a value carrying an 8/9 digit can only be a `0o`
literal serde_yaml already decoded (`0o755` -> 493) and is taken as the bits
verbatim. The renderer keeps a single canonical octal value, so `mode: 700`,
`mode: "0700"` and `mode: 0o700` all emit `mode=700`.

## Tests

- `internal/compose/types/volume.rs`: bare `700`/`644` parse to `0o700`/`0o644`;
  `int_mode_bits` unit covers the 8/9 fallback.
- `internal/quadlet/render.rs`: end-to-end parse+render of `mode: 700` asserts
  `Tmpfs=/run:mode=700` (regression guard for #917).

Verified against the release binary on rootless Podman 5.4.2: `mode: 700` now
generates `Tmpfs=/run:mode=700`.

Closes #917
