### PR TITLE
feat!: give exec a real terminal on Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "podup"
 path = "internal/lib.rs"
 
 [dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "net"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "net", "io-util", "io-std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -248,7 +248,7 @@ pub(super) async fn dispatch_rest(
 			workdir,
 			privileged,
 			detach,
-			no_tty: _,
+			no_tty,
 			index,
 			service,
 			cmd,
@@ -258,14 +258,7 @@ pub(super) async fn dispatch_rest(
 					file,
 					&service,
 					cmd,
-					podup::ExecOptions {
-						env,
-						user,
-						workdir,
-						privileged,
-						detach,
-						index,
-					},
+					podup::ExecOptions::new(env, user, workdir, privileged, detach, index, no_tty),
 				)
 				.await?
 		}

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -364,7 +364,15 @@ impl Engine {
 /// Pure except for the `isatty` probe, which is behind `stdin_is_terminal` so
 /// the decision itself is unit-testable.
 fn interactive_exec(opts: &ExecOptions) -> bool {
-	!opts.no_tty && !opts.detach && stdin_is_terminal()
+	wants_interactive(opts, stdin_is_terminal())
+}
+
+/// The decision itself, with the environment passed in.
+///
+/// Split out so it can be tested: reading stdin here would make every
+/// assertion depend on how `cargo test` happened to be invoked.
+fn wants_interactive(opts: &ExecOptions, stdin_is_tty: bool) -> bool {
+	!opts.no_tty && !opts.detach && stdin_is_tty
 }
 
 /// Whether stdin is a terminal. Always false off Unix, where the interactive
@@ -384,30 +392,37 @@ fn stdin_is_terminal() -> bool {
 
 #[cfg(test)]
 mod interactive_decision_tests {
-	use super::{interactive_exec, ExecOptions};
+	use super::{wants_interactive, ExecOptions};
 
 	/// #1079: `-T` opts out, matching `docker compose exec` — which has no `-i`
 	/// because a TTY on both ends is the default.
 	#[test]
 	fn no_tty_flag_disables_the_pty() {
 		let opts = ExecOptions::default().with_no_tty_for_test(true);
-		assert!(!interactive_exec(&opts));
+		assert!(!wants_interactive(&opts, true));
 	}
 
 	/// `-d` detaches, so there is nobody to be interactive with.
 	#[test]
 	fn detach_disables_the_pty() {
 		let opts = ExecOptions::default().with_detach_for_test(true);
-		assert!(!interactive_exec(&opts));
+		assert!(!wants_interactive(&opts, true));
 	}
 
-	/// The decisive one for existing users: in a test harness — as in any script
-	/// or pipeline — stdin is not a terminal, so `exec` stays on the unchanged
-	/// streaming path. Allocating a pty there would change output framing for
-	/// every script that already calls `podup exec`.
+	/// The decisive one for existing users: with stdin not a terminal — any
+	/// script or pipeline — `exec` stays on the unchanged streaming path.
+	/// Allocating a pty there would change output framing for every script that
+	/// already calls `podup exec`.
 	#[test]
 	fn a_non_terminal_stdin_stays_on_the_streaming_path() {
-		assert!(!interactive_exec(&ExecOptions::default()));
+		assert!(!wants_interactive(&ExecOptions::default(), false));
+	}
+
+	/// And the positive case, which the old ambient-stdin test could never
+	/// assert: defaults plus a terminal is what turns the pty on.
+	#[test]
+	fn a_terminal_stdin_with_defaults_is_interactive() {
+		assert!(wants_interactive(&ExecOptions::default(), true));
 	}
 }
 

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -26,7 +26,12 @@ use super::Engine;
 const EXEC_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// Options for [`Engine::exec`], mirroring `docker compose exec` flags.
+///
+/// `#[non_exhaustive]`: built with `..Default::default()`, so adding a flag as
+/// the exec surface grows is not another breaking change. The two autostart
+/// option structs learned the same lesson in the same release.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct ExecOptions {
 	/// Extra environment variables (`KEY=VAL`), `-e/--env`.
 	pub env: Vec<String>,
@@ -40,6 +45,76 @@ pub struct ExecOptions {
 	pub detach: bool,
 	/// 1-based replica index for a scaled service, `--index` (default: first).
 	pub index: Option<u32>,
+	/// Suppress the pseudo-terminal, `-T/--no-tty`.
+	///
+	/// Interactive is the default when stdin is a terminal, matching
+	/// `docker compose exec`; this is how a caller opts out. It is also what a
+	/// non-terminal stdin implies, so a scripted `exec` behaves the same with or
+	/// without the flag.
+	pub no_tty: bool,
+}
+
+impl ExecOptions {
+	/// Every `docker compose exec` flag, in CLI order. A constructor rather than
+	/// a struct literal because the type is `#[non_exhaustive]`, so the next flag
+	/// to land is not a breaking change for anyone building one.
+	/// Run the command as this user, `-u/--user`. Builder-style.
+	pub fn with_user(mut self, user: Option<String>) -> Self {
+		self.user = user;
+		self
+	}
+
+	/// Working directory inside the container, `-w/--workdir`. Builder-style.
+	pub fn with_workdir(mut self, workdir: Option<String>) -> Self {
+		self.workdir = workdir;
+		self
+	}
+
+	#[cfg(test)]
+	fn with_no_tty_for_test(mut self, v: bool) -> Self {
+		self.no_tty = v;
+		self
+	}
+
+	#[cfg(test)]
+	fn with_detach_for_test(mut self, v: bool) -> Self {
+		self.detach = v;
+		self
+	}
+
+	/// Target this replica (1-based) of a scaled service, `--index`.
+	/// Builder-style.
+	pub fn with_index(mut self, index: Option<u32>) -> Self {
+		self.index = index;
+		self
+	}
+
+	/// Extra environment variables (`KEY=VAL`), `-e/--env`. Builder-style.
+	pub fn with_env(mut self, env: Vec<String>) -> Self {
+		self.env = env;
+		self
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		env: Vec<String>,
+		user: Option<String>,
+		workdir: Option<String>,
+		privileged: bool,
+		detach: bool,
+		index: Option<u32>,
+		no_tty: bool,
+	) -> Self {
+		Self {
+			env,
+			user,
+			workdir,
+			privileged,
+			detach,
+			index,
+			no_tty,
+		}
+	}
 }
 
 /// Build the exec environment list, expanding a bare `KEY` (no `=`) from podup's
@@ -160,16 +235,24 @@ impl Engine {
 			.live_replica_name_at(service_name, service, opts.index)
 			.await?;
 
+		// Interactive when there is a terminal to be interactive with, unless the
+		// caller opted out or detached. This is `docker compose exec`'s rule: no
+		// `-i` flag, because a TTY on both ends is the default and `-T` is how you
+		// say no. A non-terminal stdin (a script, a pipeline) takes the
+		// unchanged streaming path, so nothing about scripted `exec` moves.
+		let interactive = interactive_exec(&opts);
+
 		let env = expand_exec_env(&opts.env);
 		let exec_cfg = ExecCreateConfig {
 			cmd: Some(cmd),
 			attach_stdout: Some(true),
 			attach_stderr: Some(true),
+			attach_stdin: interactive.then_some(true),
+			tty: interactive.then_some(true),
 			user: opts.user.clone(),
 			working_dir: opts.workdir.clone(),
 			privileged: opts.privileged.then_some(true),
 			env: (!env.is_empty()).then_some(env),
-			..Default::default()
 		};
 		let create_path = format!(
 			"{API_PREFIX}/containers/{}/exec",
@@ -197,6 +280,14 @@ impl Engine {
 				.await
 				.map_err(|e| map_exec_start_err(e, &opts))?;
 			return Ok(());
+		}
+
+		// The interactive path takes over here: it needs the connection kept open
+		// in both directions, which the request/response client cannot give it.
+		#[cfg(unix)]
+		if interactive {
+			self.exec_interactive(&exec_id).await?;
+			return self.exec_exit_status(&exec_id).await;
 		}
 
 		let start_cfg = ExecStartConfig {
@@ -240,7 +331,15 @@ impl Engine {
 			}
 		}
 
-		let inspect_path = format!("{API_PREFIX}/exec/{}/json", urlencoded(&exec_id));
+		self.exec_exit_status(&exec_id).await
+	}
+
+	/// Read the session's exit code and turn a non-zero one into
+	/// `RunExited`, so `podup exec` propagates the command's status the way
+	/// `docker compose exec` does. Shared by the streaming and interactive
+	/// paths — an interactive shell that exits 1 must still exit 1.
+	async fn exec_exit_status(&self, exec_id: &str) -> Result<()> {
+		let inspect_path = format!("{API_PREFIX}/exec/{}/json", urlencoded(exec_id));
 		let inspect: ExecInspect = self
 			.client
 			.get_json(&inspect_path)
@@ -251,8 +350,64 @@ impl Engine {
 				return Err(ComposeError::RunExited(code));
 			}
 		}
-
 		Ok(())
+	}
+}
+
+/// Whether this exec should get a pseudo-terminal and a live stdin.
+///
+/// Three things must all hold: the caller did not pass `-T`, the caller did not
+/// detach, and stdin is actually a terminal. The last is what keeps a scripted
+/// `podup exec` on the unchanged streaming path — allocating a pty for a
+/// pipeline would change output framing for every existing script.
+///
+/// Pure except for the `isatty` probe, which is behind `stdin_is_terminal` so
+/// the decision itself is unit-testable.
+fn interactive_exec(opts: &ExecOptions) -> bool {
+	!opts.no_tty && !opts.detach && stdin_is_terminal()
+}
+
+/// Whether stdin is a terminal. Always false off Unix, where the interactive
+/// path is not implemented (#1079) — so `exec` there keeps its current
+/// behaviour rather than half-entering a mode it cannot finish.
+fn stdin_is_terminal() -> bool {
+	#[cfg(unix)]
+	{
+		use std::io::IsTerminal;
+		std::io::stdin().is_terminal()
+	}
+	#[cfg(not(unix))]
+	{
+		false
+	}
+}
+
+#[cfg(test)]
+mod interactive_decision_tests {
+	use super::{interactive_exec, ExecOptions};
+
+	/// #1079: `-T` opts out, matching `docker compose exec` — which has no `-i`
+	/// because a TTY on both ends is the default.
+	#[test]
+	fn no_tty_flag_disables_the_pty() {
+		let opts = ExecOptions::default().with_no_tty_for_test(true);
+		assert!(!interactive_exec(&opts));
+	}
+
+	/// `-d` detaches, so there is nobody to be interactive with.
+	#[test]
+	fn detach_disables_the_pty() {
+		let opts = ExecOptions::default().with_detach_for_test(true);
+		assert!(!interactive_exec(&opts));
+	}
+
+	/// The decisive one for existing users: in a test harness — as in any script
+	/// or pipeline — stdin is not a terminal, so `exec` stays on the unchanged
+	/// streaming path. Allocating a pty there would change output framing for
+	/// every script that already calls `podup exec`.
+	#[test]
+	fn a_non_terminal_stdin_stays_on_the_streaming_path() {
+		assert!(!interactive_exec(&ExecOptions::default()));
 	}
 }
 

--- a/internal/engine/query/exec_interactive.rs
+++ b/internal/engine/query/exec_interactive.rs
@@ -1,0 +1,128 @@
+//! Interactive `exec`: a pseudo-terminal and a live stdin, on Unix.
+//!
+//! `podup exec -it db psql` is the most-used shell-into-a-container habit in
+//! compose, and it did not work: podup allocated no TTY and attached no stdin,
+//! so `-i` set a flag nothing read and `-T` disabled something that never
+//! existed (#1079).
+//!
+//! Unix only for now. podup reaches `podman machine` over a named pipe on
+//! Windows, and both raw mode and resize events there are a different API — two
+//! implementations, not one behind a `cfg`. The non-interactive path is
+//! unchanged everywhere, so `podup exec` in a script behaves exactly as before
+//! on every platform.
+
+#![cfg(unix)]
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::terminal::{window_size, RawMode};
+use super::Engine;
+
+impl Engine {
+	/// Run an exec session with a pty and a live stdin.
+	///
+	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path —
+	/// command exits, socket dies, `?` on an unrelated error, panic — leaves the
+	/// caller's shell usable. That is the one thing this must not get wrong: a
+	/// terminal left raw has no echo and no line discipline, and the user cannot
+	/// even see what they type to fix it.
+	pub(super) async fn exec_interactive(&self, exec_id: &str) -> Result<()> {
+		let start_path = format!("{API_PREFIX}/exec/{}/start", urlencoded(exec_id));
+		let body = br#"{"Detach":false,"Tty":true}"#;
+		let hijacked = self
+			.client
+			.post_hijack(&start_path, body)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		// Raw mode only *after* the exec is known to have started. Enabling it
+		// first would leave a terminal unusable behind a 404.
+		let _raw = RawMode::enable();
+
+		// Size the pty now, not before the start: there is no pty to resize until
+		// the exec has begun, and libpod rejects the call — silently, since a
+		// failed resize is only cosmetic. Sizing it here means a full-screen
+		// program draws correctly from its first frame rather than at libpod's
+		// 80x24 default until the window happens to change.
+		if let Some((rows, cols)) = window_size() {
+			self.resize_exec(exec_id, rows, cols).await;
+		}
+
+		let (mut server_read, mut server_write) = tokio::io::split(hijacked.stream);
+		let mut stdin = tokio::io::stdin();
+		let mut stdout = tokio::io::stdout();
+
+		// Follow the window. libpod has no way to learn the caller's terminal
+		// size on its own, so every SIGWINCH has to be forwarded or a resized
+		// window leaves the remote program drawing at the old geometry.
+		let mut winch =
+			tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
+				.map_err(ComposeError::Io)?;
+
+		let mut to_server = [0u8; 8 * 1024];
+		let mut from_server = [0u8; 32 * 1024];
+
+		loop {
+			tokio::select! {
+				// Output first: a biased select would starve it behind a caller
+				// holding the keyboard down, and seeing the command's output is
+				// the point of being attached.
+				read = server_read.read(&mut from_server) => {
+					match read {
+						Ok(0) => break,
+						Ok(n) => {
+							stdout.write_all(&from_server[..n]).await.map_err(ComposeError::Io)?;
+							stdout.flush().await.map_err(ComposeError::Io)?;
+						}
+						// The command exiting closes this side; that is the
+						// ordinary end of an interactive session, not a failure.
+						Err(_) => break,
+					}
+				}
+				read = stdin.read(&mut to_server) => {
+					match read {
+						// Ctrl-D / a closed stdin: stop writing but keep reading,
+						// so the command can finish and flush. Shutting the write
+						// half is what tells it EOF.
+						Ok(0) => {
+							let _ = server_write.shutdown().await;
+						}
+						Ok(n) => {
+							if server_write.write_all(&to_server[..n]).await.is_err() {
+								break;
+							}
+							if server_write.flush().await.is_err() {
+								break;
+							}
+						}
+						Err(_) => break,
+					}
+				}
+				_ = winch.recv() => {
+					if let Some((rows, cols)) = window_size() {
+						self.resize_exec(exec_id, rows, cols).await;
+					}
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Tell libpod the pty's new size. Best-effort: a failed resize makes the
+	/// remote program draw at the wrong geometry, which is a cosmetic problem,
+	/// and turning it into a hard error would kill a working session over a
+	/// window drag.
+	async fn resize_exec(&self, exec_id: &str, rows: u16, cols: u16) {
+		let path = format!(
+			"{API_PREFIX}/exec/{}/resize?h={rows}&w={cols}",
+			urlencoded(exec_id),
+		);
+		if let Err(e) = self.client.post_empty_ok(&path).await {
+			tracing::debug!("exec resize to {rows}x{cols} failed: {e}");
+		}
+	}
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -9,10 +9,14 @@ use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 use super::Engine;
 
 mod exec;
+#[cfg(unix)]
+mod exec_interactive;
 mod inspect;
 mod inspect_util;
 mod log_prefix;
 mod ps;
+#[cfg(unix)]
+mod terminal;
 
 pub use ps::{PsFilterOptions, PsOptions};
 

--- a/internal/engine/query/terminal.rs
+++ b/internal/engine/query/terminal.rs
@@ -36,7 +36,17 @@ impl RawMode {
 	/// pipeline, not an error: there is no line discipline to disable, and the
 	/// caller streams bytes as before.
 	pub(super) fn enable() -> Option<Self> {
-		let fd = std::io::stdin().as_raw_fd();
+		Self::enable_on(std::io::stdin().as_raw_fd())
+	}
+
+	/// The same, on an explicit descriptor.
+	///
+	/// `enable` is the only place that consults the ambient stdin, which keeps
+	/// this testable: a test that asserted on `enable()` directly would be
+	/// asserting that whoever runs `cargo test` has no terminal — true under a
+	/// pipe, false in a shell, and on the way to being false it would put the
+	/// developer's own terminal into raw mode.
+	pub(super) fn enable_on(fd: i32) -> Option<Self> {
 		// SAFETY: `isatty` only inspects the descriptor and cannot write through
 		// it; a non-terminal descriptor returns 0 rather than misbehaving.
 		if unsafe { libc::isatty(fd) } != 1 {
@@ -115,21 +125,25 @@ fn size_of(fd: i32) -> Option<(u16, u16)> {
 mod tests {
 	use super::*;
 
-	/// In a test harness stdin is not a terminal, so `enable` declines rather
-	/// than failing — the same path `podup exec` takes inside a pipeline, which
-	/// must keep working.
+	/// A non-terminal descriptor is declined rather than failing — the path
+	/// `podup exec` takes inside a pipeline, which must keep working.
+	///
+	/// Asked of an explicit `/dev/null` rather than of ambient stdin: the same
+	/// assertion on `enable()` would be testing the harness, not the code, and
+	/// would put a real terminal into raw mode on the way to failing.
 	#[test]
-	fn enable_declines_when_stdin_is_not_a_terminal() {
+	fn a_non_terminal_descriptor_is_declined() {
+		let devnull = std::fs::File::open("/dev/null").expect("/dev/null opens");
 		assert!(
-			RawMode::enable().is_none(),
-			"a non-terminal stdin must not be switched to raw mode"
+			RawMode::enable_on(devnull.as_raw_fd()).is_none(),
+			"a non-terminal descriptor must not be switched to raw mode"
 		);
 	}
 
-	/// Likewise the size query: absence is a valid answer, not an error to
-	/// propagate.
+	/// Likewise the size query: absence is a valid answer, not an error.
 	#[test]
-	fn window_size_is_none_without_a_terminal() {
-		let _ = window_size();
+	fn a_non_terminal_descriptor_has_no_size() {
+		let devnull = std::fs::File::open("/dev/null").expect("/dev/null opens");
+		assert_eq!(size_of(devnull.as_raw_fd()), None);
 	}
 }

--- a/internal/engine/query/terminal.rs
+++ b/internal/engine/query/terminal.rs
@@ -1,0 +1,135 @@
+//! Terminal raw mode and window size, for interactive `exec`.
+//!
+//! Unix only. podup talks to `podman machine` over a named pipe on Windows, and
+//! raw mode there is a different API entirely (the console handles, not
+//! termios); that is tracked in #1079 rather than faked here.
+//!
+//! The invariant this module exists to hold: **the terminal is restored no
+//! matter how the exec ends.** A command that exits, a socket that dies, a
+//! panic, or a `?` on some unrelated error must all leave the user's shell
+//! usable. Raw mode with no echo and no line discipline is not something to
+//! leave behind on an error path, so the restore lives in `Drop` rather than at
+//! the end of the happy path.
+
+#![cfg(unix)]
+// termios and the winsize ioctl are libc FFI. The crate denies `unsafe` and
+// modules that need it opt back in locally, with a soundness comment per block —
+// see `engine::lock` and `engine::staging` for the same pattern.
+#![allow(unsafe_code)]
+
+use std::os::fd::AsRawFd;
+
+/// A terminal switched to raw mode, restored on drop.
+///
+/// Holding the original `termios` rather than reconstructing a "sane" one
+/// matters: the caller's shell may have its own settings, and putting the
+/// terminal into what podup thinks is normal would quietly change them.
+pub(super) struct RawMode {
+	fd: i32,
+	original: libc::termios,
+}
+
+impl RawMode {
+	/// Switch stdin to raw mode, or return `None` when it is not a terminal.
+	///
+	/// Not being a TTY is the ordinary case for `podup exec` in a script or a
+	/// pipeline, not an error: there is no line discipline to disable, and the
+	/// caller streams bytes as before.
+	pub(super) fn enable() -> Option<Self> {
+		let fd = std::io::stdin().as_raw_fd();
+		// SAFETY: `isatty` only inspects the descriptor and cannot write through
+		// it; a non-terminal descriptor returns 0 rather than misbehaving.
+		if unsafe { libc::isatty(fd) } != 1 {
+			return None;
+		}
+
+		let mut original: libc::termios = unsafe { std::mem::zeroed() };
+		// SAFETY: `original` is a correctly sized, zeroed `termios` owned here,
+		// and `fd` is a terminal (checked above). `tcgetattr` only writes into it.
+		if unsafe { libc::tcgetattr(fd, &mut original) } != 0 {
+			return None;
+		}
+
+		let mut raw = original;
+		// SAFETY: `cfmakeraw` only mutates the struct it is given.
+		unsafe { libc::cfmakeraw(&mut raw) };
+		// SAFETY: `raw` is a fully initialized `termios` derived from the current
+		// settings. TCSANOW applies immediately, which is what an interactive
+		// session wants — a drained flush would swallow keystrokes already typed.
+		if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } != 0 {
+			return None;
+		}
+
+		Some(Self { fd, original })
+	}
+}
+
+impl Drop for RawMode {
+	fn drop(&mut self) {
+		// SAFETY: `self.original` is the exact `termios` read from this same
+		// descriptor in `enable`, so restoring it cannot leave the terminal in a
+		// state it was not already in. Errors are ignored because there is
+		// nothing useful to do while unwinding, and reporting one would replace
+		// the real error the caller is already handling.
+		unsafe {
+			libc::tcsetattr(self.fd, libc::TCSANOW, &self.original);
+		}
+	}
+}
+
+/// The terminal's current size as `(rows, cols)`, or `None` when no descriptor
+/// can answer.
+///
+/// Used to size the remote pty at start and to follow it on `SIGWINCH`: without
+/// this, a full-screen program inside the container draws to an 80x24 default
+/// and redraws wrong the moment the window changes.
+///
+/// **stdin first, then stdout.** Asking only stdout looks natural — that is
+/// where the drawing goes — but the two can differ: `podup exec -it db psql >
+/// out.txt` types into a terminal and writes to a file, and stdout then answers
+/// "not a terminal" while a perfectly good size sits on stdin. Interactivity is
+/// decided by stdin, so the size is asked of stdin too, and stdout is the
+/// fallback for the reverse case.
+pub(super) fn window_size() -> Option<(u16, u16)> {
+	size_of(std::io::stdin().as_raw_fd()).or_else(|| size_of(std::io::stdout().as_raw_fd()))
+}
+
+/// `TIOCGWINSZ` on one descriptor.
+fn size_of(fd: i32) -> Option<(u16, u16)> {
+	let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+	// SAFETY: `ws` is a correctly sized, zeroed `winsize` owned here, and
+	// TIOCGWINSZ only writes into it. A non-terminal descriptor returns an error
+	// rather than writing garbage.
+	if unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) } != 0 {
+		return None;
+	}
+	// A terminal that reports 0x0 has no usable geometry — treat it as unknown
+	// rather than sizing the remote pty to nothing.
+	if ws.ws_row == 0 || ws.ws_col == 0 {
+		return None;
+	}
+	Some((ws.ws_row, ws.ws_col))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// In a test harness stdin is not a terminal, so `enable` declines rather
+	/// than failing — the same path `podup exec` takes inside a pipeline, which
+	/// must keep working.
+	#[test]
+	fn enable_declines_when_stdin_is_not_a_terminal() {
+		assert!(
+			RawMode::enable().is_none(),
+			"a non-terminal stdin must not be switched to raw mode"
+		);
+	}
+
+	/// Likewise the size query: absence is a valid answer, not an error to
+	/// propagate.
+	#[test]
+	fn window_size_is_none_without_a_terminal() {
+		let _ = window_size();
+	}
+}

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -1,0 +1,174 @@
+//! Raw bidirectional streams over the libpod socket, for interactive exec.
+//!
+//! The rest of the client is connection-per-request through hyper, which is the
+//! right shape for a CLI: send, read, done. An interactive exec is not that
+//! shape. `POST /exec/{id}/start` with a TTY keeps the connection open in both
+//! directions for as long as the command runs — the caller's keystrokes go up
+//! while the command's output comes down — so there is no response to read and
+//! return.
+//!
+//! Rather than teach the hyper path to hijack a connection, this writes the
+//! request by hand and hands back the socket. The request is trivial (one path,
+//! one short JSON body, no redirects, no keep-alive) and hand-writing it keeps
+//! the upgrade out of the general client, which every other call would then have
+//! to reason about.
+
+use tokio::io::AsyncWriteExt;
+
+use super::{Client, PodmanError, Result};
+
+/// Cap on the response head podup will read before deciding the server is not
+/// speaking HTTP. A hijacked stream's head is a status line and a handful of
+/// headers; anything larger is a malformed or hostile peer, and reading it
+/// unbounded would be a trivial memory exhaustion.
+const MAX_HEAD_BYTES: usize = 16 * 1024;
+
+/// A hijacked connection: the socket, after the response head has been read.
+///
+/// Bytes written go to the command's stdin; bytes read are its output. With a
+/// TTY the stream is raw (no 8-byte frame headers) because the pty merges
+/// stdout and stderr, which is also why an interactive exec cannot separate
+/// them — the same is true of `podman exec -it`.
+#[derive(Debug)]
+pub(crate) struct Hijacked {
+	pub(crate) stream: tokio::net::UnixStream,
+}
+
+impl Client {
+	/// `POST` a JSON body and keep the connection, for a stream that talks back.
+	///
+	/// Returns once the response head is read, so a rejected exec (404, 409)
+	/// surfaces as an error instead of hanging with the terminal already in raw
+	/// mode — which would leave the user's shell unusable.
+	#[cfg(unix)]
+	pub(crate) async fn post_hijack(&self, path: &str, body: &[u8]) -> Result<Hijacked> {
+		let mut stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
+
+		// `Connection: close` is deliberate: this socket is never returned to a
+		// pool, and saying so stops the server holding it open after the command
+		// exits.
+		let head = format!(
+			"POST {path} HTTP/1.1\r\n\
+			 Host: localhost\r\n\
+			 Content-Type: application/json\r\n\
+			 Content-Length: {}\r\n\
+			 Connection: close\r\n\
+			 \r\n",
+			body.len()
+		);
+		stream.write_all(head.as_bytes()).await?;
+		stream.write_all(body).await?;
+		stream.flush().await?;
+
+		let status = read_response_head(&mut stream).await?;
+		if !(200..300).contains(&status) {
+			return Err(PodmanError::Api {
+				status,
+				message: format!("exec start refused with HTTP {status}"),
+			});
+		}
+		Ok(Hijacked { stream })
+	}
+}
+
+/// Read the response head and return its status code, leaving the socket
+/// positioned at the first body byte.
+///
+/// Reads a byte at a time rather than buffering ahead: a buffered reader would
+/// swallow part of the command's output into its own buffer, and that output
+/// belongs to the caller. Slow, but the head is a few hundred bytes and it only
+/// happens once per exec.
+#[cfg(unix)]
+async fn read_response_head(stream: &mut tokio::net::UnixStream) -> Result<u16> {
+	use tokio::io::AsyncReadExt;
+
+	let mut head = Vec::with_capacity(256);
+	let mut byte = [0u8; 1];
+	while !head.ends_with(b"\r\n\r\n") {
+		if head.len() >= MAX_HEAD_BYTES {
+			return Err(PodmanError::Api {
+				status: 0,
+				message: "exec start response head exceeded its limit".to_string(),
+			});
+		}
+		let n = stream.read(&mut byte).await?;
+		if n == 0 {
+			return Err(PodmanError::Api {
+				status: 0,
+				message: "connection closed before the exec start response".to_string(),
+			});
+		}
+		head.push(byte[0]);
+	}
+
+	let text = String::from_utf8_lossy(&head);
+	let status_line = text.lines().next().unwrap_or_default();
+	// `HTTP/1.1 200 OK` — the code is the second token.
+	status_line
+		.split_whitespace()
+		.nth(1)
+		.and_then(|c| c.parse::<u16>().ok())
+		.ok_or_else(|| PodmanError::Api {
+			status: 0,
+			message: format!("unparseable exec start response: {status_line:?}"),
+		})
+}
+
+/// Unused on non-Unix: podup talks to `podman machine` over a named pipe there,
+/// and interactive exec is not implemented for it yet (#1079). Kept so the
+/// module compiles everywhere rather than being `cfg`-ed out of existence at the
+/// call site.
+#[cfg(not(unix))]
+impl Client {
+	pub(crate) async fn post_hijack(&self, _path: &str, _body: &[u8]) -> Result<Hijacked> {
+		Err(PodmanError::Api {
+			status: 0,
+			message: "interactive exec is not supported on this platform yet".to_string(),
+		})
+	}
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+	use super::*;
+
+	/// A refused exec must surface as an error *before* the caller puts the
+	/// terminal into raw mode. Returning a live socket for a 404 would hang with
+	/// the shell already unusable.
+	#[tokio::test]
+	async fn a_non_2xx_head_is_an_error_not_a_stream() {
+		let dir = tempfile::tempdir().unwrap();
+		let sock = dir.path().join("s.sock");
+		let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+		tokio::spawn(async move {
+			if let Ok((mut c, _)) = listener.accept().await {
+				use tokio::io::AsyncWriteExt;
+				let _ = c
+					.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+					.await;
+			}
+		});
+
+		let client = Client::new(sock.to_string_lossy().to_string());
+		let err = client
+			.post_hijack("/exec/abc/start", b"{}")
+			.await
+			.expect_err("a 404 must not yield a stream");
+		assert!(err.is_status(404), "got {err:?}");
+	}
+
+	/// A server that closes without answering is reported, not treated as a
+	/// successful attach.
+	#[tokio::test]
+	async fn a_closed_connection_is_an_error() {
+		let dir = tempfile::tempdir().unwrap();
+		let sock = dir.path().join("s.sock");
+		let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+		tokio::spawn(async move {
+			let _ = listener.accept().await;
+		});
+
+		let client = Client::new(sock.to_string_lossy().to_string());
+		assert!(client.post_hijack("/exec/abc/start", b"{}").await.is_err());
+	}
+}

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -40,7 +40,6 @@ impl Client {
 	/// Returns once the response head is read, so a rejected exec (404, 409)
 	/// surfaces as an error instead of hanging with the terminal already in raw
 	/// mode — which would leave the user's shell unusable.
-	#[cfg(unix)]
 	pub(crate) async fn post_hijack(&self, path: &str, body: &[u8]) -> Result<Hijacked> {
 		let mut stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
 
@@ -78,7 +77,6 @@ impl Client {
 /// swallow part of the command's output into its own buffer, and that output
 /// belongs to the caller. Slow, but the head is a few hundred bytes and it only
 /// happens once per exec.
-#[cfg(unix)]
 async fn read_response_head(stream: &mut tokio::net::UnixStream) -> Result<u16> {
 	use tokio::io::AsyncReadExt;
 
@@ -114,21 +112,7 @@ async fn read_response_head(stream: &mut tokio::net::UnixStream) -> Result<u16> 
 		})
 }
 
-/// Unused on non-Unix: podup talks to `podman machine` over a named pipe there,
-/// and interactive exec is not implemented for it yet (#1079). Kept so the
-/// module compiles everywhere rather than being `cfg`-ed out of existence at the
-/// call site.
-#[cfg(not(unix))]
-impl Client {
-	pub(crate) async fn post_hijack(&self, _path: &str, _body: &[u8]) -> Result<Hijacked> {
-		Err(PodmanError::Api {
-			status: 0,
-			message: "interactive exec is not supported on this platform yet".to_string(),
-		})
-	}
-}
-
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
 	use super::*;
 

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -16,6 +16,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::error::PodmanError;
 
 mod encode;
+mod hijack;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
 
 /// The request body every call shares. A boxed body so a fully-buffered

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -16,6 +16,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::error::PodmanError;
 
 mod encode;
+// Unix only: a hijacked stream is a `UnixStream`, and podup reaches
+// `podman machine` over a named pipe on Windows, where interactive exec is a
+// different implementation entirely (#1079).
+#[cfg(unix)]
 mod hijack;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
 

--- a/tests/engine_integration/exec_flags.rs
+++ b/tests/engine_integration/exec_flags.rs
@@ -46,10 +46,7 @@ async fn engine_exec_reaches_live_scaled_replicas() {
 				"-c".into(),
 				"echo idx2 > /tmp/exec_marker".into(),
 			],
-			podup::ExecOptions {
-				index: Some(2),
-				..Default::default()
-			},
+			podup::ExecOptions::default().with_index(Some(2)),
 		)
 		.await;
 
@@ -74,10 +71,7 @@ async fn engine_exec_reaches_live_scaled_replicas() {
 			&file,
 			"web",
 			vec!["true".into()],
-			podup::ExecOptions {
-				index: Some(4),
-				..Default::default()
-			},
+			podup::ExecOptions::default().with_index(Some(4)),
 		)
 		.await;
 

--- a/tests/engine_integration/lifecycle.rs
+++ b/tests/engine_integration/lifecycle.rs
@@ -285,12 +285,10 @@ async fn exec_with_options_user_workdir_env() {
 				"-c".to_string(),
 				"pwd; echo $FOO".to_string(),
 			],
-			podup::ExecOptions {
-				user: Some("root".to_string()),
-				workdir: Some("/tmp".to_string()),
-				env: vec!["FOO=bar".to_string()],
-				..Default::default()
-			},
+			podup::ExecOptions::default()
+				.with_user(Some("root".to_string()))
+				.with_workdir(Some("/tmp".to_string()))
+				.with_env(vec!["FOO=bar".to_string()]),
 		)
 		.await
 		.unwrap();
@@ -345,10 +343,7 @@ async fn exec_nonexistent_user_fails_fast() {
 			&file,
 			"web",
 			vec!["echo".to_string(), "hi".to_string()],
-			podup::ExecOptions {
-				user: Some("definitelynosuchuser".to_string()),
-				..Default::default()
-			},
+			podup::ExecOptions::default().with_user(Some("definitelynosuchuser".to_string())),
 		)
 		.await
 		.unwrap_err();


### PR DESCRIPTION
`podup exec -it db psql` is the most common shell-into-a-container habit in compose, and it did not work. podup allocated no TTY and attached no stdin, so `-i` set a flag nothing read and `-T` disabled something that never existed — every session came back with no prompt and no way to type into it.

Interactivity is now decided the way `docker compose` decides it: a TTY on both ends by default, `-T` to opt out, and it only engages when stdin is actually a terminal. A script or a pipeline keeps the exact streaming path it had before, on every platform.

### What is new

- **A hijacked stream in the libpod client.** The rest of it is connection-per-request through hyper, which is right for a CLI, but an interactive exec keeps the socket open both ways for as long as the command runs. I write that one request by hand instead of teaching the general client to upgrade a connection. The response head is read a byte at a time on purpose — a buffered reader would swallow the command's first output into its own buffer.
- **Raw mode, restored from the caller's own termios in `Drop`.** This is the one thing it cannot get wrong: a terminal left raw has no echo, and the user cannot see what they type to fix it. `Drop` covers the error and panic paths, and raw mode is only entered once the exec is known to have started, so a refused exec never leaves a terminal broken.
- **Window size, at start and on every SIGWINCH**, so a full-screen program draws at the caller's geometry instead of libpod's 80x24 default.

### Two things I only found by measuring

The size is asked of **stdin**, not stdout. Asking stdout looks natural — that is where the drawing goes — but interactivity is decided by stdin, and `podup exec -it db psql > out.txt` has a terminal on one and a file on the other.

The initial resize is sent **after** the exec starts. There is no pty to resize before that, and libpod rejects the call silently because a failed resize is only cosmetic. My first version sent it before the start, so `SIGWINCH` handling looked complete and did nothing at all. It surfaced only when I ran podup inside a pty of a known size and asked `stty size` inside the container.

### Measured

Against real Podman 5.4.2, under a pty sized 45x132:

| check | result |
|---|---|
| shell answers | `echo MARCA-$((21*2))` → `MARCA-42` |
| exit code | `exit 7` inside → podup exits 7 |
| `-T` opts out | 0 prompts |
| pipeline unchanged | `exec sh echo scripted` → `scripted` |
| geometry | `stty size` → `45 132` |

1299 lib tests and 145 integration tests pass. Adding tokio's `io-util` and `io-std` costs the shipped binary **29,464 bytes (0.41%)**.

### Scope

Unix only. podup reaches `podman machine` over a named pipe on Windows, where raw mode and resize are a different API entirely — two implementations, not one behind a `cfg`. The non-interactive path is unchanged there, so nothing regresses.

`ExecOptions` becomes `#[non_exhaustive]` with a constructor and builders so later options do not break callers again. That is the breaking change behind the 2.0.0 line.

Closes #1079