### PR TITLE
release: 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.0.2"
+version = "3.1.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.0.2"
+version = "3.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,41 @@
+podup (3.1.0) unstable; urgency=medium
+
+  Changed
+
+  * A `file:` secret or config is read at `up` and injected as a
+    Podman-native secret instead of being bind-mounted from the host path.
+    On a host with SELinux enforcing the bind was denied outright, so the
+    container could not read its own secret while `up` still reported it
+    started; Fedora, RHEL and CentOS Stream are all enforcing by default.
+    Nothing on the host is mounted, relabelled or modified now. What the
+    container sees is unchanged: with no `mode:` the secret carries the
+    host file's own permission bits, so 0644 stays 0644 and 0600 stays
+    unreadable to a non-root container user. Note the trade: the payload
+    is a copy taken at `up`, so editing the host file afterwards no longer
+    reaches an already-running container — recreate it to pick up a new
+    value. An atomic replace never did reach one, since a file bind pins
+    the inode.
+
+  Fixes
+
+  * `config` folds `env_file` into `environment:` and drops the key, the
+    way docker compose renders it. A service taking its whole environment
+    from a file used to render with no `environment:` at all, so the one
+    command you use to ask what will actually run pointed away from the
+    answer. Precedence is unchanged: `environment:` wins over `env_file:`,
+    a later file wins over an earlier one, and a bare `KEY` stays
+    valueless.
+
+  Tests
+
+  * The secrets, configs, `env_file`, `cp`, `port`, `include`/`extends`,
+    multi-`-f` and `watch` integration tests assert the observable effect
+    rather than only that nothing errored; `include`/`extends`, multi-file
+    merge and the `rebuild` and `sync+restart` watch actions are covered
+    for the first time.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 26 Jul 2026 13:50:00 -0500
+
 podup (3.0.2) unstable; urgency=medium
 
   Fixes

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -96,6 +96,52 @@ pub fn merge_env(
 		.collect()
 }
 
+/// Fold every service's `env_file:` into its `environment:` and drop the key.
+///
+/// `config` is meant to render the canonical, fully-resolved model, and docker
+/// compose materialises `env_file` there. Leaving it unresolved meant a service
+/// that takes its whole environment from a file rendered with no `environment:`
+/// at all — so the one command you reach for to ask "what will this actually run"
+/// pointed away from the answer rather than merely omitting it (#1184).
+///
+/// Precedence is the same as at run time: `environment:` wins over `env_file:`,
+/// and a later file wins over an earlier one. Keys are emitted sorted so the
+/// output is stable across runs rather than following a hash map's order.
+///
+/// A bare `KEY` (inherit from the host) stays valueless, rendering as `KEY: null`
+/// the way the parser accepts it back.
+pub fn materialize_env_files(
+	file: &mut crate::compose::types::ComposeFile,
+	base_dir: &Path,
+) -> Result<()> {
+	for service in file.services.values_mut() {
+		let entries = service.env_file.to_entries();
+		if entries.is_empty() {
+			continue;
+		}
+		let from_files = load_env_file_entries(&entries, base_dir)?;
+		let mut merged = service.environment.to_map();
+		for (k, v) in from_files {
+			merged.entry(k).or_insert(Some(v));
+		}
+		let mut keys: Vec<String> = merged.keys().cloned().collect();
+		keys.sort();
+		let map = keys
+			.into_iter()
+			.map(|k| {
+				let value = merged
+					.get(&k)
+					.and_then(|v| v.clone())
+					.map(serde_yaml::Value::String);
+				(k, value)
+			})
+			.collect();
+		service.environment = crate::compose::types::EnvVars::Map(map);
+		service.env_file = crate::compose::types::EnvFile::Empty;
+	}
+	Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
@@ -260,5 +306,112 @@ mod tests {
 			[("PASSTHROUGH".to_string(), None)].into();
 		let result = merge_env(service_env, HashMap::new());
 		assert!(result.iter().any(|s| s == "PASSTHROUGH"));
+	}
+
+	// materialize_env_files (#1184)
+
+	/// Parse `yaml`, materialise its env files against `dir`, and return the
+	/// service's rendered `environment` map.
+	fn materialised(
+		dir: &std::path::Path,
+		yaml: &str,
+	) -> indexmap::IndexMap<String, Option<serde_yaml::Value>> {
+		let mut file = crate::compose::parse_str_raw(yaml).unwrap();
+		materialize_env_files(&mut file, dir).unwrap();
+		let service = &file.services["web"];
+		assert!(
+			matches!(service.env_file, crate::compose::types::EnvFile::Empty),
+			"env_file must be dropped once it has been folded in"
+		);
+		match &service.environment {
+			crate::compose::types::EnvVars::Map(m) => m.clone(),
+			other => panic!("expected a map, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn env_file_is_folded_into_environment() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"FROM_FILE=yes\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    env_file:\n      - a.env\n",
+		);
+		assert_eq!(
+			vars.get("FROM_FILE"),
+			Some(&Some(serde_yaml::Value::String("yes".into())))
+		);
+	}
+
+	#[test]
+	fn environment_wins_over_env_file() {
+		// The run-time precedence, kept in the rendered model: a key set in both
+		// places must render with the value the container would actually see.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"SHARED=from-file\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    environment:\n      SHARED: from-service\n    env_file:\n      - a.env\n",
+		);
+		assert_eq!(
+			vars.get("SHARED"),
+			Some(&Some(serde_yaml::Value::String("from-service".into())))
+		);
+	}
+
+	#[test]
+	fn a_later_env_file_wins_over_an_earlier_one() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"K=first\n").unwrap();
+		std::fs::write(dir.path().join("b.env"), b"K=second\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    env_file:\n      - a.env\n      - b.env\n",
+		);
+		assert_eq!(
+			vars.get("K"),
+			Some(&Some(serde_yaml::Value::String("second".into())))
+		);
+	}
+
+	#[test]
+	fn a_bare_key_stays_valueless() {
+		// `KEY` with no value inherits from the host. Rendering it as an empty
+		// string instead would change what the model means.
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"OTHER=1\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    environment:\n      - PASSTHROUGH\n    env_file:\n      - a.env\n",
+		);
+		assert_eq!(vars.get("PASSTHROUGH"), Some(&None));
+	}
+
+	#[test]
+	fn keys_are_sorted_so_the_render_is_stable() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::write(dir.path().join("a.env"), b"ZED=1\nALPHA=2\nMID=3\n").unwrap();
+		let vars = materialised(
+			dir.path(),
+			"services:\n  web:\n    image: x\n    env_file:\n      - a.env\n",
+		);
+		let keys: Vec<&String> = vars.keys().collect();
+		assert_eq!(keys, vec!["ALPHA", "MID", "ZED"]);
+	}
+
+	#[test]
+	fn a_service_without_env_file_is_left_alone() {
+		let dir = tempfile::tempdir().unwrap();
+		let mut file = crate::compose::parse_str_raw(
+			"services:\n  web:\n    image: x\n    environment:\n      A: 1\n",
+		)
+		.unwrap();
+		let before = format!("{:?}", file.services["web"].environment);
+		materialize_env_files(&mut file, dir.path()).unwrap();
+		assert_eq!(
+			before,
+			format!("{:?}", file.services["web"].environment),
+			"a service with no env_file must not be rewritten"
+		);
 	}
 }

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -452,6 +452,12 @@ async fn run() -> podup::Result<()> {
 		};
 		// Honor active profiles so `config` prints the same services `up` starts.
 		podup::retain_active_profiles(&mut resolved, &cli.profile);
+		// Fold `env_file:` into `environment:` the way docker compose does, so a
+		// service whose whole environment comes from a file does not render with no
+		// environment at all (#1184). `config` is the command you reach for to ask
+		// what will actually run; leaving the key unresolved pointed away from the
+		// answer rather than merely omitting it.
+		podup::env_file::materialize_env_files(&mut resolved, &base_dir)?;
 		// Render the resolved project name (already settled above from -p /
 		// COMPOSE_PROJECT_NAME, the top-level `name:`, then the directory
 		// basename), like `docker compose config`, rather than echoing the file's

--- a/tests/engine_integration/cli_flags.rs
+++ b/tests/engine_integration/cli_flags.rs
@@ -490,3 +490,39 @@ async fn cli_config_resolve_image_digests_pins_digest() {
 		"image must be pinned to a registry digest, got: {yaml}"
 	);
 }
+
+/// #1184: `config` left `env_file` unresolved, so a service taking its whole
+/// environment from a file rendered with no `environment:` at all — the one
+/// command you use to ask what will actually run pointed away from the answer.
+/// docker compose materialises it and drops the key; measured against
+/// docker compose v5.1.3 on this exact input.
+#[test]
+fn cli_config_materialises_env_file_into_environment() {
+	let dir = tempdir().unwrap();
+	let proj = format!("t{}-cfgenv", std::process::id());
+	fs::write(dir.path().join("app.env"), "FROM_FILE=resolved\n").unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    environment:\n      SHARED: from-service\n    env_file:\n      - app.env\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let out = run(&["-f", c, "-p", &proj, "config"]);
+	assert!(out.status.success(), "config failed: {:?}", out.stderr);
+	let yaml = String::from_utf8_lossy(&out.stdout);
+
+	assert!(
+		yaml.contains("FROM_FILE: resolved"),
+		"the env_file value was not folded into environment: {yaml}"
+	);
+	assert!(
+		!yaml.contains("env_file"),
+		"env_file must be dropped once it has been resolved, like docker compose: {yaml}"
+	);
+	assert!(
+		yaml.contains("SHARED: from-service"),
+		"a key set in both places must render the value the container would see: {yaml}"
+	);
+}


### PR DESCRIPTION
Release 3.1.0.

Two commits since the last sync to main: the `config` `env_file` fix (#1189) and
the version bump (#1201).

## Why a MINOR

`semver-checks` is clean — the public API does not change — but a `file:` secret
now carries semantics a patch number would not communicate. The payload is a copy
taken at `up`, so editing the host file afterwards no longer reaches an
already-running container, and nobody gets an error for it: the container simply
keeps serving the old value. Someone reading "3.0.3" has no reason to go looking.

## What ships

**#1174** is the reason for the release. `secrets:`/`configs:` from a `file:`
source were unreadable inside the container on **any SELinux-enforcing host** —
Fedora, RHEL and CentOS Stream, which is where Podman is the default engine —
while `up` reported the container as started, so nothing signalled the failure
except the application failing to open its own secret. Measured on Fedora 44
(Podman 5.8.1) and Rawhide (Podman 6.0.1); plain `podman run` reproduced it, so
the denial was the missing relabel rather than podup's.

Relabelling with `z` was the one-line alternative and was rejected: it rewrites
the SELinux label of a file the user owns and may share with a confined host
service, the change outlives `down`, and compose gives the user nowhere to ask
for it. Reading the bytes into a native secret leaves the host untouched. What
the container sees is preserved — with no `mode:` the secret carries the host
file's own permission bits, so 0644 stays 0644 and 0600 stays unreadable to a
non-root container user.

**#1184**: `config` folds `env_file` into `environment:` and drops the key, the
way docker compose renders it. A service taking its whole environment from a file
used to render with no `environment:` at all.

**Tests**: the secrets/configs/`env_file`, `cp`, `port`, `include`/`extends`,
multi-`-f` and `watch` integration tests now assert the observable effect rather
than only that nothing errored — `cp` in particular never checked the file
arrived, which is blind to exactly what #1097 was. `include`/`extends`, multi-file
merge and the `rebuild` and `sync+restart` watch actions are covered for the first
time. Every assertion was proved by mutation.

**CI**: the run-volume test is off the Podman 5 known-failures list (it was
SELinux, never nested virt), the lane caps integration concurrency, and the
`.github` reusables are pinned to a released tag.

## Release checks

- Three files agree at 3.1.0: `Cargo.toml`, `Cargo.lock`, `debian/changelog` —
  `dpkg-parsechangelog` reads 3.1.0. That is what `release.yml`'s `verify` job
  gates on, and the file that stranded apt users in 1.9.0 when it was missed.
- #1201 went green on all 17 checks, both lane legs included.

Not in this release: the five open Dependabot bumps, deliberately — they are
routine and this release exists for one concrete fix.
