### PR TITLE
fix: logs exits non-zero when its stream truncates live output

### DIFF
--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -172,6 +172,25 @@ fn stop_on_write_error(container_name: &str, result: std::io::Result<()>) -> boo
 	}
 }
 
+/// Whether a log stream that ended with an error truncated live output.
+///
+/// `still_running` is the out-of-band re-check: `Some(true)` the container is
+/// still up, `Some(false)` it has stopped or is gone, `None` the state could not
+/// be read.
+///
+/// `None` counts as a break. It is tempting to read "could not tell" as a clean
+/// end, and that is wrong in the exact case this matters: the severed connection
+/// that ends the stream is usually the same one the re-check needs, so treating
+/// the unknown as success turns every transport failure back into exit 0 — which
+/// is the bug, not the fix. Measured: with the permissive version, restarting the
+/// libpod socket under an attached `logs -f` reported a still-running container
+/// as stopped.
+///
+/// Pure so the rule is pinned without a live socket.
+fn log_stream_broke_mid_output(still_running: Option<bool>) -> bool {
+	!matches!(still_running, Some(false))
+}
+
 /// Build the libpod `containers/{}/logs` query string from the options.
 fn log_query(opts: &LogsOptions) -> String {
 	let mut q = format!(
@@ -312,6 +331,12 @@ impl Engine {
 		// Same rule one level down: a container that will not stream is tolerated
 		// while another does, but every target failing is the command failing.
 		let mut streamed_err: Option<ComposeError> = None;
+		// A stream that truncated live output is NOT the same class as a container
+		// that would not open one. The latter is tolerated while another streams;
+		// the former means output was lost, so it must survive the `streamed_any`
+		// shortcut below rather than being masked by a sibling that streamed fine
+		// (#1104).
+		let mut truncated_err: Option<ComposeError> = None;
 		let mut streamed_any = false;
 		let target_count = targets.len();
 
@@ -358,16 +383,43 @@ impl Engine {
 								Ok(LogOutput::StdErr { message }) => {
 									err_pfx.write(&mut std::io::stderr().lock(), &message)
 								}
-								// Diagnostic only — nothing branches on this. Naming the
-								// classification is what lets a lane run answer whether a
-								// finished stream is distinguishable from a broken one
-								// (#1104), instead of the question being argued from the
-								// source. Real 5.4.2 never reaches this arm.
+								// A `logs -f` stream ends when its container stops, and
+								// libpod marks that with a chunked terminator. A lost
+								// terminator arrives here as an `Err` indistinguishable
+								// at the transport layer from a real mid-stream break
+								// (#1104), so resolve it out of band: if the container is
+								// still running, live output was truncated and the
+								// command failed.
+								//
+								// Measured on real 5.4.2 by restarting the libpod socket
+								// under an attached `logs -f`: the arm is reached, the
+								// container is still running, and this used to exit 0.
+								// docker compose reports `unexpected EOF` and exits 1 on
+								// the same failure, so 0 was a divergence, not parity.
+								//
+								// The re-check is point-in-time, so a genuine break that
+								// coincides with the container stopping is knowingly
+								// read as a clean end — the transport cannot separate
+								// them and the container is gone either way.
 								Err(e) => {
-									tracing::warn!(
-										"logs {container_name}: stream ended [{}]: {e}",
-										e.stream_end_kind()
-									);
+									let kind = e.stream_end_kind();
+									match log_stream_broke_mid_output(
+										self.container_still_running(&container_name).await,
+									) {
+										true => {
+											tracing::warn!(
+												"logs {container_name}: stream ended while the \
+												 container was still running [{kind}]: {e}"
+											);
+											return Some(e);
+										}
+										false => {
+											tracing::warn!(
+												"logs {container_name}: stream ended as the \
+												 container stopped [{kind}]"
+											);
+										}
+									}
 									break;
 								}
 							};
@@ -431,11 +483,28 @@ impl Engine {
 						Ok(LogOutput::StdErr { message }) => {
 							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
+						// Same out-of-band resolution as the concurrent path above: a
+						// stream that ends while its container is still running
+						// truncated live output (#1104).
 						Err(e) => {
-							tracing::warn!(
-								"logs {container_name}: stream ended [{}]: {e}",
-								e.stream_end_kind()
-							);
+							let kind = e.stream_end_kind();
+							match log_stream_broke_mid_output(
+								self.container_still_running(&container_name).await,
+							) {
+								true => {
+									tracing::warn!(
+										"logs {container_name}: stream ended while the container \
+										 was still running [{kind}]: {e}"
+									);
+									truncated_err.get_or_insert(ComposeError::Podman(e));
+								}
+								false => {
+									tracing::warn!(
+										"logs {container_name}: stream ended as the container \
+										 stopped [{kind}]"
+									);
+								}
+							}
 							break;
 						}
 					};
@@ -449,10 +518,52 @@ impl Engine {
 			}
 		}
 
+		// Checked before the tolerance shortcut: output was lost, and another
+		// container streaming cleanly does not make that untrue.
+		if let Some(e) = truncated_err {
+			return Err(e);
+		}
 		if streamed_any {
 			return Ok(());
 		}
 		streamed_err.map_or(Ok(()), Err)
+	}
+
+	/// Whether `container_name` is still running, for resolving how a log stream
+	/// ended.
+	///
+	/// A `logs -f` stream lives as long as its container runs and ends when the
+	/// container stops. libpod signals that end with a chunked terminator, and a
+	/// lost terminator — a dropped connection, or a version that omits it —
+	/// arrives as an `Err` that the transport layer cannot tell apart from a real
+	/// mid-stream break (#1104). Re-checking the container out of band resolves
+	/// it: still running means the stream truncated live output.
+	///
+	/// `Ok(None)` is "could not tell" — an unreadable state is not confirmation
+	/// the end was expected, so the caller keeps the original error rather than
+	/// masking a possible failure. Mirrors the fail-closed rule `stats` uses.
+	async fn container_still_running(&self, container_name: &str) -> Option<bool> {
+		let filters = serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.ok()?;
+		entries
+			.iter()
+			.find(|e| {
+				e.names
+					.iter()
+					.any(|raw| raw.trim_start_matches('/') == container_name)
+			})
+			.map(|e| e.state == "running")
+			// A container the listing no longer holds has been removed, which is a
+			// stop by any other name — the stream had every reason to end.
+			.or(Some(false))
 	}
 
 	/// Names of this project's containers (by label) that the current compose file

--- a/internal/engine/query/tests.rs
+++ b/internal/engine/query/tests.rs
@@ -1,4 +1,7 @@
-use super::{filter_orphans, is_valid_log_time, log_query, validate_log_filters, LogsOptions};
+use super::{
+	filter_orphans, is_valid_log_time, log_query, log_stream_broke_mid_output,
+	validate_log_filters, LogsOptions,
+};
 use std::collections::HashSet;
 
 #[cfg(unix)]
@@ -330,4 +333,31 @@ async fn logs_tolerates_one_container_that_will_not_stream() {
 	)
 	.await
 	.expect("one container failing to stream must not blank the other");
+}
+
+// ---------------------------------------------------------------------------
+// #1104: telling a finished log stream from a broken one
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_stream_ending_while_the_container_runs_is_a_break() {
+	// The container outlived its own log stream, so output was truncated.
+	assert!(log_stream_broke_mid_output(Some(true)));
+}
+
+#[test]
+fn a_stream_ending_after_the_container_stopped_is_clean() {
+	// The stream is supposed to end here; libpod just did not get to say so.
+	assert!(!log_stream_broke_mid_output(Some(false)));
+}
+
+#[test]
+fn an_unreadable_state_counts_as_a_break() {
+	// The rule that is easy to get backwards, and the one that matters most: the
+	// severed connection that ends the stream is usually the same one the
+	// re-check needs, so reading "could not tell" as a clean end turns every
+	// transport failure back into exit 0. Measured — the permissive version
+	// reported a still-running container as stopped when the socket restarted
+	// under an attached `logs -f`.
+	assert!(log_stream_broke_mid_output(None));
 }


### PR DESCRIPTION
`logs -f` returned success after losing its connection to the engine, so a
monitor scraping it could not tell "the container finished" from "my socket
died". That is the ambiguity #1104 is about, applied to the first of the three
streaming commands.

## Reproduced, not argued

A container printing a line a second, `logs -f` attached, and the libpod socket
restarted underneath it — real Podman 5.4.2, on hardware:

```
$ podup logs -f
job-1 | tick
podup: warning: logs s1104-job-1: stream ended [hyper-other]: http error: error reading a body from connection
$ echo $?
0
```

The container was still running. The comment on that match arm said real 5.4.2
never reaches it; it does, once the transport actually fails.

**docker compose, same socket, same severing:** prints `unexpected EOF` and exits
**1**. So exit 0 was a divergence rather than parity, which settles the policy
question this issue had been carrying — there was nothing to choose.

## The fix

The pattern `stats` already ships (#1169): when a stream ends with an error,
re-check out of band whether the container is still running. Still running means
live output was truncated.

| case | before | after | docker |
|---|---|---|---|
| stream broken, container alive | 0 | **1** | 1 |
| `logs -f`, container finishes | 0 | 0 | 0 |
| `logs` (no `-f`), stopped container | 0 | 0 | — |
| `logs -f \| head`, broken pipe | 0 | 0 | — |

## Two mistakes of mine, both caught by measuring

**The first version did nothing.** It recorded the failure in the same
`streamed_err` the tolerance path uses, which is discarded whenever any container
streamed. It compiled and passed. A truncation is not the same class as a
container that will not open a stream — one loses output, the other is tolerated
because a sibling still works — so it now has its own channel, returned before
the tolerance shortcut.

**The second was fail-open.** I treated "could not re-check" as a clean end, which
is backwards in the exact case that matters: the severed connection that kills the
stream is the same one the re-check needs. Measured, it reported a still-running
container as stopped. The rule is now fail-closed, extracted into
`log_stream_broke_mid_output` and unit-tested across all three states — the
permissive version turns that test red, so it cannot come back quietly.

Neither would have surfaced from reading the diff.

## Test plan

- Broken-stream repro above, before and after, on real Podman 5.4.2.
- All three clean paths re-verified, since the risk of this change is breaking
  ordinary usage rather than the failure case.
- Full integration suite **172/172** locally; 1350 library tests; `fmt` and
  `clippy --all-targets` clean.
- Mutation: restoring the permissive rule fails
  `an_unreadable_state_counts_as_a_break`.

## What I expect from the lane, and why it is the point

Making `logs`/`stats`/`events` report a mid-stream error previously reddened
**fifteen tests on the Podman 5.8.1 leg while real 5.4.2 stayed green on the same
commit**. That is measured, unexplained, and recorded in #1104.

This PR is deliberately `logs` only for that reason. If the lane goes red, the
finding lands on a one-command diff where it is diagnosable, instead of inside a
three-command change where it could not be attributed. A red lane here is a
result, not a setback.

Refs #1104
