### PR TITLE
test(integration): make a skipped suite fail where Podman is guaranteed

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -66,6 +66,11 @@ jobs:
                 export XDG_RUNTIME_DIR=/run/user/$(id -u)
                 systemctl --user start podman.socket
                 export PODMAN_SOCKET=$XDG_RUNTIME_DIR/podman/podman.sock
+                # In here Podman is guaranteed, so a test that cannot reach it
+                # must fail rather than skip: a skipped test reports `ok`, and a
+                # VM whose socket never came up would otherwise look like a
+                # flawless 155-pass run and clear the floor comfortably.
+                export PODUP_REQUIRE_PODMAN=1
                 cd "$HOME/podup" || exit 90
                 # Capture the FULL output: the per-failure detail (where the flake
                 # marker lives) precedes the summary, so a `tail` on the console

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -1,8 +1,9 @@
 //! Integration tests that exercise the engine against a real Podman daemon.
 //!
-//! All tests skip gracefully when Podman is not reachable. In CI the
-//! `podman` input to the rust-ci reusable starts the socket and sets
-//! `PODMAN_SOCKET` before the coverage gate runs.
+//! All tests skip gracefully when Podman is not reachable, so they are safe to
+//! run on a machine without it. Set `PODUP_REQUIRE_PODMAN=1` where Podman is
+//! guaranteed — the nested-virt lane does — and an unreachable Podman becomes a
+//! hard failure rather than a suite that reports `ok` having run nothing.
 //!
 //! The test bodies are split across the `engine_integration/` submodules to
 //! keep each file under the source line limit. Shared helpers live here at the
@@ -16,11 +17,22 @@ use podup::{parse_files_with_env_files, parse_str, Client, Engine};
 // ---------------------------------------------------------------------------
 
 async fn podman() -> Option<Client> {
-	let client = podup::podman::connect_from_env()
-		.or_else(|_| podup::podman::connect(None))
-		.ok()?;
-	client.ping().await.ok()?;
-	Some(client)
+	let connected =
+		match podup::podman::connect_from_env().or_else(|_| podup::podman::connect(None)) {
+			Ok(client) => client.ping().await.is_ok().then_some(client),
+			Err(_) => None,
+		};
+	// Skipping is the right default: these tests must not fail on a developer
+	// machine without Podman. But a silent skip reports `ok` for a test that
+	// executed nothing, and libtest counts it as passed — so an environment
+	// where Podman never came up looks identical to a clean run. Somewhere that
+	// Podman is guaranteed (the nested-virt lane), set PODUP_REQUIRE_PODMAN and
+	// the skip becomes a hard failure instead of a green lie.
+	assert!(
+		!(connected.is_none() && std::env::var_os("PODUP_REQUIRE_PODMAN").is_some()),
+		"PODUP_REQUIRE_PODMAN is set but Podman is unreachable — refusing to report this suite as passing without running it"
+	);
+	connected
 }
 
 /// Unique project name per test run + per test to avoid parallel conflicts.


### PR DESCRIPTION
Toward #1083 — the part that needs no decision from anyone.

Every integration test opens with an early return when Podman is unreachable, and libtest counts that early return as a **pass**. So a suite that executed nothing reports 155 ok, which is indistinguishable from a clean run.

In the nested-virt lane that is a real hole rather than a theoretical one: a VM whose `podman.socket` failed to start would skip all 155 tests, report a perfect score, and clear the floor of 115 comfortably. The lane would be green precisely when it tested nothing.

Skipping stays the default, because these tests must remain safe to run on a machine without Podman. What changes is that the skip can now be forbidden where Podman is guaranteed: `PODUP_REQUIRE_PODMAN=1` turns it into a hard failure, and `run-suite.sh` sets it inside the VM.

## Verified

Three paths, run locally against real Podman 5.4.2:

| case | result |
|---|---|
| real Podman, variable unset | `ok`, 11.29s — the test actually ran |
| bogus socket, variable unset | `ok`, **0.00s** — today's silent skip, deliberately preserved |
| bogus socket, variable set | **FAILED**, with the reason printed |

The middle row is the bug this closes: `ok` in zero seconds, having touched nothing.

`cargo fmt --check` and `cargo clippy --all-targets --features test-helpers` clean.

What remains on #1083 is yours to decide, and I have not touched it: the `coverage-ignore-regex` excludes 36.4% of the crate and real coverage is 79.11%, so widening the exclusion is cosmetic and lowering the threshold is surrender. Podman 6 also still gates on the floor alone, which needs classification first (#1039).