### PR TITLE
fix: reject an unknown filter instead of answering a different question

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -102,6 +102,7 @@ Build or rebuild service images (optionally only the named services).
 | `--no-cache` | Do not use the build cache. | off |
 | `--pull` | Always attempt to pull a newer base image. | off |
 | `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
+| `--progress <STYLE>` | `auto`, `plain` or `tty`. Validated but inert — see [accepted for compatibility](#accepted-for-compatibility). | `auto` |
 | `-q, --quiet` | Suppress the build output. | off |
 
 ## Inspection
@@ -438,6 +439,25 @@ when both are set.
 | `PODMAN_SOCKET` | Podman socket path (`--socket`). |
 | `DOCKER_HOST` | Docker-compatible fallback for the Podman socket, used only when `PODMAN_SOCKET` is unset. Must be a local `unix://` socket (or `npipe://` on Windows); a remote `tcp://`/`ssh://` value is rejected. |
 | `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
+
+## Accepted for compatibility
+
+These flags parse and are validated, so a script written against docker compose
+runs unchanged — but podup does not act on them. They are listed here because
+`--help` says "accepted for compatibility" without saying which flags that
+covers, and the only other way to find out was to read the dispatch code.
+
+| Flag | Why it does nothing |
+|---|---|
+| `build --progress <STYLE>` | podup renders build output one way. The value is still validated, so a typo is rejected rather than silently ignored. |
+| `config --no-normalize` | `config` always emits the normalized form. |
+| `cp -a, --archive` | Ownership/permission preservation is not meaningful for a rootless copy. |
+| `attach --no-stdin`, `--sig-proxy`, `--detach-keys` | `attach` streams output only; stdin is never attached (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
+| `run -T, --no-TTY` / `exec -T, --no-tty` | podup never allocates a pseudo-TTY, so disabling one is a no-op (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
+
+Everything else that parses does something. An **unknown** `--filter` predicate
+is rejected outright rather than dropped: a filter that silently does not apply
+returns the whole set, which a script reads as a match.
 
 ## Exit status
 

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 #[cfg(feature = "completions")]
 use clap_complete::Shell;
 
-use super::parse::{parse_pull_policy, parse_scale_pair, parse_timeout};
+use super::parse::{parse_progress, parse_pull_policy, parse_scale_pair, parse_timeout};
 use super::types::{
 	AutostartCommands, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
 };
@@ -192,8 +192,9 @@ pub(crate) enum Commands {
 		#[arg(long = "build-arg")]
 		build_arg: Vec<String>,
 		/// Set the build progress output style (auto, plain, tty); accepted for
-		/// docker-compose compatibility.
-		#[arg(long)]
+		/// docker-compose compatibility. Validated but inert: podup renders build
+		/// output one way.
+		#[arg(long, value_parser = parse_progress)]
 		progress: Option<String>,
 		/// Push each built image to its registry after a successful build.
 		#[arg(long)]

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -48,6 +48,24 @@ pub(crate) fn parse_pull_policy(value: &str) -> Result<String, String> {
 	}
 }
 
+/// Progress styles `docker compose build --progress` accepts. podup renders build
+/// output one way, so the flag is inert — but an unknown value must still be
+/// rejected rather than accepted and ignored, or a typo silently changes nothing
+/// and reports success.
+const PROGRESS_STYLES: [&str; 3] = ["auto", "plain", "tty"];
+
+/// Validate a `build --progress` value at parse time.
+pub(crate) fn parse_progress(value: &str) -> Result<String, String> {
+	if PROGRESS_STYLES.contains(&value) {
+		Ok(value.to_string())
+	} else {
+		Err(format!(
+			"invalid progress style `{value}` (expected one of: {})",
+			PROGRESS_STYLES.join(", ")
+		))
+	}
+}
+
 /// Parse a `-t/--timeout` shutdown-grace value, rejecting negatives with a clear
 /// range error rather than forwarding `-5` to Podman or letting clap report a
 /// confusing "unexpected argument" for the space form.

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -33,7 +33,7 @@ impl Engine {
 	/// [`Engine::stream_events`] with `docker compose events`-style `--since`,
 	/// `--until`, and `--filter` options.
 	pub async fn stream_events_with_options(&self, json: bool, opts: &EventsOptions) -> Result<()> {
-		let filters = build_event_filters(&self.project, &opts.filters);
+		let filters = build_event_filters(&self.project, &opts.filters)?;
 		let mut path = format!(
 			"{API_PREFIX}/events?stream=true&filters={}",
 			urlencoded(&filters.to_string()),
@@ -69,9 +69,13 @@ impl Engine {
 
 /// Build the libpod events `filters` object: always scope to this project's
 /// `podup.project` label, then merge each user `KEY=VALUE` predicate (appending
-/// to that key's value array). A predicate with no `=` is skipped. Pure so the
-/// merge is unit-tested.
-fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
+/// to that key's value array). Pure so the merge is unit-tested.
+///
+/// A predicate with no `=` is an error rather than a skip. Dropping it scoped
+/// the stream to the whole project instead — `events --filter garbage` printed
+/// everything, which a caller reads as "these all matched". docker compose
+/// errors on a malformed filter too.
+fn build_event_filters(project: &str, user_filters: &[String]) -> Result<Value> {
 	use serde_json::{Map, Value};
 	let mut map: Map<String, Value> = Map::new();
 	map.insert(
@@ -80,8 +84,9 @@ fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
 	);
 	for f in user_filters {
 		let Some((key, value)) = f.split_once('=') else {
-			tracing::warn!("events: ignoring malformed filter '{f}' (expected KEY=VALUE)");
-			continue;
+			return Err(ComposeError::Unsupported(format!(
+				"malformed events filter {f:?}: expected KEY=VALUE (e.g. event=start)"
+			)));
 		};
 		match map
 			.entry(key.to_string())
@@ -91,7 +96,7 @@ fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
 			other => *other = Value::Array(vec![Value::String(value.to_string())]),
 		}
 	}
-	Value::Object(map)
+	Ok(Value::Object(map))
 }
 
 /// Render one event. `json` emits the raw object as a compact line; otherwise a
@@ -123,7 +128,7 @@ mod tests {
 
 	#[test]
 	fn build_event_filters_scopes_to_project_label() {
-		let f = build_event_filters("demo", &[]);
+		let f = build_event_filters("demo", &[]).unwrap();
 		assert_eq!(f, json!({ "label": ["podup.project=demo"] }));
 	}
 
@@ -135,9 +140,9 @@ mod tests {
 				"event=start".to_string(),
 				"event=die".to_string(),
 				"type=container".to_string(),
-				"bogus".to_string(),
 			],
-		);
+		)
+		.unwrap();
 		assert_eq!(
 			f,
 			json!({
@@ -146,6 +151,16 @@ mod tests {
 				"type": ["container"],
 			})
 		);
+	}
+
+	/// #1081: a predicate with no `=` used to be dropped, so `events --filter
+	/// garbage` silently scoped to the whole project and printed everything — a
+	/// caller reads that back as "these all matched".
+	#[test]
+	fn malformed_filter_is_rejected_not_dropped() {
+		let err = build_event_filters("demo", &["bogus".to_string()])
+			.expect_err("a filter with no `=` must not be silently ignored");
+		assert!(format!("{err}").contains("bogus"), "got {err}");
 	}
 
 	#[test]

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -117,9 +117,13 @@ pub async fn list_projects_filtered(
 		}
 	}
 
+	// An unsupported key is an error, not a warning — see the note on the ps
+	// filters: silently answering a different question is worse than refusing.
 	let (name_filter, status_filter, unknown) = split_ls_filters(filters);
-	for u in &unknown {
-		tracing::warn!("ls: ignoring unsupported filter '{u}'");
+	if let Some(u) = unknown.first() {
+		return Err(ComposeError::Unsupported(format!(
+			"unsupported ls filter {u:?}: expected name=<NAME> or status=<running|exited>"
+		)));
 	}
 	// A project is "active" (shown without `--all`) when any replica is running
 	// or paused; only all-stopped projects are hidden by default. The `--filter`

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -248,11 +248,16 @@ impl Engine {
 			return Ok(());
 		}
 
-		// Fold `--status` and any `status=`/`name=` from `--filter` together;
-		// warn on unsupported `--filter` keys rather than silently ignoring them.
+		// Fold `--status` and any `status=`/`name=` from `--filter` together. An
+		// unsupported key is an error, not a warning: a dropped predicate means
+		// the command answers a question the caller did not ask, and a script
+		// filtering for a condition reads the unfiltered set back as a match.
+		// docker compose errors here too.
 		let (mut status_filter, name_filter, unknown) = split_ps_filters(&filters.filters);
-		for u in &unknown {
-			tracing::warn!("ps: ignoring unsupported filter '{u}'");
+		if let Some(u) = unknown.first() {
+			return Err(ComposeError::Unsupported(format!(
+				"unsupported ps filter {u:?}: expected name=<NAME> or status=<STATE>"
+			)));
 		}
 		status_filter.extend(filters.status.iter().cloned());
 


### PR DESCRIPTION
Closes #1081.

## Filters

`ps`, `ls` and `events` warned about an unsupported `--filter` predicate and then ran without it. A script filtering for a condition got the **whole set** back and read it as a match. The command answered a question nobody asked, and said so only in a warning the caller never sees.

`events` was the worst of the three: a predicate with no `=` was dropped entirely, so `events --filter garbage` scoped to the whole project and streamed forever. Measured against real Podman 5.4.2:

```
develop:  ps --filter garbage=1 -> exit 0    ls -> exit 0    events -> exit 124 (timeout killed it)
fixed:    ps                    -> exit 1    ls -> exit 1    events -> exit 1
```

docker compose errors on an unknown filter. Each message now names the keys that are actually supported, so the error tells you what to write instead:

```
unsupported ps filter "garbage=1": expected name=<NAME> or status=<STATE>
malformed events filter "garbage": expected KEY=VALUE (e.g. event=start)
```

## Flags

`build --progress` was declared, never consumed, **and** unvalidated, so `--progress bogus` was accepted too. It stays inert — podup renders build output one way — but the value is validated now:

```
error: invalid value 'bogus' for '--progress <PROGRESS>': invalid progress style `bogus` (expected one of: auto, plain, tty)
```

A flag that does nothing is a legitimate compatibility choice; a flag that accepts a typo and does nothing is not.

## Docs

The issue's real complaint about the rest is that `--help` says "accepted for compatibility" without saying which flags that covers, so the only way to find out was to read `internal/dispatch`. `docs/commands.md` gains an **Accepted for compatibility** section listing each one and why it does nothing — `build --progress`, `config --no-normalize`, `cp -a`, the three `attach` flags, and the `run`/`exec` no-TTY pair — with the two that are really #1079 pointing at it.

## Test plan

`cargo test --lib` 1269/1269, `cli_flags` + `cli_aliases` 15/15, clippy `--all-targets --all-features` clean.

New unit test that a malformed events filter is rejected rather than dropped. The existing `build_event_filters` merge test dropped its `"bogus"` case, since that input is now an error and has its own test.

Verified end to end against real Podman — the exit codes above are from the built binaries, `develop` against this branch.

Closes #1081