### PR TITLE
release: 3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+podup (3.2.0) unstable; urgency=medium
+
+  Changed
+
+  * `logs` exits non-zero when its stream truncates live output. It used to
+    report success after losing its connection to the engine, so a monitor
+    scraping it could not tell "the container finished" from "my socket
+    died". The two are indistinguishable at the transport layer, so the
+    container's state is re-checked out of band: still running means live
+    output was lost. docker compose exits 1 on the same failure, measured
+    against the same socket. A stream that ends because its container
+    stopped still exits zero, as do `logs` without `-f` and a `logs -f`
+    whose reader closes the pipe.
+
+  Dependencies
+
+  * 41 crates updated, including rustls 0.23.40 -> 0.23.42, the TLS stack
+    `podup update` uses to reach GitHub.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 26 Jul 2026 21:32:00 -0500
+
 podup (3.1.0) unstable; urgency=medium
 
   Changed


### PR DESCRIPTION
Release 3.2.0.

One commit since the last sync to main: the version bump (#1209). Everything it
releases was already brought over in #1208 and has been sitting on main since,
with the nightly lane running against it.

## Why a MINOR

`semver-checks` is clean — the public API does not change — but `logs` returns a
different exit code for a condition that used to be silent. A script reading 0
after a severed connection starts seeing 1, and a patch number would tell the
reader there is nothing to look at.

The change makes previously-broken scripts *visibly* broken rather than newly
broken: a monitor treating exit 0 as "the container finished" was already wrong
when the socket had died, it just had no way to know.

## What ships

**#1204** — `logs` exits non-zero when its stream truncates live output.
Reproduced by restarting the libpod socket under an attached `logs -f` on real
Podman 5.4.2: container still running, command returned success. docker compose,
against the same socket and severed the same way, prints `unexpected EOF` and
exits 1 — so exit 0 was a divergence rather than parity. Resolved the way `stats`
already does, by re-checking the container's state out of band; the transport
layer cannot tell a finished stream from a broken one on its own.

Clean paths still exit 0 and were re-verified, since the risk of this change is
breaking ordinary use rather than the failure case: a container that finishes on
its own, `logs` without `-f` on a stopped container, and `logs -f | head` hitting
a broken pipe.

**#1203** — 41 crates, including `rustls` 0.23.40 → 0.23.42, the TLS stack
`podup update` uses to reach GitHub. That pass also replaced eleven separate
Dependabot pull requests that would have rebased each other.

Invisible to users but shipping too: the Podman 6 lane leg runs serialised
(#1205) and gates on identity instead of a pass-count floor (#1206) — the floor
had reported that leg green through 31 failures.

## Release checks

- Three files agree at 3.2.0: `Cargo.toml`, `Cargo.lock`, `debian/changelog`;
  `dpkg-parsechangelog` reads 3.2.0. That is what `release.yml`'s `verify` job
  gates on, and the file whose omission stranded apt users in 1.9.0.
- #1209 went green on all 17 checks, both lane legs included.
