### PR TITLE
feat!: long-form mount hardening options; the compose option blocks go non-exhaustive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "2.1.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (3.0.0) unstable; urgency=medium
+
+  New
+
+  * Interactive `exec` and `run` work on Windows: raw console mode, window
+    resize (250ms poll; the console has no resize signal), and the hijacked
+    stream over the named pipe. The both-ends-are-terminals rule is unchanged,
+    so scripts, pipelines and redirects keep their exact streaming bytes.
+  * The long-form volume syntax carries the mount-hardening options
+    `noexec`, `nosuid` and `nodev`, matching what the short form's raw
+    options always did. Quadlet export carries them too.
+
+  Fixes
+
+  * An interactive session that ended with exit code 0 left podup waiting for
+    one more keypress before exiting. Sessions ending non-zero were unaffected,
+    which is what hid it.
+
+  Breaking (library only; the CLI is unchanged)
+
+  * The compose option blocks (BindOptions, VolumeOptions, DriverConfig,
+    TmpfsOptions, ServiceNetworkConfig) are #[non_exhaustive] now: construct
+    them with Default::default() and assign fields instead of a struct
+    literal. They gain a field whenever the compose surface grows, and each
+    addition used to be a breaking change.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Thu, 23 Jul 2026 06:43:00 -0500
+
 podup (2.1.0) unstable; urgency=medium
 
   New

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -137,6 +137,27 @@ volumes:
   - ./data:/app/data:Z
 ```
 
+### Per-mount hardening options (`noexec`, `nosuid`, `nodev`)
+
+The short form carries these as raw mount options (`cache:/app/cache:noexec`),
+and the long form accepts them as booleans under `volume:`:
+
+```yaml
+volumes:
+  - type: volume
+    source: cache
+    target: /app/cache
+    volume:
+      noexec: true
+      nosuid: true
+      nodev: true
+```
+
+The long-form spelling is a podup extension — the Compose Specification defines
+no per-mount hardening flags there — so a compose file using it is not portable
+back to `docker compose`, which rejects the unknown keys. `generate quadlet`
+carries the options into the exported unit.
+
 ### `network_mode: host`
 
 Attaches the container to your user's network namespace, not a privileged host

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -153,8 +153,8 @@ volumes:
       nodev: true
 ```
 
-The long-form spelling is a podup extension — the Compose Specification defines
-no per-mount hardening flags there — so a compose file using it is not portable
+The long-form spelling is a podup extension (the Compose Specification defines
+no per-mount hardening flags there), so a compose file using it is not portable
 back to `docker compose`, which rejects the unknown keys. `generate quadlet`
 carries the options into the exported unit.
 

--- a/internal/compose/diagnostics/nested_raw.rs
+++ b/internal/compose/diagnostics/nested_raw.rs
@@ -33,7 +33,15 @@
 /// `BindOptions` (volume.rs).
 const BIND_OPTIONS_KEYS: &[&str] = &["propagation", "create_host_path", "selinux"];
 /// `VolumeOptions` (volume.rs).
-const VOLUME_OPTIONS_KEYS: &[&str] = &["nocopy", "labels", "driver_config", "subpath"];
+const VOLUME_OPTIONS_KEYS: &[&str] = &[
+	"nocopy",
+	"labels",
+	"driver_config",
+	"subpath",
+	"noexec",
+	"nosuid",
+	"nodev",
+];
 /// `DriverConfig` (volume.rs).
 const DRIVER_CONFIG_KEYS: &[&str] = &["name", "options"];
 /// `TmpfsOptions` (volume.rs).
@@ -264,6 +272,9 @@ mod tests {
 				options: one_entry_map(),
 			}),
 			subpath: Some("sub".to_string()),
+			noexec: Some(true),
+			nosuid: Some(true),
+			nodev: Some(true),
 		};
 		assert_eq!(serialized_keys(&v), allowlist(VOLUME_OPTIONS_KEYS));
 	}

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -43,6 +43,12 @@ impl ServiceNetworks {
 }
 
 /// Per-network attachment options: aliases, static IPv4/IPv6, link-local addresses, and priority.
+///
+/// `#[non_exhaustive]` (3.0.0), like the volume option blocks: this grows a
+/// field whenever the compose surface does, and each addition used to be a
+/// breaking change for anyone building the literal. Construct via
+/// `Default::default()` and assign the fields you need.
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ServiceNetworkConfig {
 	/// Additional network aliases the container is reachable by.

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -27,6 +27,12 @@ pub enum VolumeType {
 }
 
 /// Sub-options for a `bind`-type volume mount.
+///
+/// `#[non_exhaustive]` (3.0.0), like every compose option block below: these
+/// structs grow a field whenever the compose surface does, and each addition
+/// used to be a breaking change for anyone building the literal. Construct via
+/// `Default::default()` and assign the fields you need.
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BindOptions {
 	/// Mount propagation mode (e.g. `rprivate`, `rshared`).
@@ -41,6 +47,9 @@ pub struct BindOptions {
 }
 
 /// Sub-options for a `volume`-type mount — nocopy flag and optional driver config.
+///
+/// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VolumeOptions {
 	/// Whether to skip copying existing target contents into the volume.
@@ -55,9 +64,28 @@ pub struct VolumeOptions {
 	/// Path within the volume to mount instead of its root.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub subpath: Option<String>,
+	/// Mount with `noexec`, denying execution of binaries from the volume.
+	///
+	/// A podup extension, like its two siblings below: the Compose
+	/// Specification defines no per-mount hardening flags on the long form,
+	/// while the short form has always carried them as raw mount options
+	/// (`cache:/app/cache:noexec`). The long form deserved the same reach —
+	/// these are the standard mount-hardening trio, and a compose file that
+	/// spells a mount out longhand should not lose them (#1160).
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub noexec: Option<bool>,
+	/// Mount with `nosuid`, ignoring setuid/setgid bits on files in the volume.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub nosuid: Option<bool>,
+	/// Mount with `nodev`, denying access to device nodes in the volume.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub nodev: Option<bool>,
 }
 
 /// Driver name and key-value options nested under `VolumeOptions`.
+///
+/// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DriverConfig {
 	/// Volume driver name.
@@ -69,6 +97,9 @@ pub struct DriverConfig {
 }
 
 /// Sub-options for a `tmpfs`-type mount — size and mode.
+///
+/// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct TmpfsOptions {
 	/// Size of the tmpfs mount in bytes.

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -253,6 +253,36 @@ mod tests {
 		assert!(named[0].options.contains(&"nocopy".to_string()));
 	}
 
+	/// The mount-hardening trio reaches the engine from the long form, matching
+	/// what the short form's raw options have always done (#1160). `false` and
+	/// absent both mean "not hardened": only an explicit `true` emits the flag.
+	#[test]
+	fn long_form_volume_hardening_options_forwarded() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Volume,
+			source: Some("myvolume".into()),
+			target: "/data".into(),
+			read_only: None,
+			bind: None,
+			volume: Some(VolumeOptions {
+				noexec: Some(true),
+				nosuid: Some(true),
+				nodev: Some(false),
+				..Default::default()
+			}),
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		assert_eq!(named.len(), 1);
+		assert!(named[0].options.contains(&"noexec".to_string()));
+		assert!(named[0].options.contains(&"nosuid".to_string()));
+		assert!(
+			!named[0].options.contains(&"nodev".to_string()),
+			"an explicit false must not emit the flag"
+		);
+	}
+
 	#[test]
 	fn long_form_volume_subpath_forwarded() {
 		let svc = svc_with_volumes(vec![VolumeMount::Long {

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -195,6 +195,18 @@ pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOp
 	if v.nocopy.unwrap_or(false) {
 		opts.push("nocopy".into());
 	}
+	// The mount-hardening trio. The short form has always carried these as raw
+	// options; the long form dropped them with an unknown-key warning, so the
+	// spelled-out mount was the one that could not be hardened (#1160).
+	if v.noexec.unwrap_or(false) {
+		opts.push("noexec".into());
+	}
+	if v.nosuid.unwrap_or(false) {
+		opts.push("nosuid".into());
+	}
+	if v.nodev.unwrap_or(false) {
+		opts.push("nodev".into());
+	}
 }
 
 #[cfg(test)]

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -84,6 +84,18 @@ pub(super) fn render_volume(vol: &VolumeMount, project: &str, declared_volumes: 
 				if v.nocopy == Some(true) {
 					opts.push("nocopy".to_string());
 				}
+				// The mount-hardening trio (#1160). Dropping these here would
+				// mean a compose file that hardens a mount exports a Quadlet
+				// unit that silently does not.
+				if v.noexec == Some(true) {
+					opts.push("noexec".to_string());
+				}
+				if v.nosuid == Some(true) {
+					opts.push("nosuid".to_string());
+				}
+				if v.nodev == Some(true) {
+					opts.push("nodev".to_string());
+				}
 			}
 			let mut out = if src.is_empty() {
 				target.clone()
@@ -487,6 +499,28 @@ mod tests {
 		assert_eq!(
 			render_volume(&nocopy, "proj", &["vol"]),
 			"proj-vol.volume:/data:ro,nocopy"
+		);
+
+		// The hardening trio survives the Quadlet export (#1160): a compose
+		// file that hardens a mount must not export a unit that does not.
+		let hardened = VolumeMount::Long {
+			volume_type: VolumeType::Volume,
+			source: Some("vol".into()),
+			target: "/data".into(),
+			read_only: None,
+			bind: None,
+			volume: Some(VolumeOptions {
+				noexec: Some(true),
+				nosuid: Some(true),
+				nodev: Some(true),
+				..Default::default()
+			}),
+			tmpfs: None,
+			consistency: None,
+		};
+		assert_eq!(
+			render_volume(&hardened, "proj", &["vol"]),
+			"proj-vol.volume:/data:noexec,nosuid,nodev"
 		);
 
 		// An empty source renders as just the target (anonymous mount).


### PR DESCRIPTION
Closes #1160.

The short-form volume syntax has always carried `noexec`/`nosuid`/`nodev` through as raw mount options; the long form dropped them with an unknown-key warning, so the spelled-out mount was the one that could not be hardened. The three now land as booleans under `volume:`, reach the engine's mount options, and survive the Quadlet export, which would otherwise write a unit that silently lost the hardening.

This is a podup extension, documented as such in the migration guide: the Compose Specification defines no per-mount hardening flags on the long form, and `docker compose` rejects the keys (measured: `additional properties 'nodev', 'noexec', 'nosuid' not allowed` from `docker-compose config`).

## Why this is a MAJOR

Adding fields to `VolumeOptions` trips `constructible_struct_adds_field` in the semver gate: the compose option blocks were pub, literal-constructible structs, so every field the compose surface grows costs a breaking change. This was the third time that class of change forced the question, so the release takes the cure along with the symptom: `BindOptions`, `VolumeOptions`, `DriverConfig`, `TmpfsOptions` and `ServiceNetworkConfig` are `#[non_exhaustive]` now, constructed with `Default::default()` plus field assignment. Future compose keys land as minor releases. The autostart option structs already worked this way; the CLI is unchanged. The only known library consumer (helmly-agent) pins podup v0.9.0 and constructs none of these types.

3.0.0 also ships what is already on develop: interactive exec/run on Windows (#1162) and the interactive-session exit hang fix (#1161).

## Test plan

- Full suite green: 1332 lib + 69 bin + 145 integration against real Podman 5.4.2.
- Live, long form against real Podman: mount reports `[noexec nosuid nodev rbind]` in `podman inspect`, exec of a file inside the volume dies with EACCES (exit 126), no unknown-key warning, and `generate quadlet` writes `Volume=...:noexec,nosuid,nodev`.
- `false` and absent both mean not-hardened: only an explicit `true` emits the flag (unit-tested).
- `cargo semver-checks` against 2.1.0: the major bump satisfies the gate (0 failures at 3.0.0).
- Version stamped in all three files: `Cargo.toml`, `Cargo.lock`, `debian/changelog`.