### PR TITLE
fix: quadlet ownership and unit permissions, and a cp chmod that could leave the destination

### DIFF
--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -162,6 +162,31 @@ fn flatten_single_wrapper_dir(dst: &Path) -> Result<()> {
 }
 
 /// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
+/// Rebuild the on-disk path `unpack_in` chose for an entry.
+///
+/// `unpack_in` keeps only [`Component::Normal`] parts — a leading `/` or a `..`
+/// is dropped rather than honoured — so an entry named `/etc/passwd` lands at
+/// `dst_dir/etc/passwd`. Reconstructing that path as `dst_dir.join(rel)` is
+/// wrong in exactly that case: [`Path::join`] with an absolute path **discards
+/// the base**, so the follow-up chmod would leave the destination and land on
+/// the real host file — a hostile image could hand back an entry named
+/// `/home/user/.ssh/id_ed25519` with mode 0o644 and have the copy loosen it.
+/// Mirroring `unpack_in`'s own rule keeps the two in agreement.
+///
+/// Returns `None` when no normal component survives (`/`, `..`, `.`), which is
+/// nothing to chmod.
+fn unpacked_path(dst_dir: &Path, rel: &Path) -> Option<std::path::PathBuf> {
+	let mut out = dst_dir.to_path_buf();
+	let mut pushed = false;
+	for component in rel.components() {
+		if let std::path::Component::Normal(part) = component {
+			out.push(part);
+			pushed = true;
+		}
+	}
+	pushed.then_some(out)
+}
+
 /// entry whose path would escape it (zip-slip) and stripping group/other-write
 /// and setuid/setgid/sticky bits the (untrusted) container set on each entry.
 ///
@@ -187,8 +212,14 @@ fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
 				"cp: refusing archive entry that escapes destination: {p}"
 			)));
 		}
-		if let (Some(rel), Some(mode)) = (rel, mode) {
-			sanitize_extracted_mode(&dst_dir.join(rel), mode);
+		match (rel, mode) {
+			(Some(rel), Some(mode)) => match unpacked_path(dst_dir, &rel) {
+				Some(path) => sanitize_extracted_mode(&path, mode),
+				None => {
+					tracing::warn!("cp: entry with no usable path component — mode not sanitized")
+				}
+			},
+			_ => tracing::warn!("cp: unreadable entry path or mode — mode not sanitized"),
 		}
 	}
 	Ok(())
@@ -266,6 +297,8 @@ fn sanitize_extracted_mode(_path: &Path, _mode: u32) {}
 
 #[cfg(test)]
 mod tests {
+	use std::path::Path;
+
 	#[test]
 	fn pack_path_single_file() {
 		let dir = tempfile::tempdir().expect("tempdir");
@@ -536,5 +569,74 @@ mod tests {
 			b"keep",
 			"the existing file must be left untouched"
 		);
+	}
+
+	#[test]
+	fn unpacked_path_mirrors_unpack_in_and_never_leaves_the_destination() {
+		// `unpack_in` drops every non-Normal component, so the chmod target must
+		// be rebuilt the same way. `dst.join(rel)` cannot be used: joining an
+		// absolute path discards the base, which is how a hostile entry name
+		// would have redirected the chmod onto a real host file.
+		let dst = Path::new("/tmp/dest");
+		assert_eq!(
+			super::unpacked_path(dst, Path::new("/etc/passwd")),
+			Some(std::path::PathBuf::from("/tmp/dest/etc/passwd"))
+		);
+		assert_eq!(
+			super::unpacked_path(dst, Path::new("../../home/u/.ssh/id_ed25519")),
+			Some(std::path::PathBuf::from("/tmp/dest/home/u/.ssh/id_ed25519"))
+		);
+		assert_eq!(
+			super::unpacked_path(dst, Path::new("a/b.txt")),
+			Some(std::path::PathBuf::from("/tmp/dest/a/b.txt"))
+		);
+		assert_eq!(super::unpacked_path(dst, Path::new("/")), None);
+		assert_eq!(super::unpacked_path(dst, Path::new("..")), None);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn absolute_entry_name_cannot_chmod_a_file_outside_the_destination() {
+		use std::os::unix::fs::PermissionsExt;
+
+		// The victim lives outside the destination and starts private.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let victim = dir.path().join("secret");
+		std::fs::write(&victim, b"private").expect("write");
+		std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+
+		let dst = dir.path().join("dest");
+		std::fs::create_dir(&dst).expect("mkdir");
+
+		// Build an entry whose stored name is the victim's ABSOLUTE path. The
+		// safe setter refuses absolute paths, but a hostile archive is not built
+		// with the safe setter, so write the header's name field directly — this
+		// is the shape the guard has to survive.
+		let target = victim.to_str().expect("utf-8");
+		let mut header = tar::Header::new_gnu();
+		header.set_size(4);
+		header.set_mode(0o644);
+		header.set_entry_type(tar::EntryType::Regular);
+		{
+			let name = &mut header.as_gnu_mut().expect("gnu header").name;
+			name.iter_mut().for_each(|b| *b = 0);
+			name[..target.len()].copy_from_slice(target.as_bytes());
+		}
+		header.set_cksum();
+		let mut builder = tar::Builder::new(Vec::new());
+		builder.append(&header, &b"evil"[..]).expect("append");
+		let bytes = builder.into_inner().expect("tar");
+
+		super::extract_tar_guarded(&bytes, &dst).expect("extraction should succeed");
+
+		let mode = std::fs::metadata(&victim)
+			.expect("stat")
+			.permissions()
+			.mode() & 0o777;
+		assert_eq!(
+			mode, 0o600,
+			"a file outside the destination must keep its mode: dst.join(absolute) discards the base"
+		);
+		assert_eq!(std::fs::read(&victim).expect("read"), b"private");
 	}
 }

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -18,6 +18,69 @@ mod warnings;
 use crate::compose::types::ComposeFile;
 use unit::{build_unit, container_unit, network_unit, volume_unit};
 
+/// The `# podup-owner: <project>` marker a unit carries as its literal first
+/// line, if present.
+fn marker_owner(contents: &str) -> Option<&str> {
+	contents
+		.lines()
+		.find_map(|line| line.strip_prefix("# podup-owner: "))
+}
+
+/// Refuse to overwrite a unit that belongs to another project.
+///
+/// Unit stems are `{project}-{service}`, so project `app` with service
+/// `extra-web` and project `app-extra` with service `web` both produce
+/// `app-extra-web.container`. Uninstall already resolves that ambiguity by
+/// reading the ownership marker, but writing had no counterpart: installing one
+/// project would overwrite the other's unit *and re-stamp the marker*, so the
+/// next `uninstall` of the wrong project would delete it.
+///
+/// An existing file with no marker is left to be overwritten with a warning
+/// rather than refused: it is either a unit from a podup old enough to predate
+/// the marker, or a foreign file, and hard-failing would strand upgrades.
+fn guard_existing_owner(
+	path: &std::path::Path,
+	filename: &str,
+	contents: &str,
+) -> std::io::Result<()> {
+	let Ok(existing) = std::fs::read_to_string(path) else {
+		return Ok(());
+	};
+	match (marker_owner(&existing), marker_owner(contents)) {
+		(Some(existing_owner), Some(new_owner)) if existing_owner != new_owner => {
+			Err(std::io::Error::new(
+				std::io::ErrorKind::AlreadyExists,
+				format!(
+					"refusing to overwrite {filename}: it belongs to project '{existing_owner}', not '{new_owner}'"
+				),
+			))
+		}
+		(None, _) => {
+			tracing::warn!("overwriting {filename}, which carries no podup ownership marker");
+			Ok(())
+		}
+		_ => Ok(()),
+	}
+}
+
+/// Write a unit private to its owner.
+///
+/// Units render each `environment:` entry as an `Environment=KEY=VALUE` line,
+/// so a compose file's database password ends up in this file verbatim. The
+/// default umask would leave it world-readable; systemd reads user units as the
+/// owning user, so 0600 costs nothing. Permissions are reset explicitly as well
+/// as at creation, so re-installing over a unit written by an older podup
+/// tightens it rather than leaving it as it was.
+fn write_unit_file(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+	std::fs::write(path, contents)?;
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+		std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+	}
+	Ok(())
+}
+
 /// A single generated unit file: its name and full contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -76,7 +139,8 @@ pub fn write_units(
 			));
 		}
 		let path = dir.join(&unit.filename);
-		std::fs::write(&path, &unit.contents)?;
+		guard_existing_owner(&path, &unit.filename, &unit.contents)?;
+		write_unit_file(&path, &unit.contents)?;
 		written.push(path);
 	}
 	Ok(written)
@@ -166,3 +230,79 @@ pub fn generate_at(file: &ComposeFile, project: &str, base_dir: &std::path::Path
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(all(test, unix))]
+mod write_guard_tests {
+	use std::os::unix::fs::PermissionsExt;
+
+	use super::{write_units, QuadletUnit};
+
+	fn unit(filename: &str, owner: &str) -> QuadletUnit {
+		QuadletUnit {
+			filename: filename.to_string(),
+			contents: format!(
+				"# podup-owner: {owner}\n[Container]\nEnvironment=PGPASSWORD=hunter2\n"
+			),
+		}
+	}
+
+	#[test]
+	fn refuses_to_overwrite_a_sibling_projects_unit() {
+		// `app` + service `extra-web` and `app-extra` + service `web` collide on
+		// one filename. Overwriting would also re-stamp the marker, so the next
+		// uninstall of the wrong project would delete the survivor.
+		let dir = tempfile::tempdir().expect("tempdir");
+		write_units(dir.path(), &[unit("app-extra-web.container", "app-extra")]).expect("first");
+
+		let err = write_units(dir.path(), &[unit("app-extra-web.container", "app")])
+			.expect_err("must refuse");
+		assert!(
+			format!("{err}").contains("belongs to project 'app-extra'"),
+			"got: {err}"
+		);
+
+		let kept =
+			std::fs::read_to_string(dir.path().join("app-extra-web.container")).expect("read");
+		assert!(
+			kept.contains("# podup-owner: app-extra"),
+			"the original owner's marker must survive"
+		);
+	}
+
+	#[test]
+	fn rewriting_your_own_unit_is_allowed() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		write_units(dir.path(), &[unit("app-web.container", "app")]).expect("first");
+		write_units(dir.path(), &[unit("app-web.container", "app")]).expect("second");
+	}
+
+	#[test]
+	fn units_are_written_private_because_they_carry_environment_values() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let written = write_units(dir.path(), &[unit("app-web.container", "app")]).expect("write");
+		let mode = std::fs::metadata(&written[0])
+			.expect("stat")
+			.permissions()
+			.mode() & 0o777;
+		assert_eq!(
+			mode, 0o600,
+			"a unit holding Environment= secrets must not be world-readable"
+		);
+	}
+
+	#[test]
+	fn an_existing_unit_written_by_an_older_podup_is_tightened() {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let path = dir.path().join("app-web.container");
+		std::fs::write(&path, "[Container]\n").expect("seed");
+		std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+
+		write_units(dir.path(), &[unit("app-web.container", "app")]).expect("write");
+
+		let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+		assert_eq!(
+			mode, 0o600,
+			"re-installing must tighten a unit left loose by an older version"
+		);
+	}
+}


### PR DESCRIPTION
Closes #1085. Also fixes a `cp` defect I chose to fix before filing rather than after — the issue for it goes up with this PR.

## `cp` container to host: the chmod could leave the destination

`extract_tar_guarded` took the entry path straight from the archive and rebuilt the permission-fix target as `dst_dir.join(rel)`. `Path::join` with an **absolute** path discards the base, so an entry stored with an absolute name sent the chmod outside the destination and onto the real host file.

The write itself was never at risk: `unpack_in` keeps only `Component::Normal`, so the bytes always landed inside `dst_dir`. Only the reconstructed path escaped — which means the mode *sanitisation*, whose job is to harden the copy, could instead loosen an unrelated file. `unpacked_path` now mirrors `unpack_in`'s own rule so the two agree.

**On reachability, stated honestly:** the defect is real and reproduced at the extraction layer. It needs an archive containing an absolute entry name, and tar's safe setter refuses to create one — the test writes the header's `name` field directly, which is what a hostile archive would do. Whether Podman's `GET /containers/{id}/archive` can be made to emit such an entry from a hostile image, I have **not** demonstrated. So: a confirmed defect with unproven reachability through the API, not a confirmed remote exploit.

Reproduced both ways before and after: with the fix the file outside the destination keeps `0o600`; without it the mode becomes `0o644`.

## Quadlet: ownership check on write, and private units

**Sibling clobber.** Unit stems are `{project}-{service}`, so `app` + `extra-web` and `app-extra` + `web` both produce `app-extra-web.container`. Uninstall already resolves that with the `# podup-owner:` marker, but writing had no counterpart: installing one project overwrote the other's unit **and re-stamped the marker**, so the next `uninstall` of the wrong project deleted it. That is the bug fixed on the uninstall side, reintroduced from the write side.

An existing file with **no** marker is still overwritten, with a warning rather than an error — it is either a unit from a podup old enough to predate the marker or a foreign file, and hard-failing there would strand upgrades. Worth a second opinion if you disagree.

**World-readable secrets.** Units render each `environment:` entry as `Environment=KEY=VALUE`, and the default umask left them 0644, so a compose file's database password sat readable by every local user in `~/.config/containers/systemd/`. Now 0600, reset explicitly as well as at creation so re-installing tightens a unit an older version left loose. systemd reads user units as the owning user, so nothing breaks.

## Verification

`cargo test --lib quadlet` 103 passed, `copy::archive` 17 passed (2 new), `cargo fmt --check` and `cargo clippy --all-targets --features test-helpers` clean. The four new quadlet tests cover the refusal, the allowed self-rewrite, the 0600 mode, and the tightening of a pre-existing loose unit.