### PR TITLE
fix(test): make the lane diagnostics actually print

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -80,7 +80,7 @@ jobs:
                 # the second run, so this stabilises the lane for required-check gating
                 # without masking genuine bugs.
                 for attempt in 1 2; do
-                  cargo test --features test-helpers --test engine_integration > /tmp/cargo.log 2>&1
+                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration > /tmp/cargo.log 2>&1
                   RC=$?
                   [ "$RC" -eq 0 ] && break
                   grep -qE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log || break

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -16,7 +16,34 @@ use podup::{parse_files_with_env_files, parse_str, Client, Engine};
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Turn podup's own `tracing` output on for the suite, once per test binary.
+///
+/// The diagnostics added for #1104 and #1097 are `tracing::warn!` calls, and
+/// `tracing` is a facade: a `warn!` with no subscriber installed in the process
+/// is discarded silently. `main` installs one, but every integration test runs
+/// in a process that never calls `main`, so the instrumentation compiled, passed
+/// review, merged — and emitted nothing on the lane, which is the one place it
+/// was written to answer a question.
+///
+/// libtest captures output and prints it only for tests that fail, which is
+/// exactly the wanted shape: a green run stays quiet, and a red one carries the
+/// classification of how the stream actually ended.
+fn enable_tracing() {
+	static ONCE: std::sync::Once = std::sync::Once::new();
+	ONCE.call_once(|| {
+		use tracing_subscriber::{fmt, EnvFilter};
+		// `warn` covers the diagnostics without the per-request noise of `debug`.
+		// RUST_LOG still wins when someone wants more.
+		let filter =
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("podup=warn"));
+		// `with_test_writer` routes through libtest's capture; a plain writer
+		// would bypass it and interleave across parallel tests.
+		let _ = fmt().with_env_filter(filter).with_test_writer().try_init();
+	});
+}
+
 async fn podman() -> Option<Client> {
+	enable_tracing();
 	let connected =
 		match podup::podman::connect_from_env().or_else(|_| podup::podman::connect(None)) {
 			Ok(client) => client.ping().await.is_ok().then_some(client),


### PR DESCRIPTION
The instrumentation I added in #1125 emitted nothing.

`tracing` is a facade: a `warn!` in a process with no subscriber installed is discarded — silently, and successfully. `main` installs one, but every integration test runs in a process that never calls `main`. So the classification compiled, passed clippy, merged, and produced zero bytes on the lane, which is the one place it exists to answer a question.

I found it by grepping the lane's own log for the strings the code emits and finding none — on a run whose Podman 6 leg had fifteen stream failures sitting there unclassified.

### The fix

The suite installs a subscriber once per test binary, filtered to `podup=warn` unless `RUST_LOG` says otherwise, routed through libtest's capture. A green run stays quiet; a red one carries the reason. The lane sets `RUST_LOG` explicitly rather than leaning on the default, so the intent is readable next to the failure.

### Verified

I pointed the instrumented PUT at a socket that accepts and immediately closes, and read the line back out of the captured output:

```
WARN podup::libpod::client: PUT /v5.0.0/libpod/containers/nope/archive
(application/x-tar, 1 bytes) failed [hyper-other]: http error: error writing a body to connection
```

### What this already tells us about #1097

The lane's Podman 6 leg does not fail only on `cp`. The same `IncompleteMessage` hits `up`, `restart`, `top` and `watch` as well:

| test | operation |
|---|---|
| `cp_flags::engine_cp_to_container_renames_a_single_file` | archive PUT |
| `commands_networking::top_scaled_service_all_replicas` | top |
| `commands_networking::restart_scaled_service_all_replicas` | restart |
| `commands_networking::up_is_idempotent_over_existing_named_volume` | up |
| `watch_tests::watch_restart_container` | watch |

That is a broad connection drop, not an archive-endpoint bug, which weakens the framing of #1097 as a `cp` problem. With this merged the next lane run names *which* end each one hit, and the two readings — one classification across all five, or `cp` distinct from the rest — separate the questions instead of leaving them entangled.

No behaviour change: nothing branches on the classification, and no exit code moves.

Part of #1104 and #1097