### PR TITLE
docs: note the Podman 6 cp and watch-sync limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ latest 5.x, rawhide for 6.x). Many distributions still ship 4.x — check
 Ubuntu releases carry 5.x; on an older release, install or upgrade Podman
 following the official guide: <https://podman.io/docs/installation>.
 
+**Known limitation on Podman 6.** Copying *into* a container — `podup cp
+./file web:/path` — and `watch` rules whose action includes `sync` fail with a
+transport error. Copying *out* of a container works on both majors, and both
+directions work on Podman 5. Fedora, Arch and Manjaro ship Podman 6 today, so
+this affects them now; it is tracked in
+[#1097](https://github.com/Glyndor/podup/issues/1097).
+
 ### Platforms
 
 Linux, macOS and Windows (x86_64 and arm64). On macOS and Windows podup talks to

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -233,6 +233,10 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `-L, --follow-link` | Follow symlinks in the host source before copying into the container. | off |
 | `-a, --archive` | Accepted for compatibility (no effect under rootless Podman). | off |
 
+> **Podman 6:** copying *into* a container fails with a transport error.
+> Copying *out* works on both majors, and both directions work on Podman 5.
+> Tracked in [#1097](https://github.com/Glyndor/podup/issues/1097).
+
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
 container exits or you detach.
@@ -338,6 +342,11 @@ The `action` of each rule may be:
 | `restart` | Restart the container without rebuilding. |
 | `sync+restart` | Sync the files, then restart the container. |
 | `sync+exec` | Sync the files, then run the rule's `exec` command in the container. |
+
+> **Podman 6:** the `sync` step copies into the container through the same path
+> as `cp`, so `sync`, `sync+restart` and `sync+exec` fail there. `rebuild` and
+> `restart` are unaffected, and every action works on Podman 5. Tracked in
+> [#1097](https://github.com/Glyndor/podup/issues/1097).
 
 ## Maintenance
 


### PR DESCRIPTION
The README claims support for the last two majors, Podman 5.x and 6.x. #1097 establishes that copying *into* a container has never worked on Podman 6 — v1.10.1 fails identically, so this is not a regression but a support claim that was never true for that path. `watch`'s `sync` action copies through the same code, so it is broken there too.

1.12.0 is already on crates.io, apt, the tap and the bucket, and Fedora, Arch and Manjaro ship Podman 6 today. Someone installing it right now reads that `cp` works. Documenting the limitation costs minutes; leaving the claim unqualified until the fix lands does not sit right with me.

Three notes, all temporary:

- `README.md`, in the Podman version section — the limitation, which direction still works, and that Podman 5 is unaffected.
- `docs/commands.md` on `cp` — same note where someone reading the command reference hits it.
- `docs/commands.md` on `watch` — which actions are affected (`sync`, `sync+restart`, `sync+exec`) and which are not (`rebuild`, `restart`).

I will remove all three in the PR that closes #1097.

**Deliberately not in here:** whether `cp` should fail with a clear "known incompatibility" message on Podman 6 rather than a raw `IncompleteMessage` transport error. #1098 raises it, and I agree it is worth doing — but it is code in `internal/engine/copy/`, which is exactly the path #1097 rewrites. It belongs in that PR, not a docs one.

## Test plan

Docs only, no code touched. I checked both files render and the three issue links resolve.

Closes #1098