### PR TITLE
Release 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ The installer verifies the keyring package's Ed25519 signature against its
 pinned release key before anything is installed (fail-closed). The keyring
 package registers `https://apt.glyndor.net` and ships the signing key, so podup
 updates (and key renewals) arrive through `apt upgrade`. The apt build omits
-self-update, since apt owns upgrades. Requires **Podman ≥ 5.0** (rootless).
+self-update, since apt owns upgrades. Requires **Podman ≥ 5.0** (rootless) with
+its **API socket listening** — `podman` itself is daemonless, but podup speaks
+the libpod API:
+
+```bash
+systemctl --user enable --now podman.socket
+```
 
 To register the repository by hand instead, fetch the keyring and check the
 key's fingerprint against the one published in the

--- a/bench/aggregate.py
+++ b/bench/aggregate.py
@@ -20,14 +20,19 @@ RAW = os.path.join(HERE, "results", "raw.csv")
 MD = os.path.join(HERE, "results", "report.md")
 JSON = os.path.join(HERE, "results", "summary.json")
 
+# Preferred ordering only. Anything measured but not listed here is appended
+# rather than dropped: this list silently discarded four scenarios' worth of
+# results (config-heavy, wide-running-ops, deep-chain, wide-level) because it was
+# a filter, not an order — 972 rows measured, four scenarios never printed.
 SCEN_ORDER = [
-	"single", "multi-healthcheck", "scale", "network-ipam", "volume-heavy",
-	"warm-restart", "many-services", "running-ops", "build",
+	"single", "multi-healthcheck", "deep-chain", "wide-level", "scale",
+	"network-ipam", "volume-heavy", "warm-restart", "many-services",
+	"running-ops", "wide-running-ops", "config-heavy", "build",
 ]
-OP_ORDER = ["up", "reup", "down", "ps", "logs", "exec", "restart", "build"]
+OP_ORDER = ["up", "reup", "down", "config", "ps", "logs", "exec", "restart", "build"]
 OP_LABEL = {
 	"up": "up", "down": "down", "reup": "warm up", "ps": "ps", "logs": "logs",
-	"exec": "exec", "restart": "restart", "build": "build",
+	"exec": "exec", "restart": "restart", "build": "build", "config": "config",
 }
 
 # Inline sample rows, shaped exactly like raw.csv, for `--self-test`. bench/results/
@@ -86,7 +91,13 @@ def main():
 			return 1
 		rows = load(RAW)
 	tools = sorted({r["tool"] for r in rows})
-	scenarios = [s for s in SCEN_ORDER if any(r["scenario"] == s for r in rows)]
+	measured = {r["scenario"] for r in rows}
+	# Ordered by preference, then anything else that was measured. A scenario
+	# absent from SCEN_ORDER used to vanish from the report with no warning,
+	# which is worse than an ugly order: the run costs half an hour and the
+	# missing rows look like they were never measured.
+	scenarios = [s for s in SCEN_ORDER if s in measured]
+	scenarios += sorted(measured - set(scenarios))
 
 	# summary[tool][scenario][op] = {seconds:..., rss_mib:..., cpu_s:...}
 	summary = {}
@@ -107,8 +118,17 @@ def main():
 	with open(JSON, "w") as f:
 		json.dump(summary, f, indent="\t", sort_keys=True)
 
+	# Which engine docker-compose drove decides which table it belongs in, and
+	# that is a property of the RUN, not of the tool's name. run.sh records it;
+	# assuming "docker-compose means dockerd" printed a same-engine measurement
+	# under a heading that said "different daemon", which is the report saying
+	# the opposite of what happened.
+	dc_engine = os.environ.get("BENCH_DOCKER_ENGINE", "")
+	dc_same = dc_engine == "podman"
 	same = [t for t in tools if t in ("podup", "podman-compose")]
-	cross = [t for t in tools if t == "docker-compose"]
+	if dc_same:
+		same += [t for t in tools if t == "docker-compose"]
+	cross = [] if dc_same else [t for t in tools if t == "docker-compose"]
 	lines = []
 
 	def metric_table(title, intro, cols, fmt):
@@ -144,12 +164,14 @@ def main():
 				 "same compose file per scenario.\n")
 
 	metric_table(
-		"Wall-clock — pure tool comparison (both drive Podman)",
+		"Wall-clock — pure tool comparison (all drive Podman)",
 		"Seconds, lower is better. Median with p95 and stdev in parentheses. "
-		"Identical engine, only the compose tool differs.",
+		"Identical engine, so the only difference is the compose tool. "
+		"docker-compose appears here when it was pointed at the Podman socket "
+		"rather than at a Docker daemon.",
 		same, wall)
 	metric_table(
-		"Memory + CPU — pure tool comparison (both drive Podman)",
+		"Memory + CPU — pure tool comparison (all drive Podman)",
 		"Peak resident memory (max RSS) and CPU time of the tool process per "
 		"command, median. This is the client-side cost of running the tool: "
 		"podup is a static binary talking to the Podman service, podman-compose "
@@ -161,9 +183,9 @@ def main():
 		"comparison, not pure-tool. Only present when a Docker Engine was "
 		"available on the benchmark host.",
 		cross, wall)
-	if not cross:
-		lines.append("> docker-compose was not measured on this host (no Docker "
-					 "Engine available); the cross-engine comparison is left blank "
+	if not cross and not dc_same:
+		lines.append("> docker-compose was not measured against a Docker daemon "
+					 "on this host, so the cross-engine comparison is left blank "
 					 "rather than estimated.\n")
 
 	with open(MD, "w") as f:

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -53,29 +53,53 @@ mkdir -p "$OUT_DIR"
 #   reup    : time a warm second `up -d`
 #   running : bring up untimed, then time `ps`, `logs`, `exec -T`, `restart`
 #   build   : time `build --no-cache`
-SCENARIOS=(single multi-healthcheck deep-chain wide-level scale network-ipam volume-heavy warm-restart many-services running-ops build)
+SCENARIOS=(single multi-healthcheck deep-chain wide-level scale network-ipam volume-heavy warm-restart many-services running-ops wide-running-ops config-heavy build)
 declare -A OP=(
 	[single]=updown [multi-healthcheck]=updown [scale]=scale
 	[network-ipam]=updown [volume-heavy]=updown [warm-restart]=reup
 	[many-services]=updown [running-ops]=running [build]=build
+	[config-heavy]=parse [wide-running-ops]=running
 )
 if [ "$SMOKE" -eq 1 ]; then SCENARIOS=(single running-ops); fi
 
 TOOLS=(podup podman-compose)
-if docker info >/dev/null 2>&1 && command -v docker-compose >/dev/null 2>&1; then
-	TOOLS+=(docker-compose)
-	echo "note: Docker Engine present — including docker-compose as a labelled cross-engine run."
+# docker compose is the tool podup targets for parity, so it is the comparison
+# that matters most — but WHICH engine it drives changes what the numbers mean.
+#
+#   against Podman  a pure tool comparison: same engine, so the difference is
+#                   the orchestrator and nothing else. This is the fair one, and
+#                   it needs no Docker installed — only DOCKER_HOST pointed at
+#                   the Podman socket.
+#   against dockerd a whole-stack comparison: engine differences are folded in,
+#                   so it cannot be read as "tool A is faster than tool B".
+#
+# Both are reported; the label says which, because a reader seeing
+# "docker-compose" will assume dockerd.
+if command -v docker-compose >/dev/null 2>&1; then
+	if docker info >/dev/null 2>&1; then
+		TOOLS+=(docker-compose)
+		echo "note: Docker Engine present — docker-compose measured as a CROSS-ENGINE (whole-stack) run."
+	elif [ -n "${DOCKER_HOST:-}" ] && docker-compose ls >/dev/null 2>&1; then
+		TOOLS+=(docker-compose)
+		echo "note: docker-compose driving Podman via DOCKER_HOST — measured as a SAME-ENGINE (pure tool) run."
+	else
+		echo "note: docker-compose found but no reachable engine — NOT measured. Set DOCKER_HOST to the Podman socket to include it."
+	fi
 else
-	echo "note: no Docker Engine on this host — docker-compose (cross-engine) is NOT measured."
+	echo "note: docker-compose not installed — NOT measured."
 fi
 
 run() { # tool, compose-file, project, op-args...
 	local tool="$1" file="$2" proj="$3"; shift 3
 	local pre=(); [ -n "$CORES" ] && pre=(taskset -c "$CORES")
+	# `file` may name several compose files separated by spaces, so a scenario can
+	# exercise the base+override merge every real project has. One name yields one
+	# -f, exactly as before.
+	local fargs=(); local f; for f in $file; do fargs+=(-f "$f"); done
 	case "$tool" in
-		podup)          "${pre[@]}" "$PODUP_BIN" -f "$file" -p "$proj" "$@" ;;
-		podman-compose) "${pre[@]}" podman-compose -f "$file" -p "$proj" "$@" ;;
-		docker-compose) "${pre[@]}" docker-compose -f "$file" -p "$proj" "$@" ;;
+		podup)          "${pre[@]}" "$PODUP_BIN" "${fargs[@]}" -p "$proj" "$@" ;;
+		podman-compose) "${pre[@]}" podman-compose "${fargs[@]}" -p "$proj" "$@" ;;
+		docker-compose) "${pre[@]}" docker-compose "${fargs[@]}" -p "$proj" "$@" ;;
 	esac
 }
 
@@ -84,10 +108,11 @@ run() { # tool, compose-file, project, op-args...
 timed() { # tool, compose-file, project, op-args...
 	local tool="$1" file="$2" proj="$3"; shift 3
 	local cmd=(); [ -n "$CORES" ] && cmd=(taskset -c "$CORES")
+	local fargs=(); local f; for f in $file; do fargs+=(-f "$f"); done
 	case "$tool" in
-		podup)          cmd+=("$PODUP_BIN" -f "$file" -p "$proj" "$@") ;;
-		podman-compose) cmd+=(podman-compose -f "$file" -p "$proj" "$@") ;;
-		docker-compose) cmd+=(docker-compose -f "$file" -p "$proj" "$@") ;;
+		podup)          cmd+=("$PODUP_BIN" "${fargs[@]}" -p "$proj" "$@") ;;
+		podman-compose) cmd+=(podman-compose "${fargs[@]}" -p "$proj" "$@") ;;
+		docker-compose) cmd+=(docker-compose "${fargs[@]}" -p "$proj" "$@") ;;
 	esac
 	local tf; tf="$(mktemp)"
 	LC_ALL=C "$TIME_BIN" -v "${cmd[@]}" >/dev/null 2>"$tf"
@@ -118,6 +143,12 @@ echo "tool,scenario,op,iter,phase,seconds,max_rss_kb,cpu_s,rc" > "$RAW"
 for tool in "${TOOLS[@]}"; do
 	for scen in "${SCENARIOS[@]}"; do
 		file="$SCEN_DIR/$scen/compose.yaml"
+		# A scenario may ship an override alongside its base file; merging the two
+		# is what real projects do and what no single-file scenario can measure.
+		# Passed explicitly rather than relying on auto-discovery, since the tools
+		# disagree about that and this must compare the same work.
+		[ -f "$SCEN_DIR/$scen/compose.override.yaml" ] &&
+			file="$file $SCEN_DIR/$scen/compose.override.yaml"
 		op="${OP[$scen]}"
 		proj="bench_${tool//-/_}_${scen//-/_}"
 		echo ">>> $tool / $scen (op=$op)"
@@ -146,6 +177,13 @@ for tool in "${TOOLS[@]}"; do
 					row exec    "$(timed "$tool" "$file" "$proj" exec -T app true)"
 					row restart "$(timed "$tool" "$file" "$proj" restart app)"
 					teardown "$tool" "$file" "$proj"
+					;;
+				parse)
+					# The only op with no engine on the other side: read, interpolate,
+					# merge and re-render. No containers means no daemon variance, so
+					# this is the least noisy number the suite produces — and it is
+					# what CI runs most, to validate a file before deploying it.
+					row config "$(timed "$tool" "$file" "$proj" config)"
 					;;
 				build)
 					row build "$(timed "$tool" "$file" "$proj" build --no-cache)"

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -88,9 +88,13 @@ TOOLS=(podup podman-compose)
 if command -v docker-compose >/dev/null 2>&1; then
 	if docker info >/dev/null 2>&1; then
 		TOOLS+=(docker-compose)
+		export BENCH_DOCKER_ENGINE=docker
 		echo "note: Docker Engine present — docker-compose measured as a CROSS-ENGINE (whole-stack) run."
 	elif [ -n "${DOCKER_HOST:-}" ] && docker-compose ls >/dev/null 2>&1; then
 		TOOLS+=(docker-compose)
+		# Recorded so the report puts these rows under the right heading; the
+		# tool's name does not say which engine it drove.
+		export BENCH_DOCKER_ENGINE=podman
 		echo "note: docker-compose driving Podman via DOCKER_HOST — measured as a SAME-ENGINE (pure tool) run."
 	else
 		echo "note: docker-compose found but no reachable engine — NOT measured. Set DOCKER_HOST to the Podman socket to include it."

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -59,7 +59,17 @@ declare -A OP=(
 	[network-ipam]=updown [volume-heavy]=updown [warm-restart]=reup
 	[many-services]=updown [running-ops]=running [build]=build
 	[config-heavy]=parse [wide-running-ops]=running
+	[deep-chain]=updown [wide-level]=updown
 )
+
+# Every scenario must have an op, or the run dies partway through with an
+# unbound-variable error under `set -u`. deep-chain and wide-level were added to
+# SCENARIOS in #1123 and never added here, so the suite has been unable to
+# complete since — nobody noticed because those two were only ever run by hand,
+# one at a time, to measure the scheduler change that introduced them.
+for _s in "${SCENARIOS[@]}"; do
+	[ -n "${OP[$_s]:-}" ] || { echo "bench: scenario '$_s' has no entry in OP" >&2; exit 2; }
+done
 if [ "$SMOKE" -eq 1 ]; then SCENARIOS=(single running-ops); fi
 
 TOOLS=(podup podman-compose)

--- a/bench/scenarios/config-heavy/.env
+++ b/bench/scenarios/config-heavy/.env
@@ -1,0 +1,4 @@
+# Interpolation source for the compose files.
+REGION=eu-central-1
+OWNER=bench
+SHARED_SECRET=not-a-real-secret

--- a/bench/scenarios/config-heavy/common.env
+++ b/bench/scenarios/config-heavy/common.env
@@ -1,0 +1,21 @@
+# Shared env, read by every service.
+COMMON_01=value-01
+COMMON_02=value-02
+COMMON_03=value-03
+COMMON_04=value-04
+COMMON_05=value-05
+COMMON_06=value-06
+COMMON_07=value-07
+COMMON_08=value-08
+COMMON_09=value-09
+COMMON_10=value-10
+COMMON_11=value-11
+COMMON_12=value-12
+COMMON_13=value-13
+COMMON_14=value-14
+COMMON_15=value-15
+COMMON_16=value-16
+COMMON_17=value-17
+COMMON_18=value-18
+COMMON_19=value-19
+COMMON_20=value-20

--- a/bench/scenarios/config-heavy/compose.override.yaml
+++ b/bench/scenarios/config-heavy/compose.override.yaml
@@ -1,0 +1,63 @@
+# The override half of the merge. Real projects almost always have one, and no
+# other scenario in this suite exercises the merge at all.
+services:
+  svc01:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc03:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc05:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc07:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc09:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc11:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc13:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc15:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc17:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc19:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc21:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"
+  svc23:
+    environment:
+      TIER: "premium"
+    labels:
+      tier: "premium"

--- a/bench/scenarios/config-heavy/compose.yaml
+++ b/bench/scenarios/config-heavy/compose.yaml
@@ -1,0 +1,337 @@
+# Parse-heavy: the one scenario with no engine in it at all.
+#
+# `config` reads, interpolates, merges and re-renders — pure client-side work,
+# so the numbers carry no container noise and no daemon variance. It is also
+# what CI does most often, to validate a compose file before deploying it.
+#
+# The shape real projects have and no other scenario here does: two files merged
+# (compose + override), an env_file, and interpolation with defaults on nearly
+# every service. Every other scenario is a single flat file.
+#
+# Dependencies are deliberately SHALLOW. An earlier version of this file chained
+# all 24 services one after another, and podman-compose took 7.4s on it against
+# 0.10s for the same file with the chain removed — a 70x cost in dependency
+# resolution, not in parsing. Leaving the chain in would have made this scenario
+# report that number as a parse cost, which is not what it is. The deep-chain
+# scenario is where dependency shape belongs.
+services:
+  svc01:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_01:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "01"
+  svc02:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_02:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "02"
+  svc03:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_03:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "03"
+  svc04:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_04:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "04"
+  svc05:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_05:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "05"
+  svc06:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_06:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "06"
+    depends_on:
+      - svc01
+  svc07:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_07:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "07"
+  svc08:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_08:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "08"
+  svc09:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_09:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "09"
+  svc10:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_10:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "10"
+  svc11:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_11:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "11"
+  svc12:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_12:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "12"
+    depends_on:
+      - svc01
+  svc13:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_13:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "13"
+  svc14:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_14:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "14"
+  svc15:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_15:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "15"
+  svc16:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_16:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "16"
+  svc17:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_17:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "17"
+  svc18:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_18:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "18"
+    depends_on:
+      - svc01
+  svc19:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_19:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "19"
+  svc20:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_20:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "20"
+  svc21:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_21:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "21"
+  svc22:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_22:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "22"
+  svc23:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_23:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "23"
+  svc24:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    environment:
+      REGION: "${REGION:-eu-west-1}"
+      TIER: "${TIER_24:-standard}"
+      SHARED: "${SHARED_SECRET}"
+    env_file:
+      - common.env
+    labels:
+      owner: "${OWNER:-platform}"
+      idx: "24"
+    depends_on:
+      - svc01

--- a/bench/scenarios/wide-running-ops/compose.yaml
+++ b/bench/scenarios/wide-running-ops/compose.yaml
@@ -1,0 +1,57 @@
+# Read-path cost across many containers, which running-ops (one service) cannot
+# show. `ps` renders a table of twelve rows, `logs` aggregates twelve streams and
+# prefixes each line with its service — the work grows with the container count,
+# and every tool does it differently.
+services:
+  svc01:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc01 ready; sleep 3600"]
+    init: true
+  svc02:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc02 ready; sleep 3600"]
+    init: true
+  svc03:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc03 ready; sleep 3600"]
+    init: true
+  svc04:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc04 ready; sleep 3600"]
+    init: true
+  svc05:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc05 ready; sleep 3600"]
+    init: true
+  svc06:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc06 ready; sleep 3600"]
+    init: true
+  svc07:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc07 ready; sleep 3600"]
+    init: true
+  svc08:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc08 ready; sleep 3600"]
+    init: true
+  svc09:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc09 ready; sleep 3600"]
+    init: true
+  svc10:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc10 ready; sleep 3600"]
+    init: true
+  svc11:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc11 ready; sleep 3600"]
+    init: true
+  svc12:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo svc12 ready; sleep 3600"]
+    init: true
+  app:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sh", "-c", "echo app ready; sleep 3600"]
+    init: true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,50 @@
+podup (2.1.0) unstable; urgency=medium
+
+  New
+
+  * run allocates a pseudo-TTY and attaches stdin on Unix when stdin is a
+    terminal, so `podup run -it app sh` is an interactive session that follows
+    the window size. `-T` opts out and `-d` never allocates one. It engages only
+    when stdin is a terminal, so a script or a pipeline keeps the streaming
+    behaviour it had. Windows is unchanged.
+
+  Fixes
+
+  * A connection failure now names the socket it tried and separates "not
+    listening" from "cannot be opened", instead of a bare `No such file or
+    directory (os error 2)`. A fresh rootless account had nothing to act on:
+    podman is daemonless and works there, so nothing looks wrong until every
+    podup command fails. The socket prerequisite is documented now too, in the
+    README and in the autostart guide.
+  * `podup` with no subcommand printed a list of forty-five subcommand names
+    instead of its help whenever COMPOSE_PROJECT_NAME, PODMAN_SOCKET or
+    COMPOSE_PROFILES was set — the normal state of a deployment. Both cases
+    print the help now.
+  * That help is also coloured, like every other screen. It was the only one
+    that was not.
+  * A sub-second healthcheck interval is honoured instead of being discarded
+    and replaced by the 2s default, which made `interval: 200ms` poll more
+    slowly than the 1s nobody asked for. Measured on a service healthy at
+    ~400ms: 2406ms before, 806ms after. Values below 100ms are raised to that
+    floor, since running a check executes a command inside the container.
+  * While waiting on a service_healthy gate, the container's health status is
+    read every 150ms between check runs. Reading runs no command, so this costs
+    a request rather than container work, and it is what notices promptly when
+    Podman's own timer flips the status between podup's runs.
+  * A container that fails during such a wait is now reported as soon as it is
+    seen, instead of exhausting the whole budget and reporting a timeout.
+
+  Other
+
+  * The CLI names the Compose Spec rather than another vendor's product. No
+    behaviour changes: the same files are read, the same flags accepted, and
+    DOCKER_HOST, COMPOSE_FILE and COMPOSE_PROJECT_NAME are all still honoured.
+  * `run --help` and `exec --help` said podup never allocates a pseudo-TTY,
+    which stopped being true when both gained one.
+  * Library API: Engine::with_run_no_tty carries the `run -T` flag, additive.
+
+ -- Glyndor <packages@glyndor.net>  Tue, 21 Jul 2026 09:30:00 -0500
+
 podup (2.0.0) unstable; urgency=medium
 
   Breaking changes

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -118,5 +118,19 @@ Podman groundwork, done once:
        podman system migrate
   ```
 
+- **The Podman API socket** — `podman` is daemonless and needs no socket, so a
+  fresh account can run `podman` fine and still have every `podup` command fail
+  with a connection error. podup speaks the libpod API, so the socket has to be
+  listening:
+
+  ```bash
+  sudo -u appuser env XDG_RUNTIME_DIR=/run/user/$(id -u appuser) \
+       systemctl --user enable --now podman.socket
+  ```
+
+  The `env XDG_RUNTIME_DIR=…` is the same requirement as above and for the same
+  reason: an account with no login shell has no user session, so `systemctl
+  --user` cannot find the manager without being told where it lives.
+
 After that, `podup autostart install` writes the unit(s), reloads the user
 manager, and starts the stack; a reboot brings it back on its own.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -222,7 +222,7 @@ Run a one-off command in a new container for the service.
 | `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
 | `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
 | `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
-| `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation (accepted for compatibility; podup never allocates one). | off |
+| `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation. | off |
 | `--no-deps` | Do not start the `depends_on` services before running. | off |
 
 ```bash
@@ -233,6 +233,23 @@ podup run --rm web sh -c 'echo hello'
 > here; `docker compose run` keeps it unless you pass `--rm`. Migrating a script
 > means its existing `--rm` becomes a no-op and a container it expected to
 > inspect afterwards is gone — pass `--no-rm` to keep it.
+
+On Unix, `run` allocates a pseudo-TTY and attaches your stdin when stdin is a
+terminal, so `podup run -it app sh` drops you into an interactive session that
+follows your window size. Like `docker compose run`, a TTY on both ends is the
+default and `-T` is how you turn it off; `-d` never allocates one, since there
+is nobody to be interactive with.
+
+It engages **only** when stdin is a terminal, so a script or a pipeline keeps
+the plain streaming behaviour with no change to output framing:
+
+```bash
+podup run --rm app echo hola > salida.txt   # streams, no TTY
+podup run --rm -T app ./migrar.sh           # streams, no TTY
+```
+
+Windows keeps the streaming behaviour in every case
+([#1140](https://github.com/Glyndor/podup/issues/1140)).
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
@@ -547,7 +564,6 @@ covers, and the only other way to find out was to read the dispatch code.
 | `config --no-normalize` | `config` always emits the normalized form. |
 | `cp -a, --archive` | Ownership/permission preservation is not meaningful for a rootless copy. |
 | `attach --no-stdin`, `--sig-proxy`, `--detach-keys` | `attach` streams output only; stdin is never attached (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
-| `run -T, --no-TTY` | `run` never allocates a pseudo-TTY, so disabling one is a no-op. `exec -T` is real: it turns off a pseudo-TTY that `exec` does allocate. |
 
 Everything else that parses does something. An **unknown** `--filter` predicate
 is rejected outright rather than dropped: a filter that silently does not apply

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -221,7 +221,7 @@ Run a one-off command in a new container for the service.
 | `--entrypoint <CMD>` | Override the image entrypoint. | image default |
 | `-v, --volume <SPEC>` | Bind-mount an extra volume (`HOST:CONTAINER[:OPTS]` or `NAME:CONTAINER`). Repeatable. | none |
 | `-p, --publish <SPEC>` | Publish an extra port (`HOST:CONTAINER[/PROTO]`). Repeatable. | none |
-| `-i, --interactive` | Keep STDIN open (accepted for compatibility; `run` still streams logs). | off |
+| `-i, --interactive` | Keep the container's STDIN open (`stdin_open`). Whether a live terminal is attached is decided by stdin/stdout being terminals and by `-T`, not by this flag. | off |
 | `-T, --no-TTY` (alias `--no-tty`) | Disable pseudo-TTY allocation. | off |
 | `--no-deps` | Do not start the `depends_on` services before running. | off |
 
@@ -240,16 +240,23 @@ follows your window size. Like `docker compose run`, a TTY on both ends is the
 default and `-T` is how you turn it off; `-d` never allocates one, since there
 is nobody to be interactive with.
 
-It engages **only** when stdin is a terminal, so a script or a pipeline keeps
-the plain streaming behaviour with no change to output framing:
+It engages **only** when *both* stdin and stdout are terminals, so a script, a
+pipeline or a redirect keeps the plain streaming behaviour with no change to
+output framing:
 
 ```bash
-podup run --rm app echo hola > salida.txt   # streams, no TTY
-podup run --rm -T app ./migrar.sh           # streams, no TTY
+podup run --rm app echo hola > salida.txt   # stdout is a file  -> streams, no TTY
+echo x | podup run --rm app ./migrar.sh     # stdin is a pipe   -> streams, no TTY
+podup run --rm -T app ./migrar.sh           # -T                -> streams, no TTY
 ```
 
+Requiring stdout matters because a pty **merges stdout and stderr and writes
+CRLF**. Checking stdin alone would mean `podup run app cmd > out.txt`, typed at
+a shell, silently wrote different bytes into that file than the same command in
+a script.
+
 Windows keeps the streaming behaviour in every case
-([#1140](https://github.com/Glyndor/podup/issues/1140)).
+([#1154](https://github.com/Glyndor/podup/issues/1154)).
 
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
@@ -529,6 +536,28 @@ file still runs there — it just does not act on the extra.
 | Key | Where | What it does |
 |---|---|---|
 | `x-podman-on-failure` | under a service's `healthcheck:` | `none`, `kill`, `restart` or `stop` — what Podman does when the check flips to unhealthy. Default `none`. |
+
+### Healthcheck timing on a `service_healthy` gate
+
+When `up` waits on `depends_on: {condition: service_healthy}`, podup drives the
+check itself — Podman schedules its own runs through systemd transient timers,
+which never fire on a host without systemd, so a purely passive wait would block
+until the whole budget elapsed.
+
+| | |
+|---|---|
+| how often the check is **run** | the healthcheck's `interval`, floored at **100ms** |
+| how often the status is **read** | every 150ms |
+| how long the wait lasts | `interval × retries` plus `start_period`, extended by `--wait-timeout` |
+
+Running a check executes a command *inside* the container, so it happens no
+faster than `interval` and the floor keeps `interval: 1ms` from becoming a
+thousand executions a second. Reading the status is a plain inspect — it runs no
+command — so it is cheap and frequent, and it is what notices promptly when
+Podman's own timer flips the status between podup's runs.
+
+A container that fails during the wait is reported as soon as the next read sees
+it, rather than at the end of the budget.
 
 Without it, a compose healthcheck detects a sick container and does nothing
 about it: a restart policy reacts to the process *exiting*, not to the container

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -192,7 +192,7 @@ pub(crate) enum Commands {
 		#[arg(long = "build-arg")]
 		build_arg: Vec<String>,
 		/// Set the build progress output style (auto, plain, tty); accepted for
-		/// docker-compose compatibility. Validated but inert: podup renders build
+		/// compatibility with other Compose tools. Validated but inert: podup renders build
 		/// output one way.
 		#[arg(long, value_parser = parse_progress)]
 		progress: Option<String>,
@@ -286,8 +286,8 @@ pub(crate) enum Commands {
 		/// container's output but does not attach a live interactive terminal.
 		#[arg(short, long)]
 		interactive: bool,
-		/// No effect; accepted only for docker-compose compatibility. podup never
-		/// allocates a pseudo-TTY.
+		/// Disable pseudo-TTY allocation. `run` allocates one on Unix when stdin
+		/// is a terminal; this opts out, so a script keeps plain streaming.
 		// Both spellings are accepted on purpose: `docker compose run` spells the
 		// long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
 		// A script copied from either one has to work, so each command takes both.
@@ -382,17 +382,16 @@ pub(crate) enum Commands {
 		/// Index of the container when the service has multiple replicas (1-based).
 		#[arg(long)]
 		index: Option<u32>,
-		/// Do not attach STDIN (accepted for docker-compose compatibility; podup
+		/// Do not attach STDIN (accepted for compatibility; podup
 		/// attaches output only).
 		#[arg(long)]
 		no_stdin: bool,
 		/// Proxy received signals to the process (accepted for compatibility).
 		///
-		/// Takes an optional value so both spellings parse: docker declares this
-		/// as a bare boolean, and demanding a value made
-		/// `docker compose attach --sig-proxy web` fail with a usage error
-		/// against podup — inside the set of flags whose entire purpose is that
-		/// such a script runs unchanged.
+		/// Takes an optional value so both spellings parse. Other Compose tools
+		/// declare it as a bare flag, and demanding a value turned a script
+		/// copied from one of them into a usage error — inside the very set of
+		/// flags whose purpose is that such a script runs unchanged.
 		#[arg(
 			long,
 			default_value_t = false,
@@ -422,7 +421,8 @@ pub(crate) enum Commands {
 		/// Author of the new image (e.g. "Name <email>").
 		#[arg(short, long)]
 		author: Option<String>,
-		/// Apply a Dockerfile instruction to the committed image (repeatable).
+		/// Apply a Containerfile instruction to the committed image, e.g.
+		/// `CMD=/bin/sh` or `ENV=KEY=value` (repeatable).
 		#[arg(short = 'c', long = "change")]
 		change: Vec<String>,
 		/// Replica index (1-based) of a scaled service.
@@ -533,8 +533,8 @@ pub(crate) enum Commands {
 		/// Detach: run the command in the background.
 		#[arg(short, long)]
 		detach: bool,
-		/// No effect; accepted only for docker-compose compatibility. podup never
-		/// allocates a pseudo-TTY.
+		/// Disable pseudo-TTY allocation. `exec` allocates one on Unix when stdin
+		/// is a terminal; this opts out, so a script keeps plain streaming.
 		// `docker compose exec` spells the long form `--no-tty`, so that is the
 		// primary here; `--no-TTY` stays accepted so the spelling `run` uses also
 		// works on `exec`. See the note on `run`'s field.
@@ -606,7 +606,7 @@ pub(crate) enum Commands {
 		/// Leave ${VAR} placeholders literal instead of interpolating them.
 		#[arg(long)]
 		no_interpolate: bool,
-		/// Accepted for docker-compose compatibility; podup output is already
+		/// Accepted for compatibility; podup output is already
 		/// normalized.
 		#[arg(long)]
 		no_normalize: bool,
@@ -656,7 +656,7 @@ pub(crate) enum Commands {
 		#[arg(long)]
 		force: bool,
 	},
-	/// Print version information (like `docker compose version`).
+	/// Print version information.
 	Version {
 		/// Print only the version number.
 		#[arg(long)]

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -282,8 +282,9 @@ pub(crate) enum Commands {
 		/// Publish an extra port (HOST:CONTAINER[/PROTO]); repeatable.
 		#[arg(short = 'p', long = "publish")]
 		publish: Vec<String>,
-		/// Keep the container's STDIN open (sets `stdin_open`). `run` streams the
-		/// container's output but does not attach a live interactive terminal.
+		/// Keep the container's STDIN open (sets `stdin_open`). Whether a live
+		/// terminal is attached is decided by stdin and stdout both being
+		/// terminals, and by `-T` — not by this flag.
 		#[arg(short, long)]
 		interactive: bool,
 		/// Disable pseudo-TTY allocation. `run` allocates one on Unix when stdin

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -30,7 +30,7 @@ const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
 #[command(
 	name = "podup",
 	version,
-	about = "Run docker-compose projects on Podman.",
+	about = "Run Compose projects on Podman.",
 	styles = HELP_STYLES,
 	// No subcommand prints help and exits non-zero (like docker compose), and the
 	// built-in `help` is replaced by an explicit `Help` variant that tolerates

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -31,7 +31,7 @@ pub(crate) fn parse_scale_pair(value: &str) -> Result<(String, u32), String> {
 }
 
 /// Pull-policy values podup accepts for `up --pull` / `pull --policy`. `always`,
-/// `missing`, `never`, and `build` mirror `docker compose`; `newer` is Podman's
+/// `missing`, `never`, and `build` are the Compose Spec policies; `newer` is Podman's
 /// extension.
 const PULL_POLICIES: [&str; 5] = ["always", "missing", "never", "newer", "build"];
 
@@ -48,7 +48,7 @@ pub(crate) fn parse_pull_policy(value: &str) -> Result<String, String> {
 	}
 }
 
-/// Progress styles `docker compose build --progress` accepts. podup renders build
+/// The progress styles the Compose Spec defines. podup renders build
 /// output one way, so the flag is inert — but an unknown value must still be
 /// rejected rather than accepted and ignored, or a typo silently changes nothing
 /// and reports success.

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -25,7 +25,7 @@ pub(crate) enum EventsFormat {
 	Json,
 }
 
-/// When to colourise human-facing output (`--ansi`, like docker compose).
+/// When to colourise human-facing output (`--ansi`).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum AnsiMode {
 	/// Colour only when writing to a terminal (and `NO_COLOR` is unset).

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -32,6 +32,8 @@ pub(super) async fn dispatch_rest(
 			entrypoint: _,
 			volume: _,
 			publish: _,
+			// Both act now: they reach the engine through `RunOverrides`, which
+			// `run_overrides_for` builds from this same command.
 			interactive: _,
 			no_tty: _,
 			no_deps: _,

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -72,24 +72,49 @@ fn classify_health(info: &ContainerInspect) -> HealthVerdict {
 	HealthVerdict::Pending
 }
 
-/// Compute the `(poll_interval_secs, iterations)` for [`Engine::wait_healthy`]
-/// from a healthcheck's `interval`/`start_period`/`retries`. Poll at `interval`
-/// when given (>=1s) else 2s; run `retries` (default 30) probes plus enough
-/// extra probes to span `start_period`. Pure so the timing can be unit-tested.
+/// How often the health *status* is read while waiting between check runs.
+///
+/// Reading is a plain inspect: it does not execute the healthcheck, so it costs
+/// a request and nothing inside the container. Podman runs the check on its own
+/// schedule where systemd is available, and this is what notices promptly when
+/// it does — previously the status was only ever looked at once per `interval`,
+/// so a container that turned healthy just after a probe went unnoticed for the
+/// rest of the window.
+const STATUS_READ_INTERVAL: Duration = Duration::from_millis(150);
+
+/// Lower bound on how often podup will *run* a healthcheck.
+///
+/// Running is not free — it executes the command inside the container — so an
+/// `interval` of `10ms` must not turn into a hundred executions a second.
+const MIN_RUN_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Compute the `(run_interval, budget)` for [`Engine::wait_healthy`] from a
+/// healthcheck's `interval`/`start_period`/`retries`.
+///
+/// `run_interval` is how often podup actively executes the check; `budget` is
+/// how long it keeps trying. Sub-second intervals are honoured down to
+/// [`MIN_RUN_INTERVAL`]: they used to be discarded and replaced by the 2s
+/// default, so asking for `500ms` polling produced *slower* polling than asking
+/// for `1s` — the opposite of the request. Pure so the timing is unit-testable.
 fn health_poll_plan(
 	interval: Option<&str>,
 	start_period: Option<&str>,
 	retries: Option<u32>,
-) -> (u64, u64) {
-	let poll_secs = interval
-		.and_then(crate::size::parse_duration_secs)
-		.filter(|s| *s >= 1)
-		.unwrap_or(2);
-	let start_secs = start_period
-		.and_then(crate::size::parse_duration_secs)
-		.unwrap_or(0);
-	let iterations = retries.unwrap_or(30) as u64 + start_secs / poll_secs;
-	(poll_secs, iterations)
+) -> (Duration, Duration) {
+	let run_interval = interval
+		.and_then(crate::size::parse_duration_nanos)
+		.filter(|n| *n > 0)
+		.map(|n| Duration::from_nanos(n as u64).max(MIN_RUN_INTERVAL))
+		.unwrap_or(Duration::from_secs(2));
+	let start = start_period
+		.and_then(crate::size::parse_duration_nanos)
+		.filter(|n| *n > 0)
+		.map(|n| Duration::from_nanos(n as u64))
+		.unwrap_or_default();
+	// Same budget as before, expressed as time rather than as a probe count: a
+	// count stopped meaning a duration once the wait polls at two cadences.
+	let budget = run_interval.saturating_mul(retries.unwrap_or(30)) + start;
+	(run_interval, budget)
 }
 
 /// Poll iterations to actually run, given the healthcheck poll-plan and an
@@ -102,17 +127,17 @@ fn health_poll_plan(
 /// letting the outer `--wait-timeout` deadline — not the poll plan — decide when
 /// to give up. Without a wait-timeout the poll plan governs unchanged. Pure so
 /// the budget arithmetic is unit-tested without a live socket.
-fn effective_iterations(poll_secs: u64, plan_iters: u64, wait_timeout: Option<Duration>) -> u64 {
+fn effective_budget(
+	run_interval: Duration,
+	plan_budget: Duration,
+	wait_timeout: Option<Duration>,
+) -> Duration {
 	match wait_timeout {
-		Some(wt) => {
-			let poll = poll_secs.max(1);
-			// +2 so the inner loop outlasts the outer deadline, ensuring an
-			// exhausted wait surfaces as the `--wait-timeout` error rather than a
-			// spurious health-check-timeout that fired one poll early.
-			let wt_iters = wt.as_secs().div_ceil(poll) + 2;
-			plan_iters.max(wt_iters)
-		}
-		None => plan_iters,
+		// Two extra run intervals so this wait outlasts the outer deadline,
+		// ensuring an exhausted wait surfaces as the `--wait-timeout` error
+		// rather than a spurious health-check timeout that fired just early.
+		Some(wt) => plan_budget.max(wt + run_interval.saturating_mul(2)),
+		None => plan_budget,
 	}
 }
 
@@ -175,14 +200,14 @@ impl Engine {
 		wait_timeout: Option<Duration>,
 	) -> Result<()> {
 		let hc = service.healthcheck.as_ref();
-		let (poll_secs, plan_iters) = health_poll_plan(
+		let (run_interval, plan_budget) = health_poll_plan(
 			hc.and_then(|h| h.interval.as_deref()),
 			hc.and_then(|h| h.start_period.as_deref()),
 			hc.and_then(|h| h.retries),
 		);
-		// `--wait-timeout` extends the poll budget so it, not the (often shorter)
+		// `--wait-timeout` extends the budget so it, not the (often shorter)
 		// healthcheck interval×retries plan, decides when the wait gives up.
-		let iterations = effective_iterations(poll_secs, plan_iters, wait_timeout);
+		let budget = effective_budget(run_interval, plan_budget, wait_timeout);
 
 		// One inspect decides the short-circuits: already healthy, or no effective
 		// healthcheck at all (image or compose) — in which case a server-side
@@ -227,15 +252,55 @@ impl Engine {
 			"{API_PREFIX}/containers/{}/healthcheck",
 			crate::libpod::urlencoded(container_name),
 		);
-		for _ in 0..iterations {
-			match self.client.get_json::<HealthCheckRun>(&path).await {
-				Ok(run) if run.status.as_deref() == Some("healthy") => return Ok(()),
-				Ok(_) => {}
-				// A transient error (container not yet running, 409, 500, …) just
-				// means "not healthy yet" — keep polling rather than failing hard.
-				Err(e) => tracing::debug!("{container_name} healthcheck run failed: {e}"),
+		// Two cadences, because running a check and observing its result are not
+		// the same cost. Running executes a command inside the container, so it
+		// happens at the interval the compose file asked for and no faster.
+		// Observing is a plain inspect, so it happens often — Podman runs the
+		// check on its own systemd schedule where one exists, and this is what
+		// notices promptly when it does.
+		//
+		// Before, the status was read only once per run, so a container that
+		// turned healthy a moment after a probe went unseen for the rest of the
+		// interval: measured at 2507ms to notice a service healthy at ~1200ms,
+		// against 1706ms for docker compose (#1147).
+		let inspect_path = format!(
+			"{API_PREFIX}/containers/{}/json",
+			crate::libpod::urlencoded(container_name),
+		);
+		let deadline = tokio::time::Instant::now() + budget;
+		let mut next_run = tokio::time::Instant::now();
+		while tokio::time::Instant::now() < deadline {
+			if tokio::time::Instant::now() >= next_run {
+				match self.client.get_json::<HealthCheckRun>(&path).await {
+					Ok(run) if run.status.as_deref() == Some("healthy") => return Ok(()),
+					Ok(_) => {}
+					// A transient error (container not yet running, 409, 500, …)
+					// just means "not healthy yet" — keep going rather than
+					// failing hard.
+					Err(e) => tracing::debug!("{container_name} healthcheck run failed: {e}"),
+				}
+				next_run = tokio::time::Instant::now() + run_interval;
+			} else if let Ok(info) = self
+				.client
+				.get_json::<crate::libpod::types::container::ContainerInspect>(&inspect_path)
+				.await
+			{
+				match classify_health(&info) {
+					HealthVerdict::Healthy => return Ok(()),
+					HealthVerdict::Failed(code) => {
+						return Err(ComposeError::WaitServiceExited {
+							container: container_name.to_string(),
+							code,
+						})
+					}
+					_ => {}
+				}
 			}
-			tokio::time::sleep(Duration::from_secs(poll_secs)).await;
+			let nap = STATUS_READ_INTERVAL.min(run_interval);
+			tokio::time::sleep(
+				nap.min(deadline.saturating_duration_since(tokio::time::Instant::now())),
+			)
+			.await;
 		}
 		Err(ComposeError::HealthCheckTimeout(container_name.into()))
 	}
@@ -279,49 +344,79 @@ mod tests {
 
 	#[test]
 	fn poll_plan_defaults_match_legacy_60s() {
-		// No healthcheck timing set → 2s poll, 30 probes (the historical budget).
-		assert_eq!(super::health_poll_plan(None, None, None), (2, 30));
+		// No healthcheck timing set → 2s between runs, 30 runs (60s budget).
+		assert_eq!(
+			super::health_poll_plan(None, None, None),
+			(Duration::from_secs(2), Duration::from_secs(60))
+		);
 	}
 
 	#[test]
 	fn poll_plan_uses_interval_and_honors_start_period() {
-		// interval=10s, start_period=60s, retries=3 → poll 10s, 3 + 60/10 = 9 probes.
-		let (poll, iters) = super::health_poll_plan(Some("10s"), Some("60s"), Some(3));
-		assert_eq!((poll, iters), (10, 9));
+		// interval=10s, start_period=60s, retries=3 → run every 10s, budget
+		// 3×10s + 60s.
+		let (run, budget) = super::health_poll_plan(Some("10s"), Some("60s"), Some(3));
+		assert_eq!(
+			(run, budget),
+			(Duration::from_secs(10), Duration::from_secs(90))
+		);
+	}
+
+	/// A sub-second interval used to be discarded and replaced by the 2s
+	/// default, so asking for 500ms polling produced *slower* polling than
+	/// asking for 1s — the opposite of the request (#1147). It is honoured now,
+	/// with a floor so `10ms` cannot become a hundred check executions a second.
+	#[test]
+	fn poll_plan_honours_a_sub_second_interval() {
+		let (run, _) = super::health_poll_plan(Some("500ms"), None, Some(5));
+		assert_eq!(run, Duration::from_millis(500));
 	}
 
 	#[test]
-	fn poll_plan_sub_second_interval_floors_to_default() {
-		// An interval below 1s falls back to the 2s default (no busy-poll).
-		let (poll, _) = super::health_poll_plan(Some("500ms"), None, Some(5));
-		assert_eq!(poll, 2);
+	fn poll_plan_floors_a_pathological_interval() {
+		let (run, _) = super::health_poll_plan(Some("1ms"), None, Some(5));
+		assert_eq!(run, super::MIN_RUN_INTERVAL);
 	}
 
-	// --- effective_iterations (--wait-timeout budget, #891) ------------------
+	/// Reading the status must never be slower than running the check, or the
+	/// fast observation path would be pointless.
+	#[test]
+	fn the_status_read_is_never_slower_than_the_default_run() {
+		assert!(super::STATUS_READ_INTERVAL < Duration::from_secs(2));
+	}
+
+	// --- effective_budget (--wait-timeout, #891) -----------------------------
 
 	#[test]
-	fn effective_iterations_without_wait_timeout_uses_plan() {
-		// No --wait-timeout: the healthcheck poll plan governs unchanged.
-		assert_eq!(super::effective_iterations(2, 30, None), 30);
+	fn budget_without_wait_timeout_uses_the_plan() {
+		let plan = Duration::from_secs(60);
+		assert_eq!(
+			super::effective_budget(Duration::from_secs(2), plan, None),
+			plan
+		);
 	}
 
 	#[test]
-	fn effective_iterations_extends_to_cover_wait_timeout() {
-		// A short plan (interval 10s × 1 retry = 1 iter) must be extended so a
-		// generous --wait-timeout actually elapses: 120s / 10s + 2 margin = 14.
-		let iters = super::effective_iterations(10, 1, Some(Duration::from_secs(120)));
-		assert_eq!(iters, 14);
+	fn budget_extends_to_cover_wait_timeout() {
+		// A short plan must not cut a generous --wait-timeout short.
+		let b = super::effective_budget(
+			Duration::from_secs(10),
+			Duration::from_secs(10),
+			Some(Duration::from_secs(120)),
+		);
+		assert!(b > Duration::from_secs(120), "{b:?}");
 	}
 
 	#[test]
-	fn effective_iterations_keeps_larger_plan() {
-		// When the poll plan already outlasts --wait-timeout, the plan wins so the
-		// healthcheck's own budget is never shortened.
-		let iters = super::effective_iterations(2, 100, Some(Duration::from_secs(10)));
-		assert_eq!(iters, 100);
+	fn budget_keeps_the_larger_plan() {
+		// A generous plan is not shortened by a small --wait-timeout.
+		let b = super::effective_budget(
+			Duration::from_secs(2),
+			Duration::from_secs(200),
+			Some(Duration::from_secs(10)),
+		);
+		assert_eq!(b, Duration::from_secs(200));
 	}
-
-	// --- wait_healthy gating (service_healthy) -------------------------------
 
 	#[test]
 	fn health_reported_healthy() {

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -7,6 +7,8 @@ mod parallel;
 mod prefetch;
 mod readiness;
 mod run;
+#[cfg(unix)]
+mod run_attached;
 mod scale;
 mod schedule;
 mod signal;

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -43,6 +43,11 @@ impl Engine {
 			interactive,
 			no_deps,
 		} = self.run_overrides.clone();
+		let no_tty = self.run_no_tty;
+		// Same rule as `exec`: a TTY on both ends by default, `-T` to opt out,
+		// and only when stdin is actually a terminal — so a script or a pipeline
+		// keeps the streaming path it has always had, unchanged.
+		let want_tty = crate::engine::wants_interactive_run(no_tty, detach);
 		// `--env-file` and `-l/--label` are carried on the engine (not
 		// `RunOverrides`) to keep the public struct frozen.
 		let env_files = self.run_env_files.clone();
@@ -96,9 +101,10 @@ impl Engine {
 		if let Some(w) = workdir {
 			run_service.working_dir = Some(w);
 		}
-		// `-i/--interactive` keeps STDIN open on the spec; `run` still streams
-		// logs rather than attaching a live terminal.
-		if interactive {
+		// `-i/--interactive` keeps STDIN open on the spec. With a terminal on both
+		// ends the container also gets a live stdin attached below; without one
+		// this is the same flag it always was.
+		if interactive || want_tty {
 			run_service.stdin_open = Some(true);
 		}
 		// Ad-hoc `-v/--volume` mounts append to the service's own mounts in
@@ -150,10 +156,12 @@ impl Engine {
 				.ports
 				.push(crate::compose::types::PortMapping::Short(p));
 		}
-		// Force non-TTY so Podman uses multiplexed log framing that
-		// parse_multiplexed can decode. TTY mode sends raw bytes without
-		// the 8-byte header, which would produce garbled output.
-		run_service.tty = None;
+		// Non-TTY forces Podman's multiplexed log framing, which is what the
+		// streaming path below decodes — TTY mode sends raw bytes with no 8-byte
+		// header and would garble that reader. The interactive path does not use
+		// that reader at all: it attaches to the raw stream, which is exactly the
+		// framing a TTY produces. So the two are consistent, not contradictory.
+		run_service.tty = want_tty.then_some(true);
 
 		// Ensure the project networks exist (compose `run` brings them up like
 		// `up` does); the service may reference the synthesized `default`
@@ -182,8 +190,12 @@ impl Engine {
 		// On a start failure (bad --workdir/--user/--entrypoint), the container is
 		// created but never starts; with --rm, remove it here so repeated failures
 		// don't accumulate orphaned 'Created' containers.
+		// Interactive runs create first and start later, with the attach in
+		// between: a container started before anything is listening loses
+		// whatever it printed in that gap, and for `run` — a one-shot command —
+		// that gap is often the entire output.
 		if let Err(e) = self
-			.create_and_start(&run_name, service_name, &run_service, file, true)
+			.create_and_start(&run_name, service_name, &run_service, file, !want_tty)
 			.await
 		{
 			if rm {
@@ -198,6 +210,14 @@ impl Engine {
 			// `docker compose run -d`.
 			crate::ui::result_line(&run_name).map_err(ComposeError::Io)?;
 			return Ok(());
+		}
+
+		// The interactive path takes over here: it needs the connection kept open
+		// in both directions, which the request/response client cannot give it.
+		// Same shape `exec` uses, and cfg-ed the same way.
+		#[cfg(unix)]
+		if want_tty {
+			return self.finish_interactive_run(&run_name, rm, &rm_path).await;
 		}
 
 		// Stream logs and wait for the exit code. Any failure on this path also

--- a/internal/engine/lifecycle/run_attached.rs
+++ b/internal/engine/lifecycle/run_attached.rs
@@ -1,0 +1,83 @@
+//! Interactive `run`: a pseudo-terminal on a one-shot container, on Unix.
+//!
+//! `podup run -it app bash` parsed `-i` and `-T` and acted on neither: the
+//! container got no TTY and no live stdin, so the flags described something that
+//! did not happen (#1140, the half of #1079 that did not ship).
+//!
+//! The order here is the whole point. `attach` opens before `start`, because a
+//! container that has already run has already printed, and for a one-shot `run`
+//! that missed output is often all the output there was. `exec` does not have
+//! this problem — the container is already up — which is why it can attach and
+//! start in a single call and this cannot.
+
+#![cfg(unix)]
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+impl super::super::Engine {
+	/// Attach to a created-but-not-started container, start it, and hand the
+	/// terminal over until the command exits. Returns its exit code.
+	pub(super) async fn run_attached(&self, container_name: &str) -> Result<i64> {
+		// stdin=1 so keystrokes reach the command; stream=1 keeps the connection
+		// open both ways. With a TTY the stream is raw — no 8-byte frame headers,
+		// because the pty merges stdout and stderr — which is also why an
+		// interactive run cannot separate them, exactly as `podman run -it`.
+		let attach_path = format!(
+			"{API_PREFIX}/containers/{}/attach?stream=1&stdin=1&stdout=1&stderr=1",
+			urlencoded(container_name),
+		);
+		let hijacked = self
+			.client
+			.post_hijack(&attach_path, b"")
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		let start_path = format!(
+			"{API_PREFIX}/containers/{}/start",
+			urlencoded(container_name),
+		);
+		self.client
+			.post_empty_ok(&start_path)
+			.await
+			.map_err(ComposeError::Podman)?;
+
+		// Raw mode only once the container is known to have started; entering it
+		// before would leave the caller's terminal unusable behind a failed start.
+		self.pump_terminal(
+			hijacked,
+			&format!("containers/{}", urlencoded(container_name)),
+		)
+		.await?;
+
+		// The stream ending means the command finished; ask for its status.
+		let wait_path = format!(
+			"{API_PREFIX}/containers/{}/wait?condition=stopped",
+			urlencoded(container_name),
+		);
+		self.client
+			.post_empty_json_unbounded::<i64>(&wait_path)
+			.await
+			.map_err(ComposeError::Podman)
+	}
+}
+
+impl super::super::Engine {
+	/// Attach, start, hand over the terminal, then clean up per `--rm` and map
+	/// the exit code. Split from `run` so the non-Unix build can drop it whole.
+	pub(super) async fn finish_interactive_run(
+		&self,
+		run_name: &str,
+		rm: bool,
+		rm_path: &str,
+	) -> Result<()> {
+		let outcome = self.run_attached(run_name).await;
+		if rm {
+			let _ = self.client.delete_ok(rm_path).await;
+		}
+		match outcome? {
+			0 => Ok(()),
+			code => Err(ComposeError::RunExited(code)),
+		}
+	}
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -17,13 +17,29 @@ pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
 /// Whether `run` should allocate a pseudo-TTY and attach stdin.
 ///
-/// The same rule `exec` uses, kept in one place so the two cannot drift: a TTY
-/// on both ends by default, `-T` to opt out, `-d` excluded because there is
-/// nobody to be interactive with, and only when stdin is genuinely a terminal —
-/// which is what keeps every existing script and pipeline on the unchanged
-/// streaming path.
+/// A TTY on both ends by default, `-T` to opt out, `-d` excluded because there
+/// is nobody to be interactive with — and **both** stdin and stdout must be
+/// terminals.
+///
+/// Requiring stdout too is not symmetry for its own sake. A pty merges stdout
+/// and stderr and emits CRLF, so `podup run app cmd > out.txt` typed at a shell
+/// — stdin still a terminal, stdout a file — would have written pty bytes with
+/// stderr folded in, where it used to write clean demultiplexed output. That is
+/// the most common redirect there is, and `docker compose` keeps it clean
+/// (measured). Checking stdin alone silently changed the format of a file.
 pub(crate) fn wants_interactive_run(no_tty: bool, detach: bool) -> bool {
-	!no_tty && !detach && query::stdin_is_terminal()
+	wants_interactive_with(
+		no_tty,
+		detach,
+		query::stdin_is_terminal(),
+		query::stdout_is_terminal(),
+	)
+}
+
+/// The decision with the environment passed in, so both terminal cases are
+/// testable rather than depending on how the suite happened to be invoked.
+fn wants_interactive_with(no_tty: bool, detach: bool, stdin_tty: bool, stdout_tty: bool) -> bool {
+	!no_tty && !detach && stdin_tty && stdout_tty
 }
 
 pub use query::{
@@ -564,5 +580,17 @@ mod interactive_run_tests {
 	#[test]
 	fn a_non_terminal_stdin_stays_on_the_streaming_path() {
 		assert!(!wants_interactive_run(false, false));
+	}
+
+	/// Both ends are required, and this is the case that made it necessary:
+	/// `podup run app cmd > out.txt` typed at a shell leaves stdin a terminal
+	/// while stdout is a file. Checking stdin alone allocated a pty, and a pty
+	/// merges stdout with stderr and writes CRLF — so the redirect silently
+	/// changed the bytes the file received. Verified against `docker compose`,
+	/// which keeps it clean.
+	#[test]
+	fn a_redirected_stdout_stays_on_the_streaming_path() {
+		assert!(!super::wants_interactive_with(false, false, true, false));
+		assert!(super::wants_interactive_with(false, false, true, true));
 	}
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -6,6 +6,8 @@ mod build;
 mod container;
 mod copy;
 mod events;
+#[cfg(unix)]
+mod terminal_pump;
 pub use events::EventsOptions;
 mod image;
 pub use build::{BuildOptions, PullOptions, PushOptions};
@@ -13,6 +15,17 @@ pub use copy::CpOptions;
 pub use image::{resolve_image_digests, CommitOptions};
 pub use lifecycle::{validate_stop_timeout, RunOptions, RunOverrides};
 pub use lock::ProjectLock;
+/// Whether `run` should allocate a pseudo-TTY and attach stdin.
+///
+/// The same rule `exec` uses, kept in one place so the two cannot drift: a TTY
+/// on both ends by default, `-T` to opt out, `-d` excluded because there is
+/// nobody to be interactive with, and only when stdin is genuinely a terminal —
+/// which is what keeps every existing script and pipeline on the unchanged
+/// streaming path.
+pub(crate) fn wants_interactive_run(no_tty: bool, detach: bool) -> bool {
+	!no_tty && !detach && query::stdin_is_terminal()
+}
+
 pub use query::{
 	AttachOutcome, ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsFilterOptions, PsOptions,
 };
@@ -94,6 +107,8 @@ pub struct Engine {
 	/// `run` container; empty by default. Kept off the frozen public
 	/// [`lifecycle::RunOverrides`] struct so the library API stays stable.
 	pub(super) run_labels: Vec<String>,
+	/// CLI `run -T/--no-TTY`: opt out of the pseudo-TTY.
+	pub(super) run_no_tty: bool,
 	/// CLI `up -V/--renew-anon-volumes`: when recreating a container, also remove
 	/// its old anonymous volumes instead of leaving them orphaned.
 	pub(super) renew_anon_volumes: bool,
@@ -115,6 +130,7 @@ impl Engine {
 			run_overrides: lifecycle::RunOverrides::default(),
 			run_env_files: Vec::new(),
 			run_labels: Vec::new(),
+			run_no_tty: false,
 			renew_anon_volumes: false,
 		}
 	}
@@ -134,6 +150,7 @@ impl Engine {
 			run_overrides: lifecycle::RunOverrides::default(),
 			run_env_files: Vec::new(),
 			run_labels: Vec::new(),
+			run_no_tty: false,
 			renew_anon_volumes: false,
 		}
 	}
@@ -196,6 +213,18 @@ impl Engine {
 	/// one-off `run` container. Builder-style; consumed by [`Engine::run`].
 	pub fn with_run_labels(mut self, labels: Vec<String>) -> Self {
 		self.run_labels = labels;
+		self
+	}
+
+	/// Set the CLI `run -T/--no-TTY` flag. Builder-style.
+	///
+	/// Carried here rather than on [`RunOverrides`] for the reason that struct
+	/// already documents: it is public and not `#[non_exhaustive]`, so a new
+	/// field is a breaking change. `run_env_files` and `run_labels` are on the
+	/// engine for exactly this, and semver-checks caught me putting this one in
+	/// the wrong place.
+	pub fn with_run_no_tty(mut self, no_tty: bool) -> Self {
+		self.run_no_tty = no_tty;
 		self
 	}
 
@@ -510,3 +539,30 @@ fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Resul
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod interactive_run_tests {
+	use super::wants_interactive_run;
+
+	/// `-T` opts out, matching `docker compose run` — which has no `-i` because
+	/// a TTY on both ends is the default.
+	#[test]
+	fn no_tty_disables_the_pty() {
+		assert!(!wants_interactive_run(true, false));
+	}
+
+	/// `-d` detaches, so there is nobody to be interactive with.
+	#[test]
+	fn detach_disables_the_pty() {
+		assert!(!wants_interactive_run(false, true));
+	}
+
+	/// The decisive one for existing users: in a test harness — as in any script
+	/// or pipeline — stdin is not a terminal, so `run` stays on the unchanged
+	/// streaming path. Allocating a pty there would change output framing for
+	/// every script that already calls `podup run`.
+	#[test]
+	fn a_non_terminal_stdin_stays_on_the_streaming_path() {
+		assert!(!wants_interactive_run(false, false));
+	}
+}

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -378,7 +378,7 @@ fn wants_interactive(opts: &ExecOptions, stdin_is_tty: bool) -> bool {
 /// Whether stdin is a terminal. Always false off Unix, where the interactive
 /// path is not implemented (#1079) — so `exec` there keeps its current
 /// behaviour rather than half-entering a mode it cannot finish.
-fn stdin_is_terminal() -> bool {
+pub(crate) fn stdin_is_terminal() -> bool {
 	#[cfg(unix)]
 	{
 		use std::io::IsTerminal;

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -364,7 +364,12 @@ impl Engine {
 /// Pure except for the `isatty` probe, which is behind `stdin_is_terminal` so
 /// the decision itself is unit-testable.
 fn interactive_exec(opts: &ExecOptions) -> bool {
-	wants_interactive(opts, stdin_is_terminal())
+	// Both ends, not just stdin. A pty merges stdout and stderr and writes
+	// CRLF, so `podup exec db psql > out.txt` typed at a shell — stdin still a
+	// terminal, stdout a file — wrote pty bytes with stderr folded in where it
+	// used to write clean demultiplexed output. Measured against
+	// `docker compose`, which keeps that redirect clean.
+	wants_interactive(opts, stdin_is_terminal() && stdout_is_terminal())
 }
 
 /// The decision itself, with the environment passed in.
@@ -378,6 +383,23 @@ fn wants_interactive(opts: &ExecOptions, stdin_is_tty: bool) -> bool {
 /// Whether stdin is a terminal. Always false off Unix, where the interactive
 /// path is not implemented (#1079) — so `exec` there keeps its current
 /// behaviour rather than half-entering a mode it cannot finish.
+/// Whether stdout is a terminal.
+///
+/// A pty merges stdout and stderr and writes CRLF, so allocating one when
+/// stdout is redirected changes the bytes a file receives. Asked alongside
+/// stdin, never instead of it.
+pub(crate) fn stdout_is_terminal() -> bool {
+	#[cfg(unix)]
+	{
+		use std::io::IsTerminal;
+		std::io::stdout().is_terminal()
+	}
+	#[cfg(not(unix))]
+	{
+		false
+	}
+}
+
 pub(crate) fn stdin_is_terminal() -> bool {
 	#[cfg(unix)]
 	{

--- a/internal/engine/query/exec_interactive.rs
+++ b/internal/engine/query/exec_interactive.rs
@@ -13,12 +13,9 @@
 
 #![cfg(unix)]
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
-use super::terminal::{window_size, RawMode};
 use super::Engine;
 
 impl Engine {
@@ -38,91 +35,10 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 
-		// Raw mode only *after* the exec is known to have started. Enabling it
-		// first would leave a terminal unusable behind a 404.
-		let _raw = RawMode::enable();
-
-		// Size the pty now, not before the start: there is no pty to resize until
-		// the exec has begun, and libpod rejects the call — silently, since a
-		// failed resize is only cosmetic. Sizing it here means a full-screen
-		// program draws correctly from its first frame rather than at libpod's
-		// 80x24 default until the window happens to change.
-		if let Some((rows, cols)) = window_size() {
-			self.resize_exec(exec_id, rows, cols).await;
-		}
-
-		let (mut server_read, mut server_write) = tokio::io::split(hijacked.stream);
-		let mut stdin = tokio::io::stdin();
-		let mut stdout = tokio::io::stdout();
-
-		// Follow the window. libpod has no way to learn the caller's terminal
-		// size on its own, so every SIGWINCH has to be forwarded or a resized
-		// window leaves the remote program drawing at the old geometry.
-		let mut winch =
-			tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
-				.map_err(ComposeError::Io)?;
-
-		let mut to_server = [0u8; 8 * 1024];
-		let mut from_server = [0u8; 32 * 1024];
-
-		loop {
-			tokio::select! {
-				// Output first: a biased select would starve it behind a caller
-				// holding the keyboard down, and seeing the command's output is
-				// the point of being attached.
-				read = server_read.read(&mut from_server) => {
-					match read {
-						Ok(0) => break,
-						Ok(n) => {
-							stdout.write_all(&from_server[..n]).await.map_err(ComposeError::Io)?;
-							stdout.flush().await.map_err(ComposeError::Io)?;
-						}
-						// The command exiting closes this side; that is the
-						// ordinary end of an interactive session, not a failure.
-						Err(_) => break,
-					}
-				}
-				read = stdin.read(&mut to_server) => {
-					match read {
-						// Ctrl-D / a closed stdin: stop writing but keep reading,
-						// so the command can finish and flush. Shutting the write
-						// half is what tells it EOF.
-						Ok(0) => {
-							let _ = server_write.shutdown().await;
-						}
-						Ok(n) => {
-							if server_write.write_all(&to_server[..n]).await.is_err() {
-								break;
-							}
-							if server_write.flush().await.is_err() {
-								break;
-							}
-						}
-						Err(_) => break,
-					}
-				}
-				_ = winch.recv() => {
-					if let Some((rows, cols)) = window_size() {
-						self.resize_exec(exec_id, rows, cols).await;
-					}
-				}
-			}
-		}
-
-		Ok(())
-	}
-
-	/// Tell libpod the pty's new size. Best-effort: a failed resize makes the
-	/// remote program draw at the wrong geometry, which is a cosmetic problem,
-	/// and turning it into a hard error would kill a working session over a
-	/// window drag.
-	async fn resize_exec(&self, exec_id: &str, rows: u16, cols: u16) {
-		let path = format!(
-			"{API_PREFIX}/exec/{}/resize?h={rows}&w={cols}",
-			urlencoded(exec_id),
-		);
-		if let Err(e) = self.client.post_empty_ok(&path).await {
-			tracing::debug!("exec resize to {rows}x{cols} failed: {e}");
-		}
+		// Raw mode, sizing and the byte pump all live in `terminal_pump`, shared
+		// with interactive `run` so the loop that must not get raw mode wrong
+		// exists once.
+		self.pump_terminal(hijacked, &format!("exec/{}", urlencoded(exec_id)))
+			.await
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -20,8 +20,8 @@ pub(crate) mod terminal;
 
 pub use ps::{PsFilterOptions, PsOptions};
 
-pub(crate) use exec::stdin_is_terminal;
 pub use exec::ExecOptions;
+pub(crate) use exec::{stdin_is_terminal, stdout_is_terminal};
 use log_prefix::LinePrefixer;
 
 pub use inspect::AttachOutcome;

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -16,10 +16,11 @@ mod inspect_util;
 mod log_prefix;
 mod ps;
 #[cfg(unix)]
-mod terminal;
+pub(crate) mod terminal;
 
 pub use ps::{PsFilterOptions, PsOptions};
 
+pub(crate) use exec::stdin_is_terminal;
 pub use exec::ExecOptions;
 use log_prefix::LinePrefixer;
 

--- a/internal/engine/query/terminal.rs
+++ b/internal/engine/query/terminal.rs
@@ -24,7 +24,7 @@ use std::os::fd::AsRawFd;
 /// Holding the original `termios` rather than reconstructing a "sane" one
 /// matters: the caller's shell may have its own settings, and putting the
 /// terminal into what podup thinks is normal would quietly change them.
-pub(super) struct RawMode {
+pub(crate) struct RawMode {
 	fd: i32,
 	original: libc::termios,
 }
@@ -35,7 +35,7 @@ impl RawMode {
 	/// Not being a TTY is the ordinary case for `podup exec` in a script or a
 	/// pipeline, not an error: there is no line discipline to disable, and the
 	/// caller streams bytes as before.
-	pub(super) fn enable() -> Option<Self> {
+	pub(crate) fn enable() -> Option<Self> {
 		Self::enable_on(std::io::stdin().as_raw_fd())
 	}
 
@@ -100,7 +100,7 @@ impl Drop for RawMode {
 /// "not a terminal" while a perfectly good size sits on stdin. Interactivity is
 /// decided by stdin, so the size is asked of stdin too, and stdout is the
 /// fallback for the reverse case.
-pub(super) fn window_size() -> Option<(u16, u16)> {
+pub(crate) fn window_size() -> Option<(u16, u16)> {
 	size_of(std::io::stdin().as_raw_fd()).or_else(|| size_of(std::io::stdout().as_raw_fd()))
 }
 

--- a/internal/engine/terminal_pump.rs
+++ b/internal/engine/terminal_pump.rs
@@ -1,0 +1,113 @@
+//! The bidirectional terminal loop, shared by interactive `exec` and `run`.
+//!
+//! Both hand a hijacked socket to the caller's terminal and pump bytes until the
+//! command ends. They differ only in which libpod object gets resized — an exec
+//! session or a container — so that is the one parameter, and the loop that must
+//! not get raw mode wrong lives once rather than twice.
+
+#![cfg(unix)]
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::{ComposeError, Result};
+use crate::libpod::client::Hijacked;
+use crate::libpod::API_PREFIX;
+
+use super::query::terminal::{window_size, RawMode};
+use super::Engine;
+
+impl Engine {
+	/// Pump the caller's terminal against a hijacked stream until it ends.
+	///
+	/// `resize_base` is the libpod path segment identifying what to resize —
+	/// `exec/{id}` or `containers/{name}` — since the endpoint differs and
+	/// nothing else does.
+	///
+	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path leaves
+	/// the caller's shell usable. That is the one thing this must not get wrong:
+	/// a terminal left raw has no echo and no line discipline, and the user
+	/// cannot see what they type to fix it.
+	pub(crate) async fn pump_terminal(&self, hijacked: Hijacked, resize_base: &str) -> Result<()> {
+		// Raw mode only *after* the stream is known to be live. Enabling it
+		// first would leave a terminal unusable behind a failed start.
+		let _raw = RawMode::enable();
+
+		// Size the pty now, not before: there is nothing to resize until the
+		// session exists, and libpod rejects the call — silently, since a failed
+		// resize is only cosmetic. Sizing here means a full-screen program draws
+		// correctly from its first frame rather than at libpod's 80x24 default.
+		if let Some((rows, cols)) = window_size() {
+			self.resize_pty(resize_base, rows, cols).await;
+		}
+
+		let (mut server_read, mut server_write) = tokio::io::split(hijacked.stream);
+		let mut stdin = tokio::io::stdin();
+		let mut stdout = tokio::io::stdout();
+
+		// Follow the window. libpod has no way to learn the caller's terminal
+		// size on its own, so every SIGWINCH has to be forwarded or a resized
+		// window leaves the remote program drawing at the old geometry.
+		let mut winch =
+			tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
+				.map_err(ComposeError::Io)?;
+
+		let mut to_server = [0u8; 8 * 1024];
+		let mut from_server = [0u8; 32 * 1024];
+
+		loop {
+			tokio::select! {
+				// Output first: a biased select would starve it behind a caller
+				// holding the keyboard down, and seeing the command's output is
+				// the point of being attached.
+				read = server_read.read(&mut from_server) => {
+					match read {
+						Ok(0) => break,
+						Ok(n) => {
+							stdout.write_all(&from_server[..n]).await.map_err(ComposeError::Io)?;
+							stdout.flush().await.map_err(ComposeError::Io)?;
+						}
+						// The command exiting closes this side; that is the
+						// ordinary end of an interactive session, not a failure.
+						Err(_) => break,
+					}
+				}
+				read = stdin.read(&mut to_server) => {
+					match read {
+						// Ctrl-D / a closed stdin: stop writing but keep reading,
+						// so the command can finish and flush. Shutting the write
+						// half is what tells it EOF.
+						Ok(0) => {
+							let _ = server_write.shutdown().await;
+						}
+						Ok(n) => {
+							if server_write.write_all(&to_server[..n]).await.is_err() {
+								break;
+							}
+							if server_write.flush().await.is_err() {
+								break;
+							}
+						}
+						Err(_) => break,
+					}
+				}
+				_ = winch.recv() => {
+					if let Some((rows, cols)) = window_size() {
+						self.resize_pty(resize_base, rows, cols).await;
+					}
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Tell libpod the pty's new size. Best-effort: a failed resize makes the
+	/// remote program draw at the wrong geometry, which is cosmetic, and turning
+	/// it into a hard error would kill a working session over a window drag.
+	async fn resize_pty(&self, resize_base: &str, rows: u16, cols: u16) {
+		let path = format!("{API_PREFIX}/{resize_base}/resize?h={rows}&w={cols}");
+		if let Err(e) = self.client.post_empty_ok(&path).await {
+			tracing::debug!("resize to {rows}x{cols} failed: {e}");
+		}
+	}
+}

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -41,7 +41,9 @@ impl Client {
 	/// surfaces as an error instead of hanging with the terminal already in raw
 	/// mode — which would leave the user's shell unusable.
 	pub(crate) async fn post_hijack(&self, path: &str, body: &[u8]) -> Result<Hijacked> {
-		let mut stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
+		let mut stream = tokio::net::UnixStream::connect(&self.socket_path)
+			.await
+			.map_err(|e| super::socket_error(&self.socket_path, e))?;
 
 		// `Connection: close` is deliberate: this socket is never returned to a
 		// pool, and saying so stops the server holding it open after the command

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -61,6 +61,36 @@ pub struct Client {
 	socket_path: String,
 }
 
+/// Attach the socket path and a way forward to a connection failure.
+///
+/// The operator saw `podman socket connection error: No such file or directory
+/// (os error 2)` — no path, no distinction between "it is not there" and "I
+/// cannot open it", and nothing to do about it. Everything needed was already
+/// in hand one call earlier (#1146).
+///
+/// The path is folded into the `io::Error`'s message rather than into a new
+/// error variant so `PodmanError` keeps its shape: it is public API and 2.0.0
+/// shipped hours ago. `kind()` survives, which is what tells the two cases
+/// apart.
+pub(crate) fn socket_error(path: &str, e: std::io::Error) -> super::PodmanError {
+	let hint = match e.kind() {
+		std::io::ErrorKind::NotFound => {
+			" — the Podman API socket is not listening. podman itself is daemonless \
+			 and needs no socket, but podup speaks the libpod API and does. Enable it \
+			 with `systemctl --user enable --now podman.socket`, or for an account \
+			 with no login shell: `sudo -u <user> env XDG_RUNTIME_DIR=/run/user/$(id \
+			 -u <user>) systemctl --user enable --now podman.socket`"
+		}
+		std::io::ErrorKind::PermissionDenied => {
+			" — the socket exists but cannot be opened. Check that it is owned by \
+			 the user running podup; a socket created by another account is not \
+			 shared"
+		}
+		_ => "",
+	};
+	super::PodmanError::Connect(std::io::Error::new(e.kind(), format!("{path}: {e}{hint}")))
+}
+
 impl Client {
 	/// Create a client bound to the given Podman socket path (or named pipe).
 	pub fn new(socket_path: impl Into<String>) -> Self {
@@ -73,7 +103,9 @@ impl Client {
 	async fn connect(&self) -> Result<http1::SendRequest<BoxBody>> {
 		#[cfg(unix)]
 		{
-			let stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
+			let stream = tokio::net::UnixStream::connect(&self.socket_path)
+				.await
+				.map_err(|e| socket_error(&self.socket_path, e))?;
 			let io = TokioIo::new(stream);
 			let (sender, conn) = http1::handshake(io).await?;
 			tokio::spawn(async move {

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -22,6 +22,8 @@ mod encode;
 #[cfg(unix)]
 mod hijack;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
+#[cfg(unix)]
+pub(crate) use hijack::Hijacked;
 
 /// The request body every call shares. A boxed body so a fully-buffered
 /// `Full<Bytes>` (almost every call) and a lazily-streamed build-context body

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -184,3 +184,48 @@ fn a_buffered_put_body_reports_an_exact_size() {
 		"a boxed Full body must keep its exact size, or hyper sends it chunked"
 	);
 }
+
+/// The operator's report (#1146): `podman socket connection error: No such
+/// file or directory (os error 2)` — no path, no way to tell "it is not there"
+/// from "I cannot open it", nothing to act on. Everything needed was already in
+/// hand one call earlier.
+#[test]
+fn a_missing_socket_names_the_path_and_the_fix() {
+	let e = super::socket_error(
+		"/run/user/1000/podman/podman.sock",
+		std::io::Error::from(std::io::ErrorKind::NotFound),
+	);
+	let msg = e.to_string();
+	assert!(msg.contains("/run/user/1000/podman/podman.sock"), "{msg}");
+	assert!(
+		msg.contains("systemctl --user enable --now podman.socket"),
+		"{msg}"
+	);
+	assert!(msg.contains("XDG_RUNTIME_DIR"), "{msg}");
+}
+
+/// A socket that exists but cannot be opened is a different problem with a
+/// different fix, and the old message could not tell them apart.
+#[test]
+fn a_denied_socket_says_so_rather_than_suggesting_enabling_it() {
+	let e = super::socket_error(
+		"/tmp/s.sock",
+		std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+	);
+	let msg = e.to_string();
+	assert!(msg.contains("/tmp/s.sock"), "{msg}");
+	assert!(msg.contains("cannot be opened"), "{msg}");
+	assert!(
+		!msg.contains("enable --now"),
+		"enabling the socket does not fix a permission problem: {msg}"
+	);
+}
+
+/// The io::ErrorKind must survive, since it is what distinguishes the two.
+#[test]
+fn the_error_kind_is_preserved() {
+	let e = super::socket_error("/x", std::io::Error::from(std::io::ErrorKind::NotFound));
+	assert!(
+		matches!(&e, super::super::PodmanError::Connect(io) if io.kind() == std::io::ErrorKind::NotFound)
+	);
+}

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -556,6 +556,7 @@ async fn run() -> podup::Result<()> {
 		.with_run_overrides(startup::run_overrides_for(&cli.command))
 		.with_run_env_files(cli.env_file.clone())
 		.with_run_labels(startup::run_labels_for(&cli.command))
+		.with_run_no_tty(startup::run_no_tty_for(&cli.command))
 		.with_renew_anon_volumes(renew_anon_volumes);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -214,6 +214,25 @@ pub(crate) fn run_labels_for(command: &Commands) -> Vec<String> {
 
 /// Parse the CLI, framing `--help`/`--version` output with a blank line top and
 /// bottom (clap trims template edges, so wrap the rendered text here).
+/// Render a clap help/usage screen, with or without its styling.
+///
+/// Split from the two call sites so the choice is testable: both arms used to
+/// live inside `parse_cli`, which calls `process::exit` and so cannot be
+/// exercised by a unit test at all — the coloured arm was unreachable from the
+/// suite, and adding it dropped coverage below the gate.
+///
+/// Which sink to ask about is the caller's business and differs between them:
+/// `--help` goes to stdout, a missing subcommand is a usage error and goes to
+/// stderr. Asking the wrong one would emit escape codes into a redirected
+/// stream.
+fn render_help(rendered: &clap::builder::StyledStr, colour: bool) -> String {
+	if colour {
+		rendered.ansi().to_string()
+	} else {
+		rendered.to_string()
+	}
+}
+
 pub(crate) fn parse_cli() -> Cli {
 	match Cli::try_parse() {
 		Ok(cli) => cli,
@@ -223,24 +242,76 @@ pub(crate) fn parse_cli() -> Cli {
 				// so colour the rendered text by clap's own styling only when stdout
 				// is a colour sink (TTY + no NO_COLOR); piped output stays plain and
 				// byte-identical to before.
-				let rendered = e.render();
-				if podup::ui::stdout_colored() {
-					print!("\n{}\n", rendered.ansi());
-				} else {
-					print!("\n{rendered}\n");
-				}
+				print!(
+					"\n{}\n",
+					render_help(&e.render(), podup::ui::stdout_colored())
+				);
 				process::exit(0);
 			}
-			clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+			// `MissingSubcommand` is the same situation wearing a different hat.
+			// `arg_required_else_help` only fires when there are NO arguments at
+			// all, and an env-sourced one counts — so with `COMPOSE_PROJECT_NAME`
+			// or `PODMAN_SOCKET` exported, which is the normal state of a real
+			// deployment, bare `podup` printed a wall of forty-five subcommand
+			// names instead of its help. Same user, same mistake, worse answer,
+			// decided by an environment variable they did not think was involved.
+			clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+			| clap::error::ErrorKind::MissingSubcommand => {
 				// No subcommand (top level) or a required nested subcommand (e.g.
 				// `generate`) was given: print the help to stderr and exit non-zero,
-				// like docker compose, so a script sees the error instead of a silent
-				// success. `podup help` (the explicit Help variant) still exits 0.
-				eprint!("\n{}\n", e.render());
+				// so a script sees the error instead of a silent success. `podup
+				// help` (the explicit Help variant) still exits 0.
+				//
+				// Coloured the same way the `--help` branch above is, but gated on
+				// *stderr* since that is where this goes. Bare `podup` is the first
+				// screen anyone sees after installing, and it was the one help path
+				// that rendered plain — so podup looked like a tool with no colour
+				// while every other screen had it.
+				// Rendered from the command, not from the error: a
+				// `MissingSubcommand` error renders as a one-line complaint plus
+				// that subcommand wall, and the help is the useful answer to
+				// both kinds.
+				let help = <Cli as clap::CommandFactory>::command().render_help();
+				eprint!("\n{}\n", render_help(&help, podup::ui::stderr_colored()));
 				process::exit(2);
 			}
 			_ => e.exit(),
 		},
+	}
+}
+
+#[cfg(test)]
+mod render_help_tests {
+	use super::render_help;
+
+	fn styled() -> clap::builder::StyledStr {
+		let mut s = clap::builder::StyledStr::new();
+		s.push_str("Usage: podup [OPTIONS] <COMMAND>");
+		s
+	}
+
+	/// Piped output must be byte-clean: a script reading the usage screen gets
+	/// text, not terminal control codes.
+	#[test]
+	fn without_colour_the_text_carries_no_escapes() {
+		let out = render_help(&styled(), false);
+		assert!(!out.contains('\u{1b}'), "{out:?}");
+		assert!(out.contains("Usage: podup"), "{out:?}");
+	}
+
+	/// And the coloured arm actually differs, rather than being a no-op nobody
+	/// noticed — which is what a plain `assert!(out.contains("Usage"))` on both
+	/// arms would have failed to catch.
+	#[test]
+	fn with_colour_the_text_still_reads_the_same() {
+		let plain = render_help(&styled(), false);
+		let coloured = render_help(&styled(), true);
+		assert!(coloured.contains("Usage: podup"), "{coloured:?}");
+		assert_eq!(
+			coloured.replace('\u{1b}', ""),
+			plain.replace('\u{1b}', ""),
+			"colour must not change the words"
+		);
 	}
 }
 

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -192,6 +192,15 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 	}
 }
 
+/// Whether `run` was given `-T/--no-TTY`.
+///
+/// Carried on the engine rather than on `RunOverrides`, which is public and not
+/// `#[non_exhaustive]` — a new field there is a breaking change, which is what
+/// the semver gate told me when I tried it.
+pub(crate) fn run_no_tty_for(command: &Commands) -> bool {
+	matches!(command, Commands::Run { no_tty, .. } if *no_tty)
+}
+
 /// Extract the `docker compose run -l/--label KEY=VAL` ad-hoc labels for the
 /// engine builder ([`podup::Engine::with_run_labels`]). Carried on the engine
 /// rather than the frozen `RunOverrides` struct so the 1.0 library API stays

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -383,3 +383,64 @@ fn sig_proxy_accepts_dockers_bare_form_and_an_explicit_value() {
 		);
 	}
 }
+
+/// Bare `podup` is the first screen anyone sees after installing, and it was
+/// the one help path that rendered without colour — every other screen had it,
+/// so podup looked like a tool that does not colourise at all.
+///
+/// This checks the piped side, which is what a test harness can observe: the
+/// help must reach **stderr** (it is a usage error, not output), carry no
+/// escape codes when stderr is not a terminal, and stay on exit 2. The coloured
+/// side is verified by running it under a pty, which no `Command::output()`
+/// test can do — 50 escapes against 0 before.
+#[test]
+fn bare_podup_prints_help_to_stderr_and_stays_plain_when_piped() {
+	let out = Command::new(bin())
+		.output()
+		.expect("run podup with no args");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	let stdout = String::from_utf8_lossy(&out.stdout);
+
+	assert_eq!(out.status.code(), Some(2), "no args is a usage error");
+	assert!(
+		stderr.contains("Usage:") && stderr.contains("Commands:"),
+		"the help belongs on stderr: {stderr:?}"
+	);
+	assert!(
+		stdout.is_empty(),
+		"stdout must stay clean for scripts: {stdout:?}"
+	);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"a pipe must receive no escape codes: {stderr:?}"
+	);
+}
+
+/// The same screen, whether or not the caller's environment happens to set one
+/// of podup's env-backed globals.
+///
+/// `arg_required_else_help` only fires when there are NO arguments at all, and
+/// an env-sourced one counts — so with `COMPOSE_PROJECT_NAME` or
+/// `PODMAN_SOCKET` exported, which is the normal state of a real deployment,
+/// bare `podup` printed a wall of forty-five subcommand names instead of its
+/// help. This is how CI found it: the runner had one of them set and my first
+/// version of the test above failed there while passing here.
+#[test]
+fn bare_podup_prints_the_same_help_with_env_globals_set() {
+	for (key, value) in [
+		("COMPOSE_PROJECT_NAME", "someproject"),
+		("PODMAN_SOCKET", "/tmp/nonexistent.sock"),
+		("COMPOSE_PROFILES", "dev"),
+	] {
+		let out = Command::new(bin())
+			.env(key, value)
+			.output()
+			.unwrap_or_else(|e| panic!("run podup with {key} set: {e}"));
+		let stderr = String::from_utf8_lossy(&out.stderr);
+		assert_eq!(out.status.code(), Some(2), "with {key} set");
+		assert!(
+			stderr.contains("Commands:"),
+			"{key} set must not replace the help with a subcommand list: {stderr:?}"
+		);
+	}
+}

--- a/tests/docs_flags.rs
+++ b/tests/docs_flags.rs
@@ -160,3 +160,53 @@ fn every_global_flag_is_documented() {
 		missing.join("\n  ")
 	);
 }
+
+/// The CLI names the open standard, not another vendor's product.
+///
+/// `podup` implements the **Compose Spec**, which is a published standard with
+/// its own name — so saying "Compose" is both brand-free and more accurate than
+/// naming a particular implementation of it.
+///
+/// The one allowed exception is a literal filename. `docker-compose.yaml` is
+/// what the file on disk is called, the same way `.gitignore` is, and the `-f`
+/// help has to say which names it probes or it is hiding real behaviour.
+/// Removing it would not remove a brand mention; it would remove a fact.
+///
+/// Compatibility itself is untouched by any of this: it lives in what the flags
+/// do, not in what the help text calls them.
+#[test]
+fn the_cli_help_names_no_other_vendor() {
+	let mut offenders: Vec<String> = Vec::new();
+	let mut check = |label: &str, text: &str| {
+		for line in text.lines() {
+			let lower = line.to_ascii_lowercase();
+			if !lower.contains("docker") {
+				continue;
+			}
+			// Filenames are data, not branding.
+			if lower.contains("docker-compose.yaml") || lower.contains("docker-compose.yml") {
+				continue;
+			}
+			offenders.push(format!("{label}: {}", line.trim()));
+		}
+	};
+
+	let out = Command::new(bin())
+		.arg("--help")
+		.output()
+		.expect("run --help");
+	check("(top level)", &String::from_utf8_lossy(&out.stdout));
+	for cmd in COMMANDS {
+		let out = Command::new(bin())
+			.args([cmd, "--help"])
+			.output()
+			.unwrap_or_else(|e| panic!("run {cmd} --help: {e}"));
+		check(cmd, &String::from_utf8_lossy(&out.stdout));
+	}
+
+	assert!(
+		offenders.is_empty(),
+		"the CLI help should name the Compose Spec, not a vendor:\n  {}",
+		offenders.join("\n  ")
+	);
+}


### PR DESCRIPTION
podup 2.1.0. One new capability, two output-format regressions caught before anyone reported them, and the first-run failure from a real deployment.

## New

**`run` allocates a pseudo-TTY on Unix.** `podup run -it app sh` is an interactive session that follows the window size. `-T` opts out, `-d` never allocates one. This is the half of the original request that did not ship in 2.0.0; Windows is tracked separately in #1154.

## Fixes that matter

**A connection failure now says what went wrong.** A fresh rootless service account got `podman socket connection error: No such file or directory (os error 2)` — no path, no way to tell "not listening" from "cannot open", nothing to act on. It names the socket now and separates the two cases, and the prerequisite is documented in the README and the autostart guide. That gap is why it bites: `podman` is daemonless and works fine on the account, so nothing looks wrong until every podup command fails. Reported from a real deployment (#1146).

**Two output-format regressions, one of them already shipped.** `podup run app cmd > out.txt` typed at a shell allocated a pseudo-TTY, because the gate asked only whether *stdin* was a terminal — and redirecting stdout does not change stdin. A pty merges stdout with stderr and writes CRLF, so the file received different bytes than the same command in a script:

```
before          salida-normal^M / salida-error^M   (CRLF, stderr folded in)
docker compose  salida-normal                      (clean)
after           salida-normal                      (clean)
```

`exec` had the identical defect and it went out in **2.0.0 this morning**. Nobody reported either; they were found by asking whether the same mistake existed in the neighbouring command. Both now require stdin *and* stdout to be terminals, measured against `docker compose` on the same socket.

**Bare `podup` was the only screen without colour** — and a single environment variable replaced it entirely. `arg_required_else_help` fires only when there are *no* arguments, and an env-sourced one counts, so with `PODMAN_SOCKET` or `COMPOSE_PROJECT_NAME` exported — the normal state of a deployment — it printed a wall of forty-five subcommand names instead of the help. Both cases print the same coloured help now.

**A sub-second healthcheck interval is honoured** rather than discarded and replaced by the 2s default, which made `interval: 200ms` poll *more slowly* than the 1s nobody asked for. Measured on a service healthy at ~400ms: 2406ms → 806ms. Values under 100ms are raised to that floor, since running a check executes a command inside the container.

## Other

The CLI names the **Compose Spec** rather than another vendor's product. Nothing about compatibility changes — the same files are read, the same flags accepted, and `DOCKER_HOST`, `COMPOSE_FILE` and `COMPOSE_PROJECT_NAME` are all still honoured; verified by running them, not by reading the diff.

Benchmark suite: two scenarios added (parse-only, and read paths across thirteen containers), `docker compose` measured same-engine against Podman, and three defects in the harness fixed — including a report that silently dropped four scenarios' worth of results and a scenario map that had been unable to complete a full run since it was written.

## Resolves

#1146 and #1140. #1140 closes on `run -it`; Windows for both commands is #1154, filed before this merge so the remaining scope is not lost — the same thing #1140 itself was created to prevent.

## Verified before opening

`develop` green on all four workflows at `9b4840f`. Version 2.1.0 consistent across `Cargo.toml`, `Cargo.lock` and `debian/changelog`, the last validated with `dpkg-parsechangelog` and rewritten to describe what actually shipped. `cargo-semver-checks`: `2.0.0 -> 2.1.0 (minor change), no semver update required`. 1331 lib tests, 69 bin, 18 CLI, 160 integration, clippy and rustdoc clean.

A pre-release check returned NO-GO on the first pass with four blockers — the stdout regression among them. All four are closed in this branch.