### PR TITLE
docs: correct post-3.0.0 documentation drift (3.0.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ sequenceDiagram
 Peak memory and per-operation latency against docker-compose and podman-compose,
 **all three driving the same rootless Podman**, same digest-pinned images,
 median of 10 measured runs (12 iterations, 2 warm-up discarded), on podup 2.1.0.
-podup leads all but one scenario — deep-chain `down`, where docker-compose's
-0.380 s edges podup's 0.390 s, inside a single standard deviation — and the
+podup leads all but one scenario (deep-chain `down`, where docker-compose's
+0.380 s edges podup's 0.390 s, inside a single standard deviation), and the
 widest gaps are the ones with many services.
 
 | | podup | docker-compose | podman-compose |

--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ sequenceDiagram
 
 Peak memory and per-operation latency against docker-compose and podman-compose,
 **all three driving the same rootless Podman**, same digest-pinned images,
-median of 10 measured runs (12 iterations, 2 warm-up discarded). podup leads every scenario; the widest gaps are the
-ones with many services.
+median of 10 measured runs (12 iterations, 2 warm-up discarded), on podup 2.1.0.
+podup leads all but one scenario — deep-chain `down`, where docker-compose's
+0.380 s edges podup's 0.390 s, inside a single standard deviation — and the
+widest gaps are the ones with many services.
 
 | | podup | docker-compose | podman-compose |
 |---|---|---|---|
@@ -157,7 +159,7 @@ ones with many services.
 | `up`, 12 services | **0.38 s** | 0.49 s | 2.43 s |
 | `config` (parse only) | **&lt;0.01 s** | 0.04 s | 0.10 s |
 
-<img src="docs/assets/bench.svg" alt="Bar chart: podup uses about 7 MiB per command against 29 MiB for docker-compose and 51 MiB for podman-compose, and leads every measured scenario" width="760">
+<img src="docs/assets/bench.svg" alt="Bar chart: podup uses about 7 MiB per command against 29 MiB for docker-compose and 51 MiB for podman-compose, and is faster in all but one measured scenario" width="760">
 
 Full tables and methodology: [docs/benchmarks.md](docs/benchmarks.md).
 
@@ -165,9 +167,11 @@ Full tables and methodology: [docs/benchmarks.md](docs/benchmarks.md).
 
 - [Commands](docs/commands.md)
 - [Migrating from Compose](docs/docker-migration.md)
+- [Autostart at boot](docs/autostart.md)
 - [Benchmarks](docs/benchmarks.md)
 - [Self-update](docs/self-update.md)
 - [Security model](docs/security-model.md)
+- [Debian packaging](docs/debian-packaging.md)
 
 ## License
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+podup (3.0.1) unstable; urgency=medium
+
+  Docs
+
+  * The `exec` reference and the `-T` help text described interactivity as
+    engaging on stdin alone; it needs both stdin and stdout to be terminals,
+    and works on Windows now, not only Unix. Corrected in the CLI help,
+    docs/commands.md and the man page.
+  * The long-form volume hardening options (noexec/nosuid/nodev) are listed in
+    the extensions table and the security model, marked as a non-portable
+    podup extension.
+  * The benchmark prose no longer claims a clean sweep: docker-compose edges
+    deep-chain `down` by 0.380 s to 0.390 s, within a standard deviation, and
+    the fairness policy keeps that row.
+  * The man page, frozen at 1.2.0, now documents `autostart`, `version`, the
+    interactive run/exec path, exit codes 126/127, and the flags added since.
+  * Removed a stale reference to the release signing secret's old name and two
+    links to closed issues; reworded doc comments anchored to "1.0" and to the
+    author's writing session.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Thu, 23 Jul 2026 13:40:00 -0500
+
 podup (3.0.0) unstable; urgency=medium
 
   New

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "June 2026" "podup 1.2.0" "User Commands"
+.TH PODUP 1 "July 2026" "podup 3.0.1" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS
@@ -64,9 +64,11 @@ Create and start all services. Options: \fB\-d\fR/\fB\-\-detach\fR,
 \fB\-\-build\fR, \fB\-w\fR/\fB\-\-watch\fR, \fB\-\-remove\-orphans\fR,
 \fB\-\-no\-recreate\fR, \fB\-\-force\-recreate\fR, \fB\-\-no\-deps\fR,
 \fB\-\-scale\fR \fISERVICE=N\fR (repeatable), \fB\-\-pull\fR \fIpolicy\fR,
-\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-wait\fR, \fB\-\-no\-start\fR.
-Accepts a trailing list of services to bring up (with their transitive
-depends_on).
+\fB\-\-no\-build\fR, \fB\-\-quiet\-pull\fR, \fB\-\-wait\fR,
+\fB\-\-wait\-timeout\fR \fISECONDS\fR, \fB\-t\fR/\fB\-\-timeout\fR \fISECONDS\fR,
+\fB\-V\fR/\fB\-\-renew\-anon\-volumes\fR, \fB\-\-timestamps\fR,
+\fB\-\-no\-start\fR. Accepts a trailing list of services to bring up (with their
+transitive depends_on).
 .TP
 .B scale \fISERVICE=N\fR...
 Set the number of running containers for services, creating missing replicas and
@@ -122,11 +124,15 @@ Resume paused service containers.
 .TP
 .B run \fISERVICE\fR [\fICOMMAND\fR...]
 Run a one-off command in a new service container. Options: \fB\-\-rm\fR
-(default true), \fB\-d\fR/\fB\-\-detach\fR, \fB\-e\fR/\fB\-\-env\fR KEY=VAL,
-\fB\-\-name\fR, \fB\-P\fR/\fB\-\-service\-ports\fR,
+(default true), \fB\-\-no\-rm\fR, \fB\-d\fR/\fB\-\-detach\fR,
+\fB\-e\fR/\fB\-\-env\fR KEY=VAL, \fB\-\-name\fR, \fB\-P\fR/\fB\-\-service\-ports\fR,
 \fB\-u\fR/\fB\-\-user\fR, \fB\-w\fR/\fB\-\-workdir\fR, \fB\-\-entrypoint\fR,
 \fB\-v\fR/\fB\-\-volume\fR (repeatable), \fB\-p\fR/\fB\-\-publish\fR (repeatable),
+\fB\-l\fR/\fB\-\-label\fR KEY=VAL (repeatable),
 \fB\-i\fR/\fB\-\-interactive\fR, \fB\-T\fR/\fB\-\-no\-TTY\fR, \fB\-\-no\-deps\fR.
+A pseudo-TTY with live stdin is allocated when both stdin and stdout are
+terminals (\fB\-T\fR opts out, \fB\-d\fR never allocates one), so
+\fBpodup run -it app sh\fR is an interactive session on Linux, macOS and Windows.
 .TP
 .B cp \fISRC\fR \fIDST\fR
 Copy files between a service container and the host. Use \fBSERVICE:PATH\fR for
@@ -182,7 +188,13 @@ View container output. \fB\-f\fR/\fB\-\-follow\fR streams new output,
 line with an RFC3339 timestamp.
 .TP
 .B exec \fISERVICE\fR \fICOMMAND\fR...
-Execute a command in a running service container.
+Execute a command in a running service container. Options:
+\fB\-e\fR/\fB\-\-env\fR KEY=VAL (repeatable), \fB\-u\fR/\fB\-\-user\fR,
+\fB\-w\fR/\fB\-\-workdir\fR, \fB\-\-privileged\fR, \fB\-d\fR/\fB\-\-detach\fR,
+\fB\-T\fR/\fB\-\-no\-tty\fR, \fB\-\-index\fR \fIN\fR. Like
+\fBdocker compose exec\fR, a pseudo-TTY with live stdin is allocated by default
+when both stdin and stdout are terminals (\fB\-T\fR opts out), on Linux, macOS
+and Windows.
 .TP
 .B pull
 Pull images for all services. \fB\-q\fR/\fB\-\-quiet\fR suppresses progress
@@ -214,6 +226,17 @@ Update podup to the latest signed release. Verifies the release's Ed25519
 signature against the embedded public key and its SHA-256 checksum, failing
 closed. \fB\-\-check\fR only reports whether a newer release exists;
 \fB\-\-force\fR reinstalls even when not newer.
+.TP
+.B autostart \fISUBCOMMAND\fR
+Manage a boot-time autostart unit for this project, rootless and user-scope via
+\fBsystemctl \-\-user\fR (units under \fB${XDG_CONFIG_HOME:-~/.config}\fR).
+Subcommands: \fBinstall\fR (\fB\-\-mode\fR \fIservice\fR|\fIquadlet\fR,
+\fB\-\-no\-start\fR, \fB\-\-dry\-run\fR), \fBuninstall\fR, \fBstatus\fR, and
+\fBrebuild\fR (for a quadlet-mode install).
+.TP
+.B version
+Print podup's version. \fB\-\-short\fR prints just the number;
+\fB\-\-format json\fR emits it as JSON. Mirrors \fBdocker compose version\fR.
 .TP
 .B completions \fISHELL\fR
 Print a shell completion script to stdout for \fBbash\fR, \fBzsh\fR, \fBfish\fR,
@@ -255,6 +278,12 @@ A usage error (invalid arguments or flags).
 .TP
 .B 3
 \fBupdate\fR failed to verify or install a release.
+.TP
+.B 126
+\fBrun\fR/\fBexec\fR: the command exists but is not executable.
+.TP
+.B 127
+\fBrun\fR/\fBexec\fR: the command was not found.
 .PP
 \fBrun\fR propagates the container's own exit code verbatim, so any other
 non-zero status comes from the container that was run.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -107,8 +107,11 @@ Go binary talking to a socket, like podup.
 
 ## Reading these numbers honestly
 
-podup leads every row here, and two of them deserve a caveat rather than a
-victory lap.
+podup leads every row in this memory-and-latency table, and two of them deserve
+a caveat rather than a victory lap. (In the full latency table above, one
+scenario goes the other way: deep-chain `down`, where docker-compose's 0.380 s
+is a hair under podup's 0.390 s, well within a standard deviation. The point of
+this benchmark is to publish the numbers whoever wins, so that row stands.)
 
 `running-ops ps` and `config-heavy config` show podup at **0.000s**. That is the
 floor of `/usr/bin/time -v`, which resolves to 10ms — the real figure is around

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -245,9 +245,9 @@ pipeline or a redirect keeps the plain streaming behaviour with no change to
 output framing:
 
 ```bash
-podup run --rm app echo hola > salida.txt   # stdout is a file  -> streams, no TTY
-echo x | podup run --rm app ./migrar.sh     # stdin is a pipe   -> streams, no TTY
-podup run --rm -T app ./migrar.sh           # -T                -> streams, no TTY
+podup run --rm app echo hello > out.txt     # stdout is a file  -> streams, no TTY
+echo x | podup run --rm app ./migrate.sh    # stdin is a pipe   -> streams, no TTY
+podup run --rm -T app ./migrate.sh          # -T                -> streams, no TTY
 ```
 
 Requiring stdout matters because a pty **merges stdout and stderr and writes
@@ -268,17 +268,19 @@ Execute a command in a running service container.
 | `-T, --no-tty` (alias `--no-TTY`) | Disable pseudo-TTY allocation. | off |
 | `--index <N>` | Target this replica (1-based) of a scaled service. | 1 |
 
-`exec` allocates a pseudo-TTY and attaches your stdin when stdin is a
-terminal, so `podup exec -it db psql` drops you into an interactive session that
-follows your window size. It is not on `-i`: like `docker compose exec`, a TTY on
-both ends is the default, and `-T` is how you turn it off.
+`exec` allocates a pseudo-TTY and attaches your stdin when both stdin and stdout
+are terminals, so `podup exec -it db psql` drops you into an interactive session
+that follows your window size. It is not on `-i`: like `docker compose exec`, a
+TTY on both ends is the default, and `-T` is how you turn it off.
 
-Interactivity engages **only** when stdin is a terminal, so a script or a
-pipeline keeps the plain streaming behaviour with no change to output framing:
+Requiring stdout too, not just stdin, keeps a redirect clean: a pty merges
+stdout and stderr and writes CRLF, so interactivity engages **only** when both
+ends are terminals, and a script, a pipeline or a redirect keeps the plain
+streaming behaviour with no change to output framing:
 
 ```bash
-podup exec db psql -c 'select 1' > out.txt   # streams, no TTY
-echo 'select 1' | podup exec -T db psql      # streams, no TTY
+podup exec db psql -c 'select 1' > out.txt   # stdout is a file -> streams, no TTY
+echo 'select 1' | podup exec -T db psql      # stdin is a pipe  -> streams, no TTY
 ```
 
 ```bash
@@ -447,9 +449,16 @@ Print a shell completion script to stdout for `bash`, `zsh`, `fish`,
 automatically; otherwise source the output from your shell startup:
 
 ```bash
+mkdir -p ~/.local/share/bash-completion/completions
 podup completions bash > ~/.local/share/bash-completion/completions/podup
-podup completions zsh  > "${fpath[1]}/_podup"
 podup completions fish > ~/.config/fish/completions/podup.fish
+```
+
+For zsh, write to a directory on your `$fpath` (run this from zsh, where
+`fpath` is defined):
+
+```zsh
+podup completions zsh > "${fpath[1]}/_podup"
 ```
 
 ### `update`
@@ -521,14 +530,17 @@ when both are set.
 ## Podman extensions
 
 Podman does more than the Compose Specification, and a few of those extras
-change behaviour rather than just observability. podup exposes them under the
-spec's reserved `x-` prefix, so a file using one **stays a valid compose file**:
-docker compose ignores an unknown `x-` key instead of erroring, and the same
-file still runs there — it just does not act on the extra.
+change behaviour rather than just observability. Most sit under the spec's
+reserved `x-` prefix, so a file using one **stays a valid compose file**: docker
+compose ignores an unknown `x-` key instead of erroring, and the same file still
+runs there, it just does not act on the extra. Two extensions are not `x-`
+prefixed and so are **not** portable back to docker compose, which rejects the
+keys; they are called out below.
 
-| Key | Where | What it does |
-|---|---|---|
-| `x-podman-on-failure` | under a service's `healthcheck:` | `none`, `kill`, `restart` or `stop` — what Podman does when the check flips to unhealthy. Default `none`. |
+| Key | Where | What it does | Portable |
+|---|---|---|---|
+| `x-podman-on-failure` | under a service's `healthcheck:` | `none`, `kill`, `restart` or `stop` — what Podman does when the check flips to unhealthy. Default `none`. | yes |
+| `noexec`, `nosuid`, `nodev` | under a long-form volume's `volume:` | mount-hardening flags; see [Per-mount hardening options](docker-migration.md#per-mount-hardening-options-noexec-nosuid-nodev). The short form carries them as raw mount options. | no |
 
 ### Healthcheck timing on a `service_healthy` gate
 
@@ -585,7 +597,7 @@ covers, and the only other way to find out was to read the dispatch code.
 | `build --progress <STYLE>` | podup renders build output one way. The value is still validated, so a typo is rejected rather than silently ignored. |
 | `config --no-normalize` | `config` always emits the normalized form. |
 | `cp -a, --archive` | Ownership/permission preservation is not meaningful for a rootless copy. |
-| `attach --no-stdin`, `--sig-proxy`, `--detach-keys` | `attach` streams output only; stdin is never attached (see [#1079](https://github.com/Glyndor/podup/issues/1079)). |
+| `attach --no-stdin`, `--sig-proxy`, `--detach-keys` | `attach` streams output only; stdin is never attached. Use `exec`/`run` for an interactive session. |
 
 Everything else that parses does something. An **unknown** `--filter` predicate
 is rejected outright rather than dropped: a filter that silently does not apply

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -105,12 +105,13 @@ each release on its own schedule.
 
 The packaging mechanics carry over regardless of channel:
 
-- **SemVer discipline** — `1.0.0` (already shipped) is in force: the CLI surface
-  is stable and breaking changes wait for a major bump.
+- **SemVer discipline**, in force since `1.0.0`: the CLI surface is stable and
+  breaking changes wait for a major bump.
 - **crates.io** — the crate metadata is in place (`cargo package` verifies
   clean) for publishing podup as a library; this is independent of the `.deb`.
 
 ## Versioning
 
 `debian/changelog` tracks the upstream version (native package, no `-1`
-revision). Bump it as part of each release PR.
+revision), and is bumped with each release so `dpkg-buildpackage` stamps the
+`.deb` with the matching version.

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -238,7 +238,7 @@ equivalent.
 |---|---|
 | `env_file.format` values other than `dotenv` | A **warning** is emitted (`format is not honored; podup always parses env files as dotenv`); the file is still read as dotenv |
 | `provider:` / model-runner services (`provider`, top-level `models`) | Modeled and parsed, but **not honored** — a not-honored warning is emitted (these are no rootless-Podman equivalent, *not* "unknown key" errors) |
-| Real-hardware smoke tests on macOS and Windows | Pending ([#48](https://github.com/Glyndor/podup/issues/48)); code paths exist but are untested on physical hardware |
+| Real-hardware smoke tests on macOS | Pending; the code paths exist but are untested on physical Apple hardware. Windows was validated end-to-end on real hardware (Windows 11, Podman 5.8.3), including the interactive `exec`/`run` path added in 3.0.0. |
 
 ## Nothing is dropped silently
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -65,6 +65,12 @@ only tighten, never widen, what the launching user already has.
   cgroup rules (a malformed entry is warned about and skipped, not fatal).
 - CDI devices (Container Device Interface, e.g. `nvidia.com/gpu=all`) requested
   under `devices:` are passed through to Podman, which resolves them by name.
+- Per-mount hardening — `noexec`, `nosuid` and `nodev` — is carried onto a
+  volume's mount options, so a mount can deny binary execution, ignore
+  setuid/setgid bits, and block device nodes. The short form spells them as raw
+  mount options (`cache:/app/cache:noexec`); the long form takes them as
+  booleans under `volume:`. See [Per-mount hardening
+  options](docker-migration.md#per-mount-hardening-options-noexec-nosuid-nodev).
 
 ## Secret and config handling
 

--- a/install.ps1
+++ b/install.ps1
@@ -103,7 +103,7 @@ try {
 	# If neither verifier can run, the install fails closed.
 
 	# Baked-in base64 (unpadded) raw Ed25519 public keys (32 bytes each) matching
-	# the release signing key (RELEASE_SIGN_KEY). Up to two are accepted: the
+	# the release signing key. Up to two are accepted: the
 	# second is empty except during a key rotation, when it holds the new key so a
 	# release signed by either key verifies. The signature passes if any key
 	# validates. Override for a fork via PODUP_RELEASE_PUBKEY_B64 / _PUBKEY2_B64.

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -287,8 +287,9 @@ pub(crate) enum Commands {
 		/// terminals, and by `-T` — not by this flag.
 		#[arg(short, long)]
 		interactive: bool,
-		/// Disable pseudo-TTY allocation. `run` allocates one on Unix when stdin
-		/// is a terminal; this opts out, so a script keeps plain streaming.
+		/// Disable pseudo-TTY allocation. `run` allocates one when stdin and
+		/// stdout are both terminals; this opts out, so a script keeps plain
+		/// streaming.
 		// Both spellings are accepted on purpose: `docker compose run` spells the
 		// long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
 		// A script copied from either one has to work, so each command takes both.
@@ -534,8 +535,9 @@ pub(crate) enum Commands {
 		/// Detach: run the command in the background.
 		#[arg(short, long)]
 		detach: bool,
-		/// Disable pseudo-TTY allocation. `exec` allocates one on Unix when stdin
-		/// is a terminal; this opts out, so a script keeps plain streaming.
+		/// Disable pseudo-TTY allocation. `exec` allocates one when stdin and
+		/// stdout are both terminals; this opts out, so a script keeps plain
+		/// streaming.
 		// `docker compose exec` spells the long form `--no-tty`, so that is the
 		// primary here; `--no-TTY` stays accepted so the spelling `run` uses also
 		// works on `exec`. See the note on `run`'s field.

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -1,3 +1,9 @@
+//! YAML merge-key (`<<:`) and anchor resolution ahead of typing a compose file.
+//!
+//! serde's tolerance of a merge key depends on the type behind it, so the tags
+//! are resolved on the raw `Value` first and the merged document is what gets
+//! deserialized — the type never sees a `<<:` key.
+
 use std::collections::HashMap;
 
 use crate::compose::types::ComposeFile;

--- a/internal/compose/order.rs
+++ b/internal/compose/order.rs
@@ -1,3 +1,11 @@
+//! Dependency ordering for `depends_on`: a topological sort of the service
+//! graph.
+//!
+//! [`resolve_order`] gives a single start sequence; [`resolve_levels`] groups
+//! services into levels that can start concurrently. Both reject a dependency
+//! cycle and a reference to a missing service rather than starting in an
+//! arbitrary order.
+
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
 

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -97,7 +97,7 @@ impl Engine {
 
 	/// Push each service's image like [`Engine::push`], with `quiet` (`-q/--quiet`)
 	/// suppressing the per-image progress output. Kept off the frozen
-	/// [`PushOptions`] struct so the 1.0 library API stays stable.
+	/// [`PushOptions`] struct so the published library API stays stable across minors.
 	pub async fn push_with_quiet(
 		&self,
 		file: &ComposeFile,

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -14,7 +14,7 @@ use super::super::Engine;
 
 /// Options for [`Engine::commit_with_options`], mirroring `docker compose commit`
 /// (`-m/--message`, `-a/--author`, `-p/--pause`, `-c/--change`). Kept off the
-/// frozen `commit` signature so the 1.0 library API stays stable.
+/// frozen `commit` signature so the published library API stays stable across minors.
 #[derive(Debug, Clone, Default)]
 pub struct CommitOptions {
 	/// Commit message recorded on the new image (`-m/--message`).

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -51,7 +51,7 @@ pub struct RunOptions {
 /// Extra `docker compose run` flag overrides threaded through the engine
 /// builder ([`Engine::with_run_overrides`]). These are CLI-only refinements of
 /// a `run` invocation; they live here rather than on the frozen [`RunOptions`]
-/// public struct so the 1.0 library API stays stable, mirroring how the `up`
+/// public struct so the published library API stays stable across minors, mirroring how the `up`
 /// image-acquisition overrides are carried on the engine.
 #[derive(Default, Clone)]
 pub struct RunOverrides {

--- a/internal/engine/lifecycle/prefetch.rs
+++ b/internal/engine/lifecycle/prefetch.rs
@@ -1,9 +1,9 @@
 //! Best-effort image prefetch ahead of the per-level `up` walk.
 //!
-//! Today, each service's image is pulled inside `up_one_service`, gated
-//! behind the dependency-level barrier: on a cold start, a level-2 service's
-//! image acquisition does not even begin until every level-1 service is fully
-//! up. This stage collects every image the upcoming `up`/`create` pass will
+//! Without this stage each service's image is pulled inside `up_one_service`,
+//! gated behind the dependency-level barrier: on a cold start, a level-2
+//! service's image acquisition does not even begin until every level-1 service
+//! is fully up. This stage collects every image the upcoming `up`/`create` pass will
 //! pull and warms the local Podman cache for all of them up front,
 //! concurrently, before the first level barrier — instead of one at a time as
 //! each level's services reach their turn.

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -236,8 +236,8 @@ impl Engine {
 	/// Carried here rather than on [`RunOverrides`] for the reason that struct
 	/// already documents: it is public and not `#[non_exhaustive]`, so a new
 	/// field is a breaking change. `run_env_files` and `run_labels` are on the
-	/// engine for exactly this, and semver-checks caught me putting this one in
-	/// the wrong place.
+	/// engine for exactly this; cargo-semver-checks flagged this field when it
+	/// was placed on `RunOverrides`.
 	pub fn with_run_no_tty(mut self, no_tty: bool) -> Self {
 		self.run_no_tty = no_tty;
 		self

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -83,7 +83,7 @@ pub async fn list_projects(client: &Client, opts: LsOptions) -> Result<()> {
 
 /// List podup projects (`docker compose ls`) narrowed by `--filter` predicates
 /// (`name=<NAME>`, `status=<running|exited>`). The `filters` slice is kept off
-/// the frozen [`LsOptions`] struct so the 1.0 library API stays stable.
+/// the frozen [`LsOptions`] struct so the published library API stays stable across minors.
 pub async fn list_projects_filtered(
 	client: &Client,
 	opts: LsOptions,

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -55,9 +55,6 @@ pub struct ExecOptions {
 }
 
 impl ExecOptions {
-	/// Every `docker compose exec` flag, in CLI order. A constructor rather than
-	/// a struct literal because the type is `#[non_exhaustive]`, so the next flag
-	/// to land is not a breaking change for anyone building one.
 	/// Run the command as this user, `-u/--user`. Builder-style.
 	pub fn with_user(mut self, user: Option<String>) -> Self {
 		self.user = user;
@@ -95,6 +92,9 @@ impl ExecOptions {
 		self
 	}
 
+	/// Every `docker compose exec` flag, in CLI order. A constructor rather than
+	/// a struct literal because the type is `#[non_exhaustive]`, so the next flag
+	/// to land is not a breaking change for anyone building one.
 	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		env: Vec<String>,
@@ -383,9 +383,10 @@ fn wants_interactive(opts: &ExecOptions, stdin_is_tty: bool) -> bool {
 ///
 /// A pty merges stdout and stderr and writes CRLF, so allocating one when
 /// stdout is redirected changes the bytes a file receives. Asked alongside
-/// stdin, never instead of it. On Windows this is `GetConsoleMode` succeeding
-/// on the handle — the same probe raw mode later relies on, so the two cannot
-/// disagree.
+/// stdin, never instead of it. On a native Windows console this agrees with the
+/// `GetConsoleMode` probe raw mode uses; under an emulated pty (MSYS/Cygwin,
+/// e.g. Git Bash) `IsTerminal` can say terminal where raw mode cannot engage,
+/// in which case the session degrades to plain streaming rather than failing.
 pub(crate) fn stdout_is_terminal() -> bool {
 	use std::io::IsTerminal;
 	std::io::stdout().is_terminal()

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -50,7 +50,7 @@ pub struct LogsOptions {
 
 /// Prefix-display options for [`Engine::logs_with_display`] (`docker compose
 /// logs --no-color` / `--no-log-prefix`). Kept off the frozen [`LogsOptions`]
-/// struct so the 1.0 library API stays stable.
+/// struct so the published library API stays stable across minors.
 #[derive(Default)]
 pub struct LogsDisplay {
 	/// Produce monochrome output (no colour in the prefix), `--no-color`.

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -21,7 +21,7 @@ pub struct PsOptions {
 
 /// Service/status/name filters for [`Engine::ps_filtered`] (`docker compose ps`
 /// `--services`, `[SERVICE...]`, `--status`, `--filter`). Kept off the frozen
-/// [`PsOptions`] struct so the 1.0 library API stays stable.
+/// [`PsOptions`] struct so the published library API stays stable across minors.
 #[derive(Default)]
 pub struct PsFilterOptions {
 	/// Print the service names instead of the container table, `--services`.

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -14,7 +14,7 @@ use super::Engine;
 
 /// Options for [`Engine::stats_with_options`], mirroring `docker compose stats`
 /// and the table-shaping flags the other list commands expose. Kept off the
-/// frozen [`Engine::stats`] signature so the 1.0 library API stays stable.
+/// frozen [`Engine::stats`] signature so the published library API stays stable across minors.
 #[derive(Default)]
 pub struct StatsOptions {
 	/// Disable streaming; print a single snapshot and exit, `--no-stream`.

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -68,9 +68,8 @@ pub struct Client {
 /// in hand one call earlier (#1146).
 ///
 /// The path is folded into the `io::Error`'s message rather than into a new
-/// error variant so `PodmanError` keeps its shape: it is public API and 2.0.0
-/// shipped hours ago. `kind()` survives, which is what tells the two cases
-/// apart.
+/// error variant so `PodmanError` keeps its shape: it is public API, frozen
+/// since 2.0.0. `kind()` survives, which is what tells the two cases apart.
 ///
 /// Unix only because the hints are: `systemctl --user` means nothing to a
 /// `podman machine` install, and the named-pipe connect path reports its

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -196,15 +196,15 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 ///
 /// Carried on the engine rather than on `RunOverrides`, which is public and not
 /// `#[non_exhaustive]` — a new field there is a breaking change, which is what
-/// the semver gate told me when I tried it.
+/// cargo-semver-checks reported when the field was tried there.
 pub(crate) fn run_no_tty_for(command: &Commands) -> bool {
 	matches!(command, Commands::Run { no_tty, .. } if *no_tty)
 }
 
 /// Extract the `docker compose run -l/--label KEY=VAL` ad-hoc labels for the
 /// engine builder ([`podup::Engine::with_run_labels`]). Carried on the engine
-/// rather than the frozen `RunOverrides` struct so the 1.0 library API stays
-/// stable, mirroring `run_overrides_for`.
+/// rather than the frozen `RunOverrides` struct so the published library API
+/// stays stable across minors, mirroring `run_overrides_for`.
 pub(crate) fn run_labels_for(command: &Commands) -> Vec<String> {
 	match command {
 		Commands::Run { label, .. } => label.clone(),

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -492,8 +492,8 @@ mod tests {
 	///
 	/// Linux only, deliberately. Whether a given kernel refuses to exec a file
 	/// held open for writing — and for a script, whether the check lands on the
-	/// script or on its interpreter — is that kernel's business, and I verified
-	/// it on Linux. Asserting it elsewhere tests the platform rather than the
+	/// script or on its interpreter — is that kernel's business, verified on
+	/// Linux. Asserting it elsewhere tests the platform rather than the
 	/// classifier, and writing the test so it passes vacuously where ETXTBSY
 	/// never fires would repeat the mistake this whole change is about. The
 	/// retry itself stays on every Unix: it is a no-op where the errno does not

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -3,8 +3,8 @@
 //! Trust anchor is the set of Ed25519 public keys embedded in this binary
 //! ([`RELEASE_PUBKEYS`]), not the download domain or TLS. A release is accepted
 //! only if `SHA256SUMS` carries a valid signature from a matching private key
-//! (held in CI as `RELEASE_SIGN_KEY`) and the downloaded binary's SHA-256 digest
-//! appears in that signed manifest. Every check fails closed.
+//! (held as a CI secret) and the downloaded binary's SHA-256 digest appears in
+//! that signed manifest. Every check fails closed.
 
 use ed25519_dalek::{Signature, VerifyingKey};
 use sha2::{Digest, Sha256};


### PR DESCRIPTION
A documentation-only pass after 3.0.0, from a three-lens audit (docs quality, audience/voice, code doc-comments). No functional code changes — only docs, `--help` strings, doc-comments and the man page — so this is a patch.

## Accuracy drift corrected

- **`exec` interactivity described as stdin-only.** `docs/commands.md` and the `-T` `--help` text for both `run` and `exec` said a TTY engages when stdin is a terminal; the real rule is both stdin and stdout, and it is no longer Unix-only. This is user-visible help text published in 3.0.0.
- **"podup leads every scenario"** (README + `benchmarks.md` + the SVG alt text) was contradicted by the project's own published table: docker-compose edges deep-chain `down`, 0.380 s to 0.390 s, within a standard deviation. The prose now says so and the row stands, per the benchmark's fairness policy.
- **Stale references:** the release signing secret's old name (`RELEASE_SIGN_KEY`, renamed and deleted 2026-07-02) in `verify.rs` and `install.ps1`; links to the closed #1079 (`attach`) and #48 (`docker-migration.md`), with Windows now recorded as hardware-validated.
- **The `stdout_is_terminal` doc-comment** claimed the `IsTerminal`/`GetConsoleMode` probes cannot disagree; under an emulated pty (MSYS/Cygwin) they can, and the session degrades to streaming.

## Completeness

- The long-form volume hardening options (`noexec`/`nosuid`/`nodev`) are in the extensions table and the security model now, marked as a non-portable podup extension.
- The **man page was frozen at 1.2.0** — no `autostart` or `version`, no interactive run/exec, missing flags added since. Regenerated against the current CLI, with exit codes 126/127.
- README links `autostart.md` and `debian-packaging.md`.

## Doc-comment hygiene

- Reworded comments anchored to "1.0" (×9, now two majors old), to "Today"/"hours ago", and to the author's own session ("I verified", "caught me"); added module docs to `compose::merge` and `compose::order`; documented `ExecOptions::new`.
- The completions snippet no longer runs a zsh `fpath` line inside a bash fence; examples are in English.

## Verification

Full suite green (1332 lib + 69 bin), `cargo fmt`/clippy clean, `cargo semver-checks` against 3.0.0 is patch-clean (0 failures), the man page lints with no warnings, and the corrected `--help` text was confirmed by running the binary.