### PR TITLE
ci: run the Podman 6 leg at one thread to test the netns hypothesis

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   podman-vm:
     runs-on: ubuntu-24.04
-    timeout-minutes: 50
+    # Raised for the one-thread experiment: serialising the suite costs wall
+    # clock, and a run that dies on the timeout answers nothing (#1039).
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
@@ -94,7 +96,21 @@ jobs:
                 # the second run, so this stabilises the lane for required-check gating
                 # without masking genuine bugs.
                 #
-                # `--test-threads=2` caps how many streaming tests hit the libpod
+                # EXPERIMENT (#1039): the thread cap is per major, substituted into
+                # this script when the seed is built — Podman 6 runs at 1, Podman 5
+                # stays at 2 as the control.
+                #
+                # Every hypothesis for Podman 6's failing tail has been falsified in
+                # turn: journald, SELinux, and a boot race on systemd-resolved, the
+                # last one killed by its own instrumentation. What survives is the
+                # shape of the error — the path that is missing is the mount
+                # DESTINATION inside Podman's rootless-netns tree, not a host file,
+                # which reads as the shared netns being torn down under a concurrent
+                # container creation. One thread is the cheapest way to test that: if
+                # the signature disappears, concurrency is the lever; if it survives,
+                # this hypothesis dies too and the search moves elsewhere.
+                #
+                # `--test-threads` caps how many streaming tests hit the libpod
                 # socket at once. The nested-virt (VM-in-runner) transport is what
                 # drops connections mid-stream — measured: on a single-level VM
                 # (Podman 5.8.1 and 6.0.1) the same suite never drops a byte, so the
@@ -104,7 +120,7 @@ jobs:
                 # a small, stable set that an identity list can gate (#1039). Kept at
                 # 2 rather than 1 so the suite still fits the VM's time budget.
                 for attempt in 1 2; do
-                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=2 > /tmp/cargo.log 2>&1
+                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=__THREADS__ > /tmp/cargo.log 2>&1
                   RC=$?
                   [ "$RC" -eq 0 ] && break
                   grep -qE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log || break
@@ -145,10 +161,19 @@ jobs:
             - bash -c 'sudo -iu tester /usr/local/bin/run-suite.sh >/dev/console 2>&1'
             - bash -c 'echo PROBE_DONE >/dev/console; sleep 2; poweroff'
           EOF
+          # The seed heredoc is quoted, so the matrix value cannot expand inside
+          # it. Substitute the per-major thread cap here instead (#1039).
+          THREADS=2
+          [ "${{ matrix.podman }}" = "6" ] && THREADS=1
+          echo "test-threads for Podman ${{ matrix.podman }}: $THREADS"
+          sed -i "s/__THREADS__/$THREADS/" "$RUNNER_TEMP/user-data"
           cloud-localds "$RUNNER_TEMP/seed.iso" "$RUNNER_TEMP/user-data"
       - name: Boot VM (9p = repo only) + capture
         run: |
-          sudo timeout 2700 qemu-system-x86_64 -enable-kvm -cpu host -m 6144 -smp 4 \
+          # Raised with the job timeout for the one-thread experiment (#1039): qemu
+          # has its own cap, and leaving it at 45m would kill the VM before the job
+          # noticed, turning a slow run into an inconclusive one.
+          sudo timeout 4200 qemu-system-x86_64 -enable-kvm -cpu host -m 6144 -smp 4 \
             -drive file="$RUNNER_TEMP/vm.qcow2",if=virtio,format=qcow2 \
             -drive file="$RUNNER_TEMP/seed.iso",if=virtio,format=raw \
             -netdev user,id=n0 -device virtio-net-pci,netdev=n0 \


### PR DESCRIPTION
**An experiment, not a fix.** Its value is the number it produces, and it is
worth merging only if that number says the hypothesis holds.

## What is being tested

Every explanation for Podman 6's failing tail has been falsified in turn:

- journald, July — real, fixed, not this
- SELinux — real, fixed in #1176, not this
- a boot race on systemd-resolved — killed by the instrumentation added to test
  it, which printed `resolv.conf resolved after 0s` on both legs while the error
  still fired

What survives is the shape of the error itself:

```
rootless netns: mount resolv.conf to
"/run/user/1000/containers/networks/rootless-netns/run/systemd/resolve/stub-resolv.conf":
no such file or directory
```

The missing path is the mount **destination**, inside Podman's own
rootless-netns tree — not a file on the host. That reads as the shared netns
being torn down underneath a concurrent container creation, which would explain
everything the other hypotheses could not: it is intermittent, load-shaped, absent
from one nightly and present in the next, and capping concurrency in #1173 moved
the numbers without removing it.

Serialising the suite is the cheapest way to find out.

## How to read the result

**If the signature disappears at one thread**, concurrency is the lever, and the
question becomes whether that is a Podman bug worth reporting upstream or
something podup should serialise itself.

**If it survives**, this hypothesis dies with the others and the search moves
elsewhere — which is still progress, and the reason this is a small isolated
change rather than a fix bolted onto a guess.

Podman 5 stays at **two** threads as the control, so a change on the 6 leg cannot
be confused with a change to the harness.

## Why this matters now

Run 30222778630 reported the Podman 6 leg **green with 31 failures** — it gates on
a pass-count floor of 115 and 141 passed. The failing set grew from the historical
8–12 to 31 purely because today's work added a dozen container-dependent tests, so
the same environment defect has more surface to knock over. Podman 6 currently has
no effective gate, and a real regression there would pass unnoticed the way #1072
did.

## Mechanics worth a look in review

- The seed heredoc is quoted, so `${{ matrix.podman }}` cannot expand inside it.
  The cap is substituted into the script with `sed` after the heredoc is written
  and before the seed ISO is built.
- **Both** timeouts are raised. The job had 50 minutes and qemu its own 45;
  serialising costs wall clock, and leaving qemu at 45 would have killed the VM
  before the job noticed, turning a slow run into an inconclusive one. That is
  the failure mode most likely to waste this experiment, so it is worth checking
  the run actually completed rather than trusting the conclusion.

Refs #1039
