### PR TITLE
release: 1.9.2

### DIFF
--- a/.github/workflows/podman-watch.yml
+++ b/.github/workflows/podman-watch.yml
@@ -38,13 +38,24 @@ jobs:
           echo "Podman $LATEST is packaged in: $DISTROS"
           # Major bump => full sweep; otherwise a lighter re-check.
           MAJ_NEW=${LATEST%%.*}; MAJ_OLD=${BASELINE%%.*}
-          KIND="patch/minor re-check"; [ "$MAJ_NEW" != "$MAJ_OLD" ] && KIND="MAJOR — full command-by-command sweep + wire-field re-probe"
+          KIND="patch/minor re-check"; EFFORT="effort:M"
+          if [ "$MAJ_NEW" != "$MAJ_OLD" ]; then
+            KIND="MAJOR — full command-by-command sweep + wire-field re-probe"
+            # A major re-probes the wire fields on top of the suite: a size more.
+            EFFORT="effort:L"
+          fi
           TITLE="Validate podup on Podman $LATEST (now packaged)"
           # Idempotent: skip if an issue for this version is already open.
           if gh issue list --state open --search "in:title $TITLE" --json title --jq '.[].title' | grep -qxF "$TITLE"; then
             echo "Issue already open — nothing to do."; exit 0
           fi
-          gh issue create --title "$TITLE" --body "Podman **$LATEST** is released and now packaged in: **$DISTROS** (baseline validated: $BASELINE).
+          # Label on creation. An unlabelled issue is a process bug, and one filed
+          # by a bot is no exception — #673 and #1016 both landed bare because this
+          # step never passed --label, and both had to be labelled by hand later.
+          gh issue create --title "$TITLE" \
+            --label "type:test" --label "prio:P2" --label "status:ready" \
+            --label "area:engine" --label "$EFFORT" \
+            --body "Podman **$LATEST** is released and now packaged in: **$DISTROS** (baseline validated: $BASELINE).
 
           This is **$KIND**.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (1.9.2) unstable; urgency=medium
+
+  * The short `tmpfs:` form ignored its options. `- /tmp:size=64m,noexec`
+    mounted a tmpfs at a directory *named* `/tmp:size=64m,noexec` and applied
+    none of the options, leaving the real /tmp untouched — read-only, when the
+    service also set `read_only: true`. It exited 0 and warned about nothing.
+    The size cap is the part that matters: an undeclared tmpfs is sized to half
+    the host's RAM and every page is charged to the container's cgroup, so a
+    service asking for a capped 64 MiB got tens of gigabytes uncapped, and
+    `noexec` silently did not apply. The path is now split from its options on
+    the first colon, matching docker compose exactly.
+
+ -- Glyndor <packages@glyndor.net>  Wed, 15 Jul 2026 10:55:00 -0500
+
 podup (1.9.1) unstable; urgency=medium
 
   * The Debian package was still built as 1.8.0 for the 1.9.0 release: the

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -141,13 +141,8 @@ pub(crate) fn build_mounts_all(
 	}
 
 	// Top-level `tmpfs:` shorthand — equivalent to volumes with type=tmpfs.
-	for path in service.tmpfs.to_list() {
-		mounts.push(Mount {
-			mount_type: "tmpfs".into(),
-			source: None,
-			destination: path,
-			options: vec![],
-		});
+	for entry in service.tmpfs.to_list() {
+		mounts.push(spec::parse_tmpfs_string(&entry));
 	}
 
 	// Materialised secrets and configs are passed as pre-built bind strings.

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -107,6 +107,32 @@ fn split_volume_spec(s: &str) -> (&str, &str, &str) {
 	}
 }
 
+/// Parse one entry of the short `tmpfs:` list into a tmpfs Mount.
+///
+/// The entry is `<path>` or `<path>:<opt>[,<opt>…]`, split on the **first**
+/// colon: everything after it is handed to the engine as mount options. That is
+/// what docker compose does, measured against it rather than inferred — for
+/// `/multi:size=64m,mode=1777,noexec` it produces the Tmpfs entry
+/// `/multi -> size=64m,mode=1777,noexec,…`, and a bare `/plain` or a trailing
+/// `/trail:` yields the path with no options.
+///
+/// Options are passed through verbatim, not trimmed or validated: docker compose
+/// does not sanitise them either, and letting the engine reject `unknown mount
+/// option " noexec"` is a better answer than silently repairing a typo.
+pub(super) fn parse_tmpfs_string(s: &str) -> Mount {
+	let (dst, opts_str) = s.split_once(':').unwrap_or((s, ""));
+	Mount {
+		mount_type: "tmpfs".into(),
+		source: None,
+		destination: dst.to_string(),
+		options: opts_str
+			.split(',')
+			.filter(|o| !o.is_empty())
+			.map(str::to_string)
+			.collect(),
+	}
+}
+
 /// Parse a pre-built bind string (secret/config) — always produces a bind Mount.
 pub(super) fn parse_bind_string(s: &str) -> Option<Mount> {
 	let parts: Vec<&str> = s.splitn(3, ':').collect();
@@ -174,10 +200,54 @@ pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOp
 #[cfg(test)]
 mod tests {
 	use super::{
-		extend_bind_opts_str, is_bind_source, map_selinux_option, parse_volume_string,
-		split_volume_spec,
+		extend_bind_opts_str, is_bind_source, map_selinux_option, parse_tmpfs_string,
+		parse_volume_string, split_volume_spec,
 	};
 	use crate::compose::types::BindOptions;
+
+	#[test]
+	fn tmpfs_short_form_splits_path_from_options() {
+		// Regression: the whole entry used to become the destination, so
+		// `/multi:size=64m,…` mounted a tmpfs at a directory *named* that, with no
+		// size cap — while the real path stayed untouched. Silent, exit 0.
+		let m = parse_tmpfs_string("/multi:size=64m,mode=1777,noexec,nosuid,nodev");
+		assert_eq!(m.destination, "/multi", "path must not carry the options");
+		assert_eq!(
+			m.options,
+			vec!["size=64m", "mode=1777", "noexec", "nosuid", "nodev"],
+			"every option must reach the engine"
+		);
+		assert_eq!(m.mount_type, "tmpfs");
+		assert!(m.source.is_none(), "a tmpfs has no source");
+	}
+
+	#[test]
+	fn tmpfs_short_form_without_options_is_unchanged() {
+		let m = parse_tmpfs_string("/plain");
+		assert_eq!(m.destination, "/plain");
+		assert!(m.options.is_empty(), "no colon means no options");
+	}
+
+	#[test]
+	fn tmpfs_short_form_trailing_colon_yields_no_options() {
+		// Matches docker compose, measured: `/trail:` mounts /trail with defaults
+		// rather than an empty-string option the engine would reject.
+		let m = parse_tmpfs_string("/trail:");
+		assert_eq!(m.destination, "/trail");
+		assert!(m.options.is_empty());
+	}
+
+	#[test]
+	fn tmpfs_short_form_splits_on_the_first_colon_only() {
+		// An option value may itself contain a colon; only the first separates
+		// the path from the options.
+		let m = parse_tmpfs_string("/x:size=1m,context=system_u:object_r:tmp_t:s0");
+		assert_eq!(m.destination, "/x");
+		assert_eq!(
+			m.options,
+			vec!["size=1m", "context=system_u:object_r:tmp_t:s0"]
+		);
+	}
 
 	#[test]
 	fn colon_less_path_is_anonymous_volume_not_bind() {


### PR DESCRIPTION
Two commits, one user-visible fix.

**#1017 — the short `tmpfs:` form ignored its options.** `- /tmp:size=64m,noexec` mounted a tmpfs at a directory *named* `/tmp:size=64m,noexec` and applied none of them; the real `/tmp` never got the mount, and with `read_only: true` it stayed read-only, so the service wrote somewhere nobody asked for. `exit 0`, no warning.

The size cap is what bites: an undeclared tmpfs is sized to **half the host's RAM** and every page is charged to the container's cgroup — so a service asking for a capped 64 MiB got tens of gigabytes uncapped, and `noexec` silently didn't apply. A request that reads as hardening quietly became its opposite. It has been shipping since at least 1.8.1 and is in 1.9.1 right now.

The target wasn't taken from the spec (the short form's `path:options` isn't in it). It was **measured against docker compose over the same Podman socket**: both now produce byte-identical `Tmpfs` maps for `/multi:size=64m,mode=1777,noexec,nosuid,nodev`, `/plain` and `/trail:`.

**#1018 — 1.9.2**, with all three version files moving together. The gate from #1014 passes (`OK: ambas en 1.9.2`).

Pre-flight on develop: `Cargo.toml`/`Cargo.lock`/`debian/changelog` all at 1.9.2; embedded key `HFv7…`; both release gates present.

After this lands, tag `v1.9.2`.