### PR TITLE
test: name how a libpod stream ended, and rule out the cp Content-Length theory

### DIFF
--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -60,7 +60,9 @@ impl Engine {
 		while let Some(event) = stream.next().await {
 			match event {
 				Ok(value) => println!("{}", format_event(&value, json)),
-				Err(e) => tracing::warn!("events: stream ended early: {e}"),
+				Err(e) => {
+					tracing::warn!("events: stream ended early [{}]: {e}", e.stream_end_kind())
+				}
 			}
 		}
 		Ok(())

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -324,7 +324,18 @@ impl Engine {
 								Ok(LogOutput::StdErr { message }) => {
 									err_pfx.write(&mut std::io::stderr().lock(), &message)
 								}
-								Err(_) => break,
+								// Diagnostic only — nothing branches on this. Naming the
+								// classification is what lets a lane run answer whether a
+								// finished stream is distinguishable from a broken one
+								// (#1104), instead of the question being argued from the
+								// source. Real 5.4.2 never reaches this arm.
+								Err(e) => {
+									tracing::warn!(
+										"logs {container_name}: stream ended [{}]: {e}",
+										e.stream_end_kind()
+									);
+									break;
+								}
 							};
 							if stop_on_write_error(&container_name, wrote) {
 								break;
@@ -375,7 +386,13 @@ impl Engine {
 						Ok(LogOutput::StdErr { message }) => {
 							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
-						Err(_) => break,
+						Err(e) => {
+							tracing::warn!(
+								"logs {container_name}: stream ended [{}]: {e}",
+								e.stream_end_kind()
+							);
+							break;
+						}
 					};
 					if stop_on_write_error(&container_name, wrote) {
 						break;

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -296,7 +296,7 @@ impl Engine {
 			match frame {
 				Ok(report) => print_frame(&report, &running, &stopped, &opts),
 				Err(e) => {
-					tracing::warn!("stats: stream ended early: {e}");
+					tracing::warn!("stats: stream ended early [{}]: {e}", e.stream_end_kind());
 					break;
 				}
 			}

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -515,9 +515,30 @@ impl Client {
 	}
 
 	/// `PUT` with raw bytes body → expect 2xx.
+	///
+	/// The failure mode here is #1097: `cp` into a container, and `watch` sync
+	/// with it, have never worked on Podman 6 — the connection closes before the
+	/// response completes. Copying *out* (`GET`) is fine on both majors, so it is
+	/// specific to this direction.
+	///
+	/// Diagnostic rather than fix: podup cannot reproduce it on Podman 5, so this
+	/// names what happened for the nested-virt lane to report. The leading
+	/// hypothesis was a `Content-Length` versus chunked mismatch, and that is now
+	/// ruled out — see `a_buffered_put_body_reports_an_exact_size` — so what
+	/// libpod 6 objects to is still open.
 	pub async fn put_bytes_ok(&self, path: &str, bytes: Bytes, content_type: &str) -> Result<()> {
+		let len = bytes.len();
 		let req = Self::build_request(Method::PUT, path, full(bytes), Some(content_type))?;
-		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
+		let resp = match self.send(req, Some(READ_TIMEOUT)).await {
+			Ok(r) => r,
+			Err(e) => {
+				tracing::warn!(
+					"PUT {path} ({content_type}, {len} bytes) failed [{}]: {e}",
+					e.stream_end_kind()
+				);
+				return Err(e);
+			}
+		};
 		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)
 	}

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -160,3 +160,27 @@ fn meets_minimum_handles_malformed_and_empty() {
 	// Leading/trailing whitespace around a valid version is tolerated.
 	assert!(meets_minimum(" 5.0.0 "));
 }
+
+/// #1097: does a buffered PUT body keep its exact size hint after boxing?
+///
+/// This is the crux of the leading hypothesis for `cp` into a container failing
+/// on Podman 6. hyper sets `Content-Length` when a body reports an exact size
+/// and falls back to `Transfer-Encoding: chunked` when it does not. If boxing
+/// erased the hint, every `PUT /containers/{id}/archive` would go out chunked —
+/// and a server that expects a length would close the connection mid-body,
+/// which is exactly the `IncompleteMessage` the lane reports.
+///
+/// Asserting it here means the hypothesis is settled locally instead of costing
+/// a lane round trip, whichever way it falls.
+#[test]
+fn a_buffered_put_body_reports_an_exact_size() {
+	use hyper::body::Body as _;
+
+	let payload = bytes::Bytes::from_static(b"hello world");
+	let body = super::full(payload.clone());
+	assert_eq!(
+		body.size_hint().exact(),
+		Some(payload.len() as u64),
+		"a boxed Full body must keep its exact size, or hyper sends it chunked"
+	);
+}

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -121,6 +121,38 @@ impl PodmanError {
 		matches!(self, Self::Api { status, .. } if *status == code)
 	}
 
+	/// How a streaming read ended, for the one question podup cannot currently
+	/// answer: was the stream *finished* or *broken*?
+	///
+	/// The parsers return `Ok(None)` on a clean body end, so in principle every
+	/// `Err` is a fault. In practice it is not — treating a mid-stream `Err` as a
+	/// command failure reddened fifteen tests on the lane's Podman 5.8.1 leg
+	/// while real 5.4.2 stayed green on the identical commit (#1104). Something
+	/// about how libpod ends a finished stream differs by version, and podup has
+	/// no way to tell which.
+	///
+	/// This names the hyper classification so a lane run can say *which* one
+	/// occurs, instead of the question being argued from the source. It is
+	/// diagnostic, not yet a decision: nothing branches on it.
+	pub(crate) fn stream_end_kind(&self) -> &'static str {
+		match self {
+			Self::Hyper(e) if e.is_incomplete_message() => "incomplete-message",
+			Self::Hyper(e) if e.is_body_write_aborted() => "body-write-aborted",
+			Self::Hyper(e) if e.is_canceled() => "canceled",
+			Self::Hyper(e) if e.is_closed() => "closed",
+			Self::Hyper(e) if e.is_timeout() => "hyper-timeout",
+			Self::Hyper(_) => "hyper-other",
+			Self::Connect(e) => match e.kind() {
+				std::io::ErrorKind::UnexpectedEof => "io-unexpected-eof",
+				std::io::ErrorKind::ConnectionReset => "io-connection-reset",
+				std::io::ErrorKind::BrokenPipe => "io-broken-pipe",
+				_ => "io-other",
+			},
+			Self::Json(_) => "malformed-frame",
+			_ => "other",
+		}
+	}
+
 	/// True if this is a client-side timeout (the request was aborted because the
 	/// socket never responded within the deadline). These carry a synthetic
 	/// status `0` and a `timed out` message; lifecycle callers use this to


### PR DESCRIPTION
Diagnostics for the two issues that cannot be reproduced on the Podman this machine runs. **No behaviour change** — nothing branches on the new information and no exit code moves.

Part of #1104 and #1097.

## Why these need the lane

Both fail only on Podman versions I cannot drive here. #1104's fifteen red tests were on the lane's **5.8.1** leg while real 5.4.2 stayed green on the identical commit; #1097 is Podman **6**, and that VM is not reachable over SSH. The lane runs both, so the honest move is to make it report the answer rather than keep arguing from the source.

## What is settled locally, for free

#1097's leading hypothesis was a **`Content-Length` versus chunked** mismatch — hyper falls back to chunked when a body cannot report its size, and a server expecting a length would close the connection mid-body, which is exactly the `IncompleteMessage` the lane sees.

**That is not what happens.** A boxed `Full` body keeps its exact size hint, so hyper sets `Content-Length`. Captured through a logging proxy against a real Podman socket:

```
PUT /v5.0.0/libpod/containers/<c>/archive?path=%2Ftmp
content-type: application/x-tar
content-length: 108
```

Now pinned by a unit test, so the question cannot come back. The field is narrower: whatever libpod 6 objects to, it is not the transfer encoding.

## What it adds

`PodmanError::stream_end_kind()` names the classification — `incomplete-message`, `body-write-aborted`, `canceled`, `closed`, `hyper-timeout`, `io-unexpected-eof`, `io-connection-reset`, `io-broken-pipe`, `malformed-frame`. `logs`, `events`, `stats` and the archive `PUT` report it when they fail.

## What each outcome decides

- **A finished stream and a dead socket classify differently** → #1104's fix is a predicate, and #1080's remaining half unblocks with it.
- **They classify the same** → those commands genuinely cannot report mid-stream failure, and that belongs in the docs as a stated limitation. Today a monitor scraping `stats` reads a truncated sample as a complete one, which is worse than saying so.
- **The archive PUT names its failure** → #1097 gets its first real fact since it was filed.

## Test plan

`cargo test --lib` 1293/1293, clippy clean. The one new assertion is the size-hint test; the rest of the value is in what the lane prints, which I will read off this PR's run.