### PR TITLE
release: 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "2.1.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,12 @@ base64 = "0.22"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+# Console raw mode and window size for interactive exec/run: GetConsoleMode/
+# SetConsoleMode and the screen-buffer query. Already in the tree transitively
+# (tokio pulls the same version), so this adds features, not a crate.
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Console"] }
+
 [features]
 default = ["watch", "completions", "update"]
 watch = ["notify"]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (3.0.0) unstable; urgency=medium
+
+  New
+
+  * Interactive `exec` and `run` work on Windows: raw console mode, window
+    resize (250ms poll; the console has no resize signal), and the hijacked
+    stream over the named pipe. The both-ends-are-terminals rule is unchanged,
+    so scripts, pipelines and redirects keep their exact streaming bytes.
+  * The long-form volume syntax carries the mount-hardening options
+    `noexec`, `nosuid` and `nodev`, matching what the short form's raw
+    options always did. Quadlet export carries them too.
+
+  Fixes
+
+  * An interactive session that ended with exit code 0 left podup waiting for
+    one more keypress before exiting. Sessions ending non-zero were unaffected,
+    which is what hid it.
+
+  Breaking (library only; the CLI is unchanged)
+
+  * The compose option blocks (BindOptions, VolumeOptions, DriverConfig,
+    TmpfsOptions, ServiceNetworkConfig) are #[non_exhaustive] now: construct
+    them with Default::default() and assign fields instead of a struct
+    literal. They gain a field whenever the compose surface grows, and each
+    addition used to be a breaking change.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Thu, 23 Jul 2026 06:43:00 -0500
+
 podup (2.1.0) unstable; urgency=medium
 
   New

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -234,7 +234,7 @@ podup run --rm web sh -c 'echo hello'
 > means its existing `--rm` becomes a no-op and a container it expected to
 > inspect afterwards is gone — pass `--no-rm` to keep it.
 
-On Unix, `run` allocates a pseudo-TTY and attaches your stdin when stdin is a
+`run` allocates a pseudo-TTY and attaches your stdin when stdin is a
 terminal, so `podup run -it app sh` drops you into an interactive session that
 follows your window size. Like `docker compose run`, a TTY on both ends is the
 default and `-T` is how you turn it off; `-d` never allocates one, since there
@@ -255,9 +255,6 @@ CRLF**. Checking stdin alone would mean `podup run app cmd > out.txt`, typed at
 a shell, silently wrote different bytes into that file than the same command in
 a script.
 
-Windows keeps the streaming behaviour in every case
-([#1154](https://github.com/Glyndor/podup/issues/1154)).
-
 ### `exec <SERVICE> <COMMAND...>`
 Execute a command in a running service container.
 
@@ -271,7 +268,7 @@ Execute a command in a running service container.
 | `-T, --no-tty` (alias `--no-TTY`) | Disable pseudo-TTY allocation. | off |
 | `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
 
-On Unix, `exec` allocates a pseudo-TTY and attaches your stdin when stdin is a
+`exec` allocates a pseudo-TTY and attaches your stdin when stdin is a
 terminal, so `podup exec -it db psql` drops you into an interactive session that
 follows your window size. It is not on `-i`: like `docker compose exec`, a TTY on
 both ends is the default, and `-T` is how you turn it off.
@@ -283,10 +280,6 @@ pipeline keeps the plain streaming behaviour with no change to output framing:
 podup exec db psql -c 'select 1' > out.txt   # streams, no TTY
 echo 'select 1' | podup exec -T db psql      # streams, no TTY
 ```
-
-Windows keeps the streaming behaviour in every case; podup reaches
-`podman machine` over a named pipe there, where raw mode and window-resize are a
-different API ([#1079](https://github.com/Glyndor/podup/issues/1079)).
 
 ```bash
 podup exec -u root web sh

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -137,6 +137,27 @@ volumes:
   - ./data:/app/data:Z
 ```
 
+### Per-mount hardening options (`noexec`, `nosuid`, `nodev`)
+
+The short form carries these as raw mount options (`cache:/app/cache:noexec`),
+and the long form accepts them as booleans under `volume:`:
+
+```yaml
+volumes:
+  - type: volume
+    source: cache
+    target: /app/cache
+    volume:
+      noexec: true
+      nosuid: true
+      nodev: true
+```
+
+The long-form spelling is a podup extension (the Compose Specification defines
+no per-mount hardening flags there), so a compose file using it is not portable
+back to `docker compose`, which rejects the unknown keys. `generate quadlet`
+carries the options into the exported unit.
+
 ### `network_mode: host`
 
 Attaches the container to your user's network namespace, not a privileged host

--- a/internal/compose/diagnostics/nested_raw.rs
+++ b/internal/compose/diagnostics/nested_raw.rs
@@ -33,7 +33,15 @@
 /// `BindOptions` (volume.rs).
 const BIND_OPTIONS_KEYS: &[&str] = &["propagation", "create_host_path", "selinux"];
 /// `VolumeOptions` (volume.rs).
-const VOLUME_OPTIONS_KEYS: &[&str] = &["nocopy", "labels", "driver_config", "subpath"];
+const VOLUME_OPTIONS_KEYS: &[&str] = &[
+	"nocopy",
+	"labels",
+	"driver_config",
+	"subpath",
+	"noexec",
+	"nosuid",
+	"nodev",
+];
 /// `DriverConfig` (volume.rs).
 const DRIVER_CONFIG_KEYS: &[&str] = &["name", "options"];
 /// `TmpfsOptions` (volume.rs).
@@ -264,6 +272,9 @@ mod tests {
 				options: one_entry_map(),
 			}),
 			subpath: Some("sub".to_string()),
+			noexec: Some(true),
+			nosuid: Some(true),
+			nodev: Some(true),
 		};
 		assert_eq!(serialized_keys(&v), allowlist(VOLUME_OPTIONS_KEYS));
 	}

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -43,6 +43,12 @@ impl ServiceNetworks {
 }
 
 /// Per-network attachment options: aliases, static IPv4/IPv6, link-local addresses, and priority.
+///
+/// `#[non_exhaustive]` (3.0.0), like the volume option blocks: this grows a
+/// field whenever the compose surface does, and each addition used to be a
+/// breaking change for anyone building the literal. Construct via
+/// `Default::default()` and assign the fields you need.
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ServiceNetworkConfig {
 	/// Additional network aliases the container is reachable by.

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -27,6 +27,12 @@ pub enum VolumeType {
 }
 
 /// Sub-options for a `bind`-type volume mount.
+///
+/// `#[non_exhaustive]` (3.0.0), like every compose option block below: these
+/// structs grow a field whenever the compose surface does, and each addition
+/// used to be a breaking change for anyone building the literal. Construct via
+/// `Default::default()` and assign the fields you need.
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BindOptions {
 	/// Mount propagation mode (e.g. `rprivate`, `rshared`).
@@ -41,6 +47,9 @@ pub struct BindOptions {
 }
 
 /// Sub-options for a `volume`-type mount — nocopy flag and optional driver config.
+///
+/// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct VolumeOptions {
 	/// Whether to skip copying existing target contents into the volume.
@@ -55,9 +64,28 @@ pub struct VolumeOptions {
 	/// Path within the volume to mount instead of its root.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub subpath: Option<String>,
+	/// Mount with `noexec`, denying execution of binaries from the volume.
+	///
+	/// A podup extension, like its two siblings below: the Compose
+	/// Specification defines no per-mount hardening flags on the long form,
+	/// while the short form has always carried them as raw mount options
+	/// (`cache:/app/cache:noexec`). The long form deserved the same reach —
+	/// these are the standard mount-hardening trio, and a compose file that
+	/// spells a mount out longhand should not lose them (#1160).
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub noexec: Option<bool>,
+	/// Mount with `nosuid`, ignoring setuid/setgid bits on files in the volume.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub nosuid: Option<bool>,
+	/// Mount with `nodev`, denying access to device nodes in the volume.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub nodev: Option<bool>,
 }
 
 /// Driver name and key-value options nested under `VolumeOptions`.
+///
+/// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DriverConfig {
 	/// Volume driver name.
@@ -69,6 +97,9 @@ pub struct DriverConfig {
 }
 
 /// Sub-options for a `tmpfs`-type mount — size and mode.
+///
+/// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct TmpfsOptions {
 	/// Size of the tmpfs mount in bytes.

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -7,7 +7,6 @@ mod parallel;
 mod prefetch;
 mod readiness;
 mod run;
-#[cfg(unix)]
 mod run_attached;
 mod scale;
 mod schedule;

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -214,8 +214,7 @@ impl Engine {
 
 		// The interactive path takes over here: it needs the connection kept open
 		// in both directions, which the request/response client cannot give it.
-		// Same shape `exec` uses, and cfg-ed the same way.
-		#[cfg(unix)]
+		// Same shape `exec` uses.
 		if want_tty {
 			return self.finish_interactive_run(&run_name, rm, &rm_path).await;
 		}

--- a/internal/engine/lifecycle/run_attached.rs
+++ b/internal/engine/lifecycle/run_attached.rs
@@ -1,4 +1,4 @@
-//! Interactive `run`: a pseudo-terminal on a one-shot container, on Unix.
+//! Interactive `run`: a pseudo-terminal on a one-shot container.
 //!
 //! `podup run -it app bash` parsed `-i` and `-T` and acted on neither: the
 //! container got no TTY and no live stdin, so the flags described something that
@@ -9,8 +9,6 @@
 //! that missed output is often all the output there was. `exec` does not have
 //! this problem — the container is already up — which is why it can attach and
 //! start in a single call and this cannot.
-
-#![cfg(unix)]
 
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
@@ -64,7 +62,8 @@ impl super::super::Engine {
 
 impl super::super::Engine {
 	/// Attach, start, hand over the terminal, then clean up per `--rm` and map
-	/// the exit code. Split from `run` so the non-Unix build can drop it whole.
+	/// the exit code. Split from `run` so the interactive tail reads as one
+	/// piece.
 	pub(super) async fn finish_interactive_run(
 		&self,
 		run_name: &str,

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -6,7 +6,6 @@ mod build;
 mod container;
 mod copy;
 mod events;
-#[cfg(unix)]
 mod terminal_pump;
 pub use events::EventsOptions;
 mod image;

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -284,7 +284,6 @@ impl Engine {
 
 		// The interactive path takes over here: it needs the connection kept open
 		// in both directions, which the request/response client cannot give it.
-		#[cfg(unix)]
 		if interactive {
 			self.exec_interactive(&exec_id).await?;
 			return self.exec_exit_status(&exec_id).await;
@@ -380,36 +379,23 @@ fn wants_interactive(opts: &ExecOptions, stdin_is_tty: bool) -> bool {
 	!opts.no_tty && !opts.detach && stdin_is_tty
 }
 
-/// Whether stdin is a terminal. Always false off Unix, where the interactive
-/// path is not implemented (#1079) — so `exec` there keeps its current
-/// behaviour rather than half-entering a mode it cannot finish.
 /// Whether stdout is a terminal.
 ///
 /// A pty merges stdout and stderr and writes CRLF, so allocating one when
 /// stdout is redirected changes the bytes a file receives. Asked alongside
-/// stdin, never instead of it.
+/// stdin, never instead of it. On Windows this is `GetConsoleMode` succeeding
+/// on the handle — the same probe raw mode later relies on, so the two cannot
+/// disagree.
 pub(crate) fn stdout_is_terminal() -> bool {
-	#[cfg(unix)]
-	{
-		use std::io::IsTerminal;
-		std::io::stdout().is_terminal()
-	}
-	#[cfg(not(unix))]
-	{
-		false
-	}
+	use std::io::IsTerminal;
+	std::io::stdout().is_terminal()
 }
 
+/// Whether stdin is a terminal — the gate that keeps a scripted `exec` on the
+/// unchanged streaming path.
 pub(crate) fn stdin_is_terminal() -> bool {
-	#[cfg(unix)]
-	{
-		use std::io::IsTerminal;
-		std::io::stdin().is_terminal()
-	}
-	#[cfg(not(unix))]
-	{
-		false
-	}
+	use std::io::IsTerminal;
+	std::io::stdin().is_terminal()
 }
 
 #[cfg(test)]

--- a/internal/engine/query/exec_interactive.rs
+++ b/internal/engine/query/exec_interactive.rs
@@ -1,17 +1,12 @@
-//! Interactive `exec`: a pseudo-terminal and a live stdin, on Unix.
+//! Interactive `exec`: a pseudo-terminal and a live stdin.
 //!
 //! `podup exec -it db psql` is the most-used shell-into-a-container habit in
 //! compose, and it did not work: podup allocated no TTY and attached no stdin,
 //! so `-i` set a flag nothing read and `-T` disabled something that never
-//! existed (#1079).
-//!
-//! Unix only for now. podup reaches `podman machine` over a named pipe on
-//! Windows, and both raw mode and resize events there are a different API — two
-//! implementations, not one behind a `cfg`. The non-interactive path is
-//! unchanged everywhere, so `podup exec` in a script behaves exactly as before
-//! on every platform.
-
-#![cfg(unix)]
+//! existed (#1079). Unix shipped first; Windows followed once the hijack ran
+//! over the named pipe and raw mode spoke the console API (#1154). The
+//! non-interactive path is unchanged everywhere, so `podup exec` in a script
+//! behaves exactly as before on every platform.
 
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -9,13 +9,11 @@ use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 use super::Engine;
 
 mod exec;
-#[cfg(unix)]
 mod exec_interactive;
 mod inspect;
 mod inspect_util;
 mod log_prefix;
 mod ps;
-#[cfg(unix)]
 pub(crate) mod terminal;
 
 pub use ps::{PsFilterOptions, PsOptions};

--- a/internal/engine/query/terminal/mod.rs
+++ b/internal/engine/query/terminal/mod.rs
@@ -1,0 +1,26 @@
+//! Terminal raw mode, window size and resize events, for interactive `exec`
+//! and `run`.
+//!
+//! One contract, two implementations. Unix speaks termios, the `TIOCGWINSZ`
+//! ioctl and `SIGWINCH`; Windows speaks the console API (`SetConsoleMode`,
+//! `GetConsoleScreenBufferInfo`) and polls for window changes, because the
+//! console has no resize signal to subscribe to. Callers see the same three
+//! names either way — [`RawMode`], [`window_size`], [`ResizeWatcher`] — and
+//! the pump in `terminal_pump` compiles once against them.
+//!
+//! The invariant both implementations exist to hold: **the terminal is
+//! restored no matter how the exec ends.** A command that exits, a socket that
+//! dies, a panic, or a `?` on some unrelated error must all leave the user's
+//! shell usable. Raw mode with no echo and no line discipline is not something
+//! to leave behind on an error path, so the restore lives in `Drop` rather
+//! than at the end of the happy path.
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub(crate) use unix::{window_size, RawMode, ResizeWatcher};
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub(crate) use windows::{window_size, RawMode, ResizeWatcher};

--- a/internal/engine/query/terminal/unix.rs
+++ b/internal/engine/query/terminal/unix.rs
@@ -1,17 +1,6 @@
-//! Terminal raw mode and window size, for interactive `exec`.
-//!
-//! Unix only. podup talks to `podman machine` over a named pipe on Windows, and
-//! raw mode there is a different API entirely (the console handles, not
-//! termios); that is tracked in #1079 rather than faked here.
-//!
-//! The invariant this module exists to hold: **the terminal is restored no
-//! matter how the exec ends.** A command that exits, a socket that dies, a
-//! panic, or a `?` on some unrelated error must all leave the user's shell
-//! usable. Raw mode with no echo and no line discipline is not something to
-//! leave behind on an error path, so the restore lives in `Drop` rather than at
-//! the end of the happy path.
+//! The termios implementation of the terminal contract — see the module doc
+//! in `mod.rs` for the contract and the restore-on-drop invariant.
 
-#![cfg(unix)]
 // termios and the winsize ioctl are libc FFI. The crate denies `unsafe` and
 // modules that need it opt back in locally, with a soundness comment per block —
 // see `engine::lock` and `engine::staging` for the same pattern.
@@ -119,6 +108,41 @@ fn size_of(fd: i32) -> Option<(u16, u16)> {
 		return None;
 	}
 	Some((ws.ws_row, ws.ws_col))
+}
+
+/// Resize events for the interactive pump: yields a size to apply whenever the
+/// caller's window changes.
+///
+/// On Unix the kernel says when: each `SIGWINCH` is followed by a fresh
+/// [`window_size`] query, so the size handed out is the one current at
+/// delivery, not at registration.
+pub(crate) struct ResizeWatcher {
+	signal: tokio::signal::unix::Signal,
+}
+
+impl ResizeWatcher {
+	/// Register for window-change signals.
+	pub(crate) fn new() -> std::io::Result<Self> {
+		Ok(Self {
+			signal: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())?,
+		})
+	}
+
+	/// The next size to apply.
+	///
+	/// Pends forever once no further signal can arrive, so a `select!` arm on
+	/// it goes quiet rather than spinning on a closed stream; and a signal
+	/// whose size cannot be read is skipped, since there is nothing to apply.
+	pub(crate) async fn next(&mut self) -> (u16, u16) {
+		loop {
+			if self.signal.recv().await.is_none() {
+				std::future::pending::<()>().await;
+			}
+			if let Some(size) = window_size() {
+				return size;
+			}
+		}
+	}
 }
 
 #[cfg(test)]

--- a/internal/engine/query/terminal/windows.rs
+++ b/internal/engine/query/terminal/windows.rs
@@ -1,0 +1,316 @@
+//! The console-API implementation of the terminal contract — see the module
+//! doc in `mod.rs` for the contract and the restore-on-drop invariant.
+//!
+//! Windows has no termios: raw mode is a console *mode* cleared on the stdin
+//! handle (line input, echo, Ctrl-C processing) plus virtual-terminal flags on
+//! both ends, so keystrokes arrive as VT byte sequences and the remote pty's
+//! VT output renders instead of printing as garbage. And it has no `SIGWINCH`:
+//! window changes are found by polling the screen-buffer size, which is cheap
+//! enough at four times a second to be imperceptible and avoids competing with
+//! the stdin pump for console input events.
+
+// The console mode and screen-buffer calls are Win32 FFI. The crate denies
+// `unsafe` and modules that need it opt back in locally, with a soundness
+// comment per block — see `engine::lock` and `engine::staging` for the same
+// pattern.
+#![allow(unsafe_code)]
+
+use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Console::{
+	GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, SetConsoleMode, CONSOLE_MODE,
+	CONSOLE_SCREEN_BUFFER_INFO, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
+	ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING, STD_ERROR_HANDLE,
+	STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
+
+/// A console switched to raw mode, restored on drop.
+///
+/// Holding the *original* modes rather than reconstructing "sane" ones
+/// matters: the caller's shell may run with its own console flags, and putting
+/// the console into what podup thinks is normal would quietly change them.
+/// Both ends are touched — stdin so keystrokes stop being line-buffered and
+/// echoed, stdout so the VT sequences a pty emits are interpreted — so both
+/// originals are held and both are restored.
+pub(crate) struct RawMode {
+	stdin: HANDLE,
+	stdin_original: CONSOLE_MODE,
+	stdout: HANDLE,
+	stdout_original: CONSOLE_MODE,
+}
+
+// SAFETY: the standard console handles are process-global pseudo-handles, not
+// tied to the thread that retrieved them; `SetConsoleMode` is documented as
+// callable from any thread. The raw pointers inside `HANDLE` are what stops
+// the auto-impl, not any real thread affinity.
+unsafe impl Send for RawMode {}
+
+impl RawMode {
+	/// Switch the console to raw mode, or return `None` when stdin or stdout
+	/// is not a console.
+	///
+	/// Not being a console is the ordinary case for `podup exec` in a script
+	/// or a pipeline, not an error: there is no line discipline to disable,
+	/// and the caller streams bytes as before.
+	pub(crate) fn enable() -> Option<Self> {
+		// SAFETY: `GetStdHandle` takes no pointers and only returns a handle;
+		// a missing standard handle comes back null or invalid, checked below.
+		let stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+		let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+		Self::enable_on(stdin, stdout)
+	}
+
+	/// The same, on explicit handles.
+	///
+	/// `enable` is the only place that consults the ambient handles, which
+	/// keeps this testable: a test that asserted on `enable()` directly would
+	/// be asserting on whether the test runner has a console — and on the way
+	/// to failing it would put that console into raw mode.
+	pub(super) fn enable_on(stdin: HANDLE, stdout: HANDLE) -> Option<Self> {
+		if stdin.is_null() || stdin == INVALID_HANDLE_VALUE {
+			return None;
+		}
+		if stdout.is_null() || stdout == INVALID_HANDLE_VALUE {
+			return None;
+		}
+
+		let mut stdin_original: CONSOLE_MODE = 0;
+		// SAFETY: `stdin_original` is a correctly sized mode owned here, and
+		// `GetConsoleMode` only writes into it. A non-console handle fails the
+		// call rather than misbehaving — that is exactly the "not a terminal"
+		// answer.
+		if unsafe { GetConsoleMode(stdin, &mut stdin_original) } == 0 {
+			return None;
+		}
+		let mut stdout_original: CONSOLE_MODE = 0;
+		// SAFETY: as above, for the output handle.
+		if unsafe { GetConsoleMode(stdout, &mut stdout_original) } == 0 {
+			return None;
+		}
+
+		// Line input and echo are the console's line discipline; processed
+		// input turns Ctrl-C into an event instead of a byte. All three must
+		// go so keystrokes — including Ctrl-C — travel to the remote command,
+		// which is what raw mode means. Virtual-terminal input makes arrows
+		// and function keys arrive as the VT sequences the remote pty expects.
+		let stdin_raw = (stdin_original
+			& !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT))
+			| ENABLE_VIRTUAL_TERMINAL_INPUT;
+		// SAFETY: the handle is a console (its mode was just read) and the
+		// mode is a plain flag word derived from the current one.
+		if unsafe { SetConsoleMode(stdin, stdin_raw) } == 0 {
+			return None;
+		}
+
+		// Added to the current flags, never replacing them: anstream may have
+		// already enabled VT processing for colour output, and clobbering the
+		// rest of the mode word would undo whatever else the shell had set.
+		let stdout_raw = stdout_original | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+		// SAFETY: as above, for the output handle.
+		if unsafe { SetConsoleMode(stdout, stdout_raw) } == 0 {
+			// stdin is already raw; put it back before reporting "no console"
+			// so a failed enable never half-changes the caller's terminal.
+			// SAFETY: restoring the exact mode read from this handle above.
+			unsafe { SetConsoleMode(stdin, stdin_original) };
+			return None;
+		}
+
+		Some(Self {
+			stdin,
+			stdin_original,
+			stdout,
+			stdout_original,
+		})
+	}
+}
+
+impl Drop for RawMode {
+	fn drop(&mut self) {
+		// SAFETY: these are the exact modes read from these same handles in
+		// `enable_on`, so restoring them cannot put the console in a state it
+		// was not already in. Errors are ignored because there is nothing
+		// useful to do while unwinding, and reporting one would replace the
+		// real error the caller is already handling.
+		unsafe {
+			SetConsoleMode(self.stdin, self.stdin_original);
+			SetConsoleMode(self.stdout, self.stdout_original);
+		}
+	}
+}
+
+/// The console window's current size as `(rows, cols)`, or `None` when no
+/// handle can answer.
+///
+/// Used to size the remote pty at start and to follow it on window changes:
+/// without this, a full-screen program inside the container draws to an 80x24
+/// default and redraws wrong the moment the window changes.
+///
+/// **stdout first, then stderr** — not stdin, unlike Unix: the screen buffer
+/// is an output-side object, and the input handle does not answer
+/// `GetConsoleScreenBufferInfo`. stderr covers a redirected stdout, the same
+/// reverse case the Unix fallback covers.
+pub(crate) fn window_size() -> Option<(u16, u16)> {
+	// SAFETY: `GetStdHandle` takes no pointers; `size_of` validates what it
+	// returns.
+	let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+	let stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) };
+	size_of(stdout).or_else(|| size_of(stderr))
+}
+
+/// `GetConsoleScreenBufferInfo` on one handle.
+fn size_of(handle: HANDLE) -> Option<(u16, u16)> {
+	if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+		return None;
+	}
+	// SAFETY: `info` is a correctly sized, zeroed struct owned here, and the
+	// call only writes into it. A non-console handle fails the call rather
+	// than writing garbage.
+	let mut info: CONSOLE_SCREEN_BUFFER_INFO = unsafe { std::mem::zeroed() };
+	if unsafe { GetConsoleScreenBufferInfo(handle, &mut info) } != 0 {
+		return window_extent(&info);
+	}
+	None
+}
+
+/// The *visible window* extent from a screen-buffer report, as `(rows, cols)`.
+///
+/// `srWindow`, not `dwSize`: the buffer runs thousands of lines of scrollback,
+/// and sizing the remote pty to it would have a full-screen program paint a
+/// frame taller than the screen. The rectangle is inclusive on both ends,
+/// hence the `+ 1`s. Pure, so the arithmetic — the part worth pinning — is
+/// testable without a console.
+fn window_extent(info: &CONSOLE_SCREEN_BUFFER_INFO) -> Option<(u16, u16)> {
+	let rows = i32::from(info.srWindow.Bottom) - i32::from(info.srWindow.Top) + 1;
+	let cols = i32::from(info.srWindow.Right) - i32::from(info.srWindow.Left) + 1;
+	// A degenerate or inverted rectangle has no usable geometry — treat it as
+	// unknown rather than sizing the remote pty to nothing.
+	if rows <= 0 || cols <= 0 {
+		return None;
+	}
+	Some((rows as u16, cols as u16))
+}
+
+/// Resize events for the interactive pump: yields a size to apply whenever the
+/// caller's window changes.
+///
+/// The console has no resize signal, so this polls [`window_size`] four times
+/// a second and reports only changes. The alternative — `ReadConsoleInput`
+/// watching `WINDOW_BUFFER_SIZE_EVENT` — is event-driven but competes with the
+/// stdin byte pump for the same console handle; polling costs one cheap call
+/// per tick and touches nothing the pump owns.
+pub(crate) struct ResizeWatcher {
+	interval: tokio::time::Interval,
+	last: Option<(u16, u16)>,
+}
+
+impl ResizeWatcher {
+	/// Start watching, from the current size.
+	///
+	/// `Result` for signature parity with the Unix watcher, whose signal
+	/// registration can genuinely fail; this one cannot.
+	pub(crate) fn new() -> std::io::Result<Self> {
+		let mut interval = tokio::time::interval(std::time::Duration::from_millis(250));
+		// A pump busy streaming output can miss ticks; catching up in a burst
+		// would report the same size several times for no reason.
+		interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+		Ok(Self {
+			interval,
+			last: window_size(),
+		})
+	}
+
+	/// The next size to apply: pends until a poll observes a change.
+	pub(crate) async fn next(&mut self) -> (u16, u16) {
+		loop {
+			self.interval.tick().await;
+			if let Some(size) = resize_due(&mut self.last, window_size()) {
+				return size;
+			}
+		}
+	}
+}
+
+/// Whether a polled size warrants a resize: `Some` only when it is readable
+/// and differs from the last one reported, recording it as reported. Pure so
+/// the dedup — the part that decides whether the pump spams resize calls —
+/// is testable without a console.
+fn resize_due(last: &mut Option<(u16, u16)>, current: Option<(u16, u16)>) -> Option<(u16, u16)> {
+	let current = current?;
+	if *last == Some(current) {
+		return None;
+	}
+	*last = Some(current);
+	Some(current)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// A non-console handle is declined rather than failing — the path
+	/// `podup exec` takes inside a pipeline, which must keep working.
+	///
+	/// Asked of an explicit `NUL` handle rather than of ambient stdin: the
+	/// same assertion on `enable()` would be testing how the harness was
+	/// invoked, and on the way to failing it would put a real console into
+	/// raw mode.
+	#[test]
+	fn a_non_console_handle_is_declined() {
+		use std::os::windows::io::AsRawHandle;
+		let devnull = std::fs::File::open("NUL").expect("NUL opens");
+		let handle = devnull.as_raw_handle() as HANDLE;
+		assert!(
+			RawMode::enable_on(handle, handle).is_none(),
+			"a non-console handle must not be switched to raw mode"
+		);
+	}
+
+	/// Likewise the size query: absence is a valid answer, not an error.
+	#[test]
+	fn a_non_console_handle_has_no_size() {
+		use std::os::windows::io::AsRawHandle;
+		let devnull = std::fs::File::open("NUL").expect("NUL opens");
+		assert_eq!(size_of(devnull.as_raw_handle() as HANDLE), None);
+	}
+
+	/// The window extent comes from `srWindow` and is inclusive on both ends;
+	/// `dwSize` (the scrollback buffer) must play no part in it.
+	#[test]
+	fn the_window_extent_is_the_visible_rectangle() {
+		let mut info: CONSOLE_SCREEN_BUFFER_INFO = unsafe { std::mem::zeroed() };
+		info.dwSize.X = 120;
+		info.dwSize.Y = 9001; // scrollback: must not leak into the answer
+		info.srWindow.Left = 0;
+		info.srWindow.Right = 119;
+		info.srWindow.Top = 8971;
+		info.srWindow.Bottom = 9000;
+		assert_eq!(window_extent(&info), Some((30, 120)));
+	}
+
+	/// A degenerate rectangle is unknown geometry, not a 0x0 pty.
+	#[test]
+	fn a_degenerate_window_has_no_size() {
+		// A zeroed rectangle is a legal 1x1 window, so degeneracy has to be
+		// forced: an inverted extent (Right < Left) yields a non-positive
+		// width.
+		let mut info: CONSOLE_SCREEN_BUFFER_INFO = unsafe { std::mem::zeroed() };
+		info.srWindow.Right = -2;
+		assert_eq!(window_extent(&info), None);
+	}
+
+	/// The poll dedup: only a *changed*, readable size is worth a resize call.
+	#[test]
+	fn resize_is_due_only_on_a_changed_readable_size() {
+		let mut last = Some((24, 80));
+		// Unchanged: nothing to do.
+		assert_eq!(resize_due(&mut last, Some((24, 80))), None);
+		// Unreadable (window lost): nothing to apply, and the last size is
+		// kept so regaining the same one stays quiet.
+		assert_eq!(resize_due(&mut last, None), None);
+		assert_eq!(last, Some((24, 80)));
+		// Changed: due, and recorded.
+		assert_eq!(resize_due(&mut last, Some((30, 120))), Some((30, 120)));
+		assert_eq!(last, Some((30, 120)));
+		// The same change again: already reported.
+		assert_eq!(resize_due(&mut last, Some((30, 120))), None);
+	}
+}

--- a/internal/engine/terminal_pump.rs
+++ b/internal/engine/terminal_pump.rs
@@ -4,8 +4,10 @@
 //! command ends. They differ only in which libpod object gets resized — an exec
 //! session or a container — so that is the one parameter, and the loop that must
 //! not get raw mode wrong lives once rather than twice.
-
-#![cfg(unix)]
+//!
+//! The loop itself is platform-independent: raw mode, the size query and the
+//! resize events differ per platform, and all three live behind the one
+//! signature `query::terminal` exports.
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -13,7 +15,7 @@ use crate::error::{ComposeError, Result};
 use crate::libpod::client::Hijacked;
 use crate::libpod::API_PREFIX;
 
-use super::query::terminal::{window_size, RawMode};
+use super::query::terminal::{window_size, RawMode, ResizeWatcher};
 use super::Engine;
 
 impl Engine {
@@ -45,11 +47,9 @@ impl Engine {
 		let mut stdout = tokio::io::stdout();
 
 		// Follow the window. libpod has no way to learn the caller's terminal
-		// size on its own, so every SIGWINCH has to be forwarded or a resized
+		// size on its own, so every change has to be forwarded or a resized
 		// window leaves the remote program drawing at the old geometry.
-		let mut winch =
-			tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
-				.map_err(ComposeError::Io)?;
+		let mut resize = ResizeWatcher::new().map_err(ComposeError::Io)?;
 
 		let mut to_server = [0u8; 8 * 1024];
 		let mut from_server = [0u8; 32 * 1024];
@@ -90,10 +90,9 @@ impl Engine {
 						Err(_) => break,
 					}
 				}
-				_ = winch.recv() => {
-					if let Some((rows, cols)) = window_size() {
-						self.resize_pty(resize_base, rows, cols).await;
-					}
+				size = resize.next() => {
+					let (rows, cols) = size;
+					self.resize_pty(resize_base, rows, cols).await;
 				}
 			}
 		}

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -253,6 +253,36 @@ mod tests {
 		assert!(named[0].options.contains(&"nocopy".to_string()));
 	}
 
+	/// The mount-hardening trio reaches the engine from the long form, matching
+	/// what the short form's raw options have always done (#1160). `false` and
+	/// absent both mean "not hardened": only an explicit `true` emits the flag.
+	#[test]
+	fn long_form_volume_hardening_options_forwarded() {
+		let svc = svc_with_volumes(vec![VolumeMount::Long {
+			volume_type: VolumeType::Volume,
+			source: Some("myvolume".into()),
+			target: "/data".into(),
+			read_only: None,
+			bind: None,
+			volume: Some(VolumeOptions {
+				noexec: Some(true),
+				nosuid: Some(true),
+				nodev: Some(false),
+				..Default::default()
+			}),
+			tmpfs: None,
+			consistency: None,
+		}]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		assert_eq!(named.len(), 1);
+		assert!(named[0].options.contains(&"noexec".to_string()));
+		assert!(named[0].options.contains(&"nosuid".to_string()));
+		assert!(
+			!named[0].options.contains(&"nodev".to_string()),
+			"an explicit false must not emit the flag"
+		);
+	}
+
 	#[test]
 	fn long_form_volume_subpath_forwarded() {
 		let svc = svc_with_volumes(vec![VolumeMount::Long {

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -195,6 +195,18 @@ pub(super) fn extend_volume_opts_str(opts: &mut Vec<String>, v: Option<&VolumeOp
 	if v.nocopy.unwrap_or(false) {
 		opts.push("nocopy".into());
 	}
+	// The mount-hardening trio. The short form has always carried these as raw
+	// options; the long form dropped them with an unknown-key warning, so the
+	// spelled-out mount was the one that could not be hardened (#1160).
+	if v.noexec.unwrap_or(false) {
+		opts.push("noexec".into());
+	}
+	if v.nosuid.unwrap_or(false) {
+		opts.push("nosuid".into());
+	}
+	if v.nodev.unwrap_or(false) {
+		opts.push("nodev".into());
+	}
 }
 
 #[cfg(test)]

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -13,9 +13,9 @@
 //! the upgrade out of the general client, which every other call would then have
 //! to reason about.
 
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncRead, AsyncWriteExt};
 
-use super::{Client, PodmanError, Result};
+use super::{Client, PodmanError, Result, SocketStream};
 
 /// Cap on the response head podup will read before deciding the server is not
 /// speaking HTTP. A hijacked stream's head is a status line and a handful of
@@ -31,7 +31,7 @@ const MAX_HEAD_BYTES: usize = 16 * 1024;
 /// them — the same is true of `podman exec -it`.
 #[derive(Debug)]
 pub(crate) struct Hijacked {
-	pub(crate) stream: tokio::net::UnixStream,
+	pub(crate) stream: SocketStream,
 }
 
 impl Client {
@@ -41,9 +41,7 @@ impl Client {
 	/// surfaces as an error instead of hanging with the terminal already in raw
 	/// mode — which would leave the user's shell unusable.
 	pub(crate) async fn post_hijack(&self, path: &str, body: &[u8]) -> Result<Hijacked> {
-		let mut stream = tokio::net::UnixStream::connect(&self.socket_path)
-			.await
-			.map_err(|e| super::socket_error(&self.socket_path, e))?;
+		let mut stream = SocketStream::connect(&self.socket_path).await?;
 
 		// `Connection: close` is deliberate: this socket is never returned to a
 		// pool, and saying so stops the server holding it open after the command
@@ -79,7 +77,7 @@ impl Client {
 /// swallow part of the command's output into its own buffer, and that output
 /// belongs to the caller. Slow, but the head is a few hundred bytes and it only
 /// happens once per exec.
-async fn read_response_head(stream: &mut tokio::net::UnixStream) -> Result<u16> {
+async fn read_response_head<S: AsyncRead + Unpin>(stream: &mut S) -> Result<u16> {
 	use tokio::io::AsyncReadExt;
 
 	let mut head = Vec::with_capacity(256);
@@ -114,7 +112,10 @@ async fn read_response_head(stream: &mut tokio::net::UnixStream) -> Result<u16> 
 		})
 }
 
-#[cfg(test)]
+// The harness listens on a Unix socket; the code under test is the same on
+// Windows via the transport enum, whose named-pipe variant CI exercises through
+// the client's request path.
+#[cfg(all(test, unix))]
 mod tests {
 	use super::*;
 

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -16,14 +16,11 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::error::PodmanError;
 
 mod encode;
-// Unix only: a hijacked stream is a `UnixStream`, and podup reaches
-// `podman machine` over a named pipe on Windows, where interactive exec is a
-// different implementation entirely (#1079).
-#[cfg(unix)]
 mod hijack;
+mod stream;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
-#[cfg(unix)]
 pub(crate) use hijack::Hijacked;
+use stream::SocketStream;
 
 /// The request body every call shares. A boxed body so a fully-buffered
 /// `Full<Bytes>` (almost every call) and a lazily-streamed build-context body
@@ -74,6 +71,11 @@ pub struct Client {
 /// error variant so `PodmanError` keeps its shape: it is public API and 2.0.0
 /// shipped hours ago. `kind()` survives, which is what tells the two cases
 /// apart.
+///
+/// Unix only because the hints are: `systemctl --user` means nothing to a
+/// `podman machine` install, and the named-pipe connect path reports its
+/// errors raw.
+#[cfg(unix)]
 pub(crate) fn socket_error(path: &str, e: std::io::Error) -> super::PodmanError {
 	let hint = match e.kind() {
 		std::io::ErrorKind::NotFound => {
@@ -103,56 +105,13 @@ impl Client {
 
 	/// Open a new HTTP/1.1 sender over the platform socket.
 	async fn connect(&self) -> Result<http1::SendRequest<BoxBody>> {
-		#[cfg(unix)]
-		{
-			let stream = tokio::net::UnixStream::connect(&self.socket_path)
-				.await
-				.map_err(|e| socket_error(&self.socket_path, e))?;
-			let io = TokioIo::new(stream);
-			let (sender, conn) = http1::handshake(io).await?;
-			tokio::spawn(async move {
-				let _ = conn.await;
-			});
-			Ok(sender)
-		}
-
-		#[cfg(windows)]
-		{
-			// Named pipes may be momentarily busy; retry a few times.
-			let pipe = {
-				let mut last_err = None;
-				let mut result = None;
-				for _ in 0..20 {
-					match tokio::net::windows::named_pipe::ClientOptions::new()
-						.open(&self.socket_path)
-					{
-						Ok(p) => {
-							result = Some(p);
-							break;
-						}
-						Err(e) if e.raw_os_error() == Some(231) => {
-							last_err = Some(e);
-							tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-						}
-						Err(e) => return Err(PodmanError::Connect(e)),
-					}
-				}
-				result.ok_or_else(|| {
-					PodmanError::Connect(last_err.unwrap_or_else(|| {
-						std::io::Error::new(
-							std::io::ErrorKind::TimedOut,
-							"named pipe busy after 20 retries",
-						)
-					}))
-				})?
-			};
-			let io = TokioIo::new(pipe);
-			let (sender, conn) = http1::handshake(io).await?;
-			tokio::spawn(async move {
-				let _ = conn.await;
-			});
-			Ok(sender)
-		}
+		let stream = SocketStream::connect(&self.socket_path).await?;
+		let io = TokioIo::new(stream);
+		let (sender, conn) = http1::handshake(io).await?;
+		tokio::spawn(async move {
+			let _ = conn.await;
+		});
+		Ok(sender)
 	}
 
 	/// Build a request with an optional JSON body.

--- a/internal/libpod/client/stream.rs
+++ b/internal/libpod/client/stream.rs
@@ -1,0 +1,120 @@
+//! The platform transport under every libpod connection.
+//!
+//! Linux and macOS reach Podman over a Unix socket; Windows reaches
+//! `podman machine` over a named pipe. Both are byte streams, and everything
+//! above this file — the hyper client, the hand-written hijack — only needs
+//! `AsyncRead + AsyncWrite`. This enum is the one place that knows which kind
+//! of stream a platform uses, so the request path and the hijack path connect
+//! through the same code instead of each carrying its own `cfg` blocks.
+//!
+//! An enum rather than a `Box<dyn ...>` because each build has exactly one
+//! variant; the match compiles down to a direct call and the type stays
+//! `Debug`-derivable, matching the crate's style.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use super::Result;
+
+/// A connected stream to the Podman API: a Unix socket, or a named pipe on
+/// Windows.
+#[derive(Debug)]
+pub(crate) enum SocketStream {
+	#[cfg(unix)]
+	Unix(tokio::net::UnixStream),
+	#[cfg(windows)]
+	NamedPipe(tokio::net::windows::named_pipe::NamedPipeClient),
+}
+
+impl SocketStream {
+	/// Open a new connection to the given socket path (or pipe name).
+	#[cfg(unix)]
+	pub(crate) async fn connect(socket_path: &str) -> Result<Self> {
+		let stream = tokio::net::UnixStream::connect(socket_path)
+			.await
+			.map_err(|e| super::socket_error(socket_path, e))?;
+		Ok(Self::Unix(stream))
+	}
+
+	/// Open a new connection to the given socket path (or pipe name).
+	///
+	/// Named pipes may be momentarily busy (`ERROR_PIPE_BUSY`, os error 231)
+	/// while another client's slot frees up; retry a few times before giving
+	/// up rather than failing on a transient.
+	#[cfg(windows)]
+	pub(crate) async fn connect(socket_path: &str) -> Result<Self> {
+		use super::PodmanError;
+
+		let mut last_err = None;
+		for _ in 0..20 {
+			match tokio::net::windows::named_pipe::ClientOptions::new().open(socket_path) {
+				Ok(p) => return Ok(Self::NamedPipe(p)),
+				Err(e) if e.raw_os_error() == Some(231) => {
+					last_err = Some(e);
+					tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+				}
+				Err(e) => return Err(PodmanError::Connect(e)),
+			}
+		}
+		Err(PodmanError::Connect(last_err.unwrap_or_else(|| {
+			std::io::Error::new(
+				std::io::ErrorKind::TimedOut,
+				"named pipe busy after 20 retries",
+			)
+		})))
+	}
+}
+
+// Plain delegation: each poll forwards to the one variant this build has. No
+// buffering, no translation — the enum exists only to give the two transports
+// one type.
+
+impl AsyncRead for SocketStream {
+	fn poll_read(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &mut ReadBuf<'_>,
+	) -> Poll<std::io::Result<()>> {
+		match self.get_mut() {
+			#[cfg(unix)]
+			Self::Unix(s) => Pin::new(s).poll_read(cx, buf),
+			#[cfg(windows)]
+			Self::NamedPipe(s) => Pin::new(s).poll_read(cx, buf),
+		}
+	}
+}
+
+impl AsyncWrite for SocketStream {
+	fn poll_write(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &[u8],
+	) -> Poll<std::io::Result<usize>> {
+		match self.get_mut() {
+			#[cfg(unix)]
+			Self::Unix(s) => Pin::new(s).poll_write(cx, buf),
+			#[cfg(windows)]
+			Self::NamedPipe(s) => Pin::new(s).poll_write(cx, buf),
+		}
+	}
+
+	fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+		match self.get_mut() {
+			#[cfg(unix)]
+			Self::Unix(s) => Pin::new(s).poll_flush(cx),
+			#[cfg(windows)]
+			Self::NamedPipe(s) => Pin::new(s).poll_flush(cx),
+		}
+	}
+
+	fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+		match self.get_mut() {
+			#[cfg(unix)]
+			Self::Unix(s) => Pin::new(s).poll_shutdown(cx),
+			#[cfg(windows)]
+			Self::NamedPipe(s) => Pin::new(s).poll_shutdown(cx),
+		}
+	}
+}

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -189,6 +189,7 @@ fn a_buffered_put_body_reports_an_exact_size() {
 /// file or directory (os error 2)` — no path, no way to tell "it is not there"
 /// from "I cannot open it", nothing to act on. Everything needed was already in
 /// hand one call earlier.
+#[cfg(unix)]
 #[test]
 fn a_missing_socket_names_the_path_and_the_fix() {
 	let e = super::socket_error(
@@ -206,6 +207,7 @@ fn a_missing_socket_names_the_path_and_the_fix() {
 
 /// A socket that exists but cannot be opened is a different problem with a
 /// different fix, and the old message could not tell them apart.
+#[cfg(unix)]
 #[test]
 fn a_denied_socket_says_so_rather_than_suggesting_enabling_it() {
 	let e = super::socket_error(
@@ -222,6 +224,7 @@ fn a_denied_socket_says_so_rather_than_suggesting_enabling_it() {
 }
 
 /// The io::ErrorKind must survive, since it is what distinguishes the two.
+#[cfg(unix)]
 #[test]
 fn the_error_kind_is_preserved() {
 	let e = super::socket_error("/x", std::io::Error::from(std::io::ErrorKind::NotFound));

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -68,7 +68,16 @@ fn run_to_exit() {
 		.enable_all()
 		.build()
 		.expect("build Tokio runtime");
-	match runtime.block_on(run()) {
+	let outcome = runtime.block_on(run());
+	// Shut the runtime down without waiting for its blocking pool. An
+	// interactive exec/run always leaves one stdin read in flight there
+	// (tokio's stdin reads on a blocking thread), and a plain drop waits for
+	// it — so a session that ended with code 0 hung until the next keypress,
+	// while any other code left through `process::exit` below and never
+	// noticed (#1161). Everything user-visible is written and flushed by the
+	// time `block_on` returns.
+	runtime.shutdown_background();
+	match outcome {
 		Ok(()) => {}
 		Err(podup::ComposeError::RunExited(code)) => process::exit(code as i32),
 		// 128 + SIGINT, the shell convention, and what `docker compose up` returns

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -84,6 +84,18 @@ pub(super) fn render_volume(vol: &VolumeMount, project: &str, declared_volumes: 
 				if v.nocopy == Some(true) {
 					opts.push("nocopy".to_string());
 				}
+				// The mount-hardening trio (#1160). Dropping these here would
+				// mean a compose file that hardens a mount exports a Quadlet
+				// unit that silently does not.
+				if v.noexec == Some(true) {
+					opts.push("noexec".to_string());
+				}
+				if v.nosuid == Some(true) {
+					opts.push("nosuid".to_string());
+				}
+				if v.nodev == Some(true) {
+					opts.push("nodev".to_string());
+				}
 			}
 			let mut out = if src.is_empty() {
 				target.clone()
@@ -487,6 +499,28 @@ mod tests {
 		assert_eq!(
 			render_volume(&nocopy, "proj", &["vol"]),
 			"proj-vol.volume:/data:ro,nocopy"
+		);
+
+		// The hardening trio survives the Quadlet export (#1160): a compose
+		// file that hardens a mount must not export a unit that does not.
+		let hardened = VolumeMount::Long {
+			volume_type: VolumeType::Volume,
+			source: Some("vol".into()),
+			target: "/data".into(),
+			read_only: None,
+			bind: None,
+			volume: Some(VolumeOptions {
+				noexec: Some(true),
+				nosuid: Some(true),
+				nodev: Some(true),
+				..Default::default()
+			}),
+			tmpfs: None,
+			consistency: None,
+		};
+		assert_eq!(
+			render_volume(&hardened, "proj", &["vol"]),
+			"proj-vol.volume:/data:noexec,nosuid,nodev"
 		);
 
 		// An empty source renders as just the target (anonymous mount).


### PR DESCRIPTION
Promotes develop to main for the 3.0.0 release.

New since 2.1.0:

- Interactive `exec` and `run` on Windows (#1162): raw console mode, resize follow, hijack over the named pipe. The both-terminals rule is unchanged everywhere.
- Long-form volume syntax carries `noexec`/`nosuid`/`nodev`, matching the short form; Quadlet export carries them too (#1163).
- Fix: an interactive session ending with code 0 no longer hangs waiting for a keypress (#1161).
- Benchmark docs and chart generation for 2.1.0 measurements (#1157).

Breaking (library only, the CLI is unchanged): the compose option blocks (`BindOptions`, `VolumeOptions`, `DriverConfig`, `TmpfsOptions`, `ServiceNetworkConfig`) are `#[non_exhaustive]`; construct with `Default::default()` plus field assignment. Future compose keys land as minor releases.

Version stamped in `Cargo.toml`, `Cargo.lock` and `debian/changelog`. Full suite green on develop, including both podman-vm lanes and the Windows/macOS test matrix.