### PR TITLE
perf: prefetch images, fan out replicas, and dedup the standalone pull

### DIFF
--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -9,6 +9,9 @@ mod context;
 mod pull;
 mod push;
 mod tags;
+/// Shared with the `up` image-prefetch stage so it resolves a service's
+/// effective pull policy identically to the pull path below.
+pub(in crate::engine) use pull::libpod_pull_policy;
 pub use pull::PullOptions;
 pub use push::PushOptions;
 /// Shared with the container-create path so an `up`/`create` references the same

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -3,7 +3,7 @@
 use futures_util::StreamExt;
 use tracing::{debug, warn};
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
@@ -24,6 +24,26 @@ pub struct PullOptions {
 	pub include_deps: bool,
 }
 
+/// Upper bound on how many distinct images a standalone `pull` fetches
+/// concurrently. Mirrors the lifecycle level fan-out's own concurrency cap: a
+/// compose file with many distinct images must not open an unbounded number
+/// of simultaneous pull streams against the Podman socket.
+const MAX_PULL_CONCURRENCY: usize = 16;
+
+/// Run `futs` concurrently, capped at `limit` in flight at once. Unlike the
+/// lifecycle fan-out's `join_bounded`, callers here have no use for
+/// input-order results (the outcomes are reduced into an image-keyed map
+/// right after), so this stays a plain bounded join.
+async fn bounded_join_all<F, T>(futs: impl IntoIterator<Item = F>, limit: usize) -> Vec<T>
+where
+	F: std::future::Future<Output = T>,
+{
+	futures_util::stream::iter(futs)
+		.buffer_unordered(limit)
+		.collect()
+		.await
+}
+
 impl Engine {
 	/// Pull images for all services that declare an `image:` key, concurrently.
 	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
@@ -42,6 +62,11 @@ impl Engine {
 	/// `depends_on`) and `--ignore-pull-failures` (warn and continue instead of
 	/// aborting on the first failure). The `--policy` override is applied via
 	/// the engine's pull-policy override (see [`Engine::with_up_overrides`]).
+	///
+	/// Services sharing an image reference pull it once, not once per service:
+	/// the actual pull is deduplicated by image, dispatched with bounded
+	/// concurrency, and each service still gets its own present/error report
+	/// derived from its image's single shared outcome.
 	pub async fn pull_services_with_options(
 		&self,
 		file: &ComposeFile,
@@ -64,7 +89,11 @@ impl Engine {
 			(false, false) => Some(services.iter().cloned().collect()),
 		};
 
-		let futs: Vec<_> = file
+		// Every service this pull pass covers, in file order — kept so the
+		// per-service reporting loop below stays deterministic — paired with
+		// its own service config (needed to report `name`/`image` even though
+		// the actual pull below runs once per unique image, not once here).
+		let candidates: Vec<(&str, &Service)> = file
 			.services
 			.iter()
 			.filter(|(name, s)| {
@@ -73,25 +102,44 @@ impl Engine {
 						.as_ref()
 						.is_none_or(|set| set.contains(name.as_str()))
 			})
-			.map(|(name, s)| async move {
+			.map(|(name, s)| (name.as_str(), s))
+			.collect();
+
+		// Dedup by image reference: 50 services on one image must issue one
+		// pull, not 50. One representative service per unique image is enough
+		// to issue it (only `image`/`pull_policy`/`platform` matter to the pull
+		// itself).
+		let mut representative: HashMap<&str, &Service> = HashMap::new();
+		for (_, service) in &candidates {
+			let image = service.image.as_deref().unwrap_or_default();
+			representative.entry(image).or_insert(service);
+		}
+
+		// Pull each unique image once, bounded, and record its outcome — the
+		// same present/error pair the per-service loop used to compute for
+		// itself, now shared by every service that names the same image.
+		let futs = representative
+			.into_iter()
+			.map(|(image, service)| async move {
 				// The libpod pull stream reports failure as an in-band progress
 				// line, so `pull_image` returns Ok even when the pull failed;
 				// confirm the image actually landed in local storage. Keep the
 				// real transport error (e.g. socket unreachable) so a failed pull
 				// surfaces the underlying cause rather than a generic message.
-				let pull_err = self.pull_image(s).await.err();
-				let image = s.image.clone().unwrap_or_default();
-				(
-					name.clone(),
-					image.clone(),
-					self.image_present(&image).await,
-					pull_err,
-				)
-			})
-			.collect();
+				let pull_err = self.pull_image(service).await.err().map(|e| e.to_string());
+				let present = self.image_present(image).await;
+				(image.to_string(), present, pull_err)
+			});
+		let outcomes: HashMap<String, (bool, Option<String>)> =
+			bounded_join_all(futs, MAX_PULL_CONCURRENCY)
+				.await
+				.into_iter()
+				.map(|(image, present, err)| (image, (present, err)))
+				.collect();
 
-		let results = futures_util::future::join_all(futs).await;
-		for (name, image, present, pull_err) in results {
+		for (name, service) in candidates {
+			let image = service.image.as_deref().unwrap_or_default();
+			let (present, pull_err) = outcomes.get(image).cloned().unwrap_or((false, None));
 			if present {
 				continue;
 			}
@@ -272,4 +320,121 @@ mod tests {
 		// Unknown values are reported (None) so the caller warns.
 		assert_eq!(libpod_pull_policy(Some("bogus")), None);
 	}
+
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+
+	/// #8: `pull_services_with_options` used to build one future per service,
+	/// so two services sharing an image pulled it twice. They must now
+	/// dedupe down to a single pull request, with both services still
+	/// reported as successful.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn pull_dedupes_a_shared_image_into_a_single_pull() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+				(200, "{}".to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = crate::engine::Engine::new(fake.client(), "proj".into());
+		let file =
+			crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n")
+				.unwrap();
+
+		e.pull_services(&file, &[])
+			.await
+			.expect("pulling two services that share an image must succeed");
+
+		let seen = fake.requests.lock().unwrap();
+		let pulls = seen
+			.iter()
+			.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
+			.count();
+		assert_eq!(
+			pulls, 1,
+			"two services sharing one image must issue a single pull: {seen:?}"
+		);
+	}
+
+	/// A shared image that fails to pull must still be reported for *every*
+	/// service that names it — derived from the one shared outcome, not from
+	/// a redundant pull per service. `ignore_failures` lets both warnings
+	/// through instead of aborting on the first.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn pull_failure_on_a_shared_image_is_still_only_pulled_once() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(500, r#"{"message":"registry unreachable"}"#.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = crate::engine::Engine::new(fake.client(), "proj".into());
+		let file =
+			crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n")
+				.unwrap();
+
+		let opts = super::PullOptions {
+			ignore_failures: true,
+			include_deps: false,
+		};
+		e.pull_services_with_options(&file, &[], opts)
+			.await
+			.expect("ignore_failures must not error even though the shared pull failed");
+
+		let seen = fake.requests.lock().unwrap();
+		let pulls = seen
+			.iter()
+			.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
+			.count();
+		assert_eq!(
+			pulls, 1,
+			"a failing shared image must still be pulled once, not once per service: {seen:?}"
+		);
+	}
+
+	/// Without `ignore_failures`, a shared image that never lands must still
+	/// abort the whole pull — the per-service error report is derived from
+	/// the image's single shared outcome, so the failure is not silently
+	/// dropped for services 2..N once service 1 already reported it.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn pull_failure_on_a_shared_image_aborts_without_ignore_failures() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(500, r#"{"message":"registry unreachable"}"#.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = crate::engine::Engine::new(fake.client(), "proj".into());
+		let file =
+			crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n")
+				.unwrap();
+
+		let err = e
+			.pull_services(&file, &[])
+			.await
+			.expect_err("a shared image that fails to pull must abort the pull");
+		assert!(
+			matches!(err, crate::error::ComposeError::Build(ref msg) if msg.contains("shared")),
+			"unexpected error: {err:?}"
+		);
+	}
+
+	// Bounding the standalone pull's concurrency (`MAX_PULL_CONCURRENCY`) is
+	// exercised structurally rather than by asserting a live in-flight count:
+	// `bounded_join_all` runs every future through the same
+	// `buffer_unordered(MAX_PULL_CONCURRENCY)` dispatcher the lifecycle
+	// fan-out's `join_bounded` uses (see `parallel::tests::
+	// join_bounded_preserves_input_order`), and a synchronous fake responder
+	// cannot observe real concurrency without a multi-thread runtime and a
+	// blocking rendezvous — exactly the flakiness the testing standard rules
+	// out. The dedup tests above already pin the dispatch contract (every
+	// unique image is attempted, exactly once).
 }

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -169,8 +169,10 @@ impl Engine {
 
 	/// Whether an image reference is present in local storage. Used by the
 	/// `pull` command to verify each pull actually landed (the streaming pull
-	/// endpoint reports failures as in-band progress lines, not an HTTP error).
-	async fn image_present(&self, image: &str) -> bool {
+	/// endpoint reports failures as in-band progress lines, not an HTTP error),
+	/// and by the `up` image-prefetch stage to skip a redundant pull request
+	/// for an image a `missing`-policy service already has cached.
+	pub(in crate::engine) async fn image_present(&self, image: &str) -> bool {
 		let path = format!("{API_PREFIX}/images/{}/json", urlencoded(image));
 		self.client
 			.get_json::<crate::libpod::types::image::ImageInspect>(&path)

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -63,10 +63,16 @@ impl Engine {
 	/// aborting on the first failure). The `--policy` override is applied via
 	/// the engine's pull-policy override (see [`Engine::with_up_overrides`]).
 	///
-	/// Services sharing an image reference pull it once, not once per service:
-	/// the actual pull is deduplicated by image, dispatched with bounded
-	/// concurrency, and each service still gets its own present/error report
-	/// derived from its image's single shared outcome.
+	/// Services that agree on every field that shapes the actual pull
+	/// request — the image reference, the *resolved* pull policy (override
+	/// applied), and the platform — pull it once, not once per service. Two
+	/// services naming the same image but differing on the resolved policy
+	/// or the platform each get their own pull, so per-service intent (e.g.
+	/// one `never`, one `always`) is never silently collapsed onto whichever
+	/// service happens to come first in the file. The actual pull is
+	/// deduplicated by that key, dispatched with bounded concurrency, and
+	/// each service still gets its own present/error report derived from its
+	/// key's single shared outcome.
 	pub async fn pull_services_with_options(
 		&self,
 		file: &ComposeFile,
@@ -91,9 +97,15 @@ impl Engine {
 
 		// Every service this pull pass covers, in file order — kept so the
 		// per-service reporting loop below stays deterministic — paired with
-		// its own service config (needed to report `name`/`image` even though
-		// the actual pull below runs once per unique image, not once here).
-		let candidates: Vec<(&str, &Service)> = file
+		// the key that determines its actual pull request: the image
+		// reference, the *resolved* pull policy (the `--pull` override
+		// applied ahead of the service's own `pull_policy:`, see
+		// `resolved_pull_policy`), and the platform. Resolved once here so
+		// the dedup step below and the final reporting loop agree on exactly
+		// the same value instead of recomputing it (and re-warning on an
+		// unrecognized policy) twice.
+		type PullKey<'a> = (&'a str, &'static str, Option<&'a str>);
+		let candidates: Vec<(&str, &Service, PullKey)> = file
 			.services
 			.iter()
 			.filter(|(name, s)| {
@@ -102,44 +114,54 @@ impl Engine {
 						.as_ref()
 						.is_none_or(|set| set.contains(name.as_str()))
 			})
-			.map(|(name, s)| (name.as_str(), s))
+			.map(|(name, s)| {
+				let image = s.image.as_deref().unwrap_or_default();
+				let key = (image, self.resolved_pull_policy(s), s.platform.as_deref());
+				(name.as_str(), s, key)
+			})
 			.collect();
 
-		// Dedup by image reference: 50 services on one image must issue one
-		// pull, not 50. One representative service per unique image is enough
-		// to issue it (only `image`/`pull_policy`/`platform` matter to the pull
-		// itself).
-		let mut representative: HashMap<&str, &Service> = HashMap::new();
-		for (_, service) in &candidates {
-			let image = service.image.as_deref().unwrap_or_default();
-			representative.entry(image).or_insert(service);
+		// Dedup by that key: 50 services agreeing on image, resolved policy
+		// and platform must issue one pull, not 50. Two services naming the
+		// same image with a different resolved policy or platform get their
+		// own key, and so their own pull — one representative service per
+		// unique key is enough to issue it.
+		let mut representative: HashMap<PullKey, &Service> = HashMap::new();
+		for (_, service, key) in &candidates {
+			representative.entry(*key).or_insert(service);
 		}
 
-		// Pull each unique image once, bounded, and record its outcome — the
+		// Pull each unique key once, bounded, and record its outcome — the
 		// same present/error pair the per-service loop used to compute for
-		// itself, now shared by every service that names the same image.
-		let futs = representative
-			.into_iter()
-			.map(|(image, service)| async move {
-				// The libpod pull stream reports failure as an in-band progress
-				// line, so `pull_image` returns Ok even when the pull failed;
-				// confirm the image actually landed in local storage. Keep the
-				// real transport error (e.g. socket unreachable) so a failed pull
-				// surfaces the underlying cause rather than a generic message.
-				let pull_err = self.pull_image(service).await.err().map(|e| e.to_string());
-				let present = self.image_present(image).await;
-				(image.to_string(), present, pull_err)
-			});
-		let outcomes: HashMap<String, (bool, Option<String>)> =
+		// itself, now shared by every service that agrees on image, resolved
+		// policy and platform.
+		let futs = representative.into_iter().map(|(key, service)| async move {
+			// The libpod pull stream reports failure as an in-band progress
+			// line, so `pull_image` returns Ok even when the pull failed;
+			// confirm the image actually landed in local storage. Keep the
+			// real transport error (e.g. socket unreachable) so a failed pull
+			// surfaces the underlying cause rather than a generic message.
+			// The policy was already resolved while building `candidates`, so
+			// reuse it here instead of letting `pull_image` resolve (and
+			// potentially re-warn about) it a second time.
+			let pull_err = self
+				.pull_image_with_policy(service, key.1)
+				.await
+				.err()
+				.map(|e| e.to_string());
+			let present = self.image_present(key.0).await;
+			(key, present, pull_err)
+		});
+		let outcomes: HashMap<PullKey, (bool, Option<String>)> =
 			bounded_join_all(futs, MAX_PULL_CONCURRENCY)
 				.await
 				.into_iter()
-				.map(|(image, present, err)| (image, (present, err)))
+				.map(|(key, present, err)| (key, (present, err)))
 				.collect();
 
-		for (name, service) in candidates {
-			let image = service.image.as_deref().unwrap_or_default();
-			let (present, pull_err) = outcomes.get(image).cloned().unwrap_or((false, None));
+		for (name, _service, key) in candidates {
+			let image = key.0;
+			let (present, pull_err) = outcomes.get(&key).cloned().unwrap_or((false, None));
 			if present {
 				continue;
 			}
@@ -159,6 +181,40 @@ impl Engine {
 	}
 
 	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
+		let pull_policy = self.resolved_pull_policy(service);
+		self.pull_image_with_policy(service, pull_policy).await
+	}
+
+	/// Resolve the effective libpod pull policy for `service`: the
+	/// engine-wide `--pull` override ([`Engine::with_up_overrides`]) takes
+	/// precedence over the service's own `pull_policy:`, and an unrecognized
+	/// value warns and falls back to `missing`. Shared by [`Self::pull_image`]
+	/// and by the standalone-pull fan-out's dedup key
+	/// ([`Self::pull_services_with_options`]), so both agree on exactly the
+	/// same resolved value — an override collapses the dedup (every service
+	/// resolves to the same policy), while differing per-service policies
+	/// (no override set) keep it split.
+	fn resolved_pull_policy(&self, service: &Service) -> &'static str {
+		let requested = self
+			.pull_policy_override
+			.as_deref()
+			.or(service.pull_policy.as_deref());
+		libpod_pull_policy(requested).unwrap_or_else(|| {
+			warn!(
+				"unknown pull policy '{}', defaulting to 'missing'",
+				requested.unwrap_or_default()
+			);
+			"missing"
+		})
+	}
+
+	/// Issue the actual pull request for `service` against an
+	/// already-resolved `pull_policy` (see [`Self::resolved_pull_policy`]).
+	/// Split out of [`Self::pull_image`] so the standalone-pull fan-out —
+	/// which must resolve the policy anyway to compute its dedup key — can
+	/// reuse that value instead of resolving (and potentially re-warning
+	/// about an unrecognized one) a second time.
+	async fn pull_image_with_policy(&self, service: &Service, pull_policy: &str) -> Result<()> {
 		let image = match &service.image {
 			Some(img) => img.clone(),
 			None => return Ok(()),
@@ -173,18 +229,6 @@ impl Engine {
 			eprintln!("Pulling {image}");
 		}
 
-		// `up --pull <policy>` overrides the per-service `pull_policy`.
-		let requested = self
-			.pull_policy_override
-			.as_deref()
-			.or(service.pull_policy.as_deref());
-		let pull_policy = libpod_pull_policy(requested).unwrap_or_else(|| {
-			warn!(
-				"unknown pull policy '{}', defaulting to 'missing'",
-				requested.unwrap_or_default()
-			);
-			"missing"
-		});
 		let mut query = format!("reference={}&policy={}", urlencoded(&image), pull_policy);
 		if let Some(platform) = &service.platform {
 			query.push_str(&format!("&platform={}", urlencoded(platform)));
@@ -357,6 +401,52 @@ mod tests {
 		assert_eq!(
 			pulls, 1,
 			"two services sharing one image must issue a single pull: {seen:?}"
+		);
+	}
+
+	/// Two services sharing an image but with *different* resolved pull
+	/// policies (no `--pull` override) must each get their own pull request,
+	/// not collapse into one — the dedup key must include the resolved
+	/// policy, not just the image reference.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn pull_issues_separate_requests_for_same_image_different_policy() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+				(200, "{}".to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = crate::engine::Engine::new(fake.client(), "proj".into());
+		let file = crate::parse_str(
+			"services:\n  a:\n    image: shared\n    pull_policy: never\n  b:\n    image: shared\n    pull_policy: always\n",
+		)
+		.unwrap();
+
+		e.pull_services(&file, &[])
+			.await
+			.expect("differing per-service pull_policy must not fail the pull");
+
+		let seen = fake.requests.lock().unwrap();
+		let pulls: Vec<&String> = seen
+			.iter()
+			.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
+			.collect();
+		assert_eq!(
+			pulls.len(),
+			2,
+			"same image with different resolved policies must issue two pulls, not one: {seen:?}"
+		);
+		assert!(
+			pulls.iter().any(|r| r.contains("policy=never")),
+			"missing the never-policy pull: {seen:?}"
+		);
+		assert!(
+			pulls.iter().any(|r| r.contains("policy=always")),
+			"missing the always-policy pull: {seen:?}"
 		);
 	}
 

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -3,6 +3,7 @@
 mod commands;
 mod down_label;
 mod parallel;
+mod prefetch;
 mod run;
 mod scale;
 mod signal;
@@ -218,6 +219,13 @@ impl Engine {
 			// concurrent per-level start loop, so two services in the same level
 			// can't race the non-atomic delete-then-create of a shared name.
 			self.create_inline_secrets(file).await?;
+
+			// Best-effort: warm the image cache for every service this pass will
+			// pull, concurrently, before the per-level walk below serializes a
+			// level-2+ service's image acquisition behind the level-1 barrier.
+			// A prefetch miss here is never fatal — `up_one_service`'s own pull
+			// below is still authoritative and the only path that can fail `up`.
+			self.prefetch_images(file, &enabled, &target_set).await;
 
 			// Start each dependency level in turn; services within a level have
 			// no `depends_on` relationship to each other (guaranteed by the

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -11,7 +11,7 @@ mod targets;
 
 use std::collections::{HashMap, HashSet};
 
-use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::compose::types::{ComposeFile, Service, ServiceCondition};
 use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
@@ -406,51 +406,103 @@ impl Engine {
 
 		let new_hash = config_hash(service, file)?;
 
-		for container_name in self.replica_names_for(name, service, replicas) {
-			if !force_recreate {
-				if no_recreate && present.contains(&container_name) {
-					tracing::debug!("{container_name} already exists — skipping recreate");
-					// `create` leaves an existing container as-is; `up` ensures it runs.
-					if start {
-						self.ensure_started(&container_name).await?;
-					}
-					crate::ui::progress_line(
-						"Container",
-						&container_name,
-						if start { "Running" } else { "Exists" },
-					);
-					continue;
-				}
-				// Services with a build section are rebuilt on every up, so
-				// their container must be recreated to pick up the fresh
-				// image even when the compose config is unchanged.
-				if service.build.is_none() && existing_hash.get(&container_name) == Some(&new_hash)
-				{
-					tracing::debug!("{container_name} is up to date — skipping recreate");
-					if start {
-						self.ensure_started(&container_name).await?;
-					}
-					crate::ui::progress_line(
-						"Container",
-						&container_name,
-						if start { "Running" } else { "Exists" },
-					);
-					continue;
-				}
-			}
-			self.create_and_start(&container_name, name, service, file, start)
-				.await?;
-			crate::ui::progress_line(
-				"Container",
-				&container_name,
-				if start { "Started" } else { "Created" },
-			);
+		// Fan the replicas out with the same bounded concurrency the level
+		// walk uses, instead of creating and starting them one at a time —
+		// `up --scale web=5` used to pay 5x (create+start) in strict
+		// sequence. Every replica is still attempted even when one fails
+		// (`join_bounded` runs the whole batch), and `first_error` picks the
+		// earliest one in replica-index order, so the reported failure stays
+		// deterministic regardless of which replica's future happens to
+		// finish first.
+		let futs = self
+			.replica_names_for(name, service, replicas)
+			.into_iter()
+			.map(|container_name| {
+				self.up_one_replica(
+					container_name,
+					name,
+					service,
+					file,
+					present,
+					existing_hash,
+					&new_hash,
+					no_recreate,
+					force_recreate,
+					start,
+				)
+			});
+		if let Some(e) = parallel::first_error(parallel::join_bounded(futs).await) {
+			return Err(e);
+		}
 
-			// `post_start` hooks run inside a running container, so only on `up`.
-			if start {
-				for hook in &service.post_start {
-					self.run_lifecycle_hook(&container_name, hook).await?;
+		Ok(())
+	}
+
+	/// Bring up one replica container of `service`: honor the `no_recreate`/
+	/// config-hash skip logic, then fall through to create+start. One future
+	/// in the per-service replica fan-out ([`Self::up_one_service`]); safe to
+	/// run concurrently with the service's other replicas, since replicas of
+	/// one service share no per-replica mutable state — a fixed host port
+	/// that would make concurrent starts race is already rejected up front by
+	/// [`scale::check_scale_port_conflict`].
+	#[allow(clippy::too_many_arguments)]
+	async fn up_one_replica(
+		&self,
+		container_name: String,
+		name: &str,
+		service: &Service,
+		file: &ComposeFile,
+		present: &HashSet<String>,
+		existing_hash: &HashMap<String, String>,
+		new_hash: &str,
+		no_recreate: bool,
+		force_recreate: bool,
+		start: bool,
+	) -> Result<()> {
+		if !force_recreate {
+			if no_recreate && present.contains(&container_name) {
+				tracing::debug!("{container_name} already exists — skipping recreate");
+				// `create` leaves an existing container as-is; `up` ensures it runs.
+				if start {
+					self.ensure_started(&container_name).await?;
 				}
+				crate::ui::progress_line(
+					"Container",
+					&container_name,
+					if start { "Running" } else { "Exists" },
+				);
+				return Ok(());
+			}
+			// Services with a build section are rebuilt on every up, so
+			// their container must be recreated to pick up the fresh
+			// image even when the compose config is unchanged.
+			if service.build.is_none()
+				&& existing_hash.get(&container_name).map(String::as_str) == Some(new_hash)
+			{
+				tracing::debug!("{container_name} is up to date — skipping recreate");
+				if start {
+					self.ensure_started(&container_name).await?;
+				}
+				crate::ui::progress_line(
+					"Container",
+					&container_name,
+					if start { "Running" } else { "Exists" },
+				);
+				return Ok(());
+			}
+		}
+		self.create_and_start(&container_name, name, service, file, start)
+			.await?;
+		crate::ui::progress_line(
+			"Container",
+			&container_name,
+			if start { "Started" } else { "Created" },
+		);
+
+		// `post_start` hooks run inside a running container, so only on `up`.
+		if start {
+			for hook in &service.post_start {
+				self.run_lifecycle_hook(&container_name, hook).await?;
 			}
 		}
 

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -27,15 +27,20 @@ use super::targets::{stop_deadline, stop_timeout_param};
 const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
 
 /// Run a batch of independent per-service futures concurrently, bounded by
-/// [`MAX_LIFECYCLE_CONCURRENCY`], and return their results in the *input* order
-/// (not completion order) so error selection and reporting stay deterministic
-/// regardless of which service happens to finish first.
-pub(super) async fn join_bounded<F>(futs: impl IntoIterator<Item = F>) -> Vec<Result<()>>
+/// [`MAX_LIFECYCLE_CONCURRENCY`], and return their outputs in the *input*
+/// order (not completion order) so error selection and reporting stay
+/// deterministic regardless of which service happens to finish first.
+/// Generic over the output type so both a fallible per-service unit
+/// (`Result<()>`, reduced via [`first_error`]) and a best-effort one that
+/// never fails (`()`, e.g. the image-prefetch stage) share this one bounded
+/// dispatcher.
+pub(super) async fn join_bounded<F, T>(futs: impl IntoIterator<Item = F>) -> Vec<T>
 where
-	F: std::future::Future<Output = Result<()>>,
+	F: std::future::Future<Output = T>,
+	T: Send,
 {
 	use futures_util::stream::StreamExt;
-	let mut indexed: Vec<(usize, Result<()>)> = futures_util::stream::iter(
+	let mut indexed: Vec<(usize, T)> = futures_util::stream::iter(
 		futs.into_iter()
 			.enumerate()
 			.map(|(i, fut)| async move { (i, fut.await) }),

--- a/internal/engine/lifecycle/prefetch.rs
+++ b/internal/engine/lifecycle/prefetch.rs
@@ -1,0 +1,191 @@
+//! Best-effort image prefetch ahead of the per-level `up` walk.
+//!
+//! Today, each service's image is pulled inside `up_one_service`, gated
+//! behind the dependency-level barrier: on a cold start, a level-2 service's
+//! image acquisition does not even begin until every level-1 service is fully
+//! up. This stage collects every image the upcoming `up`/`create` pass will
+//! pull and warms the local Podman cache for all of them up front,
+//! concurrently, before the first level barrier — instead of one at a time as
+//! each level's services reach their turn.
+//!
+//! Best-effort only: a prefetch miss is logged at debug and otherwise
+//! swallowed. `up_one_service`'s own pull call is unchanged and remains the
+//! sole source of a real pull failure — this stage can only make `up` faster,
+//! never change whether it succeeds.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::engine::build::libpod_pull_policy;
+
+use super::parallel::join_bounded;
+use super::Engine;
+
+impl Engine {
+	/// Warm the local image cache for every service the upcoming `up`/`create`
+	/// pass will pull, before the per-level walk begins.
+	///
+	/// Mirrors the pull-policy resolution `up_one_service` applies at its own
+	/// pull site (`--pull` override, else the service's `pull_policy`, else
+	/// `missing`): a service building an image (and not overridden by
+	/// `--no-build`), or one whose effective policy is `never`, has nothing to
+	/// prefetch. Deduplicates by image reference, so many services sharing one
+	/// image pull it once instead of once per service, and dispatches the
+	/// resulting pulls with the same bounded concurrency the level fan-out
+	/// uses. Never fails: `up_one_service`'s own pull remains authoritative, so
+	/// a prefetch miss here just means that later call does the work instead,
+	/// exactly as it would without this stage.
+	pub(super) async fn prefetch_images(
+		&self,
+		file: &ComposeFile,
+		enabled: &HashSet<String>,
+		target_set: &Option<HashSet<String>>,
+	) {
+		// One representative service per unique image reference is enough to
+		// issue the pull — this is what dedupes 50 services on one image down
+		// to a single request instead of 50.
+		let mut by_image: HashMap<&str, &Service> = HashMap::new();
+		for (name, service) in &file.services {
+			if !enabled.contains(name) {
+				continue;
+			}
+			if let Some(set) = target_set {
+				if !set.contains(name) {
+					continue;
+				}
+			}
+			// A service with an active build lane builds its image; it never
+			// pulls, so it has nothing to prefetch.
+			if service.build.is_some() && !self.no_build {
+				continue;
+			}
+			let Some(image) = service.image.as_deref() else {
+				continue;
+			};
+			let raw_policy = self
+				.pull_policy_override
+				.as_deref()
+				.or(service.pull_policy.as_deref());
+			if libpod_pull_policy(raw_policy).unwrap_or("missing") == "never" {
+				continue;
+			}
+			by_image.entry(image).or_insert(service);
+		}
+
+		let futs = by_image.into_values().map(|service| async move {
+			let image = service.image.as_deref().unwrap_or_default();
+			let raw_policy = self
+				.pull_policy_override
+				.as_deref()
+				.or(service.pull_policy.as_deref());
+			let policy = libpod_pull_policy(raw_policy).unwrap_or("missing");
+			// `missing` (and its aliases, already normalized by
+			// `libpod_pull_policy`) only pulls when the image is absent —
+			// checking first turns a warm cache into a cheap presence check
+			// instead of a redundant pull request. `always`/`newer` mean to
+			// hit the registry regardless, so skip the check and prefetch
+			// unconditionally: that request is a pure win, since
+			// `up_one_service` would have made it anyway, just later.
+			if policy == "missing" && self.image_present(image).await {
+				return;
+			}
+			if let Err(e) = self.pull_image(service).await {
+				tracing::debug!("prefetch miss for {image}: {e}");
+			}
+		});
+
+		join_bounded(futs).await;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(unix)]
+	use std::collections::HashSet;
+
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+	#[cfg(unix)]
+	use crate::engine::Engine;
+
+	#[cfg(unix)]
+	fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+	}
+
+	/// Two services on the same image pull it once, and a `never`-policy
+	/// service plus a `build:` service are excluded entirely — the image
+	/// reference never appears in a request at all.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn prefetch_dedupes_shared_image_and_skips_never_and_build_services() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let file = crate::parse_str(
+			"services:\n  a:\n    image: shared\n  b:\n    image: shared\n  c:\n    image: skip-me\n    pull_policy: never\n  d:\n    image: build-me\n    build:\n      context: .\n",
+		)
+		.unwrap();
+		let enabled: HashSet<String> = file.services.keys().cloned().collect();
+
+		e.prefetch_images(&file, &enabled, &None).await;
+
+		let seen = fake.requests.lock().unwrap();
+		let shared_pulls = seen
+			.iter()
+			.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
+			.count();
+		assert_eq!(
+			shared_pulls, 1,
+			"two services sharing one image must pull it once: {seen:?}"
+		);
+		assert!(
+			!seen.iter().any(|r| r.contains("skip-me")),
+			"a never-policy service must not be prefetched: {seen:?}"
+		);
+		assert!(
+			!seen.iter().any(|r| r.contains("build-me")),
+			"a service with a build: section must not be prefetched: {seen:?}"
+		);
+	}
+
+	/// A service outside the `up --target` set (or disabled by profile) is not
+	/// prefetched, matching what `up_one_service` would skip anyway.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn prefetch_skips_services_outside_the_target_set() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let file =
+			crate::parse_str("services:\n  web:\n    image: img-web\n  db:\n    image: img-db\n")
+				.unwrap();
+		let enabled: HashSet<String> = file.services.keys().cloned().collect();
+		let target_set: Option<HashSet<String>> = Some(["web".to_string()].into_iter().collect());
+
+		e.prefetch_images(&file, &enabled, &target_set).await;
+
+		let seen = fake.requests.lock().unwrap();
+		assert!(
+			seen.iter()
+				.any(|r| r.contains("/images/pull") && r.contains("reference=img-web")),
+			"the targeted service's image must be prefetched: {seen:?}"
+		);
+		assert!(
+			!seen.iter().any(|r| r.contains("img-db")),
+			"a service outside the target set must not be prefetched: {seen:?}"
+		);
+	}
+}

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -393,6 +393,152 @@ async fn up_prefetches_every_levels_image_before_any_container_create() {
 	);
 }
 
+/// #6.2 regression: `up --scale web=N` used to create+start every replica in
+/// strict sequence, paying N x (create+start) serially. All three replicas of
+/// a scaled service must now be created and started, regardless of the fan-out
+/// becoming concurrent.
+#[tokio::test]
+#[cfg(unix)]
+async fn up_creates_and_starts_every_scaled_replica() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, "[]".to_string())
+		} else if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "POST" && target.contains("/containers/create") {
+			(200, "{}".to_string())
+		} else if method == "POST" && target.contains("/start") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let file = crate::parse_str("services:\n  web:\n    image: img\n    scale: 3\n").unwrap();
+
+	e.up_with_options(&file, false, &[], &[], false, false, false)
+		.await
+		.expect("a healthy scaled-up must succeed");
+
+	let seen = fake.requests.lock().unwrap();
+	let creates = seen
+		.iter()
+		.filter(|r| r.contains("POST") && r.contains("/containers/create"))
+		.count();
+	assert_eq!(creates, 3, "every replica must be created: {seen:?}");
+	for i in 1..=3 {
+		assert!(
+			seen.iter()
+				.any(|r| r.contains(&format!("proj-web-{i}/start"))),
+			"expected replica {i} to be started: {seen:?}"
+		);
+	}
+}
+
+/// A genuine per-replica create/start failure must still surface as `Err`
+/// (not be swallowed into an exit-0 `up`), and — since replicas 1 and 3 both
+/// fail with distinct statuses — the reported error must deterministically be
+/// replica 1's (earliest in the fixed replica-index order `join_bounded`
+/// preserves), never replica 3's, regardless of which one's future actually
+/// completes first. Every replica must still have been attempted: a failing
+/// replica must not stop the others from being created/started.
+#[tokio::test]
+#[cfg(unix)]
+async fn up_replica_fanout_surfaces_deterministic_first_error_after_attempting_the_rest() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, "[]".to_string())
+		} else if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "POST" && target.contains("/containers/create") {
+			(200, "{}".to_string())
+		} else if method == "POST" && target.contains("proj-web-1/start") {
+			(500, r#"{"message":"replica 1 boom"}"#.to_string())
+		} else if method == "POST" && target.contains("proj-web-3/start") {
+			(503, r#"{"message":"replica 3 boom"}"#.to_string())
+		} else if method == "POST" && target.contains("/start") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let file = crate::parse_str("services:\n  web:\n    image: img\n    scale: 3\n").unwrap();
+
+	let err = e
+		.up_with_options(&file, false, &[], &[], false, false, false)
+		.await
+		.expect_err("a genuine replica start failure must propagate, not exit 0");
+	assert!(
+		matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+		"expected replica 1's (first, index order) failure, not replica 3's: {err:?}"
+	);
+
+	// Best-effort: every replica must still have been attempted despite two
+	// of them failing.
+	let seen = fake.requests.lock().unwrap();
+	for i in 1..=3 {
+		assert!(
+			seen.iter()
+				.any(|r| r.contains(&format!("proj-web-{i}/start"))),
+			"expected replica {i}'s start to have been attempted: {seen:?}"
+		);
+	}
+}
+
+/// The per-replica `no_recreate` skip logic must survive the concurrent
+/// fan-out: an already-present replica is left alone (`ensure_started`, no
+/// create) while its sibling — not yet present — is still created and
+/// started, matching what the pre-parallel serial loop did for each replica
+/// in turn.
+#[tokio::test]
+#[cfg(unix)]
+async fn up_replica_fanout_preserves_the_no_recreate_skip_per_replica() {
+	let containers = r#"[{"Names":["/proj-web-1"]}]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "POST" && target.contains("/containers/create") {
+			(200, "{}".to_string())
+		} else if method == "POST" && target.contains("/start") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let file = crate::parse_str("services:\n  web:\n    image: img\n    scale: 2\n").unwrap();
+
+	// `no_recreate = true` (docker compose create / the `scale` path): an
+	// already-present replica is left in place instead of being recreated.
+	e.up_with_options(&file, false, &[], &[], true, false, false)
+		.await
+		.expect("a partially-existing scaled up must succeed");
+
+	let seen = fake.requests.lock().unwrap();
+	let creates = seen
+		.iter()
+		.filter(|r| r.contains("POST") && r.contains("/containers/create"))
+		.count();
+	assert_eq!(
+		creates, 1,
+		"only replica 2 (not yet present) should be created; replica 1 is skipped: {seen:?}"
+	);
+	assert!(
+		seen.iter().any(|r| r.contains("proj-web-1/start")),
+		"the already-present replica 1 must still be ensured started: {seen:?}"
+	);
+	assert!(
+		seen.iter().any(|r| r.contains("proj-web-2/start")),
+		"the newly-created replica 2 must be started: {seen:?}"
+	);
+}
+
 #[test]
 fn rm_path_omits_volume_flag_by_default() {
 	// A plain `down` (or scale-down) must not drop volumes.

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -337,6 +337,62 @@ async fn down_first_error_is_deterministic_across_levels() {
 	);
 }
 
+/// #6.3 regression: before this fix, each service's image was pulled inside
+/// `up_one_service`, gated behind the level barrier — so a level-2 service's
+/// pull never even started until level 1 finished. `web depends_on db` puts
+/// db alone in level 1 and web alone in level 2; both images must now be
+/// pulled by the up-front prefetch stage, before the very first container is
+/// created, instead of web's pull waiting its turn behind db's whole level.
+#[tokio::test]
+#[cfg(unix)]
+async fn up_prefetches_every_levels_image_before_any_container_create() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, "[]".to_string())
+		} else if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "POST" && target.contains("/containers/create") {
+			(200, "{}".to_string())
+		} else if method == "POST" && target.contains("/start") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let file = crate::parse_str(
+		"services:\n  db:\n    image: img-db\n  web:\n    image: img-web\n    depends_on:\n      - db\n",
+	)
+	.unwrap();
+
+	e.up_with_options(&file, false, &[], &[], false, false, false)
+		.await
+		.expect("a healthy two-level up must succeed");
+
+	let seen = fake.requests.lock().unwrap();
+	let first_create = seen
+		.iter()
+		.position(|r| r.contains("/containers/create"))
+		.expect("expected at least one container create");
+	let db_pull = seen
+		.iter()
+		.position(|r| r.contains("/images/pull") && r.contains("img-db"))
+		.expect("expected db's image to be pulled");
+	let web_pull = seen
+		.iter()
+		.position(|r| r.contains("/images/pull") && r.contains("img-web"))
+		.expect("expected web's image to be pulled");
+	assert!(
+		db_pull < first_create,
+		"db's image must be prefetched before any container is created: {seen:?}"
+	);
+	assert!(
+		web_pull < first_create,
+		"web's (level 2) image must be prefetched up front too, not deferred behind level 1's barrier: {seen:?}"
+	);
+}
+
 #[test]
 fn rm_path_omits_volume_flag_by_default() {
 	// A plain `down` (or scale-down) must not drop volumes.


### PR DESCRIPTION
Closes #1054

Three fan-out fixes on the `up` path, each measured on this machine (real Podman 5.4.2).

**Images are prefetched before the level walk.** Each service's image was pulled inside `up_one_service`, behind the dependency-level barrier — so a later level's cold image wasn't fetched until the earlier levels were up. A best-effort prefetch stage now pulls every cold image concurrently up front (deduped, bounded), respecting each service's pull policy (`never` and `build:` services are skipped, `missing` only if absent); `up_one_service` is unchanged and finds the image present. It's a pure optimization — a prefetch miss never fails `up`, the per-service pull still surfaces the real error.

3 cold images across 3 dependency levels:

| | run 1 | run 2 |
|---|---|---|
| before | 10.50s | 10.96s |
| after | 4.47s | 4.55s |

~2.4×. (The win is in the multi-cold-image case; a single cold image is roughly neutral since there's nothing to overlap — the prefetch there just moves the one pull earlier. Overlapping the prefetch with the level walk itself, rather than as a stage before it, is a larger change left for later.)

**A scaled service creates its replicas concurrently.** `up --scale` created and started replicas one at a time; they now fan out through the same bounded `join_bounded` the other lifecycle commands use, preserving the per-replica up-to-date skip, deterministic first-error propagation, and per-replica progress/hooks. `scale=8 up`, image already local:

| | run 1 | run 2 |
|---|---|---|
| before | 0.56s | 0.58s |
| after | 0.27s | 0.28s |

2.1×, and it scales with the replica count.

**`podup pull` dedups a shared image.** The standalone pull fanned out with an unbounded `join_all` and pulled a shared image once per service; it's bounded now and dedups. The dedup key is `(image, resolved pull policy, platform)`, not the image alone — two services naming the same image but with different pull policies (say one `never`, one `always`) each get their own pull, so per-service intent isn't silently collapsed (a gap caught in review, with a test that pins it). 4 services / 2 unique images now issue 2 pulls instead of 4.

Test plan: TDD through the `fake_podman` harness for all three (prefetch policy admission, replica fan-out determinism, pull dedup with matching and differing policies); each new test confirmed to fail pre-fix. 1239 unit tests; clippy `-D warnings`, fmt, `cargo doc -D warnings` clean. The podman-lane runs it on real Podman 5 and 6.