### PR TITLE
fix(bench): give deep-chain and wide-level an op, and refuse to start without one

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -59,7 +59,17 @@ declare -A OP=(
 	[network-ipam]=updown [volume-heavy]=updown [warm-restart]=reup
 	[many-services]=updown [running-ops]=running [build]=build
 	[config-heavy]=parse [wide-running-ops]=running
+	[deep-chain]=updown [wide-level]=updown
 )
+
+# Every scenario must have an op, or the run dies partway through with an
+# unbound-variable error under `set -u`. deep-chain and wide-level were added to
+# SCENARIOS in #1123 and never added here, so the suite has been unable to
+# complete since — nobody noticed because those two were only ever run by hand,
+# one at a time, to measure the scheduler change that introduced them.
+for _s in "${SCENARIOS[@]}"; do
+	[ -n "${OP[$_s]:-}" ] || { echo "bench: scenario '$_s' has no entry in OP" >&2; exit 2; }
+done
 if [ "$SMOKE" -eq 1 ]; then SCENARIOS=(single running-ops); fi
 
 TOOLS=(podup podman-compose)


### PR DESCRIPTION
The benchmark suite could not complete.

`deep-chain` and `wide-level` were added to `SCENARIOS` in #1123 and never added to the `OP` map, so a full run died partway through:

```
>>> podup / single (op=updown)
>>> podup / multi-healthcheck (op=updown)
bench/run.sh: line 152: OP[$scen]: unbound variable
```

Two scenarios measured and discarded, then an abort.

### Why nobody noticed

Those two scenarios were only ever run **by hand, one at a time**, to measure the scheduler change that introduced them (the 1326ms → 1135ms number in #1123). The full suite had not been run since — I found this by running it, which is the only thing that could have found it.

Both are `updown`: the point of a dependency-shaped scenario is the latency of bringing it up, which is what that op times.

### The guard is the actual fix

A missing entry now fails **before the first container starts**, naming the scenario, instead of thirty minutes into a run whose earlier measurements are then lost:

```bash
for _s in "${SCENARIOS[@]}"; do
	[ -n "${OP[$_s]:-}" ] || { echo "bench: scenario '$_s' has no entry in OP" >&2; exit 2; }
done
```

Verified by adding a scenario with no op:

```
bench: scenario 'inventado' has no entry in OP
```

Adding a scenario is two edits in two places, and the cost of forgetting the second one was a silent half-hour. Now it is a one-line error.