### PR TITLE
ci: adopt the v1.10.0 reusables and drop two inline workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint repository configuration.
+self-hosted-runner:
+  # "bench" is the label of the controlled self-hosted benchmark runner that
+  # benchmark.yml targets; declared here so actionlint's runner-label check
+  # recognizes it instead of flagging it as unknown.
+  labels:
+    - bench

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       coverage-threshold: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       coverage-threshold: 90

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/dco.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/dco.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,26 +5,15 @@ on:
     - cron: "0 7 * * 1"  # Every Monday at 07:00 UTC
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [parse_compose, substitute, size, dotenv, stream_frame]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install nightly toolchain
-        run: |
-          rustup toolchain install nightly --profile minimal --component rust-src
-          rustup default nightly
-
-      - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --version "^0.13" --locked
-
-      - name: Fuzz ${{ matrix.target }}
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60 -rss_limit_mb=2048 -timeout=10
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    with:
+      targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
+      max-total-time: "60"
+      timeout: "10"
+      rss-limit-mb: "2048"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,31 +21,6 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Syntax check
-        shell: pwsh
-        run: |
-          $errors = $null
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path install.ps1), [ref]$null, [ref]$errors) | Out-Null
-          if ($errors) {
-            $errors | ForEach-Object { Write-Error $_.Message }
-            exit 1
-          }
-          Write-Host 'Parse OK'
-
-      - name: Run PSScriptAnalyzer
-        shell: pwsh
-        run: |
-          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
-          # Write-Host is intentional: the script is piped to `iex`, so console
-          # status must not leak into the output stream that Write-Output feeds.
-          # Surface every finding (advisory), then fail only on Error severity —
-          # the parse check above is the hard syntax gate.
-          Invoke-ScriptAnalyzer -Path install.ps1 -ExcludeRule PSAvoidUsingWriteHost |
-            Format-Table -AutoSize
-          Invoke-ScriptAnalyzer -Path install.ps1 -Severity Error `
-            -ExcludeRule PSAvoidUsingWriteHost -EnableExit
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    with:
+      paths: "install.ps1"

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -24,3 +24,7 @@ jobs:
     uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
     with:
       paths: "install.ps1"
+      # install.ps1 is piped to `iex`, so human-facing status must go through
+      # Write-Host — Write-Output would leak into the stream the pipe feeds.
+      # Same exclusion the previous inline job carried.
+      exclude-rules: "PSAvoidUsingWriteHost"

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,10 +231,12 @@ jobs:
           dpkg-buildpackage -us -uc -b
 
       - name: Stage the .deb into the workspace
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          deb=$(ls ../podup_*_${{ matrix.arch }}.deb 2>/dev/null | head -n1)
+          deb=$(find .. -maxdepth 1 -name "podup_*_${ARCH}.deb" | sort | head -n1)
           if [ -z "$deb" ]; then
-            echo "::error::no ${{ matrix.arch }} .deb artifact was produced"
+            echo "::error::no ${ARCH} .deb artifact was produced"
             exit 1
           fi
           cp "$deb" "$(basename "$deb")"
@@ -286,7 +288,7 @@ jobs:
           # cargo-cyclonedx names the file after the package (podup.cdx.json),
           # so only rename when an older/different layout emitted another name —
           # mv onto itself errors ("are the same file").
-          src="$(ls ./*.cdx.json | head -n1)"
+          src="$(find . -maxdepth 1 -name "*.cdx.json" | sort | head -n1)"
           [ "$src" = "./podup.cdx.json" ] || mv "$src" podup.cdx.json
           cargo about generate about.hbs > NOTICES.html
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@505d78df893bfc2f73261ff285529e6afd46f5ac # v1.9.1
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,14 @@
+name: Workflow lint
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-lint:
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7f386e098ac242fc82e2e9a2b5e02c50cf00eedf # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 5.1
 #
-# podup installer for Windows — downloads a release binary, verifies it and
+# podup installer for Windows - downloads a release binary, verifies it and
 # installs it.
 #
 # Usage:
@@ -78,7 +78,7 @@ try {
 
 	# Checksum alone is not a trust anchor: a tampered release can ship a matching
 	# SHA256SUMS. The binary is trusted only after at least one cryptographic proof
-	# tied to the release key or the repository's build identity succeeds — the
+	# tied to the release key or the repository's build identity succeeds - the
 	# Ed25519 signature over SHA256SUMS, or the GitHub build-provenance attestation.
 	# If neither verifier can run, the install fails closed.
 
@@ -115,7 +115,7 @@ try {
 		$python = Find-Python
 		if ($python) {
 			$pyScript = Join-Path $TmpDir 'verify_ed25519.py'
-			# Python source — indentation is significant, keep as-is.
+			# Python source - indentation is significant, keep as-is.
 			$pySource = @'
 import base64, sys
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
@@ -138,7 +138,7 @@ sys.exit(1)
 				Write-LogOk 'SHA256SUMS signature verified'
 				$verified = $true
 			} else {
-				Fail 'SHA256SUMS signature verification failed — release may be tampered'
+				Fail 'SHA256SUMS signature verification failed - release may be tampered'
 			}
 		} else {
 			# A release public key IS configured: the pinned key is the trust anchor
@@ -147,13 +147,13 @@ sys.exit(1)
 			Fail "python3 with the 'cryptography' package is required to verify the release signature against the pinned key. Install it and re-run."
 		}
 	} else {
-		Write-LogInfo 'no release public key configured — skipping Ed25519 signature check'
+		Write-LogInfo 'no release public key configured - skipping Ed25519 signature check'
 	}
 
 	# Build-provenance attestation: proves the binary was produced by this repo's
 	# release workflow (GitHub OIDC). Defence-in-depth next to the pinned key; the
 	# trust anchor when no release public key is configured. Pinned to the release
-	# workflow — a repo-scoped check would accept an attestation from any workflow
+	# workflow - a repo-scoped check would accept an attestation from any workflow
 	# in the repo.
 	$ghAttestation = $false
 	if (Get-Command gh -ErrorAction SilentlyContinue) {
@@ -167,11 +167,11 @@ sys.exit(1)
 		Write-LogOk 'Attestation verified'
 		$verified = $true
 	} else {
-		Write-LogInfo 'GitHub CLI with attestation support not found — cannot check attestation'
+		Write-LogInfo 'GitHub CLI with attestation support not found - cannot check attestation'
 	}
 
 	# Fail closed: a strong cryptographic proof is mandatory. A checksum alone is not
-	# a trust anchor, and there is no opt-out — hardened environments require
+	# a trust anchor, and there is no opt-out - hardened environments require
 	# verifiable supply-chain integrity at install time.
 	if (-not $verified) {
 		Fail "No signature or attestation verifier available. Install 'gh' (>= 2.49) or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, then re-run."


### PR DESCRIPTION
Closes #1035

Adopts the upcoming `.github` release — this PR's full matrix going green is the consumer proof that gates the tag.

- **All caller pins → the v1.10.0 candidate SHA.** The release pins every tool the reusables install (llvm-cov, semver-checks, cargo-fuzz, audit/deny/about/cyclonedx, bun, shellcheck, the fuzz nightly, the debian image), so a new tool release can't move our gates by itself anymore.
- **`fuzz.yml` becomes a thin caller.** The reusable gained `rss-limit-mb`, which was the only input the inline copy had over it. Targets, times and limits carried over exactly.
- **`lint-powershell.yml` becomes a thin caller.** One deliberate difference surfaced during the swap: `install.ps1` uses `Write-Host` on purpose (the script is piped through `iex`; `Write-Output` would pollute the pipeline), and the shared workflow now takes `exclude-rules` for exactly this — the swap is what forced that input to exist upstream, which is the consumer proof doing its job.
- **New `workflow-lint` caller.** This repo's own release/lane YAML — where the phantom-check and PowerShell traps have historically lived — was linted by nobody. Making it green meant paying down three pre-existing findings: the `bench` runner label is now declared in `.github/actionlint.yaml`, and the two `ls`-parsing sites in `release.yml` are `find`-based (with the `${{ matrix.arch }}` interpolation moved into `env:` while I was in the line). The find replacements were tested side by side against the old commands across match/no-match/single/multiple cases — identical output including the `./` prefix the mv-guard compares.

Test plan: actionlint clean over the whole tree (zero findings — that's the new check passing on our own YAML); fuzz and PowerShell input mappings listed side by side against the old inline values; the release-script changes exercised in fixtures. The lanes, matrix and podman-vm legs run on this PR as always.