### PR TITLE
ci: gate the Podman 6 leg on identity, with an empty classified list

### DIFF
--- a/.github/podman-known-failures-6
+++ b/.github/podman-known-failures-6
@@ -1,0 +1,33 @@
+# Integration tests that fail on the Podman 6 nested-virt lane for environmental
+# reasons, not because podup is broken. The lane fails when a failing test is NOT
+# on this list — a new identity is a real regression, whatever the pass count says.
+#
+# The list is deliberately EMPTY. That is a claim, and here is the evidence for it.
+#
+# Podman 6 ran without an identity list for months because its failing set carried
+# a variable tail that a list built from observation would have turned into false
+# reds. It gated on the pass-count floor alone, and that floor reported the leg
+# GREEN through 31 failures in run 30222778630 — 141 passed against a floor of
+# 115. The floor also loses resolution as the suite grows: those 31 were the same
+# environment defect as the historical 8–12, with more container-dependent tests
+# added for it to knock over.
+#
+# The tail turned out to be one cause. Serialising the leg (#1039, run
+# 30225458799) took it from 31 failures to zero, with the
+# `rootless netns: mount resolv.conf … stub-resolv.conf: no such file or
+# directory` signature — four occurrences in the previous run — absent from the
+# log entirely. Podman 5 stayed at two threads as the control and produced its
+# usual timing, so the change was not in the harness. Concurrent container
+# creation against the shared rootless netns was the cause; nested virtualisation,
+# the image, and boot ordering were not, and each had been proposed and falsified
+# in turn.
+#
+# WHAT THIS LIST RESTS ON: exactly one clean run. That is thin, and it is the
+# same thin evidence this file's Podman 5 counterpart warns about in the other
+# direction. If a failure appears here, the first question is whether the tail is
+# genuinely gone or whether one run was luck.
+#
+# When that happens: classify it with a run, the way every Podman 5 entry was, and
+# add it here with the evidence. Do NOT delete this file to make the red go away —
+# an empty list is what makes a regression loud, and going back to a count gate is
+# how #1072 shipped a bug with the pass count sitting comfortably above the floor.

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -267,19 +267,23 @@ jobs:
           # (a suite that half-executed reports few failures and few passes),
           # which the identity gate above cannot see. It stays for both majors.
           #
-          # Why the failure COUNT is still only a warning, and why Podman 6 has
-          # no identity list yet: the count never separated a regression from
-          # noise — measured on this lane, Podman 5 fails the same ~10
-          # streaming/attach/run tests every run with ZERO connection-drop
-          # signatures, so "FAIL <= drop count" would redden every run. The
-          # identity gate replaces it for any major with a classified list.
-          # Podman 5 has one: every entry was proved environmental by running
-          # the same suite on a real host (155/155 passed) while the lane
-          # reported 10 failures. Podman 6 does not, because its set carries a
-          # variable tail (identities seen in 1-of-5 runs) that would redden
-          # innocent pull requests — the exact failure that forced this floor
-          # down from 120 to 115. Classifying it is #1039; until then Podman 6
-          # keeps the floor alone, and that gap is deliberate.
+          # Why the failure COUNT is still only a warning: it never separated a
+          # regression from noise — measured on this lane, Podman 5 fails the
+          # same ~10 streaming/attach/run tests every run with ZERO
+          # connection-drop signatures, so "FAIL <= drop count" would redden
+          # every run. The identity gate replaces it for any major with a
+          # classified list, and BOTH majors now have one.
+          #
+          # Podman 5's entries were each proved environmental by running the same
+          # suite on a real host (155/155) while the lane reported failures.
+          #
+          # Podman 6 went without a list because its failing set carried a
+          # variable tail that observation would have turned into false reds —
+          # and the floor it gated on instead reported the leg green through 31
+          # failures (141 passed, floor 115). That tail was one cause:
+          # serialising the leg removed it, and its list is now empty, so any
+          # failure there is a regression. See the file's own header for the
+          # evidence and for how thin it is.
           BASELINE="$(cat "$GITHUB_WORKSPACE/.github/podman-baseline-tests")"
           [ "$PASS" -ge "$BASELINE" ] || { echo "::error::core suite degraded on Podman $VER ($PASS passed, baseline >= $BASELINE) — real regression or fewer tests ran"; exit 1; }
           if [ "$FAIL" -gt "$FLAKY" ]; then


### PR DESCRIPTION
Podman 6 gated on a pass-count floor rather than on which tests fail, because its
failing set carried a variable tail that a list built from observation would have
turned into false reds.

That floor reported the leg **green through 31 failures** in run 30222778630 —
141 passed against a floor of 115. And it decays: those 31 were the same
environment defect as the historical 8–12, with a dozen container-dependent tests
added the same day for it to knock over. A count gate does not just miss a
one-test regression the way #1072 did; it loses resolution every time the suite
grows.

#1205 removed the tail — 31 failures to zero, the rootless-netns signature gone
from the log — so the list can finally exist. It is **empty**: any failure on
Podman 6 is now a regression.

## No code change

The gate already derives the major from the Podman the VM booted and looks for
`.github/podman-known-failures-<major>`. Dropping the file in is the whole
change. The rest of the diff corrects the comments that still described Podman 6
as unclassifiable and the floor as the deliberate gap.

## The part I want reviewed sceptically

**This rests on exactly one clean run.** That is thin evidence, and it is the same
thin evidence the Podman 5 list warns about in the other direction — its header
records a claim made honestly, with a run, that was still wrong. Three
explanations for this tail were proposed and falsified before the concurrency one
held.

So the risk is concrete: if the tail is not truly gone, the first flake turns the
lane red and blocks an unrelated pull request. I think that is the right trade —
a loud red on a leg that currently cannot see a regression at all is better than a
quiet green — but it is a trade, not a free win, and it may need reverting.

If a failure does appear, the answer is to classify it with a run and add it to
the file with the evidence, the way every Podman 5 entry was. Not to delete the
file to make the red go away.

## Cost already paid

The serialisation in #1205 took the Podman 6 leg from ~10 minutes of suite time to
~27. That lands on a lane that was already the long pole. Worth restating here
because this PR is what converts that cost into something: without the identity
gate, the extra time buys a cleaner run that nothing checks.

Refs #1039
