### PR TITLE
release: 1.9.0

### DIFF
--- a/.github/scripts/verify-signing-key.py
+++ b/.github/scripts/verify-signing-key.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Prove a freshly signed artifact verifies against the keys consumers embed.
+
+Usage:
+  verify-signing-key.py <signed-file> [<sig-file>]
+
+sign.py checks only that GLYNDOR_RELEASE_ED25519_KEY is base64 that decodes to
+32 bytes. A well-formed but WRONG seed therefore signs happily, and the release
+publishes with a signature no installer, updater or apt client can verify — a
+dead release, and releases are immutable, so the version is burnt and the fix is
+a whole new one. The 2026-07 rotation made that concrete: the signing secret and
+the embedded keys are edited in different places at different times, and nothing
+compared them.
+
+This closes the loop by verifying the produced signature against the public keys
+that ship to users, read straight out of install.sh rather than restated here —
+a copy in this file could drift from the installer and would prove nothing about
+what a user actually runs. Any populated slot may verify (rotation trusts two
+keys at once); the check fails only when NO embedded key accepts the signature,
+which is exactly the condition that would strand every consumer.
+
+Exit: 0 verified, 1 mismatch or malformed input.
+"""
+import base64
+import re
+import sys
+from pathlib import Path
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+INSTALLER = Path(__file__).resolve().parents[2] / "install.sh"
+
+# Matches the installer's two slots, taking the default from the ${VAR:-DEFAULT}
+# form so CI reads the same literal a user gets when the env override is unset.
+SLOT_RE = re.compile(
+	r'^PODUP_RELEASE_PUBKEY2?_B64="\$\{PODUP_RELEASE_PUBKEY2?_B64:-([^}]*)\}"$',
+	re.MULTILINE,
+)
+
+
+def embedded_pubkeys() -> list[str]:
+	"""Return the non-empty release pubkeys install.sh ships, in slot order."""
+	if not INSTALLER.is_file():
+		sys.exit(f"cannot read {INSTALLER}; refusing to publish unverified")
+	slots = SLOT_RE.findall(INSTALLER.read_text(encoding="utf-8"))
+	if not slots:
+		sys.exit(f"found no PODUP_RELEASE_PUBKEY*_B64 slots in {INSTALLER}")
+	return [s for s in slots if s]
+
+
+def main() -> None:
+	if len(sys.argv) < 2:
+		print(__doc__, file=sys.stderr)
+		sys.exit(1)
+
+	signed = Path(sys.argv[1])
+	sig = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(str(signed) + ".sig")
+
+	data = signed.read_bytes()
+	signature = sig.read_bytes()
+
+	keys = embedded_pubkeys()
+	if not keys:
+		sys.exit("every embedded key slot is empty; nothing could verify this release")
+
+	for slot, key_b64 in enumerate(keys):
+		pad = "=" * (-len(key_b64) % 4)
+		try:
+			raw = base64.b64decode(key_b64 + pad, validate=True)
+			Ed25519PublicKey.from_public_bytes(raw).verify(signature, data)
+		except (ValueError, base64.binascii.Error) as exc:
+			sys.exit(f"embedded key slot {slot} is not a valid Ed25519 public key: {exc}")
+		except InvalidSignature:
+			continue
+		print(f"{signed.name}: verified against embedded key slot {slot} ({key_b64})")
+		return
+
+	sys.exit(
+		f"{signed.name}: the signature GLYNDOR_RELEASE_ED25519_KEY just produced "
+		f"verifies against NONE of the {len(keys)} embedded key(s): {', '.join(keys)}.\n"
+		"The signing secret and the keys baked into install.sh / install.ps1 / "
+		"internal/update/verify.rs disagree, so this release would be unverifiable "
+		"and uninstallable. Refusing to publish. Fix whichever side is wrong before "
+		"retagging — the tag is immutable once the release exists."
+	)
+
+
+if __name__ == "__main__":
+	main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,6 +313,18 @@ jobs:
           "$venv_py" .github/scripts/sign.py install.sh
           "$venv_py" .github/scripts/sign.py install.ps1
 
+      - name: Verify the signature against the keys consumers embed
+        run: |
+          # sign.py only checks the seed is base64 of 32 bytes, so a wrong-but-
+          # well-formed GLYNDOR_RELEASE_ED25519_KEY signs happily and publishes a
+          # release nothing can verify. Releases are immutable, so that mistake
+          # burns the version. Do here, once, what every installer does on every
+          # machine: verify SHA256SUMS.sig against the keys install.sh ships. A
+          # mismatch fails the release instead of shipping it.
+          venv_py="$RUNNER_TEMP/signvenv/bin/python"
+          [ -x "$venv_py" ] || venv_py="$RUNNER_TEMP/signvenv/Scripts/python.exe"
+          "$venv_py" .github/scripts/verify-signing-key.py SHA256SUMS
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -72,9 +72,9 @@ is no longer the one unverifiable link in the chain.
 
 ## The embedded public keys
 
-Each consumer holds **up to two** accepted release keys. Both slots are
-currently populated (base64 `YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM` and
-`gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE`), embedded in three places:
+Each consumer holds **up to two** accepted release keys. Slot 0 holds the
+active key; slot 1 is the empty rotation slot, populated only during a
+rotation. Embedded in three places:
 
 - `internal/update/verify.rs` — `RELEASE_PUBKEYS[0]` and `[1]` (raw 32 bytes).
 - `install.sh` — `PODUP_RELEASE_PUBKEY_B64` and `PODUP_RELEASE_PUBKEY2_B64`.
@@ -116,7 +116,7 @@ python3 - <<'PY'
 import base64
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 key = Ed25519PublicKey.from_public_bytes(
-    base64.b64decode("YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM" + "=="))
+    base64.b64decode("HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM" + "=="))
 key.verify(open("SHA256SUMS.sig", "rb").read(), open("SHA256SUMS", "rb").read())
 print("SHA256SUMS signature OK")
 PY

--- a/install.ps1
+++ b/install.ps1
@@ -87,8 +87,8 @@ try {
 	# second is empty except during a key rotation, when it holds the new key so a
 	# release signed by either key verifies. The signature passes if any key
 	# validates. Override for a fork via PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64.
-	$PubKeyB64  = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM' }
-	$PubKey2B64 = if ($env:PODUP_RELEASE_PUBKEY2_B64) { $env:PODUP_RELEASE_PUBKEY2_B64 } else { 'gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE' }
+	$PubKeyB64  = if ($env:PODUP_RELEASE_PUBKEY_B64) { $env:PODUP_RELEASE_PUBKEY_B64 } else { 'HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM' }
+	$PubKey2B64 = if ($env:PODUP_RELEASE_PUBKEY2_B64) { $env:PODUP_RELEASE_PUBKEY2_B64 } else { '' }
 	$PubKeys = @($PubKeyB64, $PubKey2B64 | Where-Object { $_ })
 
 	$verified = $false

--- a/install.sh
+++ b/install.sh
@@ -97,8 +97,8 @@ download() {
 # release signed by either key verifies during a make-before-break rotation; the
 # signature passes if any key validates. Retire a key by clearing its slot here.
 # Override for a fork via the PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64 env vars.
-PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM}"
-PODUP_RELEASE_PUBKEY2_B64="${PODUP_RELEASE_PUBKEY2_B64:-gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE}"
+PODUP_RELEASE_PUBKEY_B64="${PODUP_RELEASE_PUBKEY_B64:-HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM}"
+PODUP_RELEASE_PUBKEY2_B64="${PODUP_RELEASE_PUBKEY2_B64:-}"
 
 PUBKEYS=()
 [[ -n "$PODUP_RELEASE_PUBKEY_B64" ]]  && PUBKEYS+=("$PODUP_RELEASE_PUBKEY_B64")

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -11,12 +11,13 @@ use sha2::{Digest, Sha256};
 
 use crate::ComposeError;
 
-/// Accepted Ed25519 release public keys — at most two. Both slots are populated
-/// with the current release keys (`GLYNDOR_RELEASE_ED25519_KEY` in slot 0,
-/// `GLYNDOR_RELEASE_ED25519_KEY_2` in slot 1); a signature is trusted if it
-/// validates under either. The keys are public by design — their integrity comes
-/// from being baked into the signed, build-provenance-attested binary, so an
-/// attacker cannot swap them without invalidating the binary itself.
+/// Accepted Ed25519 release public keys — at most two. Slot 0 holds the active
+/// release key (`GLYNDOR_RELEASE_ED25519_KEY`); slot 1 is the empty rotation
+/// slot, populated only during a key rotation (see below). A signature is
+/// trusted if it validates under either non-zero slot. The keys are public by
+/// design — their integrity comes from being baked into the signed,
+/// build-provenance-attested binary, so an attacker cannot swap them without
+/// invalidating the binary itself.
 ///
 /// Verified against the genuine published `SHA256SUMS.sig` (see
 /// `embedded_key_verifies_real_release`). [`release_pubkeys`] still fails closed
@@ -36,20 +37,18 @@ use crate::ComposeError;
 ///
 /// If the outgoing private key is LOST, step 1 is impossible — no release can be
 /// signed by the old key — so fielded self-updaters cannot migrate in-band and
-/// must be re-installed out-of-band (rotated `install.sh` / apt). The two keys
-/// below are both freshly generated for exactly that reason; keep both live and
-/// signed until a normal (key-available) rotation can retire one.
+/// must be re-installed out-of-band (rotated `install.sh` / apt). That happened
+/// here: the key below is a fresh key with no relationship to any previously
+/// embedded key, and slot 1 starts zeroed (the normal steady state) rather than
+/// carrying a second live key.
 pub const RELEASE_PUBKEYS: [[u8; 32]; 2] = [
-	// GLYNDOR_RELEASE_ED25519_KEY = YUn5BN/lYIxJzDvjoUROgGGQjmlq100/SqbnhF1vvfM
+	// GLYNDOR_RELEASE_ED25519_KEY = HFv7vg5FCY7YyKUDbJhaQSfB9SboJGSblJtFbLmLHzM
 	[
-		97, 73, 249, 4, 223, 229, 96, 140, 73, 204, 59, 227, 161, 68, 78, 128, 97, 144, 142, 105,
-		106, 215, 77, 63, 74, 166, 231, 132, 93, 111, 189, 243,
+		28, 91, 251, 190, 14, 69, 9, 142, 216, 200, 165, 3, 108, 152, 90, 65, 39, 193, 245, 38,
+		232, 36, 100, 155, 148, 155, 69, 108, 185, 139, 31, 51,
 	],
-	// GLYNDOR_RELEASE_ED25519_KEY_2 = gWmPpZyqOogAwSDRonGyL21u3Xj2GTfcvjwXrmA8qQE
-	[
-		129, 105, 143, 165, 156, 170, 58, 136, 0, 193, 32, 209, 162, 113, 178, 47, 109, 110, 221,
-		120, 246, 25, 55, 220, 190, 60, 23, 174, 96, 60, 169, 1,
-	],
+	// Empty rotation slot — populate during the next key rotation.
+	[0u8; 32],
 ];
 
 /// A parsed `MAJOR.MINOR.PATCH` version, ordered for comparison.

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -3,29 +3,43 @@
 //! `podup:` program prefix — while stdout stays a clean YAML pipe for `config`.
 
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
+
+use tempfile::TempDir;
 
 fn bin() -> &'static str {
 	env!("CARGO_BIN_EXE_podup")
 }
 
-/// Write a compose file with an unsupported key into a fresh temp dir and
-/// return its path. The unknown key drives the forward-compat diagnostic.
-fn compose_with_unknown_key() -> std::path::PathBuf {
-	let dir = std::env::temp_dir().join(format!("podup-diag-{}", std::process::id()));
-	fs::create_dir_all(&dir).expect("create temp dir");
-	let path = dir.join("compose.yaml");
-	fs::write(
-		&path,
+/// Write `contents` as a compose file in a temp dir of its own.
+///
+/// The directory must be unique **per call**, not per process: cargo runs the
+/// tests in one binary as threads, so a path keyed on the pid is shared by every
+/// test in this file. Two tests writing the same compose file then race —
+/// `fs::write` truncates before it writes, so a concurrent reader can see an
+/// empty file and fail validation. Returning the [`TempDir`] hands the caller
+/// the directory's lifetime: hold it for the length of the test, and it is
+/// removed on drop rather than left in /tmp forever.
+fn compose_file(name: &str, contents: &str) -> (TempDir, PathBuf) {
+	let dir = tempfile::tempdir().expect("create temp dir");
+	let path = dir.path().join(name);
+	fs::write(&path, contents).expect("write compose file");
+	(dir, path)
+}
+
+/// A compose file with an unsupported key, which drives the forward-compat
+/// diagnostic.
+fn compose_with_unknown_key() -> (TempDir, PathBuf) {
+	compose_file(
+		"compose.yaml",
 		"services:\n  web:\n    image: nginx:1.27\n    bogus_field: oops\n",
 	)
-	.expect("write compose file");
-	path
 }
 
 #[test]
 fn config_warns_on_stderr_with_clean_stdout_and_no_rust_log() {
-	let file = compose_with_unknown_key();
+	let (_dir, file) = compose_with_unknown_key();
 	let output = Command::new(bin())
 		.arg("-f")
 		.arg(&file)
@@ -56,8 +70,6 @@ fn config_warns_on_stderr_with_clean_stdout_and_no_rust_log() {
 		!stdout.contains("warning"),
 		"stdout stays a clean pipe; got stdout:\n{stdout}"
 	);
-
-	let _ = fs::remove_dir_all(file.parent().unwrap());
 }
 
 #[test]
@@ -76,21 +88,16 @@ fn completions_emit_a_script_to_stdout() {
 }
 
 /// A minimal valid two-service compose file in a fresh temp dir.
-fn compose_two_services() -> std::path::PathBuf {
-	let dir = std::env::temp_dir().join(format!("podup-cfg-{}", std::process::id()));
-	fs::create_dir_all(&dir).expect("create temp dir");
-	let path = dir.join("compose.yaml");
-	fs::write(
-		&path,
+fn compose_two_services() -> (TempDir, PathBuf) {
+	compose_file(
+		"compose.yaml",
 		"services:\n  web:\n    image: nginx:1.27\n  db:\n    image: postgres:16\n",
 	)
-	.expect("write compose file");
-	path
 }
 
 #[test]
 fn config_services_lists_service_names() {
-	let file = compose_two_services();
+	let (_dir, file) = compose_two_services();
 	let out = Command::new(bin())
 		.args(["-f", file.to_str().unwrap(), "config", "--services"])
 		.output()
@@ -105,7 +112,7 @@ fn config_services_lists_service_names() {
 
 #[test]
 fn config_format_json_emits_json() {
-	let file = compose_two_services();
+	let (_dir, file) = compose_two_services();
 	let out = Command::new(bin())
 		.args(["-f", file.to_str().unwrap(), "config", "--format", "json"])
 		.output()
@@ -118,7 +125,7 @@ fn config_format_json_emits_json() {
 
 #[test]
 fn config_quiet_validates_without_output() {
-	let valid = compose_two_services();
+	let (_dir, valid) = compose_two_services();
 	let ok = Command::new(bin())
 		.args(["-f", valid.to_str().unwrap(), "config", "-q"])
 		.output()
@@ -127,10 +134,10 @@ fn config_quiet_validates_without_output() {
 	assert!(ok.stdout.is_empty(), "quiet must print nothing");
 
 	// A syntactically broken compose file fails validation (non-zero exit).
-	let dir = std::env::temp_dir().join(format!("podup-cfgbad-{}", std::process::id()));
-	fs::create_dir_all(&dir).unwrap();
-	let badfile = dir.join("compose.yaml");
-	fs::write(&badfile, "services:\n  web:\n    image: [unterminated\n").unwrap();
+	let (_bad_dir, badfile) = compose_file(
+		"compose.yaml",
+		"services:\n  web:\n    image: [unterminated\n",
+	);
 	let err = Command::new(bin())
 		.args(["-f", badfile.to_str().unwrap(), "config", "-q"])
 		.output()
@@ -140,14 +147,10 @@ fn config_quiet_validates_without_output() {
 
 #[test]
 fn config_no_interpolate_keeps_placeholders_literal() {
-	let dir = std::env::temp_dir().join(format!("podup-noint-{}", std::process::id()));
-	fs::create_dir_all(&dir).unwrap();
-	let compose = dir.join("docker-compose.yml");
-	fs::write(
-		&compose,
+	let (_dir, compose) = compose_file(
+		"docker-compose.yml",
 		"services:\n  web:\n    image: \"alpine:${PODUP_TAG}\"\n",
-	)
-	.unwrap();
+	);
 	let c = compose.to_str().unwrap();
 
 	// Default config interpolates ${PODUP_TAG} (unset → empty).
@@ -216,14 +219,10 @@ fn create_rejects_no_recreate_with_force_recreate() {
 fn config_warns_on_unset_interpolation_variable() {
 	// An unset `${VAR}` interpolates to an empty string but must warn on stderr
 	// (matching docker compose) so a config typo does not pass silently.
-	let dir = std::env::temp_dir().join(format!("podup-unset-warn-{}", std::process::id()));
-	fs::create_dir_all(&dir).unwrap();
-	let compose = dir.join("docker-compose.yml");
-	fs::write(
-		&compose,
+	let (_dir, compose) = compose_file(
+		"docker-compose.yml",
 		"services:\n  web:\n    image: ${PODUP_UNSET_IMAGE}\n",
-	)
-	.unwrap();
+	);
 	let c = compose.to_str().unwrap();
 
 	let out = Command::new(bin())
@@ -243,14 +242,10 @@ fn config_no_interpolate_skips_required_var_error() {
 	// `--no-interpolate` must not evaluate a required-var `${VAR:?msg}`: with the
 	// variable unset the command should still succeed and print the placeholder
 	// literally, rather than failing on the required-var check.
-	let dir = std::env::temp_dir().join(format!("podup-noint-req-{}", std::process::id()));
-	fs::create_dir_all(&dir).unwrap();
-	let compose = dir.join("docker-compose.yml");
-	fs::write(
-		&compose,
+	let (_dir, compose) = compose_file(
+		"docker-compose.yml",
 		"services:\n  web:\n    image: ${MUST_SET:?required}\n",
-	)
-	.unwrap();
+	);
 	let c = compose.to_str().unwrap();
 
 	// With interpolation on, the required-var error fails the command.


### PR DESCRIPTION
Promotes the four commits that make a release possible at all. **main is currently unreleasable**, and #1007 made that worse rather than better: it auto-merged the moment #1008 turned CI green, so main now signs with `GLYNDOR_RELEASE_ED25519_KEY` (= `HFv7…`) while `install.sh`, `install.ps1` and `verify.rs` still embed the *previous* pair. A tag cut from main right now would publish a release whose own installer rejects its signature — and `cargo publish` runs last, so the version would be burnt on crates.io permanently. Nothing was tagged, so no damage; this closes it.

- **#1006** — rotate the embedded key to `HFv7…` (slot 1 zeroed), so what we sign with and what we ship now agree. Hard swap: the previous private half was lost, so no transition release is possible and every pre-existing install must reinstall via install.sh or apt. The apt keyring already trusts this key.
- **#1010** — after signing and before publishing, verify `SHA256SUMS.sig` against the keys `install.sh` actually ships. `sign.py` only checks the seed is base64 of 32 bytes, so a wrong-but-well-formed key signs happily; this is what makes that a free CI failure instead of a permanent crates.io mistake.
- **#1009** — 1.9.0, not 1.8.1. develop carries three features since 1.8.0 (`autostart` with service mode, the `version` subcommand + `--project-name` alias, the nested-unknown-key compose warning).
- **#1011** — kill the temp-dir race that reddened Coverage at random: three tests shared one `compose.yaml` keyed on the pid, which cargo shares across a binary's test threads.

After this lands, tag `v1.9.0` on main.