### PR TITLE
Release 1.11.1

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -92,6 +92,17 @@ jobs:
                 FLAKY=$(grep -cE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log)
                 echo "PODUP_TESTS_RC=$RC"
                 echo "PODUP_SUMMARY pass=${PASS:-0} fail=${FAIL:-0} flaky=${FLAKY:-0}"
+                # Emit the IDENTITIES of the failing tests, not just the count.
+                # The floor gate can only tighten to a per-test known-flaky
+                # allowlist once the flaky set is small and stable (#1039), and
+                # building that allowlist starts with observing which tests
+                # actually fail across nested-virt runs — which the count alone
+                # cannot tell you. cargo prints a final `failures:` block of bare
+                # test names (the earlier block carries `---- name stdout ----`
+                # detail lines, which the 4-space-exact match skips); no failures
+                # yields an empty list, not an error.
+                FAILED_TESTS=$(sed -n '/^failures:$/,/^test result:/p' /tmp/cargo.log | grep -oE '^    [A-Za-z0-9_:]+$' | tr -d ' ' | paste -sd, -)
+                echo "PODUP_FAILED_TESTS=${FAILED_TESTS}"
           runcmd:
             - bash -c 'F=$(findmnt -no FSTYPE /); case $F in btrfs) btrfs filesystem resize max / ;; xfs) xfs_growfs / ;; ext4) resize2fs $(findmnt -no SOURCE /) ;; esac >/dev/console 2>&1; echo "DISK=$(df -h / | tail -1)" >/dev/console'
             - bash -c 'dnf install -y podman rust cargo gcc git >/dev/console 2>&1'
@@ -132,6 +143,13 @@ jobs:
           FLAKY=$(echo "$SUM" | grep -oE 'flaky=[0-9]+' | cut -d= -f2)
           PASS=${PASS:-0}; FAIL=${FAIL:-0}; FLAKY=${FLAKY:-0}
           echo "Podman $VER: $PASS passed, $FAIL failed ($FLAKY look like connection-drop flakes)"
+          # Surface the failing-test identities (informational) so the nightly
+          # runs accumulate the data a per-test known-flaky allowlist will need
+          # before the gate can tighten past the floor (#1039).
+          FAILED_TESTS=$(grep -oE 'PODUP_FAILED_TESTS=.*' "$L" | tail -1 | cut -d= -f2- || true)
+          if [ -n "$FAILED_TESTS" ]; then
+            echo "Failing tests on Podman $VER: $FAILED_TESTS"
+          fi
           # Gate: the core must pass the baseline in .github/podman-baseline-tests.
           # A real regression breaks previously-passing tests and knocks PASS
           # below the floor; the baseline is versioned so it is bumped

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,18 +320,56 @@ jobs:
             fi
           done
 
-      - name: Generate SBOM and license attribution
+      - name: Generate per-target SBOMs and license attribution
         # Government/enterprise consumers require a machine-readable SBOM
-        # (CycloneDX, per US EO 14028) and a third-party license attribution.
+        # (CycloneDX, per US EO 14028). A single --all-features run over-declares
+        # every artifact: the .deb drops the self-update stack (ureq/TLS/Ed25519)
+        # and each OS pulls different cfg-gated deps, yet all shipped the same
+        # union SBOM. Generate one CycloneDX per released artifact with that
+        # artifact's exact target triple and feature set, so each lists only what
+        # its binary actually contains (releases standard: "the per-artifact SBOM
+        # lists only that platform's dependencies").
+        #
+        # cargo-cyclonedx's --target uses cargo's --filter-platform resolution,
+        # which needs only the triple, not an installed std — so the six
+        # cross-platform binary targets resolve here without `rustup target add`.
+        # The binaries carry the default feature set; the .debs are built
+        # --no-default-features --features watch,completions (debian/rules), so
+        # their SBOMs pass the same flags or they would misdeclare the package.
+        # License attribution (NOTICES.html) stays a single union — over-listing
+        # licenses is the safe direction for attribution, never under-listing.
         run: |
           cargo install --locked cargo-cyclonedx --version "=0.5.9"
           cargo install --locked --features cli cargo-about --version "=0.9.0"
-          cargo cyclonedx --format json --all-features
-          # cargo-cyclonedx names the file after the package (podup.cdx.json),
-          # so only rename when an older/different layout emitted another name —
-          # mv onto itself errors ("are the same file").
-          src="$(find . -maxdepth 1 -name "*.cdx.json" | sort | head -n1)"
-          [ "$src" = "./podup.cdx.json" ] || mv "$src" podup.cdx.json
+
+          # $1 = output basename (the artifact the SBOM describes; ".cdx.json" is
+          #      appended), $2 = target triple, $3.. = extra cargo-cyclonedx flags.
+          gen_sbom() {
+            local out="$1" target="$2"
+            shift 2
+            cargo cyclonedx --format json --target "$target" \
+              --override-filename "${out}.cdx" "$@"
+          }
+
+          # Binaries — default feature set, one SBOM per target triple.
+          gen_sbom podup-linux-x86_64        x86_64-unknown-linux-musl
+          gen_sbom podup-linux-arm64         aarch64-unknown-linux-musl
+          gen_sbom podup-darwin-arm64        aarch64-apple-darwin
+          gen_sbom podup-darwin-x86_64       x86_64-apple-darwin
+          gen_sbom podup-windows-x86_64.exe  x86_64-pc-windows-msvc
+          gen_sbom podup-windows-arm64.exe   aarch64-pc-windows-msvc
+
+          # Debian packages — the packaged binary drops the `update` feature and
+          # links glibc (gnu), not musl. Name each SBOM after its own .deb.
+          for arch in amd64 arm64; do
+            case "$arch" in
+              amd64) triple=x86_64-unknown-linux-gnu ;;
+              arm64) triple=aarch64-unknown-linux-gnu ;;
+            esac
+            deb="$(ls podup_*_"${arch}".deb)"
+            gen_sbom "$deb" "$triple" --no-default-features --features watch,completions
+          done
+
           cargo about generate about.hbs > NOTICES.html
 
       - name: Generate checksums
@@ -345,7 +383,14 @@ jobs:
             podup-windows-arm64.exe \
             podup_*_amd64.deb \
             podup_*_arm64.deb \
-            podup.cdx.json \
+            podup-linux-x86_64.cdx.json \
+            podup-linux-arm64.cdx.json \
+            podup-darwin-arm64.cdx.json \
+            podup-darwin-x86_64.cdx.json \
+            podup-windows-x86_64.exe.cdx.json \
+            podup-windows-arm64.exe.cdx.json \
+            podup_*_amd64.deb.cdx.json \
+            podup_*_arm64.deb.cdx.json \
             NOTICES.html \
             install.sh \
             install.ps1 \
@@ -372,7 +417,10 @@ jobs:
             "$venv_py" .github/scripts/sign.py "$deb"
           done
           # Sign the supply-chain artifacts so consumers can verify them offline.
-          "$venv_py" .github/scripts/sign.py podup.cdx.json
+          # Every per-target SBOM (the only *.cdx.json files in the workspace).
+          for sbom in *.cdx.json; do
+            "$venv_py" .github/scripts/sign.py "$sbom"
+          done
           "$venv_py" .github/scripts/sign.py NOTICES.html
           # Sign the installers so a user pinning PODUP_VERSION can verify the
           # script they pipe to a shell, not just the binaries it fetches.
@@ -417,8 +465,8 @@ jobs:
             podup_*_arm64.deb.sig \
             SHA256SUMS \
             SHA256SUMS.sig \
-            podup.cdx.json \
-            podup.cdx.json.sig \
+            podup*.cdx.json \
+            podup*.cdx.json.sig \
             NOTICES.html \
             NOTICES.html.sig \
             install.sh \
@@ -427,7 +475,7 @@ jobs:
             install.ps1.sig
 
       - name: Remove release artifacts
-        run: rm -f podup-* podup_* podup.cdx.json* NOTICES.html* SHA256SUMS SHA256SUMS.sig install.sh.sig install.ps1.sig
+        run: rm -f podup-* podup_* NOTICES.html* SHA256SUMS SHA256SUMS.sig install.sh.sig install.ps1.sig
 
       - name: Publish to crates.io
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+podup (1.11.1) unstable; urgency=medium
+
+  * build streams the build context to the engine instead of buffering the
+    whole tar in memory, so building a large context no longer grows memory
+    with the size of the context.
+  * up shares a single healthcheck poller across all of a container's
+    dependents instead of starting one per dependent, cutting the redundant
+    polling when several services wait on the same dependency.
+  * Every release artifact now ships a per-target CycloneDX SBOM alongside it,
+    so the exact dependency set of each binary and .deb can be audited.
+
+ -- Glyndor <packages@glyndor.net>  Sat, 18 Jul 2026 20:32:01 -0500
+
 podup (1.11.0) unstable; urgency=medium
 
   * up, down and scale now exit non-zero when the operation actually fails,

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -123,9 +123,12 @@ PY
 sha256sum --check --ignore-missing SHA256SUMS
 ```
 
-The release also ships a CycloneDX SBOM (`podup.cdx.json`) and a third-party
-license attribution (`NOTICES.html`), each with a detached `.sig` that verifies
-against the same key.
+The release also ships a CycloneDX SBOM **per artifact** — one for each binary
+(e.g. `podup-linux-x86_64.cdx.json`) and each Debian package
+(`podup_<version>_amd64.deb.cdx.json`), listing only that target's actual
+dependencies rather than a union across every platform — plus a third-party
+license attribution (`NOTICES.html`). Each carries a detached `.sig` that
+verifies against the same key.
 
 ## Air-gapped installation
 

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -80,52 +80,23 @@ fn append_extra_files<W: std::io::Write>(
 	Ok(())
 }
 
-/// Write inline Dockerfile content into the context tar as `.dockerfile-inline`.
-pub(super) fn build_context_tar_with_inline(
-	context: &Path,
-	inline: &str,
-	extra_files: &[(String, Vec<u8>)],
-) -> Result<(Vec<u8>, String)> {
-	let inline_name = ".dockerfile-inline";
-	let ignore_patterns = read_dockerignore(context);
+/// The `.dockerfile-inline` entry name synthesized for an inline Dockerfile.
+pub(super) const INLINE_DOCKERFILE_NAME: &str = ".dockerfile-inline";
 
-	let encoder = GzEncoder::new(Vec::new(), Compression::default());
-	let mut tar = tar::Builder::new(encoder);
-
-	let mut header = tar::Header::new_gnu();
-	header.set_size(inline.len() as u64);
-	header.set_mode(0o644);
-	header.set_cksum();
-	tar.append_data(&mut header, inline_name, inline.as_bytes())
-		.map_err(|e| ComposeError::Build(e.to_string()))?;
-
-	// Skip the user's `.dockerignore` here; it is rewritten below with extra
-	// rules excluding every synthesized entry (inline Dockerfile, build secrets).
-	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"], &[])?;
-
-	let mut synthesized: Vec<&str> = vec![inline_name];
-	synthesized.extend(extra_files.iter().map(|(n, _)| n.as_str()));
-	append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
-
-	append_extra_files(&mut tar, extra_files)?;
-
-	let gz = tar
-		.into_inner()
-		.map_err(|e| ComposeError::Build(e.to_string()))?;
-	let bytes = gz
-		.finish()
-		.map_err(|e| ComposeError::Build(e.to_string()))?;
-	Ok((bytes, inline_name.to_string()))
-}
-
-pub(crate) fn build_context_tar(
+/// Assemble the gzipped build-context tar and write it straight to `writer`.
+///
+/// This is the shared core of context assembly. `build_context_tar` wraps it
+/// to collect the bytes into a `Vec` (tests, non-streaming callers); the build
+/// path feeds a channel-backed writer so a multi-gigabyte context is streamed to
+/// the socket without ever inflating the process's RSS.
+pub(super) fn stream_build_context<W: std::io::Write>(
+	writer: W,
 	context: &Path,
 	dockerfile: &str,
 	extra_files: &[(String, Vec<u8>)],
-) -> Result<Vec<u8>> {
+) -> Result<()> {
 	let ignore_patterns = read_dockerignore(context);
-
-	let encoder = GzEncoder::new(Vec::new(), Compression::default());
+	let encoder = GzEncoder::new(writer, Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
 	// Force-include the active Dockerfile so a `.dockerignore` that matches it
@@ -147,15 +118,81 @@ pub(crate) fn build_context_tar(
 		append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
 	}
 	append_extra_files(&mut tar, extra_files)?;
+	finish_tar(tar)
+}
 
+/// As [`stream_build_context`], but injects an inline Dockerfile as
+/// [`INLINE_DOCKERFILE_NAME`] instead of shipping one from the context.
+pub(super) fn stream_build_context_with_inline<W: std::io::Write>(
+	writer: W,
+	context: &Path,
+	inline: &str,
+	extra_files: &[(String, Vec<u8>)],
+) -> Result<()> {
+	let ignore_patterns = read_dockerignore(context);
+	let encoder = GzEncoder::new(writer, Compression::default());
+	let mut tar = tar::Builder::new(encoder);
+
+	let mut header = tar::Header::new_gnu();
+	header.set_size(inline.len() as u64);
+	header.set_mode(0o644);
+	header.set_cksum();
+	tar.append_data(&mut header, INLINE_DOCKERFILE_NAME, inline.as_bytes())
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+
+	// Skip the user's `.dockerignore` here; it is rewritten below with extra
+	// rules excluding every synthesized entry (inline Dockerfile, build secrets).
+	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"], &[])?;
+
+	let mut synthesized: Vec<&str> = vec![INLINE_DOCKERFILE_NAME];
+	synthesized.extend(extra_files.iter().map(|(n, _)| n.as_str()));
+	append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
+
+	append_extra_files(&mut tar, extra_files)?;
+	finish_tar(tar)
+}
+
+/// Finish the gzip stream and flush the sink. `GzEncoder::finish` writes the
+/// trailer but does not flush the underlying writer, so a channel-backed writer
+/// would strand its last buffered chunk without this explicit flush.
+fn finish_tar<W: std::io::Write>(tar: tar::Builder<GzEncoder<W>>) -> Result<()> {
 	let gz = tar
 		.into_inner()
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
-	let bytes = gz
+	let mut writer = gz
 		.finish()
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	writer
+		.flush()
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+	Ok(())
+}
 
-	Ok(bytes)
+/// Collect [`stream_build_context_with_inline`] into a `Vec`. Test-only: the
+/// build path streams the tar; these wrappers let the tar assembly be asserted
+/// on its bytes.
+#[cfg(test)]
+pub(super) fn build_context_tar_with_inline(
+	context: &Path,
+	inline: &str,
+	extra_files: &[(String, Vec<u8>)],
+) -> Result<(Vec<u8>, String)> {
+	let mut buf = Vec::new();
+	stream_build_context_with_inline(&mut buf, context, inline, extra_files)?;
+	Ok((buf, INLINE_DOCKERFILE_NAME.to_string()))
+}
+
+/// Collect [`stream_build_context`] into a `Vec`. Test-only (see
+/// [`build_context_tar_with_inline`]).
+#[cfg(test)]
+pub(crate) fn build_context_tar(
+	context: &Path,
+	dockerfile: &str,
+	extra_files: &[(String, Vec<u8>)],
+) -> Result<Vec<u8>> {
+	let mut buf = Vec::new();
+	stream_build_context(&mut buf, context, dockerfile, extra_files)?;
+	Ok(buf)
 }
 
 /// Append a synthesized `.dockerignore` entry to the context tar.

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,6 +8,7 @@
 mod context;
 mod pull;
 mod push;
+mod stream;
 mod tags;
 /// Shared with the `up` image-prefetch stage so it resolves a service's
 /// effective pull policy identically to the pull path below.
@@ -29,7 +30,8 @@ use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
 use crate::size;
 
-use context::{build_context_tar, build_context_tar_with_inline, map_additional_context};
+use context::{map_additional_context, INLINE_DOCKERFILE_NAME};
+use stream::{context_body, ContextSource};
 use tags::{is_remote_context, looks_like_secret};
 
 use super::Engine;
@@ -37,6 +39,19 @@ use super::Engine;
 /// Files to ship inside the build-context tar plus their matching `secrets=`
 /// specs (`id=NAME,src=ENTRY`) for the libpod build endpoint.
 type ResolvedBuildSecrets = (Vec<(String, Vec<u8>)>, Vec<String>);
+
+/// How `build_service` sends the context to the libpod build endpoint.
+enum BodyPlan {
+	/// A Git/URL context — Podman clones it server-side, so the body is empty.
+	Empty,
+	/// A local context, streamed to the socket from a `spawn_blocking` tar writer
+	/// so its size never drives the process's RSS.
+	Stream {
+		context: std::path::PathBuf,
+		source: ContextSource,
+		secrets: Vec<(String, Vec<u8>)>,
+	},
+}
 
 /// `docker compose build`-style CLI overrides. Each augments (never weakens)
 /// the per-service `build:` config: a flag forces the behaviour on even when
@@ -119,7 +134,7 @@ impl Engine {
 		// A Git/URL context is cloned server-side by Podman via the `remote`
 		// query parameter — there is no local directory to tar. Tar-only features
 		// (inline Dockerfile, in-tar build secrets) do not apply.
-		let (tar_bytes, dockerfile_name, secret_specs) = if remote_context {
+		let (body_plan, dockerfile_name, secret_specs) = if remote_context {
 			info!("building {tag} from remote context {context_str}");
 			if build.dockerfile_inline().is_some() {
 				warn!("build.dockerfile_inline is ignored for a remote build context");
@@ -128,7 +143,7 @@ impl Engine {
 				warn!("build.secrets are ignored for a remote build context");
 			}
 			let df = build.dockerfile().unwrap_or("Dockerfile").to_string();
-			(Vec::new(), df, Vec::new())
+			(BodyPlan::Empty, df, Vec::new())
 		} else {
 			let context_path = self.base_dir.join(&context_str);
 			// Fail fast with the service name and the resolved context path if the
@@ -150,31 +165,40 @@ impl Engine {
 			// over the socket).
 			let (secret_files, secret_specs) = self.resolve_build_secrets(build, file)?;
 
-			let inline = build.dockerfile_inline().map(|s| s.to_string());
-			// Honour an explicit dockerfile; otherwise prefer Dockerfile but fall
-			// back to Podman's native Containerfile when only the latter is present.
-			let df = match build.dockerfile() {
-				Some(name) => name.to_string(),
-				None if !context_path.join("Dockerfile").is_file()
-					&& context_path.join("Containerfile").is_file() =>
-				{
-					"Containerfile".to_string()
+			// The context tar is streamed to the socket (see the POST below), never
+			// buffered, so a multi-gigabyte context doesn't inflate RSS. Decide the
+			// source and the dockerfile name here; the blocking tar walk happens
+			// while the request body is being sent.
+			let (source, dockerfile_name) = match build.dockerfile_inline() {
+				Some(inline) => (
+					ContextSource::Inline(inline.to_string()),
+					INLINE_DOCKERFILE_NAME.to_string(),
+				),
+				None => {
+					// Honour an explicit dockerfile; otherwise prefer Dockerfile
+					// but fall back to Podman's native Containerfile when only the
+					// latter is present.
+					let df = match build.dockerfile() {
+						Some(name) => name.to_string(),
+						None if !context_path.join("Dockerfile").is_file()
+							&& context_path.join("Containerfile").is_file() =>
+						{
+							"Containerfile".to_string()
+						}
+						None => "Dockerfile".to_string(),
+					};
+					(ContextSource::Dockerfile(df.clone()), df)
 				}
-				None => "Dockerfile".to_string(),
 			};
-			let ctx = context_path.clone();
-			let (bytes, name) =
-				tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String)> {
-					if let Some(inline_s) = inline {
-						build_context_tar_with_inline(&ctx, &inline_s, &secret_files)
-					} else {
-						let bytes = build_context_tar(&ctx, &df, &secret_files)?;
-						Ok((bytes, df))
-					}
-				})
-				.await
-				.map_err(|e| ComposeError::Build(e.to_string()))??;
-			(bytes, name, secret_specs)
+			(
+				BodyPlan::Stream {
+					context: context_path,
+					source,
+					secrets: secret_files,
+				},
+				dockerfile_name,
+				secret_specs,
+			)
 		};
 
 		let arg_map = build.args().to_map();
@@ -332,12 +356,39 @@ impl Engine {
 		}
 
 		let path = format!("{API_PREFIX}/build?{qs}");
-		let body_bytes = Bytes::from(tar_bytes);
-		let resp = self
-			.client
-			.post_bytes_stream(&path, body_bytes, "application/x-tar")
-			.await
-			.map_err(ComposeError::Podman)?;
+		let resp = match body_plan {
+			BodyPlan::Empty => self
+				.client
+				.post_bytes_stream(&path, Bytes::new(), "application/x-tar")
+				.await
+				.map_err(ComposeError::Podman)?,
+			BodyPlan::Stream {
+				context,
+				source,
+				secrets,
+			} => {
+				// The tar writer runs on a blocking thread feeding the request
+				// body; drain the body first, then join the writer — joining
+				// before the body is drained would deadlock on the bounded
+				// channel. If the request itself failed, that transport error is
+				// the real cause; otherwise surface any context-assembly error.
+				let (producer, body) = context_body(context, source, secrets);
+				let sent = self
+					.client
+					.post_stream_body(&path, body, "application/x-tar")
+					.await;
+				let produced = producer
+					.await
+					.map_err(|e| ComposeError::Build(e.to_string()))?;
+				match sent {
+					Ok(resp) => {
+						produced?;
+						resp
+					}
+					Err(e) => return Err(ComposeError::Podman(e)),
+				}
+			}
+		};
 		let mut stream = crate::libpod::parse_json_lines::<BuildOutput>(resp.into_body());
 
 		while let Some(result) = stream.next().await {

--- a/internal/engine/build/stream.rs
+++ b/internal/engine/build/stream.rs
@@ -1,0 +1,172 @@
+//! Stream a build-context tar to the libpod build endpoint without buffering
+//! the whole context in memory.
+//!
+//! [`context_body`] runs the (blocking) tar+gzip writer on a `spawn_blocking`
+//! thread that feeds a bounded channel, and returns an async body stream that
+//! drains it. Peak memory is roughly `CHANNEL_CAP * CHUNK_BYTES` regardless of
+//! context size — a multi-gigabyte context no longer drives the process's RSS.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use bytes::{Bytes, BytesMut};
+use futures_util::Stream;
+use hyper::body::Frame;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use super::context::{stream_build_context, stream_build_context_with_inline};
+use crate::error::Result;
+
+/// Items handed to the request body: a data frame, or a terminal error that
+/// aborts the upload.
+type BodyItem = io::Result<Frame<Bytes>>;
+
+/// How many pending chunks the channel buffers. Bounds peak memory to about
+/// `CHANNEL_CAP * CHUNK_BYTES` while still decoupling the blocking tar writer
+/// from the async socket writer so both run concurrently.
+const CHANNEL_CAP: usize = 8;
+
+/// Coalesce the tar writer's many small writes into ~64 KiB frames, so the body
+/// is a handful of sizeable chunks rather than thousands of tiny ones.
+const CHUNK_BYTES: usize = 64 * 1024;
+
+/// Which Dockerfile the context ships: one synthesized from an inline string, or
+/// a named file already inside the context directory.
+pub(super) enum ContextSource {
+	/// `build.dockerfile_inline` content.
+	Inline(String),
+	/// The resolved Dockerfile/Containerfile name within the context.
+	Dockerfile(String),
+}
+
+/// A [`Write`] sink that forwards the tar bytes to an async channel as `Bytes`
+/// frames, coalescing small writes to `CHUNK_BYTES`. Blocks (backpressure) when
+/// the consumer is behind; errors if the consumer has gone away.
+struct ChannelWriter {
+	tx: mpsc::Sender<BodyItem>,
+	buf: BytesMut,
+}
+
+impl ChannelWriter {
+	fn send_pending(&mut self) -> io::Result<()> {
+		if self.buf.is_empty() {
+			return Ok(());
+		}
+		let chunk = self.buf.split().freeze();
+		self.tx.blocking_send(Ok(Frame::data(chunk))).map_err(|_| {
+			io::Error::new(
+				io::ErrorKind::BrokenPipe,
+				"build-context receiver dropped before the tar finished",
+			)
+		})
+	}
+}
+
+impl Write for ChannelWriter {
+	fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+		self.buf.extend_from_slice(data);
+		if self.buf.len() >= CHUNK_BYTES {
+			self.send_pending()?;
+		}
+		Ok(data.len())
+	}
+
+	fn flush(&mut self) -> io::Result<()> {
+		self.send_pending()
+	}
+}
+
+/// Spawn the blocking tar writer and return `(producer, body)`.
+///
+/// The producer's `JoinHandle` yields the context-assembly `Result` (a tar/IO
+/// error surfaces here with its descriptive message); the `body` is the stream
+/// the client sends as the request body. Await the body request first, then the
+/// producer — awaiting the producer before draining the body would deadlock on
+/// the bounded channel.
+pub(super) fn context_body(
+	context: PathBuf,
+	source: ContextSource,
+	secret_files: Vec<(String, Vec<u8>)>,
+) -> (
+	JoinHandle<Result<()>>,
+	impl Stream<Item = BodyItem> + Send + 'static,
+) {
+	let (tx, rx) = mpsc::channel::<BodyItem>(CHANNEL_CAP);
+
+	let producer = tokio::task::spawn_blocking(move || -> Result<()> {
+		let mut writer = ChannelWriter {
+			tx,
+			buf: BytesMut::with_capacity(CHUNK_BYTES),
+		};
+		match source {
+			ContextSource::Inline(inline) => {
+				stream_build_context_with_inline(&mut writer, &context, &inline, &secret_files)
+			}
+			ContextSource::Dockerfile(dockerfile) => {
+				stream_build_context(&mut writer, &context, &dockerfile, &secret_files)
+			}
+		}
+	});
+
+	// Turn the receiver into a body stream without pulling in `tokio-stream`:
+	// `unfold` re-yields the receiver after each `recv`, ending on channel close.
+	let body = futures_util::stream::unfold(rx, |mut rx| async move {
+		rx.recv().await.map(|item| (item, rx))
+	});
+
+	(producer, body)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::super::context::build_context_tar;
+	use super::*;
+	use futures_util::StreamExt;
+
+	/// The streamed body must be byte-identical to the buffered tar the
+	/// non-streaming path produced: same entries, same gzip, just delivered in
+	/// chunks. This pins the equivalence the whole refactor rests on.
+	#[tokio::test]
+	async fn streamed_body_matches_buffered_tar() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("Dockerfile"), "FROM scratch\n").unwrap();
+		std::fs::write(dir.path().join("app.txt"), "hello world").unwrap();
+
+		let (producer, body) = context_body(
+			dir.path().to_path_buf(),
+			ContextSource::Dockerfile("Dockerfile".to_string()),
+			Vec::new(),
+		);
+		futures_util::pin_mut!(body);
+		let mut streamed = Vec::new();
+		while let Some(item) = body.next().await {
+			let frame = item.expect("no stream error");
+			if let Ok(data) = frame.into_data() {
+				streamed.extend_from_slice(&data);
+			}
+		}
+		producer.await.expect("join").expect("producer succeeds");
+
+		let buffered = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+		assert_eq!(
+			streamed, buffered,
+			"streamed tar must be byte-identical to the buffered tar"
+		);
+	}
+
+	/// A missing context directory surfaces as the producer's error, and the body
+	/// still terminates (the writer is dropped) rather than hanging.
+	#[tokio::test]
+	async fn missing_context_errors_via_producer() {
+		let (producer, body) = context_body(
+			std::path::PathBuf::from("/nonexistent/podup/context"),
+			ContextSource::Dockerfile("Dockerfile".to_string()),
+			Vec::new(),
+		);
+		futures_util::pin_mut!(body);
+		while body.next().await.is_some() {}
+		let produced = producer.await.expect("join");
+		assert!(produced.is_err(), "walking a missing context must error");
+	}
+}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -4,6 +4,7 @@ mod commands;
 mod down_label;
 mod parallel;
 mod prefetch;
+mod readiness;
 mod run;
 mod scale;
 mod signal;
@@ -12,8 +13,10 @@ mod targets;
 use std::collections::{HashMap, HashSet};
 
 use crate::compose::types::{ComposeFile, Service, ServiceCondition};
-use crate::error::Result;
+use crate::error::{ComposeError, Result};
 use crate::libpod::API_PREFIX;
+
+use readiness::SharedReady;
 
 pub use targets::validate_stop_timeout;
 use targets::{expand_targets, filter_services, in_started_set, validate_targets};
@@ -232,6 +235,9 @@ impl Engine {
 			// layering), so they start concurrently. The barrier between levels
 			// preserves ordering and `service_healthy`/`service_completed`
 			// semantics: a level only begins once the previous one is up.
+			// One shared healthcheck poller per waited-on container, so several
+			// dependents in a level don't each run the same container's healthcheck.
+			let readiness = self.build_readiness_map(file, &enabled, &target_set, start);
 			for level in &levels {
 				let started = level.iter().map(|name| {
 					self.up_one_service(
@@ -244,6 +250,7 @@ impl Engine {
 						no_recreate,
 						force_recreate,
 						start,
+						&readiness,
 					)
 				});
 				futures_util::future::try_join_all(started).await?;
@@ -293,6 +300,7 @@ impl Engine {
 		no_recreate: bool,
 		force_recreate: bool,
 		start: bool,
+		readiness: &HashMap<String, SharedReady<'_>>,
 	) -> Result<()> {
 		if let Some(set) = target_set {
 			if !set.contains(name) {
@@ -356,7 +364,17 @@ impl Engine {
 						);
 						Ok(())
 					} else {
-						self.wait_healthy(&dep_container, dep_service, None).await
+						// Await the one shared poller for this container instead of
+						// starting our own, so a container N services wait on has its
+						// healthcheck run once per interval, not N times. Fall back to
+						// a direct wait if the map somehow lacks this container.
+						match readiness.get(&dep_container) {
+							Some(shared) => shared
+								.clone()
+								.await
+								.map_err(ComposeError::DependencyNotReady),
+							None => self.wait_healthy(&dep_container, dep_service, None).await,
+						}
 					}
 				}
 				ServiceCondition::ServiceCompletedSuccessfully => {

--- a/internal/engine/lifecycle/readiness.rs
+++ b/internal/engine/lifecycle/readiness.rs
@@ -1,0 +1,203 @@
+//! Shared healthcheck readiness for the concurrent `up` path.
+//!
+//! When several services in a dependency level declare `depends_on: <svc>:
+//! {condition: service_healthy}`, they start concurrently and would each poll
+//! that container's healthcheck — and every poll *runs* the check inside the
+//! container, so a service N others wait on gets its healthcheck executed ~N×
+//! per interval for the whole startup. [`Engine::build_readiness_map`] memoizes
+//! one poller per container so the check runs once per interval regardless of
+//! how many depend on it.
+
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures_util::future::{FutureExt, Shared};
+
+use crate::compose::types::{ComposeFile, ServiceCondition};
+use crate::engine::Engine;
+use crate::error::ComposeError;
+
+use super::in_started_set;
+
+/// A `wait_healthy` future shared across every dependent of one container, so a
+/// service that N others wait on has its healthcheck polled by a single poller
+/// rather than ~N× per interval. Lazy: the poll begins when the first dependent
+/// awaits it. The error is `Arc`-wrapped because [`Shared`] needs a `Clone`
+/// output and [`ComposeError`] is not `Clone`.
+pub(super) type SharedReady<'a> =
+	Shared<Pin<Box<dyn Future<Output = std::result::Result<(), Arc<ComposeError>>> + Send + 'a>>>;
+
+impl Engine {
+	/// Build one shared readiness future per container that any starting service
+	/// waits on with `condition: service_healthy`.
+	///
+	/// The predicate mirrors the wait guard in `up_one_service`; a container it
+	/// misses simply falls back to a direct wait there, so a mismatch degrades to
+	/// the old per-dependent behaviour rather than a panic.
+	pub(super) fn build_readiness_map<'a>(
+		&'a self,
+		file: &'a ComposeFile,
+		enabled: &HashSet<String>,
+		target_set: &Option<HashSet<String>>,
+		start: bool,
+	) -> HashMap<String, SharedReady<'a>> {
+		let mut map: HashMap<String, SharedReady<'a>> = HashMap::new();
+		// `create` (start = false) gates on nothing, so there are no waits to share.
+		if !start {
+			return map;
+		}
+		for (sname, service) in &file.services {
+			// Only services this pass actually starts run their readiness waits.
+			if let Some(set) = target_set {
+				if !set.contains(sname) {
+					continue;
+				}
+			}
+			if !enabled.contains(sname) {
+				continue;
+			}
+			for dep in service.depends_on.service_names() {
+				if !matches!(
+					service.depends_on.condition_for(&dep),
+					ServiceCondition::ServiceHealthy
+				) {
+					continue;
+				}
+				if !in_started_set(target_set, &dep) {
+					continue;
+				}
+				let Some(dep_service) = file.services.get(&dep) else {
+					continue;
+				};
+				if !enabled.contains(&dep) {
+					continue;
+				}
+				// A disabled healthcheck is treated as satisfied — never polled.
+				if dep_service
+					.healthcheck
+					.as_ref()
+					.is_some_and(|h| h.is_disabled())
+				{
+					continue;
+				}
+				let container = self.first_replica_name(&dep, dep_service);
+				map.entry(container.clone()).or_insert_with(|| {
+					let c = container.clone();
+					async move {
+						self.wait_healthy(&c, dep_service, None)
+							.await
+							.map_err(Arc::new)
+					}
+					.boxed()
+					.shared()
+				});
+			}
+		}
+		map
+	}
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+	use std::collections::HashSet;
+
+	use crate::engine::Engine;
+	use crate::libpod::Client;
+
+	fn engine(project: &str) -> Engine {
+		// The map is built without any socket call (the shared futures are lazy),
+		// so a client bound to a never-opened path is enough — no runtime needed.
+		let client = Client::new("/tmp/podup-readiness-test.sock");
+		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+	}
+
+	fn enabled_all(file: &crate::compose::types::ComposeFile) -> HashSet<String> {
+		file.services.keys().cloned().collect()
+	}
+
+	#[test]
+	fn shares_one_poller_per_service_healthy_container() {
+		// web and api both wait on db with `service_healthy`; cache is waited on
+		// with `service_started` (never polled). Exactly one shared entry — db's
+		// container — must result, not one per dependent.
+		let yaml = "\
+services:
+  db:
+    image: x
+    healthcheck:
+      test: [\"CMD\", \"true\"]
+  cache:
+    image: x
+  web:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_started
+  api:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine("proj");
+		let map = e.build_readiness_map(&file, &enabled_all(&file), &None, true);
+		let keys: Vec<&String> = map.keys().collect();
+		assert_eq!(map.len(), 1, "one shared poller expected, got {keys:?}");
+		assert!(
+			keys[0].contains("db"),
+			"shared container should be db, got {keys:?}"
+		);
+	}
+
+	#[test]
+	fn create_only_shares_nothing() {
+		// `create` (start = false) gates on no dependency, so nothing is shared.
+		let yaml = "\
+services:
+  db:
+    image: x
+    healthcheck:
+      test: [\"CMD\", \"true\"]
+  web:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine("proj");
+		assert!(e
+			.build_readiness_map(&file, &enabled_all(&file), &None, false)
+			.is_empty());
+	}
+
+	#[test]
+	fn disabled_healthcheck_is_not_shared() {
+		// A dependency whose healthcheck is disabled is treated as satisfied, so it
+		// is never polled and must not get a shared poller.
+		let yaml = "\
+services:
+  db:
+    image: x
+    healthcheck:
+      disable: true
+  web:
+    image: x
+    depends_on:
+      db:
+        condition: service_healthy
+";
+		let file = crate::compose::parse_str(yaml).unwrap();
+		let e = engine("proj");
+		assert!(
+			e.build_readiness_map(&file, &enabled_all(&file), &None, true)
+				.is_empty(),
+			"a disabled healthcheck must not be shared or polled"
+		);
+	}
+}

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -123,6 +123,26 @@ pub enum ComposeError {
 	/// written/removed, or the requested mode is not yet available. The string is
 	/// a ready-to-print message.
 	Autostart(String),
+	/// A `service_healthy` dependency did not become ready. Wraps the shared
+	/// readiness error in an `Arc` so one poller's result can fan out to every
+	/// dependent waiting on the same container (the error type is otherwise not
+	/// `Clone`). Transparent: it displays as, and sources, the wrapped error.
+	DependencyNotReady(std::sync::Arc<ComposeError>),
+}
+
+impl ComposeError {
+	/// Peel [`Self::DependencyNotReady`] wrappers to the underlying cause.
+	///
+	/// The readiness fan-out wraps a poller's error so it can be shared; callers
+	/// that classify an error by variant (e.g. the CLI's exit-code mapping) want
+	/// the real cause, not the wrapper.
+	pub fn innermost(&self) -> &ComposeError {
+		let mut e = self;
+		while let Self::DependencyNotReady(inner) = e {
+			e = inner;
+		}
+		e
+	}
 }
 
 /// Escape control characters (tabs, newlines, ESC, …) in an interpolated,
@@ -263,6 +283,8 @@ impl fmt::Display for ComposeError {
 			),
 			Self::EnvFile(s) => write!(f, "{s}"),
 			Self::Autostart(s) => write!(f, "{s}"),
+			// Transparent: the wrapper only exists to make the cause shareable.
+			Self::DependencyNotReady(inner) => write!(f, "{inner}"),
 		}
 	}
 }
@@ -274,6 +296,7 @@ impl std::error::Error for ComposeError {
 			Self::Io(e) => Some(e),
 			Self::Podman(e) => Some(e),
 			Self::IoPath { source, .. } | Self::BuildContext { source, .. } => Some(source),
+			Self::DependencyNotReady(inner) => Some(inner),
 			_ => None,
 		}
 	}

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -5,8 +5,9 @@
 //! API calls are sequential and infrequent.
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full, Limited};
-use hyper::body::Incoming;
+use futures_util::Stream;
+use http_body_util::{BodyExt, Full, Limited, StreamBody};
+use hyper::body::{Frame, Incoming};
 use hyper::client::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
@@ -17,7 +18,20 @@ use super::error::PodmanError;
 mod encode;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
 
-type BoxBody = Full<Bytes>;
+/// The request body every call shares. A boxed body so a fully-buffered
+/// `Full<Bytes>` (almost every call) and a lazily-streamed build-context body
+/// (the `build` endpoint) travel the same client path. `Unsync` because hyper's
+/// `send_request` only requires the body to be `Send`, and the streamed body is
+/// not `Sync`.
+type BoxBody = http_body_util::combinators::UnsyncBoxBody<Bytes, std::io::Error>;
+
+/// Box a fully-buffered byte payload into [`BoxBody`]. `Full`'s error is
+/// `Infallible`, mapped to the unified `io::Error` (which it never produces).
+fn full(bytes: Bytes) -> BoxBody {
+	Full::new(bytes)
+		.map_err(|never| match never {})
+		.boxed_unsync()
+}
 
 /// Upper bound on a buffered (non-streaming) response body. Caps memory use
 /// when the daemon returns an oversized or runaway response.
@@ -272,7 +286,7 @@ impl Client {
 	/// SpecGenerator or libpod-native call fail with an obscure 4xx.
 	pub async fn ping(&self) -> Result<()> {
 		// Deliberately omits the version prefix: `_ping` is version-independent.
-		let req = Self::build_request(Method::GET, "/libpod/_ping", Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::GET, "/libpod/_ping", full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		// Read the version header before the body is consumed below.
 		let reported = resp
@@ -291,7 +305,7 @@ impl Client {
 
 	/// `GET` → deserialize JSON response.
 	pub async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::GET, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
@@ -300,7 +314,7 @@ impl Client {
 
 	/// `GET` → return raw `Response<Incoming>` for streaming.
 	pub async fn get_stream(&self, path: &str) -> Result<Response<Incoming>> {
-		let req = Self::build_request(Method::GET, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::GET, path, full(Bytes::new()), None)?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
@@ -314,7 +328,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
@@ -329,7 +343,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
@@ -347,7 +361,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
@@ -355,7 +369,7 @@ impl Client {
 
 	/// `POST` with empty body → ignore response body (expect 2xx or 304).
 	pub async fn post_empty_ok(&self, path: &str) -> Result<()> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		// 304 Not Modified is fine for idempotent ops
@@ -379,7 +393,7 @@ impl Client {
 		path: &str,
 		deadline: Option<std::time::Duration>,
 	) -> Result<()> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, deadline).await?;
 		let (status, body) = Self::read_body(resp, deadline).await?;
 		// 304 Not Modified is fine for idempotent ops
@@ -411,7 +425,7 @@ impl Client {
 		let req = Self::build_request(
 			Method::POST,
 			path,
-			Full::new(Bytes::from(json)),
+			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
 		Self::stream_or_err(self.send(req, head_timeout).await?).await
@@ -419,13 +433,13 @@ impl Client {
 
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with empty body → deserialize JSON response.
 	pub async fn post_empty_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
@@ -443,7 +457,7 @@ impl Client {
 	/// this method must impose their own outer budget (e.g. a
 	/// [`tokio::time::timeout`]) to stay bounded.
 	pub async fn post_empty_json_unbounded<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-		let req = Self::build_request(Method::POST, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, None).await?;
 		let (status, body) = Self::read_body(resp, None).await?;
 		Self::check_status(status, &body)?;
@@ -457,7 +471,28 @@ impl Client {
 		bytes: Bytes,
 		content_type: &str,
 	) -> Result<Response<Incoming>> {
-		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
+		let req = Self::build_request(Method::POST, path, full(bytes), Some(content_type))?;
+		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
+	}
+
+	/// `POST` with a **streamed** body → return raw `Response<Incoming>` for
+	/// streaming.
+	///
+	/// The body is produced lazily from `chunks` rather than buffered whole, so a
+	/// large upload (a multi-gigabyte build-context tar) never inflates the
+	/// process's RSS. Each item is an `http_body`-style frame or a terminal
+	/// `io::Error` that aborts the request.
+	pub async fn post_stream_body<S>(
+		&self,
+		path: &str,
+		chunks: S,
+		content_type: &str,
+	) -> Result<Response<Incoming>>
+	where
+		S: Stream<Item = std::result::Result<Frame<Bytes>, std::io::Error>> + Send + 'static,
+	{
+		let body = StreamBody::new(chunks).boxed_unsync();
+		let req = Self::build_request(Method::POST, path, body, Some(content_type))?;
 		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
 	}
 
@@ -472,7 +507,7 @@ impl Client {
 		bytes: Bytes,
 		content_type: &str,
 	) -> Result<T> {
-		let req = Self::build_request(Method::POST, path, Full::new(bytes), Some(content_type))?;
+		let req = Self::build_request(Method::POST, path, full(bytes), Some(content_type))?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
@@ -481,7 +516,7 @@ impl Client {
 
 	/// `PUT` with raw bytes body → expect 2xx.
 	pub async fn put_bytes_ok(&self, path: &str, bytes: Bytes, content_type: &str) -> Result<()> {
-		let req = Self::build_request(Method::PUT, path, Full::new(bytes), Some(content_type))?;
+		let req = Self::build_request(Method::PUT, path, full(bytes), Some(content_type))?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)
@@ -495,7 +530,7 @@ impl Client {
 	pub async fn head_path_is_dir(&self, path: &str) -> Result<Option<bool>> {
 		use base64::Engine as _;
 
-		let req = Self::build_request(Method::HEAD, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::HEAD, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let status = resp.status();
 		if status == StatusCode::NOT_FOUND {
@@ -534,7 +569,7 @@ impl Client {
 	/// no-op, so it can avoid reporting a phantom "removed" for a container that
 	/// never existed.
 	pub async fn delete_existed(&self, path: &str) -> Result<bool> {
-		let req = Self::build_request(Method::DELETE, path, Full::new(Bytes::new()), None)?;
+		let req = Self::build_request(Method::DELETE, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		if status == StatusCode::NOT_FOUND {

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -54,20 +54,24 @@ fn check_status_falls_back_to_raw_body_on_non_json() {
 #[test]
 fn build_request_valid_path() {
 	use bytes::Bytes;
-	use http_body_util::Full;
 	use hyper::Method;
-	Client::build_request(Method::GET, "/libpod/_ping", Full::new(Bytes::new()), None).unwrap();
+	Client::build_request(
+		Method::GET,
+		"/libpod/_ping",
+		super::full(Bytes::new()),
+		None,
+	)
+	.unwrap();
 }
 
 #[test]
 fn build_request_sets_content_type_when_given() {
 	use bytes::Bytes;
-	use http_body_util::Full;
 	use hyper::Method;
 	let req = Client::build_request(
 		Method::POST,
 		"/libpod/secrets/create",
-		Full::new(Bytes::new()),
+		super::full(Bytes::new()),
 		Some("application/json"),
 	)
 	.unwrap();
@@ -82,14 +86,13 @@ fn build_request_sets_content_type_when_given() {
 #[test]
 fn build_request_rejects_unparseable_path() {
 	use bytes::Bytes;
-	use http_body_util::Full;
 	use hyper::Method;
 	// A control character makes `http://localhost<path>` an invalid URI, which
 	// must surface as a structured Api error rather than panicking.
 	let err = Client::build_request(
 		Method::GET,
 		"/libpod/bad\u{7f}path",
-		Full::new(Bytes::new()),
+		super::full(Bytes::new()),
 		None,
 	)
 	.unwrap_err();

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -69,8 +69,10 @@ fn run_to_exit() {
 			print_error(&e);
 			// A `run`/`exec` whose command cannot be launched arrives as a Podman
 			// (OCI/crun) error; map it onto docker's conventional codes (127 not
-			// found, 126 not executable) instead of the generic exit 1.
-			let code = match &e {
+			// found, 126 not executable) instead of the generic exit 1. Peel a
+			// `DependencyNotReady` wrapper first so a failed readiness wait maps on
+			// its real cause, exactly as an unwrapped one would.
+			let code = match e.innermost() {
 				podup::ComposeError::Podman(_) => command_failure_exit_code(&e.to_string()),
 				_ => 1,
 			};

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -328,30 +328,32 @@ mod tests {
 		);
 	}
 
-	// STALE VECTOR after the 2026 key rotation: this SHA256SUMS + signature was
-	// signed by the previous release key, whose private half was lost, so it no
-	// longer validates against the rotated RELEASE_PUBKEYS. Re-vector it from the
-	// first release signed with GLYNDOR_RELEASE_ED25519_KEY (take that release's
-	// SHA256SUMS and SHA256SUMS.sig), then drop the #[ignore]. The synthetic
-	// tests below still exercise the verify path against known keypairs.
 	#[test]
-	#[ignore = "re-vector from the first release signed with the rotated key"]
 	fn embedded_key_verifies_real_release() {
 		// Regression vector: the genuine published podup SHA256SUMS and its
 		// signature must verify against the embedded key. If a future edit
-		// swaps the key, this fails loudly.
+		// swaps the key, this fails loudly. Vectored from the v1.11.0 release
+		// (the first signed with GLYNDOR_RELEASE_ED25519_KEY); the signature
+		// covers the full manifest byte-for-byte, so all listed assets are here.
 		let sha256sums = "\
-52d6148bf50d9d3f24a634402ec39d44302d73b21e3b74ed6a28877fdd7b93ea  podup-linux-x86_64
-95202fc77b4ff60d1f67f198c312baafe710bec2e9d3a6d48fc92ba0f5a0774f  podup-linux-arm64
-8e935c2b28d5955867ea0c94fe2a4fc1a6aa6951011b02eff850eb98ae41e239  podup-darwin-arm64
-efb48becd0c057f6248e91ccbc5b0795edcfbdf66eb5535f24938a5bba7c4ab2  podup-darwin-x86_64
-2fcbef1ae50e976b4d072c101fa2d03a235b2c17ee1ff6a3bfdf6e3df1d15389  podup-windows-x86_64.exe
+0be7f2b09d518ea452a5711ea845fa76a6a6283bc883972d24b9caa3a78902d0  podup-linux-x86_64
+b9e041bb9177e482b887531c383fe9ba12fd8a636208c5e9f1e8e79e02776b77  podup-linux-arm64
+c0d896932ada2a391e7115c05cc940a9d42d7ee67f5ada35408a40a3d3be9f19  podup-darwin-arm64
+255530d6dfcffb7fa7df282be2e6987b708d770afee0bca3a5cbbf6303138cdd  podup-darwin-x86_64
+cfae018f6078e40289c15003ce5b24843864b8bb65cd03ecbd16d57212ae2e62  podup-windows-x86_64.exe
+bdf2296df8eb75d36c11244d7d433398719b5aed61e6c601151de92170018b2c  podup-windows-arm64.exe
+6f8fea9446de2ac4c7ec4c7a0cfebb18263befabb824fa585058a50932d08a5d  podup_1.11.0_amd64.deb
+1a24b7a4972c07e66088c486c15852c70affbb6970b43f2eaa1b85ec3218ea1b  podup_1.11.0_arm64.deb
+4f3a3b3e008ca5b4a8d2fa0eff91762b580d7a2fa4f1ccb707e6e3846b8468b3  podup.cdx.json
+6739b03a00653b7ffa755cf032985c38cef03ebb46d8e8675b1469b6fe13f9d8  NOTICES.html
+f12e41867749c42afd77ac027fe77e406e2272a4f28e2de6700b73ee134d5e89  install.sh
+f4aa771d1bf238fea5b764d90258ec43e6b034de74ce1cd41ef41af1500d7cf9  install.ps1
 ";
 		let signature: [u8; 64] = [
-			242, 54, 152, 188, 196, 207, 89, 151, 84, 217, 6, 0, 46, 45, 6, 218, 150, 236, 75, 144,
-			192, 84, 216, 67, 161, 125, 33, 43, 162, 172, 217, 138, 252, 241, 202, 49, 40, 147,
-			184, 80, 158, 122, 152, 153, 175, 99, 167, 132, 8, 171, 166, 43, 170, 39, 149, 74, 219,
-			134, 101, 155, 15, 109, 136, 11,
+			135, 229, 99, 176, 177, 206, 51, 152, 206, 73, 1, 225, 53, 63, 104, 166, 202, 110, 104,
+			21, 165, 52, 193, 38, 82, 186, 106, 125, 158, 3, 95, 175, 226, 114, 80, 249, 215, 173,
+			19, 60, 56, 205, 224, 100, 216, 54, 237, 79, 215, 111, 4, 157, 78, 70, 150, 192, 63,
+			145, 10, 249, 7, 17, 109, 12,
 		];
 		verify_signature(sha256sums.as_bytes(), &signature).unwrap();
 
@@ -359,7 +361,7 @@ efb48becd0c057f6248e91ccbc5b0795edcfbdf66eb5535f24938a5bba7c4ab2  podup-darwin-x
 		let digest = expected_digest(sha256sums.as_bytes(), "podup-linux-x86_64").unwrap();
 		assert_eq!(
 			digest,
-			"52d6148bf50d9d3f24a634402ec39d44302d73b21e3b74ed6a28877fdd7b93ea"
+			"0be7f2b09d518ea452a5711ea845fa76a6a6283bc883972d24b9caa3a78902d0"
 		);
 	}
 


### PR DESCRIPTION
Promote develop to main for the 1.11.1 release. Contents since v1.11.0:

- perf(build): stream the build-context tar instead of buffering it (#1066) — build memory no longer scales with context size
- perf(up): share one healthcheck poller across a container's dependents (#1067)
- ci(release): generate a per-target SBOM for each artifact (#1064)
- ci(podman-lane): log the identities of failing tests, not just the count (#1065)
- test(update): re-vector the embedded-key regression test from v1.11.0 (#1062)
- chore(release): 1.11.1 (#1068) — version bump

After this merges, the signed tag v1.11.1 is cut on the merge commit, which triggers release.yml (build 5 targets + per-target SBOMs, sign SHA256SUMS against the org release key, publish to crates.io and the GitHub release).