### PR TITLE
perf(up): share one healthcheck poller across a container's dependents

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -4,6 +4,7 @@ mod commands;
 mod down_label;
 mod parallel;
 mod prefetch;
+mod readiness;
 mod run;
 mod scale;
 mod signal;
@@ -12,8 +13,10 @@ mod targets;
 use std::collections::{HashMap, HashSet};
 
 use crate::compose::types::{ComposeFile, Service, ServiceCondition};
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 use crate::libpod::API_PREFIX;
+
+use readiness::SharedReady;
 
 pub use targets::validate_stop_timeout;
 use targets::{expand_targets, filter_services, in_started_set, validate_targets};
@@ -232,6 +235,9 @@ impl Engine {
 			// layering), so they start concurrently. The barrier between levels
 			// preserves ordering and `service_healthy`/`service_completed`
 			// semantics: a level only begins once the previous one is up.
+			// One shared healthcheck poller per waited-on container, so several
+			// dependents in a level don't each run the same container's healthcheck.
+			let readiness = self.build_readiness_map(file, &enabled, &target_set, start);
 			for level in &levels {
 				let started = level.iter().map(|name| {
 					self.up_one_service(
@@ -244,6 +250,7 @@ impl Engine {
 						no_recreate,
 						force_recreate,
 						start,
+						&readiness,
 					)
 				});
 				futures_util::future::try_join_all(started).await?;
@@ -293,6 +300,7 @@ impl Engine {
 		no_recreate: bool,
 		force_recreate: bool,
 		start: bool,
+		readiness: &HashMap<String, SharedReady<'_>>,
 	) -> Result<()> {
 		if let Some(set) = target_set {
 			if !set.contains(name) {
@@ -356,7 +364,17 @@ impl Engine {
 						);
 						Ok(())
 					} else {
-						self.wait_healthy(&dep_container, dep_service, None).await
+						// Await the one shared poller for this container instead of
+						// starting our own, so a container N services wait on has its
+						// healthcheck run once per interval, not N times. Fall back to
+						// a direct wait if the map somehow lacks this container.
+						match readiness.get(&dep_container) {
+							Some(shared) => shared
+								.clone()
+								.await
+								.map_err(ComposeError::DependencyNotReady),
+							None => self.wait_healthy(&dep_container, dep_service, None).await,
+						}
 					}
 				}
 				ServiceCondition::ServiceCompletedSuccessfully => {

--- a/internal/engine/lifecycle/readiness.rs
+++ b/internal/engine/lifecycle/readiness.rs
@@ -1,0 +1,203 @@
+//! Shared healthcheck readiness for the concurrent `up` path.
+//!
+//! When several services in a dependency level declare `depends_on: <svc>:
+//! {condition: service_healthy}`, they start concurrently and would each poll
+//! that container's healthcheck — and every poll *runs* the check inside the
+//! container, so a service N others wait on gets its healthcheck executed ~N×
+//! per interval for the whole startup. [`Engine::build_readiness_map`] memoizes
+//! one poller per container so the check runs once per interval regardless of
+//! how many depend on it.
+
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures_util::future::{FutureExt, Shared};
+
+use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::engine::Engine;
+use crate::error::ComposeError;
+
+use super::in_started_set;
+
+/// A `wait_healthy` future shared across every dependent of one container, so a
+/// service that N others wait on has its healthcheck polled by a single poller
+/// rather than ~N× per interval. Lazy: the poll begins when the first dependent
+/// awaits it. The error is `Arc`-wrapped because [`Shared`] needs a `Clone`
+/// output and [`ComposeError`] is not `Clone`.
+pub(super) type SharedReady<'a> =
+	Shared<Pin<Box<dyn Future<Output = std::result::Result<(), Arc<ComposeError>>> + Send + 'a>>>;
+
+impl Engine {
+	/// Build one shared readiness future per container that any starting service
+	/// waits on with `condition: service_healthy`.
+	///
+	/// The predicate mirrors the wait guard in `up_one_service`; a container it
+	/// misses simply falls back to a direct wait there, so a mismatch degrades to
+	/// the old per-dependent behaviour rather than a panic.
+	pub(super) fn build_readiness_map<'a>(
+		&'a self,
+		file: &'a ComposeFile,
+		enabled: &HashSet<String>,
+		target_set: &Option<HashSet<String>>,
+		start: bool,
+	) -> HashMap<String, SharedReady<'a>> {
+		let mut map: HashMap<String, SharedReady<'a>> = HashMap::new();
+		// `create` (start = false) gates on nothing, so there are no waits to share.
+		if !start {
+			return map;
+		}
+		for (sname, service) in &file.services {
+			// Only services this pass actually starts run their readiness waits.
+			if let Some(set) = target_set {
+				if !set.contains(sname) {
+					continue;
+				}
+			}
+			if !enabled.contains(sname) {
+				continue;
+			}
+			for dep in service.depends_on.service_names() {
+				if !matches!(
+					service.depends_on.condition_for(&dep),
+					ServiceCondition::ServiceHealthy
+				) {
+					continue;
+				}
+				if !in_started_set(target_set, &dep) {
+					continue;
+				}
+				let Some(dep_service) = file.services.get(&dep) else {
+					continue;
+				};
+				if !enabled.contains(&dep) {
+					continue;
+				}
+				// A disabled healthcheck is treated as satisfied — never polled.
+				if dep_service
+					.healthcheck
+					.as_ref()
+					.is_some_and(|h| h.is_disabled())
+				{
+					continue;
+				}
+				let container = self.first_replica_name(&dep, dep_service);
+				map.entry(container.clone()).or_insert_with(|| {
+					let c = container.clone();
+					async move {
+						self.wait_healthy(&c, dep_service, None)
+							.await
+							.map_err(Arc::new)
+					}
+					.boxed()
+					.shared()
+				});
+			}
+		}
+		map
+	}
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+	use std::collections::HashSet;
+
+	use crate::engine::Engine;
+	use crate::libpod::Client;
+
+	fn engine(project: &str) -> Engine {
+		// The map is built without any socket call (the shared futures are lazy),
+		// so a client bound to a never-opened path is enough — no runtime needed.
+		let client = Client::new("/tmp/podup-readiness-test.sock");
+		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+	}
+
+	fn enabled_all(file: &crate::compose::types::ComposeFile) -> HashSet<String> {
+		file.services.keys().cloned().collect()
+	}
+
+	#[test]
+	fn shares_one_poller_per_service_healthy_container() {
+		// web and api both wait on db with `service_healthy`; cache is waited on
+		// with `service_started` (never polled). Exactly one shared entry — db's
+		// container — must result, not one per dependent.
+		let yaml = "\
+services:
+  db:
+    image: x
+    healthcheck:
+      test: [\"CMD\", \"true\"]
+  cache:
+    image: x
+  web:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_started
+  api:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine("proj");
+		let map = e.build_readiness_map(&file, &enabled_all(&file), &None, true);
+		let keys: Vec<&String> = map.keys().collect();
+		assert_eq!(map.len(), 1, "one shared poller expected, got {keys:?}");
+		assert!(
+			keys[0].contains("db"),
+			"shared container should be db, got {keys:?}"
+		);
+	}
+
+	#[test]
+	fn create_only_shares_nothing() {
+		// `create` (start = false) gates on no dependency, so nothing is shared.
+		let yaml = "\
+services:
+  db:
+    image: x
+    healthcheck:
+      test: [\"CMD\", \"true\"]
+  web:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine("proj");
+		assert!(e
+			.build_readiness_map(&file, &enabled_all(&file), &None, false)
+			.is_empty());
+	}
+
+	#[test]
+	fn disabled_healthcheck_is_not_shared() {
+		// A dependency whose healthcheck is disabled is treated as satisfied, so it
+		// is never polled and must not get a shared poller.
+		let yaml = "\
+services:
+  db:
+    image: x
+    healthcheck:
+      disable: true
+  web:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine("proj");
+		assert!(
+			e.build_readiness_map(&file, &enabled_all(&file), &None, true)
+				.is_empty(),
+			"a disabled healthcheck must not be shared or polled"
+		);
+	}
+}

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -123,6 +123,26 @@ pub enum ComposeError {
 	/// written/removed, or the requested mode is not yet available. The string is
 	/// a ready-to-print message.
 	Autostart(String),
+	/// A `service_healthy` dependency did not become ready. Wraps the shared
+	/// readiness error in an `Arc` so one poller's result can fan out to every
+	/// dependent waiting on the same container (the error type is otherwise not
+	/// `Clone`). Transparent: it displays as, and sources, the wrapped error.
+	DependencyNotReady(std::sync::Arc<ComposeError>),
+}
+
+impl ComposeError {
+	/// Peel [`Self::DependencyNotReady`] wrappers to the underlying cause.
+	///
+	/// The readiness fan-out wraps a poller's error so it can be shared; callers
+	/// that classify an error by variant (e.g. the CLI's exit-code mapping) want
+	/// the real cause, not the wrapper.
+	pub fn innermost(&self) -> &ComposeError {
+		let mut e = self;
+		while let Self::DependencyNotReady(inner) = e {
+			e = inner;
+		}
+		e
+	}
 }
 
 /// Escape control characters (tabs, newlines, ESC, …) in an interpolated,
@@ -263,6 +283,8 @@ impl fmt::Display for ComposeError {
 			),
 			Self::EnvFile(s) => write!(f, "{s}"),
 			Self::Autostart(s) => write!(f, "{s}"),
+			// Transparent: the wrapper only exists to make the cause shareable.
+			Self::DependencyNotReady(inner) => write!(f, "{inner}"),
 		}
 	}
 }
@@ -274,6 +296,7 @@ impl std::error::Error for ComposeError {
 			Self::Io(e) => Some(e),
 			Self::Podman(e) => Some(e),
 			Self::IoPath { source, .. } | Self::BuildContext { source, .. } => Some(source),
+			Self::DependencyNotReady(inner) => Some(inner),
 			_ => None,
 		}
 	}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -69,8 +69,10 @@ fn run_to_exit() {
 			print_error(&e);
 			// A `run`/`exec` whose command cannot be launched arrives as a Podman
 			// (OCI/crun) error; map it onto docker's conventional codes (127 not
-			// found, 126 not executable) instead of the generic exit 1.
-			let code = match &e {
+			// found, 126 not executable) instead of the generic exit 1. Peel a
+			// `DependencyNotReady` wrapper first so a failed readiness wait maps on
+			// its real cause, exactly as an unwrapped one would.
+			let code = match e.innermost() {
 				podup::ComposeError::Podman(_) => command_failure_exit_code(&e.to_string()),
 				_ => 1,
 			};


### PR DESCRIPTION
## What

When several services in a dependency level declare `depends_on: <svc>: {condition: service_healthy}`, they start concurrently and each dependent's `up_one_service` independently polled that container's healthcheck. Every poll hits `GET /containers/<svc>/healthcheck`, which **runs** the healthcheck inside the container — so a service N others wait on had its healthcheck executed ~N× per interval for the whole startup.

This memoizes **one shared readiness future per waited-on container** in the `up` context (`build_readiness_map`, new `lifecycle/readiness.rs`), so every dependent awaits a single poller.

- The future is `Arc`-wrapped to satisfy `Shared`'s `Clone`-output bound (`ComposeError` is not `Clone`).
- A new transparent `ComposeError::DependencyNotReady(Arc<ComposeError>)` carries the shared error for the required-dependency path; the CLI's exit-code mapping peels it via `ComposeError::innermost`, so exit codes and messages are unchanged.
- A container the map misses falls back to a direct wait, so a predicate mismatch degrades to the old per-dependent behaviour rather than panicking.

## Why

Deferred from the streams/health perf pass (#1056): sharing a future across the concurrent `up_one_service` tasks (with the `Engine` borrow) warranted its own PR.

## Measured — real Podman 5.4.2, 8 services depending on one `db` (service_healthy), healthy after ~3s

| | `db` healthcheck runs | `db` inspects |
|---|---|---|
| before (develop) | **32** (8 independent pollers) | 8 |
| after (this PR) | **4** (one shared poller) | 1 |

Counted from `RUST_LOG=podup=debug` `GET .../healthcheck` calls; `up` succeeded identically in both.

## Tests

- `readiness::tests` — the predicate shares exactly one poller per `service_healthy` container, shares nothing for `create` (start=false), and skips a disabled healthcheck.
- Full lib suite green (1244), clippy `-D warnings` and `fmt` clean.

Note: adds a variant to the `#[non_exhaustive]` public `ComposeError` and a `pub fn innermost` — additive, non-breaking.

Closes #1057