### PR TITLE
feat(cli): add `podup autostart` with service mode

### DIFF
--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -1,0 +1,583 @@
+//! `podup autostart` service mode: a single rootless `systemctl --user` unit that
+//! brings a compose stack up at boot.
+//!
+//! Everything here is user-scope only — the unit lives under
+//! `${XDG_CONFIG_HOME:-~/.config}/systemd/user/` and every action goes through
+//! `systemctl --user` / `loginctl`. No root, no `sudo`, nothing under `/etc` or
+//! the system systemd. External-command calls go through the `SystemCtl` seam so
+//! the install/uninstall/status logic is unit-testable without a live systemd.
+
+mod service;
+
+pub use service::{render_service_unit, ServiceUnitOpts};
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use crate::ComposeError;
+
+/// Seam over the external `systemctl --user` / `loginctl` commands. The real impl
+/// shells out; tests substitute a fake that records the argument vectors and
+/// returns canned output, so install/uninstall/status are exercised without
+/// touching the host's systemd.
+pub trait SystemCtl {
+	/// Run `systemctl --user <args>`.
+	fn systemctl(&self, args: &[&str]) -> io::Result<Output>;
+	/// Run `loginctl <args>`.
+	fn loginctl(&self, args: &[&str]) -> io::Result<Output>;
+}
+
+/// The production [`SystemCtl`]: invokes the real `systemctl --user` and
+/// `loginctl` binaries.
+pub struct RealSystemCtl;
+
+impl SystemCtl for RealSystemCtl {
+	fn systemctl(&self, args: &[&str]) -> io::Result<Output> {
+		Command::new("systemctl").arg("--user").args(args).output()
+	}
+
+	fn loginctl(&self, args: &[&str]) -> io::Result<Output> {
+		Command::new("loginctl").args(args).output()
+	}
+}
+
+/// Options for [`install`].
+pub struct InstallOptions {
+	/// The unit to render and install.
+	pub unit: ServiceUnitOpts,
+	/// Install the unit but do not `enable --now` it (no immediate start).
+	pub no_start: bool,
+	/// Print the unit and the actions that would run, but change nothing.
+	pub dry_run: bool,
+}
+
+/// `${XDG_CONFIG_HOME:-~/.config}`. Falls back to `$HOME/.config`, then `.config`
+/// in the working directory if even `HOME` is unset (so a path is always formed).
+fn config_home() -> PathBuf {
+	if let Some(x) = std::env::var_os("XDG_CONFIG_HOME").filter(|s| !s.is_empty()) {
+		return PathBuf::from(x);
+	}
+	match std::env::var_os("HOME").filter(|s| !s.is_empty()) {
+		Some(home) => PathBuf::from(home).join(".config"),
+		None => PathBuf::from(".config"),
+	}
+}
+
+/// Directory that holds `systemctl --user` unit files.
+fn unit_dir() -> PathBuf {
+	config_home().join("systemd").join("user")
+}
+
+/// The unit's file name: `podup-<project>.service`. The project name is validated
+/// as a safe path component before reaching here, so it cannot escape `unit_dir`.
+fn unit_file_name(project: &str) -> String {
+	format!("podup-{project}.service")
+}
+
+/// Full path to the unit file for a project.
+fn unit_path(project: &str) -> PathBuf {
+	unit_dir().join(unit_file_name(project))
+}
+
+/// The current login user, for `loginctl` and linger queries. Read from the
+/// environment to avoid an `unsafe` `getuid` FFI call.
+fn current_user() -> Option<String> {
+	std::env::var("USER")
+		.ok()
+		.or_else(|| std::env::var("LOGNAME").ok())
+		.filter(|s| !s.is_empty())
+}
+
+/// Quadlet autostart units for this project, if any exist on disk. Service mode
+/// and Quadlet mode would both try to start the same stack at boot, so an
+/// existing Quadlet install is a conflict to surface, not to silently overwrite.
+/// Looks for `<project>-*.container` under
+/// `${XDG_CONFIG_HOME:-~/.config}/containers/systemd/`.
+fn quadlet_units_present(project: &str) -> Vec<PathBuf> {
+	let dir = config_home().join("containers").join("systemd");
+	let prefix = format!("{project}-");
+	let mut found = Vec::new();
+	if let Ok(entries) = std::fs::read_dir(&dir) {
+		for entry in entries.flatten() {
+			let name = entry.file_name();
+			let name = name.to_string_lossy();
+			if name.starts_with(&prefix) && name.ends_with(".container") {
+				found.push(entry.path());
+			}
+		}
+	}
+	found.sort();
+	found
+}
+
+/// Whether linger is enabled for `user` (so the user manager — and the stack —
+/// survives logout and starts at boot). Parses `loginctl show-user <user>
+/// --value --property=Linger`, treating any error/unexpected output as "off".
+fn linger_enabled<S: SystemCtl>(sc: &S, user: &str) -> bool {
+	match sc.loginctl(&["show-user", user, "--value", "--property=Linger"]) {
+		Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+			.trim()
+			.eq_ignore_ascii_case("yes"),
+		_ => false,
+	}
+}
+
+/// Advisory when linger is off: without it the user manager is not started at
+/// boot, so the unit will not bring the stack up until first login. Returns the
+/// message to print, or `None` when linger is already enabled.
+fn linger_warning<S: SystemCtl>(sc: &S) -> Option<String> {
+	let user = current_user()?;
+	if linger_enabled(sc, &user) {
+		return None;
+	}
+	Some(format!(
+		"linger is not enabled for {user}; the stack will not start at boot until you run:\n    \
+		 loginctl enable-linger {user}"
+	))
+}
+
+/// Advisory when `XDG_RUNTIME_DIR` is unset: `systemctl --user` needs a live user
+/// session bus, which is otherwise missing (so the calls below will likely fail).
+/// Returns the message to print, or `None` when the variable is set.
+fn runtime_dir_warning() -> Option<String> {
+	let present = std::env::var_os("XDG_RUNTIME_DIR").is_some_and(|s| !s.is_empty());
+	if present {
+		return None;
+	}
+	Some(
+		"XDG_RUNTIME_DIR is not set; `systemctl --user` needs an active user session. \
+		 Open one (e.g. `machinectl shell <user>@`) or export XDG_RUNTIME_DIR before retrying."
+			.to_string(),
+	)
+}
+
+/// Print the linger and runtime-dir advisories to stderr (warn, never fail).
+fn emit_guards<S: SystemCtl>(sc: &S) {
+	for warning in [linger_warning(sc), runtime_dir_warning()]
+		.into_iter()
+		.flatten()
+	{
+		eprintln!("podup: warning: {warning}");
+	}
+}
+
+/// Turn a `systemctl` invocation result into a `Result`, mapping a launch failure
+/// or a non-zero exit into a clear autostart error naming the action.
+fn checked(res: io::Result<Output>, what: &str) -> crate::Result<()> {
+	let out = res.map_err(|e| {
+		ComposeError::Autostart(format!("failed to run `systemctl --user {what}`: {e}"))
+	})?;
+	if out.status.success() {
+		return Ok(());
+	}
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	Err(ComposeError::Autostart(format!(
+		"`systemctl --user {what}` failed: {}",
+		stderr.trim()
+	)))
+}
+
+/// Install (and, unless `no_start`, enable + start) the service-mode autostart
+/// unit. Writes only under `${XDG_CONFIG_HOME:-~/.config}/systemd/user/`.
+pub fn install<S: SystemCtl>(sc: &S, opts: &InstallOptions) -> crate::Result<()> {
+	let project = &opts.unit.project;
+	let path = unit_path(project);
+
+	// Refuse to stack service mode on top of an existing Quadlet autostart install
+	// for the same project — both would start the stack at boot.
+	let quadlet = quadlet_units_present(project);
+	if !quadlet.is_empty() {
+		let names: Vec<String> = quadlet.iter().map(|p| p.display().to_string()).collect();
+		return Err(ComposeError::Autostart(format!(
+			"quadlet autostart units for project '{project}' already exist:\n    {}\n\
+			 remove them before installing service mode (quadlet autostart is tracked by #993).",
+			names.join("\n    ")
+		)));
+	}
+
+	let unit_text = render_service_unit(&opts.unit);
+	let unit_name = unit_file_name(project);
+
+	// Surface the linger / session guards before acting (or previewing).
+	emit_guards(sc);
+
+	if opts.dry_run {
+		print!("{unit_text}");
+		println!("\n# would write {}", path.display());
+		println!("# would run: systemctl --user daemon-reload");
+		if opts.no_start {
+			println!("# (--no-start) would not enable or start the unit");
+		} else {
+			println!("# would run: systemctl --user enable --now {unit_name}");
+		}
+		return Ok(());
+	}
+
+	let dir = unit_dir();
+	std::fs::create_dir_all(&dir)
+		.map_err(|e| ComposeError::Autostart(format!("cannot create {}: {e}", dir.display())))?;
+	std::fs::write(&path, unit_text.as_bytes())
+		.map_err(|e| ComposeError::Autostart(format!("cannot write {}: {e}", path.display())))?;
+	eprintln!("podup: wrote {}", path.display());
+
+	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
+	if opts.no_start {
+		eprintln!("podup: installed {unit_name} (not enabled; --no-start)");
+	} else {
+		checked(
+			sc.systemctl(&["enable", "--now", &unit_name]),
+			&format!("enable --now {unit_name}"),
+		)?;
+		eprintln!("podup: enabled and started {unit_name}");
+	}
+	Ok(())
+}
+
+/// Uninstall the service-mode autostart unit: disable + stop it, remove the unit
+/// file, and reload the user manager. A "unit not loaded" disable failure is
+/// ignored so uninstall is idempotent.
+pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
+	let unit_name = unit_file_name(project);
+	// Best-effort: ignore failures (e.g. the unit was never loaded).
+	let _ = sc.systemctl(&["disable", "--now", &unit_name]);
+
+	let path = unit_path(project);
+	if path.exists() {
+		std::fs::remove_file(&path).map_err(|e| {
+			ComposeError::Autostart(format!("cannot remove {}: {e}", path.display()))
+		})?;
+		eprintln!("podup: removed {}", path.display());
+	} else {
+		eprintln!(
+			"podup: no unit file at {} (already removed)",
+			path.display()
+		);
+	}
+
+	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
+	Ok(())
+}
+
+/// A snapshot of the autostart unit's state, gathered for `status`.
+pub struct StatusReport {
+	/// Absolute path to where the unit file would live.
+	pub unit_path: PathBuf,
+	/// Whether the unit file exists on disk.
+	pub unit_exists: bool,
+	/// The unit file's permission bits (Unix only), when it exists.
+	pub unit_mode: Option<u32>,
+	/// `systemctl --user is-active` output (e.g. `active`, `inactive`, `failed`).
+	pub is_active: String,
+	/// `systemctl --user is-enabled` output (e.g. `enabled`, `disabled`).
+	pub is_enabled: String,
+	/// Whether linger is enabled for the current user.
+	pub linger: bool,
+	/// Whether `XDG_RUNTIME_DIR` is set (a user session is present).
+	pub runtime_dir: bool,
+}
+
+/// Read the unit file's permission bits, on Unix. Other platforms have no POSIX
+/// mode, so this is always `None` there.
+#[cfg(unix)]
+fn file_mode(path: &Path) -> Option<u32> {
+	use std::os::unix::fs::PermissionsExt;
+	std::fs::metadata(path).ok().map(|m| m.permissions().mode())
+}
+
+#[cfg(not(unix))]
+fn file_mode(_path: &Path) -> Option<u32> {
+	None
+}
+
+/// Run a `systemctl --user` query that reports state through its stdout (e.g.
+/// `is-active`, `is-enabled`); these exit non-zero for the negative answer, so
+/// the trimmed stdout is the report regardless of exit status.
+fn query<S: SystemCtl>(sc: &S, arg: &str, unit_name: &str) -> String {
+	match sc.systemctl(&[arg, unit_name]) {
+		Ok(out) => {
+			let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+			if s.is_empty() {
+				"unknown".to_string()
+			} else {
+				s
+			}
+		}
+		Err(e) => format!("unknown ({e})"),
+	}
+}
+
+/// Gather the autostart status for a project, going through the [`SystemCtl`] seam
+/// so it is testable without a live systemd.
+pub fn collect_status<S: SystemCtl>(sc: &S, project: &str) -> StatusReport {
+	let unit_name = unit_file_name(project);
+	let path = unit_path(project);
+	let unit_exists = path.exists();
+	StatusReport {
+		unit_mode: if unit_exists { file_mode(&path) } else { None },
+		unit_exists,
+		unit_path: path,
+		is_active: query(sc, "is-active", &unit_name),
+		is_enabled: query(sc, "is-enabled", &unit_name),
+		linger: current_user().is_some_and(|u| linger_enabled(sc, &u)),
+		runtime_dir: std::env::var_os("XDG_RUNTIME_DIR").is_some_and(|s| !s.is_empty()),
+	}
+}
+
+/// Print the autostart status for a project.
+pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
+	let r = collect_status(sc, project);
+	println!("unit:       {}", r.unit_path.display());
+	println!("installed:  {}", if r.unit_exists { "yes" } else { "no" });
+	if let Some(mode) = r.unit_mode {
+		println!("mode:       {:04o}", mode & 0o7777);
+	}
+	println!("active:     {}", r.is_active);
+	println!("enabled:    {}", r.is_enabled);
+	println!(
+		"linger:     {}",
+		if r.linger { "enabled" } else { "disabled" }
+	);
+	println!(
+		"session:    {}",
+		if r.runtime_dir {
+			"XDG_RUNTIME_DIR set"
+		} else {
+			"XDG_RUNTIME_DIR unset (systemctl --user needs a user session)"
+		}
+	);
+	Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+	use super::*;
+	use std::cell::RefCell;
+	use std::os::unix::process::ExitStatusExt;
+	use std::process::ExitStatus;
+
+	/// Recording fake: captures every `systemctl`/`loginctl` arg vector and returns
+	/// canned output keyed off the first argument.
+	struct FakeCtl {
+		systemctl_calls: RefCell<Vec<Vec<String>>>,
+		loginctl_calls: RefCell<Vec<Vec<String>>>,
+		linger: String,
+		is_active: String,
+		is_enabled: String,
+		fail: bool,
+	}
+
+	impl FakeCtl {
+		fn new() -> Self {
+			FakeCtl {
+				systemctl_calls: RefCell::new(Vec::new()),
+				loginctl_calls: RefCell::new(Vec::new()),
+				linger: "yes".to_string(),
+				is_active: "active".to_string(),
+				is_enabled: "enabled".to_string(),
+				fail: false,
+			}
+		}
+
+		fn systemctl_log(&self) -> Vec<Vec<String>> {
+			self.systemctl_calls.borrow().clone()
+		}
+	}
+
+	fn out(code: i32, stdout: &str) -> Output {
+		Output {
+			status: ExitStatus::from_raw(code),
+			stdout: stdout.as_bytes().to_vec(),
+			stderr: Vec::new(),
+		}
+	}
+
+	impl SystemCtl for FakeCtl {
+		fn systemctl(&self, args: &[&str]) -> io::Result<Output> {
+			self.systemctl_calls
+				.borrow_mut()
+				.push(args.iter().map(|s| s.to_string()).collect());
+			let code = if self.fail { 256 } else { 0 };
+			let stdout = match args.first().copied() {
+				Some("is-active") => self.is_active.as_str(),
+				Some("is-enabled") => self.is_enabled.as_str(),
+				_ => "",
+			};
+			// is-active/is-enabled report through stdout; their exit status is not
+			// consulted, so leave it successful for those queries.
+			let code = if matches!(args.first().copied(), Some("is-active" | "is-enabled")) {
+				0
+			} else {
+				code
+			};
+			Ok(out(code, stdout))
+		}
+
+		fn loginctl(&self, args: &[&str]) -> io::Result<Output> {
+			self.loginctl_calls
+				.borrow_mut()
+				.push(args.iter().map(|s| s.to_string()).collect());
+			Ok(out(0, &self.linger))
+		}
+	}
+
+	fn opts(dir: &Path, project: &str, dry_run: bool, no_start: bool) -> InstallOptions {
+		InstallOptions {
+			unit: ServiceUnitOpts {
+				exe: PathBuf::from("/usr/local/bin/podup"),
+				compose_files: vec![dir.join("docker-compose.yml")],
+				project: project.to_string(),
+				working_dir: dir.to_path_buf(),
+				profiles: Vec::new(),
+				env_files: Vec::new(),
+			},
+			no_start,
+			dry_run,
+		}
+	}
+
+	/// Run `f` with a fresh temp `XDG_CONFIG_HOME`, `USER`, and `XDG_RUNTIME_DIR`
+	/// set, so the install/status paths resolve under the temp dir.
+	fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
+		let tmp = tempfile::tempdir().unwrap();
+		let root = tmp.path().to_path_buf();
+		temp_env::with_vars(
+			[
+				("XDG_CONFIG_HOME", Some(root.as_os_str())),
+				("XDG_RUNTIME_DIR", Some(root.as_os_str())),
+				("USER", Some(std::ffi::OsStr::new("tester"))),
+			],
+			|| f(&root),
+		)
+	}
+
+	#[test]
+	fn install_writes_unit_and_enables() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install(&sc, &opts(root, "app", false, false)).unwrap();
+			let path = root.join("systemd/user/podup-app.service");
+			assert!(path.is_file(), "unit file written");
+			let body = std::fs::read_to_string(&path).unwrap();
+			assert!(body.contains("Description=podup app"));
+			let calls = sc.systemctl_log();
+			assert_eq!(calls[0], vec!["daemon-reload"]);
+			assert_eq!(calls[1], vec!["enable", "--now", "podup-app.service"]);
+		});
+	}
+
+	#[test]
+	fn install_no_start_skips_enable() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install(&sc, &opts(root, "app", false, true)).unwrap();
+			let calls = sc.systemctl_log();
+			assert_eq!(calls, vec![vec!["daemon-reload"]]);
+		});
+	}
+
+	#[test]
+	fn dry_run_writes_nothing_and_runs_no_systemctl() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install(&sc, &opts(root, "app", true, false)).unwrap();
+			assert!(!root.join("systemd/user/podup-app.service").exists());
+			assert!(sc.systemctl_log().is_empty());
+		});
+	}
+
+	#[test]
+	fn uninstall_disables_removes_and_reloads() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install(&sc, &opts(root, "app", false, true)).unwrap();
+			let path = root.join("systemd/user/podup-app.service");
+			assert!(path.exists());
+
+			let sc2 = FakeCtl::new();
+			uninstall(&sc2, "app").unwrap();
+			assert!(!path.exists(), "unit file removed");
+			let calls = sc2.systemctl_log();
+			assert_eq!(calls[0], vec!["disable", "--now", "podup-app.service"]);
+			assert_eq!(calls[1], vec!["daemon-reload"]);
+		});
+	}
+
+	#[test]
+	fn install_refuses_on_quadlet_conflict() {
+		with_env(|root| {
+			let qdir = root.join("containers/systemd");
+			std::fs::create_dir_all(&qdir).unwrap();
+			std::fs::write(qdir.join("app-web.container"), b"[Container]\n").unwrap();
+			let sc = FakeCtl::new();
+			let err = install(&sc, &opts(root, "app", false, false)).unwrap_err();
+			assert!(matches!(err, ComposeError::Autostart(_)));
+			assert!(err.to_string().contains("quadlet"));
+			// Nothing was installed.
+			assert!(!root.join("systemd/user/podup-app.service").exists());
+			assert!(sc.systemctl_log().is_empty());
+		});
+	}
+
+	#[test]
+	fn linger_off_produces_warning() {
+		let mut sc = FakeCtl::new();
+		sc.linger = "no".to_string();
+		temp_env::with_var("USER", Some("tester"), || {
+			assert!(linger_warning(&sc).is_some());
+		});
+	}
+
+	#[test]
+	fn linger_on_produces_no_warning() {
+		let sc = FakeCtl::new(); // linger = "yes"
+		temp_env::with_var("USER", Some("tester"), || {
+			assert!(linger_warning(&sc).is_none());
+		});
+	}
+
+	#[test]
+	fn missing_runtime_dir_produces_warning() {
+		temp_env::with_var_unset("XDG_RUNTIME_DIR", || {
+			assert!(runtime_dir_warning().is_some());
+		});
+		temp_env::with_var("XDG_RUNTIME_DIR", Some("/run/user/1000"), || {
+			assert!(runtime_dir_warning().is_none());
+		});
+	}
+
+	#[test]
+	fn collect_status_reports_installed_and_state() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install(&sc, &opts(root, "app", false, true)).unwrap();
+			let r = collect_status(&sc, "app");
+			assert!(r.unit_exists);
+			assert!(r.unit_mode.is_some());
+			assert_eq!(r.is_active, "active");
+			assert_eq!(r.is_enabled, "enabled");
+			assert!(r.linger);
+			assert!(r.runtime_dir);
+		});
+	}
+
+	#[test]
+	fn collect_status_reports_absent_unit() {
+		with_env(|_root| {
+			let sc = FakeCtl::new();
+			let r = collect_status(&sc, "nope");
+			assert!(!r.unit_exists);
+			assert!(r.unit_mode.is_none());
+		});
+	}
+
+	#[test]
+	fn install_surfaces_systemctl_failure() {
+		with_env(|root| {
+			let mut sc = FakeCtl::new();
+			sc.fail = true;
+			let err = install(&sc, &opts(root, "app", false, false)).unwrap_err();
+			assert!(matches!(err, ComposeError::Autostart(_)));
+		});
+	}
+}

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -1,0 +1,231 @@
+//! Pure rendering of the `podup-<project>.service` systemd user unit.
+//!
+//! The unit is a `Type=oneshot` `RemainAfterExit=yes` service that runs `podup
+//! ... up -d --build` at boot and `podup ... down` on stop. systemd has no cwd
+//! and no relative-path context, so every path the unit embeds is absolute and
+//! every argument is escaped per the systemd exec-line syntax.
+
+use std::path::PathBuf;
+
+/// Inputs to render a service-mode autostart unit. Every path must be absolute:
+/// systemd resolves the `ExecStart`/`ExecStop` lines with no working directory of
+/// its own, so a relative path would be interpreted against `/`.
+pub struct ServiceUnitOpts {
+	/// Absolute path to the `podup` executable.
+	pub exe: PathBuf,
+	/// Absolute compose-file paths, in `-f` order (later overrides earlier).
+	pub compose_files: Vec<PathBuf>,
+	/// Project name (already validated as a safe path component).
+	pub project: String,
+	/// Absolute working directory (the project base directory).
+	pub working_dir: PathBuf,
+	/// Active profiles, passed through as `--profile` flags.
+	pub profiles: Vec<String>,
+	/// Extra env files, passed through as `--env-file` flags.
+	pub env_files: Vec<String>,
+}
+
+/// Whether a token is safe to place on a systemd exec line without quoting:
+/// only an unambiguous, shell-neutral subset of ASCII. Anything else (a space, a
+/// quote, a control byte, a glob/redirect metacharacter) forces double-quoting.
+fn is_bare_safe(token: &str) -> bool {
+	!token.is_empty()
+		&& token.bytes().all(|b| {
+			b.is_ascii_alphanumeric()
+				|| matches!(
+					b,
+					b'-' | b'_' | b'.' | b'/' | b':' | b'=' | b'@' | b'+' | b','
+				)
+		})
+}
+
+/// Quote a single argument for a systemd `ExecStart=`/`ExecStop=` line. Tokens
+/// made only of the safe subset are emitted verbatim; everything else is wrapped
+/// in double quotes with `\` and `"` (and the C-style control escapes systemd
+/// understands) backslash-escaped, so a path with spaces survives as one argument.
+fn quote_arg(token: &str) -> String {
+	if is_bare_safe(token) {
+		return token.to_string();
+	}
+	let mut out = String::with_capacity(token.len() + 2);
+	out.push('"');
+	for ch in token.chars() {
+		match ch {
+			'"' => out.push_str("\\\""),
+			'\\' => out.push_str("\\\\"),
+			'\n' => out.push_str("\\n"),
+			'\t' => out.push_str("\\t"),
+			'\r' => out.push_str("\\r"),
+			c => out.push(c),
+		}
+	}
+	out.push('"');
+	out
+}
+
+/// The leading `podup` arguments shared by both the start and stop commands:
+/// `-f <file>...  -p <project>  [--profile P]...  [--env-file E]...`. These must
+/// precede the subcommand (`-f`/`-p` are not global flags).
+fn leading_args(opts: &ServiceUnitOpts) -> Vec<String> {
+	let mut args = Vec::new();
+	for f in &opts.compose_files {
+		args.push("-f".to_string());
+		args.push(f.to_string_lossy().into_owned());
+	}
+	args.push("-p".to_string());
+	args.push(opts.project.clone());
+	for p in &opts.profiles {
+		args.push("--profile".to_string());
+		args.push(p.clone());
+	}
+	for e in &opts.env_files {
+		args.push("--env-file".to_string());
+		args.push(e.clone());
+	}
+	args
+}
+
+/// Render a full exec line: the absolute exe, the shared leading args, then the
+/// command-specific trailing args, every token escaped and space-joined.
+fn exec_line(opts: &ServiceUnitOpts, trailing: &[&str]) -> String {
+	let mut tokens = Vec::new();
+	tokens.push(opts.exe.to_string_lossy().into_owned());
+	tokens.extend(leading_args(opts));
+	tokens.extend(trailing.iter().map(|s| s.to_string()));
+	tokens
+		.iter()
+		.map(|t| quote_arg(t))
+		.collect::<Vec<_>>()
+		.join(" ")
+}
+
+/// Render the full `.service` unit file content for service-mode autostart.
+pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
+	let start = exec_line(opts, &["up", "-d", "--build"]);
+	let stop = exec_line(opts, &["down"]);
+	// No `network-online.target` ordering: that target is a system-manager
+	// concept and stays inert in the `--user` instance, so depending on it would
+	// imply a network-readiness gate that never fires. Under linger the user
+	// manager starts after the system network is already up, and podup reaches
+	// Podman over a socket on demand, so no explicit network ordering is needed.
+	format!(
+		"[Unit]\n\
+		 Description=podup {project}\n\
+		 \n\
+		 [Service]\n\
+		 Type=oneshot\n\
+		 RemainAfterExit=yes\n\
+		 WorkingDirectory={workdir}\n\
+		 ExecStart={start}\n\
+		 ExecStop={stop}\n\
+		 \n\
+		 [Install]\n\
+		 WantedBy=default.target\n",
+		project = opts.project,
+		workdir = opts.working_dir.display(),
+		start = start,
+		stop = stop,
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::path::PathBuf;
+
+	fn opts_single() -> ServiceUnitOpts {
+		ServiceUnitOpts {
+			exe: PathBuf::from("/usr/local/bin/podup"),
+			compose_files: vec![PathBuf::from("/srv/app/docker-compose.yml")],
+			project: "app".to_string(),
+			working_dir: PathBuf::from("/srv/app"),
+			profiles: Vec::new(),
+			env_files: Vec::new(),
+		}
+	}
+
+	#[test]
+	fn renders_single_file_unit() {
+		let s = render_service_unit(&opts_single());
+		assert!(s.contains("Description=podup app"));
+		// A `--user` unit must NOT order against the system `network-online.target`
+		// (it is inert in the user manager); assert it is absent.
+		assert!(!s.contains("network-online.target"));
+		assert!(s.contains("Type=oneshot"));
+		assert!(s.contains("RemainAfterExit=yes"));
+		assert!(s.contains("WorkingDirectory=/srv/app"));
+		assert!(s.contains("WantedBy=default.target"));
+		assert!(s.contains(
+			"ExecStart=/usr/local/bin/podup -f /srv/app/docker-compose.yml -p app up -d --build"
+		));
+		assert!(
+			s.contains("ExecStop=/usr/local/bin/podup -f /srv/app/docker-compose.yml -p app down")
+		);
+	}
+
+	#[test]
+	fn renders_multiple_files_in_order() {
+		let mut o = opts_single();
+		o.compose_files = vec![
+			PathBuf::from("/srv/app/base.yml"),
+			PathBuf::from("/srv/app/override.yml"),
+		];
+		let s = render_service_unit(&o);
+		assert!(s.contains(
+			"ExecStart=/usr/local/bin/podup -f /srv/app/base.yml -f /srv/app/override.yml -p app up -d --build"
+		));
+		assert!(s.contains(
+			"ExecStop=/usr/local/bin/podup -f /srv/app/base.yml -f /srv/app/override.yml -p app down"
+		));
+	}
+
+	#[test]
+	fn includes_profiles_and_env_files() {
+		let mut o = opts_single();
+		o.profiles = vec!["prod".to_string(), "web".to_string()];
+		o.env_files = vec!["/srv/app/.env.prod".to_string()];
+		let s = render_service_unit(&o);
+		assert!(s.contains(
+			"-p app --profile prod --profile web --env-file /srv/app/.env.prod up -d --build"
+		));
+		assert!(
+			s.contains("-p app --profile prod --profile web --env-file /srv/app/.env.prod down")
+		);
+	}
+
+	#[test]
+	fn quotes_paths_with_spaces() {
+		let mut o = opts_single();
+		o.exe = PathBuf::from("/opt/my tools/podup");
+		o.compose_files = vec![PathBuf::from("/srv/my app/compose.yml")];
+		o.working_dir = PathBuf::from("/srv/my app");
+		let s = render_service_unit(&o);
+		// The exe and the compose path are double-quoted as single arguments.
+		assert!(s.contains(
+			"ExecStart=\"/opt/my tools/podup\" -f \"/srv/my app/compose.yml\" -p app up -d --build"
+		));
+		// WorkingDirectory takes the rest of the line literally, so it is not quoted.
+		assert!(s.contains("WorkingDirectory=/srv/my app"));
+	}
+
+	#[test]
+	fn ends_with_newline() {
+		assert!(render_service_unit(&opts_single()).ends_with("WantedBy=default.target\n"));
+	}
+
+	#[test]
+	fn bare_safe_accepts_paths_rejects_spaces() {
+		assert!(is_bare_safe("/srv/app/compose.yml"));
+		assert!(is_bare_safe("app-1_v2.0"));
+		assert!(!is_bare_safe("has space"));
+		assert!(!is_bare_safe(""));
+		assert!(!is_bare_safe("a\"b"));
+	}
+
+	#[test]
+	fn quote_arg_escapes_quotes_and_backslashes() {
+		assert_eq!(quote_arg("a b"), "\"a b\"");
+		assert_eq!(quote_arg("a\"b"), "\"a\\\"b\"");
+		assert_eq!(quote_arg("a\\b"), "\"a\\\\b\"");
+	}
+}

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -1,0 +1,94 @@
+//! The `autostart` command group: manage a rootless `systemctl --user` unit that
+//! brings the compose stack up at boot. Split out of `main::run` so that function
+//! stays within the source line limit; `install` and `status` work from the
+//! compose file alone and never contact Podman, while `uninstall --purge` is the
+//! only branch that connects (to run the `down -v` teardown).
+
+use std::path::PathBuf;
+
+use podup::compose::types::ComposeFile;
+use podup::ComposeError;
+
+use crate::cli::{AutostartCommands, AutostartMode};
+
+/// The slice of CLI globals the `autostart` dispatch needs, gathered up so the
+/// already-consumed `Cli` (its `project` is moved earlier) need not be borrowed
+/// whole.
+pub(crate) struct AutostartEnv<'a> {
+	pub profile: &'a [String],
+	pub env_files: &'a [String],
+	pub socket: Option<String>,
+}
+
+/// Handle the `autostart` command group. `install` and `status` never contact
+/// Podman; `uninstall --purge` is the only branch that connects, to run the
+/// `down -v` teardown.
+pub(crate) async fn dispatch(
+	env: &AutostartEnv<'_>,
+	compose_files: &[PathBuf],
+	project: String,
+	base_dir: PathBuf,
+	file: &ComposeFile,
+	kind: &AutostartCommands,
+) -> podup::Result<()> {
+	match kind {
+		AutostartCommands::Install {
+			mode,
+			no_start,
+			dry_run,
+		} => {
+			// Only service mode is implemented; quadlet mode is honest about it.
+			if *mode == AutostartMode::Quadlet {
+				return Err(ComposeError::Autostart(
+					"autostart --mode quadlet is not yet implemented (see #993); \
+					 use the default --mode service"
+						.to_string(),
+				));
+			}
+			// systemd has no relative-path context, so resolve the exe, every compose
+			// file, and the working directory to absolute paths the unit can embed.
+			let exe = std::env::current_exe().map_err(|e| {
+				ComposeError::Autostart(format!("cannot locate the podup executable: {e}"))
+			})?;
+			let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
+			let mut abs_files = Vec::with_capacity(compose_files.len());
+			for f in compose_files {
+				abs_files.push(std::fs::canonicalize(f).map_err(|e| {
+					ComposeError::Autostart(format!(
+						"cannot resolve compose file {}: {e}",
+						f.display()
+					))
+				})?);
+			}
+			let working_dir = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
+			let opts = podup::autostart::InstallOptions {
+				unit: podup::autostart::ServiceUnitOpts {
+					exe,
+					compose_files: abs_files,
+					project,
+					working_dir,
+					profiles: env.profile.to_vec(),
+					env_files: env.env_files.to_vec(),
+				},
+				no_start: *no_start,
+				dry_run: *dry_run,
+			};
+			podup::autostart::install(&podup::autostart::RealSystemCtl, &opts)
+		}
+		AutostartCommands::Uninstall { purge } => {
+			podup::autostart::uninstall(&podup::autostart::RealSystemCtl, &project)?;
+			if *purge {
+				// `--purge` is the only autostart branch that touches Podman: tear the
+				// stack down and remove its named volumes via the normal `down -v` path.
+				let client = podup::podman::connect(env.socket.as_deref())?;
+				let engine = podup::Engine::with_base_dir(client, project, base_dir);
+				let _lock = engine.lock_project()?;
+				engine.down_with_options(file, true).await?;
+			}
+			Ok(())
+		}
+		AutostartCommands::Status => {
+			podup::autostart::status(&podup::autostart::RealSystemCtl, &project)
+		}
+	}
+}

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -8,7 +8,9 @@ use clap::Subcommand;
 use clap_complete::Shell;
 
 use super::parse::{parse_pull_policy, parse_scale_pair, parse_timeout};
-use super::types::{ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope};
+use super::types::{
+	AutostartCommands, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
+};
 
 #[derive(Subcommand)]
 pub(crate) enum Commands {
@@ -602,6 +604,17 @@ pub(crate) enum Commands {
 	Generate {
 		#[command(subcommand)]
 		kind: GenerateCommands,
+	},
+	/// Manage a boot-time autostart unit for this compose project (rootless,
+	/// user-scope `systemctl --user`).
+	#[command(
+		alias = "boot",
+		subcommand_required = true,
+		arg_required_else_help = true
+	)]
+	Autostart {
+		#[command(subcommand)]
+		kind: AutostartCommands,
 	},
 	/// Print help for podup, or for a specific command.
 	Help {

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -9,7 +9,8 @@ mod parse;
 mod types;
 pub(crate) use commands::Commands;
 pub(crate) use types::{
-	AnsiMode, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
+	AnsiMode, AutostartCommands, AutostartMode, ConfigFormat, EventsFormat, GenerateCommands,
+	OutputFormat, RmiScope,
 };
 
 /// Help-screen colours (clap honours its own TTY/`NO_COLOR`/`CLICOLOR` detection

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -66,6 +66,43 @@ pub(crate) enum ConfigFormat {
 	Json,
 }
 
+/// Which autostart backend `autostart install` sets up.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum AutostartMode {
+	/// A single `Type=oneshot` `systemctl --user` service that runs `podup up`
+	/// at boot and `podup down` on stop. The only mode implemented today.
+	#[default]
+	Service,
+	/// Per-service Podman Quadlet units. Not yet implemented (tracked by #993).
+	Quadlet,
+}
+
+/// Subcommands of `autostart`.
+#[derive(clap::Subcommand)]
+pub(crate) enum AutostartCommands {
+	/// Install (and, by default, enable + start) the autostart unit for this
+	/// project. User-scope only: writes under `${XDG_CONFIG_HOME:-~/.config}`.
+	Install {
+		/// Autostart backend to use (only `service` is implemented).
+		#[arg(long, value_enum, default_value_t)]
+		mode: AutostartMode,
+		/// Install the unit but do not enable or start it immediately.
+		#[arg(long)]
+		no_start: bool,
+		/// Print the unit and the actions that would run, but change nothing.
+		#[arg(long)]
+		dry_run: bool,
+	},
+	/// Disable, stop, and remove this project's autostart unit.
+	Uninstall {
+		/// Also tear the stack down and remove its named volumes (`down -v`).
+		#[arg(long)]
+		purge: bool,
+	},
+	/// Report this project's autostart unit and session state.
+	Status,
+}
+
 /// Subcommands of `generate`.
 #[derive(clap::Subcommand)]
 pub(crate) enum GenerateCommands {

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -525,6 +525,7 @@ pub(crate) async fn dispatch(
 		}
 		Commands::Config { .. } => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
+		Commands::Autostart { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(file).await?,
 		Commands::Help { .. } => unreachable!("handled before compose parsing"),
 		Commands::Ls { .. } => unreachable!("handled before compose parsing"),

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -118,6 +118,11 @@ pub enum ComposeError {
 	/// entry such as an unterminated quoted value. The string is a ready-to-print
 	/// message.
 	EnvFile(String),
+	/// A `podup autostart` operation failed — a `systemctl --user`/`loginctl`
+	/// command could not run or returned non-zero, a unit file could not be
+	/// written/removed, or the requested mode is not yet available. The string is
+	/// a ready-to-print message.
+	Autostart(String),
 }
 
 /// Escape control characters (tabs, newlines, ESC, …) in an interpolated,
@@ -257,6 +262,7 @@ impl fmt::Display for ComposeError {
 				"invalid --timeout {secs}: use -1 to wait indefinitely or a non-negative number of seconds"
 			),
 			Self::EnvFile(s) => write!(f, "{s}"),
+			Self::Autostart(s) => write!(f, "{s}"),
 		}
 	}
 }
@@ -427,6 +433,10 @@ mod tests {
 			(
 				"env file not found: app.env",
 				ComposeError::EnvFile("env file not found: app.env".into()),
+			),
+			(
+				"linger is not enabled",
+				ComposeError::Autostart("linger is not enabled".into()),
 			),
 		];
 		for (expected_prefix, err) in cases {

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -9,6 +9,9 @@
 // new `unsafe` block elsewhere fails the build.
 #![deny(unsafe_code)]
 
+/// `podup autostart`: render and manage a rootless `systemctl --user` unit that
+/// brings a compose stack up at boot (service mode).
+pub mod autostart;
 /// Compose-file parsing, `extends:`/`include:` resolution, and topological
 /// service ordering.
 pub mod compose;

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -8,6 +8,7 @@ use std::process;
 #[cfg(feature = "completions")]
 use clap::CommandFactory;
 
+mod autostart_cmd;
 mod cli;
 mod dispatch;
 mod generate;
@@ -463,6 +464,19 @@ async fn run() -> podup::Result<()> {
 		let mut filtered = file.clone();
 		podup::retain_active_profiles(&mut filtered, &cli.profile);
 		return write_quadlet(&filtered, &project, output.as_deref());
+	}
+
+	// `autostart` manages a rootless `systemctl --user` unit that brings the stack
+	// up at boot. Like `generate` it works from the compose file alone and never
+	// contacts Podman — except `uninstall --purge`, which tears the stack's volumes
+	// down and so connects only in that branch.
+	if let Commands::Autostart { kind } = &cli.command {
+		let env = autostart_cmd::AutostartEnv {
+			profile: &cli.profile,
+			env_files: &cli.env_file,
+			socket: resolve_socket(cli.socket.as_deref()),
+		};
+		return autostart_cmd::dispatch(&env, &compose_files, project, base_dir, &file, kind).await;
 	}
 
 	let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;


### PR DESCRIPTION
Phase 1 of #991. Closes #992.

## What

A new `podup autostart` group that makes a compose stack come back up after a reboot, on the rootless isolated-user model podup targets — no hand-written systemd units.

```
podup autostart install [--mode service|quadlet] [--no-start] [--dry-run]
podup autostart uninstall [--purge]
podup autostart status
```

**Service mode** (default) writes a single rootless `systemctl --user` oneshot unit `~/.config/systemd/user/podup-<project>.service`:

```ini
[Unit]
Description=podup <project>
[Service]
Type=oneshot
RemainAfterExit=yes
WorkingDirectory=<abs base dir>
ExecStart=<abs podup> -f <abs compose>… -p <project> [--profile …] [--env-file …] up -d --build
ExecStop=<abs podup> … down
[Install]
WantedBy=default.target
```

## Design notes

- **Rootless / user-scope only.** Never root, sudo, or `/etc`; everything under `${XDG_CONFIG_HOME:-~/.config}`. podup is rootless-oriented, so this is too.
- **`WantedBy=default.target`**, not `multi-user.target`: the latter is inert in a `--user` instance and would never autostart. `default.target` is the user manager's top target under linger (and stays valid if ever loaded by a system manager).
- **No `network-online.target` ordering**: that target is a system-manager concept and is inert under `--user`; under linger the user manager already starts after the network, and podup reaches Podman over a socket on demand.
- **`--build` in ExecStart** makes every (re)start rebuild — so a stack with a `build:` service picks up source changes on restart.
- **Not per-container supervision** (that's `--mode quadlet`, #993): crash-restart here relies on the compose `restart:` policy via Podman.

## Surfaced, never silently swallowed

- Linger off → prints the `loginctl enable-linger <user>` it can't run for the user.
- Missing `XDG_RUNTIME_DIR` → warns that `systemctl --user` needs a session.
- A conflicting Quadlet autostart already present for the project → refuses with guidance.

## Removal

`uninstall` removes the `podup-<project>.service` by prefix + `daemon-reload`; `--purge` also `down -v`. Everything is prefix-findable.

## Tests / gate

- 18 new `autostart::*` unit tests (render: single/multi-file, profiles, env-files, quoting; install/uninstall/status/guards via a `SystemCtl` test seam — no real systemctl in CI).
- `--dry-run` writes nothing and issues no systemctl calls (e2e verified).
- Full gate green: 1176 lib + 155 live integration (Podman 5.4.2), `fmt`/`clippy -D warnings`/`doc`/`semver-checks` (no public API change).

`--mode quadlet` is accepted but returns an honest "not yet implemented" error (phase 2, #993). No version bump — rides the next release.