### PR TITLE
Release 1.7.1: sync develop into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+podup (1.7.1) unstable; urgency=medium
+
+  * `port` now validates its arguments: `--protocol` accepts only tcp/udp
+    (case-insensitive) and rejects anything else instead of printing nothing,
+    and the port argument is parsed strictly (no leading `+`, no leading zeros,
+    no trailing junk).
+  * `podup ps` shows the exit code in the human table (`Exited (7)`), matching
+    the JSON output and docker compose, so a crash is distinguishable from a
+    clean stop.
+  * `exec --index` now targets running scaled replicas (like `cp`), so it can
+    reach any replica of a service scaled with `--scale`.
+  * `up` now implicitly starts a profiled service that an active service depends
+    on, matching docker compose (without over-activating unrelated profiles).
+  * Invalid volume/network names are rejected client-side with a clear error
+    before the engine call, instead of surfacing a raw Podman HTTP 500.
+  * `generate quadlet` renders a bare numeric tmpfs `mode` correctly
+    (`mode: 700` -> `mode=700`, no longer re-encoded to octal).
+  * Corrected the `--env-file` help text (it replaces the default `.env`; the
+    old "`.env` still wins" note was wrong).
+
+ -- Glyndor <packages@glyndor.net>  Mon, 29 Jun 2026 12:43:26 -0500
+
 podup (1.7.0) unstable; urgency=medium
 
   * Safety: `down --rmi all|local` no longer force-removes an in-use image and so

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -67,7 +67,7 @@ pub(crate) struct Cli {
 	#[arg(long, global = true)]
 	pub(crate) project_directory: Option<PathBuf>,
 
-	/// Extra env file(s) for interpolation (repeatable, later win; process env and `.env` still win).
+	/// Extra env file(s) for interpolation (repeatable; later `--env-file` wins, and these replace the default `.env`; process env still wins).
 	/// With `run`, they also seed the one-off container's environment (below `environment:`/`-e`).
 	#[arg(long = "env-file", global = true)]
 	pub(crate) env_file: Vec<String>,

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -76,9 +76,10 @@ pub struct TmpfsOptions {
 	pub size: Option<u64>,
 	/// File mode of the tmpfs mount, stored as the actual permission bits.
 	///
-	/// A leading-zero string (`0700`) or an explicit `0o700` is interpreted as
-	/// octal — the conventional Unix file-mode notation — rather than erroring or
-	/// being silently re-interpreted; invalid input is a clear error.
+	/// A compose `mode:` is conventionally octal, so every spelling is normalised
+	/// to the same permission bits: a leading-zero string (`0700`), an explicit
+	/// `0o700`, and a bare `700` all yield `0o700` (448). Invalid input is a clear
+	/// error rather than a silent re-interpretation.
 	#[serde(
 		default,
 		deserialize_with = "deserialize_octal_mode",
@@ -89,11 +90,14 @@ pub struct TmpfsOptions {
 
 /// Deserialize a tmpfs `mode` as octal-aware permission bits.
 ///
-/// YAML numeric scalars are already decoded by the parser (`0o700` → 448), so an
-/// integer node is taken as the actual permission bits. A string node — which is
-/// how a leading-zero literal like `0700` reaches us (and what previously failed
-/// with an opaque untagged error) — is parsed as octal, accepting an optional
-/// `0o` prefix and rejecting non-octal digits with a clear message.
+/// A compose `mode:` is conventionally octal, but serde_yaml decodes the spelling
+/// before we see it: a `0o`-prefixed literal arrives as its numeric value
+/// (`0o700` → 448), a leading-zero literal (`0700`) arrives as a string, and a
+/// bare `700` arrives unchanged. We normalise all of them to the actual
+/// permission bits (see [`int_mode_bits`] for the integer case), so the renderer
+/// can octal-encode a single canonical value. A string is parsed as octal,
+/// accepting an optional `0o` prefix and rejecting non-octal digits with a clear
+/// message.
 fn deserialize_octal_mode<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
 where
 	D: serde::Deserializer<'de>,
@@ -109,7 +113,7 @@ where
 
 	match Option::<Raw>::deserialize(deserializer)? {
 		None => Ok(None),
-		Some(Raw::Int(bits)) => Ok(Some(bits)),
+		Some(Raw::Int(n)) => Ok(Some(int_mode_bits(n))),
 		Some(Raw::Str(s)) => {
 			let trimmed = s.trim();
 			let digits = trimmed
@@ -123,6 +127,18 @@ where
 			})
 		}
 	}
+}
+
+/// Interpret a bare YAML integer `mode:` as octal permission bits.
+///
+/// A bare `700` is the octal file-mode the user typed, so its decimal digits are
+/// read as octal (`700` → `0o700` = 448). A digit of `8` or `9` cannot be a real
+/// octal digit, so such a value can only be a `0o` literal that serde_yaml has
+/// already decoded to its numeric value (`0o700` → 448, `0o755` → 493); it is
+/// taken as the actual permission bits verbatim. The same fallback covers an
+/// out-of-range octal reading, so the conversion never panics.
+fn int_mode_bits(n: u32) -> u32 {
+	u32::from_str_radix(&n.to_string(), 8).unwrap_or(n)
 }
 
 /// A volume mount entry — either a short-form string or a long-form typed block.
@@ -321,6 +337,27 @@ mod tests {
 		// A non-octal string is rejected with a clear error, not silently coerced.
 		let err = serde_yaml::from_str::<TmpfsOptions>("mode: \"0o9\"\n").unwrap_err();
 		assert!(err.to_string().contains("tmpfs mode"), "got: {err}");
+	}
+
+	#[test]
+	fn tmpfs_mode_bare_decimal_is_interpreted_as_octal() {
+		// A bare `700` is the octal file-mode the user typed, not a decimal value:
+		// it must yield the same permission bits as `0700`/`0o700` (issue #917)
+		// instead of being octal-encoded a second time at render time.
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: 700\n").unwrap();
+		assert_eq!(opts.mode, Some(0o700));
+		let opts: TmpfsOptions = serde_yaml::from_str("mode: 644\n").unwrap();
+		assert_eq!(opts.mode, Some(0o644));
+	}
+
+	#[test]
+	fn int_mode_bits_treats_decoded_0o_literals_as_bits() {
+		// A value carrying an 8/9 digit can only be a `0o` literal serde_yaml
+		// already decoded (`0o755` → 493), so it is taken as the bits verbatim;
+		// a value of valid octal digits is read as the octal the user typed.
+		assert_eq!(int_mode_bits(700), 0o700);
+		assert_eq!(int_mode_bits(0o755), 0o755);
+		assert_eq!(int_mode_bits(0o700), 0o700);
 	}
 
 	// VolumeMount::target

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -41,13 +41,10 @@ impl Engine {
 		start: bool,
 	) -> Result<()> {
 		// Reject an invalid container name client-side (podman would otherwise
-		// answer with an opaque HTTP 500 from its name-regex check).
-		if !crate::libpod::is_valid_object_name(container_name) {
-			return Err(ComposeError::Unsupported(format!(
-				"invalid container name {container_name:?}: names must start with an ASCII \
-				 letter or digit and contain only letters, digits, '_', '.', '-'"
-			)));
-		}
+		// answer with an opaque HTTP 500 from its name-regex check). Covers the
+		// ad-hoc `run --name` path too, which never passes through the up-time
+		// preflight in `validate_object_names`.
+		super::names::ensure_valid_object_name("container", service_name, container_name)?;
 
 		let derived_image;
 		let image: &str = if let Some(img) = service.image.as_deref() {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -144,6 +144,11 @@ impl Engine {
 		start: bool,
 	) -> Result<()> {
 		async {
+			// Reject any volume/network/container name Podman's regex would refuse
+			// before issuing a single create, so a bad name surfaces as a clear
+			// client-side error (not an opaque HTTP 500) with nothing created.
+			self.validate_object_names(file)?;
+
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
 			// Which services this `up`/`create` should start. A profiled service

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -20,7 +20,7 @@ use targets::{expand_targets, filter_services, in_started_set, validate_targets}
 use super::container::config_hash;
 
 use super::network::resolve_network_name;
-use super::profiles::{active_profiles_set, service_in_profiles};
+use super::profiles::{active_profiles_set, enabled_profile_services};
 use super::Engine;
 
 /// Options for [`Engine::run`].
@@ -146,6 +146,11 @@ impl Engine {
 		async {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
+			// Which services this `up`/`create` should start. A profiled service
+			// that an active service depends on is implicitly activated here —
+			// the same set `config` reports — so `up` never leaves a started
+			// service with an unsatisfied (never-created) dependency.
+			let enabled = enabled_profile_services(file, &active, target_services);
 
 			// Validate every `--scale SERVICE=N` override against the file before
 			// doing any work: an override naming a service the compose file does
@@ -210,7 +215,7 @@ impl Engine {
 					self.up_one_service(
 						name,
 						file,
-						&active,
+						&enabled,
 						&target_set,
 						&present,
 						&existing_hash,
@@ -259,7 +264,7 @@ impl Engine {
 		&self,
 		name: &str,
 		file: &ComposeFile,
-		active: &HashSet<String>,
+		enabled: &HashSet<String>,
 		target_set: &Option<HashSet<String>>,
 		present: &HashSet<String>,
 		existing_hash: &HashMap<String, String>,
@@ -274,7 +279,7 @@ impl Engine {
 		}
 		let service = &file.services[name];
 
-		if !service_in_profiles(service, active) {
+		if !enabled.contains(name) {
 			tracing::debug!("skipping {name}: no active profile match");
 			return Ok(());
 		}
@@ -305,7 +310,7 @@ impl Engine {
 				Some(s) => s,
 				None => continue,
 			};
-			if !service_in_profiles(dep_service, active) {
+			if !enabled.contains(&dep) {
 				continue;
 			}
 			// Scaled dep has no base-named container; wait on its first replica.

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -52,6 +52,10 @@ impl Engine {
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
 
+		// Reject any bad volume/network/container name before creating anything
+		// (the run path pre-creates the project networks below).
+		self.validate_object_names(file)?;
+
 		// Compose `run` brings up the service's `depends_on` services first (and
 		// waits on their conditions), unless `--no-deps` is given. The service
 		// itself is excluded — only its transitive dependencies are started.

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -18,6 +18,7 @@ mod container_config;
 mod health;
 mod lifecycle;
 mod lock;
+mod names;
 mod network;
 mod profiles;
 pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};

--- a/internal/engine/names.rs
+++ b/internal/engine/names.rs
@@ -1,0 +1,160 @@
+//! Client-side validation of the object names podup hands to Podman.
+//!
+//! Podman enforces an object-name regex (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`) on
+//! volumes, networks, and containers, rejecting anything else with an opaque
+//! HTTP 500 ("names must match …"). [`Engine::validate_object_names`] applies
+//! the same check up front — before a single create is issued — so a bad name
+//! (typically an explicit `name:` on a top-level volume/network, or an explicit
+//! `container_name:`) surfaces as a clear error naming the offending object,
+//! and nothing is created.
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::is_valid_object_name;
+
+use super::network::resolve_network_name;
+use super::Engine;
+
+impl Engine {
+	/// Reject any volume, network, or container name that Podman's object-name
+	/// regex would refuse, before issuing a single create. Validates the
+	/// resolved host names podup will actually pass to the API: the
+	/// project-prefixed default or the explicit `name:`/`container_name:`
+	/// override. External resources are looked up, not created, so a bad
+	/// external name surfaces as the clearer "does not exist" error instead.
+	pub(super) fn validate_object_names(&self, file: &ComposeFile) -> Result<()> {
+		validate_object_names(file, &self.project)
+	}
+}
+
+/// Pure form of [`Engine::validate_object_names`], taking the project name
+/// directly so it can be unit-tested without a live engine.
+fn validate_object_names(file: &ComposeFile, project: &str) -> Result<()> {
+	for (key, config) in &file.volumes {
+		if config.as_ref().and_then(|c| c.external).unwrap_or(false) {
+			continue;
+		}
+		let name = config
+			.as_ref()
+			.and_then(|c| c.name.as_deref())
+			.map(str::to_string)
+			.unwrap_or_else(|| format!("{project}_{key}"));
+		ensure_valid_object_name("volume", key, &name)?;
+	}
+
+	for (key, config) in &file.networks {
+		if config.as_ref().and_then(|c| c.external).unwrap_or(false) {
+			continue;
+		}
+		let name = resolve_network_name(key, file, project);
+		ensure_valid_object_name("network", key, &name)?;
+	}
+
+	for (svc_name, service) in &file.services {
+		// Only the base name needs checking: replica suffixes (`-1`, `-2`, …)
+		// append digits and a dash, which never turn a valid base invalid.
+		let name = service
+			.container_name
+			.clone()
+			.unwrap_or_else(|| format!("{project}-{svc_name}"));
+		ensure_valid_object_name("container", svc_name, &name)?;
+	}
+
+	Ok(())
+}
+
+/// Error out (with a message naming the offending object) when `name` is not a
+/// valid Podman object name. `kind` is the resource word ("volume", "network",
+/// "container"); `key` is the compose key it derives from, mentioned only when
+/// it differs from the resolved name so the user can locate the declaration.
+pub(super) fn ensure_valid_object_name(kind: &str, key: &str, name: &str) -> Result<()> {
+	if is_valid_object_name(name) {
+		return Ok(());
+	}
+	let origin = if name == key {
+		String::new()
+	} else {
+		format!(" (from {kind} '{key}')")
+	};
+	Err(ComposeError::Unsupported(format!(
+		"invalid {kind} name {name:?}{origin}: names must start with an ASCII letter or digit \
+		 and contain only letters, digits, '_', '.', '-'"
+	)))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::parse_str_raw;
+
+	fn file(yaml: &str) -> ComposeFile {
+		parse_str_raw(yaml).unwrap()
+	}
+
+	#[test]
+	fn clean_project_passes() {
+		let f =
+			file("services:\n  web:\n    image: nginx\nvolumes:\n  data:\nnetworks:\n  back:\n");
+		validate_object_names(&f, "proj").unwrap();
+	}
+
+	#[test]
+	fn bad_explicit_volume_name_is_rejected() {
+		let f = file(
+			"services:\n  web:\n    image: nginx\nvolumes:\n  badvol:\n    name: \"x@bad name!\"\n",
+		);
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("invalid volume name"), "got: {msg}");
+		assert!(msg.contains("x@bad name!"), "got: {msg}");
+		assert!(msg.contains("badvol"), "got: {msg}");
+	}
+
+	#[test]
+	fn bad_default_volume_name_via_key_is_rejected() {
+		// No explicit `name:`; the bad characters come from the key, so the
+		// resolved name `proj_bad key` is rejected without a redundant origin.
+		let f = file("services:\n  web:\n    image: nginx\nvolumes:\n  bad key:\n");
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		assert!(
+			err.to_string().contains("invalid volume name"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn bad_explicit_network_name_is_rejected() {
+		let f =
+			file("services:\n  web:\n    image: nginx\nnetworks:\n  net:\n    name: \"bad@net\"\n");
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("invalid network name"), "got: {msg}");
+		assert!(msg.contains("bad@net"), "got: {msg}");
+	}
+
+	#[test]
+	fn bad_container_name_is_rejected() {
+		let f = file("services:\n  web:\n    image: nginx\n    container_name: \"bad name!\"\n");
+		let err = validate_object_names(&f, "proj").unwrap_err();
+		assert!(
+			err.to_string().contains("invalid container name"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn external_resources_are_not_name_validated() {
+		// An external resource is looked up by its name, not created, so the
+		// strict create-time regex does not apply here.
+		let f = file(
+			"services:\n  web:\n    image: nginx\nvolumes:\n  ext:\n    external: true\n    name: \"weird:name\"\nnetworks:\n  en:\n    external: true\n    name: \"weird:net\"\n",
+		);
+		validate_object_names(&f, "proj").unwrap();
+	}
+
+	#[test]
+	fn origin_is_omitted_when_name_equals_key() {
+		let err = ensure_valid_object_name("volume", "bad name", "bad name").unwrap_err();
+		assert!(!err.to_string().contains("(from"), "got: {err}");
+	}
+}

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -24,6 +24,29 @@ pub fn retain_active_profiles_with_targets(
 	targets: &[String],
 ) {
 	let set = active_profiles_set(active);
+	let enabled = enabled_profile_services(file, &set, targets);
+	file.services.retain(|name, _| enabled.contains(name));
+}
+
+/// The set of service names that should run under the active profile set.
+///
+/// A service is enabled when it is unprofiled, matches an active profile (or the
+/// `*` wildcard), or is explicitly named in `targets` (naming a service on the
+/// command line activates its profile). Implicit activation then pulls in the
+/// transitive `depends_on` targets of every enabled service — even profiled
+/// ones whose profile is inactive — so a started service never depends on a
+/// service that was filtered out. Mirrors docker compose, which activates a
+/// profiled service that is depended on by a started one.
+///
+/// This is the single source of truth for "which services does an `up`/`config`
+/// with these profiles touch": [`retain_active_profiles_with_targets`] uses it
+/// to prune the config, and the `up`/`create` lifecycle path uses it to decide
+/// which services to actually start — so the two never disagree.
+pub(crate) fn enabled_profile_services(
+	file: &ComposeFile,
+	active: &HashSet<String>,
+	targets: &[String],
+) -> HashSet<String> {
 	let named: HashSet<&str> = targets.iter().map(|s| s.as_str()).collect();
 
 	// Directly enabled: an unprofiled service, a profile match (or `*`), or a
@@ -31,14 +54,13 @@ pub fn retain_active_profiles_with_targets(
 	let mut enabled: HashSet<String> = file
 		.services
 		.iter()
-		.filter(|(name, svc)| service_in_profiles(svc, &set) || named.contains(name.as_str()))
+		.filter(|(name, svc)| service_in_profiles(svc, active) || named.contains(name.as_str()))
 		.map(|(name, _)| name.clone())
 		.collect();
 
 	// Implicit activation: pull in profiled `depends_on` targets of enabled
 	// services, transitively, so a retained service never references a dropped
-	// dependency. Mirrors docker compose, which enables a profiled service that
-	// is depended on by a started one.
+	// dependency.
 	let mut stack: Vec<String> = enabled.iter().cloned().collect();
 	while let Some(name) = stack.pop() {
 		if let Some(svc) = file.services.get(&name) {
@@ -50,7 +72,7 @@ pub fn retain_active_profiles_with_targets(
 		}
 	}
 
-	file.services.retain(|name, _| enabled.contains(name));
+	enabled
 }
 
 /// Build the active-profile set, falling back to `COMPOSE_PROFILES` env var.
@@ -251,6 +273,41 @@ mod tests {
 		});
 		assert!(file.services.contains_key("db"));
 		assert!(!file.services.contains_key("extra"));
+	}
+
+	#[test]
+	fn enabled_set_activates_profiled_dependency_for_up() {
+		// The `up`/`create` lifecycle path consults this set directly. `app`
+		// (unprofiled, started) depends on `db` (profiles: [storage]). With no
+		// profile active, `db` must be in the enabled set so `up` actually
+		// creates it — otherwise `app` runs with an unsatisfied dependency.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n";
+		let file = crate::parse_str(yaml).unwrap();
+		let active: HashSet<String> = HashSet::new();
+		let enabled = enabled_profile_services(&file, &active, &[]);
+		assert!(enabled.contains("app"));
+		assert!(
+			enabled.contains("db"),
+			"profiled depends_on target is in the started set"
+		);
+	}
+
+	#[test]
+	fn enabled_set_excludes_unrelated_profiled_service() {
+		// Only dependencies are pulled in — an unrelated profiled service stays
+		// out of the started set, so `up` does not over-activate it.
+		let yaml = "services:\n  \
+			app:\n    image: x\n    depends_on: [db]\n  \
+			db:\n    image: x\n    profiles: [storage]\n  \
+			extra:\n    image: x\n    profiles: [other]\n";
+		let file = crate::parse_str(yaml).unwrap();
+		let active: HashSet<String> = HashSet::new();
+		let enabled = enabled_profile_services(&file, &active, &[]);
+		assert!(enabled.contains("app"));
+		assert!(enabled.contains("db"));
+		assert!(!enabled.contains("extra"));
 	}
 
 	#[test]

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -152,10 +152,13 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
-		// Resolve the target replica through the shared helper so `--index 0` (and
-		// out-of-range indexes) are rejected consistently with `cp`/`port`/etc.,
-		// rather than aliasing index 0 to the first replica.
-		let container_name = self.replica_name_at(service_name, service, opts.index)?;
+		// Resolve the target replica against the *running* containers (matching
+		// `cp`), so `--index N` and a bare `exec` reach a live replica of a service
+		// scaled by an earlier `up --scale`/`scale` — not just the compose static
+		// count. `--index 0`/out-of-range indexes stay rejected consistently.
+		let container_name = self
+			.live_replica_name_at(service_name, service, opts.index)
+			.await?;
 
 		let env = expand_exec_env(&opts.env);
 		let exec_cfg = ExecCreateConfig {

--- a/internal/engine/query/inspect_util.rs
+++ b/internal/engine/query/inspect_util.rs
@@ -42,20 +42,63 @@ pub(super) fn select_replica(
 /// Resolve the `(port, proto)` for `port` from a `PORT` or `PORT/proto` argument,
 /// the `/proto` suffix overriding the `--protocol` flag — matching
 /// `docker compose port`. Pure so the parsing is unit-tested.
-pub(super) fn parse_port_proto<'a>(
-	private_port: &'a str,
-	proto_flag: &'a str,
-) -> Result<(u16, &'a str)> {
-	let (port, proto) = match private_port.split_once('/') {
+///
+/// The private port is parsed strictly like docker's port spec: only a canonical
+/// decimal `1..=65535` is accepted, so a leading `+`/`-`, leading zeros
+/// (`080`), surrounding whitespace, or any trailing junk (`80/tcp/extra`) are
+/// rejected rather than silently coerced. The protocol is validated to
+/// `tcp`/`udp` (case-insensitive) and normalised to lowercase so it matches the
+/// lowercase keys Podman reports — an unknown or empty protocol errors clearly
+/// instead of yielding an empty, exit-0 "no mapping" result.
+pub(super) fn parse_port_proto(
+	private_port: &str,
+	proto_flag: &str,
+) -> Result<(u16, &'static str)> {
+	let (port_str, proto_str) = match private_port.split_once('/') {
 		Some((p, pr)) => (p, pr),
 		None => (private_port, proto_flag),
 	};
-	let port: u16 = port.parse().map_err(|_| {
+	let port = parse_strict_port(port_str, private_port)?;
+	let proto = normalise_proto(proto_str)?;
+	Ok((port, proto))
+}
+
+/// Parse a private port strictly: a canonical decimal in `1..=65535`. Rejects an
+/// empty string, a leading sign (`+80`/`-80`), leading zeros (`080`), embedded
+/// whitespace, and any non-digit (so trailing junk cannot slip through).
+fn parse_strict_port(port_str: &str, private_port: &str) -> Result<u16> {
+	let invalid = || {
 		ComposeError::InvalidPort(format!(
 			"port '{private_port}' is not a valid PORT or PORT/proto"
 		))
-	})?;
-	Ok((port, proto))
+	};
+	if port_str.is_empty() || !port_str.bytes().all(|b| b.is_ascii_digit()) {
+		return Err(invalid());
+	}
+	// Reject non-canonical leading zeros (e.g. `080`); a bare `0` is caught below.
+	if port_str.len() > 1 && port_str.starts_with('0') {
+		return Err(invalid());
+	}
+	let port: u16 = port_str.parse().map_err(|_| invalid())?;
+	if port == 0 {
+		return Err(invalid());
+	}
+	Ok(port)
+}
+
+/// Validate and normalise a protocol to `tcp`/`udp` (case-insensitive). Returns a
+/// lowercase `&'static str` so it matches the keys Podman reports; anything else
+/// (including an empty string) is a clear error.
+fn normalise_proto(proto: &str) -> Result<&'static str> {
+	if proto.eq_ignore_ascii_case("tcp") {
+		Ok("tcp")
+	} else if proto.eq_ignore_ascii_case("udp") {
+		Ok("udp")
+	} else {
+		Err(ComposeError::InvalidPort(format!(
+			"protocol '{proto}' is not valid (expected 'tcp' or 'udp')"
+		)))
+	}
 }
 
 /// Deduplicate a list of strings, preserving first-seen order. Used so `top web
@@ -256,6 +299,35 @@ mod tests {
 	fn non_numeric_port_is_rejected() {
 		assert!(parse_port_proto("http", "tcp").is_err());
 		assert!(parse_port_proto("abc/tcp", "tcp").is_err());
+	}
+
+	#[test]
+	fn protocol_flag_is_case_insensitive() {
+		assert_eq!(parse_port_proto("80", "TCP").unwrap(), (80, "tcp"));
+		assert_eq!(parse_port_proto("80", "Udp").unwrap(), (80, "udp"));
+		assert_eq!(parse_port_proto("53/UDP", "tcp").unwrap(), (53, "udp"));
+	}
+
+	#[test]
+	fn unknown_or_empty_protocol_is_rejected() {
+		// Previously these silently produced an empty, exit-0 "no mapping".
+		assert!(parse_port_proto("80", "sctp").is_err());
+		assert!(parse_port_proto("80", "").is_err());
+		assert!(parse_port_proto("80/sctp", "tcp").is_err());
+	}
+
+	#[test]
+	fn non_canonical_private_port_is_rejected() {
+		// Leading sign, leading zeros, whitespace, and trailing junk must all
+		// error rather than being coerced or silently mis-handled.
+		assert!(parse_port_proto("+80", "tcp").is_err());
+		assert!(parse_port_proto("-80", "tcp").is_err());
+		assert!(parse_port_proto("080", "tcp").is_err());
+		assert!(parse_port_proto(" 80", "tcp").is_err());
+		assert!(parse_port_proto("80 ", "tcp").is_err());
+		assert!(parse_port_proto("80/tcp/extra", "tcp").is_err());
+		assert!(parse_port_proto("0", "tcp").is_err());
+		assert!(parse_port_proto("65536", "tcp").is_err());
 	}
 
 	#[test]

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -45,6 +45,21 @@ fn display_status(c: &ContainerListEntry) -> &str {
 	}
 }
 
+/// Table STATUS cell. Podman's list endpoint reports an exited container with a
+/// bare `exited` state and no code, which is indistinguishable from a clean exit;
+/// surface the exit code the way `docker compose ps` does (`Exited (0)` /
+/// `Exited (7)`). For every other state fall back to [`display_status`].
+fn table_status(c: &ContainerListEntry) -> String {
+	let status = display_status(c);
+	let exited = c.state.eq_ignore_ascii_case("exited") || c.state.eq_ignore_ascii_case("dead");
+	// Only synthesize when the status text doesn't already carry the code, so a
+	// richer Docker-style `Exited (7) 4 seconds ago` is left untouched.
+	if exited && !status.contains("Exited (") {
+		return format!("Exited ({})", c.exit_code.unwrap_or(0));
+	}
+	status.to_string()
+}
+
 /// The container's display name (leading slash stripped).
 fn name_of(c: &ContainerListEntry) -> String {
 	c.names.join(", ").trim_start_matches('/').to_string()
@@ -300,7 +315,7 @@ impl Engine {
 			table.push(vec![
 				name_of(c),
 				c.image.clone(),
-				display_status(c).to_string(),
+				table_status(c),
 				format_ports(&c.ports),
 			]);
 		}
@@ -367,6 +382,40 @@ mod tests {
 			display_status(&entry("Up 2 seconds", "running")),
 			"Up 2 seconds"
 		);
+	}
+
+	fn entry_exit(state: &str, code: Option<i32>) -> ContainerListEntry {
+		ContainerListEntry {
+			exit_code: code,
+			..entry("", state)
+		}
+	}
+
+	#[test]
+	fn table_status_shows_exit_code_for_bare_exited() {
+		// A crash (non-zero) and a clean exit (zero) must be distinguishable,
+		// even though libpod reports both as a bare `exited` state.
+		assert_eq!(table_status(&entry_exit("exited", Some(7))), "Exited (7)");
+		assert_eq!(table_status(&entry_exit("exited", Some(0))), "Exited (0)");
+		// Missing exit code defaults to 0 rather than rendering a bare word.
+		assert_eq!(table_status(&entry_exit("exited", None)), "Exited (0)");
+		// `dead` is treated like an exit too.
+		assert_eq!(table_status(&entry_exit("dead", Some(255))), "Exited (255)");
+	}
+
+	#[test]
+	fn table_status_keeps_running_and_rich_status_text() {
+		assert_eq!(
+			table_status(&entry("Up 2 seconds", "running")),
+			"Up 2 seconds"
+		);
+		assert_eq!(table_status(&entry("", "running")), "running");
+		// A Docker-style status that already carries the code is left untouched.
+		let c = ContainerListEntry {
+			exit_code: Some(7),
+			..entry("Exited (7) 4 seconds ago", "exited")
+		};
+		assert_eq!(table_status(&c), "Exited (7) 4 seconds ago");
 	}
 
 	#[test]

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -543,6 +543,15 @@ mod tests {
 		assert!(render_tmpfs_mount(&VolumeMount::Short("a:/b".into())).is_none());
 	}
 
+	#[test]
+	fn render_tmpfs_mount_bare_decimal_mode_is_not_octal_re_encoded() {
+		// Regression for #917: a long-form tmpfs with a bare `mode: 700` must
+		// render `mode=700`, not `mode=1274` (700 octal-encoded a second time).
+		let yaml = "type: tmpfs\ntarget: /run\ntmpfs:\n  mode: 700\n";
+		let mount: VolumeMount = serde_yaml::from_str(yaml).expect("parse tmpfs mount");
+		assert_eq!(render_tmpfs_mount(&mount).as_deref(), Some("/run:mode=700"));
+	}
+
 	// --- escape_unit_value (bug: incomplete systemd value escaping) ---
 
 	#[test]

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -43,6 +43,8 @@ mod build_resources;
 mod commands_networking;
 #[path = "engine_integration/cp_flags.rs"]
 mod cp_flags;
+#[path = "engine_integration/exec_flags.rs"]
+mod exec_flags;
 #[path = "engine_integration/health_targeting.rs"]
 mod health_targeting;
 #[path = "engine_integration/lifecycle.rs"]

--- a/tests/engine_integration/exec_flags.rs
+++ b/tests/engine_integration/exec_flags.rs
@@ -1,0 +1,130 @@
+//! `exec` replica-resolution integration tests: a bare `exec` and `exec
+//! --index N` must reach a *running* replica of a service scaled by an earlier
+//! `up --scale`/`scale`, not the compose static count (issue #795). Skip
+//! gracefully when Podman is unreachable.
+use super::*;
+
+#[cfg(feature = "test-helpers")]
+use std::collections::HashMap;
+
+/// Bring up `web` with three replicas, then drive `exec` from a *fresh* engine
+/// whose compose file still declares the default single replica — exactly the
+/// real CLI case where a later `podup exec` knows nothing of the prior
+/// `up --scale`. Before the fix, `exec` resolved the replica count from that
+/// static default (1): a bare `exec` targeted the unsuffixed `web` (which does
+/// not exist once scaled) and `--index 2` was rejected as "no replica 2".
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn engine_exec_reaches_live_scaled_replicas() {
+	let (scaler_client, exec_client) = match (podman().await, podman().await) {
+		(Some(a), Some(b)) => (a, b),
+		_ => return,
+	};
+	let proj = proj("execscale");
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	// Scale to three replicas with a dedicated engine (mirrors `up --scale web=3`).
+	let scaler = Engine::new(scaler_client, proj.clone())
+		.with_scale_overrides(HashMap::from([("web".to_string(), 3)]));
+	scaler.up(&file).await.unwrap();
+
+	// A fresh engine with NO scale override: it sees only the compose default of
+	// one replica, just like a separate `podup exec` invocation would.
+	let engine = Engine::new(exec_client, proj.clone());
+
+	// `--index 2` must reach the *running* web-2. Drop a marker in it via exec,
+	// then read each replica back to prove exactly web-2 was hit.
+	let by_index = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"echo idx2 > /tmp/exec_marker".into(),
+			],
+			podup::ExecOptions {
+				index: Some(2),
+				..Default::default()
+			},
+		)
+		.await;
+
+	// A bare `exec` (no index) must reach the lowest-numbered running replica,
+	// web-1 — not the never-created unsuffixed `web`.
+	let bare = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"echo bare > /tmp/exec_bare".into(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
+
+	// `--index 4` is out of range against the three running replicas.
+	let out_of_range = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec!["true".into()],
+			podup::ExecOptions {
+				index: Some(4),
+				..Default::default()
+			},
+		)
+		.await;
+
+	let marker_in_2 = engine
+		.test_exec_capture(
+			&format!("{proj}-web-2"),
+			vec!["cat".into(), "/tmp/exec_marker".into()],
+		)
+		.await;
+	let marker_in_1 = engine
+		.test_exec_capture(
+			&format!("{proj}-web-1"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"cat /tmp/exec_marker 2>/dev/null || true".into(),
+			],
+		)
+		.await;
+	let bare_in_1 = engine
+		.test_exec_capture(
+			&format!("{proj}-web-1"),
+			vec!["cat".into(), "/tmp/exec_bare".into()],
+		)
+		.await;
+
+	scaler.down(&file).await.unwrap();
+
+	by_index.unwrap();
+	bare.unwrap();
+	assert!(
+		matches!(
+			out_of_range,
+			Err(podup::ComposeError::ReplicaIndex { ref service, index: 4 }) if service == "web"
+		),
+		"out-of-range --index against running scale must error, got {out_of_range:?}"
+	);
+	assert!(
+		marker_in_2.unwrap_or_default().contains("idx2"),
+		"`exec --index 2` must run inside the running web-2"
+	);
+	assert!(
+		!marker_in_1.unwrap_or_default().contains("idx2"),
+		"`exec --index 2` must NOT touch web-1"
+	);
+	assert!(
+		bare_in_1.unwrap_or_default().contains("bare"),
+		"bare `exec` must run inside the lowest-numbered running replica web-1"
+	);
+}

--- a/tests/parse/fields/extends_build.rs
+++ b/tests/parse/fields/extends_build.rs
@@ -160,13 +160,15 @@ services:
         target: /run
         tmpfs:
           size: 67108864
-          mode: 1023
+          mode: 1750
 "#;
 	let v = &parse_str(yaml).unwrap().services["app"].volumes[0];
 	match v {
 		VolumeMount::Long { tmpfs: Some(t), .. } => {
 			assert_eq!(t.size, Some(67108864));
-			assert_eq!(t.mode, Some(1023));
+			// A bare `mode:` is octal (issue #917): `1750` is `0o1750`, the same
+			// bits `0o1750`/`01750` would yield, not the decimal 1750.
+			assert_eq!(t.mode, Some(0o1750));
 		}
 		_ => panic!("expected tmpfs mount"),
 	}


### PR DESCRIPTION
Patch 1.7.1: real fixes for the 8 findings the 1.7.0 live verification caught as partially fixed (#852, #853, #739, #795, #777, #767, #917, #770), each re-validated live against the built binary. Brings 1.7.1 to main for release.