### PR TITLE
fix: stop declaring the gzipped archive upload as a plain tar

### DIFF
--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -208,7 +208,13 @@ impl Engine {
 			urlencoded(&extract_dir),
 		);
 		self.client
-			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/x-tar")
+			// `pack_path` gzips, so the body is a gzipped tar and saying
+			// `application/x-tar` is simply false. Podman 5 sniffs the magic bytes
+			// and forgives it; the working theory for #1097 is that Podman 6 no
+			// longer does, which would explain why every archive PUT there dies
+			// mid-message on bodies of ~110 bytes — the size of a gzipped tar, not
+			// of a tar (a bare tar header alone is 512).
+			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/gzip")
 			.await
 			.map_err(ComposeError::Podman)?;
 

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -209,11 +209,10 @@ impl Engine {
 		);
 		self.client
 			// `pack_path` gzips, so the body is a gzipped tar and saying
-			// `application/x-tar` is simply false. Podman 5 sniffs the magic bytes
-			// and forgives it; the working theory for #1097 is that Podman 6 no
-			// longer does, which would explain why every archive PUT there dies
-			// mid-message on bodies of ~110 bytes — the size of a gzipped tar, not
-			// of a tar (a bare tar header alone is 512).
+			// `application/x-tar` was simply false. Podman 5 sniffs the magic bytes
+			// and forgives either label. This does NOT fix #1097 — the lane proved
+			// Podman 6 rejects the upload identically both ways — it just stops
+			// podup lying about what it sends.
 			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/gzip")
 			.await
 			.map_err(ComposeError::Podman)?;

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -324,7 +324,10 @@ impl Engine {
 			urlencoded(&dest_dir),
 		);
 		self.client
-			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/x-tar")
+			// Gzipped, like `cp`'s: `watch` has its own copy of this upload rather
+			// than reusing `Engine::cp`, which is how the two drifted to different
+			// content types for the same body.
+			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/gzip")
 			.await
 			.map_err(ComposeError::Podman)?;
 


### PR DESCRIPTION
`pack_path` gzips, so the body of `PUT /containers/{id}/archive` is a **gzipped** tar. Both call sites labelled it `application/x-tar`. Podman 5 sniffs the magic bytes and accepts either label, so the lie never surfaced.

### This does not fix #1097 — I predicted it would, and I was wrong

The original version of this PR predicted the Podman 6 leg would drop from 10 failures to 4 and lose its nine `failed [incomplete-message]` lines. [Run 29776963260](https://github.com/Glyndor/podup/actions/runs/29776963260):

```
PODUP_SUMMARY pass=150 fail=10 flaky=21
```

Same count, same ten tests, nine `incomplete-message` lines. The change *did* take effect — the diagnostics print the content type, and the failures came back split:

| Content-Type | failed PUTs |
|---|---|
| `application/gzip` (the changed `cp` path) | 5 |
| `application/x-tar` (an unchanged path) | 4 |

The endpoint rejects the upload identically either way. Content-Type is not the cause, and Podman 5's tolerance of the mismatch was a red herring: it accepts both because it does not care.

### What the refutation surfaced

That split is the other half of this PR. Four failures still said `x-tar` because **`watch` has its own copy of the upload** (`internal/engine/watch/mod.rs:327`) rather than reusing `cp`'s (`internal/engine/copy.rs:211`) — which is how the two drifted to different content types for the same body, and why `watch` sits beside `cp` in the Podman 6 failure set at all.

Both say `gzip` now. No `put_bytes_ok` declares `x-tar` any more.

### Why keep it

podup should not describe a gzip stream as a tar. It only ever worked because one implementation guesses, and the next one that stops guessing would break it for a reason nobody could see. Verified against Podman 5.4.2 on both paths.

Marked `Part of #1097`, not `Closes` — the bug is still open and now has one fewer candidate cause.