### PR TITLE
Release 1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ latest 5.x, rawhide for 6.x). Many distributions still ship 4.x — check
 Ubuntu releases carry 5.x; on an older release, install or upgrade Podman
 following the official guide: <https://podman.io/docs/installation>.
 
+**Known limitation on Podman 6.** Copying *into* a container — `podup cp
+./file web:/path` — and `watch` rules whose action includes `sync` fail with a
+transport error. Copying *out* of a container works on both majors, and both
+directions work on Podman 5. Fedora, Arch and Manjaro ship Podman 6 today, so
+this affects them now; it is tracked in
+[#1097](https://github.com/Glyndor/podup/issues/1097).
+
 ### Platforms
 
 Linux, macOS and Windows (x86_64 and arm64). On macOS and Windows podup talks to

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,41 @@
+podup (1.13.0) unstable; urgency=medium
+
+  * up now builds a service only when its image is missing, matching compose.
+    It used to rebuild unconditionally with the cache, which could retag the
+    image back to an older layer chain and silently discard a `build
+    --no-cache` that had just run.
+  * A failed pull is no longer reported as success. libpod reports it as an
+    in-band error on a 200 response; that line was dropped, so `up --pull
+    always` against an unreachable registry started the stale local image and
+    exited 0.
+  * .containerignore is read, and never combined with .dockerignore. Podman
+    prefers its own name and applies exactly one file; applying both produced
+    an image missing content that `podman build` includes.
+  * The compose override file (compose.override.yaml and its three siblings) is
+    discovered and merged when no explicit -f is given, as docker compose does.
+  * Service merging across -f and extends now unions networks and merges
+    sysctls per key, and appends env_file, dns, dns_search, dns_opt, tmpfs and
+    label_file instead of replacing them. A service losing a network on an
+    override was the worst of these: it dropped off the network and service
+    discovery failed at run time.
+  * Quadlet units emit EnvironmentFile= as an absolute path. systemd resolves a
+    relative one against the unit's own directory, so an `env_file: .env` unit
+    looked for a file that is not there and the container never started.
+  * autostart uninstall reports a unit it could not stop instead of printing
+    its removal lines and exiting 0.
+  * An unknown --filter predicate is rejected rather than silently returning
+    the unfiltered set, and `build --progress` validates its value.
+  * stats --format json emits NDJSON while streaming (it was concatenated
+    pretty-printed arrays, which no parser accepts), and `port` exits non-zero
+    when there is no host binding.
+  * logs -f exits when the reader closes the pipe instead of streaming into it
+    forever.
+  * Documented: the known Podman 6 limitation on `cp` into a container and
+    `watch` sync, the deliberate compatibility no-op flags, and the corrected
+    --env-file precedence rule (a project .env is replaced, not preserved).
+
+ -- Glyndor <packages@glyndor.net>  Mon, 20 Jul 2026 04:15:00 -0500
+
 podup (1.12.0) unstable; urgency=medium
 
   * cp no longer applies an archive entry's permissions outside the destination

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -450,3 +450,14 @@ when both are set.
 | `126` | `run`/`exec`: the command exists but is not executable. |
 | `127` | `run`/`exec`: the command was not found. |
 | other | `run` propagates the container's own exit code verbatim. |
+
+`exec` propagates the command's exit code the same way `run` does, and `wait`
+returns the last non-zero code it saw.
+
+**`watch` is the exception.** A sync, rebuild, restart or exec that fails during
+a watch session is reported as a warning and the session keeps going; `watch`
+exits 0 unless it cannot start at all. This matches `docker compose watch` — a
+long-running developer loop should not die because one rebuild failed — but it
+does mean the exit code of a `watch` session says nothing about whether every
+action in it succeeded. Read the warnings, not the status, and do not gate
+automation on it.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,7 +19,8 @@ These appear before the subcommand and may also come from the environment.
 | `--socket <PATH>` | `PODMAN_SOCKET` | Podman socket path; overrides auto-detection. |
 | `--profile <NAMES>` | `COMPOSE_PROFILES` | Active profiles, comma-separated. |
 | `--project-directory <PATH>` | | Base directory for relative paths (env_file, build context, bind mounts, config/secret sources). Defaults to the compose file's directory. |
-| `--env-file <PATH>` | | Extra env file for interpolation. Repeatable; later files win. The process environment and a project `.env` still take precedence. |
+| `--ansi <WHEN>` | | Colour output: `auto`, `always` or `never`. `always` forces colour even into a pipe or file. | 
+| `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it — when this is given, `.env` is not read. The process environment still takes precedence over both. |
 
 ## Lifecycle
 
@@ -38,7 +39,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--no-deps` | Do not start the `depends_on` services of the named services. | off |
 | `-t, --timeout <SECS>` | Seconds to wait for a container to stop when recreating. | Podman default |
 | `--scale <SERVICE=N>` | Override a service's replica count for this run. Repeatable. | from file |
-| `--pull <POLICY>` | Pull policy before starting: `always`, `missing`, `never`. | per service |
+| `--pull <POLICY>` | Pull policy before starting: `always`, `missing`, `never`, `newer`, `build`. (`newer` is Podman's extension.) | per service |
 | `--no-build` | Do not build images, even for services with a `build:` section. | off |
 | `--quiet-pull` | Suppress image-pull progress output. | off |
 | `--wait` | Wait until services are running/healthy before returning. | off |
@@ -103,6 +104,7 @@ Build or rebuild service images (optionally only the named services).
 | `--pull` | Always attempt to pull a newer base image. | off |
 | `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
 | `--progress <STYLE>` | `auto`, `plain` or `tty`. Validated but inert — see [accepted for compatibility](#accepted-for-compatibility). | `auto` |
+| `--push` | Push each built image to its registry after a successful build. | off |
 | `-q, --quiet` | Suppress the build output. | off |
 
 ## Inspection
@@ -115,6 +117,9 @@ List project containers.
 | `-a, --all` | Include stopped containers. | running only |
 | `-q, --quiet` | Print container IDs only. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
+| `--status <STATE>` | Show only containers in this state. Repeatable; folded together with any `status=` from `--filter`. | all |
+| `--filter <KEY=VAL>` | `name=<NAME>` or `status=<STATE>`. An unknown key is an error. | none |
+| `--services` | Print service names only. | off |
 
 ### `ls`
 List podup compose projects on the host. Needs no compose file.
@@ -135,6 +140,8 @@ View container output for the named services (or all).
 | `--since <TIME>` | Show logs since a timestamp or relative time (e.g. `10m`). | start |
 | `--until <TIME>` | Show logs before a timestamp or relative time. | end |
 | `-t, --timestamps` | Prefix each line with an RFC3339 timestamp. | off |
+| `--no-color` | Monochrome prefix even on a colour-capable stdout. | off |
+| `--no-log-prefix` | Drop the `{service} \| ` tag entirely. | off |
 
 ### `events`
 Stream Podman events for this project's containers.
@@ -148,6 +155,10 @@ Stream Podman events for this project's containers.
 ### `top [SERVICE...]`
 Show the running processes of service containers.
 
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FMT>` | `table` or `json` (an array of `{Container, Titles, Processes}`). | `table` |
+
 ### `stats [SERVICE...]`
 Live resource usage (CPU, memory, network, block I/O, PIDs) for service
 containers.
@@ -155,6 +166,9 @@ containers.
 | Flag | Description | Default |
 |---|---|---|
 | `--no-stream` | Print one snapshot and exit. | stream |
+| `-a, --all` | Include non-running containers as zeroed rows. | running only |
+| `--no-trunc` | Do not truncate long container names. | truncate at 32 |
+| `--format <FMT>` | `table` or `json`. While streaming, `json` is NDJSON — one compact array per line. | `table` |
 
 ### `port <SERVICE> <PRIVATE_PORT>`
 Print the public binding for a port.
@@ -194,6 +208,7 @@ Run a one-off command in a new container for the service.
 | `-e, --env <KEY=VAL>` | Set an environment variable. Repeatable. | none |
 | `--name <NAME>` | Override the container name. | generated |
 | `-P, --service-ports` | Publish the service's declared ports. | off |
+| `-l, --label <KEY=VAL>` | Add a label to the one-off container. Repeatable. | none |
 | `-u, --user <NAME\|UID[:GID]>` | Run the command as this user. | image default |
 | `-w, --workdir <PATH>` | Working directory inside the container. | image default |
 | `--entrypoint <CMD>` | Override the image entrypoint. | image default |
@@ -206,6 +221,11 @@ Run a one-off command in a new container for the service.
 ```bash
 podup run --rm web sh -c 'echo hello'
 ```
+
+> **Differs from docker on purpose.** `run` removes the container by default
+> here; `docker compose run` keeps it unless you pass `--rm`. Migrating a script
+> means its existing `--rm` becomes a no-op and a container it expected to
+> inspect afterwards is gone — pass `--no-rm` to keep it.
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
@@ -240,7 +260,14 @@ container side, e.g. `podup cp web:/app/data ./local`.
 
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
-container exits or you detach.
+container exits or you detach. Output only — stdin is never attached.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
+| `--no-stdin` | Accepted for compatibility; stdin is never attached anyway. | off |
+| `--sig-proxy` | Accepted for compatibility; no effect. | off |
+| `--detach-keys <KEYS>` | Accepted for compatibility; no effect. | none |
 
 ### `kill [SERVICE...]`
 Send a signal to service containers.
@@ -281,6 +308,10 @@ Commit a service container's current state to a new image reference
 | Flag | Description | Default |
 |---|---|---|
 | `--index <N>` | Select a replica (1-based) of a scaled service. | 1 |
+| `-m, --message <MSG>` | Commit message recorded on the image. | none |
+| `-a, --author <AUTHOR>` | Author recorded on the image. | none |
+| `-c, --change <INSTRUCTION>` | Apply a Dockerfile instruction to the created image. Repeatable. | none |
+| `--pause` | Pause the container while committing. | off |
 
 ### `export <SERVICE>`
 Export a service container's filesystem as a tar archive.
@@ -359,6 +390,11 @@ Print the resolved compose file (after substitution, extends, include).
 |---|---|---|
 | `--format <FMT>` | `yaml` or `json`. | `yaml` |
 | `--services` | List service names, one per line. | off |
+| `--volumes` | List named volumes, one per line. | off |
+| `--images` | List the images services use, one per line. | off |
+| `--profiles` | List the profiles the file declares, one per line. | off |
+| `--hash` | Print a stable per-service config hash. | off |
+| `--no-normalize` | Accepted for compatibility; `config` always emits the normalized form. | off |
 | `-q, --quiet` | Only validate; print nothing. | off |
 | `--no-interpolate` | Leave `${VAR}` placeholders literal. | off |
 | `--resolve-image-digests` | Rewrite each service `image:` to its registry digest (`repo@sha256:...`). | off |
@@ -473,6 +509,12 @@ returns the whole set, which a script reads as a match.
 
 `exec` propagates the command's exit code the same way `run` does, and `wait`
 returns the last non-zero code it saw.
+
+**`stats --format json` differs from docker on purpose.** podup emits numbers
+(`"CPUPerc": 12.5`) where docker emits preformatted strings (`"12.50%"`), and
+splits `NetIO`/`BlockIO` into separate input/output fields. Raw numbers are
+exact and need no parsing, but it does mean a docker-compose JSON consumer needs
+adapting rather than working unchanged.
 
 **`watch` is the exception.** A sync, rebuild, restart or exec that fails during
 a watch session is reported as a warning and the session keeps going; `watch`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -199,7 +199,7 @@ Run a one-off command in a new container for the service.
 | `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
 | `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
 | `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
-| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
 | `--no-deps` | Do not start the `depends_on` services before running. | off |
 
 ```bash
@@ -216,7 +216,7 @@ Execute a command in a running service container.
 | `-w, --workdir <PATH>` | Working directory inside the container. | container default |
 | `--privileged` | Give extended privileges to the command. | off |
 | `-d, --detach` | Run the command in the background. | off |
-| `-T, --no-TTY` | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `-T, --no-tty` (alias `--no-TTY`) | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
 | `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -102,6 +102,7 @@ Build or rebuild service images (optionally only the named services).
 | `--no-cache` | Do not use the build cache. | off |
 | `--pull` | Always attempt to pull a newer base image. | off |
 | `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
+| `--progress <STYLE>` | `auto`, `plain` or `tty`. Validated but inert — see [accepted for compatibility](#accepted-for-compatibility). | `auto` |
 | `-q, --quiet` | Suppress the build output. | off |
 
 ## Inspection
@@ -438,6 +439,25 @@ when both are set.
 | `PODMAN_SOCKET` | Podman socket path (`--socket`). |
 | `DOCKER_HOST` | Docker-compatible fallback for the Podman socket, used only when `PODMAN_SOCKET` is unset. Must be a local `unix://` socket (or `npipe://` on Windows); a remote `tcp://`/`ssh://` value is rejected. |
 | `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
+
+## Accepted for compatibility
+
+These flags parse and are validated, so a script written against docker compose
+runs unchanged — but podup does not act on them. They are listed here because
+`--help` says "accepted for compatibility" without saying which flags that
+covers, and the only other way to find out was to read the dispatch code.
+
+| Flag | Why it does nothing |
+|---|---|
+| `build --progress <STYLE>` | podup renders build output one way. The value is still validated, so a typo is rejected rather than silently ignored. |
+| `config --no-normalize` | `config` always emits the normalized form. |
+| `cp -a, --archive` | Ownership/permission preservation is not meaningful for a rootless copy. |
+| `attach --no-stdin`, `--sig-proxy`, `--detach-keys` | `attach` streams output only; stdin is never attached (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
+| `run -T, --no-TTY` / `exec -T, --no-tty` | podup never allocates a pseudo-TTY, so disabling one is a no-op (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
+
+Everything else that parses does something. An **unknown** `--filter` predicate
+is rejected outright rather than dropped: a filter that silently does not apply
+returns the whole set, which a script reads as a match.
 
 ## Exit status
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -233,6 +233,10 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `-L, --follow-link` | Follow symlinks in the host source before copying into the container. | off |
 | `-a, --archive` | Accepted for compatibility (no effect under rootless Podman). | off |
 
+> **Podman 6:** copying *into* a container fails with a transport error.
+> Copying *out* works on both majors, and both directions work on Podman 5.
+> Tracked in [#1097](https://github.com/Glyndor/podup/issues/1097).
+
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
 container exits or you detach.
@@ -338,6 +342,11 @@ The `action` of each rule may be:
 | `restart` | Restart the container without rebuilding. |
 | `sync+restart` | Sync the files, then restart the container. |
 | `sync+exec` | Sync the files, then run the rule's `exec` command in the container. |
+
+> **Podman 6:** the `sync` step copies into the container through the same path
+> as `cp`, so `sync`, `sync+restart` and `sync+exec` fail there. `rebuild` and
+> `restart` are unaffected, and every action works on Podman 5. Tracked in
+> [#1097](https://github.com/Glyndor/podup/issues/1097).
 
 ## Maintenance
 

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -240,15 +240,48 @@ pub fn install<S: SystemCtl>(sc: &S, opts: &InstallOptions) -> crate::Result<()>
 	Ok(())
 }
 
+/// Whether systemd knows anything about `unit` — loaded, enabled, running, or
+/// merely present as a fragment.
+///
+/// `systemctl is-active` exits **4** for a unit it has never heard of and
+/// something else for every other state (0 active, 3 inactive/failed/activating).
+/// That numeric 4 is the only reliable "there is nothing here" signal: the
+/// message text is localised, and the *fragment file* is not a proxy for it —
+/// measured, a unit whose file is deleted out of band stays loaded, enabled and
+/// running, and `disable --now` still exits 0, removes its `.wants/` symlink and
+/// stops it. Gating on the file would delete the only way out of that state.
+///
+/// A probe that cannot even be spawned returns `true`: the right response to
+/// "I could not ask" is to attempt the disable anyway and let `checked` report
+/// whatever happens, never to assume there is nothing to do.
+fn unit_is_known<S: SystemCtl>(sc: &S, unit: &str) -> bool {
+	sc.systemctl(&["is-active", "--quiet", unit])
+		.map(|o| o.status.code() != Some(4))
+		.unwrap_or(true)
+}
+
 /// Uninstall the service-mode autostart unit: disable + stop it, remove the unit
-/// file, and reload the user manager. A "unit not loaded" disable failure is
-/// ignored so uninstall is idempotent.
+/// file, and reload the user manager.
+///
+/// Idempotent — uninstalling when nothing is installed is a quiet no-op — but a
+/// `disable` that genuinely fails is reported rather than swallowed, so the
+/// command cannot claim success while the service is still enabled and running.
 pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	let unit_name = unit_file_name(project);
-	// Best-effort: ignore failures (e.g. the unit was never loaded).
-	let _ = sc.systemctl(&["disable", "--now", &unit_name]);
-
 	let path = unit_path(project);
+
+	// Disable whenever systemd knows the unit, whether or not its file is still
+	// there. `disable --now` is idempotent across every state it can be in
+	// (enabled, never enabled, running, stopped, fragment deleted out of band),
+	// so the only case worth skipping is the one where systemd has never heard
+	// of it — which is exactly what `unit_is_known` answers.
+	if unit_is_known(sc, &unit_name) {
+		checked(
+			sc.systemctl(&["disable", "--now", &unit_name]),
+			"disable --now",
+		)?;
+	}
+
 	if path.exists() {
 		std::fs::remove_file(&path).map_err(|e| {
 			ComposeError::Autostart(format!("cannot remove {}: {e}", path.display()))
@@ -380,234 +413,4 @@ pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 }
 
 #[cfg(all(test, unix))]
-mod tests {
-	use super::*;
-	use std::cell::RefCell;
-	use std::os::unix::process::ExitStatusExt;
-	use std::process::ExitStatus;
-
-	/// Recording fake: captures every `systemctl`/`loginctl` arg vector and returns
-	/// canned output keyed off the first argument.
-	struct FakeCtl {
-		systemctl_calls: RefCell<Vec<Vec<String>>>,
-		loginctl_calls: RefCell<Vec<Vec<String>>>,
-		linger: String,
-		is_active: String,
-		is_enabled: String,
-		fail: bool,
-	}
-
-	impl FakeCtl {
-		fn new() -> Self {
-			FakeCtl {
-				systemctl_calls: RefCell::new(Vec::new()),
-				loginctl_calls: RefCell::new(Vec::new()),
-				linger: "yes".to_string(),
-				is_active: "active".to_string(),
-				is_enabled: "enabled".to_string(),
-				fail: false,
-			}
-		}
-
-		fn systemctl_log(&self) -> Vec<Vec<String>> {
-			self.systemctl_calls.borrow().clone()
-		}
-	}
-
-	fn out(code: i32, stdout: &str) -> Output {
-		Output {
-			status: ExitStatus::from_raw(code),
-			stdout: stdout.as_bytes().to_vec(),
-			stderr: Vec::new(),
-		}
-	}
-
-	impl SystemCtl for FakeCtl {
-		fn systemctl(&self, args: &[&str]) -> io::Result<Output> {
-			self.systemctl_calls
-				.borrow_mut()
-				.push(args.iter().map(|s| s.to_string()).collect());
-			let code = if self.fail { 256 } else { 0 };
-			let stdout = match args.first().copied() {
-				Some("is-active") => self.is_active.as_str(),
-				Some("is-enabled") => self.is_enabled.as_str(),
-				_ => "",
-			};
-			// is-active/is-enabled report through stdout; their exit status is not
-			// consulted, so leave it successful for those queries.
-			let code = if matches!(args.first().copied(), Some("is-active" | "is-enabled")) {
-				0
-			} else {
-				code
-			};
-			Ok(out(code, stdout))
-		}
-
-		fn loginctl(&self, args: &[&str]) -> io::Result<Output> {
-			self.loginctl_calls
-				.borrow_mut()
-				.push(args.iter().map(|s| s.to_string()).collect());
-			Ok(out(0, &self.linger))
-		}
-	}
-
-	fn opts(dir: &Path, project: &str, dry_run: bool, no_start: bool) -> InstallOptions {
-		InstallOptions {
-			unit: ServiceUnitOpts {
-				exe: PathBuf::from("/usr/local/bin/podup"),
-				compose_files: vec![dir.join("docker-compose.yml")],
-				project: project.to_string(),
-				working_dir: dir.to_path_buf(),
-				profiles: Vec::new(),
-				env_files: Vec::new(),
-			},
-			no_start,
-			dry_run,
-		}
-	}
-
-	/// Run `f` with a fresh temp `XDG_CONFIG_HOME`, `USER`, and `XDG_RUNTIME_DIR`
-	/// set, so the install/status paths resolve under the temp dir.
-	fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
-		let tmp = tempfile::tempdir().unwrap();
-		let root = tmp.path().to_path_buf();
-		temp_env::with_vars(
-			[
-				("XDG_CONFIG_HOME", Some(root.as_os_str())),
-				("XDG_RUNTIME_DIR", Some(root.as_os_str())),
-				("USER", Some(std::ffi::OsStr::new("tester"))),
-			],
-			|| f(&root),
-		)
-	}
-
-	#[test]
-	fn install_writes_unit_and_enables() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install(&sc, &opts(root, "app", false, false)).unwrap();
-			let path = root.join("systemd/user/podup-app.service");
-			assert!(path.is_file(), "unit file written");
-			let body = std::fs::read_to_string(&path).unwrap();
-			assert!(body.contains("Description=podup app"));
-			let calls = sc.systemctl_log();
-			assert_eq!(calls[0], vec!["daemon-reload"]);
-			assert_eq!(calls[1], vec!["enable", "--now", "podup-app.service"]);
-		});
-	}
-
-	#[test]
-	fn install_no_start_skips_enable() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install(&sc, &opts(root, "app", false, true)).unwrap();
-			let calls = sc.systemctl_log();
-			assert_eq!(calls, vec![vec!["daemon-reload"]]);
-		});
-	}
-
-	#[test]
-	fn dry_run_writes_nothing_and_runs_no_systemctl() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install(&sc, &opts(root, "app", true, false)).unwrap();
-			assert!(!root.join("systemd/user/podup-app.service").exists());
-			assert!(sc.systemctl_log().is_empty());
-		});
-	}
-
-	#[test]
-	fn uninstall_disables_removes_and_reloads() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install(&sc, &opts(root, "app", false, true)).unwrap();
-			let path = root.join("systemd/user/podup-app.service");
-			assert!(path.exists());
-
-			let sc2 = FakeCtl::new();
-			uninstall(&sc2, "app").unwrap();
-			assert!(!path.exists(), "unit file removed");
-			let calls = sc2.systemctl_log();
-			assert_eq!(calls[0], vec!["disable", "--now", "podup-app.service"]);
-			assert_eq!(calls[1], vec!["daemon-reload"]);
-		});
-	}
-
-	#[test]
-	fn install_refuses_on_quadlet_conflict() {
-		with_env(|root| {
-			let qdir = root.join("containers/systemd");
-			std::fs::create_dir_all(&qdir).unwrap();
-			std::fs::write(qdir.join("app-web.container"), b"[Container]\n").unwrap();
-			let sc = FakeCtl::new();
-			let err = install(&sc, &opts(root, "app", false, false)).unwrap_err();
-			assert!(matches!(err, ComposeError::Autostart(_)));
-			assert!(err.to_string().contains("quadlet"));
-			// Nothing was installed.
-			assert!(!root.join("systemd/user/podup-app.service").exists());
-			assert!(sc.systemctl_log().is_empty());
-		});
-	}
-
-	#[test]
-	fn linger_off_produces_warning() {
-		let mut sc = FakeCtl::new();
-		sc.linger = "no".to_string();
-		temp_env::with_var("USER", Some("tester"), || {
-			assert!(linger_warning(&sc).is_some());
-		});
-	}
-
-	#[test]
-	fn linger_on_produces_no_warning() {
-		let sc = FakeCtl::new(); // linger = "yes"
-		temp_env::with_var("USER", Some("tester"), || {
-			assert!(linger_warning(&sc).is_none());
-		});
-	}
-
-	#[test]
-	fn missing_runtime_dir_produces_warning() {
-		temp_env::with_var_unset("XDG_RUNTIME_DIR", || {
-			assert!(runtime_dir_warning().is_some());
-		});
-		temp_env::with_var("XDG_RUNTIME_DIR", Some("/run/user/1000"), || {
-			assert!(runtime_dir_warning().is_none());
-		});
-	}
-
-	#[test]
-	fn collect_status_reports_installed_and_state() {
-		with_env(|root| {
-			let sc = FakeCtl::new();
-			install(&sc, &opts(root, "app", false, true)).unwrap();
-			let r = collect_status(&sc, "app");
-			assert!(r.unit_exists);
-			assert!(r.unit_mode.is_some());
-			assert_eq!(r.is_active, "active");
-			assert_eq!(r.is_enabled, "enabled");
-			assert!(r.linger);
-			assert!(r.runtime_dir);
-		});
-	}
-
-	#[test]
-	fn collect_status_reports_absent_unit() {
-		with_env(|_root| {
-			let sc = FakeCtl::new();
-			let r = collect_status(&sc, "nope");
-			assert!(!r.unit_exists);
-			assert!(r.unit_mode.is_none());
-		});
-	}
-
-	#[test]
-	fn install_surfaces_systemctl_failure() {
-		with_env(|root| {
-			let mut sc = FakeCtl::new();
-			sc.fail = true;
-			let err = install(&sc, &opts(root, "app", false, false)).unwrap_err();
-			assert!(matches!(err, ComposeError::Autostart(_)));
-		});
-	}
-}
+mod tests;

--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -200,14 +200,37 @@ pub fn install_quadlet<S: SystemCtl>(
 
 /// Uninstall quadlet-mode autostart: stop this project's container services, remove
 /// its `<project>-*` unit files, and reload the user manager. Idempotent — a
-/// service that was never loaded, or a file already gone, is not an error.
+/// service that was never started, or a file already gone, is not an error.
+///
+/// A service that *is* running and refuses to stop is a different matter: the
+/// unit files are still removed and the manager still reloaded, but the failure
+/// is returned, so uninstall cannot report success while a container keeps
+/// running.
 pub fn uninstall_quadlet<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	let units = installed_units(project);
-	// Stop the container services first (best-effort) while their units still exist.
+	let mut first_err: Option<ComposeError> = None;
+	// Stop the container services first, while their units still exist.
 	for path in &units {
 		if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
 			if let Some(stem) = name.strip_suffix(".container") {
-				let _ = sc.systemctl(&["stop", &format!("{stem}.service")]);
+				let service = format!("{stem}.service");
+				// Stop unconditionally. There is no state here worth probing for
+				// first: measured against real systemd, `stop` on a unit whose
+				// fragment is on disk exits 0 whether it is running, inactive, or
+				// was never started at all — and every unit in this loop has its
+				// fragment on disk, because that is what `installed_units` found.
+				// (`stop` only fails with "not loaded" when no fragment exists,
+				// which cannot happen here.)
+				//
+				// Gating on `is-active` would be worse than redundant: a service
+				// that is still coming up reports `activating`, which `is-active`
+				// calls a failure — so a stack caught mid-start, or one sitting in
+				// `activating (auto-restart)`, would be skipped and left running
+				// while uninstall deleted its units and reported success.
+				if let Err(e) = checked(sc.systemctl(&["stop", &service]), "stop") {
+					tracing::warn!("{e}");
+					first_err.get_or_insert(e);
+				}
 			}
 		}
 	}
@@ -223,7 +246,7 @@ pub fn uninstall_quadlet<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<(
 		eprintln!("podup: no quadlet autostart units for '{project}' (already removed)");
 	}
 	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
-	Ok(())
+	first_err.map_or(Ok(()), Err)
 }
 
 /// Rebuild one or all built images of a quadlet-mode install. A `.build` unit is

--- a/internal/autostart/quadlet/tests.rs
+++ b/internal/autostart/quadlet/tests.rs
@@ -40,6 +40,49 @@ impl SystemCtl for FakeCtl {
 	}
 }
 
+/// A [`FakeCtl`] whose exit status is decided per call, so a test can make one
+/// specific `systemctl` verb fail while the rest succeed. `FakeCtl` always
+/// reports 0, which cannot express "this service is not running" (`is-active`
+/// non-zero) or "the stop was refused".
+struct ScriptedCtl {
+	calls: RefCell<Vec<Vec<String>>>,
+	/// Exit code for a given arg vector; 0 means success.
+	code: ExitCodeFor,
+}
+
+/// Decides a scripted `systemctl` call's exit code from its arguments.
+type ExitCodeFor = Box<dyn Fn(&[&str]) -> i32>;
+impl ScriptedCtl {
+	fn new(code: impl Fn(&[&str]) -> i32 + 'static) -> Self {
+		ScriptedCtl {
+			calls: RefCell::new(Vec::new()),
+			code: Box::new(code),
+		}
+	}
+	fn log(&self) -> Vec<Vec<String>> {
+		self.calls.borrow().clone()
+	}
+}
+impl SystemCtl for ScriptedCtl {
+	fn systemctl(&self, args: &[&str]) -> std::io::Result<Output> {
+		self.calls
+			.borrow_mut()
+			.push(args.iter().map(|s| s.to_string()).collect());
+		Ok(Output {
+			status: ExitStatus::from_raw((self.code)(args) << 8),
+			stdout: Vec::new(),
+			stderr: b"scripted failure".to_vec(),
+		})
+	}
+	fn loginctl(&self, _args: &[&str]) -> std::io::Result<Output> {
+		Ok(Output {
+			status: ExitStatus::from_raw(0),
+			stdout: b"yes".to_vec(),
+			stderr: Vec::new(),
+		})
+	}
+}
+
 /// Run `f` with a fresh temp `XDG_CONFIG_HOME`/`XDG_RUNTIME_DIR`/`USER`, so
 /// `quadlet_dir` and the guards resolve under the temp dir.
 fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
@@ -163,6 +206,81 @@ fn uninstall_stops_removes_and_reloads() {
 		let calls = sc.log();
 		assert!(calls.contains(&vec!["stop".to_string(), "proj-web.service".to_string()]));
 		assert_eq!(calls.last().unwrap(), &vec!["daemon-reload".to_string()]);
+	});
+}
+
+/// The stop is unconditional, and must stay that way.
+///
+/// An earlier version probed `is-active` first and skipped the stop when it
+/// failed. Measured against real systemd, that is wrong twice over: `stop` on a
+/// unit whose fragment is on disk exits 0 in *every* state (running, inactive,
+/// never started), so the probe bought nothing — and a service still coming up
+/// reports `activating`, which `is-active` calls a failure, so a stack caught
+/// mid-start would have been skipped and left running while its units were
+/// deleted.
+///
+/// Here `is-active` would report "not active"; the stop must be issued anyway.
+#[test]
+fn uninstall_stops_unconditionally_without_probing_is_active() {
+	with_env(|_root| {
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(IMG).unwrap(),
+			"proj",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		// Anything that asks `is-active` gets "not active"; everything else succeeds.
+		let sc = ScriptedCtl::new(|args| i32::from(args.first() == Some(&"is-active")) * 3);
+		uninstall_quadlet(&sc, "proj").expect("stopping an inactive unit is not a failure");
+		let calls = sc.log();
+		assert!(
+			calls.contains(&vec!["stop".to_string(), "proj-web.service".to_string()]),
+			"the stop must be issued regardless of is-active: {calls:?}"
+		);
+		assert!(
+			!calls
+				.iter()
+				.any(|c| c.first().map(String::as_str) == Some("is-active")),
+			"uninstall must not probe is-active at all: {calls:?}"
+		);
+	});
+}
+
+/// #1080: a running service that refuses to stop was swallowed by `let _ =`, so
+/// uninstall exited 0 with the container still up. It must now report — while
+/// still removing the unit files and reloading, so the uninstall is not left
+/// half-done.
+#[test]
+fn uninstall_reports_a_stop_failure_but_still_removes_and_reloads() {
+	with_env(|root| {
+		install_quadlet(
+			&FakeCtl::new(),
+			&parse_str(IMG).unwrap(),
+			"proj",
+			Path::new(BASE),
+			true,
+			false,
+		)
+		.unwrap();
+		// Running (`is-active` 0), but the stop is refused.
+		let sc = ScriptedCtl::new(|args| i32::from(args.first() == Some(&"stop")));
+		let err = uninstall_quadlet(&sc, "proj")
+			.expect_err("a refused stop must not be reported as a clean uninstall");
+		assert!(format!("{err}").contains("stop"), "got {err:?}");
+
+		assert!(
+			!root.join("containers/systemd/proj-web.container").exists(),
+			"the unit file must still be removed"
+		);
+		let calls = sc.log();
+		assert_eq!(
+			calls.last().unwrap(),
+			&vec!["daemon-reload".to_string()],
+			"the manager must still be reloaded: {calls:?}"
+		);
 	});
 }
 

--- a/internal/autostart/tests.rs
+++ b/internal/autostart/tests.rs
@@ -1,0 +1,310 @@
+//! Unit tests for the service-mode autostart install/uninstall/status logic.
+//!
+//! Split out of `mod.rs` to keep that file within the source line limit, the
+//! same way the quadlet-mode tests live in `quadlet/tests.rs`.
+
+use super::*;
+use std::cell::RefCell;
+use std::os::unix::process::ExitStatusExt;
+use std::process::ExitStatus;
+
+/// Recording fake: captures every `systemctl`/`loginctl` arg vector and returns
+/// canned output keyed off the first argument.
+struct FakeCtl {
+	systemctl_calls: RefCell<Vec<Vec<String>>>,
+	loginctl_calls: RefCell<Vec<Vec<String>>>,
+	linger: String,
+	is_active: String,
+	is_enabled: String,
+	/// Exit code for `is-active`, as a raw wait status (code << 8). 0 by
+	/// default; `4 << 8` is systemd's "no such unit", the only value
+	/// `unit_is_known` treats as "there is nothing here".
+	is_active_code: i32,
+	fail: bool,
+}
+
+impl FakeCtl {
+	fn new() -> Self {
+		FakeCtl {
+			systemctl_calls: RefCell::new(Vec::new()),
+			loginctl_calls: RefCell::new(Vec::new()),
+			linger: "yes".to_string(),
+			is_active: "active".to_string(),
+			is_enabled: "enabled".to_string(),
+			is_active_code: 0,
+			fail: false,
+		}
+	}
+
+	fn systemctl_log(&self) -> Vec<Vec<String>> {
+		self.systemctl_calls.borrow().clone()
+	}
+}
+
+fn out(code: i32, stdout: &str) -> Output {
+	Output {
+		status: ExitStatus::from_raw(code),
+		stdout: stdout.as_bytes().to_vec(),
+		stderr: Vec::new(),
+	}
+}
+
+impl SystemCtl for FakeCtl {
+	fn systemctl(&self, args: &[&str]) -> io::Result<Output> {
+		self.systemctl_calls
+			.borrow_mut()
+			.push(args.iter().map(|s| s.to_string()).collect());
+		let code = if self.fail { 256 } else { 0 };
+		let stdout = match args.first().copied() {
+			Some("is-active") => self.is_active.as_str(),
+			Some("is-enabled") => self.is_enabled.as_str(),
+			_ => "",
+		};
+		// `is-enabled` is read through stdout only, so its status stays
+		// successful. `is-active`'s status *is* consulted (`unit_is_known`
+		// keys off exit 4), so it comes from its own field rather than the
+		// blanket `fail` flag.
+		let code = match args.first().copied() {
+			Some("is-active") => self.is_active_code,
+			Some("is-enabled") => 0,
+			_ => code,
+		};
+		Ok(out(code, stdout))
+	}
+
+	fn loginctl(&self, args: &[&str]) -> io::Result<Output> {
+		self.loginctl_calls
+			.borrow_mut()
+			.push(args.iter().map(|s| s.to_string()).collect());
+		Ok(out(0, &self.linger))
+	}
+}
+
+fn opts(dir: &Path, project: &str, dry_run: bool, no_start: bool) -> InstallOptions {
+	InstallOptions {
+		unit: ServiceUnitOpts {
+			exe: PathBuf::from("/usr/local/bin/podup"),
+			compose_files: vec![dir.join("docker-compose.yml")],
+			project: project.to_string(),
+			working_dir: dir.to_path_buf(),
+			profiles: Vec::new(),
+			env_files: Vec::new(),
+		},
+		no_start,
+		dry_run,
+	}
+}
+
+/// Run `f` with a fresh temp `XDG_CONFIG_HOME`, `USER`, and `XDG_RUNTIME_DIR`
+/// set, so the install/status paths resolve under the temp dir.
+fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
+	let tmp = tempfile::tempdir().unwrap();
+	let root = tmp.path().to_path_buf();
+	temp_env::with_vars(
+		[
+			("XDG_CONFIG_HOME", Some(root.as_os_str())),
+			("XDG_RUNTIME_DIR", Some(root.as_os_str())),
+			("USER", Some(std::ffi::OsStr::new("tester"))),
+		],
+		|| f(&root),
+	)
+}
+
+#[test]
+fn install_writes_unit_and_enables() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(&sc, &opts(root, "app", false, false)).unwrap();
+		let path = root.join("systemd/user/podup-app.service");
+		assert!(path.is_file(), "unit file written");
+		let body = std::fs::read_to_string(&path).unwrap();
+		assert!(body.contains("Description=podup app"));
+		let calls = sc.systemctl_log();
+		assert_eq!(calls[0], vec!["daemon-reload"]);
+		assert_eq!(calls[1], vec!["enable", "--now", "podup-app.service"]);
+	});
+}
+
+#[test]
+fn install_no_start_skips_enable() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(&sc, &opts(root, "app", false, true)).unwrap();
+		let calls = sc.systemctl_log();
+		assert_eq!(calls, vec![vec!["daemon-reload"]]);
+	});
+}
+
+#[test]
+fn dry_run_writes_nothing_and_runs_no_systemctl() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(&sc, &opts(root, "app", true, false)).unwrap();
+		assert!(!root.join("systemd/user/podup-app.service").exists());
+		assert!(sc.systemctl_log().is_empty());
+	});
+}
+
+#[test]
+fn uninstall_disables_removes_and_reloads() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(&sc, &opts(root, "app", false, true)).unwrap();
+		let path = root.join("systemd/user/podup-app.service");
+		assert!(path.exists());
+
+		let sc2 = FakeCtl::new();
+		uninstall(&sc2, "app").unwrap();
+		assert!(!path.exists(), "unit file removed");
+		let calls = sc2.systemctl_log();
+		// The `is-active` probe only asks whether systemd knows the unit at
+		// all; anything but exit 4 means disable it.
+		assert_eq!(calls[0], vec!["is-active", "--quiet", "podup-app.service"]);
+		assert_eq!(calls[1], vec!["disable", "--now", "podup-app.service"]);
+		assert_eq!(calls[2], vec!["daemon-reload"]);
+	});
+}
+
+/// #1080: a `disable --now` that fails on an installed unit was swallowed by
+/// `let _ =`, so uninstall exited 0 with the service still enabled and
+/// running. Measured against real systemd: with the unit file present,
+/// `disable --now` exits 0 whether or not the unit was ever enabled or
+/// started, so a non-zero exit here is always a real failure.
+#[test]
+fn uninstall_reports_a_failed_disable() {
+	with_env(|root| {
+		install(&FakeCtl::new(), &opts(root, "app", false, true)).unwrap();
+		let path = root.join("systemd/user/podup-app.service");
+		assert!(path.exists());
+
+		let mut sc = FakeCtl::new();
+		sc.fail = true;
+		let err = uninstall(&sc, "app")
+			.expect_err("a failed disable must not be reported as a clean uninstall");
+		assert!(matches!(err, ComposeError::Autostart(_)), "got {err:?}");
+		assert!(err.to_string().contains("disable"), "got {err}");
+	});
+}
+
+/// Uninstalling when systemd has never heard of the unit stays a silent
+/// no-op. `is-active` exit 4 ("no such unit") is the signal — not the unit
+/// file, which is a poor proxy: a fragment deleted out of band leaves the
+/// unit loaded, enabled and running, and only `disable --now` clears it.
+#[test]
+fn uninstall_runs_no_disable_when_systemd_does_not_know_the_unit() {
+	with_env(|_root| {
+		let mut sc = FakeCtl::new();
+		sc.is_active_code = 4 << 8; // systemd: no such unit
+		uninstall(&sc, "app").expect("uninstalling nothing is not a failure");
+		let calls = sc.systemctl_log();
+		assert!(
+			!calls
+				.iter()
+				.any(|c| c.first().map(String::as_str) == Some("disable")),
+			"nothing is installed, so nothing should be disabled: {calls:?}"
+		);
+		assert_eq!(calls.last().unwrap(), &vec!["daemon-reload".to_string()]);
+	});
+}
+
+/// The mirror case, and the reason the file is not the gate: the unit file is
+/// gone but systemd still has the unit loaded and running (a manual `rm`, a
+/// restored `~/.config`, a half-finished uninstall). `disable --now` is the
+/// only thing that clears that state, so it must still run.
+#[test]
+fn uninstall_disables_a_known_unit_whose_file_is_already_gone() {
+	with_env(|root| {
+		let path = root.join("systemd/user/podup-app.service");
+		assert!(!path.exists());
+		// Default `is_active_code` is 0 — systemd knows the unit.
+		let sc = FakeCtl::new();
+		uninstall(&sc, "app").expect("uninstall must still succeed");
+		let calls = sc.systemctl_log();
+		assert!(
+			calls.contains(&vec![
+				"disable".to_string(),
+				"--now".to_string(),
+				"podup-app.service".to_string()
+			]),
+			"a unit systemd still knows must be disabled even with no file: {calls:?}"
+		);
+	});
+}
+
+#[test]
+fn install_refuses_on_quadlet_conflict() {
+	with_env(|root| {
+		let qdir = root.join("containers/systemd");
+		std::fs::create_dir_all(&qdir).unwrap();
+		std::fs::write(qdir.join("app-web.container"), b"[Container]\n").unwrap();
+		let sc = FakeCtl::new();
+		let err = install(&sc, &opts(root, "app", false, false)).unwrap_err();
+		assert!(matches!(err, ComposeError::Autostart(_)));
+		assert!(err.to_string().contains("quadlet"));
+		// Nothing was installed.
+		assert!(!root.join("systemd/user/podup-app.service").exists());
+		assert!(sc.systemctl_log().is_empty());
+	});
+}
+
+#[test]
+fn linger_off_produces_warning() {
+	let mut sc = FakeCtl::new();
+	sc.linger = "no".to_string();
+	temp_env::with_var("USER", Some("tester"), || {
+		assert!(linger_warning(&sc).is_some());
+	});
+}
+
+#[test]
+fn linger_on_produces_no_warning() {
+	let sc = FakeCtl::new(); // linger = "yes"
+	temp_env::with_var("USER", Some("tester"), || {
+		assert!(linger_warning(&sc).is_none());
+	});
+}
+
+#[test]
+fn missing_runtime_dir_produces_warning() {
+	temp_env::with_var_unset("XDG_RUNTIME_DIR", || {
+		assert!(runtime_dir_warning().is_some());
+	});
+	temp_env::with_var("XDG_RUNTIME_DIR", Some("/run/user/1000"), || {
+		assert!(runtime_dir_warning().is_none());
+	});
+}
+
+#[test]
+fn collect_status_reports_installed_and_state() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(&sc, &opts(root, "app", false, true)).unwrap();
+		let r = collect_status(&sc, "app");
+		assert!(r.unit_exists);
+		assert!(r.unit_mode.is_some());
+		assert_eq!(r.is_active, "active");
+		assert_eq!(r.is_enabled, "enabled");
+		assert!(r.linger);
+		assert!(r.runtime_dir);
+	});
+}
+
+#[test]
+fn collect_status_reports_absent_unit() {
+	with_env(|_root| {
+		let sc = FakeCtl::new();
+		let r = collect_status(&sc, "nope");
+		assert!(!r.unit_exists);
+		assert!(r.unit_mode.is_none());
+	});
+}
+
+#[test]
+fn install_surfaces_systemctl_failure() {
+	with_env(|root| {
+		let mut sc = FakeCtl::new();
+		sc.fail = true;
+		let err = install(&sc, &opts(root, "app", false, false)).unwrap_err();
+		assert!(matches!(err, ComposeError::Autostart(_)));
+	});
+}

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -89,14 +89,20 @@ pub(crate) async fn dispatch(
 		AutostartCommands::Uninstall { purge } => {
 			// Remove whichever mode is installed — the two never coexist, and asking
 			// the user to name the mode only risks a no-op against the wrong one.
-			match podup::autostart::installed_mode(&project) {
+			// Hold the uninstall's outcome rather than `?`-ing it here. By the time
+			// it can fail, the unit files are already gone and `installed_mode`
+			// would no longer recognise the project — so short-circuiting would
+			// skip `--purge` exactly when the stack is still up and most needs
+			// tearing down, leaving its named volumes behind and the state
+			// unrecognisable. Purge first, report the failure after.
+			let uninstalled = match podup::autostart::installed_mode(&project) {
 				podup::autostart::InstalledMode::Quadlet => {
-					podup::autostart::uninstall_quadlet(&podup::autostart::RealSystemCtl, &project)?
+					podup::autostart::uninstall_quadlet(&podup::autostart::RealSystemCtl, &project)
 				}
 				// Service or nothing installed: the service uninstall is idempotent and
 				// prints "already removed" when there is nothing there.
-				_ => podup::autostart::uninstall(&podup::autostart::RealSystemCtl, &project)?,
-			}
+				_ => podup::autostart::uninstall(&podup::autostart::RealSystemCtl, &project),
+			};
 			if *purge {
 				// `--purge` is the only autostart branch that touches Podman: tear the
 				// stack down and remove its named volumes via the normal `down -v` path.
@@ -105,7 +111,7 @@ pub(crate) async fn dispatch(
 				let _lock = engine.lock_project()?;
 				engine.down_with_options(file, true).await?;
 			}
-			Ok(())
+			uninstalled
 		}
 		AutostartCommands::Status => {
 			podup::autostart::status(&podup::autostart::RealSystemCtl, &project)

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 #[cfg(feature = "completions")]
 use clap_complete::Shell;
 
-use super::parse::{parse_pull_policy, parse_scale_pair, parse_timeout};
+use super::parse::{parse_progress, parse_pull_policy, parse_scale_pair, parse_timeout};
 use super::types::{
 	AutostartCommands, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
 };
@@ -192,8 +192,9 @@ pub(crate) enum Commands {
 		#[arg(long = "build-arg")]
 		build_arg: Vec<String>,
 		/// Set the build progress output style (auto, plain, tty); accepted for
-		/// docker-compose compatibility.
-		#[arg(long)]
+		/// docker-compose compatibility. Validated but inert: podup renders build
+		/// output one way.
+		#[arg(long, value_parser = parse_progress)]
 		progress: Option<String>,
 		/// Push each built image to its registry after a successful build.
 		#[arg(long)]

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -287,7 +287,10 @@ pub(crate) enum Commands {
 		interactive: bool,
 		/// No effect; accepted only for docker-compose compatibility. podup never
 		/// allocates a pseudo-TTY.
-		#[arg(short = 'T', long = "no-TTY")]
+		// Both spellings are accepted on purpose: `docker compose run` spells the
+		// long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
+		// A script copied from either one has to work, so each command takes both.
+		#[arg(short = 'T', long = "no-TTY", visible_alias = "no-tty")]
 		no_tty: bool,
 		/// Do not start linked services (depends_on) before running.
 		#[arg(long)]
@@ -519,7 +522,10 @@ pub(crate) enum Commands {
 		detach: bool,
 		/// No effect; accepted only for docker-compose compatibility. podup never
 		/// allocates a pseudo-TTY.
-		#[arg(short = 'T', long = "no-TTY")]
+		// `docker compose exec` spells the long form `--no-tty`, so that is the
+		// primary here; `--no-TTY` stays accepted so the spelling `run` uses also
+		// works on `exec`. See the note on `run`'s field.
+		#[arg(short = 'T', long = "no-tty", visible_alias = "no-TTY")]
 		no_tty: bool,
 		/// Index of the container when the service has multiple replicas (1-based).
 		#[arg(long)]

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -48,6 +48,24 @@ pub(crate) fn parse_pull_policy(value: &str) -> Result<String, String> {
 	}
 }
 
+/// Progress styles `docker compose build --progress` accepts. podup renders build
+/// output one way, so the flag is inert — but an unknown value must still be
+/// rejected rather than accepted and ignored, or a typo silently changes nothing
+/// and reports success.
+const PROGRESS_STYLES: [&str; 3] = ["auto", "plain", "tty"];
+
+/// Validate a `build --progress` value at parse time.
+pub(crate) fn parse_progress(value: &str) -> Result<String, String> {
+	if PROGRESS_STYLES.contains(&value) {
+		Ok(value.to_string())
+	} else {
+		Err(format!(
+			"invalid progress style `{value}` (expected one of: {})",
+			PROGRESS_STYLES.join(", ")
+		))
+	}
+}
+
 /// Parse a `-t/--timeout` shutdown-grace value, rejecting negatives with a clear
 /// range error rather than forwarding `-5` to Podman or letting clap report a
 /// confusing "unexpected argument" for the space form.

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -68,20 +68,42 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		out
 	}
 
+	/// Append, do not replace. docker compose concatenates these sequences
+	/// across `-f` and `extends`; replacing silently dropped the base's entries,
+	/// so an override adding one nameserver removed every other one.
 	fn merge_sol(base: StringOrList, over: StringOrList) -> StringOrList {
 		if over.is_empty() {
-			base
-		} else {
-			over
+			return base;
 		}
+		if base.is_empty() {
+			return over;
+		}
+		let mut out = base.to_list();
+		for item in over.to_list() {
+			if !out.contains(&item) {
+				out.push(item);
+			}
+		}
+		StringOrList::List(out)
 	}
 
+	/// Append, do not replace: docker compose reads the base's env files *and*
+	/// the override's, in order. Replacing meant an override adding one file
+	/// silently stopped loading every other one.
 	fn merge_env_file(base: EnvFile, over: EnvFile) -> EnvFile {
 		if over.is_empty() {
-			base
-		} else {
-			over
+			return base;
 		}
+		if base.is_empty() {
+			return over;
+		}
+		let mut out = base.to_entries();
+		for entry in over.to_entries() {
+			if !out.iter().any(|e| e.path() == entry.path()) {
+				out.push(entry);
+			}
+		}
+		EnvFile::List(out)
 	}
 
 	// compose-go unions `depends_on` across `extends`: the base's dependencies and
@@ -136,11 +158,12 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		volumes_from: merge_vec(base.volumes_from, override_svc.volumes_from),
 		configs: merge_vec(base.configs, override_svc.configs),
 		secrets: merge_vec(base.secrets, override_svc.secrets),
-		networks: if matches!(override_svc.networks, ServiceNetworks::Empty) {
-			base.networks
-		} else {
-			override_svc.networks
-		},
+		// Union, not replace. A service on `backend` in the base and `monitoring`
+		// in the override silently lost `backend`, dropped off the network, and
+		// service discovery failed at run time — far from the config that caused
+		// it. docker compose unions them; the override's per-network config wins
+		// for a network both declare.
+		networks: merge_networks(base.networks, override_svc.networks),
 		hostname: override_svc.hostname.or(base.hostname),
 		domainname: override_svc.domainname.or(base.domainname),
 		mac_address: override_svc.mac_address.or(base.mac_address),
@@ -210,11 +233,8 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		oom_score_adj: override_svc.oom_score_adj.or(base.oom_score_adj),
 		blkio_config: override_svc.blkio_config.or(base.blkio_config),
 		logging: override_svc.logging.or(base.logging),
-		sysctls: if matches!(override_svc.sysctls, Sysctls::Empty) {
-			base.sysctls
-		} else {
-			override_svc.sysctls
-		},
+		// Merged per key, like `environment` and `labels` — not replaced.
+		sysctls: merge_sysctls(base.sysctls, override_svc.sysctls),
 		ulimits: {
 			let mut m = base.ulimits;
 			for (k, v) in override_svc.ulimits {
@@ -243,230 +263,69 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 	}
 }
 
-#[cfg(test)]
-mod tests {
-	use crate::parse_str;
-
-	#[test]
-	fn extends_unions_sequence_fields() {
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-    ports:
-      - "80:80"
-      - "81:81"
-  app:
-    extends: base
-    ports:
-      - "90:90"
-"#;
-		let file = parse_str(yaml).unwrap();
-		// Compose `extends` combines sequences (base first, then the extending
-		// service's items) rather than replacing the base wholesale.
-		assert_eq!(file.services["app"].ports.len(), 3);
+/// Union two `networks:` declarations, keeping the base's attachments and adding
+/// the override's. For a network both declare, the override's per-network config
+/// wins; a bare-list entry contributes no config, so it never erases one.
+///
+/// The short (list) and long (map) forms mix freely across `-f` and `extends`,
+/// so both collapse to the map form whenever either side carries config.
+fn merge_networks(base: ServiceNetworks, over: ServiceNetworks) -> ServiceNetworks {
+	if matches!(over, ServiceNetworks::Empty) {
+		return base;
 	}
-
-	#[test]
-	fn extends_dedups_identical_sequence_entries() {
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-    ports:
-      - "80:80"
-  app:
-    extends: base
-    ports:
-      - "80:80"
-      - "90:90"
-"#;
-		let file = parse_str(yaml).unwrap();
-		// An exact duplicate from the extending service is dropped.
-		assert_eq!(file.services["app"].ports.len(), 2);
+	if matches!(base, ServiceNetworks::Empty) {
+		return over;
 	}
-
-	#[test]
-	fn absent_list_field_falls_back_to_base() {
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-    ports:
-      - "80:80"
-  app:
-    extends: base
-"#;
-		let file = parse_str(yaml).unwrap();
-		assert_eq!(file.services["app"].ports.len(), 1);
+	// Preserve declaration order: the base's networks first, then any the
+	// override introduces.
+	let mut out: indexmap::IndexMap<String, Option<crate::compose::types::ServiceNetworkConfig>> =
+		indexmap::IndexMap::new();
+	for name in base.names() {
+		let cfg = base.config_for(&name).cloned();
+		out.insert(name, cfg);
 	}
-
-	#[test]
-	fn labels_are_merged_with_override_winning() {
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-    labels:
-      a: base
-      keep: base
-  app:
-    extends: base
-    labels:
-      a: over
-      b: over
-"#;
-		let file = parse_str(yaml).unwrap();
-		let labels = file.services["app"].labels.to_map();
-		assert_eq!(labels.get("a").map(|s| s.as_str()), Some("over"));
-		assert_eq!(labels.get("keep").map(|s| s.as_str()), Some("base"));
-		assert_eq!(labels.get("b").map(|s| s.as_str()), Some("over"));
+	for name in over.names() {
+		let cfg = over.config_for(&name).cloned();
+		match out.entry(name) {
+			indexmap::map::Entry::Occupied(mut e) => {
+				// A bare name in the override must not wipe config the base set.
+				if cfg.is_some() {
+					e.insert(cfg);
+				}
+			}
+			indexmap::map::Entry::Vacant(e) => {
+				e.insert(cfg);
+			}
+		}
 	}
-
-	#[test]
-	fn empty_override_keeps_base_depends_on() {
-		let yaml = r#"
-services:
-  db:
-    image: postgres
-  base:
-    image: alpine
-    depends_on:
-      - db
-  app:
-    extends: base
-"#;
-		let file = parse_str(yaml).unwrap();
-		assert_eq!(
-			file.services["app"].depends_on.service_names(),
-			vec!["db".to_string()]
-		);
+	// Stay in the short form when nothing carries per-network config. That is the
+	// form the user wrote and the one docker keeps — and a map of all-`None`
+	// values is pruned as empty by the `config` renderer's null-stripping, which
+	// would drop the networks from the rendered file entirely.
+	if out.values().all(Option::is_none) {
+		return ServiceNetworks::List(out.into_keys().collect());
 	}
-
-	#[test]
-	fn extends_unions_depends_on() {
-		let yaml = r#"
-services:
-  db:
-    image: postgres
-  cache:
-    image: redis
-  base:
-    image: alpine
-    depends_on:
-      - db
-  app:
-    extends: base
-    depends_on:
-      - cache
-"#;
-		let file = parse_str(yaml).unwrap();
-		// compose-go unions the base and extending depends_on rather than letting
-		// the override replace the base wholesale.
-		let mut names = file.services["app"].depends_on.service_names();
-		names.sort();
-		assert_eq!(names, vec!["cache".to_string(), "db".to_string()]);
-	}
-
-	#[test]
-	fn extends_depends_on_override_wins_on_conflict() {
-		let yaml = r#"
-services:
-  db:
-    image: postgres
-  base:
-    image: alpine
-    depends_on:
-      db:
-        condition: service_started
-  app:
-    extends: base
-    depends_on:
-      db:
-        condition: service_healthy
-"#;
-		let file = parse_str(yaml).unwrap();
-		// On an overlapping key the extending service's condition wins.
-		assert_eq!(
-			file.services["app"].depends_on.condition_for("db"),
-			crate::compose::types::ServiceCondition::ServiceHealthy
-		);
-	}
-
-	#[test]
-	fn absent_override_keeps_base_environment() {
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-    environment:
-      A: "1"
-  app:
-    extends: base
-"#;
-		let file = parse_str(yaml).unwrap();
-		let env = file.services["app"].environment.to_map();
-		assert_eq!(env.get("A").and_then(|v| v.clone()).as_deref(), Some("1"));
-	}
-
-	#[test]
-	fn scalar_or_list_field_override_replaces_base() {
-		// `dns` is a StringOrList: a non-empty override replaces the base wholesale
-		// (merge_sol), it is not unioned.
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-    dns:
-      - 1.1.1.1
-  app:
-    extends: base
-    dns:
-      - 9.9.9.9
-"#;
-		let file = parse_str(yaml).unwrap();
-		assert_eq!(file.services["app"].dns.to_list(), vec!["9.9.9.9"]);
-	}
-
-	#[test]
-	fn env_file_override_replaces_base() {
-		// env_file is replaced (not unioned) when the extending service sets it.
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-    env_file:
-      - base.env
-  app:
-    extends: base
-    env_file:
-      - app.env
-"#;
-		let file = parse_str(yaml).unwrap();
-		let entries = file.services["app"].env_file.to_entries();
-		assert_eq!(entries.len(), 1);
-		assert_eq!(entries[0].path(), "app.env");
-	}
-
-	#[test]
-	fn depends_on_unions_when_base_has_none() {
-		// The base declares no depends_on; the extending service's dependencies are
-		// carried through unchanged (merge_depends_on base-empty branch).
-		let yaml = r#"
-services:
-  base:
-    image: alpine
-  db:
-    image: postgres
-  app:
-    extends: base
-    depends_on:
-      - db
-"#;
-		let file = parse_str(yaml).unwrap();
-		assert!(file.services["app"]
-			.depends_on
-			.service_names()
-			.contains(&"db".to_string()));
-	}
+	ServiceNetworks::Map(out)
 }
+
+/// Merge `sysctls:` per key, the way `environment` and `labels` already merge —
+/// the override wins for a key both set, and the base keeps the rest.
+fn merge_sysctls(base: Sysctls, over: Sysctls) -> Sysctls {
+	if matches!(over, Sysctls::Empty) {
+		return base;
+	}
+	if matches!(base, Sysctls::Empty) {
+		return over;
+	}
+	let mut out: indexmap::IndexMap<String, serde_yaml::Value> = indexmap::IndexMap::new();
+	for (k, v) in base.to_map() {
+		out.insert(k, serde_yaml::Value::String(v));
+	}
+	for (k, v) in over.to_map() {
+		out.insert(k, serde_yaml::Value::String(v));
+	}
+	Sysctls::Map(out)
+}
+
+#[cfg(test)]
+mod tests;

--- a/internal/compose/extends/merge/tests.rs
+++ b/internal/compose/extends/merge/tests.rs
@@ -1,0 +1,354 @@
+//! Tests for the `extends` / multi-`-f` service merge.
+//!
+//! Split out of `merge.rs` to keep that file within the source line limit.
+
+use crate::parse_str;
+
+#[test]
+fn extends_unions_sequence_fields() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    ports:
+      - "80:80"
+      - "81:81"
+  app:
+    extends: base
+    ports:
+      - "90:90"
+"#;
+	let file = parse_str(yaml).unwrap();
+	// Compose `extends` combines sequences (base first, then the extending
+	// service's items) rather than replacing the base wholesale.
+	assert_eq!(file.services["app"].ports.len(), 3);
+}
+
+#[test]
+fn extends_dedups_identical_sequence_entries() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    ports:
+      - "80:80"
+  app:
+    extends: base
+    ports:
+      - "80:80"
+      - "90:90"
+"#;
+	let file = parse_str(yaml).unwrap();
+	// An exact duplicate from the extending service is dropped.
+	assert_eq!(file.services["app"].ports.len(), 2);
+}
+
+#[test]
+fn absent_list_field_falls_back_to_base() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    ports:
+      - "80:80"
+  app:
+    extends: base
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(file.services["app"].ports.len(), 1);
+}
+
+#[test]
+fn labels_are_merged_with_override_winning() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    labels:
+      a: base
+      keep: base
+  app:
+    extends: base
+    labels:
+      a: over
+      b: over
+"#;
+	let file = parse_str(yaml).unwrap();
+	let labels = file.services["app"].labels.to_map();
+	assert_eq!(labels.get("a").map(|s| s.as_str()), Some("over"));
+	assert_eq!(labels.get("keep").map(|s| s.as_str()), Some("base"));
+	assert_eq!(labels.get("b").map(|s| s.as_str()), Some("over"));
+}
+
+#[test]
+fn empty_override_keeps_base_depends_on() {
+	let yaml = r#"
+services:
+  db:
+    image: postgres
+  base:
+    image: alpine
+    depends_on:
+      - db
+  app:
+    extends: base
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.services["app"].depends_on.service_names(),
+		vec!["db".to_string()]
+	);
+}
+
+#[test]
+fn extends_unions_depends_on() {
+	let yaml = r#"
+services:
+  db:
+    image: postgres
+  cache:
+    image: redis
+  base:
+    image: alpine
+    depends_on:
+      - db
+  app:
+    extends: base
+    depends_on:
+      - cache
+"#;
+	let file = parse_str(yaml).unwrap();
+	// compose-go unions the base and extending depends_on rather than letting
+	// the override replace the base wholesale.
+	let mut names = file.services["app"].depends_on.service_names();
+	names.sort();
+	assert_eq!(names, vec!["cache".to_string(), "db".to_string()]);
+}
+
+#[test]
+fn extends_depends_on_override_wins_on_conflict() {
+	let yaml = r#"
+services:
+  db:
+    image: postgres
+  base:
+    image: alpine
+    depends_on:
+      db:
+        condition: service_started
+  app:
+    extends: base
+    depends_on:
+      db:
+        condition: service_healthy
+"#;
+	let file = parse_str(yaml).unwrap();
+	// On an overlapping key the extending service's condition wins.
+	assert_eq!(
+		file.services["app"].depends_on.condition_for("db"),
+		crate::compose::types::ServiceCondition::ServiceHealthy
+	);
+}
+
+#[test]
+fn absent_override_keeps_base_environment() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    environment:
+      A: "1"
+  app:
+    extends: base
+"#;
+	let file = parse_str(yaml).unwrap();
+	let env = file.services["app"].environment.to_map();
+	assert_eq!(env.get("A").and_then(|v| v.clone()).as_deref(), Some("1"));
+}
+
+/// #1078: `dns` and its siblings are appended, not replaced. docker compose
+/// concatenates these sequences; replacing meant an override adding one
+/// nameserver silently removed every other one.
+#[test]
+fn scalar_or_list_field_override_appends_to_base() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    dns:
+      - 1.1.1.1
+  app:
+    extends: base
+    dns:
+      - 9.9.9.9
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert_eq!(
+		file.services["app"].dns.to_list(),
+		vec!["1.1.1.1", "9.9.9.9"],
+		"the base's nameserver must survive an override that adds one"
+	);
+}
+
+/// #1078: `env_file` is appended too — the base's files are still read, in
+/// order, followed by the override's.
+#[test]
+fn env_file_override_appends_to_base() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    env_file:
+      - base.env
+  app:
+    extends: base
+    env_file:
+      - app.env
+"#;
+	let file = parse_str(yaml).unwrap();
+	let entries = file.services["app"].env_file.to_entries();
+	assert_eq!(entries.len(), 2, "both env files must be read");
+	assert_eq!(entries[0].path(), "base.env");
+	assert_eq!(entries[1].path(), "app.env");
+}
+
+#[test]
+fn depends_on_unions_when_base_has_none() {
+	// The base declares no depends_on; the extending service's dependencies are
+	// carried through unchanged (merge_depends_on base-empty branch).
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+  db:
+    image: postgres
+  app:
+    extends: base
+    depends_on:
+      - db
+"#;
+	let file = parse_str(yaml).unwrap();
+	assert!(file.services["app"]
+		.depends_on
+		.service_names()
+		.contains(&"db".to_string()));
+}
+
+/// #1078, the one the issue calls worse than a wrong value: a service on
+/// `backend` in the base and `monitoring` in the override silently lost
+/// `backend`. It dropped off the network and service discovery failed at run
+/// time, far from the config that caused it.
+#[test]
+fn networks_are_unioned_not_replaced() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    networks:
+      - backend
+  app:
+    extends: base
+    networks:
+      - monitoring
+networks:
+  backend:
+  monitoring:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let names = file.services["app"].networks.names();
+	assert!(
+		names.contains(&"backend".to_string()),
+		"the base's network must survive: {names:?}"
+	);
+	assert!(
+		names.contains(&"monitoring".to_string()),
+		"the override's network must be added: {names:?}"
+	);
+}
+
+/// A bare name in the override must not erase per-network config the base
+/// set — the union keeps the config unless the override supplies its own.
+#[test]
+fn network_union_keeps_base_config_for_a_bare_override_entry() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    networks:
+      backend:
+        aliases:
+          - db
+  app:
+    extends: base
+    networks:
+      - backend
+networks:
+  backend:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let cfg = file.services["app"].networks.config_for("backend");
+	assert!(
+		cfg.is_some_and(|c| c
+			.aliases
+			.as_ref()
+			.is_some_and(|a| a.contains(&"db".to_string()))),
+		"a bare override entry must not wipe the base's aliases"
+	);
+}
+
+/// #1078: `sysctls` merges per key like `environment` and `labels`, rather
+/// than the override replacing the whole map.
+#[test]
+fn sysctls_merge_per_key() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    sysctls:
+      net.core.somaxconn: "1024"
+      net.ipv4.tcp_syncookies: "1"
+  app:
+    extends: base
+    sysctls:
+      net.core.somaxconn: "4096"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let m = file.services["app"].sysctls.to_map();
+	assert_eq!(
+		m.get("net.core.somaxconn").map(String::as_str),
+		Some("4096"),
+		"the override wins for a key both set"
+	);
+	assert_eq!(
+		m.get("net.ipv4.tcp_syncookies").map(String::as_str),
+		Some("1"),
+		"a key only the base sets must survive"
+	);
+}
+
+/// The union must survive serialization: `config` renders the merged service
+/// back to YAML, and a map whose values are all `None` must still emit its
+/// network names rather than an empty block.
+#[test]
+fn unioned_networks_serialize_back_to_their_names() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    networks:
+      - backend
+  app:
+    extends: base
+    networks:
+      - monitoring
+networks:
+  backend:
+  monitoring:
+"#;
+	let file = parse_str(yaml).unwrap();
+	let rendered = serde_yaml::to_string(&file.services["app"].networks).unwrap();
+	assert!(
+		rendered.contains("backend") && rendered.contains("monitoring"),
+		"serialized form lost the network names: {rendered}"
+	);
+}

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -33,8 +33,12 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 
 /// Like [`parse_file`], additionally loading `env_files` (the global
 /// `--env-file` flag) into the variable map used for interpolation. These take
-/// effect for the top-level file and any included files; the process
-/// environment and a project `.env` still take precedence.
+/// effect for the top-level file and any included files.
+///
+/// They **replace** a project `.env` rather than adding to it: when `env_files`
+/// is non-empty, `.env` is not read. That is docker-correct — and the opposite
+/// of what this comment used to claim, which also reached docs.rs readers. The
+/// process environment still takes precedence over both.
 pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<ComposeFile> {
 	parse_file_with_env_files_interp(path, env_files, true)
 }

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -1,8 +1,11 @@
-//! Build context tar assembly and `.dockerignore` matching.
+//! Build context tar assembly and ignore-file matching (`.containerignore` / `.dockerignore`).
 //!
-//! Walks the build context directory, applies `.dockerignore` semantics
-//! (last-match-wins with `!` re-includes, `*`/`?`/`**` globs), and packs the
-//! result into a gzipped tar suitable for the libpod build endpoint.
+//! Walks the build context directory, applies ignore semantics (last-match-wins
+//! with `!` re-includes, `*`/`?`/`**` globs), and packs the result into a
+//! gzipped tar suitable for the libpod build endpoint.
+//!
+//! Podman reads `.containerignore` or `.dockerignore` and prefers its own when
+//! both exist; exactly one applies, never the union. See [`ignore_file`].
 
 use std::path::Path;
 
@@ -95,27 +98,32 @@ pub(super) fn stream_build_context<W: std::io::Write>(
 	dockerfile: &str,
 	extra_files: &[(String, Vec<u8>)],
 ) -> Result<()> {
-	let ignore_patterns = read_dockerignore(context);
+	let (ignore_name, ignore_patterns) = ignore_file(context);
 	let encoder = GzEncoder::new(writer, Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
-	// Force-include the active Dockerfile so a `.dockerignore` that matches it
+	// Force-include the active Dockerfile so an ignore file that matches it
 	// cannot drop it from the context the builder receives (Docker parity).
 	if extra_files.is_empty() {
 		append_context(&mut tar, context, &ignore_patterns, &[], &[dockerfile])?;
 	} else {
-		// Skip the user's `.dockerignore`; it is rewritten with an exclusion per
+		// Skip the user's ignore file; it is rewritten with an exclusion per
 		// synthesized entry so a `COPY .` in the build cannot bake secret bytes
-		// into image layers.
+		// into image layers. It must be skipped and re-emitted under the same
+		// name the server will read, or the exclusions never apply.
 		append_context(
 			&mut tar,
 			context,
 			&ignore_patterns,
-			&[".dockerignore"],
+			&[ignore_name],
 			&[dockerfile],
 		)?;
 		let synthesized: Vec<&str> = extra_files.iter().map(|(n, _)| n.as_str()).collect();
-		append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
+		append_ignore_file(
+			&mut tar,
+			ignore_name,
+			&synthesized_ignore_file(context, ignore_name, &synthesized),
+		)?;
 	}
 	append_extra_files(&mut tar, extra_files)?;
 	finish_tar(tar)
@@ -129,7 +137,7 @@ pub(super) fn stream_build_context_with_inline<W: std::io::Write>(
 	inline: &str,
 	extra_files: &[(String, Vec<u8>)],
 ) -> Result<()> {
-	let ignore_patterns = read_dockerignore(context);
+	let (ignore_name, ignore_patterns) = ignore_file(context);
 	let encoder = GzEncoder::new(writer, Compression::default());
 	let mut tar = tar::Builder::new(encoder);
 
@@ -140,13 +148,18 @@ pub(super) fn stream_build_context_with_inline<W: std::io::Write>(
 	tar.append_data(&mut header, INLINE_DOCKERFILE_NAME, inline.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))?;
 
-	// Skip the user's `.dockerignore` here; it is rewritten below with extra
-	// rules excluding every synthesized entry (inline Dockerfile, build secrets).
-	append_context(&mut tar, context, &ignore_patterns, &[".dockerignore"], &[])?;
+	// Skip the user's ignore file here; it is rewritten below with extra rules
+	// excluding every synthesized entry (inline Dockerfile, build secrets), under
+	// the same name the server will read.
+	append_context(&mut tar, context, &ignore_patterns, &[ignore_name], &[])?;
 
 	let mut synthesized: Vec<&str> = vec![INLINE_DOCKERFILE_NAME];
 	synthesized.extend(extra_files.iter().map(|(n, _)| n.as_str()));
-	append_dockerignore(&mut tar, &synthesized_dockerignore(context, &synthesized))?;
+	append_ignore_file(
+		&mut tar,
+		ignore_name,
+		&synthesized_ignore_file(context, ignore_name, &synthesized),
+	)?;
 
 	append_extra_files(&mut tar, extra_files)?;
 	finish_tar(tar)
@@ -196,24 +209,30 @@ pub(crate) fn build_context_tar(
 }
 
 /// Append a synthesized `.dockerignore` entry to the context tar.
-fn append_dockerignore<W: std::io::Write>(tar: &mut tar::Builder<W>, content: &str) -> Result<()> {
+fn append_ignore_file<W: std::io::Write>(
+	tar: &mut tar::Builder<W>,
+	name: &str,
+	content: &str,
+) -> Result<()> {
 	let mut header = tar::Header::new_gnu();
 	header.set_size(content.len() as u64);
 	header.set_mode(0o644);
 	header.set_cksum();
-	tar.append_data(&mut header, ".dockerignore", content.as_bytes())
+	tar.append_data(&mut header, name, content.as_bytes())
 		.map_err(|e| ComposeError::Build(e.to_string()))
 }
 
-/// Build the `.dockerignore` content for a context tar carrying synthesized
-/// entries: any user rules plus a final exclusion per synthesized name, so a
-/// `COPY .` in the build does not capture the inline Dockerfile or a build
-/// secret. The libpod `secrets=id=…,src=…` mount reads straight from the
-/// extracted context, which `.dockerignore` does not filter, so excluded
-/// secret entries remain mountable.
-fn synthesized_dockerignore(context: &Path, names: &[&str]) -> String {
-	let existing =
-		crate::filesystem::read_to_string_capped(context.join(".dockerignore")).unwrap_or_default();
+/// Build the ignore-file content for a context tar carrying synthesized entries:
+/// any user rules plus a final exclusion per synthesized name, so a `COPY .` in
+/// the build does not capture the inline Dockerfile or a build secret. The
+/// libpod `secrets=id=…,src=…` mount reads straight from the extracted context,
+/// which the ignore file does not filter, so excluded secret entries remain
+/// mountable.
+///
+/// `name` is the ignore file the server will read (see [`ignore_file`]); the
+/// user rules are carried over from that same file, never from the other one.
+fn synthesized_ignore_file(context: &Path, name: &str, names: &[&str]) -> String {
+	let existing = crate::filesystem::read_to_string_capped(context.join(name)).unwrap_or_default();
 	let mut out = existing.trim_end_matches(['\n', '\r']).to_string();
 	for name in names {
 		if !out.is_empty() {
@@ -240,16 +259,34 @@ pub(super) fn map_additional_context(base_dir: &Path, value: &str) -> String {
 	}
 }
 
-fn read_dockerignore(context: &Path) -> Vec<String> {
-	let path = context.join(".dockerignore");
-	let Ok(content) = crate::filesystem::read_to_string_capped(path) else {
-		return Vec::new();
-	};
-	content
-		.lines()
-		.map(|l| l.trim().to_string())
-		.filter(|l| !l.is_empty() && !l.starts_with('#'))
-		.collect()
+/// The ignore file podman would read for `context`, and its patterns.
+///
+/// podman-build(1): "If the file `.containerignore` or `.dockerignore` exists in
+/// the context directory, podman build reads its contents. […] if both are in
+/// the context directory, podman build only uses `.containerignore`."
+///
+/// So exactly one file applies — never the union. Applying both client-side
+/// produced an image missing content that `podman build` puts in, because we
+/// filtered by `.dockerignore` (a file podman would have ignored entirely) and
+/// the server then filtered by `.containerignore`.
+///
+/// The returned name is also the name any synthesized ignore file must be
+/// written under, or the server would read the *other* one and our exclusions
+/// would not apply. When neither file exists, `.containerignore` is the name to
+/// synthesize: podman prefers it, so it cannot be shadowed.
+fn ignore_file(context: &Path) -> (&'static str, Vec<String>) {
+	for name in [".containerignore", ".dockerignore"] {
+		let Ok(content) = crate::filesystem::read_to_string_capped(context.join(name)) else {
+			continue;
+		};
+		let patterns = content
+			.lines()
+			.map(|l| l.trim().to_string())
+			.filter(|l| !l.is_empty() && !l.starts_with('#'))
+			.collect();
+		return (name, patterns);
+	}
+	(".containerignore", Vec::new())
 }
 
 /// Decide whether `path` is excluded from the build context.

--- a/internal/engine/build/context/tests.rs
+++ b/internal/engine/build/context/tests.rs
@@ -3,8 +3,8 @@
 //! line limit).
 
 use super::{
-	build_context_tar, build_context_tar_with_inline, glob_match, is_ignored,
-	map_additional_context, read_dockerignore,
+	build_context_tar, build_context_tar_with_inline, glob_match, ignore_file, is_ignored,
+	map_additional_context,
 };
 use std::fs;
 use std::path::Path;
@@ -110,7 +110,10 @@ fn inline_tar_excludes_build_secrets_via_dockerignore() {
 	let mut di = String::new();
 	for entry in archive.entries().unwrap() {
 		let mut entry = entry.unwrap();
-		if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+		// No user ignore file in this context, so the synthesized one is
+		// written as `.containerignore` — the name podman prefers, so a
+		// stray `.dockerignore` cannot shadow our exclusions.
+		if entry.path().unwrap().to_string_lossy() == ".containerignore" {
 			entry.read_to_string(&mut di).unwrap();
 		}
 	}
@@ -242,7 +245,7 @@ fn dockerignore_negation_order_matters() {
 	assert!(is_ignored("logs/keep/secret.txt", &patterns));
 }
 
-// read_dockerignore ----------------------------------------------------
+// ignore_file ----------------------------------------------------------
 
 #[test]
 fn dockerignore_parsed_correctly() {
@@ -252,14 +255,45 @@ fn dockerignore_parsed_correctly() {
 		b"# comment\n\ntarget/\n*.log\n",
 	)
 	.unwrap();
-	let patterns = read_dockerignore(dir.path());
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".dockerignore");
 	assert_eq!(patterns, vec!["target/", "*.log"]);
 }
 
 #[test]
-fn dockerignore_missing_returns_empty() {
+fn containerignore_is_read_when_it_is_the_only_one() {
 	let dir = tempdir().unwrap();
-	let patterns = read_dockerignore(dir.path());
+	fs::write(dir.path().join(".containerignore"), b"secrets/\n*.key\n").unwrap();
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".containerignore");
+	assert_eq!(patterns, vec!["secrets/", "*.key"]);
+}
+
+/// podman-build(1): "if both are in the context directory, podman build only
+/// uses `.containerignore`". Applying both client-side is what produced an image
+/// missing content that `podman build` includes.
+#[test]
+fn containerignore_wins_and_dockerignore_is_not_merged() {
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join(".containerignore"), b"a.txt\n").unwrap();
+	fs::write(dir.path().join(".dockerignore"), b"b.txt\n").unwrap();
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".containerignore");
+	assert_eq!(
+		patterns,
+		vec!["a.txt"],
+		"the two files must never be unioned"
+	);
+}
+
+/// With neither present the name still matters: it is what a synthesized ignore
+/// file is written under, and podman prefers `.containerignore`, so choosing it
+/// means our exclusions cannot be shadowed by a `.dockerignore`.
+#[test]
+fn no_ignore_file_defaults_to_containerignore_with_no_patterns() {
+	let dir = tempdir().unwrap();
+	let (name, patterns) = ignore_file(dir.path());
+	assert_eq!(name, ".containerignore");
 	assert!(patterns.is_empty());
 }
 
@@ -342,7 +376,10 @@ fn inline_dockerfile_excluded_via_dockerignore() {
 	let mut di = String::new();
 	for entry in archive.entries().unwrap() {
 		let mut entry = entry.unwrap();
-		if entry.path().unwrap().to_string_lossy() == ".dockerignore" {
+		// No user ignore file in this context, so the synthesized one is
+		// written as `.containerignore` — the name podman prefers, so a
+		// stray `.dockerignore` cannot shadow our exclusions.
+		if entry.path().unwrap().to_string_lossy() == ".containerignore" {
 			entry.read_to_string(&mut di).unwrap();
 		}
 	}
@@ -460,4 +497,72 @@ fn glob_match_question_mark_matches_single_non_slash_char() {
 	assert!(glob_match("file?.txt", "file1.txt"));
 	assert!(!glob_match("file?.txt", "file.txt"));
 	assert!(!glob_match("a?b", "a/b"));
+}
+
+/// #1096: with both ignore files present, only `.containerignore` may filter the
+/// context tar. Applying both client-side is what made podup ship an image
+/// missing content that `podman build` includes: we dropped `b.txt` per
+/// `.dockerignore` — a file podman ignores entirely here — and the server then
+/// dropped `a.txt` per `.containerignore`, so the union of both applied.
+#[test]
+fn context_tar_filters_by_containerignore_only_when_both_exist() {
+	use flate2::read::GzDecoder;
+	use std::io::Read;
+
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	fs::write(dir.path().join("a.txt"), b"A").unwrap();
+	fs::write(dir.path().join("b.txt"), b"B").unwrap();
+	fs::write(dir.path().join(".containerignore"), b"a.txt\n").unwrap();
+	fs::write(dir.path().join(".dockerignore"), b"b.txt\n").unwrap();
+
+	let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+	let mut raw = Vec::new();
+	GzDecoder::new(bytes.as_slice())
+		.read_to_end(&mut raw)
+		.unwrap();
+	let mut archive = tar::Archive::new(raw.as_slice());
+	let names: Vec<String> = archive
+		.entries()
+		.unwrap()
+		.map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+		.collect();
+
+	assert!(
+		!names.iter().any(|n| n == "a.txt"),
+		"`.containerignore` must exclude a.txt: {names:?}"
+	);
+	assert!(
+		names.iter().any(|n| n == "b.txt"),
+		"`.dockerignore` must NOT apply when `.containerignore` exists: {names:?}"
+	);
+}
+
+/// The mirror: with only `.dockerignore` present it is the one that applies, so
+/// existing projects that never had a `.containerignore` are unaffected.
+#[test]
+fn context_tar_falls_back_to_dockerignore_when_alone() {
+	use flate2::read::GzDecoder;
+	use std::io::Read;
+
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	fs::write(dir.path().join("b.txt"), b"B").unwrap();
+	fs::write(dir.path().join(".dockerignore"), b"b.txt\n").unwrap();
+
+	let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+	let mut raw = Vec::new();
+	GzDecoder::new(bytes.as_slice())
+		.read_to_end(&mut raw)
+		.unwrap();
+	let mut archive = tar::Archive::new(raw.as_slice());
+	let names: Vec<String> = archive
+		.entries()
+		.unwrap()
+		.map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+		.collect();
+	assert!(
+		!names.iter().any(|n| n == "b.txt"),
+		"`.dockerignore` must still apply when it is the only one: {names:?}"
+	);
 }

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -162,7 +162,13 @@ impl Engine {
 		for (name, _service, key) in candidates {
 			let image = key.0;
 			let (present, pull_err) = outcomes.get(&key).cloned().unwrap_or((false, None));
-			if present {
+			// Presence alone is not success. A stale copy of the image already in
+			// local storage makes the probe pass while the pull actually failed,
+			// so `pull` against an unreachable registry exited 0 and reported
+			// nothing — the same way `up --pull always` did (#1076). The pull
+			// having reported an error is decisive; the probe only covers the
+			// case where it reported nothing and the image still is not there.
+			if present && pull_err.is_none() {
 				continue;
 			}
 			if opts.ignore_failures {
@@ -242,6 +248,15 @@ impl Engine {
 			.map_err(ComposeError::Podman)?;
 		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
 
+		// libpod reports a failed pull as an in-band `error` line on a 200
+		// response, not as an HTTP status, so the first one has to be kept and
+		// returned. It used to be warned about and dropped, which made every
+		// caller believe the pull had succeeded.
+		//
+		// A transport error mid-stream stays a warning: the same
+		// finished-stream-looks-like-an-error ambiguity that #1104 is about, and
+		// unlike the in-band line it is not libpod telling us the pull failed.
+		let mut pull_err: Option<String> = None;
 		while let Some(result) = stream.next().await {
 			match result {
 				Ok(progress) => {
@@ -250,13 +265,17 @@ impl Engine {
 					}
 					if !progress.error.is_empty() {
 						warn!("pull error: {}", progress.error);
+						pull_err.get_or_insert_with(|| progress.error.clone());
 					}
 				}
 				Err(e) => warn!("pull warning: {e}"),
 			}
 		}
 
-		Ok(())
+		match pull_err {
+			Some(e) => Err(ComposeError::Build(format!("pull {image} failed: {e}"))),
+			None => Ok(()),
+		}
 	}
 
 	/// Whether an image reference is present in local storage. Used by the
@@ -527,4 +546,72 @@ mod tests {
 	// blocking rendezvous — exactly the flakiness the testing standard rules
 	// out. The dedup tests above already pin the dispatch contract (every
 	// unique image is attempted, exactly once).
+
+	/// #1076: libpod reports a failed pull as an in-band `error` line on a 200
+	/// response. That line used to be warned about and dropped, so every caller
+	/// believed the pull had succeeded.
+	///
+	/// The image is present here — a stale copy from an earlier pull — which is
+	/// exactly the case a presence probe cannot catch: it passes while the pull
+	/// failed. `up --pull always` against an unreachable registry therefore
+	/// started yesterday's image and exited 0.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_failed_pull_is_reported_even_when_a_stale_image_is_present() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				// 200 with an in-band error, the way libpod reports it.
+				(
+					200,
+					r#"{"error":"initializing source: pinging container registry: connection refused"}"#
+						.to_string(),
+				)
+			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+				// The stale image is in local storage.
+				(200, "{}".to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = crate::engine::Engine::new(fake.client(), "proj".into());
+		let file = crate::parse_str("services:\n  a:\n    image: stale:v1\n").unwrap();
+
+		let err = e
+			.pull_services(&file, &[])
+			.await
+			.expect_err("a pull that libpod reported as failed must not be reported as success");
+		assert!(
+			format!("{err}").contains("connection refused"),
+			"the underlying cause must survive: {err}"
+		);
+	}
+
+	/// The escape hatch still works: `--ignore-pull-failures` is deliberately
+	/// exit-0, and that must not change just because the failure is now visible.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn ignore_pull_failures_still_exits_zero_on_an_in_band_error() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, r#"{"error":"connection refused"}"#.to_string())
+			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+				(200, "{}".to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = crate::engine::Engine::new(fake.client(), "proj".into());
+		let file = crate::parse_str("services:\n  a:\n    image: stale:v1\n").unwrap();
+
+		e.pull_services_with_options(
+			&file,
+			&[],
+			crate::engine::PullOptions {
+				ignore_failures: true,
+				..Default::default()
+			},
+		)
+		.await
+		.expect("--ignore-pull-failures must stay exit 0");
+	}
 }

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -33,7 +33,7 @@ impl Engine {
 	/// [`Engine::stream_events`] with `docker compose events`-style `--since`,
 	/// `--until`, and `--filter` options.
 	pub async fn stream_events_with_options(&self, json: bool, opts: &EventsOptions) -> Result<()> {
-		let filters = build_event_filters(&self.project, &opts.filters);
+		let filters = build_event_filters(&self.project, &opts.filters)?;
 		let mut path = format!(
 			"{API_PREFIX}/events?stream=true&filters={}",
 			urlencoded(&filters.to_string()),
@@ -69,9 +69,13 @@ impl Engine {
 
 /// Build the libpod events `filters` object: always scope to this project's
 /// `podup.project` label, then merge each user `KEY=VALUE` predicate (appending
-/// to that key's value array). A predicate with no `=` is skipped. Pure so the
-/// merge is unit-tested.
-fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
+/// to that key's value array). Pure so the merge is unit-tested.
+///
+/// A predicate with no `=` is an error rather than a skip. Dropping it scoped
+/// the stream to the whole project instead — `events --filter garbage` printed
+/// everything, which a caller reads as "these all matched". docker compose
+/// errors on a malformed filter too.
+fn build_event_filters(project: &str, user_filters: &[String]) -> Result<Value> {
 	use serde_json::{Map, Value};
 	let mut map: Map<String, Value> = Map::new();
 	map.insert(
@@ -80,8 +84,9 @@ fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
 	);
 	for f in user_filters {
 		let Some((key, value)) = f.split_once('=') else {
-			tracing::warn!("events: ignoring malformed filter '{f}' (expected KEY=VALUE)");
-			continue;
+			return Err(ComposeError::Unsupported(format!(
+				"malformed events filter {f:?}: expected KEY=VALUE (e.g. event=start)"
+			)));
 		};
 		match map
 			.entry(key.to_string())
@@ -91,7 +96,7 @@ fn build_event_filters(project: &str, user_filters: &[String]) -> Value {
 			other => *other = Value::Array(vec![Value::String(value.to_string())]),
 		}
 	}
-	Value::Object(map)
+	Ok(Value::Object(map))
 }
 
 /// Render one event. `json` emits the raw object as a compact line; otherwise a
@@ -123,7 +128,7 @@ mod tests {
 
 	#[test]
 	fn build_event_filters_scopes_to_project_label() {
-		let f = build_event_filters("demo", &[]);
+		let f = build_event_filters("demo", &[]).unwrap();
 		assert_eq!(f, json!({ "label": ["podup.project=demo"] }));
 	}
 
@@ -135,9 +140,9 @@ mod tests {
 				"event=start".to_string(),
 				"event=die".to_string(),
 				"type=container".to_string(),
-				"bogus".to_string(),
 			],
-		);
+		)
+		.unwrap();
 		assert_eq!(
 			f,
 			json!({
@@ -146,6 +151,16 @@ mod tests {
 				"type": ["container"],
 			})
 		);
+	}
+
+	/// #1081: a predicate with no `=` used to be dropped, so `events --filter
+	/// garbage` silently scoped to the whole project and printed everything — a
+	/// caller reads that back as "these all matched".
+	#[test]
+	fn malformed_filter_is_rejected_not_dropped() {
+		let err = build_event_filters("demo", &["bogus".to_string()])
+			.expect_err("a filter with no `=` must not be silently ignored");
+		assert!(format!("{err}").contains("bogus"), "got {err}");
 	}
 
 	#[test]

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -50,10 +50,17 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut stream = crate::libpod::parse_json_lines::<Value>(resp.into_body());
+		// Warned, never fatal. The parser only yields `Err` on a transport
+		// failure or an unparseable frame — but "transport failure" turns out to
+		// include how libpod ends a finished stream on some versions:
+		// `engine_events_stream_connects` went red on the live lane's Podman
+		// 5.8.1 when this was treated as a command failure, while the same suite
+		// is green on 5.4.2. Until podup can tell that apart from a socket that
+		// genuinely died, reporting it would fail commands that worked.
 		while let Some(event) = stream.next().await {
 			match event {
 				Ok(value) => println!("{}", format_event(&value, json)),
-				Err(e) => tracing::warn!("events: {e}"),
+				Err(e) => tracing::warn!("events: stream ended early: {e}"),
 			}
 		}
 		Ok(())

--- a/internal/engine/lifecycle/images.rs
+++ b/internal/engine/lifecycle/images.rs
@@ -1,0 +1,79 @@
+//! Deciding which image a service runs, and getting it there.
+//!
+//! Split out of `mod.rs` to keep that file within the source line limit.
+
+use crate::compose::types::{ComposeFile, Service};
+use crate::error::Result;
+
+use super::Engine;
+
+impl Engine {
+	/// The image tag a service resolves to: its explicit `image:` when set,
+	/// otherwise the tag its build produces (`build.tags[0]`, else the
+	/// project-scoped `{project}-{service}:latest`).
+	///
+	/// This is the name `up` checks for presence and the name `down --rmi local`
+	/// removes, so both must agree on it — they used to compute it separately.
+	pub(super) fn service_image_tag(&self, name: &str, service: &Service) -> String {
+		match &service.image {
+			Some(image) => image.clone(),
+			None => crate::engine::build::primary_build_tag(
+				&self.project,
+				name,
+				None,
+				service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
+			),
+		}
+	}
+
+	/// Make the service's image available before its containers are created:
+	/// build it, pull it, or leave the local one alone.
+	pub(super) async fn acquire_service_image(
+		&self,
+		name: &str,
+		service: &Service,
+		file: &ComposeFile,
+	) -> Result<()> {
+		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
+		// suppresses building even for services with a `build:` section (they fall
+		// back to pulling/using an existing image).
+		let policy = self
+			.pull_policy_override
+			.as_deref()
+			.or(service.pull_policy.as_deref())
+			.unwrap_or("missing");
+		// Build on `up` only when the service's image is not already there, which
+		// is what docker compose does: `up` converges on the declared state and
+		// `--build` is the flag that forces a rebuild.
+		//
+		// Building unconditionally was worse than redundant. The rebuild runs
+		// *with* the cache, so it can resolve to an older layer chain and retag
+		// the image backwards — silently undoing a `podup build --no-cache` that
+		// just ran. `build --no-cache && up -d`, the ordinary deploy shape, would
+		// start the previous image. It also made `--build` look like a no-op,
+		// since the default already always built.
+		//
+		// `--build` is handled before this by an explicit `build_all`, so a forced
+		// rebuild has already happened and the image is present by the time we get
+		// here.
+		let needs_build = if service.build.is_some() && !self.no_build {
+			!self
+				.image_present(&self.service_image_tag(name, service))
+				.await
+		} else {
+			false
+		};
+		match (needs_build, policy) {
+			(true, _) => {
+				self.build_service(name, service, file, &crate::engine::BuildOptions::default())
+					.await?
+			}
+			// A service with a `build:` whose image is already present needs no
+			// pull either — the local tag is the declared state.
+			(false, _) if service.build.is_some() => {}
+			(false, "never") => {}
+			(false, _) => self.pull_image(service).await?,
+		}
+		Ok(())
+	}
+}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod down_label;
+mod images;
 mod parallel;
 mod prefetch;
 mod readiness;
@@ -392,22 +393,7 @@ impl Engine {
 			}
 		}
 
-		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
-		// suppresses building even for services with a `build:` section (they fall
-		// back to pulling/using an existing image).
-		let policy = self
-			.pull_policy_override
-			.as_deref()
-			.or(service.pull_policy.as_deref())
-			.unwrap_or("missing");
-		match (service.build.is_some() && !self.no_build, policy) {
-			(true, _) => {
-				self.build_service(name, service, file, &crate::engine::BuildOptions::default())
-					.await?
-			}
-			(false, "never") => {}
-			(false, _) => self.pull_image(service).await?,
-		}
+		self.acquire_service_image(name, service, file).await?;
 
 		let replicas = self.resolve_replicas(name, service);
 		// Bound the replica count (covers an untrusted compose `deploy.replicas`/
@@ -688,14 +674,7 @@ impl Engine {
 			}
 			let image = match &service.image {
 				Some(img) => img.clone(),
-				// A build-only service's image is the tag the build step produced
-				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
-				None if builds_locally => super::build::primary_build_tag(
-					&self.project,
-					name,
-					None,
-					service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
-				),
+				None if builds_locally => self.service_image_tag(name, service),
 				None => continue,
 			};
 			// Do NOT force: a force-removal cascades to every container using the

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -117,9 +117,13 @@ pub async fn list_projects_filtered(
 		}
 	}
 
+	// An unsupported key is an error, not a warning — see the note on the ps
+	// filters: silently answering a different question is worse than refusing.
 	let (name_filter, status_filter, unknown) = split_ls_filters(filters);
-	for u in &unknown {
-		tracing::warn!("ls: ignoring unsupported filter '{u}'");
+	if let Some(u) = unknown.first() {
+		return Err(ComposeError::Unsupported(format!(
+			"unsupported ls filter {u:?}: expected name=<NAME> or status=<running|exited>"
+		)));
 	}
 	// A project is "active" (shown without `--all`) when any replica is running
 	// or paused; only all-stopped projects are hidden by default. The `--filter`

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -164,10 +164,16 @@ impl Engine {
 				let host = b.host_ip.as_deref().unwrap_or("0.0.0.0");
 				let port = b.host_port.as_deref().unwrap_or("");
 				println!("{host}:{port}");
+				Ok(())
 			}
-			None => println!(),
+			// No binding is a failure, not an empty answer. Printing a blank line
+			// and exiting 0 made `HOST=$(podup port web 80)` yield an empty string
+			// with a success status, so a script cannot tell "not published" from
+			// "published at ''". docker compose exits 1 with a message here.
+			None => Err(ComposeError::Unsupported(format!(
+				"no host binding for {service_name} port {port}/{proto}"
+			))),
 		}
-		Ok(())
 	}
 
 	/// List images used by each service as a table (default options).

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -46,11 +46,18 @@ impl LinePrefixer {
 	}
 
 	/// Buffer `chunk` and write every complete line it now completes.
-	pub(super) fn write(&mut self, out: &mut impl Write, chunk: &[u8]) {
+	///
+	/// Returns `Err` when the sink is gone. Every write used to be discarded with
+	/// `let _ =`, so a reader that closed the pipe — `logs -f | head`,
+	/// `| grep -q`, `| less` and quit — was never noticed and the follow loop
+	/// streamed into a dead pipe until the process was killed. The error is
+	/// returned rather than handled here so the caller decides: a broken pipe is
+	/// a clean end of output, any other io error is a real failure.
+	pub(super) fn write(&mut self, out: &mut impl Write, chunk: &[u8]) -> std::io::Result<()> {
 		self.pending.extend_from_slice(chunk);
 		while let Some(nl) = self.pending.iter().position(|&b| b == b'\n') {
-			let _ = out.write_all(self.label.as_bytes());
-			let _ = out.write_all(&self.pending[..=nl]);
+			out.write_all(self.label.as_bytes())?;
+			out.write_all(&self.pending[..=nl])?;
 			self.pending.drain(..=nl);
 		}
 		// The remaining bytes are a partial line with no newline yet. Bound it:
@@ -58,15 +65,18 @@ impl LinePrefixer {
 		// data) would otherwise grow `pending` without limit. Break the
 		// over-long partial into its own prefixed line and start fresh.
 		if self.pending.len() >= MAX_PENDING {
-			let _ = out.write_all(self.label.as_bytes());
-			let _ = out.write_all(&self.pending);
-			let _ = out.write_all(b"\n");
+			out.write_all(self.label.as_bytes())?;
+			out.write_all(&self.pending)?;
+			out.write_all(b"\n")?;
 			self.pending.clear();
 		}
-		let _ = out.flush();
+		out.flush()
 	}
 
 	/// Flush a trailing line that never received a newline (e.g. at stream end).
+	///
+	/// Best-effort: this runs after the stream is done, so a sink that has gone
+	/// away has nothing left to tell the caller.
 	pub(super) fn flush_tail(&mut self, out: &mut impl Write) {
 		if !self.pending.is_empty() {
 			let _ = out.write_all(self.label.as_bytes());
@@ -86,10 +96,10 @@ mod tests {
 	fn line_prefixer_tags_lines_and_buffers_partials() {
 		let mut p = LinePrefixer::new("web", true, false);
 		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"hello\nwor");
+		p.write(&mut out, b"hello\nwor").unwrap();
 		// The complete line is tagged; the partial "wor" waits for its newline.
 		assert_eq!(out, b"web  | hello\n");
-		p.write(&mut out, b"ld\n");
+		p.write(&mut out, b"ld\n").unwrap();
 		assert_eq!(out, b"web  | hello\nweb  | world\n");
 	}
 
@@ -97,7 +107,7 @@ mod tests {
 	fn line_prefixer_flush_tail_emits_unterminated_line() {
 		let mut p = LinePrefixer::new("db", true, false);
 		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"partial");
+		p.write(&mut out, b"partial").unwrap();
 		assert!(out.is_empty(), "a line with no newline is held back");
 		p.flush_tail(&mut out);
 		assert_eq!(out, b"db  | partial\n");
@@ -111,7 +121,7 @@ mod tests {
 		// Feed more than the cap with no newline in sight, in small chunks.
 		let chunk = vec![b'x'; 4096];
 		for _ in 0..((MAX_PENDING / chunk.len()) + 2) {
-			p.write(&mut out, &chunk);
+			p.write(&mut out, &chunk).unwrap();
 		}
 		// The partial was flushed as a prefixed line instead of being buffered
 		// unbounded, and nothing is left pending beyond the last sub-cap chunk.
@@ -135,10 +145,36 @@ mod tests {
 		// `--no-log-prefix`: lines pass through with no `{label} | ` tag.
 		let mut p = LinePrefixer::new("web", false, false);
 		let mut out: Vec<u8> = Vec::new();
-		p.write(&mut out, b"hello\n");
+		p.write(&mut out, b"hello\n").unwrap();
 		assert_eq!(out, b"hello\n");
-		p.write(&mut out, b"tail");
+		p.write(&mut out, b"tail").unwrap();
 		p.flush_tail(&mut out);
 		assert_eq!(out, b"hello\ntail\n");
+	}
+
+	/// #1102: a sink that has gone away must surface as an error, not be
+	/// swallowed. Every write here used to be `let _ =`, so `logs -f | head`
+	/// streamed into a closed pipe forever instead of exiting.
+	#[test]
+	fn line_prefixer_surfaces_a_broken_pipe() {
+		/// A writer that refuses everything the way a closed pipe does.
+		struct ClosedPipe;
+		impl std::io::Write for ClosedPipe {
+			fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+				Err(std::io::Error::new(
+					std::io::ErrorKind::BrokenPipe,
+					"broken pipe",
+				))
+			}
+			fn flush(&mut self) -> std::io::Result<()> {
+				Ok(())
+			}
+		}
+
+		let mut p = LinePrefixer::new("web", true, false);
+		let err = p
+			.write(&mut ClosedPipe, b"hello\n")
+			.expect_err("a closed sink must be reported");
+		assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -134,6 +134,25 @@ fn is_go_duration(v: &str) -> bool {
 	segments > 0
 }
 
+/// Whether a failed write to the log sink should end the follow loop.
+///
+/// A `BrokenPipe` is the ordinary way a piped consumer signals it has read
+/// enough — `logs -f | head`, `| grep -q`, `| less` and quit. It is a clean end
+/// of output, not a failure, and the loop must stop: podup used to discard the
+/// write result entirely and go on streaming into a dead pipe until the process
+/// was killed. Any other io error is worth a warning before stopping, since it
+/// means output is being lost for a reason the user cannot see.
+fn stop_on_write_error(container_name: &str, result: std::io::Result<()>) -> bool {
+	match result {
+		Ok(()) => false,
+		Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => true,
+		Err(e) => {
+			tracing::warn!("logs {container_name}: cannot write output: {e}");
+			true
+		}
+	}
+}
+
 /// Build the libpod `containers/{}/logs` query string from the options.
 fn log_query(opts: &LogsOptions) -> String {
 	let mut q = format!(
@@ -283,14 +302,17 @@ impl Engine {
 						let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 						let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 						while let Some(msg) = stream.next().await {
-							match msg {
+							let wrote = match msg {
 								Ok(LogOutput::StdOut { message }) => {
-									out_pfx.write(&mut std::io::stdout().lock(), &message);
+									out_pfx.write(&mut std::io::stdout().lock(), &message)
 								}
 								Ok(LogOutput::StdErr { message }) => {
-									err_pfx.write(&mut std::io::stderr().lock(), &message);
+									err_pfx.write(&mut std::io::stderr().lock(), &message)
 								}
 								Err(_) => break,
+							};
+							if stop_on_write_error(&container_name, wrote) {
+								break;
 							}
 						}
 						out_pfx.flush_tail(&mut std::io::stdout().lock());
@@ -332,12 +354,15 @@ impl Engine {
 				let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 				let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
 				while let Some(msg) = stream.next().await {
-					match msg {
+					let wrote = match msg {
 						Ok(LogOutput::StdOut { message }) => out_pfx.write(&mut out, &message),
 						Ok(LogOutput::StdErr { message }) => {
 							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
 						Err(_) => break,
+					};
+					if stop_on_write_error(&container_name, wrote) {
+						break;
 					}
 				}
 				out_pfx.flush_tail(&mut out);

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -248,11 +248,16 @@ impl Engine {
 			return Ok(());
 		}
 
-		// Fold `--status` and any `status=`/`name=` from `--filter` together;
-		// warn on unsupported `--filter` keys rather than silently ignoring them.
+		// Fold `--status` and any `status=`/`name=` from `--filter` together. An
+		// unsupported key is an error, not a warning: a dropped predicate means
+		// the command answers a question the caller did not ask, and a script
+		// filtering for a condition reads the unfiltered set back as a match.
+		// docker compose errors here too.
 		let (mut status_filter, name_filter, unknown) = split_ps_filters(&filters.filters);
-		for u in &unknown {
-			tracing::warn!("ps: ignoring unsupported filter '{u}'");
+		if let Some(u) = unknown.first() {
+			return Err(ComposeError::Unsupported(format!(
+				"unsupported ps filter {u:?}: expected name=<NAME> or status=<STATE>"
+			)));
 		}
 		status_filter.extend(filters.status.iter().cloned());
 

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -403,10 +403,18 @@ fn print_frame(
 
 	if opts.json {
 		let json: Vec<_> = rows.iter().map(stat_json_row).collect();
-		println!(
-			"{}",
-			serde_json::to_string_pretty(&json).unwrap_or_default()
-		);
+		// While streaming, one compact array per line — NDJSON, the shape
+		// `events` already emits. A pretty-printed array per frame, concatenated,
+		// is neither a single JSON document nor NDJSON, so no parser accepts it:
+		// `stats --format json` was unreadable by anything for as long as it
+		// streamed. `--no-stream` prints one frame and exits, so it stays a
+		// single pretty document, which is valid JSON and nicer to read.
+		let text = if opts.no_stream {
+			serde_json::to_string_pretty(&json)
+		} else {
+			serde_json::to_string(&json)
+		};
+		println!("{}", text.unwrap_or_default());
 		return;
 	}
 

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -283,11 +283,20 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
+		// Raised from `debug!` to `warn!` so a stream that dies mid-sample is at
+		// least visible at the default level — it used to vanish entirely, and a
+		// monitor scraping `stats` read a truncated sample as a complete one.
+		//
+		// Not fatal, though. The sibling streaming commands showed on the live
+		// lane that a finished libpod stream can end in a way hyper reports as an
+		// error on some Podman versions, so failing the command here would fail
+		// runs that worked. Making the exit code trustworthy needs that
+		// distinction first.
 		while let Some(frame) = frames.next().await {
 			match frame {
 				Ok(report) => print_frame(&report, &running, &stopped, &opts),
 				Err(e) => {
-					tracing::debug!("stats stream ended: {e}");
+					tracing::warn!("stats: stream ended early: {e}");
 					break;
 				}
 			}

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -58,6 +58,14 @@ struct RuleEntry {
 
 impl Engine {
 	/// Set up filesystem watchers from `develop.watch` rules and dispatch sync/rebuild/restart/exec actions on file changes.
+	///
+	/// **The session's exit status does not reflect the actions it ran.** A sync,
+	/// rebuild, restart or exec that fails is warned about and the loop
+	/// continues, so this returns `Ok(())` unless the watchers cannot be set up
+	/// at all. That is deliberate and matches `docker compose watch`: a
+	/// long-running developer loop should survive one failed rebuild rather than
+	/// exit. Unlike every other command here, it means a caller cannot gate on
+	/// the status — see the exit-status section of `docs/commands.md`.
 	pub async fn watch(&self, file: &ComposeFile) -> Result<()> {
 		let mut rule_entries: Vec<RuleEntry> = Vec::new();
 

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -16,7 +16,7 @@ mod unit;
 mod warnings;
 
 use crate::compose::types::ComposeFile;
-use unit::{build_unit, container_unit, network_unit, volume_unit};
+use unit::{build_unit, container_unit, network_unit, volume_unit, UnitContext};
 
 /// The `# podup-owner: <project>` marker a unit carries as its literal first
 /// line, if present.
@@ -208,21 +208,21 @@ pub fn generate_at(file: &ComposeFile, project: &str, base_dir: &std::path::Path
 		.filter(|(_, cfg)| cfg.as_ref().is_none_or(|c| c.external != Some(true)))
 		.map(|(name, _)| name.as_str())
 		.collect();
+	let ctx = UnitContext {
+		project,
+		declared_volumes: &declared_volumes,
+		declared_networks: &declared_networks,
+		secrets: &file.secrets,
+		base_dir,
+	};
 	for (name, service) in &file.services {
 		// Emit a `.build` unit first so the systemd generator builds the image
 		// before the container that references it via `Image=<stem>.build`.
 		if let Some(unit) = build_unit(name, project, service, base_dir, &mut out.warnings) {
 			out.units.push(unit);
 		}
-		out.units.push(container_unit(
-			name,
-			project,
-			service,
-			&declared_volumes,
-			&declared_networks,
-			&file.secrets,
-			&mut out.warnings,
-		));
+		out.units
+			.push(container_unit(name, service, &ctx, &mut out.warnings));
 	}
 
 	out

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -132,9 +132,17 @@ services:
 	let file = parse_str(yaml).unwrap();
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-app.container").contents;
+	// Absolute, resolved against the compose base dir: systemd resolves a relative
+	// `EnvironmentFile=` against the unit's own directory, not the project's, so
+	// `./app.env` would never be found once installed. Built with `join` so the
+	// separator matches the host (this test is not Unix-gated).
+	let env_file = format!(
+		"EnvironmentFile={}",
+		std::path::Path::new("/srv/app").join("app.env").display()
+	);
 	for needle in [
 		"ContainerName=custom",
-		"EnvironmentFile=./app.env",
+		&env_file,
 		"Tmpfs=/run",
 		"Sysctl=net.core.somaxconn=1024",
 		"Ulimit=nofile=1024:2048",
@@ -475,4 +483,53 @@ services:
 		!c.contains("Volume=/cache"),
 		"tmpfs wrongly emitted as a Volume in:\n{c}"
 	);
+}
+
+/// #1091: `EnvironmentFile=` is resolved by podman-systemd.unit(5) against the
+/// unit file's own directory, not the compose file's. Units land in
+/// `~/.config/containers/systemd`, so a relative entry emitted verbatim points
+/// at a file that is not there — and `--env-file` on a missing path is fatal, so
+/// the container never starts. Every relative entry must come out absolute
+/// against the compose base directory; an already-absolute one is untouched.
+#[test]
+fn env_file_entries_are_absolute_against_the_compose_base_dir() {
+	let yaml = r#"
+services:
+  app:
+    image: app:1.0
+    env_file:
+      - .env
+      - ./config/extra.env
+      - ../shared/team.env
+      - /etc/glyndor/absolute.env
+"#;
+	let file = parse_str(yaml).unwrap();
+	// A base directory that is deliberately not the process's cwd, so a bug that
+	// resolved against the cwd instead would still show up here.
+	let base = std::path::Path::new("/srv/app");
+	let out = generate_at(&file, "p", base);
+	let c = &unit_named(&out, "p-app.container").contents;
+	// `abs_against` joins with the OS separator, so build the expectations the
+	// same way rather than as POSIX literals — these render tests are not
+	// Unix-gated and would otherwise fail on Windows.
+	for rel in [".env", "config/extra.env", "../shared/team.env"] {
+		let needle = format!("EnvironmentFile={}", base.join(rel).display());
+		assert!(c.contains(&needle), "missing `{needle}` in:\n{c}");
+	}
+	// An already-absolute entry is passed through verbatim, separators included.
+	assert!(
+		c.contains("EnvironmentFile=/etc/glyndor/absolute.env"),
+		"an absolute entry must be untouched in:\n{c}"
+	);
+	// No entry may survive as a compose-relative path: systemd would resolve it
+	// against the unit directory. Checked by prefix rather than `is_absolute()`,
+	// which on Windows demands a drive letter that a `/srv/app` base never has.
+	let base_prefix = base.display().to_string();
+	for line in c.lines().filter(|l| l.starts_with("EnvironmentFile=")) {
+		let value = line.trim_start_matches("EnvironmentFile=");
+		assert!(
+			value.starts_with(&base_prefix) || value.starts_with("/etc/"),
+			"`{line}` was not resolved against the compose base directory"
+		);
+	}
 }

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -192,6 +192,57 @@ services:
 	}
 }
 
+/// #1092: `env_file: [{path, required: false}]` says a missing file is fine.
+/// Quadlet cannot express that — `EnvironmentFile=` becomes `--env-file`, which
+/// is fatal on a missing path — so the entry is emitted anyway and the container
+/// refuses to start. That is the only behaviour available; what must not happen
+/// is emitting it silently.
+#[test]
+fn warns_when_an_optional_env_file_cannot_stay_optional() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    env_file:
+      - path: .env
+        required: true
+      - path: .env.production
+        required: false
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let joined = out.warnings.join("\n");
+	assert!(
+		joined.contains("env_file") && joined.contains("required: false"),
+		"expected a warning naming the unmappable `required: false`, got:\n{joined}"
+	);
+	// The entry is still emitted — dropping it would lose configuration the user
+	// asked for whenever the file does exist. Built with `join` so the separator
+	// matches the host (this test is not Unix-gated).
+	let c = &unit_named(&out, "p-s.container").contents;
+	let needle = format!(
+		"EnvironmentFile={}",
+		std::path::Path::new("/srv/app")
+			.join(".env.production")
+			.display()
+	);
+	assert!(c.contains(&needle), "missing `{needle}` in:\n{c}");
+}
+
+/// The warning is about `required: false` specifically, so an env_file list
+/// where every entry is required must stay quiet.
+#[test]
+fn no_env_file_warning_when_every_entry_is_required() {
+	let yaml = "services:\n  s:\n    image: x\n    env_file:\n      - .env\n";
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	assert!(
+		!out.warnings.iter().any(|w| w.contains("env_file")),
+		"unexpected env_file warning: {:?}",
+		out.warnings
+	);
+}
+
 #[test]
 fn hostile_service_name_cannot_escape_output_directory() {
 	// A compose key containing path separators must never yield a unit

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -16,19 +16,13 @@ use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
 /// own, resolving a relative `SetWorkingDirectory` against the unit file's own
 /// directory (`~/.config/containers/systemd`) — where there is no Dockerfile. So
 /// the context, which compose interprets relative to the compose file, must be
-/// made absolute against that base directory here. `.` means the base dir itself.
+/// made absolute against that base directory here.
+///
+/// The rule is not specific to a build context: every compose-relative path a
+/// generated unit carries needs it, which is why the resolution itself lives in
+/// [`abs_against`].
 fn abs_context(base_dir: &Path, context: &str) -> String {
-	let ctx = Path::new(context);
-	if ctx.is_absolute() {
-		return context.to_string();
-	}
-	if ctx == Path::new(".") {
-		return base_dir.display().to_string();
-	}
-	// Strip a leading `./` so the joined path stays clean (`/base/src`, not
-	// `/base/./src`) — cosmetic, both resolve identically.
-	let rel = context.strip_prefix("./").unwrap_or(context);
-	base_dir.join(rel).display().to_string()
+	super::abs_against(base_dir, context)
 }
 
 /// The `.build` unit file name for a service, e.g. `proj-web.build`. The

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -9,26 +9,48 @@ use crate::size::parse_duration_secs;
 use super::health::render_healthcheck;
 use super::security::{is_inline_secret, map_security_opt, render_secret};
 use super::{
-	collect_warnings, owner_marker, render_command, render_publish_port, render_restart,
-	render_tmpfs_mount, render_volume, sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit,
-	Section,
+	abs_against, collect_warnings, owner_marker, render_command, render_publish_port,
+	render_restart, render_tmpfs_mount, render_volume, sorted_label_pairs, sorted_pairs, unit_stem,
+	QuadletUnit, Section,
 };
+
+/// Project-wide inputs every generated unit needs, as opposed to the per-service
+/// ones (`name`, `service`). Grouped rather than passed loose because the set
+/// only grows as more compose keys gain a Quadlet mapping, and because they are
+/// identical for every service in one `generate_at` call.
+pub(crate) struct UnitContext<'a> {
+	/// Compose project name, stamped as the `podup.project` ownership label.
+	pub project: &'a str,
+	/// Volumes the compose file declares (external ones excluded).
+	pub declared_volumes: &'a [&'a str],
+	/// Networks the compose file declares (external ones excluded).
+	pub declared_networks: &'a [&'a str],
+	/// Top-level `secrets:` definitions, for resolving a service's secret refs.
+	pub secrets: &'a IndexMap<String, SecretConfig>,
+	/// Directory compose resolves relative paths against — the compose file's
+	/// own directory, not the unit's. See [`abs_against`].
+	pub base_dir: &'a std::path::Path,
+}
 
 /// Build the `.container` unit for one compose `service`.
 ///
-/// `project` is the compose project name; it is stamped onto the unit as the
-/// `podup.project` ownership label (and the service key as `podup.service`),
-/// matching the labels the live engine applies, so generated containers are
-/// traceable back to their project the same way running ones are.
+/// The project name is stamped onto the unit as the `podup.project` ownership
+/// label (and the service key as `podup.service`), matching the labels the live
+/// engine applies, so generated containers are traceable back to their project
+/// the same way running ones are.
 pub(crate) fn container_unit(
 	name: &str,
-	project: &str,
 	service: &Service,
-	declared_volumes: &[&str],
-	declared_networks: &[&str],
-	secrets: &IndexMap<String, SecretConfig>,
+	ctx: &UnitContext<'_>,
 	warnings: &mut Vec<String>,
 ) -> QuadletUnit {
+	let UnitContext {
+		project,
+		declared_volumes,
+		declared_networks,
+		secrets,
+		base_dir,
+	} = ctx;
 	let mut unit = Section::new("Unit");
 	unit.add("Description", format!("{name} (podup)"));
 	for dep in service.depends_on.service_names() {
@@ -154,8 +176,14 @@ pub(crate) fn container_unit(
 	for ann in sorted_label_pairs(service.annotations.to_map()) {
 		container.add("Annotation", format!("{}={}", ann.0, ann.1));
 	}
+	// `EnvironmentFile=` is resolved by podman-systemd.unit(5) against the unit
+	// file's own directory, not the compose file's. Units are installed to
+	// `~/.config/containers/systemd`, so `env_file: .env` would render to a unit
+	// looking for `~/.config/containers/systemd/.env` — and `--env-file` on a
+	// missing path is fatal, so the container never starts. Resolve against the
+	// compose base directory, the same way the build context is.
 	for entry in service.env_file.to_entries() {
-		container.add("EnvironmentFile", entry.path().to_string());
+		container.add("EnvironmentFile", abs_against(base_dir, entry.path()));
 	}
 	for t in service.tmpfs.to_list() {
 		container.add("Tmpfs", t);

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -8,7 +8,7 @@ mod security;
 mod volume;
 
 pub(super) use build::build_unit;
-pub(super) use container::container_unit;
+pub(super) use container::{container_unit, UnitContext};
 pub(super) use network::network_unit;
 pub(super) use volume::volume_unit;
 
@@ -37,4 +37,27 @@ use super::QuadletUnit;
 /// `crate::autostart::quadlet`) must read instead.
 fn owner_marker(project: &str) -> String {
 	format!("# podup-owner: {project}\n")
+}
+
+/// Resolve a compose-relative path against the compose base directory.
+///
+/// Compose interprets a relative path against the compose file's directory.
+/// systemd interprets one against **the unit file's** directory — units are
+/// installed under `~/.config/containers/systemd`, which is not where the
+/// project lives. Any path a generated unit carries must therefore be made
+/// absolute here, or it silently resolves somewhere else once installed.
+///
+/// An already-absolute path is returned untouched, and `.` means the base
+/// directory itself. A leading `./` is stripped so the result stays clean
+/// (`/base/src`, not `/base/./src`) — cosmetic, both resolve identically.
+fn abs_against(base_dir: &std::path::Path, path: &str) -> String {
+	let p = std::path::Path::new(path);
+	if p.is_absolute() {
+		return path.to_string();
+	}
+	if p == std::path::Path::new(".") {
+		return base_dir.display().to_string();
+	}
+	let rel = path.strip_prefix("./").unwrap_or(path);
+	base_dir.join(rel).display().to_string()
 }

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -64,6 +64,20 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 		}
 	}
 
+	// `env_file: [{path, required: false}]` means a missing file is not an error.
+	// Quadlet has no way to say that: `EnvironmentFile=` becomes
+	// `podman run --env-file`, which is fatal on a missing path. So an entry the
+	// compose file marks optional becomes a container that refuses to start —
+	// and this is the deployment-local override pattern (a `.env.production`
+	// deliberately absent from the repo), so it fails exactly where the file is
+	// meant to be missing.
+	if service.env_file.to_entries().iter().any(|e| !e.required()) {
+		warn(
+			"env_file",
+			"`required: false` cannot be expressed in Quadlet; the file will be required at run time and the container will not start without it",
+		);
+	}
+
 	// Fields that are honoured at runtime but have no [Container] Quadlet key and
 	// no unambiguous PodmanArgs= fallback. Warn so the generated unit is never
 	// silently incomplete; add the flag by hand if it is required.

--- a/internal/resolve.rs
+++ b/internal/resolve.rs
@@ -45,10 +45,43 @@ pub(crate) fn resolve_compose_files(explicit: &[PathBuf]) -> Vec<PathBuf> {
 	}
 	for candidate in COMPOSE_FILE_CANDIDATES {
 		if Path::new(candidate).is_file() {
-			return vec![PathBuf::from(candidate)];
+			let mut files = vec![PathBuf::from(candidate)];
+			files.extend(override_for(Path::new(candidate)));
+			return files;
 		}
 	}
 	vec![PathBuf::from("docker-compose.yml")]
+}
+
+/// Override-file names, in the compose-spec precedence order. Only the first one
+/// present is used — docker compose does not merge two overrides.
+const OVERRIDE_FILE_CANDIDATES: [&str; 4] = [
+	"compose.override.yaml",
+	"compose.override.yml",
+	"docker-compose.override.yaml",
+	"docker-compose.override.yml",
+];
+
+/// The override file to merge on top of an auto-discovered `base`, if one sits
+/// beside it.
+///
+/// Base file plus `docker-compose.override.yml` is how nearly every repository
+/// separates dev from prod, and docker compose merges it automatically whenever
+/// no explicit `-f` is given. podup ran the base alone and said nothing: wrong
+/// image tags, wrong published ports, missing dev bind mounts, exit 0 — about a
+/// file the user never named on the command line, so nothing in the invocation
+/// hinted at what went wrong.
+///
+/// Discovery is deliberately limited to the auto-discovery path. An explicit
+/// `-f` means the caller is choosing the file set themselves, and `COMPOSE_FILE`
+/// is that same choice by another name; docker compose skips the override in
+/// both cases too.
+fn override_for(base: &Path) -> Option<PathBuf> {
+	let dir = base.parent().unwrap_or(Path::new(""));
+	OVERRIDE_FILE_CANDIDATES
+		.iter()
+		.map(|name| dir.join(name))
+		.find(|path| path.is_file())
 }
 
 /// Resolve the base directory for relative-path resolution. An explicit
@@ -121,8 +154,8 @@ pub(crate) fn sanitize_project_name(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
 	use super::{
-		resolve_base_dir, resolve_compose_files, resolve_project_name, sanitize_project_name,
-		validate_project_directory,
+		override_for, resolve_base_dir, resolve_compose_files, resolve_project_name,
+		sanitize_project_name, validate_project_directory,
 	};
 	use std::path::{Path, PathBuf};
 
@@ -249,5 +282,53 @@ mod tests {
 	fn sanitize_empty_result_falls_back_to_podup() {
 		assert_eq!(sanitize_project_name("!!!"), "podup");
 		assert_eq!(sanitize_project_name(""), "podup");
+	}
+
+	/// #1077: base plus `docker-compose.override.yml` is how nearly every
+	/// repository separates dev from prod, and docker compose merges it
+	/// automatically when no `-f` is given. podup ran the base alone, silently.
+	#[test]
+	fn auto_discovery_picks_up_the_override_file() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("compose.yaml"), b"services: {}\n").unwrap();
+		std::fs::write(dir.path().join("compose.override.yaml"), b"services: {}\n").unwrap();
+		let found = override_for(&dir.path().join("compose.yaml"));
+		assert_eq!(found, Some(dir.path().join("compose.override.yaml")));
+	}
+
+	/// Only the first override in precedence order is used — docker compose does
+	/// not merge two of them.
+	#[test]
+	fn only_the_highest_precedence_override_is_used() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("compose.yaml"), b"services: {}\n").unwrap();
+		for name in [
+			"compose.override.yml",
+			"docker-compose.override.yaml",
+			"compose.override.yaml",
+		] {
+			std::fs::write(dir.path().join(name), b"services: {}\n").unwrap();
+		}
+		assert_eq!(
+			override_for(&dir.path().join("compose.yaml")),
+			Some(dir.path().join("compose.override.yaml")),
+			"compose.override.yaml outranks the rest"
+		);
+	}
+
+	/// No override beside the base is the ordinary case and must stay silent.
+	#[test]
+	fn no_override_file_is_not_an_error() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("compose.yaml"), b"services: {}\n").unwrap();
+		assert_eq!(override_for(&dir.path().join("compose.yaml")), None);
+	}
+
+	/// An explicit `-f` means the caller is choosing the file set, so the
+	/// override is not added behind their back. docker compose skips it too.
+	#[test]
+	fn explicit_files_suppress_override_discovery() {
+		let explicit = vec![std::path::PathBuf::from("only.yaml")];
+		assert_eq!(resolve_compose_files(&explicit), explicit);
 	}
 }

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -178,11 +178,16 @@ fn prune_json_nulls(v: &mut serde_json::Value) {
 /// the value under an `environment:` key so a map-form host-passthrough var
 /// (`MYVAR:` → null) is not stripped from the output — it is forwarded at runtime,
 /// so `config` must show it, matching docker compose (which never drops the key).
+///
+/// It is set for `networks:` for the same reason: a null value there means
+/// "attach with default options", not "nothing". Dropping it removed a network
+/// the service is genuinely on — visible once merging could produce a map mixing
+/// a configured network with a bare one (#1078).
 fn prune_json(v: &mut serde_json::Value, preserve_nulls: bool) {
 	match v {
 		serde_json::Value::Object(map) => {
 			for (k, val) in map.iter_mut() {
-				prune_json(val, k == "environment");
+				prune_json(val, k == "environment" || k == "networks");
 			}
 			if !preserve_nulls {
 				map.retain(|_, val| !is_empty_json(val));
@@ -218,7 +223,7 @@ fn prune_yaml(v: &mut serde_yaml::Value, preserve_nulls: bool) {
 	match v {
 		serde_yaml::Value::Mapping(map) => {
 			for (k, val) in map.iter_mut() {
-				let child_preserve = k.as_str() == Some("environment");
+				let child_preserve = matches!(k.as_str(), Some("environment" | "networks"));
 				prune_yaml(val, child_preserve);
 			}
 			if !preserve_nulls {
@@ -489,5 +494,25 @@ mod tests {
 			out.contains("x-anchors"),
 			"x- extension must survive: {out}"
 		);
+	}
+
+	/// #1078: a null value under `networks:` means "attach with default
+	/// options", not "nothing". It used to be pruned like any other empty leaf,
+	/// which silently removed a network the service is genuinely on — reachable
+	/// once merging could produce a map mixing a configured network with a bare
+	/// one.
+	#[test]
+	fn a_bare_network_entry_survives_pruning() {
+		let mut v: serde_yaml::Value = serde_yaml::from_str(
+			"networks:\n  backend:\n    aliases:\n    - db\n  monitoring: null\n",
+		)
+		.unwrap();
+		prune_yaml_nulls(&mut v);
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(
+			out.contains("monitoring"),
+			"a bare network entry must not be pruned: {out}"
+		);
+		assert!(out.contains("backend"), "{out}");
 	}
 }

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -174,6 +174,43 @@ fn run_no_rm_parses_and_is_documented() {
 	);
 }
 
+/// Both spellings of the no-TTY flag parse on both `run` and `exec`, and both
+/// are listed in each command's help.
+///
+/// docker-compose is inconsistent with itself here: `docker compose run` spells
+/// the long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
+/// A script copied from either command has to work, so podup accepts both on
+/// both — a superset of docker rather than a guess at which one is canonical.
+#[test]
+fn no_tty_accepts_both_spellings_on_run_and_exec() {
+	for cmd in ["run", "exec"] {
+		let help = Command::new(bin())
+			.args([cmd, "--help"])
+			.output()
+			.expect("run --help");
+		assert!(help.status.success(), "`{cmd} --help` failed");
+		let help_out = String::from_utf8_lossy(&help.stdout);
+		for flag in ["--no-TTY", "--no-tty"] {
+			assert!(
+				help_out.contains(flag),
+				"`{cmd}` help is missing {flag}; got:\n{help_out}"
+			);
+		}
+
+		for flag in ["--no-TTY", "--no-tty", "-T"] {
+			let out = Command::new(bin())
+				.args(["--socket", "/nonexistent.sock", cmd, flag, "web", "true"])
+				.output()
+				.expect("run no-tty flag");
+			assert!(
+				!is_clap_usage_error(&out),
+				"`{cmd} {flag}` should parse; got clap usage error:\n{}",
+				String::from_utf8_lossy(&out.stderr)
+			);
+		}
+	}
+}
+
 /// `logs` and `restart` accept a trailing multi-service list (like every sibling
 /// command), so `logs a b` and `restart a b` parse rather than erroring on the
 /// extra positional.

--- a/tests/docs_flags.rs
+++ b/tests/docs_flags.rs
@@ -1,0 +1,108 @@
+//! `docs/commands.md` must document every flag the CLI actually accepts.
+//!
+//! The command reference was written per command by hand and drifted every time
+//! a flag landed — #1084 counted fourteen commands with missing flags and one
+//! precedence rule that was simply false. Fixing the text once only resets the
+//! clock; this test is what stops it recurring, by diffing `--help` against the
+//! document rather than trusting either.
+//!
+//! It asserts one direction only: every flag clap exposes appears in the docs.
+//! The reverse (documented flags that no longer exist) is a different failure
+//! and a different fix, and folding both into one assertion would make the
+//! message ambiguous.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Long flags clap prints in a `--help` body, e.g. `--no-cache`.
+///
+/// Only long forms are collected: a short form is always printed beside its long
+/// one, so requiring the long spelling covers both without needing to model
+/// clap's `-x, --xyz` layout.
+fn flags_in_help(help: &str) -> BTreeSet<String> {
+	let mut out = BTreeSet::new();
+	for line in help.lines() {
+		let trimmed = line.trim_start();
+		// Flag lines start with the short form or the long one; anything else is
+		// prose, a usage line, or a subcommand listing.
+		if !trimmed.starts_with('-') {
+			continue;
+		}
+		for token in trimmed.split_whitespace() {
+			let token = token.trim_end_matches([',', '.']);
+			if let Some(name) = token.strip_prefix("--") {
+				let name = name
+					.split(['=', '<', '['])
+					.next()
+					.unwrap_or_default()
+					.trim_end_matches('>');
+				if !name.is_empty() && name != "help" && name != "version" {
+					out.insert(format!("--{name}"));
+				}
+			}
+		}
+	}
+	out
+}
+
+/// The subcommands whose flag tables the reference documents. Aliases are
+/// excluded: they resolve to the same command and share its table.
+const COMMANDS: [&str; 29] = [
+	"up", "down", "create", "start", "stop", "restart", "build", "ps", "ls", "logs", "events",
+	"top", "stats", "port", "images", "volumes", "run", "exec", "cp", "attach", "kill", "rm",
+	"wait", "scale", "commit", "export", "pull", "push", "config",
+];
+
+#[test]
+fn every_cli_flag_is_documented() {
+	let docs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/commands.md"))
+		.expect("read docs/commands.md");
+
+	let mut missing: Vec<String> = Vec::new();
+	for cmd in COMMANDS {
+		let out = Command::new(bin())
+			.args([cmd, "--help"])
+			.output()
+			.unwrap_or_else(|e| panic!("run {cmd} --help: {e}"));
+		assert!(out.status.success(), "`{cmd} --help` failed");
+		let help = String::from_utf8_lossy(&out.stdout);
+		for flag in flags_in_help(&help) {
+			if !docs.contains(&flag) {
+				missing.push(format!("{cmd}: {flag}"));
+			}
+		}
+	}
+
+	assert!(
+		missing.is_empty(),
+		"flags accepted by the CLI but absent from docs/commands.md:\n  {}",
+		missing.join("\n  ")
+	);
+}
+
+/// The global options table is written separately from the per-command ones, so
+/// it drifts separately too.
+#[test]
+fn every_global_flag_is_documented() {
+	let docs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/commands.md"))
+		.expect("read docs/commands.md");
+	let out = Command::new(bin())
+		.arg("--help")
+		.output()
+		.expect("run --help");
+	let help = String::from_utf8_lossy(&out.stdout);
+
+	let missing: Vec<String> = flags_in_help(&help)
+		.into_iter()
+		.filter(|f| !docs.contains(f))
+		.collect();
+	assert!(
+		missing.is_empty(),
+		"global flags absent from docs/commands.md:\n  {}",
+		missing.join("\n  ")
+	);
+}

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -49,6 +49,8 @@ fn bin() -> &'static str {
 // Test groups (see engine_integration/*.rs)
 // ---------------------------------------------------------------------------
 
+#[path = "engine_integration/autostart_quadlet.rs"]
+mod autostart_quadlet;
 #[path = "engine_integration/build_resources.rs"]
 mod build_resources;
 #[path = "engine_integration/commands_networking.rs"]

--- a/tests/engine_integration/autostart_quadlet.rs
+++ b/tests/engine_integration/autostart_quadlet.rs
@@ -1,0 +1,218 @@
+//! Quadlet-mode autostart against real Podman **and real systemd `--user`**.
+//!
+//! The install/uninstall/rebuild flow shipped covered by unit tests only — a
+//! fake `SystemCtl` plus the pure renderer tests — so nothing exercised the part
+//! that actually breaks: units written to the systemd directory, generated,
+//! started, and the containers coming up. #1091 is what that gap costs. Its bug
+//! (a relative `EnvironmentFile=` resolving against the unit directory once
+//! installed) is invisible to every renderer test, because the rendered text was
+//! exactly what the test expected — it only fails when systemd reads it.
+//!
+//! **These tests touch the caller's real systemd.** `systemd --user` reads
+//! `XDG_CONFIG_HOME` from the manager process, set at login, so a test process
+//! cannot redirect it the way the unit tests do: the units really are written to
+//! `~/.config/containers/systemd/` and really are started. Two consequences,
+//! both load-bearing:
+//!
+//! * every test uses a per-process project name, so a run cannot collide with
+//!   another run, with the developer's own stacks, or with a sibling test;
+//! * cleanup runs from `Drop`, so a panic mid-test cannot leave an enabled unit
+//!   behind. That is not tidiness — a leaked quadlet unit starts its container
+//!   on the user's next boot.
+//!
+//! They skip when Podman or `systemd --user` is unreachable, which is every
+//! non-Linux runner and the main CI job; the nested-virt lane is where they run.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use super::{bin, proj};
+
+/// Whether a usable `systemd --user` session is reachable. `systemctl --user`
+/// needs a session bus, so this is false in a plain container and on any
+/// non-Linux host.
+fn systemd_user_available() -> bool {
+	Command::new("systemctl")
+		.args(["--user", "show", "--property=Version"])
+		.output()
+		.map(|o| o.status.success())
+		.unwrap_or(false)
+}
+
+/// `${XDG_CONFIG_HOME:-~/.config}/containers/systemd`, the directory Quadlet
+/// reads. Resolved the same way podup resolves it.
+fn quadlet_dir() -> PathBuf {
+	let base = std::env::var_os("XDG_CONFIG_HOME")
+		.filter(|s| !s.is_empty())
+		.map(PathBuf::from)
+		.or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))
+		.unwrap_or_default();
+	base.join("containers").join("systemd")
+}
+
+/// Runs `podup` with `-f <compose> -p <project>` and returns the exit status.
+fn podup(compose: &std::path::Path, project: &str, args: &[&str]) -> std::process::Output {
+	Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", project])
+		.args(args)
+		.output()
+		.expect("run podup")
+}
+
+fn unit_active(service: &str) -> bool {
+	Command::new("systemctl")
+		.args(["--user", "is-active", "--quiet", service])
+		.status()
+		.map(|s| s.success())
+		.unwrap_or(false)
+}
+
+/// Tears the install down however the test ends.
+///
+/// A quadlet unit left installed is not inert: it starts its container at the
+/// next boot. So uninstall runs from `Drop`, which a panicking assertion cannot
+/// skip, and `down -v` follows to reclaim the containers and volumes.
+struct Installed {
+	compose: PathBuf,
+	project: String,
+}
+
+impl Drop for Installed {
+	fn drop(&mut self) {
+		let _ = podup(&self.compose, &self.project, &["autostart", "uninstall"]);
+		let _ = podup(&self.compose, &self.project, &["down", "-v"]);
+	}
+}
+
+/// Write a one-service compose file into a fresh temp dir, and return both.
+fn fixture(tag: &str) -> (tempfile::TempDir, PathBuf) {
+	let dir = tempfile::tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	std::fs::write(
+		&compose,
+		format!(
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n\
+			 \n# {tag}\n"
+		),
+	)
+	.unwrap();
+	(dir, compose)
+}
+
+/// Install writes the units, systemd generates and starts them, and uninstall
+/// leaves nothing behind — the whole round trip, through the real generator.
+#[tokio::test]
+async fn quadlet_autostart_installs_starts_and_uninstalls() {
+	if super::podman().await.is_none() || !systemd_user_available() {
+		return;
+	}
+	let project = proj("qauto");
+	let (_dir, compose) = fixture(&project);
+	let guard = Installed {
+		compose: compose.clone(),
+		project: project.clone(),
+	};
+
+	let out = podup(
+		&compose,
+		&project,
+		&["autostart", "install", "--mode", "quadlet"],
+	);
+	assert!(
+		out.status.success(),
+		"install failed: {}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+
+	let unit = quadlet_dir().join(format!("{project}-web.container"));
+	assert!(unit.is_file(), "unit not written to {}", unit.display());
+
+	// The generator runs on `daemon-reload`, so the service exists only if the
+	// unit it produced was valid — a unit Quadlet rejects silently yields no
+	// service at all, which is the failure mode a renderer test cannot see.
+	let service = format!("{project}-web.service");
+	let mut active = false;
+	for _ in 0..30 {
+		if unit_active(&service) {
+			active = true;
+			break;
+		}
+		std::thread::sleep(std::time::Duration::from_millis(500));
+	}
+	assert!(active, "{service} never became active");
+
+	drop(guard);
+
+	assert!(!unit.exists(), "uninstall left {} behind", unit.display());
+	assert!(!unit_active(&service), "uninstall left {service} running");
+}
+
+/// #1091 as a regression test: a service with a relative `env_file` must come up
+/// with the variable set.
+///
+/// This is the one the renderer could not catch. The generated
+/// `EnvironmentFile=` was exactly the string the unit tests asserted; it was
+/// systemd resolving it against the unit's own directory — not the compose
+/// file's — that made `--env-file` fatal on a path that does not exist there, so
+/// the container never started.
+#[tokio::test]
+async fn quadlet_autostart_resolves_a_relative_env_file() {
+	if super::podman().await.is_none() || !systemd_user_available() {
+		return;
+	}
+	let project = proj("qenv");
+	let dir = tempfile::tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	std::fs::write(dir.path().join(".env"), b"PODUP_MARKER=present\n").unwrap();
+	std::fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    env_file:\n      - .env\n    \
+		 command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let _guard = Installed {
+		compose: compose.clone(),
+		project: project.clone(),
+	};
+
+	let out = podup(
+		&compose,
+		&project,
+		&["autostart", "install", "--mode", "quadlet"],
+	);
+	assert!(
+		out.status.success(),
+		"install failed: {}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+
+	let service = format!("{project}-web.service");
+	let mut active = false;
+	for _ in 0..30 {
+		if unit_active(&service) {
+			active = true;
+			break;
+		}
+		std::thread::sleep(std::time::Duration::from_millis(500));
+	}
+	assert!(
+		active,
+		"{service} never became active — a relative env_file that resolves against \
+		 the unit directory makes --env-file fatal, so the container cannot start"
+	);
+
+	let env = Command::new("podman")
+		.args([
+			"exec",
+			&format!("{project}-web"),
+			"printenv",
+			"PODUP_MARKER",
+		])
+		.output()
+		.expect("run podman exec");
+	assert_eq!(
+		String::from_utf8_lossy(&env.stdout).trim(),
+		"present",
+		"the env_file entry did not reach the container"
+	);
+}

--- a/tests/engine_integration/build_resources.rs
+++ b/tests/engine_integration/build_resources.rs
@@ -438,3 +438,69 @@ async fn remove_orphans_removes_container() {
 }
 
 // ---------------------------------------------------------------------------
+
+/// The image ID a tag currently resolves to, via the podman CLI — the same
+/// out-of-band check the sibling tests in this file use to observe state podup
+/// itself reports on. Empty when the tag is absent.
+fn image_id(tag: &str) -> String {
+	let out = std::process::Command::new("podman")
+		.args(["inspect", tag, "--format", "{{.Id}}"])
+		.output()
+		.expect("run podman inspect");
+	String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// #1094: `up` must not rebuild a service whose image is already present.
+///
+/// It used to rebuild unconditionally, *with* the cache, so the rebuild could
+/// resolve to an older layer chain and retag the image backwards — silently
+/// discarding a `build --no-cache` that had just run. That breaks the ordinary
+/// deploy shape: build explicitly, then start.
+///
+/// The sequence matters. A plain `build` first seeds the cache with one chain;
+/// `build --no-cache` then produces a different one and tags it. Without both
+/// steps there is no older chain for `up` to revert to and the bug does not
+/// appear at all.
+#[tokio::test]
+async fn up_keeps_the_image_a_no_cache_build_produced() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("upnb");
+	let tag = format!("podup-test-upnb-{}:latest", std::process::id());
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let yaml = format!(
+		"services:\n  app:\n    build:\n      context: .\n      dockerfile_inline: |\n        FROM alpine:latest\n        RUN echo marker > /marker\n    image: {tag}\n    command: [\"sleep\", \"infinity\"]\n"
+	);
+	let file = parse_str(&yaml).unwrap();
+
+	// Seed the cache with one chain, then force a different one.
+	engine.build_all(&file, &[]).await.unwrap();
+	engine
+		.build_all_with_options(
+			&file,
+			&[],
+			&podup::BuildOptions {
+				no_cache: true,
+				..Default::default()
+			},
+		)
+		.await
+		.unwrap();
+	let after_build = image_id(&tag);
+
+	engine
+		.up_with_options(&file, true, &[], &[], false, false, false)
+		.await
+		.unwrap();
+	let after_up = image_id(&tag);
+
+	assert_eq!(
+		after_build, after_up,
+		"`up` must not retag the image built by `build --no-cache`"
+	);
+
+	engine.down_with_options(&file, true).await.ok();
+}

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -100,3 +100,101 @@ fn run(c: &str, proj: &str, args: &[&str]) -> String {
 	);
 	String::from_utf8_lossy(&out.stdout).into_owned()
 }
+
+/// #1082: `stats --format json` while streaming emitted one pretty-printed array
+/// per sampling frame, concatenated. That is neither a single JSON document nor
+/// NDJSON, so no parser accepts it — the machine-readable format was unreadable
+/// by machines for as long as it streamed.
+///
+/// Streaming now emits one compact array per line. `--no-stream` prints a single
+/// frame and exits, so it stays a pretty document, which is valid on its own.
+#[tokio::test]
+async fn cli_stats_streaming_json_is_ndjson() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-ndj", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	let run = |args: &[&str]| {
+		Command::new(bin())
+			.args(["-f", c, "-p", &proj])
+			.args(args)
+			.output()
+			.expect("run podup")
+	};
+	run(&["up", "-d"]);
+
+	// Take a couple of frames, then stop: the stream never ends on its own.
+	let out = Command::new("timeout")
+		.args([
+			"4",
+			bin(),
+			"-f",
+			c,
+			"-p",
+			&proj,
+			"stats",
+			"--format",
+			"json",
+		])
+		.output()
+		.expect("run podup stats");
+	let text = String::from_utf8_lossy(&out.stdout);
+	let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+	assert!(!lines.is_empty(), "no stats frames were emitted");
+	for line in &lines {
+		serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|e| {
+			panic!("streaming frame is not valid JSON on its own ({e}): {line}")
+		});
+	}
+
+	// `--no-stream` stays a single valid document.
+	let one = run(&["stats", "--no-stream", "--format", "json"]);
+	serde_json::from_slice::<serde_json::Value>(&one.stdout)
+		.expect("--no-stream must emit one valid JSON document");
+
+	run(&["down", "-v"]);
+}
+
+/// #1082: `port` with no host binding printed a blank line and exited 0, so
+/// `HOST=$(podup port web 80)` yielded an empty string with a success status and
+/// a script could not tell "not published" from "published at ''".
+#[tokio::test]
+async fn cli_port_without_a_binding_exits_nonzero() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-prt", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	let run = |args: &[&str]| {
+		Command::new(bin())
+			.args(["-f", c, "-p", &proj])
+			.args(args)
+			.output()
+			.expect("run podup")
+	};
+	run(&["up", "-d"]);
+
+	let out = run(&["port", "web", "80"]);
+	assert!(
+		!out.status.success(),
+		"an unpublished port must not report success: stdout={:?}",
+		String::from_utf8_lossy(&out.stdout)
+	);
+
+	run(&["down", "-v"]);
+}


### PR DESCRIPTION
Fifteen commits closing eleven issues from the audit backlog. **Do not squash** — a release merge is a merge commit, so `main` absorbs `develop` exactly and the next release PR only shows new work.

## Read this first — behaviour changes

Three of these will surprise an existing user, so they are here rather than in the list below.

**`compose.override.yaml` is now discovered and merged** when no explicit `-f` is given (#1077). A project that has one — and that podup was silently ignoring — will now run something different. This is what docker compose has always done, which is why it is a fix and not a feature flag, but it is the change most likely to alter someone's stack on upgrade.

**`up` no longer rebuilds unconditionally** (#1094). It builds when the image is missing, as compose does; `--build` forces. A workflow that relied on `up` to rebuild needs that flag now. The old behaviour was actively harmful — the rebuild ran *with* the cache and could retag the image back to an older layer chain, silently discarding a `build --no-cache` that had just run.

**Several commands now exit non-zero where they exited 0**: an unknown `--filter` (#1081), a `port` with no host binding (#1082), and a pull the registry refused (#1076). Each was reporting success for work it had not done, but a script that tolerated the old exit code will now fail.

**Version:** 1.13.0 — MINOR because the override discovery is a new feature, and the library's public API is unchanged (`cargo-semver-checks` green on every PR in this range). If you read the second and third bullets as breaking rather than corrective, this should be 2.0.0; that call is easier now than after the tag.

## Correctness

- **#1076** — a failed pull is no longer reported as success. libpod reports it as an in-band error on a 200 response; that line was dropped, so `up --pull always` against an unreachable registry started the stale local image and exited 0. The standalone `pull` had the same hole: its presence probe passes when a stale copy exists.
- **#1094** — `up` builds only when the image is missing.
- **#1096** — `.containerignore` is read, and never combined with `.dockerignore`. Podman prefers its own name and applies exactly one; applying both produced an image missing content `podman build` includes.
- **#1078** (partial) — service merging unions `networks` and merges `sysctls` per key, and appends `env_file`/`dns`/`dns_search`/`dns_opt`/`tmpfs`/`label_file`. A service silently losing a network on an override was the worst of these: it dropped off the network and service discovery failed at run time, far from the config that caused it.
- **#1091 / #1092** — Quadlet emits `EnvironmentFile=` as an absolute path (systemd resolves a relative one against the *unit's* directory, so the container never started), and warns when `required: false` cannot be expressed.
- **#1080** (partial) — `autostart uninstall` reports a unit it could not stop instead of printing its removal lines and exiting 0.
- **#1102** — `logs -f | head` exits instead of streaming into a closed pipe forever.
- **#1081 / #1082** (partial) — unknown filters rejected, `build --progress` validated, streaming `stats --format json` is NDJSON rather than concatenated pretty arrays no parser accepts, `port` exits non-zero without a binding.
- **#1079** (partial) — both spellings of the no-TTY flag parse on both `run` and `exec`. docker is inconsistent with itself here; podup now accepts either on either.

## Tests and docs

- **#1030** — quadlet autostart covered against real Podman **and real systemd**, the gap that let #1091 ship. Cleanup runs from `Drop`, because a leaked quadlet unit starts its container on the user's next boot.
- **#1084** — the false `--env-file` precedence rule corrected in the reference *and* the library doc-comment, and the flag drift closed by a test that diffs `--help` against the document rather than another hand-written pass.
- **#1098** — the known Podman 6 limitation on `cp` and `watch` sync documented while #1097 is open.

## Knowingly left open

- **#1104** — podup cannot tell a finished libpod stream from a broken one. Two attempts to make `logs`/`stats`/`events` report failures were rejected by the live lane; real Podman 5.4.2 is green on commits where 5.8.1 goes red. Blocks the rest of #1080.
- **#1097** — `cp` into a container on Podman 6, blocked on VM access. Documented in the meantime.
- **#1093** — needs `ServiceUnitOpts`/`InstallOptions` to gain `#[non_exhaustive]`, which is a MAJOR.
- **#1083** — what the coverage gate should measure is a decision, not a patch.
- Remainders of **#1078** (same-target `volumes`, `!override`/`!reset`) and **#1082** (output-shape items).

## Verification

Every behaviour change in this range was reproduced against real Podman 5.4.2 before and after, not only unit-tested; the numbers are in each PR. `cargo test --lib` 1275/1275. The nested-virt lane passed on both supported Podman majors for every commit here.
