### PR TITLE
ci(podman-lane): record which image each leg booted

### DIFF
--- a/.github/podman-known-failures-6
+++ b/.github/podman-known-failures-6
@@ -31,3 +31,15 @@
 # add it here with the evidence. Do NOT delete this file to make the red go away —
 # an empty list is what makes a regression loud, and going back to a count gate is
 # how #1072 shipped a bug with the pass count sitting comfortably above the floor.
+#
+# ONE THING TO KNOW BEFORE CLASSIFYING ANYTHING HERE: this leg's environment is not
+# fixed. It boots whatever Fedora Rawhide compose is newest when the job runs, so
+# most days it is a different operating system — different kernel, different
+# systemd, everything below Podman. Two runs of this leg are not two observations
+# of one environment, which is very likely part of why the tail this file's header
+# describes resisted classification for as long as it did. The gate now prints the
+# image alongside the counts (#1222); read it before deciding a failure is
+# environmental, and say which image you saw it on when you add a line here.
+#
+# The same caveat does not apply to Podman 5: that leg boots a released Fedora 44
+# image, which changes only when Fedora respins it.

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -45,6 +45,13 @@ jobs:
           fi
           [ -n "$img" ] || { echo "::error::could not resolve a Fedora image name for Podman $SEL at $base"; exit 1; }
           echo "image: $img"
+          # Carry it to the gate step. The name resolves to whatever compose is
+          # newest at this moment, so the Podman 6 leg boots a DIFFERENT operating
+          # system most days — and until now that fact lived only in the middle of
+          # this step's log. Two runs of this leg are not the same environment, and
+          # anyone comparing a failure against the run before it has to know which
+          # one they got (#1222).
+          echo "VM_IMAGE=$img" >> "$GITHUB_ENV"
           # The rawhide qcow2 is ~500 MB and the mirror occasionally drops the
           # connection mid-transfer (curl exit 18). Resume + retry so a transient
           # network blip doesn't fail the lane.
@@ -214,6 +221,15 @@ jobs:
           FLAKY=$(echo "$SUM" | grep -oE 'flaky=[0-9]+' | cut -d= -f2)
           PASS=${PASS:-0}; FAIL=${FAIL:-0}; FLAKY=${FLAKY:-0}
           echo "Podman $VER: $PASS passed, $FAIL failed ($FLAKY look like connection-drop flakes)"
+          echo "Podman $VER ran on image: ${VM_IMAGE:-unknown}"
+          # The run page, not just the log: whoever reads a red lane needs the
+          # environment next to the counts, and the rawhide leg's environment
+          # changes under it (#1222).
+          {
+            echo "### Podman $VER — $PASS passed, $FAIL failed, $FLAKY drop-like"
+            echo ""
+            echo "image: \`${VM_IMAGE:-unknown}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
           # Strip CR: the VM talks to us over `-serial stdio`, so every line of
           # this log arrives CRLF-terminated. The counts survive because they are
           # extracted with numeric patterns, but the identity list keeps the CR on
@@ -247,6 +263,7 @@ jobs:
             if [ -n "$unexpected" ]; then
               echo "::error::Podman $VER: these failing tests are not in $(basename "$known") — a test that used to pass is failing, which is a regression, not nested-virt noise:"
               echo "$unexpected" | awk '{print "  " $0}'
+              echo "Environment: Podman $VER on ${VM_IMAGE:-an unrecorded image}. Before concluding, check whether the run you are comparing against booted the same one — the rawhide leg usually does not (#1222)."
               echo "If a run proves the failure is environmental, add it to that file with the evidence; do not add it to make this red go away."
               exit 1
             fi


### PR DESCRIPTION
The lane now says which operating system it ran on, in the places where somebody is
actually deciding something.

## What was wrong

The image name resolves to whatever compose is newest at the moment the job runs:

```
img=$(curl -fsSL "$base" | grep -oE 'Fedora-Cloud-Base-Generic-Rawhide-[0-9]+\.n\.[0-9]+\.x86_64\.qcow2' | sort -u | tail -1)
```

So the Podman 6 leg boots a **different operating system most days** — kernel,
systemd, everything below Podman — and that fact lived in the middle of one step's
log. Every comparison between two runs quietly assumed an environment they did not
share.

I ran into it closing #1214. A leg that had failed at two threads came back green at
two threads, and it took four runs to establish that the newer rawhide was not the
reason, because nothing in the gate said the image had changed:

| run | image | threads | result |
|---|---|---|---|
| 30222778630 | `20260726.n.0` | 2 | 141 passed, 31 failed |
| 30225458799 | `20260726.n.0` | 1 | 172 passed, 0 failed |
| 30285800114 | `20260727.n.0` | **2** | 172 passed, 0 failed |
| 30288756745 / 63334 / 70662 | `20260727.n.0` | 2 | 32 / 13 / 33 failed |

The first two are a controlled pair. The third looked like one and was not.

## What this adds

`VM_IMAGE` travels from the fetch step to the gate, and comes out in three places:

- the gate's output line, beside the counts;
- **the run page's summary** — so a red lane shows its environment without anyone
  opening a log;
- the regression error itself, with a sentence telling the reader to check whether
  the run they are comparing against booted the same image.

And `.github/podman-known-failures-6` now says its environment is not fixed. That
file reads as though the leg were one environment observed repeatedly, which is
exactly the assumption that makes a variable tail impossible to classify — very
likely part of why #1039 took as long as it did. Podman 5 boots a released Fedora 44
image and does not have the problem; the note says that too.

## What this deliberately does not do

**It does not pin the image.** The rawhide leg exists to catch the next Podman
early, and a pin turns that into a chore that someone has to remember — the same
maintenance shape as `.github/podman-baseline`, for less benefit. Recording the
image makes two runs comparable, which was the actual problem; freezing it trades
away the point of the leg. If a pin is wanted later, that is a separate decision
with the evidence for it now visible in every run.

Closes #1222
