### PR TITLE
ci: wait for resolv.conf to resolve before running the podman lane suite

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -80,6 +80,27 @@ jobs:
                 export XDG_RUNTIME_DIR=/run/user/$(id -u)
                 systemctl --user start podman.socket
                 export PODMAN_SOCKET=$XDG_RUNTIME_DIR/podman/podman.sock
+                # Podman builds the rootless netns by bind-mounting the host's
+                # resolv.conf, and here /etc/resolv.conf is a symlink to a stub
+                # that systemd-resolved has not necessarily written by the time
+                # cloud-init reaches this script. Losing that race makes every
+                # container fail to start with `rootless netns: mount resolv.conf
+                # ... no such file or directory` — ten of Podman 6's thirteen
+                # failures in run 30141959995 were that error or its wake, and the
+                # nightly before it did not show the signature once, which is what
+                # a race looks like.
+                #
+                # So wait for the link to resolve, and report how long it took. The
+                # number is the point: if it is 0s on every run then the race is
+                # not the explanation and this says so out loud rather than fixing
+                # something that was never broken (#1039).
+                WAITED=0
+                until [ -e /etc/resolv.conf ] || [ "$WAITED" -ge 60 ]; do
+                  WAITED=$((WAITED + 1))
+                  sleep 1
+                done
+                echo "=== resolv.conf resolved after ${WAITED}s ==="
+                [ -e /etc/resolv.conf ] || echo "::warning::/etc/resolv.conf is still a dangling symlink after ${WAITED}s"
                 # In here Podman is guaranteed, so a test that cannot reach it
                 # must fail rather than skip: a skipped test reports `ok`, and a
                 # VM whose socket never came up would otherwise look like a


### PR DESCRIPTION
Podman builds the rootless netns by bind-mounting the host's `resolv.conf`. In the
lane VM `/etc/resolv.conf` is a symlink to a stub that systemd-resolved has not
necessarily written by the time cloud-init reaches `run-suite.sh`, and nothing in
the script waits for it. Losing that race makes every container fail to start:

```
podman API error (HTTP 500): rootless netns: mount resolv.conf to
"/run/user/1000/containers/networks/rootless-netns/run/systemd/resolve/stub-resolv.conf":
no such file or directory
```

Ten of Podman 6's thirteen failures in run 30141959995 were that error or its
wake — the two `lifecycle_output` tests and the three `scale` tests report it
verbatim, `niche::cli_attach_streams_output_until_exit` fails with `container is
not running (state: created)`, and the `commands_networking`, `create_ls` and
`stats_flags` failures are what a project whose containers never started looks
like. The nightly before it does not carry the signature once, which is the shape
of a race rather than a property of the image.

So the script waits for the link to resolve before starting, and prints how long
it took.

The number is the point. I could not reproduce this on demand — on my own
single-level Rawhide VM (Podman 6.0.1) the stub file is present and `podman run`
is clean — so this is a hypothesis with a cheap test attached rather than a
confirmed fix. If the lane reports `resolv.conf resolved after 0s` on every run
from here, the race is not the explanation and I go looking elsewhere instead of
believing I fixed something that was never broken. If it reports a wait, the run
tells us how long for free.

The 60s ceiling is a bound, not an expectation; past it the step warns and the
suite runs anyway, so a dangling link fails loudly rather than hanging the lane.

## Test plan

- The change is a wait and an echo in the VM's boot script; there is nothing to
  run locally that would exercise it. The lane run on this PR is the measurement,
  and the line it prints is the result.
- Nothing else in the script moved, so a run that reports `0s` is identical to
  today's behaviour.

Refs #1039
