### PR TITLE
fix: read .containerignore, and never union it with .dockerignore

### DIFF
--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -1,8 +1,11 @@
-//! Build context tar assembly and `.dockerignore` matching.
+//! Build context tar assembly and ignore-file matching (`.containerignore` / `.dockerignore`).
 //!
-//! Walks the build context directory, applies `.dockerignore` semantics
-//! (last-match-wins with `!` re-includes, `*`/`?`/`**` globs), and packs the
-//! result into a gzipped tar suitable for the libpod build endpoint.
+//! Walks the build context directory, applies ignore semantics (last-match-wins
+//! with `!` re-includes, `*`/`?`/`**` globs), and packs the result into a
+//! gzipped tar suitable for the libpod build endpoint.
+//!
+//! Podman reads `.containerignore` or `.dockerignore` and prefers its own when
+//! both exist; exactly one applies, never the union. See [`ignore_file`].
 
 use std::path::Path;
 
@@ -95,27 +98,32 @@ pub(super) fn stream_build_context<W: std::io::Write>(
 	dockerfile: &str,
 	extra_files: &[(String, Vec<u8>)],
 ) -> Result<()> {
-	let ignore_patterns = read_dockerignore(context);
+	let (ignore_name, ignore_patterns) = ignore_file(context);
 	let encoder = GzEncoder::new(writer, Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	// Force-include the active Dockerfile so a `.dockerignore` that matches it
+	// Force-include the active Dockerfile so an ignore file that matches it
 	// cannot drop it from the context the builder receives (Docker parity).
 	if extra_files.is_empty() {
 		append_context(&mut tar, context, &ignore_patterns, &[], &[dockerfile])?;
 	} else {
-		// Skip the user's `.dockerignore`; it is rewritten with an exclusion per
+		// Skip the user's ignore file; it is rewritten with an exclusion per
 		// synthesized entry so a `COPY .` in the build cannot bake secret bytes
-		// into image layers.
+		// into image layers. It must be skipped and re-emitted under the same
+		// name the server will read, or the exclusions never apply.
 		append_context(
 			&mut tar,
 			context,
 			&ignore_patterns,
-			&[".dockerignore"],
+			&[ignore_name],
 			&[dockerfile],
 		)?;
 		let synthesized: Vec<&str> = extra_files.iter().map(|(n, _)| n.as_str()).collect();
-		append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
+		append_ignore_file(
+			&mut tar,
+			ignore_name,
+			&synthesized_ignore_file(context, ignore_name, &synthesized),
+		)?;
 	}
 	append_extra_files(&mut tar, extra_files)?;
 	finish_tar(tar)
@@ -129,7 +137,7 @@ pub(super) fn stream_build_context_with_inline<W: std::io::Write>(
 	inline: &str,
 	extra_files: &[(String, Vec<u8>)],
 ) -> Result<()> {
-	let ignore_patterns = read_dockerignore(context);
+	let (ignore_name, ignore_patterns) = ignore_file(context);
 	let encoder = GzEncoder::new(writer, Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
@@ -140,13 +148,18 @@ pub(super) fn stream_build_context_with_inline<W: std::io::Write>(
 	tar.append_data(&mut header, INLINE_DOCKERFILE_NAME, inline.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-	// Skip the user's `.dockerignore` here; it is rewritten below with extra
-	// rules excluding every synthesized entry (inline Dockerfile, build secrets).
-	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"], &[])?;
+	// Skip the user's ignore file here; it is rewritten below with extra rules
+	// excluding every synthesized entry (inline Dockerfile, build secrets), under
+	// the same name the server will read.
+	append_context(&mut tar, context, &ignore_patterns, &[ignore_name], &[])?;
 
 	let mut synthesized: Vec<&str> = vec![INLINE_DOCKERFILE_NAME];
 	synthesized.extend(extra_files.iter().map(|(n, _)| n.as_str()));
-	append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
+	append_ignore_file(
+		&mut tar,
+		ignore_name,
+		&synthesized_ignore_file(context, ignore_name, &synthesized),
+	)?;
 
 	append_extra_files(&mut tar, extra_files)?;
 	finish_tar(tar)
@@ -196,24 +209,30 @@ pub(crate) fn build_context_tar(
 }
 
 /// Append a synthesized `.dockerignore` entry to the context tar.
-fn append_dockerignore<W: std::io::Write>(tar: &mut tar::Builder<W>, content: &str) -> Result<()> {
+fn append_ignore_file<W: std::io::Write>(
+	tar: &mut tar::Builder<W>,
+	name: &str,
+	content: &str,
+) -> Result<()> {
 	let mut header = tar::Header::new_gnu();
 	header.set_size(content.len() as u64);
 	header.set_mode(0o644);
 	header.set_cksum();
-	tar.append_data(&mut header, ".dockerignore", content.as_bytes())
+	tar.append_data(&mut header, name, content.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))
 }
 
-/// Build the `.dockerignore` content for a context tar carrying synthesized
-/// entries: any user rules plus a final exclusion per synthesized name, so a
-/// `COPY .` in the build does not capture the inline Dockerfile or a build
-/// secret. The libpod `secrets=id=…,src=…` mount reads straight from the
-/// extracted context, which `.dockerignore` does not filter, so excluded
-/// secret entries remain mountable.
-fn synthesized_dockerignore(context: &Path, names: &[&str]) -> String {
-	let existing =
-		crate::filesystem::read_to_string_capped(context.join(".dockerignore")).unwrap_or_default();
+/// Build the ignore-file content for a context tar carrying synthesized entries:
+/// any user rules plus a final exclusion per synthesized name, so a `COPY .` in
+/// the build does not capture the inline Dockerfile or a build secret. The
+/// libpod `secrets=id=…,src=…` mount reads straight from the extracted context,
+/// which the ignore file does not filter, so excluded secret entries remain
+/// mountable.
+///
+/// `name` is the ignore file the server will read (see [`ignore_file`]); the
+/// user rules are carried over from that same file, never from the other one.
+fn synthesized_ignore_file(context: &Path, name: &str, names: &[&str]) -> String {
+	let existing = crate::filesystem::read_to_string_capped(context.join(name)).unwrap_or_default();
 	let mut out = existing.trim_end_matches(['\n', '\r']).to_string();
 	for name in names {
 		if !out.is_empty() {
@@ -240,16 +259,34 @@ pub(super) fn map_additional_context(base_dir: &Path, value: &str) -> String {
 	}
 }
 
-fn read_dockerignore(context: &Path) -> Vec<String> {
-	let path = context.join(".dockerignore");
-	let Ok(content) = crate::filesystem::read_to_string_capped(path) else {
-		return Vec::new();
-	};
-	content
-		.lines()
-		.map(|l| l.trim().to_string())
-		.filter(|l| !l.is_empty() && !l.starts_with('#'))
-		.collect()
+/// The ignore file podman would read for `context`, and its patterns.
+///
+/// podman-build(1): "If the file `.containerignore` or `.dockerignore` exists in
+/// the context directory, podman build reads its contents. […] if both are in
+/// the context directory, podman build only uses `.containerignore`."
+///
+/// So exactly one file applies — never the union. Applying both client-side
+/// produced an image missing content that `podman build` puts in, because we
+/// filtered by `.dockerignore` (a file podman would have ignored entirely) and
+/// the server then filtered by `.containerignore`.
+///
+/// The returned name is also the name any synthesized ignore file must be
+/// written under, or the server would read the *other* one and our exclusions
+/// would not apply. When neither file exists, `.containerignore` is the name to
+/// synthesize: podman prefers it, so it cannot be shadowed.
+fn ignore_file(context: &Path) -> (&'static str, Vec<String>) {
+	for name in [".containerignore", ".dockerignore"] {
+		let Ok(content) = crate::filesystem::read_to_string_capped(context.join(name)) else {
+			continue;
+		};
+		let patterns = content
+			.lines()
+			.map(|l| l.trim().to_string())
+			.filter(|l| !l.is_empty() && !l.starts_with('#'))
+			.collect();
+		return (name, patterns);
+	}
+	(".containerignore", Vec::new())
 }
 
 /// Decide whether `path` is excluded from the build context.

--- a/internal/engine/build/context/tests.rs
+++ b/internal/engine/build/context/tests.rs
@@ -3,8 +3,8 @@
 //! line limit).
 
 use super::{
-	build_context_tar, build_context_tar_with_inline, glob_match, is_ignored,
-	map_additional_context, read_dockerignore,
+	build_context_tar, build_context_tar_with_inline, glob_match, ignore_file, is_ignored,
+	map_additional_context,
 };
 use std::fs;
 use std::path::Path;
@@ -110,7 +110,10 @@ fn inline_tar_excludes_build_secrets_via_dockerignore() {
 	let mut di = String::new();
 	for entry in archive.entries().unwrap() {
 		let mut entry = entry.unwrap();
-		if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+		// No user ignore file in this context, so the synthesized one is
+		// written as `.containerignore` — the name podman prefers, so a
+		// stray `.dockerignore` cannot shadow our exclusions.
+		if entry.path().unwrap().to_string_lossy() == ".containerignore" {
 			entry.read_to_string(&mut di).unwrap();
 		}
 	}
@@ -242,7 +245,7 @@ fn dockerignore_negation_order_matters() {
 	assert!(is_ignored("logs/keep/secret.txt", &patterns));
 }
 
-// read_dockerignore ----------------------------------------------------
+// ignore_file ----------------------------------------------------------
 
 #[test]
 fn dockerignore_parsed_correctly() {
@@ -252,14 +255,45 @@ fn dockerignore_parsed_correctly() {
 		b"# comment\n\ntarget/\n*.log\n",
 	)
 	.unwrap();
-	let patterns = read_dockerignore(dir.path());
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".dockerignore");
 	assert_eq!(patterns, vec!["target/", "*.log"]);
 }
 
 #[test]
-fn dockerignore_missing_returns_empty() {
+fn containerignore_is_read_when_it_is_the_only_one() {
 	let dir = tempdir().unwrap();
-	let patterns = read_dockerignore(dir.path());
+	fs::write(dir.path().join(".containerignore"), b"secrets/\n*.key\n").unwrap();
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".containerignore");
+	assert_eq!(patterns, vec!["secrets/", "*.key"]);
+}
+
+/// podman-build(1): "if both are in the context directory, podman build only
+/// uses `.containerignore`". Applying both client-side is what produced an image
+/// missing content that `podman build` includes.
+#[test]
+fn containerignore_wins_and_dockerignore_is_not_merged() {
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join(".containerignore"), b"a.txt\n").unwrap();
+	fs::write(dir.path().join(".dockerignore"), b"b.txt\n").unwrap();
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".containerignore");
+	assert_eq!(
+		patterns,
+		vec!["a.txt"],
+		"the two files must never be unioned"
+	);
+}
+
+/// With neither present the name still matters: it is what a synthesized ignore
+/// file is written under, and podman prefers `.containerignore`, so choosing it
+/// means our exclusions cannot be shadowed by a `.dockerignore`.
+#[test]
+fn no_ignore_file_defaults_to_containerignore_with_no_patterns() {
+	let dir = tempdir().unwrap();
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".containerignore");
 	assert!(patterns.is_empty());
 }
 
@@ -342,7 +376,10 @@ fn inline_dockerfile_excluded_via_dockerignore() {
 	let mut di = String::new();
 	for entry in archive.entries().unwrap() {
 		let mut entry = entry.unwrap();
-		if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+		// No user ignore file in this context, so the synthesized one is
+		// written as `.containerignore` — the name podman prefers, so a
+		// stray `.dockerignore` cannot shadow our exclusions.
+		if entry.path().unwrap().to_string_lossy() == ".containerignore" {
 			entry.read_to_string(&mut di).unwrap();
 		}
 	}
@@ -460,4 +497,72 @@ fn glob_match_question_mark_matches_single_non_slash_char() {
 	assert!(glob_match("file?.txt", "file1.txt"));
 	assert!(!glob_match("file?.txt", "file.txt"));
 	assert!(!glob_match("a?b", "a/b"));
+}
+
+/// #1096: with both ignore files present, only `.containerignore` may filter the
+/// context tar. Applying both client-side is what made podup ship an image
+/// missing content that `podman build` includes: we dropped `b.txt` per
+/// `.dockerignore` — a file podman ignores entirely here — and the server then
+/// dropped `a.txt` per `.containerignore`, so the union of both applied.
+#[test]
+fn context_tar_filters_by_containerignore_only_when_both_exist() {
+	use flate2::read::GzDecoder;
+	use std::io::Read;
+
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	fs::write(dir.path().join("a.txt"), b"A").unwrap();
+	fs::write(dir.path().join("b.txt"), b"B").unwrap();
+	fs::write(dir.path().join(".containerignore"), b"a.txt\n").unwrap();
+	fs::write(dir.path().join(".dockerignore"), b"b.txt\n").unwrap();
+
+	let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+	let mut raw = Vec::new();
+	GzDecoder::new(bytes.as_slice())
+		.read_to_end(&mut raw)
+		.unwrap();
+	let mut archive = tar::Archive::new(raw.as_slice());
+	let names: Vec<String> = archive
+		.entries()
+		.unwrap()
+		.map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+		.collect();
+
+	assert!(
+		!names.iter().any(|n| n == "a.txt"),
+		"`.containerignore` must exclude a.txt: {names:?}"
+	);
+	assert!(
+		names.iter().any(|n| n == "b.txt"),
+		"`.dockerignore` must NOT apply when `.containerignore` exists: {names:?}"
+	);
+}
+
+/// The mirror: with only `.dockerignore` present it is the one that applies, so
+/// existing projects that never had a `.containerignore` are unaffected.
+#[test]
+fn context_tar_falls_back_to_dockerignore_when_alone() {
+	use flate2::read::GzDecoder;
+	use std::io::Read;
+
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	fs::write(dir.path().join("b.txt"), b"B").unwrap();
+	fs::write(dir.path().join(".dockerignore"), b"b.txt\n").unwrap();
+
+	let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+	let mut raw = Vec::new();
+	GzDecoder::new(bytes.as_slice())
+		.read_to_end(&mut raw)
+		.unwrap();
+	let mut archive = tar::Archive::new(raw.as_slice());
+	let names: Vec<String> = archive
+		.entries()
+		.unwrap()
+		.map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+		.collect();
+	assert!(
+		!names.iter().any(|n| n == "b.txt"),
+		"`.dockerignore` must still apply when it is the only one: {names:?}"
+	);
 }


### PR DESCRIPTION
Closes #1096.

## Both halves of podman's rule were missing

podman-build(1): *"If the file `.containerignore` or `.dockerignore` exists in the context directory, podman build reads its contents. […] if both are in the context directory, podman build only uses `.containerignore`."*

`read_dockerignore` only ever opened `.dockerignore` — so neither the alternative name nor the precedence.

### 1. Both present: we built a different image than podman does

Context with `a.txt`, `b.txt`, a `.containerignore` listing `a.txt`, and a `.dockerignore` listing `b.txt`. Measured on real Podman 5.4.2:

```
podman build        ->  Containerfile b.txt compose.yaml
podup build (before)->  Containerfile       compose.yaml     <- b.txt missing
podup build (after) ->  Containerfile b.txt compose.yaml     <- matches
```

We filtered `b.txt` client-side per `.dockerignore` — a file podman ignores entirely here — and the server then dropped `a.txt` per `.containerignore`. The union of both applied, so the image was missing content `podman build` puts in it, silently and with exit 0. This is the serious half, and it bites exactly the people migrating from Docker who keep both files.

### 2. Only `.containerignore`: the whole payload still crossed the socket

Nothing was filtered before the tar went out. The image came out right (the server applies `.containerignore` to `COPY`/`ADD`) but everything the user excluded was sent anyway. With a 200 MB ignored file:

```
before: 680 ms
after:  142 ms
```

Beyond the time, that is the confidentiality point from the issue: an excluded `.env.production` or key no longer leaves the client.

## The name is load-bearing, not just the patterns

`ignore_file` returns the chosen name alongside its patterns, because the name is needed twice. When the tar carries synthesized entries (inline Dockerfile, build secrets) the user's ignore file is skipped and re-emitted with extra exclusions — and it has to be re-emitted **under the name the server will read**, or those exclusions silently do nothing.

With neither file present the synthesized one is now written as `.containerignore`: podman prefers that name, so a `.dockerignore` sitting in the context cannot shadow our exclusions.

Both context-tar builders (`stream_build_context` and `stream_build_context_with_inline`) had the same bug and both are fixed.

## Test plan

`cargo test --lib` 1262/1262, clippy `--all-targets --all-features` clean.

Unit tests for all four cases the issue asks for — only `.dockerignore`, only `.containerignore`, both present, neither — plus two tar-level tests that assert the *filtering* follows the right file: with both present `a.txt` is gone and `b.txt` survives, and with only `.dockerignore` it still applies so existing projects are unaffected.

Two existing tests changed on purpose: they read the synthesized ignore entry out of the tar by name, and in contexts with no user ignore file that name is now `.containerignore`. Comments explain why.

Verified end to end against real Podman 5.4.2 — the measured output above is from the built binary, compared against `podman build` on the identical context.

Closes #1096