### PR TITLE
ci: sanitize podman-watch, fix the benchmark smoke, attest the .deb

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,8 +4,13 @@
 # or the maintainer's machine), never a shared GitHub runner — shared runners are
 # too noisy to be trustworthy. So this workflow has two jobs:
 #
-#   smoke      — on a shared GitHub runner, runs `bench/run.sh --smoke` to prove
-#                the harness still runs. It produces NO published numbers.
+#   smoke      — on a shared GitHub runner, validates the harness code itself:
+#                shell syntax, Python syntax, and the aggregation stats path run
+#                against inline sample rows. It does NOT install Podman or drive
+#                podup — ubuntu-latest ships Podman 4.9, below podup's floor
+#                (Podman >= 5.0), so a shared-runner engine run would either fail
+#                or exercise an unsupported configuration. It produces NO
+#                published numbers and proves nothing about podup on real Podman.
 #   benchmark  — on a self-hosted runner (manual dispatch), runs the full suite
 #                and uploads the report artifact. It is skipped until a runner with
 #                the `bench` label exists.
@@ -25,22 +30,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install Podman and podman-compose
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          pipx install podman-compose || pip install --user podman-compose
-      - name: Build podup
-        run: cargo build --release --all-features --locked
-      - name: Pre-pull pinned images
-        run: |
-          grep -rhoE 'docker\.io/[^ ]+@sha256:[a-f0-9]+' bench/scenarios | sort -u | while read -r img; do
-            podman pull -q "$img"
-          done
-      - name: Smoke-run the harness
-        run: PODUP_BIN=target/release/podup bash bench/run.sh --smoke
-      - name: Aggregate (sanity)
-        run: python3 bench/aggregate.py
+      - name: Check the harness shell syntax
+        run: bash -n bench/run.sh
+      - name: Check the harness Python syntax
+        run: python3 -m py_compile bench/aggregate.py
+      - name: Exercise the aggregation stats path on inline sample rows
+        run: python3 bench/aggregate.py --self-test
 
   benchmark:
     runs-on: [self-hosted, bench]

--- a/.github/workflows/podman-watch.yml
+++ b/.github/workflows/podman-watch.yml
@@ -22,6 +22,9 @@ jobs:
           set -euo pipefail
           BASELINE=$(tr -d '[:space:]' < .github/podman-baseline)
           LATEST=$(gh api repos/containers/podman/releases/latest --jq '.tag_name' | sed 's/^v//')
+          # LATEST is a third-party-controlled release tag. Reject anything but a
+          # plain SemVer before it is used anywhere else in this script.
+          [[ "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::unexpected Podman release tag '$LATEST' — not a plain version"; exit 1; }
           echo "baseline=$BASELINE  latest=$LATEST"
           # Nothing to do unless LATEST is strictly newer than BASELINE.
           if [ "$LATEST" = "$BASELINE" ] || \
@@ -29,9 +32,11 @@ jobs:
             echo "No newer Podman than the validated baseline ($BASELINE)."; exit 0
           fi
           # Which distros already package LATEST? (testable => packaged somewhere)
+          # LATEST reaches python via the environment, never interpolated into the
+          # script string, so it cannot inject into the parser.
           DISTROS=$(curl -fsSL -H 'User-Agent: podup-podman-watch' \
             "https://repology.org/api/v1/project/podman" \
-            | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(sorted({p['repo'] for p in d if p.get('version')=='$LATEST'})))")
+            | LATEST="$LATEST" python3 -c "import os,sys,json;d=json.load(sys.stdin);latest=os.environ['LATEST'];print(', '.join(sorted({p['repo'] for p in d if p.get('version')==latest})))")
           if [ -z "$DISTROS" ]; then
             echo "Podman $LATEST is released but not packaged in any distro yet — keep watching."; exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,8 @@ jobs:
     container: debian:sid
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -270,6 +272,11 @@ jobs:
           fi
           cp "$deb" "$(basename "$deb")"
           echo "Staged $(basename "$deb")"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: podup_*_${{ matrix.arch }}.deb
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/bench/README.md
+++ b/bench/README.md
@@ -23,8 +23,9 @@ A podup loss is published exactly like a podup win.
 - **Controlled environment.** The real run happens on a dedicated/self-hosted
   runner or the maintainer's machine, with the CPU governor pinned and the tool
   process taskset-pinned to reduce variance. **Shared CI runners are too noisy for
-  published numbers** — CI only runs a smoke check (`--smoke`) that proves the
-  harness works, never the numbers in the README.
+  published numbers** — CI only static-checks the harness (`bash -n`, a Python
+  compile, and `aggregate.py --self-test` on fixture rows), never running the
+  scenarios or the numbers in the README.
 - **No cherry-picking.** Every scenario is published, whoever wins.
 
 ## Scenarios
@@ -71,7 +72,7 @@ python3 bench/aggregate.py
 # -> bench/results/report.md and bench/results/summary.json
 ```
 
-`--smoke` runs a single scenario once (used by CI to check the harness runs).
+`--smoke` runs a single scenario once, for a quick local check against a real engine (CI no longer uses it — it static-checks the harness instead; see above).
 
 ## Output
 

--- a/bench/aggregate.py
+++ b/bench/aggregate.py
@@ -30,6 +30,22 @@ OP_LABEL = {
 	"exec": "exec", "restart": "restart", "build": "build",
 }
 
+# Inline sample rows, shaped exactly like raw.csv, for `--self-test`. bench/results/
+# is a local, git-ignored artifact directory (real numbers only come from the
+# controlled, self-hosted benchmark run), so a shared-runner smoke check has no
+# raw.csv to read. These rows exercise the same filtering and statistics path
+# (warm-up discarded, failed rows discarded, median/p95/stdev computed) without
+# depending on committed benchmark data or a real Podman engine.
+SELF_TEST_ROWS = [
+	{"tool": "podup", "scenario": "single", "op": "up", "iter": "0", "phase": "warmup", "seconds": "0.520", "max_rss_kb": "10240", "cpu_s": "0.110", "rc": "0"},
+	{"tool": "podup", "scenario": "single", "op": "up", "iter": "1", "phase": "measured", "seconds": "0.500", "max_rss_kb": "10000", "cpu_s": "0.100", "rc": "0"},
+	{"tool": "podup", "scenario": "single", "op": "up", "iter": "2", "phase": "measured", "seconds": "0.510", "max_rss_kb": "10100", "cpu_s": "0.105", "rc": "0"},
+	{"tool": "podup", "scenario": "single", "op": "down", "iter": "1", "phase": "measured", "seconds": "0.200", "max_rss_kb": "9500", "cpu_s": "0.050", "rc": "0"},
+	{"tool": "podup", "scenario": "single", "op": "down", "iter": "2", "phase": "measured", "seconds": "0.210", "max_rss_kb": "9600", "cpu_s": "0.052", "rc": "0"},
+	{"tool": "podman-compose", "scenario": "single", "op": "up", "iter": "1", "phase": "measured", "seconds": "0.800", "max_rss_kb": "30000", "cpu_s": "0.300", "rc": "0"},
+	{"tool": "podman-compose", "scenario": "single", "op": "up", "iter": "2", "phase": "measured", "seconds": "0.001", "max_rss_kb": "1", "cpu_s": "0.001", "rc": "1"},
+]
+
 
 def pct(values, p):
 	"""Nearest-rank percentile; honest for small n."""
@@ -50,21 +66,25 @@ def stats(values):
 	}
 
 
+def filter_measured(rows):
+	"""Keep only completed, successful iterations (drop warm-up and failures)."""
+	return [r for r in rows if r["phase"] == "measured" and int(r["rc"]) == 0]
+
+
 def load(path):
-	rows = []
 	with open(path, newline="") as f:
-		for r in csv.DictReader(f):
-			if r["phase"] != "measured" or int(r["rc"]) != 0:
-				continue
-			rows.append(r)
-	return rows
+		return filter_measured(list(csv.DictReader(f)))
 
 
 def main():
-	if not os.path.exists(RAW):
-		print(f"no raw data at {RAW}", file=sys.stderr)
-		return 1
-	rows = load(RAW)
+	self_test = "--self-test" in sys.argv
+	if self_test:
+		rows = filter_measured(SELF_TEST_ROWS)
+	else:
+		if not os.path.exists(RAW):
+			print(f"no raw data at {RAW}", file=sys.stderr)
+			return 1
+		rows = load(RAW)
 	tools = sorted({r["tool"] for r in rows})
 	scenarios = [s for s in SCEN_ORDER if any(r["scenario"] == s for r in rows)]
 


### PR DESCRIPTION
Closes #1040

Three CI items from the audit.

- **podman-watch no longer feeds a third-party tag into python.** The watcher reads `containers/podman`'s latest release tag — a value the upstream project controls — and interpolated it straight into a `python3 -c` string. A crafted tag could break out of the string literal and run code, in a job that holds `issues: write`. The tag is now rejected unless it's a plain `X.Y.Z`, and it reaches the parser through the environment (`os.environ`), never string interpolation — two independent layers, either one sufficient. repology stays (it's the one allowlisted CI service now, and its only power is opening a tracking issue).
- **The benchmark smoke stops pretending to test podup on an unsupported engine.** It installed Ubuntu's Podman (4.9) and drove podup, but podup's floor is Podman 5.0 — so the smoke either failed or exercised a config we don't support. It now validates the harness itself without an engine: `bash -n`, a Python compile, and a new `aggregate.py --self-test` that runs the real median/p95/stdev + warm-up/failed-row filtering against fixture rows. The self-hosted `benchmark` job — the one that produces published numbers — is untouched.
- **The .deb builds are attested.** The binaries carried a build-provenance attestation; the Debian packages didn't. Each arch's `.deb` now gets one from the same pinned action, so every published artifact — binary or package — is provenance-verifiable, not just signature-verifiable.

Per-target SBOMs (one CycloneDX per platform's feature set instead of a single `--all-features` file) are a real refactor — they'd touch all 8 build legs plus the SHA256SUMS/sign/asset-list machinery — so I left that as a follow-up rather than fold it into this batch; the single SBOM over-declares but isn't wrong.

Test plan: actionlint clean tree-wide; the injection fix verified against an actual working exploit of the old code (rejected at the regex, inert even past it); the smoke's static checks and self-test run locally. The `.deb` attestation only exercises live OIDC at a real tag — the next release (v1.11.0) is its proof.