### PR TITLE
fix(debian): ship the released version in the .deb, and gate it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,28 @@ jobs:
           fi
           echo "Releasing version ${VERSION}."
 
+      - name: Debian package version must equal Cargo.toml version
+        # dpkg-buildpackage takes the .deb version from debian/changelog, which
+        # is a separate hand-maintained file. 1.9.0 shipped with the bump applied
+        # to Cargo.toml but not here, so the release carried podup_1.8.0_*.deb:
+        # apt saw the version it already had, reported no upgrade, and Debian
+        # users were stranded — with no self-update either, since podup redirects
+        # a dpkg-owned binary to `apt upgrade`. The tag check above cannot catch
+        # this; only comparing the two versions can.
+        run: |
+          # Read the version off the first line rather than with
+          # dpkg-parsechangelog: that tool lives in dpkg-dev, which this job
+          # never installs, and a gate that only runs at tag time must not
+          # depend on what happens to be on the runner image. The first-line
+          # format is fixed by Debian policy.
+          DEB_VERSION="$(sed -n '1s/^[^(]*(\([^)]*\)).*/\1/p' debian/changelog)"
+          CRATE_VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "$DEB_VERSION" != "$CRATE_VERSION" ]; then
+            echo "::error::debian/changelog is at ${DEB_VERSION} but Cargo.toml is at ${CRATE_VERSION}; add a changelog entry so the .deb carries the released version."
+            exit 1
+          fi
+          echo "Debian package version ${DEB_VERSION} matches."
+
       - name: Tag must be on main
         # Releases are cut only from `main` (develop → main merge, then tag).
         # Refuse a tag pushed to any other branch so an unreviewed commit can

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+podup (1.9.1) unstable; urgency=medium
+
+  * The Debian package was still built as 1.8.0 for the 1.9.0 release: the
+    version bump touched Cargo.toml but not this file, so apt saw no upgrade
+    and Debian users were left on 1.8.0. This release carries the correct
+    version, and CI now fails when the two disagree.
+  * `podup autostart` installs a systemd user service that runs `podup up`
+    for a project, with `--no-start`, `--dry-run` and uninstall.
+  * New `podup version` subcommand, and `--project-name` as an alias for
+    `-p/--project-name`.
+  * `config` now warns about unknown keys inside nested option blocks, not
+    only at the top level.
+  * The release signing key has been rotated. A binary installed before this
+    release cannot verify a newer one and `podup update` will refuse; apt is
+    unaffected, since the archive keyring already trusts the new key.
+  * `secrets`: the file mode is parsed as octal and defaults to 0444, per the
+    compose spec.
+  * `build`: the Dockerfile is always sent even when .dockerignore matches it,
+    and build secrets are kept out of the COPY-able context.
+  * `update`: the self-test is pinned to the resolved release version, and
+    transient release downloads are retried with backoff.
+  * `autostart`: control characters in unit-embedded paths are rejected.
+
+ -- Glyndor <packages@glyndor.net>  Wed, 15 Jul 2026 06:45:00 -0500
+
 podup (1.8.0) unstable; urgency=medium
 
   * Container names are now always index-suffixed (`project-service-1`, even for


### PR DESCRIPTION
**The 1.9.0 release carries `podup_1.8.0_amd64.deb` and `podup_1.8.0_arm64.deb`.** `dpkg-buildpackage` reads the version from `debian/changelog`, and the bump in #1009 touched `Cargo.toml`/`Cargo.lock` but not that file — so the packages shipped labelled with the version users already had. My miss: I copied the shape of the previous bump, which had already dropped the changelog (1.7.0 and 1.7.1 both updated it; 1.8.1 didn't, and was never released, so nobody noticed).

**The effect is worse than a wrong label:**

1. The key rotation makes `podup update` refuse on any pre-1.9.0 binary.
2. The docs say: reinstall via install.sh **or apt**.
3. On Debian, `podup update` detects a dpkg-owned binary and redirects to `apt upgrade`.
4. apt sees 1.8.0 available against 1.8.0 installed → **no upgrade**.
5. The user can't self-update, and their official escape hatch says there's nothing to get.

The archive rebuilds from each product's latest release **daily at 06:00 UTC**. Today's run was at 06:00; v1.9.0 published at 06:02 — so apt is *not* contaminated yet, and tomorrow's run would ingest the mislabelled package. That's the deadline this is racing.

1.9.0 is published and immutable, so this ships as **1.9.1**: both versions bumped together, plus the changelog entry 1.9.0 never had.

**And the gate that should have existed.** The release workflow already refuses to publish when the tag and `Cargo.toml` disagree — it had nothing to say about a *third* version living in `debian/changelog`. Now it compares those too, before anything is built. Version is read off the changelog's first line rather than with `dpkg-parsechangelog`: that tool ships in `dpkg-dev`, which the `verify` job never installs, and a gate that only runs at tag time must not depend on what happens to be on the runner image.

Verified both ways: the gate fails on the exact state that shipped 1.9.0 (`changelog=1.8.0 vs Cargo.toml=1.9.0 -> BLOQUEA`) and passes with both at 1.9.1.