### PR TITLE
chore: bump to 3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+podup (3.2.0) unstable; urgency=medium
+
+  Changed
+
+  * `logs` exits non-zero when its stream truncates live output. It used to
+    report success after losing its connection to the engine, so a monitor
+    scraping it could not tell "the container finished" from "my socket
+    died". The two are indistinguishable at the transport layer, so the
+    container's state is re-checked out of band: still running means live
+    output was lost. docker compose exits 1 on the same failure, measured
+    against the same socket. A stream that ends because its container
+    stopped still exits zero, as do `logs` without `-f` and a `logs -f`
+    whose reader closes the pipe.
+
+  Dependencies
+
+  * 41 crates updated, including rustls 0.23.40 -> 0.23.42, the TLS stack
+    `podup update` uses to reach GitHub.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 26 Jul 2026 21:32:00 -0500
+
 podup (3.1.0) unstable; urgency=medium
 
   Changed


### PR DESCRIPTION
Version bump for 3.2.0.

## Why a MINOR and not 3.1.1

Same reasoning as 3.1.0. `semver-checks` is clean — the public API does not
change — so a patch would be formally valid. But `logs` now returns a different
exit code for a condition that used to be silent: a script reading 0 after a
severed connection starts seeing 1. A patch number tells the reader there is
nothing to look at, and here there is.

Worth noting the change makes previously-broken scripts *visibly* broken rather
than newly broken. A monitor that treated exit 0 as "the container finished" was
already wrong when the socket had died; it just had no way to know.

## What ships

**#1204** — `logs` exits non-zero when its stream truncates live output.
Reproduced by restarting the libpod socket under an attached `logs -f` on real
Podman 5.4.2: the container was still running and the command returned success.
docker compose, pointed at the same socket and severed the same way, prints
`unexpected EOF` and exits 1 — so exit 0 was a divergence, not parity. Resolved
the way `stats` already does, by re-checking the container out of band.

Clean paths still exit 0, verified: a container that finishes on its own, `logs`
without `-f` on a stopped container, and `logs -f | head` hitting a broken pipe.

**#1203** — 41 crates, including `rustls` 0.23.40 → 0.23.42, the TLS stack
`podup update` uses to reach GitHub.

Also on this branch but invisible to users: the Podman 6 lane leg now runs
serialised (#1205) and gates on identity rather than a pass-count floor (#1206).

## The three files

`Cargo.toml`, `Cargo.lock` and `debian/changelog`, bumped together and verified —
`dpkg-parsechangelog` reads 3.2.0 and all three agree. That is what `release.yml`'s
`verify` job gates on before anything is built, and the file that stranded apt
users in 1.9.0 when it was missed.
