### PR TITLE
chore(release): 1.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (1.9.2) unstable; urgency=medium
+
+  * The short `tmpfs:` form ignored its options. `- /tmp:size=64m,noexec`
+    mounted a tmpfs at a directory *named* `/tmp:size=64m,noexec` and applied
+    none of the options, leaving the real /tmp untouched — read-only, when the
+    service also set `read_only: true`. It exited 0 and warned about nothing.
+    The size cap is the part that matters: an undeclared tmpfs is sized to half
+    the host's RAM and every page is charged to the container's cgroup, so a
+    service asking for a capped 64 MiB got tens of gigabytes uncapped, and
+    `noexec` silently did not apply. The path is now split from its options on
+    the first colon, matching docker compose exactly.
+
+ -- Glyndor <packages@glyndor.net>  Wed, 15 Jul 2026 10:55:00 -0500
+
 podup (1.9.1) unstable; urgency=medium
 
   * The Debian package was still built as 1.8.0 for the 1.9.0 release: the


### PR DESCRIPTION
A patch: the only change since 1.9.1 is #1017, the short-`tmpfs` fix — a bug fix, no new surface.

All three version files move together this time: `Cargo.toml`, `Cargo.lock` **and `debian/changelog`**. 1.9.0 shipped `podup_1.8.0_*.deb` by missing that last one, which left apt users with nothing to upgrade to; the gate added in #1014 now refuses to build when they disagree, and it passes here (`OK: ambas en 1.9.2`).

The changelog entry says what a Debian user actually needs to know: their capped 64 MiB tmpfs wasn't capped.