### PR TITLE
test: assert the effect in the secrets, configs and env_file tests

### DIFF
--- a/tests/engine_integration/build_resources.rs
+++ b/tests/engine_integration/build_resources.rs
@@ -23,7 +23,26 @@ async fn file_config_bound() {
 	let file = parse_str(&yaml).unwrap();
 
 	engine.up(&file).await.unwrap();
+	// Read the config from inside the container. Asserting only that `up` and
+	// `down` succeed passes just as happily when the config is missing, empty or
+	// unreadable — the mount is not the effect, the content is.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /filecfg)\" = key=from-file".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"config /filecfg did not carry the file's contents: {read:?}"
+	);
 }
 
 #[test]
@@ -43,7 +62,23 @@ fn env_config_materialized() {
 			.unwrap();
 
 			engine.up(&file).await.unwrap();
+			let read = engine
+				.exec_with_options(
+					&file,
+					"web",
+					vec![
+						"sh".to_string(),
+						"-c".to_string(),
+						"test \"$(cat /envcfg)\" = cfg-from-env".to_string(),
+					],
+					podup::ExecOptions::default(),
+				)
+				.await;
 			engine.down(&file).await.unwrap();
+			assert!(
+				read.is_ok(),
+				"config /envcfg did not carry the environment variable's value: {read:?}"
+			);
 		});
 	});
 }
@@ -265,16 +300,28 @@ async fn secret_long_form_ref() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine
+	// `cat` alone only proves the path exists — it exits 0 on an empty or wrong
+	// file, and says nothing about the `mode:`/`uid:` the compose file asks for.
+	// Check the content and the permissions the long form actually requested.
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/run/secrets/custom_name".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /run/secrets/custom_name)\" = topsecret \
+				 && test \"$(stat -c '%a %u' /run/secrets/custom_name)\" = '400 0'"
+					.to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the long-form secret did not land at the requested target with mode 0400 and uid 0: {read:?}"
+	);
 }
 
 #[tokio::test]
@@ -291,16 +338,23 @@ async fn config_long_form_ref() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/etc/app.conf".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /etc/app.conf)\" = key=value".to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the long-form config did not land at /etc/app.conf with its content: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/health_targeting.rs
+++ b/tests/engine_integration/health_targeting.rs
@@ -186,14 +186,33 @@ async fn env_file_loaded() {
 
 	let proj = proj("evf");
 	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
-	// env_file covers container.rs L278 (load_env_file_entries)
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    env_file:\n      - test.env\n",
 	)
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	// The variable has to reach the container's environment. Reaching the line
+	// that loads the file is not the same thing: this test used to note which
+	// source line it covered and then assert nothing, so it would have passed just
+	// as well with `env_file` dropped on the floor.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$MYVAR\" = hello".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"MYVAR from env_file did not reach the container's environment: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -36,17 +36,25 @@ async fn inline_secret_materialized() {
 
 	engine.up(&file).await.unwrap();
 	// Inline content is created as a Podman-native secret and mounted at the
-	// usual /run/secrets/<name> path — verify by exec-ing a read.
-	engine
+	// usual /run/secrets/<name> path. `cat` alone only proves the path exists —
+	// it exits 0 on an empty file too — so compare the bytes.
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/run/secrets/mysecret".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /run/secrets/mysecret)\" = supersecret".to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the inline secret did not reach /run/secrets/mysecret with its content: {read:?}"
+	);
 }
 
 #[tokio::test]
@@ -113,7 +121,25 @@ fn env_secret_materialized() {
 			.unwrap();
 
 			engine.up(&file).await.unwrap();
+			// The point of an `environment:` source is that the variable's value
+			// becomes the secret. Starting the container proves neither half.
+			let read = engine
+				.exec_with_options(
+					&file,
+					"web",
+					vec![
+						"sh".to_string(),
+						"-c".to_string(),
+						"test \"$(cat /run/secrets/envsecret)\" = env-secret-value".to_string(),
+					],
+					podup::ExecOptions::default(),
+				)
+				.await;
 			engine.down(&file).await.unwrap();
+			assert!(
+				read.is_ok(),
+				"the env-sourced secret did not carry the variable's value: {read:?}"
+			);
 		});
 	});
 }
@@ -126,18 +152,23 @@ async fn invalid_secret_name_rejected() {
 	};
 	let proj = proj("isec");
 	let engine = Engine::new(client, proj.clone());
-	// Secret name with path traversal
+	// A traversal name must be refused: it would otherwise become part of a
+	// project-scoped Podman secret name and a URL query parameter.
+	//
+	// This test used to declare a perfectly ordinary secret called `evils`, discard
+	// both results with `let _ =`, and say in a comment that it could not test the
+	// thing its name promises. It asserted nothing at all, in either direction.
 	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - evils\nsecrets:\n  evils:\n    content: bad\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - '../evil'\nsecrets:\n  '../evil':\n    content: bad\n",
+	)
+	.unwrap();
+
+	let result = engine.up(&file).await;
+	let _ = engine.down(&file).await;
+	assert!(
+		result.is_err(),
+		"a secret named '../evil' was accepted instead of being rejected"
 	);
-	// Parse succeeds; but engine should reject the traversal during up()
-	// We can't actually test a ".." name since parse_str would accept it.
-	// Instead, verify that a normal name works (already covered by inline_secret test).
-	// This test exercises the path-validation code via a valid name edge case.
-	if let Ok(f) = file {
-		let _ = engine.up(&f).await;
-		let _ = engine.down(&f).await;
-	}
 }
 
 #[tokio::test]
@@ -154,7 +185,26 @@ async fn inline_config_materialized() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	// A config defaults to an absolute container-root path, unlike a secret's
+	// /run/secrets/<name> — so this also pins the default target, not just the
+	// content.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /mycfg)\" = key=value".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the inline config did not reach /mycfg with its content: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
> Stacked on #1178 — based on that branch, not `develop`, because the `file:`
> config test's expectations depend on it. Retarget to `develop` once #1178 lands.

Nine tests in the secrets, configs and `env_file` slice started a container,
stopped it, and asserted nothing about the thing they are named for. They passed
whether or not it happened.

`env_file_loaded` is the clearest: it wrote `MYVAR=hello`, brought the service up,
brought it down, and carried a comment saying which source line it covered. Line
coverage, not effect. It would have passed with `env_file` dropped on the floor.

This matters because #1174 — a `file:` secret unreadable on every SELinux host —
lived in this exact slice for the whole life of the feature, on a lane that runs
Fedora with SELinux enforcing and therefore had every chance to catch it. The
environment was never the gap. The assertion was. That slice is also on the
2026-06-25 empirical sweep's own list of surfaces it never reached.

Each test now checks the observable result from inside the container through
`exec`, whose non-zero exit surfaces as `RunExited`, so the exit code *is* the
assertion and no sleep stands in for synchronisation.

| test | was | now |
|---|---|---|
| `env_file_loaded` | nothing | reads `$MYVAR` |
| `file_config_bound` | nothing | compares the content |
| `env_config_materialized` | nothing | compares the content |
| `inline_config_materialized` | nothing | content, and pins the container-root default target that distinguishes a config from a secret |
| `inline_secret_materialized` | `cat` exits 0 | compares the content |
| `secret_long_form_ref` | `cat` exits 0 | content plus the `mode: 0400` and `uid` the compose file asks for |
| `config_long_form_ref` | `cat` exits 0 | content at its absolute target |
| `invalid_secret_name_rejected` | **nothing at all** | requires `up` to reject `../evil` |

`cat` on its own exits 0 on an empty file, which is what the two tests that did
exec were really asserting.

`invalid_secret_name_rejected` deserves its own line. It declared an ordinary
secret called `evils`, discarded both results with `let _ =`, and stated in a
comment that it could not test the traversal its name promises. It was not a weak
test; it documented its own uselessness and was kept.

## Test plan

- All nine pass locally against real Podman 5.4.2.
- **Every new assertion proved by mutation.** Breaking the input turns the test
  red with its own diagnostic, then the input is restored:

  ```
  test health_targeting::env_file_loaded ... FAILED
  test build_resources::file_config_bound ... FAILED
  MYVAR from env_file did not reach the container's environment: Err(RunExited(1))
  config /filecfg did not carry the file's contents: Err(RunExited(1))
  ```

  An assertion that has never failed is another line of false confidence, which
  is the whole point of this PR.
- `cargo fmt --check` and `clippy --all-targets` clean.
- The lane runs both majors on Fedora with SELinux enforcing, which is where the
  strengthened `file_config_bound` has teeth.

## Not covered

The rest of the 2026-06-25 sweep list stays open: `attach`, `watch` rebuild,
`push` (needs a registry in the lane), multi-`-f`, `include`/`extends` and
per-command `--help`. So do the weak assertions outside this slice — a scan for
integration tests with no `assert` in the body returns 71 of 160, and #1180
samples the rest.

Refs #1180
