### PR TITLE
fix: require a terminal on both ends, and bump to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,50 @@
+podup (2.1.0) unstable; urgency=medium
+
+  New
+
+  * run allocates a pseudo-TTY and attaches stdin on Unix when stdin is a
+    terminal, so `podup run -it app sh` is an interactive session that follows
+    the window size. `-T` opts out and `-d` never allocates one. It engages only
+    when stdin is a terminal, so a script or a pipeline keeps the streaming
+    behaviour it had. Windows is unchanged.
+
+  Fixes
+
+  * A connection failure now names the socket it tried and separates "not
+    listening" from "cannot be opened", instead of a bare `No such file or
+    directory (os error 2)`. A fresh rootless account had nothing to act on:
+    podman is daemonless and works there, so nothing looks wrong until every
+    podup command fails. The socket prerequisite is documented now too, in the
+    README and in the autostart guide.
+  * `podup` with no subcommand printed a list of forty-five subcommand names
+    instead of its help whenever COMPOSE_PROJECT_NAME, PODMAN_SOCKET or
+    COMPOSE_PROFILES was set — the normal state of a deployment. Both cases
+    print the help now.
+  * That help is also coloured, like every other screen. It was the only one
+    that was not.
+  * A sub-second healthcheck interval is honoured instead of being discarded
+    and replaced by the 2s default, which made `interval: 200ms` poll more
+    slowly than the 1s nobody asked for. Measured on a service healthy at
+    ~400ms: 2406ms before, 806ms after. Values below 100ms are raised to that
+    floor, since running a check executes a command inside the container.
+  * While waiting on a service_healthy gate, the container's health status is
+    read every 150ms between check runs. Reading runs no command, so this costs
+    a request rather than container work, and it is what notices promptly when
+    Podman's own timer flips the status between podup's runs.
+  * A container that fails during such a wait is now reported as soon as it is
+    seen, instead of exhausting the whole budget and reporting a timeout.
+
+  Other
+
+  * The CLI names the Compose Spec rather than another vendor's product. No
+    behaviour changes: the same files are read, the same flags accepted, and
+    DOCKER_HOST, COMPOSE_FILE and COMPOSE_PROJECT_NAME are all still honoured.
+  * `run --help` and `exec --help` said podup never allocates a pseudo-TTY,
+    which stopped being true when both gained one.
+  * Library API: Engine::with_run_no_tty carries the `run -T` flag, additive.
+
+ -- Glyndor <packages@glyndor.net>  Tue, 21 Jul 2026 09:30:00 -0500
+
 podup (2.0.0) unstable; urgency=medium
 
   Breaking changes

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -221,7 +221,7 @@ Run a one-off command in a new container for the service.
 | `--entrypoint <CMD>` | Override the image entrypoint. | image default |
 | `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
 | `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
-| `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
+| `-i, --interactive` | Keep the container's STDIN open (`stdin_open`). Whether a live terminal is attached is decided by stdin/stdout being terminals and by `-T`, not by this flag. | off |
 | `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation. | off |
 | `--no-deps` | Do not start the `depends_on` services before running. | off |
 
@@ -240,16 +240,23 @@ follows your window size. Like `docker compose run`, a TTY on both ends is the
 default and `-T` is how you turn it off; `-d` never allocates one, since there
 is nobody to be interactive with.
 
-It engages **only** when stdin is a terminal, so a script or a pipeline keeps
-the plain streaming behaviour with no change to output framing:
+It engages **only** when *both* stdin and stdout are terminals, so a script, a
+pipeline or a redirect keeps the plain streaming behaviour with no change to
+output framing:
 
 ```bash
-podup run --rm app echo hola > salida.txt   # streams, no TTY
-podup run --rm -T app ./migrar.sh           # streams, no TTY
+podup run --rm app echo hola > salida.txt   # stdout is a file  -> streams, no TTY
+echo x | podup run --rm app ./migrar.sh     # stdin is a pipe   -> streams, no TTY
+podup run --rm -T app ./migrar.sh           # -T                -> streams, no TTY
 ```
 
+Requiring stdout matters because a pty **merges stdout and stderr and writes
+CRLF**. Checking stdin alone would mean `podup run app cmd > out.txt`, typed at
+a shell, silently wrote different bytes into that file than the same command in
+a script.
+
 Windows keeps the streaming behaviour in every case
-([#1140](https://github.com/Glyndor/podup/issues/1140)).
+([#1154](https://github.com/Glyndor/podup/issues/1154)).
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
@@ -529,6 +536,28 @@ file still runs there — it just does not act on the extra.
 | Key | Where | What it does |
 |---|---|---|
 | `x-podman-on-failure` | under a service's `healthcheck:` | `none`, `kill`, `restart` or `stop` — what Podman does when the check flips to unhealthy. Default `none`. |
+
+### Healthcheck timing on a `service_healthy` gate
+
+When `up` waits on `depends_on: {condition: service_healthy}`, podup drives the
+check itself — Podman schedules its own runs through systemd transient timers,
+which never fire on a host without systemd, so a purely passive wait would block
+until the whole budget elapsed.
+
+| | |
+|---|---|
+| how often the check is **run** | the healthcheck's `interval`, floored at **100ms** |
+| how often the status is **read** | every 150ms |
+| how long the wait lasts | `interval × retries` plus `start_period`, extended by `--wait-timeout` |
+
+Running a check executes a command *inside* the container, so it happens no
+faster than `interval` and the floor keeps `interval: 1ms` from becoming a
+thousand executions a second. Reading the status is a plain inspect — it runs no
+command — so it is cheap and frequent, and it is what notices promptly when
+Podman's own timer flips the status between podup's runs.
+
+A container that fails during the wait is reported as soon as the next read sees
+it, rather than at the end of the budget.
 
 Without it, a compose healthcheck detects a sick container and does nothing
 about it: a restart policy reacts to the process *exiting*, not to the container

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -282,8 +282,9 @@ pub(crate) enum Commands {
 		/// Publish an extra port (HOST:CONTAINER[/PROTO]); repeatable.
 		#[arg(short = 'p', long = "publish")]
 		publish: Vec<String>,
-		/// Keep the container's STDIN open (sets `stdin_open`). `run` streams the
-		/// container's output but does not attach a live interactive terminal.
+		/// Keep the container's STDIN open (sets `stdin_open`). Whether a live
+		/// terminal is attached is decided by stdin and stdout both being
+		/// terminals, and by `-T` — not by this flag.
 		#[arg(short, long)]
 		interactive: bool,
 		/// Disable pseudo-TTY allocation. `run` allocates one on Unix when stdin

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -17,13 +17,29 @@ pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
 /// Whether `run` should allocate a pseudo-TTY and attach stdin.
 ///
-/// The same rule `exec` uses, kept in one place so the two cannot drift: a TTY
-/// on both ends by default, `-T` to opt out, `-d` excluded because there is
-/// nobody to be interactive with, and only when stdin is genuinely a terminal —
-/// which is what keeps every existing script and pipeline on the unchanged
-/// streaming path.
+/// A TTY on both ends by default, `-T` to opt out, `-d` excluded because there
+/// is nobody to be interactive with — and **both** stdin and stdout must be
+/// terminals.
+///
+/// Requiring stdout too is not symmetry for its own sake. A pty merges stdout
+/// and stderr and emits CRLF, so `podup run app cmd > out.txt` typed at a shell
+/// — stdin still a terminal, stdout a file — would have written pty bytes with
+/// stderr folded in, where it used to write clean demultiplexed output. That is
+/// the most common redirect there is, and `docker compose` keeps it clean
+/// (measured). Checking stdin alone silently changed the format of a file.
 pub(crate) fn wants_interactive_run(no_tty: bool, detach: bool) -> bool {
-	!no_tty && !detach && query::stdin_is_terminal()
+	wants_interactive_with(
+		no_tty,
+		detach,
+		query::stdin_is_terminal(),
+		query::stdout_is_terminal(),
+	)
+}
+
+/// The decision with the environment passed in, so both terminal cases are
+/// testable rather than depending on how the suite happened to be invoked.
+fn wants_interactive_with(no_tty: bool, detach: bool, stdin_tty: bool, stdout_tty: bool) -> bool {
+	!no_tty && !detach && stdin_tty && stdout_tty
 }
 
 pub use query::{
@@ -564,5 +580,17 @@ mod interactive_run_tests {
 	#[test]
 	fn a_non_terminal_stdin_stays_on_the_streaming_path() {
 		assert!(!wants_interactive_run(false, false));
+	}
+
+	/// Both ends are required, and this is the case that made it necessary:
+	/// `podup run app cmd > out.txt` typed at a shell leaves stdin a terminal
+	/// while stdout is a file. Checking stdin alone allocated a pty, and a pty
+	/// merges stdout with stderr and writes CRLF — so the redirect silently
+	/// changed the bytes the file received. Verified against `docker compose`,
+	/// which keeps it clean.
+	#[test]
+	fn a_redirected_stdout_stays_on_the_streaming_path() {
+		assert!(!super::wants_interactive_with(false, false, true, false));
+		assert!(super::wants_interactive_with(false, false, true, true));
 	}
 }

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -364,7 +364,12 @@ impl Engine {
 /// Pure except for the `isatty` probe, which is behind `stdin_is_terminal` so
 /// the decision itself is unit-testable.
 fn interactive_exec(opts: &ExecOptions) -> bool {
-	wants_interactive(opts, stdin_is_terminal())
+	// Both ends, not just stdin. A pty merges stdout and stderr and writes
+	// CRLF, so `podup exec db psql > out.txt` typed at a shell — stdin still a
+	// terminal, stdout a file — wrote pty bytes with stderr folded in where it
+	// used to write clean demultiplexed output. Measured against
+	// `docker compose`, which keeps that redirect clean.
+	wants_interactive(opts, stdin_is_terminal() && stdout_is_terminal())
 }
 
 /// The decision itself, with the environment passed in.
@@ -378,6 +383,23 @@ fn wants_interactive(opts: &ExecOptions, stdin_is_tty: bool) -> bool {
 /// Whether stdin is a terminal. Always false off Unix, where the interactive
 /// path is not implemented (#1079) — so `exec` there keeps its current
 /// behaviour rather than half-entering a mode it cannot finish.
+/// Whether stdout is a terminal.
+///
+/// A pty merges stdout and stderr and writes CRLF, so allocating one when
+/// stdout is redirected changes the bytes a file receives. Asked alongside
+/// stdin, never instead of it.
+pub(crate) fn stdout_is_terminal() -> bool {
+	#[cfg(unix)]
+	{
+		use std::io::IsTerminal;
+		std::io::stdout().is_terminal()
+	}
+	#[cfg(not(unix))]
+	{
+		false
+	}
+}
+
 pub(crate) fn stdin_is_terminal() -> bool {
 	#[cfg(unix)]
 	{

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -20,8 +20,8 @@ pub(crate) mod terminal;
 
 pub use ps::{PsFilterOptions, PsOptions};
 
-pub(crate) use exec::stdin_is_terminal;
 pub use exec::ExecOptions;
+pub(crate) use exec::{stdin_is_terminal, stdout_is_terminal};
 use log_prefix::LinePrefixer;
 
 pub use inspect::AttachOutcome;


### PR DESCRIPTION
A pre-release check came back **NO-GO**. The serious finding was a regression I had introduced — and then written documentation asserting the opposite of.

### `podup run app cmd > out.txt` typed at a shell allocated a pty

The gate asked only whether **stdin** was a terminal, and redirecting stdout does not change stdin. A pty merges stdout with stderr and writes CRLF, so that file received different bytes than the same command in a script:

```
before          salida-normal^M      <- CRLF
                salida-error^M       <- stderr folded into stdout
docker compose  salida-normal        <- clean
after           salida-normal        <- clean
```

**`exec` had the same defect, and it shipped in 2.0.0.** I found it by checking whether the pattern repeated, not because anyone hit it.

Both require stdin **and** stdout to be terminals now, measured against `docker compose` on the same socket. Interactive use is untouched — a real terminal still gets the pty, the window size (`stty size` → `30 110`) and the exit code.

The decision moved behind `wants_interactive_with(no_tty, detach, stdin_tty, stdout_tty)`, so the redirect case is a unit test rather than something that depends on how the suite happened to be invoked.

### Three documentation blockers, all 2.0.0's shape again

- **`-i/--interactive` was still described as inert**, in `docs/commands.md:224` and in the flag's own help. I fixed exactly this for `-T` in the same series and left `-i` saying `run` "still streams logs".
- **The example written to document the change asserted the broken behaviour** — `podup run --rm app echo hola > salida.txt   # streams, no TTY`. It is true now, and the text says *why* both ends are required.
- **Healthcheck timing was undocumented** beyond the sub-second interval: the 100ms run floor, the 150ms status read, and a container failing mid-wait now being reported at once instead of exhausting the budget. Three user-visible changes, none of them in `docs/` or the changelog.

### `Closes #1140` would have closed half an issue, again

Which is the exact failure #1140 was filed to prevent when #1079 did it. `run -it` on Unix shipped; Windows did not, for either command. That is now **#1154**, and `docs/commands.md` points there rather than at an issue about to close.

### 2.1.0, not 2.0.1

`run -it` is new behaviour and `Engine::with_run_no_tty` is new public API. `cargo-semver-checks` agrees: `2.0.0 -> 2.1.0 (minor change), no semver update required`. All three version files move together — `Cargo.toml`, `Cargo.lock`, `debian/changelog` — and `dpkg-parsechangelog` validates the entry.

1331 lib tests, 69 bin, 18 CLI, 160 integration, clippy and rustdoc clean.