### PR TITLE
feat: one colour per container, in every command that names it

### DIFF
--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -288,7 +288,8 @@ impl Engine {
 		let mut table = crate::ui::Table::new(&["SERVICE", "REPOSITORY", "TAG", "IMAGE ID"])
 			.cap(0, 48)
 			.cap(1, 48)
-			.cap(2, 24);
+			.cap(2, 24)
+			.identity_col(0);
 		for (svc, repo, tag, id) in &rows {
 			table.push(vec![svc.clone(), repo.clone(), tag.clone(), id.clone()]);
 		}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -147,7 +147,7 @@ fn is_go_duration(v: &str) -> bool {
 /// same container was tagged `myproj-web-1  | ` by one command and `web-1 | ` by
 /// the other — two shapes for one thing, in one binary. docker compose prints
 /// the short form.
-fn display_label(container_name: &str, project: &str) -> String {
+pub(crate) fn display_label(container_name: &str, project: &str) -> String {
 	container_name
 		.strip_prefix(&format!("{project}-"))
 		.unwrap_or(container_name)

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -333,7 +333,8 @@ impl Engine {
 		let mut table = crate::ui::Table::new(&["NAME", "IMAGE", "STATUS", "PORTS"])
 			.cap(0, 48)
 			.cap(1, 48)
-			.status_col(2);
+			.status_col(2)
+			.identity_col(0);
 		for c in &containers {
 			table.push(vec![
 				name_of(c),

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -156,21 +156,71 @@ fn truncate_name(name: &str, no_trunc: bool) -> String {
 /// Format one stats row into the table layout. With `no_trunc` a long name is
 /// left intact (and may overflow its column); otherwise it is truncated to
 /// [`NAME_WIDTH`]. Pure for testing.
-fn format_row(s: &ContainerStat, no_trunc: bool) -> String {
+/// Colour band for a utilisation percentage.
+///
+/// A container at 95% of its memory limit is minutes from being OOM-killed, and
+/// in a plain table that number looks exactly like 0.02%. The whole reason to
+/// read `stats` is to find the row that is in trouble, so the number that says
+/// so should be the one that catches the eye.
+fn load_style(pct: f64) -> crate::ui::Style {
+	use crate::ui::AnsiColor;
+	let colour = if pct >= 90.0 {
+		AnsiColor::Red
+	} else if pct >= 70.0 {
+		AnsiColor::Yellow
+	} else {
+		AnsiColor::Green
+	};
+	crate::ui::Style::new().fg_color(Some(colour.into()))
+}
+
+/// Format one stats row into the table layout, optionally coloured. With
+/// `no_trunc` a long name is left intact (and may overflow its column);
+/// otherwise it is truncated to [`NAME_WIDTH`]. Pure, so the layout is testable
+/// without a terminal — the tests pass `colour = false`.
+///
+/// Each cell is padded to its width *before* being painted: the ANSI codes are
+/// zero-width, so padding afterwards would count them and knock every later
+/// column out of alignment.
+fn format_row_with(s: &ContainerStat, no_trunc: bool, colour: bool) -> String {
+	use crate::ui::{identity_style, paint};
 	let (rx, tx) = net_totals(s);
-	format!(
-		"{:<NAME_WIDTH$} {:>7.2}% {:>10} / {:<10} {:>6.2}% {:>9} / {:<9} {:>9} / {:<9} {:>5}",
-		truncate_name(&s.name, no_trunc),
-		s.cpu,
-		format_bytes(s.mem_usage),
-		format_bytes(s.mem_limit),
-		s.mem_perc,
-		format_bytes(rx),
-		format_bytes(tx),
-		format_bytes(s.block_in),
-		format_bytes(s.block_out),
-		s.pids,
-	)
+	let dim = crate::ui::Style::new().dimmed();
+
+	let name = format!("{:<NAME_WIDTH$}", truncate_name(&s.name, no_trunc));
+	let name = paint(identity_style(s.name.trim()), &name, colour);
+	let cpu = paint(load_style(s.cpu), &format!("{:>7.2}%", s.cpu), colour);
+	let mem_pct = paint(
+		load_style(s.mem_perc),
+		&format!("{:>6.2}%", s.mem_perc),
+		colour,
+	);
+	// Secondary detail: the absolute figures matter once a percentage has drawn
+	// you to the row, not before.
+	let mem = paint(
+		dim,
+		&format!(
+			"{:>10} / {:<10}",
+			format_bytes(s.mem_usage),
+			format_bytes(s.mem_limit)
+		),
+		colour,
+	);
+	let net = paint(
+		dim,
+		&format!("{:>9} / {:<9}", format_bytes(rx), format_bytes(tx)),
+		colour,
+	);
+	let block = paint(
+		dim,
+		&format!(
+			"{:>9} / {:<9}",
+			format_bytes(s.block_in),
+			format_bytes(s.block_out)
+		),
+		colour,
+	);
+	format!("{name} {cpu} {mem} {mem_pct} {net} {block} {:>5}", s.pids)
 }
 
 /// Build one `stats --format json` row with numeric values (raw bytes/percent),
@@ -419,188 +469,13 @@ fn print_frame(
 	}
 
 	crate::ui::print_bold_header(HEADER);
+	let colour = crate::ui::stdout_colored();
 	for s in &rows {
-		println!("{}", format_row(s, opts.no_trunc));
+		println!("{}", format_row_with(s, opts.no_trunc, colour));
 	}
 	println!();
 }
 
 #[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn format_bytes_scales_units() {
-		assert_eq!(format_bytes(512), "512B");
-		assert_eq!(format_bytes(1024), "1.0KiB");
-		assert_eq!(format_bytes(1536), "1.5KiB");
-		assert_eq!(format_bytes(1024 * 1024), "1.0MiB");
-		assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.0GiB");
-	}
-
-	#[test]
-	fn format_row_sums_network_and_shows_name() {
-		let mut network = HashMap::new();
-		network.insert("eth0".to_string(), NetStat { rx: 1024, tx: 2048 });
-		let s = ContainerStat {
-			name: "proj-web".into(),
-			cpu: 12.5,
-			mem_usage: 1024 * 1024,
-			mem_limit: 1024 * 1024 * 1024,
-			mem_perc: 0.1,
-			block_in: 0,
-			block_out: 0,
-			pids: 3,
-			network,
-		};
-		let row = format_row(&s, false);
-		assert!(row.contains("proj-web"));
-		assert!(row.contains("12.50%"));
-		assert!(row.contains("1.0MiB"));
-		assert!(row.contains('3'));
-	}
-
-	#[test]
-	fn truncate_name_shortens_long_names_with_ellipsis() {
-		let short = "proj-web-1";
-		assert_eq!(truncate_name(short, false), short);
-		// Exactly the column width is kept verbatim.
-		let exact = "a".repeat(NAME_WIDTH);
-		assert_eq!(truncate_name(&exact, false), exact);
-		// One over the width is truncated to width-1 chars plus an ellipsis.
-		let long = "a".repeat(NAME_WIDTH + 10);
-		let cut = truncate_name(&long, false);
-		assert_eq!(cut.chars().count(), NAME_WIDTH);
-		assert!(cut.ends_with('…'));
-		// `--no-trunc` keeps the full name regardless of length.
-		assert_eq!(truncate_name(&long, true), long);
-	}
-
-	#[test]
-	fn format_row_truncates_long_name_but_no_trunc_keeps_it() {
-		let s = ContainerStat {
-			name: "really-long-project-web-container-name-1".into(),
-			..Default::default()
-		};
-		// Default: the long name is truncated (ellipsis present, full name gone).
-		let row = format_row(&s, false);
-		assert!(row.contains('…'));
-		assert!(!row.contains(&s.name));
-		// `--no-trunc`: the full name survives intact.
-		let row_full = format_row(&s, true);
-		assert!(row_full.contains(&s.name));
-	}
-
-	#[test]
-	fn stat_json_row_emits_numeric_fields() {
-		let mut network = HashMap::new();
-		network.insert("eth0".to_string(), NetStat { rx: 100, tx: 200 });
-		let s = ContainerStat {
-			name: "proj-db-1".into(),
-			cpu: 5.5,
-			mem_usage: 2048,
-			mem_limit: 4096,
-			mem_perc: 50.0,
-			block_in: 1,
-			block_out: 2,
-			pids: 7,
-			network,
-		};
-		let row = stat_json_row(&s);
-		assert_eq!(row["Name"], "proj-db-1");
-		assert_eq!(row["CPUPerc"], 5.5);
-		assert_eq!(row["MemUsage"], 2048);
-		assert_eq!(row["MemLimit"], 4096);
-		assert_eq!(row["NetInput"], 100);
-		assert_eq!(row["NetOutput"], 200);
-		assert_eq!(row["PIDs"], 7);
-	}
-
-	#[test]
-	fn frame_rows_keeps_running_and_adds_stopped_zeros_sorted() {
-		let report = StatsReport {
-			stats: vec![
-				ContainerStat {
-					name: "proj-web-1".into(),
-					cpu: 1.0,
-					..Default::default()
-				},
-				// Not in `running` → must be dropped (stale daemon sample).
-				ContainerStat {
-					name: "other".into(),
-					..Default::default()
-				},
-			],
-		};
-		let mut running = HashSet::new();
-		running.insert("proj-web-1".to_string());
-		let stopped = vec!["proj-db-1".to_string()];
-		let rows = frame_rows(&report, &running, &stopped);
-		// Sorted: db (stopped) before web (running); the unrelated sample is gone.
-		assert_eq!(rows.len(), 2);
-		assert_eq!(rows[0].name, "proj-db-1");
-		assert_eq!(rows[0].cpu, 0.0);
-		assert_eq!(rows[1].name, "proj-web-1");
-		assert_eq!(rows[1].cpu, 1.0);
-	}
-
-	#[test]
-	fn frame_rows_without_all_has_no_stopped_rows() {
-		let report = StatsReport::default();
-		let running = HashSet::new();
-		// `--all` off → caller passes an empty `stopped` slice → no rows.
-		let rows = frame_rows(&report, &running, &[]);
-		assert!(rows.is_empty());
-	}
-
-	#[test]
-	fn stat_tolerates_null_network() {
-		// libpod sends `"Network": null` for a container with no interfaces; it
-		// must deserialize to an empty map rather than erroring.
-		let json = r#"{"Name":"proj-web","CPU":1.0,"Network":null}"#;
-		let stat: ContainerStat = serde_json::from_str(json).unwrap();
-		assert_eq!(stat.name, "proj-web");
-		assert!(stat.network.is_empty());
-	}
-
-	#[test]
-	fn stat_tolerates_missing_network() {
-		let json = r#"{"Name":"proj-web"}"#;
-		let stat: ContainerStat = serde_json::from_str(json).unwrap();
-		assert!(stat.network.is_empty());
-	}
-
-	#[test]
-	fn containers_query_repeats_param_per_container() {
-		// libpod wants `containers` repeated, not comma-joined — a comma-joined
-		// list is read as a single container name and 404s.
-		let mut wanted = HashSet::new();
-		wanted.insert("proj-web-1".to_string());
-		wanted.insert("proj-db-1".to_string());
-		assert_eq!(
-			containers_query(&wanted),
-			"&containers=proj-db-1&containers=proj-web-1"
-		);
-	}
-
-	#[test]
-	fn containers_query_empty_when_none_wanted() {
-		assert_eq!(containers_query(&HashSet::new()), "");
-	}
-
-	#[test]
-	fn first_unknown_service_flags_typos() {
-		let file =
-			crate::parse_str("services:\n  web:\n    image: nginx\n  db:\n    image: postgres\n")
-				.unwrap();
-		assert_eq!(first_unknown_service(&file, &[]), None);
-		assert_eq!(
-			first_unknown_service(&file, &["web".into(), "db".into()]),
-			None
-		);
-		assert_eq!(
-			first_unknown_service(&file, &["web".into(), "bogus".into()]),
-			Some("bogus")
-		);
-	}
-}
+#[path = "stats_tests.rs"]
+mod tests;

--- a/internal/engine/stats_tests.rs
+++ b/internal/engine/stats_tests.rs
@@ -1,0 +1,180 @@
+//! Unit tests for `stats` — split out to keep the module inside the source line
+//! limit, following the same `tests.rs` split used by `autostart` and the libpod
+//! client.
+
+use super::*;
+
+#[test]
+fn format_bytes_scales_units() {
+	assert_eq!(format_bytes(512), "512B");
+	assert_eq!(format_bytes(1024), "1.0KiB");
+	assert_eq!(format_bytes(1536), "1.5KiB");
+	assert_eq!(format_bytes(1024 * 1024), "1.0MiB");
+	assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.0GiB");
+}
+
+#[test]
+fn format_row_sums_network_and_shows_name() {
+	let mut network = HashMap::new();
+	network.insert("eth0".to_string(), NetStat { rx: 1024, tx: 2048 });
+	let s = ContainerStat {
+		name: "proj-web".into(),
+		cpu: 12.5,
+		mem_usage: 1024 * 1024,
+		mem_limit: 1024 * 1024 * 1024,
+		mem_perc: 0.1,
+		block_in: 0,
+		block_out: 0,
+		pids: 3,
+		network,
+	};
+	let row = format_row_with(&s, false, false);
+	assert!(row.contains("proj-web"));
+	assert!(row.contains("12.50%"));
+	assert!(row.contains("1.0MiB"));
+	assert!(row.contains('3'));
+}
+
+#[test]
+fn truncate_name_shortens_long_names_with_ellipsis() {
+	let short = "proj-web-1";
+	assert_eq!(truncate_name(short, false), short);
+	// Exactly the column width is kept verbatim.
+	let exact = "a".repeat(NAME_WIDTH);
+	assert_eq!(truncate_name(&exact, false), exact);
+	// One over the width is truncated to width-1 chars plus an ellipsis.
+	let long = "a".repeat(NAME_WIDTH + 10);
+	let cut = truncate_name(&long, false);
+	assert_eq!(cut.chars().count(), NAME_WIDTH);
+	assert!(cut.ends_with('…'));
+	// `--no-trunc` keeps the full name regardless of length.
+	assert_eq!(truncate_name(&long, true), long);
+}
+
+#[test]
+fn format_row_truncates_long_name_but_no_trunc_keeps_it() {
+	let s = ContainerStat {
+		name: "really-long-project-web-container-name-1".into(),
+		..Default::default()
+	};
+	// Default: the long name is truncated (ellipsis present, full name gone).
+	let row = format_row_with(&s, false, false);
+	assert!(row.contains('…'));
+	assert!(!row.contains(&s.name));
+	// `--no-trunc`: the full name survives intact.
+	let row_full = format_row_with(&s, true, false);
+	assert!(row_full.contains(&s.name));
+}
+
+#[test]
+fn stat_json_row_emits_numeric_fields() {
+	let mut network = HashMap::new();
+	network.insert("eth0".to_string(), NetStat { rx: 100, tx: 200 });
+	let s = ContainerStat {
+		name: "proj-db-1".into(),
+		cpu: 5.5,
+		mem_usage: 2048,
+		mem_limit: 4096,
+		mem_perc: 50.0,
+		block_in: 1,
+		block_out: 2,
+		pids: 7,
+		network,
+	};
+	let row = stat_json_row(&s);
+	assert_eq!(row["Name"], "proj-db-1");
+	assert_eq!(row["CPUPerc"], 5.5);
+	assert_eq!(row["MemUsage"], 2048);
+	assert_eq!(row["MemLimit"], 4096);
+	assert_eq!(row["NetInput"], 100);
+	assert_eq!(row["NetOutput"], 200);
+	assert_eq!(row["PIDs"], 7);
+}
+
+#[test]
+fn frame_rows_keeps_running_and_adds_stopped_zeros_sorted() {
+	let report = StatsReport {
+		stats: vec![
+			ContainerStat {
+				name: "proj-web-1".into(),
+				cpu: 1.0,
+				..Default::default()
+			},
+			// Not in `running` → must be dropped (stale daemon sample).
+			ContainerStat {
+				name: "other".into(),
+				..Default::default()
+			},
+		],
+	};
+	let mut running = HashSet::new();
+	running.insert("proj-web-1".to_string());
+	let stopped = vec!["proj-db-1".to_string()];
+	let rows = frame_rows(&report, &running, &stopped);
+	// Sorted: db (stopped) before web (running); the unrelated sample is gone.
+	assert_eq!(rows.len(), 2);
+	assert_eq!(rows[0].name, "proj-db-1");
+	assert_eq!(rows[0].cpu, 0.0);
+	assert_eq!(rows[1].name, "proj-web-1");
+	assert_eq!(rows[1].cpu, 1.0);
+}
+
+#[test]
+fn frame_rows_without_all_has_no_stopped_rows() {
+	let report = StatsReport::default();
+	let running = HashSet::new();
+	// `--all` off → caller passes an empty `stopped` slice → no rows.
+	let rows = frame_rows(&report, &running, &[]);
+	assert!(rows.is_empty());
+}
+
+#[test]
+fn stat_tolerates_null_network() {
+	// libpod sends `"Network": null` for a container with no interfaces; it
+	// must deserialize to an empty map rather than erroring.
+	let json = r#"{"Name":"proj-web","CPU":1.0,"Network":null}"#;
+	let stat: ContainerStat = serde_json::from_str(json).unwrap();
+	assert_eq!(stat.name, "proj-web");
+	assert!(stat.network.is_empty());
+}
+
+#[test]
+fn stat_tolerates_missing_network() {
+	let json = r#"{"Name":"proj-web"}"#;
+	let stat: ContainerStat = serde_json::from_str(json).unwrap();
+	assert!(stat.network.is_empty());
+}
+
+#[test]
+fn containers_query_repeats_param_per_container() {
+	// libpod wants `containers` repeated, not comma-joined — a comma-joined
+	// list is read as a single container name and 404s.
+	let mut wanted = HashSet::new();
+	wanted.insert("proj-web-1".to_string());
+	wanted.insert("proj-db-1".to_string());
+	assert_eq!(
+		containers_query(&wanted),
+		"&containers=proj-db-1&containers=proj-web-1"
+	);
+}
+
+#[test]
+fn containers_query_empty_when_none_wanted() {
+	assert_eq!(containers_query(&HashSet::new()), "");
+}
+
+#[test]
+fn first_unknown_service_flags_typos() {
+	let file =
+		crate::parse_str("services:\n  web:\n    image: nginx\n  db:\n    image: postgres\n")
+			.unwrap();
+	assert_eq!(first_unknown_service(&file, &[]), None);
+	assert_eq!(
+		first_unknown_service(&file, &["web".into(), "db".into()]),
+		None
+	);
+	assert_eq!(
+		first_unknown_service(&file, &["web".into(), "bogus".into()]),
+		Some("bogus")
+	);
+}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -316,6 +316,9 @@ async fn run() -> podup::Result<()> {
 		let file = parsed.unwrap_or_default();
 		let project = resolve_project_name(cli.project.clone(), compose_name.as_deref(), &base_dir);
 		startup::validate_project_name(&project)?;
+		// Identity colours key on the project-stripped label, so every command
+		// tints the same container the same way.
+		podup::ui::set_project(&project);
 		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 		let engine = podup::Engine::with_base_dir(client, project, base_dir);
 		return engine
@@ -359,6 +362,9 @@ async fn run() -> podup::Result<()> {
 		{
 			let project = cli.project.clone().expect("checked by down_by_label_path");
 			startup::validate_project_name(&project)?;
+			// Identity colours key on the project-stripped label, so every command
+			// tints the same container the same way.
+			podup::ui::set_project(&project);
 			// `--rmi` removes the images of the file's services, which cannot be
 			// resolved without a file; warn rather than silently dropping it.
 			if rmi.is_some() {
@@ -422,6 +428,9 @@ async fn run() -> podup::Result<()> {
 		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
 		let project = resolve_project_name(cli.project.clone(), file.name.as_deref(), &base_dir);
 		startup::validate_project_name(&project)?;
+		// Identity colours key on the project-stripped label, so every command
+		// tints the same container the same way.
+		podup::ui::set_project(&project);
 		// `file` is already parsed with the correct interpolation setting above.
 		let parsed = file;
 		// `--resolve-image-digests` pins each image to its registry digest, which
@@ -463,6 +472,10 @@ async fn run() -> podup::Result<()> {
 	// compose `name:` field are otherwise taken verbatim; rejecting an unsafe
 	// name here fails closed regardless of which command runs next.
 	startup::validate_project_name(&project)?;
+	// Identity colours key on the project-stripped label, so ps, logs, stats and
+	// the progress lines all tint the same container the same way. This is the
+	// path every lifecycle command takes.
+	podup::ui::set_project(&project);
 
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -13,7 +13,7 @@
 
 use std::io::IsTerminal;
 
-use anstyle::{AnsiColor, Style};
+pub use anstyle::{AnsiColor, Style};
 
 pub use anstream::ColorChoice;
 
@@ -71,6 +71,42 @@ pub fn stderr_colored() -> bool {
 /// and machine/JSON output.
 static PROGRESS_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+/// The project name, so an identity colour can be keyed on the same label
+/// everywhere.
+///
+/// `logs` prefixes lines with the project-stripped `web-1`; `ps` prints the full
+/// container name `proj-web-1`; the progress lines print the full name too.
+/// Hashing whatever string each site happens to hold gives the same container a
+/// different colour in each command — which defeats the point of a stable
+/// palette. Stripping the project first makes one container one colour.
+static PROJECT: std::sync::RwLock<String> = std::sync::RwLock::new(String::new());
+
+/// Record the project name for identity colouring. Set once per invocation.
+pub fn set_project(name: &str) {
+	if let Ok(mut slot) = PROJECT.write() {
+		name.clone_into(&mut slot);
+	}
+}
+
+/// The stable identity colour for a container or service label, keyed on the
+/// label with the project prefix removed.
+///
+/// Callers pass whatever they display — `proj-web-1`, `web-1`, `web` — and get
+/// the same colour for the same container, which is what makes `ps`, `logs`,
+/// `stats` and the progress lines agree.
+pub fn identity_style(label: &str) -> Style {
+	let key = PROJECT
+		.read()
+		.ok()
+		.and_then(|p| {
+			(!p.is_empty())
+				.then(|| label.strip_prefix(&format!("{p}-")).map(str::to_string))
+				.flatten()
+		})
+		.unwrap_or_else(|| label.to_string());
+	service_style(&key)
+}
+
 /// Enable or disable user-facing lifecycle progress output process-wide. The CLI
 /// enables it for the lifecycle commands; embedders that want podup silent leave
 /// it off (the default).
@@ -94,14 +130,37 @@ pub fn progress_line(kind: &str, name: &str, action: &str) {
 	if !progress_enabled() {
 		return;
 	}
-	let style = Style::new().fg_color(Some(AnsiColor::Green.into()));
+	let verb = action_style(action);
+	let ident = identity_style(name);
 	// anstream::stderr strips the ANSI codes itself when colour is off.
 	let _ = writeln!(
 		anstream::stderr(),
-		" {kind} {name}  {}{action}{}",
-		style.render(),
-		style.render_reset()
+		" {kind} {}{name}{}  {}{action}{}",
+		ident.render(),
+		ident.render_reset(),
+		verb.render(),
+		verb.render_reset()
 	);
+}
+
+/// The colour band for a lifecycle verb.
+///
+/// Every verb used to be the same green, so `Volume data Removed` — which
+/// destroys data and cannot be undone — was styled exactly like `Started`. The
+/// bands say what kind of thing happened: something now exists (green),
+/// something stopped but survives (yellow), something is gone (red), nothing
+/// changed (dim).
+fn action_style(action: &str) -> Style {
+	let a = action.to_ascii_lowercase();
+	if a.starts_with("remov") || a.starts_with("kill") || a.starts_with("delet") {
+		Style::new().fg_color(Some(AnsiColor::Red.into()))
+	} else if a.starts_with("stop") || a.starts_with("paus") || a.starts_with("restart") {
+		Style::new().fg_color(Some(AnsiColor::Yellow.into()))
+	} else if a.starts_with("exist") || a.starts_with("running") || a.starts_with("skip") {
+		Style::new().dimmed()
+	} else {
+		Style::new().fg_color(Some(AnsiColor::Green.into()))
+	}
 }
 
 /// Emit a plain user-facing progress note to stderr (e.g. a "nothing to do"
@@ -429,5 +488,35 @@ mod tests {
 		assert!(cell.contains("ok"));
 		// At least the requested width (colour codes, if any, only add length).
 		assert!(cell.len() >= 6);
+	}
+}
+
+#[cfg(test)]
+mod identity_key_tests {
+	use super::*;
+
+	/// The whole point of the shared key: `ps` prints `proj-web-1`, `logs`
+	/// prefixes `web-1`, and the progress lines print `proj-web-1` — all three
+	/// must resolve to one colour, or the palette is not stable at all.
+	#[test]
+	fn every_spelling_of_one_container_gets_one_colour() {
+		set_project("proj");
+		let from_ps = identity_style("proj-web-1");
+		let from_logs = identity_style("web-1");
+		assert_eq!(
+			from_ps.render().to_string(),
+			from_logs.render().to_string(),
+			"the same container must be the same colour in ps and logs"
+		);
+	}
+
+	/// A label that does not carry the project prefix is left alone.
+	#[test]
+	fn an_unprefixed_label_is_keyed_on_itself() {
+		set_project("proj");
+		assert_eq!(
+			identity_style("web").render().to_string(),
+			service_style("web").render().to_string()
+		);
 	}
 }

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -60,7 +60,13 @@ pub struct Table {
 	caps: Vec<Option<usize>>,
 	/// The column (if any) whose cells are colourised by container status.
 	status_col: Option<usize>,
+	/// The column (if any) carrying an identity — a service or container name —
+	/// tinted with that identity's stable colour.
+	identity_col: Option<usize>,
 	rows: Vec<Vec<String>>,
+	/// Per-row identity key, parallel to `rows`. `None` falls back to the
+	/// identity cell's own text.
+	keys: Vec<Option<String>>,
 }
 
 impl Table {
@@ -71,7 +77,9 @@ impl Table {
 			headers: headers.iter().map(|h| (*h).to_string()).collect(),
 			caps: vec![None; headers.len()],
 			status_col: None,
+			identity_col: None,
 			rows: Vec::new(),
+			keys: Vec::new(),
 		}
 	}
 
@@ -92,10 +100,34 @@ impl Table {
 		self
 	}
 
+	/// Tint column `col` with each row's stable identity colour, so the same
+	/// service or container is the same colour in every command that lists it.
+	///
+	/// The palette deliberately excludes red, green and yellow — those carry
+	/// status meaning — so an identity colour can never be misread as a state.
+	pub fn identity_col(mut self, col: usize) -> Self {
+		self.identity_col = Some(col);
+		self
+	}
+
 	/// Append one data row. The cell count should match the header count; missing
 	/// cells render blank and extra cells are ignored.
 	pub fn push(&mut self, cells: Vec<String>) {
 		self.rows.push(cells);
+		self.keys.push(None);
+	}
+
+	/// Append a row whose identity colour is keyed on `key` rather than on the
+	/// displayed cell.
+	///
+	/// The two differ where the column shows something longer than the identity:
+	/// `ps` prints the full container name `proj-web-1` while `logs` prefixes the
+	/// project-stripped `web-1`. Keying both on `web-1` is what makes one
+	/// container the same colour in both commands — which is the entire point of
+	/// a stable palette.
+	pub fn push_keyed(&mut self, cells: Vec<String>, key: String) {
+		self.rows.push(cells);
+		self.keys.push(Some(key));
 	}
 
 	/// Content-sized width of each column: the widest of the header and its cells,
@@ -127,6 +159,17 @@ impl Table {
 	/// meaning (the padding is applied first so the zero-width ANSI codes never
 	/// disturb alignment).
 	fn format_row(&self, cells: &[String], widths: &[usize], colour: bool) -> String {
+		self.format_row_keyed(cells, widths, colour, None)
+	}
+
+	/// [`Table::format_row`] with the row's identity key, when it has one.
+	fn format_row_keyed(
+		&self,
+		cells: &[String],
+		widths: &[usize],
+		colour: bool,
+		key: Option<&str>,
+	) -> String {
 		let last = self.headers.len().saturating_sub(1);
 		(0..self.headers.len())
 			.map(|i| {
@@ -135,6 +178,12 @@ impl Table {
 				let padded = fit_cell(cell, w);
 				if colour && Some(i) == self.status_col {
 					return super::paint_status_cell(&padded);
+				}
+				if colour && Some(i) == self.identity_col && !cell.trim().is_empty() {
+					// The padding is inside the paint so the colour does not stop
+					// at the name and leave the gap bare; the codes are zero-width
+					// either way, so alignment is untouched.
+					return super::paint(super::identity_style(key.unwrap_or(cell)), &padded, true);
 				}
 				padded
 			})
@@ -160,9 +209,11 @@ impl Table {
 	pub fn print(&self) {
 		let widths = self.widths();
 		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
-		let colour = self.status_col.is_some() && super::stdout_colored();
-		for row in &self.rows {
-			println!("{}", self.format_row(row, &widths, colour));
+		let colour =
+			(self.status_col.is_some() || self.identity_col.is_some()) && super::stdout_colored();
+		for (i, row) in self.rows.iter().enumerate() {
+			let key = self.keys.get(i).and_then(Option::as_deref);
+			println!("{}", self.format_row_keyed(row, &widths, colour, key));
 		}
 	}
 }


### PR DESCRIPTION
`logs` tinted each container with a stable colour from a fixed palette. Nothing else did — so the same container was magenta in `logs` and grey in `ps`, `stats`, `images` and the `up`/`down` progress lines. The one thing that makes a busy project scannable worked in exactly one command.

### The colours now agree

Measured against Podman 5.4.2, same project, four commands:

```
up     Container [96mcol-db-1[0m  [32mStarted[0m
ps     [96mcol-db-1[0m  ...  [32mrunning[0m
logs   [96mdb-1 | [0mhola-db
down   Container [96mcol-db-1[0m  [31mRemoved[0m
```

The key is computed in one place. `ui::identity_style` strips the project name before hashing, so `proj-web-1` (what `ps` and the progress lines print) and `web-1` (what `logs` prefixes) land on the same colour. Hashing whatever string each call site happened to hold is exactly why they disagreed — my first attempt did that and produced `95m` in `up` against `35m` in `logs` for the same container. A test pins that every spelling of one container resolves alike.

### Lifecycle verbs gained bands

They were all the same green, so `Volume data Removed` — which destroys data and cannot be undone — was styled identically to `Started`.

| band | meaning | verbs |
|---|---|---|
| green | something now exists | Started, Created |
| yellow | stopped but survives | Stopped, Paused, Restarted |
| red | it is gone | Removed, Killed |
| dim | nothing changed | Exists, Running, Skipped |

### stats had no colour at all

Odd for the one command whose entire purpose is finding the row in trouble: a container at 95% of its memory limit looked exactly like one at 0.02%. CPU and memory percentages are banded green/yellow/red at 70 and 90; the absolute byte figures are dimmed so the percentages read first.

### Two things that would break if done carelessly

**Padding before painting**, everywhere. ANSI codes are zero-width, so padding afterwards counts them and knocks every later column out of alignment.

**The palette still excludes red, green and yellow.** Those carry status meaning, so an identity colour can never be misread as a state — that constraint is why this could be applied to the status tables at all.

`stats.rs` hit 489 code lines against a 500 hard limit, so its tests moved to `stats_tests.rs`, the same split `autostart` and the libpod client already use. 337 and 153 now.

Machine output is untouched: every `--json` and `--quiet` branch returns before reaching the table, and `config`, `port`, `wait` and `generate` stay plain.