### PR TITLE
ci: adopt .github v1.9.0 and pin the Rust toolchain

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       coverage-threshold: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       coverage-threshold: 90

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@e22b97f79921a0a1d37d18d91e0ce62aac4f56cd # v1.9.0


### PR DESCRIPTION
`.github` v1.9.0 gives `rust-ci` a `toolchain` input pinned to **1.97** instead of installing `stable` — which is what let CI upgrade itself on 2026-07-07 and turn **every open PR here red** on a clippy lint nobody introduced (fixed in #1008, after it had blocked the release-key rotation and the 1.9.0 release).

The pin lives in the reusable, but **only a caller pinned to v1.9.0 gets it** — so adopting it is what actually stops the recurrence.

**No-op for the compiler.** `1.97` resolves to `rustc 1.97.0 (2d8144b78)`, exactly what these jobs already ran. What changes: 1.98 will no longer arrive unannounced. It arrives when the pin is bumped in `.github` and this caller adopts that release — deliberately, seeing which lints it gained.

Brings the other pins up in the same move, from v1.7.0 (and `line-limit` from v1.6.0, two releases behind):

| reusable | v1.7.0 → v1.9.0 brings | impact here |
|---|---|---|
| `rust-ci` | pinned toolchain | the point of this PR |
| `shell-ci` | opt-in `test-command` lane | unused, no change |
| `main-guard` | head must live in this repo, not just be named `develop` | satisfied by develop → main |
| all | concurrency keyed on working-directory | no cross-directory cancels |
| `line-limit` | stops counting Rust attributes as comments | was on v1.6.0 |

The one to watch is `line-limit`: it's jumping two releases and counts differently now. If it flags a file, that's a real finding, not a regression — the file splits in #1005 should have it covered.