### PR TITLE
chore: bring develop to main

### DIFF
--- a/.github/podman-known-failures-6
+++ b/.github/podman-known-failures-6
@@ -1,0 +1,33 @@
+# Integration tests that fail on the Podman 6 nested-virt lane for environmental
+# reasons, not because podup is broken. The lane fails when a failing test is NOT
+# on this list — a new identity is a real regression, whatever the pass count says.
+#
+# The list is deliberately EMPTY. That is a claim, and here is the evidence for it.
+#
+# Podman 6 ran without an identity list for months because its failing set carried
+# a variable tail that a list built from observation would have turned into false
+# reds. It gated on the pass-count floor alone, and that floor reported the leg
+# GREEN through 31 failures in run 30222778630 — 141 passed against a floor of
+# 115. The floor also loses resolution as the suite grows: those 31 were the same
+# environment defect as the historical 8–12, with more container-dependent tests
+# added for it to knock over.
+#
+# The tail turned out to be one cause. Serialising the leg (#1039, run
+# 30225458799) took it from 31 failures to zero, with the
+# `rootless netns: mount resolv.conf … stub-resolv.conf: no such file or
+# directory` signature — four occurrences in the previous run — absent from the
+# log entirely. Podman 5 stayed at two threads as the control and produced its
+# usual timing, so the change was not in the harness. Concurrent container
+# creation against the shared rootless netns was the cause; nested virtualisation,
+# the image, and boot ordering were not, and each had been proposed and falsified
+# in turn.
+#
+# WHAT THIS LIST RESTS ON: exactly one clean run. That is thin, and it is the
+# same thin evidence this file's Podman 5 counterpart warns about in the other
+# direction. If a failure appears here, the first question is whether the tail is
+# genuinely gone or whether one run was luck.
+#
+# When that happens: classify it with a run, the way every Podman 5 entry was, and
+# add it here with the evidence. Do NOT delete this file to make the red go away —
+# an empty list is what makes a regression loud, and going back to a count gate is
+# how #1072 shipped a bug with the pass count sitting comfortably above the floor.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check the harness shell syntax
         run: bash -n bench/run.sh
       - name: Check the harness Python syntax
@@ -43,7 +43,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build podup
         run: cargo build --release --all-features --locked
       - name: Pre-pull pinned images

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   podman-vm:
     runs-on: ubuntu-24.04
-    timeout-minutes: 50
+    # Raised for the one-thread experiment: serialising the suite costs wall
+    # clock, and a run that dies on the timeout answers nothing (#1039).
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
@@ -94,7 +96,21 @@ jobs:
                 # the second run, so this stabilises the lane for required-check gating
                 # without masking genuine bugs.
                 #
-                # `--test-threads=2` caps how many streaming tests hit the libpod
+                # EXPERIMENT (#1039): the thread cap is per major, substituted into
+                # this script when the seed is built — Podman 6 runs at 1, Podman 5
+                # stays at 2 as the control.
+                #
+                # Every hypothesis for Podman 6's failing tail has been falsified in
+                # turn: journald, SELinux, and a boot race on systemd-resolved, the
+                # last one killed by its own instrumentation. What survives is the
+                # shape of the error — the path that is missing is the mount
+                # DESTINATION inside Podman's rootless-netns tree, not a host file,
+                # which reads as the shared netns being torn down under a concurrent
+                # container creation. One thread is the cheapest way to test that: if
+                # the signature disappears, concurrency is the lever; if it survives,
+                # this hypothesis dies too and the search moves elsewhere.
+                #
+                # `--test-threads` caps how many streaming tests hit the libpod
                 # socket at once. The nested-virt (VM-in-runner) transport is what
                 # drops connections mid-stream — measured: on a single-level VM
                 # (Podman 5.8.1 and 6.0.1) the same suite never drops a byte, so the
@@ -104,7 +120,7 @@ jobs:
                 # a small, stable set that an identity list can gate (#1039). Kept at
                 # 2 rather than 1 so the suite still fits the VM's time budget.
                 for attempt in 1 2; do
-                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=2 > /tmp/cargo.log 2>&1
+                  RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=__THREADS__ > /tmp/cargo.log 2>&1
                   RC=$?
                   [ "$RC" -eq 0 ] && break
                   grep -qE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log || break
@@ -145,10 +161,19 @@ jobs:
             - bash -c 'sudo -iu tester /usr/local/bin/run-suite.sh >/dev/console 2>&1'
             - bash -c 'echo PROBE_DONE >/dev/console; sleep 2; poweroff'
           EOF
+          # The seed heredoc is quoted, so the matrix value cannot expand inside
+          # it. Substitute the per-major thread cap here instead (#1039).
+          THREADS=2
+          [ "${{ matrix.podman }}" = "6" ] && THREADS=1
+          echo "test-threads for Podman ${{ matrix.podman }}: $THREADS"
+          sed -i "s/__THREADS__/$THREADS/" "$RUNNER_TEMP/user-data"
           cloud-localds "$RUNNER_TEMP/seed.iso" "$RUNNER_TEMP/user-data"
       - name: Boot VM (9p = repo only) + capture
         run: |
-          sudo timeout 2700 qemu-system-x86_64 -enable-kvm -cpu host -m 6144 -smp 4 \
+          # Raised with the job timeout for the one-thread experiment (#1039): qemu
+          # has its own cap, and leaving it at 45m would kill the VM before the job
+          # noticed, turning a slow run into an inconclusive one.
+          sudo timeout 4200 qemu-system-x86_64 -enable-kvm -cpu host -m 6144 -smp 4 \
             -drive file="$RUNNER_TEMP/vm.qcow2",if=virtio,format=qcow2 \
             -drive file="$RUNNER_TEMP/seed.iso",if=virtio,format=raw \
             -netdev user,id=n0 -device virtio-net-pci,netdev=n0 \

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -267,19 +267,23 @@ jobs:
           # (a suite that half-executed reports few failures and few passes),
           # which the identity gate above cannot see. It stays for both majors.
           #
-          # Why the failure COUNT is still only a warning, and why Podman 6 has
-          # no identity list yet: the count never separated a regression from
-          # noise — measured on this lane, Podman 5 fails the same ~10
-          # streaming/attach/run tests every run with ZERO connection-drop
-          # signatures, so "FAIL <= drop count" would redden every run. The
-          # identity gate replaces it for any major with a classified list.
-          # Podman 5 has one: every entry was proved environmental by running
-          # the same suite on a real host (155/155 passed) while the lane
-          # reported 10 failures. Podman 6 does not, because its set carries a
-          # variable tail (identities seen in 1-of-5 runs) that would redden
-          # innocent pull requests — the exact failure that forced this floor
-          # down from 120 to 115. Classifying it is #1039; until then Podman 6
-          # keeps the floor alone, and that gap is deliberate.
+          # Why the failure COUNT is still only a warning: it never separated a
+          # regression from noise — measured on this lane, Podman 5 fails the
+          # same ~10 streaming/attach/run tests every run with ZERO
+          # connection-drop signatures, so "FAIL <= drop count" would redden
+          # every run. The identity gate replaces it for any major with a
+          # classified list, and BOTH majors now have one.
+          #
+          # Podman 5's entries were each proved environmental by running the same
+          # suite on a real host (155/155) while the lane reported failures.
+          #
+          # Podman 6 went without a list because its failing set carried a
+          # variable tail that observation would have turned into false reds —
+          # and the floor it gated on instead reported the leg green through 31
+          # failures (141 passed, floor 115). That tail was one cause:
+          # serialising the leg removed it, and its list is now empty, so any
+          # failure there is a regression. See the file's own header for the
+          # evidence and for how thin it is.
           BASELINE="$(cat "$GITHUB_WORKSPACE/.github/podman-baseline-tests")"
           [ "$PASS" -ge "$BASELINE" ] || { echo "::error::core suite degraded on Podman $VER ($PASS passed, baseline >= $BASELINE) — real regression or fewer tests ran"; exit 1; }
           if [ "$FAIL" -gt "$FLAKY" ]; then

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         podman: ["5", "6"]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install qemu + cloud tools
         run: sudo apt-get update -qq && sudo apt-get install -y -qq qemu-system-x86 qemu-utils cloud-image-utils
       - name: Fetch Fedora cloud image (Podman 6 = rawhide, 5 = Fedora 44)

--- a/.github/workflows/podman-watch.yml
+++ b/.github/workflows/podman-watch.yml
@@ -14,7 +14,7 @@ jobs:
   watch:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Detect newer packaged Podman
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
@@ -148,7 +148,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
@@ -250,7 +250,7 @@ jobs:
             cargo \
             rustc
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
@@ -294,7 +294,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -102,15 +102,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -124,9 +124,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -145,23 +145,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -234,7 +234,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
@@ -346,30 +346,30 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -462,9 +462,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
  "bitflags",
  "inotify-sys",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -566,9 +566,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -747,18 +747,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -904,9 +904,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -914,29 +914,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -1023,9 +1023,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1049,9 +1049,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1092,18 +1103,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1117,13 +1128,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1145,7 +1156,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1275,9 +1286,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1461,6 +1472,6 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -172,6 +172,25 @@ fn stop_on_write_error(container_name: &str, result: std::io::Result<()>) -> boo
 	}
 }
 
+/// Whether a log stream that ended with an error truncated live output.
+///
+/// `still_running` is the out-of-band re-check: `Some(true)` the container is
+/// still up, `Some(false)` it has stopped or is gone, `None` the state could not
+/// be read.
+///
+/// `None` counts as a break. It is tempting to read "could not tell" as a clean
+/// end, and that is wrong in the exact case this matters: the severed connection
+/// that ends the stream is usually the same one the re-check needs, so treating
+/// the unknown as success turns every transport failure back into exit 0 — which
+/// is the bug, not the fix. Measured: with the permissive version, restarting the
+/// libpod socket under an attached `logs -f` reported a still-running container
+/// as stopped.
+///
+/// Pure so the rule is pinned without a live socket.
+fn log_stream_broke_mid_output(still_running: Option<bool>) -> bool {
+	!matches!(still_running, Some(false))
+}
+
 /// Build the libpod `containers/{}/logs` query string from the options.
 fn log_query(opts: &LogsOptions) -> String {
 	let mut q = format!(
@@ -312,6 +331,12 @@ impl Engine {
 		// Same rule one level down: a container that will not stream is tolerated
 		// while another does, but every target failing is the command failing.
 		let mut streamed_err: Option<ComposeError> = None;
+		// A stream that truncated live output is NOT the same class as a container
+		// that would not open one. The latter is tolerated while another streams;
+		// the former means output was lost, so it must survive the `streamed_any`
+		// shortcut below rather than being masked by a sibling that streamed fine
+		// (#1104).
+		let mut truncated_err: Option<ComposeError> = None;
 		let mut streamed_any = false;
 		let target_count = targets.len();
 
@@ -358,16 +383,43 @@ impl Engine {
 								Ok(LogOutput::StdErr { message }) => {
 									err_pfx.write(&mut std::io::stderr().lock(), &message)
 								}
-								// Diagnostic only — nothing branches on this. Naming the
-								// classification is what lets a lane run answer whether a
-								// finished stream is distinguishable from a broken one
-								// (#1104), instead of the question being argued from the
-								// source. Real 5.4.2 never reaches this arm.
+								// A `logs -f` stream ends when its container stops, and
+								// libpod marks that with a chunked terminator. A lost
+								// terminator arrives here as an `Err` indistinguishable
+								// at the transport layer from a real mid-stream break
+								// (#1104), so resolve it out of band: if the container is
+								// still running, live output was truncated and the
+								// command failed.
+								//
+								// Measured on real 5.4.2 by restarting the libpod socket
+								// under an attached `logs -f`: the arm is reached, the
+								// container is still running, and this used to exit 0.
+								// docker compose reports `unexpected EOF` and exits 1 on
+								// the same failure, so 0 was a divergence, not parity.
+								//
+								// The re-check is point-in-time, so a genuine break that
+								// coincides with the container stopping is knowingly
+								// read as a clean end — the transport cannot separate
+								// them and the container is gone either way.
 								Err(e) => {
-									tracing::warn!(
-										"logs {container_name}: stream ended [{}]: {e}",
-										e.stream_end_kind()
-									);
+									let kind = e.stream_end_kind();
+									match log_stream_broke_mid_output(
+										self.container_still_running(&container_name).await,
+									) {
+										true => {
+											tracing::warn!(
+												"logs {container_name}: stream ended while the \
+												 container was still running [{kind}]: {e}"
+											);
+											return Some(e);
+										}
+										false => {
+											tracing::warn!(
+												"logs {container_name}: stream ended as the \
+												 container stopped [{kind}]"
+											);
+										}
+									}
 									break;
 								}
 							};
@@ -431,11 +483,28 @@ impl Engine {
 						Ok(LogOutput::StdErr { message }) => {
 							err_pfx.write(&mut std::io::stderr().lock(), &message)
 						}
+						// Same out-of-band resolution as the concurrent path above: a
+						// stream that ends while its container is still running
+						// truncated live output (#1104).
 						Err(e) => {
-							tracing::warn!(
-								"logs {container_name}: stream ended [{}]: {e}",
-								e.stream_end_kind()
-							);
+							let kind = e.stream_end_kind();
+							match log_stream_broke_mid_output(
+								self.container_still_running(&container_name).await,
+							) {
+								true => {
+									tracing::warn!(
+										"logs {container_name}: stream ended while the container \
+										 was still running [{kind}]: {e}"
+									);
+									truncated_err.get_or_insert(ComposeError::Podman(e));
+								}
+								false => {
+									tracing::warn!(
+										"logs {container_name}: stream ended as the container \
+										 stopped [{kind}]"
+									);
+								}
+							}
 							break;
 						}
 					};
@@ -449,10 +518,52 @@ impl Engine {
 			}
 		}
 
+		// Checked before the tolerance shortcut: output was lost, and another
+		// container streaming cleanly does not make that untrue.
+		if let Some(e) = truncated_err {
+			return Err(e);
+		}
 		if streamed_any {
 			return Ok(());
 		}
 		streamed_err.map_or(Ok(()), Err)
+	}
+
+	/// Whether `container_name` is still running, for resolving how a log stream
+	/// ended.
+	///
+	/// A `logs -f` stream lives as long as its container runs and ends when the
+	/// container stops. libpod signals that end with a chunked terminator, and a
+	/// lost terminator — a dropped connection, or a version that omits it —
+	/// arrives as an `Err` that the transport layer cannot tell apart from a real
+	/// mid-stream break (#1104). Re-checking the container out of band resolves
+	/// it: still running means the stream truncated live output.
+	///
+	/// `Ok(None)` is "could not tell" — an unreadable state is not confirmation
+	/// the end was expected, so the caller keeps the original error rather than
+	/// masking a possible failure. Mirrors the fail-closed rule `stats` uses.
+	async fn container_still_running(&self, container_name: &str) -> Option<bool> {
+		let filters = serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.ok()?;
+		entries
+			.iter()
+			.find(|e| {
+				e.names
+					.iter()
+					.any(|raw| raw.trim_start_matches('/') == container_name)
+			})
+			.map(|e| e.state == "running")
+			// A container the listing no longer holds has been removed, which is a
+			// stop by any other name — the stream had every reason to end.
+			.or(Some(false))
 	}
 
 	/// Names of this project's containers (by label) that the current compose file

--- a/internal/engine/query/tests.rs
+++ b/internal/engine/query/tests.rs
@@ -1,4 +1,7 @@
-use super::{filter_orphans, is_valid_log_time, log_query, validate_log_filters, LogsOptions};
+use super::{
+	filter_orphans, is_valid_log_time, log_query, log_stream_broke_mid_output,
+	validate_log_filters, LogsOptions,
+};
 use std::collections::HashSet;
 
 #[cfg(unix)]
@@ -330,4 +333,31 @@ async fn logs_tolerates_one_container_that_will_not_stream() {
 	)
 	.await
 	.expect("one container failing to stream must not blank the other");
+}
+
+// ---------------------------------------------------------------------------
+// #1104: telling a finished log stream from a broken one
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_stream_ending_while_the_container_runs_is_a_break() {
+	// The container outlived its own log stream, so output was truncated.
+	assert!(log_stream_broke_mid_output(Some(true)));
+}
+
+#[test]
+fn a_stream_ending_after_the_container_stopped_is_clean() {
+	// The stream is supposed to end here; libpod just did not get to say so.
+	assert!(!log_stream_broke_mid_output(Some(false)));
+}
+
+#[test]
+fn an_unreadable_state_counts_as_a_break() {
+	// The rule that is easy to get backwards, and the one that matters most: the
+	// severed connection that ends the stream is usually the same one the
+	// re-check needs, so reading "could not tell" as a clean end turns every
+	// transport failure back into exit 0. Measured — the permissive version
+	// reported a still-running container as stopped when the socket restarted
+	// under an attached `logs -f`.
+	assert!(log_stream_broke_mid_output(None));
 }


### PR DESCRIPTION
Bringing develop to main. **No tag, no release** — this is a branch sync, and
nothing here publishes on a push to main (`release.yml` fires only on `v*` tags
and `workflow_dispatch`).

## Why now rather than with the next release

The nightly lane runs from the default branch, so it currently uses **main's**
copy of `podman-lane.yml` — the pre-serialisation one, gating the Podman 6 leg on
a pass-count floor. That configuration reported the leg green through **31
failures** (141 passed against a floor of 115). Until main carries the fix, the
nightly safety net can keep doing exactly that, while pull requests get the
corrected lane.

## What is in it

- **#1204** — `logs` exits non-zero when its stream truncates live output. The
  only user-visible change here: it previously returned success after losing its
  connection to the engine, so a monitor could not tell "the container finished"
  from "my socket died". docker compose exits 1 on the same failure, measured
  against the same socket.
- **#1205** — the Podman 6 lane leg runs serialised. This is what identified the
  cause of that leg's failing tail: concurrent container creation against the
  shared rootless netns. 31 failures to zero, with the error signature absent
  from the log.
- **#1206** — that leg now gates on identity with an empty classified list, so
  any failure there is a regression rather than noise.
- **#1203** — 41 crates updated in one pass, including `rustls` 0.23.40 →
  0.23.42; it also replaced eleven separate Dependabot pull requests that would
  have rebased each other.

## Version

Stays at 3.1.0. That means main will carry the `logs` behaviour change under a
version already published, so main and the `v3.1.0` tag no longer match in
content — the same wrinkle as #1188, and deliberate here too. The next release
will settle it.

Worth stating plainly since it is the one thing this sync gets wrong on purpose.
