### PR TITLE
chore(release): 1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+podup (1.12.0) unstable; urgency=medium
+
+  * cp no longer applies an archive entry's permissions outside the destination
+    directory: an entry stored with an absolute name sent the permission fix to
+    the real host path instead of the extracted copy.
+  * Quadlet units are written with 0600 permissions and are no longer
+    overwritten when they belong to another project. Units embed environment
+    values, so the previous default left compose passwords readable by any
+    local user; re-installing tightens a unit an older version left loose.
+  * Several commands no longer report success on a real failure: a panic whose
+    message merely mentioned a broken pipe exited 0, ps exited 0 on a compose
+    file that does not parse, down --rmi exited 0 when an image could not be
+    removed, build exited 0 with requested extra tags missing, and config --hash
+    printed the hash of an empty string when a service could not be serialised.
+  * The live-Podman integration suite can no longer report success without
+    running: where Podman is guaranteed, an unreachable one is now a failure
+    rather than a silent skip.
+  * The live lane gates on which tests fail rather than how many, against a
+    per-major list of failures classified as environmental on real hardware.
+
+ -- Glyndor <packages@glyndor.net>  Sun, 19 Jul 2026 20:21:15 -0500
+
 podup (1.11.1) unstable; urgency=medium
 
   * build streams the build context to the engine instead of buffering the


### PR DESCRIPTION
Version bump only. All three files that stamp a version move together — `Cargo.toml`, `Cargo.lock` and `debian/changelog` — because the `.deb` reads its version from the changelog and nowhere else, and shipping a `.deb` labelled with the version the user already has means apt reports nothing to upgrade.

**Minor, not patch.** Four of the fixes in this release change observable behaviour rather than only correcting it: `ps`, `down --rmi`, `build` and `config --hash` now exit non-zero where they exited 0, and quadlet units are written 0600 where they were 0644. Someone's script can notice.

Contents:

- **#1087** — `cp` could apply an archive entry's permissions outside the destination; quadlet units are written private and no longer overwrite another project's unit.
- **#1088** — five commands stopped reporting success on a real failure, the broadest being a panic hook that exited 0 for any panic whose text mentioned a broken pipe.
- **#1086** — the integration suite can no longer report `ok` for tests that executed nothing.
- **#1074** — the live lane gates on which tests fail, not how many.

The release PR to `main` follows as a **merge commit**, never a squash.