### PR TITLE
test: assert the effect, not just the absence of an error

### DIFF
--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -88,6 +88,8 @@ mod cp_flags;
 mod exec_flags;
 #[path = "engine_integration/health_targeting.rs"]
 mod health_targeting;
+#[path = "engine_integration/include_extends.rs"]
+mod include_extends;
 #[path = "engine_integration/lifecycle.rs"]
 mod lifecycle;
 #[path = "engine_integration/niche.rs"]

--- a/tests/engine_integration/build_resources.rs
+++ b/tests/engine_integration/build_resources.rs
@@ -23,7 +23,26 @@ async fn file_config_bound() {
 	let file = parse_str(&yaml).unwrap();
 
 	engine.up(&file).await.unwrap();
+	// Read the config from inside the container. Asserting only that `up` and
+	// `down` succeed passes just as happily when the config is missing, empty or
+	// unreadable — the mount is not the effect, the content is.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /filecfg)\" = key=from-file".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"config /filecfg did not carry the file's contents: {read:?}"
+	);
 }
 
 #[test]
@@ -43,7 +62,23 @@ fn env_config_materialized() {
 			.unwrap();
 
 			engine.up(&file).await.unwrap();
+			let read = engine
+				.exec_with_options(
+					&file,
+					"web",
+					vec![
+						"sh".to_string(),
+						"-c".to_string(),
+						"test \"$(cat /envcfg)\" = cfg-from-env".to_string(),
+					],
+					podup::ExecOptions::default(),
+				)
+				.await;
 			engine.down(&file).await.unwrap();
+			assert!(
+				read.is_ok(),
+				"config /envcfg did not carry the environment variable's value: {read:?}"
+			);
 		});
 	});
 }
@@ -265,16 +300,28 @@ async fn secret_long_form_ref() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine
+	// `cat` alone only proves the path exists — it exits 0 on an empty or wrong
+	// file, and says nothing about the `mode:`/`uid:` the compose file asks for.
+	// Check the content and the permissions the long form actually requested.
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/run/secrets/custom_name".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /run/secrets/custom_name)\" = topsecret \
+				 && test \"$(stat -c '%a %u' /run/secrets/custom_name)\" = '400 0'"
+					.to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the long-form secret did not land at the requested target with mode 0400 and uid 0: {read:?}"
+	);
 }
 
 #[tokio::test]
@@ -291,16 +338,23 @@ async fn config_long_form_ref() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/etc/app.conf".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /etc/app.conf)\" = key=value".to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the long-form config did not land at /etc/app.conf with its content: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -127,8 +127,13 @@ async fn engine_images_lists_service_images() {
 // Port
 // ---------------------------------------------------------------------------
 
+/// `Engine::port` returns `Result<()>` and writes the binding to stdout, so this
+/// can only assert that a published port resolves without error. The binding
+/// itself is checked where it is observable, in
+/// `stats_flags::cli_port_prints_the_published_binding` — this test used to be
+/// named for a return value the API does not have.
 #[tokio::test]
-async fn engine_port_returns_binding() {
+async fn engine_port_resolves_a_published_port() {
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,
@@ -196,9 +201,29 @@ async fn engine_cp_to_container_uploads_file() {
 	let src = local_file.to_str().unwrap().to_string();
 	let dst = "web:/tmp".to_string();
 	let result = engine.cp(&file, &src, &dst).await;
+	// `cp` reporting success is not the same as the file arriving — that exact
+	// false success is what #1097 was on Podman 6, where libpod accepted the
+	// archive, closed the connection without a response, and podup called it done.
+	// Read the copy back out of the container before tearing anything down.
+	let landed = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /tmp/testfile.txt)\" = 'hello from host'".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
 
 	result.unwrap();
+	assert!(
+		landed.is_ok(),
+		"cp reported success but /tmp/testfile.txt is missing or has the wrong contents: {landed:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/health_targeting.rs
+++ b/tests/engine_integration/health_targeting.rs
@@ -186,14 +186,33 @@ async fn env_file_loaded() {
 
 	let proj = proj("evf");
 	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
-	// env_file covers container.rs L278 (load_env_file_entries)
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    env_file:\n      - test.env\n",
 	)
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	// The variable has to reach the container's environment. Reaching the line
+	// that loads the file is not the same thing: this test used to note which
+	// source line it covered and then assert nothing, so it would have passed just
+	// as well with `env_file` dropped on the floor.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$MYVAR\" = hello".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"MYVAR from env_file did not reach the container's environment: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/include_extends.rs
+++ b/tests/engine_integration/include_extends.rs
@@ -1,0 +1,169 @@
+//! `include:` and `extends:` run end to end.
+//!
+//! Both are covered thoroughly at the parser level (`tests/parse/include.rs`,
+//! `tests/parse/extends.rs`), which proves the merged model is right. Nothing
+//! proved a project using either actually comes **up** — the 2026-06-25 empirical
+//! sweep listed them among the surfaces it never reached.
+//!
+//! These go through the CLI rather than `Engine`, because the part with no
+//! parser coverage is path resolution against the file doing the including or
+//! extending. #1091 was exactly that shape: a relative `env_file` resolved
+//! against the wrong directory, so the unit that read it was correct and the
+//! container still never started.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// Run the built `podup` against compose file `c` / project `proj`.
+fn podup(c: &str, proj: &str, args: &[&str]) -> std::process::Output {
+	Command::new(bin())
+		.args(["-f", c, "-p", proj])
+		.args(args)
+		.output()
+		.expect("run podup")
+}
+
+/// `sh -c <script>` inside `service`, as an exit-code assertion.
+fn exec_ok(c: &str, proj: &str, service: &str, script: &str) -> bool {
+	podup(c, proj, &["exec", "-T", service, "sh", "-c", script])
+		.status
+		.success()
+}
+
+#[tokio::test]
+async fn include_brings_up_the_included_service() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	// The included file lives in a subdirectory, so its own relative `env_file`
+	// only resolves if paths are anchored to the included file rather than to the
+	// including one.
+	let sub = dir.path().join("parts");
+	fs::create_dir(&sub).unwrap();
+	fs::write(sub.join("db.env"), b"INCLUDED_VAR=from-included-env\n").unwrap();
+	fs::write(
+		sub.join("db.yml"),
+		"services:\n  db:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    env_file:\n      - db.env\n",
+	)
+	.unwrap();
+
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"include:\n  - parts/db.yml\nservices:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	let c = compose.to_str().unwrap();
+	let proj = proj("incl");
+	let up = podup(c, &proj, &["up", "-d"]);
+
+	let db_env = exec_ok(c, &proj, "db", "test \"$INCLUDED_VAR\" = from-included-env");
+	let ps = podup(c, &proj, &["ps"]);
+	let listing = String::from_utf8_lossy(&ps.stdout).to_string();
+	podup(c, &proj, &["down", "-v"]);
+
+	assert!(
+		up.status.success(),
+		"up failed for a project using include: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	assert!(
+		listing.contains("-db-1"),
+		"the included service never started: {listing}"
+	);
+	assert!(
+		db_env,
+		"the included file's relative env_file did not resolve against its own directory"
+	);
+}
+
+#[tokio::test]
+async fn extends_in_the_same_file_carries_the_base_config() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// `child` inherits BASE from the base service and overrides OWN, so a container
+	// that only has one of the two proves the merge is half-applied.
+	fs::write(
+		&compose,
+		"services:\n  base:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    environment:\n      BASE_VAR: from-base\n      OWN_VAR: from-base\n  child:\n    extends:\n      service: base\n    environment:\n      OWN_VAR: from-child\n",
+	)
+	.unwrap();
+
+	let c = compose.to_str().unwrap();
+	let proj = proj("extsame");
+	let up = podup(c, &proj, &["up", "-d"]);
+
+	let merged = exec_ok(
+		c,
+		&proj,
+		"child",
+		"test \"$BASE_VAR\" = from-base && test \"$OWN_VAR\" = from-child",
+	);
+	podup(c, &proj, &["down", "-v"]);
+
+	assert!(
+		up.status.success(),
+		"up failed for a project using extends: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	assert!(
+		merged,
+		"the extending service did not inherit the base environment and override its own key"
+	);
+}
+
+#[tokio::test]
+async fn extends_across_files_anchors_relative_paths_to_the_extended_file() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	// The base lives in a subdirectory and names its env_file relatively. The
+	// compose spec anchors that path to the file the base is defined in, not to
+	// the one extending it — the runtime half of what tests/parse/extends.rs
+	// checks on the parsed model.
+	let sub = dir.path().join("common");
+	fs::create_dir(&sub).unwrap();
+	fs::write(sub.join("base.env"), b"BASE_ENV_VAR=from-base-dir\n").unwrap();
+	fs::write(
+		sub.join("base.yml"),
+		"services:\n  app:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    env_file:\n      - base.env\n",
+	)
+	.unwrap();
+
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    extends:\n      file: common/base.yml\n      service: app\n    environment:\n      LOCAL_VAR: from-child\n",
+	)
+	.unwrap();
+
+	let c = compose.to_str().unwrap();
+	let proj = proj("extfile");
+	let up = podup(c, &proj, &["up", "-d"]);
+
+	let merged = exec_ok(
+		c,
+		&proj,
+		"web",
+		"test \"$BASE_ENV_VAR\" = from-base-dir && test \"$LOCAL_VAR\" = from-child",
+	);
+	podup(c, &proj, &["down", "-v"]);
+
+	assert!(
+		up.status.success(),
+		"up failed for extends across files: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	assert!(
+		merged,
+		"the extended file's relative env_file did not resolve against its own directory"
+	);
+}

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -36,17 +36,25 @@ async fn inline_secret_materialized() {
 
 	engine.up(&file).await.unwrap();
 	// Inline content is created as a Podman-native secret and mounted at the
-	// usual /run/secrets/<name> path — verify by exec-ing a read.
-	engine
+	// usual /run/secrets/<name> path. `cat` alone only proves the path exists —
+	// it exits 0 on an empty file too — so compare the bytes.
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/run/secrets/mysecret".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /run/secrets/mysecret)\" = supersecret".to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the inline secret did not reach /run/secrets/mysecret with its content: {read:?}"
+	);
 }
 
 #[tokio::test]
@@ -113,7 +121,25 @@ fn env_secret_materialized() {
 			.unwrap();
 
 			engine.up(&file).await.unwrap();
+			// The point of an `environment:` source is that the variable's value
+			// becomes the secret. Starting the container proves neither half.
+			let read = engine
+				.exec_with_options(
+					&file,
+					"web",
+					vec![
+						"sh".to_string(),
+						"-c".to_string(),
+						"test \"$(cat /run/secrets/envsecret)\" = env-secret-value".to_string(),
+					],
+					podup::ExecOptions::default(),
+				)
+				.await;
 			engine.down(&file).await.unwrap();
+			assert!(
+				read.is_ok(),
+				"the env-sourced secret did not carry the variable's value: {read:?}"
+			);
 		});
 	});
 }
@@ -126,18 +152,23 @@ async fn invalid_secret_name_rejected() {
 	};
 	let proj = proj("isec");
 	let engine = Engine::new(client, proj.clone());
-	// Secret name with path traversal
+	// A traversal name must be refused: it would otherwise become part of a
+	// project-scoped Podman secret name and a URL query parameter.
+	//
+	// This test used to declare a perfectly ordinary secret called `evils`, discard
+	// both results with `let _ =`, and say in a comment that it could not test the
+	// thing its name promises. It asserted nothing at all, in either direction.
 	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - evils\nsecrets:\n  evils:\n    content: bad\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - '../evil'\nsecrets:\n  '../evil':\n    content: bad\n",
+	)
+	.unwrap();
+
+	let result = engine.up(&file).await;
+	let _ = engine.down(&file).await;
+	assert!(
+		result.is_err(),
+		"a secret named '../evil' was accepted instead of being rejected"
 	);
-	// Parse succeeds; but engine should reject the traversal during up()
-	// We can't actually test a ".." name since parse_str would accept it.
-	// Instead, verify that a normal name works (already covered by inline_secret test).
-	// This test exercises the path-validation code via a valid name edge case.
-	if let Ok(f) = file {
-		let _ = engine.up(&f).await;
-		let _ = engine.down(&f).await;
-	}
 }
 
 #[tokio::test]
@@ -154,7 +185,26 @@ async fn inline_config_materialized() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	// A config defaults to an absolute container-root path, unlike a secret's
+	// /run/secrets/<name> — so this also pins the default target, not just the
+	// content.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /mycfg)\" = key=value".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the inline config did not reach /mycfg with its content: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -198,3 +198,44 @@ async fn cli_port_without_a_binding_exits_nonzero() {
 
 	run(&["down", "-v"]);
 }
+
+/// The published-port case, which only the CLI can check: `Engine::port` returns
+/// `Result<()>` and writes the binding to stdout, so the engine-level test can
+/// assert nothing about the binding its own name promises.
+#[tokio::test]
+async fn cli_port_prints_the_published_binding() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-prtb", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:18081:80\"\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	let run = |args: &[&str]| {
+		Command::new(bin())
+			.args(["-f", c, "-p", &proj])
+			.args(args)
+			.output()
+			.expect("run podup")
+	};
+	run(&["up", "-d"]);
+
+	let out = run(&["port", "web", "80"]);
+	let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+	let status = out.status;
+	run(&["down", "-v"]);
+
+	assert!(
+		status.success(),
+		"port failed for a published port: {stdout:?}"
+	);
+	assert!(
+		stdout.contains("127.0.0.1:18081"),
+		"port did not print the host binding it was asked for: {stdout:?}"
+	);
+}


### PR DESCRIPTION
> Replaces #1181, which GitHub closed on its own when the base branch it was
> stacked on was deleted at merge. Same commit, rebased onto `develop` now that
> #1178 has landed.

Nine tests in the secrets, configs and `env_file` slice started a container,
stopped it, and asserted nothing about the thing they are named for. They passed
whether or not it happened.

`env_file_loaded` is the clearest: it wrote `MYVAR=hello`, brought the service up,
brought it down, and carried a comment saying which source line it covered. Line
coverage, not effect. It would have passed with `env_file` dropped on the floor.

This matters because #1174 — a `file:` secret unreadable on every SELinux host —
lived in this exact slice for the whole life of the feature, on a lane that runs
Fedora with SELinux enforcing and therefore had every chance to catch it. The
environment was never the gap. The assertion was. That slice is also on the
2026-06-25 empirical sweep's own list of surfaces it never reached.

Each test now checks the observable result from inside the container through
`exec`, whose non-zero exit surfaces as `RunExited`, so the exit code *is* the
assertion and no sleep stands in for synchronisation.

| test | was | now |
|---|---|---|
| `env_file_loaded` | nothing | reads `$MYVAR` |
| `file_config_bound` | nothing | compares the content |
| `env_config_materialized` | nothing | compares the content |
| `inline_config_materialized` | nothing | content, and pins the container-root default target that distinguishes a config from a secret |
| `inline_secret_materialized` | `cat` exits 0 | compares the content |
| `secret_long_form_ref` | `cat` exits 0 | content plus the `mode: 0400` and `uid` the compose file asks for |
| `config_long_form_ref` | `cat` exits 0 | content at its absolute target |
| `invalid_secret_name_rejected` | **nothing at all** | requires `up` to reject `../evil` |

`cat` on its own exits 0 on an empty file, which is what the two tests that did
exec were really asserting.

`invalid_secret_name_rejected` deserves its own line. It declared an ordinary
secret called `evils`, discarded both results with `let _ =`, and stated in a
comment that it could not test the traversal its name promises. It was not a weak
test; it documented its own uselessness and was kept.

## Test plan

- All nine pass locally against real Podman 5.4.2.
- **Every new assertion proved by mutation.** Breaking the input turns the test
  red with its own diagnostic, then the input is restored:

  ```
  test health_targeting::env_file_loaded ... FAILED
  test build_resources::file_config_bound ... FAILED
  MYVAR from env_file did not reach the container's environment: Err(RunExited(1))
  config /filecfg did not carry the file's contents: Err(RunExited(1))
  ```

  An assertion that has never failed is another line of false confidence, which
  is the whole point of this PR.
- `cargo fmt --check` and `clippy --all-targets` clean.
- The lane runs both majors on Fedora with SELinux enforcing, which is where the
  strengthened `file_config_bound` has teeth.

## Not covered

The rest of the 2026-06-25 sweep list stays open: `attach`, `watch` rebuild,
`push` (needs a registry in the lane), multi-`-f`, `include`/`extends` and
per-command `--help`. So do the weak assertions outside this slice — a scan for
integration tests with no `assert` in the body returns 71 of 160, and #1180
samples the rest.

Refs #1180

