### PR TITLE
fix: stats exits non-zero when a live sample is truncated

### DIFF
--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -65,6 +65,22 @@ fn containers_query(wanted: &HashSet<String>) -> String {
 		.collect::<String>()
 }
 
+/// Whether a `stats --stream` stream that ended with an error broke while a
+/// sampled container was still running.
+///
+/// The stream lives as long as any sampled container runs and ends once none
+/// remain, so the error is a real failure only when the re-checked running set
+/// still holds one of the containers the stream was sampling. When every
+/// sampled container has stopped, the end was expected and the missing terminal
+/// frame is the finished-vs-broken ambiguity (#1104), not a fault. Pure so the
+/// decision is unit-tested without a live socket.
+fn stats_stream_broke_mid_sample(
+	sampled: &HashSet<String>,
+	still_running: &HashSet<String>,
+) -> bool {
+	sampled.iter().any(|c| still_running.contains(c))
+}
+
 /// Deserialize a map field, treating an explicit JSON `null` as the default
 /// (empty) map. libpod sends `"Network": null` for a container with no
 /// interfaces, which plain `#[serde(default)]` does not tolerate.
@@ -333,20 +349,58 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
-		// Raised from `debug!` to `warn!` so a stream that dies mid-sample is at
-		// least visible at the default level — it used to vanish entirely, and a
-		// monitor scraping `stats` read a truncated sample as a complete one.
-		//
-		// Not fatal, though. The sibling streaming commands showed on the live
-		// lane that a finished libpod stream can end in a way hyper reports as an
-		// error on some Podman versions, so failing the command here would fail
-		// runs that worked. Making the exit code trustworthy needs that
-		// distinction first.
 		while let Some(frame) = frames.next().await {
 			match frame {
 				Ok(report) => print_frame(&report, &running, &stopped, &opts),
 				Err(e) => {
-					tracing::warn!("stats: stream ended early [{}]: {e}", e.stream_end_kind());
+					// A `stats --stream` stream lives as long as any sampled
+					// container is running, and ends once none remain. libpod
+					// signals that end with a chunked terminator, but a lost
+					// terminator (a dropped connection, or a version that omits it)
+					// reaches here as an `Err` that is *indistinguishable* from a
+					// real mid-sample break at the transport layer (#1104). Resolve
+					// it out of band: re-check what is still running. If nothing the
+					// stream was sampling is alive, the end was expected and the
+					// command succeeded; if something is still running, the stream
+					// truncated a live sample and the command failed — which is the
+					// exit code a monitor scraping `stats` needs (#1080).
+					//
+					// The re-check is point-in-time: it samples state a moment after
+					// the break, so a genuine break that happens to coincide with
+					// every sampled container stopping is knowingly tolerated as a
+					// clean end — the transport layer cannot tell the two apart, and
+					// the sampled containers are gone either way.
+					let still_running = match self.target_containers(file, target_services).await {
+						Ok(targets) => targets
+							.into_iter()
+							.filter(|c| c.running)
+							.map(|c| c.name)
+							.collect::<HashSet<String>>(),
+						// Fail closed: an unreadable running set is not confirmation
+						// the end was expected, so the original error stands rather
+						// than masking a possible failure. Decided here, at the point
+						// of the inconclusive re-check, so the guarantee does not
+						// depend on the sampled set being non-empty.
+						Err(_) => {
+							tracing::warn!(
+								"stats: stream ended and the running set could not be \
+								 re-checked [{}]: {e}",
+								e.stream_end_kind()
+							);
+							return Err(ComposeError::Podman(e));
+						}
+					};
+					if stats_stream_broke_mid_sample(&running, &still_running) {
+						tracing::warn!(
+							"stats: stream broke while a container was still running [{}]: {e}",
+							e.stream_end_kind()
+						);
+						return Err(ComposeError::Podman(e));
+					}
+					tracing::debug!(
+						"stats: stream ended as its containers stopped [{}]",
+						e.stream_end_kind()
+					);
 					break;
 				}
 			}

--- a/internal/engine/stats_tests.rs
+++ b/internal/engine/stats_tests.rs
@@ -163,6 +163,43 @@ fn containers_query_empty_when_none_wanted() {
 	assert_eq!(containers_query(&HashSet::new()), "");
 }
 
+fn name_set(names: &[&str]) -> HashSet<String> {
+	names.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn stats_stream_break_is_fatal_only_while_a_sampled_container_still_runs() {
+	let sampled = name_set(&["proj-web-1", "proj-db-1"]);
+
+	// A sampled container is still running: the stream truncated a live sample,
+	// so the error is a real failure (#1080) — the exit code a monitor needs.
+	assert!(stats_stream_broke_mid_sample(
+		&sampled,
+		&name_set(&["proj-web-1"])
+	));
+
+	// Every sampled container has stopped: the stream ended because there was
+	// nothing left to sample, and the missing terminal frame is the
+	// finished-vs-broken ambiguity (#1104), not a fault.
+	assert!(!stats_stream_broke_mid_sample(&sampled, &HashSet::new()));
+
+	// A different, unrelated container is running (e.g. another project): it was
+	// never sampled, so it does not make this stream's end a failure.
+	assert!(!stats_stream_broke_mid_sample(
+		&sampled,
+		&name_set(&["other-app-1"])
+	));
+}
+
+#[test]
+fn stats_stream_break_with_no_sampled_containers_is_never_fatal() {
+	// Nothing was being sampled, so no end can be a truncated-sample failure.
+	assert!(!stats_stream_broke_mid_sample(
+		&HashSet::new(),
+		&name_set(&["proj-web-1"])
+	));
+}
+
 #[test]
 fn first_unknown_service_flags_typos() {
 	let file =


### PR DESCRIPTION
Part of #1080; applies the container-state disambiguation the #1104 investigation pointed to.

## Problem
A `stats --stream` stream ends when its sampled containers stop, and libpod marks that end with a chunked terminal frame. A lost terminator (a dropped connection, or a Podman version that omits it) reaches the parser as an `Err` indistinguishable from a real mid-sample break at the transport layer (#1104). So `stats` treated every stream-end error as a clean stop and exited 0; a monitor scraping it read a truncated sample as complete.

## Fix
Re-check what is still running on a stream-end error: a sampled container still alive means the stream truncated a live sample and the command fails (the exit code #1080 wants); every sampled container stopped means the end was expected and it succeeds. Fail-closed is decided at the point of the inconclusive re-check, so it does not depend on the sampled set being non-empty (per the silent-failure review). The decision is a pure function, unit-tested both ways.

## Safety
Inert on 5.4.2 (it always sends the terminator — verified down to a SIGKILL'd conmon). No integration test exercises the streaming stats path (all use --no-stream), so no lane exposure; the 15 tests #1104 mentions were logs/archive, untouched.

## Scope
Does not close #1080 (down --rmi, build extra tags, config --hash, events remain) or #1104 (pattern applied to stats only; the 5.8.x-on-metal measurement is still owed).

## Test plan
1334 lib (2 new) + 145 integration green on real Podman 5.4.2; streaming stats exits 0 when containers stop mid-stream (verified live); fmt/clippy clean. Reviewed by silent-failure-hunter + bug reviewer — one MEDIUM addressed, no bugs.