### PR TITLE
fix: config folds env_file into environment instead of leaving it unresolved

### DIFF
--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -96,6 +96,52 @@ pub fn merge_env(
 		.collect()
 }
 
+/// Fold every service's `env_file:` into its `environment:` and drop the key.
+///
+/// `config` is meant to render the canonical, fully-resolved model, and docker
+/// compose materialises `env_file` there. Leaving it unresolved meant a service
+/// that takes its whole environment from a file rendered with no `environment:`
+/// at all — so the one command you reach for to ask "what will this actually run"
+/// pointed away from the answer rather than merely omitting it (#1184).
+///
+/// Precedence is the same as at run time: `environment:` wins over `env_file:`,
+/// and a later file wins over an earlier one. Keys are emitted sorted so the
+/// output is stable across runs rather than following a hash map's order.
+///
+/// A bare `KEY` (inherit from the host) stays valueless, rendering as `KEY: null`
+/// the way the parser accepts it back.
+pub fn materialize_env_files(
+	file: &mut crate::compose::types::ComposeFile,
+	base_dir: &Path,
+) -> Result<()> {
+	for service in file.services.values_mut() {
+		let entries = service.env_file.to_entries();
+		if entries.is_empty() {
+			continue;
+		}
+		let from_files = load_env_file_entries(&entries, base_dir)?;
+		let mut merged = service.environment.to_map();
+		for (k, v) in from_files {
+			merged.entry(k).or_insert(Some(v));
+		}
+		let mut keys: Vec<String> = merged.keys().cloned().collect();
+		keys.sort();
+		let map = keys
+			.into_iter()
+			.map(|k| {
+				let value = merged
+					.get(&k)
+					.and_then(|v| v.clone())
+					.map(serde_yaml::Value::String);
+				(k, value)
+			})
+			.collect();
+		service.environment = crate::compose::types::EnvVars::Map(map);
+		service.env_file = crate::compose::types::EnvFile::Empty;
+	}
+	Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
@@ -260,5 +306,112 @@ mod tests {
 			[("PASSTHROUGH".to_string(), None)].into();
 		let result = merge_env(service_env, HashMap::new());
 		assert!(result.iter().any(|s| s == "PASSTHROUGH"));
+	}
+
+	// materialize_env_files (#1184)
+
+	/// Parse `yaml`, materialise its env files against `dir`, and return the
+	/// service's rendered `environment` map.
+	fn materialised(
+		dir: &std::path::Path,
+		yaml: &str,
+	) -> indexmap::IndexMap<String, Option<serde_yaml::Value>> {
+		let mut file = crate::compose::parse_str_raw(yaml).unwrap();
+		materialize_env_files(&mut file, dir).unwrap();
+		let service = &file.services["web"];
+		assert!(
+			matches!(service.env_file, crate::compose::types::EnvFile::Empty),
+			"env_file must be dropped once it has been folded in"
+		);
+		match &service.environment {
+			crate::compose::types::EnvVars::Map(m) => m.clone(),
+			other => panic!("expected a map, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn env_file_is_folded_into_environment() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"FROM_FILE=yes\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    env_file:\n      - a.env\n",
+		);
+		assert_eq!(
+			vars.get("FROM_FILE"),
+			Some(&Some(serde_yaml::Value::String("yes".into())))
+		);
+	}
+
+	#[test]
+	fn environment_wins_over_env_file() {
+		// The run-time precedence, kept in the rendered model: a key set in both
+		// places must render with the value the container would actually see.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"SHARED=from-file\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    environment:\n      SHARED: from-service\n    env_file:\n      - a.env\n",
+		);
+		assert_eq!(
+			vars.get("SHARED"),
+			Some(&Some(serde_yaml::Value::String("from-service".into())))
+		);
+	}
+
+	#[test]
+	fn a_later_env_file_wins_over_an_earlier_one() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"K=first\n").unwrap();
+		std::fs::write(dir.path().join("b.env"), b"K=second\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    env_file:\n      - a.env\n      - b.env\n",
+		);
+		assert_eq!(
+			vars.get("K"),
+			Some(&Some(serde_yaml::Value::String("second".into())))
+		);
+	}
+
+	#[test]
+	fn a_bare_key_stays_valueless() {
+		// `KEY` with no value inherits from the host. Rendering it as an empty
+		// string instead would change what the model means.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"OTHER=1\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    environment:\n      - PASSTHROUGH\n    env_file:\n      - a.env\n",
+		);
+		assert_eq!(vars.get("PASSTHROUGH"), Some(&None));
+	}
+
+	#[test]
+	fn keys_are_sorted_so_the_render_is_stable() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"ZED=1\nALPHA=2\nMID=3\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    env_file:\n      - a.env\n",
+		);
+		let keys: Vec<&String> = vars.keys().collect();
+		assert_eq!(keys, vec!["ALPHA", "MID", "ZED"]);
+	}
+
+	#[test]
+	fn a_service_without_env_file_is_left_alone() {
+		let dir = tempfile::tempdir().unwrap();
+		let mut file = crate::compose::parse_str_raw(
+			"services:\n  web:\n    image: x\n    environment:\n      A: 1\n",
+		)
+		.unwrap();
+		let before = format!("{:?}", file.services["web"].environment);
+		materialize_env_files(&mut file, dir.path()).unwrap();
+		assert_eq!(
+			before,
+			format!("{:?}", file.services["web"].environment),
+			"a service with no env_file must not be rewritten"
+		);
 	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -452,6 +452,12 @@ async fn run() -> podup::Result<()> {
 		};
 		// Honor active profiles so `config` prints the same services `up` starts.
 		podup::retain_active_profiles(&mut resolved, &cli.profile);
+		// Fold `env_file:` into `environment:` the way docker compose does, so a
+		// service whose whole environment comes from a file does not render with no
+		// environment at all (#1184). `config` is the command you reach for to ask
+		// what will actually run; leaving the key unresolved pointed away from the
+		// answer rather than merely omitting it.
+		podup::env_file::materialize_env_files(&mut resolved, &base_dir)?;
 		// Render the resolved project name (already settled above from -p /
 		// COMPOSE_PROJECT_NAME, the top-level `name:`, then the directory
 		// basename), like `docker compose config`, rather than echoing the file's

--- a/tests/engine_integration/cli_flags.rs
+++ b/tests/engine_integration/cli_flags.rs
@@ -490,3 +490,39 @@ async fn cli_config_resolve_image_digests_pins_digest() {
 		"image must be pinned to a registry digest, got: {yaml}"
 	);
 }
+
+/// #1184: `config` left `env_file` unresolved, so a service taking its whole
+/// environment from a file rendered with no `environment:` at all — the one
+/// command you use to ask what will actually run pointed away from the answer.
+/// docker compose materialises it and drops the key; measured against
+/// docker compose v5.1.3 on this exact input.
+#[test]
+fn cli_config_materialises_env_file_into_environment() {
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-cfgenv", std::process::id());
+	fs::write(dir.path().join("app.env"), "FROM_FILE=resolved\n").unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    environment:\n      SHARED: from-service\n    env_file:\n      - app.env\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let out = run(&["-f", c, "-p", &proj, "config"]);
+	assert!(out.status.success(), "config failed: {:?}", out.stderr);
+	let yaml = String::from_utf8_lossy(&out.stdout);
+
+	assert!(
+		yaml.contains("FROM_FILE: resolved"),
+		"the env_file value was not folded into environment: {yaml}"
+	);
+	assert!(
+		!yaml.contains("env_file"),
+		"env_file must be dropped once it has been resolved, like docker compose: {yaml}"
+	);
+	assert!(
+		yaml.contains("SHARED: from-service"),
+		"a key set in both places must render the value the container would see: {yaml}"
+	);
+}


### PR DESCRIPTION
`config` renders the canonical, fully-resolved model, and ours left `env_file`
alone — so a service taking its whole environment from a file rendered with no
`environment:` at all.

Before, on the same project docker compose v5.1.3 renders with
`environment: {SOLO: un-fichero}`:

```yaml
    image: alpine:latest
    command:
    - sleep
    - infinity
    env_file:
    - .env.app
```

After:

```yaml
    image: alpine:latest
    command:
    - sleep
    - infinity
    environment:
      SOLO: un-fichero
```

## Why this was worth fixing rather than documenting

`config` is the command you reach for to ask what podup is actually going to run.
Someone debugging a variable that is not reaching their container looks there,
sees a service with no environment, and concludes the `env_file` was never picked
up — when it was. The output pointed away from the truth rather than merely
omitting it. It also breaks anything consuming the rendered model, since the
environment a downstream tool would read was simply absent.

The runtime was never wrong. The variables reach the container, and a relative
path still anchors to the project directory across several `-f` — both measured.

## Details worth review

- `materialize_env_files` lives in the **library**, not in `startup`, so
  `cargo test --lib` covers it. A module of the binary only runs its tests under
  `--bins`, which is how a test can look present and never execute.
- Precedence matches run time: `environment:` beats `env_file:`, a later file
  beats an earlier one, and a bare `KEY` stays valueless so it still means
  "inherit from the host" rather than "set to empty".
- Keys are sorted, so the render is stable across runs instead of following a
  hash map's iteration order.
- `env_file` is dropped once folded in, which is what docker does. Keeping both
  would be more informative but is not what the reference emits, and `config`
  output is the surface people diff between the two tools.

## Test plan

- Six library unit tests: folding, `environment` winning, later-file-wins, the
  bare-key case, sorted keys, and a service without `env_file` left untouched.
- One CLI test asserting the rendered output, **verified by disabling the call
  and watching it go red**:

  ```
  test cli_flags::cli_config_materialises_env_file_into_environment ... FAILED
  the env_file value was not folded into environment: name: t1455734-cfgenv
  ```

- `config` output still parses back through `podup -f -`, so the round-trip the
  renderer is written to preserve still holds.
- 1336 library tests, the parse and env_file suites, `cargo fmt --check` and
  `clippy --all-targets` all clean.

Closes #1184
