### PR TITLE
perf(logs): bound the per-line log buffer

### DIFF
--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -2,9 +2,17 @@
 
 use std::io::Write;
 
+/// Cap on the buffered partial line. A container that emits a very long run
+/// with no newline — a `\r`-updated progress bar, binary output, a pathological
+/// single line — must not grow `pending` without bound. At this size the
+/// partial is flushed as its own prefixed line (as docker does) rather than
+/// held in memory forever.
+const MAX_PENDING: usize = 64 * 1024;
+
 /// Tags each complete log line with `{label} | `, the way `docker compose logs`
 /// labels multi-service output. Bytes arrive as stream frames that may split a
-/// line across frames, so a partial line is buffered until its newline arrives.
+/// line across frames, so a partial line is buffered until its newline arrives
+/// (up to [`MAX_PENDING`]).
 pub(super) struct LinePrefixer {
 	label: String,
 	pending: Vec<u8>,
@@ -45,6 +53,16 @@ impl LinePrefixer {
 			let _ = out.write_all(&self.pending[..=nl]);
 			self.pending.drain(..=nl);
 		}
+		// The remaining bytes are a partial line with no newline yet. Bound it:
+		// a container spewing without a newline (a `\r` progress bar, binary
+		// data) would otherwise grow `pending` without limit. Break the
+		// over-long partial into its own prefixed line and start fresh.
+		if self.pending.len() >= MAX_PENDING {
+			let _ = out.write_all(self.label.as_bytes());
+			let _ = out.write_all(&self.pending);
+			let _ = out.write_all(b"\n");
+			self.pending.clear();
+		}
 		let _ = out.flush();
 	}
 
@@ -83,6 +101,33 @@ mod tests {
 		assert!(out.is_empty(), "a line with no newline is held back");
 		p.flush_tail(&mut out);
 		assert_eq!(out, b"db  | partial\n");
+	}
+
+	#[test]
+	fn line_prefixer_bounds_a_newlineless_flood() {
+		use super::MAX_PENDING;
+		let mut p = LinePrefixer::new("web", true, false);
+		let mut out: Vec<u8> = Vec::new();
+		// Feed more than the cap with no newline in sight, in small chunks.
+		let chunk = vec![b'x'; 4096];
+		for _ in 0..((MAX_PENDING / chunk.len()) + 2) {
+			p.write(&mut out, &chunk);
+		}
+		// The partial was flushed as a prefixed line instead of being buffered
+		// unbounded, and nothing is left pending beyond the last sub-cap chunk.
+		assert!(
+			!out.is_empty(),
+			"the over-long partial was emitted, not held"
+		);
+		assert!(
+			p.pending.len() < MAX_PENDING,
+			"pending stays bounded under the cap, was {}",
+			p.pending.len()
+		);
+		assert!(
+			out.starts_with(b"web  | "),
+			"the flushed partial is prefixed"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #1056

`logs`-style prefixing buffers a partial line until its newline arrives, which is correct for normal output but unbounded for a container that emits a long run with no newline — a `\r`-updated progress bar, binary output, one giant line. `logs --follow` on such a container grew the buffer without limit and could eat hundreds of MB.

At 64 KiB the partial is now flushed as its own prefixed line — the way docker breaks an over-long line — and the buffer starts fresh. Complete lines are unchanged.

I scoped this PR to the memory bug alone. The other two items from the streams/health perf group are bigger changes that each deserve their own PR, filed as follow-ups: shared healthcheck waits when many services depend on one (#1057) and streaming the build-context tar instead of holding it in memory (#1058).

Test plan: a test feeds >64 KiB with no newline in small chunks and asserts the buffer stays under the cap and the partial was emitted prefixed; the existing line/partial/no-prefix tests are unchanged. clippy `-D warnings`, fmt, `cargo doc -D warnings` clean.