### PR TITLE
fix: lifecycle commands must exit non-zero when the operation fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ test-helpers = []
 [dev-dependencies]
 tempfile = "3"
 temp-env = "0.3"
+# Only pulled in for test/bench targets (edition 2021's feature resolver keeps
+# dev-dependency features out of the shipped binary): the fake-Podman test
+# harness (`internal/engine/fake_podman.rs`) reads/writes a raw HTTP/1.1
+# request over a Unix socket by hand, needing `AsyncReadExt`/`AsyncWriteExt`.
+tokio = { version = "1", features = ["io-util"] }
 
 [workspace]
 exclude = ["fuzz"]

--- a/internal/engine/fake_podman.rs
+++ b/internal/engine/fake_podman.rs
@@ -1,0 +1,139 @@
+//! Test-only fake Podman socket.
+//!
+//! A minimal libpod HTTP responder bound to a Unix domain socket, so
+//! lifecycle/scale/query tests can assert exit-code semantics against canned
+//! API responses without a real Podman daemon. [`Client`] opens a fresh
+//! connection per request (see `internal/libpod/client/mod.rs`), so this only
+//! ever needs to answer one HTTP/1.1 request per accepted connection — no
+//! keep-alive, no chunked framing.
+
+#![cfg(unix)]
+
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::task::JoinHandle;
+
+use crate::libpod::Client;
+
+/// A test's routing rule: `(method, target) -> (status, JSON body)`, where
+/// `target` is the request path plus its raw query string (e.g.
+/// `/v5.0.0/libpod/containers/proj-web-1/start`).
+type Responder = dyn Fn(&str, &str) -> (u16, String) + Send + Sync;
+
+/// A fake libpod socket driven by a routing closure; see [`Responder`].
+pub(super) struct FakePodman {
+	sock_path: std::path::PathBuf,
+	/// Every request answered so far, as `"METHOD target"` — lets a test assert
+	/// that a best-effort pass attempted every container even after one of them
+	/// failed.
+	pub(super) requests: Arc<Mutex<Vec<String>>>,
+	_dir: tempfile::TempDir,
+	task: JoinHandle<()>,
+}
+
+impl FakePodman {
+	/// A fresh [`Client`] pointed at this fake socket. [`Client`] is a thin,
+	/// stateless per-request handle (see `internal/libpod/client/mod.rs`), so a
+	/// new one is created on every call rather than shared/cloned.
+	pub(super) fn client(&self) -> Client {
+		Client::new(self.sock_path.to_string_lossy().into_owned())
+	}
+}
+
+impl Drop for FakePodman {
+	fn drop(&mut self) {
+		// Stop accepting new connections; in-flight ones simply finish or are
+		// dropped along with the temp dir (the test is already done with them).
+		self.task.abort();
+	}
+}
+
+/// Start a fake Podman socket that answers every request via `respond`.
+/// Connection-per-request, matching how [`Client`] talks to the real daemon.
+pub(super) fn start<F>(respond: F) -> FakePodman
+where
+	F: Fn(&str, &str) -> (u16, String) + Send + Sync + 'static,
+{
+	let dir = tempfile::tempdir().expect("create temp dir for fake podman socket");
+	let sock_path = dir.path().join("podman.sock");
+	let listener = UnixListener::bind(&sock_path).expect("bind fake podman socket");
+	let respond: Arc<Responder> = Arc::new(respond);
+	let requests: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+
+	let task_requests = requests.clone();
+	let task = tokio::spawn(async move {
+		loop {
+			let Ok((stream, _)) = listener.accept().await else {
+				break;
+			};
+			let respond = respond.clone();
+			let requests = task_requests.clone();
+			tokio::spawn(async move {
+				let _ = serve_one(stream, respond.as_ref(), &requests).await;
+			});
+		}
+	});
+
+	FakePodman {
+		sock_path,
+		requests,
+		_dir: dir,
+		task,
+	}
+}
+
+/// Read one HTTP/1.1 request line (every request this harness serves carries
+/// an empty body, so the header block is the whole request) and write back
+/// the canned response.
+async fn serve_one(
+	mut stream: UnixStream,
+	respond: &Responder,
+	requests: &Mutex<Vec<String>>,
+) -> std::io::Result<()> {
+	let mut buf = Vec::new();
+	let mut chunk = [0u8; 1024];
+	loop {
+		let n = stream.read(&mut chunk).await?;
+		if n == 0 {
+			break;
+		}
+		buf.extend_from_slice(&chunk[..n]);
+		if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+			break;
+		}
+	}
+
+	let head = String::from_utf8_lossy(&buf);
+	let request_line = head.lines().next().unwrap_or_default();
+	let mut parts = request_line.split_whitespace();
+	let method = parts.next().unwrap_or_default().to_string();
+	let target = parts.next().unwrap_or_default().to_string();
+
+	requests.lock().unwrap().push(format!("{method} {target}"));
+
+	let (status, body) = respond(&method, &target);
+	let response = format!(
+		"HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {len}\r\nconnection: close\r\n\r\n{body}",
+		reason = reason_phrase(status),
+		len = body.len(),
+	);
+	stream.write_all(response.as_bytes()).await?;
+	stream.shutdown().await?;
+	Ok(())
+}
+
+/// Reason phrase for the statuses this harness's tests use; anything else
+/// falls back to a placeholder (the client only parses the numeric code).
+fn reason_phrase(status: u16) -> &'static str {
+	match status {
+		200 => "OK",
+		204 => "No Content",
+		304 => "Not Modified",
+		404 => "Not Found",
+		409 => "Conflict",
+		500 => "Internal Server Error",
+		_ => "Unknown",
+	}
+}

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -35,8 +35,8 @@ impl Engine {
 	/// failure is remembered and returned at the end instead of being swallowed
 	/// into a warning — mirroring the fix applied to [`Engine::down_with_options`]
 	/// (#598). A stalled or failed `stop` does NOT count towards this: the
-	/// force-remove that follows SIGKILLs the container regardless (see
-	/// [`super::container_rm_path`]), so only a genuine removal failure
+	/// force-remove that follows SIGKILLs the container regardless (the
+	/// container-removal path forces removal), so only a genuine removal failure
 	/// aggregates. A 404 (already gone) stays an idempotent no-op throughout.
 	pub async fn down_by_label(&self, remove_volumes: bool) -> Result<()> {
 		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -28,10 +28,20 @@ impl Engine {
 	/// compose file is absent. Unlike [`Engine::down_with_options`], which works
 	/// through the parsed service graph, this enumerates everything by label, so
 	/// it reaps all of the project's resources regardless of whether a file would
-	/// parse. Best-effort throughout: a missing resource (404) is an idempotent
-	/// no-op and an individual delete failure is logged, not fatal.
+	/// parse.
+	///
+	/// Best-effort across every container/network/volume so one failure never
+	/// leaves the rest of the teardown undone, but the first real REMOVAL
+	/// failure is remembered and returned at the end instead of being swallowed
+	/// into a warning — mirroring the fix applied to [`Engine::down_with_options`]
+	/// (#598). A stalled or failed `stop` does NOT count towards this: the
+	/// force-remove that follows SIGKILLs the container regardless (see
+	/// [`super::container_rm_path`]), so only a genuine removal failure
+	/// aggregates. A 404 (already gone) stays an idempotent no-op throughout.
 	pub async fn down_by_label(&self, remove_volumes: bool) -> Result<()> {
 		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);
+		let mut first_err: Option<crate::error::ComposeError> = None;
+
 		for container_name in self.list_project_container_names(None).await? {
 			let stop_path = format!(
 				"{API_PREFIX}/containers/{}/stop?t={}",
@@ -54,30 +64,50 @@ impl Engine {
 			match self.client.delete_ok(&rm_path).await {
 				Ok(()) => crate::ui::progress_line("Container", &container_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
-				Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
+				Err(e) => {
+					tracing::warn!("could not remove {container_name}: {e}");
+					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+				}
 			}
 		}
 
-		// Networks, named volumes and internal secrets are all reaped by label.
-		self.remove_project_networks_by_label().await;
+		// Networks and named volumes are reaped by label; each sweep is
+		// best-effort internally and reports its own first removal failure back
+		// here instead of swallowing it.
+		if let Some(e) = self.remove_project_networks_by_label().await {
+			first_err.get_or_insert(e);
+		}
 		if remove_volumes {
-			self.remove_project_volumes_by_label().await;
+			if let Some(e) = self.remove_project_volumes_by_label().await {
+				first_err.get_or_insert(e);
+			}
 		}
 		// An empty file carries no declared secrets/configs, so this falls straight
 		// through to the by-label orphan sweep that already backs `down`.
 		self.remove_internal_secrets(&ComposeFile::default())
 			.await?;
+
+		if let Some(e) = first_err {
+			return Err(e);
+		}
 		Ok(())
 	}
 
 	/// Remove every network carrying this project's `podup.project` label — the
 	/// implicit `<project>_default`, a network whose compose key changed, or any
 	/// project network when no file is present. Only podup-labelled networks
-	/// match, so a user's external network is never touched. Best-effort: a list
-	/// failure leaves networks in place rather than aborting teardown.
+	/// match, so a user's external network is never touched. Best-effort across
+	/// every network: a list failure leaves networks in place rather than
+	/// aborting teardown, and one network's removal failure never blocks the
+	/// rest — but the first genuine removal failure is returned to the caller
+	/// (a 404 stays an idempotent no-op) so it can decide whether to aggregate
+	/// it, matching [`Engine::down_by_label`]'s exit-code contract for the same
+	/// class of failure (#598).
 	///
 	/// Shared by [`Engine::down_with_options`] and [`Engine::down_by_label`].
-	pub(super) async fn remove_project_networks_by_label(&self) {
+	pub(super) async fn remove_project_networks_by_label(
+		&self,
+	) -> Option<crate::error::ComposeError> {
 		let net_filters =
 			serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
 		let list_path = format!(
@@ -89,8 +119,9 @@ impl Engine {
 			.get_json::<Vec<serde_json::Value>>(&list_path)
 			.await
 		else {
-			return;
+			return None;
 		};
+		let mut first_err = None;
 		for net in nets {
 			let Some(net_name) = net.get("name").and_then(|n| n.as_str()) else {
 				continue;
@@ -99,21 +130,31 @@ impl Engine {
 			match self.client.delete_ok(&del).await {
 				Ok(_) => crate::ui::progress_line("Network", net_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
-				Err(e) => tracing::warn!("could not remove network {net_name}: {e}"),
+				Err(e) => {
+					tracing::warn!("could not remove network {net_name}: {e}");
+					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+				}
 			}
 		}
+		first_err
 	}
 
 	/// Remove every named volume carrying this project's `podup.project` label.
 	/// libpod's `/volumes/json` is fetched in full and filtered client-side by
 	/// the label (mirroring the secret sweep) so only podup-created volumes are
 	/// deleted — a user's hand-made or external volume is never touched.
-	/// Best-effort: a list failure leaves volumes in place.
-	pub(super) async fn remove_project_volumes_by_label(&self) {
+	/// Best-effort across every volume: a list failure leaves volumes in place,
+	/// and one volume's removal failure never blocks the rest — but the first
+	/// genuine removal failure is returned to the caller (a 404 stays an
+	/// idempotent no-op), matching [`Engine::remove_project_networks_by_label`].
+	pub(super) async fn remove_project_volumes_by_label(
+		&self,
+	) -> Option<crate::error::ComposeError> {
 		let path = format!("{API_PREFIX}/volumes/json");
 		let Ok(vols) = self.client.get_json::<Vec<serde_json::Value>>(&path).await else {
-			return;
+			return None;
 		};
+		let mut first_err = None;
 		for vol in vols {
 			if !volume_owned_by(&vol, &self.project) {
 				continue;
@@ -125,9 +166,13 @@ impl Engine {
 			match self.client.delete_ok(&del).await {
 				Ok(_) => crate::ui::progress_line("Volume", name, "Removed"),
 				Err(e) if e.is_status(404) => {}
-				Err(e) => tracing::warn!("could not remove volume {name}: {e}"),
+				Err(e) => {
+					tracing::warn!("could not remove volume {name}: {e}");
+					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+				}
 			}
 		}
+		first_err
 	}
 }
 
@@ -145,6 +190,18 @@ fn volume_owned_by(vol: &serde_json::Value, project: &str) -> bool {
 mod tests {
 	use super::volume_owned_by;
 
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+	#[cfg(unix)]
+	use crate::engine::Engine;
+	#[cfg(unix)]
+	use crate::error::ComposeError;
+
+	#[cfg(unix)]
+	fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+	}
+
 	#[test]
 	fn volume_owned_by_matches_project_label() {
 		let vol = serde_json::json!({
@@ -158,5 +215,68 @@ mod tests {
 		assert!(!volume_owned_by(&unlabelled, "proj"));
 		let no_labels = serde_json::json!({ "Name": "loose" });
 		assert!(!volume_owned_by(&no_labels, "proj"));
+	}
+
+	/// #598 (unfixed on this path until now): `down -p PROJECT` with no compose
+	/// file only ever warned on a removal failure and unconditionally returned
+	/// `Ok`. Two labelled containers, one whose force-remove genuinely fails —
+	/// `down_by_label` must still attempt (and complete) the other before
+	/// exiting non-zero for the first.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn down_by_label_propagates_a_real_removal_failure_after_completing_the_rest() {
+		let containers = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-db-1"]}]"#;
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, containers.to_string())
+			} else if method == "POST" && target.contains("/stop") {
+				(200, String::new())
+			} else if method == "DELETE" && target.contains("/proj-web-1?force=true") {
+				(500, r#"{"message":"device or resource busy"}"#.to_string())
+			} else if method == "DELETE" && target.contains("/proj-db-1?force=true") {
+				(200, String::new())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let err = e
+			.down_by_label(false)
+			.await
+			.expect_err("a real container-removal failure must propagate");
+		assert!(
+			matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+			"got {err:?}"
+		);
+
+		// Best-effort: the healthy container must still have been reached even
+		// though the other one failed.
+		let seen = fake.requests.lock().unwrap();
+		assert!(
+			seen.iter()
+				.any(|r| r.contains("DELETE") && r.contains("/proj-db-1?force=true")),
+			"expected proj-db-1 to be removed despite proj-web-1 failing: {seen:?}"
+		);
+	}
+
+	/// A `down -p PROJECT` on an already torn-down project (no live containers,
+	/// nothing left to sweep by label) must still exit 0 — idempotency is
+	/// preserved on the label-only path exactly as on `Engine::down`.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn down_by_label_on_an_already_torn_down_project_is_still_ok() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, "[]".to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		e.down_by_label(false)
+			.await
+			.expect("a re-run down_by_label on a torn-down project must still exit 0");
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -463,6 +463,14 @@ impl Engine {
 		// one container-list round-trip per service (S+1 → 1 for the ordered pass).
 		let live_by_service = self.list_project_containers_by_service().await?;
 
+		// Best-effort across every container/network/volume so one failure never
+		// leaves the rest of the teardown undone, but the first real failure is
+		// remembered and returned at the end instead of being swallowed into a
+		// warning — a `down` whose container removal genuinely fails (storage
+		// error, active exec session) must exit non-zero, not print a warning and
+		// exit 0 (#598). A 404 (already gone) stays an idempotent no-op throughout.
+		let mut first_err: Option<crate::error::ComposeError> = None;
+
 		for name in &order {
 			let service = &file.services[name];
 			// Act only on containers Podman actually has. A defined-but-never-
@@ -501,6 +509,7 @@ impl Engine {
 				{
 					if !e.is_status(404) {
 						tracing::warn!("could not stop {container_name}: {e}");
+						first_err.get_or_insert(crate::error::ComposeError::Podman(e));
 					}
 				}
 
@@ -508,7 +517,10 @@ impl Engine {
 				match self.client.delete_ok(&rm_path).await {
 					Ok(()) => crate::ui::progress_line("Container", container_name, "Removed"),
 					Err(e) if e.is_status(404) => {}
-					Err(e) => tracing::warn!("could not remove {container_name}: {e}"),
+					Err(e) => {
+						tracing::warn!("could not remove {container_name}: {e}");
+						first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+					}
 				}
 			}
 		}
@@ -534,7 +546,10 @@ impl Engine {
 			match self.client.delete_ok(&net_path).await {
 				Ok(_) => crate::ui::progress_line("Network", &network_name, "Removed"),
 				Err(e) if e.is_status(404) => {}
-				Err(e) => tracing::warn!("could not remove network {network_name}: {e}"),
+				Err(e) => {
+					tracing::warn!("could not remove network {network_name}: {e}");
+					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+				}
 			}
 		}
 
@@ -563,7 +578,10 @@ impl Engine {
 				match self.client.delete_ok(&vol_path).await {
 					Ok(_) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
 					Err(e) if e.is_status(404) => {}
-					Err(e) => tracing::warn!("could not remove volume {volume_name}: {e}"),
+					Err(e) => {
+						tracing::warn!("could not remove volume {volume_name}: {e}");
+						first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+					}
 				}
 			}
 		}
@@ -571,6 +589,10 @@ impl Engine {
 		// Internal native secrets are podup-owned (not user data), so remove
 		// them unconditionally — independent of `remove_volumes`.
 		self.remove_internal_secrets(file).await?;
+
+		if let Some(e) = first_err {
+			return Err(e);
+		}
 		Ok(())
 	}
 

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -83,7 +83,7 @@ impl Engine {
 		);
 		match self.client.post_empty_ok(&path).await {
 			Ok(()) => Ok(()),
-			Err(e) if e.is_status(304) || e.is_status(404) => {
+			Err(e) if e.is_status(404) => {
 				tracing::debug!("{container_name}: start skipped ({e})");
 				Ok(())
 			}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -71,15 +71,24 @@ impl Engine {
 			.await
 	}
 
-	/// Start a container by name, ignoring an error from an already-running one.
-	/// Used when `up` leaves an unchanged container in place but wants to ensure
-	/// it is running.
-	async fn ensure_started(&self, container_name: &str) {
+	/// Start a container by name. Used when `up` leaves an unchanged container in
+	/// place but wants to ensure it is running. "Already in the desired state"
+	/// (304) and "no such container" (404) are idempotent no-ops, matching
+	/// [`Self::run_lifecycle_op`]; any other failure (e.g. the container's
+	/// published port is now taken) propagates instead of being swallowed.
+	async fn ensure_started(&self, container_name: &str) -> Result<()> {
 		let path = format!(
 			"{API_PREFIX}/containers/{}/start",
 			crate::libpod::urlencoded(container_name)
 		);
-		let _ = self.client.post_empty_ok(&path).await;
+		match self.client.post_empty_ok(&path).await {
+			Ok(()) => Ok(()),
+			Err(e) if e.is_status(304) || e.is_status(404) => {
+				tracing::debug!("{container_name}: start skipped ({e})");
+				Ok(())
+			}
+			Err(e) => Err(crate::error::ComposeError::Podman(e)),
+		}
 	}
 
 	/// Start services with explicit options. When `no_recreate` is true, running containers are left untouched. On partial failure, staging directories are cleaned up.
@@ -395,7 +404,7 @@ impl Engine {
 					tracing::debug!("{container_name} already exists — skipping recreate");
 					// `create` leaves an existing container as-is; `up` ensures it runs.
 					if start {
-						self.ensure_started(&container_name).await;
+						self.ensure_started(&container_name).await?;
 					}
 					crate::ui::progress_line(
 						"Container",
@@ -411,7 +420,7 @@ impl Engine {
 				{
 					tracing::debug!("{container_name} is up to date — skipping recreate");
 					if start {
-						self.ensure_started(&container_name).await;
+						self.ensure_started(&container_name).await?;
 					}
 					crate::ui::progress_line(
 						"Container",
@@ -620,32 +629,4 @@ pub(super) fn container_rm_path(name: &str, remove_volumes: bool) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-	use super::container_rm_path;
-
-	#[test]
-	fn rm_path_omits_volume_flag_by_default() {
-		// A plain `down` (or scale-down) must not drop volumes.
-		let path = container_rm_path("proj-web-1", false);
-		assert!(path.ends_with("/proj-web-1?force=true"), "got: {path}");
-		assert!(!path.contains("v=true"), "got: {path}");
-	}
-
-	#[test]
-	fn rm_path_requests_anonymous_volume_removal() {
-		// `down -v` must pass `v=true` so podman reclaims the container's
-		// anonymous (image VOLUME / short-form) volumes.
-		let path = container_rm_path("proj-web-1", true);
-		assert!(path.contains("force=true"), "got: {path}");
-		assert!(path.contains("&v=true"), "got: {path}");
-	}
-
-	#[test]
-	fn rm_path_url_encodes_container_name() {
-		// Names are URL-encoded so a slash in a container name cannot alter the
-		// request path.
-		let path = container_rm_path("weird/name", true);
-		assert!(!path.contains("weird/name"), "got: {path}");
-		assert!(path.contains("weird%2Fname"), "got: {path}");
-	}
-}
+mod tests;

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -464,11 +464,15 @@ impl Engine {
 		let live_by_service = self.list_project_containers_by_service().await?;
 
 		// Best-effort across every container/network/volume so one failure never
-		// leaves the rest of the teardown undone, but the first real failure is
-		// remembered and returned at the end instead of being swallowed into a
-		// warning — a `down` whose container removal genuinely fails (storage
-		// error, active exec session) must exit non-zero, not print a warning and
-		// exit 0 (#598). A 404 (already gone) stays an idempotent no-op throughout.
+		// leaves the rest of the teardown undone, but the first real REMOVAL
+		// failure is remembered and returned at the end instead of being
+		// swallowed into a warning — a `down` whose container/network/volume
+		// removal genuinely fails (storage error, active exec session) must exit
+		// non-zero, not print a warning and exit 0 (#598). A stalled or failed
+		// `stop` does NOT count towards this: the force-remove below SIGKILLs the
+		// container regardless (see `container_rm_path`), so only the removal
+		// outcome is aggregated. A 404 (already gone) stays an idempotent no-op
+		// throughout.
 		let mut first_err: Option<crate::error::ComposeError> = None;
 
 		for name in &order {
@@ -501,7 +505,10 @@ impl Engine {
 				);
 				// A 404 (container already gone, or a profile-gated service that was
 				// never created) is an idempotent no-op here, exactly as the network
-				// and volume removal arms below treat it — not a warning.
+				// and volume removal arms below treat it — not a warning. A stalled
+				// or failed stop is not fatal either: the force-remove just below
+				// SIGKILLs the container regardless, so its outcome is logged but
+				// never folded into `first_err` — only a genuine removal failure is.
 				if let Err(e) = self
 					.client
 					.post_empty_ok_within(&stop_path, targets::stop_deadline(grace))
@@ -509,7 +516,6 @@ impl Engine {
 				{
 					if !e.is_status(404) {
 						tracing::warn!("could not stop {container_name}: {e}");
-						first_err.get_or_insert(crate::error::ComposeError::Podman(e));
 					}
 				}
 
@@ -558,7 +564,11 @@ impl Engine {
 		// network whose compose key changed — mirroring the container sweep so
 		// teardown is complete regardless of how the file was parsed. Only
 		// podup-labelled networks match, so external networks are never touched.
-		self.remove_project_networks_by_label().await;
+		// This is a supplementary catch-all on top of the file-driven network
+		// loop above (which already aggregates its own failures into
+		// `first_err`), so a failure here is intentionally swallowed rather than
+		// folded in again.
+		let _ = self.remove_project_networks_by_label().await;
 
 		if remove_volumes {
 			for (key, config) in &file.volumes {

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -8,6 +8,7 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
+use super::parallel::first_error;
 use super::targets::{stop_deadline, stop_timeout_param};
 
 /// A live project container: the name to act on plus its machine-readable
@@ -139,6 +140,12 @@ impl Engine {
 	/// desired `target`-replica set (the scale-down half of reconciliation).
 	/// Surplus containers are stopped and removed concurrently so a large
 	/// scale-down costs roughly one grace period rather than one per replica.
+	///
+	/// Best-effort across every surplus replica — one that fails to stop/remove
+	/// must not block the rest from being reclaimed — but the first real
+	/// failure is remembered and returned once every replica has been
+	/// attempted, so `scale`/`up --scale` does not exit 0 with a surplus
+	/// replica silently left running (#598).
 	pub(super) async fn remove_surplus_replicas(
 		&self,
 		service_name: &str,
@@ -162,20 +169,27 @@ impl Engine {
 			.collect();
 		// Scaling down removes surplus replicas but keeps their data volumes
 		// (only `down -v` reclaims volumes).
-		futures_util::future::join_all(
+		let results = futures_util::future::join_all(
 			surplus
 				.iter()
 				.map(|name| self.stop_and_remove(name, grace, false)),
 		)
 		.await;
-		Ok(())
+		first_error(results).map_or(Ok(()), Err)
 	}
 
 	/// Stop (best-effort) then force-remove a container by name. With
 	/// `remove_volumes`, the container's anonymous volumes are reclaimed too
 	/// (`podman rm -v`), so a label-based teardown sweep does not leave image
-	/// `VOLUME`/anonymous volumes behind.
-	pub(super) async fn stop_and_remove(&self, name: &str, grace: i32, remove_volumes: bool) {
+	/// `VOLUME`/anonymous volumes behind. "No such container" (404) is an
+	/// idempotent no-op; any other removal failure propagates instead of being
+	/// swallowed into a debug log.
+	pub(super) async fn stop_and_remove(
+		&self,
+		name: &str,
+		grace: i32,
+		remove_volumes: bool,
+	) -> Result<()> {
 		// Bound the stop by the grace window: the force-remove below SIGKILLs the
 		// container, so a stop that stalls past the grace must not pin us for the
 		// full client READ_TIMEOUT before we fall through to it.
@@ -189,10 +203,16 @@ impl Engine {
 			.post_empty_ok_within(&stop_path, stop_deadline(grace))
 			.await;
 		let rm_path = super::container_rm_path(name, remove_volumes);
-		if let Err(e) = self.client.delete_ok(&rm_path).await {
-			tracing::debug!("scale-down rm {name}: {e}");
-		} else {
-			crate::ui::progress_line("Container", name, "Removed");
+		match self.client.delete_ok(&rm_path).await {
+			Ok(()) => {
+				crate::ui::progress_line("Container", name, "Removed");
+				Ok(())
+			}
+			Err(e) if e.is_status(404) => {
+				tracing::debug!("scale-down rm {name}: already gone ({e})");
+				Ok(())
+			}
+			Err(e) => Err(ComposeError::Podman(e)),
 		}
 	}
 
@@ -319,6 +339,79 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+	#[cfg(unix)]
+	use crate::engine::Engine;
+	#[cfg(unix)]
+	use crate::error::ComposeError;
+
+	#[cfg(unix)]
+	fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+	}
+
+	/// #598: a `scale`/`up --scale` down-sizing that can't remove a surplus
+	/// replica (e.g. an active exec session) must not exit 0 with it left
+	/// running — but a sibling replica that removes cleanly must still be
+	/// reclaimed.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn remove_surplus_replicas_propagates_a_real_rm_failure_after_completing_the_rest() {
+		let live = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-web-2"]}]"#;
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, live.to_string())
+			} else if (method == "POST" && target.contains("/stop"))
+				|| (method == "DELETE" && target.contains("/proj-web-1?force=true"))
+			{
+				(200, String::new())
+			} else if method == "DELETE" && target.contains("/proj-web-2?force=true") {
+				(500, r#"{"message":"device or resource busy"}"#.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		// target = 0 desired replicas, so every live container is surplus
+		// (mirrors the `replica_names_for_zero_scale_is_empty` contract).
+		let err = e
+			.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
+			.await
+			.expect_err("a real surplus-removal failure must propagate");
+		assert!(
+			matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+			"got {err:?}"
+		);
+
+		let seen = fake.requests.lock().unwrap();
+		assert!(
+			seen.iter()
+				.any(|r| r.contains("DELETE") && r.contains("/proj-web-1?force=true")),
+			"expected proj-web-1 to still be removed despite proj-web-2 failing: {seen:?}"
+		);
+	}
+
+	/// Surplus replicas that are already gone (404 on removal) stay an
+	/// idempotent no-op — a re-run of `scale` down must still exit 0.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn remove_surplus_replicas_tolerates_already_gone() {
+		let live = r#"[{"Names":["/proj-web-1"]}]"#;
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, live.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+		e.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
+			.await
+			.expect("an already-gone surplus replica must still exit 0");
+	}
+
 	use super::{
 		check_fixed_name_scale, check_replica_limit, check_scale_port_conflict, state_is_active,
 		DEFAULT_MAX_REPLICAS,

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -114,6 +114,52 @@ async fn down_propagates_a_real_removal_failure_after_completing_the_rest() {
 	);
 }
 
+/// #598 regression: `container_rm_path` always forces removal (`?force=true`),
+/// which SIGKILLs the container regardless of how `stop` went — so a stop
+/// that fails or stalls (HTTP 500) is superseded, not fatal, once the
+/// force-remove that follows it succeeds. This pins the exact gap that let the
+/// bug through: folding the `stop` failure into `first_err` made `down` return
+/// `Err` even though teardown fully succeeded.
+#[tokio::test]
+#[cfg(unix)]
+async fn down_tolerates_a_stalled_stop_when_the_force_remove_succeeds() {
+	let containers = r#"[{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}}]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else if method == "POST" && target.contains("/stop") {
+			(
+				500,
+				r#"{"message":"timed out waiting for container to exit"}"#.to_string(),
+			)
+		} else if method == "DELETE" && target.contains("/proj-web-1?force=true") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	file.services.insert("web".into(), Service::default());
+
+	e.down_with_options(&file, false)
+		.await
+		.expect("a stalled/failed stop superseded by a successful force-remove must not fail down");
+
+	let seen = fake.requests.lock().unwrap();
+	assert!(
+		seen.iter()
+			.any(|r| r.contains("POST") && r.contains("/stop")),
+		"expected the stop to have been attempted: {seen:?}"
+	);
+	assert!(
+		seen.iter()
+			.any(|r| r.contains("DELETE") && r.contains("/proj-web-1?force=true")),
+		"expected the force-remove to have been attempted: {seen:?}"
+	);
+}
+
 /// A second `down` on an already torn-down project (no live containers,
 /// nothing left to sweep) must still exit 0 — idempotency is preserved.
 #[tokio::test]

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -1,0 +1,90 @@
+use super::container_rm_path;
+
+#[cfg(unix)]
+use super::Engine;
+#[cfg(unix)]
+use crate::engine::fake_podman;
+#[cfg(unix)]
+use crate::error::ComposeError;
+
+#[cfg(unix)]
+fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+}
+
+/// #598: a repeated `up` finding a stopped-but-unchanged container must not
+/// silently succeed when the start genuinely fails (e.g. its published host
+/// port is now taken by something else).
+#[tokio::test]
+#[cfg(unix)]
+async fn ensure_started_propagates_a_real_start_failure() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/proj-web-1/start") {
+			(500, r#"{"message":"address already in use"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+	let err = e
+		.ensure_started("proj-web-1")
+		.await
+		.expect_err("a real start failure must propagate, not exit 0 silently");
+	match err {
+		ComposeError::Podman(pe) => assert!(pe.is_status(500), "got {pe}"),
+		other => panic!("expected a Podman error, got {other:?}"),
+	}
+	assert!(
+		fake.requests
+			.lock()
+			.unwrap()
+			.iter()
+			.any(|r| r.contains("/proj-web-1/start")),
+		"expected the fake socket to have received the start request"
+	);
+}
+
+/// A container that vanished between the presence check and the start
+/// (or one Podman reports as already running, 304) is an idempotent no-op,
+/// matching `run_lifecycle_op`.
+#[tokio::test]
+#[cfg(unix)]
+async fn ensure_started_tolerates_404_and_304() {
+	let fake = fake_podman::start(|_, _| (404, r#"{"message":"no such container"}"#.to_string()));
+	let e = engine_with(fake.client(), "proj");
+	e.ensure_started("proj-web-1")
+		.await
+		.expect("404 must be an idempotent no-op");
+
+	let fake = fake_podman::start(|_, _| (304, String::new()));
+	let e = engine_with(fake.client(), "proj");
+	e.ensure_started("proj-web-1")
+		.await
+		.expect("304 must be an idempotent no-op");
+}
+
+#[test]
+fn rm_path_omits_volume_flag_by_default() {
+	// A plain `down` (or scale-down) must not drop volumes.
+	let path = container_rm_path("proj-web-1", false);
+	assert!(path.ends_with("/proj-web-1?force=true"), "got: {path}");
+	assert!(!path.contains("v=true"), "got: {path}");
+}
+
+#[test]
+fn rm_path_requests_anonymous_volume_removal() {
+	// `down -v` must pass `v=true` so podman reclaims the container's
+	// anonymous (image VOLUME / short-form) volumes.
+	let path = container_rm_path("proj-web-1", true);
+	assert!(path.contains("force=true"), "got: {path}");
+	assert!(path.contains("&v=true"), "got: {path}");
+}
+
+#[test]
+fn rm_path_url_encodes_container_name() {
+	// Names are URL-encoded so a slash in a container name cannot alter the
+	// request path.
+	let path = container_rm_path("weird/name", true);
+	assert!(!path.contains("weird/name"), "got: {path}");
+	assert!(path.contains("weird%2Fname"), "got: {path}");
+}

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -3,6 +3,8 @@ use super::container_rm_path;
 #[cfg(unix)]
 use super::Engine;
 #[cfg(unix)]
+use crate::compose::types::{ComposeFile, Service};
+#[cfg(unix)]
 use crate::engine::fake_podman;
 #[cfg(unix)]
 use crate::error::ComposeError;
@@ -61,6 +63,77 @@ async fn ensure_started_tolerates_404_and_304() {
 	e.ensure_started("proj-web-1")
 		.await
 		.expect("304 must be an idempotent no-op");
+}
+
+/// Two containers to tear down: one whose removal genuinely fails (a busy
+/// mount, an active exec session), one that removes cleanly. `down` must
+/// still attempt (and complete) the second before exiting non-zero for the
+/// first (#598) — a CI teardown must not be told it succeeded.
+#[tokio::test]
+#[cfg(unix)]
+async fn down_propagates_a_real_removal_failure_after_completing_the_rest() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else if method == "POST" && target.contains("/stop") {
+			(200, String::new())
+		} else if method == "DELETE" && target.contains("/proj-web-1?force=true") {
+			(500, r#"{"message":"device or resource busy"}"#.to_string())
+		} else if method == "DELETE" && target.contains("/proj-db-1?force=true") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	file.services.insert("web".into(), Service::default());
+	file.services.insert("db".into(), Service::default());
+
+	let err = e
+		.down_with_options(&file, false)
+		.await
+		.expect_err("a real container-removal failure must propagate");
+	assert!(
+		matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+		"got {err:?}"
+	);
+
+	// Best-effort: the healthy container must still have been reached even
+	// though the other one failed.
+	let seen = fake.requests.lock().unwrap();
+	assert!(
+		seen.iter()
+			.any(|r| r.contains("DELETE") && r.contains("/proj-db-1?force=true")),
+		"expected proj-db-1 to be removed despite proj-web-1 failing: {seen:?}"
+	);
+}
+
+/// A second `down` on an already torn-down project (no live containers,
+/// nothing left to sweep) must still exit 0 — idempotency is preserved.
+#[tokio::test]
+#[cfg(unix)]
+async fn down_on_an_already_torn_down_project_is_still_ok() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, "[]".to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	file.services.insert("web".into(), Service::default());
+
+	e.down_with_options(&file, false)
+		.await
+		.expect("a re-run down on a torn-down project must still exit 0");
 }
 
 #[test]

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -15,6 +15,8 @@ pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
 pub use query::{ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsFilterOptions, PsOptions};
 mod container_config;
+#[cfg(test)]
+mod fake_podman;
 mod health;
 mod lifecycle;
 mod lock;

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -361,13 +361,28 @@ impl Engine {
 	}
 
 	/// Remove containers labelled for this project that are not defined in the current compose file.
+	///
+	/// Best-effort across every orphan — one that fails to remove must not stop
+	/// the rest from being reaped — but the first real failure is remembered and
+	/// returned once every orphan has been attempted, so a removal that
+	/// genuinely fails does not exit 0 with the orphan left behind (#598). A 404
+	/// (already gone) stays an idempotent no-op.
 	pub async fn remove_orphans(&self, file: &ComposeFile) -> Result<()> {
+		let mut first_err: Option<ComposeError> = None;
 		for name in self.orphan_container_names(file).await? {
 			tracing::info!("removing orphan container {name}");
 			let rm_path = format!("{API_PREFIX}/containers/{}?force=true", urlencoded(&name));
-			if let Err(e) = self.client.delete_ok(&rm_path).await {
-				tracing::debug!("orphan delete {name}: {e}");
+			match self.client.delete_ok(&rm_path).await {
+				Ok(()) => {}
+				Err(e) if e.is_status(404) => {}
+				Err(e) => {
+					tracing::debug!("orphan delete {name}: {e}");
+					first_err.get_or_insert(ComposeError::Podman(e));
+				}
 			}
+		}
+		if let Some(e) = first_err {
+			return Err(e);
 		}
 		Ok(())
 	}
@@ -397,6 +412,86 @@ fn filter_orphans(names: Vec<String>, known: &std::collections::HashSet<String>)
 mod tests {
 	use super::{filter_orphans, is_valid_log_time, log_query, validate_log_filters, LogsOptions};
 	use std::collections::HashSet;
+
+	#[cfg(unix)]
+	use crate::compose::types::{ComposeFile, Service};
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+	#[cfg(unix)]
+	use crate::engine::Engine;
+	#[cfg(unix)]
+	use crate::error::ComposeError;
+
+	#[cfg(unix)]
+	fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+	}
+
+	/// #598: `--remove-orphans` that can't remove every orphan (e.g. an active
+	/// exec session) must not exit 0 with one silently left behind — but a
+	/// sibling orphan that removes cleanly must still be reclaimed.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn remove_orphans_propagates_a_real_failure_after_completing_the_rest() {
+		// "web" is still declared in the file (known); the two "ghost" containers
+		// are not, so both are orphans.
+		let containers = r#"[
+			{"Names":["/proj-web-1"]},
+			{"Names":["/proj-ghost-1"]},
+			{"Names":["/proj-ghost-2"]}
+		]"#;
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, containers.to_string())
+			} else if method == "DELETE" && target.contains("/proj-ghost-1?force=true") {
+				(200, String::new())
+			} else if method == "DELETE" && target.contains("/proj-ghost-2?force=true") {
+				(500, r#"{"message":"device or resource busy"}"#.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let mut file = ComposeFile::default();
+		file.services.insert("web".into(), Service::default());
+
+		let err = e
+			.remove_orphans(&file)
+			.await
+			.expect_err("a real orphan-removal failure must propagate");
+		assert!(
+			matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+			"got {err:?}"
+		);
+
+		let seen = fake.requests.lock().unwrap();
+		assert!(
+			seen.iter()
+				.any(|r| r.contains("DELETE") && r.contains("/proj-ghost-1?force=true")),
+			"expected proj-ghost-1 to still be removed despite proj-ghost-2 failing: {seen:?}"
+		);
+	}
+
+	/// An orphan that is already gone (404) stays an idempotent no-op.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn remove_orphans_tolerates_already_gone() {
+		let containers = r#"[{"Names":["/proj-ghost-1"]}]"#;
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, containers.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+		let file = ComposeFile::default();
+
+		e.remove_orphans(&file)
+			.await
+			.expect("an already-gone orphan must still exit 0");
+	}
 
 	#[test]
 	fn filter_orphans_keeps_only_unknown_names() {


### PR DESCRIPTION
Closes #1043

Three more places where a lifecycle command reported success while the operation had actually failed — the same class as #598, which fixed stop/start/restart/kill/pause/unpause but left these behind.

- **`up` no longer reports a dead container as `Running`.** `ensure_started` — the path a repeated `up` takes for an unchanged, stopped container — discarded every error from the start call. So a start that fails for real (the host port is now taken, a bind mount source vanished) printed `Running` and exited 0. It returns a result now: an already-running (304) or already-gone (404) container stays a no-op, every other error propagates.
- **`down` (with and without a compose file) exits non-zero when a real teardown fails.** `down_with_options`, `remove_orphans`, and `down_by_label` (the `-p PROJECT` path) degraded genuine stop/rm/network/volume failures to a log line and returned `Ok`, so a `down` that couldn't remove a container exited 0 and a CI script assumed it was gone. They're best-effort now — every removal is attempted — but the first real removal failure is returned after the pass. A stalled *stop* stays non-fatal on purpose: the forced remove that follows supersedes it, so folding a stop timeout into the error would fail an otherwise-complete teardown (that was a bug in the first cut of this branch, caught in review and pinned with a test).
- **`scale` down surfaces a failure to remove surplus replicas** instead of leaving them running at exit 0.

Idempotency is preserved throughout: a 404/already-gone stays a no-op, so a second `down` on a torn-down project still exits 0.

Test plan: introduced a `#[cfg(test)]` Unix-socket libpod stand-in (`fake_podman.rs`) — the repo had no mock transport — and drove each path through it. 1209 tests pass; each fix has a test asserting `Err` on a real 500 AND `Ok` on the 404/idempotent path; the stop-tolerance test was confirmed to fail against the pre-fix code. clippy `-D warnings` and fmt clean. The podman-lane runs the whole thing against real Podman 5 and 6 on this PR.