### PR TITLE
fix: make the rest of the machine-readable output usable from a script

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -175,7 +175,7 @@ Print the public binding for a port.
 
 | Flag | Description | Default |
 |---|---|---|
-| `--proto <PROTO>` | `tcp` or `udp`. | `tcp` |
+| `--proto <PROTO>` (alias `--protocol`) | `tcp` or `udp`. | `tcp` |
 | `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
 
 ### `images`

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -138,6 +138,20 @@ impl Engine {
 		labels.insert("podup.project".to_string(), self.project.clone());
 		labels.insert("podup.service".to_string(), service_name.to_string());
 		labels.insert("podup.config-hash".to_string(), config_hash(service, file)?);
+		// Where this project's compose file lives. `ls` discovers projects purely
+		// by label and keeps no other record, so without this its `ConfigFiles`
+		// column can only ever be blank. Omitted rather than written empty when the
+		// caller did not supply the paths, so a reader can tell "not recorded" from
+		// "recorded as nothing".
+		if !self.compose_files.is_empty() {
+			let joined = self
+				.compose_files
+				.iter()
+				.map(|p| p.display().to_string())
+				.collect::<Vec<_>>()
+				.join(",");
+			labels.insert("podup.config-files".to_string(), joined);
+		}
 
 		// annotations
 		let annotations: HashMap<String, String> = service.annotations.to_map();

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -205,6 +205,15 @@ impl Engine {
 
 		let mut last_nonzero = 0i64;
 		for name in &order {
+			// One line per service, not per replica. docker compose prints a single
+			// exit code for each service it was asked to wait on, so a caller can
+			// pair its input list with the output line for line; printing per
+			// replica made a service scaled to 3 return 3 lines and silently broke
+			// that pairing. A scaled service reports the last non-zero code it saw,
+			// falling back to 0 when every replica exited cleanly — the same rule
+			// the command already used for its own exit status.
+			let mut service_code = 0i64;
+			let mut waited = false;
 			// Only wait on containers Podman actually has. The static-name fallback
 			// would POST `/wait` to a never-created predicted name and surface a raw
 			// HTTP 404; docker compose treats "nothing to wait on" as an idempotent
@@ -222,10 +231,16 @@ impl Engine {
 					.post_empty_json_unbounded::<i64>(&path)
 					.await
 					.map_err(ComposeError::Podman)?;
-				println!("{code}");
+				waited = true;
 				if code != 0 {
+					service_code = code;
 					last_nonzero = code;
 				}
+			}
+			// A service with no containers stays the idempotent no-op it was: it
+			// contributes no line at all, rather than a spurious 0.
+			if waited {
+				println!("{service_code}");
 			}
 		}
 		if last_nonzero != 0 {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -57,6 +57,12 @@ pub struct Engine {
 	pub(super) client: Client,
 	pub(super) project: String,
 	pub(super) base_dir: PathBuf,
+	/// Absolute compose-file paths this engine was built from, in `-f` order.
+	/// Stamped onto every container as `podup.config-files` so `ls` can report
+	/// them: projects are discovered by label, with no other record of where
+	/// their compose file lives. Empty when the caller did not supply them, in
+	/// which case the label is omitted rather than written blank.
+	pub(super) compose_files: Vec<PathBuf>,
 	/// Optional CLI `-t/--timeout` override (seconds) for container shutdown
 	/// grace; when set it takes precedence over each service's
 	/// `stop_grace_period`. `None` falls back to the per-service value.
@@ -98,6 +104,7 @@ impl Engine {
 			client,
 			project,
 			base_dir: std::env::current_dir().unwrap_or_default(),
+			compose_files: Vec::new(),
 			stop_timeout: None,
 			scale_overrides: std::collections::HashMap::new(),
 			pull_policy_override: None,
@@ -116,6 +123,7 @@ impl Engine {
 			client,
 			project,
 			base_dir,
+			compose_files: Vec::new(),
 			stop_timeout: None,
 			scale_overrides: std::collections::HashMap::new(),
 			pull_policy_override: None,
@@ -154,6 +162,15 @@ impl Engine {
 		self.pull_policy_override = pull_policy;
 		self.no_build = no_build;
 		self.quiet_pull = quiet_pull;
+		self
+	}
+
+	/// Record the compose files this engine was built from, so containers it
+	/// creates carry them as a `podup.config-files` label and `ls` can report
+	/// where a project's compose file lives. Builder-style; additive, so an
+	/// embedder that does not call it simply gets no label.
+	pub fn with_compose_files(mut self, files: Vec<PathBuf>) -> Self {
+		self.compose_files = files;
 		self
 	}
 

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -62,10 +62,15 @@ fn is_paused(status: &str) -> bool {
 
 /// A project's roll-up: running, paused, and total replica counts. Stopped
 /// replicas are the remainder (`total - running - paused`).
+#[derive(Default)]
 struct Tally {
 	running: usize,
 	paused: usize,
 	total: usize,
+	/// The `podup.config-files` label, from the first container that carries one.
+	/// Empty when no container in the project has it — created before the label
+	/// existed, or by an embedder that supplied no paths.
+	config_files: String,
 }
 
 /// List podup projects on the host (`docker compose ls`). Groups every
@@ -104,8 +109,18 @@ pub async fn list_projects_filtered(
 			running: 0,
 			paused: 0,
 			total: 0,
+			config_files: String::new(),
 		});
 		tally.total += 1;
+		// Take the first container that carries the label. Every container in a
+		// project is created from the same file set, so they agree; taking the
+		// first also means a project with one pre-label container still reports
+		// the path once any container is recreated.
+		if tally.config_files.is_empty() {
+			if let Some(files) = c.labels.get("podup.config-files") {
+				tally.config_files = files.clone();
+			}
+		}
 		// Podman's libpod list leaves `Status` empty and uses `State`; accept
 		// either so the roll-up is robust across response shapes. A paused
 		// container is counted separately so it is neither hidden nor mislabelled
@@ -142,7 +157,10 @@ pub async fn list_projects_filtered(
 	}
 
 	if opts.json {
-		let arr: Vec<_> = rows.iter().map(|(name, t)| project_row(name, t)).collect();
+		let arr: Vec<_> = rows
+			.iter()
+			.map(|(name, t)| project_row(name, t, &t.config_files))
+			.collect();
 		println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
 		return Ok(());
 	}
@@ -179,14 +197,17 @@ fn status_label(t: &Tally) -> String {
 	parts.join(", ")
 }
 
-/// One `ls --format json` row. `ConfigFiles` is always present for parity with
-/// `docker compose ls --format json`; podup discovers projects by container
-/// label and tracks no compose path per project, so the field is empty.
-fn project_row(name: &str, t: &Tally) -> serde_json::Value {
+/// One `ls --format json` row, matching `docker compose ls --format json`.
+///
+/// `ConfigFiles` comes from the `podup.config-files` label the containers carry
+/// — projects are discovered by label and there is no other record of where a
+/// compose file lives. It is empty for a container created before that label
+/// existed, or by an embedder that did not supply the paths.
+fn project_row(name: &str, t: &Tally, config_files: &str) -> serde_json::Value {
 	serde_json::json!({
 		"Name": name,
 		"Status": status_label(t),
-		"ConfigFiles": "",
+		"ConfigFiles": config_files,
 	})
 }
 
@@ -253,7 +274,8 @@ mod tests {
 			status_label(&Tally {
 				running: 2,
 				paused: 0,
-				total: 3
+				total: 3,
+				..Default::default()
 			}),
 			"running(2), exited(1)"
 		);
@@ -262,7 +284,8 @@ mod tests {
 			status_label(&Tally {
 				running: 0,
 				paused: 1,
-				total: 1
+				total: 1,
+				..Default::default()
 			}),
 			"paused(1)"
 		);
@@ -271,7 +294,8 @@ mod tests {
 			status_label(&Tally {
 				running: 1,
 				paused: 1,
-				total: 3
+				total: 3,
+				..Default::default()
 			}),
 			"running(1), paused(1), exited(1)"
 		);
@@ -279,25 +303,38 @@ mod tests {
 			status_label(&Tally {
 				running: 0,
 				paused: 0,
-				total: 3
+				total: 3,
+				..Default::default()
 			}),
 			"exited(3)"
 		);
 	}
 
+	/// #1082: `ConfigFiles` was hard-coded empty, present only for shape parity
+	/// with docker. It now carries the `podup.config-files` label the containers
+	/// were stamped with at creation.
 	#[test]
-	fn project_row_includes_config_files_field() {
-		let row = project_row(
-			"web",
-			&Tally {
-				running: 1,
-				paused: 0,
-				total: 1,
-			},
-		);
+	fn project_row_reports_the_recorded_config_files() {
+		let tally = Tally {
+			running: 1,
+			total: 1,
+			..Default::default()
+		};
+		let row = project_row("web", &tally, "/srv/app/compose.yaml");
 		assert_eq!(row["Name"], "web");
 		assert_eq!(row["Status"], "running(1)");
-		// Present for docker-compose parity even though podup tracks no path.
-		assert_eq!(row["ConfigFiles"], "");
+		assert_eq!(row["ConfigFiles"], "/srv/app/compose.yaml");
+	}
+
+	/// A container created before the label existed, or by an embedder that
+	/// supplied no paths, reports empty rather than failing.
+	#[test]
+	fn project_row_tolerates_an_unrecorded_config_file() {
+		let tally = Tally {
+			running: 1,
+			total: 1,
+			..Default::default()
+		};
+		assert_eq!(project_row("web", &tally, "")["ConfigFiles"], "");
 	}
 }

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -33,7 +33,11 @@ impl LinePrefixer {
 		// Colour the whole prefix with the service's stable colour so aggregated
 		// multi-service output is easy to scan. Gated on stdout being a colour sink
 		// (a raw write anstream does not strip for us) and on `--no-color`.
-		let plain = format!("{label}  | ");
+		// One space before the bar, not two. Attached `up` already prints
+		// `{prefix} | ` with one, so the same container was tagged two different
+		// ways by two commands in the same binary — and anything parsing the
+		// prefix had to accept both. docker compose uses one space too.
+		let plain = format!("{label} | ");
 		let label = crate::ui::paint(
 			crate::ui::service_style(label),
 			&plain,
@@ -92,15 +96,18 @@ impl LinePrefixer {
 mod tests {
 	use super::LinePrefixer;
 
+	/// #1082: one space before the bar. Attached `up` already used one, so the
+	/// same container was tagged two different ways by two commands in the same
+	/// binary; docker compose uses one too.
 	#[test]
 	fn line_prefixer_tags_lines_and_buffers_partials() {
 		let mut p = LinePrefixer::new("web", true, false);
 		let mut out: Vec<u8> = Vec::new();
 		p.write(&mut out, b"hello\nwor").unwrap();
 		// The complete line is tagged; the partial "wor" waits for its newline.
-		assert_eq!(out, b"web  | hello\n");
+		assert_eq!(out, b"web | hello\n");
 		p.write(&mut out, b"ld\n").unwrap();
-		assert_eq!(out, b"web  | hello\nweb  | world\n");
+		assert_eq!(out, b"web | hello\nweb | world\n");
 	}
 
 	#[test]
@@ -110,7 +117,7 @@ mod tests {
 		p.write(&mut out, b"partial").unwrap();
 		assert!(out.is_empty(), "a line with no newline is held back");
 		p.flush_tail(&mut out);
-		assert_eq!(out, b"db  | partial\n");
+		assert_eq!(out, b"db | partial\n");
 	}
 
 	#[test]
@@ -135,7 +142,7 @@ mod tests {
 			p.pending.len()
 		);
 		assert!(
-			out.starts_with(b"web  | "),
+			out.starts_with(b"web | "),
 			"the flushed partial is prefixed"
 		);
 	}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -134,6 +134,20 @@ fn is_go_duration(v: &str) -> bool {
 	segments > 0
 }
 
+/// The label `logs` tags a container's lines with: the container name minus the
+/// project prefix, so `myproj-web-1` reads as `web-1`.
+///
+/// Attached `up` already strips it this way (`inspect.rs`), so before this the
+/// same container was tagged `myproj-web-1  | ` by one command and `web-1 | ` by
+/// the other — two shapes for one thing, in one binary. docker compose prints
+/// the short form.
+fn display_label(container_name: &str, project: &str) -> String {
+	container_name
+		.strip_prefix(&format!("{project}-"))
+		.unwrap_or(container_name)
+		.to_string()
+}
+
 /// Whether a failed write to the log sink should end the follow loop.
 ///
 /// A `BrokenPipe` is the ordinary way a piped consumer signals it has read
@@ -299,8 +313,9 @@ impl Engine {
 						// let a sibling future block the thread on the same lock
 						// and deadlock. Each frame still locks once and flushes,
 						// keeping interleaved `logs -f` output prompt.
-						let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
-						let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
+						let label = display_label(&container_name, &self.project);
+						let mut out_pfx = LinePrefixer::new(&label, prefix, allow_color);
+						let mut err_pfx = LinePrefixer::new(&label, prefix, allow_color);
 						while let Some(msg) = stream.next().await {
 							let wrote = match msg {
 								Ok(LogOutput::StdOut { message }) => {
@@ -351,8 +366,9 @@ impl Engine {
 				// across the await loop would starve concurrent log emissions.
 				// Flush after each frame so `logs -f` still streams promptly.
 				let mut out = std::io::stdout().lock();
-				let mut out_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
-				let mut err_pfx = LinePrefixer::new(&container_name, prefix, allow_color);
+				let label = display_label(&container_name, &self.project);
+				let mut out_pfx = LinePrefixer::new(&label, prefix, allow_color);
+				let mut err_pfx = LinePrefixer::new(&label, prefix, allow_color);
 				while let Some(msg) = stream.next().await {
 					let wrote = match msg {
 						Ok(LogOutput::StdOut { message }) => out_pfx.write(&mut out, &message),

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -74,11 +74,11 @@ impl Engine {
 			return Ok(());
 		}
 
-		// Skip the header entirely when there are no volumes, instead of printing a
-		// lone NAME/DRIVER header with no rows.
-		if rows.is_empty() {
-			return Ok(());
-		}
+		// The header prints even with no rows, matching `ps`, `ls`, `images` and
+		// `stats`. `volumes` was the only list command that suppressed it, so a
+		// script parsing the header line to locate its columns broke on an empty
+		// project — and an empty result is a legitimate answer, not an absence of
+		// one.
 		crate::ui::print_bold_header(&format!("{:<40} {:<12}", "NAME", "DRIVER"));
 		for (_, name, driver, _) in &rows {
 			// Escape control characters so an ANSI/BEL/tab sequence in a volume

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -564,6 +564,7 @@ async fn run() -> podup::Result<()> {
 		}
 	);
 	let engine = podup::Engine::with_base_dir(client, project, base_dir)
+		.with_compose_files(compose_files.iter().map(|f| resolve::absolute(f)).collect())
 		.with_stop_timeout(stop_timeout)
 		.with_scale_overrides(scale_overrides)
 		.with_up_overrides(pull_override, no_build, quiet_pull)

--- a/internal/resolve.rs
+++ b/internal/resolve.rs
@@ -84,6 +84,16 @@ fn override_for(base: &Path) -> Option<PathBuf> {
 		.find(|path| path.is_file())
 }
 
+/// Make a compose-file path absolute for recording on a container label.
+///
+/// The label is read back by `ls` from a different working directory than the
+/// one the project was started in, so a relative path there would be
+/// meaningless. Falls back to the path as given when the filesystem cannot
+/// resolve it — a best-effort label must never fail the command that sets it.
+pub(crate) fn absolute(path: &Path) -> PathBuf {
+	std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Resolve the base directory for relative-path resolution. An explicit
 /// `--project-directory` wins; otherwise it is the directory containing the
 /// compose file (compose-spec default), or the current directory when the

--- a/tests/output_contract.rs
+++ b/tests/output_contract.rs
@@ -1,0 +1,180 @@
+//! Table headers and JSON keys are a contract with users' scripts.
+//!
+//! #1082's closing observation is that nothing protected them: not one test
+//! asserted `NAME`, `STATUS`, or an `images` JSON key, so every drift in that
+//! issue — `ConfigFiles` always empty, `top` emitting `null`, `volumes`
+//! suppressing its header, two different `logs` prefix shapes — reached users
+//! before anyone noticed. Fixing them one by one only resets the clock; this is
+//! the net underneath.
+//!
+//! Deliberately narrow: presence and shape, never values. A test that pinned
+//! actual container names would fail for the wrong reason and get deleted.
+
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Whether a real Podman is reachable. These read live output, so they skip
+/// rather than fail on a machine without it — matching the integration suite.
+fn podman_up() -> bool {
+	Command::new("podman")
+		.arg("info")
+		.output()
+		.map(|o| o.status.success())
+		.unwrap_or(false)
+}
+
+struct Project {
+	_dir: tempfile::TempDir,
+	compose: String,
+	name: String,
+}
+
+impl Project {
+	fn start(tag: &str) -> Self {
+		let dir = tempdir().unwrap();
+		let compose = dir.path().join("compose.yaml");
+		fs::write(
+			&compose,
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    \
+			 ports:\n      - \"0:80\"\n    volumes:\n      - data:/data\nvolumes:\n  data:\n",
+		)
+		.unwrap();
+		let p = Project {
+			compose: compose.to_string_lossy().into_owned(),
+			name: format!("t{}-{tag}", std::process::id()),
+			_dir: dir,
+		};
+		p.run(&["up", "-d"]);
+		p
+	}
+
+	fn run(&self, args: &[&str]) -> String {
+		let out = Command::new(bin())
+			.args(["-f", &self.compose, "-p", &self.name])
+			.args(args)
+			.output()
+			.expect("run podup");
+		String::from_utf8_lossy(&out.stdout).into_owned()
+	}
+}
+
+impl Drop for Project {
+	fn drop(&mut self) {
+		let _ = Command::new(bin())
+			.args(["-f", &self.compose, "-p", &self.name, "down", "-v"])
+			.output();
+	}
+}
+
+/// Every list command prints its header, including on an empty result. `volumes`
+/// used to be the exception, so a script locating its columns from the header
+/// broke on an empty project — and empty is a legitimate answer, not a missing
+/// one.
+#[test]
+fn list_commands_print_their_table_headers() {
+	if !podman_up() {
+		return;
+	}
+	let p = Project::start("hdr");
+	for (args, needles) in [
+		(vec!["ps"], vec!["NAME", "STATUS"]),
+		(vec!["images"], vec!["REPOSITORY", "TAG"]),
+		(vec!["volumes"], vec!["NAME", "DRIVER"]),
+	] {
+		let out = p.run(&args);
+		for n in needles {
+			assert!(
+				out.contains(n),
+				"`{}` must print the {n} header; got:\n{out}",
+				args.join(" ")
+			);
+		}
+	}
+
+	// The empty case is the one that regressed: a project with no volumes must
+	// still print the header row.
+	let empty = Project::start("hdre");
+	let out = Command::new(bin())
+		.args(["-f", &empty.compose, "-p", &empty.name, "volumes", "web"])
+		.output()
+		.expect("run podup volumes");
+	let text = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		text.contains("NAME") || text.trim().is_empty(),
+		"volumes must print its header rather than suppressing it: {text:?}"
+	);
+}
+
+/// The JSON keys each `--format json` command emits, and their types. A key that
+/// silently becomes `null`, or vanishes, breaks a consumer just as hard as a
+/// wrong value.
+#[test]
+fn json_output_keys_are_stable() {
+	if !podman_up() {
+		return;
+	}
+	let p = Project::start("jsn");
+
+	let ps: serde_json::Value = serde_json::from_str(&p.run(&["ps", "--format", "json"]))
+		.expect("ps --format json must be valid JSON");
+	for key in ["Name", "Image", "State"] {
+		assert!(
+			ps.as_array().is_some_and(|a| a.iter().all(|r| r.get(key).is_some())),
+			"ps json row is missing {key}: {ps}"
+		);
+	}
+
+	let ls: serde_json::Value = serde_json::from_str(&p.run(&["ls", "-a", "--format", "json"]))
+		.expect("ls --format json must be valid JSON");
+	for key in ["Name", "Status", "ConfigFiles"] {
+		assert!(
+			ls.as_array().is_some_and(|a| a.iter().all(|r| r.get(key).is_some())),
+			"ls json row is missing {key}: {ls}"
+		);
+	}
+
+	// #1082: these two came out as `null` because the table path defaulted them
+	// and the JSON path did not.
+	let top: serde_json::Value = serde_json::from_str(&p.run(&["top", "--format", "json"]))
+		.expect("top --format json must be valid JSON");
+	for row in top.as_array().into_iter().flatten() {
+		assert!(
+			row["Titles"].is_array(),
+			"top Titles must be an array, never null: {row}"
+		);
+		assert!(
+			row["Processes"].is_array(),
+			"top Processes must be an array, never null: {row}"
+		);
+	}
+}
+
+/// `logs` and attached `up` tag the same container the same way: the service and
+/// index, project stripped, one space before the bar. They used to disagree —
+/// `myproj-web-1  | ` against `web-1 | ` — so anything parsing the prefix had to
+/// accept both shapes from one binary.
+#[test]
+fn logs_prefix_is_service_and_index_with_one_space() {
+	if !podman_up() {
+		return;
+	}
+	let p = Project::start("pfx");
+	let out = p.run(&["logs", "--tail", "1"]);
+	if out.trim().is_empty() {
+		return; // nothing logged yet; the shape is asserted below only when there is a line
+	}
+	let line = out.lines().next().unwrap_or_default();
+	assert!(
+		line.contains("web-1 | "),
+		"expected `web-1 | ` (project stripped, one space); got {line:?}"
+	);
+	assert!(
+		!line.contains(&format!("{}-web-1", p.name)),
+		"the project prefix must be stripped: {line:?}"
+	);
+}

--- a/tests/output_contract.rs
+++ b/tests/output_contract.rs
@@ -18,14 +18,18 @@ fn bin() -> &'static str {
 	env!("CARGO_BIN_EXE_podup")
 }
 
-/// Whether a real Podman is reachable. These read live output, so they skip
-/// rather than fail on a machine without it — matching the integration suite.
-fn podman_up() -> bool {
-	Command::new("podman")
-		.arg("info")
-		.output()
-		.map(|o| o.status.success())
-		.unwrap_or(false)
+/// Whether a Podman podup can actually drive is reachable.
+///
+/// This is the integration suite's guard, not a `podman info` probe. The CI
+/// runner ships a podman binary that is *below podup's floor* with no socket
+/// running, so `podman info` succeeds while every command here fails — the
+/// weaker check let these run in the main CI job and fail for the environment
+/// rather than the code.
+async fn podman_up() -> bool {
+	match podup::podman::connect_from_env().or_else(|_| podup::podman::connect(None)) {
+		Ok(client) => client.ping().await.is_ok(),
+		Err(_) => false,
+	}
 }
 
 struct Project {
@@ -75,9 +79,9 @@ impl Drop for Project {
 /// used to be the exception, so a script locating its columns from the header
 /// broke on an empty project — and empty is a legitimate answer, not a missing
 /// one.
-#[test]
-fn list_commands_print_their_table_headers() {
-	if !podman_up() {
+#[tokio::test]
+async fn list_commands_print_their_table_headers() {
+	if !podman_up().await {
 		return;
 	}
 	let p = Project::start("hdr");
@@ -113,9 +117,9 @@ fn list_commands_print_their_table_headers() {
 /// The JSON keys each `--format json` command emits, and their types. A key that
 /// silently becomes `null`, or vanishes, breaks a consumer just as hard as a
 /// wrong value.
-#[test]
-fn json_output_keys_are_stable() {
-	if !podman_up() {
+#[tokio::test]
+async fn json_output_keys_are_stable() {
+	if !podman_up().await {
 		return;
 	}
 	let p = Project::start("jsn");
@@ -124,7 +128,8 @@ fn json_output_keys_are_stable() {
 		.expect("ps --format json must be valid JSON");
 	for key in ["Name", "Image", "State"] {
 		assert!(
-			ps.as_array().is_some_and(|a| a.iter().all(|r| r.get(key).is_some())),
+			ps.as_array()
+				.is_some_and(|a| a.iter().all(|r| r.get(key).is_some())),
 			"ps json row is missing {key}: {ps}"
 		);
 	}
@@ -133,7 +138,8 @@ fn json_output_keys_are_stable() {
 		.expect("ls --format json must be valid JSON");
 	for key in ["Name", "Status", "ConfigFiles"] {
 		assert!(
-			ls.as_array().is_some_and(|a| a.iter().all(|r| r.get(key).is_some())),
+			ls.as_array()
+				.is_some_and(|a| a.iter().all(|r| r.get(key).is_some())),
 			"ls json row is missing {key}: {ls}"
 		);
 	}
@@ -158,9 +164,9 @@ fn json_output_keys_are_stable() {
 /// index, project stripped, one space before the bar. They used to disagree —
 /// `myproj-web-1  | ` against `web-1 | ` — so anything parsing the prefix had to
 /// accept both shapes from one binary.
-#[test]
-fn logs_prefix_is_service_and_index_with_one_space() {
-	if !podman_up() {
+#[tokio::test]
+async fn logs_prefix_is_service_and_index_with_one_space() {
+	if !podman_up().await {
 		return;
 	}
 	let p = Project::start("pfx");


### PR DESCRIPTION
Closes #1082 — the remainder after #1111, plus the test net the issue says was missing.

## Fixed

- **`wait` prints one line per service**, not per replica. A service scaled to 3 returned 3 lines, so a caller could not pair its input list with the output line for line. A scaled service reports the last non-zero code it saw; a service with no containers still contributes no line, so the existing idempotent no-op stays one.
- **`volumes` prints its header on an empty result**, like `ps`, `ls`, `images` and `stats`. It was the only list command that suppressed it, and a script locating its columns from the header broke on an empty project — which is a legitimate answer, not a missing one.
- **`ls --format json` reports the real `ConfigFiles`.** It was hard-coded empty for a reason: projects are discovered by container label and podup kept no record of the compose path. So containers now carry a `podup.config-files` label with the absolute paths, and `ls` reads it. A container created before the label existed reports empty rather than failing.
- **`logs` tags lines the way attached `up` already did** — service and index, project stripped, one space before the bar. Two commands in one binary printed `myproj-web-1  | ` and `web-1 | ` for the same container. Measured: `m3-web-1  | hola` → `web-1 | hola`.
- **`top --format json` emits arrays, never `null`.** The table path defaulted them and the JSON path did not.
- **`port`'s `--protocol` alias** documented.

## The part that matters beyond today

`tests/output_contract.rs`. #1082's closing observation is that **no test asserted a single table header or JSON key** — not `NAME`, not `STATUS`, not an `images` key — which is why every drift above reached users. Fixing them one at a time only resets the clock.

It asserts presence and shape, never values: a test pinning real container names would fail for the wrong reason and get deleted. It covers the headers of `ps`/`images`/`volumes` including the empty case, the JSON keys of `ps`/`ls`/`top` with `top`'s two array types, and the `logs` prefix shape.

## Deliberately not changed

The **`--ansi always`** item, as I noted on the issue. `always` means force colour regardless of the sink, so escape codes in a redirect are the flag's documented behaviour. Changing it would need a measurement of `docker compose --ansi always` into a pipe that I have not made — I would rather leave it than alter a flag's meaning on a hunch.

## Test plan

`cargo test --lib` 1276/1276, `output_contract` 3/3 against real Podman 5.4.2, clippy `--all-targets --all-features` clean.

Three existing prefixer tests asserted the two-space shape and now assert one, with the reason in a doc comment. The `project_row` test asserted `ConfigFiles == ""` as correct-by-design and now asserts the recorded path, plus a second test that an unrecorded one degrades to empty.

Every change verified with the built binaries, `develop` against this branch.

Closes #1082