### PR TITLE
chore: bump to 3.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+podup (3.2.1) unstable; urgency=medium
+
+  Changed
+
+  * A severed stream is now named `body-unexpected-eof` in podup's diagnostics
+    instead of the catch-all `hyper-other`. `IncompleteMessage`, the predicate
+    that sounds like it covers this, is about the message head — a body cut
+    off mid-flight matched none of hyper's own predicates and fell through to
+    the least informative label there is. Measured against a socket that
+    severs a chunked body on purpose: both places a cut can land arrive as a
+    body error wrapping an unexpected end-of-file. Nothing branches on the
+    label, so no command behaves differently; this is what podup tells you
+    while a streaming bug is being tracked down (#1104).
+
+  Dependencies
+
+  * clap_complete 4.6.7 -> 4.6.8, used to generate the shell completions.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 27 Jul 2026 22:21:02 -0500
+
 podup (3.2.0) unstable; urgency=medium
 
   Changed


### PR DESCRIPTION
Version bump only. Three files, because `dpkg-buildpackage` reads the `.deb` version
from `debian/changelog` and nothing derives it from `Cargo.toml` — miss it and apt
reports nothing to upgrade, which for a package-managed install is the only path there
is (podup 1.9.0 shipped `podup_1.8.0_*.deb` for exactly that reason).

I grepped the tree for anything else stamping `3.2.0` rather than copying the shape of
the last bump, as the releases standard asks. Nothing else does. The man page's `.TH`
carries a stale version deliberately — `debian/rules` stamps it from the changelog at
build time.

## What 3.2.1 actually contains

Said plainly, because it is thin:

- **A diagnostic label.** A severed stream is now named `body-unexpected-eof` instead
  of the catch-all `hyper-other`. `IncompleteMessage` — the predicate that sounds like
  it covers this — is about the message *head*; a body cut off mid-flight matched none
  of hyper's own predicates and fell through to the least informative label available.
  Measured against a socket that severs a chunked body on purpose. **Nothing branches
  on the label, so no command behaves differently** (#1224, toward #1104).
- **clap_complete 4.6.7 → 4.6.8** (#1225), used to generate the shell completions.

Everything else that landed on `develop` since 3.2.0 is CI, the benchmark harness,
docs, and test-only code — none of it reaches the installed binary. I said so when
this release was proposed and the call was made to cut it anyway; the changelog states
the scope rather than dressing it up.
