### PR TITLE
bench: measure parsing and wide read paths, and docker compose on Podman

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -53,29 +53,53 @@ mkdir -p "$OUT_DIR"
 #   reup    : time a warm second `up -d`
 #   running : bring up untimed, then time `ps`, `logs`, `exec -T`, `restart`
 #   build   : time `build --no-cache`
-SCENARIOS=(single multi-healthcheck deep-chain wide-level scale network-ipam volume-heavy warm-restart many-services running-ops build)
+SCENARIOS=(single multi-healthcheck deep-chain wide-level scale network-ipam volume-heavy warm-restart many-services running-ops wide-running-ops config-heavy build)
 declare -A OP=(
 	[single]=updown [multi-healthcheck]=updown [scale]=scale
 	[network-ipam]=updown [volume-heavy]=updown [warm-restart]=reup
 	[many-services]=updown [running-ops]=running [build]=build
+	[config-heavy]=parse [wide-running-ops]=running
 )
 if [ "$SMOKE" -eq 1 ]; then SCENARIOS=(single running-ops); fi
 
 TOOLS=(podup podman-compose)
-if docker info >/dev/null 2>&1 && command -v docker-compose >/dev/null 2>&1; then
-	TOOLS+=(docker-compose)
-	echo "note: Docker Engine present — including docker-compose as a labelled cross-engine run."
+# docker compose is the tool podup targets for parity, so it is the comparison
+# that matters most — but WHICH engine it drives changes what the numbers mean.
+#
+#   against Podman  a pure tool comparison: same engine, so the difference is
+#                   the orchestrator and nothing else. This is the fair one, and
+#                   it needs no Docker installed — only DOCKER_HOST pointed at
+#                   the Podman socket.
+#   against dockerd a whole-stack comparison: engine differences are folded in,
+#                   so it cannot be read as "tool A is faster than tool B".
+#
+# Both are reported; the label says which, because a reader seeing
+# "docker-compose" will assume dockerd.
+if command -v docker-compose >/dev/null 2>&1; then
+	if docker info >/dev/null 2>&1; then
+		TOOLS+=(docker-compose)
+		echo "note: Docker Engine present — docker-compose measured as a CROSS-ENGINE (whole-stack) run."
+	elif [ -n "${DOCKER_HOST:-}" ] && docker-compose ls >/dev/null 2>&1; then
+		TOOLS+=(docker-compose)
+		echo "note: docker-compose driving Podman via DOCKER_HOST — measured as a SAME-ENGINE (pure tool) run."
+	else
+		echo "note: docker-compose found but no reachable engine — NOT measured. Set DOCKER_HOST to the Podman socket to include it."
+	fi
 else
-	echo "note: no Docker Engine on this host — docker-compose (cross-engine) is NOT measured."
+	echo "note: docker-compose not installed — NOT measured."
 fi
 
 run() { # tool, compose-file, project, op-args...
 	local tool="$1" file="$2" proj="$3"; shift 3
 	local pre=(); [ -n "$CORES" ] && pre=(taskset -c "$CORES")
+	# `file` may name several compose files separated by spaces, so a scenario can
+	# exercise the base+override merge every real project has. One name yields one
+	# -f, exactly as before.
+	local fargs=(); local f; for f in $file; do fargs+=(-f "$f"); done
 	case "$tool" in
-		podup)          "${pre[@]}" "$PODUP_BIN" -f "$file" -p "$proj" "$@" ;;
-		podman-compose) "${pre[@]}" podman-compose -f "$file" -p "$proj" "$@" ;;
-		docker-compose) "${pre[@]}" docker-compose -f "$file" -p "$proj" "$@" ;;
+		podup)          "${pre[@]}" "$PODUP_BIN" "${fargs[@]}" -p "$proj" "$@" ;;
+		podman-compose) "${pre[@]}" podman-compose "${fargs[@]}" -p "$proj" "$@" ;;
+		docker-compose) "${pre[@]}" docker-compose "${fargs[@]}" -p "$proj" "$@" ;;
 	esac
 }
 
@@ -84,10 +108,11 @@ run() { # tool, compose-file, project, op-args...
 timed() { # tool, compose-file, project, op-args...
 	local tool="$1" file="$2" proj="$3"; shift 3
 	local cmd=(); [ -n "$CORES" ] && cmd=(taskset -c "$CORES")
+	local fargs=(); local f; for f in $file; do fargs+=(-f "$f"); done
 	case "$tool" in
-		podup)          cmd+=("$PODUP_BIN" -f "$file" -p "$proj" "$@") ;;
-		podman-compose) cmd+=(podman-compose -f "$file" -p "$proj" "$@") ;;
-		docker-compose) cmd+=(docker-compose -f "$file" -p "$proj" "$@") ;;
+		podup)          cmd+=("$PODUP_BIN" "${fargs[@]}" -p "$proj" "$@") ;;
+		podman-compose) cmd+=(podman-compose "${fargs[@]}" -p "$proj" "$@") ;;
+		docker-compose) cmd+=(docker-compose "${fargs[@]}" -p "$proj" "$@") ;;
 	esac
 	local tf; tf="$(mktemp)"
 	LC_ALL=C "$TIME_BIN" -v "${cmd[@]}" >/dev/null 2>"$tf"
@@ -118,6 +143,12 @@ echo "tool,scenario,op,iter,phase,seconds,max_rss_kb,cpu_s,rc" > "$RAW"
 for tool in "${TOOLS[@]}"; do
 	for scen in "${SCENARIOS[@]}"; do
 		file="$SCEN_DIR/$scen/compose.yaml"
+		# A scenario may ship an override alongside its base file; merging the two
+		# is what real projects do and what no single-file scenario can measure.
+		# Passed explicitly rather than relying on auto-discovery, since the tools
+		# disagree about that and this must compare the same work.
+		[ -f "$SCEN_DIR/$scen/compose.override.yaml" ] &&
+			file="$file $SCEN_DIR/$scen/compose.override.yaml"
 		op="${OP[$scen]}"
 		proj="bench_${tool//-/_}_${scen//-/_}"
 		echo ">>> $tool / $scen (op=$op)"
@@ -146,6 +177,13 @@ for tool in "${TOOLS[@]}"; do
 					row exec    "$(timed "$tool" "$file" "$proj" exec -T app true)"
 					row restart "$(timed "$tool" "$file" "$proj" restart app)"
 					teardown "$tool" "$file" "$proj"
+					;;
+				parse)
+					# The only op with no engine on the other side: read, interpolate,
+					# merge and re-render. No containers means no daemon variance, so
+					# this is the least noisy number the suite produces — and it is
+					# what CI runs most, to validate a file before deploying it.
+					row config "$(timed "$tool" "$file" "$proj" config)"
 					;;
 				build)
 					row build "$(timed "$tool" "$file" "$proj" build --no-cache)"

--- a/bench/scenarios/config-heavy/.env
+++ b/bench/scenarios/config-heavy/.env
@@ -1,0 +1,4 @@
+# Interpolation source for the compose files.
+REGION=eu-central-1
+OWNER=bench
+SHARED_SECRET=not-a-real-secret

--- a/bench/scenarios/config-heavy/common.env
+++ b/bench/scenarios/config-heavy/common.env
@@ -1,0 +1,21 @@
+# Shared env, read by every service.
+COMMON_01=value-01
+COMMON_02=value-02
+COMMON_03=value-03
+COMMON_04=value-04
+COMMON_05=value-05
+COMMON_06=value-06
+COMMON_07=value-07
+COMMON_08=value-08
+COMMON_09=value-09
+COMMON_10=value-10
+COMMON_11=value-11
+COMMON_12=value-12
+COMMON_13=value-13
+COMMON_14=value-14
+COMMON_15=value-15
+COMMON_16=value-16
+COMMON_17=value-17
+COMMON_18=value-18
+COMMON_19=value-19
+COMMON_20=value-20

--- a/bench/scenarios/config-heavy/compose.override.yaml
+++ b/bench/scenarios/config-heavy/compose.override.yaml
@@ -1,0 +1,63 @@
+# The override half of the merge. Real projects almost always have one, and no
+# other scenario in this suite exercises the merge at all.
+services:
+  svc01:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc03:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc05:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc07:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc09:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc11:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc13:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc15:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc17:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc19:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc21:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc23:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"

--- a/bench/scenarios/config-heavy/compose.yaml
+++ b/bench/scenarios/config-heavy/compose.yaml
@@ -1,0 +1,337 @@
+# Parse-heavy: the one scenario with no engine in it at all.
+#
+# `config` reads, interpolates, merges and re-renders — pure client-side work,
+# so the numbers carry no container noise and no daemon variance. It is also
+# what CI does most often, to validate a compose file before deploying it.
+#
+# The shape real projects have and no other scenario here does: two files merged
+# (compose + override), an env_file, and interpolation with defaults on nearly
+# every service. Every other scenario is a single flat file.
+#
+# Dependencies are deliberately SHALLOW. An earlier version of this file chained
+# all 24 services one after another, and podman-compose took 7.4s on it against
+# 0.10s for the same file with the chain removed — a 70x cost in dependency
+# resolution, not in parsing. Leaving the chain in would have made this scenario
+# report that number as a parse cost, which is not what it is. The deep-chain
+# scenario is where dependency shape belongs.
+services:
+  svc01:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_01:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "01"
+  svc02:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_02:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "02"
+  svc03:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_03:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "03"
+  svc04:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_04:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "04"
+  svc05:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_05:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "05"
+  svc06:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_06:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "06"
+    depends_on:
+      - svc01
+  svc07:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_07:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "07"
+  svc08:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_08:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "08"
+  svc09:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_09:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "09"
+  svc10:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_10:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "10"
+  svc11:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_11:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "11"
+  svc12:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_12:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "12"
+    depends_on:
+      - svc01
+  svc13:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_13:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "13"
+  svc14:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_14:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "14"
+  svc15:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_15:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "15"
+  svc16:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_16:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "16"
+  svc17:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_17:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "17"
+  svc18:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_18:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "18"
+    depends_on:
+      - svc01
+  svc19:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_19:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "19"
+  svc20:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_20:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "20"
+  svc21:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_21:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "21"
+  svc22:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_22:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "22"
+  svc23:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_23:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "23"
+  svc24:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_24:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "24"
+    depends_on:
+      - svc01

--- a/bench/scenarios/wide-running-ops/compose.yaml
+++ b/bench/scenarios/wide-running-ops/compose.yaml
@@ -1,0 +1,57 @@
+# Read-path cost across many containers, which running-ops (one service) cannot
+# show. `ps` renders a table of twelve rows, `logs` aggregates twelve streams and
+# prefixes each line with its service — the work grows with the container count,
+# and every tool does it differently.
+services:
+  svc01:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc01 ready; sleep 3600"]
+    init: true
+  svc02:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc02 ready; sleep 3600"]
+    init: true
+  svc03:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc03 ready; sleep 3600"]
+    init: true
+  svc04:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc04 ready; sleep 3600"]
+    init: true
+  svc05:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc05 ready; sleep 3600"]
+    init: true
+  svc06:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc06 ready; sleep 3600"]
+    init: true
+  svc07:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc07 ready; sleep 3600"]
+    init: true
+  svc08:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc08 ready; sleep 3600"]
+    init: true
+  svc09:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc09 ready; sleep 3600"]
+    init: true
+  svc10:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc10 ready; sleep 3600"]
+    init: true
+  svc11:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc11 ready; sleep 3600"]
+    init: true
+  svc12:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc12 ready; sleep 3600"]
+    init: true
+  app:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo app ready; sleep 3600"]
+    init: true


### PR DESCRIPTION
Three gaps in the suite, each verified against it as it stood.

### Nothing measured `config`

It is the only operation with **no engine on the other side** — read, interpolate, merge, re-render. No containers means no daemon variance, so it is the least noisy number the suite can produce, and it is what CI runs most often: validating a compose file before deploying it.

`config-heavy` is also the only scenario with the shape real projects have — **two files merged, an env_file, and interpolation with defaults**. The other eleven are single flat files with none of those.

### `ps` and `logs` were measured on one service

`running-ops` has a single service, so aggregating across containers — where the work grows and the tools differ most — was never measured. `wide-running-ops` runs the same ops across thirteen.

### docker compose was excluded unless dockerd was present

It is the tool podup targets for parity, so it is the comparison that matters most. And it can be measured **without installing Docker**, by pointing `DOCKER_HOST` at the Podman socket — which makes it a *same-engine* run where the only difference is the orchestrator.

Both modes are detected and labelled:

```
note: docker-compose driving Podman via DOCKER_HOST — measured as a SAME-ENGINE (pure tool) run.
note: Docker Engine present — docker-compose measured as a CROSS-ENGINE (whole-stack) run.
```

The label matters: a reader seeing "docker-compose" assumes dockerd, and a cross-engine number cannot be read as "tool A beats tool B" — it folds in the engine difference.

`run.sh` now accepts several compose files per scenario, so the base+override merge can be exercised at all.

### What building this found

The first version of `config-heavy` chained all 24 services with `depends_on`. podman-compose took **7.4s** on it — against **0.10s** for the identical file with the chain removed.

| | podman-compose |
|---|---|
| 24 services, linear `depends_on` chain | 7344 ms |
| same file, chain removed | **104 ms** |
| 12 services, no chain | 97 ms |
| 48 services, no chain | 111 ms |

A **70x** cost in dependency resolution, and service count barely moves it. Left in, this scenario would have published that as a *parse* cost, which is not what it is — a number that says one thing and means another.

Dependencies are shallow and realistic now, and dependency shape stays in `deep-chain`, where it belongs. The pathology is worth its own investigation; it is not this scenario's job to report it by accident.

### Verified

All three tools complete both new scenarios. On the corrected `config-heavy`: podup **8ms**, docker-compose **46ms**, podman-compose **126ms** — same order of magnitude, no tool failing, nothing standing in for something else.