### PR TITLE
perf(build): stream the build-context tar instead of buffering it

### DIFF
--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -80,52 +80,23 @@ fn append_extra_files<W: std::io::Write>(
 	Ok(())
 }
 
-/// Write inline Dockerfile content into the context tar as `.dockerfile-inline`.
-pub(super) fn build_context_tar_with_inline(
-	context: &Path,
-	inline: &str,
-	extra_files: &[(String, Vec<u8>)],
-) -> Result<(Vec<u8>, String)> {
-	let inline_name = ".dockerfile-inline";
-	let ignore_patterns = read_dockerignore(context);
+/// The `.dockerfile-inline` entry name synthesized for an inline Dockerfile.
+pub(super) const INLINE_DOCKERFILE_NAME: &str = ".dockerfile-inline";
 
-	let encoder = GzEncoder::new(Vec::new(), Compression::default());
-	let mut tar = tar::Builder::new(encoder);
-
-	let mut header = tar::Header::new_gnu();
-	header.set_size(inline.len() as u64);
-	header.set_mode(0o644);
-	header.set_cksum();
-	tar.append_data(&mut header, inline_name, inline.as_bytes())
-		.map_err(|e| ComposeError::Build(e.to_string()))?;
-
-	// Skip the user's `.dockerignore` here; it is rewritten below with extra
-	// rules excluding every synthesized entry (inline Dockerfile, build secrets).
-	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"], &[])?;
-
-	let mut synthesized: Vec<&str> = vec![inline_name];
-	synthesized.extend(extra_files.iter().map(|(n, _)| n.as_str()));
-	append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
-
-	append_extra_files(&mut tar, extra_files)?;
-
-	let gz = tar
-		.into_inner()
-		.map_err(|e| ComposeError::Build(e.to_string()))?;
-	let bytes = gz
-		.finish()
-		.map_err(|e| ComposeError::Build(e.to_string()))?;
-	Ok((bytes, inline_name.to_string()))
-}
-
-pub(crate) fn build_context_tar(
+/// Assemble the gzipped build-context tar and write it straight to `writer`.
+///
+/// This is the shared core of context assembly. `build_context_tar` wraps it
+/// to collect the bytes into a `Vec` (tests, non-streaming callers); the build
+/// path feeds a channel-backed writer so a multi-gigabyte context is streamed to
+/// the socket without ever inflating the process's RSS.
+pub(super) fn stream_build_context<W: std::io::Write>(
+	writer: W,
 	context: &Path,
 	dockerfile: &str,
 	extra_files: &[(String, Vec<u8>)],
-) -> Result<Vec<u8>> {
+) -> Result<()> {
 	let ignore_patterns = read_dockerignore(context);
-
-	let encoder = GzEncoder::new(Vec::new(), Compression::default());
+	let encoder = GzEncoder::new(writer, Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
 	// Force-include the active Dockerfile so a `.dockerignore` that matches it
@@ -147,15 +118,81 @@ pub(crate) fn build_context_tar(
 		append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
 	}
 	append_extra_files(&mut tar, extra_files)?;
+	finish_tar(tar)
+}
 
+/// As [`stream_build_context`], but injects an inline Dockerfile as
+/// [`INLINE_DOCKERFILE_NAME`] instead of shipping one from the context.
+pub(super) fn stream_build_context_with_inline<W: std::io::Write>(
+	writer: W,
+	context: &Path,
+	inline: &str,
+	extra_files: &[(String, Vec<u8>)],
+) -> Result<()> {
+	let ignore_patterns = read_dockerignore(context);
+	let encoder = GzEncoder::new(writer, Compression::default());
+	let mut tar = tar::Builder::new(encoder);
+
+	let mut header = tar::Header::new_gnu();
+	header.set_size(inline.len() as u64);
+	header.set_mode(0o644);
+	header.set_cksum();
+	tar.append_data(&mut header, INLINE_DOCKERFILE_NAME, inline.as_bytes())
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+
+	// Skip the user's `.dockerignore` here; it is rewritten below with extra
+	// rules excluding every synthesized entry (inline Dockerfile, build secrets).
+	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"], &[])?;
+
+	let mut synthesized: Vec<&str> = vec![INLINE_DOCKERFILE_NAME];
+	synthesized.extend(extra_files.iter().map(|(n, _)| n.as_str()));
+	append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
+
+	append_extra_files(&mut tar, extra_files)?;
+	finish_tar(tar)
+}
+
+/// Finish the gzip stream and flush the sink. `GzEncoder::finish` writes the
+/// trailer but does not flush the underlying writer, so a channel-backed writer
+/// would strand its last buffered chunk without this explicit flush.
+fn finish_tar<W: std::io::Write>(tar: tar::Builder<GzEncoder<W>>) -> Result<()> {
 	let gz = tar
 		.into_inner()
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
-	let bytes = gz
+	let mut writer = gz
 		.finish()
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	writer
+		.flush()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	Ok(())
+}
 
-	Ok(bytes)
+/// Collect [`stream_build_context_with_inline`] into a `Vec`. Test-only: the
+/// build path streams the tar; these wrappers let the tar assembly be asserted
+/// on its bytes.
+#[cfg(test)]
+pub(super) fn build_context_tar_with_inline(
+	context: &Path,
+	inline: &str,
+	extra_files: &[(String, Vec<u8>)],
+) -> Result<(Vec<u8>, String)> {
+	let mut buf = Vec::new();
+	stream_build_context_with_inline(&mut buf, context, inline, extra_files)?;
+	Ok((buf, INLINE_DOCKERFILE_NAME.to_string()))
+}
+
+/// Collect [`stream_build_context`] into a `Vec`. Test-only (see
+/// [`build_context_tar_with_inline`]).
+#[cfg(test)]
+pub(crate) fn build_context_tar(
+	context: &Path,
+	dockerfile: &str,
+	extra_files: &[(String, Vec<u8>)],
+) -> Result<Vec<u8>> {
+	let mut buf = Vec::new();
+	stream_build_context(&mut buf, context, dockerfile, extra_files)?;
+	Ok(buf)
 }
 
 /// Append a synthesized `.dockerignore` entry to the context tar.

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,6 +8,7 @@
 mod context;
 mod pull;
 mod push;
+mod stream;
 mod tags;
 /// Shared with the `up` image-prefetch stage so it resolves a service's
 /// effective pull policy identically to the pull path below.
@@ -29,7 +30,8 @@ use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
 use crate::size;
 
-use context::{build_context_tar, build_context_tar_with_inline, map_additional_context};
+use context::{map_additional_context, INLINE_DOCKERFILE_NAME};
+use stream::{context_body, ContextSource};
 use tags::{is_remote_context, looks_like_secret};
 
 use super::Engine;
@@ -37,6 +39,19 @@ use super::Engine;
 /// Files to ship inside the build-context tar plus their matching `secrets=`
 /// specs (`id=NAME,src=ENTRY`) for the libpod build endpoint.
 type ResolvedBuildSecrets = (Vec<(String, Vec<u8>)>, Vec<String>);
+
+/// How `build_service` sends the context to the libpod build endpoint.
+enum BodyPlan {
+	/// A Git/URL context — Podman clones it server-side, so the body is empty.
+	Empty,
+	/// A local context, streamed to the socket from a `spawn_blocking` tar writer
+	/// so its size never drives the process's RSS.
+	Stream {
+		context: std::path::PathBuf,
+		source: ContextSource,
+		secrets: Vec<(String, Vec<u8>)>,
+	},
+}
 
 /// `docker compose build`-style CLI overrides. Each augments (never weakens)
 /// the per-service `build:` config: a flag forces the behaviour on even when
@@ -119,7 +134,7 @@ impl Engine {
 		// A Git/URL context is cloned server-side by Podman via the `remote`
 		// query parameter — there is no local directory to tar. Tar-only features
 		// (inline Dockerfile, in-tar build secrets) do not apply.
-		let (tar_bytes, dockerfile_name, secret_specs) = if remote_context {
+		let (body_plan, dockerfile_name, secret_specs) = if remote_context {
 			info!("building {tag} from remote context {context_str}");
 			if build.dockerfile_inline().is_some() {
 				warn!("build.dockerfile_inline is ignored for a remote build context");
@@ -128,7 +143,7 @@ impl Engine {
 				warn!("build.secrets are ignored for a remote build context");
 			}
 			let df = build.dockerfile().unwrap_or("Dockerfile").to_string();
-			(Vec::new(), df, Vec::new())
+			(BodyPlan::Empty, df, Vec::new())
 		} else {
 			let context_path = self.base_dir.join(&context_str);
 			// Fail fast with the service name and the resolved context path if the
@@ -150,31 +165,40 @@ impl Engine {
 			// over the socket).
 			let (secret_files, secret_specs) = self.resolve_build_secrets(build, file)?;
 
-			let inline = build.dockerfile_inline().map(|s| s.to_string());
-			// Honour an explicit dockerfile; otherwise prefer Dockerfile but fall
-			// back to Podman's native Containerfile when only the latter is present.
-			let df = match build.dockerfile() {
-				Some(name) => name.to_string(),
-				None if !context_path.join("Dockerfile").is_file()
-					&& context_path.join("Containerfile").is_file() =>
-				{
-					"Containerfile".to_string()
+			// The context tar is streamed to the socket (see the POST below), never
+			// buffered, so a multi-gigabyte context doesn't inflate RSS. Decide the
+			// source and the dockerfile name here; the blocking tar walk happens
+			// while the request body is being sent.
+			let (source, dockerfile_name) = match build.dockerfile_inline() {
+				Some(inline) => (
+					ContextSource::Inline(inline.to_string()),
+					INLINE_DOCKERFILE_NAME.to_string(),
+				),
+				None => {
+					// Honour an explicit dockerfile; otherwise prefer Dockerfile
+					// but fall back to Podman's native Containerfile when only the
+					// latter is present.
+					let df = match build.dockerfile() {
+						Some(name) => name.to_string(),
+						None if !context_path.join("Dockerfile").is_file()
+							&& context_path.join("Containerfile").is_file() =>
+						{
+							"Containerfile".to_string()
+						}
+						None => "Dockerfile".to_string(),
+					};
+					(ContextSource::Dockerfile(df.clone()), df)
 				}
-				None => "Dockerfile".to_string(),
 			};
-			let ctx = context_path.clone();
-			let (bytes, name) =
-				tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String)> {
-					if let Some(inline_s) = inline {
-						build_context_tar_with_inline(&ctx, &inline_s, &secret_files)
-					} else {
-						let bytes = build_context_tar(&ctx, &df, &secret_files)?;
-						Ok((bytes, df))
-					}
-				})
-				.await
-				.map_err(|e| ComposeError::Build(e.to_string()))??;
-			(bytes, name, secret_specs)
+			(
+				BodyPlan::Stream {
+					context: context_path,
+					source,
+					secrets: secret_files,
+				},
+				dockerfile_name,
+				secret_specs,
+			)
 		};
 
 		let arg_map = build.args().to_map();
@@ -332,12 +356,39 @@ impl Engine {
 		}
 
 		let path = format!("{API_PREFIX}/build?{qs}");
-		let body_bytes = Bytes::from(tar_bytes);
-		let resp = self
-			.client
-			.post_bytes_stream(&path, body_bytes, "application/x-tar")
-			.await
-			.map_err(ComposeError::Podman)?;
+		let resp = match body_plan {
+			BodyPlan::Empty => self
+				.client
+				.post_bytes_stream(&path, Bytes::new(), "application/x-tar")
+				.await
+				.map_err(ComposeError::Podman)?,
+			BodyPlan::Stream {
+				context,
+				source,
+				secrets,
+			} => {
+				// The tar writer runs on a blocking thread feeding the request
+				// body; drain the body first, then join the writer — joining
+				// before the body is drained would deadlock on the bounded
+				// channel. If the request itself failed, that transport error is
+				// the real cause; otherwise surface any context-assembly error.
+				let (producer, body) = context_body(context, source, secrets);
+				let sent = self
+					.client
+					.post_stream_body(&path, body, "application/x-tar")
+					.await;
+				let produced = producer
+					.await
+					.map_err(|e| ComposeError::Build(e.to_string()))?;
+				match sent {
+					Ok(resp) => {
+						produced?;
+						resp
+					}
+					Err(e) => return Err(ComposeError::Podman(e)),
+				}
+			}
+		};
 		let mut stream = crate::libpod::parse_json_lines::<BuildOutput>(resp.into_body());
 
 		while let Some(result) = stream.next().await {

--- a/internal/engine/build/stream.rs
+++ b/internal/engine/build/stream.rs
@@ -1,0 +1,172 @@
+//! Stream a build-context tar to the libpod build endpoint without buffering
+//! the whole context in memory.
+//!
+//! [`context_body`] runs the (blocking) tar+gzip writer on a `spawn_blocking`
+//! thread that feeds a bounded channel, and returns an async body stream that
+//! drains it. Peak memory is roughly `CHANNEL_CAP * CHUNK_BYTES` regardless of
+//! context size — a multi-gigabyte context no longer drives the process's RSS.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use bytes::{Bytes, BytesMut};
+use futures_util::Stream;
+use hyper::body::Frame;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use super::context::{stream_build_context, stream_build_context_with_inline};
+use crate::error::Result;
+
+/// Items handed to the request body: a data frame, or a terminal error that
+/// aborts the upload.
+type BodyItem = io::Result<Frame<Bytes>>;
+
+/// How many pending chunks the channel buffers. Bounds peak memory to about
+/// `CHANNEL_CAP * CHUNK_BYTES` while still decoupling the blocking tar writer
+/// from the async socket writer so both run concurrently.
+const CHANNEL_CAP: usize = 8;
+
+/// Coalesce the tar writer's many small writes into ~64 KiB frames, so the body
+/// is a handful of sizeable chunks rather than thousands of tiny ones.
+const CHUNK_BYTES: usize = 64 * 1024;
+
+/// Which Dockerfile the context ships: one synthesized from an inline string, or
+/// a named file already inside the context directory.
+pub(super) enum ContextSource {
+	/// `build.dockerfile_inline` content.
+	Inline(String),
+	/// The resolved Dockerfile/Containerfile name within the context.
+	Dockerfile(String),
+}
+
+/// A [`Write`] sink that forwards the tar bytes to an async channel as `Bytes`
+/// frames, coalescing small writes to `CHUNK_BYTES`. Blocks (backpressure) when
+/// the consumer is behind; errors if the consumer has gone away.
+struct ChannelWriter {
+	tx: mpsc::Sender<BodyItem>,
+	buf: BytesMut,
+}
+
+impl ChannelWriter {
+	fn send_pending(&mut self) -> io::Result<()> {
+		if self.buf.is_empty() {
+			return Ok(());
+		}
+		let chunk = self.buf.split().freeze();
+		self.tx.blocking_send(Ok(Frame::data(chunk))).map_err(|_| {
+			io::Error::new(
+				io::ErrorKind::BrokenPipe,
+				"build-context receiver dropped before the tar finished",
+			)
+		})
+	}
+}
+
+impl Write for ChannelWriter {
+	fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+		self.buf.extend_from_slice(data);
+		if self.buf.len() >= CHUNK_BYTES {
+			self.send_pending()?;
+		}
+		Ok(data.len())
+	}
+
+	fn flush(&mut self) -> io::Result<()> {
+		self.send_pending()
+	}
+}
+
+/// Spawn the blocking tar writer and return `(producer, body)`.
+///
+/// The producer's `JoinHandle` yields the context-assembly `Result` (a tar/IO
+/// error surfaces here with its descriptive message); the `body` is the stream
+/// the client sends as the request body. Await the body request first, then the
+/// producer — awaiting the producer before draining the body would deadlock on
+/// the bounded channel.
+pub(super) fn context_body(
+	context: PathBuf,
+	source: ContextSource,
+	secret_files: Vec<(String, Vec<u8>)>,
+) -> (
+	JoinHandle<Result<()>>,
+	impl Stream<Item = BodyItem> + Send + 'static,
+) {
+	let (tx, rx) = mpsc::channel::<BodyItem>(CHANNEL_CAP);
+
+	let producer = tokio::task::spawn_blocking(move || -> Result<()> {
+		let mut writer = ChannelWriter {
+			tx,
+			buf: BytesMut::with_capacity(CHUNK_BYTES),
+		};
+		match source {
+			ContextSource::Inline(inline) => {
+				stream_build_context_with_inline(&mut writer, &context, &inline, &secret_files)
+			}
+			ContextSource::Dockerfile(dockerfile) => {
+				stream_build_context(&mut writer, &context, &dockerfile, &secret_files)
+			}
+		}
+	});
+
+	// Turn the receiver into a body stream without pulling in `tokio-stream`:
+	// `unfold` re-yields the receiver after each `recv`, ending on channel close.
+	let body = futures_util::stream::unfold(rx, |mut rx| async move {
+		rx.recv().await.map(|item| (item, rx))
+	});
+
+	(producer, body)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::super::context::build_context_tar;
+	use super::*;
+	use futures_util::StreamExt;
+
+	/// The streamed body must be byte-identical to the buffered tar the
+	/// non-streaming path produced: same entries, same gzip, just delivered in
+	/// chunks. This pins the equivalence the whole refactor rests on.
+	#[tokio::test]
+	async fn streamed_body_matches_buffered_tar() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("Dockerfile"), "FROM scratch\n").unwrap();
+		std::fs::write(dir.path().join("app.txt"), "hello world").unwrap();
+
+		let (producer, body) = context_body(
+			dir.path().to_path_buf(),
+			ContextSource::Dockerfile("Dockerfile".to_string()),
+			Vec::new(),
+		);
+		futures_util::pin_mut!(body);
+		let mut streamed = Vec::new();
+		while let Some(item) = body.next().await {
+			let frame = item.expect("no stream error");
+			if let Ok(data) = frame.into_data() {
+				streamed.extend_from_slice(&data);
+			}
+		}
+		producer.await.expect("join").expect("producer succeeds");
+
+		let buffered = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+		assert_eq!(
+			streamed, buffered,
+			"streamed tar must be byte-identical to the buffered tar"
+		);
+	}
+
+	/// A missing context directory surfaces as the producer's error, and the body
+	/// still terminates (the writer is dropped) rather than hanging.
+	#[tokio::test]
+	async fn missing_context_errors_via_producer() {
+		let (producer, body) = context_body(
+			std::path::PathBuf::from("/nonexistent/podup/context"),
+			ContextSource::Dockerfile("Dockerfile".to_string()),
+			Vec::new(),
+		);
+		futures_util::pin_mut!(body);
+		while body.next().await.is_some() {}
+		let produced = producer.await.expect("join");
+		assert!(produced.is_err(), "walking a missing context must error");
+	}
+}

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -5,8 +5,9 @@
 //! API calls are sequential and infrequent.
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full, Limited};
-use hyper::body::Incoming;
+use futures_util::Stream;
+use http_body_util::{BodyExt, Full, Limited, StreamBody};
+use hyper::body::{Frame, Incoming};
 use hyper::client::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
@@ -17,7 +18,20 @@ use super::error::PodmanError;
 mod encode;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
 
-type BoxBody = Full<Bytes>;
+/// The request body every call shares. A boxed body so a fully-buffered
+/// `Full<Bytes>` (almost every call) and a lazily-streamed build-context body
+/// (the `build` endpoint) travel the same client path. `Unsync` because hyper's
+/// `send_request` only requires the body to be `Send`, and the streamed body is
+/// not `Sync`.
+type BoxBody = http_body_util::combinators::UnsyncBoxBody<Bytes, std::io::Error>;
+
+/// Box a fully-buffered byte payload into [`BoxBody`]. `Full`'s error is
+/// `Infallible`, mapped to the unified `io::Error` (which it never produces).
+fn full(bytes: Bytes) -> BoxBody {
+	Full::new(bytes)
+		.map_err(|never| match never {})
+		.boxed_unsync()
+}
 
 /// Upper bound on a buffered (non-streaming) response body. Caps memory use
 /// when the daemon returns an oversized or runaway response.
@@ -272,7 +286,7 @@ impl Client {
 	/// SpecGenerator or libpod-native call fail with an obscure 4xx.
 	pub async fn ping(&self) -> Result<()> {
 		// Deliberately omits the version prefix: `_ping` is version-independent.
-		let req = Self::build_request(Method::GET, "/libpod/_ping", Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::GET, "/libpod/_ping", full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		// Read the version header before the body is consumed below.
 		let reported = resp
@@ -291,7 +305,7 @@ impl Client {
 
 	/// `GET` → deserialize JSON response.
 	pub async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::GET, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
@@ -300,7 +314,7 @@ impl Client {
 
 	/// `GET` → return raw `Response<Incoming>` for streaming.
 	pub async fn get_stream(&self, path: &str) -> Result<Response<Incoming>> {
-		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::GET, path, full(Bytes::new()), None)?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
@@ -314,7 +328,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
@@ -329,7 +343,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
@@ -347,7 +361,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
@@ -355,7 +369,7 @@ impl Client {
 
 	/// `POST` with empty body → ignore response body (expect 2xx or 304).
 	pub async fn post_empty_ok(&self, path: &str) -> Result<()> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		// 304 Not Modified is fine for idempotent ops
@@ -379,7 +393,7 @@ impl Client {
 		path: &str,
 		deadline: Option<std::time::Duration>,
 	) -> Result<()> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, deadline).await?;
 		let (status, body) = Self::read_body(resp, deadline).await?;
 		// 304 Not Modified is fine for idempotent ops
@@ -411,7 +425,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		Self::stream_or_err(self.send(req, head_timeout).await?).await
@@ -419,13 +433,13 @@ impl Client {
 
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with empty body → deserialize JSON response.
 	pub async fn post_empty_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
@@ -443,7 +457,7 @@ impl Client {
 	/// this method must impose their own outer budget (e.g. a
 	/// [`tokio::time::timeout`]) to stay bounded.
 	pub async fn post_empty_json_unbounded<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, None).await?;
 		let (status, body) = Self::read_body(resp, None).await?;
 		Self::check_status(status, &body)?;
@@ -457,7 +471,28 @@ impl Client {
 		bytes: Bytes,
 		content_type: &str,
 	) -> Result<Response<Incoming>> {
-		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
+		let req = Self::build_request(Method::POST, path, full(bytes), Some(content_type))?;
+		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
+	}
+
+	/// `POST` with a **streamed** body → return raw `Response<Incoming>` for
+	/// streaming.
+	///
+	/// The body is produced lazily from `chunks` rather than buffered whole, so a
+	/// large upload (a multi-gigabyte build-context tar) never inflates the
+	/// process's RSS. Each item is an `http_body`-style frame or a terminal
+	/// `io::Error` that aborts the request.
+	pub async fn post_stream_body<S>(
+		&self,
+		path: &str,
+		chunks: S,
+		content_type: &str,
+	) -> Result<Response<Incoming>>
+	where
+		S: Stream<Item = std::result::Result<Frame<Bytes>, std::io::Error>> + Send + 'static,
+	{
+		let body = StreamBody::new(chunks).boxed_unsync();
+		let req = Self::build_request(Method::POST, path, body, Some(content_type))?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
@@ -472,7 +507,7 @@ impl Client {
 		bytes: Bytes,
 		content_type: &str,
 	) -> Result<T> {
-		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
+		let req = Self::build_request(Method::POST, path, full(bytes), Some(content_type))?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
@@ -481,7 +516,7 @@ impl Client {
 
 	/// `PUT` with raw bytes body → expect 2xx.
 	pub async fn put_bytes_ok(&self, path: &str, bytes: Bytes, content_type: &str) -> Result<()> {
-		let req = Self::build_request(Method::PUT, path, Full::new(bytes), Some(content_type))?;
+		let req = Self::build_request(Method::PUT, path, full(bytes), Some(content_type))?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)
@@ -495,7 +530,7 @@ impl Client {
 	pub async fn head_path_is_dir(&self, path: &str) -> Result<Option<bool>> {
 		use base64::Engine as _;
 
-		let req = Self::build_request(Method::HEAD, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::HEAD, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let status = resp.status();
 		if status == StatusCode::NOT_FOUND {
@@ -534,7 +569,7 @@ impl Client {
 	/// no-op, so it can avoid reporting a phantom "removed" for a container that
 	/// never existed.
 	pub async fn delete_existed(&self, path: &str) -> Result<bool> {
-		let req = Self::build_request(Method::DELETE, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::DELETE, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		if status == StatusCode::NOT_FOUND {

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -54,20 +54,24 @@ fn check_status_falls_back_to_raw_body_on_non_json() {
 #[test]
 fn build_request_valid_path() {
 	use bytes::Bytes;
-	use http_body_util::Full;
 	use hyper::Method;
-	Client::build_request(Method::GET, "/libpod/_ping", Full::new(Bytes::new()), None).unwrap();
+	Client::build_request(
+		Method::GET,
+		"/libpod/_ping",
+		super::full(Bytes::new()),
+		None,
+	)
+	.unwrap();
 }
 
 #[test]
 fn build_request_sets_content_type_when_given() {
 	use bytes::Bytes;
-	use http_body_util::Full;
 	use hyper::Method;
 	let req = Client::build_request(
 		Method::POST,
 		"/libpod/secrets/create",
-		Full::new(Bytes::new()),
+		super::full(Bytes::new()),
 		Some("application/json"),
 	)
 	.unwrap();
@@ -82,14 +86,13 @@ fn build_request_sets_content_type_when_given() {
 #[test]
 fn build_request_rejects_unparseable_path() {
 	use bytes::Bytes;
-	use http_body_util::Full;
 	use hyper::Method;
 	// A control character makes `http://localhost<path>` an invalid URI, which
 	// must surface as a structured Api error rather than panicking.
 	let err = Client::build_request(
 		Method::GET,
 		"/libpod/bad\u{7f}path",
-		Full::new(Bytes::new()),
+		super::full(Bytes::new()),
 		None,
 	)
 	.unwrap_err();


### PR DESCRIPTION
## What

`build_service` compiled the whole build-context tar into a `Vec<u8>` and sent it as a `Full<Bytes>` body, so a 1-2 GB build context meant 1-2 GB of peak RSS in the podup process.

This streams the tar instead: a `spawn_blocking` writer walks the context and writes gzip chunks into a bounded channel that the request body drains, so peak memory is a handful of 64 KiB chunks (`CHANNEL_CAP * CHUNK_BYTES`) regardless of context size.

- The client's request body type becomes a boxed body (`UnsyncBoxBody<Bytes, io::Error>`) so every fully-buffered call and the new streamed build body share one path; `post_stream_body` sends the streamed body.
- Context assembly is extracted into `stream_build_context*<W: Write>`; the `Vec`-returning wrappers stay (now `#[cfg(test)]`) for the byte-level tests.
- The blocking tar writer feeds the body; the request drains it first, then the producer is joined — a transport error wins as the cause, otherwise a context-assembly error surfaces with its descriptive message.

## Why

The releases/perf backlog: a large context should not drive the process's RSS. Deferred from the streams/health pass (#1056) because it changes the client's build-call body type.

## Measured — real Podman 5.4.2, 512 MiB incompressible context

| | peak RSS of `podup build` |
|---|---|
| buffered (develop) | **~533 MiB** |
| streamed (this PR) | **~20 MiB** |

~26× lower and now **flat regardless of context size**; both runs produced an identical image (`Successfully built`). Peak RSS sampled via `/proc/<pid>/status` `VmHWM`.

## Tests

- `streamed_body_matches_buffered_tar` — the streamed body is byte-identical to the buffered tar (same entries, same gzip, chunked delivery).
- `missing_context_errors_via_producer` — a bad context surfaces as the producer's error and the body still terminates (no hang).
- Full lib suite green (1243), clippy `-D warnings` clean.

Note: streaming moves the tar+gzip work inside the request window (it was in `spawn_blocking` before the send). For the pathological multi-GB contexts where that could approach the response head-wait timeout, the buffered path would have OOM'd instead — so this is strictly better or neutral, never a regression on a context that works today.

Closes #1058