### PR TITLE
docs: re-measure the benchmark on 3.0.1 and fix the apt install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Package: [crates.io/crates/podup](https://crates.io/crates/podup) Â· MSRV 1.85 Â
 Register the signed Glyndor repository and install. Copy-paste:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Glyndor/podup/main/install.sh | bash -s -- --apt
+curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
 ```
 
 The installer verifies the keyring package's Ed25519 signature against its
@@ -147,17 +147,17 @@ sequenceDiagram
 
 Peak memory and per-operation latency against docker-compose and podman-compose,
 **all three driving the same rootless Podman**, same digest-pinned images,
-median of 10 measured runs (12 iterations, 2 warm-up discarded), on podup 2.1.0.
-podup leads all but one scenario (deep-chain `down`, where docker-compose's
-0.380 s edges podup's 0.390 s, inside a single standard deviation), and the
-widest gaps are the ones with many services.
+median of 10 measured runs (12 iterations, 2 warm-up discarded), on podup 3.0.1.
+podup is fastest in every scenario but one teardown (`many-services down`, where
+docker-compose's 0.565 s edges podup's 0.580 s, inside a single standard
+deviation), and the widest gaps are the ones with many services.
 
 | | podup | docker-compose | podman-compose |
 |---|---|---|---|
-| memory per command | **7.5 MiB** | 28.7 MiB | 51.2 MiB |
-| `up`, 42 services | **1.18 s** | 1.65 s | 7.85 s |
-| `up`, 12 services | **0.38 s** | 0.49 s | 2.43 s |
-| `config` (parse only) | **&lt;0.01 s** | 0.04 s | 0.10 s |
+| memory per command | **7.8 MiB** | 28.7 MiB | 51.7 MiB |
+| `up`, 42 services | **1.12 s** | 1.54 s | 7.69 s |
+| `up`, 12 services | **0.38 s** | 0.48 s | 2.37 s |
+| `config` (parse only) | **&lt;0.01 s** | 0.04 s | 0.13 s |
 
 <img src="docs/assets/bench.svg" alt="Bar chart: podup uses about 7 MiB per command against 29 MiB for docker-compose and 51 MiB for podman-compose, and is faster in all but one measured scenario" width="760">
 

--- a/docs/assets/bench.svg
+++ b/docs/assets/bench.svg
@@ -10,42 +10,42 @@
   <text class="l" x="24" y="47">median of 10 measured runs · lower is better</text>
   <text class="t" x="24" y="72">memory per command</text>
   <text class="l" x="168" y="97" text-anchor="end">podup</text>
-  <rect x="176" y="82" width="71" height="22" rx="3" fill="#3fb950"/>
-  <text class="v" x="255" y="97">7.46 MiB</text>
+  <rect x="176" y="82" width="73" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="257" y="97">7.78 MiB</text>
   <text class="l" x="168" y="123" text-anchor="end">docker-compose</text>
-  <rect x="176" y="108" width="273" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="457" y="123">28.68 MiB</text>
+  <rect x="176" y="108" width="270" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="454" y="123">28.68 MiB</text>
   <text class="l" x="168" y="149" text-anchor="end">podman-compose</text>
   <rect x="176" y="134" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="149">51.16 MiB</text>
+  <text class="v" x="672" y="149">51.68 MiB</text>
   <text class="t" x="24" y="188">up · 42 services</text>
   <text class="l" x="168" y="213" text-anchor="end">podup</text>
-  <rect x="176" y="198" width="73" height="22" rx="3" fill="#3fb950"/>
-  <text class="v" x="257" y="213">1.18 s</text>
+  <rect x="176" y="198" width="71" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="255" y="213">1.12 s</text>
   <text class="l" x="168" y="239" text-anchor="end">docker-compose</text>
-  <rect x="176" y="224" width="102" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="286" y="239">1.65 s</text>
+  <rect x="176" y="224" width="98" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="282" y="239">1.54 s</text>
   <text class="l" x="168" y="265" text-anchor="end">podman-compose</text>
   <rect x="176" y="250" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="265">7.85 s</text>
+  <text class="v" x="672" y="265">7.69 s</text>
   <text class="t" x="24" y="304">up · 12 services</text>
   <text class="l" x="168" y="329" text-anchor="end">podup</text>
-  <rect x="176" y="314" width="76" height="22" rx="3" fill="#3fb950"/>
-  <text class="v" x="260" y="329">0.38 s</text>
+  <rect x="176" y="314" width="78" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="262" y="329">0.38 s</text>
   <text class="l" x="168" y="355" text-anchor="end">docker-compose</text>
-  <rect x="176" y="340" width="99" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="283" y="355">0.49 s</text>
+  <rect x="176" y="340" width="100" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="284" y="355">0.48 s</text>
   <text class="l" x="168" y="381" text-anchor="end">podman-compose</text>
   <rect x="176" y="366" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="381">2.43 s</text>
+  <text class="v" x="672" y="381">2.37 s</text>
   <text class="t" x="24" y="420">config · parse only</text>
   <text class="l" x="168" y="445" text-anchor="end">podup</text>
   <rect x="176" y="430" width="2" height="22" rx="3" fill="#3fb950"/>
   <text class="v" x="186" y="445">&lt;0.01 s</text>
   <text class="l" x="168" y="471" text-anchor="end">docker-compose</text>
-  <rect x="176" y="456" width="195" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="379" y="471">0.04 s</text>
+  <rect x="176" y="456" width="150" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="334" y="471">0.04 s</text>
   <text class="l" x="168" y="497" text-anchor="end">podman-compose</text>
   <rect x="176" y="482" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="497">0.10 s</text>
+  <text class="v" x="672" y="497">0.13 s</text>
 </svg>

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -114,7 +114,7 @@ tied-fastest in all but one of the wall-clock rows. The exception is
 so it is a coin toss rather than a real gap. Two teardown rows land in an exact
 tie (`deep-chain down` and `running-ops restart`, both 0.170–0.380 s to the
 millisecond). The point of this benchmark is to publish the numbers whoever
-wins, so those rows stand as measured — and which teardown row falls on which
+wins, so those rows stand as measured, and which teardown row falls on which
 side of the line shifts run to run within that noise.
 
 `running-ops ps` and `config-heavy config` show podup at **0.000s**. That is the

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -32,40 +32,40 @@ include docker-compose), then `python3 bench/aggregate.py`. Raw per-iteration
 rows land in `bench/results/raw.csv`; the statistics are computed there and
 never by the runner.
 
-Measured on podup **2.1.0** installed from apt — the same binary a user gets,
+Measured on podup **3.0.1** installed from apt — the same binary a user gets,
 not a local build.
 
 ## Wall-clock (seconds, lower is better)
 
 | scenario | op | podman-compose | podup | docker-compose |
 |---|---|---|---|---|
-| single | up | 0.400 (p95 0.430, sd 0.012) | 0.090 (p95 0.100, sd 0.006) | 0.110 (p95 0.150, sd 0.013) |
-| single | down | 0.400 (p95 0.450, sd 0.022) | 0.140 (p95 0.240, sd 0.034) | 0.165 (p95 0.180, sd 0.013) |
-| multi-healthcheck | up | 0.645 (p95 0.680, sd 0.023) | 0.220 (p95 0.470, sd 0.095) | 0.700 (p95 0.710, sd 0.006) |
-| multi-healthcheck | down | 0.515 (p95 0.540, sd 0.020) | 0.245 (p95 0.350, sd 0.040) | 0.280 (p95 0.300, sd 0.016) |
-| deep-chain | up | 1.295 (p95 1.340, sd 0.027) | 0.400 (p95 0.470, sd 0.031) | 0.855 (p95 0.880, sd 0.015) |
-| deep-chain | down | 0.775 (p95 0.870, sd 0.040) | 0.390 (p95 0.480, sd 0.028) | 0.380 (p95 0.470, sd 0.032) |
-| wide-level | up | 7.850 (p95 8.180, sd 0.119) | 1.180 (p95 1.260, sd 0.032) | 1.650 (p95 1.880, sd 0.110) |
-| wide-level | down | 4.470 (p95 5.360, sd 0.390) | 1.840 (p95 2.070, sd 0.151) | 2.150 (p95 2.720, sd 0.297) |
-| scale | up | 0.415 (p95 0.440, sd 0.011) | 0.190 (p95 0.210, sd 0.010) | 0.395 (p95 0.480, sd 0.031) |
-| scale | down | 0.400 (p95 0.440, sd 0.017) | 0.260 (p95 0.300, sd 0.022) | 0.290 (p95 0.380, sd 0.031) |
-| network-ipam | up | 0.615 (p95 0.720, sd 0.046) | 0.110 (p95 0.120, sd 0.008) | 0.135 (p95 0.190, sd 0.020) |
-| network-ipam | down | 0.510 (p95 0.580, sd 0.033) | 0.170 (p95 0.250, sd 0.026) | 0.200 (p95 0.240, sd 0.015) |
-| volume-heavy | up | 0.855 (p95 0.950, sd 0.038) | 0.110 (p95 0.110, sd 0.006) | 0.130 (p95 0.140, sd 0.008) |
-| volume-heavy | down | 0.565 (p95 0.600, sd 0.017) | 0.150 (p95 0.210, sd 0.025) | 0.190 (p95 0.230, sd 0.016) |
-| warm-restart | warm up | 0.365 (p95 0.490, sd 0.044) | 0.030 (p95 0.040, sd 0.004) | 0.040 (p95 0.050, sd 0.006) |
-| many-services | up | 2.430 (p95 2.480, sd 0.029) | 0.380 (p95 0.450, sd 0.025) | 0.495 (p95 0.560, sd 0.024) |
-| many-services | down | 1.385 (p95 1.480, sd 0.050) | 0.520 (p95 0.770, sd 0.104) | 0.615 (p95 0.800, sd 0.095) |
-| running-ops | ps | 0.110 (p95 0.140, sd 0.009) | 0.000 (p95 0.000, sd 0.000) | 0.020 (p95 0.020, sd 0.000) |
-| running-ops | logs | 0.130 (p95 0.140, sd 0.005) | 0.020 (p95 0.020, sd 0.005) | 0.030 (p95 0.030, sd 0.000) |
-| running-ops | exec | 0.180 (p95 0.180, sd 0.005) | 0.060 (p95 0.070, sd 0.005) | 0.070 (p95 0.070, sd 0.005) |
-| running-ops | restart | 0.290 (p95 0.360, sd 0.024) | 0.170 (p95 0.180, sd 0.007) | 0.180 (p95 0.250, sd 0.025) |
-| wide-running-ops | ps | 0.120 (p95 0.120, sd 0.003) | 0.010 (p95 0.010, sd 0.003) | 0.040 (p95 0.130, sd 0.028) |
-| wide-running-ops | logs | 0.140 (p95 0.150, sd 0.005) | 0.010 (p95 0.020, sd 0.005) | 0.030 (p95 0.080, sd 0.015) |
-| wide-running-ops | exec | 0.185 (p95 0.210, sd 0.011) | 0.060 (p95 0.070, sd 0.004) | 0.070 (p95 0.110, sd 0.013) |
-| wide-running-ops | restart | 0.250 (p95 0.260, sd 0.008) | 0.125 (p95 0.130, sd 0.011) | 0.150 (p95 0.310, sd 0.050) |
-| config-heavy | config | 0.100 (p95 0.120, sd 0.007) | 0.000 (p95 0.000, sd 0.000) | 0.040 (p95 0.040, sd 0.004) |
-| build | build | 0.340 (p95 0.360, sd 0.009) | 0.200 (p95 0.210, sd 0.007) | 0.260 (p95 0.290, sd 0.014) |
+| single | up | 0.415 (p95 0.460, sd 0.019) | 0.080 (p95 0.090, sd 0.005) | 0.110 (p95 0.120, sd 0.006) |
+| single | down | 0.395 (p95 0.430, sd 0.020) | 0.135 (p95 0.190, sd 0.019) | 0.150 (p95 0.180, sd 0.014) |
+| multi-healthcheck | up | 0.650 (p95 0.680, sd 0.018) | 0.280 (p95 0.400, sd 0.087) | 0.690 (p95 0.710, sd 0.007) |
+| multi-healthcheck | down | 0.510 (p95 0.540, sd 0.016) | 0.245 (p95 0.310, sd 0.029) | 0.275 (p95 0.380, sd 0.034) |
+| deep-chain | up | 1.300 (p95 1.340, sd 0.022) | 0.370 (p95 0.390, sd 0.011) | 0.845 (p95 0.910, sd 0.028) |
+| deep-chain | down | 0.770 (p95 0.850, sd 0.033) | 0.380 (p95 0.410, sd 0.017) | 0.380 (p95 0.400, sd 0.015) |
+| wide-level | up | 7.690 (p95 7.860, sd 0.094) | 1.120 (p95 1.270, sd 0.055) | 1.545 (p95 1.730, sd 0.069) |
+| wide-level | down | 4.375 (p95 4.620, sd 0.118) | 1.885 (p95 2.380, sd 0.245) | 2.145 (p95 3.660, sd 0.519) |
+| scale | up | 0.435 (p95 0.540, sd 0.038) | 0.190 (p95 0.220, sd 0.012) | 0.380 (p95 0.390, sd 0.008) |
+| scale | down | 0.420 (p95 0.450, sd 0.019) | 0.275 (p95 0.310, sd 0.023) | 0.285 (p95 0.330, sd 0.020) |
+| network-ipam | up | 0.590 (p95 0.620, sd 0.020) | 0.100 (p95 0.110, sd 0.005) | 0.130 (p95 0.140, sd 0.005) |
+| network-ipam | down | 0.500 (p95 0.520, sd 0.018) | 0.165 (p95 0.180, sd 0.011) | 0.190 (p95 0.210, sd 0.016) |
+| volume-heavy | up | 0.830 (p95 1.000, sd 0.069) | 0.100 (p95 0.120, sd 0.011) | 0.120 (p95 0.150, sd 0.010) |
+| volume-heavy | down | 0.550 (p95 0.680, sd 0.052) | 0.145 (p95 0.160, sd 0.010) | 0.190 (p95 0.210, sd 0.014) |
+| warm-restart | warm up | 0.360 (p95 0.370, sd 0.008) | 0.030 (p95 0.030, sd 0.004) | 0.040 (p95 0.050, sd 0.005) |
+| many-services | up | 2.365 (p95 2.430, sd 0.042) | 0.380 (p95 0.430, sd 0.025) | 0.485 (p95 0.520, sd 0.017) |
+| many-services | down | 1.420 (p95 1.480, sd 0.035) | 0.580 (p95 0.730, sd 0.092) | 0.565 (p95 0.600, sd 0.039) |
+| running-ops | ps | 0.110 (p95 0.130, sd 0.007) | 0.000 (p95 0.000, sd 0.000) | 0.020 (p95 0.020, sd 0.000) |
+| running-ops | logs | 0.150 (p95 0.170, sd 0.010) | 0.030 (p95 0.050, sd 0.007) | 0.035 (p95 0.040, sd 0.005) |
+| running-ops | exec | 0.185 (p95 0.200, sd 0.009) | 0.060 (p95 0.060, sd 0.003) | 0.070 (p95 0.080, sd 0.005) |
+| running-ops | restart | 0.290 (p95 0.320, sd 0.018) | 0.170 (p95 0.200, sd 0.013) | 0.170 (p95 0.200, sd 0.010) |
+| wide-running-ops | ps | 0.130 (p95 0.140, sd 0.010) | 0.010 (p95 0.020, sd 0.003) | 0.035 (p95 0.040, sd 0.005) |
+| wide-running-ops | logs | 0.160 (p95 0.170, sd 0.008) | 0.030 (p95 0.030, sd 0.005) | 0.040 (p95 0.040, sd 0.004) |
+| wide-running-ops | exec | 0.200 (p95 0.210, sd 0.012) | 0.060 (p95 0.070, sd 0.005) | 0.070 (p95 0.070, sd 0.003) |
+| wide-running-ops | restart | 0.240 (p95 0.270, sd 0.013) | 0.115 (p95 0.120, sd 0.007) | 0.140 (p95 0.160, sd 0.009) |
+| config-heavy | config | 0.130 (p95 0.140, sd 0.006) | 0.000 (p95 0.000, sd 0.000) | 0.040 (p95 0.040, sd 0.005) |
+| build | build | 0.340 (p95 0.380, sd 0.019) | 0.200 (p95 0.210, sd 0.006) | 0.260 (p95 0.280, sd 0.010) |
 
 ## Memory + CPU per command (peak RSS / CPU time, median)
 
@@ -77,41 +77,45 @@ Go binary talking to a socket, like podup.
 
 | scenario | op | podman-compose | podup | docker-compose |
 |---|---|---|---|---|
-| single | up | 51.2 MiB / 0.405 s | 7.5 MiB / 0.000 s | 28.7 MiB / 0.020 s |
-| single | down | 49.0 MiB / 0.345 s | 7.2 MiB / 0.000 s | 28.2 MiB / 0.010 s |
-| multi-healthcheck | up | 51.8 MiB / 0.610 s | 7.5 MiB / 0.000 s | 29.0 MiB / 0.020 s |
-| multi-healthcheck | down | 49.1 MiB / 0.460 s | 7.3 MiB / 0.000 s | 28.2 MiB / 0.020 s |
-| deep-chain | up | 51.8 MiB / 1.210 s | 7.5 MiB / 0.000 s | 29.1 MiB / 0.025 s |
-| deep-chain | down | 49.1 MiB / 0.810 s | 7.4 MiB / 0.000 s | 28.7 MiB / 0.020 s |
-| wide-level | up | 52.1 MiB / 6.890 s | 7.9 MiB / 0.025 s | 34.6 MiB / 0.090 s |
-| wide-level | down | 49.5 MiB / 5.535 s | 7.5 MiB / 0.010 s | 31.1 MiB / 0.060 s |
-| scale | up | 50.8 MiB / 0.420 s | 7.5 MiB / 0.000 s | 29.0 MiB / 0.025 s |
-| scale | down | 49.0 MiB / 0.340 s | 7.3 MiB / 0.000 s | 28.5 MiB / 0.020 s |
-| network-ipam | up | 51.2 MiB / 0.570 s | 7.4 MiB / 0.000 s | 28.8 MiB / 0.020 s |
-| network-ipam | down | 48.7 MiB / 0.460 s | 7.4 MiB / 0.000 s | 28.4 MiB / 0.020 s |
-| volume-heavy | up | 51.3 MiB / 0.960 s | 7.4 MiB / 0.000 s | 28.7 MiB / 0.020 s |
-| volume-heavy | down | 49.2 MiB / 0.530 s | 7.3 MiB / 0.000 s | 28.9 MiB / 0.020 s |
-| warm-restart | warm up | 49.4 MiB / 0.410 s | 7.5 MiB / 0.000 s | 29.0 MiB / 0.020 s |
-| many-services | up | 51.8 MiB / 2.125 s | 7.6 MiB / 0.000 s | 30.6 MiB / 0.040 s |
-| many-services | down | 49.1 MiB / 1.625 s | 7.4 MiB / 0.000 s | 29.2 MiB / 0.030 s |
-| running-ops | ps | 47.6 MiB / 0.130 s | 7.0 MiB / 0.000 s | 28.7 MiB / 0.015 s |
-| running-ops | logs | 64.0 MiB / 0.130 s | 7.3 MiB / 0.000 s | 28.5 MiB / 0.015 s |
-| running-ops | exec | 47.4 MiB / 0.130 s | 7.4 MiB / 0.000 s | 26.9 MiB / 0.010 s |
-| running-ops | restart | 47.8 MiB / 0.170 s | 7.2 MiB / 0.000 s | 28.5 MiB / 0.020 s |
-| wide-running-ops | ps | 48.8 MiB / 0.135 s | 7.1 MiB / 0.000 s | 29.5 MiB / 0.030 s |
-| wide-running-ops | logs | 63.5 MiB / 0.130 s | 7.3 MiB / 0.000 s | 29.3 MiB / 0.020 s |
-| wide-running-ops | exec | 47.1 MiB / 0.130 s | 7.3 MiB / 0.000 s | 26.7 MiB / 0.010 s |
-| wide-running-ops | restart | 47.7 MiB / 0.175 s | 7.2 MiB / 0.000 s | 28.5 MiB / 0.020 s |
-| config-heavy | config | 37.9 MiB / 0.110 s | 6.8 MiB / 0.000 s | 29.2 MiB / 0.050 s |
-| build | build | 55.6 MiB / 0.360 s | 7.3 MiB / 0.000 s | 29.3 MiB / 0.020 s |
+| single | up | 51.7 MiB / 0.410 s | 7.8 MiB / 0.000 s | 28.7 MiB / 0.020 s |
+| single | down | 49.5 MiB / 0.335 s | 7.6 MiB / 0.000 s | 28.3 MiB / 0.010 s |
+| multi-healthcheck | up | 52.4 MiB / 0.590 s | 7.9 MiB / 0.000 s | 29.0 MiB / 0.020 s |
+| multi-healthcheck | down | 49.6 MiB / 0.450 s | 7.6 MiB / 0.000 s | 28.3 MiB / 0.020 s |
+| deep-chain | up | 53.0 MiB / 1.180 s | 7.7 MiB / 0.000 s | 29.4 MiB / 0.030 s |
+| deep-chain | down | 50.0 MiB / 0.760 s | 7.7 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| wide-level | up | 52.8 MiB / 6.520 s | 8.4 MiB / 0.020 s | 33.3 MiB / 0.080 s |
+| wide-level | down | 50.1 MiB / 4.990 s | 7.9 MiB / 0.010 s | 30.4 MiB / 0.050 s |
+| scale | up | 51.7 MiB / 0.405 s | 7.8 MiB / 0.000 s | 29.7 MiB / 0.020 s |
+| scale | down | 49.8 MiB / 0.330 s | 7.5 MiB / 0.000 s | 28.7 MiB / 0.010 s |
+| network-ipam | up | 52.2 MiB / 0.540 s | 7.8 MiB / 0.000 s | 29.1 MiB / 0.020 s |
+| network-ipam | down | 49.9 MiB / 0.430 s | 7.6 MiB / 0.000 s | 28.4 MiB / 0.020 s |
+| volume-heavy | up | 52.2 MiB / 0.940 s | 7.8 MiB / 0.000 s | 28.9 MiB / 0.020 s |
+| volume-heavy | down | 49.6 MiB / 0.520 s | 7.5 MiB / 0.000 s | 29.1 MiB / 0.020 s |
+| warm-restart | warm up | 50.3 MiB / 0.390 s | 7.7 MiB / 0.000 s | 29.6 MiB / 0.020 s |
+| many-services | up | 52.6 MiB / 2.005 s | 8.0 MiB / 0.000 s | 30.2 MiB / 0.040 s |
+| many-services | down | 49.8 MiB / 1.520 s | 7.6 MiB / 0.000 s | 28.9 MiB / 0.030 s |
+| running-ops | ps | 48.5 MiB / 0.120 s | 7.3 MiB / 0.000 s | 28.5 MiB / 0.010 s |
+| running-ops | logs | 64.1 MiB / 0.130 s | 7.6 MiB / 0.000 s | 28.4 MiB / 0.010 s |
+| running-ops | exec | 47.7 MiB / 0.135 s | 7.6 MiB / 0.000 s | 26.9 MiB / 0.010 s |
+| running-ops | restart | 48.3 MiB / 0.175 s | 7.5 MiB / 0.000 s | 28.7 MiB / 0.020 s |
+| wide-running-ops | ps | 49.5 MiB / 0.140 s | 7.3 MiB / 0.000 s | 29.5 MiB / 0.030 s |
+| wide-running-ops | logs | 64.3 MiB / 0.140 s | 7.6 MiB / 0.000 s | 28.4 MiB / 0.020 s |
+| wide-running-ops | exec | 48.1 MiB / 0.140 s | 7.6 MiB / 0.000 s | 27.0 MiB / 0.010 s |
+| wide-running-ops | restart | 48.8 MiB / 0.180 s | 7.5 MiB / 0.000 s | 28.6 MiB / 0.020 s |
+| config-heavy | config | 37.8 MiB / 0.125 s | 7.1 MiB / 0.000 s | 29.3 MiB / 0.045 s |
+| build | build | 57.2 MiB / 0.355 s | 7.7 MiB / 0.000 s | 30.0 MiB / 0.020 s |
 
 ## Reading these numbers honestly
 
-podup leads every row in this memory-and-latency table, and two of them deserve
-a caveat rather than a victory lap. (In the full latency table above, one
-scenario goes the other way: deep-chain `down`, where docker-compose's 0.380 s
-is a hair under podup's 0.390 s, well within a standard deviation. The point of
-this benchmark is to publish the numbers whoever wins, so that row stands.)
+podup is fastest in every row of the memory-and-CPU table, and the fastest or
+tied-fastest in all but one of the wall-clock rows. The exception is
+`many-services down`, where docker-compose's 0.565 s edges podup's 0.580 s —
+0.015 s apart, well inside podup's own 0.092 s standard deviation on that row,
+so it is a coin toss rather than a real gap. Two teardown rows land in an exact
+tie (`deep-chain down` and `running-ops restart`, both 0.170–0.380 s to the
+millisecond). The point of this benchmark is to publish the numbers whoever
+wins, so those rows stand as measured — and which teardown row falls on which
+side of the line shifts run to run within that noise.
 
 `running-ops ps` and `config-heavy config` show podup at **0.000s**. That is the
 floor of `/usr/bin/time -v`, which resolves to 10ms — the real figure is around
@@ -119,7 +123,7 @@ floor of `/usr/bin/time -v`, which resolves to 10ms — the real figure is aroun
 below what the instrument can see.
 
 The `multi-healthcheck` row moved the most between releases: 1.275s in 2.0.0
-against 0.220s here. That is not a scheduling trick, it is a bug fix — podup
+against 0.280s here. That is not a scheduling trick, it is a bug fix — podup
 used to read a container's health status once per healthcheck `interval` and
 now reads it every 150ms between runs, so a container that turns healthy just
 after a probe is noticed at once instead of at the end of the window.


### PR DESCRIPTION
Two documentation fixes.

## Benchmark re-measured on 3.0.1

Re-ran `bench/run.sh` on the 3.0.1 apt binary, same machine, docker-compose pointed at the Podman socket via `DOCKER_HOST` so all three tools share the engine (the same-engine methodology the docs already describe). Regenerated `docs/benchmarks.md`, the README headline table and `docs/assets/bench.svg` from the measured `summary.json`.

The numbers track 2.1.0 within noise — 3.0.1 carries no Linux-runtime change (the diff since was Windows console code, compose parse-time options, docs), so this is an honest re-measure at the current version, not a claimed improvement.

One thing did move: the single scenario docker-compose edges is now `many-services down` (0.565 s vs podup's 0.580 s, inside podup's 0.092 s stdev), while `deep-chain down` — the row the old README called out — is now an exact tie. Which teardown lands on which side of the line shifts run to run within that noise, so the prose says that instead of naming a permanent loser. The chart and the headline table agree to the rounded value.

## apt install one-liner → glyndor.net

The recommended apt command still fetched `install.sh` from `raw.githubusercontent.com`; every other install command in the docs already used `https://glyndor.net/podup/install/unix`, which is the URL the installers themselves cite. Both `/podup/install/unix` and `/podup/install/windows` were verified serving 200. Aligned the last outlier.

Docs-only, no code change.