### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.9.3"
+version = "1.10.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+podup (1.10.0) unstable; urgency=medium
+
+  * `autostart` gained a second backend: `--mode quadlet` hands the stack to
+    systemd as native Podman Quadlet units (one `.container`/`.build`/`.volume`/
+    `.network` per resource) under `~/.config/containers/systemd/`, instead of
+    the single `podup up` unit `--mode service` installs. systemd then owns each
+    service's boot, restart and ordering directly. `uninstall` auto-detects which
+    mode is installed and removes it; a new `autostart rebuild [service]` restarts
+    a service's oneshot `.build` unit and its container to pick up a fresh image.
+  * Fixed a `generate quadlet` bug the new mode exposed: a service's `.build`
+    unit carried its build `context` verbatim (e.g. `.`), which the systemd
+    generator resolves against the unit directory rather than the compose file,
+    so every build failed with "no Dockerfile in context directory". The context
+    is now resolved to an absolute path against the compose file's directory.
+    This also fixes `generate quadlet -o` for build-based stacks.
+  * Documented the rootless autostart flow in docs/autostart.md (lingering, the
+    two modes, the login-less-account XDG_RUNTIME_DIR requirement, subuid/subgid).
+
+ -- Glyndor <packages@glyndor.net>  Fri, 17 Jul 2026 04:05:00 -0500
+
 podup (1.9.3) unstable; urgency=medium
 
   * The autostart service unit destroyed the stack on a clean shutdown and


### PR DESCRIPTION
Minor release for the quadlet autostart backend (#993) and its docs (#994).

Version bumped in all three places it lives — `Cargo.toml`, `Cargo.lock`, `debian/changelog` — and I ran the release workflow's version gate locally: Cargo.toml and the changelog both read `1.10.0` (MATCH). Missing the changelog is what shipped `podup_1.8.0_*.deb` under the 1.9.0 tag; the gate now catches that.

This is a **minor** bump: `cargo-semver-checks` confirmed the new `quadlet::generate_at` is additive and `generate` is unchanged — no breaking API change.

What ships:
- `autostart --mode quadlet` (native systemd/Quadlet units, per-service), `autostart rebuild`, and auto-detecting `uninstall` (#1025);
- the `.build` absolute-context fix, which also repairs `generate quadlet -o` for build-based stacks;
- `docs/autostart.md` + the corrected `commands.md` autostart entry (#1026).

1697 tests pass; fmt and clippy (`--locked --all-targets --all-features -D warnings`) clean.