### PR TITLE
docs(podman-lane): correct the entry count in the known-failures file

### DIFF
--- a/.github/podman-known-failures-5
+++ b/.github/podman-known-failures-5
@@ -17,8 +17,8 @@
 # the failure mode that already forced the pass-count floor down from 120 to 115.
 # Podman 6 keeps the floor until its set is both classified and stable (#1039).
 
-# The `run` family: needs a controlling terminal the VM's serial console cannot
-# provide. All four pass on a real host.
+# The `run` family (7): needs a controlling terminal the VM's serial console
+# cannot provide. All seven passed in the real-host run that classified them.
 commands_networking::engine_run_command_succeeds
 commands_networking::engine_run_nonzero_exit_returns_run_exited
 run_flags::engine_run_applies_user_workdir_env_and_entrypoint


### PR DESCRIPTION
I wrote "All four pass on a real host" above seven entries in `.github/podman-known-failures-5`.

The claim is true — the real-host run that classified them was 155/155 — but the count is wrong, and it is wrong in the one file whose stated premise is that every line is a claim requiring a run. Caught while reviewing test health.

No behaviour change; the gate reads only the non-comment lines.