### PR TITLE
fix(engine): satisfy the question_mark lint on Rust 1.97

### DIFF
--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -333,10 +333,9 @@ fn signal_number(name: &str) -> Option<i64> {
 fn realtime_signal_number(name: &str) -> Option<i64> {
 	let (base, rest) = if let Some(rest) = name.strip_prefix("RTMIN") {
 		(SIGRTMIN, rest)
-	} else if let Some(rest) = name.strip_prefix("RTMAX") {
-		(SIGRTMAX, rest)
 	} else {
-		return None;
+		let rest = name.strip_prefix("RTMAX")?;
+		(SIGRTMAX, rest)
 	};
 	let number = if rest.is_empty() {
 		base


### PR DESCRIPTION
rust-ci installs the floating `stable` toolchain, so CI moved itself to Rust 1.97.0 (released 2026-07-07). 1.97 widens clippy's `question_mark` lint to reach the RTMIN/RTMAX chain in `realtime_signal_number`, and `-D warnings` makes it fatal — so **every open PR here is red on Format & lint right now**, whatever it touches. #1006 and #998 are both blocked behind this.

Folds the RTMAX arm into the else branch with `?`, as clippy suggests. Same behaviour: a name matching neither prefix still returns `None`.

Verified against the toolchain CI actually runs (1.97.0), not my local default (1.96): `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean, `cargo fmt --check` is clean, and the 11 signal tests pass — including `stop_signal_resolves_realtime_signals` and `stop_signal_rejects_out_of_range_realtime_offset`, which cover the exact path.

Worth a follow-up: this will happen again on 1.98. `.github`'s rust-ci pins nothing, while v1.8.0 just pinned ruff/pytest in python-ci for this same reason. rust-ci deserves the same treatment.