### PR TITLE
fix: dedup volumes by target, and honour the !override and !reset tags

### DIFF
--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -11,6 +11,76 @@ use super::super::types::{
 	ServiceNetworks, StringOrList, Sysctls,
 };
 
+/// [`merge_service`] with the overriding file's `!override`/`!reset` tags.
+///
+/// A key tagged `!override` takes the overriding value whole, skipping whatever
+/// combine rule would normally apply; `!reset` drops the key entirely, leaving
+/// the type's default. Both were accepted and silently ignored before, so a file
+/// asking for replacement got an append instead — the opposite of what it said.
+///
+/// Implemented by pre-shaping the two sides and then running the ordinary merge,
+/// rather than by branching inside it: `!reset` empties both sides so the result
+/// is the default, and `!override` empties only the base so the combine rule has
+/// nothing to combine with and the overriding value survives whole. One rule
+/// each, and the field-by-field merge below stays the single place that knows
+/// how any given key combines.
+pub(in crate::compose) fn merge_service_tagged(
+	base: Service,
+	override_svc: Service,
+	tagged: Option<&std::collections::HashMap<String, crate::compose::tags::MergeTag>>,
+) -> Service {
+	let Some(tagged) = tagged.filter(|t| !t.is_empty()) else {
+		return merge_service(base, override_svc);
+	};
+	let mut base = base;
+	let mut over = override_svc;
+	for (key, tag) in tagged {
+		clear_service_key(&mut base, key);
+		if matches!(tag, crate::compose::tags::MergeTag::Reset) {
+			clear_service_key(&mut over, key);
+		}
+	}
+	merge_service(base, over)
+}
+
+/// Reset one service key to its default, by name — the primitive both tags are
+/// built from.
+///
+/// A key podup does not model is ignored: a tag cannot change a merge that never
+/// happens, and refusing it would reject a file that is valid elsewhere.
+fn clear_service_key(svc: &mut Service, key: &str) {
+	match key {
+		"ports" => svc.ports = Vec::new(),
+		"expose" => svc.expose = Vec::new(),
+		"volumes" => svc.volumes = Vec::new(),
+		"volumes_from" => svc.volumes_from = Vec::new(),
+		"networks" => svc.networks = Default::default(),
+		"environment" => svc.environment = Default::default(),
+		"env_file" => svc.env_file = Default::default(),
+		"labels" => svc.labels = Default::default(),
+		"label_file" => svc.label_file = Default::default(),
+		"dns" => svc.dns = Default::default(),
+		"dns_search" => svc.dns_search = Default::default(),
+		"dns_opt" => svc.dns_opt = Default::default(),
+		"tmpfs" => svc.tmpfs = Default::default(),
+		"sysctls" => svc.sysctls = Default::default(),
+		"cap_add" => svc.cap_add = Vec::new(),
+		"cap_drop" => svc.cap_drop = Vec::new(),
+		"devices" => svc.devices = Vec::new(),
+		"extra_hosts" => svc.extra_hosts = Vec::new(),
+		"ulimits" => svc.ulimits = Default::default(),
+		"depends_on" => svc.depends_on = Default::default(),
+		"secrets" => svc.secrets = Vec::new(),
+		"configs" => svc.configs = Vec::new(),
+		"links" => svc.links = Vec::new(),
+		"external_links" => svc.external_links = Vec::new(),
+		"group_add" => svc.group_add = Vec::new(),
+		"security_opt" => svc.security_opt = Vec::new(),
+		"profiles" => svc.profiles = Vec::new(),
+		_ => {}
+	}
+}
+
 pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) -> Service {
 	fn opt<T>(o: Option<T>, b: Option<T>) -> Option<T> {
 		o.or(b)
@@ -153,7 +223,7 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		expose: merge_vec(base.expose, override_svc.expose),
 		environment: merge_envvars(base.environment, override_svc.environment),
 		env_file: merge_env_file(base.env_file, override_svc.env_file),
-		volumes: merge_vec(base.volumes, override_svc.volumes),
+		volumes: merge_volumes(base.volumes, override_svc.volumes),
 		tmpfs: merge_sol(base.tmpfs, override_svc.tmpfs),
 		volumes_from: merge_vec(base.volumes_from, override_svc.volumes_from),
 		configs: merge_vec(base.configs, override_svc.configs),
@@ -261,6 +331,30 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 			u
 		},
 	}
+}
+
+/// Merge `volumes:` by **container-side target**, with the override winning.
+///
+/// `merge_vec` dedups by serialized form, so a base mounting `./a:/data` and an
+/// override remapping it to `./b:/data` produced both entries — and
+/// `podman create` refused the container with `duplicate mount destination`.
+/// docker compose replaces the mount at a target it already has, which is what
+/// remapping a path in an override is *for*.
+///
+/// Base order is preserved so an unchanged mount stays where it was; an override
+/// introducing a new target appends.
+fn merge_volumes(
+	base: Vec<crate::compose::types::VolumeMount>,
+	over: Vec<crate::compose::types::VolumeMount>,
+) -> Vec<crate::compose::types::VolumeMount> {
+	let mut out = base;
+	for item in over {
+		match out.iter().position(|m| m.target() == item.target()) {
+			Some(i) => out[i] = item,
+			None => out.push(item),
+		}
+	}
+	out
 }
 
 /// Union two `networks:` declarations, keeping the base's attachments and adding

--- a/internal/compose/extends/merge/tests.rs
+++ b/internal/compose/extends/merge/tests.rs
@@ -352,3 +352,97 @@ networks:
 		"serialized form lost the network names: {rendered}"
 	);
 }
+
+/// #1078: a base and an override mounting different sources at the *same*
+/// target used to emit both, and `podman create` refused the container with
+/// `duplicate mount destination`. Remapping a path in an override is exactly
+/// what the override is for, so the later one wins.
+#[test]
+fn volumes_at_the_same_target_are_replaced_not_duplicated() {
+	let yaml = r#"
+services:
+  base:
+    image: alpine
+    volumes:
+      - ./a:/data
+      - ./logs:/var/log
+  app:
+    extends: base
+    volumes:
+      - ./b:/data
+"#;
+	let file = parse_str(yaml).unwrap();
+	let mounts = &file.services["app"].volumes;
+	let at_data: Vec<_> = mounts.iter().filter(|m| m.target() == "/data").collect();
+	assert_eq!(at_data.len(), 1, "one mount per target: {mounts:?}");
+	assert!(
+		format!("{:?}", at_data[0]).contains("./b"),
+		"the override's source must win: {:?}",
+		at_data[0]
+	);
+	// A target only the base declares is untouched.
+	assert!(
+		mounts.iter().any(|m| m.target() == "/var/log"),
+		"an unrelated base mount must survive: {mounts:?}"
+	);
+}
+
+/// #1078: `!override` takes the overriding value whole instead of appending.
+/// Both tags were accepted and silently ignored, so a file asking for
+/// replacement got a merge — the opposite of what it said.
+#[test]
+fn override_tag_replaces_instead_of_appending() {
+	let base =
+		parse_str("services:\n  web:\n    image: alpine\n    ports: [\"8080:80\"]\n").unwrap();
+	let over = parse_str("services:\n  web:\n    ports: !override [\"9090:80\"]\n").unwrap();
+	let raw: serde_yaml::Value =
+		serde_yaml::from_str("services:\n  web:\n    ports: !override [\"9090:80\"]\n").unwrap();
+	let directives = crate::compose::tags::collect(&raw);
+
+	let merged = crate::compose::extends::merge_service_tagged(
+		base.services["web"].clone(),
+		over.services["web"].clone(),
+		directives.get("web"),
+	);
+	assert_eq!(
+		merged.ports.len(),
+		1,
+		"!override must replace, not append: {:?}",
+		merged.ports
+	);
+}
+
+/// `!reset` drops the key entirely, leaving the type's default.
+#[test]
+fn reset_tag_clears_the_base_value() {
+	let base = parse_str("services:\n  web:\n    image: alpine\n    dns: [\"1.1.1.1\"]\n").unwrap();
+	let over = parse_str("services:\n  web:\n    dns: !reset []\n").unwrap();
+	let raw: serde_yaml::Value =
+		serde_yaml::from_str("services:\n  web:\n    dns: !reset []\n").unwrap();
+	let directives = crate::compose::tags::collect(&raw);
+
+	let merged = crate::compose::extends::merge_service_tagged(
+		base.services["web"].clone(),
+		over.services["web"].clone(),
+		directives.get("web"),
+	);
+	assert!(
+		merged.dns.to_list().is_empty(),
+		"!reset must clear the base: {:?}",
+		merged.dns
+	);
+}
+
+/// Without a tag the ordinary merge rule still applies — the tags must not
+/// change the default behaviour of anything they are not on.
+#[test]
+fn an_untagged_key_still_merges_normally() {
+	let base = parse_str("services:\n  web:\n    image: alpine\n    dns: [\"1.1.1.1\"]\n").unwrap();
+	let over = parse_str("services:\n  web:\n    dns: [\"9.9.9.9\"]\n").unwrap();
+	let merged = crate::compose::extends::merge_service_tagged(
+		base.services["web"].clone(),
+		over.services["web"].clone(),
+		None,
+	);
+	assert_eq!(merged.dns.to_list(), vec!["1.1.1.1", "9.9.9.9"]);
+}

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -17,7 +17,7 @@ use super::parse_file_inner;
 use super::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
-pub(in crate::compose) use merge::merge_service;
+pub(in crate::compose) use merge::{merge_service, merge_service_tagged};
 
 const MAX_EXTENDS_DEPTH: usize = 16;
 

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -39,7 +39,12 @@ pub(super) fn deserialize_with_merge_interp(
 	content: &str,
 	vars: Option<&HashMap<String, String>>,
 ) -> Result<ComposeFile> {
-	let value = interpolated_value(content, vars)?;
+	let mut value = interpolated_value(content, vars)?;
+	// Drop the merge tags before typing: whether serde tolerates one depends on
+	// the field's Rust type, so leaving them in makes `!reset` fail the file on
+	// `dns` and do nothing on `ports`. What each tag means is decided by the
+	// merge (see `compose::tags`), not by which type happens to be behind a key.
+	super::tags::strip(&mut value);
 	let file: ComposeFile = serde_yaml::from_value(value)?;
 	Ok(file)
 }

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -9,6 +9,7 @@ mod extends;
 mod include;
 mod merge;
 mod order;
+mod tags;
 mod validate;
 
 use std::path::{Path, PathBuf};
@@ -145,7 +146,11 @@ pub fn parse_files_with_env_files_interp(
 	let mut merged = parse_file_with_env_files_interp(first, env_files, interpolate)?;
 	for path in iter {
 		let other = parse_file_with_env_files_interp(path, env_files, interpolate)?;
-		merge_override(&mut merged, other);
+		// `!override`/`!reset` are attached to keys in the raw document and are
+		// gone by the time it is a typed `ComposeFile`, so they are collected
+		// from the file itself and passed alongside.
+		let directives = tags::collect_from_file(path);
+		merge_override(&mut merged, other, &directives);
 	}
 	normalize_default_network(&mut merged);
 	// Semantic validation runs only on the interpolated file: `--no-interpolate`
@@ -234,10 +239,11 @@ pub(crate) fn normalize_default_network(file: &mut ComposeFile) {
 /// Merge `other` into `target` with `other` winning (compose `-f` override
 /// semantics): services are merged field-by-field, other top-level maps replace
 /// on key conflict.
-fn merge_override(target: &mut ComposeFile, other: ComposeFile) {
+fn merge_override(target: &mut ComposeFile, other: ComposeFile, directives: &tags::Directives) {
 	for (name, svc) in other.services {
 		if let Some(base) = target.services.get_mut(&name) {
-			*base = extends::merge_service(std::mem::take(base), svc);
+			let tagged = directives.get(&name);
+			*base = extends::merge_service_tagged(std::mem::take(base), svc, tagged);
 		} else {
 			target.services.insert(name, svc);
 		}
@@ -387,7 +393,7 @@ mod tests {
 		let mut other = ComposeFile::default();
 		other.models.insert("llm".to_string(), model("over/m"));
 		other.models.insert("extra".to_string(), model("e/m"));
-		merge_override(&mut target, other);
+		merge_override(&mut target, other, &tags::Directives::new());
 		// Override file wins on conflict; the override-only model is added.
 		assert_eq!(target.models["llm"].model.as_deref(), Some("over/m"));
 		assert_eq!(target.models["extra"].model.as_deref(), Some("e/m"));
@@ -434,7 +440,7 @@ mod tests {
 			.configs
 			.insert("extra".to_string(), ConfigConfig::default());
 
-		merge_override(&mut target, other);
+		merge_override(&mut target, other, &tags::Directives::new());
 
 		assert!(target.volumes.contains_key("data"));
 		assert!(target.volumes.contains_key("cache"));

--- a/internal/compose/tags.rs
+++ b/internal/compose/tags.rs
@@ -1,0 +1,196 @@
+//! The `!override` and `!reset` merge tags.
+//!
+//! Compose defines two YAML tags that change how a key merges across `-f` files
+//! and `extends`, and they are the documented escape hatch from every merge rule
+//! that would otherwise combine rather than replace:
+//!
+//! ```yaml
+//! services:
+//!   web:
+//!     ports: !override ["9090:80"]   # replace the base's ports, do not append
+//!     dns:   !reset []               # drop the base's dns entirely
+//! ```
+//!
+//! podup accepted both and then **ignored them silently** — `!override` still
+//! appended and `!reset` still kept the base. Silently doing the opposite of
+//! what a key asks for is worse than refusing it, and the tags exist precisely
+//! for the cases where the default merge is wrong.
+//!
+//! The tag is lost when YAML is deserialized into the typed `Service`, which is
+//! where merging happens, so it has to be collected from the raw document first.
+//! That is what this module does: read which service keys carry which tag, and
+//! hand that to the merge as a side channel.
+
+use std::collections::HashMap;
+
+use serde_yaml::Value;
+
+/// What a tag asks the merge to do with one key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MergeTag {
+	/// `!override` — take the overriding file's value whole, skipping the
+	/// combine rule that would otherwise apply.
+	Override,
+	/// `!reset` — drop the key entirely, leaving the type's default.
+	Reset,
+}
+
+/// Tagged keys per service name: `services.<name>.<key>` → tag.
+pub(crate) type Directives = HashMap<String, HashMap<String, MergeTag>>;
+
+/// Collect the merge tags in a raw compose document.
+///
+/// Reads the document only for its structure, so interpolation is irrelevant —
+/// a tag is attached to a key, never to a value's contents.
+///
+/// An unrecognized tag is ignored rather than rejected: the compose spec lets a
+/// document carry tags this tool does not define, and refusing them would break
+/// files that are valid elsewhere.
+pub(crate) fn collect(raw: &Value) -> Directives {
+	let mut out: Directives = HashMap::new();
+	let Some(services) = raw.get("services").and_then(Value::as_mapping) else {
+		return out;
+	};
+	for (name, service) in services {
+		let (Some(name), Some(fields)) = (name.as_str(), service.as_mapping()) else {
+			continue;
+		};
+		let mut tagged: HashMap<String, MergeTag> = HashMap::new();
+		for (key, value) in fields {
+			let (Some(key), Value::Tagged(t)) = (key.as_str(), value) else {
+				continue;
+			};
+			let tag = match t.tag.to_string().as_str() {
+				"!override" => MergeTag::Override,
+				"!reset" => MergeTag::Reset,
+				_ => continue,
+			};
+			tagged.insert(key.to_string(), tag);
+		}
+		if !tagged.is_empty() {
+			out.insert(name.to_string(), tagged);
+		}
+	}
+	out
+}
+
+/// Remove every `!override`/`!reset` tag from a document, keeping the value it
+/// wraps.
+///
+/// This has to run before the document is deserialized into typed structs.
+/// Whether a tag is tolerated otherwise depends entirely on the field's Rust
+/// type: `ports` is a `Vec`, which quietly ignores it, but `dns` is an untagged
+/// enum, and serde refuses those outright — so `dns: !reset []` failed the whole
+/// file with "failed to parse compose file" while `ports: !reset []` parsed and
+/// did nothing. Two different wrong behaviours for the same tag, decided by an
+/// implementation detail the user cannot see.
+///
+/// Stripping first makes the tag mean the same thing everywhere; what it *does*
+/// is then decided by [`collect`] and the merge, not by serde.
+pub(crate) fn strip(value: &mut Value) {
+	match value {
+		Value::Tagged(t) => {
+			let mut inner = std::mem::replace(&mut t.value, Value::Null);
+			strip(&mut inner);
+			*value = inner;
+		}
+		Value::Mapping(map) => {
+			// A tag can sit on a key's value at any depth, and rebuilding the map
+			// preserves insertion order, which the compose output relies on.
+			let entries: Vec<(Value, Value)> = std::mem::take(map).into_iter().collect();
+			for (k, mut v) in entries {
+				strip(&mut v);
+				map.insert(k, v);
+			}
+		}
+		Value::Sequence(seq) => {
+			for v in seq.iter_mut() {
+				strip(v);
+			}
+		}
+		_ => {}
+	}
+}
+
+/// Read a compose file's merge tags, or an empty set when it cannot be read or
+/// parsed.
+///
+/// Best-effort by design: this runs alongside the real parse, which reports any
+/// genuine syntax error with a proper message. Failing here too would only
+/// duplicate that, and returning empty simply means "no tags", which is the
+/// behaviour every file without them already gets.
+pub(crate) fn collect_from_file(path: &std::path::Path) -> Directives {
+	let Ok(text) = std::fs::read_to_string(path) else {
+		return Directives::new();
+	};
+	match serde_yaml::from_str::<Value>(&text) {
+		Ok(raw) => collect(&raw),
+		Err(_) => Directives::new(),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn parse(y: &str) -> Directives {
+		collect(&serde_yaml::from_str::<Value>(y).unwrap())
+	}
+
+	#[test]
+	fn collects_override_and_reset_per_service() {
+		let d = parse(
+			"services:\n  web:\n    ports: !override [\"9090:80\"]\n    dns: !reset []\n  db:\n    image: x\n",
+		);
+		let web = d.get("web").expect("web has tags");
+		assert_eq!(web.get("ports"), Some(&MergeTag::Override));
+		assert_eq!(web.get("dns"), Some(&MergeTag::Reset));
+		assert!(!d.contains_key("db"), "a service with no tags is absent");
+	}
+
+	#[test]
+	fn untagged_document_yields_nothing() {
+		assert!(parse("services:\n  web:\n    ports: [\"80:80\"]\n").is_empty());
+	}
+
+	/// A tag this tool does not define is ignored, not rejected — the document
+	/// may be valid for something else.
+	#[test]
+	fn unknown_tag_is_ignored() {
+		let d = parse("services:\n  web:\n    ports: !whatever [\"80:80\"]\n");
+		assert!(d.is_empty(), "{d:?}");
+	}
+
+	#[test]
+	fn a_document_without_services_is_not_an_error() {
+		assert!(parse("volumes:\n  data:\n").is_empty());
+	}
+
+	/// Stripping is what makes a tag mean the same thing on every key. Left in,
+	/// serde decides: a `Vec` field ignores it and an untagged enum refuses the
+	/// whole file.
+	#[test]
+	fn strip_removes_tags_at_any_depth() {
+		let mut v: Value = serde_yaml::from_str(
+			"services:\n  web:\n    ports: !override [\"9090:80\"]\n    dns: !reset []\n",
+		)
+		.unwrap();
+		strip(&mut v);
+		let out = serde_yaml::to_string(&v).unwrap();
+		assert!(!out.contains("!override"), "{out}");
+		assert!(!out.contains("!reset"), "{out}");
+		// The wrapped value survives — stripping removes the tag, not the data.
+		assert!(out.contains("9090:80"), "{out}");
+	}
+
+	/// The document is otherwise untouched, including key order, which the
+	/// `config` output depends on.
+	#[test]
+	fn strip_preserves_an_untagged_document_verbatim() {
+		let text = "services:\n  web:\n    image: alpine\n    ports:\n    - 80:80\n";
+		let mut v: Value = serde_yaml::from_str(text).unwrap();
+		let before = serde_yaml::to_string(&v).unwrap();
+		strip(&mut v);
+		assert_eq!(serde_yaml::to_string(&v).unwrap(), before);
+	}
+}


### PR DESCRIPTION
Closes #1078 — the last two divergences after #1112.

## Same-target volumes

Deduped by serialized form, so a base mounting `./a:/data` and an override remapping it to `./b:/data` produced **both**, and Podman refused the container:

```
develop:  podman API error (HTTP 500): "/data": duplicate mount destination
fixed:    Container vt-web-1 Started      /data holds the override's content
```

Dedup is by container-side target now, override winning — which is what remapping a path in an override is *for*. Base order is preserved and a target only the base declares is untouched.

## The tags were worse than the issue said, in two ways at once

#1078 calls `!override`/`!reset` a "hard parse failure". I measured it and got the opposite — silently ignored — and said so. **We were both right, and that was the actual bug.** Measured on `develop`:

```
!reset on dns    -> "failed to parse compose file"
!reset on ports  -> silently ignored, base kept
```

Which one you got depended on the field's **Rust type**: `ports` is a `Vec`, which quietly ignores a tag; `dns` is an untagged enum, which serde refuses outright. Two different wrong behaviours for the same tag, decided by an implementation detail invisible from the compose file. My earlier measurement happened to pick `ports`, which is why I only saw half of it.

## The fix

Tags are stripped from the document **before** it is typed, so a tag means the same thing on every key. What each one *does* is then decided by the merge, not by serde:

- **`!override`** clears the base, so the combine rule has nothing to combine with and the overriding value survives whole.
- **`!reset`** clears both sides, so the result is the type's default.

One rule each, and the field-by-field merge stays the single place that knows how any given key combines — rather than growing a tag branch per field.

```
!override ["9090:80"]  ->  9090:80          (was: 8080:80, 9090:80)
!reset [] on dns       ->  no dns           (was: parse failure)
!reset [] on ports     ->  no ports         (was: base kept)
```

An unrecognised tag is ignored rather than rejected: a document may legitimately carry tags this tool does not define.

## Test plan

`cargo test --lib` 1285/1285, clippy `--all-targets --all-features` clean, `docs_flags` green.

New: the `tags` module with its own tests (collection per service, unknown tags ignored, stripping at any depth, an untagged document preserved verbatim including key order — which `config` output depends on), plus merge tests for override/reset/untagged and the same-target volume case.

**One I nearly shipped broken:** the volume test compiled but never ran. I appended it to `merge/tests.rs`, which is a module *body* with no wrapping braces, so my append ate the previous function's closing brace and nested the new test inside it — `#[test]` on an inner function is legal and simply never collected. Caught it by counting registered tests (15, not 16) rather than trusting the green run. Same trap as `startup` only being in `--bins`.

Verified end to end against real Podman 5.4.2 — the numbers above are from the built binaries, `develop` against this branch.

Closes #1078