### PR TITLE
chore(release): 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"


### PR DESCRIPTION
`develop` says 1.8.1, but it carries three features since 1.8.0:

- `feat(cli): add \`podup autostart\` with service mode` (#995)
- `feat(cli): add a version subcommand and a --project-name alias`
- `feat(compose): warn on unknown keys inside nested option blocks` (#990)

Features are a minor under SemVer, so 1.9.0. Shipping them as a patch would tell users nothing changed.

Cargo.toml + Cargo.lock only, same shape as the 1.8.1 bump. Goes in before the release PR (#1007) so `main` lands already carrying the right version.