### PR TITLE
chore(release): 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+podup (1.11.1) unstable; urgency=medium
+
+  * build streams the build context to the engine instead of buffering the
+    whole tar in memory, so building a large context no longer grows memory
+    with the size of the context.
+  * up shares a single healthcheck poller across all of a container's
+    dependents instead of starting one per dependent, cutting the redundant
+    polling when several services wait on the same dependency.
+  * Every release artifact now ships a per-target CycloneDX SBOM alongside it,
+    so the exact dependency set of each binary and .deb can be audited.
+
+ -- Glyndor <packages@glyndor.net>  Sat, 18 Jul 2026 20:32:01 -0500
+
 podup (1.11.0) unstable; urgency=medium
 
   * up, down and scale now exit non-zero when the operation actually fails,


### PR DESCRIPTION
Version bump for 1.11.1 — Cargo.toml, Cargo.lock, and a debian/changelog stanza. Rolls up the five commits already on develop since v1.11.0:

- perf(build): stream the build-context tar instead of buffering it (#1066)
- perf(up): share one healthcheck poller across a container's dependents (#1067)
- ci(release): generate a per-target SBOM for each artifact (#1064)
- ci(podman-lane): log the identities of failing tests, not just the count (#1065)
- test(update): re-vector the embedded-key regression test from v1.11.0 (#1062)

The changelog lists only the user-facing changes (the two perf items and the SBOM); the CI/test commits are internal. After this lands on develop, a `Release 1.11.1` PR promotes develop→main and the tag is cut.