### PR TITLE
perf: parallelize down teardown within each dependency level

### DIFF
--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -38,37 +38,21 @@ impl Engine {
 	/// force-remove that follows SIGKILLs the container regardless (the
 	/// container-removal path forces removal), so only a genuine removal failure
 	/// aggregates. A 404 (already gone) stays an idempotent no-op throughout.
+	///
+	/// With no compose file there is no dependency graph to level, so — unlike
+	/// [`Engine::down_with_options`]'s level walk — every labelled container is
+	/// independent from podup's point of view and all of them tear down in one
+	/// bounded concurrent batch instead of strictly sequentially.
 	pub async fn down_by_label(&self, remove_volumes: bool) -> Result<()> {
 		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);
 		let mut first_err: Option<crate::error::ComposeError> = None;
 
-		for container_name in self.list_project_container_names(None).await? {
-			let stop_path = format!(
-				"{API_PREFIX}/containers/{}/stop?t={}",
-				urlencoded(&container_name),
-				super::targets::stop_timeout_param(grace),
-			);
-			// A 404 (already gone) is an idempotent no-op, like the network/volume
-			// arms below; the force-remove that follows SIGKILLs a stubborn one.
-			if let Err(e) = self
-				.client
-				.post_empty_ok_within(&stop_path, super::targets::stop_deadline(grace))
-				.await
-			{
-				if !e.is_status(404) {
-					tracing::warn!("could not stop {container_name}: {e}");
-				}
-			}
-
-			let rm_path = super::container_rm_path(&container_name, remove_volumes);
-			match self.client.delete_ok(&rm_path).await {
-				Ok(()) => crate::ui::progress_line("Container", &container_name, "Removed"),
-				Err(e) if e.is_status(404) => {}
-				Err(e) => {
-					tracing::warn!("could not remove {container_name}: {e}");
-					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
-				}
-			}
+		let containers = self.list_project_container_names(None).await?;
+		let futs = containers.iter().map(|container_name| {
+			self.teardown_one_container(container_name, grace, &[], remove_volumes)
+		});
+		if let Some(e) = super::parallel::first_error(super::parallel::join_bounded(futs).await) {
+			first_err.get_or_insert(e);
 		}
 
 		// Networks and named volumes are reaped by label; each sweep is

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -456,16 +456,20 @@ impl Engine {
 
 	/// Stop and remove services in reverse dependency order. Optionally removes named volumes and orphaned containers.
 	pub async fn down_with_options(&self, file: &ComposeFile, remove_volumes: bool) -> Result<()> {
-		let mut order = crate::compose::resolve_order(file)?;
-		order.reverse();
+		let mut levels = crate::compose::resolve_levels(file)?;
+		// Teardown inverts startup: a dependent must stop before the service it
+		// depends on, so the dependency levels `up` would walk front-to-back are
+		// walked back-to-front here (the same inversion the other lifecycle
+		// commands' level walk uses, see `parallel.rs`).
+		levels.reverse();
 
 		// Prefetch every project container once and group by service, instead of
-		// one container-list round-trip per service (S+1 → 1 for the ordered pass).
+		// one container-list round-trip per service (S+1 → 1 for the level walk).
 		let live_by_service = self.list_project_containers_by_service().await?;
 
-		// Best-effort across every container/network/volume so one failure never
-		// leaves the rest of the teardown undone, but the first real REMOVAL
-		// failure is remembered and returned at the end instead of being
+		// Best-effort across every level/container/network/volume so one failure
+		// never leaves the rest of the teardown undone, but the first real
+		// REMOVAL failure is remembered and returned at the end instead of being
 		// swallowed into a warning — a `down` whose container/network/volume
 		// removal genuinely fails (storage error, active exec session) must exit
 		// non-zero, not print a warning and exit 0 (#598). A stalled or failed
@@ -473,66 +477,51 @@ impl Engine {
 		// container regardless (see `container_rm_path`), so only the removal
 		// outcome is aggregated. A 404 (already gone) stays an idempotent no-op
 		// throughout.
+		//
+		// Levels are walked strictly in order — every container in one level is
+		// attempted before the next level starts, preserving the dependency
+		// inversion above — but the containers *within* one level tear down
+		// concurrently via `join_bounded`, which returns results in input
+		// (service, then container) order rather than completion order. That
+		// keeps "the first error" deterministic regardless of which container
+		// happens to finish first: `first_error` picks the earliest in that
+		// fixed order, and since levels themselves are visited in a fixed
+		// sequence, only the first level with any failure can ever set
+		// `first_err` — a later level's failure is never mistaken for "first".
 		let mut first_err: Option<crate::error::ComposeError> = None;
 
-		for name in &order {
-			let service = &file.services[name];
-			// Act only on containers Podman actually has. A defined-but-never-
-			// created service (or one already torn down) has no live containers,
-			// so skip it rather than synthesizing predicted names and POSTing
-			// stop/rm to them — those 404 and, pre-fix, leaked warnings. docker
-			// compose enumerates by label and treats "nothing there" as a quiet
-			// idempotent no-op (#758).
-			let Some(container_names) = live_by_service.get(name).filter(|live| !live.is_empty())
-			else {
-				continue;
-			};
-			for container_name in container_names {
-				for hook in &service.pre_stop {
-					if let Err(e) = self.run_lifecycle_hook(container_name, hook).await {
-						tracing::debug!("pre_stop hook {container_name}: {e}");
-					}
-				}
-
+		for level in &levels {
+			let futs = level.iter().flat_map(|name| {
+				let service = &file.services[name];
 				let grace = self.grace_period_secs(service);
-				// Bound the stop by the grace window so a container ignoring SIGTERM
-				// does not pin recreation for the full client READ_TIMEOUT; the
-				// force-remove below SIGKILLs it regardless.
-				let stop_path = format!(
-					"{API_PREFIX}/containers/{}/stop?t={}",
-					crate::libpod::urlencoded(container_name),
-					targets::stop_timeout_param(grace),
-				);
-				// A 404 (container already gone, or a profile-gated service that was
-				// never created) is an idempotent no-op here, exactly as the network
-				// and volume removal arms below treat it — not a warning. A stalled
-				// or failed stop is not fatal either: the force-remove just below
-				// SIGKILLs the container regardless, so its outcome is logged but
-				// never folded into `first_err` — only a genuine removal failure is.
-				if let Err(e) = self
-					.client
-					.post_empty_ok_within(&stop_path, targets::stop_deadline(grace))
-					.await
-				{
-					if !e.is_status(404) {
-						tracing::warn!("could not stop {container_name}: {e}");
-					}
-				}
-
-				let rm_path = container_rm_path(container_name, remove_volumes);
-				match self.client.delete_ok(&rm_path).await {
-					Ok(()) => crate::ui::progress_line("Container", container_name, "Removed"),
-					Err(e) if e.is_status(404) => {}
-					Err(e) => {
-						tracing::warn!("could not remove {container_name}: {e}");
-						first_err.get_or_insert(crate::error::ComposeError::Podman(e));
-					}
-				}
+				// Act only on containers Podman actually has. A defined-but-never-
+				// created service (or one already torn down) has no live
+				// containers, so it contributes nothing here rather than
+				// synthesizing predicted names and POSTing stop/rm to them —
+				// those 404 and, pre-fix, leaked warnings. docker compose
+				// enumerates by label and treats "nothing there" as a quiet
+				// idempotent no-op (#758).
+				live_by_service
+					.get(name)
+					.filter(|live| !live.is_empty())
+					.into_iter()
+					.flatten()
+					.map(move |container_name| {
+						self.teardown_one_container(
+							container_name,
+							grace,
+							&service.pre_stop,
+							remove_volumes,
+						)
+					})
+			});
+			if let Some(e) = parallel::first_error(parallel::join_bounded(futs).await) {
+				first_err.get_or_insert(e);
 			}
 		}
 
 		// Scaled replicas (`up --scale`/`scale`) carry the `podup.service` label
-		// of a service still in the file, so the ordered pass above already swept
+		// of a service still in the file, so the level walk above already swept
 		// them via `live_by_service`. Orphan containers of services *removed* from
 		// the file are deliberately NOT touched here: docker compose only reaps
 		// them under `--remove-orphans`, which the dispatch layer handles via

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -4,20 +4,21 @@
 //! ([`crate::compose::resolve_levels`]): every service in one level has its
 //! `depends_on` satisfied by an earlier level, so services *within* a level have
 //! no ordering between them and can be acted on concurrently. The whole-project
-//! lifecycle commands (stop/start/restart/kill/rm/pause/unpause) walk the levels
-//! in order — preserving the cross-level dependency ordering — but dispatch each
-//! level's per-service operations in parallel instead of strictly serially, so a
-//! restart/stop of many independent services no longer serializes every grace
-//! period (#757). This mirrors what the `up`/`create` path already does.
+//! lifecycle commands (stop/start/restart/kill/rm/pause/unpause/down) walk the
+//! levels in order — preserving the cross-level dependency ordering — but
+//! dispatch each level's per-service (or, for teardown, per-container)
+//! operations in parallel instead of strictly serially, so a restart/stop/down
+//! of many independent services no longer serializes every grace period (#757).
+//! This mirrors what the `up`/`create` path already does.
 
 use std::collections::HashSet;
 
-use crate::compose::types::{ComposeFile, Service};
+use crate::compose::types::{ComposeFile, LifecycleHook, Service};
 use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
-use super::targets::stop_timeout_param;
+use super::targets::{stop_deadline, stop_timeout_param};
 
 /// Upper bound on the number of same-level services a lifecycle command acts on
 /// concurrently. Services within a dependency level have no ordering between
@@ -282,6 +283,71 @@ impl Engine {
 			}
 		}
 		first_err.map_or(Ok(()), Err)
+	}
+
+	/// Tear down one already-known-live container: run its `pre_stop` hooks (if
+	/// any), a best-effort stop bounded by `grace`, then a forced removal. One
+	/// unit of work in a concurrent teardown level/batch — shared by
+	/// [`super::Engine::down_with_options`] (per dependency level) and
+	/// [`super::Engine::down_by_label`] (one label-scoped batch, no dependency
+	/// graph to level).
+	///
+	/// A stalled or failed `stop` is never surfaced as an error here — the
+	/// forced removal that follows SIGKILLs the container regardless of how
+	/// `stop` went (`container_rm_path` always passes `force=true`), so only a
+	/// genuine removal failure propagates. A 404 (container already gone) is an
+	/// idempotent no-op at every step. This preserves the pre-parallel `down`
+	/// error semantics (#598) byte-for-byte; only the dispatch became
+	/// concurrent.
+	pub(super) async fn teardown_one_container(
+		&self,
+		container_name: &str,
+		grace: i32,
+		pre_stop: &[LifecycleHook],
+		remove_volumes: bool,
+	) -> Result<()> {
+		for hook in pre_stop {
+			if let Err(e) = self.run_lifecycle_hook(container_name, hook).await {
+				tracing::debug!("pre_stop hook {container_name}: {e}");
+			}
+		}
+
+		// Bound the stop by the grace window so a container ignoring SIGTERM
+		// does not pin recreation for the full client READ_TIMEOUT; the
+		// force-remove below SIGKILLs it regardless.
+		let stop_path = format!(
+			"{API_PREFIX}/containers/{}/stop?t={}",
+			urlencoded(container_name),
+			stop_timeout_param(grace),
+		);
+		// A 404 (container already gone, or a profile-gated service that was
+		// never created) is an idempotent no-op here, exactly as the network and
+		// volume removal arms treat it — not a warning. A stalled or failed stop
+		// is not fatal either: the force-remove just below SIGKILLs the
+		// container regardless, so its outcome is logged but never returned as
+		// an error — only a genuine removal failure is.
+		if let Err(e) = self
+			.client
+			.post_empty_ok_within(&stop_path, stop_deadline(grace))
+			.await
+		{
+			if !e.is_status(404) {
+				tracing::warn!("could not stop {container_name}: {e}");
+			}
+		}
+
+		let rm_path = super::container_rm_path(container_name, remove_volumes);
+		match self.client.delete_ok(&rm_path).await {
+			Ok(()) => {
+				crate::ui::progress_line("Container", container_name, "Removed");
+				Ok(())
+			}
+			Err(e) if e.is_status(404) => Ok(()),
+			Err(e) => {
+				tracing::warn!("could not remove {container_name}: {e}");
+				Err(ComposeError::Podman(e))
+			}
+		}
 	}
 }
 

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -182,6 +182,161 @@ async fn down_on_an_already_torn_down_project_is_still_ok() {
 		.expect("a re-run down on a torn-down project must still exit 0");
 }
 
+/// `down` now walks dependency levels (reversed) instead of a flat reversed
+/// order, fanning out within a level via `join_bounded`. `web depends_on db`
+/// puts web alone in the first (post-reversal) level and db alone in the
+/// second, so this isolates the cross-level ordering guarantee from
+/// within-level concurrency: web's whole teardown (stop + rm) must complete
+/// before db is even asked to stop, exactly like the pre-parallel flat
+/// reversed-order walk.
+#[tokio::test]
+#[cfg(unix)]
+async fn down_tears_down_dependent_levels_before_their_dependencies() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else if (method == "POST" && target.contains("/stop"))
+			|| (method == "DELETE" && target.contains("force=true"))
+		{
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let file = crate::parse_str(
+		"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
+	)
+	.unwrap();
+
+	e.down_with_options(&file, false)
+		.await
+		.expect("a healthy two-level teardown must succeed");
+
+	let seen = fake.requests.lock().unwrap();
+	let web_rm = seen
+		.iter()
+		.position(|r| r.contains("DELETE") && r.contains("proj-web-1?force=true"))
+		.expect("web must have been removed");
+	let db_stop = seen
+		.iter()
+		.position(|r| r.contains("POST") && r.contains("proj-db-1") && r.contains("stop"))
+		.expect("db must have been stopped");
+	assert!(
+		web_rm < db_stop,
+		"expected web's level to fully complete before db's level's stop begins: {seen:?}"
+	);
+}
+
+/// `web` and `cache` share no `depends_on` relationship, so `resolve_levels`
+/// groups them into a single level and `down_with_options` dispatches both
+/// containers' teardown through the same `join_bounded` (`buffer_unordered`)
+/// mechanism proven order-independent by
+/// `parallel::tests::join_bounded_preserves_input_order`, instead of one
+/// await-per-container in strict sequence. Asserting real wall-clock overlap
+/// against a synchronous test responder would require a multi-thread runtime
+/// and a blocking rendezvous inside the fake — a source of exactly the
+/// flakiness the testing standard forbids — so this test instead pins the
+/// dispatch contract (both containers are targeted, the level completes) and
+/// leaves the concurrency guarantee itself to `join_bounded`'s own test plus
+/// the code structure (no `.await` between the two containers' futures).
+#[tokio::test]
+#[cfg(unix)]
+async fn down_targets_every_independent_service_within_one_level() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-cache-1"],"Labels":{"podup.service":"cache"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else if (method == "POST" && target.contains("/stop"))
+			|| (method == "DELETE" && target.contains("force=true"))
+		{
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	file.services.insert("web".into(), Service::default());
+	file.services.insert("cache".into(), Service::default());
+
+	e.down_with_options(&file, false)
+		.await
+		.expect("a healthy single-level teardown of two independent services must succeed");
+
+	let seen = fake.requests.lock().unwrap();
+	assert!(
+		seen.iter()
+			.any(|r| r.contains("DELETE") && r.contains("proj-web-1?force=true")),
+		"expected web to have been targeted: {seen:?}"
+	);
+	assert!(
+		seen.iter()
+			.any(|r| r.contains("DELETE") && r.contains("proj-cache-1?force=true")),
+		"expected cache to have been targeted: {seen:?}"
+	);
+}
+
+/// Determinism regression: with `web depends_on db`, both containers' removal
+/// fail with distinct statuses. Levels are visited in a fixed order (web's
+/// level first, post-reversal), so `down` must return web's failure — never
+/// db's — regardless of how `join_bounded`'s internal `buffer_unordered`
+/// happens to interleave completions within each level. db's level must still
+/// be attempted (best-effort teardown continues past the first failing
+/// level).
+#[tokio::test]
+#[cfg(unix)]
+async fn down_first_error_is_deterministic_across_levels() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else if method == "POST" && target.contains("/stop") {
+			(200, String::new())
+		} else if method == "DELETE" && target.contains("proj-web-1?force=true") {
+			(500, r#"{"message":"web busy"}"#.to_string())
+		} else if method == "DELETE" && target.contains("proj-db-1?force=true") {
+			(503, r#"{"message":"db unavailable"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let file = crate::parse_str(
+		"services:\n  db:\n    image: x\n  web:\n    image: x\n    depends_on:\n      - db\n",
+	)
+	.unwrap();
+
+	let err = e
+		.down_with_options(&file, false)
+		.await
+		.expect_err("both levels fail to remove their container");
+	assert!(
+		matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+		"expected web's (first, post-reversal) level failure, not db's: {err:?}"
+	);
+
+	let seen = fake.requests.lock().unwrap();
+	assert!(
+		seen.iter()
+			.any(|r| r.contains("DELETE") && r.contains("proj-db-1?force=true")),
+		"expected db's level to still be attempted after web's level failed: {seen:?}"
+	);
+}
+
 #[test]
 fn rm_path_omits_volume_flag_by_default() {
 	// A plain `down` (or scale-down) must not drop volumes.


### PR DESCRIPTION
Closes #1052

`down` stopped and removed containers strictly one at a time, so its wall-clock was the SUM of every container's stop-grace window. On a stack where services are slow to stop — anything that ignores SIGTERM rides its full grace period — that adds up fast. #757 already parallelized stop/start/restart/kill within dependency levels; `down` was still on the old flat sequential path.

It now walks `resolve_levels` (reversed, since teardown inverts startup) and fans out each level's containers through the same `join_bounded` (bounded at 16) the other lifecycle commands use — per-level MAX instead of the sum. `down_by_label` (no compose file, no dependency graph) fans out its containers in a single bounded batch. The per-container body (pre_stop hooks → grace-bounded stop → forced rm) moved into a shared `teardown_one_container`.

**Measured on this machine (real Podman 5.4.2)** — 6 services that ignore SIGTERM, 6s grace each, two runs:

| | run 1 | run 2 |
|---|---|---|
| before (sequential) | 36.66s | 36.60s |
| after (per-level) | 6.31s | 6.33s |

5.8× here, and it scales with the service count: the old cost was N × grace, the new cost is one grace window. (The removal lines now interleave in completion order rather than strict reverse order — expected with the fan-out.)

The #1044 exit-code semantics are preserved exactly: a stalled/failed `stop` stays best-effort (the forced remove supersedes it, so it's never folded into the error), a 404 is an idempotent no-op, only a genuine removal failure aggregates, best-effort teardown attempts every level, and the returned first-error stays deterministic — `join_bounded` yields input-ordered results and levels are visited in a fixed sequence, so completion order can't change which error surfaces. Three new tests pin cross-level ordering, within-level dispatch, and cross-level first-error determinism; the five existing #598/#1044 regression tests are unchanged and green. 1229 unit tests; clippy `-D warnings`, fmt, `cargo doc -D warnings` clean. The podman-lane exercises it on real Podman 5 and 6.