### PR TITLE
ci: cap podman-lane integration concurrency to cut nested-virt flakes

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -93,8 +93,18 @@ jobs:
                 # as Hyper(IncompleteMessage) and kin). A real failure reproduces on
                 # the second run, so this stabilises the lane for required-check gating
                 # without masking genuine bugs.
+                #
+                # `--test-threads=2` caps how many streaming tests hit the libpod
+                # socket at once. The nested-virt (VM-in-runner) transport is what
+                # drops connections mid-stream — measured: on a single-level VM
+                # (Podman 5.8.1 and 6.0.1) the same suite never drops a byte, so the
+                # flake is the double-virt socket under concurrent load, not a podup
+                # or libpod bug. Fewer concurrent streams means less peak pressure,
+                # which is the lever to shrink Podman 6's variable flaky tail toward
+                # a small, stable set that an identity list can gate (#1039). Kept at
+                # 2 rather than 1 so the suite still fits the VM's time budget.
                 for attempt in 1 2; do
-                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration > /tmp/cargo.log 2>&1
+                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=2 > /tmp/cargo.log 2>&1
                   RC=$?
                   [ "$RC" -eq 0 ] && break
                   grep -qE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log || break


### PR DESCRIPTION
First step of #1039.

The lane's `IncompleteMessage` failures are **nested-virt transport drops, not podup or libpod bugs** — measured this session on single-level KVM VMs (Podman 5.8.1 and 6.0.1): the same integration suite never drops a byte, while the CI's VM-in-runner double-virt drops connections mid-stream under load. The suite ran at full parallelism, so many streaming tests hit the libpod socket at once.

Capping the integration suite at `--test-threads=2` cuts the peak concurrent socket pressure that causes the drops. That is the lever #1039 needs: shrink Podman 6's variable flaky tail toward a small, stable set that a per-test known-failures list can gate (as Podman 5 already does), instead of the pass-count floor alone. Kept at 2, not 1, so the suite still fits the VM's time budget; the retry-once-on-transient stays.

This PR's own podman-lane run exercises the change directly. The effect on the flaky set needs observation across several runs (the nightly and subsequent PRs) before the Podman 6 identity list can be built — this lands the mitigation; the classification follows. Per-repo workflow, so no org-wide blast radius.