### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.10.1"
+version = "1.11.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.10.1"
+version = "1.11.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+podup (1.11.0) unstable; urgency=medium
+
+  * up, down and scale now exit non-zero when the operation actually fails,
+    instead of reporting success. A repeated up that can't restart a stopped
+    container no longer prints Running with exit 0, and a down or scale whose
+    teardown genuinely fails now exits non-zero. A stalled stop stays
+    non-fatal (the forced remove supersedes it).
+  * logs shows every replica of a scaled service, ps --status returns the
+    filtered containers without needing -a, port rendering no longer overflows
+    on a pathological libpod record, and a restarting container without a
+    healthcheck is no longer reported as health: starting.
+  * autostart escapes systemd %-specifiers in the generated unit, and
+    autostart uninstall no longer removes a sibling project's units (ownership
+    is now proven by an unforgeable marker).
+  * The installers pin the redirect transport and bound the download; the
+    Windows self-update cleans up its old backup on the next run; the invalid
+    project-name message now matches the rule it enforces.
+  * down tears containers down in parallel within each dependency level
+    (per-level max instead of the sum of every stop grace), up prefetches
+    cold images concurrently and creates a scaled service's replicas
+    concurrently, and logs bounds its per-line buffer so a newline-less
+    stream can't grow it without limit.
+
+ -- Glyndor <packages@glyndor.net>  Sat, 18 Jul 2026 01:57:34 -0500
 podup (1.10.1) unstable; urgency=medium
 
   * Relicensed from Apache-2.0 to MIT, part of the org-wide switch to a single


### PR DESCRIPTION
Bumps to 1.11.0 across Cargo.toml, Cargo.lock and debian/changelog together (the release verify gate fails if they disagree), and adds the changelog entry.

This release ships the correctness and performance work that's accumulated on develop:

- **Correctness:** up/down/scale exit non-zero on real failure instead of reporting success; logs shows every replica after a scale; ps --status returns filtered containers; port rendering can't overflow; a restarting container isn't mislabelled health: starting; systemd %-specifiers are escaped in autostart units; autostart uninstall can no longer delete a sibling project's units; installer transport is pinned and bounded; the Windows backup is cleaned up; the project-name error matches the enforced rule.
- **Performance (measured on real Podman):** down tears down in parallel per dependency level (36.6s→6.3s on a slow-stop 6-service stack); up prefetches cold images concurrently (~2.4× on a multi-image cold start) and creates replicas concurrently (2.1× at scale=8); logs bounds its per-line buffer.

Once this is on develop, the develop→main release PR and the v1.11.0 tag follow.