### PR TITLE
docs: rootless autostart guide, both modes

### DIFF
--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -1,0 +1,122 @@
+# Rootless autostart
+
+`podup autostart` keeps a compose stack running across reboots, entirely
+**rootless and user-scope**: it writes only under `${XDG_CONFIG_HOME:-~/.config}`
+and drives everything through `systemctl --user`. Nothing touches `/etc`, the
+system systemd, or root. The stack runs as an unprivileged user, and systemd
+brings it up at boot.
+
+## Prerequisite: lingering
+
+A user's systemd manager normally exists only while that user has a session, and
+`/run/user/<uid>` is created at login and torn down at logout. A service account
+never logs in, so without lingering there is no user manager at boot and the stack
+never starts. Enable it once, as root:
+
+```bash
+sudo loginctl enable-linger appuser
+loginctl show-user appuser --property=Linger   # → Linger=yes
+```
+
+Lingering starts the user manager at boot and creates `/run/user/<uid>` up front,
+independent of any login. `podup autostart install` warns if lingering is off,
+because the unit it writes will not start at boot until you enable it.
+
+## Picking a mode
+
+`--mode` selects the backend. Both are rootless and user-scope; they differ in
+who owns the containers.
+
+| Mode | What it installs | Choose it when |
+|---|---|---|
+| `service` (default) | One `Type=oneshot` unit that runs `podup up -d` at boot and `podup stop` on shutdown. | You want the whole stack managed as a unit, the simplest option — one thing to enable, one to remove. |
+| `quadlet` | One native Podman Quadlet unit per service (`.container`/`.build`/`.volume`/`.network`), which systemd owns directly. | You want per-container supervision — systemd restarts, ordering and status for each service independently. |
+
+Service mode keeps the compose front-end (`.env`, interpolation, profiles) on the
+runtime path; systemd starts `podup`, and `podup` reads the compose file. Quadlet
+mode renders the stack to systemd units once, at install time, and hands them over
+— after that systemd runs the containers with no `podup` process in the loop.
+
+The two cannot coexist for one project: each install refuses if the other is
+present, since both would bring the same stack up at boot.
+
+## Commands
+
+```bash
+podup autostart install                  # service mode (default)
+podup autostart install --mode quadlet   # quadlet mode
+podup autostart install --no-start       # write the unit(s) but don't start yet
+podup autostart install --dry-run        # print what would be written/run, change nothing
+
+podup autostart status                   # this project's unit and session state
+podup autostart uninstall                # remove whichever mode is installed
+podup autostart uninstall --purge        # also tear the stack down and drop its volumes
+
+podup autostart rebuild                   # quadlet only: rebuild every built image + restart
+podup autostart rebuild web               # rebuild just one service
+```
+
+`uninstall` detects which mode is installed and removes that one; you never pass
+`--mode` to it. `rebuild` applies to quadlet mode: a Quadlet `.build` unit is
+`Type=oneshot`, so an image only rebuilds when its build service is restarted, and
+the container is then restarted to pick it up. Service mode has no `rebuild` — it
+builds at deploy time, whenever you run `podup up`.
+
+## Why `--user` and `default.target`
+
+The unit is a `--user` unit wired into `default.target`, not the system
+`multi-user.target`. `multi-user.target` is a system-manager concept and is inert
+in the user instance, so ordering against it would imply a boot gate that never
+fires. Under lingering the user manager starts after the system network is already
+up, and `podup` reaches Podman over a socket on demand, so no explicit network
+ordering is needed. The generated units carry no `network-online.target` ordering
+for the same reason.
+
+## Running `systemctl --user` for a login-less account
+
+An isolated service account has no login shell, so you cannot open a session for
+it — `su - appuser` and `machinectl shell appuser@` both bounce, because they try
+to launch a login shell that does not exist. With no session there is no D-Bus
+session bus, and `systemctl --user` without a bus fails:
+
+```
+$ systemctl --user is-system-running
+Failed to connect to user scope bus via local transport:
+$DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
+```
+
+Lingering already created the runtime directory, so the fix is to point
+`systemctl` at it explicitly:
+
+```bash
+uid=$(id -u appuser)
+ls -d /run/user/$uid          # exists thanks to lingering
+
+sudo -u appuser env XDG_RUNTIME_DIR=/run/user/$uid \
+     podup autostart install --mode quadlet
+```
+
+Every `systemctl --user` / `podup autostart` invocation for that account needs
+`XDG_RUNTIME_DIR=/run/user/<uid>` in its environment. The same applies over SSH:
+a non-login SSH command has no runtime dir set, so export it before running
+`podup autostart`.
+
+## One-time rootless setup
+
+For a dedicated service account the account itself needs the usual rootless
+Podman groundwork, done once:
+
+- **Subordinate UID/GID ranges** — rootless Podman maps container users into the
+  host user's subordinate ranges. Ensure the account has entries in
+  `/etc/subuid` and `/etc/subgid` (e.g. `appuser:100000:65536`).
+- **`podman system migrate` as the user** — run it **as the account**, never via
+  `sudo` as root, so the migration writes the account's own storage config rather
+  than root's:
+
+  ```bash
+  sudo -u appuser env XDG_RUNTIME_DIR=/run/user/$(id -u appuser) \
+       podman system migrate
+  ```
+
+After that, `podup autostart install` writes the unit(s), reloads the user
+manager, and starts the stack; a reboot brings it back on its own.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -379,19 +379,22 @@ mismatch aborts before the installed binary is touched. See
 ### `autostart` (alias `boot`)
 Manage a boot-time autostart unit for this compose project — rootless,
 user-scope `systemctl --user` (enable lingering with
-`loginctl enable-linger` so the unit starts without a login session).
+`loginctl enable-linger` so the unit starts without a login session). See
+[Rootless autostart](autostart.md) for the full setup, the two backends, and
+running it under an isolated service account.
 
 | Subcommand | Description |
 |---|---|
-| `install` | Install (and, by default, enable + start) the unit. Writes only under `${XDG_CONFIG_HOME:-~/.config}/systemd/user/`. |
-| `uninstall` | Disable, stop, and remove this project's unit. |
+| `install` | Install (and, by default, start) the autostart unit(s) for this project. Writes only under `${XDG_CONFIG_HOME:-~/.config}`. |
+| `uninstall` | Remove whichever mode is installed (auto-detected). `--purge` also tears the stack down and drops its volumes. |
 | `status` | Report this project's unit and session state. |
+| `rebuild [service]` | Quadlet mode only: rebuild the built image(s) and restart the container(s). Omit the argument to rebuild every built service. |
 
 | Flag (`install`) | Description | Default |
 |---|---|---|
-| `--mode <MODE>` | Autostart backend; only `service` (a `Type=oneshot` unit running `podup up -d --build` at boot, `podup down` on stop) is implemented. | `service` |
-| `--no-start` | Install the unit but do not enable or start it. | off |
-| `--dry-run` | Print the unit and the actions that would run; change nothing. | off |
+| `--mode <MODE>` | Autostart backend: `service` (one `Type=oneshot` unit running `podup up -d` at boot, `podup stop` on shutdown) or `quadlet` (one native Podman Quadlet unit per service, owned by systemd directly). | `service` |
+| `--no-start` | Install the unit(s) but do not start them. | off |
+| `--dry-run` | Print what would be written and run; change nothing. | off |
 
 ### `version`
 Print version information, like `docker compose version`. `podup --version`


### PR DESCRIPTION
Adds `docs/autostart.md` (part of #991, phase 3) and fixes the stale `autostart` entry in `docs/commands.md`.

## `docs/autostart.md`

A guide to keeping a compose stack up across reboots, rootless and user-scope:

- the **lingering** prerequisite (`loginctl enable-linger`) and why it is needed;
- **picking a mode** — `service` (one unit running `podup up -d` / `podup stop`, whole-stack, simplest) vs `quadlet` (one native systemd unit per service, per-container supervision), and that the two cannot coexist;
- the `install` / `uninstall` / `status` / `rebuild` commands;
- why the unit is `--user` and wired into `default.target`, not the system `multi-user.target`;
- running `systemctl --user` for a **login-less service account**: no session means no D-Bus bus, so `XDG_RUNTIME_DIR=/run/user/<uid>` must be passed explicitly (lingering already created it);
- the one-time rootless setup — `subuid`/`subgid` ranges and `podman system migrate` run **as the account**, not via `sudo`.

## `docs/commands.md` fix

The `autostart` entry was stale on two counts, both now corrected: it claimed only `service` mode was implemented (quadlet ships as of #993), and it described the old `up -d --build` / `down` unit — service mode has run `up -d` / `stop` since #1021. Adds the `rebuild` subcommand and notes that `uninstall` auto-detects the mode.

Closes #994