### PR TITLE
fix: build on up only when the service's image is missing

### DIFF
--- a/internal/engine/lifecycle/images.rs
+++ b/internal/engine/lifecycle/images.rs
@@ -1,0 +1,79 @@
+//! Deciding which image a service runs, and getting it there.
+//!
+//! Split out of `mod.rs` to keep that file within the source line limit.
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::error::Result;
+
+use super::Engine;
+
+impl Engine {
+	/// The image tag a service resolves to: its explicit `image:` when set,
+	/// otherwise the tag its build produces (`build.tags[0]`, else the
+	/// project-scoped `{project}-{service}:latest`).
+	///
+	/// This is the name `up` checks for presence and the name `down --rmi local`
+	/// removes, so both must agree on it — they used to compute it separately.
+	pub(super) fn service_image_tag(&self, name: &str, service: &Service) -> String {
+		match &service.image {
+			Some(image) => image.clone(),
+			None => crate::engine::build::primary_build_tag(
+				&self.project,
+				name,
+				None,
+				service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
+			),
+		}
+	}
+
+	/// Make the service's image available before its containers are created:
+	/// build it, pull it, or leave the local one alone.
+	pub(super) async fn acquire_service_image(
+		&self,
+		name: &str,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<()> {
+		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
+		// suppresses building even for services with a `build:` section (they fall
+		// back to pulling/using an existing image).
+		let policy = self
+			.pull_policy_override
+			.as_deref()
+			.or(service.pull_policy.as_deref())
+			.unwrap_or("missing");
+		// Build on `up` only when the service's image is not already there, which
+		// is what docker compose does: `up` converges on the declared state and
+		// `--build` is the flag that forces a rebuild.
+		//
+		// Building unconditionally was worse than redundant. The rebuild runs
+		// *with* the cache, so it can resolve to an older layer chain and retag
+		// the image backwards — silently undoing a `podup build --no-cache` that
+		// just ran. `build --no-cache && up -d`, the ordinary deploy shape, would
+		// start the previous image. It also made `--build` look like a no-op,
+		// since the default already always built.
+		//
+		// `--build` is handled before this by an explicit `build_all`, so a forced
+		// rebuild has already happened and the image is present by the time we get
+		// here.
+		let needs_build = if service.build.is_some() && !self.no_build {
+			!self
+				.image_present(&self.service_image_tag(name, service))
+				.await
+		} else {
+			false
+		};
+		match (needs_build, policy) {
+			(true, _) => {
+				self.build_service(name, service, file, &crate::engine::BuildOptions::default())
+					.await?
+			}
+			// A service with a `build:` whose image is already present needs no
+			// pull either — the local tag is the declared state.
+			(false, _) if service.build.is_some() => {}
+			(false, "never") => {}
+			(false, _) => self.pull_image(service).await?,
+		}
+		Ok(())
+	}
+}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod down_label;
+mod images;
 mod parallel;
 mod prefetch;
 mod readiness;
@@ -392,22 +393,7 @@ impl Engine {
 			}
 		}
 
-		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
-		// suppresses building even for services with a `build:` section (they fall
-		// back to pulling/using an existing image).
-		let policy = self
-			.pull_policy_override
-			.as_deref()
-			.or(service.pull_policy.as_deref())
-			.unwrap_or("missing");
-		match (service.build.is_some() && !self.no_build, policy) {
-			(true, _) => {
-				self.build_service(name, service, file, &crate::engine::BuildOptions::default())
-					.await?
-			}
-			(false, "never") => {}
-			(false, _) => self.pull_image(service).await?,
-		}
+		self.acquire_service_image(name, service, file).await?;
 
 		let replicas = self.resolve_replicas(name, service);
 		// Bound the replica count (covers an untrusted compose `deploy.replicas`/
@@ -688,14 +674,7 @@ impl Engine {
 			}
 			let image = match &service.image {
 				Some(img) => img.clone(),
-				// A build-only service's image is the tag the build step produced
-				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
-				None if builds_locally => super::build::primary_build_tag(
-					&self.project,
-					name,
-					None,
-					service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
-				),
+				None if builds_locally => self.service_image_tag(name, service),
 				None => continue,
 			};
 			// Do NOT force: a force-removal cascades to every container using the

--- a/tests/engine_integration/build_resources.rs
+++ b/tests/engine_integration/build_resources.rs
@@ -438,3 +438,69 @@ async fn remove_orphans_removes_container() {
 }
 
 // ---------------------------------------------------------------------------
+
+/// The image ID a tag currently resolves to, via the podman CLI — the same
+/// out-of-band check the sibling tests in this file use to observe state podup
+/// itself reports on. Empty when the tag is absent.
+fn image_id(tag: &str) -> String {
+	let out = std::process::Command::new("podman")
+		.args(["inspect", tag, "--format", "{{.Id}}"])
+		.output()
+		.expect("run podman inspect");
+	String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// #1094: `up` must not rebuild a service whose image is already present.
+///
+/// It used to rebuild unconditionally, *with* the cache, so the rebuild could
+/// resolve to an older layer chain and retag the image backwards — silently
+/// discarding a `build --no-cache` that had just run. That breaks the ordinary
+/// deploy shape: build explicitly, then start.
+///
+/// The sequence matters. A plain `build` first seeds the cache with one chain;
+/// `build --no-cache` then produces a different one and tags it. Without both
+/// steps there is no older chain for `up` to revert to and the bug does not
+/// appear at all.
+#[tokio::test]
+async fn up_keeps_the_image_a_no_cache_build_produced() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("upnb");
+	let tag = format!("podup-test-upnb-{}:latest", std::process::id());
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let yaml = format!(
+		"services:\n  app:\n    build:\n      context: .\n      dockerfile_inline: |\n        FROM alpine:latest\n        RUN echo marker > /marker\n    image: {tag}\n    command: [\"sleep\", \"infinity\"]\n"
+	);
+	let file = parse_str(&yaml).unwrap();
+
+	// Seed the cache with one chain, then force a different one.
+	engine.build_all(&file, &[]).await.unwrap();
+	engine
+		.build_all_with_options(
+			&file,
+			&[],
+			&podup::BuildOptions {
+				no_cache: true,
+				..Default::default()
+			},
+		)
+		.await
+		.unwrap();
+	let after_build = image_id(&tag);
+
+	engine
+		.up_with_options(&file, true, &[], &[], false, false, false)
+		.await
+		.unwrap();
+	let after_up = image_id(&tag);
+
+	assert_eq!(
+		after_build, after_up,
+		"`up` must not retag the image built by `build --no-cache`"
+	);
+
+	engine.down_with_options(&file, true).await.ok();
+}


### PR DESCRIPTION
Closes #1094.

## The bug, reproduced

`up` rebuilt any service with a `build:` section unconditionally. That rebuild runs *with* the cache, so it could resolve to an older layer chain and retag the image backwards — silently discarding a `build --no-cache` that had just run.

The sequence matters, and my first attempt to reproduce it failed because I got it wrong: I cleared the cache first, so there was no older chain to revert to and the image stayed put. The real repro needs a prior build to fall back onto. Against real Podman 5.4.2, on the `develop` binary:

```
1. build            : 10fc39d1d6319c12     <- seeds the cache with one chain
2. build --no-cache : dcaac20105f0e9b9     <- a different chain, now tagged
3. up -d            : 10fc39d1d6319c12     <- reverted to (1)
```

With this branch:

```
1. build            : 9d2d0e4e1ab5722d
2. build --no-cache : fc45b8d5ce917acf
3. up -d            : fc45b8d5ce917acf     (container runs fc45b8d5ce917acf)
```

## The fix

`up` builds only when the image is absent, which is what docker compose does: `up` converges on the declared state and `--build` is what forces a rebuild. That also un-breaks `--build`, which looked like a no-op because the default already always built — `up --build` still rebuilds, verified.

A service with a `build:` whose image is already present no longer pulls either: the local tag is the declared state, and pulling would be the same "replace what you just built" surprise by a different route.

## Refactor in the same commit

The change put `internal/engine/lifecycle/mod.rs` one code line over the 500-line hard limit, so the build-or-pull decision and the tag it keys off move to `lifecycle/images.rs`. They are cohesive — the decision exists to serve that tag — rather than an arbitrary cut. `mod.rs` is now 471 lines, the new file 45.

It also removes a small duplication: `up` and `down --rmi local` each computed the service's image tag separately and now share one `service_image_tag`.

## Test plan

`cargo test --lib` 1258/1258, clippy `--all-targets --all-features` clean.

New integration test `up_keeps_the_image_a_no_cache_build_produced`, running the three-step sequence above against real Podman and asserting the image ID is unchanged. **Verified it fails without the fix**:

```
assertion `left == right` failed: `up` must not retag the image built by `build --no-cache`
  left:  1361824b02ed771696b1bddb864adb594537943f1ed7260adcb72b00f3db9e18
  right: 8f90226f6d4613a6c23d2cabc2e85a85dfc06d99929561d5273b8bfd37988f95
```

The test's doc comment spells out why the plain `build` step is needed first, so nobody simplifies it into a version that cannot fail.

Full integration suite green locally against Podman 5.4.2.

Closes #1094