### PR TITLE
fix: resolve quadlet env_file paths against the compose base, and warn when required:false cannot be honoured

### DIFF
--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -16,7 +16,7 @@ mod unit;
 mod warnings;
 
 use crate::compose::types::ComposeFile;
-use unit::{build_unit, container_unit, network_unit, volume_unit};
+use unit::{build_unit, container_unit, network_unit, volume_unit, UnitContext};
 
 /// The `# podup-owner: <project>` marker a unit carries as its literal first
 /// line, if present.
@@ -208,21 +208,21 @@ pub fn generate_at(file: &ComposeFile, project: &str, base_dir: &std::path::Path
 		.filter(|(_, cfg)| cfg.as_ref().is_none_or(|c| c.external != Some(true)))
 		.map(|(name, _)| name.as_str())
 		.collect();
+	let ctx = UnitContext {
+		project,
+		declared_volumes: &declared_volumes,
+		declared_networks: &declared_networks,
+		secrets: &file.secrets,
+		base_dir,
+	};
 	for (name, service) in &file.services {
 		// Emit a `.build` unit first so the systemd generator builds the image
 		// before the container that references it via `Image=<stem>.build`.
 		if let Some(unit) = build_unit(name, project, service, base_dir, &mut out.warnings) {
 			out.units.push(unit);
 		}
-		out.units.push(container_unit(
-			name,
-			project,
-			service,
-			&declared_volumes,
-			&declared_networks,
-			&file.secrets,
-			&mut out.warnings,
-		));
+		out.units
+			.push(container_unit(name, service, &ctx, &mut out.warnings));
 	}
 
 	out

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -132,12 +132,17 @@ services:
 	let file = parse_str(yaml).unwrap();
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-app.container").contents;
+	// Absolute, resolved against the compose base dir: systemd resolves a relative
+	// `EnvironmentFile=` against the unit's own directory, not the project's, so
+	// `./app.env` would never be found once installed. Built with `join` so the
+	// separator matches the host (this test is not Unix-gated).
+	let env_file = format!(
+		"EnvironmentFile={}",
+		std::path::Path::new("/srv/app").join("app.env").display()
+	);
 	for needle in [
 		"ContainerName=custom",
-		// Absolute, resolved against the compose base dir: systemd resolves a
-		// relative `EnvironmentFile=` against the unit's own directory, not the
-		// project's, so `./app.env` here would never be found once installed.
-		"EnvironmentFile=/srv/app/app.env",
+		&env_file,
 		"Tmpfs=/run",
 		"Sysctl=net.core.somaxconn=1024",
 		"Ulimit=nofile=1024:2048",
@@ -501,23 +506,30 @@ services:
 	let file = parse_str(yaml).unwrap();
 	// A base directory that is deliberately not the process's cwd, so a bug that
 	// resolved against the cwd instead would still show up here.
-	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let base = std::path::Path::new("/srv/app");
+	let out = generate_at(&file, "p", base);
 	let c = &unit_named(&out, "p-app.container").contents;
-	for needle in [
-		"EnvironmentFile=/srv/app/.env",
-		"EnvironmentFile=/srv/app/config/extra.env",
-		"EnvironmentFile=/srv/app/../shared/team.env",
-		"EnvironmentFile=/etc/glyndor/absolute.env",
-	] {
-		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
+	// `abs_against` joins with the OS separator, so build the expectations the
+	// same way rather than as POSIX literals — these render tests are not
+	// Unix-gated and would otherwise fail on Windows.
+	for rel in [".env", "config/extra.env", "../shared/team.env"] {
+		let needle = format!("EnvironmentFile={}", base.join(rel).display());
+		assert!(c.contains(&needle), "missing `{needle}` in:\n{c}");
 	}
-	// No entry may survive as a relative path: systemd would resolve it against
-	// the unit directory.
+	// An already-absolute entry is passed through verbatim, separators included.
+	assert!(
+		c.contains("EnvironmentFile=/etc/glyndor/absolute.env"),
+		"an absolute entry must be untouched in:\n{c}"
+	);
+	// No entry may survive as a compose-relative path: systemd would resolve it
+	// against the unit directory. Checked by prefix rather than `is_absolute()`,
+	// which on Windows demands a drive letter that a `/srv/app` base never has.
+	let base_prefix = base.display().to_string();
 	for line in c.lines().filter(|l| l.starts_with("EnvironmentFile=")) {
 		let value = line.trim_start_matches("EnvironmentFile=");
 		assert!(
-			std::path::Path::new(value).is_absolute(),
-			"`{line}` is relative; it would resolve against the unit directory"
+			value.starts_with(&base_prefix) || value.starts_with("/etc/"),
+			"`{line}` was not resolved against the compose base directory"
 		);
 	}
 }

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -134,7 +134,10 @@ services:
 	let c = &unit_named(&out, "p-app.container").contents;
 	for needle in [
 		"ContainerName=custom",
-		"EnvironmentFile=./app.env",
+		// Absolute, resolved against the compose base dir: systemd resolves a
+		// relative `EnvironmentFile=` against the unit's own directory, not the
+		// project's, so `./app.env` here would never be found once installed.
+		"EnvironmentFile=/srv/app/app.env",
 		"Tmpfs=/run",
 		"Sysctl=net.core.somaxconn=1024",
 		"Ulimit=nofile=1024:2048",
@@ -475,4 +478,46 @@ services:
 		!c.contains("Volume=/cache"),
 		"tmpfs wrongly emitted as a Volume in:\n{c}"
 	);
+}
+
+/// #1091: `EnvironmentFile=` is resolved by podman-systemd.unit(5) against the
+/// unit file's own directory, not the compose file's. Units land in
+/// `~/.config/containers/systemd`, so a relative entry emitted verbatim points
+/// at a file that is not there — and `--env-file` on a missing path is fatal, so
+/// the container never starts. Every relative entry must come out absolute
+/// against the compose base directory; an already-absolute one is untouched.
+#[test]
+fn env_file_entries_are_absolute_against_the_compose_base_dir() {
+	let yaml = r#"
+services:
+  app:
+    image: app:1.0
+    env_file:
+      - .env
+      - ./config/extra.env
+      - ../shared/team.env
+      - /etc/glyndor/absolute.env
+"#;
+	let file = parse_str(yaml).unwrap();
+	// A base directory that is deliberately not the process's cwd, so a bug that
+	// resolved against the cwd instead would still show up here.
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-app.container").contents;
+	for needle in [
+		"EnvironmentFile=/srv/app/.env",
+		"EnvironmentFile=/srv/app/config/extra.env",
+		"EnvironmentFile=/srv/app/../shared/team.env",
+		"EnvironmentFile=/etc/glyndor/absolute.env",
+	] {
+		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
+	}
+	// No entry may survive as a relative path: systemd would resolve it against
+	// the unit directory.
+	for line in c.lines().filter(|l| l.starts_with("EnvironmentFile=")) {
+		let value = line.trim_start_matches("EnvironmentFile=");
+		assert!(
+			std::path::Path::new(value).is_absolute(),
+			"`{line}` is relative; it would resolve against the unit directory"
+		);
+	}
 }

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -192,6 +192,53 @@ services:
 	}
 }
 
+/// #1092: `env_file: [{path, required: false}]` says a missing file is fine.
+/// Quadlet cannot express that — `EnvironmentFile=` becomes `--env-file`, which
+/// is fatal on a missing path — so the entry is emitted anyway and the container
+/// refuses to start. That is the only behaviour available; what must not happen
+/// is emitting it silently.
+#[test]
+fn warns_when_an_optional_env_file_cannot_stay_optional() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    env_file:
+      - path: .env
+        required: true
+      - path: .env.production
+        required: false
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let joined = out.warnings.join("\n");
+	assert!(
+		joined.contains("env_file") && joined.contains("required: false"),
+		"expected a warning naming the unmappable `required: false`, got:\n{joined}"
+	);
+	// The entry is still emitted — dropping it would lose configuration the user
+	// asked for whenever the file does exist.
+	let c = &unit_named(&out, "p-s.container").contents;
+	assert!(
+		c.contains("EnvironmentFile=/srv/app/.env.production"),
+		"{c}"
+	);
+}
+
+/// The warning is about `required: false` specifically, so an env_file list
+/// where every entry is required must stay quiet.
+#[test]
+fn no_env_file_warning_when_every_entry_is_required() {
+	let yaml = "services:\n  s:\n    image: x\n    env_file:\n      - .env\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	assert!(
+		!out.warnings.iter().any(|w| w.contains("env_file")),
+		"unexpected env_file warning: {:?}",
+		out.warnings
+	);
+}
+
 #[test]
 fn hostile_service_name_cannot_escape_output_directory() {
 	// A compose key containing path separators must never yield a unit

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -217,12 +217,16 @@ services:
 		"expected a warning naming the unmappable `required: false`, got:\n{joined}"
 	);
 	// The entry is still emitted — dropping it would lose configuration the user
-	// asked for whenever the file does exist.
+	// asked for whenever the file does exist. Built with `join` so the separator
+	// matches the host (this test is not Unix-gated).
 	let c = &unit_named(&out, "p-s.container").contents;
-	assert!(
-		c.contains("EnvironmentFile=/srv/app/.env.production"),
-		"{c}"
+	let needle = format!(
+		"EnvironmentFile={}",
+		std::path::Path::new("/srv/app")
+			.join(".env.production")
+			.display()
 	);
+	assert!(c.contains(&needle), "missing `{needle}` in:\n{c}");
 }
 
 /// The warning is about `required: false` specifically, so an env_file list

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -16,19 +16,13 @@ use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
 /// own, resolving a relative `SetWorkingDirectory` against the unit file's own
 /// directory (`~/.config/containers/systemd`) — where there is no Dockerfile. So
 /// the context, which compose interprets relative to the compose file, must be
-/// made absolute against that base directory here. `.` means the base dir itself.
+/// made absolute against that base directory here.
+///
+/// The rule is not specific to a build context: every compose-relative path a
+/// generated unit carries needs it, which is why the resolution itself lives in
+/// [`abs_against`].
 fn abs_context(base_dir: &Path, context: &str) -> String {
-	let ctx = Path::new(context);
-	if ctx.is_absolute() {
-		return context.to_string();
-	}
-	if ctx == Path::new(".") {
-		return base_dir.display().to_string();
-	}
-	// Strip a leading `./` so the joined path stays clean (`/base/src`, not
-	// `/base/./src`) — cosmetic, both resolve identically.
-	let rel = context.strip_prefix("./").unwrap_or(context);
-	base_dir.join(rel).display().to_string()
+	super::abs_against(base_dir, context)
 }
 
 /// The `.build` unit file name for a service, e.g. `proj-web.build`. The

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -9,26 +9,48 @@ use crate::size::parse_duration_secs;
 use super::health::render_healthcheck;
 use super::security::{is_inline_secret, map_security_opt, render_secret};
 use super::{
-	collect_warnings, owner_marker, render_command, render_publish_port, render_restart,
-	render_tmpfs_mount, render_volume, sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit,
-	Section,
+	abs_against, collect_warnings, owner_marker, render_command, render_publish_port,
+	render_restart, render_tmpfs_mount, render_volume, sorted_label_pairs, sorted_pairs, unit_stem,
+	QuadletUnit, Section,
 };
+
+/// Project-wide inputs every generated unit needs, as opposed to the per-service
+/// ones (`name`, `service`). Grouped rather than passed loose because the set
+/// only grows as more compose keys gain a Quadlet mapping, and because they are
+/// identical for every service in one `generate_at` call.
+pub(crate) struct UnitContext<'a> {
+	/// Compose project name, stamped as the `podup.project` ownership label.
+	pub project: &'a str,
+	/// Volumes the compose file declares (external ones excluded).
+	pub declared_volumes: &'a [&'a str],
+	/// Networks the compose file declares (external ones excluded).
+	pub declared_networks: &'a [&'a str],
+	/// Top-level `secrets:` definitions, for resolving a service's secret refs.
+	pub secrets: &'a IndexMap<String, SecretConfig>,
+	/// Directory compose resolves relative paths against — the compose file's
+	/// own directory, not the unit's. See [`abs_against`].
+	pub base_dir: &'a std::path::Path,
+}
 
 /// Build the `.container` unit for one compose `service`.
 ///
-/// `project` is the compose project name; it is stamped onto the unit as the
-/// `podup.project` ownership label (and the service key as `podup.service`),
-/// matching the labels the live engine applies, so generated containers are
-/// traceable back to their project the same way running ones are.
+/// The project name is stamped onto the unit as the `podup.project` ownership
+/// label (and the service key as `podup.service`), matching the labels the live
+/// engine applies, so generated containers are traceable back to their project
+/// the same way running ones are.
 pub(crate) fn container_unit(
 	name: &str,
-	project: &str,
 	service: &Service,
-	declared_volumes: &[&str],
-	declared_networks: &[&str],
-	secrets: &IndexMap<String, SecretConfig>,
+	ctx: &UnitContext<'_>,
 	warnings: &mut Vec<String>,
 ) -> QuadletUnit {
+	let UnitContext {
+		project,
+		declared_volumes,
+		declared_networks,
+		secrets,
+		base_dir,
+	} = ctx;
 	let mut unit = Section::new("Unit");
 	unit.add("Description", format!("{name} (podup)"));
 	for dep in service.depends_on.service_names() {
@@ -154,8 +176,14 @@ pub(crate) fn container_unit(
 	for ann in sorted_label_pairs(service.annotations.to_map()) {
 		container.add("Annotation", format!("{}={}", ann.0, ann.1));
 	}
+	// `EnvironmentFile=` is resolved by podman-systemd.unit(5) against the unit
+	// file's own directory, not the compose file's. Units are installed to
+	// `~/.config/containers/systemd`, so `env_file: .env` would render to a unit
+	// looking for `~/.config/containers/systemd/.env` — and `--env-file` on a
+	// missing path is fatal, so the container never starts. Resolve against the
+	// compose base directory, the same way the build context is.
 	for entry in service.env_file.to_entries() {
-		container.add("EnvironmentFile", entry.path().to_string());
+		container.add("EnvironmentFile", abs_against(base_dir, entry.path()));
 	}
 	for t in service.tmpfs.to_list() {
 		container.add("Tmpfs", t);

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -8,7 +8,7 @@ mod security;
 mod volume;
 
 pub(super) use build::build_unit;
-pub(super) use container::container_unit;
+pub(super) use container::{container_unit, UnitContext};
 pub(super) use network::network_unit;
 pub(super) use volume::volume_unit;
 
@@ -37,4 +37,27 @@ use super::QuadletUnit;
 /// `crate::autostart::quadlet`) must read instead.
 fn owner_marker(project: &str) -> String {
 	format!("# podup-owner: {project}\n")
+}
+
+/// Resolve a compose-relative path against the compose base directory.
+///
+/// Compose interprets a relative path against the compose file's directory.
+/// systemd interprets one against **the unit file's** directory — units are
+/// installed under `~/.config/containers/systemd`, which is not where the
+/// project lives. Any path a generated unit carries must therefore be made
+/// absolute here, or it silently resolves somewhere else once installed.
+///
+/// An already-absolute path is returned untouched, and `.` means the base
+/// directory itself. A leading `./` is stripped so the result stays clean
+/// (`/base/src`, not `/base/./src`) — cosmetic, both resolve identically.
+fn abs_against(base_dir: &std::path::Path, path: &str) -> String {
+	let p = std::path::Path::new(path);
+	if p.is_absolute() {
+		return path.to_string();
+	}
+	if p == std::path::Path::new(".") {
+		return base_dir.display().to_string();
+	}
+	let rel = path.strip_prefix("./").unwrap_or(path);
+	base_dir.join(rel).display().to_string()
 }

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -64,6 +64,20 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 		}
 	}
 
+	// `env_file: [{path, required: false}]` means a missing file is not an error.
+	// Quadlet has no way to say that: `EnvironmentFile=` becomes
+	// `podman run --env-file`, which is fatal on a missing path. So an entry the
+	// compose file marks optional becomes a container that refuses to start —
+	// and this is the deployment-local override pattern (a `.env.production`
+	// deliberately absent from the repo), so it fails exactly where the file is
+	// meant to be missing.
+	if service.env_file.to_entries().iter().any(|e| !e.required()) {
+		warn(
+			"env_file",
+			"`required: false` cannot be expressed in Quadlet; the file will be required at run time and the container will not start without it",
+		);
+	}
+
 	// Fields that are honoured at runtime but have no [Container] Quadlet key and
 	// no unambiguous PodmanArgs= fallback. Warn so the generated unit is never
 	// silently incomplete; add the flag by hand if it is required.


### PR DESCRIPTION
Closes #1091 and #1092. They land together because they are the same three lines of `container.rs` and the same `env_file` contract — separate PRs would have guaranteed a rebase for no benefit.

## #1091 — `EnvironmentFile=` was emitted relative

podman-systemd.unit(5) resolves a relative `EnvironmentFile=` against **the unit file's** directory, not the compose file's. Units install to `~/.config/containers/systemd`, so `env_file: .env` produced a unit looking for `~/.config/containers/systemd/.env`, and `--env-file` on a missing path is fatal — the container never started. This hit `autostart install --mode quadlet` as well as `generate quadlet`; both go through `generate_at`.

The machinery already existed for the build context, which has the same problem for the same reason. I moved that resolution out of `build.rs` into a shared `abs_against()` and threaded the compose base directory into `container_unit`. An already-absolute entry passes through untouched.

Threading it in pushed `container_unit` to eight arguments and clippy flagged it. I did not silence the lint — four of those parameters are project-wide rather than per-service, so they are a `UnitContext` struct now. That set only grows as more compose keys gain a Quadlet mapping (#1093 and #1095 both land here).

## #1092 — `required: false` is silently unhonourable

The compose long form can mark an env file optional. Quadlet has no key for it: `EnvironmentFile=` becomes `--env-file`, fatal on a missing path. So an entry the compose file marks optional became a container that refuses to start — and this is the deployment-local override pattern (a `.env.production` deliberately absent from the repo), so it failed exactly where the file is meant to be missing.

The behaviour is right and unchanged; there is no key to target, and dropping the entry would lose configuration the user asked for whenever the file *does* exist. What was missing is the warning, which now joins the rest of the unmappable-field contract in `warnings.rs`.

## Test plan

`cargo test --lib` 1258/1258, clippy `--all-targets --all-features` clean.

One existing test pinned the bug (`EnvironmentFile=./app.env`); updated, with the reason in a comment so it does not get reverted. New unit tests cover a bare relative entry, a `./`-prefixed one, a `../` traversal, an already-absolute one, and a base directory that is deliberately not the process cwd — plus an assertion that *no* emitted entry is relative. For #1092, one test that the warning fires and one that it stays quiet when every entry is required.

**Verified against the real Quadlet generator**, which is how #1091 was originally reproduced. Same units, only the `EnvironmentFile=` form differing:

```
# relative, as it was
$ /usr/libexec/podman/quadlet --dryrun --user | grep -o '\-\-env-file [^ ]*'
--env-file <XDG_CONFIG_HOME>/containers/systemd/.env
--env-file <XDG_CONFIG_HOME>/containers/systemd/config/extra.env

# absolute, as of this PR
--env-file <project>/.env
--env-file <project>/config/extra.env
```

The generator substitutes the unit directory for the project directory, exactly as the issue described.

**And end to end on real systemd + real Podman 5.4.2** — `autostart install --mode quadlet` on a project with two `env_file` entries:

```
service: active
KEY   inside the container -> base
EXTRA inside the container -> 1
```

Both entries resolve and both variables reach the container. Uninstall afterwards left no units, containers or networks behind.

Closes #1091
Closes #1092