### PR TITLE
security(release): rotate the Ed25519 release signing key

### DIFF
--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -72,9 +72,9 @@ is no longer the one unverifiable link in the chain.
 
 ## The embedded public keys
 
-Each consumer holds **up to two** accepted release keys. Both slots are
-currently populated (base64 `YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM` and
-`gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE`), embedded in three places:
+Each consumer holds **up to two** accepted release keys. Slot 0 holds the
+active key; slot 1 is the empty rotation slot, populated only during a
+rotation. Embedded in three places:
 
 - `internal/update/verify.rs` — `RELEASE_PUBKEYS[0]` and `[1]` (raw 32 bytes).
 - `install.sh` — `PODUP_RELEASE_PUBKEY_B64` and `PODUP_RELEASE_PUBKEY2_B64`.
@@ -116,7 +116,7 @@ python3 - <<'PY'
 import base64
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 key = Ed25519PublicKey.from_public_bytes(
-    base64.b64decode("YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM" + "=="))
+    base64.b64decode("HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM" + "=="))
 key.verify(open("SHA256SUMS.sig", "rb").read(), open("SHA256SUMS", "rb").read())
 print("SHA256SUMS signature OK")
 PY

--- a/install.ps1
+++ b/install.ps1
@@ -87,8 +87,8 @@ try {
 	# second is empty except during a key rotation, when it holds the new key so a
 	# release signed by either key verifies. The signature passes if any key
 	# validates. Override for a fork via PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64.
-	$PubKeyB64  = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM' }
-	$PubKey2B64 = if ($env:PODUP_RELEASE_PUBKEY2_B64) { $env:PODUP_RELEASE_PUBKEY2_B64 } else { 'gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE' }
+	$PubKeyB64  = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM' }
+	$PubKey2B64 = if ($env:PODUP_RELEASE_PUBKEY2_B64) { $env:PODUP_RELEASE_PUBKEY2_B64 } else { '' }
 	$PubKeys = @($PubKeyB64, $PubKey2B64 | Where-Object { $_ })
 
 	$verified = $false

--- a/install.sh
+++ b/install.sh
@@ -97,8 +97,8 @@ download() {
 # release signed by either key verifies during a make-before-break rotation; the
 # signature passes if any key validates. Retire a key by clearing its slot here.
 # Override for a fork via the PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64 env vars.
-PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM}"
-PODUP_RELEASE_PUBKEY2_B64="${PODUP_RELEASE_PUBKEY2_B64:-gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE}"
+PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM}"
+PODUP_RELEASE_PUBKEY2_B64="${PODUP_RELEASE_PUBKEY2_B64:-}"
 
 PUBKEYS=()
 [[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]  && PUBKEYS+=("$PODUP_RELEASE_PUBKEY_B64")

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -11,12 +11,13 @@ use sha2::{Digest, Sha256};
 
 use crate::ComposeError;
 
-/// Accepted Ed25519 release public keys — at most two. Both slots are populated
-/// with the current release keys (`GLYNDOR_RELEASE_ED25519_KEY` in slot 0,
-/// `GLYNDOR_RELEASE_ED25519_KEY_2` in slot 1); a signature is trusted if it
-/// validates under either. The keys are public by design — their integrity comes
-/// from being baked into the signed, build-provenance-attested binary, so an
-/// attacker cannot swap them without invalidating the binary itself.
+/// Accepted Ed25519 release public keys — at most two. Slot 0 holds the active
+/// release key (`GLYNDOR_RELEASE_ED25519_KEY`); slot 1 is the empty rotation
+/// slot, populated only during a key rotation (see below). A signature is
+/// trusted if it validates under either non-zero slot. The keys are public by
+/// design — their integrity comes from being baked into the signed,
+/// build-provenance-attested binary, so an attacker cannot swap them without
+/// invalidating the binary itself.
 ///
 /// Verified against the genuine published `SHA256SUMS.sig` (see
 /// `embedded_key_verifies_real_release`). [`release_pubkeys`] still fails closed
@@ -36,20 +37,18 @@ use crate::ComposeError;
 ///
 /// If the outgoing private key is LOST, step 1 is impossible — no release can be
 /// signed by the old key — so fielded self-updaters cannot migrate in-band and
-/// must be re-installed out-of-band (rotated `install.sh` / apt). The two keys
-/// below are both freshly generated for exactly that reason; keep both live and
-/// signed until a normal (key-available) rotation can retire one.
+/// must be re-installed out-of-band (rotated `install.sh` / apt). That happened
+/// here: the key below is a fresh key with no relationship to any previously
+/// embedded key, and slot 1 starts zeroed (the normal steady state) rather than
+/// carrying a second live key.
 pub const RELEASE_PUBKEYS: [[u8; 32]; 2] = [
-	// GLYNDOR_RELEASE_ED25519_KEY = YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM
+	// GLYNDOR_RELEASE_ED25519_KEY = HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM
 	[
-		97, 73, 249, 4, 223, 229, 96, 140, 73, 204, 59, 227, 161, 68, 78, 128, 97, 144, 142, 105,
-		106, 215, 77, 63, 74, 166, 231, 132, 93, 111, 189, 243,
+		28, 91, 251, 190, 14, 69, 9, 142, 216, 200, 165, 3, 108, 152, 90, 65, 39, 193, 245, 38,
+		232, 36, 100, 155, 148, 155, 69, 108, 185, 139, 31, 51,
 	],
-	// GLYNDOR_RELEASE_ED25519_KEY_2 = gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE
-	[
-		129, 105, 143, 165, 156, 170, 58, 136, 0, 193, 32, 209, 162, 113, 178, 47, 109, 110, 221,
-		120, 246, 25, 55, 220, 190, 60, 23, 174, 96, 60, 169, 1,
-	],
+	// Empty rotation slot — populate during the next key rotation.
+	[0u8; 32],
 ];
 
 /// A parsed `MAJOR.MINOR.PATCH` version, ordered for comparison.


### PR DESCRIPTION
The previous release key's private half was lost. Rotates to a fresh key and, for the first time, actually unifies it with helmly/helmly-agent/unitpm (they'd each drifted onto a different embedded key despite the shared-key design). Slot 1 returns to empty. Requires the org secret GLYNDOR_RELEASE_ED25519_KEY (scoped to epistle, helmly, helmly-agent, podup, unitpm). Breaks in-band self-update for every existing install; reinstall required.