### PR TITLE
security(release): prove the signing key matches what consumers embed

### DIFF
--- a/.github/scripts/verify-signing-key.py
+++ b/.github/scripts/verify-signing-key.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Prove a freshly signed artifact verifies against the keys consumers embed.
+
+Usage:
+  verify-signing-key.py <signed-file> [<sig-file>]
+
+sign.py checks only that GLYNDOR_RELEASE_ED25519_KEY is base64 that decodes to
+32 bytes. A well-formed but WRONG seed therefore signs happily, and the release
+publishes with a signature no installer, updater or apt client can verify — a
+dead release, and releases are immutable, so the version is burnt and the fix is
+a whole new one. The 2026-07 rotation made that concrete: the signing secret and
+the embedded keys are edited in different places at different times, and nothing
+compared them.
+
+This closes the loop by verifying the produced signature against the public keys
+that ship to users, read straight out of install.sh rather than restated here —
+a copy in this file could drift from the installer and would prove nothing about
+what a user actually runs. Any populated slot may verify (rotation trusts two
+keys at once); the check fails only when NO embedded key accepts the signature,
+which is exactly the condition that would strand every consumer.
+
+Exit: 0 verified, 1 mismatch or malformed input.
+"""
+import base64
+import re
+import sys
+from pathlib import Path
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+INSTALLER = Path(__file__).resolve().parents[2] / "install.sh"
+
+# Matches the installer's two slots, taking the default from the ${VAR:-DEFAULT}
+# form so CI reads the same literal a user gets when the env override is unset.
+SLOT_RE = re.compile(
+	r'^PODUP_RELEASE_PUBKEY2?_B64="\$\{PODUP_RELEASE_PUBKEY2?_B64:-([^}]*)\}"$',
+	re.MULTILINE,
+)
+
+
+def embedded_pubkeys() -> list[str]:
+	"""Return the non-empty release pubkeys install.sh ships, in slot order."""
+	if not INSTALLER.is_file():
+		sys.exit(f"cannot read {INSTALLER}; refusing to publish unverified")
+	slots = SLOT_RE.findall(INSTALLER.read_text(encoding="utf-8"))
+	if not slots:
+		sys.exit(f"found no PODUP_RELEASE_PUBKEY*_B64 slots in {INSTALLER}")
+	return [s for s in slots if s]
+
+
+def main() -> None:
+	if len(sys.argv) < 2:
+		print(__doc__, file=sys.stderr)
+		sys.exit(1)
+
+	signed = Path(sys.argv[1])
+	sig = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(str(signed) + ".sig")
+
+	data = signed.read_bytes()
+	signature = sig.read_bytes()
+
+	keys = embedded_pubkeys()
+	if not keys:
+		sys.exit("every embedded key slot is empty; nothing could verify this release")
+
+	for slot, key_b64 in enumerate(keys):
+		pad = "=" * (-len(key_b64) % 4)
+		try:
+			raw = base64.b64decode(key_b64 + pad, validate=True)
+			Ed25519PublicKey.from_public_bytes(raw).verify(signature, data)
+		except (ValueError, base64.binascii.Error) as exc:
+			sys.exit(f"embedded key slot {slot} is not a valid Ed25519 public key: {exc}")
+		except InvalidSignature:
+			continue
+		print(f"{signed.name}: verified against embedded key slot {slot} ({key_b64})")
+		return
+
+	sys.exit(
+		f"{signed.name}: the signature GLYNDOR_RELEASE_ED25519_KEY just produced "
+		f"verifies against NONE of the {len(keys)} embedded key(s): {', '.join(keys)}.\n"
+		"The signing secret and the keys baked into install.sh / install.ps1 / "
+		"internal/update/verify.rs disagree, so this release would be unverifiable "
+		"and uninstallable. Refusing to publish. Fix whichever side is wrong before "
+		"retagging — the tag is immutable once the release exists."
+	)
+
+
+if __name__ == "__main__":
+	main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,6 +313,18 @@ jobs:
           "$venv_py" .github/scripts/sign.py install.sh
           "$venv_py" .github/scripts/sign.py install.ps1
 
+      - name: Verify the signature against the keys consumers embed
+        run: |
+          # sign.py only checks the seed is base64 of 32 bytes, so a wrong-but-
+          # well-formed GLYNDOR_RELEASE_ED25519_KEY signs happily and publishes a
+          # release nothing can verify. Releases are immutable, so that mistake
+          # burns the version. Do here, once, what every installer does on every
+          # machine: verify SHA256SUMS.sig against the keys install.sh ships. A
+          # mismatch fails the release instead of shipping it.
+          venv_py="$RUNNER_TEMP/signvenv/bin/python"
+          [ -x "$venv_py" ] || venv_py="$RUNNER_TEMP/signvenv/Scripts/python.exe"
+          "$venv_py" .github/scripts/verify-signing-key.py SHA256SUMS
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
`sign.py` checks only that `GLYNDOR_RELEASE_ED25519_KEY` is base64 decoding to 32 bytes. A **wrong-but-well-formed** seed signs without complaint, and `release.yml` goes straight from signing to `gh release create` — so we'd publish a release whose signature no installer, updater or apt client can verify. Releases are immutable, so that burns the version.

Not hypothetical. The signing secret and the embedded keys live in different files, edited at different times: the 2026-07 rotation set the secret on the 7th while `install.sh` / `install.ps1` / `verify.rs` still carried the old pair, and nothing in CI compared them. **Right now `develop` signs with the rotated key and embeds the old one** — #1006 fixes that, but nothing would have *caught* it.

So: verify `SHA256SUMS.sig` against the keys `install.sh` actually ships, after signing and before publishing. The same check every user's installer runs — done once in CI, where failing is free.

Two design notes:
- **Keys are parsed out of `install.sh`, not restated in the script.** A second copy could drift from the installer and would prove nothing about what a user actually runs.
- **Any populated slot may verify**, since a rotation legitimately trusts two keys at once. Only "no embedded key accepts this signature" fails — exactly the state that strands every consumer.

Verified both paths against the real `install.sh` with a throwaway keypair:
- matching key → `verified against embedded key slot 0`, exit 0
- mismatched key → `sign.py` signs it happily, then this rejects with exit 1 and the release aborts

Wants to land before the v1.9.0 tag — it's the thing that makes a bad key a free CI failure instead of a burnt version.