### PR TITLE
Release 1.8.0: sync develop into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+podup (1.8.0) unstable; urgency=medium
+
+  * Container names are now always index-suffixed (`project-service-1`, even for
+    a single replica), matching docker compose and podman-compose, which never
+    expose a bare, unnumbered container name. Scaling a service down to one
+    replica now keeps the surviving container (`service-1`) instead of removing
+    every numbered replica and recreating a fresh unnumbered one, so the
+    survivor keeps its identity, uptime and in-memory state (named volumes were
+    already preserved either way). A `links:`/`volumes_from:`/`network_mode:
+    service:` reference to another service now resolves to that service's first
+    replica. Services reach each other by their bare service name on the network
+    exactly as before. An explicit `container_name:` is still honoured verbatim.
+  * Upgrade note: on the first `up` after upgrading, an existing project's old
+    `project-service` container is seen as an orphan and recreated once as
+    `project-service-1`.
+
+ -- Glyndor <packages@glyndor.net>  Mon, 29 Jun 2026 15:42:29 -0500
+
 podup (1.7.1) unstable; urgency=medium
 
   * `port` now validates its arguments: `--protocol` accepts only tcp/udp

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -217,7 +217,6 @@ equivalent.
 |---|---|
 | `env_file.format` values other than `dotenv` | A **warning** is emitted (`format is not honored; podup always parses env files as dotenv`); the file is still read as dotenv |
 | `provider:` / model-runner services (`provider`, top-level `models`) | Modeled and parsed, but **not honored** — a not-honored warning is emitted (these are no rootless-Podman equivalent, *not* "unknown key" errors) |
-| Container naming | A single-replica service is named `<project>-<service>` (e.g. `myapp-web`); docker-compose v2 always appends a `-1` replica index (`myapp-web-1`). Scaled replicas (>1) do get the `-N` suffix. Scripts that reference containers by exact name should account for this. |
 | Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
 
 ## Nothing is dropped silently

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -100,7 +100,9 @@ pub(super) fn resolve_links(service: &Service, file: &ComposeFile, project: &str
 				.map(|svc| {
 					svc.container_name
 						.clone()
-						.unwrap_or_else(|| format!("{project}-{target}"))
+						// Auto-generated container names are always index-suffixed;
+						// a link/volumes_from references the first replica.
+						.unwrap_or_else(|| format!("{project}-{target}-1"))
 				})
 				.unwrap_or_else(|| target.to_string());
 			format!("{container}:{alias}")
@@ -117,7 +119,8 @@ pub(super) fn resolve_links(service: &Service, file: &ComposeFile, project: &str
 /// `service:<name>`, or `container:<name>`, any of which may carry a trailing
 /// `:ro`/`:rw` access-mode suffix. The bare-service and `service:` forms are
 /// rewritten to the referenced service's container name (an explicit
-/// `container_name:` is honoured, otherwise `{project}-{service}`), preserving
+/// `container_name:` is honoured, otherwise the first replica
+/// `{project}-{service}-1`), preserving
 /// the access mode. The `container:` form already names a container outside the
 /// project and is passed through verbatim, as is any service name that is not
 /// declared in this compose file.
@@ -145,7 +148,9 @@ pub(super) fn resolve_volumes_from(
 					.map(|svc| {
 						svc.container_name
 							.clone()
-							.unwrap_or_else(|| format!("{project}-{target}"))
+							// Auto-generated container names are always index-suffixed;
+							// a link/volumes_from references the first replica.
+							.unwrap_or_else(|| format!("{project}-{target}-1"))
 					})
 					// Unknown service: leave the reference untouched.
 					.unwrap_or_else(|| target.to_string())
@@ -406,8 +411,10 @@ mod tests {
 		)
 		.unwrap();
 		let links = resolve_links(&file.services["web"], &file, "proj");
-		assert!(links.contains(&"proj-db:db".to_string()));
-		assert!(links.contains(&"proj-db:primary".to_string()));
+		// Auto-generated names are always index-suffixed; a link targets the
+		// first replica.
+		assert!(links.contains(&"proj-db-1:db".to_string()));
+		assert!(links.contains(&"proj-db-1:primary".to_string()));
 		assert!(links.contains(&"legacy_db:db".to_string()));
 	}
 
@@ -428,8 +435,8 @@ mod tests {
 		)
 		.unwrap();
 		let resolved = resolve_volumes_from(&file.services["web"], &file, "proj");
-		// Bare service name resolves to `{project}-{service}`.
-		assert!(resolved.contains(&"proj-db".to_string()));
+		// Bare service name resolves to the first replica `{project}-{service}-1`.
+		assert!(resolved.contains(&"proj-db-1".to_string()));
 		// An explicit container_name is honoured.
 		assert!(resolved.contains(&"my-cache".to_string()));
 	}
@@ -443,8 +450,8 @@ mod tests {
 		let resolved = resolve_volumes_from(&file.services["web"], &file, "proj");
 		// The `:ro`/`:rw` suffix survives the rewrite, and the `service:` prefix
 		// is stripped before resolving.
-		assert!(resolved.contains(&"proj-db:ro".to_string()));
-		assert!(resolved.contains(&"proj-db:rw".to_string()));
+		assert!(resolved.contains(&"proj-db-1:ro".to_string()));
+		assert!(resolved.contains(&"proj-db-1:rw".to_string()));
 	}
 
 	#[test]

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -389,12 +389,7 @@ impl Engine {
 
 		let new_hash = config_hash(service, file)?;
 
-		for i in 1..=replicas {
-			let container_name = if replicas <= 1 {
-				self.container_name(name, service)
-			} else {
-				format!("{}-{i}", self.container_name(name, service))
-			};
+		for container_name in self.replica_names_for(name, service, replicas) {
 			if !force_recreate {
 				if no_recreate && present.contains(&container_name) {
 					tracing::debug!("{container_name} already exists — skipping recreate");

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -145,12 +145,14 @@ impl Engine {
 		service: &Service,
 		target: u32,
 	) -> Result<()> {
-		let base = self.container_name(service_name, service);
-		let desired: HashSet<String> = if target <= 1 {
-			std::iter::once(base).collect()
-		} else {
-			(1..=target).map(|i| format!("{base}-{i}")).collect()
-		};
+		// The desired set is the index-suffixed name at every count (`svc-1`
+		// even for a single replica), so a scale N→1 keeps the running `svc-1`
+		// instead of treating the bare `svc` as desired and destroying every
+		// numbered replica (#815).
+		let desired: HashSet<String> = self
+			.replica_names_for(service_name, service, target as usize)
+			.into_iter()
+			.collect();
 		let grace = self.grace_period_secs(service);
 		let surplus: Vec<String> = self
 			.list_project_container_names(Some(service_name))

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -299,24 +299,49 @@ impl Engine {
 			.unwrap_or_else(|| format!("{}-{}", self.project, service_name))
 	}
 
-	pub(super) fn replica_names(&self, service_name: &str, service: &Service) -> Vec<String> {
-		let replicas = self.resolve_replicas(service_name, service);
-		let base = self.container_name(service_name, service);
-		if replicas <= 1 {
-			vec![base]
-		} else {
-			(1..=replicas).map(|i| format!("{base}-{i}")).collect()
+	/// Container names for `service` at exactly `count` replicas.
+	///
+	/// The auto-generated name is **always** index-suffixed (`{project}-{svc}-1`
+	/// even for a single replica), matching docker-compose and podman-compose,
+	/// which never expose a bare, unnumbered container name. An explicit
+	/// `container_name:` is honoured verbatim at a single replica (and
+	/// `{name}-1..-N` only when forced past one), since the user asked for that
+	/// exact name. A `count` of 0 (`--scale svc=0`) yields no names.
+	pub(super) fn replica_names_for(
+		&self,
+		service_name: &str,
+		service: &Service,
+		count: usize,
+	) -> Vec<String> {
+		match &service.container_name {
+			Some(explicit) if count <= 1 => {
+				if count == 0 {
+					Vec::new()
+				} else {
+					vec![explicit.clone()]
+				}
+			}
+			Some(explicit) => (1..=count).map(|i| format!("{explicit}-{i}")).collect(),
+			None => {
+				let base = format!("{}-{}", self.project, service_name);
+				(1..=count).map(|i| format!("{base}-{i}")).collect()
+			}
 		}
 	}
 
-	pub(super) fn first_replica_name(&self, service_name: &str, service: &Service) -> String {
+	pub(super) fn replica_names(&self, service_name: &str, service: &Service) -> Vec<String> {
 		let replicas = self.resolve_replicas(service_name, service);
-		let base = self.container_name(service_name, service);
-		if replicas <= 1 {
-			base
-		} else {
-			format!("{base}-1")
-		}
+		self.replica_names_for(service_name, service, replicas)
+	}
+
+	pub(super) fn first_replica_name(&self, service_name: &str, service: &Service) -> String {
+		// Falls back to the bare base only when the service resolves to zero
+		// replicas (`--scale svc=0`), so callers that cannot represent "no
+		// container" still get a stable, addressable name.
+		self.replica_names(service_name, service)
+			.into_iter()
+			.next()
+			.unwrap_or_else(|| self.container_name(service_name, service))
 	}
 
 	/// Resolve the container name for a service replica from the statically
@@ -483,6 +508,47 @@ mod tests {
 	}
 
 	#[test]
+	fn replica_names_always_index_suffix_default_name() {
+		// The #815 contract: an auto-generated container name is ALWAYS
+		// index-suffixed, even for a single replica (docker/podman parity).
+		let e = engine("proj");
+		assert_eq!(
+			e.replica_names("web", &Service::default()),
+			vec!["proj-web-1".to_string()]
+		);
+		assert_eq!(
+			e.replica_names("web", &scaled_service(3)),
+			vec![
+				"proj-web-1".to_string(),
+				"proj-web-2".to_string(),
+				"proj-web-3".to_string(),
+			]
+		);
+	}
+
+	#[test]
+	fn replica_names_honour_explicit_container_name_verbatim() {
+		// An explicit `container_name:` is the user's exact choice and is never
+		// index-suffixed at a single replica.
+		let e = engine("proj");
+		let svc = Service {
+			container_name: Some("my-db".to_string()),
+			..Service::default()
+		};
+		assert_eq!(e.replica_names("db", &svc), vec!["my-db".to_string()]);
+		assert_eq!(e.first_replica_name("db", &svc), "my-db");
+	}
+
+	#[test]
+	fn replica_names_for_zero_scale_is_empty() {
+		// `--scale svc=0` resolves to no containers, so the name set is empty.
+		let e = engine("proj");
+		assert!(e
+			.replica_names_for("web", &Service::default(), 0)
+			.is_empty());
+	}
+
+	#[test]
 	fn replica_name_at_index_zero_is_rejected() {
 		// `--index` is 1-based; index 0 must be an error, never replica 1.
 		let e = engine("proj");
@@ -532,10 +598,11 @@ mod tests {
 	#[test]
 	fn replica_name_at_none_is_first_replica() {
 		let e = engine("proj");
-		// Single replica: the unsuffixed container name.
+		// Single replica: the first index-suffixed name (always-suffix parity
+		// with docker/podman — there is no bare, unnumbered container).
 		assert_eq!(
 			e.replica_name_at("web", &Service::default(), None).unwrap(),
-			"proj-web"
+			"proj-web-1"
 		);
 		// Multiple replicas: the first suffixed name.
 		assert_eq!(

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -215,30 +215,16 @@ pub(super) fn resolve_network_mode(
 /// Resolve the container name that a `network_mode: service:<name>` reference
 /// should attach to.
 ///
-/// An explicit `container_name` is honoured verbatim. Otherwise the name is
-/// derived from the project + service. A scaled service (replicas > 1 via
-/// `deploy.replicas` or `scale:`) has no base-named container — its replicas are
-/// `{project}-{svc}-1..N` — so we point at replica `-1`, matching docker-compose,
-/// which attaches `network_mode: service:` references to the first replica.
+/// An explicit `container_name` is honoured verbatim. Otherwise the auto-generated
+/// replicas are always index-suffixed `{project}-{svc}-1..N` (there is no
+/// base-named container at any replica count), so we point at replica `-1`,
+/// matching docker-compose, which attaches `network_mode: service:` references to
+/// the first replica.
 fn resolve_target_container_name(svc_name: &str, service: &Service, project: &str) -> String {
 	if let Some(name) = &service.container_name {
 		return name.clone();
 	}
-	let base = format!("{project}-{svc_name}");
-	if service_replicas(service) > 1 {
-		format!("{base}-1")
-	} else {
-		base
-	}
-}
-
-/// Number of replicas a service declares in the compose file, via `scale:` or
-/// `deploy.replicas`. Defaults to 1. Does not consult CLI `--scale` overrides.
-fn service_replicas(service: &Service) -> u32 {
-	service
-		.scale
-		.or(service.deploy.as_ref().and_then(|d| d.replicas))
-		.unwrap_or(1)
+	format!("{project}-{svc_name}-1")
 }
 
 /// Resolve the actual network name on the host for a compose network key.

--- a/internal/engine/network/tests.rs
+++ b/internal/engine/network/tests.rs
@@ -61,7 +61,9 @@ fn file_with_service(svc_name: &str, svc: Service) -> ComposeFile {
 }
 
 #[test]
-fn network_mode_service_single_replica_uses_base_name() {
+fn network_mode_service_single_replica_uses_first_replica_name() {
+	// Auto-generated container names are always index-suffixed, so even a
+	// single-replica `network_mode: service:` target attaches to `-1`.
 	let target = Service::default();
 	let file = file_with_service("db", target);
 	let svc = Service {
@@ -71,7 +73,7 @@ fn network_mode_service_single_replica_uses_base_name() {
 	let (ns, _) = resolve_network_mode("web", &svc, &file, "proj");
 	let ns = ns.unwrap();
 	assert_eq!(ns.nsmode, "container");
-	assert_eq!(ns.value.as_deref(), Some("proj-db"));
+	assert_eq!(ns.value.as_deref(), Some("proj-db-1"));
 }
 
 #[test]

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -68,7 +68,7 @@ impl Engine {
 					let abs = self.base_dir.join(&rule.path);
 					rule_entries.push(RuleEntry {
 						service_name: name.clone(),
-						container_name: self.container_name(name, service),
+						container_name: self.first_replica_name(name, service),
 						rule: rule.clone(),
 						abs_path: abs,
 					});
@@ -340,7 +340,7 @@ impl Engine {
 		// Inline secrets/configs are materialised up front rather than in the
 		// per-container path; ensure they exist before recreating the container.
 		self.create_inline_secrets(file).await?;
-		let container_name = self.container_name(service_name, service);
+		let container_name = self.first_replica_name(service_name, service);
 		self.create_and_start(&container_name, service_name, service, file, true)
 			.await
 	}

--- a/tests/engine_integration/build_resources.rs
+++ b/tests/engine_integration/build_resources.rs
@@ -390,7 +390,7 @@ async fn external_secret_injected_into_container() {
 	let file = parse_str(&yaml).unwrap();
 	let engine = Engine::new(client, proj.clone());
 	engine.up(&file).await.unwrap();
-	let cname = format!("{proj}-app");
+	let cname = format!("{proj}-app-1");
 	let out = engine
 		.test_exec_capture(&cname, vec!["cat".into(), "/run/secrets/tok".into()])
 		.await

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -367,7 +367,7 @@ async fn sibling_resolves_service_by_name_on_shared_network() {
 	// a network alias. Retry briefly while the server's httpd comes up.
 	let out = engine
 		.test_exec_capture(
-			&format!("{proj}-client"),
+			&format!("{proj}-client-1"),
 			vec![
 				"sh".into(),
 				"-c".into(),
@@ -413,7 +413,7 @@ async fn sibling_resolves_service_by_name_without_networks_block() {
 	engine.up(&file).await.unwrap();
 	let out = engine
 		.test_exec_capture(
-			&format!("{proj}-client"),
+			&format!("{proj}-client-1"),
 			vec![
 				"sh".into(),
 				"-c".into(),

--- a/tests/engine_integration/cp_flags.rs
+++ b/tests/engine_integration/cp_flags.rs
@@ -77,7 +77,7 @@ async fn engine_cp_follow_link_uploads_target_contents() {
 		.await;
 	let out = engine
 		.test_exec_capture(
-			&format!("{proj}-web"),
+			&format!("{proj}-web-1"),
 			vec!["cat".into(), "/tmp/link.txt".into()],
 		)
 		.await;
@@ -116,7 +116,7 @@ async fn engine_cp_to_container_renames_a_single_file() {
 	// `test -f` succeeds only for a regular file; a directory (the old bug) fails it.
 	let out = engine
 		.test_exec_capture(
-			&format!("{proj}-web"),
+			&format!("{proj}-web-1"),
 			vec![
 				"sh".into(),
 				"-c".into(),

--- a/tests/engine_integration/health_targeting.rs
+++ b/tests/engine_integration/health_targeting.rs
@@ -136,7 +136,7 @@ async fn external_config_injected_into_container() {
 	let file = parse_str(&yaml).unwrap();
 	let engine = Engine::new(client, proj.clone());
 	engine.up(&file).await.unwrap();
-	let cname = format!("{proj}-app");
+	let cname = format!("{proj}-app-1");
 	let out = engine
 		.test_exec_capture(&cname, vec!["cat".into(), "/etc/app.conf".into()])
 		.await

--- a/tests/engine_integration/scale.rs
+++ b/tests/engine_integration/scale.rs
@@ -22,6 +22,15 @@ fn run(args: &[&str]) -> std::process::Output {
 	Command::new(bin()).args(args).output().unwrap()
 }
 
+/// Podman container id for `name`, or empty when it does not exist.
+fn container_id(name: &str) -> String {
+	let out = Command::new("podman")
+		.args(["inspect", "-f", "{{.Id}}", name])
+		.output()
+		.unwrap();
+	String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
 #[tokio::test]
 async fn up_scale_creates_replicas_and_down_removes_them() {
 	if super::podman().await.is_none() {
@@ -85,6 +94,59 @@ async fn scale_subcommand_scales_up_then_down() {
 		down.stderr
 	);
 	assert_eq!(running_count(c, &proj), 1, "scale down must remove surplus");
+
+	run(&["-f", c, "-p", &proj, "down"]);
+	assert_eq!(running_count(c, &proj), 0);
+}
+
+/// #815 regression: scaling down to one must PRESERVE the surviving replica
+/// (`worker-1`), not destroy and recreate it. Containers are always named
+/// `worker-1..N`, so the desired set at target 1 is `{worker-1}` — which matches
+/// the running `worker-1` and keeps it. Before the fix the desired set was the
+/// bare, never-created `worker`, so every numbered replica (incl. the survivor)
+/// was removed and a fresh container took its place — losing the container's
+/// identity, uptime and in-memory state.
+#[tokio::test]
+async fn scale_down_to_one_preserves_surviving_replica() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-scalekeep", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	let survivor = format!("{proj}-worker-1");
+
+	// A single `up` already names the container `worker-1` (always-suffix).
+	let up = run(&["-f", c, "-p", &proj, "up", "--detach"]);
+	assert!(up.status.success(), "up failed: {:?}", up.stderr);
+	let id_before = container_id(&survivor);
+	assert!(
+		!id_before.is_empty(),
+		"single `up` must create the index-suffixed container {survivor}"
+	);
+
+	// Scale up to three, then back down to one.
+	assert!(run(&["-f", c, "-p", &proj, "scale", "worker=3"])
+		.status
+		.success());
+	assert_eq!(running_count(c, &proj), 3, "scale up must add replicas");
+	assert!(run(&["-f", c, "-p", &proj, "scale", "worker=1"])
+		.status
+		.success());
+	assert_eq!(running_count(c, &proj), 1, "scale down must remove surplus");
+
+	// The survivor must be the very same container — same id, never recreated.
+	let id_after = container_id(&survivor);
+	assert_eq!(
+		id_before, id_after,
+		"scale-down to 1 must keep {survivor} (id {id_before}), not recreate it (got {id_after})"
+	);
 
 	run(&["-f", c, "-p", &proj, "down"]);
 	assert_eq!(running_count(c, &proj), 0);

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -26,8 +26,8 @@ async fn cli_stats_flags_truncate_all_and_format() {
 	)
 	.unwrap();
 	let c = compose.to_str().unwrap();
-	// A single-replica service's container is named `{proj}-{svc}` (no `-1`).
-	let full = format!("{proj}-{svc}");
+	// A container is always index-suffixed `{proj}-{svc}-1`, even at one replica.
+	let full = format!("{proj}-{svc}-1");
 
 	Command::new(bin())
 		.args(["-f", c, "-p", &proj, "up", "-d"])

--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -49,7 +49,7 @@ async fn watch_sync_file_to_container() {
 
 	engine.up(&file).await.unwrap();
 	engine
-		.test_sync_to_container(&format!("{proj}-web"), &src_file, "/tmp/app.txt")
+		.test_sync_to_container(&format!("{proj}-web-1"), &src_file, "/tmp/app.txt")
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -70,7 +70,7 @@ async fn watch_restart_container() {
 
 	engine.up(&file).await.unwrap();
 	engine
-		.test_watch_restart(&format!("{proj}-web"))
+		.test_watch_restart(&format!("{proj}-web-1"))
 		.await
 		.unwrap();
 	engine.down(&file).await.unwrap();
@@ -92,7 +92,7 @@ async fn watch_exec_in_container() {
 	engine.up(&file).await.unwrap();
 	engine
 		.test_watch_exec(
-			&format!("{proj}-web"),
+			&format!("{proj}-web-1"),
 			vec!["echo".to_string(), "from-watch-exec".to_string()],
 		)
 		.await
@@ -128,7 +128,7 @@ async fn watch_initial_sync_runs() {
 
 	// Poll for the observable effect of initial_sync (the file appearing in the
 	// container) instead of sleeping a fixed duration and assuming it ran.
-	let cname = format!("{proj}-web");
+	let cname = format!("{proj}-web-1");
 	let synced = poll_synced(&engine, &cname, "/tmp/app.txt", "initial", 60).await;
 
 	handle.abort();
@@ -157,7 +157,7 @@ async fn watch_sync_creates_missing_target_directory() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	let cname = format!("{proj}-web");
+	let cname = format!("{proj}-web-1");
 	// Sync into a directory that does not exist in the image; podup must create
 	// it (like docker compose watch) rather than fail.
 	engine


### PR DESCRIPTION
Promotes 1.8.0 to main for release.

- fix(engine): always index-suffix replica names for docker/podman parity (#988) — closes #815. Container names are now `project-service-1` even at a single replica; scaling down to one preserves the surviving container instead of recreating it.

Regression gate before this sync: 1136 unit + 155 live integration tests green (Podman 5.4.2), fmt/clippy/doc/semver clean, and the 60 naming-sensitive previously-fixed findings re-verified live with 0 regressions.

Tagging `v1.8.0` after merge cuts the release.