### PR TITLE
chore: bring develop to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels: ["dependencies", "type:ci"]
+    labels: ["type:deps", "type:ci"]
     open-pull-requests-limit: 10
     target-branch: "develop"
 
@@ -13,6 +13,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels: ["dependencies"]
+    labels: ["type:deps"]
     open-pull-requests-limit: 10
     target-branch: "develop"

--- a/.github/podman-known-failures-5
+++ b/.github/podman-known-failures-5
@@ -15,6 +15,14 @@
 # all pass now. The claim "cannot pass under nested virt" was made honestly, with
 # a run, and was still wrong: the physical host that proved 155/155 also had a
 # working journald, so the comparison could not see the difference.
+#
+# 2026-07-25: the same mistake again, and the same shape. run_flags::engine_run_
+# applies_volume_publish_and_interactive was never about nested virt either — it
+# bind-mounted a host directory with no SELinux relabel, so on an enforcing host
+# the container read it as `Permission denied`. Measured on Fedora 44 + Podman
+# 5.8.1 with plain `podman run`, no podup involved: without `z` the read is
+# denied, with `z` it succeeds. The test now asks for the relabel a user on such
+# a host writes too, and passes there. My physical host runs no SELinux, which is
+# once more why the 155/155 comparison could not see the difference.
 
 niche::engine_events_stream_connects
-run_flags::engine_run_applies_volume_publish_and_interactive

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
       max-total-time: "60"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -93,8 +93,18 @@ jobs:
                 # as Hyper(IncompleteMessage) and kin). A real failure reproduces on
                 # the second run, so this stabilises the lane for required-check gating
                 # without masking genuine bugs.
+                #
+                # `--test-threads=2` caps how many streaming tests hit the libpod
+                # socket at once. The nested-virt (VM-in-runner) transport is what
+                # drops connections mid-stream — measured: on a single-level VM
+                # (Podman 5.8.1 and 6.0.1) the same suite never drops a byte, so the
+                # flake is the double-virt socket under concurrent load, not a podup
+                # or libpod bug. Fewer concurrent streams means less peak pressure,
+                # which is the lever to shrink Podman 6's variable flaky tail toward
+                # a small, stable set that an identity list can gate (#1039). Kept at
+                # 2 rather than 1 so the suite still fits the VM's time budget.
                 for attempt in 1 2; do
-                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration > /tmp/cargo.log 2>&1
+                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=2 > /tmp/cargo.log 2>&1
                   RC=$?
                   [ "$RC" -eq 0 ] && break
                   grep -qE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log || break

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@b12b4c0bb5c2caec50ea8e46a21a5c0519b73ad9 # v1.10.0-pre
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1-pre

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -53,10 +53,11 @@ GPU driver and CDI setup, not on podup alone.
 A secret or config declared `external: true` is mounted from an existing
 Podman secret rather than from a value in the project tree — the recommended
 pattern for production credentials, since the secret material never appears in
-the compose file or its history. (Inline `content:`/`environment:` sources are
-also injected as Podman-native secrets, not host bind-mounts, but their value
-still lives in the compose file.) Create the secret before running, exactly as
-you would with `docker secret`:
+the compose file or its history. (Every other source — inline
+`content:`/`environment:` and `file:` alike — is injected as a Podman-native
+secret too, never a host bind mount, but its value still lives in the compose
+file or next to it.) Create the secret before running, exactly as you would with
+`docker secret`:
 
 ```sh
 printf '%s' "$DB_PASSWORD" | podman secret create db_password -

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -74,14 +74,21 @@ only tighten, never widen, what the launching user already has.
 
 ## Secret and config handling
 
-- `secrets:`/`configs:` sourced from inline `content:` or `environment:` are
-  created as Podman-native secrets over the libpod API (under a project-scoped
-  name) and injected into the container — podup writes no secret material to a
-  host directory. They are removed again on `podup down`.
+- `secrets:`/`configs:` sourced from inline `content:` or `environment:`, and
+  from a `file:` path, are created as Podman-native secrets over the libpod API
+  (under a project-scoped name) and injected into the container — podup writes no
+  secret material to a host directory. They are removed again on `podup down`.
 - `external: true` secrets/configs are injected as Podman-native secrets
   (pre-flighted for existence), pointing at a pre-existing `podman secret`.
-- `file:` secrets/configs are bind-mounted read-only from the host path you
-  provide; the file already lives on the host, so no copy is made.
+- A `file:` source is read at `up` time and its bytes become the secret. Nothing
+  on the host is mounted, relabelled or otherwise modified. With no `mode:` given
+  the secret is mounted with the host file's own permission bits, so a `0600`
+  secret stays unreadable to a non-root container user.
+- Because the payload is a copy taken at `up`, editing the host file afterwards
+  does not reach an already-running container; recreate it to pick up a new
+  value. (A rotation that replaces the file atomically — write-new-then-rename,
+  which is what careful tools do — was never visible to a running container
+  either, because a file bind mount pins the inode.)
 - Dangerous secret file modes (setuid/setgid/sticky/executable) are rejected.
 - The `config` subcommand redacts inline `content:` secrets before printing.
 

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -75,16 +75,12 @@ impl Engine {
 			})
 			.collect();
 
-		// --- Secrets and configs become bind mounts ---
-		let secret_binds = self.build_secret_binds(service, file)?;
-		let config_binds = self.build_config_binds(service, file)?;
-		// Inline and `external: true` secrets/configs are injected as Podman-native
-		// secrets, not bind mounts. Inline ones are created up front by
-		// `create_inline_secrets`; here we only build the references and preflight
-		// external ones for existence.
+		// Every secret/config source — inline, `file:` and `external: true` — is
+		// injected as a Podman-native secret, never a bind mount. The ones podup
+		// owns are created up front by `create_project_secrets`; here we only build
+		// the references and preflight external ones for existence.
 		let native_secrets = self.build_native_secrets(service, file).await?;
-		let (mut mounts, mut named_volumes) =
-			build_mounts_all(service, &self.base_dir, &secret_binds, &config_binds);
+		let (mut mounts, mut named_volumes) = build_mounts_all(service, &self.base_dir);
 		// Resolve relative bind sources against the project base directory (and
 		// expand a leading `~`) so they don't depend on Podman's working
 		// directory; absolute paths (incl. staged secrets/configs) are untouched.

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -224,7 +224,7 @@ impl Engine {
 			// Pre-create the union of inline secrets/configs once, before the
 			// concurrent per-level start loop, so two services in the same level
 			// can't race the non-atomic delete-then-create of a shared name.
-			self.create_inline_secrets(file).await?;
+			self.create_project_secrets(file).await?;
 
 			// Best-effort: warm the image cache for every service this pass will
 			// pull, concurrently, before the per-level walk below serializes a

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -170,7 +170,7 @@ impl Engine {
 		// Inline secrets/configs are created up front (no longer in the
 		// per-container build path), so materialise them here too before the run
 		// container is created.
-		self.create_inline_secrets(file).await?;
+		self.create_project_secrets(file).await?;
 
 		// Refuse to clobber a pre-existing container of the same name (data-loss
 		// footgun): `create_and_start` would force-remove it. Only the verbatim

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -1,24 +1,40 @@
 //! Secret and config injection.
 //!
-//! `file:` secret/config sources are bind-mounted read-only from the host —
-//! the file already lives there, so no copy is made. Inline `content:` and
-//! `environment:` sources, and `external: true` references, are injected as
-//! Podman-native secrets attached to the container create spec:
+//! Every source is injected as a Podman-native secret attached to the container
+//! create spec:
 //!
-//! * inline `content:`/`environment:` → created over the libpod API
+//! * inline `content:`/`environment:` and `file:` → created over the libpod API
 //!   (`secrets/create`, removing any prior secret of the name first so a re-`up`
 //!   is idempotent) under a project-scoped name, so nothing is written to a host
-//!   staging directory. The project's whole inline union is created once up
-//!   front by [`Engine::create_inline_secrets`] (before services start
+//!   staging directory. The project's whole payload union is created once up
+//!   front by [`Engine::create_project_secrets`] (before services start
 //!   concurrently), not per-service, so a shared name is never raced.
 //! * `external: true` → mapped to a pre-existing `podman secret`, preflighted
 //!   with [`Engine::ensure_external_exists`] so a missing secret fails closed.
+//!
+//! `file:` sources used to be read-only bind mounts of the host path instead.
+//! That worked until the host enforced SELinux, where the container is denied
+//! the read outright and `up` still reports the container as started — measured
+//! on Fedora with both supported Podman majors, and reproduced by plain `podman
+//! run`, so the denial was the missing relabel and not podup. Relabelling was
+//! the other way out, but `z` rewrites the label of a file the user owns and may
+//! share with a confined host service, and compose gives them nowhere to ask for
+//! it. Reading the bytes into a native secret leaves the host untouched and puts
+//! `file:` on the path the other two sources already took. What the container
+//! sees is unchanged: the mount mode mirrors the host file's own bits (see
+//! [`plan::host_file_secret_mode`]) rather than defaulting to `0444`.
+//!
+//! The trade is that the payload is a copy taken at `up`, so an in-place edit of
+//! the host file no longer reaches a running container. An atomic replace never
+//! did — a file bind pins the inode, so the write-new-and-rename that every
+//! careful rotation tool performs was already invisible.
 //!
 //! The pure compose→plan mapping lives in [`plan`].
 
 mod plan;
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
@@ -26,98 +42,59 @@ use crate::libpod::types::container::Secret;
 use crate::libpod::{urlencoded, API_PREFIX};
 
 use plan::{
-	check_secret_size, collect_native_plans, is_inline_source, ref_name_target, scoped_name,
+	check_secret_size, collect_native_plans, host_file_secret_mode, is_podup_created_source,
+	scoped_name, Payload,
 };
 
 use super::Engine;
 
 impl Engine {
-	/// Bind strings for `file:` secrets referenced by `service`. Inline and
-	/// external secrets are injected natively (see [`Engine::build_native_secrets`])
-	/// and are skipped here.
-	pub(super) fn build_secret_binds(
-		&self,
-		service: &Service,
-		file: &ComposeFile,
-	) -> Result<Vec<String>> {
-		let mut binds = Vec::new();
-		for secret_ref in &service.secrets {
-			let (name, target_override) = ref_name_target(secret_ref.source(), secret_ref.target());
-			if let Some(def) = file.secrets.get(&name) {
-				if let Some(host_path) = &def.file {
-					let target = target_override.unwrap_or_else(|| format!("/run/secrets/{name}"));
-					// Resolve like a bind-mount source: a relative `file:` is anchored
-					// to the project dir (not the Podman service's cwd) and `~` is
-					// expanded — same handling as `volumes:`.
-					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(make_bind(&name, &resolved, &target)?);
-				}
-			}
-		}
-		Ok(binds)
-	}
-
-	/// Bind strings for `file:` configs referenced by `service`. Inline and
-	/// external configs are injected natively and are skipped here.
-	pub(super) fn build_config_binds(
-		&self,
-		service: &Service,
-		file: &ComposeFile,
-	) -> Result<Vec<String>> {
-		let mut binds = Vec::new();
-		for config_ref in &service.configs {
-			let (name, target_override) = ref_name_target(config_ref.source(), config_ref.target());
-			if let Some(def) = file.configs.get(&name) {
-				if let Some(host_path) = &def.file {
-					let target = target_override.unwrap_or_else(|| format!("/{name}"));
-					let resolved = super::container::resolve_bind_source(host_path, &self.base_dir);
-					binds.push(make_bind(&name, &resolved, &target)?);
-				}
-			}
-		}
-		Ok(binds)
-	}
-
-	/// Build the Podman-native secret references for a service. Inline
-	/// `content:`/`environment:` sources must already have been created by
-	/// [`Engine::create_inline_secrets`] (run once up front), so this only
-	/// preflights `external: true` sources for existence — failing closed
-	/// rather than starting a container that lacks the secret — and assembles
-	/// the per-service references attached to the container spec. `file:`
-	/// sources are handled as bind mounts.
+	/// Build the Podman-native secret references for a service. Every source podup
+	/// creates — `content:`, `environment:` and `file:` — must already have been
+	/// created by [`Engine::create_project_secrets`] (run once up front), so this
+	/// only preflights `external: true` sources for existence — failing closed
+	/// rather than starting a container that lacks the secret — and assembles the
+	/// per-service references attached to the container spec.
 	///
 	/// Creation is deliberately *not* done here: services in the same
 	/// dependency level are brought up concurrently, and a per-service
-	/// delete-then-create on a shared inline secret name would race (one create
-	/// could clobber a secret another service's container is about to use). The
-	/// up-front pass creates each inline secret exactly once instead.
+	/// delete-then-create on a shared secret name would race (one create could
+	/// clobber a secret another service's container is about to use). The up-front
+	/// pass creates each secret exactly once instead.
 	pub(super) async fn build_native_secrets(
 		&self,
 		service: &Service,
 		file: &ComposeFile,
 	) -> Result<Vec<Secret>> {
-		let plans = collect_native_plans(&self.project, service, file)?;
+		let plans = collect_native_plans(&self.project, service, file, &self.base_dir)?;
 		let mut secrets = Vec::with_capacity(plans.len());
 		for plan in plans {
-			// Inline payloads are created up front; only external sources need a
+			// Payloads podup owns are created up front; only external sources need a
 			// (read-only, idempotent) existence preflight here.
 			if plan.payload.is_none() {
 				self.ensure_external_exists("secret", "secrets", &plan.source)
 					.await?;
 			}
+			// A `file:` source with no explicit `mode:` mounts with the host file's
+			// own bits, so what the container sees does not change now that the file
+			// is copied into a native secret rather than bind-mounted.
+			let mode = match (&plan.payload, plan.mode) {
+				(Some(Payload::File(path)), None) => Some(host_file_secret_mode(path)),
+				_ => plan.mode,
+			};
 			secrets.push(Secret {
 				source: plan.source,
 				target: Some(plan.target),
 				uid: plan.uid,
 				gid: plan.gid,
-				mode: plan.mode,
+				mode,
 			});
 		}
 		Ok(secrets)
 	}
 
-	/// Create the union of inline `content:`/`environment:` secrets and configs
-	/// declared across *all* services in the project, once, before the
+	/// Create the union of the `content:`/`environment:`/`file:` secrets and
+	/// configs declared across *all* services in the project, once, before the
 	/// per-level start loop — mirroring how [`Engine::create_networks`] and
 	/// [`Engine::create_volumes`] pre-create their resources.
 	///
@@ -128,8 +105,21 @@ impl Engine {
 	/// created exactly once here (later services share it), and each created
 	/// secret carries the `podup.project=<proj>` label so the label-guarded
 	/// teardown on `down` still only removes secrets podup owns.
-	pub(super) async fn create_inline_secrets(&self, file: &ComposeFile) -> Result<()> {
-		for (name, bytes) in collect_inline_union(&self.project, file)? {
+	pub(super) async fn create_project_secrets(&self, file: &ComposeFile) -> Result<()> {
+		for (name, payload) in collect_payload_union(&self.project, file, &self.base_dir)? {
+			let bytes = match payload {
+				Payload::Inline(bytes) => bytes,
+				// Read here rather than in the planner, which stays free of I/O so
+				// the compose→plan mapping remains unit-testable. The cap is the
+				// same bounded read the compose-adjacent files get; Podman's own
+				// 512 kB secret limit is enforced right after, in `create_secret`.
+				Payload::File(path) => crate::filesystem::read_capped(&path).map_err(|e| {
+					ComposeError::Unsupported(format!(
+						"secret/config source {} could not be read: {e}",
+						path.display()
+					))
+				})?,
+			};
 			self.create_secret(&name, &bytes).await?;
 		}
 		Ok(())
@@ -192,28 +182,30 @@ impl Engine {
 			.map_err(ComposeError::Podman)
 	}
 
-	/// Remove the project-scoped native secrets created on `up` for inline
-	/// `content:`/`environment:` secrets and configs, mirroring the volume and
-	/// network teardown on `down`. `external:` and `file:` references own no
-	/// podup-created secret and are left untouched; a missing secret is ignored
-	/// (`delete_ok` swallows a 404). Best-effort: a delete failure is logged, not
-	/// fatal, so the rest of teardown proceeds.
+	/// Remove the project-scoped native secrets created on `up` for the
+	/// `content:`/`environment:`/`file:` secrets and configs, mirroring the volume
+	/// and network teardown on `down`. `external:` references own no podup-created
+	/// secret and are left untouched; a missing secret is ignored (`delete_ok`
+	/// swallows a 404). Best-effort: a delete failure is logged, not fatal, so the
+	/// rest of teardown proceeds.
 	pub(super) async fn remove_internal_secrets(&self, file: &ComposeFile) -> Result<()> {
 		for (name, def) in &file.secrets {
-			if is_inline_source(
+			if is_podup_created_source(
 				def.external,
 				def.content.as_deref(),
 				def.environment.as_deref(),
+				def.file.as_deref(),
 			) {
 				self.delete_secret(&scoped_name(&self.project, "secret", name))
 					.await;
 			}
 		}
 		for (name, def) in &file.configs {
-			if is_inline_source(
+			if is_podup_created_source(
 				def.external,
 				def.content.as_deref(),
 				def.environment.as_deref(),
+				def.file.as_deref(),
 			) {
 				self.delete_secret(&scoped_name(&self.project, "config", name))
 					.await;
@@ -300,42 +292,24 @@ impl Engine {
 	}
 }
 
-/// Build a `source:target:ro` bind string for a `file:` secret/config, rejecting
-/// a colon in either the resolved host path or the target.
+/// Collect the project's podup-created secret/config payloads, deduplicated by
+/// their scoped Podman secret name.
 ///
-/// The bind string is later split with `splitn(3, ':')`; a stray colon in the
-/// source or target shifts the field boundaries — redirecting the mount
-/// destination, or merging the `:ro` flag into a malformed `rw:ro` token that
-/// silently drops the read-only guarantee. A colon is not meaningful in a
-/// container mount path, so reject it at the boundary instead of mis-parsing.
-fn make_bind(name: &str, resolved: &str, target: &str) -> Result<String> {
-	if resolved.contains(':') {
-		return Err(ComposeError::Unsupported(format!(
-			"secret/config '{name}': host path must not contain a colon: {resolved}"
-		)));
-	}
-	if target.contains(':') {
-		return Err(ComposeError::Unsupported(format!(
-			"secret/config '{name}': mount target must not contain a colon: {target}"
-		)));
-	}
-	Ok(format!("{resolved}:{target}:ro"))
-}
-
-/// Collect the project's inline `content:`/`environment:` secret/config
-/// payloads, deduplicated by their scoped Podman secret name.
-///
-/// The same inline secret referenced by several services resolves to one
-/// project-scoped name, so it is created once and shared. A first writer wins:
-/// every reference to a given name yields the identical payload (the bytes come
-/// from the single compose def), so the dedup is value-stable. No daemon access,
-/// so the union and its dedup are unit-testable.
-fn collect_inline_union(project: &str, file: &ComposeFile) -> Result<HashMap<String, Vec<u8>>> {
-	let mut payloads: HashMap<String, Vec<u8>> = HashMap::new();
+/// The same secret referenced by several services resolves to one project-scoped
+/// name, so it is created once and shared. A first writer wins: every reference
+/// to a given name yields the identical payload (inline bytes and `file:` paths
+/// alike come from the single compose def), so the dedup is value-stable. No
+/// daemon access and no file reads, so the union and its dedup are unit-testable.
+fn collect_payload_union(
+	project: &str,
+	file: &ComposeFile,
+	base_dir: &Path,
+) -> Result<HashMap<String, Payload>> {
+	let mut payloads: HashMap<String, Payload> = HashMap::new();
 	for service in file.services.values() {
-		for plan in collect_native_plans(project, service, file)? {
-			if let Some(bytes) = plan.payload {
-				payloads.entry(plan.source).or_insert(bytes);
+		for plan in collect_native_plans(project, service, file, base_dir)? {
+			if let Some(payload) = plan.payload {
+				payloads.entry(plan.source).or_insert(payload);
 			}
 		}
 	}
@@ -356,19 +330,25 @@ mod tests {
 		)
 	}
 
+	/// The path a `file:` payload will be read from, for the single planned secret.
+	fn only_file_path(engine: &Engine, yaml: &str) -> PathBuf {
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let union = collect_payload_union("proj", &file, &engine.base_dir).unwrap();
+		assert_eq!(union.len(), 1);
+		match union.into_values().next().unwrap() {
+			Payload::File(p) => p,
+			Payload::Inline(_) => panic!("expected a file payload"),
+		}
+	}
+
 	#[test]
 	fn secret_file_relative_path_is_anchored_to_base_dir() {
 		// A relative `file:` resolves against the project dir, not the Podman
-		// service's cwd — same as a bind-mount source.
+		// service's cwd — same as a bind-mount source, which is what this was.
 		let base = PathBuf::from("/srv/project");
 		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: secret.txt\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
 		let engine = engine_with_base(&base.to_string_lossy());
-		let binds = engine
-			.build_secret_binds(&file.services["web"], &file)
-			.unwrap();
-		let expected = format!("{}:/run/secrets/tok:ro", base.join("secret.txt").display());
-		assert_eq!(binds, vec![expected]);
+		assert_eq!(only_file_path(&engine, yaml), base.join("secret.txt"));
 	}
 
 	#[cfg(unix)]
@@ -376,21 +356,10 @@ mod tests {
 	fn config_file_absolute_path_is_passed_through() {
 		// Absolute paths are honored unchanged, exactly as `volumes:` does.
 		let yaml = "services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: /etc/app/cfg.yaml\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
 		let engine = engine_with_base("/srv/project");
-		let binds = engine
-			.build_config_binds(&file.services["web"], &file)
-			.unwrap();
-		assert_eq!(binds, vec!["/etc/app/cfg.yaml:/cfg:ro"]);
-	}
-
-	#[test]
-	fn make_bind_rejects_colon_in_path_or_target() {
-		assert!(make_bind("s", "/host/a:b", "/run/secrets/s").is_err());
-		assert!(make_bind("s", "/host/a", "/run/secrets/s:rw").is_err());
 		assert_eq!(
-			make_bind("s", "/host/a", "/run/secrets/s").unwrap(),
-			"/host/a:/run/secrets/s:ro"
+			only_file_path(&engine, yaml),
+			PathBuf::from("/etc/app/cfg.yaml")
 		);
 	}
 
@@ -401,37 +370,37 @@ mod tests {
 		// service — which is what previously raced delete-then-create.
 		let yaml = "services:\n  a:\n    image: nginx\n    secrets: [tok]\n  b:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    content: shared\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let union = collect_inline_union("proj", &file).unwrap();
+		let union = collect_payload_union("proj", &file, Path::new("/base")).unwrap();
 		assert_eq!(union.len(), 1);
+		assert!(matches!(
+			union.get("proj_secret_tok"),
+			Some(Payload::Inline(b)) if b == b"shared"
+		));
+	}
+
+	#[test]
+	fn payload_union_collects_every_source_podup_creates_but_not_external() {
+		// The union spans secrets and configs across sources (distinct scoped names)
+		// and excludes only `external:`, which podup never creates and must never
+		// remove on `down`.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok, ext, onfile]\n    configs: [cfg]\nsecrets:\n  tok:\n    content: s\n  ext:\n    external: true\n  onfile:\n    file: ./f.txt\nconfigs:\n  cfg:\n    content: c\n";
+		let file = crate::compose::parse_str_raw(yaml).unwrap();
+		let union = collect_payload_union("proj", &file, Path::new("/base")).unwrap();
+		let mut names: Vec<&String> = union.keys().collect();
+		names.sort();
 		assert_eq!(
-			union.get("proj_secret_tok").map(Vec::as_slice),
-			Some(b"shared".as_slice())
+			names,
+			vec!["proj_config_cfg", "proj_secret_onfile", "proj_secret_tok"]
 		);
 	}
 
 	#[test]
-	fn inline_union_collects_secrets_and_configs_skips_external_and_file() {
-		// The union spans inline secrets and inline configs (distinct scoped
-		// names), and excludes `external:` (podup never creates it) and `file:`
-		// (a bind mount) sources.
-		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok, ext, onfile]\n    configs: [cfg]\nsecrets:\n  tok:\n    content: s\n  ext:\n    external: true\n  onfile:\n    file: ./f.txt\nconfigs:\n  cfg:\n    content: c\n";
+	fn external_secret_is_never_in_the_payload_union() {
+		// podup does not create an `external:` secret, so it must never appear in
+		// the union that `up` creates and `down` removes.
+		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    external: true\n";
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let union = collect_inline_union("proj", &file).unwrap();
-		let mut names: Vec<&String> = union.keys().collect();
-		names.sort();
-		assert_eq!(names, vec!["proj_config_cfg", "proj_secret_tok"]);
-	}
-
-	#[test]
-	fn inline_secret_produces_no_bind() {
-		// An inline `content:` secret is injected natively, so it contributes no
-		// bind string — only `file:` secrets do.
-		let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    content: data\n";
-		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		let engine = engine_with_base("/srv/project");
-		let binds = engine
-			.build_secret_binds(&file.services["web"], &file)
-			.unwrap();
-		assert!(binds.is_empty());
+		let union = collect_payload_union("proj", &file, Path::new("/base")).unwrap();
+		assert!(union.is_empty());
 	}
 }

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -2,6 +2,8 @@
 //! plans. No daemon access, so the mapping is unit-testable; the create and
 //! preflight side effects live in [`super`]'s `Engine` impl.
 
+use std::path::{Path, PathBuf};
+
 use crate::compose::types::{ComposeFile, Service, ServiceConfigRef, ServiceSecretRef};
 use crate::error::{ComposeError, Result};
 
@@ -11,25 +13,49 @@ use super::super::staging;
 /// payload must be larger than 0 and strictly smaller than this many bytes.
 pub(super) const MAX_SECRET_BYTES: usize = 512_000;
 
+/// Where the bytes of a podup-created secret come from.
+///
+/// A `file:` source carries the resolved host path rather than its contents:
+/// this module maps compose to plans with no I/O at all, which is what keeps the
+/// mapping unit-testable, so the read happens in the effectful layer that creates
+/// the secret.
+pub(super) enum Payload {
+	/// Inline `content:`/`environment:` — the bytes, already resolved.
+	Inline(Vec<u8>),
+	/// `file:` — the resolved host path to read at creation time.
+	File(PathBuf),
+}
+
 /// A planned native secret for a service: the Podman secret `source` to attach,
-/// the in-container `target`, optional permissions, and — for inline
-/// `content:`/`environment:` sources — the `payload` to create under `source`.
-/// `external: true` references carry no payload (the secret must pre-exist).
+/// the in-container `target`, optional permissions, and — for every source podup
+/// creates itself — the `payload` to create under `source`. `external: true`
+/// references carry no payload (the secret must pre-exist).
 pub(super) struct NativePlan {
 	pub(super) source: String,
 	pub(super) target: String,
 	pub(super) mode: Option<u32>,
 	pub(super) uid: Option<u32>,
 	pub(super) gid: Option<u32>,
-	pub(super) payload: Option<Vec<u8>>,
+	pub(super) payload: Option<Payload>,
+}
+
+/// The fields of a `secrets:`/`configs:` definition that decide where its bytes
+/// come from. A borrowed view, so the two distinct compose types (`SecretConfig`
+/// and `ConfigConfig`) resolve through one function.
+struct SourceDef<'a> {
+	content: Option<&'a str>,
+	environment: Option<&'a str>,
+	file_source: Option<&'a str>,
+	external: bool,
+	external_name: Option<&'a str>,
 }
 
 /// Where a secret/config's bytes come from once the compose def is resolved.
 enum Source {
-	/// `file:` — handled by the bind path, never a native secret.
-	Bind,
 	/// Inline `content:`/`environment:` — `(scoped podman name, payload bytes)`.
 	Inline(String, Vec<u8>),
+	/// `file:` — `(scoped podman name, resolved host path)`.
+	File(String, PathBuf),
 	/// `external: true` — name of the pre-existing podman secret.
 	External(String),
 }
@@ -41,6 +67,7 @@ pub(super) fn collect_native_plans(
 	project: &str,
 	service: &Service,
 	file: &ComposeFile,
+	base_dir: &Path,
 ) -> Result<Vec<NativePlan>> {
 	let mut plans = Vec::new();
 
@@ -51,10 +78,14 @@ pub(super) fn collect_native_plans(
 				project,
 				"secret",
 				&name,
-				def.content.as_deref(),
-				def.environment.as_deref(),
-				def.external == Some(true),
-				def.name.as_deref(),
+				SourceDef {
+					content: def.content.as_deref(),
+					environment: def.environment.as_deref(),
+					file_source: def.file.as_deref(),
+					external: def.external == Some(true),
+					external_name: def.name.as_deref(),
+				},
+				base_dir,
 			)?;
 			// A bare target name lands under /run/secrets/<name>, matching the
 			// bind-mount default and the external-secret behaviour.
@@ -76,10 +107,14 @@ pub(super) fn collect_native_plans(
 				project,
 				"config",
 				&name,
-				def.content.as_deref(),
-				def.environment.as_deref(),
-				def.external == Some(true),
-				def.name.as_deref(),
+				SourceDef {
+					content: def.content.as_deref(),
+					environment: def.environment.as_deref(),
+					file_source: def.file.as_deref(),
+					external: def.external == Some(true),
+					external_name: def.name.as_deref(),
+				},
+				base_dir,
 			)?;
 			// Configs default to an absolute container-root path, matching the
 			// bind-mount config behaviour.
@@ -92,23 +127,30 @@ pub(super) fn collect_native_plans(
 }
 
 /// Resolve a secret/config definition to its native [`Source`]. `external`
-/// wins (it may also carry a custom `name:`); otherwise inline `content:` or
-/// `environment:` become a project-scoped native secret; anything else (a
-/// `file:` source, or an empty def) is left to the bind path.
+/// wins (it may also carry a custom `name:`); every other populated source —
+/// inline `content:`/`environment:` and `file:` alike — becomes a project-scoped
+/// native secret. An empty def yields `None` and contributes no plan.
 fn resolve_source(
 	project: &str,
 	kind: &str,
 	name: &str,
-	content: Option<&str>,
-	environment: Option<&str>,
-	external: bool,
-	external_name: Option<&str>,
-) -> Result<Source> {
+	def: SourceDef<'_>,
+	base_dir: &Path,
+) -> Result<Option<Source>> {
+	let SourceDef {
+		content,
+		environment,
+		file_source,
+		external,
+		external_name,
+	} = def;
 	if external {
-		return Ok(Source::External(external_name.unwrap_or(name).to_string()));
+		return Ok(Some(Source::External(
+			external_name.unwrap_or(name).to_string(),
+		)));
 	}
-	let is_inline = content.is_some() || environment.is_some();
-	if is_inline && !staging::is_safe_project_name(name) {
+	let podup_created = content.is_some() || environment.is_some() || file_source.is_some();
+	if podup_created && !staging::is_safe_project_name(name) {
 		// The name becomes part of the project-scoped Podman secret name and a URL
 		// query parameter, so require a bounded, well-formed identifier rather than
 		// an arbitrary (possibly huge or control-laden) YAML key.
@@ -118,10 +160,10 @@ fn resolve_source(
 		)));
 	}
 	if let Some(content) = content {
-		return Ok(Source::Inline(
+		return Ok(Some(Source::Inline(
 			scoped_name(project, kind, name),
 			content.as_bytes().to_vec(),
-		));
+		)));
 	}
 	if let Some(env_var) = environment {
 		let value = std::env::var(env_var).map_err(|_| {
@@ -129,36 +171,57 @@ fn resolve_source(
 				"{kind} '{name}' references env var '{env_var}' which is not set"
 			))
 		})?;
-		return Ok(Source::Inline(
+		return Ok(Some(Source::Inline(
 			scoped_name(project, kind, name),
 			value.into_bytes(),
-		));
+		)));
 	}
-	Ok(Source::Bind)
+	if let Some(host_path) = file_source {
+		// Resolve like a bind-mount source: a relative `file:` is anchored to the
+		// project dir (not the Podman service's cwd) and `~` is expanded — the same
+		// handling `volumes:` gets, and the same this had when it was a bind.
+		return Ok(Some(Source::File(
+			scoped_name(project, kind, name),
+			PathBuf::from(super::super::container::resolve_bind_source(
+				host_path, base_dir,
+			)),
+		)));
+	}
+	Ok(None)
 }
 
-/// Append a [`NativePlan`] for a resolved source, dropping `file:` sources and
+/// Append a [`NativePlan`] for a resolved source, dropping an empty def and
 /// rejecting a dangerous `mode:` before the spec is built. `uid`/`gid` are
 /// numeric in libpod, so a non-numeric value (a user/group name) is dropped to
 /// the default rather than erroring.
 fn push_plan(
 	plans: &mut Vec<NativePlan>,
-	source: Source,
+	source: Option<Source>,
 	target: String,
 	mode: Option<u32>,
 	uid: Option<String>,
 	gid: Option<String>,
 ) -> Result<()> {
-	let (source, payload) = match source {
-		Source::Bind => return Ok(()),
-		Source::Inline(s, p) => (s, Some(p)),
-		Source::External(s) => (s, None),
+	let (source, payload, from_file) = match source {
+		None => return Ok(()),
+		Some(Source::Inline(s, p)) => (s, Some(Payload::Inline(p)), false),
+		Some(Source::File(s, p)) => (s, Some(Payload::File(p)), true),
+		Some(Source::External(s)) => (s, None, false),
 	};
 	// Default to the Compose Specification's world-readable `0444` when no `mode:`
 	// is given. A Podman-native secret otherwise mounts at `0000`, which a non-root
 	// container user cannot read (only root reads it via DAC override), diverging
 	// from docker-compose where the default is readable.
-	let mode = mode.or(Some(0o444));
+	//
+	// A `file:` source is the exception: it is left unset here so the effectful
+	// layer can mirror the host file's own permission bits. That keeps what the
+	// container sees identical to the bind this used to be — a `0600` secret stays
+	// unreadable to a non-root container user instead of being widened to `0444`.
+	let mode = if from_file {
+		mode
+	} else {
+		mode.or(Some(0o444))
+	};
 	if let Some(m) = mode {
 		staging::reject_dangerous_secret_mode(m, &source)?;
 	}
@@ -191,20 +254,41 @@ pub(super) fn check_secret_size(name: &str, len: usize) -> Result<()> {
 	Ok(())
 }
 
-/// Whether a secret/config def is an inline `content:`/`environment:` source —
-/// i.e. one podup creates as a project-scoped native secret. `external:` wins
-/// (it is never created by podup) and a bare `file:` source is a bind mount.
-pub(super) fn is_inline_source(
+/// Whether a secret/config def is one podup creates as a project-scoped native
+/// secret — inline `content:`/`environment:` or a `file:` source. `external:`
+/// wins and is never created (nor removed) by podup.
+pub(super) fn is_podup_created_source(
 	external: Option<bool>,
 	content: Option<&str>,
 	environment: Option<&str>,
+	file_source: Option<&str>,
 ) -> bool {
-	external != Some(true) && (content.is_some() || environment.is_some())
+	external != Some(true) && (content.is_some() || environment.is_some() || file_source.is_some())
 }
 
-/// `(name, target_override)` for a service secret/config reference.
-pub(super) fn ref_name_target(source: &str, target: Option<&str>) -> (String, Option<String>) {
-	(source.to_string(), target.map(str::to_string))
+/// The permission bits to mount a `file:` secret with when the compose file
+/// names no `mode:` — the host file's own, so the container sees what it saw
+/// when this was a bind mount.
+///
+/// Execute and the special bits are masked off: a secret holds data, never code,
+/// and letting a `0755` host file through would trip the dangerous-mode guard and
+/// fail an `up` that used to work. Unreadable metadata falls back to the Compose
+/// Specification's `0444`; the create call fails right after with a clearer
+/// message than a permissions guess would give.
+pub(super) fn host_file_secret_mode(path: &Path) -> u32 {
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+		match std::fs::metadata(path) {
+			Ok(md) => md.permissions().mode() & 0o666,
+			Err(_) => 0o444,
+		}
+	}
+	#[cfg(not(unix))]
+	{
+		let _ = path;
+		0o444
+	}
 }
 
 /// Decompose a secret reference into `(name, target, mode, uid, gid)`.
@@ -269,14 +353,104 @@ mod tests {
 
 	fn plans(yaml: &str) -> Vec<NativePlan> {
 		let file = crate::compose::parse_str_raw(yaml).unwrap();
-		collect_native_plans("proj", &file.services["web"], &file).unwrap()
+		collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).unwrap()
+	}
+
+	/// The inline bytes of a plan's payload, or `None` for an external/file source.
+	fn inline_bytes(p: &NativePlan) -> Option<&[u8]> {
+		match &p.payload {
+			Some(Payload::Inline(b)) => Some(b),
+			_ => None,
+		}
 	}
 
 	#[test]
-	fn file_secret_is_not_a_native_secret() {
-		// A `file:` secret is a bind mount, never a native secret.
+	fn file_secret_is_a_scoped_native_secret_carrying_its_path() {
+		// A `file:` secret is a project-scoped native secret like any other source.
+		// The plan carries the resolved path, not the bytes: this module does no I/O,
+		// so the read belongs to the layer that creates the secret.
 		let p = plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n");
+		assert_eq!(p.len(), 1);
+		assert_eq!(p[0].source, "proj_secret_tok");
+		assert_eq!(p[0].target, "tok");
+		assert!(
+			matches!(&p[0].payload, Some(Payload::File(path)) if path == Path::new("/base/tok.txt"))
+		);
+	}
+
+	#[test]
+	fn file_secret_leaves_mode_unset_for_the_host_bits() {
+		// With no `mode:` the plan stays unset so the effectful layer can mirror the
+		// host file's own bits, rather than widening a 0600 secret to the 0444 the
+		// other sources default to.
+		let p = plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: ./tok.txt\n");
+		assert_eq!(p[0].mode, None);
+	}
+
+	#[test]
+	fn file_secret_honours_an_explicit_mode() {
+		let p = plans("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 0400\nsecrets:\n  tok:\n    file: ./tok.txt\n");
+		assert_eq!(p[0].mode, Some(0o400));
+	}
+
+	#[test]
+	fn file_config_is_native_with_absolute_default_target() {
+		let p = plans("services:\n  web:\n    image: nginx\n    configs: [cfg]\nconfigs:\n  cfg:\n    file: ./cfg.yaml\n");
+		assert_eq!(p.len(), 1);
+		assert_eq!(p[0].source, "proj_config_cfg");
+		assert_eq!(p[0].target, "/cfg");
+	}
+
+	#[test]
+	fn file_secret_with_unsafe_name_is_rejected() {
+		// The compose key becomes part of a Podman secret name for a `file:` source
+		// too, so it faces the same bound as an inline one.
+		let file = crate::compose::parse_str_raw(
+			"services:\n  web:\n    image: x\n    secrets: ['../evil']\nsecrets:\n  '../evil':\n    file: ./tok.txt\n",
+		)
+		.unwrap();
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
+	}
+
+	#[test]
+	fn empty_def_contributes_no_plan() {
+		// A def with no content:, environment:, file: or external: is not a secret
+		// podup can produce anything for.
+		let p =
+			plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok: {}\n");
 		assert!(p.is_empty());
+	}
+
+	// Unix-only: `PermissionsExt` does not exist on Windows, where a host file has
+	// no mode to mirror and `host_file_secret_mode` returns the 0444 default.
+	#[cfg(unix)]
+	#[test]
+	fn host_file_mode_masks_execute_and_special_bits() {
+		// A secret holds data, never code. Mirroring a 0755 host file verbatim would
+		// trip the dangerous-mode guard and fail an `up` that used to work.
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("s.txt");
+		std::fs::write(&path, b"x").unwrap();
+		for (host, want) in [
+			(0o644, 0o644),
+			(0o600, 0o600),
+			(0o755, 0o644),
+			(0o4700, 0o600),
+		] {
+			use std::os::unix::fs::PermissionsExt;
+			std::fs::set_permissions(&path, std::fs::Permissions::from_mode(host)).unwrap();
+			assert_eq!(host_file_secret_mode(&path), want, "host mode {host:o}");
+		}
+	}
+
+	#[test]
+	fn host_file_mode_of_a_missing_file_falls_back_to_0444() {
+		assert_eq!(
+			host_file_secret_mode(Path::new("/nonexistent/secret")),
+			0o444
+		);
 	}
 
 	#[test]
@@ -287,7 +461,7 @@ mod tests {
 		assert_eq!(p.len(), 1);
 		assert_eq!(p[0].source, "proj_secret_tok");
 		assert_eq!(p[0].target, "tok");
-		assert_eq!(p[0].payload.as_deref(), Some(b"supersecret".as_slice()));
+		assert_eq!(inline_bytes(&p[0]), Some(b"supersecret".as_slice()));
 	}
 
 	#[test]
@@ -297,7 +471,7 @@ mod tests {
 		assert_eq!(p.len(), 1);
 		assert_eq!(p[0].source, "proj_config_cfg");
 		assert_eq!(p[0].target, "/cfg");
-		assert_eq!(p[0].payload.as_deref(), Some(b"key=value".as_slice()));
+		assert_eq!(inline_bytes(&p[0]), Some(b"key=value".as_slice()));
 	}
 
 	#[test]
@@ -306,7 +480,7 @@ mod tests {
 			let p = plans("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    environment: PODUP_TEST_SECRET\n");
 			assert_eq!(p.len(), 1);
 			assert_eq!(p[0].source, "proj_secret_tok");
-			assert_eq!(p[0].payload.as_deref(), Some(b"env-value".as_slice()));
+			assert_eq!(inline_bytes(&p[0]), Some(b"env-value".as_slice()));
 		});
 	}
 
@@ -314,7 +488,10 @@ mod tests {
 	fn env_secret_missing_var_errors() {
 		temp_env::with_var("PODUP_TEST_MISSING", None::<&str>, || {
 			let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    environment: PODUP_TEST_MISSING\n").unwrap();
-			assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+			assert!(
+				collect_native_plans("proj", &file.services["web"], &file, Path::new("/base"))
+					.is_err()
+			);
 		});
 	}
 
@@ -365,28 +542,36 @@ mod tests {
 	fn native_secret_rejects_setuid_mode() {
 		// 0o4000 (= 2048) is setuid; refused before the spec reaches Podman.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 2048\nsecrets:\n  tok:\n    external: true\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
 	fn native_secret_rejects_execute_mode() {
 		// 0o777 (= 511) sets execute bits; a secret holds data, never code.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 511\nsecrets:\n  tok:\n    external: true\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
 	fn native_config_rejects_setgid_mode() {
 		// External configs share the mode guard. 0o2000 (= 1024) is setgid.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    configs:\n      - source: cfg\n        mode: 1024\nconfigs:\n  cfg:\n    external: true\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
 	fn inline_secret_rejects_dangerous_mode() {
 		// The mode guard also covers project-created inline secrets.
 		let file = crate::compose::parse_str_raw("services:\n  web:\n    image: nginx\n    secrets:\n      - source: tok\n        mode: 511\nsecrets:\n  tok:\n    content: data\n").unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
@@ -412,7 +597,9 @@ mod tests {
 			"services:\n  web:\n    image: x\n    secrets: ['../evil']\nsecrets:\n  '../evil':\n    content: data\n",
 		)
 		.unwrap();
-		assert!(collect_native_plans("proj", &file.services["web"], &file).is_err());
+		assert!(
+			collect_native_plans("proj", &file.services["web"], &file, Path::new("/base")).is_err()
+		);
 	}
 
 	#[test]
@@ -433,10 +620,12 @@ mod tests {
 	}
 
 	#[test]
-	fn is_inline_source_classifies_sources() {
-		assert!(is_inline_source(None, Some("x"), None));
-		assert!(is_inline_source(None, None, Some("VAR")));
-		assert!(!is_inline_source(Some(true), Some("x"), None));
-		assert!(!is_inline_source(None, None, None));
+	fn is_podup_created_source_classifies_sources() {
+		assert!(is_podup_created_source(None, Some("x"), None, None));
+		assert!(is_podup_created_source(None, None, Some("VAR"), None));
+		// A `file:` source is created by podup too, so `down` must remove it.
+		assert!(is_podup_created_source(None, None, None, Some("./tok.txt")));
+		assert!(!is_podup_created_source(Some(true), Some("x"), None, None));
+		assert!(!is_podup_created_source(None, None, None, None));
 	}
 }

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -1,9 +1,10 @@
 //! Volume mount helpers.
 //!
-//! [`build_mounts_all`] converts all `volumes:` entries, secret bind-strings,
-//! and config bind-strings into OCI `Mount` entries and `NamedVolume` entries
-//! for the SpecGenerator. Named volumes go in `volumes`; everything else
-//! (bind, tmpfs, npipe, cluster) goes in `mounts`.
+//! [`build_mounts_all`] converts all `volumes:` entries into OCI `Mount` entries
+//! and `NamedVolume` entries for the SpecGenerator. Named volumes go in
+//! `volumes`; everything else (bind, tmpfs, npipe, cluster) goes in `mounts`.
+//! Secrets and configs are not here: every source is a Podman-native secret
+//! attached to the spec, never a mount.
 
 use std::path::Path;
 
@@ -11,10 +12,7 @@ use crate::compose::types::{Service, VolumeMount, VolumeType};
 use crate::libpod::types::container::{Mount, NamedVolume};
 
 mod spec;
-use spec::{
-	access_opts, extend_bind_opts_str, extend_volume_opts_str, parse_bind_string,
-	parse_volume_string,
-};
+use spec::{access_opts, extend_bind_opts_str, extend_volume_opts_str, parse_volume_string};
 
 /// Build all OCI mounts and named volume attachments for a container.
 ///
@@ -24,8 +22,6 @@ use spec::{
 pub(crate) fn build_mounts_all(
 	service: &Service,
 	base_dir: &Path,
-	secret_binds: &[String],
-	config_binds: &[String],
 ) -> (Vec<Mount>, Vec<NamedVolume>) {
 	let mut mounts = Vec::new();
 	let mut named = Vec::new();
@@ -145,13 +141,6 @@ pub(crate) fn build_mounts_all(
 		mounts.push(spec::parse_tmpfs_string(&entry));
 	}
 
-	// Materialised secrets and configs are passed as pre-built bind strings.
-	for bind in secret_binds.iter().chain(config_binds.iter()) {
-		if let Some(m) = parse_bind_string(bind) {
-			mounts.push(m);
-		}
-	}
-
 	(mounts, named)
 }
 
@@ -175,7 +164,7 @@ mod tests {
 	#[test]
 	fn short_form_bind_passthrough() {
 		let svc = svc_with_volumes(vec![VolumeMount::Short("./data:/app/data".into())]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert!(named.is_empty());
 		assert_eq!(mounts[0].mount_type, "bind");
@@ -185,7 +174,7 @@ mod tests {
 	#[test]
 	fn short_form_named_volume() {
 		let svc = svc_with_volumes(vec![VolumeMount::Short("myvolume:/data".into())]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(mounts.is_empty());
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].name, "myvolume");
@@ -204,7 +193,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "bind");
 		assert!(mounts[0].options.contains(&"ro".to_string()));
@@ -227,7 +216,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(mounts[0].options.contains(&"rshared".to_string()));
 	}
 
@@ -246,7 +235,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(mounts.is_empty());
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].name, "myvolume");
@@ -273,7 +262,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(named.len(), 1);
 		assert!(named[0].options.contains(&"noexec".to_string()));
 		assert!(named[0].options.contains(&"nosuid".to_string()));
@@ -298,7 +287,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (_, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (_, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(named.len(), 1);
 		assert_eq!(named[0].sub_path.as_deref(), Some("nested/dir"));
 	}
@@ -317,7 +306,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, Path::new("/base"));
 		assert!(named.is_empty());
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "npipe");
@@ -337,7 +326,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "cluster");
 		assert_eq!(mounts[0].destination, "/data");
@@ -360,21 +349,12 @@ mod tests {
 			}),
 			consistency: None,
 		}]);
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "tmpfs");
 		assert_eq!(mounts[0].destination, "/tmp/cache");
 		assert!(mounts[0].options.iter().any(|o| o.starts_with("size=")));
 		assert!(mounts[0].options.iter().any(|o| o.starts_with("mode=")));
-	}
-
-	#[test]
-	fn secret_binds_appended() {
-		let svc = svc_with_volumes(vec![]);
-		let secret = "/run/secrets/mydb:/run/secrets/mydb:ro".to_string();
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[secret], &[]);
-		assert_eq!(mounts.len(), 1);
-		assert_eq!(mounts[0].destination, "/run/secrets/mydb");
 	}
 
 	#[test]
@@ -395,7 +375,7 @@ mod tests {
 			tmpfs: None,
 			consistency: None,
 		}]);
-		build_mounts_all(&svc, dir.path(), &[], &[]);
+		build_mounts_all(&svc, dir.path());
 		assert!(dir.path().join(rel).exists());
 	}
 
@@ -408,7 +388,7 @@ mod tests {
 		let dir = tempfile::tempdir().unwrap();
 		let rel = "missing-dir";
 		let svc = svc_with_volumes(vec![VolumeMount::Short(format!("./{rel}:/app/data"))]);
-		let (mounts, named) = build_mounts_all(&svc, dir.path(), &[], &[]);
+		let (mounts, named) = build_mounts_all(&svc, dir.path());
 		assert!(named.is_empty());
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "bind");
@@ -425,7 +405,7 @@ mod tests {
 			tmpfs: StringOrList::List(vec!["/tmp".into(), "/run".into()]),
 			..Default::default()
 		};
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 2);
 		assert_eq!(mounts[0].mount_type, "tmpfs");
 		assert_eq!(mounts[0].destination, "/tmp");
@@ -439,7 +419,7 @@ mod tests {
 			tmpfs: StringOrList::Single("/tmp".into()),
 			..Default::default()
 		};
-		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"), &[], &[]);
+		let (mounts, _) = build_mounts_all(&svc, Path::new("/base"));
 		assert_eq!(mounts.len(), 1);
 		assert_eq!(mounts[0].mount_type, "tmpfs");
 		assert_eq!(mounts[0].destination, "/tmp");

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -133,31 +133,6 @@ pub(super) fn parse_tmpfs_string(s: &str) -> Mount {
 	}
 }
 
-/// Parse a pre-built bind string (secret/config) — always produces a bind Mount.
-pub(super) fn parse_bind_string(s: &str) -> Option<Mount> {
-	let parts: Vec<&str> = s.splitn(3, ':').collect();
-	let (src, dst, opts_str) = match parts.len() {
-		1 => (parts[0], parts[0], ""),
-		2 => (parts[0], parts[1], ""),
-		_ => (parts[0], parts[1], parts[2]),
-	};
-	let opts: Vec<String> = opts_str
-		.split(',')
-		.map(|o| o.trim().to_string())
-		.filter(|o| !o.is_empty())
-		.collect();
-	Some(Mount {
-		mount_type: "bind".into(),
-		source: if src.is_empty() {
-			None
-		} else {
-			Some(src.to_string())
-		},
-		destination: dst.to_string(),
-		options: opts,
-	})
-}
-
 pub(super) fn access_opts(read_only: Option<bool>) -> Vec<String> {
 	if read_only.unwrap_or(false) {
 		vec!["ro".into()]

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -344,7 +344,7 @@ impl Engine {
 		.await?;
 		// Inline secrets/configs are materialised up front rather than in the
 		// per-container path; ensure they exist before recreating the container.
-		self.create_inline_secrets(file).await?;
+		self.create_project_secrets(file).await?;
 		let container_name = self.first_replica_name(service_name, service);
 		self.create_and_start(&container_name, service_name, service, file, true)
 			.await

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -113,6 +113,8 @@ mod cli_lifecycle;
 mod create_ls;
 #[path = "engine_integration/lifecycle_output.rs"]
 mod lifecycle_output;
+#[path = "engine_integration/multi_file.rs"]
+mod multi_file;
 #[path = "engine_integration/scale.rs"]
 mod scale;
 #[path = "engine_integration/stats_flags.rs"]

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -88,6 +88,8 @@ mod cp_flags;
 mod exec_flags;
 #[path = "engine_integration/health_targeting.rs"]
 mod health_targeting;
+#[path = "engine_integration/include_extends.rs"]
+mod include_extends;
 #[path = "engine_integration/lifecycle.rs"]
 mod lifecycle;
 #[path = "engine_integration/niche.rs"]

--- a/tests/engine_integration/build_resources.rs
+++ b/tests/engine_integration/build_resources.rs
@@ -23,7 +23,26 @@ async fn file_config_bound() {
 	let file = parse_str(&yaml).unwrap();
 
 	engine.up(&file).await.unwrap();
+	// Read the config from inside the container. Asserting only that `up` and
+	// `down` succeed passes just as happily when the config is missing, empty or
+	// unreadable — the mount is not the effect, the content is.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /filecfg)\" = key=from-file".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"config /filecfg did not carry the file's contents: {read:?}"
+	);
 }
 
 #[test]
@@ -43,7 +62,23 @@ fn env_config_materialized() {
 			.unwrap();
 
 			engine.up(&file).await.unwrap();
+			let read = engine
+				.exec_with_options(
+					&file,
+					"web",
+					vec![
+						"sh".to_string(),
+						"-c".to_string(),
+						"test \"$(cat /envcfg)\" = cfg-from-env".to_string(),
+					],
+					podup::ExecOptions::default(),
+				)
+				.await;
 			engine.down(&file).await.unwrap();
+			assert!(
+				read.is_ok(),
+				"config /envcfg did not carry the environment variable's value: {read:?}"
+			);
 		});
 	});
 }
@@ -265,16 +300,28 @@ async fn secret_long_form_ref() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine
+	// `cat` alone only proves the path exists — it exits 0 on an empty or wrong
+	// file, and says nothing about the `mode:`/`uid:` the compose file asks for.
+	// Check the content and the permissions the long form actually requested.
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/run/secrets/custom_name".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /run/secrets/custom_name)\" = topsecret \
+				 && test \"$(stat -c '%a %u' /run/secrets/custom_name)\" = '400 0'"
+					.to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the long-form secret did not land at the requested target with mode 0400 and uid 0: {read:?}"
+	);
 }
 
 #[tokio::test]
@@ -291,16 +338,23 @@ async fn config_long_form_ref() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/etc/app.conf".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /etc/app.conf)\" = key=value".to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the long-form config did not land at /etc/app.conf with its content: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -127,8 +127,13 @@ async fn engine_images_lists_service_images() {
 // Port
 // ---------------------------------------------------------------------------
 
+/// `Engine::port` returns `Result<()>` and writes the binding to stdout, so this
+/// can only assert that a published port resolves without error. The binding
+/// itself is checked where it is observable, in
+/// `stats_flags::cli_port_prints_the_published_binding` — this test used to be
+/// named for a return value the API does not have.
 #[tokio::test]
-async fn engine_port_returns_binding() {
+async fn engine_port_resolves_a_published_port() {
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,
@@ -196,9 +201,29 @@ async fn engine_cp_to_container_uploads_file() {
 	let src = local_file.to_str().unwrap().to_string();
 	let dst = "web:/tmp".to_string();
 	let result = engine.cp(&file, &src, &dst).await;
+	// `cp` reporting success is not the same as the file arriving — that exact
+	// false success is what #1097 was on Podman 6, where libpod accepted the
+	// archive, closed the connection without a response, and podup called it done.
+	// Read the copy back out of the container before tearing anything down.
+	let landed = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /tmp/testfile.txt)\" = 'hello from host'".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
 
 	result.unwrap();
+	assert!(
+		landed.is_ok(),
+		"cp reported success but /tmp/testfile.txt is missing or has the wrong contents: {landed:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/health_targeting.rs
+++ b/tests/engine_integration/health_targeting.rs
@@ -186,14 +186,33 @@ async fn env_file_loaded() {
 
 	let proj = proj("evf");
 	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
-	// env_file covers container.rs L278 (load_env_file_entries)
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    env_file:\n      - test.env\n",
 	)
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	// The variable has to reach the container's environment. Reaching the line
+	// that loads the file is not the same thing: this test used to note which
+	// source line it covered and then assert nothing, so it would have passed just
+	// as well with `env_file` dropped on the floor.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$MYVAR\" = hello".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"MYVAR from env_file did not reach the container's environment: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/include_extends.rs
+++ b/tests/engine_integration/include_extends.rs
@@ -1,0 +1,169 @@
+//! `include:` and `extends:` run end to end.
+//!
+//! Both are covered thoroughly at the parser level (`tests/parse/include.rs`,
+//! `tests/parse/extends.rs`), which proves the merged model is right. Nothing
+//! proved a project using either actually comes **up** — the 2026-06-25 empirical
+//! sweep listed them among the surfaces it never reached.
+//!
+//! These go through the CLI rather than `Engine`, because the part with no
+//! parser coverage is path resolution against the file doing the including or
+//! extending. #1091 was exactly that shape: a relative `env_file` resolved
+//! against the wrong directory, so the unit that read it was correct and the
+//! container still never started.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// Run the built `podup` against compose file `c` / project `proj`.
+fn podup(c: &str, proj: &str, args: &[&str]) -> std::process::Output {
+	Command::new(bin())
+		.args(["-f", c, "-p", proj])
+		.args(args)
+		.output()
+		.expect("run podup")
+}
+
+/// `sh -c <script>` inside `service`, as an exit-code assertion.
+fn exec_ok(c: &str, proj: &str, service: &str, script: &str) -> bool {
+	podup(c, proj, &["exec", "-T", service, "sh", "-c", script])
+		.status
+		.success()
+}
+
+#[tokio::test]
+async fn include_brings_up_the_included_service() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	// The included file lives in a subdirectory, so its own relative `env_file`
+	// only resolves if paths are anchored to the included file rather than to the
+	// including one.
+	let sub = dir.path().join("parts");
+	fs::create_dir(&sub).unwrap();
+	fs::write(sub.join("db.env"), b"INCLUDED_VAR=from-included-env\n").unwrap();
+	fs::write(
+		sub.join("db.yml"),
+		"services:\n  db:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    env_file:\n      - db.env\n",
+	)
+	.unwrap();
+
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"include:\n  - parts/db.yml\nservices:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	let c = compose.to_str().unwrap();
+	let proj = proj("incl");
+	let up = podup(c, &proj, &["up", "-d"]);
+
+	let db_env = exec_ok(c, &proj, "db", "test \"$INCLUDED_VAR\" = from-included-env");
+	let ps = podup(c, &proj, &["ps"]);
+	let listing = String::from_utf8_lossy(&ps.stdout).to_string();
+	podup(c, &proj, &["down", "-v"]);
+
+	assert!(
+		up.status.success(),
+		"up failed for a project using include: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	assert!(
+		listing.contains("-db-1"),
+		"the included service never started: {listing}"
+	);
+	assert!(
+		db_env,
+		"the included file's relative env_file did not resolve against its own directory"
+	);
+}
+
+#[tokio::test]
+async fn extends_in_the_same_file_carries_the_base_config() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// `child` inherits BASE from the base service and overrides OWN, so a container
+	// that only has one of the two proves the merge is half-applied.
+	fs::write(
+		&compose,
+		"services:\n  base:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    environment:\n      BASE_VAR: from-base\n      OWN_VAR: from-base\n  child:\n    extends:\n      service: base\n    environment:\n      OWN_VAR: from-child\n",
+	)
+	.unwrap();
+
+	let c = compose.to_str().unwrap();
+	let proj = proj("extsame");
+	let up = podup(c, &proj, &["up", "-d"]);
+
+	let merged = exec_ok(
+		c,
+		&proj,
+		"child",
+		"test \"$BASE_VAR\" = from-base && test \"$OWN_VAR\" = from-child",
+	);
+	podup(c, &proj, &["down", "-v"]);
+
+	assert!(
+		up.status.success(),
+		"up failed for a project using extends: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	assert!(
+		merged,
+		"the extending service did not inherit the base environment and override its own key"
+	);
+}
+
+#[tokio::test]
+async fn extends_across_files_anchors_relative_paths_to_the_extended_file() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	// The base lives in a subdirectory and names its env_file relatively. The
+	// compose spec anchors that path to the file the base is defined in, not to
+	// the one extending it — the runtime half of what tests/parse/extends.rs
+	// checks on the parsed model.
+	let sub = dir.path().join("common");
+	fs::create_dir(&sub).unwrap();
+	fs::write(sub.join("base.env"), b"BASE_ENV_VAR=from-base-dir\n").unwrap();
+	fs::write(
+		sub.join("base.yml"),
+		"services:\n  app:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    env_file:\n      - base.env\n",
+	)
+	.unwrap();
+
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    extends:\n      file: common/base.yml\n      service: app\n    environment:\n      LOCAL_VAR: from-child\n",
+	)
+	.unwrap();
+
+	let c = compose.to_str().unwrap();
+	let proj = proj("extfile");
+	let up = podup(c, &proj, &["up", "-d"]);
+
+	let merged = exec_ok(
+		c,
+		&proj,
+		"web",
+		"test \"$BASE_ENV_VAR\" = from-base-dir && test \"$LOCAL_VAR\" = from-child",
+	);
+	podup(c, &proj, &["down", "-v"]);
+
+	assert!(
+		up.status.success(),
+		"up failed for extends across files: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	assert!(
+		merged,
+		"the extended file's relative env_file did not resolve against its own directory"
+	);
+}

--- a/tests/engine_integration/multi_file.rs
+++ b/tests/engine_integration/multi_file.rs
@@ -1,0 +1,204 @@
+//! Merge semantics across several `-f` files, measured against docker compose.
+//!
+//! #1078 landed the merge rules and was closed while three of its cases stayed
+//! unverified: same-target `volumes` dedup, `!override` and `!reset`. All three
+//! turn out to be implemented — measured here against docker compose v5.1.3 on
+//! the same inputs — but nothing pinned them, so a regression would have been
+//! silent. That is what these are for.
+//!
+//! They drive the CLI because multi-`-f` merging and project-directory anchoring
+//! only exist there; `parse_str` takes a single document.
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// Write `contents` to `dir/name`, creating parent directories.
+fn write(dir: &Path, name: &str, contents: &str) {
+	let path = dir.join(name);
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent).unwrap();
+	}
+	fs::write(path, contents).unwrap();
+}
+
+/// `podup -f <files…> -p <proj> <args…>`.
+fn podup(dir: &Path, files: &[&str], proj: &str, args: &[&str]) -> std::process::Output {
+	let mut cmd = Command::new(bin());
+	for f in files {
+		cmd.arg("-f").arg(dir.join(f));
+	}
+	cmd.args(["-p", proj]).args(args);
+	cmd.output().expect("run podup")
+}
+
+/// The rendered `config` for a multi-file project.
+fn config(dir: &Path, files: &[&str], proj: &str) -> String {
+	let out = podup(dir, files, proj, &["config"]);
+	assert!(
+		out.status.success(),
+		"config failed: {}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+	String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn same_target_volume_is_replaced_not_duplicated() {
+	// docker compose v5.1.3 on these exact files keeps only `volb:/data`. Appending
+	// instead would hand Podman two mounts on one mount point.
+	let dir = tempdir().unwrap();
+	write(
+		dir.path(),
+		"a.yml",
+		"services:\n  web:\n    image: alpine:latest\n    volumes:\n      - vola:/data\nvolumes:\n  vola:\n  volb:\n",
+	);
+	write(
+		dir.path(),
+		"b.yml",
+		"services:\n  web:\n    volumes:\n      - volb:/data\n",
+	);
+
+	let rendered = config(dir.path(), &["a.yml", "b.yml"], &proj("mfvol"));
+	assert!(
+		rendered.contains("volb:/data"),
+		"the overriding volume is missing: {rendered}"
+	);
+	assert!(
+		!rendered.contains("vola:/data"),
+		"both volumes survived on the same target: {rendered}"
+	);
+}
+
+#[test]
+fn volumes_on_different_targets_are_both_kept() {
+	// The other half of the same rule, and the one that tells a real merge from a
+	// wholesale replacement of the list — which would pass the test above too.
+	let dir = tempdir().unwrap();
+	write(
+		dir.path(),
+		"a.yml",
+		"services:\n  web:\n    image: alpine:latest\n    volumes:\n      - vola:/data\nvolumes:\n  vola:\n  volb:\n",
+	);
+	write(
+		dir.path(),
+		"b.yml",
+		"services:\n  web:\n    volumes:\n      - volb:/other\n",
+	);
+
+	let rendered = config(dir.path(), &["a.yml", "b.yml"], &proj("mfvol2"));
+	assert!(
+		rendered.contains("vola:/data") && rendered.contains("volb:/other"),
+		"a distinct target was dropped, so the list was replaced rather than merged: {rendered}"
+	);
+}
+
+#[test]
+fn override_tag_replaces_the_whole_mapping() {
+	// `!override` discards the base's keys instead of merging them.
+	let dir = tempdir().unwrap();
+	write(
+		dir.path(),
+		"a.yml",
+		"services:\n  web:\n    image: alpine:latest\n    environment:\n      A: from-a\n      B: from-a\n",
+	);
+	write(
+		dir.path(),
+		"b.yml",
+		"services:\n  web:\n    environment: !override\n      C: from-b\n",
+	);
+
+	let rendered = config(dir.path(), &["a.yml", "b.yml"], &proj("mfovr"));
+	assert!(
+		rendered.contains("from-b"),
+		"the overriding value is missing: {rendered}"
+	);
+	assert!(
+		!rendered.contains("from-a"),
+		"!override merged instead of replacing: {rendered}"
+	);
+}
+
+#[test]
+fn reset_tag_removes_the_key() {
+	// `!reset null` drops the base's value entirely rather than leaving it or
+	// rendering an empty one.
+	let dir = tempdir().unwrap();
+	write(
+		dir.path(),
+		"a.yml",
+		"services:\n  web:\n    image: alpine:latest\n    environment:\n      A: from-a\n",
+	);
+	write(
+		dir.path(),
+		"b.yml",
+		"services:\n  web:\n    environment: !reset null\n",
+	);
+
+	let rendered = config(dir.path(), &["a.yml", "b.yml"], &proj("mfrst"));
+	assert!(
+		!rendered.contains("from-a"),
+		"!reset left the base value in place: {rendered}"
+	);
+	assert!(
+		!rendered.contains("environment:"),
+		"!reset left an empty environment behind: {rendered}"
+	);
+}
+
+#[tokio::test]
+async fn relative_paths_anchor_to_the_first_file_not_each_file() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	// The compose spec anchors a relative path to the *project* directory — the
+	// first `-f`'s directory — not to the file the key was written in. Both
+	// directories hold a `shared.env`, so reading the wrong one is visible rather
+	// than merely absent, and docker compose v5.1.3 resolves this pair to the
+	// root's file.
+	//
+	// `config` cannot answer this: podup renders `env_file` unresolved rather than
+	// materialising it into `environment` the way docker does. So this asks the
+	// running container, which is the behaviour that matters anyway.
+	let dir = tempdir().unwrap();
+	write(dir.path(), "shared.env", "WHICH=root-dir\n");
+	write(dir.path(), "sub/shared.env", "WHICH=sub-dir\n");
+	write(
+		dir.path(),
+		"a.yml",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	);
+	write(
+		dir.path(),
+		"sub/b.yml",
+		"services:\n  web:\n    env_file:\n      - shared.env\n",
+	);
+
+	let files = ["a.yml", "sub/b.yml"];
+	let project = proj("mfanch");
+	podup(dir.path(), &files, &project, &["up", "-d"]);
+	let anchored = podup(
+		dir.path(),
+		&files,
+		&project,
+		&[
+			"exec",
+			"-T",
+			"web",
+			"sh",
+			"-c",
+			"test \"$WHICH\" = root-dir",
+		],
+	)
+	.status
+	.success();
+	podup(dir.path(), &files, &project, &["down", "-v"]);
+
+	assert!(
+		anchored,
+		"a relative env_file declared in sub/b.yml resolved against its own directory \
+		 instead of the project directory"
+	);
+}

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -36,17 +36,25 @@ async fn inline_secret_materialized() {
 
 	engine.up(&file).await.unwrap();
 	// Inline content is created as a Podman-native secret and mounted at the
-	// usual /run/secrets/<name> path — verify by exec-ing a read.
-	engine
+	// usual /run/secrets/<name> path. `cat` alone only proves the path exists —
+	// it exits 0 on an empty file too — so compare the bytes.
+	let read = engine
 		.exec_with_options(
 			&file,
 			"web",
-			vec!["cat".to_string(), "/run/secrets/mysecret".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /run/secrets/mysecret)\" = supersecret".to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
-		.await
-		.unwrap();
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the inline secret did not reach /run/secrets/mysecret with its content: {read:?}"
+	);
 }
 
 #[tokio::test]
@@ -113,7 +121,25 @@ fn env_secret_materialized() {
 			.unwrap();
 
 			engine.up(&file).await.unwrap();
+			// The point of an `environment:` source is that the variable's value
+			// becomes the secret. Starting the container proves neither half.
+			let read = engine
+				.exec_with_options(
+					&file,
+					"web",
+					vec![
+						"sh".to_string(),
+						"-c".to_string(),
+						"test \"$(cat /run/secrets/envsecret)\" = env-secret-value".to_string(),
+					],
+					podup::ExecOptions::default(),
+				)
+				.await;
 			engine.down(&file).await.unwrap();
+			assert!(
+				read.is_ok(),
+				"the env-sourced secret did not carry the variable's value: {read:?}"
+			);
 		});
 	});
 }
@@ -126,18 +152,23 @@ async fn invalid_secret_name_rejected() {
 	};
 	let proj = proj("isec");
 	let engine = Engine::new(client, proj.clone());
-	// Secret name with path traversal
+	// A traversal name must be refused: it would otherwise become part of a
+	// project-scoped Podman secret name and a URL query parameter.
+	//
+	// This test used to declare a perfectly ordinary secret called `evils`, discard
+	// both results with `let _ =`, and say in a comment that it could not test the
+	// thing its name promises. It asserted nothing at all, in either direction.
 	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - evils\nsecrets:\n  evils:\n    content: bad\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    secrets:\n      - '../evil'\nsecrets:\n  '../evil':\n    content: bad\n",
+	)
+	.unwrap();
+
+	let result = engine.up(&file).await;
+	let _ = engine.down(&file).await;
+	assert!(
+		result.is_err(),
+		"a secret named '../evil' was accepted instead of being rejected"
 	);
-	// Parse succeeds; but engine should reject the traversal during up()
-	// We can't actually test a ".." name since parse_str would accept it.
-	// Instead, verify that a normal name works (already covered by inline_secret test).
-	// This test exercises the path-validation code via a valid name edge case.
-	if let Ok(f) = file {
-		let _ = engine.up(&f).await;
-		let _ = engine.down(&f).await;
-	}
 }
 
 #[tokio::test]
@@ -154,7 +185,26 @@ async fn inline_config_materialized() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	// A config defaults to an absolute container-root path, unlike a secret's
+	// /run/secrets/<name> — so this also pins the default target, not just the
+	// content.
+	let read = engine
+		.exec_with_options(
+			&file,
+			"web",
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"test \"$(cat /mycfg)\" = key=value".to_string(),
+			],
+			podup::ExecOptions::default(),
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the inline config did not reach /mycfg with its content: {read:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -68,7 +68,32 @@ async fn file_secret_bound() {
 	let file = parse_str(&yaml).unwrap();
 
 	engine.up(&file).await.unwrap();
+	// The container must READ the secret, not merely be started with it attached.
+	// Asserting only that `up` and `down` succeed is what let a `file:` secret stay
+	// unreadable on every SELinux-enforcing host for the life of the feature: the
+	// mount was there, at the right path, with the right bytes behind it, and the
+	// container was denied the open. `run` propagates the command's exit code, so
+	// the read is checked without a sleep standing in for synchronisation.
+	let read = engine
+		.run(
+			&file,
+			"web",
+			podup::RunOptions {
+				cmd: vec![
+					"sh".to_string(),
+					"-c".to_string(),
+					"test \"$(cat /run/secrets/filesecret)\" = file-secret-content".to_string(),
+				],
+				rm: true,
+				..Default::default()
+			},
+		)
+		.await;
 	engine.down(&file).await.unwrap();
+	assert!(
+		read.is_ok(),
+		"the container could not read /run/secrets/filesecret: {read:?}"
+	);
 }
 
 #[test]

--- a/tests/engine_integration/run_flags.rs
+++ b/tests/engine_integration/run_flags.rs
@@ -52,7 +52,14 @@ async fn engine_run_applies_volume_publish_and_interactive() {
 	};
 	let dir = tempfile::tempdir().unwrap();
 	fs::write(dir.path().join("marker.txt"), b"present").unwrap();
-	let mount = format!("{}:/mnt/in:ro", dir.path().to_str().unwrap());
+	// `z` relabels the host directory so a confined container can read it. Without
+	// it this test fails on every SELinux-enforcing host — measured on Fedora 44 +
+	// Podman 5.8.1, where a `user_tmp_t` file bound read-only gives the container
+	// `cat: can't open '/mnt/in/marker.txt': Permission denied`. Plain `podman run`
+	// behaves identically, so the denial was never podup's; the mount just needed
+	// the relabel a user on such a host writes too. Where SELinux is off the option
+	// is a no-op, so the same spec covers both.
+	let mount = format!("{}:/mnt/in:ro,z", dir.path().to_str().unwrap());
 
 	let proj = proj("rvp");
 	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides {

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -198,3 +198,44 @@ async fn cli_port_without_a_binding_exits_nonzero() {
 
 	run(&["down", "-v"]);
 }
+
+/// The published-port case, which only the CLI can check: `Engine::port` returns
+/// `Result<()>` and writes the binding to stdout, so the engine-level test can
+/// assert nothing about the binding its own name promises.
+#[tokio::test]
+async fn cli_port_prints_the_published_binding() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-prtb", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:18081:80\"\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+	let run = |args: &[&str]| {
+		Command::new(bin())
+			.args(["-f", c, "-p", &proj])
+			.args(args)
+			.output()
+			.expect("run podup")
+	};
+	run(&["up", "-d"]);
+
+	let out = run(&["port", "web", "80"]);
+	let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+	let status = out.status;
+	run(&["down", "-v"]);
+
+	assert!(
+		status.success(),
+		"port failed for a published port: {stdout:?}"
+	);
+	assert!(
+		stdout.contains("127.0.0.1:18081"),
+		"port did not print the host binding it was asked for: {stdout:?}"
+	);
+}

--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -175,6 +175,118 @@ async fn watch_sync_creates_missing_target_directory() {
 	);
 }
 
+/// `rebuild` was the one watch action with no coverage at all, and it is the
+/// only one that goes all the way back through `build` and container recreation
+/// rather than touching a running container. It reads its trigger file into the
+/// image, so a rebuild that silently did nothing — or that rebuilt the image and
+/// left the old container running — is visible as stale content.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watch_rebuild_recreates_the_container_from_the_new_image() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	fs::write(dir.path().join("app.txt"), b"v1").unwrap();
+	fs::write(
+		dir.path().join("Dockerfile"),
+		b"FROM alpine:latest\nCOPY app.txt /app.txt\nCMD [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	let proj = proj("wrb");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let file = parse_str(
+		"services:\n  web:\n    build: .\n    develop:\n      watch:\n        - path: app.txt\n          action: rebuild\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web-1");
+	// The image really did carry v1 before the change, so a stale read later means
+	// the rebuild did not happen rather than the fixture never being right.
+	let before = poll_synced(&engine, &cname, "/app.txt", "v1", 30).await;
+
+	let client2 = podup::podman::connect_from_env()
+		.or_else(|_| podup::podman::connect(None))
+		.unwrap();
+	let engine2 = Engine::with_base_dir(client2, proj.clone(), dir.path().to_path_buf());
+	let file2 = file.clone();
+	let handle = tokio::spawn(async move { engine2.watch(&file2).await });
+
+	// Give the watcher a moment to register before changing the file, then poll
+	// for the effect rather than assuming a fixed rebuild duration.
+	tokio::time::sleep(Duration::from_secs(2)).await;
+	fs::write(dir.path().join("app.txt"), b"v2").unwrap();
+	let rebuilt = poll_synced(&engine, &cname, "/app.txt", "v2", 120).await;
+
+	handle.abort();
+	let containers = engine
+		.test_project_container_names()
+		.await
+		.unwrap_or_default();
+	engine.down(&file).await.unwrap();
+
+	assert!(before, "the image did not carry v1 before the change");
+	assert!(
+		rebuilt,
+		"the container still serves the old image, so rebuild did not recreate it"
+	);
+	assert_eq!(
+		containers.len(),
+		1,
+		"rebuild left the previous container behind: {containers:?}"
+	);
+}
+
+/// `sync+restart` is two effects in one action, and a test that only checks the
+/// file arrived would pass with the restart half missing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watch_sync_and_restart_does_both() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	fs::write(dir.path().join("app.txt"), b"synced-value").unwrap();
+
+	let proj = proj("wsr");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	// The command appends one line per start. A restart re-runs it against the
+	// same (persisting) filesystem, so the line count is a container-scoped
+	// counter of how many times the process was started — unlike /proc/uptime,
+	// which is not namespaced and would report the host's.
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo start >> /starts; sleep infinity\"]\n    develop:\n      watch:\n        - path: app.txt\n          action: sync+restart\n          target: /tmp/app.txt\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web-1");
+
+	let client2 = podup::podman::connect_from_env()
+		.or_else(|_| podup::podman::connect(None))
+		.unwrap();
+	let engine2 = Engine::with_base_dir(client2, proj.clone(), dir.path().to_path_buf());
+	let file2 = file.clone();
+	let handle = tokio::spawn(async move { engine2.watch(&file2).await });
+
+	tokio::time::sleep(Duration::from_secs(2)).await;
+	fs::write(dir.path().join("app.txt"), b"changed-value").unwrap();
+	let synced = poll_synced(&engine, &cname, "/tmp/app.txt", "changed-value", 60).await;
+
+	// Poll for the second start line rather than sleeping and hoping.
+	let restarted = poll_synced(&engine, &cname, "/starts", "start\nstart", 60).await;
+
+	handle.abort();
+	engine.down(&file).await.unwrap();
+	assert!(synced, "sync+restart did not copy the file");
+	assert!(
+		restarted,
+		"sync+restart copied the file but never restarted the container"
+	);
+}
+
 /// Poll until `cat`-ing `path` in the container yields `expect`, or `secs`
 /// elapse. Read-only: used when the trigger already happened (initial_sync).
 async fn poll_synced(engine: &Engine, cname: &str, path: &str, expect: &str, secs: u64) -> bool {


### PR DESCRIPTION
Bringing develop to main so the license and the Dependabot config are the ones on the default branch. **No tag, no release** — this is a branch sync, and nothing here publishes on a push to main.

Dependabot reads its config from the **default branch** and only re-registers when that file changes there, so while main carries the old copy this repository keeps getting no update pull requests at all.

This carries more than the two config changes, because develop has been ahead for a while. Everything in it is already reviewed and merged:

- ci: label Dependabot pull requests with the org taxonomy (#1187)
- test: pin the multi-file merge rules against docker compose (#1185)
- test: assert the effect, not just the absence of an error (#1183)
- fix: read a file: secret into a native secret so it works on SELinux hosts (#1178)
- ci: the .github pins point at a released tag, not a candidate (#1182)
- ci: adopt the .github reusables at the v1.10.1 candidate (#1179)
- test: relabel the bind in the run volume test so it passes on SELinux hosts (#1176)
- ci: cap podman-lane integration concurrency to cut nested-virt flakes (#1173)