### PR TITLE
release: 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.9.3"
+version = "1.10.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+podup (1.10.0) unstable; urgency=medium
+
+  * `autostart` gained a second backend: `--mode quadlet` hands the stack to
+    systemd as native Podman Quadlet units (one `.container`/`.build`/`.volume`/
+    `.network` per resource) under `~/.config/containers/systemd/`, instead of
+    the single `podup up` unit `--mode service` installs. systemd then owns each
+    service's boot, restart and ordering directly. `uninstall` auto-detects which
+    mode is installed and removes it; a new `autostart rebuild [service]` restarts
+    a service's oneshot `.build` unit and its container to pick up a fresh image.
+  * Fixed a `generate quadlet` bug the new mode exposed: a service's `.build`
+    unit carried its build `context` verbatim (e.g. `.`), which the systemd
+    generator resolves against the unit directory rather than the compose file,
+    so every build failed with "no Dockerfile in context directory". The context
+    is now resolved to an absolute path against the compose file's directory.
+    This also fixes `generate quadlet -o` for build-based stacks.
+  * Documented the rootless autostart flow in docs/autostart.md (lingering, the
+    two modes, the login-less-account XDG_RUNTIME_DIR requirement, subuid/subgid).
+
+ -- Glyndor <packages@glyndor.net>  Fri, 17 Jul 2026 04:05:00 -0500
+
 podup (1.9.3) unstable; urgency=medium
 
   * The autostart service unit destroyed the stack on a clean shutdown and

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -1,0 +1,122 @@
+# Rootless autostart
+
+`podup autostart` keeps a compose stack running across reboots, entirely
+**rootless and user-scope**: it writes only under `${XDG_CONFIG_HOME:-~/.config}`
+and drives everything through `systemctl --user`. Nothing touches `/etc`, the
+system systemd, or root. The stack runs as an unprivileged user, and systemd
+brings it up at boot.
+
+## Prerequisite: lingering
+
+A user's systemd manager normally exists only while that user has a session, and
+`/run/user/<uid>` is created at login and torn down at logout. A service account
+never logs in, so without lingering there is no user manager at boot and the stack
+never starts. Enable it once, as root:
+
+```bash
+sudo loginctl enable-linger appuser
+loginctl show-user appuser --property=Linger   # → Linger=yes
+```
+
+Lingering starts the user manager at boot and creates `/run/user/<uid>` up front,
+independent of any login. `podup autostart install` warns if lingering is off,
+because the unit it writes will not start at boot until you enable it.
+
+## Picking a mode
+
+`--mode` selects the backend. Both are rootless and user-scope; they differ in
+who owns the containers.
+
+| Mode | What it installs | Choose it when |
+|---|---|---|
+| `service` (default) | One `Type=oneshot` unit that runs `podup up -d` at boot and `podup stop` on shutdown. | You want the whole stack managed as a unit, the simplest option — one thing to enable, one to remove. |
+| `quadlet` | One native Podman Quadlet unit per service (`.container`/`.build`/`.volume`/`.network`), which systemd owns directly. | You want per-container supervision — systemd restarts, ordering and status for each service independently. |
+
+Service mode keeps the compose front-end (`.env`, interpolation, profiles) on the
+runtime path; systemd starts `podup`, and `podup` reads the compose file. Quadlet
+mode renders the stack to systemd units once, at install time, and hands them over
+— after that systemd runs the containers with no `podup` process in the loop.
+
+The two cannot coexist for one project: each install refuses if the other is
+present, since both would bring the same stack up at boot.
+
+## Commands
+
+```bash
+podup autostart install                  # service mode (default)
+podup autostart install --mode quadlet   # quadlet mode
+podup autostart install --no-start       # write the unit(s) but don't start yet
+podup autostart install --dry-run        # print what would be written/run, change nothing
+
+podup autostart status                   # this project's unit and session state
+podup autostart uninstall                # remove whichever mode is installed
+podup autostart uninstall --purge        # also tear the stack down and drop its volumes
+
+podup autostart rebuild                   # quadlet only: rebuild every built image + restart
+podup autostart rebuild web               # rebuild just one service
+```
+
+`uninstall` detects which mode is installed and removes that one; you never pass
+`--mode` to it. `rebuild` applies to quadlet mode: a Quadlet `.build` unit is
+`Type=oneshot`, so an image only rebuilds when its build service is restarted, and
+the container is then restarted to pick it up. Service mode has no `rebuild` — it
+builds at deploy time, whenever you run `podup up`.
+
+## Why `--user` and `default.target`
+
+The unit is a `--user` unit wired into `default.target`, not the system
+`multi-user.target`. `multi-user.target` is a system-manager concept and is inert
+in the user instance, so ordering against it would imply a boot gate that never
+fires. Under lingering the user manager starts after the system network is already
+up, and `podup` reaches Podman over a socket on demand, so no explicit network
+ordering is needed. The generated units carry no `network-online.target` ordering
+for the same reason.
+
+## Running `systemctl --user` for a login-less account
+
+An isolated service account has no login shell, so you cannot open a session for
+it — `su - appuser` and `machinectl shell appuser@` both bounce, because they try
+to launch a login shell that does not exist. With no session there is no D-Bus
+session bus, and `systemctl --user` without a bus fails:
+
+```
+$ systemctl --user is-system-running
+Failed to connect to user scope bus via local transport:
+$DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
+```
+
+Lingering already created the runtime directory, so the fix is to point
+`systemctl` at it explicitly:
+
+```bash
+uid=$(id -u appuser)
+ls -d /run/user/$uid          # exists thanks to lingering
+
+sudo -u appuser env XDG_RUNTIME_DIR=/run/user/$uid \
+     podup autostart install --mode quadlet
+```
+
+Every `systemctl --user` / `podup autostart` invocation for that account needs
+`XDG_RUNTIME_DIR=/run/user/<uid>` in its environment. The same applies over SSH:
+a non-login SSH command has no runtime dir set, so export it before running
+`podup autostart`.
+
+## One-time rootless setup
+
+For a dedicated service account the account itself needs the usual rootless
+Podman groundwork, done once:
+
+- **Subordinate UID/GID ranges** — rootless Podman maps container users into the
+  host user's subordinate ranges. Ensure the account has entries in
+  `/etc/subuid` and `/etc/subgid` (e.g. `appuser:100000:65536`).
+- **`podman system migrate` as the user** — run it **as the account**, never via
+  `sudo` as root, so the migration writes the account's own storage config rather
+  than root's:
+
+  ```bash
+  sudo -u appuser env XDG_RUNTIME_DIR=/run/user/$(id -u appuser) \
+       podman system migrate
+  ```
+
+After that, `podup autostart install` writes the unit(s), reloads the user
+manager, and starts the stack; a reboot brings it back on its own.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -379,19 +379,22 @@ mismatch aborts before the installed binary is touched. See
 ### `autostart` (alias `boot`)
 Manage a boot-time autostart unit for this compose project — rootless,
 user-scope `systemctl --user` (enable lingering with
-`loginctl enable-linger` so the unit starts without a login session).
+`loginctl enable-linger` so the unit starts without a login session). See
+[Rootless autostart](autostart.md) for the full setup, the two backends, and
+running it under an isolated service account.
 
 | Subcommand | Description |
 |---|---|
-| `install` | Install (and, by default, enable + start) the unit. Writes only under `${XDG_CONFIG_HOME:-~/.config}/systemd/user/`. |
-| `uninstall` | Disable, stop, and remove this project's unit. |
+| `install` | Install (and, by default, start) the autostart unit(s) for this project. Writes only under `${XDG_CONFIG_HOME:-~/.config}`. |
+| `uninstall` | Remove whichever mode is installed (auto-detected). `--purge` also tears the stack down and drops its volumes. |
 | `status` | Report this project's unit and session state. |
+| `rebuild [service]` | Quadlet mode only: rebuild the built image(s) and restart the container(s). Omit the argument to rebuild every built service. |
 
 | Flag (`install`) | Description | Default |
 |---|---|---|
-| `--mode <MODE>` | Autostart backend; only `service` (a `Type=oneshot` unit running `podup up -d --build` at boot, `podup down` on stop) is implemented. | `service` |
-| `--no-start` | Install the unit but do not enable or start it. | off |
-| `--dry-run` | Print the unit and the actions that would run; change nothing. | off |
+| `--mode <MODE>` | Autostart backend: `service` (one `Type=oneshot` unit running `podup up -d` at boot, `podup stop` on shutdown) or `quadlet` (one native Podman Quadlet unit per service, owned by systemd directly). | `service` |
+| `--no-start` | Install the unit(s) but do not start them. | off |
+| `--dry-run` | Print what would be written and run; change nothing. | off |
 
 ### `version`
 Print version information, like `docker compose version`. `podup --version`

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -7,8 +7,10 @@
 //! the system systemd. External-command calls go through the `SystemCtl` seam so
 //! the install/uninstall/status logic is unit-testable without a live systemd.
 
+mod quadlet;
 mod service;
 
+pub use quadlet::{install_quadlet, rebuild_quadlet, uninstall_quadlet};
 pub use service::{render_service_unit, ServiceUnitOpts};
 
 use std::io;
@@ -261,6 +263,30 @@ pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 
 	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
 	Ok(())
+}
+
+/// Which autostart mode, if any, is installed for a project. Service and quadlet
+/// mode cannot coexist — each install refuses the other — so at most one is present.
+/// `uninstall` uses this to remove whichever is there without the caller naming a
+/// mode (and mistakenly no-op'ing against the wrong one).
+pub enum InstalledMode {
+	/// The service-mode `podup-<project>.service` unit is present.
+	Service,
+	/// Quadlet `<project>-*.container` units are present.
+	Quadlet,
+	/// Neither — nothing is installed.
+	None,
+}
+
+/// Detect the installed autostart mode for `project` from what is on disk.
+pub fn installed_mode(project: &str) -> InstalledMode {
+	if unit_path(project).exists() {
+		InstalledMode::Service
+	} else if !quadlet_units_present(project).is_empty() {
+		InstalledMode::Quadlet
+	} else {
+		InstalledMode::None
+	}
 }
 
 /// A snapshot of the autostart unit's state, gathered for `status`.

--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -1,0 +1,436 @@
+//! `podup autostart --mode quadlet`: hand the whole stack to systemd as native
+//! Podman Quadlet units under the rootless `~/.config/containers/systemd/`.
+//!
+//! Where service mode installs one unit that shells out to `podup up` at boot,
+//! quadlet mode writes the same `.container`/`.build`/`.volume`/`.network` units
+//! `generate quadlet` emits, so systemd owns boot, restart and dependency
+//! ordering directly. The generated `.container` units already carry
+//! `[Install] WantedBy=default.target`, so a `daemon-reload` wires them into boot
+//! on its own — this module writes them, reloads, and starts them now; it never
+//! `enable`s a generated unit (systemd does not enable generator output).
+
+use std::path::{Path, PathBuf};
+
+use crate::compose::types::ComposeFile;
+use crate::{quadlet, ComposeError};
+
+use super::{checked, config_home, emit_guards, unit_path, SystemCtl};
+
+/// `${XDG_CONFIG_HOME:-~/.config}/containers/systemd/` — where Quadlet reads a
+/// user's units from. The same directory `generate quadlet` documents.
+pub fn quadlet_dir() -> PathBuf {
+	config_home().join("containers").join("systemd")
+}
+
+/// The `.service` names systemd derives from the generated `.container` units:
+/// Quadlet turns `<stem>.container` into `<stem>.service`.
+fn container_services(units: &[quadlet::QuadletUnit]) -> Vec<String> {
+	units
+		.iter()
+		.filter_map(|u| u.filename.strip_suffix(".container"))
+		.map(|stem| format!("{stem}.service"))
+		.collect()
+}
+
+/// This project's installed quadlet unit files (`<project>-*`), sorted. Drives
+/// uninstall (remove by prefix) and rebuild (find `.build` units).
+fn installed_units(project: &str) -> Vec<PathBuf> {
+	let dir = quadlet_dir();
+	let prefix = format!("{project}-");
+	let mut found = Vec::new();
+	if let Ok(entries) = std::fs::read_dir(&dir) {
+		for entry in entries.flatten() {
+			if entry.file_name().to_string_lossy().starts_with(&prefix) {
+				found.push(entry.path());
+			}
+		}
+	}
+	found.sort();
+	found
+}
+
+/// Install quadlet-mode autostart: render the stack's units, write them under
+/// `~/.config/containers/systemd/`, reload the user manager, and (unless
+/// `no_start`) start each container service now. Boot start comes from the units'
+/// own `[Install] WantedBy=default.target`, so no `enable` is needed.
+pub fn install_quadlet<S: SystemCtl>(
+	sc: &S,
+	file: &ComposeFile,
+	project: &str,
+	base_dir: &Path,
+	no_start: bool,
+	dry_run: bool,
+) -> crate::Result<()> {
+	// Refuse to stack on top of a service-mode unit for the same project: both
+	// would bring the same stack up at boot.
+	let service = unit_path(project);
+	if service.exists() {
+		return Err(ComposeError::Autostart(format!(
+			"service-mode autostart unit for '{project}' already exists at {}; \
+			 remove it with `podup autostart uninstall` before installing quadlet mode \
+			 (both would start the stack at boot).",
+			service.display()
+		)));
+	}
+
+	let result = quadlet::generate_at(file, project, base_dir);
+	if let Some(dup) = result.duplicate_filename() {
+		return Err(ComposeError::Autostart(format!(
+			"quadlet: two resources map to the same unit file {dup:?}; \
+			 rename one so their names do not collide after sanitization."
+		)));
+	}
+	for warning in &result.warnings {
+		eprintln!("podup: warning: {warning}");
+	}
+
+	let dir = quadlet_dir();
+	let services = container_services(&result.units);
+	emit_guards(sc);
+
+	if dry_run {
+		for unit in &result.units {
+			println!("# {}", unit.filename);
+			print!("{}", unit.contents);
+		}
+		println!(
+			"\n# would write {} unit(s) to {}",
+			result.units.len(),
+			dir.display()
+		);
+		println!("# would run: systemctl --user daemon-reload");
+		if no_start {
+			println!("# (--no-start) would not start any container service");
+		} else {
+			for svc in &services {
+				println!("# would run: systemctl --user start {svc}");
+			}
+		}
+		return Ok(());
+	}
+
+	let written = quadlet::write_units(&dir, &result.units).map_err(|e| {
+		ComposeError::Autostart(format!(
+			"cannot write quadlet units to {}: {e}",
+			dir.display()
+		))
+	})?;
+	for path in &written {
+		eprintln!("podup: wrote {}", path.display());
+	}
+
+	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
+	if no_start {
+		eprintln!(
+			"podup: installed {} quadlet unit(s) for '{project}' (not started; --no-start)",
+			written.len()
+		);
+	} else {
+		for svc in &services {
+			checked(sc.systemctl(&["start", svc]), &format!("start {svc}"))?;
+		}
+		eprintln!(
+			"podup: started {} container service(s) for '{project}'",
+			services.len()
+		);
+	}
+	Ok(())
+}
+
+/// Uninstall quadlet-mode autostart: stop this project's container services, remove
+/// its `<project>-*` unit files, and reload the user manager. Idempotent — a
+/// service that was never loaded, or a file already gone, is not an error.
+pub fn uninstall_quadlet<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
+	let units = installed_units(project);
+	// Stop the container services first (best-effort) while their units still exist.
+	for path in &units {
+		if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+			if let Some(stem) = name.strip_suffix(".container") {
+				let _ = sc.systemctl(&["stop", &format!("{stem}.service")]);
+			}
+		}
+	}
+	let mut removed = 0usize;
+	for path in &units {
+		std::fs::remove_file(path).map_err(|e| {
+			ComposeError::Autostart(format!("cannot remove {}: {e}", path.display()))
+		})?;
+		eprintln!("podup: removed {}", path.display());
+		removed += 1;
+	}
+	if removed == 0 {
+		eprintln!("podup: no quadlet autostart units for '{project}' (already removed)");
+	}
+	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
+	Ok(())
+}
+
+/// Rebuild one or all built images of a quadlet-mode install. A `.build` unit is
+/// `Type=oneshot`, so its image only rebuilds when the build service is restarted;
+/// the container is then restarted to pick up the new image. With `service` given,
+/// only that service rebuilds; otherwise every service that has a `.build` unit.
+pub fn rebuild_quadlet<S: SystemCtl>(
+	sc: &S,
+	project: &str,
+	service: Option<&str>,
+) -> crate::Result<()> {
+	let prefix = format!("{project}-");
+	let builds: Vec<String> = installed_units(project)
+		.iter()
+		.filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
+		.filter_map(|n| n.strip_suffix(".build").map(String::from))
+		.collect();
+	if builds.is_empty() {
+		return Err(ComposeError::Autostart(format!(
+			"no quadlet build units for '{project}' — nothing to rebuild. Only a service \
+			 with a compose `build:` produces a `.build` unit, and quadlet-mode autostart \
+			 must be installed first (`podup autostart install --mode quadlet`)."
+		)));
+	}
+	let targets: Vec<String> = match service {
+		Some(svc) => {
+			let stem = format!("{prefix}{svc}");
+			if !builds.contains(&stem) {
+				let names: Vec<&str> = builds
+					.iter()
+					.map(|b| b.strip_prefix(&prefix).unwrap_or(b))
+					.collect();
+				return Err(ComposeError::Autostart(format!(
+					"service '{svc}' has no build unit under '{project}'; built services are: {}",
+					names.join(", ")
+				)));
+			}
+			vec![stem]
+		}
+		None => builds,
+	};
+	for stem in &targets {
+		checked(
+			sc.systemctl(&["restart", &format!("{stem}-build.service")]),
+			&format!("restart {stem}-build.service"),
+		)?;
+		checked(
+			sc.systemctl(&["restart", &format!("{stem}.service")]),
+			&format!("restart {stem}.service"),
+		)?;
+		eprintln!("podup: rebuilt {stem}");
+	}
+	Ok(())
+}
+
+// Unix-gated: the fake `SystemCtl` builds `Output`s via `os::unix` and the paths
+// asserted are POSIX. Autostart is a `systemctl --user` feature, so this matches
+// the service-mode tests, which gate the same way.
+#[cfg(all(test, unix))]
+mod tests {
+	use super::{container_services, install_quadlet, rebuild_quadlet, uninstall_quadlet};
+	use crate::autostart::SystemCtl;
+	use crate::{parse_str, quadlet};
+	use std::cell::RefCell;
+	use std::os::unix::process::ExitStatusExt;
+	use std::path::Path;
+	use std::process::{ExitStatus, Output};
+
+	/// Records every `systemctl` arg vector; `loginctl` always reports linger on.
+	struct FakeCtl {
+		calls: RefCell<Vec<Vec<String>>>,
+	}
+	impl FakeCtl {
+		fn new() -> Self {
+			FakeCtl {
+				calls: RefCell::new(Vec::new()),
+			}
+		}
+		fn log(&self) -> Vec<Vec<String>> {
+			self.calls.borrow().clone()
+		}
+	}
+	impl SystemCtl for FakeCtl {
+		fn systemctl(&self, args: &[&str]) -> std::io::Result<Output> {
+			self.calls
+				.borrow_mut()
+				.push(args.iter().map(|s| s.to_string()).collect());
+			Ok(Output {
+				status: ExitStatus::from_raw(0),
+				stdout: Vec::new(),
+				stderr: Vec::new(),
+			})
+		}
+		fn loginctl(&self, _args: &[&str]) -> std::io::Result<Output> {
+			Ok(Output {
+				status: ExitStatus::from_raw(0),
+				stdout: b"yes".to_vec(),
+				stderr: Vec::new(),
+			})
+		}
+	}
+
+	/// Run `f` with a fresh temp `XDG_CONFIG_HOME`/`XDG_RUNTIME_DIR`/`USER`, so
+	/// `quadlet_dir` and the guards resolve under the temp dir.
+	fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
+		let tmp = tempfile::tempdir().unwrap();
+		let root = tmp.path().to_path_buf();
+		temp_env::with_vars(
+			[
+				("XDG_CONFIG_HOME", Some(root.as_os_str())),
+				("XDG_RUNTIME_DIR", Some(root.as_os_str())),
+				("USER", Some(std::ffi::OsStr::new("tester"))),
+			],
+			|| f(&root),
+		)
+	}
+
+	const IMG: &str = "services:\n  web:\n    image: nginx\n";
+	const BUILD: &str = "services:\n  web:\n    build: .\n";
+	const BASE: &str = "/srv/app";
+
+	#[test]
+	fn container_services_names_only_containers() {
+		let file = parse_str(IMG).unwrap();
+		let units = quadlet::generate_at(&file, "proj", Path::new(BASE)).units;
+		// The default network unit is present too, but only `.container`s become services.
+		assert_eq!(
+			container_services(&units),
+			vec!["proj-web.service".to_string()]
+		);
+	}
+
+	#[test]
+	fn install_writes_units_reloads_then_starts() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install_quadlet(
+				&sc,
+				&parse_str(IMG).unwrap(),
+				"proj",
+				Path::new(BASE),
+				false,
+				false,
+			)
+			.unwrap();
+			assert!(root.join("containers/systemd/proj-web.container").is_file());
+			let calls = sc.log();
+			assert_eq!(calls[0], vec!["daemon-reload"]);
+			assert_eq!(calls[1], vec!["start", "proj-web.service"]);
+		});
+	}
+
+	#[test]
+	fn no_start_reloads_but_starts_nothing() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install_quadlet(
+				&sc,
+				&parse_str(IMG).unwrap(),
+				"proj",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			assert!(root.join("containers/systemd/proj-web.container").is_file());
+			assert_eq!(sc.log(), vec![vec!["daemon-reload".to_string()]]);
+		});
+	}
+
+	#[test]
+	fn dry_run_writes_nothing_and_runs_no_systemctl() {
+		with_env(|root| {
+			let sc = FakeCtl::new();
+			install_quadlet(
+				&sc,
+				&parse_str(IMG).unwrap(),
+				"proj",
+				Path::new(BASE),
+				false,
+				true,
+			)
+			.unwrap();
+			assert!(!root.join("containers/systemd/proj-web.container").exists());
+			assert!(sc.log().is_empty());
+		});
+	}
+
+	#[test]
+	fn install_refuses_when_service_mode_is_present() {
+		with_env(|root| {
+			let sd = root.join("systemd/user");
+			std::fs::create_dir_all(&sd).unwrap();
+			std::fs::write(sd.join("podup-proj.service"), "x").unwrap();
+			let err = install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(IMG).unwrap(),
+				"proj",
+				Path::new(BASE),
+				false,
+				false,
+			)
+			.unwrap_err();
+			assert!(format!("{err}").contains("service-mode autostart unit"));
+		});
+	}
+
+	#[test]
+	fn uninstall_stops_removes_and_reloads() {
+		with_env(|root| {
+			install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(IMG).unwrap(),
+				"proj",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			let sc = FakeCtl::new();
+			uninstall_quadlet(&sc, "proj").unwrap();
+			assert!(!root.join("containers/systemd/proj-web.container").exists());
+			let calls = sc.log();
+			assert!(calls.contains(&vec!["stop".to_string(), "proj-web.service".to_string()]));
+			assert_eq!(calls.last().unwrap(), &vec!["daemon-reload".to_string()]);
+		});
+	}
+
+	#[test]
+	fn rebuild_restarts_build_then_container() {
+		with_env(|_root| {
+			install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(BUILD).unwrap(),
+				"proj",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			let sc = FakeCtl::new();
+			rebuild_quadlet(&sc, "proj", Some("web")).unwrap();
+			assert_eq!(
+				sc.log(),
+				vec![
+					vec!["restart".to_string(), "proj-web-build.service".to_string()],
+					vec!["restart".to_string(), "proj-web.service".to_string()],
+				]
+			);
+		});
+	}
+
+	#[test]
+	fn rebuild_unknown_service_errors_and_lists_valid_ones() {
+		with_env(|_root| {
+			install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(BUILD).unwrap(),
+				"proj",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			let err = rebuild_quadlet(&FakeCtl::new(), "proj", Some("nope")).unwrap_err();
+			let msg = format!("{err}");
+			assert!(msg.contains("has no build unit"), "{msg}");
+			assert!(msg.contains("web"), "{msg}");
+		});
+	}
+}

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -33,18 +33,29 @@ pub(crate) async fn dispatch(
 ) -> podup::Result<()> {
 	match kind {
 		AutostartCommands::Install {
-			mode,
+			mode: AutostartMode::Quadlet,
 			no_start,
 			dry_run,
 		} => {
-			// Only service mode is implemented; quadlet mode is honest about it.
-			if *mode == AutostartMode::Quadlet {
-				return Err(ComposeError::Autostart(
-					"autostart --mode quadlet is not yet implemented (see #993); \
-					 use the default --mode service"
-						.to_string(),
-				));
-			}
+			// Quadlet mode hands the stack to systemd as native units rendered from
+			// the compose file. It still needs the base directory absolute: a
+			// `.build` unit's context is resolved by the systemd generator with no
+			// cwd, so a relative context would look under the unit directory.
+			let base_dir = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
+			podup::autostart::install_quadlet(
+				&podup::autostart::RealSystemCtl,
+				file,
+				&project,
+				&base_dir,
+				*no_start,
+				*dry_run,
+			)
+		}
+		AutostartCommands::Install {
+			mode: AutostartMode::Service,
+			no_start,
+			dry_run,
+		} => {
 			// systemd has no relative-path context, so resolve the exe, every compose
 			// file, and the working directory to absolute paths the unit can embed.
 			let exe = std::env::current_exe().map_err(|e| {
@@ -76,7 +87,16 @@ pub(crate) async fn dispatch(
 			podup::autostart::install(&podup::autostart::RealSystemCtl, &opts)
 		}
 		AutostartCommands::Uninstall { purge } => {
-			podup::autostart::uninstall(&podup::autostart::RealSystemCtl, &project)?;
+			// Remove whichever mode is installed — the two never coexist, and asking
+			// the user to name the mode only risks a no-op against the wrong one.
+			match podup::autostart::installed_mode(&project) {
+				podup::autostart::InstalledMode::Quadlet => {
+					podup::autostart::uninstall_quadlet(&podup::autostart::RealSystemCtl, &project)?
+				}
+				// Service or nothing installed: the service uninstall is idempotent and
+				// prints "already removed" when there is nothing there.
+				_ => podup::autostart::uninstall(&podup::autostart::RealSystemCtl, &project)?,
+			}
 			if *purge {
 				// `--purge` is the only autostart branch that touches Podman: tear the
 				// stack down and remove its named volumes via the normal `down -v` path.
@@ -90,5 +110,10 @@ pub(crate) async fn dispatch(
 		AutostartCommands::Status => {
 			podup::autostart::status(&podup::autostart::RealSystemCtl, &project)
 		}
+		AutostartCommands::Rebuild { service } => podup::autostart::rebuild_quadlet(
+			&podup::autostart::RealSystemCtl,
+			&project,
+			service.as_deref(),
+		),
 	}
 }

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -69,11 +69,13 @@ pub(crate) enum ConfigFormat {
 /// Which autostart backend `autostart install` sets up.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum AutostartMode {
-	/// A single `Type=oneshot` `systemctl --user` service that runs `podup up`
-	/// at boot and `podup down` on stop. The only mode implemented today.
+	/// A single `Type=oneshot` `systemctl --user` service that runs `podup up -d`
+	/// at boot and `podup stop` on shutdown. The default.
 	#[default]
 	Service,
-	/// Per-service Podman Quadlet units. Not yet implemented (tracked by #993).
+	/// Per-service Podman Quadlet units: hand the stack to systemd as native
+	/// `.container`/`.build`/`.volume`/`.network` units, so systemd owns boot,
+	/// restart and dependency ordering directly.
 	Quadlet,
 }
 
@@ -83,7 +85,8 @@ pub(crate) enum AutostartCommands {
 	/// Install (and, by default, enable + start) the autostart unit for this
 	/// project. User-scope only: writes under `${XDG_CONFIG_HOME:-~/.config}`.
 	Install {
-		/// Autostart backend to use (only `service` is implemented).
+		/// Autostart backend: `service` (one unit that runs `podup up`) or
+		/// `quadlet` (native systemd units, one per service).
 		#[arg(long, value_enum, default_value_t)]
 		mode: AutostartMode,
 		/// Install the unit but do not enable or start it immediately.
@@ -101,6 +104,15 @@ pub(crate) enum AutostartCommands {
 	},
 	/// Report this project's autostart unit and session state.
 	Status,
+	/// Rebuild the image(s) of a quadlet-mode install and restart the container(s).
+	///
+	/// A Quadlet `.build` unit is `Type=oneshot`, so an image only rebuilds when its
+	/// build service is restarted. This restarts `<project>-<service>-build.service`
+	/// then the container service. Applies to `--mode quadlet` installs only.
+	Rebuild {
+		/// Rebuild only this service; omit to rebuild every built service.
+		service: Option<String>,
+	},
 }
 
 /// Subcommands of `generate`.

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -74,12 +74,13 @@ fn write_stdout(buf: &str) -> podup::Result<()> {
 pub(crate) fn write_quadlet(
 	file: &podup::compose::types::ComposeFile,
 	project: &str,
+	base_dir: &Path,
 	output: Option<&Path>,
 ) -> podup::Result<()> {
 	// Reject configs the running commands would reject, before emitting anything.
 	validate_for_quadlet(file)?;
 
-	let result = podup::quadlet::generate(file, project);
+	let result = podup::quadlet::generate_at(file, project, base_dir);
 	if let Some(dup) = result.duplicate_filename() {
 		return Err(std::io::Error::new(
 			std::io::ErrorKind::InvalidInput,
@@ -98,23 +99,8 @@ pub(crate) fn write_quadlet(
 	}
 	match output {
 		Some(dir) => {
-			std::fs::create_dir_all(dir)?;
 			let mut progress = String::new();
-			for unit in &result.units {
-				// Defense in depth: the unit stem is already sanitized in the
-				// library, but never write a unit whose name is anything but a
-				// plain file inside `dir` (rejects separators, `.` and `..`).
-				if Path::new(&unit.filename).file_name()
-					!= Some(std::ffi::OsStr::new(&unit.filename))
-				{
-					return Err(std::io::Error::new(
-						std::io::ErrorKind::InvalidInput,
-						format!("refusing unsafe quadlet unit file name: {}", unit.filename),
-					)
-					.into());
-				}
-				let path = dir.join(&unit.filename);
-				std::fs::write(&path, &unit.contents)?;
+			for path in podup::quadlet::write_units(dir, &result.units)? {
 				progress.push_str(&format!("wrote {}\n", path.display()));
 			}
 			write_stdout(&progress)?;
@@ -155,7 +141,7 @@ mod tests {
 			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
 		)
 		.unwrap();
-		let err = write_quadlet(&file, "proj", None).unwrap_err();
+		let err = write_quadlet(&file, "proj", std::path::Path::new("/srv/app"), None).unwrap_err();
 		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
 	}
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -481,7 +481,10 @@ async fn run() -> podup::Result<()> {
 		// services (which would make `--profile` a no-op on this subcommand).
 		let mut filtered = file.clone();
 		podup::retain_active_profiles(&mut filtered, &cli.profile);
-		return write_quadlet(&filtered, &project, output.as_deref());
+		// Absolute base dir so a `.build` unit's context resolves under the compose
+		// file, not the unit directory the systemd generator would otherwise use.
+		let base_dir = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
+		return write_quadlet(&filtered, &project, &base_dir, output.as_deref());
 	}
 
 	// `autostart` manages a rootless `systemctl --user` unit that brings the stack

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -54,13 +54,52 @@ impl QuadletOutput {
 	}
 }
 
-/// Translate a compose file into Quadlet units for the given project name.
+/// Write `units` into `dir`, creating it if needed, and return the paths written
+/// in order. Defense in depth: refuse any unit whose file name is not a plain path
+/// component. The library already sanitizes stems, but a write target must never
+/// contain a separator, `.` or `..` that could escape `dir`. Shared by
+/// `generate quadlet -o` and `autostart --mode quadlet`, so both place units
+/// through the identical safety check.
+pub fn write_units(
+	dir: &std::path::Path,
+	units: &[QuadletUnit],
+) -> std::io::Result<Vec<std::path::PathBuf>> {
+	std::fs::create_dir_all(dir)?;
+	let mut written = Vec::with_capacity(units.len());
+	for unit in units {
+		if std::path::Path::new(&unit.filename).file_name()
+			!= Some(std::ffi::OsStr::new(&unit.filename))
+		{
+			return Err(std::io::Error::new(
+				std::io::ErrorKind::InvalidInput,
+				format!("refusing unsafe quadlet unit file name: {}", unit.filename),
+			));
+		}
+		let path = dir.join(&unit.filename);
+		std::fs::write(&path, &unit.contents)?;
+		written.push(path);
+	}
+	Ok(written)
+}
+
+/// Translate a compose file into Quadlet units for the given project name,
+/// resolving relative build contexts against the current directory (the common
+/// case: running from the project directory). Use [`generate_at`] to resolve them
+/// against an explicit base directory instead.
+pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
+	generate_at(file, project, &std::env::current_dir().unwrap_or_default())
+}
+
+/// As [`generate`], but resolves a service's relative `build:` context against
+/// `base_dir` (the compose file's directory) rather than the current directory.
+/// The systemd generator runs a `.build` unit with no cwd, so a unit written for
+/// it must carry an absolute `SetWorkingDirectory`; pass the compose base here.
 ///
 /// Emits one `.container` per service, one `.network` per declared network,
-/// and one `.volume` per declared named volume. Replica scaling, build
-/// services, and other fields without a Quadlet mapping are reported as
-/// warnings rather than silently dropped.
-pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
+/// and one `.volume` per declared named volume. Replica scaling, inline-Dockerfile
+/// builds, and other fields without a Quadlet mapping are reported as warnings
+/// rather than silently dropped.
+pub fn generate_at(file: &ComposeFile, project: &str, base_dir: &std::path::Path) -> QuadletOutput {
 	let mut out = QuadletOutput::default();
 
 	// External networks/volumes are assumed to pre-exist. Emitting a unit would
@@ -108,7 +147,7 @@ pub fn generate(file: &ComposeFile, project: &str) -> QuadletOutput {
 	for (name, service) in &file.services {
 		// Emit a `.build` unit first so the systemd generator builds the image
 		// before the container that references it via `Image=<stem>.build`.
-		if let Some(unit) = build_unit(name, project, service, &mut out.warnings) {
+		if let Some(unit) = build_unit(name, project, service, base_dir, &mut out.warnings) {
 			out.units.push(unit);
 		}
 		out.units.push(container_unit(

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -1,6 +1,6 @@
 use super::unit_named;
 use crate::parse_str;
-use crate::quadlet::generate;
+use crate::quadlet::generate_at;
 
 #[test]
 fn maps_the_full_container_field_set() {
@@ -28,7 +28,7 @@ services:
         protocol: udp
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "proj-app.container").contents;
 	assert!(c.contains("HostName=app-host"));
 	// `user: "1000:1000"` splits into separate User=/Group= keys.
@@ -60,7 +60,7 @@ fn restart_policies_map_to_systemd() {
 	for (policy, expected) in cases {
 		let yaml = format!("services:\n  s:\n    image: x\n    restart: {policy}\n");
 		let file = parse_str(&yaml).unwrap();
-		let out = generate(&file, "p");
+		let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 		assert!(
 			unit_named(&out, "p-s.container")
 				.contents
@@ -84,7 +84,7 @@ services:
     image: redis
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(c.contains("After=proj-cache.service"));
 	assert!(c.contains("Wants=proj-cache.service"));
@@ -130,7 +130,7 @@ services:
     restart: "on-failure:5"
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-app.container").contents;
 	for needle in [
 		"ContainerName=custom",
@@ -168,7 +168,7 @@ services:
       - "80"
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PublishPort=80"));
 	assert!(!c.contains("PublishPort=:80"));
@@ -178,7 +178,7 @@ services:
 fn user_with_gid_splits_into_user_and_group() {
 	let yaml = "services:\n  s:\n    image: x\n    user: \"1000:2000\"\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("User=1000"));
 	assert!(c.contains("Group=2000"));
@@ -203,7 +203,7 @@ secrets:
     file: ./cred
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Secret=tok"));
 	assert!(c.contains("Secret=cred,target=/run/cred,uid=100"));
@@ -241,7 +241,7 @@ networks:
   net:
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	for needle in [
 		"GroupAdd=audio",
@@ -274,7 +274,7 @@ services:
       - "apparmor=my-profile"
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("PodmanArgs=--memory=512m"),
@@ -307,7 +307,7 @@ services:
     cpu_period: 100000
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	for expected in [
 		"PodmanArgs=--cpus=1.5",
@@ -334,7 +334,7 @@ services:
           cpus: "2"
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("PodmanArgs=--cpus=2"),
@@ -358,7 +358,7 @@ networks:
   net:
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("IP=10.5.0.7"), "missing IP= in:\n{c}");
 	assert!(c.contains("IP6=2001:db8::7"), "missing IP6= in:\n{c}");
@@ -370,7 +370,7 @@ fn network_mode_none_maps_to_network_none() {
 	// rather than being warned and dropped.
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: none\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Network=none"), "missing Network=none in:\n{c}");
 	assert!(
@@ -391,7 +391,7 @@ services:
       - "label=nested"
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("SecurityLabelFileType=usr_t"), "in:\n{c}");
 	assert!(c.contains("SecurityLabelNested=true"), "in:\n{c}");
@@ -415,7 +415,7 @@ services:
         window: 2m
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Restart=on-failure"), "in:\n{c}");
 	assert!(c.contains("StartLimitBurst=4"), "in:\n{c}");
@@ -426,7 +426,7 @@ services:
 fn deploy_restart_condition_none_maps_to_no() {
 	let yaml = "services:\n  s:\n    image: x\n    deploy:\n      restart_policy:\n        condition: none\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	assert!(unit_named(&out, "p-s.container")
 		.contents
 		.contains("Restart=no"));
@@ -444,7 +444,7 @@ services:
           pids: 256
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PidsLimit=256"), "missing PidsLimit in:\n{c}");
 }
@@ -465,7 +465,7 @@ services:
           mode: 0o755
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Tmpfs=/cache:size=64000000,mode=755"),

--- a/internal/quadlet/tests/network_volume.rs
+++ b/internal/quadlet/tests/network_volume.rs
@@ -1,6 +1,6 @@
 use super::unit_named;
 use crate::parse_str;
-use crate::quadlet::generate;
+use crate::quadlet::generate_at;
 
 #[test]
 fn external_network_and_volume_emit_no_unit_and_use_bare_name() {
@@ -20,7 +20,7 @@ volumes:
     external: true
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	// No unit is generated for external resources.
 	assert!(!out
 		.units
@@ -50,7 +50,7 @@ services:
           propagation: rshared
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Volume=/host/data:/data:z,rshared"),
@@ -78,7 +78,7 @@ volumes:
       tier: vol
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let net = &unit_named(&out, "p-net.network").contents;
 	assert!(net.contains("Driver=bridge"));
 	assert!(net.contains("Internal=true"));
@@ -109,7 +109,7 @@ networks:
           ip_range: 10.7.0.128/25
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let net = &unit_named(&out, "p-net.network").contents;
 	// A custom name overrides the project-prefixed default.
 	assert!(net.contains("NetworkName=custom-net"), "in:\n{net}");
@@ -144,7 +144,7 @@ volumes:
       custom: extra
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(vol.contains("VolumeName=custom-vol"), "in:\n{vol}");
 	assert!(!vol.contains("VolumeName=p_vol"), "in:\n{vol}");
@@ -172,7 +172,7 @@ services:
       start_interval: 2s
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("HealthInterval=5s"), "in:\n{c}");
 	assert!(
@@ -200,7 +200,7 @@ services:
   : { image: postgres }
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let web = &unit_named(&out, "proj-web.container").contents;
 	assert!(web.contains("After=proj-db_1.service"), "in:\n{web}");
 	assert!(web.contains("Requires=proj-db_1.service"), "in:\n{web}");
@@ -217,7 +217,7 @@ fn network_mode_service_maps_to_dot_container() {
 	// stems are project-prefixed, so the dependency is `p-db.container`.
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:db\"\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Network=p-db.container"),
@@ -232,7 +232,7 @@ fn network_mode_container_maps_to_join_form() {
 	// (that would name a non-existent unit and fail to start).
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"container:sidecar\"\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
 		c.contains("Network=container:sidecar"),
@@ -250,7 +250,7 @@ fn duplicate_network_aliases_are_emitted_once() {
 	// podman may reject at container create.
 	let yaml = "services:\n  s:\n    image: x\n    networks:\n      front:\n        aliases: [dup, dup, uniq]\nnetworks:\n  front:\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert_eq!(
 		c.matches("NetworkAlias=dup").count(),
@@ -267,7 +267,7 @@ fn ipam_options_warn_because_quadlet_cannot_emit_them() {
 	// of silently diverging.
 	let yaml = "networks:\n  net:\n    ipam:\n      options:\n        foo: bar\nservices:\n  s:\n    image: x\n    networks: [net]\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	assert!(
 		out.warnings.iter().any(|w| w.contains("ipam.options")),
 		"expected an ipam.options warning; got: {:?}",
@@ -279,7 +279,7 @@ fn ipam_options_warn_because_quadlet_cannot_emit_them() {
 fn network_mode_service_target_is_sanitized() {
 	let yaml = "services:\n  s:\n    image: x\n    network_mode: \"service:web:1\"\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("Network=p-web_1.container"), "in:\n{c}");
 }
@@ -296,7 +296,7 @@ volumes:
   vol:
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let net = &unit_named(&out, "p-net.network").contents;
 	let vol = &unit_named(&out, "p-vol.volume").contents;
 	assert!(

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -1,6 +1,6 @@
 use super::unit_named;
 use crate::parse_str;
-use crate::quadlet::{generate, QuadletOutput, QuadletUnit};
+use crate::quadlet::{generate_at, QuadletOutput, QuadletUnit};
 
 #[test]
 fn container_name_defaults_to_project_prefixed() {
@@ -8,7 +8,7 @@ fn container_name_defaults_to_project_prefixed() {
 	// `{project}-{service}`, matching how `up` names the running container,
 	// rather than a bare `web` that would collide across projects.
 	let file = parse_str("services:\n  web:\n    image: nginx\n").unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let web = unit_named(&out, "proj-web.container");
 	assert!(web.contents.contains("ContainerName=proj-web"));
 }
@@ -55,7 +55,7 @@ networks:
   frontend:
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 
 	let web = unit_named(&out, "proj-web.container");
 	assert!(web.contents.contains("Image=nginx:1.27"));
@@ -96,7 +96,7 @@ services:
     image: app:latest
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	// A `.build` unit is generated (no longer just a warning) and the container
 	// references it so Quadlet builds before running.
 	let build = out
@@ -106,7 +106,14 @@ services:
 		.expect("a build service must emit an app.build unit");
 	assert!(build.contents.contains("[Build]"));
 	assert!(build.contents.contains("ImageTag=app:latest"));
-	assert!(build.contents.contains("SetWorkingDirectory=./src"));
+	// `abs_context` joins with the OS separator, so build the expected path the
+	// same way — `/srv/app/src` on Unix, `/srv/app\src` on Windows — rather than a
+	// POSIX literal that fails the render tests (which are not Unix-gated) on Windows.
+	let expected_ctx = format!(
+		"SetWorkingDirectory={}",
+		std::path::Path::new("/srv/app").join("src").display()
+	);
+	assert!(build.contents.contains(&expected_ctx), "{}", build.contents);
 	assert!(build.contents.contains("File=Dockerfile.app"));
 	assert!(build.contents.contains("Target=runtime"));
 	let container = out
@@ -122,7 +129,7 @@ services:
 fn inline_dockerfile_build_warns_and_emits_no_build_unit() {
 	let yaml = "services:\n  app:\n    build:\n      dockerfile_inline: \"FROM alpine\"\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	assert!(!out.units.iter().any(|u| u.filename == "proj-app.build"));
 	assert!(out.warnings.iter().any(|w| w.contains("dockerfile_inline")));
 }
@@ -137,7 +144,7 @@ services:
       - ./html:/usr/share/nginx/html:ro
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let web = unit_named(&out, "proj-web.container");
 	assert!(web
 		.contents
@@ -159,7 +166,7 @@ volumes:
   pgdata:
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "proj-db.container").contents;
 	assert!(c.contains("Volume=proj-pgdata.volume:/var/lib/postgresql/data:ro"));
 }
@@ -178,7 +185,7 @@ services:
       replicas: 3
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let joined = out.warnings.join("\n");
 	for needle in ["network_mode", "profiles", "volumes_from", "scale/replicas"] {
 		assert!(joined.contains(needle), "expected warning for {needle}");
@@ -191,7 +198,7 @@ fn hostile_service_name_cannot_escape_output_directory() {
 	// file name that escapes the output directory.
 	let yaml = "services:\n  ? \"../../evil\"\n  : { image: x }\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let unit = &out.units[0];
 	assert!(
 		!unit.filename.contains('/') && !unit.filename.contains('\\'),
@@ -208,7 +215,7 @@ fn newline_in_value_cannot_inject_unit_directives() {
 	let yaml =
 		"services:\n  web:\n    image: x\n    environment:\n      EVIL: \"a\\nExecStartPre=/bin/rm -rf /\"\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(
 		!c.lines().any(|l| l.starts_with("ExecStartPre")),
@@ -220,7 +227,7 @@ fn newline_in_value_cannot_inject_unit_directives() {
 fn privileged_maps_to_podman_arg() {
 	let yaml = "services:\n  s:\n    image: x\n    privileged: true\n";
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "p");
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(c.contains("PodmanArgs=--privileged"), "in:\n{c}");
 	assert!(
@@ -245,7 +252,7 @@ volumes:
   vol:
 "#;
 	let file = parse_str(yaml).unwrap();
-	let out = generate(&file, "proj");
+	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 
 	let c = &unit_named(&out, "proj-web.container").contents;
 	assert!(

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -4,9 +4,32 @@
 //! generator to build the image before the `.container` unit that consumes it
 //! runs. The container references the result via `Image=<stem>.build`.
 
+use std::path::Path;
+
 use crate::compose::types::{BuildConfig, Service};
 
 use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
+
+/// Resolve a compose build `context` to an absolute `SetWorkingDirectory` value.
+///
+/// The systemd generator runs a `.build` unit with no working directory of its
+/// own, resolving a relative `SetWorkingDirectory` against the unit file's own
+/// directory (`~/.config/containers/systemd`) — where there is no Dockerfile. So
+/// the context, which compose interprets relative to the compose file, must be
+/// made absolute against that base directory here. `.` means the base dir itself.
+fn abs_context(base_dir: &Path, context: &str) -> String {
+	let ctx = Path::new(context);
+	if ctx.is_absolute() {
+		return context.to_string();
+	}
+	if ctx == Path::new(".") {
+		return base_dir.display().to_string();
+	}
+	// Strip a leading `./` so the joined path stays clean (`/base/src`, not
+	// `/base/./src`) — cosmetic, both resolve identically.
+	let rel = context.strip_prefix("./").unwrap_or(context);
+	base_dir.join(rel).display().to_string()
+}
 
 /// The `.build` unit file name for a service, e.g. `proj-web.build`. The
 /// container unit points its `Image=` at this so Quadlet builds then runs; the
@@ -39,6 +62,7 @@ pub(crate) fn build_unit(
 	name: &str,
 	project: &str,
 	service: &Service,
+	base_dir: &Path,
 	warnings: &mut Vec<String>,
 ) -> Option<QuadletUnit> {
 	let build = service.build.as_ref()?;
@@ -53,7 +77,7 @@ pub(crate) fn build_unit(
 
 	match build {
 		BuildConfig::Context(context) => {
-			section.add("SetWorkingDirectory", context.clone());
+			section.add("SetWorkingDirectory", abs_context(base_dir, context));
 		}
 		BuildConfig::Config {
 			context,
@@ -76,7 +100,7 @@ pub(crate) fn build_unit(
 			}
 			section.add(
 				"SetWorkingDirectory",
-				context.clone().unwrap_or_else(|| ".".to_string()),
+				abs_context(base_dir, context.as_deref().unwrap_or(".")),
 			);
 			if let Some(df) = dockerfile {
 				section.add("File", df.clone());
@@ -111,4 +135,27 @@ pub(crate) fn build_unit(
 		filename: build_unit_filename(project, name),
 		contents: section.render(),
 	})
+}
+
+// Unix-gated: the asserted paths are POSIX (separators and `/`-absolute), so the
+// values differ on Windows. `abs_context` itself is cross-platform; only the
+// literal expectations are Unix-specific.
+#[cfg(all(test, unix))]
+mod tests {
+	use super::abs_context;
+	use std::path::Path;
+
+	#[test]
+	fn abs_context_makes_relative_build_contexts_absolute() {
+		let base = Path::new("/srv/app");
+		// `.` is the compose file's own directory.
+		assert_eq!(abs_context(base, "."), "/srv/app");
+		// A `./`-prefixed or bare relative path joins under the base, kept clean.
+		assert_eq!(abs_context(base, "./src"), "/srv/app/src");
+		assert_eq!(abs_context(base, "src"), "/srv/app/src");
+		// A parent traversal is preserved (systemd/podman resolve it).
+		assert_eq!(abs_context(base, "../shared"), "/srv/app/../shared");
+		// An already-absolute context is passed through untouched.
+		assert_eq!(abs_context(base, "/opt/build"), "/opt/build");
+	}
 }

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -198,7 +198,7 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 #[cfg(test)]
 mod tests {
 	use crate::parse_str;
-	use crate::quadlet::generate;
+	use crate::quadlet::generate_at;
 
 	#[test]
 	fn warns_for_every_unmapped_field() {
@@ -227,7 +227,7 @@ configs:
     file: ./c.txt
 "#;
 		let file = parse_str(yaml).unwrap();
-		let warnings = generate(&file, "proj").warnings;
+		let warnings = generate_at(&file, "proj", std::path::Path::new("/srv/app")).warnings;
 		let joined = warnings.join("\n");
 
 		for field in [
@@ -261,7 +261,9 @@ configs:
 		for mode in ["service:db", "container:other"] {
 			let yaml = format!("services:\n  s:\n    image: x\n    network_mode: \"{mode}\"\n");
 			let file = parse_str(&yaml).unwrap();
-			let joined = generate(&file, "proj").warnings.join("\n");
+			let joined = generate_at(&file, "proj", std::path::Path::new("/srv/app"))
+				.warnings
+				.join("\n");
 			assert!(
 				!joined.contains("network_mode"),
 				"{mode} should be mapped, not warned; got:\n{joined}"
@@ -294,7 +296,9 @@ services:
       weight: 300
 "#;
 		let file = parse_str(yaml).unwrap();
-		let joined = generate(&file, "proj").warnings.join("\n");
+		let joined = generate_at(&file, "proj", std::path::Path::new("/srv/app"))
+			.warnings
+			.join("\n");
 		for field in [
 			"ipc",
 			"pid",
@@ -341,7 +345,9 @@ services:
     cpu_rt_period: 1000000
 "#;
 		let file = parse_str(yaml).unwrap();
-		let joined = generate(&file, "proj").warnings.join("\n");
+		let joined = generate_at(&file, "proj", std::path::Path::new("/srv/app"))
+			.warnings
+			.join("\n");
 		for field in [
 			"gpus",
 			"platform",
@@ -372,7 +378,7 @@ services:
       - "unmask=ALL"
 "#;
 		let file = parse_str(yaml).unwrap();
-		let out = generate(&file, "proj");
+		let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
 		let contents = out
 			.units
 			.iter()
@@ -409,7 +415,9 @@ networks:
   b:
 "#;
 		let file = parse_str(yaml).unwrap();
-		let joined = generate(&file, "proj").warnings.join("\n");
+		let joined = generate_at(&file, "proj", std::path::Path::new("/srv/app"))
+			.warnings
+			.join("\n");
 		assert!(
 			joined.contains("ipv4_address/ipv6_address"),
 			"missing multi-network static-IP warning; got:\n{joined}"
@@ -440,7 +448,9 @@ services:
     use_api_socket: true
 "#;
 		let file = parse_str(yaml).unwrap();
-		let joined = generate(&file, "proj").warnings.join("\n");
+		let joined = generate_at(&file, "proj", std::path::Path::new("/srv/app"))
+			.warnings
+			.join("\n");
 		for field in [
 			"cpu_count",
 			"cpu_percent",
@@ -466,6 +476,8 @@ services:
     image: nginx:1.27
 "#;
 		let file = parse_str(yaml).unwrap();
-		assert!(generate(&file, "proj").warnings.is_empty());
+		assert!(generate_at(&file, "proj", std::path::Path::new("/srv/app"))
+			.warnings
+			.is_empty());
 	}
 }


### PR DESCRIPTION
Release 1.10.0 — the quadlet autostart backend.

## What ships

**`autostart --mode quadlet`** (#1025): a second backend for keeping a rootless stack up across reboots. Where `--mode service` installs one `Type=oneshot` unit that runs `podup up -d`, quadlet mode renders the stack to native Podman Quadlet units (`.container`/`.build`/`.volume`/`.network`) under `~/.config/containers/systemd/` and hands them to systemd, which then owns each service's boot, restart and ordering directly. `uninstall` auto-detects the installed mode; a new `autostart rebuild [service]` restarts a service's oneshot `.build` unit and its container to pick up a fresh image.

**Renderer fix**: the `.build` unit carried its build `context` verbatim (e.g. `.`), which the systemd generator resolves against the unit directory rather than the compose file — so a build-based stack failed with `no Dockerfile in context directory`. The context is now absolute. This also fixes `generate quadlet -o` for build stacks.

**Docs** (#1026): `docs/autostart.md` covers the rootless flow; the stale `commands.md` autostart entry is corrected.

## Semver

Minor bump. `cargo-semver-checks` confirmed the change is additive (new `quadlet::generate_at`; `generate` unchanged) — no breaking API change.

## Verification

- 1697 tests pass; fmt and clippy (`--locked --all-targets --all-features -D warnings`) clean; `podman-vm` lanes green on Podman 5 and 6.
- The quadlet install/uninstall/rebuild path was exercised against a real Podman 5.4.2 + `systemd --user`: both an image-based and a build-based service came up, `rebuild` recreated the container from a fresh image, and `uninstall` left nothing behind.
- Version matches across `Cargo.toml`, `Cargo.lock`, `debian/changelog`; the release workflow's version gate was run locally.

Known gap (follow-up, not a blocker): the quadlet-autostart real-Podman path has no automated integration test — it is covered by unit tests with a fake `SystemCtl` plus the manual 5.4.2 run above.