### PR TITLE
fix: stop five commands reporting success on a real failure

### DIFF
--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -410,7 +410,7 @@ impl Engine {
 			}
 		}
 
-		self.apply_extra_tags(build, &tag).await;
+		self.apply_extra_tags(build, &tag).await?;
 		Ok(())
 	}
 
@@ -467,7 +467,7 @@ impl Engine {
 	/// The primary `tag` is skipped: when no `image:` is set it is already
 	/// `tags[0]`, which the build itself produced, so re-tagging it onto itself
 	/// would be a no-op API call.
-	async fn apply_extra_tags(&self, build: &BuildConfig, tag: &str) {
+	async fn apply_extra_tags(&self, build: &BuildConfig, tag: &str) -> Result<()> {
 		for extra_tag in build.tags() {
 			if extra_tag == tag {
 				continue;
@@ -482,10 +482,14 @@ impl Engine {
 				urlencoded(&repo),
 				urlencoded(&tag_str),
 			);
-			if let Err(e) = self.client.post_empty_ok(&tag_path).await {
-				warn!("failed to apply extra tag {extra_tag}: {e}");
-			}
+			// Returning () here meant `build` could not report a failed tag at
+			// all: it exited 0 with the requested tags missing.
+			self.client
+				.post_empty_ok(&tag_path)
+				.await
+				.map_err(ComposeError::Podman)?;
 		}
+		Ok(())
 	}
 }
 

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -677,6 +677,10 @@ impl Engine {
 	/// `local_only`, only images of services that build locally (a `build:`
 	/// section) are removed — matching `docker compose down --rmi local`.
 	pub async fn remove_service_images(&self, file: &ComposeFile, local_only: bool) -> Result<()> {
+		// Aggregate like every sibling loop in this teardown: complete the sweep,
+		// then report the first real failure. Warning and returning Ok meant
+		// `down --rmi` exited 0 having left images behind.
+		let mut first_err: Option<crate::error::ComposeError> = None;
 		for (name, service) in &file.services {
 			let builds_locally = service.build.is_some();
 			if local_only && !builds_locally {
@@ -706,10 +710,13 @@ impl Engine {
 				Err(e) if e.is_image_in_use() => {
 					tracing::debug!("image {image} is still in use — skipping removal")
 				}
-				Err(e) => tracing::warn!("could not remove image {image}: {e}"),
+				Err(e) => {
+					tracing::warn!("could not remove image {image}: {e}");
+					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+				}
 			}
 		}
-		Ok(())
+		first_err.map_or(Ok(()), Err)
 	}
 }
 

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -564,3 +564,56 @@ fn rm_path_url_encodes_container_name() {
 	assert!(!path.contains("weird/name"), "got: {path}");
 	assert!(path.contains("weird%2Fname"), "got: {path}");
 }
+
+/// `down --rmi` used to warn and return Ok on a real removal failure, so it
+/// reported success having left images behind — the one arm of this teardown
+/// that did not aggregate, while its network, volume and container siblings all
+/// did.
+#[cfg(unix)]
+#[tokio::test]
+async fn remove_service_images_reports_a_real_failure_after_trying_them_all() {
+	let attempted = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+	let seen = std::sync::Arc::clone(&attempted);
+	let fake = fake_podman::start(move |method, target| {
+		if method == "DELETE" && target.contains("/images/") {
+			seen.lock().expect("lock").push(target.to_string());
+			// A 500 that is neither 404 nor an in-use conflict is a real failure.
+			if target.contains("broken") {
+				return (500, r#"{"message":"internal error"}"#.to_string());
+			}
+			return (200, String::new());
+		}
+		(404, r#"{"message":"not found"}"#.to_string())
+	});
+	let engine = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	file.services.insert(
+		"a".into(),
+		Service {
+			image: Some("broken:latest".into()),
+			..Default::default()
+		},
+	);
+	file.services.insert(
+		"b".into(),
+		Service {
+			image: Some("fine:latest".into()),
+			..Default::default()
+		},
+	);
+
+	let err = engine
+		.remove_service_images(&file, false)
+		.await
+		.expect_err("a real image-removal failure must propagate");
+	assert!(
+		matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+		"got: {err}"
+	);
+	assert_eq!(
+		attempted.lock().expect("lock").len(),
+		2,
+		"the sweep must finish before reporting: both images are attempted"
+	);
+}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -30,7 +30,16 @@ fn main() {
 		// ignores SIGPIPE. With `panic = "abort"` that would escalate to SIGABRT
 		// (exit 134) and a misleading bug-report notice; instead exit quietly with
 		// success like any well-behaved Unix tool.
-		if startup::is_broken_pipe_panic(&info.to_string()) {
+		// Match the panic PAYLOAD, not `info.to_string()`: the latter also carries
+		// the source location, widening a substring search to text the panic
+		// itself never chose.
+		let payload = info.payload();
+		let message = payload
+			.downcast_ref::<&str>()
+			.copied()
+			.or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+			.unwrap_or_default();
+		if startup::is_broken_pipe_panic(message) {
 			std::process::exit(0);
 		}
 		eprintln!("podup: internal error: {info}");
@@ -318,8 +327,19 @@ async fn run() -> podup::Result<()> {
 		// Parse the compose file when it is present and valid so `--services` and a
 		// positional `SERVICE` filter can resolve service names and replicas;
 		// otherwise fall back to an empty model (and the directory basename for the
-		// project name) rather than failing, matching `docker compose ps`.
-		let parsed = podup::parse_files_with_env_files(&compose_files, &cli.env_file).ok();
+		// project name) rather than failing.
+		//
+		// A file that is PRESENT but does not parse is a different case and is
+		// propagated: the old `.ok()` swallowed it, so `podup ps` printed a bare
+		// header and exited 0 on a broken compose file, which a health check or a
+		// deploy gate reads as "nothing running, no error". `docker compose ps`
+		// exits non-zero there, and so does every other podup command on the same
+		// file.
+		let parsed = match podup::parse_files_with_env_files(&compose_files, &cli.env_file) {
+			Ok(f) => Some(f),
+			Err(e) if compose_files.iter().any(|p| p.exists()) => return Err(e),
+			Err(_) => None,
+		};
 		let compose_name = parsed.as_ref().and_then(|f| f.name.clone());
 		let file = parsed.unwrap_or_default();
 		let project = resolve_project_name(cli.project.clone(), compose_name.as_deref(), &base_dir);

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -128,12 +128,17 @@ pub(crate) fn render_config(
 /// SHA-256 of a service's resolved configuration, hex-encoded. Used by
 /// `config --hash` so a deploy pipeline can detect a changed service. Pure so it
 /// is unit-tested.
-fn service_config_hash(svc: &podup::compose::types::Service) -> String {
-	let json = serde_json::to_vec(svc).unwrap_or_default();
-	Sha256::digest(&json)
+fn service_config_hash(svc: &podup::compose::types::Service) -> podup::Result<String> {
+	// Not `unwrap_or_default()`: an empty vec hashes to the SHA-256 of the empty
+	// string, which looks like a perfectly stable hash. A deploy pipeline keyed
+	// on `config --hash` would quietly stop noticing that the service changed.
+	let json = serde_json::to_vec(svc)
+		.map_err(|e| podup::ComposeError::Build(format!("could not hash service config: {e}")))?;
+	let hash = Sha256::digest(&json)
 		.iter()
 		.map(|b| format!("{b:02x}"))
-		.collect()
+		.collect();
+	Ok(hash)
 }
 
 /// `config --hash`: print `SERVICE HASH` for all services ("*") or the given
@@ -156,7 +161,7 @@ fn render_config_hash(
 			.services
 			.get(&name)
 			.ok_or_else(|| podup::ComposeError::ServiceNotFound(name.clone()))?;
-		println!("{name} {}", service_config_hash(svc));
+		println!("{name} {}", service_config_hash(svc)?);
 	}
 	Ok(())
 }
@@ -385,10 +390,13 @@ mod tests {
 	#[test]
 	fn service_config_hash_is_stable_and_distinct() {
 		let file = sample_file();
-		let web = service_config_hash(&file.services["web"]);
-		let db = service_config_hash(&file.services["db"]);
+		let web = service_config_hash(&file.services["web"]).expect("hash");
+		let db = service_config_hash(&file.services["db"]).expect("hash");
 		// Stable for the same input, and distinct across different services.
-		assert_eq!(web, service_config_hash(&file.services["web"]));
+		assert_eq!(
+			web,
+			service_config_hash(&file.services["web"]).expect("hash")
+		);
 		assert_ne!(web, db);
 		assert_eq!(web.len(), 64, "sha-256 hex is 64 chars");
 	}

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -128,11 +128,24 @@ pub(crate) fn internal_error_notice() -> String {
 
 /// Whether a panic message denotes a broken pipe (a downstream reader closed the
 /// pipe early). Rust ignores SIGPIPE, so a failing `println!`/`eprintln!` panics
-/// with this message; we treat it as a clean exit rather than an internal error.
-/// Pure so it can be unit-tested. Matches both the textual reason and the raw OS
-/// error number (EPIPE = 32 on Linux).
+/// rather than dying by signal; that specific panic is a clean exit, not an
+/// internal error.
+///
+/// The match is anchored to the exact prefix the standard library uses, because
+/// a bare substring search over the panic text is far too wide: it exits 0 for
+/// **any** panic whose message happens to mention a broken pipe — an
+/// `.expect()` on an unrelated io error, or a Podman error quoting a downstream
+/// EPIPE — and with `panic = "abort"` this hook is the only thing between a
+/// panic and the exit status, so a real crash would report success and print
+/// nothing. Pure so it can be unit-tested.
 pub(crate) fn is_broken_pipe_panic(msg: &str) -> bool {
-	let lower = msg.to_ascii_lowercase();
+	let Some(reason) = msg
+		.strip_prefix("failed printing to stdout: ")
+		.or_else(|| msg.strip_prefix("failed printing to stderr: "))
+	else {
+		return false;
+	};
+	let lower = reason.to_ascii_lowercase();
 	lower.contains("broken pipe") || lower.contains("os error 32")
 }
 
@@ -307,8 +320,25 @@ mod tests {
 		assert!(is_broken_pipe_panic(
 			"failed printing to stdout: Broken pipe (os error 32)"
 		));
-		assert!(is_broken_pipe_panic("Broken pipe"));
+		assert!(is_broken_pipe_panic(
+			"failed printing to stderr: Broken pipe (os error 32)"
+		));
 		assert!(!is_broken_pipe_panic("some other internal error"));
+	}
+
+	#[test]
+	fn an_unrelated_panic_mentioning_a_broken_pipe_is_not_swallowed() {
+		// These are real crashes. Matching them would exit 0 and print nothing,
+		// and `panic = "abort"` leaves this hook as the only gate before the exit
+		// status, so the process would report success on a genuine bug.
+		assert!(!is_broken_pipe_panic("Broken pipe"));
+		assert!(!is_broken_pipe_panic(
+			"called `Result::unwrap()` on an `Err` value: Os { code: 32, kind: BrokenPipe, message: \"Broken pipe\" }"
+		));
+		assert!(!is_broken_pipe_panic(
+			"podman refused the request: broken pipe reading from the container"
+		));
+		assert!(!is_broken_pipe_panic("assertion failed at os error 32"));
 	}
 
 	#[test]


### PR DESCRIPTION
Five of the items on #1080. The issue stays open for the rest — see the end.

**The panic hook, which is the broadest one.** It decided "this was a broken pipe" by substring-searching `info.to_string()` — the panic message *and* its source location. Any panic whose text merely mentioned a broken pipe or `os error 32` exited **0 with no output**: an `.expect()` on an unrelated io error, a Podman error quoting a downstream EPIPE. With `panic = "abort"` there is no unwinding, so this hook is the only thing between a panic and the exit status. It now reads the payload alone and anchors to the exact prefix the standard library uses (`failed printing to stdout: `), so the real case still exits cleanly and a genuine crash cannot pretend to be it. Verified: `podup completions bash | head -c 20` still exits 0, which is #597's case.

**`ps` swallowed parse errors.** `.ok()` meant a malformed compose file printed a bare header and exited 0 — read by a health check or deploy gate as "nothing running, no error". The comment justified it as matching `docker compose ps`; measured, docker exits 1 there. A *missing* file is still tolerated, which is the part that genuinely matches. Verified both: broken file → exit 1 with the parse error, no file → exit 0.

**`down --rmi`** warned and returned `Ok`, the only arm of that teardown that did not aggregate while its network, volume and container siblings all did. Now aggregates, with a test in the established `fake_podman` style asserting both that the failure propagates and that the sweep finishes first.

**`apply_extra_tags` returned `()`** — it structurally could not report, so `build` exited 0 with the requested `build.tags` missing.

**`config --hash` used `unwrap_or_default()`**, hashing the empty string on a serialisation failure. A stable-looking wrong hash is worse than an error: a deploy pipeline keyed on it would quietly stop noticing that a service changed.

## Left open on #1080, deliberately

`logs`, `watch`, `stats` and `events` all swallow stream failures, and `autostart uninstall` leaves a unit that fails to stop. Those are not one-line changes — each needs a decision about what a partial stream failure *should* do to a long-running command, and `watch` in particular behaves the same way in docker compose. Also unresolved: Ctrl-C on an attached `up` returns 0 where docker returns 130.

I would rather leave them named on the issue than quietly close it having done the easy half.

## Verification

`cargo test --lib` 1249 passed, `--bins` 61 passed, `fmt --check`, `clippy --all-targets --features test-helpers` and `RUSTDOCFLAGS="-D warnings" cargo doc` all clean. The `ps` and broken-pipe behaviours were checked by running the built binary, not only by unit test.