### PR TITLE
feat!: exit 130 when an attached up is interrupted

### DIFF
--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -100,10 +100,17 @@ pub(crate) async fn dispatch(
 			if watch {
 				engine.watch(file).await?;
 			} else if !detach {
-				engine.attach_logs_with_options(file, timestamps).await?;
+				let outcome = engine.attach_logs_with_options(file, timestamps).await?;
 				// A failed teardown must surface as a non-zero exit, not be
 				// swallowed after the log streams end.
 				engine.stop(file, &[]).await?;
+				// Reported after the teardown, never instead of it: returning the
+				// interrupt straight from `attach` would short-circuit the `?`
+				// above and leave the project running, which is a worse bug than
+				// the exit code.
+				if outcome == podup::AttachOutcome::Interrupted {
+					return Err(podup::ComposeError::Interrupted);
+				}
 			}
 		}
 		Commands::Down {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -13,7 +13,9 @@ pub use copy::CpOptions;
 pub use image::{resolve_image_digests, CommitOptions};
 pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
-pub use query::{ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsFilterOptions, PsOptions};
+pub use query::{
+	AttachOutcome, ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsFilterOptions, PsOptions,
+};
 mod container_config;
 #[cfg(test)]
 mod fake_podman;

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -13,6 +13,22 @@ use super::inspect_util::{
 };
 use super::Engine;
 
+/// How an attached `up` stopped streaming.
+///
+/// The distinction has to survive back to the caller because the two endings
+/// mean opposite things to a script: the containers finishing on their own is
+/// success, and the operator pressing Ctrl-C is not. The caller still tears the
+/// project down either way — reporting the interrupt as an error from `attach`
+/// would short-circuit that and leave the containers running, which is a worse
+/// bug than the exit code this exists to fix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachOutcome {
+	/// Every stream ended on its own.
+	StreamsEnded,
+	/// SIGINT or SIGTERM arrived while streaming.
+	Interrupted,
+}
+
 impl Engine {
 	/// Display running processes in each service container (`docker compose top`).
 	///
@@ -386,7 +402,7 @@ impl Engine {
 	}
 
 	/// Attach to log streams for all services with `attach: true` (the default). Streams are multiplexed to stdout with a service-name prefix.
-	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<()> {
+	pub async fn attach_logs(&self, file: &ComposeFile) -> Result<AttachOutcome> {
 		self.attach_logs_with_options(file, false).await
 	}
 
@@ -397,7 +413,7 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		timestamps: bool,
-	) -> Result<()> {
+	) -> Result<AttachOutcome> {
 		// Carry (display_name, container_name, is_tty) so the log parser matches
 		// the container's framing mode: TTY containers emit raw bytes; non-TTY
 		// containers emit multiplexed 8-byte-header frames.
@@ -419,7 +435,8 @@ impl Engine {
 			.collect();
 
 		if attached.is_empty() {
-			return Ok(());
+			// Nothing to stream is not an interruption.
+			return Ok(AttachOutcome::StreamsEnded);
 		}
 
 		let streams: Vec<_> = attached
@@ -462,23 +479,28 @@ impl Engine {
 			})
 			.collect();
 
+		// Which arm wins is the whole point: `docker compose up` exits 130 on both
+		// SIGINT and SIGTERM (measured against v5.1.3, not assumed — it is 130 for
+		// SIGTERM too, not the 143 the signal number would suggest), and podup
+		// exited 0 for both. A CI job that runs `up` in the foreground and is
+		// cancelled therefore reported success.
 		#[cfg(unix)]
-		{
+		let outcome = {
 			use tokio::signal::unix::{signal, SignalKind};
 			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
 			tokio::select! {
-				_ = futures_util::future::join_all(streams) => {}
-				_ = tokio::signal::ctrl_c() => {}
-				_ = sigterm.recv() => {}
+				_ = futures_util::future::join_all(streams) => AttachOutcome::StreamsEnded,
+				_ = tokio::signal::ctrl_c() => AttachOutcome::Interrupted,
+				_ = sigterm.recv() => AttachOutcome::Interrupted,
 			}
-		}
+		};
 		#[cfg(not(unix))]
-		tokio::select! {
-			_ = futures_util::future::join_all(streams) => {}
-			_ = tokio::signal::ctrl_c() => {}
-		}
+		let outcome = tokio::select! {
+			_ = futures_util::future::join_all(streams) => AttachOutcome::StreamsEnded,
+			_ = tokio::signal::ctrl_c() => AttachOutcome::Interrupted,
+		};
 
-		Ok(())
+		Ok(outcome)
 	}
 }
 
@@ -499,5 +521,18 @@ mod tests {
 		let q = attach_log_query();
 		assert!(q.contains("follow=true"), "got: {q}");
 		assert!(q.contains("tail=0"), "got: {q}");
+	}
+}
+
+#[cfg(test)]
+mod attach_outcome_tests {
+	use super::AttachOutcome;
+
+	/// The two endings must stay distinguishable. They are the difference
+	/// between a CI job that ran to completion and one that was cancelled, and
+	/// before this existed both reported exit 0.
+	#[test]
+	fn the_two_endings_are_not_equal() {
+		assert_ne!(AttachOutcome::StreamsEnded, AttachOutcome::Interrupted);
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -19,6 +19,8 @@ pub use ps::{PsFilterOptions, PsOptions};
 pub use exec::ExecOptions;
 use log_prefix::LinePrefixer;
 
+pub use inspect::AttachOutcome;
+
 /// Options for [`Engine::images_with_options`].
 #[derive(Default)]
 pub struct ImagesOptions {

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -56,6 +56,11 @@ pub enum ComposeError {
 	/// A `run` container exited; carries its non-zero exit code so the CLI can
 	/// propagate it as its own process exit status.
 	RunExited(i64),
+	/// An attached `up` was ended by SIGINT or SIGTERM rather than by its
+	/// streams finishing. Carried as an error only so it reaches the exit-status
+	/// mapping; it is not printed, because the operator who pressed Ctrl-C does
+	/// not need to be told what they just did.
+	Interrupted,
 	/// `podup update` (self-update) failed.
 	Update(String),
 	/// An `external: true` secret/config/network/volume is absent.
@@ -218,6 +223,7 @@ impl fmt::Display for ComposeError {
 			Self::Watch(s) => write!(f, "watch error: {s}"),
 			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
+			Self::Interrupted => write!(f, "interrupted"),
 			Self::Update(s) => write!(f, "update error: {s}"),
 			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
 			Self::ScalePortConflict {

--- a/internal/exit_status.rs
+++ b/internal/exit_status.rs
@@ -1,0 +1,81 @@
+//! Mapping a failure onto a process exit status, and printing its reason.
+//!
+//! Split out of `main` because it is a closed responsibility with conventions
+//! of its own to hold — docker's 126/127 for a command that cannot be launched,
+//! 130 for an interrupt — and because `main` had reached the source line limit.
+
+/// Map a failed launch onto docker's conventional exit codes by inspecting the
+/// OCI/crun error text: a "command not found" failure → 127, a
+/// "not executable"/"permission denied"/"exec format error" failure → 126,
+/// anything else → 1. Pure string inspection so it is unit-testable.
+/// Exit status for an attached `up` ended by a signal: 128 + SIGINT, the shell
+/// convention, and what `docker compose up` returns for SIGTERM as well.
+pub(crate) const fn interrupt_exit_code() -> i32 {
+	130
+}
+
+pub(crate) fn command_failure_exit_code(msg: &str) -> i32 {
+	let m = msg.to_ascii_lowercase();
+	let not_found = m.contains("executable file not found")
+		|| m.contains("not found in $path")
+		|| (m.contains("oci runtime") && m.contains("no such file"));
+	let not_executable = m.contains("exec format error")
+		|| m.contains("not executable")
+		|| (m.contains("oci runtime") && m.contains("permission denied"));
+	if not_found {
+		127
+	} else if not_executable {
+		126
+	} else {
+		1
+	}
+}
+
+/// Print a top-level error to stderr with a colour-aware bold-red `error:` label.
+/// anstream strips the styling when stderr is not a terminal or colour is off.
+pub(crate) fn print_error(e: &podup::ComposeError) {
+	use std::io::Write;
+	let style = podup::ui::error_style();
+	let mut err = anstream::stderr();
+	let _ = writeln!(
+		err,
+		"podup: {}error:{} {e}",
+		style.render(),
+		style.render_reset()
+	);
+}
+
+#[cfg(test)]
+mod exit_code_tests {
+	use super::command_failure_exit_code;
+
+	#[test]
+	fn not_found_maps_to_127() {
+		assert_eq!(
+			command_failure_exit_code(
+				"podman error: crun: executable file `foo` not found in $PATH: \
+				 No such file or directory: OCI runtime command not found error"
+			),
+			127
+		);
+		assert_eq!(
+			command_failure_exit_code("OCI runtime error: ...: no such file or directory"),
+			127
+		);
+	}
+
+	#[test]
+	fn not_executable_maps_to_126() {
+		assert_eq!(
+			command_failure_exit_code("OCI runtime error: permission denied"),
+			126
+		);
+		assert_eq!(command_failure_exit_code("exec format error"), 126);
+	}
+
+	#[test]
+	fn unrelated_errors_map_to_1() {
+		assert_eq!(command_failure_exit_code("some other failure"), 1);
+		assert_eq!(command_failure_exit_code("container is restarting"), 1);
+	}
+}

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -51,9 +51,9 @@ pub use compose::{
 pub use engine::{
 	is_safe_project_name, list_projects, list_projects_filtered, resolve_image_digests,
 	retain_active_profiles, retain_active_profiles_with_targets, validate_stop_timeout,
-	BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions, ImagesOptions,
-	LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsFilterOptions, PsOptions, PullOptions,
-	PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesOptions,
+	AttachOutcome, BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions,
+	ImagesOptions, LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsFilterOptions, PsOptions,
+	PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -11,11 +11,13 @@ use clap::CommandFactory;
 mod autostart_cmd;
 mod cli;
 mod dispatch;
+mod exit_status;
 mod generate;
 mod resolve;
 mod startup;
 
 use cli::*;
+use exit_status::{command_failure_exit_code, interrupt_exit_code, print_error};
 use generate::write_quadlet;
 use resolve::*;
 use startup::{init_tracing, internal_error_notice, is_label_only, is_mutating, parse_cli};
@@ -128,33 +130,6 @@ fn print_command_help(commands: &[String]) -> podup::Result<()> {
 	Ok(())
 }
 
-/// Map a failed launch onto docker's conventional exit codes by inspecting the
-/// OCI/crun error text: a "command not found" failure → 127, a
-/// "not executable"/"permission denied"/"exec format error" failure → 126,
-/// anything else → 1. Pure string inspection so it is unit-testable.
-/// Exit status for an attached `up` ended by a signal: 128 + SIGINT, the shell
-/// convention, and what `docker compose up` returns for SIGTERM as well.
-const fn interrupt_exit_code() -> i32 {
-	130
-}
-
-fn command_failure_exit_code(msg: &str) -> i32 {
-	let m = msg.to_ascii_lowercase();
-	let not_found = m.contains("executable file not found")
-		|| m.contains("not found in $path")
-		|| (m.contains("oci runtime") && m.contains("no such file"));
-	let not_executable = m.contains("exec format error")
-		|| m.contains("not executable")
-		|| (m.contains("oci runtime") && m.contains("permission denied"));
-	if not_found {
-		127
-	} else if not_executable {
-		126
-	} else {
-		1
-	}
-}
-
 /// Whether a `down` invocation should tear the project down purely by its
 /// `podup.project` label: the command is `down`, an explicit project name was
 /// given (`-p` / `COMPOSE_PROJECT_NAME`), and no compose file resolves on disk.
@@ -162,20 +137,6 @@ fn command_failure_exit_code(msg: &str) -> i32 {
 /// file is absent. Pure so it is unit-testable without a Podman daemon.
 fn down_by_label_path(command: &Commands, project: Option<&str>, compose_present: bool) -> bool {
 	matches!(command, Commands::Down { .. }) && project.is_some() && !compose_present
-}
-
-/// Print a top-level error to stderr with a colour-aware bold-red `error:` label.
-/// anstream strips the styling when stderr is not a terminal or colour is off.
-fn print_error(e: &podup::ComposeError) {
-	use std::io::Write;
-	let style = podup::ui::error_style();
-	let mut err = anstream::stderr();
-	let _ = writeln!(
-		err,
-		"podup: {}error:{} {e}",
-		style.render(),
-		style.render_reset()
-	);
 }
 
 /// Orchestrate one CLI invocation: parse args, then short-circuit the commands
@@ -630,41 +591,6 @@ mod down_by_label_tests {
 		// Only `down` is routed by label here; another command with `-p` and no file
 		// must not be diverted.
 		assert!(!down_by_label_path(&Commands::Watch, Some("proj"), false));
-	}
-}
-
-#[cfg(test)]
-mod exit_code_tests {
-	use super::command_failure_exit_code;
-
-	#[test]
-	fn not_found_maps_to_127() {
-		assert_eq!(
-			command_failure_exit_code(
-				"podman error: crun: executable file `foo` not found in $PATH: \
-				 No such file or directory: OCI runtime command not found error"
-			),
-			127
-		);
-		assert_eq!(
-			command_failure_exit_code("OCI runtime error: ...: no such file or directory"),
-			127
-		);
-	}
-
-	#[test]
-	fn not_executable_maps_to_126() {
-		assert_eq!(
-			command_failure_exit_code("OCI runtime error: permission denied"),
-			126
-		);
-		assert_eq!(command_failure_exit_code("exec format error"), 126);
-	}
-
-	#[test]
-	fn unrelated_errors_map_to_1() {
-		assert_eq!(command_failure_exit_code("some other failure"), 1);
-		assert_eq!(command_failure_exit_code("container is restarting"), 1);
 	}
 }
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -69,6 +69,11 @@ fn run_to_exit() {
 	match runtime.block_on(run()) {
 		Ok(()) => {}
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
+		// 128 + SIGINT, the shell convention, and what `docker compose up` returns
+		// for SIGTERM as well as SIGINT. Nothing is printed: the operator pressed
+		// Ctrl-C and knows it, and a compose file's own teardown output has
+		// already gone to the terminal.
+		Err(podup::ComposeError::Interrupted) => process::exit(interrupt_exit_code()),
 		#[cfg(feature = "update")]
 		Err(e @ podup::ComposeError::Update(_)) => {
 			print_error(&e);
@@ -127,6 +132,12 @@ fn print_command_help(commands: &[String]) -> podup::Result<()> {
 /// OCI/crun error text: a "command not found" failure → 127, a
 /// "not executable"/"permission denied"/"exec format error" failure → 126,
 /// anything else → 1. Pure string inspection so it is unit-testable.
+/// Exit status for an attached `up` ended by a signal: 128 + SIGINT, the shell
+/// convention, and what `docker compose up` returns for SIGTERM as well.
+const fn interrupt_exit_code() -> i32 {
+	130
+}
+
 fn command_failure_exit_code(msg: &str) -> i32 {
 	let m = msg.to_ascii_lowercase();
 	let not_found = m.contains("executable file not found")
@@ -698,6 +709,15 @@ fn first_misused_global(matches: &clap::ArgMatches) -> Option<&'static str> {
 
 #[cfg(all(test, feature = "update"))]
 mod tests {
+
+	/// 130 is 128 + SIGINT, and it is what `docker compose up` returns for
+	/// SIGTERM too — measured against v5.1.3 rather than derived from the signal
+	/// number, which would have said 143. podup returned 0 for both, so a
+	/// cancelled CI job reported success.
+	#[test]
+	fn an_interrupt_maps_onto_the_shell_convention() {
+		assert_eq!(interrupt_exit_code(), 130);
+	}
 	use super::*;
 	use clap::CommandFactory;
 


### PR DESCRIPTION
`podup up` in the foreground returned **0** when it was killed. A CI job that runs the project attached and is cancelled — by a timeout, by an operator, by the runner shutting down — reported success, and anything gating on that exit status could not tell a completed run from an abandoned one.

### Measured, not assumed

`docker compose` v5.1.3 pointed at the same Podman socket:

| signal | docker compose | podup before | podup now |
|---|---|---|---|
| SIGINT | 130 | 0 | 130 |
| SIGTERM | **130** | 0 | 130 |
| streams end on their own | 0 | 0 | 0 |

SIGTERM returning 130 rather than 143 is the part I would have got wrong by reasoning from the signal number. It came out of running it.

### The teardown had to survive

The dispatch does this:

```rust
engine.attach_logs_with_options(file, timestamps).await?;
engine.stop(file, &[]).await?;
```

Reporting the interrupt as an error from `attach` — the obvious implementation — short-circuits the `?` and leaves the whole project running. Leaking containers to fix an exit code is a straight downgrade, so the outcome travels back as a value (`AttachOutcome`), the stop happens either way, and only then does the interrupt become an exit status.

Verified against Podman 5.4.2 with a service that traps SIGTERM:

```
podup + SIGINT  -> exit 130   contenedor: Exited (0)
podup + SIGTERM -> exit 130   contenedor: Exited (0)
```

`Exited (0)` is the container's own handler running — the graceful stop still happens, it is not a kill.

Nothing is printed for the interrupt. The operator pressed Ctrl-C and knows it, and the teardown output has already reached the terminal.

`AttachOutcome` is new public API and `attach_logs`'s return type changed, hence the breaking marker.

Part of #1080