### PR TITLE
fix!: accept docker's bare --sig-proxy, and scope the docs test per command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,6 +43,7 @@ Create and start all services (or only the named ones, plus their transitive
 | `--no-build` | Do not build images, even for services with a `build:` section. | off |
 | `--quiet-pull` | Suppress image-pull progress output. | off |
 | `--wait` | Wait until services are running/healthy before returning. | off |
+| `--wait-timeout <SECS>` | Maximum seconds to wait with `--wait` before giving up. | no limit |
 | `--no-start` | Create the containers but do not start them. | off |
 | `--timestamps` | Prefix attached log lines with a timestamp (ignored with `-d`). | off |
 | `-V, --renew-anon-volumes` | Recreate anonymous volumes instead of keeping the previous ones. | off |
@@ -71,6 +72,8 @@ created containers.
 | `--build` | Build images before creating containers. | off |
 | `--force-recreate` | Recreate containers even if their config is unchanged. | off |
 | `--no-recreate` | Leave existing containers in place. | off |
+| `--no-deps` | Do not create the `depends_on` services of the named ones. | off |
+| `--pull <POLICY>` | Pull policy before creating: `always`, `missing`, `never`, `newer`, `build`. | Podman default |
 
 ### `start`
 Start existing stopped containers. Accepts a trailing service list.
@@ -129,6 +132,7 @@ List podup compose projects on the host. Needs no compose file.
 | `-a, --all` | Include stopped projects. | running only |
 | `-q, --quiet` | Print project names only. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
+| `--filter <FILTER>` | Keep only projects matching a predicate: `name=<NAME>` or `status=<running\|exited>`. Repeatable. | none |
 
 ### `logs [SERVICE...]`
 View container output for the named services (or all).
@@ -149,6 +153,9 @@ Stream Podman events for this project's containers.
 | Flag | Description | Default |
 |---|---|---|
 | `--format <FMT>` | `table` (a `TYPE ACTION NAME` summary) or `json` (one object per line). | `table` |
+| `--filter <FILTER>` | Keep only events matching a predicate (`KEY=VALUE`, e.g. `event=start`). Repeatable. | none |
+| `--since <TIME>` | Only stream events at or after this timestamp or relative time. | stream start |
+| `--until <TIME>` | Only stream events up to this timestamp or relative time. | no end |
 
 `--json` is a hidden deprecated alias for `--format json`.
 
@@ -266,7 +273,7 @@ container exits or you detach. Output only — stdin is never attached.
 |---|---|---|
 | `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
 | `--no-stdin` | Accepted for compatibility; stdin is never attached anyway. | off |
-| `--sig-proxy` | Accepted for compatibility; no effect. | off |
+| `--sig-proxy [<BOOL>]` | Accepted for compatibility; no effect. Takes docker's bare form or an explicit value. | off |
 | `--detach-keys <KEYS>` | Accepted for compatibility; no effect. | none |
 
 ### `kill [SERVICE...]`
@@ -311,7 +318,7 @@ Commit a service container's current state to a new image reference
 | `-m, --message <MSG>` | Commit message recorded on the image. | none |
 | `-a, --author <AUTHOR>` | Author recorded on the image. | none |
 | `-c, --change <INSTRUCTION>` | Apply a Dockerfile instruction to the created image. Repeatable. | none |
-| `--pause` | Pause the container while committing. | off |
+| `-p, --pause [<BOOL>]` | Pause the container during commit for a consistent snapshot. `--pause=false` snapshots it live. | **on** |
 
 ### `export <SERVICE>`
 Export a service container's filesystem as a tar archive.
@@ -339,6 +346,7 @@ skipped). Credentials come from `podman login`.
 
 | Flag | Description | Default |
 |---|---|---|
+| `-q, --quiet` | Suppress the push progress output. | off |
 | `--ignore-push-failures` | Continue after a failure. | off |
 | `--tls-verify <BOOL>` | Verify the registry TLS cert; `false` allows an insecure/HTTP registry. | Podman default |
 
@@ -393,7 +401,7 @@ Print the resolved compose file (after substitution, extends, include).
 | `--volumes` | List named volumes, one per line. | off |
 | `--images` | List the images services use, one per line. | off |
 | `--profiles` | List the profiles the file declares, one per line. | off |
-| `--hash` | Print a stable per-service config hash. | off |
+| `--hash <SERVICES>` | Print a stable per-service config hash for the given comma-separated services, or `'*'` for all. | none |
 | `--no-normalize` | Accepted for compatibility; `config` always emits the normalized form. | off |
 | `-q, --quiet` | Only validate; print nothing. | off |
 | `--no-interpolate` | Leave `${VAR}` placeholders literal. | off |

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -387,8 +387,20 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		no_stdin: bool,
 		/// Proxy received signals to the process (accepted for compatibility).
-		#[arg(long)]
-		sig_proxy: Option<bool>,
+		///
+		/// Takes an optional value so both spellings parse: docker declares this
+		/// as a bare boolean, and demanding a value made
+		/// `docker compose attach --sig-proxy web` fail with a usage error
+		/// against podup — inside the set of flags whose entire purpose is that
+		/// such a script runs unchanged.
+		#[arg(
+			long,
+			default_value_t = false,
+			action = clap::ArgAction::Set,
+			num_args = 0..=1,
+			default_missing_value = "true",
+		)]
+		sig_proxy: bool,
 		/// Override the detach key sequence (accepted for compatibility).
 		#[arg(long)]
 		detach_keys: Option<String>,

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -356,3 +356,30 @@ fn config_projections_render_lists() {
 
 	let _ = fs::remove_dir_all(&dir);
 }
+
+/// `--sig-proxy` must accept docker's bare spelling.
+///
+/// It lives in the "accepted for compatibility" set, whose entire promise is
+/// that a script written against docker compose runs unchanged. Docker declares
+/// it as a bare boolean; podup declared it as one that demands a value, so
+/// `docker compose attach --sig-proxy web` came back as a usage error and exit
+/// 2 — a no-op flag rejecting the command it was supposed to tolerate.
+///
+/// Asserted as "not a clap error": these never reach Podman, so the run fails
+/// later on the missing compose file, which is exactly the point — parsing got
+/// past the flag.
+#[test]
+fn sig_proxy_accepts_dockers_bare_form_and_an_explicit_value() {
+	for args in [
+		vec!["attach", "web", "--sig-proxy"],
+		vec!["attach", "web", "--sig-proxy=true"],
+		vec!["attach", "web", "--sig-proxy=false"],
+	] {
+		let out = run_offline(&args);
+		assert!(
+			!is_clap_usage_error(&out) && !is_clap_value_error(&out),
+			"{args:?} must parse; got {}",
+			String::from_utf8_lossy(&out.stderr)
+		);
+	}
+}

--- a/tests/docs_flags.rs
+++ b/tests/docs_flags.rs
@@ -10,6 +10,18 @@
 //! The reverse (documented flags that no longer exist) is a different failure
 //! and a different fix, and folding both into one assertion would make the
 //! message ambiguous.
+//!
+//! The match is scoped to the command's own `###` section. Searching the whole
+//! document — which this did until #1132 — means a flag documented anywhere
+//! satisfies every command, so eight flags sat undocumented in their own tables
+//! while the test stayed green. Scoping it is also the honest reading of what
+//! the test claims to check: that a reader looking up `create` finds `--pull`
+//! under `create`, not somewhere else entirely.
+//!
+//! It still checks names, never descriptions. A row can say the opposite of
+//! what the code does and this will not notice — `exec`'s pseudo-TTY shipped
+//! next to "podup never allocates one" (#1079), and `commit --pause` documented
+//! a default of off while the code defaults it on (#1132).
 
 use std::collections::BTreeSet;
 use std::process::Command;
@@ -57,10 +69,47 @@ const COMMANDS: [&str; 29] = [
 	"wait", "scale", "commit", "export", "pull", "push", "config",
 ];
 
+/// The lines of `docs/commands.md` documenting one command: from its `###`
+/// heading to the next heading of any level.
+///
+/// Headings carry their positional arguments — ``### `cp <SRC> <DST>` `` — so a
+/// command matches when the first backticked word of the heading is its name.
+/// `pause` and `unpause` share one heading, which the `/`-separated form covers.
+fn section_for(docs: &str, cmd: &str) -> Option<String> {
+	let mut lines = docs.lines();
+	let heading = lines.by_ref().find(|line| {
+		line.strip_prefix("### ").is_some_and(|rest| {
+			rest.split('/').any(|part| {
+				part.trim().trim_start_matches('`').split(['`', ' ']).next() == Some(cmd)
+			})
+		})
+	});
+	heading?;
+	Some(
+		lines
+			// Both levels, and not a bare `#` test: a fenced bash block starts its
+			// comments with `#` at column zero, and stopping there would truncate
+			// the section early and fail a documented flag.
+			.take_while(|line| !line.starts_with("## ") && !line.starts_with("### "))
+			.collect::<Vec<_>>()
+			.join("\n"),
+	)
+}
+
 #[test]
 fn every_cli_flag_is_documented() {
 	let docs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/commands.md"))
 		.expect("read docs/commands.md");
+
+	// clap marks the compose-wide options `global`, so every command's `--help`
+	// reprints them — but they are documented once, in the global table, not in
+	// each command's own. Subtract them or the per-command check demands that
+	// `--socket` be listed under all twenty-nine.
+	let global = Command::new(bin())
+		.arg("--help")
+		.output()
+		.expect("run --help");
+	let globals = flags_in_help(&String::from_utf8_lossy(&global.stdout));
 
 	let mut missing: Vec<String> = Vec::new();
 	for cmd in COMMANDS {
@@ -70,8 +119,13 @@ fn every_cli_flag_is_documented() {
 			.unwrap_or_else(|e| panic!("run {cmd} --help: {e}"));
 		assert!(out.status.success(), "`{cmd} --help` failed");
 		let help = String::from_utf8_lossy(&out.stdout);
+		let section = section_for(&docs, cmd)
+			.unwrap_or_else(|| panic!("docs/commands.md has no `### {cmd}` section"));
 		for flag in flags_in_help(&help) {
-			if !docs.contains(&flag) {
+			if globals.contains(&flag) {
+				continue;
+			}
+			if !section.contains(&flag) {
 				missing.push(format!("{cmd}: {flag}"));
 			}
 		}


### PR DESCRIPTION
`--sig-proxy` lives in the **accepted for compatibility** set, whose whole promise is that a script written against docker compose runs unchanged. It did not.

```
$ docker-compose attach --help
      --sig-proxy            Proxy all received signals to the process

$ podup attach web --sig-proxy
error: a value is required for '--sig-proxy <SIG_PROXY>' but none was supplied
```

Exit 2. A no-op flag is harmless; a no-op flag that *rejects the command it was meant to tolerate* is worse than not accepting it at all. It now takes docker's bare form and an explicit value, reusing the clap shape `commit --pause` already uses.

### Three rows that said the opposite of the code

All checked against the built binary, not read:

| row | documented | actual |
|---|---|---|
| `commit --pause` | default **off** | default **on** (`default_value_t = true`); `-p` and `=true\|false` undocumented |
| `config --hash` | a boolean | requires a selector — bare `--hash` exits 2; the repo's own test uses `--hash '*'` |
| `attach --sig-proxy` | default "off" | a boolean that did not exist |

The `commit --pause` one is the one that would bite: a reader following the docs believes `commit` snapshots a live container unless they opt in, when it quiesces it unless they opt out.

### Why nothing caught it

`docs_flags.rs` matched each flag against the **whole document** (`docs.contains(&flag)`), so a flag documented anywhere satisfied every command. Scoped to the command's own `###` section, it immediately found eight flags absent from their own tables — `up --wait-timeout`, `create --no-deps`, `create --pull`, `ls --filter`, `events --filter`/`--since`/`--until`, `push -q/--quiet`. All now documented.

**The scoping took two passes, and the first was wrong in an instructive way.** It ended a section at the next line starting with `"## "` — which `"### logs"` does not match, because the third character is `#`, not a space. So `ls`'s section ran on through the seven commands after it, and deleting the `ls --all` row still passed. I only found it by falsifying the test on a *mid-document* section instead of the last one. Both boundaries are checked now.

Global flags are subtracted from the per-command check: clap marks them `global` so every command's `--help` reprints them, but they are documented once, in their own table.

### What it still does not check

Names, never descriptions. A row can contradict the code and this stays green — that is exactly how #1079 shipped `exec`'s pseudo-TTY next to "podup never allocates one", and why the three rows above had to be found by hand.

Closes #1132