### PR TITLE
docs: publish the 3.2.0 benchmark and fix what the harness misreported

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -34,13 +34,17 @@ A podup loss is published exactly like a podup win.
 |---|---|
 | `single` | one container — minimal lifecycle cost |
 | `multi-healthcheck` | `depends_on: service_healthy` gate on `up` |
+| `deep-chain` | a dependency chain behind a fast service: where a level-barrier scheduler loses to a per-service DAG (#1071) |
+| `wide-level` | 41 services in one level plus one dependent — the batching cost the two-service `deep-chain` cannot show |
 | `scale` | `--scale app=5` replica fan-out |
 | `network-ipam` | custom bridge network with explicit IPAM |
 | `volume-heavy` | several named volumes created/removed |
+| `secrets` | six `file:` secrets — materialised as Podman-native secrets since 3.1.0, which is an API call per secret each way |
 | `warm-restart` | a second `up` on an already-running project |
-| `many-services
-- **deep-chain** — a fast and a slow service in the same dependency level, with a chain behind the fast one. The shape where a level-barrier scheduler would lose to a per-service DAG (#1071); kept so that claim stays falsifiable rather than assumed.` | a 12-service compose file |
+| `many-services` | a 12-service compose file, the realistic upper end |
 | `running-ops` | `ps`, `logs`, `exec`, `restart` on a running stack |
+| `wide-running-ops` | the same read path across twelve containers, where the work grows with the container count |
+| `config-heavy` | `config` over a base + override pair: the one scenario with no engine in it, so no daemon variance |
 | `build` | `build --no-cache` from a Dockerfile (base pinned by digest) |
 
 The lifecycle scenarios time `up -d` and `down -v` (`warm-restart` times the warm

--- a/bench/aggregate.py
+++ b/bench/aggregate.py
@@ -19,6 +19,20 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 RAW = os.path.join(HERE, "results", "raw.csv")
 MD = os.path.join(HERE, "results", "report.md")
 JSON = os.path.join(HERE, "results", "summary.json")
+ENGINE = os.path.join(HERE, "results", "engine")
+
+
+def read_engine():
+	"""Which engine docker-compose drove, as recorded by run.sh next to raw.csv.
+
+	Empty when the file is absent — an older results directory, or a run where
+	docker-compose was not measured at all.
+	"""
+	try:
+		with open(ENGINE) as f:
+			return f.read().strip()
+	except OSError:
+		return ""
 
 # Preferred ordering only. Anything measured but not listed here is appended
 # rather than dropped: this list silently discarded four scenarios' worth of
@@ -26,7 +40,7 @@ JSON = os.path.join(HERE, "results", "summary.json")
 # a filter, not an order — 972 rows measured, four scenarios never printed.
 SCEN_ORDER = [
 	"single", "multi-healthcheck", "deep-chain", "wide-level", "scale",
-	"network-ipam", "volume-heavy", "warm-restart", "many-services",
+	"network-ipam", "volume-heavy", "secrets", "warm-restart", "many-services",
 	"running-ops", "wide-running-ops", "config-heavy", "build",
 ]
 OP_ORDER = ["up", "reup", "down", "config", "ps", "logs", "exec", "restart", "build"]
@@ -115,15 +129,20 @@ def main():
 				}
 				summary.setdefault(tool, {}).setdefault(scen, {})[op] = cell
 
-	with open(JSON, "w") as f:
-		json.dump(summary, f, indent="\t", sort_keys=True)
+	if not self_test:
+		with open(JSON, "w") as f:
+			json.dump(summary, f, indent="\t", sort_keys=True)
 
 	# Which engine docker-compose drove decides which table it belongs in, and
 	# that is a property of the RUN, not of the tool's name. run.sh records it;
 	# assuming "docker-compose means dockerd" printed a same-engine measurement
 	# under a heading that said "different daemon", which is the report saying
 	# the opposite of what happened.
-	dc_engine = os.environ.get("BENCH_DOCKER_ENGINE", "")
+	# The env var only reaches here when the aggregator runs inside run.sh's own
+	# process; the documented flow is two separate commands, so the file run.sh
+	# leaves beside raw.csv is the path that actually works. Env wins when set, so
+	# a hand-driven run can still override it.
+	dc_engine = os.environ.get("BENCH_DOCKER_ENGINE", "") or read_engine()
 	dc_same = dc_engine == "podman"
 	same = [t for t in tools if t in ("podup", "podman-compose")]
 	if dc_same:
@@ -187,6 +206,13 @@ def main():
 		lines.append("> docker-compose was not measured against a Docker daemon "
 					 "on this host, so the cross-engine comparison is left blank "
 					 "rather than estimated.\n")
+
+	if self_test:
+		# The self-test runs on six fixture rows. Writing them out would replace a
+		# real report and summary — the output of a benchmark that takes the better
+		# part of an hour and cannot be recomputed, since raw.csv is the only copy.
+		print(f"self-test ok ({len(rows)} fixture rows); {MD} and {JSON} left untouched")
+		return 0
 
 	with open(MD, "w") as f:
 		f.write("\n".join(lines))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -85,16 +85,26 @@ TOOLS=(podup podman-compose)
 #
 # Both are reported; the label says which, because a reader seeing
 # "docker-compose" will assume dockerd.
+# Which engine docker-compose drove is written NEXT TO THE RESULTS, not only
+# exported. An env var dies with this process, and the documented flow is two
+# commands (`bash bench/run.sh`, then `python3 bench/aggregate.py`), so the
+# aggregator never saw it and fell back to assuming dockerd — printing a
+# same-engine measurement under a heading that says "different daemon". The file
+# travels with raw.csv, which is the only thing that can still be read afterwards.
+ENGINE_FILE="$OUT_DIR/engine"
+rm -f "$ENGINE_FILE"
 if command -v docker-compose >/dev/null 2>&1; then
 	if docker info >/dev/null 2>&1; then
 		TOOLS+=(docker-compose)
 		export BENCH_DOCKER_ENGINE=docker
+		echo docker > "$ENGINE_FILE"
 		echo "note: Docker Engine present — docker-compose measured as a CROSS-ENGINE (whole-stack) run."
 	elif [ -n "${DOCKER_HOST:-}" ] && docker-compose ls >/dev/null 2>&1; then
 		TOOLS+=(docker-compose)
 		# Recorded so the report puts these rows under the right heading; the
 		# tool's name does not say which engine it drove.
 		export BENCH_DOCKER_ENGINE=podman
+		echo podman > "$ENGINE_FILE"
 		echo "note: docker-compose driving Podman via DOCKER_HOST — measured as a SAME-ENGINE (pure tool) run."
 	else
 		echo "note: docker-compose found but no reachable engine — NOT measured. Set DOCKER_HOST to the Podman socket to include it."

--- a/docs/assets/bench.svg
+++ b/docs/assets/bench.svg
@@ -10,42 +10,42 @@
   <text class="l" x="24" y="47">median of 10 measured runs · lower is better</text>
   <text class="t" x="24" y="72">memory per command</text>
   <text class="l" x="168" y="97" text-anchor="end">podup</text>
-  <rect x="176" y="82" width="73" height="22" rx="3" fill="#3fb950"/>
-  <text class="v" x="257" y="97">7.78 MiB</text>
+  <rect x="176" y="82" width="71" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="255" y="97">7.66 MiB</text>
   <text class="l" x="168" y="123" text-anchor="end">docker-compose</text>
-  <rect x="176" y="108" width="270" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="454" y="123">28.68 MiB</text>
+  <rect x="176" y="108" width="264" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="448" y="123">28.41 MiB</text>
   <text class="l" x="168" y="149" text-anchor="end">podman-compose</text>
   <rect x="176" y="134" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="149">51.68 MiB</text>
+  <text class="v" x="672" y="149">52.51 MiB</text>
   <text class="t" x="24" y="188">up · 42 services</text>
   <text class="l" x="168" y="213" text-anchor="end">podup</text>
-  <rect x="176" y="198" width="71" height="22" rx="3" fill="#3fb950"/>
-  <text class="v" x="255" y="213">1.12 s</text>
+  <rect x="176" y="198" width="75" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="259" y="213">1.04 s</text>
   <text class="l" x="168" y="239" text-anchor="end">docker-compose</text>
-  <rect x="176" y="224" width="98" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="282" y="239">1.54 s</text>
+  <rect x="176" y="224" width="108" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="292" y="239">1.50 s</text>
   <text class="l" x="168" y="265" text-anchor="end">podman-compose</text>
   <rect x="176" y="250" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="265">7.69 s</text>
+  <text class="v" x="672" y="265">6.74 s</text>
   <text class="t" x="24" y="304">up · 12 services</text>
   <text class="l" x="168" y="329" text-anchor="end">podup</text>
-  <rect x="176" y="314" width="78" height="22" rx="3" fill="#3fb950"/>
-  <text class="v" x="262" y="329">0.38 s</text>
+  <rect x="176" y="314" width="87" height="22" rx="3" fill="#3fb950"/>
+  <text class="v" x="271" y="329">0.38 s</text>
   <text class="l" x="168" y="355" text-anchor="end">docker-compose</text>
-  <rect x="176" y="340" width="100" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="284" y="355">0.48 s</text>
+  <rect x="176" y="340" width="110" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="294" y="355">0.47 s</text>
   <text class="l" x="168" y="381" text-anchor="end">podman-compose</text>
   <rect x="176" y="366" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="381">2.37 s</text>
+  <text class="v" x="672" y="381">2.09 s</text>
   <text class="t" x="24" y="420">config · parse only</text>
   <text class="l" x="168" y="445" text-anchor="end">podup</text>
   <rect x="176" y="430" width="2" height="22" rx="3" fill="#3fb950"/>
   <text class="v" x="186" y="445">&lt;0.01 s</text>
   <text class="l" x="168" y="471" text-anchor="end">docker-compose</text>
-  <rect x="176" y="456" width="150" height="22" rx="3" fill="#58a6ff"/>
-  <text class="v" x="334" y="471">0.04 s</text>
+  <rect x="176" y="456" width="177" height="22" rx="3" fill="#58a6ff"/>
+  <text class="v" x="361" y="471">0.04 s</text>
   <text class="l" x="168" y="497" text-anchor="end">podman-compose</text>
   <rect x="176" y="482" width="488" height="22" rx="3" fill="#f778ba"/>
-  <text class="v" x="672" y="497">0.13 s</text>
+  <text class="v" x="672" y="497">0.11 s</text>
 </svg>

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -32,40 +32,45 @@ include docker-compose), then `python3 bench/aggregate.py`. Raw per-iteration
 rows land in `bench/results/raw.csv`; the statistics are computed there and
 never by the runner.
 
-Measured on podup **3.0.1** installed from apt — the same binary a user gets,
-not a local build.
+Measured on podup **3.2.0** installed from apt — the same binary a user gets,
+not a local build — against podman-compose 1.3.0 and docker-compose 5.1.3 on
+rootless Podman 5.4.2, 16 cores. Six unrelated containers of my own were running
+on the host throughout, for every tool alike; that is a fair comparison but not an
+idle machine, and it is part of why the teardown rows spread the way they do.
 
 ## Wall-clock (seconds, lower is better)
 
 | scenario | op | podman-compose | podup | docker-compose |
 |---|---|---|---|---|
-| single | up | 0.415 (p95 0.460, sd 0.019) | 0.080 (p95 0.090, sd 0.005) | 0.110 (p95 0.120, sd 0.006) |
-| single | down | 0.395 (p95 0.430, sd 0.020) | 0.135 (p95 0.190, sd 0.019) | 0.150 (p95 0.180, sd 0.014) |
-| multi-healthcheck | up | 0.650 (p95 0.680, sd 0.018) | 0.280 (p95 0.400, sd 0.087) | 0.690 (p95 0.710, sd 0.007) |
-| multi-healthcheck | down | 0.510 (p95 0.540, sd 0.016) | 0.245 (p95 0.310, sd 0.029) | 0.275 (p95 0.380, sd 0.034) |
-| deep-chain | up | 1.300 (p95 1.340, sd 0.022) | 0.370 (p95 0.390, sd 0.011) | 0.845 (p95 0.910, sd 0.028) |
-| deep-chain | down | 0.770 (p95 0.850, sd 0.033) | 0.380 (p95 0.410, sd 0.017) | 0.380 (p95 0.400, sd 0.015) |
-| wide-level | up | 7.690 (p95 7.860, sd 0.094) | 1.120 (p95 1.270, sd 0.055) | 1.545 (p95 1.730, sd 0.069) |
-| wide-level | down | 4.375 (p95 4.620, sd 0.118) | 1.885 (p95 2.380, sd 0.245) | 2.145 (p95 3.660, sd 0.519) |
-| scale | up | 0.435 (p95 0.540, sd 0.038) | 0.190 (p95 0.220, sd 0.012) | 0.380 (p95 0.390, sd 0.008) |
-| scale | down | 0.420 (p95 0.450, sd 0.019) | 0.275 (p95 0.310, sd 0.023) | 0.285 (p95 0.330, sd 0.020) |
-| network-ipam | up | 0.590 (p95 0.620, sd 0.020) | 0.100 (p95 0.110, sd 0.005) | 0.130 (p95 0.140, sd 0.005) |
-| network-ipam | down | 0.500 (p95 0.520, sd 0.018) | 0.165 (p95 0.180, sd 0.011) | 0.190 (p95 0.210, sd 0.016) |
-| volume-heavy | up | 0.830 (p95 1.000, sd 0.069) | 0.100 (p95 0.120, sd 0.011) | 0.120 (p95 0.150, sd 0.010) |
-| volume-heavy | down | 0.550 (p95 0.680, sd 0.052) | 0.145 (p95 0.160, sd 0.010) | 0.190 (p95 0.210, sd 0.014) |
-| warm-restart | warm up | 0.360 (p95 0.370, sd 0.008) | 0.030 (p95 0.030, sd 0.004) | 0.040 (p95 0.050, sd 0.005) |
-| many-services | up | 2.365 (p95 2.430, sd 0.042) | 0.380 (p95 0.430, sd 0.025) | 0.485 (p95 0.520, sd 0.017) |
-| many-services | down | 1.420 (p95 1.480, sd 0.035) | 0.580 (p95 0.730, sd 0.092) | 0.565 (p95 0.600, sd 0.039) |
-| running-ops | ps | 0.110 (p95 0.130, sd 0.007) | 0.000 (p95 0.000, sd 0.000) | 0.020 (p95 0.020, sd 0.000) |
-| running-ops | logs | 0.150 (p95 0.170, sd 0.010) | 0.030 (p95 0.050, sd 0.007) | 0.035 (p95 0.040, sd 0.005) |
-| running-ops | exec | 0.185 (p95 0.200, sd 0.009) | 0.060 (p95 0.060, sd 0.003) | 0.070 (p95 0.080, sd 0.005) |
-| running-ops | restart | 0.290 (p95 0.320, sd 0.018) | 0.170 (p95 0.200, sd 0.013) | 0.170 (p95 0.200, sd 0.010) |
-| wide-running-ops | ps | 0.130 (p95 0.140, sd 0.010) | 0.010 (p95 0.020, sd 0.003) | 0.035 (p95 0.040, sd 0.005) |
-| wide-running-ops | logs | 0.160 (p95 0.170, sd 0.008) | 0.030 (p95 0.030, sd 0.005) | 0.040 (p95 0.040, sd 0.004) |
-| wide-running-ops | exec | 0.200 (p95 0.210, sd 0.012) | 0.060 (p95 0.070, sd 0.005) | 0.070 (p95 0.070, sd 0.003) |
-| wide-running-ops | restart | 0.240 (p95 0.270, sd 0.013) | 0.115 (p95 0.120, sd 0.007) | 0.140 (p95 0.160, sd 0.009) |
-| config-heavy | config | 0.130 (p95 0.140, sd 0.006) | 0.000 (p95 0.000, sd 0.000) | 0.040 (p95 0.040, sd 0.005) |
-| build | build | 0.340 (p95 0.380, sd 0.019) | 0.200 (p95 0.210, sd 0.006) | 0.260 (p95 0.280, sd 0.010) |
+| single | up | 0.380 (p95 0.430, sd 0.017) | 0.090 (p95 0.100, sd 0.006) | 0.110 (p95 0.120, sd 0.006) |
+| single | down | 0.360 (p95 0.440, sd 0.025) | 0.130 (p95 0.150, sd 0.010) | 0.150 (p95 0.170, sd 0.010) |
+| multi-healthcheck | up | 0.600 (p95 0.690, sd 0.033) | 0.355 (p95 0.370, sd 0.072) | 0.695 (p95 0.720, sd 0.010) |
+| multi-healthcheck | down | 0.500 (p95 0.530, sd 0.016) | 0.260 (p95 0.300, sd 0.028) | 0.270 (p95 0.290, sd 0.011) |
+| deep-chain | up | 1.180 (p95 1.190, sd 0.009) | 0.380 (p95 0.420, sd 0.019) | 0.840 (p95 0.860, sd 0.011) |
+| deep-chain | down | 0.690 (p95 0.770, sd 0.033) | 0.380 (p95 0.400, sd 0.010) | 0.390 (p95 0.410, sd 0.013) |
+| wide-level | up | 6.745 (p95 6.820, sd 0.045) | 1.040 (p95 1.100, sd 0.033) | 1.500 (p95 1.710, sd 0.081) |
+| wide-level | down | 4.500 (p95 5.210, sd 0.399) | 1.900 (p95 2.490, sd 0.251) | 2.165 (p95 2.640, sd 0.284) |
+| scale | up | 0.400 (p95 0.420, sd 0.008) | 0.180 (p95 0.190, sd 0.006) | 0.380 (p95 0.390, sd 0.011) |
+| scale | down | 0.390 (p95 0.470, sd 0.025) | 0.250 (p95 0.280, sd 0.012) | 0.295 (p95 0.320, sd 0.018) |
+| network-ipam | up | 0.560 (p95 0.620, sd 0.027) | 0.100 (p95 0.110, sd 0.005) | 0.130 (p95 0.150, sd 0.008) |
+| network-ipam | down | 0.475 (p95 0.510, sd 0.020) | 0.170 (p95 0.180, sd 0.011) | 0.195 (p95 0.220, sd 0.012) |
+| volume-heavy | up | 0.850 (p95 0.920, sd 0.023) | 0.105 (p95 0.170, sd 0.021) | 0.130 (p95 0.130, sd 0.005) |
+| volume-heavy | down | 0.555 (p95 0.600, sd 0.017) | 0.150 (p95 0.160, sd 0.010) | 0.195 (p95 0.210, sd 0.012) |
+| secrets | up | 0.390 (p95 0.520, sd 0.041) | 0.100 (p95 0.100, sd 0.005) | 0.110 (p95 0.120, sd 0.006) |
+| secrets | down | 0.375 (p95 0.390, sd 0.009) | 0.135 (p95 0.150, sd 0.007) | 0.155 (p95 0.160, sd 0.008) |
+| warm-restart | warm up | 0.330 (p95 0.370, sd 0.014) | 0.030 (p95 0.040, sd 0.006) | 0.040 (p95 0.050, sd 0.004) |
+| many-services | up | 2.090 (p95 2.110, sd 0.021) | 0.375 (p95 0.410, sd 0.023) | 0.475 (p95 0.520, sd 0.017) |
+| many-services | down | 1.235 (p95 1.600, sd 0.135) | 0.495 (p95 0.880, sd 0.119) | 0.565 (p95 0.670, sd 0.050) |
+| running-ops | ps | 0.120 (p95 0.120, sd 0.005) | 0.000 (p95 0.010, sd 0.003) | 0.020 (p95 0.020, sd 0.000) |
+| running-ops | logs | 0.140 (p95 0.140, sd 0.003) | 0.020 (p95 0.030, sd 0.005) | 0.030 (p95 0.040, sd 0.004) |
+| running-ops | exec | 0.180 (p95 0.190, sd 0.004) | 0.060 (p95 0.070, sd 0.004) | 0.070 (p95 0.070, sd 0.003) |
+| running-ops | restart | 0.280 (p95 0.300, sd 0.009) | 0.165 (p95 0.180, sd 0.010) | 0.180 (p95 0.200, sd 0.009) |
+| wide-running-ops | ps | 0.120 (p95 0.130, sd 0.005) | 0.010 (p95 0.010, sd 0.003) | 0.040 (p95 0.040, sd 0.004) |
+| wide-running-ops | logs | 0.150 (p95 0.170, sd 0.009) | 0.020 (p95 0.030, sd 0.003) | 0.035 (p95 0.040, sd 0.005) |
+| wide-running-ops | exec | 0.195 (p95 0.210, sd 0.008) | 0.060 (p95 0.080, sd 0.006) | 0.070 (p95 0.080, sd 0.003) |
+| wide-running-ops | restart | 0.240 (p95 0.260, sd 0.009) | 0.115 (p95 0.140, sd 0.012) | 0.140 (p95 0.150, sd 0.006) |
+| config-heavy | config | 0.110 (p95 0.110, sd 0.000) | 0.000 (p95 0.010, sd 0.003) | 0.040 (p95 0.040, sd 0.005) |
+| build | build | 0.355 (p95 0.370, sd 0.010) | 0.205 (p95 0.220, sd 0.007) | 0.265 (p95 0.270, sd 0.007) |
 
 ## Memory + CPU per command (peak RSS / CPU time, median)
 
@@ -77,53 +82,79 @@ Go binary talking to a socket, like podup.
 
 | scenario | op | podman-compose | podup | docker-compose |
 |---|---|---|---|---|
-| single | up | 51.7 MiB / 0.410 s | 7.8 MiB / 0.000 s | 28.7 MiB / 0.020 s |
-| single | down | 49.5 MiB / 0.335 s | 7.6 MiB / 0.000 s | 28.3 MiB / 0.010 s |
-| multi-healthcheck | up | 52.4 MiB / 0.590 s | 7.9 MiB / 0.000 s | 29.0 MiB / 0.020 s |
-| multi-healthcheck | down | 49.6 MiB / 0.450 s | 7.6 MiB / 0.000 s | 28.3 MiB / 0.020 s |
-| deep-chain | up | 53.0 MiB / 1.180 s | 7.7 MiB / 0.000 s | 29.4 MiB / 0.030 s |
-| deep-chain | down | 50.0 MiB / 0.760 s | 7.7 MiB / 0.000 s | 28.5 MiB / 0.020 s |
-| wide-level | up | 52.8 MiB / 6.520 s | 8.4 MiB / 0.020 s | 33.3 MiB / 0.080 s |
-| wide-level | down | 50.1 MiB / 4.990 s | 7.9 MiB / 0.010 s | 30.4 MiB / 0.050 s |
-| scale | up | 51.7 MiB / 0.405 s | 7.8 MiB / 0.000 s | 29.7 MiB / 0.020 s |
-| scale | down | 49.8 MiB / 0.330 s | 7.5 MiB / 0.000 s | 28.7 MiB / 0.010 s |
-| network-ipam | up | 52.2 MiB / 0.540 s | 7.8 MiB / 0.000 s | 29.1 MiB / 0.020 s |
-| network-ipam | down | 49.9 MiB / 0.430 s | 7.6 MiB / 0.000 s | 28.4 MiB / 0.020 s |
-| volume-heavy | up | 52.2 MiB / 0.940 s | 7.8 MiB / 0.000 s | 28.9 MiB / 0.020 s |
-| volume-heavy | down | 49.6 MiB / 0.520 s | 7.5 MiB / 0.000 s | 29.1 MiB / 0.020 s |
-| warm-restart | warm up | 50.3 MiB / 0.390 s | 7.7 MiB / 0.000 s | 29.6 MiB / 0.020 s |
-| many-services | up | 52.6 MiB / 2.005 s | 8.0 MiB / 0.000 s | 30.2 MiB / 0.040 s |
-| many-services | down | 49.8 MiB / 1.520 s | 7.6 MiB / 0.000 s | 28.9 MiB / 0.030 s |
-| running-ops | ps | 48.5 MiB / 0.120 s | 7.3 MiB / 0.000 s | 28.5 MiB / 0.010 s |
-| running-ops | logs | 64.1 MiB / 0.130 s | 7.6 MiB / 0.000 s | 28.4 MiB / 0.010 s |
-| running-ops | exec | 47.7 MiB / 0.135 s | 7.6 MiB / 0.000 s | 26.9 MiB / 0.010 s |
-| running-ops | restart | 48.3 MiB / 0.175 s | 7.5 MiB / 0.000 s | 28.7 MiB / 0.020 s |
-| wide-running-ops | ps | 49.5 MiB / 0.140 s | 7.3 MiB / 0.000 s | 29.5 MiB / 0.030 s |
-| wide-running-ops | logs | 64.3 MiB / 0.140 s | 7.6 MiB / 0.000 s | 28.4 MiB / 0.020 s |
-| wide-running-ops | exec | 48.1 MiB / 0.140 s | 7.6 MiB / 0.000 s | 27.0 MiB / 0.010 s |
-| wide-running-ops | restart | 48.8 MiB / 0.180 s | 7.5 MiB / 0.000 s | 28.6 MiB / 0.020 s |
-| config-heavy | config | 37.8 MiB / 0.125 s | 7.1 MiB / 0.000 s | 29.3 MiB / 0.045 s |
-| build | build | 57.2 MiB / 0.355 s | 7.7 MiB / 0.000 s | 30.0 MiB / 0.020 s |
+| single | up | 52.5 MiB / 0.450 s | 7.7 MiB / 0.000 s | 28.4 MiB / 0.020 s |
+| single | down | 49.8 MiB / 0.370 s | 7.4 MiB / 0.000 s | 28.1 MiB / 0.020 s |
+| multi-healthcheck | up | 53.0 MiB / 0.665 s | 7.7 MiB / 0.000 s | 28.8 MiB / 0.030 s |
+| multi-healthcheck | down | 50.2 MiB / 0.490 s | 7.4 MiB / 0.000 s | 28.2 MiB / 0.020 s |
+| deep-chain | up | 53.1 MiB / 1.300 s | 7.7 MiB / 0.000 s | 28.7 MiB / 0.030 s |
+| deep-chain | down | 50.2 MiB / 0.850 s | 7.4 MiB / 0.000 s | 28.6 MiB / 0.020 s |
+| wide-level | up | 53.3 MiB / 7.070 s | 8.1 MiB / 0.020 s | 34.6 MiB / 0.090 s |
+| wide-level | down | 50.7 MiB / 5.800 s | 7.5 MiB / 0.010 s | 31.4 MiB / 0.065 s |
+| scale | up | 52.1 MiB / 0.445 s | 7.6 MiB / 0.000 s | 28.7 MiB / 0.030 s |
+| scale | down | 50.0 MiB / 0.370 s | 7.3 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| network-ipam | up | 52.5 MiB / 0.610 s | 7.7 MiB / 0.000 s | 28.6 MiB / 0.025 s |
+| network-ipam | down | 50.1 MiB / 0.480 s | 7.4 MiB / 0.000 s | 28.1 MiB / 0.020 s |
+| volume-heavy | up | 52.4 MiB / 1.085 s | 7.6 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| volume-heavy | down | 49.8 MiB / 0.585 s | 7.4 MiB / 0.000 s | 28.7 MiB / 0.020 s |
+| secrets | up | 52.3 MiB / 0.450 s | 7.6 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| secrets | down | 49.8 MiB / 0.365 s | 7.4 MiB / 0.000 s | 28.3 MiB / 0.020 s |
+| warm-restart | warm up | 50.8 MiB / 0.440 s | 7.5 MiB / 0.000 s | 28.9 MiB / 0.020 s |
+| many-services | up | 53.1 MiB / 2.195 s | 7.8 MiB / 0.000 s | 30.5 MiB / 0.040 s |
+| many-services | down | 50.2 MiB / 1.720 s | 7.4 MiB / 0.000 s | 29.3 MiB / 0.030 s |
+| running-ops | ps | 48.6 MiB / 0.130 s | 7.2 MiB / 0.000 s | 28.4 MiB / 0.010 s |
+| running-ops | logs | 66.4 MiB / 0.130 s | 7.4 MiB / 0.000 s | 28.3 MiB / 0.015 s |
+| running-ops | exec | 47.9 MiB / 0.140 s | 7.5 MiB / 0.000 s | 26.8 MiB / 0.010 s |
+| running-ops | restart | 48.7 MiB / 0.180 s | 7.4 MiB / 0.000 s | 28.3 MiB / 0.010 s |
+| wide-running-ops | ps | 49.8 MiB / 0.140 s | 7.1 MiB / 0.000 s | 29.3 MiB / 0.030 s |
+| wide-running-ops | logs | 66.1 MiB / 0.140 s | 7.4 MiB / 0.000 s | 28.8 MiB / 0.020 s |
+| wide-running-ops | exec | 48.3 MiB / 0.140 s | 7.5 MiB / 0.000 s | 27.0 MiB / 0.000 s |
+| wide-running-ops | restart | 48.6 MiB / 0.180 s | 7.2 MiB / 0.000 s | 28.5 MiB / 0.020 s |
+| config-heavy | config | 38.0 MiB / 0.110 s | 7.2 MiB / 0.000 s | 28.9 MiB / 0.050 s |
+| build | build | 58.8 MiB / 0.390 s | 7.5 MiB / 0.000 s | 29.1 MiB / 0.020 s |
 
 ## Reading these numbers honestly
 
-podup is fastest in every row of the memory-and-CPU table, and the fastest or
-tied-fastest in all but one of the wall-clock rows. The exception is
-`many-services down`, where docker-compose's 0.565 s edges podup's 0.580 s —
-0.015 s apart, well inside podup's own 0.092 s standard deviation on that row,
-so it is a coin toss rather than a real gap. Two teardown rows land in an exact
-tie (`deep-chain down` and `running-ops restart`, both 0.170–0.380 s to the
-millisecond). The point of this benchmark is to publish the numbers whoever
-wins, so those rows stand as measured, and which teardown row falls on which
-side of the line shifts run to run within that noise.
+podup is fastest in every row of both tables in this run. **Three of those wins
+are not real**, and they are worth naming rather than counting:
+
+| row | podup | best of the others | gap | podup's own sd |
+|---|---|---|---|---|
+| multi-healthcheck down | 0.260 | 0.270 | 0.010 | 0.028 |
+| deep-chain down | 0.380 | 0.390 | 0.010 | 0.010 |
+| many-services down | 0.495 | 0.565 | 0.070 | 0.119 |
+
+Each gap is inside podup's own standard deviation on that row, so those three are
+coin tosses that happened to land this way. `many-services down` landed the other
+way in the 3.0.1 run — docker-compose ahead by 0.015 s, also inside the noise —
+and nothing about either tool changed in between. Teardown is where this benchmark
+is noisiest, and a row that flips between runs is telling you the spread, not the
+winner.
 
 `running-ops ps` and `config-heavy config` show podup at **0.000s**. That is the
-floor of `/usr/bin/time -v`, which resolves to 10ms — the real figure is around
-8ms, dominated by process startup rather than by the work. It is not zero, it is
-below what the instrument can see.
+floor of `/usr/bin/time -v`, which resolves to 10 ms. Timed separately over 50
+invocations, `ps` against a project that does not exist takes 7.7 ms and `config`
+on this two-file scenario 8.3 ms, and 2.0 ms of that is process start — the binary
+spawning, building its command tree and its async runtime, before any work. It is
+not zero, it is below what the instrument can see.
 
-The `multi-healthcheck` row moved the most between releases: 1.275s in 2.0.0
-against 0.280s here. That is not a scheduling trick, it is a bug fix — podup
-used to read a container's health status once per healthcheck `interval` and
-now reads it every 150ms between runs, so a container that turns healthy just
-after a probe is noticed at once instead of at the end of the window.
+`multi-healthcheck up` is the noisiest row in the suite (sd 0.072 here, 0.087 in
+the 3.0.1 run) and the one most likely to be misread across releases: it reads
+0.355 s here against 0.280 s for 3.0.1, which looks like a regression and is not
+one. Run head-to-head on the same machine, alternating binaries per iteration,
+3.2.0 came out at 0.295 s against 3.0.1's 0.350 s — the two numbers in this table
+are further apart than the two binaries are. Compare releases by running them
+against each other, never by subtracting two published tables.
+
+What that row does show, against 2.0.0's 1.275 s, is a bug fix rather than a
+scheduling trick: podup used to read a container's health status once per
+healthcheck `interval` and now reads it every 150 ms between runs, so a container
+that turns healthy just after a probe is noticed at once instead of at the end of
+the window.
+
+The `secrets` scenario is new here, and it is the one place where a correctness
+fix cost measurable time. Six `file:` secrets used to be six read-only bind
+mounts; since 3.1.0 each is read and created as a Podman-native secret, because a
+bind mount is denied outright on an SELinux host while `up` still reports the
+container as started. That is three API calls per secret at `up` and two at
+`down`, and it puts about 10 ms on each direction of this scenario. The fix is
+worth the 10 ms.


### PR DESCRIPTION
The published tables were 3.0.1, and the harness had three ways of describing a
run that did not match the run.

## Re-measured

All fourteen scenarios on **3.2.0 installed from apt** — the binary a user gets,
not a local build — against podman-compose 1.3.0 and docker-compose 5.1.3, all
three driving the same rootless Podman 5.4.2. 12 iterations, first 2 discarded,
1044 rows, zero non-zero exits. `secrets` appears in a published table for the
first time.

podup is fastest in every row this time. **Three of those wins are inside its own
standard deviation** and the reading section says so by name:

| row | podup | best of the others | gap | podup's sd |
|---|---|---|---|---|
| multi-healthcheck down | 0.260 | 0.270 | 0.010 | 0.028 |
| deep-chain down | 0.380 | 0.390 | 0.010 | 0.010 |
| many-services down | 0.495 | 0.565 | 0.070 | 0.119 |

`many-services down` landed the *other* way in the 3.0.1 run — docker-compose ahead
by 0.015 s, also inside the noise — with nothing about either tool changed in
between. That row reports the spread, not a winner, and the doc now says that
rather than claiming a win.

Two estimates became measurements:

- the `0.000 s` cells are the 10 ms floor of `/usr/bin/time -v`. Timed separately
  over 50 invocations: `ps` 7.7 ms, `config` 8.3 ms, of which 2.0 ms is process
  start (spawn, command tree, async runtime).
- `multi-healthcheck up` reads 0.355 s here against 0.280 s for 3.0.1, which looks
  like a regression and is not one. Run head-to-head on this machine, alternating
  binaries per iteration, 3.2.0 came out at 0.295 s against 3.0.1's 0.350 s — the
  two published numbers are further apart than the two binaries. The doc now says
  to compare releases by running them against each other, never by subtracting two
  tables.

## Three harness defects

- **The engine label died with the process.** `run.sh` exports
  `BENCH_DOCKER_ENGINE`; `aggregate.py` reads it — but the documented flow is two
  separate commands, so docker-compose landed under the "drives dockerd" heading
  for a run that drove Podman through `DOCKER_HOST`. It is written beside
  `raw.csv` now; the env var still wins when set.
- **`secrets` was missing from `SCEN_ORDER`**, so the newest scenario printed last,
  after `build`.
- **`--self-test` wrote its fixture rows over `report.md` and `summary.json`** —
  `bench/results/` is gitignored and `raw.csv` is the only copy, so a self-test
  destroyed the output of a 40-minute run. It builds everything and writes nothing
  now.

`bench/README.md`'s scenario table was also missing five scenarios and had
`deep-chain`'s description spliced into the middle of the `many-services` row,
which broke the table.

## Disclosure about the environment

Six unrelated containers of mine were running on the host throughout, for every
tool alike. That is a fair comparison but not an idle machine, and the doc says so
— it is part of why the teardown rows spread the way they do. Say the word and I
will re-measure with the host quiet.

For this run I supplied the engine label by hand (`echo podman >
bench/results/engine`) because the pre-fix `run.sh` had not written it. It is not a
guess: the run recorded it itself in `bench/results/run.log`, first line —
`docker-compose driving Podman via DOCKER_HOST — measured as a SAME-ENGINE (pure
tool) run.`

Closes #1216
