### PR TITLE
chore(release): 1.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.9.2"
+version = "1.9.3"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+podup (1.9.3) unstable; urgency=medium
+
+  * The autostart service unit destroyed the stack on a clean shutdown and
+    rebuilt it on every boot. `ExecStop` ran `down`, which removes the
+    containers, so shutting the machine down deleted the stack and the next
+    boot recreated it from scratch, losing container identity and logs.
+    `ExecStop` now runs `stop`, which leaves the containers on disk for
+    `ExecStart` to find and honours each container's own stop_signal and
+    stop_grace_period. `ExecStart` also ran `up -d --build`, making a boot
+    depend on the network and a reachable registry; a build that failed left
+    the stack down on an unattended machine. It now runs `up -d`.
+    If you installed autostart with 1.9.0-1.9.2, re-run
+    `podup autostart install` to regenerate the unit.
+
+ -- Glyndor <packages@glyndor.net>  Thu, 16 Jul 2026 01:05:00 -0500
+
 podup (1.9.2) unstable; urgency=medium
 
   * The short `tmpfs:` form ignored its options. `- /tmp:size=64m,noexec`


### PR DESCRIPTION
Version bump for 1.9.3, carrying the autostart shutdown fix (#1021 / #1022).

All three places the version lives are updated together — `Cargo.toml`, `Cargo.lock` and `debian/changelog`. Missing the changelog is what made v1.9.0 ship `podup_1.8.0_*.deb`; the release workflow now gates on those two agreeing, and I ran that gate locally before pushing:

```
Cargo.toml: 1.9.3
changelog:  1.9.3
MATCH
```

The changelog entry tells anyone who installed autostart on 1.9.0-1.9.2 to re-run `podup autostart install`. The binary self-updates but the unit file does not: it is generated once at install time and never touched again, so the fix cannot reach an already-generated unit on its own. That window is ~24h wide (autostart shipped in v1.9.0 yesterday), which is why this is a changelog line and not a staleness check in the code.

1688 tests pass; fmt and clippy (`--locked --all-targets --all-features -D warnings`) are clean.