### PR TITLE
chore: bump to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.0.2"
+version = "3.1.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.0.2"
+version = "3.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,41 @@
+podup (3.1.0) unstable; urgency=medium
+
+  Changed
+
+  * A `file:` secret or config is read at `up` and injected as a
+    Podman-native secret instead of being bind-mounted from the host path.
+    On a host with SELinux enforcing the bind was denied outright, so the
+    container could not read its own secret while `up` still reported it
+    started; Fedora, RHEL and CentOS Stream are all enforcing by default.
+    Nothing on the host is mounted, relabelled or modified now. What the
+    container sees is unchanged: with no `mode:` the secret carries the
+    host file's own permission bits, so 0644 stays 0644 and 0600 stays
+    unreadable to a non-root container user. Note the trade: the payload
+    is a copy taken at `up`, so editing the host file afterwards no longer
+    reaches an already-running container — recreate it to pick up a new
+    value. An atomic replace never did reach one, since a file bind pins
+    the inode.
+
+  Fixes
+
+  * `config` folds `env_file` into `environment:` and drops the key, the
+    way docker compose renders it. A service taking its whole environment
+    from a file used to render with no `environment:` at all, so the one
+    command you use to ask what will actually run pointed away from the
+    answer. Precedence is unchanged: `environment:` wins over `env_file:`,
+    a later file wins over an earlier one, and a bare `KEY` stays
+    valueless.
+
+  Tests
+
+  * The secrets, configs, `env_file`, `cp`, `port`, `include`/`extends`,
+    multi-`-f` and `watch` integration tests assert the observable effect
+    rather than only that nothing errored; `include`/`extends`, multi-file
+    merge and the `rebuild` and `sync+restart` watch actions are covered
+    for the first time.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 26 Jul 2026 13:50:00 -0500
+
 podup (3.0.2) unstable; urgency=medium
 
   Fixes


### PR DESCRIPTION
Version bump for 3.1.0.

## Why a MINOR and not 3.0.3

`semver-checks` stays clean — the public API does not change — so a patch would
be formally valid. I went to a minor anyway, because a `file:` secret now carries
semantics a bug-fix number does not communicate: the payload is a **copy taken at
`up`**, so editing the host file afterwards no longer reaches an already-running
container. Nobody gets an error for that; the container simply keeps serving the
old value. Someone reading "3.0.3" has no reason to go looking, and this is worth
looking at.

(An atomic replace — write-new-then-rename, what careful rotation tools do —
never reached a running container either, because a file bind pins the inode. So
what is actually lost is the in-place rewrite, the narrower of the two.)

## What ships

**The reason for the release** is #1174: `secrets:`/`configs:` from a `file:`
source were unreadable inside the container on **any SELinux-enforcing host** —
Fedora, RHEL and CentOS Stream, which is where Podman is the default engine —
while `up` reported the container as started. Measured on Fedora 44 (Podman
5.8.1) and Rawhide (Podman 6.0.1); plain `podman run` reproduced it, so the
denial was the missing relabel rather than podup's. Relabelling was rejected as
the fix because `z` rewrites the SELinux label of a file the user owns and may
share with a confined host service, and compose gives them nowhere to ask for it.

Also in: the `config` `env_file` rendering fix (#1184), and the integration-test
sweep — secrets/configs/`env_file`, `cp`, `port`, `include`/`extends`, multi-`-f`
and `watch`, with `include`/`extends`, multi-file merge and the `rebuild` and
`sync+restart` watch actions covered for the first time.

## The three files

`Cargo.toml`, `Cargo.lock` and `debian/changelog`, bumped together. The changelog
is the one that ships the `.deb` version and nothing derives it from
`Cargo.toml`; missing it is what stranded apt users in 1.9.0. Verified:
`dpkg-parsechangelog` reads 3.1.0 and all three agree, which is what `release.yml`'s
`verify` job checks before anything is built.

Deliberately **not** in this release: the five open Dependabot bumps. They are
routine, and this release exists for one concrete fix.
