### PR TITLE
fix: read a file: secret into a native secret so it works on SELinux hosts

### DIFF
--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -53,10 +53,11 @@ GPU driver and CDI setup, not on podup alone.
 A secret or config declared `external: true` is mounted from an existing
 Podman secret rather than from a value in the project tree — the recommended
 pattern for production credentials, since the secret material never appears in
-the compose file or its history. (Inline `content:`/`environment:` sources are
-also injected as Podman-native secrets, not host bind-mounts, but their value
-still lives in the compose file.) Create the secret before running, exactly as
-you would with `docker secret`:
+the compose file or its history. (Every other source — inline
+`content:`/`environment:` and `file:` alike — is injected as a Podman-native
+secret too, never a host bind mount, but its value still lives in the compose
+file or next to it.) Create the secret before running, exactly as you would with
+`docker secret`:
 
 ```sh
 printf '%s' "$DB_PASSWORD" | podman secret create db_password -

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -74,14 +74,21 @@ only tighten, never widen, what the launching user already has.
 
 ## Secret and config handling
 
-- `secrets:`/`configs:` sourced from inline `content:` or `environment:` are
-  created as Podman-native secrets over the libpod API (under a project-scoped
-  name) and injected into the container — podup writes no secret material to a
-  host directory. They are removed again on `podup down`.
+- `secrets:`/`configs:` sourced from inline `content:` or `environment:`, and
+  from a `file:` path, are created as Podman-native secrets over the libpod API
+  (under a project-scoped name) and injected into the container — podup writes no
+  secret material to a host directory. They are removed again on `podup down`.
 - `external: true` secrets/configs are injected as Podman-native secrets
   (pre-flighted for existence), pointing at a pre-existing `podman secret`.
-- `file:` secrets/configs are bind-mounted read-only from the host path you
-  provide; the file already lives on the host, so no copy is made.
+- A `file:` source is read at `up` time and its bytes become the secret. Nothing
+  on the host is mounted, relabelled or otherwise modified. With no `mode:` given
+  the secret is mounted with the host file's own permission bits, so a `0600`
+  secret stays unreadable to a non-root container user.
+- Because the payload is a copy taken at `up`, editing the host file afterwards
+  does not reach an already-running container; recreate it to pick up a new
+  value. (A rotation that replaces the file atomically — write-new-then-rename,
+  which is what careful tools do — was never visible to a running container
+  either, because a file bind mount pins the inode.)
 - Dangerous secret file modes (setuid/setgid/sticky/executable) are rejected.
 - The `config` subcommand redacts inline `content:` secrets before printing.
 

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -75,16 +75,12 @@ impl Engine {
 			})
 			.collect();
 
-		// --- Secrets and configs become bind mounts ---
-		let secret_binds = self.build_secret_binds(service, file)?;
-		let config_binds = self.build_config_binds(service, file)?;
-		// Inline and `external: true` secrets/configs are injected as Podman-native
-		// secrets, not bind mounts. Inline ones are created up front by
-		// `create_inline_secrets`; here we only build the references and preflight
-		// external ones for existence.
+		// Every secret/config source — inline, `file:` and `external: true` — is
+		// injected as a Podman-native secret, never a bind mount. The ones podup
+		// owns are created up front by `create_project_secrets`; here we only build
+		// the references and preflight external ones for existence.
 		let native_secrets = self.build_native_secrets(service, file).await?;
-		let (mut mounts, mut named_volumes) =
-			build_mounts_all(service, &self.base_dir, &secret_binds, &config_binds);
+		let (mut mounts, mut named_volumes) = build_mounts_all(service, &self.base_dir);
 		// Resolve relative bind sources against the project base directory (and
 		// expand a leading `~`) so they don't depend on Podman's working
 		// directory; absolute paths (incl. staged secrets/configs) are untouched.

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -224,7 +224,7 @@ impl Engine {
 			// Pre-create the union of inline secrets/configs once, before the
 			// concurrent per-level start loop, so two services in the same level
 			// can't race the non-atomic delete-then-create of a shared name.
-			self.create_inline_secrets(file).await?;
+			self.create_project_secrets(file).await?;
 
 			// Best-effort: warm the image cache for every service this pass will
 			// pull, concurrently, before the per-level walk below serializes a

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -170,7 +170,7 @@ impl Engine {
 		// Inline secrets/configs are created up front (no longer in the
 		// per-container build path), so materialise them here too before the run
 		// container is created.
-		self.create_inline_secrets(file).await?;
+		self.create_project_secrets(file).await?;
 
 		// Refuse to clobber a pre-existing container of the same name (data-loss
 		// footgun): `create_and_start` would force-remove it. Only the verbatim

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -1,24 +1,40 @@
 //! Secret and config injection.
 //!
-//! `file:` secret/config sources are bind-mounted read-only from the host —
-//! the file already lives there, so no copy is made. Inline `content:` and
-//! `environment:` sources, and `external: true` references, are injected as
-//! Podman-native secrets attached to the container create spec:
+//! Every source is injected as a Podman-native secret attached to the container
+//! create spec:
 //!
-//! * inline `content:`/`environment:` → created over the libpod API
+//! * inline `content:`/`environment:` and `file:` → created over the libpod API
 //!   (`secrets/create`, removing any prior secret of the name first so a re-`up`
 //!   is idempotent) under a project-scoped name, so nothing is written to a host
-//!   staging directory. The project's whole inline union is created once up
-//!   front by [`Engine::create_inline_secrets`] (before services start
+//!   staging directory. The project's whole payload union is created once up
+//!   front by [`Engine::create_project_secrets`] (before services start
 //!   concurrently), not per-service, so a shared name is never raced.
 //! * `external: true` → mapped to a pre-existing `podman secret`, preflighted
 //!   with [`Engine::ensure_external_exists`] so a missing secret fails closed.
+//!
+//! `file:` sources used to be read-only bind mounts of the host path instead.
+//! That worked until the host enforced SELinux, where the container is denied
+//! the read outright and `up` still reports the container as started — measured
+//! on Fedora with both supported Podman majors, and reproduced by plain `podman
+//! run`, so the denial was the missing relabel and not podup. Relabelling was
+//! the other way out, but `z` rewrites the label of a file the user owns and may
+//! share with a confined host service, and compose gives them nowhere to ask for
+//! it. Reading the bytes into a native secret leaves the host untouched and puts
+//! `file:` on the path the other two sources already took. What the container
+//! sees is unchanged: the mount mode mirrors the host file's own bits (see
+//! [`plan::host_file_secret_mode`]) rather than defaulting to `0444`.
+//!
+//! The trade is that the payload is a copy taken at `up`, so an in-place edit of
+//! the host file no longer reaches a running container. An atomic replace never
+//! did — a file bind pins the inode, so the write-new-and-rename that every
+//! careful rotation tool performs was already invisible.
 //!
 //! The pure compose→plan mapping lives in [`plan`].
 
 mod plan;
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
@@ -26,98 +42,59 @@ use crate::libpod::types::container::Secret;
 use crate::libpod::{urlencoded, API_PREFIX};
 
 use plan::{
-	check_secret_size, collect_native_plans, is_inline_source, ref_name_target, scoped_name,
+	check_secret_size, collect_native_plans, host_file_secret_mode, is_podup_created_source,
+	scoped_name, Payload,
 };
 
 use super::Engine;
 
 impl Engine {
-	/// Bind strings for `file:` secrets referenced by `service`. Inline and
-	/// external secrets are injected natively (see [`Engine::build_native_secrets`])
-	/// and are skipped here.
-	pub(super) fn build_secret_binds(
-		&self,
-		service: &Service,
-		file: &ComposeFile,
-	) -> Result<Vec<String>> {
-		let mut binds = Vec::new();
-		for secret_ref in &service.secrets {
-			let (name, target_override) = ref_name_target(secret_ref.source(), secret_ref.target());
-			if let Some(def) = file.secrets.get(&name) {
-				if let Some(host_path) = &def.file {
-					let target = target_override.unwrap_or_else(|| format!("/run/secrets/{name}"));
-					// Resolve like a bind-mount source: a relative `file:` is anchored
-					// to the project dir (not the Podman service's cwd) and `~` is
-					// expanded — same handling as `volumes:`.
-					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(make_bind(&name, &resolved, &target)?);
-				}
-			}
-		}
-		Ok(binds)
-	}
-
-	/// Bind strings for `file:` configs referenced by `service`. Inline and
-	/// external configs are injected natively and are skipped here.
-	pub(super) fn build_config_binds(
-		&self,
-		service: &Service,
-		file: &ComposeFile,
-	) -> Result<Vec<String>> {
-		let mut binds = Vec::new();
-		for config_ref in &service.configs {
-			let (name, target_override) = ref_name_target(config_ref.source(), config_ref.target());
-			if let Some(def) = file.configs.get(&name) {
-				if let Some(host_path) = &def.file {
-					let target = target_override.unwrap_or_else(|| format!("/{name}"));
-					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(make_bind(&name, &resolved, &target)?);
-				}
-			}
-		}
-		Ok(binds)
-	}
-
-	/// Build the Podman-native secret references for a service. Inline
-	/// `content:`/`environment:` sources must already have been created by
-	/// [`Engine::create_inline_secrets`] (run once up front), so this only
-	/// preflights `external: true` sources for existence — failing closed
-	/// rather than starting a container that lacks the secret — and assembles
-	/// the per-service references attached to the container spec. `file:`
-	/// sources are handled as bind mounts.
+	/// Build the Podman-native secret references for a service. Every source podup
+	/// creates — `content:`, `environment:` and `file:` — must already have been
+	/// created by [`Engine::create_project_secrets`] (run once up front), so this
+	/// only preflights `external: true` sources for existence — failing closed
+	/// rather than starting a container that lacks the secret — and assembles the
+	/// per-service references attached to the container spec.
 	///
 	/// Creation is deliberately *not* done here: services in the same
 	/// dependency level are brought up concurrently, and a per-service
-	/// delete-then-create on a shared inline secret name would race (one create
-	/// could clobber a secret another service's container is about to use). The
-	/// up-front pass creates each inline secret exactly once instead.
+	/// delete-then-create on a shared secret name would race (one create could
+	/// clobber a secret another service's container is about to use). The up-front
+	/// pass creates each secret exactly once instead.
 	pub(super) async fn build_native_secrets(
 		&self,
 		service: &Service,
 		file: &ComposeFile,
 	) -> Result<Vec<Secret>> {
-		let plans = collect_native_plans(&self.project, service, file)?;
+		let plans = collect_native_plans(&self.project, service, file, &self.base_dir)?;
 		let mut secrets = Vec::with_capacity(plans.len());
 		for plan in plans {
-			// Inline payloads are created up front; only external sources need a
+			// Payloads podup owns are created up front; only external sources need a
 			// (read-only, idempotent) existence preflight here.
 			if plan.payload.is_none() {
 				self.ensure_external_exists("secret", "secrets", &plan.source)
 					.await?;
 			}
+			// A `file:` source with no explicit `mode:` mounts with the host file's
+			// own bits, so what the container sees does not change now that the file
+			// is copied into a native secret rather than bind-mounted.
+			let mode = match (&plan.payload, plan.mode) {
+				(Some(Payload::File(path)), None) => Some(host_file_secret_mode(path)),
+				_ => plan.mode,
+			};
 			secrets.push(Secret {
 				source: plan.source,
 				target: Some(plan.target),
 				uid: plan.uid,
 				gid: plan.gid,
-				mode: plan.mode,
+				mode,
 			});
 		}
 		Ok(secrets)
 	}
 
-	/// Create the union of inline `content:`/`environment:` secrets and configs
-	/// declared across *all* services in the project, once, before the
+	/// Create the union of the `content:`/`environment:`/`file:` secrets and
+	/// configs declared across *all* services in the project, once, before the
 	/// per-level start loop — mirroring how [`Engine::create_networks`] and
 	/// [`Engine::create_volumes`] pre-create their resources.
 	///
@@ -128,8 +105,21 @@ impl Engine {
 	/// created exactly once here (later services share it), and each created
 	/// secret carries the `podup.project=<proj>` label so the label-guarded
 	/// teardown on `down` still only removes secrets podup owns.
-	pub(super) async fn create_inline_secrets(&self, file: &ComposeFile) -> Result<()> {
-		for (name, bytes) in collect_inline_union(&self.project, file)? {
+	pub(super) async fn create_project_secrets(&self, file: &ComposeFile) -> Result<()> {
+		for (name, payload) in collect_payload_union(&self.project, file, &self.base_dir)? {
+			let bytes = match payload {
+				Payload::Inline(bytes) => bytes,
+				// Read here rather than in the planner, which stays free of I/O so
+				// the compose→plan mapping remains unit-testable. The cap is the
+				// same bounded read the compose-adjacent files get; Podman's own
+				// 512 kB secret limit is enforced right after, in `create_secret`.
+				Payload::File(path) => crate::filesystem::read_capped(&path).map_err(|e| {
+					ComposeError::Unsupported(format!(
+						"secret/config source {} could not be read: {e}",
+						path.display()
+					))
+				})?,
+			};
 			self.create_secret(&name, &bytes).await?;
 		}
 		Ok(())
@@ -192,28 +182,30 @@ impl Engine {
 			.map_err(ComposeError::Podman)
 	}
 
-	/// Remove the project-scoped native secrets created on `up` for inline
-	/// `content:`/`environment:` secrets and configs, mirroring the volume and
-	/// network teardown on `down`. `external:` and `file:` references own no
-	/// podup-created secret and are left untouched; a missing secret is ignored
-	/// (`delete_ok` swallows a 404). Best-effort: a delete failure is logged, not
-	/// fatal, so the rest of teardown proceeds.
+	/// Remove the project-scoped native secrets created on `up` for the
+	/// `content:`/`environment:`/`file:` secrets and configs, mirroring the volume
+	/// and network teardown on `down`. `external:` references own no podup-created
+	/// secret and are left untouched; a missing secret is ignored (`delete_ok`
+	/// swallows a 404). Best-effort: a delete failure is logged, not fatal, so the
+	/// rest of teardown proceeds.
 	pub(super) async fn remove_internal_secrets(&self, file: &ComposeFile) -> Result<()> {
 		for (name, def) in &file.secrets {
-			if is_inline_source(
+			if is_podup_created_source(
 				def.external,
 				def.content.as_deref(),
 				def.environment.as_deref(),
+				def.file.as_deref(),
 			) {
 				self.delete_secret(&scoped_name(&self.project, "secret", name))
 					.await;
 			}
 		}
 		for (name, def) in &file.configs {
-			if is_inline_source(
+			if is_podup_created_source(
 				def.external,
 				def.content.as_deref(),
 				def.environment.as_deref(),
+				def.file.as_deref(),
 			) {
 				self.delete_secret(&scoped_name(&self.project, "config", name))
 					.await;
@@ -300,42 +292,24 @@ impl Engine {
 	}
 }
 
-/// Build a `source:target:ro` bind string for a `file:` secret/config, rejecting
-/// a colon in either the resolved host path or the target.
+/// Collect the project's podup-created secret/config payloads, deduplicated by
+/// their scoped Podman secret name.
 ///
-/// The bind string is later split with `splitn(3, ':')`; a stray colon in the
-/// source or target shifts the field boundaries — redirecting the mount
-/// destination, or merging the `:ro` flag into a malformed `rw:ro` token that
-/// silently drops the read-only guarantee. A colon is not meaningful in a
-/// container mount path, so reject it at the boundary instead of mis-parsing.
-fn make_bind(name: &str, resolved: &str, target: &str) -> Result<String> {
-	if resolved.contains(':') {
-		return Err(ComposeError::Unsupported(format!(
-			"secret/config '{name}': host path must not contain a colon: {resolved}"
-		)));
-	}
-	if target.contains(':') {
-		return Err(ComposeError::Unsupported(format!(
-			"secret/config '{name}': mount target must not contain a colon: {target}"
-		)));
-	}
-	Ok(format!("{resolved}:{target}:ro"))
-}
-
-/// Collect the project's inline `content:`/`environment:` secret/config
-/// payloads, deduplicated by their scoped Podman secret name.
-///
-/// The same inline secret referenced by several services resolves to one
-/// project-scoped name, so it is created once and shared. A first writer wins:
-/// every reference to a given name yields the identical payload (the bytes come
-/// from the single compose def), so the dedup is value-stable. No daemon access,
-/// so the union and its dedup are unit-testable.
-fn collect_inline_union(project: &str, file: &ComposeFile) -> Result<HashMap<String, Vec<u8>>> {
-	let mut payloads: HashMap<String, Vec<u8>> = HashMap::new();
+/// The same secret referenced by several services resolves to one project-scoped
+/// name, so it is created once and shared. A first writer wins: every reference
+/// to a given name yields the identical payload (inline bytes and `file:` paths
+/// alike come from the single compose def), so the dedup is value-stable. No
+/// daemon access and no file reads, so the union and its dedup are unit-testable.
+fn collect_payload_union(
+	project: &str,
+	file: &ComposeFile,
+	base_dir: &Path,
+) -> Result<HashMap<String, Payload>> {
+	let mut payloads: HashMap<String, Payload> = HashMap::new();
 	for service in file.services.values() {
-		for plan in collect_native_plans(project, service, file)? {
-			if let Some(bytes) = plan.payload {
-				payloads.entry(plan.source).or_insert(bytes);
+		for plan in collect_native_plans(project, service, file, base_dir)? {
+			if let Some(payload) = plan.payload {
+				payloads.entry(plan.source).or_insert(payload);
 			}
 		}
 	}
@@ -356,19 +330,25 @@ mod tests {
 		)
 	}
 
+	/// The path a `file:` payload will be read from, for the single planned secret.
+	fn only_file_path(engine: &Engine, yaml: &str) -> PathBuf {
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let union = collect_payload_union("proj", &file, &engine.base_dir).unwrap();
+		assert_eq!(union.len(), 1);
+		match union.into_values().next().unwrap() {
+			Payload::File(p) => p,
+			Payload::Inline(_) => panic!("expected a file payload"),
+		}
+	}
+
 	#[test]
 	fn secret_file_relative_path_is_anchored_to_base_dir() {
 		// A relative `file:` resolves against the project dir, not the Podman
-		// service's cwd — same as a bind-mount source.
+		// service's cwd — same as a bind-mount source, which is what this was.
 		let base = PathBuf::from("/srv/project");
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: secret.txt\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
 		let engine = engine_with_base(&base.to_string_lossy());
-		let binds = engine
-			.build_secret_binds(&file.services["web"], &file)
-			.unwrap();
-		let expected = format!("{}:/run/secrets/tok:ro", base.join("secret.txt").display());
-		assert_eq!(binds, vec![expected]);
+		assert_eq!(only_file_path(&engine, yaml), base.join("secret.txt"));
 	}
 
 	#[cfg(unix)]
@@ -376,21 +356,10 @@ mod tests {
 	fn config_file_absolute_path_is_passed_through() {
 		// Absolute paths are honored unchanged, exactly as `volumes:` does.
 		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: /etc/app/cfg.yaml\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
 		let engine = engine_with_base("/srv/project");
-		let binds = engine
-			.build_config_binds(&file.services["web"], &file)
-			.unwrap();
-		assert_eq!(binds, vec!["/etc/app/cfg.yaml:/cfg:ro"]);
-	}
-
-	#[test]
-	fn make_bind_rejects_colon_in_path_or_target() {
-		assert!(make_bind("s", "/host/a:b", "/run/secrets/s").is_err());
-		assert!(make_bind("s", "/host/a", "/run/secrets/s:rw").is_err());
 		assert_eq!(
-			make_bind("s", "/host/a", "/run/secrets/s").unwrap(),
-			"/host/a:/run/secrets/s:ro"
+			only_file_path(&engine, yaml),
+			PathBuf::from("/etc/app/cfg.yaml")
 		);
 	}
 
@@ -401,37 +370,37 @@ mod tests {
 		// service — which is what previously raced delete-then-create.
 		let yaml = "services:\n  a:\n    image: nginx\n    secrets: [tok]\n  b:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    content: shared\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let union = collect_inline_union("proj", &file).unwrap();
+		let union = collect_payload_union("proj", &file, Path::new("/base")).unwrap();
 		assert_eq!(union.len(), 1);
+		assert!(matches!(
+			union.get("proj_secret_tok"),
+			Some(Payload::Inline(b)) if b == b"shared"
+		));
+	}
+
+	#[test]
+	fn payload_union_collects_every_source_podup_creates_but_not_external() {
+		// The union spans secrets and configs across sources (distinct scoped names)
+		// and excludes only `external:`, which podup never creates and must never
+		// remove on `down`.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok, ext, onfile]\n    configs: [cfg]\nsecrets:\n  tok:\n    content: s\n  ext:\n    external: true\n  onfile:\n    file: ./f.txt\nconfigs:\n  cfg:\n    content: c\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let union = collect_payload_union("proj", &file, Path::new("/base")).unwrap();
+		let mut names: Vec<&String> = union.keys().collect();
+		names.sort();
 		assert_eq!(
-			union.get("proj_secret_tok").map(Vec::as_slice),
-			Some(b"shared".as_slice())
+			names,
+			vec!["proj_config_cfg", "proj_secret_onfile", "proj_secret_tok"]
 		);
 	}
 
 	#[test]
-	fn inline_union_collects_secrets_and_configs_skips_external_and_file() {
-		// The union spans inline secrets and inline configs (distinct scoped
-		// names), and excludes `external:` (podup never creates it) and `file:`
-		// (a bind mount) sources.
-		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok, ext, onfile]\n    configs: [cfg]\nsecrets:\n  tok:\n    content: s\n  ext:\n    external: true\n  onfile:\n    file: ./f.txt\nconfigs:\n  cfg:\n    content: c\n";
+	fn external_secret_is_never_in_the_payload_union() {
+		// podup does not create an `external:` secret, so it must never appear in
+		// the union that `up` creates and `down` removes.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let union = collect_inline_union("proj", &file).unwrap();
-		let mut names: Vec<&String> = union.keys().collect();
-		names.sort();
-		assert_eq!(names, vec!["proj_config_cfg", "proj_secret_tok"]);
-	}
-
-	#[test]
-	fn inline_secret_produces_no_bind() {
-		// An inline `content:` secret is injected natively, so it contributes no
-		// bind string — only `file:` secrets do.
-		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    content: data\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let engine = engine_with_base("/srv/project");
-		let binds = engine
-			.build_secret_binds(&file.services["web"], &file)
-			.unwrap();
-		assert!(binds.is_empty());
+		let union = collect_payload_union("proj", &file, Path::new("/base")).unwrap();
+		assert!(union.is_empty());
 	}
 }

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -423,6 +423,9 @@ mod tests {
 		assert!(p.is_empty());
 	}
 
+	// Unix-only: `PermissionsExt` does not exist on Windows, where a host file has
+	// no mode to mirror and `host_file_secret_mode` returns the 0444 default.
+	#[cfg(unix)]
 	#[test]
 	fn host_file_mode_masks_execute_and_special_bits() {
 		// A secret holds data, never code. Mirroring a 0755 host file verbatim would

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -2,6 +2,8 @@
 //! plans. No daemon access, so the mapping is unit-testable; the create and
 //! preflight side effects live in [`super`]'s `Engine` impl.
 
+use std::path::{Path, PathBuf};
+
 use crate::compose::types::{ComposeFile, Service, ServiceConfigRef, ServiceSecretRef};
 use crate::error::{ComposeError, Result};
 
@@ -11,25 +13,49 @@ use super::super::staging;
 /// payload must be larger than 0 and strictly smaller than this many bytes.
 pub(super) const MAX_SECRET_BYTES: usize = 512_000;
 
+/// Where the bytes of a podup-created secret come from.
+///
+/// A `file:` source carries the resolved host path rather than its contents:
+/// this module maps compose to plans with no I/O at all, which is what keeps the
+/// mapping unit-testable, so the read happens in the effectful layer that creates
+/// the secret.
+pub(super) enum Payload {
+	/// Inline `content:`/`environment:` — the bytes, already resolved.
+	Inline(Vec<u8>),
+	/// `file:` — the resolved host path to read at creation time.
+	File(PathBuf),
+}
+
 /// A planned native secret for a service: the Podman secret `source` to attach,
-/// the in-container `target`, optional permissions, and — for inline
-/// `content:`/`environment:` sources — the `payload` to create under `source`.
-/// `external: true` references carry no payload (the secret must pre-exist).
+/// the in-container `target`, optional permissions, and — for every source podup
+/// creates itself — the `payload` to create under `source`. `external: true`
+/// references carry no payload (the secret must pre-exist).
 pub(super) struct NativePlan {
 	pub(super) source: String,
 	pub(super) target: String,
 	pub(super) mode: Option<u32>,
 	pub(super) uid: Option<u32>,
 	pub(super) gid: Option<u32>,
-	pub(super) payload: Option<Vec<u8>>,
+	pub(super) payload: Option<Payload>,
+}
+
+/// The fields of a `secrets:`/`configs:` definition that decide where its bytes
+/// come from. A borrowed view, so the two distinct compose types (`SecretConfig`
+/// and `ConfigConfig`) resolve through one function.
+struct SourceDef<'a> {
+	content: Option<&'a str>,
+	environment: Option<&'a str>,
+	file_source: Option<&'a str>,
+	external: bool,
+	external_name: Option<&'a str>,
 }
 
 /// Where a secret/config's bytes come from once the compose def is resolved.
 enum Source {
-	/// `file:` — handled by the bind path, never a native secret.
-	Bind,
 	/// Inline `content:`/`environment:` — `(scoped podman name, payload bytes)`.
 	Inline(String, Vec<u8>),
+	/// `file:` — `(scoped podman name, resolved host path)`.
+	File(String, PathBuf),
 	/// `external: true` — name of the pre-existing podman secret.
 	External(String),
 }
@@ -41,6 +67,7 @@ pub(super) fn collect_native_plans(
 	project: &str,
 	service: &Service,
 	file: &ComposeFile,
+	base_dir: &Path,
 ) -> Result<Vec<NativePlan>> {
 	let mut plans = Vec::new();
 
@@ -51,10 +78,14 @@ pub(super) fn collect_native_plans(
 				project,
 				"secret",
 				&name,
-				def.content.as_deref(),
-				def.environment.as_deref(),
-				def.external == Some(true),
-				def.name.as_deref(),
+				SourceDef {
+					content: def.content.as_deref(),
+					environment: def.environment.as_deref(),
+					file_source: def.file.as_deref(),
+					external: def.external == Some(true),
+					external_name: def.name.as_deref(),
+				},
+				base_dir,
 			)?;
 			// A bare target name lands under /run/secrets/<name>, matching the
 			// bind-mount default and the external-secret behaviour.
@@ -76,10 +107,14 @@ pub(super) fn collect_native_plans(
 				project,
 				"config",
 				&name,
-				def.content.as_deref(),
-				def.environment.as_deref(),
-				def.external == Some(true),
-				def.name.as_deref(),
+				SourceDef {
+					content: def.content.as_deref(),
+					environment: def.environment.as_deref(),
+					file_source: def.file.as_deref(),
+					external: def.external == Some(true),
+					external_name: def.name.as_deref(),
+				},
+				base_dir,
 			)?;
 			// Configs default to an absolute container-root path, matching the
 			// bind-mount config behaviour.
@@ -92,23 +127,30 @@ pub(super) fn collect_native_plans(
 }
 
 /// Resolve a secret/config definition to its native [`Source`]. `external`
-/// wins (it may also carry a custom `name:`); otherwise inline `content:` or
-/// `environment:` become a project-scoped native secret; anything else (a
-/// `file:` source, or an empty def) is left to the bind path.
+/// wins (it may also carry a custom `name:`); every other populated source —
+/// inline `content:`/`environment:` and `file:` alike — becomes a project-scoped
+/// native secret. An empty def yields `None` and contributes no plan.
 fn resolve_source(
 	project: &str,
 	kind: &str,
 	name: &str,
-	content: Option<&str>,
-	environment: Option<&str>,
-	external: bool,
-	external_name: Option<&str>,
-) -> Result<Source> {
+	def: SourceDef<'_>,
+	base_dir: &Path,
+) -> Result<Option<Source>> {
+	let SourceDef {
+		content,
+		environment,
+		file_source,
+		external,
+		external_name,
+	} = def;
 	if external {
-		return Ok(Source::External(external_name.unwrap_or(name).to_string()));
+		return Ok(Some(Source::External(
+			external_name.unwrap_or(name).to_string(),
+		)));
 	}
-	let is_inline = content.is_some() || environment.is_some();
-	if is_inline && !staging::is_safe_project_name(name) {
+	let podup_created = content.is_some() || environment.is_some() || file_source.is_some();
+	if podup_created && !staging::is_safe_project_name(name) {
 		// The name becomes part of the project-scoped Podman secret name and a URL
 		// query parameter, so require a bounded, well-formed identifier rather than
 		// an arbitrary (possibly huge or control-laden) YAML key.
@@ -118,10 +160,10 @@ fn resolve_source(
 		)));
 	}
 	if let Some(content) = content {
-		return Ok(Source::Inline(
+		return Ok(Some(Source::Inline(
 			scoped_name(project, kind, name),
 			content.as_bytes().to_vec(),
-		));
+		)));
 	}
 	if let Some(env_var) = environment {
 		let value = std::env::var(env_var).map_err(|_| {
@@ -129,36 +171,57 @@ fn resolve_source(
 				"{kind} '{name}' references env var '{env_var}' which is not set"
 			))
 		})?;
-		return Ok(Source::Inline(
+		return Ok(Some(Source::Inline(
 			scoped_name(project, kind, name),
 			value.into_bytes(),
-		));
+		)));
 	}
-	Ok(Source::Bind)
+	if let Some(host_path) = file_source {
+		// Resolve like a bind-mount source: a relative `file:` is anchored to the
+		// project dir (not the Podman service's cwd) and `~` is expanded — the same
+		// handling `volumes:` gets, and the same this had when it was a bind.
+		return Ok(Some(Source::File(
+			scoped_name(project, kind, name),
+			PathBuf::from(super::super::container::resolve_bind_source(
+				host_path, base_dir,
+			)),
+		)));
+	}
+	Ok(None)
 }
 
-/// Append a [`NativePlan`] for a resolved source, dropping `file:` sources and
+/// Append a [`NativePlan`] for a resolved source, dropping an empty def and
 /// rejecting a dangerous `mode:` before the spec is built. `uid`/`gid` are
 /// numeric in libpod, so a non-numeric value (a user/group name) is dropped to
 /// the default rather than erroring.
 fn push_plan(
 	plans: &mut Vec<NativePlan>,
-	source: Source,
+	source: Option<Source>,
 	target: String,
 	mode: Option<u32>,
 	uid: Option<String>,
 	gid: Option<String>,
 ) -> Result<()> {
-	let (source, payload) = match source {
-		Source::Bind => return Ok(()),
-		Source::Inline(s, p) => (s, Some(p)),
-		Source::External(s) => (s, None),
+	let (source, payload, from_file) = match source {
+		None => return Ok(()),
+		Some(Source::Inline(s, p)) => (s, Some(Payload::Inline(p)), false),
+		Some(Source::File(s, p)) => (s, Some(Payload::File(p)), true),
+		Some(Source::External(s)) => (s, None, false),
 	};
 	// Default to the Compose Specification's world-readable `0444` when no `mode:`
 	// is given. A Podman-native secret otherwise mounts at `0000`, which a non-root
 	// container user cannot read (only root reads it via DAC override), diverging
 	// from docker-compose where the default is readable.
-	let mode = mode.or(Some(0o444));
+	//
+	// A `file:` source is the exception: it is left unset here so the effectful
+	// layer can mirror the host file's own permission bits. That keeps what the
+	// container sees identical to the bind this used to be — a `0600` secret stays
+	// unreadable to a non-root container user instead of being widened to `0444`.
+	let mode = if from_file {
+		mode
+	} else {
+		mode.or(Some(0o444))
+	};
 	if let Some(m) = mode {
 		staging::reject_dangerous_secret_mode(m, &source)?;
 	}
@@ -191,20 +254,41 @@ pub(super) fn check_secret_size(name: &str, len: usize) -> Result<()> {
 	Ok(())
 }
 
-/// Whether a secret/config def is an inline `content:`/`environment:` source —
-/// i.e. one podup creates as a project-scoped native secret. `external:` wins
-/// (it is never created by podup) and a bare `file:` source is a bind mount.
-pub(super) fn is_inline_source(
+/// Whether a secret/config def is one podup creates as a project-scoped native
+/// secret — inline `content:`/`environment:` or a `file:` source. `external:`
+/// wins and is never created (nor removed) by podup.
+pub(super) fn is_podup_created_source(
 	external: Option<bool>,
 	content: Option<&str>,
 	environment: Option<&str>,
+	file_source: Option<&str>,
 ) -> bool {
-	external != Some(true) && (content.is_some() || environment.is_some())
+	external != Some(true) && (content.is_some() || environment.is_some() || file_source.is_some())
 }
 
-/// `(name, target_override)` for a service secret/config reference.
-pub(super) fn ref_name_target(source: &str, target: Option<&str>) -> (String, Option<String>) {
-	(source.to_string(), target.map(str::to_string))
+/// The permission bits to mount a `file:` secret with when the compose file
+/// names no `mode:` — the host file's own, so the container sees what it saw
+/// when this was a bind mount.
+///
+/// Execute and the special bits are masked off: a secret holds data, never code,
+/// and letting a `0755` host file through would trip the dangerous-mode guard and
+/// fail an `up` that used to work. Unreadable metadata falls back to the Compose
+/// Specification's `0444`; the create call fails right after with a clearer
+/// message than a permissions guess would give.
+pub(super) fn host_file_secret_mode(path: &Path) -> u32 {
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+		match std::fs::metadata(path) {
+			Ok(md) => md.permissions().mode() & 0o666,
+			Err(_) => 0o444,
+		}
+	}
+	#[cfg(not(unix))]
+	{
+		let _ = path;
+		0o444
+	}
 }
 
 /// Decompose a secret reference into `(name, target, mode, uid, gid)`.
@@ -269,14 +353,101 @@ mod tests {
 
 	fn plans(yaml: &str) -> Vec<NativePlan> {
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		collect_native_plans("proj", &file.services["web"], &file).unwrap()
+		collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).unwrap()
+	}
+
+	/// The inline bytes of a plan's payload, or `None` for an external/file source.
+	fn inline_bytes(p: &NativePlan) -> Option<&[u8]> {
+		match &p.payload {
+			Some(Payload::Inline(b)) => Some(b),
+			_ => None,
+		}
 	}
 
 	#[test]
-	fn file_secret_is_not_a_native_secret() {
-		// A `file:` secret is a bind mount, never a native secret.
+	fn file_secret_is_a_scoped_native_secret_carrying_its_path() {
+		// A `file:` secret is a project-scoped native secret like any other source.
+		// The plan carries the resolved path, not the bytes: this module does no I/O,
+		// so the read belongs to the layer that creates the secret.
 		let p = plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n");
+		assert_eq!(p.len(), 1);
+		assert_eq!(p[0].source, "proj_secret_tok");
+		assert_eq!(p[0].target, "tok");
+		assert!(
+			matches!(&p[0].payload, Some(Payload::File(path)) if path == Path::new("/base/tok.txt"))
+		);
+	}
+
+	#[test]
+	fn file_secret_leaves_mode_unset_for_the_host_bits() {
+		// With no `mode:` the plan stays unset so the effectful layer can mirror the
+		// host file's own bits, rather than widening a 0600 secret to the 0444 the
+		// other sources default to.
+		let p = plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n");
+		assert_eq!(p[0].mode, None);
+	}
+
+	#[test]
+	fn file_secret_honours_an_explicit_mode() {
+		let p = plans("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 0400\nsecrets:\n  tok:\n    file: ./tok.txt\n");
+		assert_eq!(p[0].mode, Some(0o400));
+	}
+
+	#[test]
+	fn file_config_is_native_with_absolute_default_target() {
+		let p = plans("services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: ./cfg.yaml\n");
+		assert_eq!(p.len(), 1);
+		assert_eq!(p[0].source, "proj_config_cfg");
+		assert_eq!(p[0].target, "/cfg");
+	}
+
+	#[test]
+	fn file_secret_with_unsafe_name_is_rejected() {
+		// The compose key becomes part of a Podman secret name for a `file:` source
+		// too, so it faces the same bound as an inline one.
+		let file = crate::compose::parse_str_raw(
+			"services:\n  web:\n    image: x\n    secrets: ['../evil']\nsecrets:\n  '../evil':\n    file: ./tok.txt\n",
+		)
+		.unwrap();
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
+	}
+
+	#[test]
+	fn empty_def_contributes_no_plan() {
+		// A def with no content:, environment:, file: or external: is not a secret
+		// podup can produce anything for.
+		let p =
+			plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok: {}\n");
 		assert!(p.is_empty());
+	}
+
+	#[test]
+	fn host_file_mode_masks_execute_and_special_bits() {
+		// A secret holds data, never code. Mirroring a 0755 host file verbatim would
+		// trip the dangerous-mode guard and fail an `up` that used to work.
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("s.txt");
+		std::fs::write(&path, b"x").unwrap();
+		for (host, want) in [
+			(0o644, 0o644),
+			(0o600, 0o600),
+			(0o755, 0o644),
+			(0o4700, 0o600),
+		] {
+			use std::os::unix::fs::PermissionsExt;
+			std::fs::set_permissions(&path, std::fs::Permissions::from_mode(host)).unwrap();
+			assert_eq!(host_file_secret_mode(&path), want, "host mode {host:o}");
+		}
+	}
+
+	#[test]
+	fn host_file_mode_of_a_missing_file_falls_back_to_0444() {
+		assert_eq!(
+			host_file_secret_mode(Path::new("/nonexistent/secret")),
+			0o444
+		);
 	}
 
 	#[test]
@@ -287,7 +458,7 @@ mod tests {
 		assert_eq!(p.len(), 1);
 		assert_eq!(p[0].source, "proj_secret_tok");
 		assert_eq!(p[0].target, "tok");
-		assert_eq!(p[0].payload.as_deref(), Some(b"supersecret".as_slice()));
+		assert_eq!(inline_bytes(&p[0]), Some(b"supersecret".as_slice()));
 	}
 
 	#[test]
@@ -297,7 +468,7 @@ mod tests {
 		assert_eq!(p.len(), 1);
 		assert_eq!(p[0].source, "proj_config_cfg");
 		assert_eq!(p[0].target, "/cfg");
-		assert_eq!(p[0].payload.as_deref(), Some(b"key=value".as_slice()));
+		assert_eq!(inline_bytes(&p[0]), Some(b"key=value".as_slice()));
 	}
 
 	#[test]
@@ -306,7 +477,7 @@ mod tests {
 			let p = plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    environment: PODUP_TEST_SECRET\n");
 			assert_eq!(p.len(), 1);
 			assert_eq!(p[0].source, "proj_secret_tok");
-			assert_eq!(p[0].payload.as_deref(), Some(b"env-value".as_slice()));
+			assert_eq!(inline_bytes(&p[0]), Some(b"env-value".as_slice()));
 		});
 	}
 
@@ -314,7 +485,10 @@ mod tests {
 	fn env_secret_missing_var_errors() {
 		temp_env::with_var("PODUP_TEST_MISSING", None::<&str>, || {
 			let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    environment: PODUP_TEST_MISSING\n").unwrap();
-			assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+			assert!(
+				collect_native_plans("proj", &file.services["web"], &file, Path::new("/base"))
+					.is_err()
+			);
 		});
 	}
 
@@ -365,28 +539,36 @@ mod tests {
 	fn native_secret_rejects_setuid_mode() {
 		// 0o4000 (= 2048) is setuid; refused before the spec reaches Podman.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 2048\nsecrets:\n  tok:\n    external: true\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
 	fn native_secret_rejects_execute_mode() {
 		// 0o777 (= 511) sets execute bits; a secret holds data, never code.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 511\nsecrets:\n  tok:\n    external: true\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
 	fn native_config_rejects_setgid_mode() {
 		// External configs share the mode guard. 0o2000 (= 1024) is setgid.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    configs:\n      - source: cfg\n        mode: 1024\nconfigs:\n  cfg:\n    external: true\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
 	fn inline_secret_rejects_dangerous_mode() {
 		// The mode guard also covers project-created inline secrets.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 511\nsecrets:\n  tok:\n    content: data\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
@@ -412,7 +594,9 @@ mod tests {
 			"services:\n  web:\n    image: x\n    secrets: ['../evil']\nsecrets:\n  '../evil':\n    content: data\n",
 		)
 		.unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
@@ -433,10 +617,12 @@ mod tests {
 	}
 
 	#[test]
-	fn is_inline_source_classifies_sources() {
-		assert!(is_inline_source(None, Some("x"), None));
-		assert!(is_inline_source(None, None, Some("VAR")));
-		assert!(!is_inline_source(Some(true), Some("x"), None));
-		assert!(!is_inline_source(None, None, None));
+	fn is_podup_created_source_classifies_sources() {
+		assert!(is_podup_created_source(None, Some("x"), None, None));
+		assert!(is_podup_created_source(None, None, Some("VAR"), None));
+		// A `file:` source is created by podup too, so `down` must remove it.
+		assert!(is_podup_created_source(None, None, None, Some("./tok.txt")));
+		assert!(!is_podup_created_source(Some(true), Some("x"), None, None));
+		assert!(!is_podup_created_source(None, None, None, None));
 	}
 }

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -1,9 +1,10 @@
 //! Volume mount helpers.
 //!
-//! [`build_mounts_all`] converts all `volumes:` entries, secret bind-strings,
-//! and config bind-strings into OCI `Mount` entries and `NamedVolume` entries
-//! for the SpecGenerator. Named volumes go in `volumes`; everything else
-//! (bind, tmpfs, npipe, cluster) goes in `mounts`.
+//! [`build_mounts_all`] converts all `volumes:` entries into OCI `Mount` entries
+//! and `NamedVolume` entries for the SpecGenerator. Named volumes go in
+//! `volumes`; everything else (bind, tmpfs, npipe, cluster) goes in `mounts`.
+//! Secrets and configs are not here: every source is a Podman-native secret
+//! attached to the spec, never a mount.
 
 use std::path::Path;
 
@@ -11,10 +12,7 @@ use crate::compose::types::{Service, VolumeMount, VolumeType};
 use crate::libpod::types::container::{Mount, NamedVolume};
 
 mod spec;
-use spec::{
-	access_opts, extend_bind_opts_str, extend_volume_opts_str, parse_bind_string,
-	parse_volume_string,
-};
+use spec::{access_opts, extend_bind_opts_str, extend_volume_opts_str, parse_volume_string};
 
 /// Build all OCI mounts and named volume attachments for a container.
 ///
@@ -24,8 +22,6 @@ use spec::{
 pub(crate) fn build_mounts_all(
 	service: &Service,
 	base_dir: &Path,
-	secret_binds: &[String],
-	config_binds: &[String],
 ) -> (Vec<Mount>, Vec<NamedVolume>) {
 	let mut mounts = Vec::new();
 	let mut named = Vec::new();
@@ -145,13 +141,6 @@ pub(crate) fn build_mounts_all(
 		mounts.push(spec::parse_tmpfs_string(&entry));
 	}
 
-	// Materialised secrets and configs are passed as pre-built bind strings.
-	for bind in secret_binds.iter().chain(config_binds.iter()) {
-		if let Some(m) = parse_bind_string(bind) {
-			mounts.push(m);
-		}
-	}
-
 	(mounts, named)
 }
 
@@ -175,7 +164,7 @@ mod tests {
 	#[test]
 	fn short_form_bind_passthrough() {
 		let svc = svc_with_volumes(vec![VolumeMount::Short("./data:/app/data".into())]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert!(named.is_empty());
 		assert_eq!(mounts[0].mount_type, "bind");
@@ -185,7 +174,7 @@ mod tests {
 	#[test]
 	fn short_form_named_volume() {
 		let svc = svc_with_volumes(vec![VolumeMount::Short("myvolume:/data".into())]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(mounts.is_empty());
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].name, "myvolume");
@@ -204,7 +193,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "bind");
 		assert!(mounts[0].options.contains(&"ro".to_string()));
@@ -227,7 +216,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(mounts[0].options.contains(&"rshared".to_string()));
 	}
 
@@ -246,7 +235,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(mounts.is_empty());
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].name, "myvolume");
@@ -273,7 +262,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(named.len(), 1);
 		assert!(named[0].options.contains(&"noexec".to_string()));
 		assert!(named[0].options.contains(&"nosuid".to_string()));
@@ -298,7 +287,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].sub_path.as_deref(), Some("nested/dir"));
 	}
@@ -317,7 +306,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(named.is_empty());
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "npipe");
@@ -337,7 +326,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "cluster");
 		assert_eq!(mounts[0].destination, "/data");
@@ -360,21 +349,12 @@ mod tests {
 			}),
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "tmpfs");
 		assert_eq!(mounts[0].destination, "/tmp/cache");
 		assert!(mounts[0].options.iter().any(|o| o.starts_with("size=")));
 		assert!(mounts[0].options.iter().any(|o| o.starts_with("mode=")));
-	}
-
-	#[test]
-	fn secret_binds_appended() {
-		let svc = svc_with_volumes(vec![]);
-		let secret = "/run/secrets/mydb:/run/secrets/mydb:ro".to_string();
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[secret], &[]);
-		assert_eq!(mounts.len(), 1);
-		assert_eq!(mounts[0].destination, "/run/secrets/mydb");
 	}
 
 	#[test]
@@ -395,7 +375,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		build_mounts_all(&svc, dir.path(), &[], &[]);
+		build_mounts_all(&svc, dir.path());
 		assert!(dir.path().join(rel).exists());
 	}
 
@@ -408,7 +388,7 @@ mod tests {
 		let dir = tempfile::tempdir().unwrap();
 		let rel = "missing-dir";
 		let svc = svc_with_volumes(vec![VolumeMount::Short(format!("./{rel}:/app/data"))]);
-		let (mounts, named) = build_mounts_all(&svc, dir.path(), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, dir.path());
 		assert!(named.is_empty());
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "bind");
@@ -425,7 +405,7 @@ mod tests {
 			tmpfs: StringOrList::List(vec!["/tmp".into(), "/run".into()]),
 			..Default::default()
 		};
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 2);
 		assert_eq!(mounts[0].mount_type, "tmpfs");
 		assert_eq!(mounts[0].destination, "/tmp");
@@ -439,7 +419,7 @@ mod tests {
 			tmpfs: StringOrList::Single("/tmp".into()),
 			..Default::default()
 		};
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "tmpfs");
 		assert_eq!(mounts[0].destination, "/tmp");

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -133,31 +133,6 @@ pub(super) fn parse_tmpfs_string(s: &str) -> Mount {
 	}
 }
 
-/// Parse a pre-built bind string (secret/config) — always produces a bind Mount.
-pub(super) fn parse_bind_string(s: &str) -> Option<Mount> {
-	let parts: Vec<&str> = s.splitn(3, ':').collect();
-	let (src, dst, opts_str) = match parts.len() {
-		1 => (parts[0], parts[0], ""),
-		2 => (parts[0], parts[1], ""),
-		_ => (parts[0], parts[1], parts[2]),
-	};
-	let opts: Vec<String> = opts_str
-		.split(',')
-		.map(|o| o.trim().to_string())
-		.filter(|o| !o.is_empty())
-		.collect();
-	Some(Mount {
-		mount_type: "bind".into(),
-		source: if src.is_empty() {
-			None
-		} else {
-			Some(src.to_string())
-		},
-		destination: dst.to_string(),
-		options: opts,
-	})
-}
-
 pub(super) fn access_opts(read_only: Option<bool>) -> Vec<String> {
 	if read_only.unwrap_or(false) {
 		vec!["ro".into()]

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -344,7 +344,7 @@ impl Engine {
 		.await?;
 		// Inline secrets/configs are materialised up front rather than in the
 		// per-container path; ensure they exist before recreating the container.
-		self.create_inline_secrets(file).await?;
+		self.create_project_secrets(file).await?;
 		let container_name = self.first_replica_name(service_name, service);
 		self.create_and_start(&container_name, service_name, service, file, true)
 			.await

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -68,7 +68,32 @@ async fn file_secret_bound() {
 	let file = parse_str(&yaml).unwrap();
 
 	engine.up(&file).await.unwrap();
+	// The container must READ the secret, not merely be started with it attached.
+	// Asserting only that `up` and `down` succeed is what let a `file:` secret stay
+	// unreadable on every SELinux-enforcing host for the life of the feature: the
+	// mount was there, at the right path, with the right bytes behind it, and the
+	// container was denied the open. `run` propagates the command's exit code, so
+	// the read is checked without a sleep standing in for synchronisation.
+	let read = engine
+		.run(
+			&file,
+			"web",
+			podup::RunOptions {
+				cmd: vec![
+					"sh".to_string(),
+					"-c".to_string(),
+					"test \"$(cat /run/secrets/filesecret)\" = file-secret-content".to_string(),
+				],
+				rm: true,
+				..Default::default()
+			},
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the container could not read /run/secrets/filesecret: {read:?}"
+	);
 }
 
 #[test]


### PR DESCRIPTION
A `file:` secret or config was bind-mounted read-only from the host path. On a
host with SELinux enforcing the container is denied that read, while `up` still
reports the container as started — so nothing signals the failure except the
application failing to open its own secret later.

```
 Container sel-secret-web-1  Started
web-1 | cat: can't open '/run/secrets/filesecret': Permission denied
```

Now every source podup owns — `content:`, `environment:` and `file:` — becomes a
Podman-native secret, and `external:` still points at a pre-existing one. Nothing
on the host is mounted, relabelled or modified.

## Why not just relabel the bind

Appending `z` was the one-line alternative and I did not take it. It rewrites the
SELinux label of a file the user owns and may share with a confined host service
— a cert or key next to a compose project is not an exotic case — and the change
outlives `down`. Neither podman nor docker relabel unless asked, and compose
gives the user nowhere to ask: the `secrets:` block takes `source`, `target`,
`uid`, `gid` and `mode`, and no mount options. So "let the user request it" was
not on the table, and doing it silently on their behalf is the one failure mode
that can break something outside the container.

## What the container sees is unchanged

With no `mode:` the secret mounts with the host file's own permission bits rather
than the `0444` the other sources default to:

| host file mode | in the container, before and after |
|---|---|
| 644 | 644 |
| 640 | 640 |
| 600 | 600 |

A `0600` secret stays unreadable to a non-root container user instead of being
widened. Execute and the special bits are masked off — a secret holds data, never
code, and mirroring a `0755` file verbatim would trip the existing dangerous-mode
guard and fail an `up` that used to work.

`uid`/`gid`/`mode` are still ignored for a `file:` source. Both docker compose
and podman-compose ignore them too (podman-compose says so in a warning) and the
Compose Specification makes them Swarm-only, so this deliberately does not start
applying them just because the native path could.

## The cost, stated plainly

The payload is a copy taken at `up`, so an in-place edit of the host file no
longer reaches a running container. An atomic replace never did — a file bind
pins the inode, so the write-new-then-rename that every careful rotation tool
performs was already invisible. Measured on the old behaviour: an in-place `>`
propagated, a `mv` did not.

Secret material now lives in Podman's secret store between `up` and `down`. The
label-guarded teardown already removes what podup creates, and the orphan sweep
catches a project whose compose file changed underneath it.

## Test plan

Fedora 44 (Podman 5.8.1) and Fedora Rawhide (Podman 6.0.1), both `getenforce` =
`Enforcing`, rootless; plus Ubuntu 6.17 with Podman 5.4.2 and no SELinux.

- The original reproduction on Rawhide now prints the secret instead of
  `Permission denied`, and `podman secret ls` is clean after `down`.
- Mode parity measured on both an enforcing and a non-enforcing host, for 644,
  640 and 600 host files — the table above.
- Full integration suite on the enforcing Fedora 44 host: 159 passed, 1 failed.
  The failure is `run_flags::engine_run_applies_volume_publish_and_interactive`,
  which #1176 fixes on its own branch — this one is cut from `develop`, which
  does not carry it yet. All five secret/config integration tests pass, including
  the strengthened one.
- 1341 library tests, `cargo fmt --check` and `clippy --all-targets` clean.
- `file_secret_bound` now reads the secret from inside the container. It asserted
  only that `up` and `down` succeeded, which is exactly why this shipped: the
  mount was present, at the right path, with the right bytes behind it, and the
  container was denied the open. It reads through `run` so the exit code is the
  assertion, with no sleep standing in for synchronisation.

Closes #1174
