### PR TITLE
ci(podman-lane): log the identities of failing tests, not just the count

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -92,6 +92,17 @@ jobs:
                 FLAKY=$(grep -cE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log)
                 echo "PODUP_TESTS_RC=$RC"
                 echo "PODUP_SUMMARY pass=${PASS:-0} fail=${FAIL:-0} flaky=${FLAKY:-0}"
+                # Emit the IDENTITIES of the failing tests, not just the count.
+                # The floor gate can only tighten to a per-test known-flaky
+                # allowlist once the flaky set is small and stable (#1039), and
+                # building that allowlist starts with observing which tests
+                # actually fail across nested-virt runs — which the count alone
+                # cannot tell you. cargo prints a final `failures:` block of bare
+                # test names (the earlier block carries `---- name stdout ----`
+                # detail lines, which the 4-space-exact match skips); no failures
+                # yields an empty list, not an error.
+                FAILED_TESTS=$(sed -n '/^failures:$/,/^test result:/p' /tmp/cargo.log | grep -oE '^    [A-Za-z0-9_:]+$' | tr -d ' ' | paste -sd, -)
+                echo "PODUP_FAILED_TESTS=${FAILED_TESTS}"
           runcmd:
             - bash -c 'F=$(findmnt -no FSTYPE /); case $F in btrfs) btrfs filesystem resize max / ;; xfs) xfs_growfs / ;; ext4) resize2fs $(findmnt -no SOURCE /) ;; esac >/dev/console 2>&1; echo "DISK=$(df -h / | tail -1)" >/dev/console'
             - bash -c 'dnf install -y podman rust cargo gcc git >/dev/console 2>&1'
@@ -132,6 +143,13 @@ jobs:
           FLAKY=$(echo "$SUM" | grep -oE 'flaky=[0-9]+' | cut -d= -f2)
           PASS=${PASS:-0}; FAIL=${FAIL:-0}; FLAKY=${FLAKY:-0}
           echo "Podman $VER: $PASS passed, $FAIL failed ($FLAKY look like connection-drop flakes)"
+          # Surface the failing-test identities (informational) so the nightly
+          # runs accumulate the data a per-test known-flaky allowlist will need
+          # before the gate can tighten past the floor (#1039).
+          FAILED_TESTS=$(grep -oE 'PODUP_FAILED_TESTS=.*' "$L" | tail -1 | cut -d= -f2- || true)
+          if [ -n "$FAILED_TESTS" ]; then
+            echo "Failing tests on Podman $VER: $FAILED_TESTS"
+          fi
           # Gate: the core must pass the baseline in .github/podman-baseline-tests.
           # A real regression breaks previously-passing tests and knocks PASS
           # below the floor; the baseline is versioned so it is bumped


### PR DESCRIPTION
## What

The live lane gates on a pass-count floor and its summary reports only *how many* tests failed. This adds the missing datum: **which** tests failed.

- In the VM, parse cargo's final `failures:` block into a `PODUP_FAILED_TESTS=` line (bare test names; the earlier block's `---- name stdout ----` detail lines are skipped by the 4-space-exact match). A clean run emits an empty list, not an error.
- In the verify step, surface those identities in the lane output (informational).

## Why

[#1039](https://github.com/Glyndor/podup/issues/1039) lays out the path to tightening the gate past the pass-count floor: *"gate on the failing-test identity against a committed known-flaky allowlist."* You can't build that allowlist without first observing which tests actually fail across nested-virt runs — and today the lane only prints a count. This is the prerequisite instrumentation.

## Scope / risk

**Instrumentation only.** The test invocation, the transient retry loop and the floor gate are all unchanged, so this cannot make the lane slower or flakier. It does not attempt the flakiness *reduction* itself (serialization / per-test retries / the Podman-6 variance root-cause) — that is a measured experiment on the nested-virt lane and stays open under #1039.

## Verified

Parsing checked locally against a synthetic cargo log (two failures → `tests::attach_tty,tests::logs_follow_stream`) and a clean log (empty list, no error). The end-to-end emission runs on this PR's own `podman-lane` job.

Toward #1039