### PR TITLE
docs: record the streaming exit rule and what config now resolves

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -427,8 +427,16 @@ The `action` of each rule may be:
 ## Maintenance
 
 ### `config`
-Print the resolved compose file (after substitution, extends, include).
-`convert` is an alias.
+Print the resolved compose file (after substitution, extends, include, and
+`env_file`). `convert` is an alias.
+
+`env_file` entries are read and folded into `environment:`, and the key is
+dropped — the same thing `docker compose config` does. Before 3.1.0 the key was
+printed unresolved, so a service taking its whole environment from a file
+rendered with no `environment:` at all, and `config` pointed away from the answer
+it is meant to give. `environment:` still wins over `env_file:`, a later file
+still wins over an earlier one, and a bare `KEY` stays valueless because it means
+"inherit from the host".
 
 | Flag | Description | Default |
 |---|---|---|
@@ -635,6 +643,27 @@ completed run from an abandoned one.
 splits `NetIO`/`BlockIO` into separate input/output fields. Raw numbers are
 exact and need no parsing, but it does mean a docker-compose JSON consumer needs
 adapting rather than working unchanged.
+
+**A streaming command that loses its connection fails.** `logs` and `stats` end
+when the containers they follow stop, and libpod marks that end with a chunked
+terminator. A lost terminator — a dropped connection, or a version that omits it
+— is indistinguishable from a real mid-stream break at the transport layer, so
+both commands resolve it out of band: they re-check whether the containers are
+still running. Still running means live output was truncated, and the command
+exits `1`.
+
+This matters for anything scraping them. `logs -f` used to return success after
+losing its socket, so a monitor could not tell "the container finished" from "my
+connection died" — and a script reading that `0` was already wrong, it just had
+no way to know. `docker compose logs -f` exits `1` on the same failure (measured
+against the same Podman socket), so the old `0` was a divergence rather than
+parity.
+
+A stream that ends because its containers stopped still exits `0`, as does
+`logs` without `-f` and a `logs -f` whose reader closes the pipe (`| head`).
+When the re-check itself cannot be made — usually because the same severed
+connection is needed for it — the command fails rather than assuming the end was
+clean.
 
 **`watch` is the exception.** A sync, rebuild, restart or exec that fails during
 a watch session is reported as a warning and the session keeps going; `watch`

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -87,8 +87,10 @@ pub(super) fn collect_native_plans(
 				},
 				base_dir,
 			)?;
-			// A bare target name lands under /run/secrets/<name>, matching the
-			// bind-mount default and the external-secret behaviour.
+			// A bare target name lands under /run/secrets/<name>, which is where
+			// Podman mounts a secret referenced by name and where a `file:` source
+			// landed back when it was a bind mount. Changing it would move every
+			// existing project's secrets.
 			push_plan(
 				&mut plans,
 				source,
@@ -116,8 +118,10 @@ pub(super) fn collect_native_plans(
 				},
 				base_dir,
 			)?;
-			// Configs default to an absolute container-root path, matching the
-			// bind-mount config behaviour.
+			// Configs default to an absolute container-root path — `/name`, not
+			// `/run/secrets/name`. That is what separates a config from a secret
+			// here, and it is the path a `file:` config landed on when it was a
+			// bind mount.
 			let target = target_override.unwrap_or_else(|| format!("/{name}"));
 			push_plan(&mut plans, source, target, mode, uid, gid)?;
 		}


### PR DESCRIPTION
Three behaviour changes shipped without reaching the docs. All three are mine,
from this stretch of streaming and exit-code work.

## What was missing

| change | shipped in | documented |
|---|---|---|
| `stats` exits non-zero on a truncated live sample | 3.0.2 | no |
| `config` folds `env_file` into `environment:` | 3.1.0 | no |
| `logs` exits non-zero on a truncated stream | 3.2.0 | no |

The exit-status section is the clearest miss. It explained **`watch`'s
exception** in detail — a long-running dev loop should not die because one
rebuild failed — while never stating the rule that exception is an exception to.
Documenting only the carve-out and not the rule is the wrong half.

## What the docs now say

**The streaming rule.** Why the transport cannot tell a finished stream from a
broken one, how `logs` and `stats` resolve it by re-checking the containers out
of band, that `docker compose logs -f` exits 1 on the same failure (measured
against the same Podman socket), and which clean paths still exit 0 — a container
that finishes on its own, `logs` without `-f`, and `logs -f | head` closing the
pipe, which is the case a reader would reasonably worry about. Also that a
re-check which cannot be made fails rather than assuming a clean end, since that
is the non-obvious half.

It notes that a script reading the old `0` was already wrong — it had no way to
know the socket had died — rather than implying this breaks working setups.

**What `config` resolves.** The entry described itself as resolving substitution,
extends and include, and has folded `env_file` in since 3.1.0. It now says so and
keeps the precedence rules, since those are what someone reading the output needs
to interpret it.

## Two code comments pointing at deleted code

`plan.rs` twice justified a default target by "matching the bind-mount
behaviour", and there is no bind-mount path for secrets or configs any more —
it was removed when `file:` sources became native secrets. A reader would have
gone looking for code that does not exist. They now state the rule and mention
the bind only as the history it is.

## What I checked and left alone

- Every version reference in the README and docs is a historical statement
  ("measured on 3.0.1", "added in 3.0.0"), not a stale claim. The benchmark being
  two releases behind is worth a re-measure at some point, but it says which
  version it ran on, so it is honest rather than wrong.
- `--project-directory` still lists `config/secret sources` among the relative
  paths it anchors, which is still true — `file:` paths are resolved the same way,
  they just feed a native secret now instead of a mount.
- The `watch` exception text is accurate and matches what I found reading the loop
  tonight, so it stays as written.

1350 library tests pass; comments and prose only, no behaviour change.
