### PR TITLE
fix: say which socket, why it matters, and how to enable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ The installer verifies the keyring package's Ed25519 signature against its
 pinned release key before anything is installed (fail-closed). The keyring
 package registers `https://apt.glyndor.net` and ships the signing key, so podup
 updates (and key renewals) arrive through `apt upgrade`. The apt build omits
-self-update, since apt owns upgrades. Requires **Podman ≥ 5.0** (rootless).
+self-update, since apt owns upgrades. Requires **Podman ≥ 5.0** (rootless) with
+its **API socket listening** — `podman` itself is daemonless, but podup speaks
+the libpod API:
+
+```bash
+systemctl --user enable --now podman.socket
+```
 
 To register the repository by hand instead, fetch the keyring and check the
 key's fingerprint against the one published in the

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -118,5 +118,19 @@ Podman groundwork, done once:
        podman system migrate
   ```
 
+- **The Podman API socket** — `podman` is daemonless and needs no socket, so a
+  fresh account can run `podman` fine and still have every `podup` command fail
+  with a connection error. podup speaks the libpod API, so the socket has to be
+  listening:
+
+  ```bash
+  sudo -u appuser env XDG_RUNTIME_DIR=/run/user/$(id -u appuser) \
+       systemctl --user enable --now podman.socket
+  ```
+
+  The `env XDG_RUNTIME_DIR=…` is the same requirement as above and for the same
+  reason: an account with no login shell has no user session, so `systemctl
+  --user` cannot find the manager without being told where it lives.
+
 After that, `podup autostart install` writes the unit(s), reloads the user
 manager, and starts the stack; a reboot brings it back on its own.

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -41,7 +41,9 @@ impl Client {
 	/// surfaces as an error instead of hanging with the terminal already in raw
 	/// mode — which would leave the user's shell unusable.
 	pub(crate) async fn post_hijack(&self, path: &str, body: &[u8]) -> Result<Hijacked> {
-		let mut stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
+		let mut stream = tokio::net::UnixStream::connect(&self.socket_path)
+			.await
+			.map_err(|e| super::socket_error(&self.socket_path, e))?;
 
 		// `Connection: close` is deliberate: this socket is never returned to a
 		// pool, and saying so stops the server holding it open after the command

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -61,6 +61,36 @@ pub struct Client {
 	socket_path: String,
 }
 
+/// Attach the socket path and a way forward to a connection failure.
+///
+/// The operator saw `podman socket connection error: No such file or directory
+/// (os error 2)` — no path, no distinction between "it is not there" and "I
+/// cannot open it", and nothing to do about it. Everything needed was already
+/// in hand one call earlier (#1146).
+///
+/// The path is folded into the `io::Error`'s message rather than into a new
+/// error variant so `PodmanError` keeps its shape: it is public API and 2.0.0
+/// shipped hours ago. `kind()` survives, which is what tells the two cases
+/// apart.
+pub(crate) fn socket_error(path: &str, e: std::io::Error) -> super::PodmanError {
+	let hint = match e.kind() {
+		std::io::ErrorKind::NotFound => {
+			" — the Podman API socket is not listening. podman itself is daemonless \
+			 and needs no socket, but podup speaks the libpod API and does. Enable it \
+			 with `systemctl --user enable --now podman.socket`, or for an account \
+			 with no login shell: `sudo -u <user> env XDG_RUNTIME_DIR=/run/user/$(id \
+			 -u <user>) systemctl --user enable --now podman.socket`"
+		}
+		std::io::ErrorKind::PermissionDenied => {
+			" — the socket exists but cannot be opened. Check that it is owned by \
+			 the user running podup; a socket created by another account is not \
+			 shared"
+		}
+		_ => "",
+	};
+	super::PodmanError::Connect(std::io::Error::new(e.kind(), format!("{path}: {e}{hint}")))
+}
+
 impl Client {
 	/// Create a client bound to the given Podman socket path (or named pipe).
 	pub fn new(socket_path: impl Into<String>) -> Self {
@@ -73,7 +103,9 @@ impl Client {
 	async fn connect(&self) -> Result<http1::SendRequest<BoxBody>> {
 		#[cfg(unix)]
 		{
-			let stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
+			let stream = tokio::net::UnixStream::connect(&self.socket_path)
+				.await
+				.map_err(|e| socket_error(&self.socket_path, e))?;
 			let io = TokioIo::new(stream);
 			let (sender, conn) = http1::handshake(io).await?;
 			tokio::spawn(async move {

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -184,3 +184,48 @@ fn a_buffered_put_body_reports_an_exact_size() {
 		"a boxed Full body must keep its exact size, or hyper sends it chunked"
 	);
 }
+
+/// The operator's report (#1146): `podman socket connection error: No such
+/// file or directory (os error 2)` — no path, no way to tell "it is not there"
+/// from "I cannot open it", nothing to act on. Everything needed was already in
+/// hand one call earlier.
+#[test]
+fn a_missing_socket_names_the_path_and_the_fix() {
+	let e = super::socket_error(
+		"/run/user/1000/podman/podman.sock",
+		std::io::Error::from(std::io::ErrorKind::NotFound),
+	);
+	let msg = e.to_string();
+	assert!(msg.contains("/run/user/1000/podman/podman.sock"), "{msg}");
+	assert!(
+		msg.contains("systemctl --user enable --now podman.socket"),
+		"{msg}"
+	);
+	assert!(msg.contains("XDG_RUNTIME_DIR"), "{msg}");
+}
+
+/// A socket that exists but cannot be opened is a different problem with a
+/// different fix, and the old message could not tell them apart.
+#[test]
+fn a_denied_socket_says_so_rather_than_suggesting_enabling_it() {
+	let e = super::socket_error(
+		"/tmp/s.sock",
+		std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+	);
+	let msg = e.to_string();
+	assert!(msg.contains("/tmp/s.sock"), "{msg}");
+	assert!(msg.contains("cannot be opened"), "{msg}");
+	assert!(
+		!msg.contains("enable --now"),
+		"enabling the socket does not fix a permission problem: {msg}"
+	);
+}
+
+/// The io::ErrorKind must survive, since it is what distinguishes the two.
+#[test]
+fn the_error_kind_is_preserved() {
+	let e = super::socket_error("/x", std::io::Error::from(std::io::ErrorKind::NotFound));
+	assert!(
+		matches!(&e, super::super::PodmanError::Connect(io) if io.kind() == std::io::ErrorKind::NotFound)
+	);
+}


### PR DESCRIPTION
A fresh rootless service account running 2.0.0 from apt got this and nothing else:

```
podup: error: podman error: podman socket connection error: No such file or directory (os error 2)
```

No path. No way to tell *"the socket is not there"* from *"it is there and I cannot open it"*. Nothing to act on. All of it was in hand one call earlier and discarded at the `Display` impl.

### After

```
/run/user/1000/podman/podman.sock: No such file or directory (os error 2) — the
Podman API socket is not listening. podman itself is daemonless and needs no
socket, but podup speaks the libpod API and does. Enable it with `systemctl
--user enable --now podman.socket`, or for an account with no login shell:
`sudo -u <user> env XDG_RUNTIME_DIR=/run/user/$(id -u <user>) systemctl --user
enable --now podman.socket`
```

```
/tmp/s.sock: Permission denied (os error 13) — the socket exists but cannot be
opened. Check that it is owned by the user running podup; a socket created by
another account is not shared
```

Both reproduced against the built binary, not asserted from the source.

The path is folded into the `io::Error` rather than into a new error variant: `PodmanError` is public API **without** `#[non_exhaustive]`, and 2.0.0 shipped hours ago — a new variant would be a 3.0.0 for a message improvement. `kind()` survives, which is the thing that distinguishes the two cases.

### The prerequisite was undocumented

The README asked for **Podman ≥ 5.0** and said nothing about the socket. `docs/autostart.md` already walks a login-less account through `podman system migrate` with the `env XDG_RUNTIME_DIR=…` dance — the very same dance that enables the socket — and never connected the two. Both say so now.

That gap is *why* this bites. `podman` works fine on the account, because it is daemonless, so nothing looks wrong until every podup command fails.

### Tests

Three, and falsified: reintroducing the old `PodmanError::Connect(e)` makes two of them fail. Worth noting that my first attempt to falsify them silently did nothing — `cargo fmt` had reformatted the line I was pattern-matching on, so the sabotage never applied and the tests "passed" against a fix that was still in place. The second attempt asserted the pattern matched first.

Closes #1146