### PR TITLE
feat: give run a real terminal on Unix

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -222,7 +222,7 @@ Run a one-off command in a new container for the service.
 | `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
 | `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
 | `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
-| `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation. | off |
 | `--no-deps` | Do not start the `depends_on` services before running. | off |
 
 ```bash
@@ -233,6 +233,23 @@ podup run --rm web sh -c 'echo hello'
 > here; `docker compose run` keeps it unless you pass `--rm`. Migrating a script
 > means its existing `--rm` becomes a no-op and a container it expected to
 > inspect afterwards is gone — pass `--no-rm` to keep it.
+
+On Unix, `run` allocates a pseudo-TTY and attaches your stdin when stdin is a
+terminal, so `podup run -it app sh` drops you into an interactive session that
+follows your window size. Like `docker compose run`, a TTY on both ends is the
+default and `-T` is how you turn it off; `-d` never allocates one, since there
+is nobody to be interactive with.
+
+It engages **only** when stdin is a terminal, so a script or a pipeline keeps
+the plain streaming behaviour with no change to output framing:
+
+```bash
+podup run --rm app echo hola > salida.txt   # streams, no TTY
+podup run --rm -T app ./migrar.sh           # streams, no TTY
+```
+
+Windows keeps the streaming behaviour in every case
+([#1140](https://github.com/Glyndor/podup/issues/1140)).
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
@@ -547,7 +564,6 @@ covers, and the only other way to find out was to read the dispatch code.
 | `config --no-normalize` | `config` always emits the normalized form. |
 | `cp -a, --archive` | Ownership/permission preservation is not meaningful for a rootless copy. |
 | `attach --no-stdin`, `--sig-proxy`, `--detach-keys` | `attach` streams output only; stdin is never attached (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
-| `run -T, --no-TTY` | `run` never allocates a pseudo-TTY, so disabling one is a no-op. `exec -T` is real: it turns off a pseudo-TTY that `exec` does allocate. |
 
 Everything else that parses does something. An **unknown** `--filter` predicate
 is rejected outright rather than dropped: a filter that silently does not apply

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -32,6 +32,8 @@ pub(super) async fn dispatch_rest(
 			entrypoint: _,
 			volume: _,
 			publish: _,
+			// Both act now: they reach the engine through `RunOverrides`, which
+			// `run_overrides_for` builds from this same command.
 			interactive: _,
 			no_tty: _,
 			no_deps: _,

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -7,6 +7,8 @@ mod parallel;
 mod prefetch;
 mod readiness;
 mod run;
+#[cfg(unix)]
+mod run_attached;
 mod scale;
 mod schedule;
 mod signal;
@@ -68,6 +70,10 @@ pub struct RunOverrides {
 	pub interactive: bool,
 	/// Do not start `depends_on` services before the run (`--no-deps`).
 	pub no_deps: bool,
+	/// Opt out of the pseudo-TTY (`-T/--no-TTY`), the way `docker compose run`
+	/// does. A TTY on both ends is the default when stdin is a terminal, so this
+	/// is how a script says it does not want one.
+	pub no_tty: bool,
 }
 
 impl Engine {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -70,10 +70,6 @@ pub struct RunOverrides {
 	pub interactive: bool,
 	/// Do not start `depends_on` services before the run (`--no-deps`).
 	pub no_deps: bool,
-	/// Opt out of the pseudo-TTY (`-T/--no-TTY`), the way `docker compose run`
-	/// does. A TTY on both ends is the default when stdin is a terminal, so this
-	/// is how a script says it does not want one.
-	pub no_tty: bool,
 }
 
 impl Engine {

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -41,8 +41,13 @@ impl Engine {
 			volumes,
 			publish,
 			interactive,
+			no_tty,
 			no_deps,
 		} = self.run_overrides.clone();
+		// Same rule as `exec`: a TTY on both ends by default, `-T` to opt out,
+		// and only when stdin is actually a terminal — so a script or a pipeline
+		// keeps the streaming path it has always had, unchanged.
+		let want_tty = crate::engine::wants_interactive_run(no_tty, detach);
 		// `--env-file` and `-l/--label` are carried on the engine (not
 		// `RunOverrides`) to keep the public struct frozen.
 		let env_files = self.run_env_files.clone();
@@ -96,9 +101,10 @@ impl Engine {
 		if let Some(w) = workdir {
 			run_service.working_dir = Some(w);
 		}
-		// `-i/--interactive` keeps STDIN open on the spec; `run` still streams
-		// logs rather than attaching a live terminal.
-		if interactive {
+		// `-i/--interactive` keeps STDIN open on the spec. With a terminal on both
+		// ends the container also gets a live stdin attached below; without one
+		// this is the same flag it always was.
+		if interactive || want_tty {
 			run_service.stdin_open = Some(true);
 		}
 		// Ad-hoc `-v/--volume` mounts append to the service's own mounts in
@@ -150,10 +156,12 @@ impl Engine {
 				.ports
 				.push(crate::compose::types::PortMapping::Short(p));
 		}
-		// Force non-TTY so Podman uses multiplexed log framing that
-		// parse_multiplexed can decode. TTY mode sends raw bytes without
-		// the 8-byte header, which would produce garbled output.
-		run_service.tty = None;
+		// Non-TTY forces Podman's multiplexed log framing, which is what the
+		// streaming path below decodes — TTY mode sends raw bytes with no 8-byte
+		// header and would garble that reader. The interactive path does not use
+		// that reader at all: it attaches to the raw stream, which is exactly the
+		// framing a TTY produces. So the two are consistent, not contradictory.
+		run_service.tty = want_tty.then_some(true);
 
 		// Ensure the project networks exist (compose `run` brings them up like
 		// `up` does); the service may reference the synthesized `default`
@@ -182,8 +190,12 @@ impl Engine {
 		// On a start failure (bad --workdir/--user/--entrypoint), the container is
 		// created but never starts; with --rm, remove it here so repeated failures
 		// don't accumulate orphaned 'Created' containers.
+		// Interactive runs create first and start later, with the attach in
+		// between: a container started before anything is listening loses
+		// whatever it printed in that gap, and for `run` — a one-shot command —
+		// that gap is often the entire output.
 		if let Err(e) = self
-			.create_and_start(&run_name, service_name, &run_service, file, true)
+			.create_and_start(&run_name, service_name, &run_service, file, !want_tty)
 			.await
 		{
 			if rm {
@@ -197,6 +209,28 @@ impl Engine {
 			// output), so scripts capturing stdout get an id like
 			// `docker compose run -d`.
 			crate::ui::result_line(&run_name).map_err(ComposeError::Io)?;
+			return Ok(());
+		}
+
+		if want_tty {
+			// Attach, then start, then hand the terminal over. The exit code is
+			// read afterwards, and --rm cleanup below runs either way.
+			let outcome = self.run_attached(&run_name).await;
+			let code = match outcome {
+				Ok(code) => code,
+				Err(e) => {
+					if rm {
+						let _ = self.client.delete_ok(&rm_path).await;
+					}
+					return Err(e);
+				}
+			};
+			if rm {
+				let _ = self.client.delete_ok(&rm_path).await;
+			}
+			if code != 0 {
+				return Err(ComposeError::RunExited(code));
+			}
 			return Ok(());
 		}
 

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -41,9 +41,9 @@ impl Engine {
 			volumes,
 			publish,
 			interactive,
-			no_tty,
 			no_deps,
 		} = self.run_overrides.clone();
+		let no_tty = self.run_no_tty;
 		// Same rule as `exec`: a TTY on both ends by default, `-T` to opt out,
 		// and only when stdin is actually a terminal — so a script or a pipeline
 		// keeps the streaming path it has always had, unchanged.
@@ -212,26 +212,12 @@ impl Engine {
 			return Ok(());
 		}
 
+		// The interactive path takes over here: it needs the connection kept open
+		// in both directions, which the request/response client cannot give it.
+		// Same shape `exec` uses, and cfg-ed the same way.
+		#[cfg(unix)]
 		if want_tty {
-			// Attach, then start, then hand the terminal over. The exit code is
-			// read afterwards, and --rm cleanup below runs either way.
-			let outcome = self.run_attached(&run_name).await;
-			let code = match outcome {
-				Ok(code) => code,
-				Err(e) => {
-					if rm {
-						let _ = self.client.delete_ok(&rm_path).await;
-					}
-					return Err(e);
-				}
-			};
-			if rm {
-				let _ = self.client.delete_ok(&rm_path).await;
-			}
-			if code != 0 {
-				return Err(ComposeError::RunExited(code));
-			}
-			return Ok(());
+			return self.finish_interactive_run(&run_name, rm, &rm_path).await;
 		}
 
 		// Stream logs and wait for the exit code. Any failure on this path also

--- a/internal/engine/lifecycle/run_attached.rs
+++ b/internal/engine/lifecycle/run_attached.rs
@@ -1,0 +1,63 @@
+//! Interactive `run`: a pseudo-terminal on a one-shot container, on Unix.
+//!
+//! `podup run -it app bash` parsed `-i` and `-T` and acted on neither: the
+//! container got no TTY and no live stdin, so the flags described something that
+//! did not happen (#1140, the half of #1079 that did not ship).
+//!
+//! The order here is the whole point. `attach` opens before `start`, because a
+//! container that has already run has already printed, and for a one-shot `run`
+//! that missed output is often all the output there was. `exec` does not have
+//! this problem — the container is already up — which is why it can attach and
+//! start in a single call and this cannot.
+
+#![cfg(unix)]
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+impl super::super::Engine {
+	/// Attach to a created-but-not-started container, start it, and hand the
+	/// terminal over until the command exits. Returns its exit code.
+	pub(super) async fn run_attached(&self, container_name: &str) -> Result<i64> {
+		// stdin=1 so keystrokes reach the command; stream=1 keeps the connection
+		// open both ways. With a TTY the stream is raw — no 8-byte frame headers,
+		// because the pty merges stdout and stderr — which is also why an
+		// interactive run cannot separate them, exactly as `podman run -it`.
+		let attach_path = format!(
+			"{API_PREFIX}/containers/{}/attach?stream=1&stdin=1&stdout=1&stderr=1",
+			urlencoded(container_name),
+		);
+		let hijacked = self
+			.client
+			.post_hijack(&attach_path, b"")
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		let start_path = format!(
+			"{API_PREFIX}/containers/{}/start",
+			urlencoded(container_name),
+		);
+		self.client
+			.post_empty_ok(&start_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		// Raw mode only once the container is known to have started; entering it
+		// before would leave the caller's terminal unusable behind a failed start.
+		self.pump_terminal(
+			hijacked,
+			&format!("containers/{}", urlencoded(container_name)),
+		)
+		.await?;
+
+		// The stream ending means the command finished; ask for its status.
+		let wait_path = format!(
+			"{API_PREFIX}/containers/{}/wait?condition=stopped",
+			urlencoded(container_name),
+		);
+		self.client
+			.post_empty_json_unbounded::<i64>(&wait_path)
+			.await
+			.map_err(ComposeError::Podman)
+	}
+}

--- a/internal/engine/lifecycle/run_attached.rs
+++ b/internal/engine/lifecycle/run_attached.rs
@@ -61,3 +61,23 @@ impl super::super::Engine {
 			.map_err(ComposeError::Podman)
 	}
 }
+
+impl super::super::Engine {
+	/// Attach, start, hand over the terminal, then clean up per `--rm` and map
+	/// the exit code. Split from `run` so the non-Unix build can drop it whole.
+	pub(super) async fn finish_interactive_run(
+		&self,
+		run_name: &str,
+		rm: bool,
+		rm_path: &str,
+	) -> Result<()> {
+		let outcome = self.run_attached(run_name).await;
+		if rm {
+			let _ = self.client.delete_ok(rm_path).await;
+		}
+		match outcome? {
+			0 => Ok(()),
+			code => Err(ComposeError::RunExited(code)),
+		}
+	}
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -107,6 +107,8 @@ pub struct Engine {
 	/// `run` container; empty by default. Kept off the frozen public
 	/// [`lifecycle::RunOverrides`] struct so the library API stays stable.
 	pub(super) run_labels: Vec<String>,
+	/// CLI `run -T/--no-TTY`: opt out of the pseudo-TTY.
+	pub(super) run_no_tty: bool,
 	/// CLI `up -V/--renew-anon-volumes`: when recreating a container, also remove
 	/// its old anonymous volumes instead of leaving them orphaned.
 	pub(super) renew_anon_volumes: bool,
@@ -128,6 +130,7 @@ impl Engine {
 			run_overrides: lifecycle::RunOverrides::default(),
 			run_env_files: Vec::new(),
 			run_labels: Vec::new(),
+			run_no_tty: false,
 			renew_anon_volumes: false,
 		}
 	}
@@ -147,6 +150,7 @@ impl Engine {
 			run_overrides: lifecycle::RunOverrides::default(),
 			run_env_files: Vec::new(),
 			run_labels: Vec::new(),
+			run_no_tty: false,
 			renew_anon_volumes: false,
 		}
 	}
@@ -209,6 +213,18 @@ impl Engine {
 	/// one-off `run` container. Builder-style; consumed by [`Engine::run`].
 	pub fn with_run_labels(mut self, labels: Vec<String>) -> Self {
 		self.run_labels = labels;
+		self
+	}
+
+	/// Set the CLI `run -T/--no-TTY` flag. Builder-style.
+	///
+	/// Carried here rather than on [`RunOverrides`] for the reason that struct
+	/// already documents: it is public and not `#[non_exhaustive]`, so a new
+	/// field is a breaking change. `run_env_files` and `run_labels` are on the
+	/// engine for exactly this, and semver-checks caught me putting this one in
+	/// the wrong place.
+	pub fn with_run_no_tty(mut self, no_tty: bool) -> Self {
+		self.run_no_tty = no_tty;
 		self
 	}
 

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -6,6 +6,8 @@ mod build;
 mod container;
 mod copy;
 mod events;
+#[cfg(unix)]
+mod terminal_pump;
 pub use events::EventsOptions;
 mod image;
 pub use build::{BuildOptions, PullOptions, PushOptions};
@@ -13,6 +15,17 @@ pub use copy::CpOptions;
 pub use image::{resolve_image_digests, CommitOptions};
 pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
+/// Whether `run` should allocate a pseudo-TTY and attach stdin.
+///
+/// The same rule `exec` uses, kept in one place so the two cannot drift: a TTY
+/// on both ends by default, `-T` to opt out, `-d` excluded because there is
+/// nobody to be interactive with, and only when stdin is genuinely a terminal —
+/// which is what keeps every existing script and pipeline on the unchanged
+/// streaming path.
+pub(crate) fn wants_interactive_run(no_tty: bool, detach: bool) -> bool {
+	!no_tty && !detach && query::stdin_is_terminal()
+}
+
 pub use query::{
 	AttachOutcome, ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsFilterOptions, PsOptions,
 };
@@ -510,3 +523,30 @@ fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Resul
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod interactive_run_tests {
+	use super::wants_interactive_run;
+
+	/// `-T` opts out, matching `docker compose run` — which has no `-i` because
+	/// a TTY on both ends is the default.
+	#[test]
+	fn no_tty_disables_the_pty() {
+		assert!(!wants_interactive_run(true, false));
+	}
+
+	/// `-d` detaches, so there is nobody to be interactive with.
+	#[test]
+	fn detach_disables_the_pty() {
+		assert!(!wants_interactive_run(false, true));
+	}
+
+	/// The decisive one for existing users: in a test harness — as in any script
+	/// or pipeline — stdin is not a terminal, so `run` stays on the unchanged
+	/// streaming path. Allocating a pty there would change output framing for
+	/// every script that already calls `podup run`.
+	#[test]
+	fn a_non_terminal_stdin_stays_on_the_streaming_path() {
+		assert!(!wants_interactive_run(false, false));
+	}
+}

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -378,7 +378,7 @@ fn wants_interactive(opts: &ExecOptions, stdin_is_tty: bool) -> bool {
 /// Whether stdin is a terminal. Always false off Unix, where the interactive
 /// path is not implemented (#1079) — so `exec` there keeps its current
 /// behaviour rather than half-entering a mode it cannot finish.
-fn stdin_is_terminal() -> bool {
+pub(crate) fn stdin_is_terminal() -> bool {
 	#[cfg(unix)]
 	{
 		use std::io::IsTerminal;

--- a/internal/engine/query/exec_interactive.rs
+++ b/internal/engine/query/exec_interactive.rs
@@ -13,12 +13,9 @@
 
 #![cfg(unix)]
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
-use super::terminal::{window_size, RawMode};
 use super::Engine;
 
 impl Engine {
@@ -38,91 +35,10 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 
-		// Raw mode only *after* the exec is known to have started. Enabling it
-		// first would leave a terminal unusable behind a 404.
-		let _raw = RawMode::enable();
-
-		// Size the pty now, not before the start: there is no pty to resize until
-		// the exec has begun, and libpod rejects the call — silently, since a
-		// failed resize is only cosmetic. Sizing it here means a full-screen
-		// program draws correctly from its first frame rather than at libpod's
-		// 80x24 default until the window happens to change.
-		if let Some((rows, cols)) = window_size() {
-			self.resize_exec(exec_id, rows, cols).await;
-		}
-
-		let (mut server_read, mut server_write) = tokio::io::split(hijacked.stream);
-		let mut stdin = tokio::io::stdin();
-		let mut stdout = tokio::io::stdout();
-
-		// Follow the window. libpod has no way to learn the caller's terminal
-		// size on its own, so every SIGWINCH has to be forwarded or a resized
-		// window leaves the remote program drawing at the old geometry.
-		let mut winch =
-			tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
-				.map_err(ComposeError::Io)?;
-
-		let mut to_server = [0u8; 8 * 1024];
-		let mut from_server = [0u8; 32 * 1024];
-
-		loop {
-			tokio::select! {
-				// Output first: a biased select would starve it behind a caller
-				// holding the keyboard down, and seeing the command's output is
-				// the point of being attached.
-				read = server_read.read(&mut from_server) => {
-					match read {
-						Ok(0) => break,
-						Ok(n) => {
-							stdout.write_all(&from_server[..n]).await.map_err(ComposeError::Io)?;
-							stdout.flush().await.map_err(ComposeError::Io)?;
-						}
-						// The command exiting closes this side; that is the
-						// ordinary end of an interactive session, not a failure.
-						Err(_) => break,
-					}
-				}
-				read = stdin.read(&mut to_server) => {
-					match read {
-						// Ctrl-D / a closed stdin: stop writing but keep reading,
-						// so the command can finish and flush. Shutting the write
-						// half is what tells it EOF.
-						Ok(0) => {
-							let _ = server_write.shutdown().await;
-						}
-						Ok(n) => {
-							if server_write.write_all(&to_server[..n]).await.is_err() {
-								break;
-							}
-							if server_write.flush().await.is_err() {
-								break;
-							}
-						}
-						Err(_) => break,
-					}
-				}
-				_ = winch.recv() => {
-					if let Some((rows, cols)) = window_size() {
-						self.resize_exec(exec_id, rows, cols).await;
-					}
-				}
-			}
-		}
-
-		Ok(())
-	}
-
-	/// Tell libpod the pty's new size. Best-effort: a failed resize makes the
-	/// remote program draw at the wrong geometry, which is a cosmetic problem,
-	/// and turning it into a hard error would kill a working session over a
-	/// window drag.
-	async fn resize_exec(&self, exec_id: &str, rows: u16, cols: u16) {
-		let path = format!(
-			"{API_PREFIX}/exec/{}/resize?h={rows}&w={cols}",
-			urlencoded(exec_id),
-		);
-		if let Err(e) = self.client.post_empty_ok(&path).await {
-			tracing::debug!("exec resize to {rows}x{cols} failed: {e}");
-		}
+		// Raw mode, sizing and the byte pump all live in `terminal_pump`, shared
+		// with interactive `run` so the loop that must not get raw mode wrong
+		// exists once.
+		self.pump_terminal(hijacked, &format!("exec/{}", urlencoded(exec_id)))
+			.await
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -16,10 +16,11 @@ mod inspect_util;
 mod log_prefix;
 mod ps;
 #[cfg(unix)]
-mod terminal;
+pub(crate) mod terminal;
 
 pub use ps::{PsFilterOptions, PsOptions};
 
+pub(crate) use exec::stdin_is_terminal;
 pub use exec::ExecOptions;
 use log_prefix::LinePrefixer;
 

--- a/internal/engine/query/terminal.rs
+++ b/internal/engine/query/terminal.rs
@@ -24,7 +24,7 @@ use std::os::fd::AsRawFd;
 /// Holding the original `termios` rather than reconstructing a "sane" one
 /// matters: the caller's shell may have its own settings, and putting the
 /// terminal into what podup thinks is normal would quietly change them.
-pub(super) struct RawMode {
+pub(crate) struct RawMode {
 	fd: i32,
 	original: libc::termios,
 }
@@ -35,7 +35,7 @@ impl RawMode {
 	/// Not being a TTY is the ordinary case for `podup exec` in a script or a
 	/// pipeline, not an error: there is no line discipline to disable, and the
 	/// caller streams bytes as before.
-	pub(super) fn enable() -> Option<Self> {
+	pub(crate) fn enable() -> Option<Self> {
 		Self::enable_on(std::io::stdin().as_raw_fd())
 	}
 
@@ -100,7 +100,7 @@ impl Drop for RawMode {
 /// "not a terminal" while a perfectly good size sits on stdin. Interactivity is
 /// decided by stdin, so the size is asked of stdin too, and stdout is the
 /// fallback for the reverse case.
-pub(super) fn window_size() -> Option<(u16, u16)> {
+pub(crate) fn window_size() -> Option<(u16, u16)> {
 	size_of(std::io::stdin().as_raw_fd()).or_else(|| size_of(std::io::stdout().as_raw_fd()))
 }
 

--- a/internal/engine/terminal_pump.rs
+++ b/internal/engine/terminal_pump.rs
@@ -1,0 +1,113 @@
+//! The bidirectional terminal loop, shared by interactive `exec` and `run`.
+//!
+//! Both hand a hijacked socket to the caller's terminal and pump bytes until the
+//! command ends. They differ only in which libpod object gets resized — an exec
+//! session or a container — so that is the one parameter, and the loop that must
+//! not get raw mode wrong lives once rather than twice.
+
+#![cfg(unix)]
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::client::Hijacked;
+use crate::libpod::API_PREFIX;
+
+use super::query::terminal::{window_size, RawMode};
+use super::Engine;
+
+impl Engine {
+	/// Pump the caller's terminal against a hijacked stream until it ends.
+	///
+	/// `resize_base` is the libpod path segment identifying what to resize —
+	/// `exec/{id}` or `containers/{name}` — since the endpoint differs and
+	/// nothing else does.
+	///
+	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path leaves
+	/// the caller's shell usable. That is the one thing this must not get wrong:
+	/// a terminal left raw has no echo and no line discipline, and the user
+	/// cannot see what they type to fix it.
+	pub(crate) async fn pump_terminal(&self, hijacked: Hijacked, resize_base: &str) -> Result<()> {
+		// Raw mode only *after* the stream is known to be live. Enabling it
+		// first would leave a terminal unusable behind a failed start.
+		let _raw = RawMode::enable();
+
+		// Size the pty now, not before: there is nothing to resize until the
+		// session exists, and libpod rejects the call — silently, since a failed
+		// resize is only cosmetic. Sizing here means a full-screen program draws
+		// correctly from its first frame rather than at libpod's 80x24 default.
+		if let Some((rows, cols)) = window_size() {
+			self.resize_pty(resize_base, rows, cols).await;
+		}
+
+		let (mut server_read, mut server_write) = tokio::io::split(hijacked.stream);
+		let mut stdin = tokio::io::stdin();
+		let mut stdout = tokio::io::stdout();
+
+		// Follow the window. libpod has no way to learn the caller's terminal
+		// size on its own, so every SIGWINCH has to be forwarded or a resized
+		// window leaves the remote program drawing at the old geometry.
+		let mut winch =
+			tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
+				.map_err(ComposeError::Io)?;
+
+		let mut to_server = [0u8; 8 * 1024];
+		let mut from_server = [0u8; 32 * 1024];
+
+		loop {
+			tokio::select! {
+				// Output first: a biased select would starve it behind a caller
+				// holding the keyboard down, and seeing the command's output is
+				// the point of being attached.
+				read = server_read.read(&mut from_server) => {
+					match read {
+						Ok(0) => break,
+						Ok(n) => {
+							stdout.write_all(&from_server[..n]).await.map_err(ComposeError::Io)?;
+							stdout.flush().await.map_err(ComposeError::Io)?;
+						}
+						// The command exiting closes this side; that is the
+						// ordinary end of an interactive session, not a failure.
+						Err(_) => break,
+					}
+				}
+				read = stdin.read(&mut to_server) => {
+					match read {
+						// Ctrl-D / a closed stdin: stop writing but keep reading,
+						// so the command can finish and flush. Shutting the write
+						// half is what tells it EOF.
+						Ok(0) => {
+							let _ = server_write.shutdown().await;
+						}
+						Ok(n) => {
+							if server_write.write_all(&to_server[..n]).await.is_err() {
+								break;
+							}
+							if server_write.flush().await.is_err() {
+								break;
+							}
+						}
+						Err(_) => break,
+					}
+				}
+				_ = winch.recv() => {
+					if let Some((rows, cols)) = window_size() {
+						self.resize_pty(resize_base, rows, cols).await;
+					}
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Tell libpod the pty's new size. Best-effort: a failed resize makes the
+	/// remote program draw at the wrong geometry, which is cosmetic, and turning
+	/// it into a hard error would kill a working session over a window drag.
+	async fn resize_pty(&self, resize_base: &str, rows: u16, cols: u16) {
+		let path = format!("{API_PREFIX}/{resize_base}/resize?h={rows}&w={cols}");
+		if let Err(e) = self.client.post_empty_ok(&path).await {
+			tracing::debug!("resize to {rows}x{cols} failed: {e}");
+		}
+	}
+}

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -22,6 +22,7 @@ mod encode;
 #[cfg(unix)]
 mod hijack;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
+pub(crate) use hijack::Hijacked;
 
 /// The request body every call shares. A boxed body so a fully-buffered
 /// `Full<Bytes>` (almost every call) and a lazily-streamed build-context body

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -22,6 +22,7 @@ mod encode;
 #[cfg(unix)]
 mod hijack;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
+#[cfg(unix)]
 pub(crate) use hijack::Hijacked;
 
 /// The request body every call shares. A boxed body so a fully-buffered

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -556,6 +556,7 @@ async fn run() -> podup::Result<()> {
 		.with_run_overrides(startup::run_overrides_for(&cli.command))
 		.with_run_env_files(cli.env_file.clone())
 		.with_run_labels(startup::run_labels_for(&cli.command))
+		.with_run_no_tty(startup::run_no_tty_for(&cli.command))
 		.with_renew_anon_volumes(renew_anon_volumes);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -177,6 +177,7 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 			volume,
 			publish,
 			interactive,
+			no_tty,
 			no_deps,
 			..
 		} => podup::RunOverrides {
@@ -186,6 +187,7 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 			volumes: volume.clone(),
 			publish: publish.clone(),
 			interactive: *interactive,
+			no_tty: *no_tty,
 			no_deps: *no_deps,
 		},
 		_ => podup::RunOverrides::default(),

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -177,7 +177,6 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 			volume,
 			publish,
 			interactive,
-			no_tty,
 			no_deps,
 			..
 		} => podup::RunOverrides {
@@ -187,11 +186,19 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 			volumes: volume.clone(),
 			publish: publish.clone(),
 			interactive: *interactive,
-			no_tty: *no_tty,
 			no_deps: *no_deps,
 		},
 		_ => podup::RunOverrides::default(),
 	}
+}
+
+/// Whether `run` was given `-T/--no-TTY`.
+///
+/// Carried on the engine rather than on `RunOverrides`, which is public and not
+/// `#[non_exhaustive]` — a new field there is a breaking change, which is what
+/// the semver gate told me when I tried it.
+pub(crate) fn run_no_tty_for(command: &Commands) -> bool {
+	matches!(command, Commands::Run { no_tty, .. } if *no_tty)
 }
 
 /// Extract the `docker compose run -l/--label KEY=VAL` ad-hoc labels for the


### PR DESCRIPTION
`podup run -it app sh` parsed `-i` and `-T` and acted on **neither**: the container got no TTY and no live stdin, so the flags described something that did not happen. This is the half of #1079 that did not ship — #1140 exists precisely so it would not be lost when that issue auto-closed.

### Verified against Podman 5.4.2, in a pty sized 30x110

```
/ # echo RUN-$((8*8))
RUN-64
/ # stty size
30 110
/ # exit 5          -> podup exits 5
```

Plus: `-T` suppresses the pty, `-d` suppresses it, and a pipeline still streams plainly. 160 integration tests pass.

### Attach opens before start

A container that has already run has already printed, and for a one-shot `run` that missed output is often **all** the output there was. `exec` does not have this problem — its container is already up — which is why it can attach and start in one call and this cannot.

`create_and_start` already took a `start` flag, so the split needed no new plumbing.

### `run_service.tty = None` was not an oversight

Its comment recorded a real dependency:

> Force non-TTY so Podman uses multiplexed log framing that `parse_multiplexed` can decode. TTY mode sends raw bytes without the 8-byte header, which would produce garbled output.

That is true, and it is why the interactive path does not use that reader **at all** — it attaches to the raw stream, which is exactly the framing a TTY produces. The two paths are consistent rather than contradictory, and the comment now says so instead of being deleted.

### One loop, not two

The bidirectional pump moved to `terminal_pump`, shared with `exec`. The part that must not get raw mode wrong — restoring the caller's terminal on **every** exit path, panics included — exists once now. A terminal left raw has no echo, and the user cannot see what they type to fix it; that is not code to keep two copies of.

The two callers differ only in which libpod object gets resized, so that is the single parameter. Getting it wrong is also how I found a bug in my own first version: I passed the bare container name where the path segment belonged, the resize 404'd silently (a failed resize is only cosmetic, so it is swallowed), and `stty size` inside the container reported nothing. Caught by asking the container for its size rather than trusting the code.

### Docs

`docs/commands.md` claimed `run` never allocates a pseudo-TTY, in two places. Both corrected. The docs test cannot catch this class — it compares flag **names**, not what they do.

Closes #1140