### PR TITLE
fix: escape systemd specifiers and make quadlet uninstall ownership unforgeable

### DIFF
--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -32,16 +32,69 @@ fn container_services(units: &[quadlet::QuadletUnit]) -> Vec<String> {
 		.collect()
 }
 
-/// This project's installed quadlet unit files (`<project>-*`), sorted. Drives
-/// uninstall (remove by prefix) and rebuild (find `.build` units).
+/// The exact `podup.project` value embedded in a generated unit file, or
+/// `None` if the file carries no such label. Every unit builder in
+/// `crate::quadlet` (`container_unit`, `build_unit`, `network_unit`,
+/// `volume_unit`) stamps a `Label=podup.project=<project>` line — mirroring
+/// the ownership label the live engine and native secrets use — inside
+/// whichever `[Section]` that unit type uses. The line shape is stable
+/// regardless of section, so a plain text scan for it (rather than a full
+/// unit-file parse) is enough to recover the owner.
+fn unit_owner(path: &Path) -> Option<String> {
+	let contents = std::fs::read_to_string(path).ok()?;
+	contents.lines().find_map(|line| {
+		line.trim()
+			.strip_prefix("Label=podup.project=")
+			.map(|v| v.trim_matches('"').to_string())
+	})
+}
+
+/// This project's installed quadlet unit files, sorted. Drives uninstall
+/// (remove) and rebuild (find `.build` units).
+///
+/// A file name starting with `<project>-` is only a candidate: project names
+/// may themselves contain `-`, so `app-extra-web.container` also starts with
+/// `app-`. Matching on that prefix alone (the old behaviour) meant
+/// `uninstall -p app` matched — and `uninstall_quadlet` then stopped and
+/// deleted — the sibling project `app-extra`'s units. Each candidate is
+/// therefore opened and kept only when its embedded `podup.project` label
+/// equals `project` EXACTLY (see `unit_owner` above); the label is exact by
+/// construction; a prefix never is.
+///
+/// A candidate with no label at all (installed before this ownership check
+/// existed) cannot be proven to belong to `project` — treating "no label" as
+/// "assume it's ours" would just reopen the same hole for those legacy
+/// installs. So it is left in place, not deleted, and reported via
+/// `tracing::warn!` so the user can re-install (which re-marks it) or remove
+/// it by hand. Quadlet-mode autostart is recent, so few if any pre-existing
+/// unmarked units are expected in the field; leaving one stale file behind
+/// for a user to clean up once is a far smaller cost than deleting a
+/// sibling project's unit.
 fn installed_units(project: &str) -> Vec<PathBuf> {
 	let dir = quadlet_dir();
 	let prefix = format!("{project}-");
 	let mut found = Vec::new();
 	if let Ok(entries) = std::fs::read_dir(&dir) {
 		for entry in entries.flatten() {
-			if entry.file_name().to_string_lossy().starts_with(&prefix) {
-				found.push(entry.path());
+			let path = entry.path();
+			if !entry.file_name().to_string_lossy().starts_with(&prefix) {
+				continue;
+			}
+			match unit_owner(&path) {
+				Some(owner) if owner == project => found.push(path),
+				// A sibling project's unit that happens to share this filename
+				// prefix (e.g. `app-extra-web.container` when `project` is `app`);
+				// the label proves it is not ours, so it is left untouched.
+				Some(_) => {}
+				None => {
+					tracing::warn!(
+						"quadlet unit {} has no podup.project ownership label and cannot be \
+						 proven to belong to '{project}'; skipping it rather than risking a \
+						 sibling project's unit — re-run `podup autostart install --mode quadlet` \
+						 to re-mark it, or remove it by hand if it is stale",
+						path.display()
+					);
+				}
 			}
 		}
 	}
@@ -388,6 +441,111 @@ mod tests {
 			let calls = sc.log();
 			assert!(calls.contains(&vec!["stop".to_string(), "proj-web.service".to_string()]));
 			assert_eq!(calls.last().unwrap(), &vec!["daemon-reload".to_string()]);
+		});
+	}
+
+	// --- bug: uninstall matched units by filename prefix alone, so
+	// `uninstall -p app` also matched (and deleted) sibling project
+	// `app-extra`'s units. installed_units must scope by the exact embedded
+	// `podup.project` ownership label instead. ---
+
+	#[test]
+	fn uninstall_scoped_by_ownership_label_leaves_sibling_project_untouched() {
+		with_env(|root| {
+			install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(IMG).unwrap(),
+				"app",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(IMG).unwrap(),
+				"app-extra",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			let sc = FakeCtl::new();
+			uninstall_quadlet(&sc, "app").unwrap();
+			// Only 'app's own unit is gone...
+			assert!(!root.join("containers/systemd/app-web.container").exists());
+			// ...the sibling 'app-extra', whose file name shares the `app-` prefix,
+			// must survive untouched.
+			assert!(root
+				.join("containers/systemd/app-extra-web.container")
+				.is_file());
+			let calls = sc.log();
+			assert!(calls.contains(&vec!["stop".to_string(), "app-web.service".to_string()]));
+			assert!(!calls.contains(&vec![
+				"stop".to_string(),
+				"app-extra-web.service".to_string()
+			]));
+		});
+	}
+
+	#[test]
+	fn uninstall_skips_legacy_unmarked_unit_instead_of_deleting_it() {
+		with_env(|root| {
+			let dir = root.join("containers/systemd");
+			std::fs::create_dir_all(&dir).unwrap();
+			// A unit installed before ownership labels existed: same naming scheme
+			// as a real 'app' unit, but no `Label=podup.project=` line anywhere in
+			// it, so it cannot be proven to belong to 'app'.
+			std::fs::write(
+				dir.join("app-web.container"),
+				"[Unit]\nDescription=web (podup)\n\n\
+				 [Container]\nImage=nginx\nContainerName=app-web\n\n\
+				 [Install]\nWantedBy=default.target\n",
+			)
+			.unwrap();
+			let sc = FakeCtl::new();
+			uninstall_quadlet(&sc, "app").unwrap();
+			// Unproven ownership: skip it, never delete it.
+			assert!(dir.join("app-web.container").is_file());
+			// The reload still runs (uninstall is otherwise a no-op success, not an
+			// error) even though nothing was removed.
+			assert_eq!(sc.log().last().unwrap(), &vec!["daemon-reload".to_string()]);
+		});
+	}
+
+	#[test]
+	fn rebuild_is_scoped_by_ownership_label_and_ignores_sibling_build_units() {
+		with_env(|_root| {
+			// 'app-extra' shares the `app-` filename prefix with 'app', so a naive
+			// prefix match would treat its `.build`/container as buildable under
+			// 'app' too.
+			install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(BUILD).unwrap(),
+				"app",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			install_quadlet(
+				&FakeCtl::new(),
+				&parse_str(BUILD).unwrap(),
+				"app-extra",
+				Path::new(BASE),
+				true,
+				false,
+			)
+			.unwrap();
+			let sc = FakeCtl::new();
+			rebuild_quadlet(&sc, "app", None).unwrap();
+			assert_eq!(
+				sc.log(),
+				vec![
+					vec!["restart".to_string(), "app-web-build.service".to_string()],
+					vec!["restart".to_string(), "app-web.service".to_string()],
+				]
+			);
 		});
 	}
 

--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -32,21 +32,28 @@ fn container_services(units: &[quadlet::QuadletUnit]) -> Vec<String> {
 		.collect()
 }
 
-/// The exact `podup.project` value embedded in a generated unit file, or
-/// `None` if the file carries no such label. Every unit builder in
-/// `crate::quadlet` (`container_unit`, `build_unit`, `network_unit`,
-/// `volume_unit`) stamps a `Label=podup.project=<project>` line — mirroring
-/// the ownership label the live engine and native secrets use — inside
-/// whichever `[Section]` that unit type uses. The line shape is stable
-/// regardless of section, so a plain text scan for it (rather than a full
-/// unit-file parse) is enough to recover the owner.
+/// The project name recorded in a generated unit file's `# podup-owner:`
+/// marker, or `None` if the file carries no such marker.
+///
+/// This deliberately does NOT read the `Label=podup.project=<project>` line
+/// every unit builder in `crate::quadlet` also stamps (that label stays, but
+/// only for its original purpose — Podman uses `podup.project` for
+/// container/secret scoping at runtime). A compose service's user-supplied
+/// `labels:` renders into the very same `[Section]`, in the very same
+/// `Key=Value` shape, so a service declaring `labels: {podup.project:
+/// other}` produces a forged `Label=podup.project=other` line that is
+/// textually indistinguishable from the real one — and would be the FIRST
+/// such line if it precedes the trusted stamp, defeating a scan that takes
+/// the first match. The `# podup-owner: <project>` marker every unit builder
+/// emits as its literal first line cannot be forged the same way: systemd
+/// treats `#`-prefixed lines as comments, and compose labels only ever
+/// render as `Label=key=value` entries, never as a comment line. So this is
+/// the one place ownership is decided.
 fn unit_owner(path: &Path) -> Option<String> {
 	let contents = std::fs::read_to_string(path).ok()?;
-	contents.lines().find_map(|line| {
-		line.trim()
-			.strip_prefix("Label=podup.project=")
-			.map(|v| v.trim_matches('"').to_string())
-	})
+	contents
+		.lines()
+		.find_map(|line| line.strip_prefix("# podup-owner: ").map(str::to_string))
 }
 
 /// This project's installed quadlet unit files, sorted. Drives uninstall
@@ -57,12 +64,13 @@ fn unit_owner(path: &Path) -> Option<String> {
 /// `app-`. Matching on that prefix alone (the old behaviour) meant
 /// `uninstall -p app` matched — and `uninstall_quadlet` then stopped and
 /// deleted — the sibling project `app-extra`'s units. Each candidate is
-/// therefore opened and kept only when its embedded `podup.project` label
-/// equals `project` EXACTLY (see `unit_owner` above); the label is exact by
-/// construction; a prefix never is.
+/// therefore opened and kept only when its `# podup-owner:` marker equals
+/// `project` EXACTLY (see `unit_owner` above); the marker is exact by
+/// construction and, unlike the `Label=podup.project=` line, cannot be
+/// pre-empted by a forged line from the compose file's own `labels:`.
 ///
-/// A candidate with no label at all (installed before this ownership check
-/// existed) cannot be proven to belong to `project` — treating "no label" as
+/// A candidate with no marker at all (installed before this ownership check
+/// existed) cannot be proven to belong to `project` — treating "no marker" as
 /// "assume it's ours" would just reopen the same hole for those legacy
 /// installs. So it is left in place, not deleted, and reported via
 /// `tracing::warn!` so the user can re-install (which re-marks it) or remove
@@ -84,11 +92,11 @@ fn installed_units(project: &str) -> Vec<PathBuf> {
 				Some(owner) if owner == project => found.push(path),
 				// A sibling project's unit that happens to share this filename
 				// prefix (e.g. `app-extra-web.container` when `project` is `app`);
-				// the label proves it is not ours, so it is left untouched.
+				// the marker proves it is not ours, so it is left untouched.
 				Some(_) => {}
 				None => {
 					tracing::warn!(
-						"quadlet unit {} has no podup.project ownership label and cannot be \
+						"quadlet unit {} has no podup-owner ownership marker and cannot be \
 						 proven to belong to '{project}'; skipping it rather than risking a \
 						 sibling project's unit — re-run `podup autostart install --mode quadlet` \
 						 to re-mark it, or remove it by hand if it is stale",
@@ -275,320 +283,4 @@ pub fn rebuild_quadlet<S: SystemCtl>(
 // asserted are POSIX. Autostart is a `systemctl --user` feature, so this matches
 // the service-mode tests, which gate the same way.
 #[cfg(all(test, unix))]
-mod tests {
-	use super::{container_services, install_quadlet, rebuild_quadlet, uninstall_quadlet};
-	use crate::autostart::SystemCtl;
-	use crate::{parse_str, quadlet};
-	use std::cell::RefCell;
-	use std::os::unix::process::ExitStatusExt;
-	use std::path::Path;
-	use std::process::{ExitStatus, Output};
-
-	/// Records every `systemctl` arg vector; `loginctl` always reports linger on.
-	struct FakeCtl {
-		calls: RefCell<Vec<Vec<String>>>,
-	}
-	impl FakeCtl {
-		fn new() -> Self {
-			FakeCtl {
-				calls: RefCell::new(Vec::new()),
-			}
-		}
-		fn log(&self) -> Vec<Vec<String>> {
-			self.calls.borrow().clone()
-		}
-	}
-	impl SystemCtl for FakeCtl {
-		fn systemctl(&self, args: &[&str]) -> std::io::Result<Output> {
-			self.calls
-				.borrow_mut()
-				.push(args.iter().map(|s| s.to_string()).collect());
-			Ok(Output {
-				status: ExitStatus::from_raw(0),
-				stdout: Vec::new(),
-				stderr: Vec::new(),
-			})
-		}
-		fn loginctl(&self, _args: &[&str]) -> std::io::Result<Output> {
-			Ok(Output {
-				status: ExitStatus::from_raw(0),
-				stdout: b"yes".to_vec(),
-				stderr: Vec::new(),
-			})
-		}
-	}
-
-	/// Run `f` with a fresh temp `XDG_CONFIG_HOME`/`XDG_RUNTIME_DIR`/`USER`, so
-	/// `quadlet_dir` and the guards resolve under the temp dir.
-	fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
-		let tmp = tempfile::tempdir().unwrap();
-		let root = tmp.path().to_path_buf();
-		temp_env::with_vars(
-			[
-				("XDG_CONFIG_HOME", Some(root.as_os_str())),
-				("XDG_RUNTIME_DIR", Some(root.as_os_str())),
-				("USER", Some(std::ffi::OsStr::new("tester"))),
-			],
-			|| f(&root),
-		)
-	}
-
-	const IMG: &str = "services:\n  web:\n    image: nginx\n";
-	const BUILD: &str = "services:\n  web:\n    build: .\n";
-	const BASE: &str = "/srv/app";
-
-	#[test]
-	fn container_services_names_only_containers() {
-		let file = parse_str(IMG).unwrap();
-		let units = quadlet::generate_at(&file, "proj", Path::new(BASE)).units;
-		// The default network unit is present too, but only `.container`s become services.
-		assert_eq!(
-			container_services(&units),
-			vec!["proj-web.service".to_string()]
-		);
-	}
-
-	#[test]
-	fn install_writes_units_reloads_then_starts() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install_quadlet(
-				&sc,
-				&parse_str(IMG).unwrap(),
-				"proj",
-				Path::new(BASE),
-				false,
-				false,
-			)
-			.unwrap();
-			assert!(root.join("containers/systemd/proj-web.container").is_file());
-			let calls = sc.log();
-			assert_eq!(calls[0], vec!["daemon-reload"]);
-			assert_eq!(calls[1], vec!["start", "proj-web.service"]);
-		});
-	}
-
-	#[test]
-	fn no_start_reloads_but_starts_nothing() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install_quadlet(
-				&sc,
-				&parse_str(IMG).unwrap(),
-				"proj",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			assert!(root.join("containers/systemd/proj-web.container").is_file());
-			assert_eq!(sc.log(), vec![vec!["daemon-reload".to_string()]]);
-		});
-	}
-
-	#[test]
-	fn dry_run_writes_nothing_and_runs_no_systemctl() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install_quadlet(
-				&sc,
-				&parse_str(IMG).unwrap(),
-				"proj",
-				Path::new(BASE),
-				false,
-				true,
-			)
-			.unwrap();
-			assert!(!root.join("containers/systemd/proj-web.container").exists());
-			assert!(sc.log().is_empty());
-		});
-	}
-
-	#[test]
-	fn install_refuses_when_service_mode_is_present() {
-		with_env(|root| {
-			let sd = root.join("systemd/user");
-			std::fs::create_dir_all(&sd).unwrap();
-			std::fs::write(sd.join("podup-proj.service"), "x").unwrap();
-			let err = install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(IMG).unwrap(),
-				"proj",
-				Path::new(BASE),
-				false,
-				false,
-			)
-			.unwrap_err();
-			assert!(format!("{err}").contains("service-mode autostart unit"));
-		});
-	}
-
-	#[test]
-	fn uninstall_stops_removes_and_reloads() {
-		with_env(|root| {
-			install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(IMG).unwrap(),
-				"proj",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			let sc = FakeCtl::new();
-			uninstall_quadlet(&sc, "proj").unwrap();
-			assert!(!root.join("containers/systemd/proj-web.container").exists());
-			let calls = sc.log();
-			assert!(calls.contains(&vec!["stop".to_string(), "proj-web.service".to_string()]));
-			assert_eq!(calls.last().unwrap(), &vec!["daemon-reload".to_string()]);
-		});
-	}
-
-	// --- bug: uninstall matched units by filename prefix alone, so
-	// `uninstall -p app` also matched (and deleted) sibling project
-	// `app-extra`'s units. installed_units must scope by the exact embedded
-	// `podup.project` ownership label instead. ---
-
-	#[test]
-	fn uninstall_scoped_by_ownership_label_leaves_sibling_project_untouched() {
-		with_env(|root| {
-			install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(IMG).unwrap(),
-				"app",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(IMG).unwrap(),
-				"app-extra",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			let sc = FakeCtl::new();
-			uninstall_quadlet(&sc, "app").unwrap();
-			// Only 'app's own unit is gone...
-			assert!(!root.join("containers/systemd/app-web.container").exists());
-			// ...the sibling 'app-extra', whose file name shares the `app-` prefix,
-			// must survive untouched.
-			assert!(root
-				.join("containers/systemd/app-extra-web.container")
-				.is_file());
-			let calls = sc.log();
-			assert!(calls.contains(&vec!["stop".to_string(), "app-web.service".to_string()]));
-			assert!(!calls.contains(&vec![
-				"stop".to_string(),
-				"app-extra-web.service".to_string()
-			]));
-		});
-	}
-
-	#[test]
-	fn uninstall_skips_legacy_unmarked_unit_instead_of_deleting_it() {
-		with_env(|root| {
-			let dir = root.join("containers/systemd");
-			std::fs::create_dir_all(&dir).unwrap();
-			// A unit installed before ownership labels existed: same naming scheme
-			// as a real 'app' unit, but no `Label=podup.project=` line anywhere in
-			// it, so it cannot be proven to belong to 'app'.
-			std::fs::write(
-				dir.join("app-web.container"),
-				"[Unit]\nDescription=web (podup)\n\n\
-				 [Container]\nImage=nginx\nContainerName=app-web\n\n\
-				 [Install]\nWantedBy=default.target\n",
-			)
-			.unwrap();
-			let sc = FakeCtl::new();
-			uninstall_quadlet(&sc, "app").unwrap();
-			// Unproven ownership: skip it, never delete it.
-			assert!(dir.join("app-web.container").is_file());
-			// The reload still runs (uninstall is otherwise a no-op success, not an
-			// error) even though nothing was removed.
-			assert_eq!(sc.log().last().unwrap(), &vec!["daemon-reload".to_string()]);
-		});
-	}
-
-	#[test]
-	fn rebuild_is_scoped_by_ownership_label_and_ignores_sibling_build_units() {
-		with_env(|_root| {
-			// 'app-extra' shares the `app-` filename prefix with 'app', so a naive
-			// prefix match would treat its `.build`/container as buildable under
-			// 'app' too.
-			install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(BUILD).unwrap(),
-				"app",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(BUILD).unwrap(),
-				"app-extra",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			let sc = FakeCtl::new();
-			rebuild_quadlet(&sc, "app", None).unwrap();
-			assert_eq!(
-				sc.log(),
-				vec![
-					vec!["restart".to_string(), "app-web-build.service".to_string()],
-					vec!["restart".to_string(), "app-web.service".to_string()],
-				]
-			);
-		});
-	}
-
-	#[test]
-	fn rebuild_restarts_build_then_container() {
-		with_env(|_root| {
-			install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(BUILD).unwrap(),
-				"proj",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			let sc = FakeCtl::new();
-			rebuild_quadlet(&sc, "proj", Some("web")).unwrap();
-			assert_eq!(
-				sc.log(),
-				vec![
-					vec!["restart".to_string(), "proj-web-build.service".to_string()],
-					vec!["restart".to_string(), "proj-web.service".to_string()],
-				]
-			);
-		});
-	}
-
-	#[test]
-	fn rebuild_unknown_service_errors_and_lists_valid_ones() {
-		with_env(|_root| {
-			install_quadlet(
-				&FakeCtl::new(),
-				&parse_str(BUILD).unwrap(),
-				"proj",
-				Path::new(BASE),
-				true,
-				false,
-			)
-			.unwrap();
-			let err = rebuild_quadlet(&FakeCtl::new(), "proj", Some("nope")).unwrap_err();
-			let msg = format!("{err}");
-			assert!(msg.contains("has no build unit"), "{msg}");
-			assert!(msg.contains("web"), "{msg}");
-		});
-	}
-}
+mod tests;

--- a/internal/autostart/quadlet/tests.rs
+++ b/internal/autostart/quadlet/tests.rs
@@ -1,0 +1,386 @@
+use super::{container_services, install_quadlet, rebuild_quadlet, uninstall_quadlet};
+use crate::autostart::SystemCtl;
+use crate::{parse_str, quadlet};
+use std::cell::RefCell;
+use std::os::unix::process::ExitStatusExt;
+use std::path::Path;
+use std::process::{ExitStatus, Output};
+
+/// Records every `systemctl` arg vector; `loginctl` always reports linger on.
+struct FakeCtl {
+	calls: RefCell<Vec<Vec<String>>>,
+}
+impl FakeCtl {
+	fn new() -> Self {
+		FakeCtl {
+			calls: RefCell::new(Vec::new()),
+		}
+	}
+	fn log(&self) -> Vec<Vec<String>> {
+		self.calls.borrow().clone()
+	}
+}
+impl SystemCtl for FakeCtl {
+	fn systemctl(&self, args: &[&str]) -> std::io::Result<Output> {
+		self.calls
+			.borrow_mut()
+			.push(args.iter().map(|s| s.to_string()).collect());
+		Ok(Output {
+			status: ExitStatus::from_raw(0),
+			stdout: Vec::new(),
+			stderr: Vec::new(),
+		})
+	}
+	fn loginctl(&self, _args: &[&str]) -> std::io::Result<Output> {
+		Ok(Output {
+			status: ExitStatus::from_raw(0),
+			stdout: b"yes".to_vec(),
+			stderr: Vec::new(),
+		})
+	}
+}
+
+/// Run `f` with a fresh temp `XDG_CONFIG_HOME`/`XDG_RUNTIME_DIR`/`USER`, so
+/// `quadlet_dir` and the guards resolve under the temp dir.
+fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
+	let tmp = tempfile::tempdir().unwrap();
+	let root = tmp.path().to_path_buf();
+	temp_env::with_vars(
+		[
+			("XDG_CONFIG_HOME", Some(root.as_os_str())),
+			("XDG_RUNTIME_DIR", Some(root.as_os_str())),
+			("USER", Some(std::ffi::OsStr::new("tester"))),
+		],
+		|| f(&root),
+	)
+}
+
+const IMG: &str = "services:\n  web:\n    image: nginx\n";
+const BUILD: &str = "services:\n  web:\n    build: .\n";
+const BASE: &str = "/srv/app";
+
+#[test]
+fn container_services_names_only_containers() {
+	let file = parse_str(IMG).unwrap();
+	let units = quadlet::generate_at(&file, "proj", Path::new(BASE)).units;
+	// The default network unit is present too, but only `.container`s become services.
+	assert_eq!(
+		container_services(&units),
+		vec!["proj-web.service".to_string()]
+	);
+}
+
+#[test]
+fn install_writes_units_reloads_then_starts() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install_quadlet(
+			&sc,
+			&parse_str(IMG).unwrap(),
+			"proj",
+			Path::new(BASE),
+			false,
+			false,
+		)
+		.unwrap();
+		assert!(root.join("containers/systemd/proj-web.container").is_file());
+		let calls = sc.log();
+		assert_eq!(calls[0], vec!["daemon-reload"]);
+		assert_eq!(calls[1], vec!["start", "proj-web.service"]);
+	});
+}
+
+#[test]
+fn no_start_reloads_but_starts_nothing() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install_quadlet(
+			&sc,
+			&parse_str(IMG).unwrap(),
+			"proj",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		assert!(root.join("containers/systemd/proj-web.container").is_file());
+		assert_eq!(sc.log(), vec![vec!["daemon-reload".to_string()]]);
+	});
+}
+
+#[test]
+fn dry_run_writes_nothing_and_runs_no_systemctl() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install_quadlet(
+			&sc,
+			&parse_str(IMG).unwrap(),
+			"proj",
+			Path::new(BASE),
+			false,
+			true,
+		)
+		.unwrap();
+		assert!(!root.join("containers/systemd/proj-web.container").exists());
+		assert!(sc.log().is_empty());
+	});
+}
+
+#[test]
+fn install_refuses_when_service_mode_is_present() {
+	with_env(|root| {
+		let sd = root.join("systemd/user");
+		std::fs::create_dir_all(&sd).unwrap();
+		std::fs::write(sd.join("podup-proj.service"), "x").unwrap();
+		let err = install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(IMG).unwrap(),
+			"proj",
+			Path::new(BASE),
+			false,
+			false,
+		)
+		.unwrap_err();
+		assert!(format!("{err}").contains("service-mode autostart unit"));
+	});
+}
+
+#[test]
+fn uninstall_stops_removes_and_reloads() {
+	with_env(|root| {
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(IMG).unwrap(),
+			"proj",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		let sc = FakeCtl::new();
+		uninstall_quadlet(&sc, "proj").unwrap();
+		assert!(!root.join("containers/systemd/proj-web.container").exists());
+		let calls = sc.log();
+		assert!(calls.contains(&vec!["stop".to_string(), "proj-web.service".to_string()]));
+		assert_eq!(calls.last().unwrap(), &vec!["daemon-reload".to_string()]);
+	});
+}
+
+// --- bug: uninstall matched units by filename prefix alone, so
+// `uninstall -p app` also matched (and deleted) sibling project
+// `app-extra`'s units. installed_units must scope by the ownership marker
+// instead. ---
+
+#[test]
+fn uninstall_scoped_by_ownership_label_leaves_sibling_project_untouched() {
+	with_env(|root| {
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(IMG).unwrap(),
+			"app",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(IMG).unwrap(),
+			"app-extra",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		let sc = FakeCtl::new();
+		uninstall_quadlet(&sc, "app").unwrap();
+		// Only 'app's own unit is gone...
+		assert!(!root.join("containers/systemd/app-web.container").exists());
+		// ...the sibling 'app-extra', whose file name shares the `app-` prefix,
+		// must survive untouched.
+		assert!(root
+			.join("containers/systemd/app-extra-web.container")
+			.is_file());
+		let calls = sc.log();
+		assert!(calls.contains(&vec!["stop".to_string(), "app-web.service".to_string()]));
+		assert!(!calls.contains(&vec![
+			"stop".to_string(),
+			"app-extra-web.service".to_string()
+		]));
+	});
+}
+
+// --- bug (deeper than the one above): a compose file's own `labels:` are
+// rendered into the same `[Section]` as the trusted `Label=podup.project=`
+// stamp, in the identical `Label=key=value` shape. A service under
+// `app-extra` declaring `labels: {podup.project: app}` therefore produces a
+// unit whose FIRST `Label=podup.project=` line reads `app` (forged) and
+// whose SECOND reads `app-extra` (the real stamp). A scope check that reads
+// the first `Label=podup.project=` match — the old behaviour — resolves this
+// unit's owner as `app`, so `uninstall -p app` deletes a sibling project's
+// unit again, through a different door than the filename-prefix bug above.
+// The `# podup-owner:` marker closes this because compose `labels:` can
+// never render as a `#`-prefixed line, so it cannot be pre-empted the same
+// way. This reproduces against the label-based check and must keep passing
+// against the marker-based one. ---
+
+#[test]
+fn uninstall_ignores_forged_project_label_from_sibling_compose_file() {
+	with_env(|root| {
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(IMG).unwrap(),
+			"app",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		// `app-extra`'s own service labels forge a `Label=podup.project=app`
+		// line ahead of its real `Label=podup.project=app-extra` stamp — the
+		// exact shape a hostile or careless compose file can produce.
+		let forged = "services:\n  web:\n    image: nginx\n    labels:\n      podup.project: app\n";
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(forged).unwrap(),
+			"app-extra",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		let unit_path = root.join("containers/systemd/app-extra-web.container");
+		let contents = std::fs::read_to_string(&unit_path).unwrap();
+		// Confirm the fixture actually reproduces the forgery: the forged
+		// `Label=podup.project=app` line precedes the real
+		// `Label=podup.project=app-extra` stamp.
+		let forged_at = contents.find("Label=podup.project=app\n").unwrap();
+		let real_at = contents.find("Label=podup.project=app-extra\n").unwrap();
+		assert!(
+			forged_at < real_at,
+			"fixture did not reproduce the forged label ordering:\n{contents}"
+		);
+
+		let sc = FakeCtl::new();
+		uninstall_quadlet(&sc, "app").unwrap();
+		// 'app's own unit is gone...
+		assert!(!root.join("containers/systemd/app-web.container").exists());
+		// ...but 'app-extra's unit must survive: its `# podup-owner:` marker
+		// (unforgeable) says `app-extra`, regardless of what its forged
+		// `Label=podup.project=` line claims.
+		assert!(
+			unit_path.is_file(),
+			"forged Label=podup.project=app caused app-extra's unit to be deleted by `uninstall -p app`"
+		);
+		let calls = sc.log();
+		assert!(calls.contains(&vec!["stop".to_string(), "app-web.service".to_string()]));
+		assert!(!calls.contains(&vec![
+			"stop".to_string(),
+			"app-extra-web.service".to_string()
+		]));
+	});
+}
+
+#[test]
+fn uninstall_skips_legacy_unmarked_unit_instead_of_deleting_it() {
+	with_env(|root| {
+		let dir = root.join("containers/systemd");
+		std::fs::create_dir_all(&dir).unwrap();
+		// A unit installed before ownership markers existed: same naming scheme
+		// as a real 'app' unit, but no `# podup-owner:` marker anywhere in it, so
+		// it cannot be proven to belong to 'app'.
+		std::fs::write(
+			dir.join("app-web.container"),
+			"[Unit]\nDescription=web (podup)\n\n\
+			 [Container]\nImage=nginx\nContainerName=app-web\n\n\
+			 [Install]\nWantedBy=default.target\n",
+		)
+		.unwrap();
+		let sc = FakeCtl::new();
+		uninstall_quadlet(&sc, "app").unwrap();
+		// Unproven ownership: skip it, never delete it.
+		assert!(dir.join("app-web.container").is_file());
+		// The reload still runs (uninstall is otherwise a no-op success, not an
+		// error) even though nothing was removed.
+		assert_eq!(sc.log().last().unwrap(), &vec!["daemon-reload".to_string()]);
+	});
+}
+
+#[test]
+fn rebuild_is_scoped_by_ownership_label_and_ignores_sibling_build_units() {
+	with_env(|_root| {
+		// 'app-extra' shares the `app-` filename prefix with 'app', so a naive
+		// prefix match would treat its `.build`/container as buildable under
+		// 'app' too.
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(BUILD).unwrap(),
+			"app",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(BUILD).unwrap(),
+			"app-extra",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		let sc = FakeCtl::new();
+		rebuild_quadlet(&sc, "app", None).unwrap();
+		assert_eq!(
+			sc.log(),
+			vec![
+				vec!["restart".to_string(), "app-web-build.service".to_string()],
+				vec!["restart".to_string(), "app-web.service".to_string()],
+			]
+		);
+	});
+}
+
+#[test]
+fn rebuild_restarts_build_then_container() {
+	with_env(|_root| {
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(BUILD).unwrap(),
+			"proj",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		let sc = FakeCtl::new();
+		rebuild_quadlet(&sc, "proj", Some("web")).unwrap();
+		assert_eq!(
+			sc.log(),
+			vec![
+				vec!["restart".to_string(), "proj-web-build.service".to_string()],
+				vec!["restart".to_string(), "proj-web.service".to_string()],
+			]
+		);
+	});
+}
+
+#[test]
+fn rebuild_unknown_service_errors_and_lists_valid_ones() {
+	with_env(|_root| {
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(BUILD).unwrap(),
+			"proj",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		let err = rebuild_quadlet(&FakeCtl::new(), "proj", Some("nope")).unwrap_err();
+		let msg = format!("{err}");
+		assert!(msg.contains("has no build unit"), "{msg}");
+		assert!(msg.contains("web"), "{msg}");
+	});
+}

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -43,9 +43,19 @@ fn is_bare_safe(token: &str) -> bool {
 /// made only of the safe subset are emitted verbatim; everything else is wrapped
 /// in double quotes with `\` and `"` (and the C-style control escapes systemd
 /// understands) backslash-escaped, so a path with spaces survives as one argument.
+///
+/// A literal `%` is doubled to `%%` first, before the bare/quoted decision:
+/// systemd expands `%`-specifiers (`%h`, `%i`, `%o`, ...) in a unit value
+/// during specifier expansion, a pass that happens before the line is split
+/// into arguments and runs whether or not the token ends up quoted. `%` is not
+/// in `is_bare_safe`'s allowed set, so a token containing it already takes the
+/// quoted path — but doubling it up front (rather than only inside the quoted
+/// branch) means the escape holds even if that allowed set ever changes, and a
+/// bare-looking token like `50%off` still comes out as `50%%off`.
 fn quote_arg(token: &str) -> String {
-	if is_bare_safe(token) {
-		return token.to_string();
+	let token = token.replace('%', "%%");
+	if is_bare_safe(&token) {
+		return token;
 	}
 	let mut out = String::with_capacity(token.len() + 2);
 	out.push('"');
@@ -149,6 +159,17 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// imply a network-readiness gate that never fires. Under linger the user
 	// manager starts after the system network is already up, and podup reaches
 	// Podman over a socket on demand, so no explicit network ordering is needed.
+	//
+	// `WorkingDirectory=` takes the rest of its line literally — unlike an
+	// exec-line token, it understands none of the C-style backslash escapes
+	// `quote_arg` uses — but `%%` is not one of those escapes: it is systemd's
+	// specifier-level escape, resolved during the same specifier-expansion pass
+	// that runs over every unit-file value before the value is otherwise
+	// interpreted. That pass does not care whether the value is a directive
+	// meant to be split into words or taken whole, so doubling a literal `%`
+	// here collapses back to one literal `%` exactly as it does on an exec
+	// line, and reaches the filesystem unexpanded by any specifier.
+	let workdir = opts.working_dir.display().to_string().replace('%', "%%");
 	format!(
 		"[Unit]\n\
 		 Description=podup {project}\n\
@@ -163,7 +184,7 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 		 [Install]\n\
 		 WantedBy=default.target\n",
 		project = opts.project,
-		workdir = opts.working_dir.display(),
+		workdir = workdir,
 		start = start,
 		stop = stop,
 	)
@@ -318,5 +339,65 @@ mod tests {
 		assert_eq!(quote_arg("a b"), "\"a b\"");
 		assert_eq!(quote_arg("a\"b"), "\"a\\\"b\"");
 		assert_eq!(quote_arg("a\\b"), "\"a\\\\b\"");
+	}
+
+	// --- bug: `%`-specifiers are not escaped in unit values (systemd expands
+	// `%h`/`%i`/`%o`/... in every unit-file value, exec tokens and
+	// `WorkingDirectory=` alike; a literal `%` must be doubled to `%%` or a path
+	// like `/srv/50%off` gets `%o`-expanded, mis-resolving or failing to start). ---
+
+	#[test]
+	fn quote_arg_doubles_percent_even_in_a_bare_looking_token() {
+		// `50%off` has no space/quote/control byte — the only reason it must be
+		// quoted at all is the `%`, and the `%` itself must be doubled so systemd's
+		// specifier expansion collapses it back to one literal `%` instead of
+		// trying to expand `%o` as a specifier.
+		assert_eq!(quote_arg("50%off"), "\"50%%off\"");
+		assert_eq!(quote_arg("100%"), "\"100%%\"");
+	}
+
+	#[test]
+	fn render_service_unit_escapes_percent_in_working_directory() {
+		let mut o = opts_single();
+		o.working_dir = PathBuf::from("/srv/50%off");
+		let s = render_service_unit(&o);
+		assert!(
+			s.contains("WorkingDirectory=/srv/50%%off"),
+			"WorkingDirectory must double a literal '%' so systemd does not expand \
+			 '%o' as a specifier:\n{s}"
+		);
+		assert!(!s.contains("WorkingDirectory=/srv/50%off\n"), "{s}");
+	}
+
+	#[test]
+	fn render_service_unit_escapes_percent_in_exec_line_tokens() {
+		let mut o = opts_single();
+		o.compose_files = vec![PathBuf::from("/srv/50%off/docker-compose.yml")];
+		let s = render_service_unit(&o);
+		assert!(
+			s.contains("50%%off/docker-compose.yml"),
+			"an exec-line token containing '%' must render it doubled as '%%':\n{s}"
+		);
+		assert!(!s.contains("50%off/docker-compose.yml"), "{s}");
+	}
+
+	#[test]
+	fn render_service_unit_normal_path_round_trips_unchanged() {
+		// A path with no '%' must not be touched by the escaping fix.
+		let s = render_service_unit(&opts_single());
+		assert!(s.contains("WorkingDirectory=/srv/app"));
+		assert!(s.contains(
+			"ExecStart=/usr/local/bin/podup -f /srv/app/docker-compose.yml -p app up -d"
+		));
+	}
+
+	#[test]
+	fn validate_accepts_percent_in_paths() {
+		// A literal '%' is a legitimate path/flag character (e.g. `/srv/50%off`);
+		// it must be escaped at render time, never rejected at validation time.
+		let mut o = opts_single();
+		o.working_dir = PathBuf::from("/srv/50%off");
+		o.compose_files = vec![PathBuf::from("/srv/50%off/docker-compose.yml")];
+		assert!(validate_unit_opts(&o).is_ok());
 	}
 }

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -170,6 +170,14 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// here collapses back to one literal `%` exactly as it does on an exec
 	// line, and reaches the filesystem unexpanded by any specifier.
 	let workdir = opts.working_dir.display().to_string().replace('%', "%%");
+	// `Description=` takes its value literally, exactly like `WorkingDirectory=`
+	// above: systemd's specifier expansion runs over every unit-file value, not
+	// only the ones this module treats specially. `opts.project` is gated
+	// upstream by `is_safe_project_name` (which forbids `%`), but this module
+	// must not lean on that external guarantee for its own %-invariant — every
+	// other interpolated value here is escaped regardless of what validates it
+	// elsewhere, so the project name is too.
+	let project = opts.project.replace('%', "%%");
 	format!(
 		"[Unit]\n\
 		 Description=podup {project}\n\
@@ -183,7 +191,7 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 		 \n\
 		 [Install]\n\
 		 WantedBy=default.target\n",
-		project = opts.project,
+		project = project,
 		workdir = workdir,
 		start = start,
 		stop = stop,
@@ -389,6 +397,23 @@ mod tests {
 		assert!(s.contains(
 			"ExecStart=/usr/local/bin/podup -f /srv/app/docker-compose.yml -p app up -d"
 		));
+	}
+
+	#[test]
+	fn render_service_unit_escapes_percent_in_project_description() {
+		// `Description=` interpolates `opts.project` directly; a literal `%` in
+		// it must be doubled exactly like every other in-unit value, so systemd's
+		// specifier expansion does not treat e.g. `%h` as a specifier. This holds
+		// regardless of the external `is_safe_project_name` gate — the module's
+		// own %-invariant should not depend on it.
+		let mut o = opts_single();
+		o.project = "50%h".to_string();
+		let s = render_service_unit(&o);
+		assert!(
+			s.contains("Description=podup 50%%h"),
+			"Description= must double a literal '%' in the project name:\n{s}"
+		);
+		assert!(!s.contains("Description=podup 50%h\n"), "{s}");
 	}
 
 	#[test]

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use crate::compose::types::{BuildConfig, Service};
 
-use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
+use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
 /// Resolve a compose build `context` to an absolute `SetWorkingDirectory` value.
 ///
@@ -131,9 +131,14 @@ pub(crate) fn build_unit(
 	// Ownership label, mirroring every other generated unit.
 	section.add("Label", format!("podup.project={project}"));
 
+	// The unforgeable ownership marker comes first, as its own comment line;
+	// see `owner_marker` for why it must stay separate from the `Label=` line.
+	let mut contents = owner_marker(project);
+	contents.push_str(&section.render());
+
 	Some(QuadletUnit {
 		filename: build_unit_filename(project, name),
-		contents: section.render(),
+		contents,
 	})
 }
 

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -9,8 +9,9 @@ use crate::size::parse_duration_secs;
 use super::health::render_healthcheck;
 use super::security::{is_inline_secret, map_security_opt, render_secret};
 use super::{
-	collect_warnings, render_command, render_publish_port, render_restart, render_tmpfs_mount,
-	render_volume, sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit, Section,
+	collect_warnings, owner_marker, render_command, render_publish_port, render_restart,
+	render_tmpfs_mount, render_volume, sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit,
+	Section,
 };
 
 /// Build the `.container` unit for one compose `service`.
@@ -382,7 +383,9 @@ pub(crate) fn container_unit(
 
 	collect_warnings(name, service, warnings);
 
-	let mut contents = String::new();
+	// The unforgeable ownership marker comes first, as its own comment line;
+	// see `owner_marker` for why it must stay separate from the `Label=` line.
+	let mut contents = owner_marker(project);
 	contents.push_str(&unit.render());
 	contents.push('\n');
 	contents.push_str(&container.render());

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -20,3 +20,21 @@ use super::render::{
 };
 use super::warnings::collect_warnings;
 use super::QuadletUnit;
+
+/// The ownership marker every generated unit carries as its literal first
+/// line: a `#` comment, ignored by systemd, naming the project that owns the
+/// unit.
+///
+/// This is deliberately separate from the `Label=podup.project=<project>`
+/// line each unit also carries (kept for runtime scoping — Podman uses it for
+/// container/secret lookups). A compose service's user-supplied `labels:` are
+/// rendered into the same section as that `Label=` line, in the same
+/// `Key=Value` shape, so a service declaring `labels: {podup.project: other}`
+/// produces an indistinguishable forged `Label=podup.project=other` line
+/// ahead of the real one. A `#`-prefixed line cannot be forged the same way:
+/// compose labels only ever become `Label=key=value` entries, never a
+/// comment, so this marker is the line ownership checks (`unit_owner` in
+/// `crate::autostart::quadlet`) must read instead.
+fn owner_marker(project: &str) -> String {
+	format!("# podup-owner: {project}\n")
+}

--- a/internal/quadlet/unit/network.rs
+++ b/internal/quadlet/unit/network.rs
@@ -2,7 +2,7 @@
 
 use crate::compose::types::NetworkConfig;
 
-use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
+use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
 /// Build the `.network` unit for one declared network. Emits a single `[Network]`
 /// section (NetworkName, then driver/internal/IPv6/IPAM/options/labels), always
@@ -65,7 +65,11 @@ pub(crate) fn network_unit(
 	// No [Install] section: the spec defines none for `.network` units, which are
 	// pulled in automatically as dependencies of the `.container` units that use
 	// them. Only `.container` units carry [Install].
-	let contents = net.render();
+	//
+	// The unforgeable ownership marker comes first, as its own comment line;
+	// see `owner_marker` for why it must stay separate from the `Label=` line.
+	let mut contents = owner_marker(project);
+	contents.push_str(&net.render());
 	QuadletUnit {
 		filename: format!("{}.network", unit_stem(project, name)),
 		contents,

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -2,7 +2,7 @@
 
 use crate::compose::types::VolumeConfig;
 
-use super::{sorted_label_pairs, unit_stem, QuadletUnit, Section};
+use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
 
 /// Build the `.volume` unit for one declared named volume. Emits a single
 /// `[Volume]` section (VolumeName, then driver/driver-opts/labels), always
@@ -43,7 +43,11 @@ pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfi
 	// No [Install] section: the spec defines none for `.volume` units, which are
 	// pulled in automatically as dependencies of the `.container` units that use
 	// them. Only `.container` units carry [Install].
-	let contents = vol.render();
+	//
+	// The unforgeable ownership marker comes first, as its own comment line;
+	// see `owner_marker` for why it must stay separate from the `Label=` line.
+	let mut contents = owner_marker(project);
+	contents.push_str(&vol.render());
 	QuadletUnit {
 		filename: format!("{}.volume", unit_stem(project, name)),
 		contents,

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -46,6 +46,7 @@ networks:
 	let out = generate(&file, "proj");
 
 	let expected = "\
+# podup-owner: proj
 [Unit]
 Description=web (podup)
 After=proj-db.service
@@ -86,11 +87,11 @@ networks:
 
 	assert_eq!(
 		unit(&out, "myproj-cache.volume"),
-		"[Volume]\nVolumeName=myproj_cache\nLabel=podup.project=myproj\n"
+		"# podup-owner: myproj\n[Volume]\nVolumeName=myproj_cache\nLabel=podup.project=myproj\n"
 	);
 	assert_eq!(
 		unit(&out, "myproj-backend.network"),
-		"[Network]\nNetworkName=myproj_backend\nLabel=podup.project=myproj\n"
+		"# podup-owner: myproj\n[Network]\nNetworkName=myproj_backend\nLabel=podup.project=myproj\n"
 	);
 }
 


### PR DESCRIPTION
Closes #1047

Two autostart bugs, the second a real cross-project deletion.

- **The service unit escapes `%`.** systemd expands `%h`/`%i`/`%%` specifiers in exec tokens and `WorkingDirectory=`, so a path like `/srv/50%off/` rendered `WorkingDirectory=/srv/50%off/` and systemd read `%o` as a specifier — the unit failed to start or mis-resolved the path. Every literal `%` is now doubled to `%%` (systemd's own literal-percent escape), in exec tokens, `WorkingDirectory=`, and `Description=`.
- **`autostart uninstall -p <project>` can no longer delete another project's units.** It scoped installed units by the filename prefix `<project>-`, and because project names can contain `-`, `uninstall -p app` matched and deleted `app-extra`'s units. Scoping by the embedded `podup.project` *label* looked like the fix — but a compose file's own `labels:` render into the same section as that label, ahead of the trusted stamp, so a sibling could forge `labels: {podup.project: app}` and get itself deleted by `uninstall -p app`. The ownership marker is now a `# podup-owner: <project>` comment written as the literal first line of every generated unit: a compose label can only ever become a `Label=key=value` line, never a `#` comment, so it can't reach the marker. Uninstall and rebuild read that. A unit with no marker (installed before this change) is skipped with a warning, never deleted — an unprovable unit is left alone rather than risk removing a sibling's.

Test plan: the runtime `Label=podup.project=` stays (Podman needs it); only the ownership *check* moved to the unforgeable comment. The attack — a sibling installed from a compose file that forges the label — is a test, confirmed to delete the sibling against the label-based code and to leave it intact with the comment marker. `%`-escaping has round-trip tests for `WorkingDirectory`, exec tokens, and `Description`. 1226 unit tests plus the golden quadlet integration tests pass; clippy `-D warnings`, fmt, and `cargo doc -D warnings` clean. The podman-lane runs it against real Podman 5 and 6.