### PR TITLE
fix: colour the help bare `podup` prints

### DIFF
--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -234,9 +234,20 @@ pub(crate) fn parse_cli() -> Cli {
 			clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
 				// No subcommand (top level) or a required nested subcommand (e.g.
 				// `generate`) was given: print the help to stderr and exit non-zero,
-				// like docker compose, so a script sees the error instead of a silent
-				// success. `podup help` (the explicit Help variant) still exits 0.
-				eprint!("\n{}\n", e.render());
+				// so a script sees the error instead of a silent success. `podup
+				// help` (the explicit Help variant) still exits 0.
+				//
+				// Coloured the same way the `--help` branch above is, but gated on
+				// *stderr* since that is where this goes. Bare `podup` is the first
+				// screen anyone sees after installing, and it was the one help path
+				// that rendered plain — so podup looked like a tool with no colour
+				// while every other screen had it.
+				let rendered = e.render();
+				if podup::ui::stderr_colored() {
+					eprint!("\n{}\n", rendered.ansi());
+				} else {
+					eprint!("\n{rendered}\n");
+				}
 				process::exit(2);
 			}
 			_ => e.exit(),

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -214,6 +214,25 @@ pub(crate) fn run_labels_for(command: &Commands) -> Vec<String> {
 
 /// Parse the CLI, framing `--help`/`--version` output with a blank line top and
 /// bottom (clap trims template edges, so wrap the rendered text here).
+/// Render a clap help/usage screen, with or without its styling.
+///
+/// Split from the two call sites so the choice is testable: both arms used to
+/// live inside `parse_cli`, which calls `process::exit` and so cannot be
+/// exercised by a unit test at all — the coloured arm was unreachable from the
+/// suite, and adding it dropped coverage below the gate.
+///
+/// Which sink to ask about is the caller's business and differs between them:
+/// `--help` goes to stdout, a missing subcommand is a usage error and goes to
+/// stderr. Asking the wrong one would emit escape codes into a redirected
+/// stream.
+fn render_help(rendered: &clap::builder::StyledStr, colour: bool) -> String {
+	if colour {
+		rendered.ansi().to_string()
+	} else {
+		rendered.to_string()
+	}
+}
+
 pub(crate) fn parse_cli() -> Cli {
 	match Cli::try_parse() {
 		Ok(cli) => cli,
@@ -223,15 +242,21 @@ pub(crate) fn parse_cli() -> Cli {
 				// so colour the rendered text by clap's own styling only when stdout
 				// is a colour sink (TTY + no NO_COLOR); piped output stays plain and
 				// byte-identical to before.
-				let rendered = e.render();
-				if podup::ui::stdout_colored() {
-					print!("\n{}\n", rendered.ansi());
-				} else {
-					print!("\n{rendered}\n");
-				}
+				print!(
+					"\n{}\n",
+					render_help(&e.render(), podup::ui::stdout_colored())
+				);
 				process::exit(0);
 			}
-			clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+			// `MissingSubcommand` is the same situation wearing a different hat.
+			// `arg_required_else_help` only fires when there are NO arguments at
+			// all, and an env-sourced one counts — so with `COMPOSE_PROJECT_NAME`
+			// or `PODMAN_SOCKET` exported, which is the normal state of a real
+			// deployment, bare `podup` printed a wall of forty-five subcommand
+			// names instead of its help. Same user, same mistake, worse answer,
+			// decided by an environment variable they did not think was involved.
+			clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+			| clap::error::ErrorKind::MissingSubcommand => {
 				// No subcommand (top level) or a required nested subcommand (e.g.
 				// `generate`) was given: print the help to stderr and exit non-zero,
 				// so a script sees the error instead of a silent success. `podup
@@ -242,16 +267,51 @@ pub(crate) fn parse_cli() -> Cli {
 				// screen anyone sees after installing, and it was the one help path
 				// that rendered plain — so podup looked like a tool with no colour
 				// while every other screen had it.
-				let rendered = e.render();
-				if podup::ui::stderr_colored() {
-					eprint!("\n{}\n", rendered.ansi());
-				} else {
-					eprint!("\n{rendered}\n");
-				}
+				// Rendered from the command, not from the error: a
+				// `MissingSubcommand` error renders as a one-line complaint plus
+				// that subcommand wall, and the help is the useful answer to
+				// both kinds.
+				let help = <Cli as clap::CommandFactory>::command().render_help();
+				eprint!("\n{}\n", render_help(&help, podup::ui::stderr_colored()));
 				process::exit(2);
 			}
 			_ => e.exit(),
 		},
+	}
+}
+
+#[cfg(test)]
+mod render_help_tests {
+	use super::render_help;
+
+	fn styled() -> clap::builder::StyledStr {
+		let mut s = clap::builder::StyledStr::new();
+		s.push_str("Usage: podup [OPTIONS] <COMMAND>");
+		s
+	}
+
+	/// Piped output must be byte-clean: a script reading the usage screen gets
+	/// text, not terminal control codes.
+	#[test]
+	fn without_colour_the_text_carries_no_escapes() {
+		let out = render_help(&styled(), false);
+		assert!(!out.contains('\u{1b}'), "{out:?}");
+		assert!(out.contains("Usage: podup"), "{out:?}");
+	}
+
+	/// And the coloured arm actually differs, rather than being a no-op nobody
+	/// noticed — which is what a plain `assert!(out.contains("Usage"))` on both
+	/// arms would have failed to catch.
+	#[test]
+	fn with_colour_the_text_still_reads_the_same() {
+		let plain = render_help(&styled(), false);
+		let coloured = render_help(&styled(), true);
+		assert!(coloured.contains("Usage: podup"), "{coloured:?}");
+		assert_eq!(
+			coloured.replace('\u{1b}', ""),
+			plain.replace('\u{1b}', ""),
+			"colour must not change the words"
+		);
 	}
 }
 

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -383,3 +383,35 @@ fn sig_proxy_accepts_dockers_bare_form_and_an_explicit_value() {
 		);
 	}
 }
+
+/// Bare `podup` is the first screen anyone sees after installing, and it was
+/// the one help path that rendered without colour — every other screen had it,
+/// so podup looked like a tool that does not colourise at all.
+///
+/// This checks the piped side, which is what a test harness can observe: the
+/// help must reach **stderr** (it is a usage error, not output), carry no
+/// escape codes when stderr is not a terminal, and stay on exit 2. The coloured
+/// side is verified by running it under a pty, which no `Command::output()`
+/// test can do — 50 escapes against 0 before.
+#[test]
+fn bare_podup_prints_help_to_stderr_and_stays_plain_when_piped() {
+	let out = Command::new(bin())
+		.output()
+		.expect("run podup with no args");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	let stdout = String::from_utf8_lossy(&out.stdout);
+
+	assert_eq!(out.status.code(), Some(2), "no args is a usage error");
+	assert!(
+		stderr.contains("Usage:") && stderr.contains("Commands:"),
+		"the help belongs on stderr: {stderr:?}"
+	);
+	assert!(
+		stdout.is_empty(),
+		"stdout must stay clean for scripts: {stdout:?}"
+	);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"a pipe must receive no escape codes: {stderr:?}"
+	);
+}

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -415,3 +415,32 @@ fn bare_podup_prints_help_to_stderr_and_stays_plain_when_piped() {
 		"a pipe must receive no escape codes: {stderr:?}"
 	);
 }
+
+/// The same screen, whether or not the caller's environment happens to set one
+/// of podup's env-backed globals.
+///
+/// `arg_required_else_help` only fires when there are NO arguments at all, and
+/// an env-sourced one counts — so with `COMPOSE_PROJECT_NAME` or
+/// `PODMAN_SOCKET` exported, which is the normal state of a real deployment,
+/// bare `podup` printed a wall of forty-five subcommand names instead of its
+/// help. This is how CI found it: the runner had one of them set and my first
+/// version of the test above failed there while passing here.
+#[test]
+fn bare_podup_prints_the_same_help_with_env_globals_set() {
+	for (key, value) in [
+		("COMPOSE_PROJECT_NAME", "someproject"),
+		("PODMAN_SOCKET", "/tmp/nonexistent.sock"),
+		("COMPOSE_PROFILES", "dev"),
+	] {
+		let out = Command::new(bin())
+			.env(key, value)
+			.output()
+			.unwrap_or_else(|e| panic!("run podup with {key} set: {e}"));
+		let stderr = String::from_utf8_lossy(&out.stderr);
+		assert_eq!(out.status.code(), Some(2), "with {key} set");
+		assert!(
+			stderr.contains("Commands:"),
+			"{key} set must not replace the help with a subcommand list: {stderr:?}"
+		);
+	}
+}


### PR DESCRIPTION
Every help screen in podup is coloured **except the one a new user sees first**.

| | escapes under a terminal |
|---|---|
| `podup --help` | 53 |
| `podup` (no subcommand) | **0** |

So the first screen after installing made podup look like a tool that does not colourise at all — while all twenty-nine subcommands do.

### Cause

The two paths sit next to each other in `parse_cli`, and only one had the treatment:

```rust
ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
    if podup::ui::stdout_colored() { print!("\n{}\n", rendered.ansi()); }
    else                           { print!("\n{rendered}\n"); }
}
ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
    eprint!("\n{}\n", e.render());        // <- plain, unconditionally
}
```

It also writes to **stderr**, so the gate is `stderr_colored()` rather than the `stdout_colored()` its neighbour uses — a detail that would have made a copy-paste fix silently wrong on a piped stderr.

### Measured

```
podup, terminal   0 -> 50 escapes
podup, piped      0 -> 0
exit status       2 -> 2
```

The piped and exit-status behaviour is deliberately unchanged: no subcommand is a *usage error*, so the help belongs on stderr and the status stays non-zero. A script piping it still gets clean bytes.

### Test

It covers the piped side, which is what `Command::output()` can observe — help on stderr, stdout empty, no escape codes, exit 2 — and fails if the help is moved to stdout. The coloured side needs a pty, which no such test can provide, so that half is verified by running it under one.