### PR TITLE
fix(engine): keep the readiness error variant across the shared poller

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -13,7 +13,7 @@ mod targets;
 use std::collections::{HashMap, HashSet};
 
 use crate::compose::types::{ComposeFile, Service, ServiceCondition};
-use crate::error::{ComposeError, Result};
+use crate::error::Result;
 use crate::libpod::API_PREFIX;
 
 use readiness::SharedReady;
@@ -372,7 +372,7 @@ impl Engine {
 							Some(shared) => shared
 								.clone()
 								.await
-								.map_err(ComposeError::DependencyNotReady),
+								.map_err(|e| readiness::unshare_readiness_error(&e)),
 							None => self.wait_healthy(&dep_container, dep_service, None).await,
 						}
 					}

--- a/internal/engine/lifecycle/readiness.rs
+++ b/internal/engine/lifecycle/readiness.rs
@@ -99,11 +99,42 @@ impl Engine {
 	}
 }
 
+/// Rebuild an owned error from a shared readiness failure, preserving the
+/// variant a caller matches on.
+///
+/// Sharing one poller across dependents forces its error behind an `Arc`
+/// ([`SharedReady`]), and `ComposeError` is not `Clone`. Wrapping that `Arc` in
+/// [`ComposeError::DependencyNotReady`] for every failure changes what `up()`
+/// returns: code matching `ComposeError::HealthCheckTimeout(_)` stops matching
+/// once the poller is shared, even though the message and the exit code are
+/// identical — an invisible break of a frozen public API.
+///
+/// `wait_healthy` fails exactly three ways. Two carry cheap owned data and are
+/// reconstructed exactly, so a caller sees the variant it saw before the poller
+/// was shared. A [`ComposeError::Podman`] transport error holds a non-`Clone`
+/// payload and cannot be rebuilt, so it keeps the transparent wrapper — which is
+/// what [`ComposeError::innermost`] exists to peel.
+pub(super) fn unshare_readiness_error(shared: &Arc<ComposeError>) -> ComposeError {
+	match &**shared {
+		ComposeError::HealthCheckTimeout(container) => {
+			ComposeError::HealthCheckTimeout(container.clone())
+		}
+		ComposeError::WaitServiceExited { container, code } => ComposeError::WaitServiceExited {
+			container: container.clone(),
+			code: *code,
+		},
+		_ => ComposeError::DependencyNotReady(Arc::clone(shared)),
+	}
+}
+
 #[cfg(all(test, unix))]
 mod tests {
 	use std::collections::HashSet;
+	use std::sync::Arc;
 
+	use super::unshare_readiness_error;
 	use crate::engine::Engine;
+	use crate::error::ComposeError;
 	use crate::libpod::Client;
 
 	fn engine(project: &str) -> Engine {
@@ -174,6 +205,41 @@ services:
 		assert!(e
 			.build_readiness_map(&file, &enabled_all(&file), &None, false)
 			.is_empty());
+	}
+
+	#[test]
+	fn sharing_a_poller_preserves_the_error_variant() {
+		// Regression guard for the public error contract: sharing the poller must
+		// not change which variant `up()` returns. Both reconstructible causes are
+		// asserted by variant, not by message — the wrapper displays transparently,
+		// so a message assertion would have passed while the contract was broken.
+		let timeout = Arc::new(ComposeError::HealthCheckTimeout("db-1".into()));
+		assert!(matches!(
+			unshare_readiness_error(&timeout),
+			ComposeError::HealthCheckTimeout(c) if c == "db-1"
+		));
+
+		let exited = Arc::new(ComposeError::WaitServiceExited {
+			container: "db-1".into(),
+			code: 3,
+		});
+		assert!(matches!(
+			unshare_readiness_error(&exited),
+			ComposeError::WaitServiceExited { container, code } if container == "db-1" && code == 3
+		));
+	}
+
+	#[test]
+	fn a_non_reconstructible_cause_keeps_the_transparent_wrapper() {
+		// `ComposeError::Podman` holds a non-`Clone` payload, so it cannot be
+		// rebuilt; it stays wrapped, and `innermost()` is what peels it.
+		let podman = Arc::new(ComposeError::Podman(crate::libpod::PodmanError::Api {
+			status: 500,
+			message: "boom".into(),
+		}));
+		let out = unshare_readiness_error(&podman);
+		assert!(matches!(out, ComposeError::DependencyNotReady(_)));
+		assert!(matches!(out.innermost(), ComposeError::Podman(_)));
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #1072.

Sharing one healthcheck poller across dependents (#1067) forced its error behind an `Arc` — `Shared` needs a `Clone` output and `ComposeError` is not `Clone`. The await site wrapped that `Arc` in `DependencyNotReady` for **every** failure, so `up()` stopped returning `HealthCheckTimeout` for a health-check timeout and started returning a wrapper around it.

Nothing looked wrong, which is why it got through: the wrapper's `Display` is transparent, and `main.rs` peels it with `innermost()` before mapping exit codes. Message identical, exit code identical. Only the variant changed — and the variant is what a library caller matches on, on an API frozen since 1.0.0.

`wait_healthy` fails exactly three ways. Two carry cheap owned data (`HealthCheckTimeout(String)`, `WaitServiceExited { container, code }`) and are now rebuilt exactly, so a caller sees what it saw before the poller was shared. A `ComposeError::Podman` transport error holds a non-`Clone` payload and cannot be rebuilt, so it keeps the transparent wrapper — which is precisely what `innermost()` exists to peel.

The two new unit tests assert the **variant**, not the message. A message assertion would have passed for the entire duration of this regression.

## Verification

Not CI — my own machine, real Podman 5.4.2, no VM:

- `health_targeting::wait_healthy_times_out` failed in 1.2s before the change (`expected HealthCheckTimeout, got: health check timeout for container …`), passes after.
- Full integration suite: **155 passed, 0 failed** in 1471s.
- `cargo fmt --check`, `cargo clippy --all-targets --features test-helpers`, and `RUSTDOCFLAGS="-D warnings" cargo doc` all clean.

That full-suite run is worth more than this fix. The lane's Podman 5 leg reports 11 failures; the same suite on real hardware reports **zero**. So ten of those eleven are nested-virt artefacts — measured, not assumed — and the eleventh was this bug. I have put that classification on #1039, where it changes what that issue should do next.

Removing the `map_err` left `ComposeError` unused in `lifecycle/mod.rs`; that wrapper was the module's only direct error construction, so the import goes with it.