### PR TITLE
test(stream): pin the finished-vs-severed stream shapes, and classify a body EOF

### DIFF
--- a/internal/engine/fake_podman.rs
+++ b/internal/engine/fake_podman.rs
@@ -5,7 +5,14 @@
 //! API responses without a real Podman daemon. [`Client`] opens a fresh
 //! connection per request (see `internal/libpod/client/mod.rs`), so this only
 //! ever needs to answer one HTTP/1.1 request per accepted connection — no
-//! keep-alive, no chunked framing.
+//! keep-alive.
+//!
+//! It does frame a chunked body, for one reason: a stream that ends *badly* has
+//! a wire shape, and podup's central open question about streaming (#1104) is
+//! whether it can tell that shape from a stream that ended well. A real Podman
+//! cannot be asked to break a stream on demand, and which shape it produces at a
+//! CLEAN end turns out to differ by version — so the two cases are pinned here,
+//! deterministically, with no daemon and no version in the picture.
 
 #![cfg(unix)]
 
@@ -17,10 +24,30 @@ use tokio::task::JoinHandle;
 
 use crate::libpod::Client;
 
-/// A test's routing rule: `(method, target) -> (status, JSON body)`, where
-/// `target` is the request path plus its raw query string (e.g.
+/// What the fake writes back for one request.
+pub(super) enum FakeReply {
+	/// A `content-length`-framed body, closed cleanly. What every routing test
+	/// that only cares about status codes wants.
+	Body(u16, String),
+	/// A 200 with a **chunked** body: each entry is written as one chunk, then
+	/// the terminating zero-length chunk is sent. This is a stream that ends the
+	/// way HTTP says it should.
+	ChunkedEnd(Vec<String>),
+	/// A 200 with a **chunked** body that stops between chunks: each entry is
+	/// written as one complete chunk and then the connection is closed with NO
+	/// terminating chunk. A stream that died where a chunk header should start.
+	ChunkedTruncated(Vec<String>),
+	/// A 200 with a **chunked** body cut in the middle of a chunk's payload: the
+	/// header promises more bytes than are then written, and the connection
+	/// closes. The other place a severed stream can land, and — measured — hyper
+	/// classifies the two differently, which is why both exist here.
+	ChunkedCutMidPayload(String),
+}
+
+/// A test's routing rule: `(method, target) -> reply`, where `target` is the
+/// request path plus its raw query string (e.g.
 /// `/v5.0.0/libpod/containers/proj-web-1/start`).
-type Responder = dyn Fn(&str, &str) -> (u16, String) + Send + Sync;
+type Responder = dyn Fn(&str, &str) -> FakeReply + Send + Sync;
 
 /// A fake libpod socket driven by a routing closure; see [`Responder`].
 pub(super) struct FakePodman {
@@ -55,6 +82,18 @@ impl Drop for FakePodman {
 pub(super) fn start<F>(respond: F) -> FakePodman
 where
 	F: Fn(&str, &str) -> (u16, String) + Send + Sync + 'static,
+{
+	start_replying(move |method, target| {
+		let (status, body) = respond(method, target);
+		FakeReply::Body(status, body)
+	})
+}
+
+/// As [`start`], but the routing closure chooses the wire shape too — including
+/// a chunked body that ends cleanly or one that is cut off mid-stream.
+pub(super) fn start_replying<F>(respond: F) -> FakePodman
+where
+	F: Fn(&str, &str) -> FakeReply + Send + Sync + 'static,
 {
 	let dir = tempfile::tempdir().expect("create temp dir for fake podman socket");
 	let sock_path = dir.path().join("podman.sock");
@@ -113,13 +152,36 @@ async fn serve_one(
 
 	requests.lock().unwrap().push(format!("{method} {target}"));
 
-	let (status, body) = respond(&method, &target);
-	let response = format!(
-		"HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {len}\r\nconnection: close\r\n\r\n{body}",
-		reason = reason_phrase(status),
-		len = body.len(),
-	);
-	stream.write_all(response.as_bytes()).await?;
+	match respond(&method, &target) {
+		FakeReply::Body(status, body) => {
+			let response = format!(
+				"HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {len}\r\nconnection: close\r\n\r\n{body}",
+				reason = reason_phrase(status),
+				len = body.len(),
+			);
+			stream.write_all(response.as_bytes()).await?;
+		}
+		FakeReply::ChunkedEnd(chunks) => {
+			write_chunked(&mut stream, &chunks).await?;
+			// The terminating zero-length chunk: this is the difference between
+			// a finished body and a severed one, and it is the whole subject of
+			// #1104.
+			stream.write_all(b"0\r\n\r\n").await?;
+		}
+		FakeReply::ChunkedTruncated(chunks) => {
+			write_chunked(&mut stream, &chunks).await?;
+			// No terminator. Closing here is what a dead stream looks like.
+		}
+		FakeReply::ChunkedCutMidPayload(chunk) => {
+			write_chunked(&mut stream, &[]).await?;
+			// Promise the whole chunk, deliver half of it, hang up.
+			let half = chunk.len() / 2;
+			stream
+				.write_all(format!("{:x}\r\n{}", chunk.len(), &chunk[..half]).as_bytes())
+				.await?;
+			stream.flush().await?;
+		}
+	}
 	stream.shutdown().await?;
 	Ok(())
 }
@@ -136,4 +198,20 @@ fn reason_phrase(status: u16) -> &'static str {
 		500 => "Internal Server Error",
 		_ => "Unknown",
 	}
+}
+
+/// Write a chunked-encoding response head and one chunk per entry, leaving the
+/// caller to decide whether the terminating chunk follows.
+async fn write_chunked(stream: &mut UnixStream, chunks: &[String]) -> std::io::Result<()> {
+	stream
+		.write_all(
+			b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n",
+		)
+		.await?;
+	for chunk in chunks {
+		stream
+			.write_all(format!("{:x}\r\n{chunk}\r\n", chunk.len()).as_bytes())
+			.await?;
+	}
+	stream.flush().await
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -556,6 +556,9 @@ fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Resul
 mod tests;
 
 #[cfg(test)]
+mod stream_end_tests;
+
+#[cfg(test)]
 mod interactive_run_tests {
 	use super::wants_interactive_run;
 

--- a/internal/engine/stream_end_tests.rs
+++ b/internal/engine/stream_end_tests.rs
@@ -1,0 +1,148 @@
+//! What a streaming read looks like when it ends well, and when it does not.
+//!
+//! #1104 is the question of whether podup can tell those apart. The argument has
+//! been circular so far because the only evidence came from a live daemon, where
+//! *both* the version and the wire shape move at once: making a mid-stream error
+//! fatal reddened fifteen tests on the lane's Podman 5.8.1 while the identical
+//! commit stayed green on 5.4.2.
+//!
+//! These tests take the daemon out of it. The fake writes the wire shapes
+//! deliberately, so what podup does with each is pinned here rather than inferred
+//! from a lane run.
+//!
+//! Two things they settle:
+//!
+//! 1. **podup's parsing is not the ambiguity.** A properly terminated chunked body
+//!    reaches the caller as a clean end, every time. So when a *finished* stream
+//!    arrives as an error on some Podman version, the framing came that way — no
+//!    predicate on `hyper::Error` can invent a difference the server did not send.
+//!    That is the case for the out-of-band re-check `logs` and `stats` already use,
+//!    and for `events` needing one of its own.
+//! 2. **A severed stream is not `IncompleteMessage`.** That predicate is about the
+//!    message head. Both places a cut can land in a body arrive as a hyper Body
+//!    error wrapping `io::ErrorKind::UnexpectedEof`, which used to fall through to
+//!    `hyper-other`. Anything keyed on the `IncompleteMessage` text — including the
+//!    lane's own flake counter — cannot see them.
+
+#![cfg(unix)]
+
+use futures_util::StreamExt;
+
+use super::fake_podman::{self, FakeReply};
+
+/// Drive one streaming GET against the fake and collect what the parser yields:
+/// the frames that arrived, and how the stream ended (`None` for a clean end).
+async fn read_stream(reply: FakeReply) -> (Vec<serde_json::Value>, Option<String>) {
+	let fake = fake_podman::start_replying(move |_method, _target| match &reply {
+		FakeReply::Body(s, b) => FakeReply::Body(*s, b.clone()),
+		FakeReply::ChunkedEnd(c) => FakeReply::ChunkedEnd(c.clone()),
+		FakeReply::ChunkedTruncated(c) => FakeReply::ChunkedTruncated(c.clone()),
+		FakeReply::ChunkedCutMidPayload(c) => FakeReply::ChunkedCutMidPayload(c.clone()),
+	});
+	let client = fake.client();
+	let resp = client
+		.get_stream(&format!("{}/events", crate::libpod::API_PREFIX))
+		.await
+		.expect("the fake answers 200");
+	let mut stream = crate::libpod::parse_json_lines::<serde_json::Value>(resp.into_body());
+
+	let mut frames = Vec::new();
+	let mut ended_as = None;
+	while let Some(item) = stream.next().await {
+		match item {
+			Ok(value) => frames.push(value),
+			Err(e) => {
+				// The classification podup would report, named rather than argued.
+				ended_as = Some(e.stream_end_kind().to_string());
+				break;
+			}
+		}
+	}
+	(frames, ended_as)
+}
+
+fn frame(action: &str) -> String {
+	format!("{{\"Type\":\"container\",\"Action\":\"{action}\"}}\n")
+}
+
+/// A stream that ends the way HTTP says it should reaches the caller as a clean
+/// end — no error at all. Every frame written arrives first.
+#[tokio::test]
+async fn a_properly_terminated_stream_ends_clean() {
+	let (frames, ended_as) =
+		read_stream(FakeReply::ChunkedEnd(vec![frame("start"), frame("die")])).await;
+
+	assert_eq!(frames.len(), 2, "both frames arrive: {frames:?}");
+	assert_eq!(
+		ended_as, None,
+		"a terminated chunked body must not surface as an error, it surfaced as {ended_as:?}"
+	);
+}
+
+/// A body cut off between chunks — the connection closes where the next chunk
+/// header should begin.
+#[tokio::test]
+async fn a_cut_between_chunks_is_a_body_eof() {
+	let (frames, ended_as) = read_stream(FakeReply::ChunkedTruncated(vec![frame("start")])).await;
+
+	assert_eq!(
+		frames.len(),
+		1,
+		"the frame written before the cut still arrives: {frames:?}"
+	);
+	assert_eq!(
+		ended_as.as_deref(),
+		Some("body-unexpected-eof"),
+		"hyper reports this as a Body error wrapping UnexpectedEof \
+		 (\"unexpected EOF during chunk size line\"), not IncompleteMessage"
+	);
+}
+
+/// And a body cut mid-payload — the chunk header promises bytes that never come.
+/// hyper words it differently (`IncompleteBody`) but the io kind is the same, and
+/// the kind is what podup keys on.
+#[tokio::test]
+async fn a_cut_mid_payload_is_also_a_body_eof() {
+	let (_frames, ended_as) = read_stream(FakeReply::ChunkedCutMidPayload(format!(
+		"{{\"Type\":\"container\",\"Action\":\"start\",\"padding\":\"{}\"}}\n",
+		"a".repeat(64)
+	)))
+	.await;
+
+	assert_eq!(ended_as.as_deref(), Some("body-unexpected-eof"));
+}
+
+/// Neither cut is `IncompleteMessage`. Its own test because the lane's flake
+/// counter greps for that word (plus "connection closed before message
+/// completed", "channel closed" and "Connection reset"), so a real mid-body drop
+/// is currently counted as a genuine failure rather than a transport flake.
+#[tokio::test]
+async fn neither_cut_is_an_incomplete_message() {
+	for reply in [
+		FakeReply::ChunkedTruncated(vec![frame("start")]),
+		FakeReply::ChunkedCutMidPayload(format!("{{\"padding\":\"{}\"}}\n", "a".repeat(64))),
+	] {
+		let (_frames, ended_as) = read_stream(reply).await;
+		assert_ne!(
+			ended_as.as_deref(),
+			Some("incomplete-message"),
+			"a severed body is not the head-level IncompleteMessage"
+		);
+	}
+}
+
+/// The crux of #1104, as a test rather than a comment: the payload delivered is
+/// identical either way, so a caller that only looks at whether an error arrived
+/// cannot tell a finished stream from a severed one. Telling them apart needs a
+/// second, out-of-band observation — is the thing this stream was following still
+/// alive?
+#[tokio::test]
+async fn the_two_shapes_carry_the_same_payload() {
+	let (clean_frames, clean_end) = read_stream(FakeReply::ChunkedEnd(vec![frame("start")])).await;
+	let (severed_frames, severed_end) =
+		read_stream(FakeReply::ChunkedTruncated(vec![frame("start")])).await;
+
+	assert_eq!(clean_frames, severed_frames, "same frames delivered");
+	assert!(clean_end.is_none(), "clean end: {clean_end:?}");
+	assert!(severed_end.is_some(), "severed end must be an error");
+}

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -150,6 +150,21 @@ impl PodmanError {
 			Self::Hyper(e) if e.is_canceled() => "canceled",
 			Self::Hyper(e) if e.is_closed() => "closed",
 			Self::Hyper(e) if e.is_timeout() => "hyper-timeout",
+			// A body that stopped short is none of the above. `is_incomplete_message`
+			// is about the message head, so a severed *body* misses every predicate
+			// hyper exposes and used to land in `hyper-other` — the least
+			// informative label, for the likeliest shape.
+			//
+			// Measured against a fake socket that cuts a chunked body deliberately
+			// (`engine::stream_end_tests`), both places a cut can land arrive as a
+			// hyper Body error wrapping `io::ErrorKind::UnexpectedEof`:
+			//
+			//   between chunks  "unexpected EOF during chunk size line"
+			//   mid-payload     IncompleteBody
+			//
+			// The kind is what this keys on; hyper's message text distinguishing the
+			// two is not something to depend on.
+			Self::Hyper(e) if body_ended_early(e) => "body-unexpected-eof",
 			Self::Hyper(_) => "hyper-other",
 			Self::Connect(e) => match e.kind() {
 				std::io::ErrorKind::UnexpectedEof => "io-unexpected-eof",
@@ -235,6 +250,23 @@ impl PodmanError {
 			_ => false,
 		}
 	}
+}
+
+/// Whether a hyper error is a body that ended before it was complete — the shape
+/// a severed stream takes, which none of hyper's own predicates report. Walks the
+/// source chain for an `io::Error` of kind `UnexpectedEof` rather than matching on
+/// message text.
+fn body_ended_early(e: &hyper::Error) -> bool {
+	let mut source: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(e);
+	while let Some(current) = source {
+		if let Some(io) = current.downcast_ref::<std::io::Error>() {
+			if io.kind() == std::io::ErrorKind::UnexpectedEof {
+				return true;
+			}
+		}
+		source = std::error::Error::source(current);
+	}
+	false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Step one of #1104: stop arguing about the wire shape and pin it. No behaviour
change — `stream_end_kind` is still diagnostic and nothing branches on it.

## Why this was stuck

Every piece of evidence so far came from a live daemon, where the Podman version and
the wire shape move together: making a mid-stream error fatal reddened fifteen tests
on the lane's 5.8.1 leg while the identical commit stayed green on real 5.4.2. And a
real Podman cannot be asked to break a stream on demand, so the broken case was never
observed directly at all.

The fake socket now frames a chunked body and can end it three ways — properly
terminated, cut between chunks, cut mid-payload — so both cases are pinned locally,
with no daemon and no version involved.

## What the tests settle

**podup's parsing is not the ambiguity.** A properly terminated chunked body reaches
the caller as a clean end, every time. So when a *finished* stream arrives as an error
on some Podman version, the framing came that way, and no predicate on `hyper::Error`
can invent a difference the server did not send.

That is the argument for the out-of-band re-check `logs` (#1204) and `stats` (#1169)
already use, and against hoping a cleverer error predicate will do instead.

## What it also turned up, unexpectedly

**A severed body is not `IncompleteMessage`.** That predicate is about the message
head. Measured, both cuts arrive as a hyper Body error wrapping
`io::ErrorKind::UnexpectedEof`:

| where the cut lands | hyper says | `stream_end_kind` before | after |
|---|---|---|---|
| between chunks | `Body, Custom { kind: UnexpectedEof, error: "unexpected EOF during chunk size line" }` | `hyper-other` | `body-unexpected-eof` |
| mid-payload | `Body, Custom { kind: UnexpectedEof, error: IncompleteBody }` | `hyper-other` | `body-unexpected-eof` |

The classifier keys on the io kind, walking the source chain, not on hyper's message
text — those two wordings are not something to depend on.

**And a consequence outside this PR:** the lane's flake counter greps for
`IncompleteMessage|connection closed before message completed|channel closed|Connection reset`.
A mid-body drop matches none of them, so it is counted as a genuine failure rather
than a transport flake. That wants a follow-up on the workflow; I left it out of here
rather than mixing a gate change into a diagnostic one.

## What is still open in #1104

- `events` has no discriminator at all: it warns and returns `Ok(())`, so a feed that
  dies halfway exits 0 — and on the versions where a finished stream ends in `Err` it
  prints a warning on a completely normal run. Its discriminator is **intent** rather
  than container state (an unbounded feed has no reason to end; with `--until` it
  does), which also catches the clean-`None` case the other two commands cannot see.
  That changes an exit code, so it is a separate decision and a separate PR.
- `attach`/`run` still to verify.
- The *clean-end* half of "which error, on which version" still needs a lane run,
  because that shape is the server's and only a real 5.8.x/6.x sends it.

1355 unit tests pass (7 new). fmt and clippy clean — the two `unused import` warnings
in `engine_integration` are pre-existing on `develop`, confirmed by running clippy on
a stashed tree.

Refs #1104
