### PR TITLE
release: 1.9.1

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       coverage-threshold: 90

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,28 @@ jobs:
           fi
           echo "Releasing version ${VERSION}."
 
+      - name: Debian package version must equal Cargo.toml version
+        # dpkg-buildpackage takes the .deb version from debian/changelog, which
+        # is a separate hand-maintained file. 1.9.0 shipped with the bump applied
+        # to Cargo.toml but not here, so the release carried podup_1.8.0_*.deb:
+        # apt saw the version it already had, reported no upgrade, and Debian
+        # users were stranded — with no self-update either, since podup redirects
+        # a dpkg-owned binary to `apt upgrade`. The tag check above cannot catch
+        # this; only comparing the two versions can.
+        run: |
+          # Read the version off the first line rather than with
+          # dpkg-parsechangelog: that tool lives in dpkg-dev, which this job
+          # never installs, and a gate that only runs at tag time must not
+          # depend on what happens to be on the runner image. The first-line
+          # format is fixed by Debian policy.
+          DEB_VERSION="$(sed -n '1s/^[^(]*(\([^)]*\)).*/\1/p' debian/changelog)"
+          CRATE_VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "$DEB_VERSION" != "$CRATE_VERSION" ]; then
+            echo "::error::debian/changelog is at ${DEB_VERSION} but Cargo.toml is at ${CRATE_VERSION}; add a changelog entry so the .deb carries the released version."
+            exit 1
+          fi
+          echo "Debian package version ${DEB_VERSION} matches."
+
       - name: Tag must be on main
         # Releases are cut only from `main` (develop → main merge, then tag).
         # Refuse a tag pushed to any other branch so an unreviewed commit can

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@367c6651f8a8055085e7cb1e3c289e68f105e1c4 # v1.7.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+podup (1.9.1) unstable; urgency=medium
+
+  * The Debian package was still built as 1.8.0 for the 1.9.0 release: the
+    version bump touched Cargo.toml but not this file, so apt saw no upgrade
+    and Debian users were left on 1.8.0. This release carries the correct
+    version, and CI now fails when the two disagree.
+  * `podup autostart` installs a systemd user service that runs `podup up`
+    for a project, with `--no-start`, `--dry-run` and uninstall.
+  * New `podup version` subcommand, and `--project-name` as an alias for
+    `-p/--project-name`.
+  * `config` now warns about unknown keys inside nested option blocks, not
+    only at the top level.
+  * The release signing key has been rotated. A binary installed before this
+    release cannot verify a newer one and `podup update` will refuse; apt is
+    unaffected, since the archive keyring already trusts the new key.
+  * `secrets`: the file mode is parsed as octal and defaults to 0444, per the
+    compose spec.
+  * `build`: the Dockerfile is always sent even when .dockerignore matches it,
+    and build secrets are kept out of the COPY-able context.
+  * `update`: the self-test is pinned to the resolved release version, and
+    transient release downloads are retried with backoff.
+  * `autostart`: control characters in unit-embedded paths are rejected.
+
+ -- Glyndor <packages@glyndor.net>  Wed, 15 Jul 2026 06:45:00 -0500
+
 podup (1.8.0) unstable; urgency=medium
 
   * Container names are now always index-suffixed (`project-service-1`, even for


### PR DESCRIPTION
Fixes the one thing 1.9.0 got wrong, and pins the toolchain that caused the night's other outage.

- **#1014 — the .deb said 1.8.0.** 1.9.0 shipped `podup_1.8.0_amd64.deb` / `_arm64.deb`, because the version bump touched `Cargo.toml` but not `debian/changelog`, which is where `dpkg-buildpackage` reads it. apt then reports nothing to upgrade — and 1.9.0 rotated the signing key, so `podup update` refuses on old binaries and redirects dpkg-owned installs to `apt upgrade`. **Both doors shut on exactly the users the rotation forces onto apt.** The archive rebuilds from the latest release daily at 06:00 UTC, so this is racing tomorrow's run. Also adds the gate: the release now refuses to build when `debian/changelog` and `Cargo.toml` disagree — verified to fail on the exact state that shipped 1.9.0.
- **#1013 — pin the Rust toolchain.** Adopts `.github` v1.9.1, whose `rust-ci` takes a `toolchain` input pinned to 1.97 instead of installing `stable`. `stable` is what let CI upgrade itself on 2026-07-07, widen a clippy lint, and turn every open PR here red for a change nobody made — blocking the key rotation and the 1.9.0 release. No-op for the compiler: 1.97 is the rustc these jobs already ran. Other pins come up from v1.7.0 (line-limit from v1.6.0) in the same move.

Pre-flight on develop: `Cargo.toml`, `Cargo.lock` and `debian/changelog` all at **1.9.1**; embedded key `HFv7…`; both release gates present.

After this lands, tag `v1.9.1` on main.