### PR TITLE
test: relabel the bind in the run volume test so it passes on SELinux hosts

### DIFF
--- a/.github/podman-known-failures-5
+++ b/.github/podman-known-failures-5
@@ -15,6 +15,14 @@
 # all pass now. The claim "cannot pass under nested virt" was made honestly, with
 # a run, and was still wrong: the physical host that proved 155/155 also had a
 # working journald, so the comparison could not see the difference.
+#
+# 2026-07-25: the same mistake again, and the same shape. run_flags::engine_run_
+# applies_volume_publish_and_interactive was never about nested virt either — it
+# bind-mounted a host directory with no SELinux relabel, so on an enforcing host
+# the container read it as `Permission denied`. Measured on Fedora 44 + Podman
+# 5.8.1 with plain `podman run`, no podup involved: without `z` the read is
+# denied, with `z` it succeeds. The test now asks for the relabel a user on such
+# a host writes too, and passes there. My physical host runs no SELinux, which is
+# once more why the 155/155 comparison could not see the difference.
 
 niche::engine_events_stream_connects
-run_flags::engine_run_applies_volume_publish_and_interactive

--- a/tests/engine_integration/run_flags.rs
+++ b/tests/engine_integration/run_flags.rs
@@ -52,7 +52,14 @@ async fn engine_run_applies_volume_publish_and_interactive() {
 	};
 	let dir = tempfile::tempdir().unwrap();
 	fs::write(dir.path().join("marker.txt"), b"present").unwrap();
-	let mount = format!("{}:/mnt/in:ro", dir.path().to_str().unwrap());
+	// `z` relabels the host directory so a confined container can read it. Without
+	// it this test fails on every SELinux-enforcing host — measured on Fedora 44 +
+	// Podman 5.8.1, where a `user_tmp_t` file bound read-only gives the container
+	// `cat: can't open '/mnt/in/marker.txt': Permission denied`. Plain `podman run`
+	// behaves identically, so the denial was never podup's; the mount just needed
+	// the relabel a user on such a host writes too. Where SELinux is off the option
+	// is a no-op, so the same spec covers both.
+	let mount = format!("{}:/mnt/in:ro,z", dir.path().to_str().unwrap());
 
 	let proj = proj("rvp");
 	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides {


### PR DESCRIPTION
`run_flags::engine_run_applies_volume_publish_and_interactive` bind-mounted a host
temp directory read-only and read a file from it, with no SELinux relabel. On an
enforcing host the container is denied that read, the command exits 1, and the
test fails. It had been carried in `.github/podman-known-failures-5` as a test
that cannot pass under nested virt, which was never the reason — the lane's own
log says so one line above the panic:

```
cat: can't open '/mnt/in/marker.txt': Permission denied
test run_flags::engine_run_applies_volume_publish_and_interactive ... FAILED
```

podup is faithful here: `podman` and `docker` deny the same read, and a user on
such a host writes the relabel too. So the test asks for it, and the option is a
no-op where SELinux is off, which lets one spec cover both lanes. The entry comes
off the Podman 5 list and the lane gates on the test again.

`niche::engine_events_stream_connects` stays on the list — it failed in the
2026-07-24 nightly, so it has not earned removal.

## Test plan

- Fedora 44, Podman 5.8.1, `getenforce` = `Enforcing`, rootless. Mechanism
  measured with plain `podman run`, no podup: `-v $D:/mnt/in:ro` gives
  `Permission denied`, `-v $D:/mnt/in:ro,z` prints the file. The bound file is
  `user_tmp_t`.
- Same host, the fixed test run from the integration binary: passes. This is the
  exact environment where it has always failed.
- Full integration suite re-run on that host to confirm nothing else moved.
- Ubuntu 6.17, Podman 5.4.2, no SELinux: `run_flags` passes, so the relabel costs
  nothing where it does not apply.

Closes #1175
