### PR TITLE
fix: accept both spellings of the no-TTY flag on run and exec

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -199,7 +199,7 @@ Run a one-off command in a new container for the service.
 | `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
 | `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
 | `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
-| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
 | `--no-deps` | Do not start the `depends_on` services before running. | off |
 
 ```bash
@@ -216,7 +216,7 @@ Execute a command in a running service container.
 | `-w, --workdir <PATH>` | Working directory inside the container. | container default |
 | `--privileged` | Give extended privileges to the command. | off |
 | `-d, --detach` | Run the command in the background. | off |
-| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `-T, --no-tty` (alias `--no-TTY`) | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
 | `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
 
 ```bash

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -523,8 +523,8 @@ pub(crate) enum Commands {
 		/// No effect; accepted only for docker-compose compatibility. podup never
 		/// allocates a pseudo-TTY.
 		// `docker compose exec` spells the long form `--no-tty`, so that is the
-		// primary here; `--no-TTY` stays accepted so the spelling `run` takes
-		// also works on `exec`. See the note on `run`'s field.
+		// primary here; `--no-TTY` stays accepted so the spelling `run` uses also
+		// works on `exec`. See the note on `run`'s field.
 		#[arg(short = 'T', long = "no-tty", visible_alias = "no-TTY")]
 		no_tty: bool,
 		/// Index of the container when the service has multiple replicas (1-based).

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -287,7 +287,10 @@ pub(crate) enum Commands {
 		interactive: bool,
 		/// No effect; accepted only for docker-compose compatibility. podup never
 		/// allocates a pseudo-TTY.
-		#[arg(short = 'T', long = "no-TTY")]
+		// Both spellings are accepted on purpose: `docker compose run` spells the
+		// long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
+		// A script copied from either one has to work, so each command takes both.
+		#[arg(short = 'T', long = "no-TTY", visible_alias = "no-tty")]
 		no_tty: bool,
 		/// Do not start linked services (depends_on) before running.
 		#[arg(long)]
@@ -519,7 +522,10 @@ pub(crate) enum Commands {
 		detach: bool,
 		/// No effect; accepted only for docker-compose compatibility. podup never
 		/// allocates a pseudo-TTY.
-		#[arg(short = 'T', long = "no-TTY")]
+		// `docker compose exec` spells the long form `--no-tty`, so that is the
+		// primary here; `--no-TTY` stays accepted so the spelling `run` takes
+		// also works on `exec`. See the note on `run`'s field.
+		#[arg(short = 'T', long = "no-tty", visible_alias = "no-TTY")]
 		no_tty: bool,
 		/// Index of the container when the service has multiple replicas (1-based).
 		#[arg(long)]

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -174,6 +174,43 @@ fn run_no_rm_parses_and_is_documented() {
 	);
 }
 
+/// Both spellings of the no-TTY flag parse on both `run` and `exec`, and both
+/// are listed in each command's help.
+///
+/// docker-compose is inconsistent with itself here: `docker compose run` spells
+/// the long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
+/// A script copied from either command has to work, so podup accepts both on
+/// both — a superset of docker rather than a guess at which one is canonical.
+#[test]
+fn no_tty_accepts_both_spellings_on_run_and_exec() {
+	for cmd in ["run", "exec"] {
+		let help = Command::new(bin())
+			.args([cmd, "--help"])
+			.output()
+			.expect("run --help");
+		assert!(help.status.success(), "`{cmd} --help` failed");
+		let help_out = String::from_utf8_lossy(&help.stdout);
+		for flag in ["--no-TTY", "--no-tty"] {
+			assert!(
+				help_out.contains(flag),
+				"`{cmd}` help is missing {flag}; got:\n{help_out}"
+			);
+		}
+
+		for flag in ["--no-TTY", "--no-tty", "-T"] {
+			let out = Command::new(bin())
+				.args(["--socket", "/nonexistent.sock", cmd, flag, "web", "true"])
+				.output()
+				.expect("run no-tty flag");
+			assert!(
+				!is_clap_usage_error(&out),
+				"`{cmd} {flag}` should parse; got clap usage error:\n{}",
+				String::from_utf8_lossy(&out.stderr)
+			);
+		}
+	}
+}
+
 /// `logs` and `restart` accept a trailing multi-service list (like every sibling
 /// command), so `logs a b` and `restart a b` parse rather than erroring on the
 /// extra positional.


### PR DESCRIPTION
#1079 reports that `podup exec --no-tty web ls` exits 2 with `unexpected argument` — a script copied from a docker workflow fails on the flag name before it even reaches the missing TTY behaviour. This is the flag-name half of that issue, split out because it is one line and the rest is not.

## What I measured

The issue says docker's long form is `--no-tty`. Checking against docker-compose 2.x on my machine, docker turns out to be inconsistent with itself:

```
$ docker-compose exec --help | grep -i tty
  -T, --no-tty            Disable pseudo-TTY allocation. By default
                          'docker compose exec' allocates a TTY.

$ docker-compose run --help | grep -i tty
  -T, --no-TTY                      Disable pseudo-TTY allocation
```

So our `--no-TTY` was correct for `run` and wrong for `exec`. The issue had the symptom right and the cause slightly off.

## What I did

Rather than pick a winner, each command declares the long form docker uses for *that* command and carries the other as a `visible_alias`:

- `run` — `--no-TTY`, alias `--no-tty`
- `exec` — `--no-tty`, alias `--no-TTY`

Both spellings work on both commands, which is a superset of docker. Drop-in fidelity is the product; a script copied from either docker command should not care.

I also moved the rationale out of the doc comment: it was rendering into `--help`, where a user does not need our reasoning — clap's `[aliases: ...]` line already tells them the other spelling exists.

`docs/commands.md` updated on both flag tables.

## What this does NOT do

The flag stays a **no-op**. podup still never allocates a pseudo-TTY and never attaches stdin, so `podup exec -it db psql` still does not work. That is the rest of #1079 and it is real work (raw-mode handling, resize propagation over the libpod attach stream). This PR only stops the flag failing to parse, so it is `Part of #1079`, not `Closes`.

## Test plan

New `no_tty_accepts_both_spellings_on_run_and_exec` in `tests/cli_aliases.rs`: asserts both spellings appear in each command's help, and that `--no-TTY`, `--no-tty` and `-T` all *parse* on both commands (using the existing `is_clap_usage_error` helper, which distinguishes a clap rejection from reaching runtime).

Reproduced the original failure against the built binary. All four combinations now exit 1 on a real runtime error instead of exit 2 on a usage error:

```
exec --no-tty -> exit 1 : podup: error: compose file not found: docker-compose.yml
run  --no-tty -> exit 1 : podup: error: compose file not found: docker-compose.yml
exec --no-TTY -> exit 1 : podup: error: compose file not found: docker-compose.yml
run  --no-TTY -> exit 1 : podup: error: compose file not found: docker-compose.yml
```

`cargo fmt --check` and `cargo clippy --all-targets --all-features` clean; `cli_aliases` + `cli_flags` 26/26 green. No Podman needed — this is parse-layer only.

Part of #1079