### PR TITLE
chore: bring develop to main

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -53,10 +53,10 @@ mkdir -p "$OUT_DIR"
 #   reup    : time a warm second `up -d`
 #   running : bring up untimed, then time `ps`, `logs`, `exec -T`, `restart`
 #   build   : time `build --no-cache`
-SCENARIOS=(single multi-healthcheck deep-chain wide-level scale network-ipam volume-heavy warm-restart many-services running-ops wide-running-ops config-heavy build)
+SCENARIOS=(single multi-healthcheck deep-chain wide-level scale network-ipam volume-heavy secrets warm-restart many-services running-ops wide-running-ops config-heavy build)
 declare -A OP=(
 	[single]=updown [multi-healthcheck]=updown [scale]=scale
-	[network-ipam]=updown [volume-heavy]=updown [warm-restart]=reup
+	[network-ipam]=updown [volume-heavy]=updown [secrets]=updown [warm-restart]=reup
 	[many-services]=updown [running-ops]=running [build]=build
 	[config-heavy]=parse [wide-running-ops]=running
 	[deep-chain]=updown [wide-level]=updown

--- a/bench/scenarios/secrets/compose.yaml
+++ b/bench/scenarios/secrets/compose.yaml
@@ -1,0 +1,26 @@
+# A service with several `file:` secrets, exercising secret materialisation and
+# teardown (down is measured with -v so the secrets are removed each iteration).
+#
+# Not covered by any other scenario, and it stopped being free in 3.1.0: a
+# `file:` source used to be a read-only bind mount and is now read and created as
+# a Podman-native secret, which is an API call per secret at `up` and a delete
+# per secret at `down`. Nothing here could see that cost.
+services:
+  app:
+    image: docker.io/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: ["sleep", "3600"]
+    init: true
+    secrets:
+      - sec1
+      - sec2
+      - sec3
+      - sec4
+      - sec5
+      - sec6
+secrets:
+  sec1: {file: ./secret1.txt}
+  sec2: {file: ./secret2.txt}
+  sec3: {file: ./secret3.txt}
+  sec4: {file: ./secret4.txt}
+  sec5: {file: ./secret5.txt}
+  sec6: {file: ./secret6.txt}

--- a/bench/scenarios/secrets/secret1.txt
+++ b/bench/scenarios/secrets/secret1.txt
@@ -1,0 +1,1 @@
+secret-value-1

--- a/bench/scenarios/secrets/secret2.txt
+++ b/bench/scenarios/secrets/secret2.txt
@@ -1,0 +1,1 @@
+secret-value-2

--- a/bench/scenarios/secrets/secret3.txt
+++ b/bench/scenarios/secrets/secret3.txt
@@ -1,0 +1,1 @@
+secret-value-3

--- a/bench/scenarios/secrets/secret4.txt
+++ b/bench/scenarios/secrets/secret4.txt
@@ -1,0 +1,1 @@
+secret-value-4

--- a/bench/scenarios/secrets/secret5.txt
+++ b/bench/scenarios/secrets/secret5.txt
@@ -1,0 +1,1 @@
+secret-value-5

--- a/bench/scenarios/secrets/secret6.txt
+++ b/bench/scenarios/secrets/secret6.txt
@@ -1,0 +1,1 @@
+secret-value-6

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -427,8 +427,16 @@ The `action` of each rule may be:
 ## Maintenance
 
 ### `config`
-Print the resolved compose file (after substitution, extends, include).
-`convert` is an alias.
+Print the resolved compose file (after substitution, extends, include, and
+`env_file`). `convert` is an alias.
+
+`env_file` entries are read and folded into `environment:`, and the key is
+dropped — the same thing `docker compose config` does. Before 3.1.0 the key was
+printed unresolved, so a service taking its whole environment from a file
+rendered with no `environment:` at all, and `config` pointed away from the answer
+it is meant to give. `environment:` still wins over `env_file:`, a later file
+still wins over an earlier one, and a bare `KEY` stays valueless because it means
+"inherit from the host".
 
 | Flag | Description | Default |
 |---|---|---|
@@ -635,6 +643,27 @@ completed run from an abandoned one.
 splits `NetIO`/`BlockIO` into separate input/output fields. Raw numbers are
 exact and need no parsing, but it does mean a docker-compose JSON consumer needs
 adapting rather than working unchanged.
+
+**A streaming command that loses its connection fails.** `logs` and `stats` end
+when the containers they follow stop, and libpod marks that end with a chunked
+terminator. A lost terminator — a dropped connection, or a version that omits it
+— is indistinguishable from a real mid-stream break at the transport layer, so
+both commands resolve it out of band: they re-check whether the containers are
+still running. Still running means live output was truncated, and the command
+exits `1`.
+
+This matters for anything scraping them. `logs -f` used to return success after
+losing its socket, so a monitor could not tell "the container finished" from "my
+connection died" — and a script reading that `0` was already wrong, it just had
+no way to know. `docker compose logs -f` exits `1` on the same failure (measured
+against the same Podman socket), so the old `0` was a divergence rather than
+parity.
+
+A stream that ends because its containers stopped still exits `0`, as does
+`logs` without `-f` and a `logs -f` whose reader closes the pipe (`| head`).
+When the re-check itself cannot be made — usually because the same severed
+connection is needed for it — the command fails rather than assuming the end was
+clean.
 
 **`watch` is the exception.** A sync, rebuild, restart or exec that fails during
 a watch session is reported as a warning and the session keeps going; `watch`

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -87,8 +87,10 @@ pub(super) fn collect_native_plans(
 				},
 				base_dir,
 			)?;
-			// A bare target name lands under /run/secrets/<name>, matching the
-			// bind-mount default and the external-secret behaviour.
+			// A bare target name lands under /run/secrets/<name>, which is where
+			// Podman mounts a secret referenced by name and where a `file:` source
+			// landed back when it was a bind mount. Changing it would move every
+			// existing project's secrets.
 			push_plan(
 				&mut plans,
 				source,
@@ -116,8 +118,10 @@ pub(super) fn collect_native_plans(
 				},
 				base_dir,
 			)?;
-			// Configs default to an absolute container-root path, matching the
-			// bind-mount config behaviour.
+			// Configs default to an absolute container-root path — `/name`, not
+			// `/run/secrets/name`. That is what separates a config from a secret
+			// here, and it is the path a `file:` config landed on when it was a
+			// bind mount.
 			let target = target_override.unwrap_or_else(|| format!("/{name}"));
 			push_plan(&mut plans, source, target, mode, uid, gid)?;
 		}


### PR DESCRIPTION
Bringing develop to main. **No tag, no release** — a branch sync; `release.yml`
fires only on `v*` tags and `workflow_dispatch`.

Two commits, neither touching code:

- **#1211** — documentation. Three behaviour changes had shipped without reaching
  the docs: `stats` exiting non-zero on a truncated live sample (3.0.2), `config`
  folding `env_file` into `environment:` (3.1.0), and `logs` exiting non-zero on a
  truncated stream (3.2.0). The exit-status section had explained `watch`'s
  exception in detail while never stating the rule that exception is an exception
  to. Also fixes two code comments that pointed at a bind-mount path for secrets
  which no longer exists.
- **#1212** — a `secrets` benchmark scenario. None of the thirteen existing ones
  used `secrets:`, so the suite could not see a cost that stopped being free in
  3.1.0: a `file:` source is now read and created as a native secret rather than
  bind-mounted, which is an API call per secret at `up` and a delete at `down`.

## Why sync a docs change on its own

GitHub serves the default branch, so `docs/commands.md` is read from main.
Documentation corrected only on develop is not corrected for anyone. That is the
whole benefit here — the benchmark scenario changes nothing for users, and neither
commit affects the binary.

Worth naming the cost: this spends a full lane run, ~30 minutes with the Podman 6
leg serialised, on prose. That is the recurring price of #1205, and it is more
visible when the content does not need the verification.

## Version

Stays at 3.2.0, which main already carries and which is published. Unlike the
previous sync, nothing here changes behaviour, so main's content still matches
what the `v3.2.0` tag describes.
