### PR TITLE
chore: ignore the tooling scratch dirs in the repo, not just on my machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ debian/*.log
 
 # Host-specific benchmark output (published numbers live in README)
 bench/results/
+
+# Local tooling scratch directories. These are ignored on my machine by a global
+# gitignore and by .git/info/exclude, neither of which travels with the repo —
+# so on a fresh clone, on CI, or for anyone else, they were unprotected. This is
+# a public repository and a single `git add -A` would publish them permanently.
+.claude/
+.superpowers/
+.playwright-mcp/


### PR DESCRIPTION
`.claude/`, `.superpowers/` and `.playwright-mcp/` sit at the repo root with files in them, and `git status` is clean — but **only here**:

```
.claude          /home/jaroc/.config/git/ignore:7
.superpowers     .git/info/exclude:20
.playwright-mcp  /home/jaroc/.config/git/ignore:11
```

A global gitignore and a per-clone exclude. Neither travels with the repository, and none of the three was in `.gitignore`. On a fresh clone, on a runner, or for anyone else, they are untracked and **unignored**.

This repository is public, and the zero-AI-trace rule covers git history — where a mistake cannot be taken back. One `git add -A` is all it takes.

That is not hypothetical. I made exactly that mistake an hour ago: a stray `Cargo.lock` from a local experiment reached a commit through `git add -A` and reddened seven jobs (#1141). That one was caught because it broke the build. These would not be — they would just be published.

### Verified in a fresh clone, not here

Checking on this machine is what made them look safe in the first place, so:

```
$ git clone --depth 1 --branch chore/gitignore-tooling-dirs file:///…/podup /tmp/clonecheck
$ cd /tmp/clonecheck
$ mkdir -p .claude .superpowers .playwright-mcp
$ touch .claude/x .superpowers/y .playwright-mcp/z
$ git status --short
(empty)
```

Before this change those three would have shown up as untracked, one `git add -A` away from a public repository.