### PR TITLE
chore(release): 1.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+podup (1.10.1) unstable; urgency=medium
+
+  * Relicensed from Apache-2.0 to MIT, part of the org-wide switch to a single
+    MIT license. LICENSE, Cargo.toml, debian/copyright and the README now read
+    MIT; the NOTICE file (an Apache-2.0 §4(d) mechanism) is removed. No code
+    change. Third-party dependency-license tooling is unchanged.
+
+ -- Glyndor <packages@glyndor.net>  Fri, 17 Jul 2026 05:55:00 -0500
+
 podup (1.10.0) unstable; urgency=medium
 
   * `autostart` gained a second backend: `--mode quadlet` hands the stack to


### PR DESCRIPTION
Patch release to publish the MIT relicense (#1029 / #1031) to `main` and crates.io. The relicense landed on `develop` in #1031; this bump carries it to users. No code change — LICENSE/Cargo/debian-copyright/README are MIT, NOTICE removed. Version matches across Cargo.toml, Cargo.lock and debian/changelog; the release gate was run locally.