### PR TITLE
feat!: bound autostart service-mode stop above the longest grace period

### DIFF
--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -44,7 +44,33 @@ impl SystemCtl for RealSystemCtl {
 	}
 }
 
+/// The longest `stop_grace_period` across a compose file's services, in seconds.
+///
+/// systemd bounds `ExecStop` independently of what runs inside it, and its
+/// default `DefaultTimeoutStopUSec` is 90s. `podup stop` honours each
+/// container's own grace period, so a stack whose slowest container needs more
+/// than that stops cleanly when a human runs it and gets killed mid-stop at
+/// reboot — the difference only shows up during an unattended shutdown, which
+/// is the worst version of it.
+///
+/// `None` when no service sets one, or when none parses, so the unit simply
+/// omits `TimeoutStopSec=` and keeps systemd's default. An unparseable duration
+/// is skipped rather than defaulted: the value is validated elsewhere, and
+/// guessing a timeout from a malformed one would be worse than not setting it.
+pub fn max_stop_grace_secs(file: &crate::compose::types::ComposeFile) -> Option<u64> {
+	file.services
+		.values()
+		.filter_map(|s| s.stop_grace_period.as_deref())
+		.filter_map(crate::size::parse_duration_secs)
+		.max()
+}
+
 /// Options for [`install`].
+///
+/// `#[non_exhaustive]`: see [`ServiceUnitOpts`] — same reason, same construction
+/// pattern.
+#[non_exhaustive]
+#[derive(Default)]
 pub struct InstallOptions {
 	/// The unit to render and install.
 	pub unit: ServiceUnitOpts,
@@ -52,6 +78,29 @@ pub struct InstallOptions {
 	pub no_start: bool,
 	/// Print the unit and the actions that would run, but change nothing.
 	pub dry_run: bool,
+}
+
+impl InstallOptions {
+	/// Install `unit` with the default flags (start it, really write it).
+	pub fn new(unit: ServiceUnitOpts) -> Self {
+		Self {
+			unit,
+			no_start: false,
+			dry_run: false,
+		}
+	}
+
+	/// Install the unit but do not `enable --now` it. Builder-style.
+	pub fn with_no_start(mut self, no_start: bool) -> Self {
+		self.no_start = no_start;
+		self
+	}
+
+	/// Print what would happen and change nothing. Builder-style.
+	pub fn with_dry_run(mut self, dry_run: bool) -> Self {
+		self.dry_run = dry_run;
+		self
+	}
 }
 
 /// `${XDG_CONFIG_HOME:-~/.config}`. Falls back to `$HOME/.config`, then `.config`

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -10,6 +10,12 @@ use std::path::PathBuf;
 /// Inputs to render a service-mode autostart unit. Every path must be absolute:
 /// systemd resolves the `ExecStart`/`ExecStop` lines with no working directory of
 /// its own, so a relative path would be interpreted against `/`.
+///
+/// `#[non_exhaustive]`: this gained a field once and will again as more of the
+/// unit becomes configurable, so it is constructed with `..Default::default()`
+/// rather than by a literal that breaks on every addition.
+#[non_exhaustive]
+#[derive(Default)]
 pub struct ServiceUnitOpts {
 	/// Absolute path to the `podup` executable.
 	pub exe: PathBuf,
@@ -23,6 +29,55 @@ pub struct ServiceUnitOpts {
 	pub profiles: Vec<String>,
 	/// Extra env files, passed through as `--env-file` flags.
 	pub env_files: Vec<String>,
+	/// Longest `stop_grace_period` across the project's services, in seconds.
+	///
+	/// systemd bounds the whole `ExecStop` independently of what podup does
+	/// inside it, and its default is 90s — so a stack whose slowest container
+	/// needs longer gets killed mid-stop at reboot, while a manual `podup stop`
+	/// honours it. `None` leaves `TimeoutStopSec=` off, which is right when no
+	/// service asks for anything unusual.
+	pub max_stop_grace_secs: Option<u64>,
+}
+
+impl ServiceUnitOpts {
+	/// The four values a unit cannot be rendered without. Everything else has a
+	/// sensible empty default and is added with the `with_*` methods.
+	pub fn new(
+		exe: PathBuf,
+		compose_files: Vec<PathBuf>,
+		project: String,
+		working_dir: PathBuf,
+	) -> Self {
+		Self {
+			exe,
+			compose_files,
+			project,
+			working_dir,
+			profiles: Vec::new(),
+			env_files: Vec::new(),
+			max_stop_grace_secs: None,
+		}
+	}
+
+	/// Active profiles, passed through as `--profile` flags. Builder-style.
+	pub fn with_profiles(mut self, profiles: Vec<String>) -> Self {
+		self.profiles = profiles;
+		self
+	}
+
+	/// Extra env files, passed through as `--env-file` flags. Builder-style.
+	pub fn with_env_files(mut self, env_files: Vec<String>) -> Self {
+		self.env_files = env_files;
+		self
+	}
+
+	/// The longest `stop_grace_period` in the project, so the unit can bound
+	/// `ExecStop` above it rather than letting systemd's 90s default cut a
+	/// slower stack off mid-shutdown. Builder-style.
+	pub fn with_max_stop_grace_secs(mut self, secs: Option<u64>) -> Self {
+		self.max_stop_grace_secs = secs;
+		self
+	}
 }
 
 /// Whether a token is safe to place on a systemd exec line without quoting:
@@ -178,6 +233,17 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// other interpolated value here is escaped regardless of what validates it
 	// elsewhere, so the project name is too.
 	let project = opts.project.replace('%', "%%");
+	// systemd bounds ExecStop on its own, at DefaultTimeoutStopUSec (90s), no
+	// matter that `podup stop` honours each container's own grace period inside
+	// it. Give it headroom over the slowest container rather than the exact
+	// value: the stop has per-container teardown around it, and a bound equal to
+	// the grace period would cut the last container off just as it finishes.
+	// Quadlet mode already gets this right via StopTimeout=, so this closes an
+	// inconsistency between the two modes rather than adding a new behaviour.
+	let stop_timeout = match opts.max_stop_grace_secs {
+		Some(secs) => format!("TimeoutStopSec={}\n", secs.saturating_add(30)),
+		None => String::new(),
+	};
 	format!(
 		"[Unit]\n\
 		 Description=podup {project}\n\
@@ -188,6 +254,7 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 		 WorkingDirectory={workdir}\n\
 		 ExecStart={start}\n\
 		 ExecStop={stop}\n\
+		 {stop_timeout}\
 		 \n\
 		 [Install]\n\
 		 WantedBy=default.target\n",
@@ -195,6 +262,7 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 		workdir = workdir,
 		start = start,
 		stop = stop,
+		stop_timeout = stop_timeout,
 	)
 }
 
@@ -211,6 +279,7 @@ mod tests {
 			working_dir: PathBuf::from("/srv/app"),
 			profiles: Vec::new(),
 			env_files: Vec::new(),
+			max_stop_grace_secs: None,
 		}
 	}
 
@@ -424,5 +493,45 @@ mod tests {
 		o.working_dir = PathBuf::from("/srv/50%off");
 		o.compose_files = vec![PathBuf::from("/srv/50%off/docker-compose.yml")];
 		assert!(validate_unit_opts(&o).is_ok());
+	}
+
+	/// #1093: systemd bounds `ExecStop` independently of what podup does inside
+	/// it, at a 90s default. A stack whose slowest container needs longer stops
+	/// cleanly when a human runs `podup stop` and gets killed mid-stop at
+	/// reboot — the difference only appears during an unattended shutdown,
+	/// which is the worst version of it.
+	#[test]
+	fn render_service_unit_bounds_stop_above_the_longest_grace_period() {
+		let mut o = opts_single();
+		o.max_stop_grace_secs = Some(120);
+		let s = render_service_unit(&o);
+		assert!(
+			s.contains("TimeoutStopSec=150"),
+			"expected the longest grace plus headroom:\n{s}"
+		);
+	}
+
+	/// Headroom, not the exact value: the stop has per-container teardown around
+	/// it, so a bound equal to the grace period would cut the last container off
+	/// just as it finishes.
+	#[test]
+	fn stop_timeout_leaves_headroom_over_the_grace_period() {
+		let mut o = opts_single();
+		o.max_stop_grace_secs = Some(10);
+		let s = render_service_unit(&o);
+		let line = s
+			.lines()
+			.find(|l| l.starts_with("TimeoutStopSec="))
+			.expect("the key is present");
+		let secs: u64 = line.trim_start_matches("TimeoutStopSec=").parse().unwrap();
+		assert!(secs > 10, "must exceed the grace period, got {secs}");
+	}
+
+	/// No service asking for anything unusual leaves the key off entirely, so
+	/// systemd keeps its own default rather than podup restating it.
+	#[test]
+	fn no_grace_period_emits_no_stop_timeout() {
+		let s = render_service_unit(&opts_single());
+		assert!(!s.contains("TimeoutStopSec"), "{s}");
 	}
 }

--- a/internal/autostart/tests.rs
+++ b/internal/autostart/tests.rs
@@ -89,6 +89,7 @@ fn opts(dir: &Path, project: &str, dry_run: bool, no_start: bool) -> InstallOpti
 			working_dir: dir.to_path_buf(),
 			profiles: Vec::new(),
 			env_files: Vec::new(),
+			max_stop_grace_secs: None,
 		},
 		no_start,
 		dry_run,
@@ -307,4 +308,35 @@ fn install_surfaces_systemctl_failure() {
 		let err = install(&sc, &opts(root, "app", false, false)).unwrap_err();
 		assert!(matches!(err, ComposeError::Autostart(_)));
 	});
+}
+
+/// #1093: the unit's `TimeoutStopSec=` is derived from the project's slowest
+/// service, so the roll-up must pick the maximum and tolerate the rest.
+#[test]
+fn max_stop_grace_picks_the_longest() {
+	let file = crate::parse_str(
+		"services:\n  a:\n    image: x\n    stop_grace_period: 10s\n  b:\n    image: x\n    stop_grace_period: 2m\n",
+	)
+	.unwrap();
+	assert_eq!(super::max_stop_grace_secs(&file), Some(120));
+}
+
+/// No service setting one yields `None`, so the unit omits the key and systemd
+/// keeps its own default rather than podup restating it.
+#[test]
+fn max_stop_grace_is_none_when_unset() {
+	let file = crate::parse_str("services:\n  a:\n    image: x\n").unwrap();
+	assert_eq!(super::max_stop_grace_secs(&file), None);
+}
+
+/// An unparseable duration is skipped rather than defaulted: the value is
+/// validated elsewhere, and guessing a timeout from a malformed one would be
+/// worse than not setting it. A valid sibling still counts.
+#[test]
+fn max_stop_grace_skips_an_unparseable_value() {
+	let file = crate::parse_str(
+		"services:\n  a:\n    image: x\n    stop_grace_period: \"nonsense\"\n  b:\n    image: x\n    stop_grace_period: 30s\n",
+	)
+	.unwrap();
+	assert_eq!(super::max_stop_grace_secs(&file), Some(30));
 }

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -72,18 +72,18 @@ pub(crate) async fn dispatch(
 				})?);
 			}
 			let working_dir = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
-			let opts = podup::autostart::InstallOptions {
-				unit: podup::autostart::ServiceUnitOpts {
-					exe,
-					compose_files: abs_files,
-					project,
-					working_dir,
-					profiles: env.profile.to_vec(),
-					env_files: env.env_files.to_vec(),
-				},
-				no_start: *no_start,
-				dry_run: *dry_run,
-			};
+			// The longest stop_grace_period in the project. systemd bounds the whole
+			// ExecStop independently of what podup does inside it, and its default
+			// is 90s — so without this a stack whose slowest container needs longer
+			// is killed mid-stop at reboot, while a manual `podup stop` honours it.
+			let max_grace = podup::autostart::max_stop_grace_secs(file);
+			let unit = podup::autostart::ServiceUnitOpts::new(exe, abs_files, project, working_dir)
+				.with_profiles(env.profile.to_vec())
+				.with_env_files(env.env_files.to_vec())
+				.with_max_stop_grace_secs(max_grace);
+			let opts = podup::autostart::InstallOptions::new(unit)
+				.with_no_start(*no_start)
+				.with_dry_run(*dry_run);
 			podup::autostart::install(&podup::autostart::RealSystemCtl, &opts)
 		}
 		AutostartCommands::Uninstall { purge } => {


### PR DESCRIPTION
Closes #1093.

> **Breaking.** `autostart::ServiceUnitOpts` and `autostart::InstallOptions` become `#[non_exhaustive]` and gain a field, so they are built with the new `::new()` constructors and `with_*` builders instead of a struct literal. This lands in the next MAJOR.

## The bug

systemd bounds the whole `ExecStop` independently of what podup does inside it, and `DefaultTimeoutStopUSec` is 90s:

```
$ systemctl --user show --property=DefaultTimeoutStopUSec
DefaultTimeoutStopUSec=1min 30s
```

`podup stop` honours each container's own `stop_grace_period`, so a stack whose slowest container needs longer stops cleanly when a human runs it and gets **killed mid-stop at reboot**. The grace period is honoured on demand and silently capped during an unattended shutdown — which is the worst version of the difference, because it only shows up when nobody is watching.

## The fix

The unit carries `TimeoutStopSec=` derived from the longest `stop_grace_period` in the project, with headroom:

```
stop_grace_period: 120s  ->  TimeoutStopSec=150
none set                 ->  key absent
```

Headroom rather than the exact value, because the stop has per-container teardown around it — a bound equal to the grace period would cut the last container off just as it finishes. A project where nothing asks for anything unusual emits no key at all, keeping systemd's default rather than podup restating it.

Quadlet mode already got this right via `StopTimeout=`, so this closes an **inconsistency between the two autostart modes** rather than adding a new behaviour.

## Why the break, and why now

I stopped on this issue earlier and left the analysis on it rather than picking: the value is only available where the compose file is parsed, and neither struct could carry it. Both were `pub`, literal-constructed and **not** `#[non_exhaustive]`, unlike the crate's other public types (`ComposeError`, several `compose::types`) — an oversight rather than a decision, and one that would have blocked the next widening too.

Given the go-ahead on version changes, fixing the attribute *at the same time as* adding the field means this is the last time either needs a breaking change to grow. Taking the break without fixing the attribute would have spent it for nothing.

The alternative I costed then — three additive `_with_*` shims — would have worked and left the underlying problem in place for a P3's sake.

## Test plan

`cargo test --lib` 1291/1291, `--bins` 66/66, clippy `--all-targets --all-features` clean.

Six new tests: the rendered unit bounds above the grace period, the bound exceeds it rather than equalling it, no grace period emits no key, and the roll-up picks the maximum, returns `None` when unset, and skips an unparseable duration while still counting a valid sibling (guessing a timeout from a malformed value would be worse than not setting one).

Verified on the built binary via `autostart install --mode service --dry-run` — the rendered values above.

Closes #1093