### PR TITLE
ci(podman-lane): let the lane recognise a dropped body, not just a dropped head

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -98,10 +98,21 @@ jobs:
                 # Capture the FULL output: the per-failure detail (where the flake
                 # marker lives) precedes the summary, so a `tail` on the console
                 # would truncate it and hide why a test failed.
-                # Retry once on a nested-virt transient (a connection drop surfaces
-                # as Hyper(IncompleteMessage) and kin). A real failure reproduces on
-                # the second run, so this stabilises the lane for required-check gating
-                # without masking genuine bugs.
+                # Retry once on a nested-virt transient (a dropped connection). A real
+                # failure reproduces on the second run, so this stabilises the lane for
+                # required-check gating without masking genuine bugs.
+                #
+                # WHAT COUNTS AS A DROP — defined once, used by both the retry above and
+                # the FLAKY counter below, because the two drifting apart is how this
+                # went wrong (#1104). The list used to hold only the head-level shapes,
+                # and a dropped BODY is none of them: measured against a socket that
+                # severs a chunked body on purpose, hyper reports a Body error wrapping
+                # io UnexpectedEof, worded "unexpected EOF during chunk size line" when
+                # the cut lands between chunks and IncompleteBody when it lands
+                # mid-payload, with the Display form "error reading a body from
+                # connection". None matched, so a drop mid-body was neither retried nor
+                # counted — it just reddened the leg, which is exactly what happened to
+                # fifteen streaming tests when a mid-stream error was made fatal.
                 #
                 # EXPERIMENT (#1039): the thread cap is per major, substituted into
                 # this script when the seed is built — Podman 6 runs at 1, Podman 5
@@ -126,22 +137,23 @@ jobs:
                 # which is the lever to shrink Podman 6's variable flaky tail toward
                 # a small, stable set that an identity list can gate (#1039). Kept at
                 # 2 rather than 1 so the suite still fits the VM's time budget.
+                DROPPED='IncompleteMessage|connection closed before message completed|channel closed|Connection reset|error reading a body from connection|unexpected EOF during chunk size line|IncompleteBody|body-unexpected-eof'
                 for attempt in 1 2; do
                   RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=__THREADS__ > /tmp/cargo.log 2>&1
                   RC=$?
                   [ "$RC" -eq 0 ] && break
-                  grep -qE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log || break
+                  grep -qE "$DROPPED" /tmp/cargo.log || break
                   echo "=== nested-virt transient on attempt $attempt; retrying suite ==="
                 done
                 tail -60 /tmp/cargo.log
                 echo "=== failures section (full) ==="
                 sed -n '/^failures:$/,/^test result:/p' /tmp/cargo.log | head -120
-                # Machine-readable summary computed from the FULL log. A nested-virt
-                # connection drop surfaces as Hyper(IncompleteMessage) (and kin);
-                # everything else counts as a real failure.
+                # Machine-readable summary computed from the FULL log, using the same
+                # drop signatures as the retry above; everything else counts as a real
+                # failure.
                 PASS=$(grep -oE 'test result: .* [0-9]+ passed' /tmp/cargo.log | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' | tail -1)
                 FAIL=$(grep -oE '[0-9]+ failed' /tmp/cargo.log | grep -oE '[0-9]+' | tail -1)
-                FLAKY=$(grep -cE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log)
+                FLAKY=$(grep -cE "$DROPPED" /tmp/cargo.log)
                 echo "PODUP_TESTS_RC=$RC"
                 echo "PODUP_SUMMARY pass=${PASS:-0} fail=${FAIL:-0} flaky=${FLAKY:-0}"
                 # Emit the IDENTITIES of the failing tests, not just the count.


### PR DESCRIPTION
The prerequisite for the rest of #1104: until the lane can recognise a dropped
body as a drop, any command that starts reporting a broken stream reddens the leg
for reasons that have nothing to do with the change.

## The gap

The retry and the `FLAKY` counter both greped for

```
IncompleteMessage|connection closed before message completed|channel closed|Connection reset
```

Every one of those is a **head-level** shape. A dropped **body** is none of them.
Measured against a socket that severs a chunked body on purpose (#1224):

| where the cut lands | what appears in the log |
|---|---|
| between chunks | `Body, Custom { kind: UnexpectedEof, error: "unexpected EOF during chunk size line" }` |
| mid-payload | `Body, Custom { kind: UnexpectedEof, error: IncompleteBody }` |
| either, Display form | `http error: error reading a body from connection` |

So a mid-body drop was **neither retried nor counted as a flake** — it just reddened
the leg.

## Why that matters beyond tidiness

It is the likeliest account of the fifteen streaming tests that went red on the 5.8.1
leg when a mid-stream error was made fatal, and it needs no version-specific libpod
behaviour to explain it. Measured today on the real Podman 5.8.1 VM:

| command | result |
|---|---|
| `podup events`, unbounded, idle project | alive at **45 s**, killed by `timeout`, no warning |
| `podup logs -f` on a running container | alive at **25 s, three runs running** (28 / 53 / 78 lines, container `running`) |

Neither ends early. Which lines up with what `podman-lane.yml` already says in its own
comment: on a single-level VM the same suite never drops a byte, so the flake is the
double-virt socket, not podup and not libpod. The leg was dropping bodies and calling
them failures.

## The change

One `DROPPED` variable, used by the retry and by the counter. They were duplicated,
and two copies of a list that must agree is how they came to disagree. Added the three
body shapes plus podup's own `body-unexpected-eof` label.

Checked both directions before committing:

```
Body … "unexpected EOF during chunk size line"   -> MATCH
Body … IncompleteBody                            -> MATCH
http error: error reading a body from connection  -> MATCH
Hyper(IncompleteMessage)                          -> MATCH
assertion failed: some ordinary test failure      -> no match
```

A real test failure is still a real test failure. Also extracted the in-VM script from
the cloud-init seed and ran `bash -n` and `shellcheck` over it — the one warning is a
pre-existing SC2155 on line 2.

## The trade this keeps, stated plainly

A genuine podup bug that manifests as a dropped body now gets retried once — exactly
as one manifesting as a dropped head already did. A real bug reproduces on the second
attempt; a transport blip does not. The identity gate is untouched, so a failure that
survives the retry is still a named regression.

## What this unblocks

With drops recognised, `events` can take the same contract as `logs`/`stats` — and
parity supports it: severing a live feed with an identical relay, `docker compose
events` prints `unexpected EOF` and exits 1 while podup warns and exits 0. That is the
next PR, and it changes an exit code, so it goes on its own.

Refs #1104
