### PR TITLE
fix: make streaming stats JSON parseable, and port report a missing binding

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -102,6 +102,7 @@ Build or rebuild service images (optionally only the named services).
 | `--no-cache` | Do not use the build cache. | off |
 | `--pull` | Always attempt to pull a newer base image. | off |
 | `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
+| `--progress <STYLE>` | `auto`, `plain` or `tty`. Validated but inert — see [accepted for compatibility](#accepted-for-compatibility). | `auto` |
 | `-q, --quiet` | Suppress the build output. | off |
 
 ## Inspection
@@ -438,6 +439,25 @@ when both are set.
 | `PODMAN_SOCKET` | Podman socket path (`--socket`). |
 | `DOCKER_HOST` | Docker-compatible fallback for the Podman socket, used only when `PODMAN_SOCKET` is unset. Must be a local `unix://` socket (or `npipe://` on Windows); a remote `tcp://`/`ssh://` value is rejected. |
 | `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
+
+## Accepted for compatibility
+
+These flags parse and are validated, so a script written against docker compose
+runs unchanged — but podup does not act on them. They are listed here because
+`--help` says "accepted for compatibility" without saying which flags that
+covers, and the only other way to find out was to read the dispatch code.
+
+| Flag | Why it does nothing |
+|---|---|
+| `build --progress <STYLE>` | podup renders build output one way. The value is still validated, so a typo is rejected rather than silently ignored. |
+| `config --no-normalize` | `config` always emits the normalized form. |
+| `cp -a, --archive` | Ownership/permission preservation is not meaningful for a rootless copy. |
+| `attach --no-stdin`, `--sig-proxy`, `--detach-keys` | `attach` streams output only; stdin is never attached (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
+| `run -T, --no-TTY` / `exec -T, --no-tty` | podup never allocates a pseudo-TTY, so disabling one is a no-op (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
+
+Everything else that parses does something. An **unknown** `--filter` predicate
+is rejected outright rather than dropped: a filter that silently does not apply
+returns the whole set, which a script reads as a match.
 
 ## Exit status
 

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 #[cfg(feature = "completions")]
 use clap_complete::Shell;
 
-use super::parse::{parse_pull_policy, parse_scale_pair, parse_timeout};
+use super::parse::{parse_progress, parse_pull_policy, parse_scale_pair, parse_timeout};
 use super::types::{
 	AutostartCommands, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
 };
@@ -192,8 +192,9 @@ pub(crate) enum Commands {
 		#[arg(long = "build-arg")]
 		build_arg: Vec<String>,
 		/// Set the build progress output style (auto, plain, tty); accepted for
-		/// docker-compose compatibility.
-		#[arg(long)]
+		/// docker-compose compatibility. Validated but inert: podup renders build
+		/// output one way.
+		#[arg(long, value_parser = parse_progress)]
 		progress: Option<String>,
 		/// Push each built image to its registry after a successful build.
 		#[arg(long)]

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -48,6 +48,24 @@ pub(crate) fn parse_pull_policy(value: &str) -> Result<String, String> {
 	}
 }
 
+/// Progress styles `docker compose build --progress` accepts. podup renders build
+/// output one way, so the flag is inert — but an unknown value must still be
+/// rejected rather than accepted and ignored, or a typo silently changes nothing
+/// and reports success.
+const PROGRESS_STYLES: [&str; 3] = ["auto", "plain", "tty"];
+
+/// Validate a `build --progress` value at parse time.
+pub(crate) fn parse_progress(value: &str) -> Result<String, String> {
+	if PROGRESS_STYLES.contains(&value) {
+		Ok(value.to_string())
+	} else {
+		Err(format!(
+			"invalid progress style `{value}` (expected one of: {})",
+			PROGRESS_STYLES.join(", ")
+		))
+	}
+}
+
 /// Parse a `-t/--timeout` shutdown-grace value, rejecting negatives with a clear
 /// range error rather than forwarding `-5` to Podman or letting clap report a
 /// confusing "unexpected argument" for the space form.

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -33,7 +33,7 @@ impl Engine {
 	/// [`Engine::stream_events`] with `docker compose events`-style `--since`,
 	/// `--until`, and `--filter` options.
 	pub async fn stream_events_with_options(&self, json: bool, opts: &EventsOptions) -> Result<()> {
-		let filters = build_event_filters(&self.project, &opts.filters);
+		let filters = build_event_filters(&self.project, &opts.filters)?;
 		let mut path = format!(
 			"{API_PREFIX}/events?stream=true&filters={}",
 			urlencoded(&filters.to_string()),
@@ -69,9 +69,13 @@ impl Engine {
 
 /// Build the libpod events `filters` object: always scope to this project's
 /// `podup.project` label, then merge each user `KEY=VALUE` predicate (appending
-/// to that key's value array). A predicate with no `=` is skipped. Pure so the
-/// merge is unit-tested.
-fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
+/// to that key's value array). Pure so the merge is unit-tested.
+///
+/// A predicate with no `=` is an error rather than a skip. Dropping it scoped
+/// the stream to the whole project instead — `events --filter garbage` printed
+/// everything, which a caller reads as "these all matched". docker compose
+/// errors on a malformed filter too.
+fn build_event_filters(project: &str, user_filters: &[String]) -> Result<Value> {
 	use serde_json::{Map, Value};
 	let mut map: Map<String, Value> = Map::new();
 	map.insert(
@@ -80,8 +84,9 @@ fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
 	);
 	for f in user_filters {
 		let Some((key, value)) = f.split_once('=') else {
-			tracing::warn!("events: ignoring malformed filter '{f}' (expected KEY=VALUE)");
-			continue;
+			return Err(ComposeError::Unsupported(format!(
+				"malformed events filter {f:?}: expected KEY=VALUE (e.g. event=start)"
+			)));
 		};
 		match map
 			.entry(key.to_string())
@@ -91,7 +96,7 @@ fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
 			other => *other = Value::Array(vec![Value::String(value.to_string())]),
 		}
 	}
-	Value::Object(map)
+	Ok(Value::Object(map))
 }
 
 /// Render one event. `json` emits the raw object as a compact line; otherwise a
@@ -123,7 +128,7 @@ mod tests {
 
 	#[test]
 	fn build_event_filters_scopes_to_project_label() {
-		let f = build_event_filters("demo", &[]);
+		let f = build_event_filters("demo", &[]).unwrap();
 		assert_eq!(f, json!({ "label": ["podup.project=demo"] }));
 	}
 
@@ -135,9 +140,9 @@ mod tests {
 				"event=start".to_string(),
 				"event=die".to_string(),
 				"type=container".to_string(),
-				"bogus".to_string(),
 			],
-		);
+		)
+		.unwrap();
 		assert_eq!(
 			f,
 			json!({
@@ -146,6 +151,16 @@ mod tests {
 				"type": ["container"],
 			})
 		);
+	}
+
+	/// #1081: a predicate with no `=` used to be dropped, so `events --filter
+	/// garbage` silently scoped to the whole project and printed everything — a
+	/// caller reads that back as "these all matched".
+	#[test]
+	fn malformed_filter_is_rejected_not_dropped() {
+		let err = build_event_filters("demo", &["bogus".to_string()])
+			.expect_err("a filter with no `=` must not be silently ignored");
+		assert!(format!("{err}").contains("bogus"), "got {err}");
 	}
 
 	#[test]

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -117,9 +117,13 @@ pub async fn list_projects_filtered(
 		}
 	}
 
+	// An unsupported key is an error, not a warning — see the note on the ps
+	// filters: silently answering a different question is worse than refusing.
 	let (name_filter, status_filter, unknown) = split_ls_filters(filters);
-	for u in &unknown {
-		tracing::warn!("ls: ignoring unsupported filter '{u}'");
+	if let Some(u) = unknown.first() {
+		return Err(ComposeError::Unsupported(format!(
+			"unsupported ls filter {u:?}: expected name=<NAME> or status=<running|exited>"
+		)));
 	}
 	// A project is "active" (shown without `--all`) when any replica is running
 	// or paused; only all-stopped projects are hidden by default. The `--filter`

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -164,10 +164,16 @@ impl Engine {
 				let host = b.host_ip.as_deref().unwrap_or("0.0.0.0");
 				let port = b.host_port.as_deref().unwrap_or("");
 				println!("{host}:{port}");
+				Ok(())
 			}
-			None => println!(),
+			// No binding is a failure, not an empty answer. Printing a blank line
+			// and exiting 0 made `HOST=$(podup port web 80)` yield an empty string
+			// with a success status, so a script cannot tell "not published" from
+			// "published at ''". docker compose exits 1 with a message here.
+			None => Err(ComposeError::Unsupported(format!(
+				"no host binding for {service_name} port {port}/{proto}"
+			))),
 		}
-		Ok(())
 	}
 
 	/// List images used by each service as a table (default options).

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -248,11 +248,16 @@ impl Engine {
 			return Ok(());
 		}
 
-		// Fold `--status` and any `status=`/`name=` from `--filter` together;
-		// warn on unsupported `--filter` keys rather than silently ignoring them.
+		// Fold `--status` and any `status=`/`name=` from `--filter` together. An
+		// unsupported key is an error, not a warning: a dropped predicate means
+		// the command answers a question the caller did not ask, and a script
+		// filtering for a condition reads the unfiltered set back as a match.
+		// docker compose errors here too.
 		let (mut status_filter, name_filter, unknown) = split_ps_filters(&filters.filters);
-		for u in &unknown {
-			tracing::warn!("ps: ignoring unsupported filter '{u}'");
+		if let Some(u) = unknown.first() {
+			return Err(ComposeError::Unsupported(format!(
+				"unsupported ps filter {u:?}: expected name=<NAME> or status=<STATE>"
+			)));
 		}
 		status_filter.extend(filters.status.iter().cloned());
 

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -403,10 +403,18 @@ fn print_frame(
 
 	if opts.json {
 		let json: Vec<_> = rows.iter().map(stat_json_row).collect();
-		println!(
-			"{}",
-			serde_json::to_string_pretty(&json).unwrap_or_default()
-		);
+		// While streaming, one compact array per line — NDJSON, the shape
+		// `events` already emits. A pretty-printed array per frame, concatenated,
+		// is neither a single JSON document nor NDJSON, so no parser accepts it:
+		// `stats --format json` was unreadable by anything for as long as it
+		// streamed. `--no-stream` prints one frame and exits, so it stays a
+		// single pretty document, which is valid JSON and nicer to read.
+		let text = if opts.no_stream {
+			serde_json::to_string_pretty(&json)
+		} else {
+			serde_json::to_string(&json)
+		};
+		println!("{}", text.unwrap_or_default());
 		return;
 	}
 

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -100,3 +100,101 @@ fn run(c: &str, proj: &str, args: &[&str]) -> String {
 	);
 	String::from_utf8_lossy(&out.stdout).into_owned()
 }
+
+/// #1082: `stats --format json` while streaming emitted one pretty-printed array
+/// per sampling frame, concatenated. That is neither a single JSON document nor
+/// NDJSON, so no parser accepts it — the machine-readable format was unreadable
+/// by machines for as long as it streamed.
+///
+/// Streaming now emits one compact array per line. `--no-stream` prints a single
+/// frame and exits, so it stays a pretty document, which is valid on its own.
+#[tokio::test]
+async fn cli_stats_streaming_json_is_ndjson() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-ndj", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	let run = |args: &[&str]| {
+		Command::new(bin())
+			.args(["-f", c, "-p", &proj])
+			.args(args)
+			.output()
+			.expect("run podup")
+	};
+	run(&["up", "-d"]);
+
+	// Take a couple of frames, then stop: the stream never ends on its own.
+	let out = Command::new("timeout")
+		.args([
+			"4",
+			bin(),
+			"-f",
+			c,
+			"-p",
+			&proj,
+			"stats",
+			"--format",
+			"json",
+		])
+		.output()
+		.expect("run podup stats");
+	let text = String::from_utf8_lossy(&out.stdout);
+	let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+	assert!(!lines.is_empty(), "no stats frames were emitted");
+	for line in &lines {
+		serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|e| {
+			panic!("streaming frame is not valid JSON on its own ({e}): {line}")
+		});
+	}
+
+	// `--no-stream` stays a single valid document.
+	let one = run(&["stats", "--no-stream", "--format", "json"]);
+	serde_json::from_slice::<serde_json::Value>(&one.stdout)
+		.expect("--no-stream must emit one valid JSON document");
+
+	run(&["down", "-v"]);
+}
+
+/// #1082: `port` with no host binding printed a blank line and exited 0, so
+/// `HOST=$(podup port web 80)` yielded an empty string with a success status and
+/// a script could not tell "not published" from "published at ''".
+#[tokio::test]
+async fn cli_port_without_a_binding_exits_nonzero() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-prt", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	let run = |args: &[&str]| {
+		Command::new(bin())
+			.args(["-f", c, "-p", &proj])
+			.args(args)
+			.output()
+			.expect("run podup")
+	};
+	run(&["up", "-d"]);
+
+	let out = run(&["port", "web", "80"]);
+	assert!(
+		!out.status.success(),
+		"an unpublished port must not report success: stdout={:?}",
+		String::from_utf8_lossy(&out.stdout)
+	);
+
+	run(&["down", "-v"]);
+}


### PR DESCRIPTION
Two of #1082's defects — the two that break automation outright. **Does not close the issue**; the rest are listed at the end.

## `stats --format json` was unreadable by any parser

While streaming it printed one **pretty-printed array per sampling frame**, concatenated. That is neither a single JSON document nor NDJSON. Measured against real Podman 5.4.2 over the first 40 lines of output:

```
develop:   0 lines parseable, 40 not
fixed:     2 frames, both parseable
```

It now emits one compact array per line — the shape `events` already uses. `--no-stream` prints a single frame and exits, so it stays a pretty document, which is valid JSON on its own and nicer to read.

## `port` reported success for a port that is not published

A missing binding printed a blank line and exited 0, so `HOST=$(podup port web 80)` gave an empty string with a success status and a script could not tell "not published" apart from "published at ''".

```
develop:  port noport 80 -> exit 0, HOST=''
fixed:    port noport 80 -> exit 1
```

docker compose exits 1 with a message here. A published port still prints `0.0.0.0:18099` and exits 0 — checked, since that is the path that must not regress.

## Deliberately not changed

**The `--ansi always` item.** #1082 calls it a leak that `podup --ansi always logs > file` writes escape sequences into the file. But that is what the flag asks for — `always` means force colour regardless of the sink. Before calling it a bug rather than the documented behaviour I would want to measure what `docker compose --ansi always` does into a pipe, and I have not. Guessing here would change a flag's meaning on a hunch.

## Still open under #1082

`logs`' prefix shape (two spaces and the full container name, where attached `up` uses one space and strips the project), `wait` printing per replica instead of per service, `ls --format json` emitting an always-empty `ConfigFiles`, `volumes` suppressing its header on an empty result, `top --format json` emitting `null`, and the documentation of the deliberate `stats` JSON divergence.

`ls --format json` is held back on purpose: it lives in `projects.rs`, which #1110 is currently changing.

The issue's own closing point — that **no test asserts any table header or JSON key** — is the one worth doing properly rather than piecemeal, and it is what would have caught all of these.

## Test plan

`cargo test --lib` 1269/1269, clippy `--all-targets --all-features` clean.

Two new integration tests against real Podman: one that every streaming `stats --format json` line parses on its own *and* that `--no-stream` is still one valid document, one that an unpublished port exits non-zero. Numbers above are from the built binaries, `develop` against this branch.

Part of #1082