### PR TITLE
feat: discover and merge the compose override file

### DIFF
--- a/internal/resolve.rs
+++ b/internal/resolve.rs
@@ -45,10 +45,43 @@ pub(crate) fn resolve_compose_files(explicit: &[PathBuf]) -> Vec<PathBuf> {
 	}
 	for candidate in COMPOSE_FILE_CANDIDATES {
 		if Path::new(candidate).is_file() {
-			return vec![PathBuf::from(candidate)];
+			let mut files = vec![PathBuf::from(candidate)];
+			files.extend(override_for(Path::new(candidate)));
+			return files;
 		}
 	}
 	vec![PathBuf::from("docker-compose.yml")]
+}
+
+/// Override-file names, in the compose-spec precedence order. Only the first one
+/// present is used — docker compose does not merge two overrides.
+const OVERRIDE_FILE_CANDIDATES: [&str; 4] = [
+	"compose.override.yaml",
+	"compose.override.yml",
+	"docker-compose.override.yaml",
+	"docker-compose.override.yml",
+];
+
+/// The override file to merge on top of an auto-discovered `base`, if one sits
+/// beside it.
+///
+/// Base file plus `docker-compose.override.yml` is how nearly every repository
+/// separates dev from prod, and docker compose merges it automatically whenever
+/// no explicit `-f` is given. podup ran the base alone and said nothing: wrong
+/// image tags, wrong published ports, missing dev bind mounts, exit 0 — about a
+/// file the user never named on the command line, so nothing in the invocation
+/// hinted at what went wrong.
+///
+/// Discovery is deliberately limited to the auto-discovery path. An explicit
+/// `-f` means the caller is choosing the file set themselves, and `COMPOSE_FILE`
+/// is that same choice by another name; docker compose skips the override in
+/// both cases too.
+fn override_for(base: &Path) -> Option<PathBuf> {
+	let dir = base.parent().unwrap_or(Path::new(""));
+	OVERRIDE_FILE_CANDIDATES
+		.iter()
+		.map(|name| dir.join(name))
+		.find(|path| path.is_file())
 }
 
 /// Resolve the base directory for relative-path resolution. An explicit
@@ -121,8 +154,8 @@ pub(crate) fn sanitize_project_name(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
 	use super::{
-		resolve_base_dir, resolve_compose_files, resolve_project_name, sanitize_project_name,
-		validate_project_directory,
+		override_for, resolve_base_dir, resolve_compose_files, resolve_project_name,
+		sanitize_project_name, validate_project_directory,
 	};
 	use std::path::{Path, PathBuf};
 
@@ -249,5 +282,53 @@ mod tests {
 	fn sanitize_empty_result_falls_back_to_podup() {
 		assert_eq!(sanitize_project_name("!!!"), "podup");
 		assert_eq!(sanitize_project_name(""), "podup");
+	}
+
+	/// #1077: base plus `docker-compose.override.yml` is how nearly every
+	/// repository separates dev from prod, and docker compose merges it
+	/// automatically when no `-f` is given. podup ran the base alone, silently.
+	#[test]
+	fn auto_discovery_picks_up_the_override_file() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("compose.yaml"), b"services: {}\n").unwrap();
+		std::fs::write(dir.path().join("compose.override.yaml"), b"services: {}\n").unwrap();
+		let found = override_for(&dir.path().join("compose.yaml"));
+		assert_eq!(found, Some(dir.path().join("compose.override.yaml")));
+	}
+
+	/// Only the first override in precedence order is used — docker compose does
+	/// not merge two of them.
+	#[test]
+	fn only_the_highest_precedence_override_is_used() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("compose.yaml"), b"services: {}\n").unwrap();
+		for name in [
+			"compose.override.yml",
+			"docker-compose.override.yaml",
+			"compose.override.yaml",
+		] {
+			std::fs::write(dir.path().join(name), b"services: {}\n").unwrap();
+		}
+		assert_eq!(
+			override_for(&dir.path().join("compose.yaml")),
+			Some(dir.path().join("compose.override.yaml")),
+			"compose.override.yaml outranks the rest"
+		);
+	}
+
+	/// No override beside the base is the ordinary case and must stay silent.
+	#[test]
+	fn no_override_file_is_not_an_error() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("compose.yaml"), b"services: {}\n").unwrap();
+		assert_eq!(override_for(&dir.path().join("compose.yaml")), None);
+	}
+
+	/// An explicit `-f` means the caller is choosing the file set, so the
+	/// override is not added behind their back. docker compose skips it too.
+	#[test]
+	fn explicit_files_suppress_override_discovery() {
+		let explicit = vec![std::path::PathBuf::from("only.yaml")];
+		assert_eq!(resolve_compose_files(&explicit), explicit);
 	}
 }


### PR DESCRIPTION
Closes #1077.

## The gap

Base file plus `docker-compose.override.yml` is how nearly every repository separates dev from prod, and docker compose merges it automatically whenever no explicit `-f` is given. `resolve_compose_files` returned a single file and there was no override discovery anywhere in the tree.

podup ran the base alone, silently. That is worse than an ordinary wrong value: wrong image tags, wrong published ports, missing dev bind mounts, exit 0 — and it concerns a file the user never named on the command line, so nothing in the invocation hints at what went wrong.

Measured on the same directory, `compose.yaml` + `compose.override.yaml`:

```
develop:   image nginx:1.0   ports 8080:80
fixed:     image nginx:2.0   ports 8080:80, 9090:80
```

## Scope

All four spec names are probed in precedence order — `compose.override.yaml`, `.yml`, `docker-compose.override.yaml`, `.yml` — and only the first present one is used. docker compose does not merge two overrides either.

Discovery is deliberately limited to the auto-discovery path. An explicit `-f` means the caller is choosing the file set themselves, and `COMPOSE_FILE` is that same choice by another name; docker compose skips the override in both cases. Verified rather than assumed: with `-f compose.yaml` the override is **not** added behind the caller's back.

## Relationship to #1078

The issue notes this lands on top of the merge bugs, and that override merging is exactly where `networks` being replaced instead of unioned bites hardest. #1112 fixes that half. The code is disjoint — this is discovery, that is merge semantics — but they compose: once both are in, an override adding a network no longer drops the base's.

## Test plan

`cargo test --bins` 65/65, clippy `--all-targets --all-features` clean.

Four new tests: the override is picked up, only the highest-precedence one is used when several exist, no override is not an error, and an explicit `-f` suppresses discovery.

Verified end to end with the built binaries, `develop` against this branch — the numbers above.

Closes #1077