### PR TITLE
docs: correct the false env-file precedence rule and close the flag drift

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,7 +19,8 @@ These appear before the subcommand and may also come from the environment.
 | `--socket <PATH>` | `PODMAN_SOCKET` | Podman socket path; overrides auto-detection. |
 | `--profile <NAMES>` | `COMPOSE_PROFILES` | Active profiles, comma-separated. |
 | `--project-directory <PATH>` | | Base directory for relative paths (env_file, build context, bind mounts, config/secret sources). Defaults to the compose file's directory. |
-| `--env-file <PATH>` | | Extra env file for interpolation. Repeatable; later files win. The process environment and a project `.env` still take precedence. |
+| `--ansi <WHEN>` | | Colour output: `auto`, `always` or `never`. `always` forces colour even into a pipe or file. | 
+| `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it — when this is given, `.env` is not read. The process environment still takes precedence over both. |
 
 ## Lifecycle
 
@@ -38,7 +39,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--no-deps` | Do not start the `depends_on` services of the named services. | off |
 | `-t, --timeout <SECS>` | Seconds to wait for a container to stop when recreating. | Podman default |
 | `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. | from file |
-| `--pull <POLICY>` | Pull policy before starting: `always`, `missing`, `never`. | per service |
+| `--pull <POLICY>` | Pull policy before starting: `always`, `missing`, `never`, `newer`, `build`. (`newer` is Podman's extension.) | per service |
 | `--no-build` | Do not build images, even for services with a `build:` section. | off |
 | `--quiet-pull` | Suppress image-pull progress output. | off |
 | `--wait` | Wait until services are running/healthy before returning. | off |
@@ -103,6 +104,7 @@ Build or rebuild service images (optionally only the named services).
 | `--pull` | Always attempt to pull a newer base image. | off |
 | `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
 | `--progress <STYLE>` | `auto`, `plain` or `tty`. Validated but inert — see [accepted for compatibility](#accepted-for-compatibility). | `auto` |
+| `--push` | Push each built image to its registry after a successful build. | off |
 | `-q, --quiet` | Suppress the build output. | off |
 
 ## Inspection
@@ -115,6 +117,9 @@ List project containers.
 | `-a, --all` | Include stopped containers. | running only |
 | `-q, --quiet` | Print container IDs only. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
+| `--status <STATE>` | Show only containers in this state. Repeatable; folded together with any `status=` from `--filter`. | all |
+| `--filter <KEY=VAL>` | `name=<NAME>` or `status=<STATE>`. An unknown key is an error. | none |
+| `--services` | Print service names only. | off |
 
 ### `ls`
 List podup compose projects on the host. Needs no compose file.
@@ -135,6 +140,8 @@ View container output for the named services (or all).
 | `--since <TIME>` | Show logs since a timestamp or relative time (e.g. `10m`). | start |
 | `--until <TIME>` | Show logs before a timestamp or relative time. | end |
 | `-t, --timestamps` | Prefix each line with an RFC3339 timestamp. | off |
+| `--no-color` | Monochrome prefix even on a colour-capable stdout. | off |
+| `--no-log-prefix` | Drop the `{service} \| ` tag entirely. | off |
 
 ### `events`
 Stream Podman events for this project's containers.
@@ -148,6 +155,10 @@ Stream Podman events for this project's containers.
 ### `top [SERVICE...]`
 Show the running processes of service containers.
 
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FMT>` | `table` or `json` (an array of `{Container, Titles, Processes}`). | `table` |
+
 ### `stats [SERVICE...]`
 Live resource usage (CPU, memory, network, block I/O, PIDs) for service
 containers.
@@ -155,6 +166,9 @@ containers.
 | Flag | Description | Default |
 |---|---|---|
 | `--no-stream` | Print one snapshot and exit. | stream |
+| `-a, --all` | Include non-running containers as zeroed rows. | running only |
+| `--no-trunc` | Do not truncate long container names. | truncate at 32 |
+| `--format <FMT>` | `table` or `json`. While streaming, `json` is NDJSON — one compact array per line. | `table` |
 
 ### `port <SERVICE> <PRIVATE_PORT>`
 Print the public binding for a port.
@@ -194,6 +208,7 @@ Run a one-off command in a new container for the service.
 | `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. | none |
 | `--name <NAME>` | Override the container name. | generated |
 | `-P, --service-ports` | Publish the service's declared ports. | off |
+| `-l, --label <KEY=VAL>` | Add a label to the one-off container. Repeatable. | none |
 | `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. | image default |
 | `-w, --workdir <PATH>` | Working directory inside the container. | image default |
 | `--entrypoint <CMD>` | Override the image entrypoint. | image default |
@@ -206,6 +221,11 @@ Run a one-off command in a new container for the service.
 ```bash
 podup run --rm web sh -c 'echo hello'
 ```
+
+> **Differs from docker on purpose.** `run` removes the container by default
+> here; `docker compose run` keeps it unless you pass `--rm`. Migrating a script
+> means its existing `--rm` becomes a no-op and a container it expected to
+> inspect afterwards is gone — pass `--no-rm` to keep it.
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
@@ -240,7 +260,14 @@ container side, e.g. `podup cp web:/app/data ./local`.
 
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
-container exits or you detach.
+container exits or you detach. Output only — stdin is never attached.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+| `--no-stdin` | Accepted for compatibility; stdin is never attached anyway. | off |
+| `--sig-proxy` | Accepted for compatibility; no effect. | off |
+| `--detach-keys <KEYS>` | Accepted for compatibility; no effect. | none |
 
 ### `kill [SERVICE...]`
 Send a signal to service containers.
@@ -281,6 +308,10 @@ Commit a service container's current state to a new image reference
 | Flag | Description | Default |
 |---|---|---|
 | `--index <N>` | Select a replica (1-based) of a scaled service. | 1 |
+| `-m, --message <MSG>` | Commit message recorded on the image. | none |
+| `-a, --author <AUTHOR>` | Author recorded on the image. | none |
+| `-c, --change <INSTRUCTION>` | Apply a Dockerfile instruction to the created image. Repeatable. | none |
+| `--pause` | Pause the container while committing. | off |
 
 ### `export <SERVICE>`
 Export a service container's filesystem as a tar archive.
@@ -359,6 +390,11 @@ Print the resolved compose file (after substitution, extends, include).
 |---|---|---|
 | `--format <FMT>` | `yaml` or `json`. | `yaml` |
 | `--services` | List service names, one per line. | off |
+| `--volumes` | List named volumes, one per line. | off |
+| `--images` | List the images services use, one per line. | off |
+| `--profiles` | List the profiles the file declares, one per line. | off |
+| `--hash` | Print a stable per-service config hash. | off |
+| `--no-normalize` | Accepted for compatibility; `config` always emits the normalized form. | off |
 | `-q, --quiet` | Only validate; print nothing. | off |
 | `--no-interpolate` | Leave `${VAR}` placeholders literal. | off |
 | `--resolve-image-digests` | Rewrite each service `image:` to its registry digest (`repo@sha256:...`). | off |
@@ -473,6 +509,12 @@ returns the whole set, which a script reads as a match.
 
 `exec` propagates the command's exit code the same way `run` does, and `wait`
 returns the last non-zero code it saw.
+
+**`stats --format json` differs from docker on purpose.** podup emits numbers
+(`"CPUPerc": 12.5`) where docker emits preformatted strings (`"12.50%"`), and
+splits `NetIO`/`BlockIO` into separate input/output fields. Raw numbers are
+exact and need no parsing, but it does mean a docker-compose JSON consumer needs
+adapting rather than working unchanged.
 
 **`watch` is the exception.** A sync, rebuild, restart or exec that fails during
 a watch session is reported as a warning and the session keeps going; `watch`

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -33,8 +33,12 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 
 /// Like [`parse_file`], additionally loading `env_files` (the global
 /// `--env-file` flag) into the variable map used for interpolation. These take
-/// effect for the top-level file and any included files; the process
-/// environment and a project `.env` still take precedence.
+/// effect for the top-level file and any included files.
+///
+/// They **replace** a project `.env` rather than adding to it: when `env_files`
+/// is non-empty, `.env` is not read. That is docker-correct — and the opposite
+/// of what this comment used to claim, which also reached docs.rs readers. The
+/// process environment still takes precedence over both.
 pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<ComposeFile> {
 	parse_file_with_env_files_interp(path, env_files, true)
 }

--- a/tests/docs_flags.rs
+++ b/tests/docs_flags.rs
@@ -1,0 +1,108 @@
+//! `docs/commands.md` must document every flag the CLI actually accepts.
+//!
+//! The command reference was written per command by hand and drifted every time
+//! a flag landed — #1084 counted fourteen commands with missing flags and one
+//! precedence rule that was simply false. Fixing the text once only resets the
+//! clock; this test is what stops it recurring, by diffing `--help` against the
+//! document rather than trusting either.
+//!
+//! It asserts one direction only: every flag clap exposes appears in the docs.
+//! The reverse (documented flags that no longer exist) is a different failure
+//! and a different fix, and folding both into one assertion would make the
+//! message ambiguous.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Long flags clap prints in a `--help` body, e.g. `--no-cache`.
+///
+/// Only long forms are collected: a short form is always printed beside its long
+/// one, so requiring the long spelling covers both without needing to model
+/// clap's `-x, --xyz` layout.
+fn flags_in_help(help: &str) -> BTreeSet<String> {
+	let mut out = BTreeSet::new();
+	for line in help.lines() {
+		let trimmed = line.trim_start();
+		// Flag lines start with the short form or the long one; anything else is
+		// prose, a usage line, or a subcommand listing.
+		if !trimmed.starts_with('-') {
+			continue;
+		}
+		for token in trimmed.split_whitespace() {
+			let token = token.trim_end_matches([',', '.']);
+			if let Some(name) = token.strip_prefix("--") {
+				let name = name
+					.split(['=', '<', '['])
+					.next()
+					.unwrap_or_default()
+					.trim_end_matches('>');
+				if !name.is_empty() && name != "help" && name != "version" {
+					out.insert(format!("--{name}"));
+				}
+			}
+		}
+	}
+	out
+}
+
+/// The subcommands whose flag tables the reference documents. Aliases are
+/// excluded: they resolve to the same command and share its table.
+const COMMANDS: [&str; 29] = [
+	"up", "down", "create", "start", "stop", "restart", "build", "ps", "ls", "logs", "events",
+	"top", "stats", "port", "images", "volumes", "run", "exec", "cp", "attach", "kill", "rm",
+	"wait", "scale", "commit", "export", "pull", "push", "config",
+];
+
+#[test]
+fn every_cli_flag_is_documented() {
+	let docs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/commands.md"))
+		.expect("read docs/commands.md");
+
+	let mut missing: Vec<String> = Vec::new();
+	for cmd in COMMANDS {
+		let out = Command::new(bin())
+			.args([cmd, "--help"])
+			.output()
+			.unwrap_or_else(|e| panic!("run {cmd} --help: {e}"));
+		assert!(out.status.success(), "`{cmd} --help` failed");
+		let help = String::from_utf8_lossy(&out.stdout);
+		for flag in flags_in_help(&help) {
+			if !docs.contains(&flag) {
+				missing.push(format!("{cmd}: {flag}"));
+			}
+		}
+	}
+
+	assert!(
+		missing.is_empty(),
+		"flags accepted by the CLI but absent from docs/commands.md:\n  {}",
+		missing.join("\n  ")
+	);
+}
+
+/// The global options table is written separately from the per-command ones, so
+/// it drifts separately too.
+#[test]
+fn every_global_flag_is_documented() {
+	let docs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/commands.md"))
+		.expect("read docs/commands.md");
+	let out = Command::new(bin())
+		.arg("--help")
+		.output()
+		.expect("run --help");
+	let help = String::from_utf8_lossy(&out.stdout);
+
+	let missing: Vec<String> = flags_in_help(&help)
+		.into_iter()
+		.filter(|f| !docs.contains(f))
+		.collect();
+	assert!(
+		missing.is_empty(),
+		"global flags absent from docs/commands.md:\n  {}",
+		missing.join("\n  ")
+	);
+}


### PR DESCRIPTION
Closes #1084.

## The false claim, measured

`docs/commands.md` said the process environment **and a project `.env`** still take precedence over `--env-file`. Half of that is false:

```
no --env-file          -> from-dotenv     (.env is read)
--env-file custom.env  -> from-envfile    (.env is NOT read — it is replaced)
TAG set in the process -> from-process    (the environment does win)
```

So the environment half is right and the `.env` half is backwards. The replacement is the docker-correct behaviour, and `internal/cli/mod.rs` already described it correctly — it was the reference and the library doc-comment that were wrong. The same sentence sat on `parse_file_with_env_files`, so it reached docs.rs readers; both are corrected.

## The drift, fixed structurally

The issue's own diagnosis is that the reference was written per command by hand and drifts every time a flag lands, and that a test diffing `--help` against the doc would stop it. That is `tests/docs_flags.rs`, and it fails naming each undocumented flag.

**It found more than the issue listed.** `--ansi` was absent from the globals table entirely, and `config --hash`, `--images` and `--profiles` were missing on top of the known set — so the hand-written list had drifted again since the issue was filed, which is rather the point.

Everything it reported is now documented: `ps --status/--filter/--services`, `logs --no-color/--no-log-prefix`, `stats -a/--no-trunc/--format`, `build --push`, `run -l/--label`, `commit -m/-a/-c/--pause`, `config --volumes/--images/--profiles/--hash/--no-normalize`, plus flag tables for `top` and `attach`, which had none.

The test asserts **one direction only**: every flag clap exposes appears in the docs. Documented flags that no longer exist are a different failure with a different fix, and folding both into one assertion would make the message ambiguous. Noted in the test's own doc comment.

## What a flag table cannot express

Three things the issue raises that needed prose, not a row:

- **`up --pull` takes five values**, not the three documented — `newer` and `build` were missing, and `newer` is Podman's extension.
- **`run` removes the container by default**, the opposite of docker. Migrating a script silently turns its existing `--rm` into a no-op and the container it expected to inspect is gone. Now called out where someone migrating would hit it, with `--no-rm` as the answer.
- **`stats --format json` emits numbers where docker emits preformatted strings**, and splits `NetIO`/`BlockIO`. That was a deliberate choice explained only in a code comment; it is a contract with users' scripts and belongs in the docs.

## Test plan

`cargo test --test docs_flags` 2/2, `--bins` 61/61, clippy `--all-targets --all-features` clean. The precedence numbers above are from the built binary, not from reading the code — that claim had already been wrong once by inspection.

Closes #1084