### PR TITLE
fix: logs must not report success when it reached nothing

### DIFF
--- a/.github/podman-known-failures-5
+++ b/.github/podman-known-failures-5
@@ -2,33 +2,19 @@
 # reasons, not because podup is broken. The lane fails when a failing test is NOT
 # on this list — a new identity is a real regression, whatever the pass count says.
 #
-# Every entry below was classified by running the SAME suite against real Podman
-# on a physical host (5.4.2, no VM, serial): 155 passed, 0 failed. The lane
-# reports 10 failures for the same code, so these ten are the environment.
-#
 # Adding a line here is a claim that a test cannot pass under nested-virt. Make
 # that claim with a run, not a guess — the whole point of this file is that the
 # 2026-07 regression (#1072) hid inside a count-only gate for a day and a
 # release. Remove a line the moment its test starts passing in the lane.
 #
-# Podman 6 is deliberately NOT gated this way, and this is not an oversight to
-# fix: its failing set carries a variable tail (identities that appear in 1-of-5
-# runs), so a list built from observation would redden innocent pull requests —
-# the failure mode that already forced the pass-count floor down from 120 to 115.
-# Podman 6 keeps the floor until its set is both classified and stable (#1039).
+# 2026-07-20: eight of the ten entries were removed, and they were never about
+# nested virt. Podman's journald log driver could not open its library in this
+# image, so every logs request returned HTTP 500 and the VM served no logs at
+# all. With the file-based driver configured the lane went from 10 failures to
+# 2 — the six run/attach tests and cli_run_subcommand and cli_logs_tail_limits_output
+# all pass now. The claim "cannot pass under nested virt" was made honestly, with
+# a run, and was still wrong: the physical host that proved 155/155 also had a
+# working journald, so the comparison could not see the difference.
 
-# The `run` family (7): needs a controlling terminal the VM's serial console
-# cannot provide. All seven passed in the real-host run that classified them.
-commands_networking::engine_run_command_succeeds
-commands_networking::engine_run_nonzero_exit_returns_run_exited
-run_flags::engine_run_applies_user_workdir_env_and_entrypoint
-run_flags::engine_run_applies_volume_publish_and_interactive
-run_flags::engine_run_no_deps_skips_dependency_startup
-run_flags::engine_run_starts_dependencies_by_default
-cli_commands::cli_run_subcommand
-
-# Streaming reads that depend on timely delivery through the guest's virtio
-# console; under nested-virt the stream is cut or arrives late.
-cli_flags::cli_logs_tail_limits_output
-niche::cli_attach_streams_output_until_exit
 niche::engine_events_stream_connects
+run_flags::engine_run_applies_volume_publish_and_interactive

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -151,11 +151,20 @@ jobs:
           grep -q 'No space left' "$L" && { echo "::error::VM disk full — run invalid"; exit 1; }
           VER=$(grep -oE 'PODMAN=podman version [0-9.]+' "$L" | grep -oE '[0-9.]+' | tail -1)
           grep -qE 'PODMAN=podman version [0-9]' "$L" || { echo "::error::Podman not detected in VM"; exit 1; }
-          # The log driver must have taken. journald cannot open its library in this
-          # image, so logs 500 — and the five tests that only unwrap the result then
-          # pass without fetching a byte. A config silently ignored would put them
-          # straight back to green-and-meaningless, which is worse than a red run.
-          grep -q 'LOGDRIVER=k8s-file' "$L" || { echo "::error::log driver is not k8s-file — logs tests would pass without reading anything"; exit 1; }
+          # The VM must be able to serve logs. Gate on that, not on which driver
+          # provides it: Fedora 44's journald cannot open its library here and every
+          # logs request 500s, while rawhide's works fine — so requiring a specific
+          # driver reddens the major that never had the problem.
+          #
+          # This is not cosmetic. With logs unavailable, the five tests that only
+          # `unwrap()` the result passed without fetching a byte, because `logs`
+          # swallowed the 500 and returned success. Green-and-meaningless is worse
+          # than red, so the signature is a hard failure.
+          echo "log driver: $(grep -oE 'LOGDRIVER=[a-z0-9-]+' "$L" | tail -1)"
+          if grep -q 'unable to open a handle to the library' "$L"; then
+            echo "::error::the VM could not serve logs (journald cannot open its library) — the logs tests would pass without reading anything"
+            exit 1
+          fi
           # Guard the matrix: the VM must actually run the Podman major it was asked to.
           case "$VER" in
             ${{ matrix.podman }}.*) : ;;

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -59,6 +59,20 @@ jobs:
               sudo: 'ALL=(ALL) NOPASSWD:ALL'
               shell: /bin/bash
           write_files:
+            # Podman's default log driver on Fedora is journald, and in this image
+            # every logs request comes back `500 ... unable to open a handle to the
+            # library` — its go-systemd binding cannot open the journal. Installing
+            # systemd-devel does not help (measured: the package installs and the
+            # error persists), so rather than keep guessing at the dlopen, use the
+            # file-based driver, which has no library to open.
+            #
+            # This is not cosmetic. With logs unavailable the suite's five logs
+            # tests passed without fetching a byte — `logs` swallowed the 500 and
+            # returned success, so their `unwrap()` succeeded on nothing.
+            - path: /etc/containers/containers.conf
+              content: |
+                [containers]
+                log_driver = "k8s-file"
             - path: /usr/local/bin/run-suite.sh
               permissions: '0755'
               content: |
@@ -110,15 +124,10 @@ jobs:
                 echo "PODUP_FAILED_TESTS=${FAILED_TESTS}"
           runcmd:
             - bash -c 'F=$(findmnt -no FSTYPE /); case $F in btrfs) btrfs filesystem resize max / ;; xfs) xfs_growfs / ;; ext4) resize2fs $(findmnt -no SOURCE /) ;; esac >/dev/console 2>&1; echo "DISK=$(df -h / | tail -1)" >/dev/console'
-            # systemd-devel provides the libsystemd.so symlink Podman dlopen()s for
-            # the journald log driver, which is the default on Fedora. Without it
-            # every logs request 500s with "unable to open a handle to the
-            # library", so the VM could not serve a single log line — and nobody
-            # noticed, because `logs` swallowed the 500 and returned success. The
-            # tests that only unwrapped the result passed without reading
-            # anything; the one that checks its output (cli_logs_tail_limits_output)
-            # has been on the known-failures list all along, filed as nested-virt.
-            - bash -c 'dnf install -y podman rust cargo gcc git systemd-devel >/dev/console 2>&1'
+            - bash -c 'dnf install -y podman rust cargo gcc git >/dev/console 2>&1'
+            # Prove the driver took, so a silently-ignored config cannot put the
+            # logs tests back to passing without reading anything.
+            - bash -c 'echo "LOGDRIVER=$(podman info --format {{.Host.LogDriver}} 2>/dev/null)" >/dev/console'
             - bash -c 'echo "PODMAN=$(podman --version)  RUST=$(rustc --version)" >/dev/console'
             - bash -c 'echo "tester:100000:65536" >/etc/subuid; echo "tester:100000:65536" >/etc/subgid'
             - bash -c 'loginctl enable-linger tester; sleep 6'
@@ -142,6 +151,11 @@ jobs:
           grep -q 'No space left' "$L" && { echo "::error::VM disk full — run invalid"; exit 1; }
           VER=$(grep -oE 'PODMAN=podman version [0-9.]+' "$L" | grep -oE '[0-9.]+' | tail -1)
           grep -qE 'PODMAN=podman version [0-9]' "$L" || { echo "::error::Podman not detected in VM"; exit 1; }
+          # The log driver must have taken. journald cannot open its library in this
+          # image, so logs 500 — and the five tests that only unwrap the result then
+          # pass without fetching a byte. A config silently ignored would put them
+          # straight back to green-and-meaningless, which is worse than a red run.
+          grep -q 'LOGDRIVER=k8s-file' "$L" || { echo "::error::log driver is not k8s-file — logs tests would pass without reading anything"; exit 1; }
           # Guard the matrix: the VM must actually run the Podman major it was asked to.
           case "$VER" in
             ${{ matrix.podman }}.*) : ;;

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -110,7 +110,15 @@ jobs:
                 echo "PODUP_FAILED_TESTS=${FAILED_TESTS}"
           runcmd:
             - bash -c 'F=$(findmnt -no FSTYPE /); case $F in btrfs) btrfs filesystem resize max / ;; xfs) xfs_growfs / ;; ext4) resize2fs $(findmnt -no SOURCE /) ;; esac >/dev/console 2>&1; echo "DISK=$(df -h / | tail -1)" >/dev/console'
-            - bash -c 'dnf install -y podman rust cargo gcc git >/dev/console 2>&1'
+            # systemd-devel provides the libsystemd.so symlink Podman dlopen()s for
+            # the journald log driver, which is the default on Fedora. Without it
+            # every logs request 500s with "unable to open a handle to the
+            # library", so the VM could not serve a single log line — and nobody
+            # noticed, because `logs` swallowed the 500 and returned success. The
+            # tests that only unwrapped the result passed without reading
+            # anything; the one that checks its output (cli_logs_tail_limits_output)
+            # has been on the known-failures list all along, filed as nested-virt.
+            - bash -c 'dnf install -y podman rust cargo gcc git systemd-devel >/dev/console 2>&1'
             - bash -c 'echo "PODMAN=$(podman --version)  RUST=$(rustc --version)" >/dev/console'
             - bash -c 'echo "tester:100000:65536" >/etc/subuid; echo "tester:100000:65536" >/etc/subgid'
             - bash -c 'loginctl enable-linger tester; sleep 6'

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -268,6 +268,12 @@ impl Engine {
 		// one service must not blank the whole command the way an `.await?` would:
 		// warn and skip that service so the rest still stream, matching the
 		// per-container tolerance below.
+		// A failure resolving ONE service is tolerated so the others still print —
+		// that is deliberate and tested. But when nothing resolves at all, the
+		// command printed nothing and still reported success, which is how an
+		// unreachable engine looked identical to a project with no logs. Kept and
+		// only consulted when there is no output to salvage.
+		let mut first_err: Option<ComposeError> = None;
 		let mut targets: Vec<(String, bool)> = Vec::new();
 		for (n, s) in file
 			.services
@@ -279,6 +285,7 @@ impl Engine {
 				Ok(names) => names,
 				Err(e) => {
 					tracing::warn!("logs: resolving replicas for service {n}: {e}");
+					first_err.get_or_insert(e);
 					continue;
 				}
 			};
@@ -286,6 +293,28 @@ impl Engine {
 				targets.push((cname, is_tty));
 			}
 		}
+
+		// A container that is simply not there yet is tolerated per-container so
+		// the services that *do* exist still stream — that is deliberate. Anything
+		// else (the socket refusing, a 500) is not a per-container fact, it is the
+		// command failing, and `logs` reported exit 0 for it. Collected here and
+		// returned at the end so every reachable container is still shown first.
+		//
+		// Nothing resolved and something went wrong: there is no partial result to
+		// preserve, so the tolerance has nothing left to protect. This is separate
+		// from #1104 — nothing here classifies how a stream *ended*, the request
+		// never opened.
+		if targets.is_empty() {
+			if let Some(e) = first_err {
+				return Err(e);
+			}
+		}
+
+		// Same rule one level down: a container that will not stream is tolerated
+		// while another does, but every target failing is the command failing.
+		let mut streamed_err: Option<ComposeError> = None;
+		let mut streamed_any = false;
+		let target_count = targets.len();
 
 		// When follow=true, streams never end until containers stop. Run them
 		// concurrently so multiple containers don't block each other.
@@ -304,7 +333,7 @@ impl Engine {
 							Ok(r) => r,
 							Err(e) => {
 								tracing::warn!("logs {container_name}: {e}");
-								return;
+								return Some(e);
 							}
 						};
 						let mut stream = if is_tty {
@@ -349,10 +378,20 @@ impl Engine {
 						}
 						out_pfx.flush_tail(&mut std::io::stdout().lock());
 						err_pfx.flush_tail(&mut std::io::stderr().lock());
+						None
 					}
 				})
 				.collect();
-			futures_util::future::join_all(futs).await;
+			let mut failures = 0usize;
+			for e in futures_util::future::join_all(futs)
+				.await
+				.into_iter()
+				.flatten()
+			{
+				failures += 1;
+				streamed_err.get_or_insert(ComposeError::Podman(e));
+			}
+			streamed_any = failures < target_count;
 		} else {
 			for (container_name, is_tty) in targets {
 				let path = format!(
@@ -367,6 +406,7 @@ impl Engine {
 					Ok(r) => r,
 					Err(e) => {
 						tracing::warn!("logs {container_name}: {e}");
+						streamed_err.get_or_insert(ComposeError::Podman(e));
 						continue;
 					}
 				};
@@ -406,10 +446,14 @@ impl Engine {
 				}
 				out_pfx.flush_tail(&mut out);
 				err_pfx.flush_tail(&mut std::io::stderr().lock());
+				streamed_any = true;
 			}
 		}
 
-		Ok(())
+		if streamed_any {
+			return Ok(());
+		}
+		streamed_err.map_or(Ok(()), Err)
 	}
 
 	/// Names of this project's containers (by label) that the current compose file

--- a/internal/engine/query/tests.rs
+++ b/internal/engine/query/tests.rs
@@ -257,3 +257,77 @@ fn is_valid_log_time_classifies_forms() {
 	assert!(!is_valid_log_time(""));
 	assert!(!is_valid_log_time("10x"));
 }
+
+/// The other side of the tolerance: when *nothing* resolves, there is no
+/// partial result left to protect.
+///
+/// An unreachable engine made `logs` print nothing and exit 0, which is
+/// indistinguishable from a project that simply has no logs — so a health check
+/// or deploy gate built on `compose logs` read success from an engine that was
+/// not there. Every service 500s here, so no target survives.
+///
+/// This is not #1104: nothing classifies how a stream *ended*. The requests
+/// never opened.
+#[tokio::test]
+#[cfg(unix)]
+async fn logs_fails_when_no_service_resolves_at_all() {
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(500, r#"{"message":"internal server error"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	file.services.insert("a".into(), Service::default());
+	file.services.insert("b".into(), Service::default());
+
+	let out = e
+		.logs_with_options(
+			&file,
+			&["a".to_string(), "b".to_string()],
+			LogsOptions::default(),
+		)
+		.await;
+	assert!(
+		out.is_err(),
+		"logs must not report success when it could reach nothing at all"
+	);
+}
+
+/// And one container failing to stream while another succeeds stays tolerated,
+/// so the logs that exist are still shown.
+#[tokio::test]
+#[cfg(unix)]
+async fn logs_tolerates_one_container_that_will_not_stream() {
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			if target.contains("podup.service%3Da") {
+				(200, r#"[{"Names":["/proj-a-1"]}]"#.to_string())
+			} else {
+				(200, r#"[{"Names":["/proj-b-1"]}]"#.to_string())
+			}
+		} else if method == "GET" && target.contains("/proj-a-1/logs") {
+			(500, r#"{"message":"boom"}"#.to_string())
+		} else if method == "GET" && target.contains("/logs") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	file.services.insert("a".into(), Service::default());
+	file.services.insert("b".into(), Service::default());
+
+	e.logs_with_options(
+		&file,
+		&["a".to_string(), "b".to_string()],
+		LogsOptions::default(),
+	)
+	.await
+	.expect("one container failing to stream must not blank the other");
+}


### PR DESCRIPTION
`podup logs` against an unreachable engine printed nothing and exited **0** — indistinguishable from a project that simply has no logs. A health check or deploy gate built on `compose logs` read success from an engine that was not there.

`stats` and `events` already exit 1 for the same condition. `logs` was the odd one out:

| socket dead | before | now |
|---|---|---|
| `stats` | 1 | 1 |
| `events` | 1 | 1 |
| `logs` | **0** | **1** |

### The failure was not where I first looked

With a dead socket `logs` never reaches `get_stream`. It fails earlier, while resolving each service's live replicas, and that arm warned and continued — leaving zero targets and a clean `Ok(())`.

### An existing test stopped my first attempt, and it was right

I made any non-404 resolution error fatal. `logs_skips_a_service_whose_replica_resolution_errors_but_still_targets_the_rest` failed, and its doc-comment explains why that tolerance exists: a transient libpod error on one service should not blank the logs of the others. That was a deliberate decision and my change overreached it.

The rule that satisfies both: **tolerate a partial failure, fail only when there is no partial result to protect.** If any service resolved, or any container streamed, `logs` succeeds exactly as before. Only when nothing resolved *and* something went wrong does it return the error.

### Measured against Podman 5.4.2

```
dead socket, nothing resolves     exit 1
one service up, one not created   exit 0, prints the one that is up
normal                            exit 0
service not in the compose file   exit 1
```

Both sides are pinned by tests, and the new one is falsifiable: removing the guard makes `logs_fails_when_no_service_resolves_at_all` fail.

### This is deliberately not #1104

Nothing here classifies how a stream *ended*. Every case is a request that never opened, which needs no predicate for telling a finished stream from a broken one. The `logs`/`stats`/`events` mid-stream behaviour stays blocked on #1104.

Part of #1080