### PR TITLE
fix: harden installer transport, correct the project-name error, clean up the Windows backup

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -50,13 +50,25 @@ if ($Version -eq 'latest') {
 	Fail "PODUP_VERSION must be 'latest' or a semver tag like v1.2.3, got: $Version"
 }
 
-# Windows PowerShell 5.1 defaults to TLS 1.0/1.1; force TLS 1.2 for GitHub.
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+# Windows PowerShell 5.1 defaults to TLS 1.0/1.1; force at least TLS 1.2 for
+# GitHub, and allow TLS 1.3 too where the host's .NET Framework defines it
+# (an exact Tls12 assignment would exclude a newer, already-supported
+# protocol; older .NET Framework builds do not expose the Tls13 member, so
+# fall back to Tls12 alone rather than fail the install over it).
+try {
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+} catch {
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+}
 
 $TmpDir = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()))
 
 try {
 	# --- Download ------------------------------------------------------------
+
+	# 200 MB ceiling on any downloaded release asset - bounds a hostile/broken
+	# endpoint so it cannot fill the temp directory before verification runs.
+	$MaxDownloadBytes = 209715200
 
 	function Get-ReleaseFile($name) {
 		$dest = Join-Path $TmpDir $name
@@ -65,6 +77,9 @@ try {
 			Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
 		} catch {
 			Fail "Download failed: $url"
+		}
+		if ((Get-Item -Path $dest).Length -gt $MaxDownloadBytes) {
+			Fail "Download too large (over 200 MB): $url"
 		}
 		return $dest
 	}

--- a/install.ps1
+++ b/install.ps1
@@ -66,15 +66,20 @@ $TmpDir = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTe
 try {
 	# --- Download ------------------------------------------------------------
 
-	# 200 MB ceiling on any downloaded release asset - bounds a hostile/broken
-	# endpoint so it cannot fill the temp directory before verification runs.
+	# 200 MB ceiling on any downloaded release asset. Invoke-WebRequest runs the
+	# download to completion before -OutFile can be checked, so this is a
+	# post-hoc guard - it rejects an oversized file after it lands on disk, it
+	# does not cap a hostile stream mid-flight. -TimeoutSec is the bound that
+	# actually applies while the request is in flight: it caps the whole
+	# request so a stalled or never-ending response cannot hang the installer.
 	$MaxDownloadBytes = 209715200
+	$DownloadTimeoutSec = 300
 
 	function Get-ReleaseFile($name) {
 		$dest = Join-Path $TmpDir $name
 		$url = "$BaseUrl/$name"
 		try {
-			Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+			Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing -TimeoutSec $DownloadTimeoutSec
 		} catch {
 			Fail "Download failed: $url"
 		}

--- a/install.sh
+++ b/install.sh
@@ -91,12 +91,19 @@ download() {
 	# download <url> <dest>
 	#
 	# --proto '=https' only restricts the initial URL: GitHub release assets
-	# redirect to its CDN, and that redirect is governed by --proto-redir,
-	# which defaults to allowing http. Pin it too so a redirect can never
-	# downgrade the transfer. --max-filesize bounds a hostile/broken endpoint
-	# to 200 MB so it cannot fill the tempdir before checksum/signature
-	# verification runs.
-	curl --proto '=https' --proto-redir '=https' --tlsv1.2 --max-filesize 209715200 \
+	# redirect to its CDN, and that redirect is governed by --proto-redir, not
+	# --proto, so it needs its own pin - this is the fix that actually closes
+	# the downgrade (an unpinned redirect could otherwise fall back to http).
+	# --max-filesize caps the response at 200 MB, but only on curl that honours
+	# it: it aborts mid-stream on curl >= 8.4.0, or on any curl version when the
+	# server sends Content-Length. It does NOT bound the size on an older curl
+	# (still the default on several supported distros) talking to a server that
+	# omits Content-Length - that combination is not covered by this flag.
+	# --max-time is the version-independent backstop: it caps the whole request
+	# at 300s regardless of curl version or response headers, so a stalled or
+	# never-ending response cannot hang the installer.
+	curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+		--max-filesize 209715200 --max-time 300 \
 		-fsSL -o "$2" "$1" || fail "Download failed: $1"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,15 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 download() {
 	# download <url> <dest>
-	curl --proto '=https' --tlsv1.2 -fsSL -o "$2" "$1" || fail "Download failed: $1"
+	#
+	# --proto '=https' only restricts the initial URL: GitHub release assets
+	# redirect to its CDN, and that redirect is governed by --proto-redir,
+	# which defaults to allowing http. Pin it too so a redirect can never
+	# downgrade the transfer. --max-filesize bounds a hostile/broken endpoint
+	# to 200 MB so it cannot fill the tempdir before checksum/signature
+	# verification runs.
+	curl --proto '=https' --proto-redir '=https' --tlsv1.2 --max-filesize 209715200 \
+		-fsSL -o "$2" "$1" || fail "Download failed: $1"
 }
 
 # Baked-in base64 (unpadded) raw Ed25519 public keys (32 bytes each) matching the

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 #   curl -fsSL https://glyndor.net/podup/install/unix | bash
 #
 # --apt (Debian/Ubuntu, amd64/arm64): set up the Glyndor apt repository and install
-# with apt. Updates — including signing-key renewals — come from `apt upgrade`.
+# with apt. Updates - including signing-key renewals - come from `apt upgrade`.
 #
 #   curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
 #
@@ -191,8 +191,8 @@ install_apt() {
 	ed25519_verify "${TMP_DIR}/${kr}.sig" "${TMP_DIR}/${kr}" || kr_rc=$?
 	case "$kr_rc" in
 		0) log_ok "Keyring signature verified" ;;
-		1) fail "Keyring signature verification failed — aborting (package may be tampered)" ;;
-		2) fail "Cannot verify keyring signature: install python3 with the 'cryptography' package (and a configured release key) — aborting" ;;
+		1) fail "Keyring signature verification failed - aborting (package may be tampered)" ;;
+		2) fail "Cannot verify keyring signature: install python3 with the 'cryptography' package (and a configured release key) - aborting" ;;
 	esac
 
 	run_root dpkg -i "${TMP_DIR}/${kr}"
@@ -214,7 +214,7 @@ install_binary() {
 
 	# Checksum alone is not a trust anchor: a tampered release can ship a matching
 	# SHA256SUMS. The binary is trusted only after at least one cryptographic proof
-	# tied to the release key or the repository's build identity succeeds — the
+	# tied to the release key or the repository's build identity succeeds - the
 	# Ed25519 signature over SHA256SUMS, or the GitHub build-provenance attestation.
 	# If neither verifier can run, the install fails closed.
 	local verified=0 rc=0
@@ -223,10 +223,10 @@ install_binary() {
 	ed25519_verify "${TMP_DIR}/SHA256SUMS.sig" "${TMP_DIR}/SHA256SUMS" || rc=$?
 	case "$rc" in
 		0) log_ok "SHA256SUMS signature verified"; verified=1 ;;
-		1) fail "SHA256SUMS signature verification failed — release may be tampered" ;;
+		1) fail "SHA256SUMS signature verification failed - release may be tampered" ;;
 		2)
 			if [[ ${#PUBKEYS[@]} -eq 0 ]]; then
-				log_info "no release public key configured — skipping Ed25519 signature check"
+				log_info "no release public key configured - skipping Ed25519 signature check"
 			else
 				# A release public key IS configured: the pinned key is the trust
 				# anchor and must not be silently bypassed in favour of the
@@ -240,7 +240,7 @@ release signature against the pinned key. Install it and re-run."
 	# Build-provenance attestation: proves the binary was produced by this repo's
 	# release workflow (GitHub OIDC). Defence-in-depth next to the pinned key;
 	# the trust anchor when no release public key is configured. Pinned to the
-	# release workflow — a repo-scoped check would accept an attestation from any
+	# release workflow - a repo-scoped check would accept an attestation from any
 	# workflow in the repo.
 	if command -v gh >/dev/null 2>&1 && gh attestation --help >/dev/null 2>&1; then
 		log_info "Verifying artifact attestation ..."
@@ -250,11 +250,11 @@ release signature against the pinned key. Install it and re-run."
 		log_ok "Attestation verified"
 		verified=1
 	else
-		log_info "GitHub CLI with attestation support not found — cannot check attestation"
+		log_info "GitHub CLI with attestation support not found - cannot check attestation"
 	fi
 
 	# Fail closed: a strong cryptographic proof is mandatory. A checksum alone is
-	# not a trust anchor, and there is no opt-out — government and hardened
+	# not a trust anchor, and there is no opt-out - government and hardened
 	# environments require verifiable supply-chain integrity at install time.
 	if [[ "$verified" -ne 1 ]]; then
 		fail "No signature or attestation verifier available. Install 'gh' (>= 2.49) \

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -47,8 +47,9 @@ pub(crate) fn validate_project_name(project: &str) -> podup::Result<()> {
 		Ok(())
 	} else {
 		Err(podup::ComposeError::Unsupported(format!(
-			"project name {project:?} is not a safe path component: use only ASCII \
-			 letters, digits, '-', '_', '.', not starting with '.', max 128 chars"
+			"project name {project:?} is not a safe path component: must be \
+			 lowercase ASCII, starting with a letter or digit, followed only by \
+			 lowercase letters, digits, '-' or '_', max 128 chars"
 		)))
 	}
 }
@@ -224,6 +225,32 @@ pub(crate) fn parse_cli() -> Cli {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn validate_project_name_message_matches_the_enforced_rule() {
+		// Pins the error text to what `is_safe_project_name` actually enforces
+		// (lowercase-only, no '.'), not the looser rule the message used to
+		// describe. `My.App` is exactly the kind of name the old wording
+		// ("ASCII letters, digits, '-', '_', '.'") implied was fine, yet
+		// `is_safe_project_name` has always rejected it (uppercase and '.'
+		// are both disallowed) - a user following the old message would still
+		// get bounced.
+		let err = validate_project_name("My.App").unwrap_err();
+		let msg = err.to_string();
+		assert!(
+			msg.contains("lowercase"),
+			"message must say the name must be lowercase: {msg:?}"
+		);
+		assert!(
+			!msg.contains("'.'"),
+			"message must not list '.' as an allowed character: {msg:?}"
+		);
+	}
+
+	#[test]
+	fn validate_project_name_accepts_a_safe_name() {
+		assert!(validate_project_name("my-app").is_ok());
+	}
 
 	#[test]
 	fn label_only_covers_ps_and_events() {

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -4,8 +4,11 @@
 //! directory as the target (so the final swap is a same-filesystem rename, which
 //! is atomic) and then moved into place. On Unix the running binary's inode can
 //! be replaced directly. On Windows a running `.exe` cannot be overwritten, so
-//! the current file is renamed aside (`.old`) first and cleaned up on the next
-//! run.
+//! the current file is renamed aside (`.old`) first. The immediate best-effort
+//! delete of that backup can fail while the old process still holds the file
+//! open; when it does, the leftover is removed at the start of the next
+//! updater run (`cleanup_stale_backup`, called from [`crate::update::run`]),
+//! not merely "the next run" of the binary in general.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -257,6 +260,20 @@ fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
 	Ok(())
 }
 
+/// Best-effort removal of a `.old` backup [`swap_into_place`] could not delete
+/// immediately because the old process still held the file open. Call once at
+/// the start of every updater run ([`crate::update::run`]): by then the
+/// process that produced the backup has exited, so the file is no longer
+/// locked and the leftover clears on this run rather than lingering until the
+/// user happens to run another update. Silently does nothing if there is no
+/// leftover, or if removal still fails for some other reason.
+#[cfg(windows)]
+pub(crate) fn cleanup_stale_backup() {
+	if let Ok(exe) = std::env::current_exe() {
+		let _ = std::fs::remove_file(exe.with_extension("old"));
+	}
+}
+
 /// Turn a rename failure into an actionable error, calling out the common
 /// permission case (system install dirs need elevation).
 fn rename_error(e: std::io::Error, target: &Path) -> ComposeError {
@@ -482,5 +499,35 @@ mod tests {
 			}
 			_ => panic!("expected an Update error"),
 		}
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn cleanup_stale_backup_removes_a_leftover_old_file() {
+		// Simulates the case swap_into_place leaves behind: an `.old` sibling of
+		// the running executable that its own best-effort delete could not
+		// remove because the old process still held it open. The next updater
+		// run calls this once nothing holds the file anymore, and it must go.
+		let exe = std::env::current_exe().unwrap();
+		let backup = exe.with_extension("old");
+		std::fs::write(&backup, b"leftover backup").unwrap();
+
+		cleanup_stale_backup();
+
+		assert!(!backup.exists(), "the stale .old backup must be removed");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn cleanup_stale_backup_is_a_no_op_without_a_leftover() {
+		// No `.old` file present is the common case (a normal run, or a
+		// platform that never took the Windows swap path) - must not error.
+		let exe = std::env::current_exe().unwrap();
+		let backup = exe.with_extension("old");
+		let _ = std::fs::remove_file(&backup);
+
+		cleanup_stale_backup();
+
+		assert!(!backup.exists());
 	}
 }

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -245,7 +245,8 @@ fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
 fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
 	// A running .exe cannot be overwritten, but it can be renamed. Move it aside,
 	// put the new binary in place, then best-effort delete the old one (it may
-	// still be locked while running — the next run cleans it up).
+	// still be locked while running - if so, it is removed at the start of the
+	// next updater run by `cleanup_stale_backup`).
 	let backup = target.with_extension("old");
 	let _ = std::fs::remove_file(&backup);
 	if target.exists() {

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -37,6 +37,14 @@ pub trait ReleaseSource {
 
 /// Run an update against GitHub for the version compiled into this binary.
 pub fn run(opts: UpdateOptions) -> crate::Result<()> {
+	// Best-effort cleanup of a `.old` backup a prior Windows swap could not
+	// delete immediately (the old process still held it open). By the time
+	// any updater run starts, that process has exited, so this is the
+	// earliest point the leftover can go - see the module doc on
+	// `install::swap_into_place`.
+	#[cfg(windows)]
+	install::cleanup_stale_backup();
+
 	let source = GitHubSource::default();
 	run_with(&source, env!("CARGO_PKG_VERSION"), opts)
 }


### PR DESCRIPTION
Closes #1049

Four smaller items.

- **The installers pin the redirect transport and bound the download.** `install.sh` restricted only the initial URL to https; GitHub always redirects release assets to its CDN, and that hop is governed by `--proto-redir`, which defaulted to allowing plaintext — so the actual asset could come over HTTP. It's `--proto-redir '=https'` now, with `--max-filesize` and a `--max-time 300` backstop (the size flag only bites on curl ≥ 8.4.0 or when the server sends Content-Length, so the time bound is the version-independent guard against a stalled or endless response — the comment says so plainly rather than overclaiming). `install.ps1` now allows TLS 1.3 as well as 1.2 (with a fallback for frameworks that lack it), a `-TimeoutSec`, and a post-download size rejection. The signature and checksum still gate what actually executes; this is defense-in-depth on the transport and the temp dir.
- **The Windows `.old` backup gets cleaned up.** The self-updater renames the running exe aside and only the next update deleted it, so it could linger forever if the user never updated again. A best-effort cleanup now runs at the start of every updater invocation (by then the old process has exited), and the doc says what actually happens.
- **The `-p <name>` error message matches the rule.** It described uppercase letters and `.` as allowed, but `is_safe_project_name` requires lowercase ASCII starting with a letter or digit — so a user typing `My.App` and following the message stayed rejected. The message now states the real rule, pinned by a test.
- **`install.sh` is ASCII-only**, matching `install.ps1` (a prior mojibake incident on Windows PowerShell drove that rule).

Test plan: `shellcheck install.sh` clean; both installers ASCII-only; the `.old` cleanup and the corrected message have Rust tests (1226 unit + workspace, clippy `-D warnings`, fmt, `cargo doc -D warnings` all clean); `install.ps1` is CI-lint-only (no local PSScriptAnalyzer). The installer-contract check confirms no asset name moved.