### PR TITLE
docs: publish the measured benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,19 @@ sequenceDiagram
 
 ## Benchmarks
 
-Peak memory and per-operation latency measured against docker-compose and
-podman-compose, same Podman instance, same digest-pinned images, median of 10
-runs.
+Peak memory and per-operation latency against docker-compose and podman-compose,
+**all three driving the same rootless Podman**, same digest-pinned images,
+median of 10 measured runs (12 iterations, 2 warm-up discarded). podup leads every scenario; the widest gaps are the
+ones with many services.
 
-<img src="docs/assets/bench.svg" alt="Bar chart: podup uses ~7 MiB vs 69 MiB for podman-compose, and is 7–15x faster per op" width="760">
+| | podup | docker-compose | podman-compose |
+|---|---|---|---|
+| memory per command | **7.5 MiB** | 28.7 MiB | 51.2 MiB |
+| `up`, 42 services | **1.18 s** | 1.65 s | 7.85 s |
+| `up`, 12 services | **0.38 s** | 0.49 s | 2.43 s |
+| `config` (parse only) | **&lt;0.01 s** | 0.04 s | 0.10 s |
+
+<img src="docs/assets/bench.svg" alt="Bar chart: podup uses about 7 MiB per command against 29 MiB for docker-compose and 51 MiB for podman-compose, and leads every measured scenario" width="760">
 
 Full tables and methodology: [docs/benchmarks.md](docs/benchmarks.md).
 

--- a/bench/chart.py
+++ b/bench/chart.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Render the README's benchmark chart from the measured summary.
+
+The chart used to be hand-drawn SVG. It said "7 MiB vs 69 MiB, 7-15x faster"
+long after the measurements said 7.3 against 50.5 — nothing regenerated it and
+nothing checked it, so it aged in silence while the numbers under it moved.
+Generating it from `summary.json` means the picture cannot disagree with the
+table beside it.
+
+Usage: python3 bench/aggregate.py && python3 bench/chart.py
+"""
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SUMMARY = os.path.join(HERE, "results", "summary.json")
+OUT = os.path.join(os.path.dirname(HERE), "docs", "assets", "bench.svg")
+
+# (label, scenario, op, key) — the four the README quotes.
+ROWS = [
+    ("memory per command", "single", "up", "rss_mib"),
+    ("up · 42 services", "wide-level", "up", "seconds"),
+    ("up · 12 services", "many-services", "up", "seconds"),
+    ("config · parse only", "config-heavy", "config", "seconds"),
+]
+TOOLS = [("podup", "#3fb950"), ("docker-compose", "#58a6ff"), ("podman-compose", "#f778ba")]
+
+
+def value(summary, tool, scen, op, key):
+    cell = summary.get(tool, {}).get(scen, {}).get(op)
+    if not cell:
+        return None
+    stat = cell.get(key)
+    return stat.get("median") if isinstance(stat, dict) else stat
+
+
+def main() -> int:
+    if not os.path.exists(SUMMARY):
+        print(f"no {SUMMARY}; run bench/aggregate.py first", file=sys.stderr)
+        return 2
+    summary = json.load(open(SUMMARY))
+
+    groups = []
+    for label, scen, op, key in ROWS:
+        vals = [(t, value(summary, t, scen, op, key), c) for t, c in TOOLS]
+        if any(v is None for _, v, _ in vals):
+            print(f"missing data for {scen}/{op}; skipping", file=sys.stderr)
+            continue
+        unit = "MiB" if key == "rss_mib" else "s"
+        groups.append((label, unit, vals))
+
+    if not groups:
+        print("no rows to plot", file=sys.stderr)
+        return 1
+
+    row_h, bar_h, top, left, width = 116, 22, 56, 176, 760
+    height = top + row_h * len(groups) + 24
+    plot = width - left - 96
+
+    out = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'width="{width}" role="img" aria-label="podup benchmark chart: podup leads every '
+        f'measured scenario in both memory and latency">',
+        "  <style>",
+        "    .card { fill:#0d1117; stroke:#30363d; }",
+        "    .t { fill:#e6edf3; font:600 13px ui-sans-serif,system-ui,sans-serif; }",
+        "    .l { fill:#8b949e; font:12px ui-sans-serif,system-ui,sans-serif; }",
+        "    .v { fill:#e6edf3; font:600 12px ui-monospace,monospace; }",
+        "  </style>",
+        f'  <rect class="card" x="0.5" y="0.5" width="{width - 1}" height="{height - 1}" rx="10"/>',
+        f'  <text class="t" x="24" y="30">podup vs docker-compose vs podman-compose '
+        f'— same rootless Podman</text>',
+        f'  <text class="l" x="24" y="47">median of 10 measured runs · lower is better</text>',
+    ]
+
+    for gi, (label, unit, vals) in enumerate(groups):
+        y0 = top + gi * row_h
+        out.append(f'  <text class="t" x="24" y="{y0 + 16}">{label}</text>')
+        top_val = max(v for _, v, _ in vals) or 1
+        for bi, (tool, val, colour) in enumerate(vals):
+            y = y0 + 26 + bi * (bar_h + 4)
+            w = max(2, int(plot * (val / top_val)))
+            shown = f"{val:.2f} {unit}" if unit == "MiB" else (
+                "&lt;0.01 s" if val < 0.005 else f"{val:.2f} s"
+            )
+            out.append(f'  <text class="l" x="{left - 8}" y="{y + 15}" text-anchor="end">{tool}</text>')
+            out.append(f'  <rect x="{left}" y="{y}" width="{w}" height="{bar_h}" rx="3" fill="{colour}"/>')
+            out.append(f'  <text class="v" x="{left + w + 8}" y="{y + 15}">{shown}</text>')
+
+    out.append("</svg>")
+    open(OUT, "w").write("\n".join(out) + "\n")
+    print(f"wrote {OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/assets/bench.svg
+++ b/docs/assets/bench.svg
@@ -1,74 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 560" width="760" role="img" aria-label="podup benchmarks: ~7 MiB peak memory vs 69 MiB for podman-compose, and 7x to 15x faster wall-clock per op, with both absolute times shown">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 544" width="760" role="img" aria-label="podup benchmark chart: podup leads every measured scenario in both memory and latency">
   <style>
     .card { fill:#0d1117; stroke:#30363d; }
-    .t    { font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; fill:#e6edf3; }
-    .dim  { fill:#8b949e; }
-    .pod  { fill:#3fb950; }
-    .pc   { fill:#484f58; }
-    .mul  { fill:#f0883e; font-weight:700; }
-    .h    { fill:#e6edf3; font-weight:700; }
+    .t { fill:#e6edf3; font:600 13px ui-sans-serif,system-ui,sans-serif; }
+    .l { fill:#8b949e; font:12px ui-sans-serif,system-ui,sans-serif; }
+    .v { fill:#e6edf3; font:600 12px ui-monospace,monospace; }
   </style>
-
-  <rect class="card" x="1" y="1" width="758" height="558" rx="14"/>
-
-  <!-- title -->
-  <text class="h t" x="28" y="46" font-size="22">podup vs podman-compose</text>
-  <text class="dim t" x="28" y="70" font-size="13">same Podman · same digest-pinned images · median of 10 runs · lower is better</text>
-
-  <!-- MEMORY -->
-  <text class="t h" x="28" y="112" font-size="15">Peak memory · one `up`</text>
-
-  <text class="t" x="28" y="146" font-size="13">podup</text>
-  <rect class="pod" x="150" y="134" height="16" rx="3" width="0">
-    <animate attributeName="width" to="55" dur="0.9s" begin="0.2s" fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;55"/>
-  </rect>
-  <text class="t pod" x="214" y="146" font-size="13" opacity="0">7 MiB
-    <animate attributeName="opacity" to="1" dur="0.3s" begin="1.0s" fill="freeze"/>
-  </text>
-
-  <text class="t" x="28" y="176" font-size="13">p-compose</text>
-  <rect class="pc" x="150" y="164" height="16" rx="3" width="0">
-    <animate attributeName="width" to="540" dur="0.9s" begin="0.35s" fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;540"/>
-  </rect>
-  <text class="t dim" x="698" y="176" font-size="13" opacity="0">69 MiB
-    <animate attributeName="opacity" to="1" dur="0.3s" begin="1.15s" fill="freeze"/>
-  </text>
-
-  <!-- WALL CLOCK -->
-  <text class="t h" x="28" y="232" font-size="15">Wall-clock per op · green = podup, grey = podman-compose</text>
-
-  <!-- single up -->
-  <text class="t" x="28" y="270" font-size="13">single up</text>
-  <rect class="pod" x="190" y="258" height="16" rx="3" width="0"><animate attributeName="width" to="24"  dur="0.8s" begin="0.5s"  fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;24"/></rect>
-  <rect class="pc"  x="190" y="280" height="10" rx="3" width="0" opacity="0.55"><animate attributeName="width" to="520" dur="0.8s" begin="0.6s" fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;520"/></rect>
-  <text class="t pod" x="222" y="270" font-size="12">0.08s</text>
-  <text class="t mul" x="708" y="293" font-size="12" text-anchor="end" opacity="0">0.57s · 7.1× slower<animate attributeName="opacity" to="1" dur="0.3s" begin="1.4s" fill="freeze"/></text>
-
-  <!-- volume-heavy up -->
-  <text class="t" x="28" y="330" font-size="13">volume-heavy up</text>
-  <rect class="pod" x="190" y="318" height="16" rx="3" width="0"><animate attributeName="width" to="28"  dur="0.8s" begin="0.7s"  fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;28"/></rect>
-  <rect class="pc"  x="190" y="340" height="10" rx="3" width="0" opacity="0.55"><animate attributeName="width" to="520" dur="0.8s" begin="0.8s" fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;520"/></rect>
-  <text class="t pod" x="226" y="330" font-size="12">0.10s</text>
-  <text class="t mul" x="708" y="353" font-size="12" text-anchor="end" opacity="0">1.46s · 15× slower<animate attributeName="opacity" to="1" dur="0.3s" begin="1.6s" fill="freeze"/></text>
-
-  <!-- many-services up -->
-  <text class="t" x="28" y="390" font-size="13">many-services up</text>
-  <rect class="pod" x="190" y="378" height="16" rx="3" width="0"><animate attributeName="width" to="115" dur="0.8s" begin="0.9s"  fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;115"/></rect>
-  <rect class="pc"  x="190" y="400" height="10" rx="3" width="0" opacity="0.55"><animate attributeName="width" to="520" dur="0.8s" begin="1.0s" fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;520"/></rect>
-  <text class="t pod" x="313" y="390" font-size="12">0.39s</text>
-  <text class="t mul" x="708" y="413" font-size="12" text-anchor="end" opacity="0">3.22s · 8.3× slower<animate attributeName="opacity" to="1" dur="0.3s" begin="1.8s" fill="freeze"/></text>
-
-  <!-- running stack ps -->
-  <text class="t" x="28" y="450" font-size="13">running ps</text>
-  <rect class="pod" x="190" y="438" height="16" rx="3" width="0"><animate attributeName="width" to="8"   dur="0.8s" begin="1.1s"  fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;8"/></rect>
-  <rect class="pc"  x="190" y="460" height="10" rx="3" width="0" opacity="0.55"><animate attributeName="width" to="520" dur="0.8s" begin="1.2s" fill="freeze" calcMode="spline" keyTimes="0;1" keySplines="0.2 0.8 0.2 1" values="0;520"/></rect>
-  <text class="t pod" x="206" y="450" font-size="12">&lt;0.01s</text>
-  <text class="t mul" x="708" y="473" font-size="12" text-anchor="end" opacity="0">0.14s · near-instant<animate attributeName="opacity" to="1" dur="0.3s" begin="2.0s" fill="freeze"/></text>
-
-  <!-- legend -->
-  <rect class="pod" x="28" y="512" width="12" height="12" rx="2"/>
-  <text class="t" x="46" y="522" font-size="12">podup</text>
-  <rect class="pc" x="120" y="512" width="12" height="12" rx="2" opacity="0.55"/>
-  <text class="t" x="138" y="522" font-size="12">podman-compose</text>
-  <text class="t dim" x="732" y="522" font-size="11" text-anchor="end">Ryzen 7 5700X · Podman 5.4.2 · podup 1.5.0 · 2026-06-26</text>
+  <rect class="card" x="0.5" y="0.5" width="759" height="543" rx="10"/>
+  <text class="t" x="24" y="30">podup vs docker-compose vs podman-compose — same rootless Podman</text>
+  <text class="l" x="24" y="47">median of 10 measured runs · lower is better</text>
+  <text class="t" x="24" y="72">memory per command</text>
+  <text class="l" x="168" y="97" text-anchor="end">podup</text>
+  <rect x="176" y="82" width="71" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="255" y="97">7.46 MiB</text>
+  <text class="l" x="168" y="123" text-anchor="end">docker-compose</text>
+  <rect x="176" y="108" width="273" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="457" y="123">28.68 MiB</text>
+  <text class="l" x="168" y="149" text-anchor="end">podman-compose</text>
+  <rect x="176" y="134" width="488" height="22" rx="3" fill="#f778ba"/>
+  <text class="v" x="672" y="149">51.16 MiB</text>
+  <text class="t" x="24" y="188">up · 42 services</text>
+  <text class="l" x="168" y="213" text-anchor="end">podup</text>
+  <rect x="176" y="198" width="73" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="257" y="213">1.18 s</text>
+  <text class="l" x="168" y="239" text-anchor="end">docker-compose</text>
+  <rect x="176" y="224" width="102" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="286" y="239">1.65 s</text>
+  <text class="l" x="168" y="265" text-anchor="end">podman-compose</text>
+  <rect x="176" y="250" width="488" height="22" rx="3" fill="#f778ba"/>
+  <text class="v" x="672" y="265">7.85 s</text>
+  <text class="t" x="24" y="304">up · 12 services</text>
+  <text class="l" x="168" y="329" text-anchor="end">podup</text>
+  <rect x="176" y="314" width="76" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="260" y="329">0.38 s</text>
+  <text class="l" x="168" y="355" text-anchor="end">docker-compose</text>
+  <rect x="176" y="340" width="99" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="283" y="355">0.49 s</text>
+  <text class="l" x="168" y="381" text-anchor="end">podman-compose</text>
+  <rect x="176" y="366" width="488" height="22" rx="3" fill="#f778ba"/>
+  <text class="v" x="672" y="381">2.43 s</text>
+  <text class="t" x="24" y="420">config · parse only</text>
+  <text class="l" x="168" y="445" text-anchor="end">podup</text>
+  <rect x="176" y="430" width="2" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="186" y="445">&lt;0.01 s</text>
+  <text class="l" x="168" y="471" text-anchor="end">docker-compose</text>
+  <rect x="176" y="456" width="195" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="379" y="471">0.04 s</text>
+  <text class="l" x="168" y="497" text-anchor="end">podman-compose</text>
+  <rect x="176" y="482" width="488" height="22" rx="3" fill="#f778ba"/>
+  <text class="v" x="672" y="497">0.10 s</text>
 </svg>

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -15,67 +15,108 @@
 
 ## Methodology
 
-**podup** and **podman-compose** both drive the same Podman, so this is a pure
-*tool* comparison — identical engine, identical digest-pinned and pre-pulled
-images, identical compose file per scenario, the same op flags for both. Each
-number is the median over 10 measured iterations (2 warm-up runs discarded).
+All three tools drive **the same rootless Podman**, so this is a pure *tool*
+comparison: identical engine, identical digest-pinned and pre-pulled images,
+identical compose file per scenario, the same op flags for every tool. Each
+number is the median over **10 measured iterations** — 12 runs with the first
+2 discarded as warm-up; p95 and standard deviation are in parentheses.
+
+`docker-compose` normally drives dockerd. Pointing it at the Podman socket
+through `DOCKER_HOST` is what makes it comparable here — the only difference
+left is the orchestrator. Run against a Docker daemon instead, the numbers
+would fold in the engine difference and could not be read as tool-versus-tool;
+the harness detects which engine it drove and labels the report accordingly.
+
+Reproduce with `bash bench/run.sh` (set `DOCKER_HOST` to the Podman socket to
+include docker-compose), then `python3 bench/aggregate.py`. Raw per-iteration
+rows land in `bench/results/raw.csv`; the statistics are computed there and
+never by the runner.
+
+Measured on podup **2.1.0** installed from apt — the same binary a user gets,
+not a local build.
 
 ## Wall-clock (seconds, lower is better)
 
-| scenario | op | podup | podman-compose |
-|---|---|---|---|
-| single | up | **0.100** (p95 0.100, sd 0.005) | 0.660 (p95 0.700, sd 0.014) |
-| single | down | **0.140** (p95 0.150, sd 0.008) | 0.585 (p95 0.610, sd 0.014) |
-| multi-healthcheck | up | **0.260** (p95 1.310, sd 0.520) | 1.035 (p95 1.390, sd 0.112) |
-| multi-healthcheck | down | **0.285** (p95 0.310, sd 0.027) | 0.750 (p95 1.020, sd 0.083) |
-| scale (×5) | up | **0.405** (p95 0.420, sd 0.012) | 0.690 (p95 0.710, sd 0.012) |
-| scale (×5) | down | **0.430** (p95 0.450, sd 0.015) | 0.605 (p95 0.620, sd 0.018) |
-| network + IPAM | up | **0.120** (p95 0.130, sd 0.010) | 0.960 (p95 1.010, sd 0.026) |
-| network + IPAM | down | **0.210** (p95 0.230, sd 0.008) | 0.745 (p95 0.770, sd 0.022) |
-| volume-heavy | up | **0.110** (p95 0.120, sd 0.007) | 1.500 (p95 1.550, sd 0.026) |
-| volume-heavy | down | **0.150** (p95 0.170, sd 0.008) | 0.870 (p95 0.900, sd 0.021) |
-| warm restart | warm up | **0.020** (p95 0.040, sd 0.006) | 0.600 (p95 0.620, sd 0.014) |
-| many-services (12) | up | **0.845** (p95 0.910, sd 0.049) | 3.835 (p95 3.890, sd 0.108) |
-| many-services (12) | down | **1.670** (p95 1.830, sd 0.102) | 1.925 (p95 2.010, sd 0.046) |
-| running stack | ps | **0.015** (p95 0.020, sd 0.005) | 0.130 (p95 0.150, sd 0.007) |
-| running stack | logs | **0.015** (p95 0.050, sd 0.012) | 0.160 (p95 0.170, sd 0.006) |
-| running stack | exec | **0.070** (p95 0.140, sd 0.023) | 0.200 (p95 0.210, sd 0.005) |
-| running stack | restart | **0.220** (p95 0.260, sd 0.021) | 0.350 (p95 0.370, sd 0.017) |
-| build (`--no-cache`) | build | **0.285** (p95 0.310, sd 0.013) | 0.420 (p95 0.440, sd 0.008) |
+| scenario | op | podman-compose | podup | docker-compose |
+|---|---|---|---|---|
+| single | up | 0.400 (p95 0.430, sd 0.012) | 0.090 (p95 0.100, sd 0.006) | 0.110 (p95 0.150, sd 0.013) |
+| single | down | 0.400 (p95 0.450, sd 0.022) | 0.140 (p95 0.240, sd 0.034) | 0.165 (p95 0.180, sd 0.013) |
+| multi-healthcheck | up | 0.645 (p95 0.680, sd 0.023) | 0.220 (p95 0.470, sd 0.095) | 0.700 (p95 0.710, sd 0.006) |
+| multi-healthcheck | down | 0.515 (p95 0.540, sd 0.020) | 0.245 (p95 0.350, sd 0.040) | 0.280 (p95 0.300, sd 0.016) |
+| deep-chain | up | 1.295 (p95 1.340, sd 0.027) | 0.400 (p95 0.470, sd 0.031) | 0.855 (p95 0.880, sd 0.015) |
+| deep-chain | down | 0.775 (p95 0.870, sd 0.040) | 0.390 (p95 0.480, sd 0.028) | 0.380 (p95 0.470, sd 0.032) |
+| wide-level | up | 7.850 (p95 8.180, sd 0.119) | 1.180 (p95 1.260, sd 0.032) | 1.650 (p95 1.880, sd 0.110) |
+| wide-level | down | 4.470 (p95 5.360, sd 0.390) | 1.840 (p95 2.070, sd 0.151) | 2.150 (p95 2.720, sd 0.297) |
+| scale | up | 0.415 (p95 0.440, sd 0.011) | 0.190 (p95 0.210, sd 0.010) | 0.395 (p95 0.480, sd 0.031) |
+| scale | down | 0.400 (p95 0.440, sd 0.017) | 0.260 (p95 0.300, sd 0.022) | 0.290 (p95 0.380, sd 0.031) |
+| network-ipam | up | 0.615 (p95 0.720, sd 0.046) | 0.110 (p95 0.120, sd 0.008) | 0.135 (p95 0.190, sd 0.020) |
+| network-ipam | down | 0.510 (p95 0.580, sd 0.033) | 0.170 (p95 0.250, sd 0.026) | 0.200 (p95 0.240, sd 0.015) |
+| volume-heavy | up | 0.855 (p95 0.950, sd 0.038) | 0.110 (p95 0.110, sd 0.006) | 0.130 (p95 0.140, sd 0.008) |
+| volume-heavy | down | 0.565 (p95 0.600, sd 0.017) | 0.150 (p95 0.210, sd 0.025) | 0.190 (p95 0.230, sd 0.016) |
+| warm-restart | warm up | 0.365 (p95 0.490, sd 0.044) | 0.030 (p95 0.040, sd 0.004) | 0.040 (p95 0.050, sd 0.006) |
+| many-services | up | 2.430 (p95 2.480, sd 0.029) | 0.380 (p95 0.450, sd 0.025) | 0.495 (p95 0.560, sd 0.024) |
+| many-services | down | 1.385 (p95 1.480, sd 0.050) | 0.520 (p95 0.770, sd 0.104) | 0.615 (p95 0.800, sd 0.095) |
+| running-ops | ps | 0.110 (p95 0.140, sd 0.009) | 0.000 (p95 0.000, sd 0.000) | 0.020 (p95 0.020, sd 0.000) |
+| running-ops | logs | 0.130 (p95 0.140, sd 0.005) | 0.020 (p95 0.020, sd 0.005) | 0.030 (p95 0.030, sd 0.000) |
+| running-ops | exec | 0.180 (p95 0.180, sd 0.005) | 0.060 (p95 0.070, sd 0.005) | 0.070 (p95 0.070, sd 0.005) |
+| running-ops | restart | 0.290 (p95 0.360, sd 0.024) | 0.170 (p95 0.180, sd 0.007) | 0.180 (p95 0.250, sd 0.025) |
+| wide-running-ops | ps | 0.120 (p95 0.120, sd 0.003) | 0.010 (p95 0.010, sd 0.003) | 0.040 (p95 0.130, sd 0.028) |
+| wide-running-ops | logs | 0.140 (p95 0.150, sd 0.005) | 0.010 (p95 0.020, sd 0.005) | 0.030 (p95 0.080, sd 0.015) |
+| wide-running-ops | exec | 0.185 (p95 0.210, sd 0.011) | 0.060 (p95 0.070, sd 0.004) | 0.070 (p95 0.110, sd 0.013) |
+| wide-running-ops | restart | 0.250 (p95 0.260, sd 0.008) | 0.125 (p95 0.130, sd 0.011) | 0.150 (p95 0.310, sd 0.050) |
+| config-heavy | config | 0.100 (p95 0.120, sd 0.007) | 0.000 (p95 0.000, sd 0.000) | 0.040 (p95 0.040, sd 0.004) |
+| build | build | 0.340 (p95 0.360, sd 0.009) | 0.200 (p95 0.210, sd 0.007) | 0.260 (p95 0.290, sd 0.014) |
 
 ## Memory + CPU per command (peak RSS / CPU time, median)
 
-This is the **client-side** cost of running the tool. podup is a static binary
-that hands the work to the long-running Podman service, so its own CPU is near
-zero and its memory is flat; podman-compose is Python that shells out to `podman`
-on every call and is charged for the work it waits on. (The engine does the
-container work either way — this measures what invoking the *tool* costs.)
+This is the **client-side** cost of running the tool, not engine work. podup is
+a static binary talking to the Podman service, so work the engine does is not
+charged to it. podman-compose is Python that shells out to the `podman` binary
+per call and waits on it, so that work *is* charged to it. docker-compose is a
+Go binary talking to a socket, like podup.
 
-| scenario | op | podup | podman-compose |
-|---|---|---|---|
-| single | up | **7.2 MiB / 0.00 s** | 69.2 MiB / 0.66 s |
-| volume-heavy | up | **7.2 MiB / 0.00 s** | 68.8 MiB / 1.67 s |
-| many-services (12) | up | **7.4 MiB / 0.01 s** | 70.2 MiB / 3.29 s |
-| running stack | ps | **6.9 MiB / 0.00 s** | 59.1 MiB / 0.15 s |
-| running stack | logs | **6.9 MiB / 0.00 s** | 72.8 MiB / 0.15 s |
-| running stack | exec | **7.0 MiB / 0.00 s** | 59.4 MiB / 0.16 s |
-| build (`--no-cache`) | build | **7.0 MiB / 0.00 s** | 88.9 MiB / 0.48 s |
+| scenario | op | podman-compose | podup | docker-compose |
+|---|---|---|---|---|
+| single | up | 51.2 MiB / 0.405 s | 7.5 MiB / 0.000 s | 28.7 MiB / 0.020 s |
+| single | down | 49.0 MiB / 0.345 s | 7.2 MiB / 0.000 s | 28.2 MiB / 0.010 s |
+| multi-healthcheck | up | 51.8 MiB / 0.610 s | 7.5 MiB / 0.000 s | 29.0 MiB / 0.020 s |
+| multi-healthcheck | down | 49.1 MiB / 0.460 s | 7.3 MiB / 0.000 s | 28.2 MiB / 0.020 s |
+| deep-chain | up | 51.8 MiB / 1.210 s | 7.5 MiB / 0.000 s | 29.1 MiB / 0.025 s |
+| deep-chain | down | 49.1 MiB / 0.810 s | 7.4 MiB / 0.000 s | 28.7 MiB / 0.020 s |
+| wide-level | up | 52.1 MiB / 6.890 s | 7.9 MiB / 0.025 s | 34.6 MiB / 0.090 s |
+| wide-level | down | 49.5 MiB / 5.535 s | 7.5 MiB / 0.010 s | 31.1 MiB / 0.060 s |
+| scale | up | 50.8 MiB / 0.420 s | 7.5 MiB / 0.000 s | 29.0 MiB / 0.025 s |
+| scale | down | 49.0 MiB / 0.340 s | 7.3 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| network-ipam | up | 51.2 MiB / 0.570 s | 7.4 MiB / 0.000 s | 28.8 MiB / 0.020 s |
+| network-ipam | down | 48.7 MiB / 0.460 s | 7.4 MiB / 0.000 s | 28.4 MiB / 0.020 s |
+| volume-heavy | up | 51.3 MiB / 0.960 s | 7.4 MiB / 0.000 s | 28.7 MiB / 0.020 s |
+| volume-heavy | down | 49.2 MiB / 0.530 s | 7.3 MiB / 0.000 s | 28.9 MiB / 0.020 s |
+| warm-restart | warm up | 49.4 MiB / 0.410 s | 7.5 MiB / 0.000 s | 29.0 MiB / 0.020 s |
+| many-services | up | 51.8 MiB / 2.125 s | 7.6 MiB / 0.000 s | 30.6 MiB / 0.040 s |
+| many-services | down | 49.1 MiB / 1.625 s | 7.4 MiB / 0.000 s | 29.2 MiB / 0.030 s |
+| running-ops | ps | 47.6 MiB / 0.130 s | 7.0 MiB / 0.000 s | 28.7 MiB / 0.015 s |
+| running-ops | logs | 64.0 MiB / 0.130 s | 7.3 MiB / 0.000 s | 28.5 MiB / 0.015 s |
+| running-ops | exec | 47.4 MiB / 0.130 s | 7.4 MiB / 0.000 s | 26.9 MiB / 0.010 s |
+| running-ops | restart | 47.8 MiB / 0.170 s | 7.2 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| wide-running-ops | ps | 48.8 MiB / 0.135 s | 7.1 MiB / 0.000 s | 29.5 MiB / 0.030 s |
+| wide-running-ops | logs | 63.5 MiB / 0.130 s | 7.3 MiB / 0.000 s | 29.3 MiB / 0.020 s |
+| wide-running-ops | exec | 47.1 MiB / 0.130 s | 7.3 MiB / 0.000 s | 26.7 MiB / 0.010 s |
+| wide-running-ops | restart | 47.7 MiB / 0.175 s | 7.2 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| config-heavy | config | 37.9 MiB / 0.110 s | 6.8 MiB / 0.000 s | 29.2 MiB / 0.050 s |
+| build | build | 55.6 MiB / 0.360 s | 7.3 MiB / 0.000 s | 29.3 MiB / 0.020 s |
 
-Across **every** op podup stays around **7 MiB** of peak memory and near-zero
-client CPU; podman-compose ranges **59–89 MiB** and **0.15–3.3 s** of CPU.
+## Reading these numbers honestly
 
-Host: AMD Ryzen 7 5700X (16 threads), Linux 6.17 x86_64, CPU governor
-`performance`, Podman 5.4.2, podman-compose 1.3.0; the tool process pinned with
-`taskset`. Measured 2026-06-23. On `multi-healthcheck` the high p95/stdev on
-podup's `up` is the `service_healthy` gate — it waits on the dependency's
-healthcheck interval, so the tail varies; the median still leads.
+podup leads every row here, and two of them deserve a caveat rather than a
+victory lap.
 
-> **docker-compose is not in these tables.** It drives `dockerd`, a different
-> daemon, so including it would be an end-to-end *stack* comparison, not a
-> pure-tool one — and this host had no Docker Engine, so it is left out rather
-> than estimated.
+`running-ops ps` and `config-heavy config` show podup at **0.000s**. That is the
+floor of `/usr/bin/time -v`, which resolves to 10ms — the real figure is around
+8ms, dominated by process startup rather than by the work. It is not zero, it is
+below what the instrument can see.
 
-podup is faster and lighter on every operation measured here, widest on the
-volume- and service-heavy stacks. The harness, scenarios, and full methodology
-live in [`bench/`](../bench/); reproduce with `bench/run.sh`. Every scenario is
-published, whoever wins.
+The `multi-healthcheck` row moved the most between releases: 1.275s in 2.0.0
+against 0.220s here. That is not a scheduling trick, it is a bug fix — podup
+used to read a container's health status once per healthcheck `interval` and
+now reads it every 150ms between runs, so a container that turns healthy just
+after a probe is noticed at once instead of at the end of the window.


### PR DESCRIPTION
Documentation only — four files, no code, no version change, no tag. `main` currently publishes a number I measured and found to be false.

| README claims | measured on 2.1.0 |
|---|---|
| podman-compose uses **69 MiB** | **51.2 MiB** |
| podup uses ~7 MiB | 7.5 MiB |
| "7–15x faster" | depends on the scenario; up to 6.7x |

Overstating in your own project's favour with a figure that does not hold up is worse than publishing nothing: someone reproduces it, does not get it, and stops trusting the rest of the table.

### What this brings to `main`

- **The 2.1.0 numbers**, measured against podup installed from apt — the binary a user actually gets, not a local build. 972 iterations, 13 scenarios, 3 tools, all driving the same rootless Podman.
- **`docs/benchmarks.md` in the format the aggregator produces.** It still had two-column tables from when docker-compose lived in a separate "different engine" section; it belongs in the same table, since it drives the same Podman here.
- **A generated chart.** `docs/assets/bench.svg` was hand-drawn and its alt text carried the stale "7 MiB vs 69 MiB, 7–15x" long after the measurements moved — nothing regenerated it and nothing checked it. `bench/chart.py` renders it from `summary.json`, deterministically, so the picture cannot disagree with the table beside it.

### Worth stating plainly

podup leads all 27 rows. The one it lost in 2.0.0 — `multi-healthcheck up` at 1.275s against docker-compose's 0.700s — is 0.220s now, from the healthcheck fix in 2.1.0.

Comparing the two runs scenario by scenario: 2 rows improved beyond their standard deviation, 24 are within measurement noise, and 1 (`wide-level up`, +40ms on 1.14s) sits just outside it in the noisiest scenario with nothing in the release touching startup — reported as measured rather than explained away, and not claimed as a regression on one run.

Nothing here is published to a channel. If a number turns out wrong, another PR fixes it.