### PR TITLE
chore(release): 1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,41 @@
+podup (1.13.0) unstable; urgency=medium
+
+  * up now builds a service only when its image is missing, matching compose.
+    It used to rebuild unconditionally with the cache, which could retag the
+    image back to an older layer chain and silently discard a `build
+    --no-cache` that had just run.
+  * A failed pull is no longer reported as success. libpod reports it as an
+    in-band error on a 200 response; that line was dropped, so `up --pull
+    always` against an unreachable registry started the stale local image and
+    exited 0.
+  * .containerignore is read, and never combined with .dockerignore. Podman
+    prefers its own name and applies exactly one file; applying both produced
+    an image missing content that `podman build` includes.
+  * The compose override file (compose.override.yaml and its three siblings) is
+    discovered and merged when no explicit -f is given, as docker compose does.
+  * Service merging across -f and extends now unions networks and merges
+    sysctls per key, and appends env_file, dns, dns_search, dns_opt, tmpfs and
+    label_file instead of replacing them. A service losing a network on an
+    override was the worst of these: it dropped off the network and service
+    discovery failed at run time.
+  * Quadlet units emit EnvironmentFile= as an absolute path. systemd resolves a
+    relative one against the unit's own directory, so an `env_file: .env` unit
+    looked for a file that is not there and the container never started.
+  * autostart uninstall reports a unit it could not stop instead of printing
+    its removal lines and exiting 0.
+  * An unknown --filter predicate is rejected rather than silently returning
+    the unfiltered set, and `build --progress` validates its value.
+  * stats --format json emits NDJSON while streaming (it was concatenated
+    pretty-printed arrays, which no parser accepts), and `port` exits non-zero
+    when there is no host binding.
+  * logs -f exits when the reader closes the pipe instead of streaming into it
+    forever.
+  * Documented: the known Podman 6 limitation on `cp` into a container and
+    `watch` sync, the deliberate compatibility no-op flags, and the corrected
+    --env-file precedence rule (a project .env is replaced, not preserved).
+
+ -- Glyndor <packages@glyndor.net>  Mon, 20 Jul 2026 04:15:00 -0500
+
 podup (1.12.0) unstable; urgency=medium
 
   * cp no longer applies an archive entry's permissions outside the destination


### PR DESCRIPTION
Version bump ahead of the `develop` → `main` release PR.

All three files, together: `Cargo.toml`, `Cargo.lock` and **`debian/changelog`**. The last one is where `dpkg-buildpackage` reads the `.deb` version from and nothing derives it — missing it ships packages labelled with the version users already have, so `apt upgrade` reports nothing to do and Debian users never receive the release. That happened in 1.9.0; `release.yml`'s verify job now refuses to build when the manifests disagree, and this bump satisfies it.

## Why MINOR

**Not PATCH:** compose override discovery (#1077) is a new feature.

**Not MAJOR:** the library's public API is unchanged — `cargo-semver-checks` passed on every PR in this range. Every behaviour change moves *toward* compose parity, which is the product's stated commitment; 1.0.0 froze the API, not the bugs.

That said, three of them are genuine surprises for an existing user and are called out at the top of the release notes rather than buried:

- **`compose.override.yaml` is now discovered and merged.** A project that has one, and that podup was silently ignoring, will now run something different.
- **`up` no longer rebuilds unconditionally.** A workflow relying on `up` to rebuild must pass `--build`.
- **Several commands now exit non-zero where they exited 0**: an unknown `--filter`, a `port` with no binding, and a pull the registry refused.

If you read the second and third as breaking rather than corrective, this should be 2.0.0 — the call is yours, and it is easier to make now than after the tag.

## Verification

`cargo test --lib` 1275/1275, `podup --version` reports `1.13.0`, and the three files agree.