### PR TITLE
ci: the .github pins point at a released tag, not a candidate

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1


### PR DESCRIPTION
## Summary

The twelve reusable pins sit on `7099f8a` with a `# v1.10.1-pre` comment, because I pinned them at the merge SHA to prove the release before cutting the tag. `v1.10.1` now exists on that exact commit, so the `-pre` suffix is stale.

Dependabot will not clean it up: it rewrites the comment only when it moves the SHA, and the SHA is already the one the tag points at. That is how the previous cycle's `# v1.10.0-pre` survived until I overwrote it.

## Changes

- Drop the `-pre` suffix from the twelve pin comments. No SHA moves, no functional change.

## Test plan

Comment-only, so CI passing is the whole check — the resolved reusables are byte-identical to the ones that were green on #1179.