### PR TITLE
fix: exit when the reader closes the pipe on logs

### DIFF
--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -46,11 +46,18 @@ impl LinePrefixer {
 	}
 
 	/// Buffer `chunk` and write every complete line it now completes.
-	pub(super) fn write(&mut self, out: &mut impl Write, chunk: &[u8]) {
+	///
+	/// Returns `Err` when the sink is gone. Every write used to be discarded with
+	/// `let _ =`, so a reader that closed the pipe — `logs -f | head`,
+	/// `| grep -q`, `| less` and quit — was never noticed and the follow loop
+	/// streamed into a dead pipe until the process was killed. The error is
+	/// returned rather than handled here so the caller decides: a broken pipe is
+	/// a clean end of output, any other io error is a real failure.
+	pub(super) fn write(&mut self, out: &mut impl Write, chunk: &[u8]) -> std::io::Result<()> {
 		self.pending.extend_from_slice(chunk);
 		while let Some(nl) = self.pending.iter().position(|&b| b == b'\n') {
-			let _ = out.write_all(self.label.as_bytes());
-			let _ = out.write_all(&self.pending[..=nl]);
+			out.write_all(self.label.as_bytes())?;
+			out.write_all(&self.pending[..=nl])?;
 			self.pending.drain(..=nl);
 		}
 		// The remaining bytes are a partial line with no newline yet. Bound it:
@@ -58,15 +65,18 @@ impl LinePrefixer {
 		// data) would otherwise grow `pending` without limit. Break the
 		// over-long partial into its own prefixed line and start fresh.
 		if self.pending.len() >= MAX_PENDING {
-			let _ = out.write_all(self.label.as_bytes());
-			let _ = out.write_all(&self.pending);
-			let _ = out.write_all(b"\n");
+			out.write_all(self.label.as_bytes())?;
+			out.write_all(&self.pending)?;
+			out.write_all(b"\n")?;
 			self.pending.clear();
 		}
-		let _ = out.flush();
+		out.flush()
 	}
 
 	/// Flush a trailing line that never received a newline (e.g. at stream end).
+	///
+	/// Best-effort: this runs after the stream is done, so a sink that has gone
+	/// away has nothing left to tell the caller.
 	pub(super) fn flush_tail(&mut self, out: &mut impl Write) {
 		if !self.pending.is_empty() {
 			let _ = out.write_all(self.label.as_bytes());
@@ -86,10 +96,10 @@ mod tests {
 	fn line_prefixer_tags_lines_and_buffers_partials() {
 		let mut p = LinePrefixer::new("web", true, false);
 		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"hello\nwor");
+		p.write(&mut out, b"hello\nwor").unwrap();
 		// The complete line is tagged; the partial "wor" waits for its newline.
 		assert_eq!(out, b"web  | hello\n");
-		p.write(&mut out, b"ld\n");
+		p.write(&mut out, b"ld\n").unwrap();
 		assert_eq!(out, b"web  | hello\nweb  | world\n");
 	}
 
@@ -97,7 +107,7 @@ mod tests {
 	fn line_prefixer_flush_tail_emits_unterminated_line() {
 		let mut p = LinePrefixer::new("db", true, false);
 		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"partial");
+		p.write(&mut out, b"partial").unwrap();
 		assert!(out.is_empty(), "a line with no newline is held back");
 		p.flush_tail(&mut out);
 		assert_eq!(out, b"db  | partial\n");
@@ -111,7 +121,7 @@ mod tests {
 		// Feed more than the cap with no newline in sight, in small chunks.
 		let chunk = vec![b'x'; 4096];
 		for _ in 0..((MAX_PENDING / chunk.len()) + 2) {
-			p.write(&mut out, &chunk);
+			p.write(&mut out, &chunk).unwrap();
 		}
 		// The partial was flushed as a prefixed line instead of being buffered
 		// unbounded, and nothing is left pending beyond the last sub-cap chunk.
@@ -135,10 +145,36 @@ mod tests {
 		// `--no-log-prefix`: lines pass through with no `{label} | ` tag.
 		let mut p = LinePrefixer::new("web", false, false);
 		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"hello\n");
+		p.write(&mut out, b"hello\n").unwrap();
 		assert_eq!(out, b"hello\n");
-		p.write(&mut out, b"tail");
+		p.write(&mut out, b"tail").unwrap();
 		p.flush_tail(&mut out);
 		assert_eq!(out, b"hello\ntail\n");
+	}
+
+	/// #1102: a sink that has gone away must surface as an error, not be
+	/// swallowed. Every write here used to be `let _ =`, so `logs -f | head`
+	/// streamed into a closed pipe forever instead of exiting.
+	#[test]
+	fn line_prefixer_surfaces_a_broken_pipe() {
+		/// A writer that refuses everything the way a closed pipe does.
+		struct ClosedPipe;
+		impl std::io::Write for ClosedPipe {
+			fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+				Err(std::io::Error::new(
+					std::io::ErrorKind::BrokenPipe,
+					"broken pipe",
+				))
+			}
+			fn flush(&mut self) -> std::io::Result<()> {
+				Ok(())
+			}
+		}
+
+		let mut p = LinePrefixer::new("web", true, false);
+		let err = p
+			.write(&mut ClosedPipe, b"hello\n")
+			.expect_err("a closed sink must be reported");
+		assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -134,6 +134,25 @@ fn is_go_duration(v: &str) -> bool {
 	segments > 0
 }
 
+/// Whether a failed write to the log sink should end the follow loop.
+///
+/// A `BrokenPipe` is the ordinary way a piped consumer signals it has read
+/// enough — `logs -f | head`, `| grep -q`, `| less` and quit. It is a clean end
+/// of output, not a failure, and the loop must stop: podup used to discard the
+/// write result entirely and go on streaming into a dead pipe until the process
+/// was killed. Any other io error is worth a warning before stopping, since it
+/// means output is being lost for a reason the user cannot see.
+fn stop_on_write_error(container_name: &str, result: std::io::Result<()>) -> bool {
+	match result {
+		Ok(()) => false,
+		Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => true,
+		Err(e) => {
+			tracing::warn!("logs {container_name}: cannot write output: {e}");
+			true
+		}
+	}
+}
+
 /// Build the libpod `containers/{}/logs` query string from the options.
 fn log_query(opts: &LogsOptions) -> String {
 	let mut q = format!(
@@ -283,14 +302,17 @@ impl Engine {
 						let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 						let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 						while let Some(msg) = stream.next().await {
-							match msg {
+							let wrote = match msg {
 								Ok(LogOutput::StdOut { message }) => {
-									out_pfx.write(&mut std::io::stdout().lock(), &message);
+									out_pfx.write(&mut std::io::stdout().lock(), &message)
 								}
 								Ok(LogOutput::StdErr { message }) => {
-									err_pfx.write(&mut std::io::stderr().lock(), &message);
+									err_pfx.write(&mut std::io::stderr().lock(), &message)
 								}
 								Err(_) => break,
+							};
+							if stop_on_write_error(&container_name, wrote) {
+								break;
 							}
 						}
 						out_pfx.flush_tail(&mut std::io::stdout().lock());
@@ -332,12 +354,15 @@ impl Engine {
 				let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 				let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 				while let Some(msg) = stream.next().await {
-					match msg {
+					let wrote = match msg {
 						Ok(LogOutput::StdOut { message }) => out_pfx.write(&mut out, &message),
 						Ok(LogOutput::StdErr { message }) => {
 							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
 						Err(_) => break,
+					};
+					if stop_on_write_error(&container_name, wrote) {
+						break;
 					}
 				}
 				out_pfx.flush_tail(&mut out);


### PR DESCRIPTION
Closes #1102, which I filed while verifying #1080 — it turned up as a real defect there but is a different symptom (a hang, not a wrong exit code) and reproduces on `develop` too, so it was never part of that PR.

## Measured

Real Podman 5.4.2, one service writing a line per second:

```
before: exit 124 after the full 15s timeout   <- hung
after:  exit 0 in 1s
```

`LinePrefixer` discarded every write with `let _ = out.write_all(..)`, so the `BrokenPipe` a closed reader returns was thrown away and the follow loop kept draining the libpod stream into a dead pipe until the process was killed.

`logs -f | head`, `| grep -q`, `| less` and quit are ordinary uses. Each one left a podup process alive holding an open stream — in a script or a CI step, a hang with no output explaining it.

## The shape of the fix

`write` returns `io::Result` and the caller classifies, because the two cases genuinely differ:

- **`BrokenPipe`** — a clean end of output. Stop the loop, say nothing. This is the reader telling us it has read enough.
- **any other io error** — warn first, then stop. Output is being lost for a reason the user cannot otherwise see.

`flush_tail` stays best-effort: it runs after the stream is done, so a sink that has gone away has nothing left to tell anyone.

## Not in scope, and why

The attached-`up` prefixer (`inspect.rs:447`) writes through `print!`, which **panics** on EPIPE, and `is_broken_pipe_panic` already converts that into a clean exit. Different mechanism, already correct — I checked rather than assuming, since the issue listed it as needing the same treatment.

## Test plan

`cargo test --lib` 1258/1258, clippy `--all-targets --all-features` clean.

New `line_prefixer_surfaces_a_broken_pipe`: drives the prefixer with a writer that returns `BrokenPipe` for everything and asserts the error reaches the caller. Needs no Podman.

Four existing prefixer tests now `.unwrap()` the write, which is the point — they would previously have passed against a sink that rejected everything.

Verified end to end against real Podman, both binaries, numbers above.

Closes #1102