### PR TITLE
perf: start each service when its own dependencies are up, not its level

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -38,7 +38,8 @@ A podup loss is published exactly like a podup win.
 | `network-ipam` | custom bridge network with explicit IPAM |
 | `volume-heavy` | several named volumes created/removed |
 | `warm-restart` | a second `up` on an already-running project |
-| `many-services` | a 12-service compose file |
+| `many-services
+- **deep-chain** — a fast and a slow service in the same dependency level, with a chain behind the fast one. The shape where a level-barrier scheduler would lose to a per-service DAG (#1071); kept so that claim stays falsifiable rather than assumed.` | a 12-service compose file |
 | `running-ops` | `ps`, `logs`, `exec`, `restart` on a running stack |
 | `build` | `build --no-cache` from a Dockerfile (base pinned by digest) |
 

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -53,7 +53,7 @@ mkdir -p "$OUT_DIR"
 #   reup    : time a warm second `up -d`
 #   running : bring up untimed, then time `ps`, `logs`, `exec -T`, `restart`
 #   build   : time `build --no-cache`
-SCENARIOS=(single multi-healthcheck deep-chain scale network-ipam volume-heavy warm-restart many-services running-ops build)
+SCENARIOS=(single multi-healthcheck deep-chain wide-level scale network-ipam volume-heavy warm-restart many-services running-ops build)
 declare -A OP=(
 	[single]=updown [multi-healthcheck]=updown [scale]=scale
 	[network-ipam]=updown [volume-heavy]=updown [warm-restart]=reup

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -53,7 +53,7 @@ mkdir -p "$OUT_DIR"
 #   reup    : time a warm second `up -d`
 #   running : bring up untimed, then time `ps`, `logs`, `exec -T`, `restart`
 #   build   : time `build --no-cache`
-SCENARIOS=(single multi-healthcheck scale network-ipam volume-heavy warm-restart many-services running-ops build)
+SCENARIOS=(single multi-healthcheck deep-chain scale network-ipam volume-heavy warm-restart many-services running-ops build)
 declare -A OP=(
 	[single]=updown [multi-healthcheck]=updown [scale]=scale
 	[network-ipam]=updown [volume-heavy]=updown [warm-restart]=reup

--- a/bench/scenarios/deep-chain/compose.yaml
+++ b/bench/scenarios/deep-chain/compose.yaml
@@ -1,0 +1,67 @@
+# The shape where a level-barrier scheduler loses to a per-service DAG (#1071).
+#
+# `up` starts services in dependency LEVELS: every service in level N must finish
+# before any service in level N+1 begins. docker compose walks a per-service DAG
+# instead, so a service starts the moment *its own* dependencies are ready.
+#
+# The two are indistinguishable unless a level contains both a fast and a slow
+# member with something behind the fast one. That is what this builds:
+#
+#   level 0:  slow (≈8s to healthy)   fast (≈1s to healthy)
+#   level 1:  after_fast  ->  fast     [waits for `slow` too, under barriers]
+#   level 2:  chain2      ->  after_fast
+#   level 3:  chain3      ->  chain2
+#
+# Under barriers, `after_fast` cannot start until `slow` is healthy, even though
+# it does not depend on it — and everything behind it inherits that wait. Under a
+# DAG the whole chain runs while `slow` is still coming up.
+#
+# The predicted gap is therefore roughly (slow − fast), once, not per level. The
+# point of measuring is to find out whether that is worth a scheduler rewrite.
+services:
+  # Slow to report healthy: a long start_period plus a first check that fails.
+  slow:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sh", "-c", "sleep 8 && touch /tmp/ready && sleep 3600"]
+    init: true
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/ready"]
+      interval: 1s
+      timeout: 2s
+      retries: 20
+
+  # Healthy almost immediately.
+  fast:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sh", "-c", "touch /tmp/ready && sleep 3600"]
+    init: true
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/ready"]
+      interval: 1s
+      timeout: 2s
+      retries: 20
+
+  # Depends only on `fast`. Under barriers it waits for `slow` as well.
+  after_fast:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+    depends_on:
+      fast:
+        condition: service_healthy
+
+  chain2:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+    depends_on:
+      after_fast:
+        condition: service_started
+
+  chain3:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+    depends_on:
+      chain2:
+        condition: service_started

--- a/bench/scenarios/deep-chain/compose.yaml
+++ b/bench/scenarios/deep-chain/compose.yaml
@@ -16,8 +16,12 @@
 # it does not depend on it — and everything behind it inherits that wait. Under a
 # DAG the whole chain runs while `slow` is still coming up.
 #
-# The predicted gap is therefore roughly (slow − fast), once, not per level. The
-# point of measuring is to find out whether that is worth a scheduler rewrite.
+# NOTE: this file does NOT show the scheduler cost, and that is worth knowing
+# before reading a run of it. Readiness is gated per dependency, so `after_fast`
+# starts while `slow` is still `starting` even under level barriers, and the
+# barrier looks free. The cost lives in level WIDTH, not depth — see the
+# `wide-level` scenario. This one stays as the readiness-ordering case, which is
+# what it actually measures.
 services:
   # Slow to report healthy: a long start_period plus a first check that fails.
   slow:

--- a/bench/scenarios/wide-level/compose.yaml
+++ b/bench/scenarios/wide-level/compose.yaml
@@ -1,0 +1,189 @@
+# Where a level-barrier scheduler actually loses to a per-service DAG (#1071).
+#
+# `up` creates each dependency level with bounded concurrency
+# (MAX_LIFECYCLE_CONCURRENCY = 16), so a wide level is created in batches. Under
+# a level barrier, NOTHING in level 1 may start until the whole of level 0 has
+# been created — including services it does not depend on. A per-service DAG
+# starts a dependent the moment its own dependencies are up.
+#
+# 41 services in level 0 (2.5 batches) and one dependent behind exactly one of
+# them. The gap is the time the dependent spends waiting for the other 40.
+#
+# Measured on real Podman 5.4.2, anchor -> dependent:
+#   podup            809 ms
+#   docker compose   129 ms
+#
+# A two-service level shows nothing (see `deep-chain`) — readiness is already
+# gated per dependency. It is the batching that costs.
+services:
+  anchor:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk01:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk02:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk03:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk04:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk05:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk06:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk07:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk08:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk09:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk10:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk11:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk12:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk13:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk14:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk15:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk16:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk17:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk18:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk19:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk20:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk21:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk22:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk23:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk24:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk25:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk26:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk27:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk28:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk29:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk30:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk31:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk32:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk33:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk34:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk35:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk36:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk37:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk38:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk39:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  bulk40:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+  dependent:
+    image: docker.io/library/busybox@sha256:1cfa4e2b09e127b9c4ed43578d3f3c18e7d44ea47b9ea98475c0cbe9086525f8
+    command: ["sleep", "3600"]
+    init: true
+    depends_on:
+      anchor:
+        condition: service_started

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -8,6 +8,7 @@ mod prefetch;
 mod readiness;
 mod run;
 mod scale;
+mod schedule;
 mod signal;
 mod targets;
 
@@ -240,100 +241,19 @@ impl Engine {
 			// dependents in a level don't each run the same container's healthcheck.
 			let readiness = self.build_readiness_map(file, &enabled, &target_set, start);
 
-			// Per-service scheduling, not level barriers. A service starts as soon
-			// as *its own* dependencies are up, rather than waiting for every
-			// service in the level ahead of it.
-			//
-			// The levels are still resolved, because that is what validates the
-			// graph (a cycle or a missing required dependency is an error before
-			// anything is created) — they just no longer gate execution.
-			//
-			// Measured cost of the barrier on a 41-service level with one dependent
-			// behind one of them: the dependent started 809ms after its dependency
-			// under barriers and 129ms under docker compose's per-service DAG,
-			// because a level is created with bounded concurrency and the barrier
-			// made the dependent wait for the last batch rather than for what it
-			// actually needed.
-			//
-			// Two things make this safe to do with plain futures:
-			//
-			// * `try_join_all` polls *every* future, so a service blocked on a
-			//   dependency yields and the others make progress. `buffer_unordered`
-			//   would deadlock here — it only polls the first N, and those N can
-			//   all be waiting on a dependency that is queued behind them.
-			// * the concurrency bound is a semaphore held only across the actual
-			//   work, never across a dependency wait, for the same reason.
-			//
-			// A failure cancels the rest: `try_join_all` drops the other futures on
-			// the first error, so a service still waiting on a dependency that will
-			// now never come up is dropped rather than hanging.
-			let scheduled: Vec<&str> = levels.iter().flatten().map(String::as_str).collect();
-			let permits = std::sync::Arc::new(tokio::sync::Semaphore::new(
-				parallel::MAX_LIFECYCLE_CONCURRENCY,
-			));
-			let done: std::collections::HashMap<&str, tokio::sync::watch::Sender<bool>> = scheduled
-				.iter()
-				.map(|name| (*name, tokio::sync::watch::channel(false).0))
-				.collect();
-
-			// Borrow the shared inputs once so the closure captures references
-			// rather than trying to move them per service.
-			let enabled = &enabled;
-			let target_set = &target_set;
-			let present = &present;
-			let existing_hash = &existing_hash;
-			let readiness = &readiness;
-			let started = scheduled.iter().map(|name| {
-				let permits = permits.clone();
-				let done = &done;
-				// Only the dependencies this service actually declares, and only
-				// those that are in this run's scheduled set — a service excluded by
-				// profiles or an explicit target list is not going to signal.
-				let deps: Vec<tokio::sync::watch::Receiver<bool>> = file
-					.services
-					.get(*name)
-					.map(|s| s.depends_on.service_names())
-					.unwrap_or_default()
-					.into_iter()
-					.filter_map(|d| done.get(d.as_str()).map(|tx| tx.subscribe()))
-					.collect();
-				async move {
-					for mut rx in deps {
-						// `changed()` errors only when every sender is gone, which
-						// here means the run is being torn down; treat it as done and
-						// let `try_join_all` surface the real error.
-						while !*rx.borrow_and_update() {
-							if rx.changed().await.is_err() {
-								break;
-							}
-						}
-					}
-					// The permit is taken *after* the waits, so a blocked service
-					// never occupies one.
-					let _permit = permits.acquire().await;
-					let result = self
-						.up_one_service(
-							name,
-							file,
-							enabled,
-							target_set,
-							present,
-							existing_hash,
-							no_recreate,
-							force_recreate,
-							start,
-							readiness,
-						)
-						.await;
-					if result.is_ok() {
-						if let Some(tx) = done.get(*name) {
-							let _ = tx.send(true);
-						}
-					}
-					result
-				}
-			});
-			futures_util::future::try_join_all(started).await?;
+			self.start_services_by_dependency(
+				&levels,
+				file,
+				&enabled,
+				&target_set,
+				&present,
+				&existing_hash,
+				no_recreate,
+				force_recreate,
+				start,
+				&readiness,
+			)
+			.await?;
 
 			// Reconcile surplus replicas for every service carrying an active
 			// `--scale` override. Replica naming is unsuffixed for one replica and

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -239,23 +239,101 @@ impl Engine {
 			// One shared healthcheck poller per waited-on container, so several
 			// dependents in a level don't each run the same container's healthcheck.
 			let readiness = self.build_readiness_map(file, &enabled, &target_set, start);
-			for level in &levels {
-				let started = level.iter().map(|name| {
-					self.up_one_service(
-						name,
-						file,
-						&enabled,
-						&target_set,
-						&present,
-						&existing_hash,
-						no_recreate,
-						force_recreate,
-						start,
-						&readiness,
-					)
-				});
-				futures_util::future::try_join_all(started).await?;
-			}
+
+			// Per-service scheduling, not level barriers. A service starts as soon
+			// as *its own* dependencies are up, rather than waiting for every
+			// service in the level ahead of it.
+			//
+			// The levels are still resolved, because that is what validates the
+			// graph (a cycle or a missing required dependency is an error before
+			// anything is created) — they just no longer gate execution.
+			//
+			// Measured cost of the barrier on a 41-service level with one dependent
+			// behind one of them: the dependent started 809ms after its dependency
+			// under barriers and 129ms under docker compose's per-service DAG,
+			// because a level is created with bounded concurrency and the barrier
+			// made the dependent wait for the last batch rather than for what it
+			// actually needed.
+			//
+			// Two things make this safe to do with plain futures:
+			//
+			// * `try_join_all` polls *every* future, so a service blocked on a
+			//   dependency yields and the others make progress. `buffer_unordered`
+			//   would deadlock here — it only polls the first N, and those N can
+			//   all be waiting on a dependency that is queued behind them.
+			// * the concurrency bound is a semaphore held only across the actual
+			//   work, never across a dependency wait, for the same reason.
+			//
+			// A failure cancels the rest: `try_join_all` drops the other futures on
+			// the first error, so a service still waiting on a dependency that will
+			// now never come up is dropped rather than hanging.
+			let scheduled: Vec<&str> = levels.iter().flatten().map(String::as_str).collect();
+			let permits = std::sync::Arc::new(tokio::sync::Semaphore::new(
+				parallel::MAX_LIFECYCLE_CONCURRENCY,
+			));
+			let done: std::collections::HashMap<&str, tokio::sync::watch::Sender<bool>> = scheduled
+				.iter()
+				.map(|name| (*name, tokio::sync::watch::channel(false).0))
+				.collect();
+
+			// Borrow the shared inputs once so the closure captures references
+			// rather than trying to move them per service.
+			let enabled = &enabled;
+			let target_set = &target_set;
+			let present = &present;
+			let existing_hash = &existing_hash;
+			let readiness = &readiness;
+			let started = scheduled.iter().map(|name| {
+				let permits = permits.clone();
+				let done = &done;
+				// Only the dependencies this service actually declares, and only
+				// those that are in this run's scheduled set — a service excluded by
+				// profiles or an explicit target list is not going to signal.
+				let deps: Vec<tokio::sync::watch::Receiver<bool>> = file
+					.services
+					.get(*name)
+					.map(|s| s.depends_on.service_names())
+					.unwrap_or_default()
+					.into_iter()
+					.filter_map(|d| done.get(d.as_str()).map(|tx| tx.subscribe()))
+					.collect();
+				async move {
+					for mut rx in deps {
+						// `changed()` errors only when every sender is gone, which
+						// here means the run is being torn down; treat it as done and
+						// let `try_join_all` surface the real error.
+						while !*rx.borrow_and_update() {
+							if rx.changed().await.is_err() {
+								break;
+							}
+						}
+					}
+					// The permit is taken *after* the waits, so a blocked service
+					// never occupies one.
+					let _permit = permits.acquire().await;
+					let result = self
+						.up_one_service(
+							name,
+							file,
+							enabled,
+							target_set,
+							present,
+							existing_hash,
+							no_recreate,
+							force_recreate,
+							start,
+							readiness,
+						)
+						.await;
+					if result.is_ok() {
+						if let Some(tx) = done.get(*name) {
+							let _ = tx.send(true);
+						}
+					}
+					result
+				}
+			});
+			futures_util::future::try_join_all(started).await?;
 
 			// Reconcile surplus replicas for every service carrying an active
 			// `--scale` override. Replica naming is unsuffixed for one replica and

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -24,7 +24,7 @@ use super::targets::{stop_deadline, stop_timeout_param};
 /// concurrently. Services within a dependency level have no ordering between
 /// them, so they run in parallel; the cap keeps a very wide compose file from
 /// opening an unbounded number of simultaneous libpod connections at once.
-const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
+pub(super) const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
 
 /// Run a batch of independent per-service futures concurrently, bounded by
 /// [`MAX_LIFECYCLE_CONCURRENCY`], and return their outputs in the *input*

--- a/internal/engine/lifecycle/schedule.rs
+++ b/internal/engine/lifecycle/schedule.rs
@@ -1,0 +1,130 @@
+//! Per-service start scheduling for `up`/`create`.
+//!
+//! Split from `mod.rs` to keep that file within the source line limit. The
+//! scheduler is a subject of its own: it is where the difference between
+//! "levels" and "a dependency graph" lives, and the two deadlock hazards it
+//! avoids are documented inline rather than being folded into `run_up`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::compose::types::ComposeFile;
+use crate::error::Result;
+
+use super::readiness::SharedReady;
+use super::Engine;
+
+impl Engine {
+	/// Start every scheduled service, each as soon as its own dependencies are
+	/// up. `levels` is used only for its membership and validation, not as a
+	/// barrier.
+	#[allow(clippy::too_many_arguments)]
+	pub(super) async fn start_services_by_dependency(
+		&self,
+		levels: &[Vec<String>],
+		file: &ComposeFile,
+		enabled: &HashSet<String>,
+		target_set: &Option<HashSet<String>>,
+		present: &HashSet<String>,
+		existing_hash: &HashMap<String, String>,
+		no_recreate: bool,
+		force_recreate: bool,
+		start: bool,
+		readiness: &HashMap<String, SharedReady<'_>>,
+	) -> Result<()> {
+		// Per-service scheduling, not level barriers. A service starts as soon
+		// as *its own* dependencies are up, rather than waiting for every
+		// service in the level ahead of it.
+		//
+		// The levels are still resolved, because that is what validates the
+		// graph (a cycle or a missing required dependency is an error before
+		// anything is created) — they just no longer gate execution.
+		//
+		// Measured cost of the barrier on a 41-service level with one dependent
+		// behind one of them: the dependent started 809ms after its dependency
+		// under barriers and 129ms under docker compose's per-service DAG,
+		// because a level is created with bounded concurrency and the barrier
+		// made the dependent wait for the last batch rather than for what it
+		// actually needed.
+		//
+		// Two things make this safe to do with plain futures:
+		//
+		// * `try_join_all` polls *every* future, so a service blocked on a
+		//   dependency yields and the others make progress. `buffer_unordered`
+		//   would deadlock here — it only polls the first N, and those N can
+		//   all be waiting on a dependency that is queued behind them.
+		// * the concurrency bound is a semaphore held only across the actual
+		//   work, never across a dependency wait, for the same reason.
+		//
+		// A failure cancels the rest: `try_join_all` drops the other futures on
+		// the first error, so a service still waiting on a dependency that will
+		// now never come up is dropped rather than hanging.
+		let scheduled: Vec<&str> = levels.iter().flatten().map(String::as_str).collect();
+		let permits = std::sync::Arc::new(tokio::sync::Semaphore::new(
+			super::parallel::MAX_LIFECYCLE_CONCURRENCY,
+		));
+		let done: std::collections::HashMap<&str, tokio::sync::watch::Sender<bool>> = scheduled
+			.iter()
+			.map(|name| (*name, tokio::sync::watch::channel(false).0))
+			.collect();
+
+		// Borrow the shared inputs once so the closure captures references
+		// rather than trying to move them per service.
+		let enabled = &enabled;
+		let target_set = &target_set;
+		let present = &present;
+		let existing_hash = &existing_hash;
+		let readiness = &readiness;
+		let started = scheduled.iter().map(|name| {
+			let permits = permits.clone();
+			let done = &done;
+			// Only the dependencies this service actually declares, and only
+			// those that are in this run's scheduled set — a service excluded by
+			// profiles or an explicit target list is not going to signal.
+			let deps: Vec<tokio::sync::watch::Receiver<bool>> = file
+				.services
+				.get(*name)
+				.map(|s| s.depends_on.service_names())
+				.unwrap_or_default()
+				.into_iter()
+				.filter_map(|d| done.get(d.as_str()).map(|tx| tx.subscribe()))
+				.collect();
+			async move {
+				for mut rx in deps {
+					// `changed()` errors only when every sender is gone, which
+					// here means the run is being torn down; treat it as done and
+					// let `try_join_all` surface the real error.
+					while !*rx.borrow_and_update() {
+						if rx.changed().await.is_err() {
+							break;
+						}
+					}
+				}
+				// The permit is taken *after* the waits, so a blocked service
+				// never occupies one.
+				let _permit = permits.acquire().await;
+				let result = self
+					.up_one_service(
+						name,
+						file,
+						enabled,
+						target_set,
+						present,
+						existing_hash,
+						no_recreate,
+						force_recreate,
+						start,
+						readiness,
+					)
+					.await;
+				if result.is_ok() {
+					if let Some(tx) = done.get(*name) {
+						let _ = tx.send(true);
+					}
+				}
+				result
+			}
+		});
+		futures_util::future::try_join_all(started).await?;
+		Ok(())
+	}
+}


### PR DESCRIPTION
Closes #1071 — by **implementing** the per-service DAG, not by closing it as answered. I nearly did the latter, on a measurement that was too weak.

## I got this wrong first, and the correction is the point

My first scenario put **two** services in the level (a fast one and a slow one, with a chain behind the fast one) and showed no gap at all: the dependent started while `slow` was still `starting`, in podup and docker alike. I was about to close the issue on that.

That scenario cannot show the cost. Readiness is **already** gated per dependency, so the barrier looks free whenever a level is narrow. The cost is in level **width**: levels are created with bounded concurrency, so a wide level goes out in batches and everything behind it waits for the last batch rather than for what it actually needs.

Rebuilt with 41 services in level 0 and one dependent behind exactly one of them:

```
                          anchor -> dependent
podup (level barriers)          809 ms
docker compose (DAG)            129 ms
```

There it is. The issue's premise was right; my test was not.

## The change

Per-service scheduling: a service starts as soon as its own dependencies are up.

```
41-service level, total up      1326 ms  ->  1135 ms   (-14%)
9-service level, to dependent    155 ms  ->   131 ms   (-15%)
```

Two details make it safe with plain futures, and both are load-bearing:

- **`try_join_all`, not `buffer_unordered`.** `try_join_all` polls *every* future, so a service blocked on a dependency yields and the rest progress. `buffer_unordered` would **deadlock** — it polls only the first N, and those N can all be waiting on a dependency queued behind them.
- **The permit is taken after the waits, never across one.** A blocked service must not occupy one of the 16, or the bound becomes the deadlock instead.

Failure handling is unchanged in effect: `try_join_all` drops the other futures on the first error, so a service waiting on a dependency that will now never come up is dropped rather than left hanging.

Levels are still resolved — that is what rejects a cycle or a missing required dependency before anything is created. They just no longer gate execution.

## What is left, and is not this issue

On a wide level the remaining `anchor -> dependent` latency is the **concurrency cap**, not the barrier: the dependent joins a FIFO permit queue behind 40 siblings. That is a deliberate bound on socket pressure, and changing it is a different decision with different risks. The end-to-end `up` still improves 14%, which is what the cap allows.

## Bench

Both scenarios ship. `wide-level` is the one that measures this. `deep-chain` stays with a comment saying explicitly that it does **not** — so nobody reads a flat result there as proof the scheduler is optimal, which is the mistake I made.

## Honest limits

Warm, one machine, 3-4 runs per configuration. Not the harness's published methodology (N iterations, median + p95, controlled runner). Enough to justify a change that is directionally consistent across two different shapes and two different metrics; not a number to publish.

## Test plan

`cargo test --lib` 1292/1292, clippy `--all-targets --all-features` clean. Full integration suite green locally against real Podman 5.4.2 — the ordering guarantees (`depends_on`, `service_healthy`, `service_completed_successfully`) are what that suite covers most heavily, and they are the thing this change could most easily break.

Closes #1071