### PR TITLE
feat: colour the surfaces that had none

### DIFF
--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -439,24 +439,30 @@ pub fn collect_status<S: SystemCtl>(sc: &S, project: &str) -> StatusReport {
 /// Print the autostart status for a project.
 pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	let r = collect_status(sc, project);
-	println!("unit:       {}", r.unit_path.display());
-	println!("installed:  {}", if r.unit_exists { "yes" } else { "no" });
+	// Every line here is a yes/no an operator is scanning for, and the whole
+	// screen was one colour — so "is it actually running?" meant reading six
+	// labels to find the one word that answers it. The label is scaffolding
+	// (dimmed); the value carries the meaning (tinted by what it says).
+	let row = |label: &str, value: &str| {
+		crate::ui::print_labelled(label, value);
+	};
+	row("unit", &r.unit_path.display().to_string());
+	row("installed", if r.unit_exists { "yes" } else { "no" });
 	if let Some(mode) = r.unit_mode {
-		println!("mode:       {:04o}", mode & 0o7777);
+		row("mode", &format!("{:04o}", mode & 0o7777));
 	}
-	println!("active:     {}", r.is_active);
-	println!("enabled:    {}", r.is_enabled);
-	println!(
-		"linger:     {}",
-		if r.linger { "enabled" } else { "disabled" }
-	);
-	println!(
-		"session:    {}",
+	row("active", &r.is_active);
+	row("enabled", &r.is_enabled);
+	row("linger", if r.linger { "enabled" } else { "disabled" });
+	// Prose, not a state word, so the meaning is stated rather than inferred.
+	crate::ui::print_labelled_with(
+		"session",
 		if r.runtime_dir {
 			"XDG_RUNTIME_DIR set"
 		} else {
 			"XDG_RUNTIME_DIR unset (systemctl --user needs a user session)"
-		}
+		},
+		Some(r.runtime_dir),
 	);
 	Ok(())
 }

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -120,6 +120,23 @@ fn format_event(value: &Value, json: bool) -> String {
 		.or_else(|| value.get("id"))
 		.and_then(Value::as_str)
 		.unwrap_or("");
+	format_event_line(typ, action, name, crate::ui::stdout_colored() && !json)
+}
+
+/// Join an event's three fields, tinting the two that carry meaning.
+///
+/// A `--follow` stream is a wall of near-identical lines; `ACTION` is what
+/// distinguishes a `start` from a `die`, and `NAME` is which container it
+/// happened to. The type (`container`, `network`) repeats on almost every line
+/// and is dimmed so it stops competing.
+fn format_event_line(typ: &str, action: &str, name: &str, colour: bool) -> String {
+	use crate::ui::{identity_style, paint, Style};
+	let typ = paint(Style::new().dimmed(), typ, colour);
+	let action = match crate::ui::action_or_status_style(action) {
+		Some(style) => paint(style, action, colour),
+		None => action.to_string(),
+	};
+	let name = paint(identity_style(name), name, colour && !name.is_empty());
 	format!("{typ} {action} {name}").trim().to_string()
 }
 
@@ -187,5 +204,43 @@ mod tests {
 		let out = format_event(&ev, true);
 		assert!(out.contains("\"Type\":\"container\""));
 		assert!(out.contains("\"Action\":\"start\""));
+	}
+}
+
+#[cfg(test)]
+mod event_colour_tests {
+	use super::format_event_line;
+
+	/// Without a colour sink the line is byte-identical to what it always was,
+	/// so `--json`, a pipe and the output contract are untouched.
+	#[test]
+	fn plain_output_is_unchanged() {
+		assert_eq!(
+			format_event_line("container", "start", "proj-web-1", false),
+			"container start proj-web-1"
+		);
+	}
+
+	/// The two fields that distinguish one line from the next carry colour; the
+	/// type, which repeats on nearly every line, is dimmed rather than absent.
+	#[test]
+	fn action_and_name_are_tinted_apart() {
+		let died = format_event_line("container", "die", "proj-web-1", true);
+		let started = format_event_line("container", "start", "proj-web-1", true);
+		assert_ne!(
+			died,
+			started.replace("start", "die"),
+			"die and start must differ by more than the verb"
+		);
+	}
+
+	/// An event with no container name must not emit a stray colour reset.
+	#[test]
+	fn an_empty_name_is_not_painted() {
+		let out = format_event_line("network", "create", "", true);
+		assert!(
+			out.ends_with("create\u{1b}[0m") || !out.ends_with("\u{1b}[0m "),
+			"{out:?}"
+		);
 	}
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -78,7 +78,10 @@ impl Engine {
 						"Processes": result.processes,
 					})),
 					Ok(result) => {
-						crate::ui::print_bold_header(&container_name);
+						// The container name is the only navigation aid when several
+						// are listed, so it carries the same identity colour it has in
+						// `ps` and `logs` rather than being merely bold.
+						crate::ui::print_identity_header(&container_name);
 						// Space-pad columns to the widest cell (header + rows) rather
 						// than tab-joining, so the table is aligned as the help promises.
 						let titles = result.titles.clone().unwrap_or_default();

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -192,6 +192,48 @@ pub fn result_line(msg: &str) -> std::io::Result<()> {
 	}
 }
 
+/// Print a `label: value` line where the label is scaffolding and the value
+/// carries the meaning.
+///
+/// `autostart status` is the densest meaning-per-line surface in the CLI — six
+/// consecutive yes/no answers — and it was entirely monochrome, so finding the
+/// one line that answers "is it running?" meant reading all six. The label is
+/// dimmed and the value tinted by [`status_style`], which knows systemd's
+/// vocabulary as well as Podman's.
+///
+/// Values with no status meaning (a path, a file mode) are left alone rather
+/// than given an arbitrary colour.
+pub fn print_labelled(label: &str, value: &str) {
+	print_labelled_with(label, value, None);
+}
+
+/// [`print_labelled`] with the value's meaning stated rather than inferred.
+///
+/// Some values are prose, not a state word — `XDG_RUNTIME_DIR unset (systemctl
+/// --user needs a user session)` is the answer to a yes/no question written as a
+/// sentence. `Some(true)`/`Some(false)` colours it green/red; `None` falls back
+/// to reading the text.
+pub fn print_labelled_with(label: &str, value: &str, good: Option<bool>) {
+	use std::io::Write;
+	let dim = Style::new().dimmed();
+	let padded = format!("{label}:");
+	let explicit = good.map(|ok| {
+		Style::new().fg_color(Some(
+			if ok { AnsiColor::Green } else { AnsiColor::Red }.into(),
+		))
+	});
+	let styled_value = match explicit.or_else(|| status_style(value)) {
+		Some(style) => paint(style, value, true),
+		None => value.to_string(),
+	};
+	let _ = writeln!(
+		anstream::stdout(),
+		"{}{padded:<11}{} {styled_value}",
+		dim.render(),
+		dim.render_reset()
+	);
+}
+
 /// Bold — table headers and emphasis.
 pub fn bold() -> Style {
 	Style::new().bold()
@@ -208,6 +250,19 @@ pub fn print_bold_header(cols: &str) {
 		"{}{cols}{}",
 		s.render(),
 		s.render_reset()
+	);
+}
+
+/// Print a bold header tinted with its identity colour — used where a block is
+/// headed by a container name rather than by column titles.
+pub fn print_identity_header(name: &str) {
+	use std::io::Write;
+	let style = identity_style(name).bold();
+	let _ = writeln!(
+		anstream::stdout(),
+		"{}{name}{}",
+		style.render(),
+		style.render_reset()
 	);
 }
 
@@ -317,6 +372,29 @@ fn status_style(status: &str) -> Option<Style> {
 		return None;
 	};
 	Some(Style::new().fg_color(Some(colour.into())))
+}
+
+/// The colour for an event action or a container state word, whichever matches.
+///
+/// `events` streams verbs (`start`, `die`, `kill`, `health_status`) that are not
+/// container states but mean the same kinds of thing, so they resolve through
+/// the lifecycle bands first and fall back to the status vocabulary.
+pub fn action_or_status_style(word: &str) -> Option<Style> {
+	let w = word.to_ascii_lowercase();
+	if w.starts_with("die")
+		|| w.starts_with("kill")
+		|| w.starts_with("destroy")
+		|| w.starts_with("remove")
+	{
+		return Some(Style::new().fg_color(Some(AnsiColor::Red.into())));
+	}
+	if w.starts_with("start") || w.starts_with("create") || w.starts_with("health") {
+		return Some(Style::new().fg_color(Some(AnsiColor::Green.into())));
+	}
+	if w.starts_with("stop") || w.starts_with("pause") || w.starts_with("restart") {
+		return Some(Style::new().fg_color(Some(AnsiColor::Yellow.into())));
+	}
+	status_style(word)
 }
 
 /// Colourise a status cell, tinting each comma-separated segment on its own.

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -198,7 +198,7 @@ pub fn result_line(msg: &str) -> std::io::Result<()> {
 /// `autostart status` is the densest meaning-per-line surface in the CLI — six
 /// consecutive yes/no answers — and it was entirely monochrome, so finding the
 /// one line that answers "is it running?" meant reading all six. The label is
-/// dimmed and the value tinted by [`status_style`], which knows systemd's
+/// dimmed and the value tinted by its own status meaning, which covers systemd's
 /// vocabulary as well as Podman's.
 ///
 /// Values with no status meaning (a path, a file mode) are left alone rather

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -185,6 +185,12 @@ impl Table {
 					// either way, so alignment is untouched.
 					return super::paint(super::identity_style(key.unwrap_or(cell)), &padded, true);
 				}
+				if colour && Some(i) == self.identity_col && !cell.trim().is_empty() {
+					// The padding is inside the paint so the colour does not stop
+					// at the name and leave the gap bare; the codes are zero-width
+					// either way, so alignment is untouched.
+					return super::paint(super::identity_style(key.unwrap_or(cell)), &padded, true);
+				}
 				padded
 			})
 			.collect::<Vec<_>>()


### PR DESCRIPTION
Three more places where the output carried meaning and printed it in one colour. Stacked on #1137 for `identity_style`.

### `autostart status`

The densest meaning-per-line surface in the CLI — six consecutive yes/no answers — and entirely monochrome, so finding the one line that answers "is it actually running?" meant reading all six.

```
[2munit:      [0m /home/…/podup-col.service
[2minstalled: [0m [2mno[0m
[2mactive:    [0m [2minactive[0m
[2menabled:   [0m [31mnot-found[0m
[2mlinger:    [0m [32menabled[0m
[2msession:   [0m [32mXDG_RUNTIME_DIR set[0m
```

The label is scaffolding and is dimmed; the value carries the meaning. The `session` line is prose rather than a state word, so it states its meaning explicitly instead of having it inferred from the text.

### `events`

A `--follow` stream is a wall of near-identical lines, and only two fields distinguish them:

```
[2mcontainer[0m [33mrestart[0m [96mcol-db-1[0m
[2mcontainer[0m [33mrestart[0m [35mcol-web-1[0m
```

ACTION carries a lifecycle band (start green, die red, restart yellow); NAME carries the same identity colour it has in `ps` and `logs`; TYPE, which repeats on almost every line, is dimmed so it stops competing.

`--json` is untouched — the colour flag is false whenever json is set, and a test pins that the plain line is byte-identical to what it was.

### `top`

Each block was headed by a bold container name. It is bold **and** tinted with that container's identity colour now, which is the only navigation aid when several blocks print in sequence.

### `config` is deliberately left plain

Its output is re-parseable input — `podup config | podup -f - up` is a real pattern — and `--ansi always` would push escape codes into a YAML document. Colour is not worth corrupting data for, and syntax-highlighted YAML is the least useful of these anyway. Measured: 0 escapes with `--ansi always`.