### PR TITLE
fix: close the gaps a pre-release check found in 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "1.13.1"
+version = "2.0.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "2.0.0"
+version = "1.13.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,17 +1,57 @@
 podup (2.0.0) unstable; urgency=medium
 
-  * BREAKING: autostart::ServiceUnitOpts and autostart::InstallOptions are
-    #[non_exhaustive] and gain a field. Build them with the new ::new()
-    constructors and with_* builders instead of a struct literal. Neither had
-    the attribute the crate's other public types carry, so every future
-    widening would have been another break; fixing it now means this is the
-    last one either needs.
-  * up starts each service as soon as its own dependencies are up, instead of
-    walking dependency levels with a barrier between them. On a 41-service
-    level, up went from 1326ms to 1135ms.
+  Breaking changes
+
+  * exec allocates a pseudo-TTY and attaches stdin on Unix when stdin is a
+    terminal, so `podup exec -it db psql` is an interactive session that
+    follows the window size. It engages ONLY when stdin is a terminal, so a
+    script or a pipeline keeps the streaming behaviour it had. `-T` opts out.
+    Windows is unchanged. `run` is still not interactive.
+  * An attached `up` ended by SIGINT or SIGTERM exits 130 instead of 0. A CI
+    job running `podup up` in the foreground and cancelled used to report
+    success. The project is still torn down before the code is returned.
+  * `--sig-proxy` accepts docker's bare form. It required a value, so
+    `docker compose attach --sig-proxy web` failed with a usage error against
+    podup — inside the set of flags whose purpose is that such a script runs
+    unchanged.
   * autostart service mode bounds ExecStop above the project's longest
     stop_grace_period. systemd's own 90s default was cutting a slower stack off
     mid-shutdown at reboot, while a manual `podup stop` honoured it.
+  * Library API: ExecOptions, autostart::ServiceUnitOpts and
+    autostart::InstallOptions are #[non_exhaustive] and gain fields. Build them
+    with the new ::new() constructors and with_* builders instead of a struct
+    literal. None carried the attribute the crate's other public types do, so
+    every future widening would have been another break.
+  * Library API: Engine::attach_logs and attach_logs_with_options return
+    Result<AttachOutcome> rather than Result<()>, so a caller can tell a
+    finished stream from an interrupted one. The teardown still runs either
+    way.
+
+  Other changes
+
+  * up starts each service as soon as its own dependencies are up, instead of
+    walking dependency levels with a barrier between them. On a 41-service
+    level, up went from 1326ms to 1135ms.
+  * A self-update no longer rolls itself back over a transient ETXTBSY. The
+    retry existed but could never fire: the errno was formatted into a string
+    before the check read it, so a signed, verified, working update was
+    discarded and reported as broken.
+  * logs exits non-zero when it could reach nothing at all. Against an
+    unreachable engine it printed nothing and exited 0, which is
+    indistinguishable from a project with no logs.
+  * Output carries colour consistently: one stable colour per container across
+    ps, logs, stats, top, events and the up/down progress lines; status words
+    tinted by meaning; CPU and memory banded by threshold. Two colours that
+    said the opposite of the truth are fixed — a half-running project rendered
+    entirely red, and a container that finished cleanly rendered as a failure.
+    Machine output (--json, --quiet, config, port, wait) stays plain, and
+    colour is off automatically when stdout is not a terminal.
+  * volumes reports an EXTERNAL column. podup neither creates nor deletes an
+    external volume, and the table was the only place that fact was missing.
+  * Eight flags the CLI accepts were absent from their own command's table in
+    the reference, and three rows described the opposite of what the code does.
+    The docs test now checks each command's own section rather than the whole
+    document.
   * The coverage gate measures the whole crate. It read 90% while a third of
     the code was excluded from the measurement.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -563,10 +563,22 @@ returns the whole set, which a script reads as a match.
 | `3` | `update` failed to verify or install a release. |
 | `126` | `run`/`exec`: the command exists but is not executable. |
 | `127` | `run`/`exec`: the command was not found. |
+| `130` | An attached `up` was ended by SIGINT or SIGTERM. |
 | other | `run` propagates the container's own exit code verbatim. |
 
 `exec` propagates the command's exit code the same way `run` does, and `wait`
 returns the last non-zero code it saw.
+
+**`130` for SIGTERM as well as SIGINT.** The signal number would suggest 143 for
+SIGTERM, but `docker compose up` returns 130 for both and podup matches it
+(measured against v5.1.3 pointed at the same Podman socket). The project is
+still torn down before the code is returned, so an interrupted `up` leaves
+nothing running.
+
+This matters most in CI: a job that runs `podup up` in the foreground and is
+cancelled — by a timeout, by an operator, by the runner shutting down — used to
+report **success**. Anything gating on that exit status could not tell a
+completed run from an abandoned one.
 
 **`stats --format json` differs from docker on purpose.** podup emits numbers
 (`"CPUPerc": 12.5`) where docker emits preformatted strings (`"12.50%"`), and

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -21,6 +21,10 @@ use super::Engine;
 /// project down either way — reporting the interrupt as an error from `attach`
 /// would short-circuit that and leave the containers running, which is a worse
 /// bug than the exit code this exists to fix.
+/// `#[non_exhaustive]` for the same reason the other public types in this
+/// release gained it: a later ending — a stream that died rather than finished
+/// — is a variant, and without this it would be a major bump to add one.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttachOutcome {
 	/// Every stream ended on its own.


### PR DESCRIPTION
A go/no-go pass before opening the release PR came back **NO-GO**. All five findings held up when I checked them by hand.

### `AttachOutcome` was public without `#[non_exhaustive]`

This release adds that attribute to three types precisely so none of them needs another major bump — and then introduced a fourth public type guaranteeing one. A later ending (a stream that *died* rather than finished) is a variant. One line before the tag; a 3.0.0 after it.

### Exit 130 was documented nowhere

The headline break of the release. `130`, `SIGINT`, `Ctrl-C` and `interrupt` appeared **zero times** in `docs/commands.md` and `README.md`, and release notes are `--generate-notes` from commit subjects. Auto-update is on by default, so a user would have received it silently.

The exit-status table lists it now, together with the part that is not guessable: **SIGTERM also yields 130**, not the 143 its signal number implies — measured against `docker compose` v5.1.3 on the same socket.

### `debian/changelog` described a different release

The 2.0.0 entry was written before four of the six breaking changes landed, and named only one. It ships as `changelog.Debian.gz` and is what `apt changelog podup` prints — and the release gate checks the version *number*, never the content. Rewritten to list all six breaks plus the fixes an operator cares about.

### `Closes #1079` would have auto-closed a half-done issue

It is titled "exec **and run** cannot be interactive", and `run` still discards the flags:

```rust
// internal/dispatch/rest.rs:35-36
interactive: _,
no_tty: _,
// internal/engine/lifecycle/run.rs:156
run_service.tty = None;
```

So `podup run -it app bash` behaves exactly like `podup run app bash` — the same defect the issue described for `exec`. `exec` on Windows is also unimplemented.

The remainder is now #1140, linked from #1079. That was the alternative to rewriting a merged commit message.

### The `breaking` label was missing on #1126, #1130 and #1133

Added.

### One thing worth knowing about the gate itself

`cargo-semver-checks` is **vacuous** on this branch. At 2.0.0:

```
Checking podup v1.13.0 -> v2.0.0 (major change)
0 checks: 0 pass, 253 skip
Summary no semver update required
```

A major bump permits everything, so the check cannot fail exactly when the most is breaking. Forced to 1.13.1 it gives **222 pass, 1 fail** (`struct_marked_non_exhaustive`). It also misses the `attach_logs` return-type change entirely, catching only the `#[non_exhaustive]` additions — so the break list has to be derived by hand, not trusted from the gate.