### PR TITLE
docs: name the Compose Spec in the CLI, not another vendor

### DIFF
--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -192,7 +192,7 @@ pub(crate) enum Commands {
 		#[arg(long = "build-arg")]
 		build_arg: Vec<String>,
 		/// Set the build progress output style (auto, plain, tty); accepted for
-		/// docker-compose compatibility. Validated but inert: podup renders build
+		/// compatibility with other Compose tools. Validated but inert: podup renders build
 		/// output one way.
 		#[arg(long, value_parser = parse_progress)]
 		progress: Option<String>,
@@ -286,8 +286,8 @@ pub(crate) enum Commands {
 		/// container's output but does not attach a live interactive terminal.
 		#[arg(short, long)]
 		interactive: bool,
-		/// No effect; accepted only for docker-compose compatibility. podup never
-		/// allocates a pseudo-TTY.
+		/// Disable pseudo-TTY allocation. `run` allocates one on Unix when stdin
+		/// is a terminal; this opts out, so a script keeps plain streaming.
 		// Both spellings are accepted on purpose: `docker compose run` spells the
 		// long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
 		// A script copied from either one has to work, so each command takes both.
@@ -382,17 +382,16 @@ pub(crate) enum Commands {
 		/// Index of the container when the service has multiple replicas (1-based).
 		#[arg(long)]
 		index: Option<u32>,
-		/// Do not attach STDIN (accepted for docker-compose compatibility; podup
+		/// Do not attach STDIN (accepted for compatibility; podup
 		/// attaches output only).
 		#[arg(long)]
 		no_stdin: bool,
 		/// Proxy received signals to the process (accepted for compatibility).
 		///
-		/// Takes an optional value so both spellings parse: docker declares this
-		/// as a bare boolean, and demanding a value made
-		/// `docker compose attach --sig-proxy web` fail with a usage error
-		/// against podup — inside the set of flags whose entire purpose is that
-		/// such a script runs unchanged.
+		/// Takes an optional value so both spellings parse. Other Compose tools
+		/// declare it as a bare flag, and demanding a value turned a script
+		/// copied from one of them into a usage error — inside the very set of
+		/// flags whose purpose is that such a script runs unchanged.
 		#[arg(
 			long,
 			default_value_t = false,
@@ -422,7 +421,8 @@ pub(crate) enum Commands {
 		/// Author of the new image (e.g. "Name <email>").
 		#[arg(short, long)]
 		author: Option<String>,
-		/// Apply a Dockerfile instruction to the committed image (repeatable).
+		/// Apply a Containerfile instruction to the committed image, e.g.
+		/// `CMD=/bin/sh` or `ENV=KEY=value` (repeatable).
 		#[arg(short = 'c', long = "change")]
 		change: Vec<String>,
 		/// Replica index (1-based) of a scaled service.
@@ -533,8 +533,8 @@ pub(crate) enum Commands {
 		/// Detach: run the command in the background.
 		#[arg(short, long)]
 		detach: bool,
-		/// No effect; accepted only for docker-compose compatibility. podup never
-		/// allocates a pseudo-TTY.
+		/// Disable pseudo-TTY allocation. `exec` allocates one on Unix when stdin
+		/// is a terminal; this opts out, so a script keeps plain streaming.
 		// `docker compose exec` spells the long form `--no-tty`, so that is the
 		// primary here; `--no-TTY` stays accepted so the spelling `run` uses also
 		// works on `exec`. See the note on `run`'s field.
@@ -606,7 +606,7 @@ pub(crate) enum Commands {
 		/// Leave ${VAR} placeholders literal instead of interpolating them.
 		#[arg(long)]
 		no_interpolate: bool,
-		/// Accepted for docker-compose compatibility; podup output is already
+		/// Accepted for compatibility; podup output is already
 		/// normalized.
 		#[arg(long)]
 		no_normalize: bool,
@@ -656,7 +656,7 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		force: bool,
 	},
-	/// Print version information (like `docker compose version`).
+	/// Print version information.
 	Version {
 		/// Print only the version number.
 		#[arg(long)]

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -30,7 +30,7 @@ const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
 #[command(
 	name = "podup",
 	version,
-	about = "Run docker-compose projects on Podman.",
+	about = "Run Compose projects on Podman.",
 	styles = HELP_STYLES,
 	// No subcommand prints help and exits non-zero (like docker compose), and the
 	// built-in `help` is replaced by an explicit `Help` variant that tolerates

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -31,7 +31,7 @@ pub(crate) fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
 }
 
 /// Pull-policy values podup accepts for `up --pull` / `pull --policy`. `always`,
-/// `missing`, `never`, and `build` mirror `docker compose`; `newer` is Podman's
+/// `missing`, `never`, and `build` are the Compose Spec policies; `newer` is Podman's
 /// extension.
 const PULL_POLICIES: [&str; 5] = ["always", "missing", "never", "newer", "build"];
 
@@ -48,7 +48,7 @@ pub(crate) fn parse_pull_policy(value: &str) -> Result<String, String> {
 	}
 }
 
-/// Progress styles `docker compose build --progress` accepts. podup renders build
+/// The progress styles the Compose Spec defines. podup renders build
 /// output one way, so the flag is inert — but an unknown value must still be
 /// rejected rather than accepted and ignored, or a typo silently changes nothing
 /// and reports success.

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -25,7 +25,7 @@ pub(crate) enum EventsFormat {
 	Json,
 }
 
-/// When to colourise human-facing output (`--ansi`, like docker compose).
+/// When to colourise human-facing output (`--ansi`).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum AnsiMode {
 	/// Colour only when writing to a terminal (and `NO_COLOR` is unset).

--- a/tests/docs_flags.rs
+++ b/tests/docs_flags.rs
@@ -160,3 +160,53 @@ fn every_global_flag_is_documented() {
 		missing.join("\n  ")
 	);
 }
+
+/// The CLI names the open standard, not another vendor's product.
+///
+/// `podup` implements the **Compose Spec**, which is a published standard with
+/// its own name — so saying "Compose" is both brand-free and more accurate than
+/// naming a particular implementation of it.
+///
+/// The one allowed exception is a literal filename. `docker-compose.yaml` is
+/// what the file on disk is called, the same way `.gitignore` is, and the `-f`
+/// help has to say which names it probes or it is hiding real behaviour.
+/// Removing it would not remove a brand mention; it would remove a fact.
+///
+/// Compatibility itself is untouched by any of this: it lives in what the flags
+/// do, not in what the help text calls them.
+#[test]
+fn the_cli_help_names_no_other_vendor() {
+	let mut offenders: Vec<String> = Vec::new();
+	let mut check = |label: &str, text: &str| {
+		for line in text.lines() {
+			let lower = line.to_ascii_lowercase();
+			if !lower.contains("docker") {
+				continue;
+			}
+			// Filenames are data, not branding.
+			if lower.contains("docker-compose.yaml") || lower.contains("docker-compose.yml") {
+				continue;
+			}
+			offenders.push(format!("{label}: {}", line.trim()));
+		}
+	};
+
+	let out = Command::new(bin())
+		.arg("--help")
+		.output()
+		.expect("run --help");
+	check("(top level)", &String::from_utf8_lossy(&out.stdout));
+	for cmd in COMMANDS {
+		let out = Command::new(bin())
+			.args([cmd, "--help"])
+			.output()
+			.unwrap_or_else(|e| panic!("run {cmd} --help: {e}"));
+		check(cmd, &String::from_utf8_lossy(&out.stdout));
+	}
+
+	assert!(
+		offenders.is_empty(),
+		"the CLI help should name the Compose Spec, not a vendor:\n  {}",
+		offenders.join("\n  ")
+	);
+}


### PR DESCRIPTION
podup's help mentioned another vendor's product **thirteen times**. It implements the **Compose Spec** — a published standard with its own name — so saying "Compose" is both brand-free and *more accurate* than naming one particular implementation of it.

```
Run docker-compose projects on Podman.   ->   Run Compose projects on Podman.
```

### Compatibility is untouched

It lives in what the flags **do**, not in what the help calls them. Verified after the change:

| | |
|---|---|
| `docker-compose.yml` picked up with no `-f` | ✅ |
| `-T`, `--no-normalize`, `--progress` parse | ✅ |
| `DOCKER_HOST` | ✅ |
| `COMPOSE_FILE`, `COMPOSE_PROJECT_NAME` | ✅ |

The entire diff is doc comments apart from **one** line of code — the `about` string.

### One mention stays, and it is not branding

The `-f` help lists the filenames probed when none is given, and `docker-compose.yaml` is what the file on disk is *called* — the same way `.gitignore` is. Dropping it would not remove a brand mention; it would hide which files podup opens.

### Two of the thirteen were also false

`run --help` and `exec --help` still said:

> No effect; accepted only for compatibility. podup never allocates a pseudo-TTY.

That stopped being true when both gained one (#1079, #1140). The help was contradicting the feature it shipped alongside — a stale claim the docs test cannot catch, since it compares flag *names*. They now describe what the flag does.

`--change` asks for a **Containerfile** instruction, which is also the right name in a Podman-native tool, and now carries an example.

### The regression test was itself checked

It reads the printed help of the top level and all twenty-nine subcommands, excepting the filename case explicitly.

Worth recording that my **first** version of it passed while a brand mention was deliberately reintroduced — because I had reintroduced it into a doc comment that is never printed. Sabotaging a string that *is* printed made it fail as it should. A test that cannot fail is not a test, and the only way to know which kind you have is to try to break it.