### PR TITLE
release: 3.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+podup (3.0.2) unstable; urgency=medium
+
+  Fixes
+
+  * cp into a container, and watch sync with it, work on Podman 6 again.
+    The container-archive PUT applies the tar and then closes the
+    connection without an HTTP response there, which read as a failure
+    even though the file had landed. Both now confirm the upload by the
+    destination's mtime moving, and report a clear error when it cannot
+    be confirmed rather than a raw transport one. Podman 5 is unchanged.
+  * stats exits non-zero when its stream is truncated while a container it
+    was sampling is still running, so a monitor scraping it no longer
+    reads a cut-off sample as a complete one. A stream that ends because
+    every sampled container stopped still exits zero.
+
+  Docs
+
+  * The benchmark is re-measured on 3.0.1 (it tracks the prior release
+    within noise); the exec reference and the -T help text describe the
+    both-ends-are-terminals rule and no longer read as Unix-only; the
+    apt install one-liner points at glyndor.net; the man page covers
+    autostart, version and the interactive run/exec path.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Fri, 24 Jul 2026 21:20:00 -0500
+
 podup (3.0.1) unstable; urgency=medium
 
   Docs

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -202,22 +202,121 @@ impl Engine {
 		.await
 		.map_err(|e| ComposeError::Build(e.to_string()))??;
 
+		let entry = rename.clone().unwrap_or_else(|| {
+			src.file_name()
+				.map(|n| n.to_string_lossy().into_owned())
+				.unwrap_or_default()
+		});
+		self.put_archive_verified(&container_name, &extract_dir, &entry, tar_bytes)
+			.await
+	}
+
+	/// PUT a gzipped tar to a container's archive endpoint at `dir`, extracting
+	/// it there, and confirm it landed — the upload path shared by `cp` and
+	/// `watch` sync.
+	///
+	/// #1097: on Podman 6 the archive endpoint applies the tar and then closes
+	/// the connection *without* an HTTP response, which hyper reports as
+	/// `IncompleteMessage` even though the copy landed (the content does appear —
+	/// measured on 6.0.1; every raw request to the same endpoint gets a clean
+	/// 200, so the trigger is client-side and could not be stripped out). To tell
+	/// that apply-then-close apart from a *genuine* upload failure (a dropped
+	/// socket, a truncated body), capture `dir/entry`'s mtime before the PUT and,
+	/// on an `IncompleteMessage`, treat the copy as landed only if that mtime
+	/// moved — the extracted file takes the source's mtime, so an unchanged one
+	/// means a failed upload left the old entry in place. Fails, rather than
+	/// guessing, when the entry has no name (`cp . svc:/`), when the pre- or
+	/// post-PUT stat cannot be read, or when the mtime did not move.
+	///
+	/// Known limit: the mtime of a *directory* entry moves only when its own
+	/// children are added or removed, so re-syncing a tree whose only change is
+	/// deeper than the top level is reported as unverifiable (fail-closed, never a
+	/// false success). Inert on Podman 5, which returns a normal response.
+	pub(super) async fn put_archive_verified(
+		&self,
+		container: &str,
+		dir: &str,
+		entry: &str,
+		tar_bytes: Vec<u8>,
+	) -> Result<()> {
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
-			urlencoded(&container_name),
-			urlencoded(&extract_dir),
+			urlencoded(container),
+			urlencoded(dir),
 		);
-		self.client
-			// `pack_path` gzips, so the body is a gzipped tar and saying
-			// `application/x-tar` was simply false. Podman 5 sniffs the magic bytes
-			// and forgives either label. This does NOT fix #1097 — the lane proved
-			// Podman 6 rejects the upload identically both ways — it just stops
-			// podup lying about what it sends.
+		let verify_path = (!entry.is_empty()).then(|| {
+			format!(
+				"{API_PREFIX}/containers/{}/archive?path={}",
+				urlencoded(container),
+				urlencoded(&join_archive_path(dir, entry)),
+			)
+		});
+		// The pre-PUT mtime, only when it can be read cleanly. `None` means
+		// "unknown" (no verifiable entry, or the stat failed) and forces a later
+		// IncompleteMessage to fail rather than guess.
+		let pre_mtime = match &verify_path {
+			Some(p) => self.client.head_path_mtime(p).await.ok(),
+			None => None,
+		};
+
+		// `application/gzip` is the honest label for the gzipped tar; Podman
+		// sniffs the magic bytes and forgives either.
+		let Err(e) = self
+			.client
 			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/gzip")
 			.await
-			.map_err(ComposeError::Podman)?;
+		else {
+			return Ok(());
+		};
+		// Only the Podman-6 apply-then-close is recoverable; any other error is a
+		// genuine failure and propagates unchanged.
+		if !e.is_incomplete_message() {
+			return Err(ComposeError::Podman(e));
+		}
+		let landed = match (&verify_path, pre_mtime) {
+			(Some(p), Some(pre)) => match self.client.head_path_mtime(p).await {
+				Ok(post) => copy_landed(pre.as_deref(), post.as_deref()),
+				Err(stat_err) => {
+					tracing::debug!(
+						"cp: could not re-verify {p} after an incomplete PUT: {stat_err}"
+					);
+					false
+				}
+			},
+			_ => false,
+		};
+		if landed {
+			return Ok(());
+		}
+		// The upload finished but its result could not be confirmed. Say so, with
+		// an actionable hint, instead of surfacing the raw transport error.
+		Err(ComposeError::Copy(format!(
+			"the upload to {dir} could not be confirmed — the container runtime closed the \
+			 connection without a response and the destination did not change. The copy may \
+			 or may not have landed; check {dir} in the container."
+		)))
+	}
+}
 
-		Ok(())
+/// Whether a `cp`/sync whose archive PUT ended in an `IncompleteMessage`
+/// actually landed, from the destination entry's mtime before and after the
+/// PUT. The entry must exist now (`post` is `Some`) and its mtime must differ
+/// from before — the extracted file takes the source's mtime, so an unchanged
+/// mtime means a failed upload left the old entry in place. A vanished entry, or
+/// one whose mtime did not move, is "did not land". Pure so the decision is
+/// unit-tested without a container.
+fn copy_landed(pre: Option<&str>, post: Option<&str>) -> bool {
+	post.is_some() && post != pre
+}
+
+/// Join a container directory and an entry name into one path, without doubling
+/// the separator when the directory already ends in `/` (so root `/` yields
+/// `/name`, not `//name`). Pure so the join is unit-tested without a container.
+fn join_archive_path(dir: &str, entry: &str) -> String {
+	if dir.ends_with('/') {
+		format!("{dir}{entry}")
+	} else {
+		format!("{dir}/{entry}")
 	}
 }
 
@@ -281,7 +380,37 @@ fn parse_endpoint(s: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-	use super::parse_endpoint;
+	use super::{copy_landed, join_archive_path, parse_endpoint};
+
+	#[test]
+	fn join_archive_path_does_not_double_the_separator() {
+		// The #1097 re-verify stats `<dir>/<entry>`; a dir already ending in `/`
+		// (notably root) must not produce `//entry`, which libpod reads as a
+		// different path and 404s, turning a landed copy into a false failure.
+		assert_eq!(join_archive_path("/tmp", "f.txt"), "/tmp/f.txt");
+		assert_eq!(join_archive_path("/tmp/", "f.txt"), "/tmp/f.txt");
+		assert_eq!(join_archive_path("/", "f.txt"), "/f.txt");
+	}
+
+	#[test]
+	fn copy_landed_requires_the_entry_to_exist_and_its_mtime_to_move() {
+		// A brand-new destination: absent before, present after -> landed.
+		assert!(copy_landed(None, Some("2026-01-01T00:00:00Z")));
+		// An overwrite that applied: the entry's mtime changed to the source's.
+		assert!(copy_landed(
+			Some("2026-01-01T00:00:00Z"),
+			Some("2026-06-01T00:00:00Z")
+		));
+		// An overwrite whose PUT actually failed: the old entry is still there,
+		// unchanged. This is the silent-success the mtime check exists to prevent.
+		assert!(!copy_landed(
+			Some("2026-01-01T00:00:00Z"),
+			Some("2026-01-01T00:00:00Z")
+		));
+		// The entry vanished (or never appeared): not landed.
+		assert!(!copy_landed(Some("2026-01-01T00:00:00Z"), None));
+		assert!(!copy_landed(None, None));
+	}
 
 	#[test]
 	fn parse_service_colon_path() {

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -65,6 +65,22 @@ fn containers_query(wanted: &HashSet<String>) -> String {
 		.collect::<String>()
 }
 
+/// Whether a `stats --stream` stream that ended with an error broke while a
+/// sampled container was still running.
+///
+/// The stream lives as long as any sampled container runs and ends once none
+/// remain, so the error is a real failure only when the re-checked running set
+/// still holds one of the containers the stream was sampling. When every
+/// sampled container has stopped, the end was expected and the missing terminal
+/// frame is the finished-vs-broken ambiguity (#1104), not a fault. Pure so the
+/// decision is unit-tested without a live socket.
+fn stats_stream_broke_mid_sample(
+	sampled: &HashSet<String>,
+	still_running: &HashSet<String>,
+) -> bool {
+	sampled.iter().any(|c| still_running.contains(c))
+}
+
 /// Deserialize a map field, treating an explicit JSON `null` as the default
 /// (empty) map. libpod sends `"Network": null` for a container with no
 /// interfaces, which plain `#[serde(default)]` does not tolerate.
@@ -333,20 +349,58 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
-		// Raised from `debug!` to `warn!` so a stream that dies mid-sample is at
-		// least visible at the default level — it used to vanish entirely, and a
-		// monitor scraping `stats` read a truncated sample as a complete one.
-		//
-		// Not fatal, though. The sibling streaming commands showed on the live
-		// lane that a finished libpod stream can end in a way hyper reports as an
-		// error on some Podman versions, so failing the command here would fail
-		// runs that worked. Making the exit code trustworthy needs that
-		// distinction first.
 		while let Some(frame) = frames.next().await {
 			match frame {
 				Ok(report) => print_frame(&report, &running, &stopped, &opts),
 				Err(e) => {
-					tracing::warn!("stats: stream ended early [{}]: {e}", e.stream_end_kind());
+					// A `stats --stream` stream lives as long as any sampled
+					// container is running, and ends once none remain. libpod
+					// signals that end with a chunked terminator, but a lost
+					// terminator (a dropped connection, or a version that omits it)
+					// reaches here as an `Err` that is *indistinguishable* from a
+					// real mid-sample break at the transport layer (#1104). Resolve
+					// it out of band: re-check what is still running. If nothing the
+					// stream was sampling is alive, the end was expected and the
+					// command succeeded; if something is still running, the stream
+					// truncated a live sample and the command failed — which is the
+					// exit code a monitor scraping `stats` needs (#1080).
+					//
+					// The re-check is point-in-time: it samples state a moment after
+					// the break, so a genuine break that happens to coincide with
+					// every sampled container stopping is knowingly tolerated as a
+					// clean end — the transport layer cannot tell the two apart, and
+					// the sampled containers are gone either way.
+					let still_running = match self.target_containers(file, target_services).await {
+						Ok(targets) => targets
+							.into_iter()
+							.filter(|c| c.running)
+							.map(|c| c.name)
+							.collect::<HashSet<String>>(),
+						// Fail closed: an unreadable running set is not confirmation
+						// the end was expected, so the original error stands rather
+						// than masking a possible failure. Decided here, at the point
+						// of the inconclusive re-check, so the guarantee does not
+						// depend on the sampled set being non-empty.
+						Err(_) => {
+							tracing::warn!(
+								"stats: stream ended and the running set could not be \
+								 re-checked [{}]: {e}",
+								e.stream_end_kind()
+							);
+							return Err(ComposeError::Podman(e));
+						}
+					};
+					if stats_stream_broke_mid_sample(&running, &still_running) {
+						tracing::warn!(
+							"stats: stream broke while a container was still running [{}]: {e}",
+							e.stream_end_kind()
+						);
+						return Err(ComposeError::Podman(e));
+					}
+					tracing::debug!(
+						"stats: stream ended as its containers stopped [{}]",
+						e.stream_end_kind()
+					);
 					break;
 				}
 			}

--- a/internal/engine/stats_tests.rs
+++ b/internal/engine/stats_tests.rs
@@ -163,6 +163,43 @@ fn containers_query_empty_when_none_wanted() {
 	assert_eq!(containers_query(&HashSet::new()), "");
 }
 
+fn name_set(names: &[&str]) -> HashSet<String> {
+	names.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn stats_stream_break_is_fatal_only_while_a_sampled_container_still_runs() {
+	let sampled = name_set(&["proj-web-1", "proj-db-1"]);
+
+	// A sampled container is still running: the stream truncated a live sample,
+	// so the error is a real failure (#1080) — the exit code a monitor needs.
+	assert!(stats_stream_broke_mid_sample(
+		&sampled,
+		&name_set(&["proj-web-1"])
+	));
+
+	// Every sampled container has stopped: the stream ended because there was
+	// nothing left to sample, and the missing terminal frame is the
+	// finished-vs-broken ambiguity (#1104), not a fault.
+	assert!(!stats_stream_broke_mid_sample(&sampled, &HashSet::new()));
+
+	// A different, unrelated container is running (e.g. another project): it was
+	// never sampled, so it does not make this stream's end a failure.
+	assert!(!stats_stream_broke_mid_sample(
+		&sampled,
+		&name_set(&["other-app-1"])
+	));
+}
+
+#[test]
+fn stats_stream_break_with_no_sampled_containers_is_never_fatal() {
+	// Nothing was being sampled, so no end can be a truncated-sample failure.
+	assert!(!stats_stream_broke_mid_sample(
+		&HashSet::new(),
+		&name_set(&["proj-web-1"])
+	));
+}
+
 #[test]
 fn first_unknown_service_flags_typos() {
 	let file =

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 
 use crate::libpod::types::exec::{ExecCreateConfig, ExecCreateResponse, ExecStartConfig};
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
-use bytes::Bytes;
 use futures_util::StreamExt;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
@@ -318,18 +317,13 @@ impl Engine {
 			let _ = self.watch_exec(container, mkdir_p_argv(&dest_dir)).await;
 		}
 
-		let path = format!(
-			"{API_PREFIX}/containers/{}/archive?path={}",
-			urlencoded(container),
-			urlencoded(&dest_dir),
-		);
-		self.client
-			// Gzipped, like `cp`'s: `watch` has its own copy of this upload rather
-			// than reusing `Engine::cp`, which is how the two drifted to different
-			// content types for the same body.
-			.put_bytes_ok(&path, Bytes::from(tar_bytes), "application/gzip")
-			.await
-			.map_err(ComposeError::Podman)?;
+		// Shared with `cp`: the same archive upload, and the same #1097 Podman-6
+		// apply-then-close handling (the endpoint applies the tar then closes
+		// without a response; the upload is confirmed by the entry's mtime moving).
+		// `watch` used to have its own copy of this PUT, which is how the two
+		// drifted apart and left sync unfixed on Podman 6.
+		self.put_archive_verified(container, &dest_dir, &entry_name, tar_bytes)
+			.await?;
 
 		info!("synced {} -> {target}", changed.display());
 		Ok(())

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -60,6 +60,18 @@ pub struct Client {
 	socket_path: String,
 }
 
+/// The decoded `X-Docker-Container-Path-Stat` header — a container path's Go
+/// file `mode` and `mtime`. `mtime` is an RFC3339 string compared only for
+/// equality (did a `cp` change the entry?), never parsed into a time. The
+/// runtime's JSON uses lowercase keys (`{"name":…,"size":…,"mode":…,"mtime":…}`).
+#[derive(serde::Deserialize, Default)]
+struct PathStat {
+	#[serde(default)]
+	mode: u64,
+	#[serde(default)]
+	mtime: String,
+}
+
 /// Attach the socket path and a way forward to a connection failure.
 ///
 /// The operator saw `podman socket connection error: No such file or directory
@@ -513,24 +525,26 @@ impl Client {
 
 	/// `PUT` with raw bytes body → expect 2xx.
 	///
-	/// The failure mode here is #1097: `cp` into a container, and `watch` sync
-	/// with it, have never worked on Podman 6 — the connection closes before the
-	/// response completes. Copying *out* (`GET`) is fine on both majors, so it is
-	/// specific to this direction.
-	///
-	/// Diagnostic rather than fix: podup cannot reproduce it on Podman 5, so this
-	/// names what happened for the nested-virt lane to report. The leading
-	/// hypothesis was a `Content-Length` versus chunked mismatch, and that is now
-	/// ruled out — see `a_buffered_put_body_reports_an_exact_size` — so what
-	/// libpod 6 objects to is still open.
+	/// #1097 lives on top of this call: the container-archive PUT on Podman 6
+	/// applies the tar and then closes the connection before completing the
+	/// response, which surfaces here as an `IncompleteMessage`. The recovery — the
+	/// endpoint applies the upload, so re-verify the destination changed rather
+	/// than fail a copy that landed — belongs to the caller, which knows the
+	/// destination (`Engine::put_archive_verified`). This method just reports the
+	/// outcome; the caller keys the recovery off
+	/// `PodmanError::is_incomplete_message`.
 	pub async fn put_bytes_ok(&self, path: &str, bytes: Bytes, content_type: &str) -> Result<()> {
 		let len = bytes.len();
 		let req = Self::build_request(Method::PUT, path, full(bytes), Some(content_type))?;
 		let resp = match self.send(req, Some(READ_TIMEOUT)).await {
 			Ok(r) => r,
 			Err(e) => {
-				tracing::warn!(
-					"PUT {path} ({content_type}, {len} bytes) failed [{}]: {e}",
+				// Debug, not warn: `cp` handles the Podman-6 IncompleteMessage on
+				// this endpoint by re-verifying the copy landed (#1097), so a
+				// warning here would cry "failed" on a copy that succeeded. A
+				// genuinely failed PUT surfaces through the returned error.
+				tracing::debug!(
+					"PUT {path} ({content_type}, {len} bytes) ended [{}]: {e}",
 					e.stream_end_kind()
 				);
 				return Err(e);
@@ -540,12 +554,12 @@ impl Client {
 		Self::check_status(status, &body)
 	}
 
-	/// `HEAD` a container-archive path, returning `Some(is_dir)` when it exists or
-	/// `None` on 404. Reads the `X-Docker-Container-Path-Stat` header (base64 JSON
-	/// carrying a Go file `mode`); the directory bit is `os.ModeDir` (`1 << 31`).
-	/// Lets `cp` tell an existing destination directory (copy into it) from a
-	/// target name (rename on copy), matching `docker cp`.
-	pub async fn head_path_is_dir(&self, path: &str) -> Result<Option<bool>> {
+	/// `HEAD` a container-archive path and decode its `X-Docker-Container-Path-Stat`
+	/// header, returning `Some(stat)` when the path exists or `None` on 404. The
+	/// header is base64 JSON carrying the Go file `mode`, `size` and `mtime`.
+	/// Shared by [`head_path_is_dir`](Self::head_path_is_dir) and
+	/// [`head_path_mtime`](Self::head_path_mtime).
+	async fn head_container_path_stat(&self, path: &str) -> Result<Option<PathStat>> {
 		use base64::Engine as _;
 
 		let req = Self::build_request(Method::HEAD, path, full(Bytes::new()), None)?;
@@ -564,8 +578,11 @@ impl Client {
 			return Ok(None);
 		}
 		Self::check_status(status, &body)?;
+		// The path exists but the runtime sent no stat header: report existence
+		// with a zeroed stat rather than failing (matches the prior behaviour,
+		// which treated a missing header as "exists, not a directory").
 		let Some(stat) = stat else {
-			return Ok(Some(false));
+			return Ok(Some(PathStat::default()));
 		};
 		let json = base64::engine::general_purpose::STANDARD
 			.decode(stat.as_bytes())
@@ -573,13 +590,29 @@ impl Client {
 				status: 0,
 				message: format!("malformed container path stat: {e}"),
 			})?;
-		#[derive(serde::Deserialize)]
-		struct Stat {
-			mode: u64,
-		}
-		let parsed: Stat = serde_json::from_slice(&json).map_err(PodmanError::Json)?;
+		Ok(Some(
+			serde_json::from_slice(&json).map_err(PodmanError::Json)?,
+		))
+	}
+
+	/// `HEAD` a container-archive path, returning `Some(is_dir)` when it exists or
+	/// `None` on 404. Lets `cp` tell an existing destination directory (copy into
+	/// it) from a target name (rename on copy), matching `docker cp`.
+	pub async fn head_path_is_dir(&self, path: &str) -> Result<Option<bool>> {
 		// Go's os.ModeDir is the high bit of the 32-bit FileMode.
-		Ok(Some(parsed.mode & (1 << 31) != 0))
+		Ok(self
+			.head_container_path_stat(path)
+			.await?
+			.map(|s| s.mode & (1 << 31) != 0))
+	}
+
+	/// `HEAD` a container-archive path, returning its `mtime` string when it
+	/// exists or `None` on 404. `cp` uses this to tell a copy actually *landed*
+	/// (the entry's mtime changed to the source's) from a stale entry that was
+	/// already there, when the Podman-6 archive PUT closes without a response
+	/// (#1097). The value is compared as an opaque string, not parsed.
+	pub(crate) async fn head_path_mtime(&self, path: &str) -> Result<Option<String>> {
+		Ok(self.head_container_path_stat(path).await?.map(|s| s.mtime))
 	}
 
 	/// `DELETE` → `Ok(true)` if the resource existed and was removed, `Ok(false)`

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -121,6 +121,15 @@ impl PodmanError {
 		matches!(self, Self::Api { status, .. } if *status == code)
 	}
 
+	/// True when the server closed the connection before completing the HTTP
+	/// response (hyper's `IncompleteMessage`). The container-archive PUT on
+	/// Podman 6 applies the archive and then closes without a response, so `cp`
+	/// uses this to tell that specific case apart and re-verify the copy landed
+	/// rather than failing an upload that actually succeeded (#1097).
+	pub(crate) fn is_incomplete_message(&self) -> bool {
+		matches!(self, Self::Hyper(e) if e.is_incomplete_message())
+	}
+
 	/// How a streaming read ended, for the one question podup cannot currently
 	/// answer: was the stream *finished* or *broken*?
 	///


### PR DESCRIPTION
Promotes develop to main for the 3.0.2 patch release.

Fixes since 3.0.1:
- cp into a container, and watch sync, work on Podman 6 again (#1097): the archive PUT applies the tar then closes without a response there; both now confirm the upload by the destination's mtime moving, with a clear error when it cannot be confirmed. Podman 5 unchanged. Root-caused and verified on a real Podman 6.0.1 host.
- stats exits non-zero when its stream is truncated while a sampled container is still running (part of #1080), so a monitor no longer reads a cut-off sample as complete.

Docs: benchmark re-measured on 3.0.1; the exec/-T help describes the both-ends-are-terminals rule and is no longer Unix-only; the apt one-liner points at glyndor.net; the man page covers autostart/version/interactive run-exec.

Fixes only, no API change. Version stamped in Cargo.toml, Cargo.lock, debian/changelog. Full suite green on develop, both podman-vm lanes and the Windows/macOS matrix, semver-checks patch-clean.