### PR TITLE
release: 3.2.1

### DIFF
--- a/.github/podman-known-failures-6
+++ b/.github/podman-known-failures-6
@@ -31,3 +31,15 @@
 # add it here with the evidence. Do NOT delete this file to make the red go away —
 # an empty list is what makes a regression loud, and going back to a count gate is
 # how #1072 shipped a bug with the pass count sitting comfortably above the floor.
+#
+# ONE THING TO KNOW BEFORE CLASSIFYING ANYTHING HERE: this leg's environment is not
+# fixed. It boots whatever Fedora Rawhide compose is newest when the job runs, so
+# most days it is a different operating system — different kernel, different
+# systemd, everything below Podman. Two runs of this leg are not two observations
+# of one environment, which is very likely part of why the tail this file's header
+# describes resisted classification for as long as it did. The gate now prints the
+# image alongside the counts (#1222); read it before deciding a failure is
+# environmental, and say which image you saw it on when you add a line here.
+#
+# The same caveat does not apply to Podman 5: that leg boots a released Fedora 44
+# image, which changes only when Fedora respins it.

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -45,6 +45,13 @@ jobs:
           fi
           [ -n "$img" ] || { echo "::error::could not resolve a Fedora image name for Podman $SEL at $base"; exit 1; }
           echo "image: $img"
+          # Carry it to the gate step. The name resolves to whatever compose is
+          # newest at this moment, so the Podman 6 leg boots a DIFFERENT operating
+          # system most days — and until now that fact lived only in the middle of
+          # this step's log. Two runs of this leg are not the same environment, and
+          # anyone comparing a failure against the run before it has to know which
+          # one they got (#1222).
+          echo "VM_IMAGE=$img" >> "$GITHUB_ENV"
           # The rawhide qcow2 is ~500 MB and the mirror occasionally drops the
           # connection mid-transfer (curl exit 18). Resume + retry so a transient
           # network blip doesn't fail the lane.
@@ -214,6 +221,15 @@ jobs:
           FLAKY=$(echo "$SUM" | grep -oE 'flaky=[0-9]+' | cut -d= -f2)
           PASS=${PASS:-0}; FAIL=${FAIL:-0}; FLAKY=${FLAKY:-0}
           echo "Podman $VER: $PASS passed, $FAIL failed ($FLAKY look like connection-drop flakes)"
+          echo "Podman $VER ran on image: ${VM_IMAGE:-unknown}"
+          # The run page, not just the log: whoever reads a red lane needs the
+          # environment next to the counts, and the rawhide leg's environment
+          # changes under it (#1222).
+          {
+            echo "### Podman $VER — $PASS passed, $FAIL failed, $FLAKY drop-like"
+            echo ""
+            echo "image: \`${VM_IMAGE:-unknown}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
           # Strip CR: the VM talks to us over `-serial stdio`, so every line of
           # this log arrives CRLF-terminated. The counts survive because they are
           # extracted with numeric patterns, but the identity list keeps the CR on
@@ -247,6 +263,7 @@ jobs:
             if [ -n "$unexpected" ]; then
               echo "::error::Podman $VER: these failing tests are not in $(basename "$known") — a test that used to pass is failing, which is a regression, not nested-virt noise:"
               echo "$unexpected" | awk '{print "  " $0}'
+              echo "Environment: Podman $VER on ${VM_IMAGE:-an unrecorded image}. Before concluding, check whether the run you are comparing against booted the same one — the rawhide leg usually does not (#1222)."
               echo "If a run proves the failure is environmental, add it to that file with the evidence; do not add it to make this red go away."
               exit 1
             fi

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -98,10 +98,21 @@ jobs:
                 # Capture the FULL output: the per-failure detail (where the flake
                 # marker lives) precedes the summary, so a `tail` on the console
                 # would truncate it and hide why a test failed.
-                # Retry once on a nested-virt transient (a connection drop surfaces
-                # as Hyper(IncompleteMessage) and kin). A real failure reproduces on
-                # the second run, so this stabilises the lane for required-check gating
-                # without masking genuine bugs.
+                # Retry once on a nested-virt transient (a dropped connection). A real
+                # failure reproduces on the second run, so this stabilises the lane for
+                # required-check gating without masking genuine bugs.
+                #
+                # WHAT COUNTS AS A DROP — defined once, used by both the retry above and
+                # the FLAKY counter below, because the two drifting apart is how this
+                # went wrong (#1104). The list used to hold only the head-level shapes,
+                # and a dropped BODY is none of them: measured against a socket that
+                # severs a chunked body on purpose, hyper reports a Body error wrapping
+                # io UnexpectedEof, worded "unexpected EOF during chunk size line" when
+                # the cut lands between chunks and IncompleteBody when it lands
+                # mid-payload, with the Display form "error reading a body from
+                # connection". None matched, so a drop mid-body was neither retried nor
+                # counted — it just reddened the leg, which is exactly what happened to
+                # fifteen streaming tests when a mid-stream error was made fatal.
                 #
                 # EXPERIMENT (#1039): the thread cap is per major, substituted into
                 # this script when the seed is built — Podman 6 runs at 1, Podman 5
@@ -126,22 +137,23 @@ jobs:
                 # which is the lever to shrink Podman 6's variable flaky tail toward
                 # a small, stable set that an identity list can gate (#1039). Kept at
                 # 2 rather than 1 so the suite still fits the VM's time budget.
+                DROPPED='IncompleteMessage|connection closed before message completed|channel closed|Connection reset|error reading a body from connection|unexpected EOF during chunk size line|IncompleteBody|body-unexpected-eof'
                 for attempt in 1 2; do
                   RUST_LOG=podup=warn cargo test --features test-helpers --test engine_integration -- --test-threads=__THREADS__ > /tmp/cargo.log 2>&1
                   RC=$?
                   [ "$RC" -eq 0 ] && break
-                  grep -qE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log || break
+                  grep -qE "$DROPPED" /tmp/cargo.log || break
                   echo "=== nested-virt transient on attempt $attempt; retrying suite ==="
                 done
                 tail -60 /tmp/cargo.log
                 echo "=== failures section (full) ==="
                 sed -n '/^failures:$/,/^test result:/p' /tmp/cargo.log | head -120
-                # Machine-readable summary computed from the FULL log. A nested-virt
-                # connection drop surfaces as Hyper(IncompleteMessage) (and kin);
-                # everything else counts as a real failure.
+                # Machine-readable summary computed from the FULL log, using the same
+                # drop signatures as the retry above; everything else counts as a real
+                # failure.
                 PASS=$(grep -oE 'test result: .* [0-9]+ passed' /tmp/cargo.log | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' | tail -1)
                 FAIL=$(grep -oE '[0-9]+ failed' /tmp/cargo.log | grep -oE '[0-9]+' | tail -1)
-                FLAKY=$(grep -cE 'IncompleteMessage|connection closed before message completed|channel closed|Connection reset' /tmp/cargo.log)
+                FLAKY=$(grep -cE "$DROPPED" /tmp/cargo.log)
                 echo "PODUP_TESTS_RC=$RC"
                 echo "PODUP_SUMMARY pass=${PASS:-0} fail=${FAIL:-0} flaky=${FLAKY:-0}"
                 # Emit the IDENTITIES of the failing tests, not just the count.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+podup (3.2.1) unstable; urgency=medium
+
+  Changed
+
+  * A severed stream is now named `body-unexpected-eof` in podup's diagnostics
+    instead of the catch-all `hyper-other`. `IncompleteMessage`, the predicate
+    that sounds like it covers this, is about the message head — a body cut
+    off mid-flight matched none of hyper's own predicates and fell through to
+    the least informative label there is. Measured against a socket that
+    severs a chunked body on purpose: both places a cut can land arrive as a
+    body error wrapping an unexpected end-of-file. Nothing branches on the
+    label, so no command behaves differently; this is what podup tells you
+    while a streaming bug is being tracked down (#1104).
+
+  Dependencies
+
+  * clap_complete 4.6.7 -> 4.6.8, used to generate the shell completions.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 27 Jul 2026 22:21:02 -0500
+
 podup (3.2.0) unstable; urgency=medium
 
   Changed

--- a/internal/engine/fake_podman.rs
+++ b/internal/engine/fake_podman.rs
@@ -5,7 +5,14 @@
 //! API responses without a real Podman daemon. [`Client`] opens a fresh
 //! connection per request (see `internal/libpod/client/mod.rs`), so this only
 //! ever needs to answer one HTTP/1.1 request per accepted connection — no
-//! keep-alive, no chunked framing.
+//! keep-alive.
+//!
+//! It does frame a chunked body, for one reason: a stream that ends *badly* has
+//! a wire shape, and podup's central open question about streaming (#1104) is
+//! whether it can tell that shape from a stream that ended well. A real Podman
+//! cannot be asked to break a stream on demand, and which shape it produces at a
+//! CLEAN end turns out to differ by version — so the two cases are pinned here,
+//! deterministically, with no daemon and no version in the picture.
 
 #![cfg(unix)]
 
@@ -17,10 +24,30 @@ use tokio::task::JoinHandle;
 
 use crate::libpod::Client;
 
-/// A test's routing rule: `(method, target) -> (status, JSON body)`, where
-/// `target` is the request path plus its raw query string (e.g.
+/// What the fake writes back for one request.
+pub(super) enum FakeReply {
+	/// A `content-length`-framed body, closed cleanly. What every routing test
+	/// that only cares about status codes wants.
+	Body(u16, String),
+	/// A 200 with a **chunked** body: each entry is written as one chunk, then
+	/// the terminating zero-length chunk is sent. This is a stream that ends the
+	/// way HTTP says it should.
+	ChunkedEnd(Vec<String>),
+	/// A 200 with a **chunked** body that stops between chunks: each entry is
+	/// written as one complete chunk and then the connection is closed with NO
+	/// terminating chunk. A stream that died where a chunk header should start.
+	ChunkedTruncated(Vec<String>),
+	/// A 200 with a **chunked** body cut in the middle of a chunk's payload: the
+	/// header promises more bytes than are then written, and the connection
+	/// closes. The other place a severed stream can land, and — measured — hyper
+	/// classifies the two differently, which is why both exist here.
+	ChunkedCutMidPayload(String),
+}
+
+/// A test's routing rule: `(method, target) -> reply`, where `target` is the
+/// request path plus its raw query string (e.g.
 /// `/v5.0.0/libpod/containers/proj-web-1/start`).
-type Responder = dyn Fn(&str, &str) -> (u16, String) + Send + Sync;
+type Responder = dyn Fn(&str, &str) -> FakeReply + Send + Sync;
 
 /// A fake libpod socket driven by a routing closure; see [`Responder`].
 pub(super) struct FakePodman {
@@ -55,6 +82,18 @@ impl Drop for FakePodman {
 pub(super) fn start<F>(respond: F) -> FakePodman
 where
 	F: Fn(&str, &str) -> (u16, String) + Send + Sync + 'static,
+{
+	start_replying(move |method, target| {
+		let (status, body) = respond(method, target);
+		FakeReply::Body(status, body)
+	})
+}
+
+/// As [`start`], but the routing closure chooses the wire shape too — including
+/// a chunked body that ends cleanly or one that is cut off mid-stream.
+pub(super) fn start_replying<F>(respond: F) -> FakePodman
+where
+	F: Fn(&str, &str) -> FakeReply + Send + Sync + 'static,
 {
 	let dir = tempfile::tempdir().expect("create temp dir for fake podman socket");
 	let sock_path = dir.path().join("podman.sock");
@@ -113,13 +152,36 @@ async fn serve_one(
 
 	requests.lock().unwrap().push(format!("{method} {target}"));
 
-	let (status, body) = respond(&method, &target);
-	let response = format!(
-		"HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {len}\r\nconnection: close\r\n\r\n{body}",
-		reason = reason_phrase(status),
-		len = body.len(),
-	);
-	stream.write_all(response.as_bytes()).await?;
+	match respond(&method, &target) {
+		FakeReply::Body(status, body) => {
+			let response = format!(
+				"HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {len}\r\nconnection: close\r\n\r\n{body}",
+				reason = reason_phrase(status),
+				len = body.len(),
+			);
+			stream.write_all(response.as_bytes()).await?;
+		}
+		FakeReply::ChunkedEnd(chunks) => {
+			write_chunked(&mut stream, &chunks).await?;
+			// The terminating zero-length chunk: this is the difference between
+			// a finished body and a severed one, and it is the whole subject of
+			// #1104.
+			stream.write_all(b"0\r\n\r\n").await?;
+		}
+		FakeReply::ChunkedTruncated(chunks) => {
+			write_chunked(&mut stream, &chunks).await?;
+			// No terminator. Closing here is what a dead stream looks like.
+		}
+		FakeReply::ChunkedCutMidPayload(chunk) => {
+			write_chunked(&mut stream, &[]).await?;
+			// Promise the whole chunk, deliver half of it, hang up.
+			let half = chunk.len() / 2;
+			stream
+				.write_all(format!("{:x}\r\n{}", chunk.len(), &chunk[..half]).as_bytes())
+				.await?;
+			stream.flush().await?;
+		}
+	}
 	stream.shutdown().await?;
 	Ok(())
 }
@@ -136,4 +198,20 @@ fn reason_phrase(status: u16) -> &'static str {
 		500 => "Internal Server Error",
 		_ => "Unknown",
 	}
+}
+
+/// Write a chunked-encoding response head and one chunk per entry, leaving the
+/// caller to decide whether the terminating chunk follows.
+async fn write_chunked(stream: &mut UnixStream, chunks: &[String]) -> std::io::Result<()> {
+	stream
+		.write_all(
+			b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n",
+		)
+		.await?;
+	for chunk in chunks {
+		stream
+			.write_all(format!("{:x}\r\n{chunk}\r\n", chunk.len()).as_bytes())
+			.await?;
+	}
+	stream.flush().await
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -556,6 +556,9 @@ fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Resul
 mod tests;
 
 #[cfg(test)]
+mod stream_end_tests;
+
+#[cfg(test)]
 mod interactive_run_tests {
 	use super::wants_interactive_run;
 

--- a/internal/engine/stream_end_tests.rs
+++ b/internal/engine/stream_end_tests.rs
@@ -1,0 +1,148 @@
+//! What a streaming read looks like when it ends well, and when it does not.
+//!
+//! #1104 is the question of whether podup can tell those apart. The argument has
+//! been circular so far because the only evidence came from a live daemon, where
+//! *both* the version and the wire shape move at once: making a mid-stream error
+//! fatal reddened fifteen tests on the lane's Podman 5.8.1 while the identical
+//! commit stayed green on 5.4.2.
+//!
+//! These tests take the daemon out of it. The fake writes the wire shapes
+//! deliberately, so what podup does with each is pinned here rather than inferred
+//! from a lane run.
+//!
+//! Two things they settle:
+//!
+//! 1. **podup's parsing is not the ambiguity.** A properly terminated chunked body
+//!    reaches the caller as a clean end, every time. So when a *finished* stream
+//!    arrives as an error on some Podman version, the framing came that way — no
+//!    predicate on `hyper::Error` can invent a difference the server did not send.
+//!    That is the case for the out-of-band re-check `logs` and `stats` already use,
+//!    and for `events` needing one of its own.
+//! 2. **A severed stream is not `IncompleteMessage`.** That predicate is about the
+//!    message head. Both places a cut can land in a body arrive as a hyper Body
+//!    error wrapping `io::ErrorKind::UnexpectedEof`, which used to fall through to
+//!    `hyper-other`. Anything keyed on the `IncompleteMessage` text — including the
+//!    lane's own flake counter — cannot see them.
+
+#![cfg(unix)]
+
+use futures_util::StreamExt;
+
+use super::fake_podman::{self, FakeReply};
+
+/// Drive one streaming GET against the fake and collect what the parser yields:
+/// the frames that arrived, and how the stream ended (`None` for a clean end).
+async fn read_stream(reply: FakeReply) -> (Vec<serde_json::Value>, Option<String>) {
+	let fake = fake_podman::start_replying(move |_method, _target| match &reply {
+		FakeReply::Body(s, b) => FakeReply::Body(*s, b.clone()),
+		FakeReply::ChunkedEnd(c) => FakeReply::ChunkedEnd(c.clone()),
+		FakeReply::ChunkedTruncated(c) => FakeReply::ChunkedTruncated(c.clone()),
+		FakeReply::ChunkedCutMidPayload(c) => FakeReply::ChunkedCutMidPayload(c.clone()),
+	});
+	let client = fake.client();
+	let resp = client
+		.get_stream(&format!("{}/events", crate::libpod::API_PREFIX))
+		.await
+		.expect("the fake answers 200");
+	let mut stream = crate::libpod::parse_json_lines::<serde_json::Value>(resp.into_body());
+
+	let mut frames = Vec::new();
+	let mut ended_as = None;
+	while let Some(item) = stream.next().await {
+		match item {
+			Ok(value) => frames.push(value),
+			Err(e) => {
+				// The classification podup would report, named rather than argued.
+				ended_as = Some(e.stream_end_kind().to_string());
+				break;
+			}
+		}
+	}
+	(frames, ended_as)
+}
+
+fn frame(action: &str) -> String {
+	format!("{{\"Type\":\"container\",\"Action\":\"{action}\"}}\n")
+}
+
+/// A stream that ends the way HTTP says it should reaches the caller as a clean
+/// end — no error at all. Every frame written arrives first.
+#[tokio::test]
+async fn a_properly_terminated_stream_ends_clean() {
+	let (frames, ended_as) =
+		read_stream(FakeReply::ChunkedEnd(vec![frame("start"), frame("die")])).await;
+
+	assert_eq!(frames.len(), 2, "both frames arrive: {frames:?}");
+	assert_eq!(
+		ended_as, None,
+		"a terminated chunked body must not surface as an error, it surfaced as {ended_as:?}"
+	);
+}
+
+/// A body cut off between chunks — the connection closes where the next chunk
+/// header should begin.
+#[tokio::test]
+async fn a_cut_between_chunks_is_a_body_eof() {
+	let (frames, ended_as) = read_stream(FakeReply::ChunkedTruncated(vec![frame("start")])).await;
+
+	assert_eq!(
+		frames.len(),
+		1,
+		"the frame written before the cut still arrives: {frames:?}"
+	);
+	assert_eq!(
+		ended_as.as_deref(),
+		Some("body-unexpected-eof"),
+		"hyper reports this as a Body error wrapping UnexpectedEof \
+		 (\"unexpected EOF during chunk size line\"), not IncompleteMessage"
+	);
+}
+
+/// And a body cut mid-payload — the chunk header promises bytes that never come.
+/// hyper words it differently (`IncompleteBody`) but the io kind is the same, and
+/// the kind is what podup keys on.
+#[tokio::test]
+async fn a_cut_mid_payload_is_also_a_body_eof() {
+	let (_frames, ended_as) = read_stream(FakeReply::ChunkedCutMidPayload(format!(
+		"{{\"Type\":\"container\",\"Action\":\"start\",\"padding\":\"{}\"}}\n",
+		"a".repeat(64)
+	)))
+	.await;
+
+	assert_eq!(ended_as.as_deref(), Some("body-unexpected-eof"));
+}
+
+/// Neither cut is `IncompleteMessage`. Its own test because the lane's flake
+/// counter greps for that word (plus "connection closed before message
+/// completed", "channel closed" and "Connection reset"), so a real mid-body drop
+/// is currently counted as a genuine failure rather than a transport flake.
+#[tokio::test]
+async fn neither_cut_is_an_incomplete_message() {
+	for reply in [
+		FakeReply::ChunkedTruncated(vec![frame("start")]),
+		FakeReply::ChunkedCutMidPayload(format!("{{\"padding\":\"{}\"}}\n", "a".repeat(64))),
+	] {
+		let (_frames, ended_as) = read_stream(reply).await;
+		assert_ne!(
+			ended_as.as_deref(),
+			Some("incomplete-message"),
+			"a severed body is not the head-level IncompleteMessage"
+		);
+	}
+}
+
+/// The crux of #1104, as a test rather than a comment: the payload delivered is
+/// identical either way, so a caller that only looks at whether an error arrived
+/// cannot tell a finished stream from a severed one. Telling them apart needs a
+/// second, out-of-band observation — is the thing this stream was following still
+/// alive?
+#[tokio::test]
+async fn the_two_shapes_carry_the_same_payload() {
+	let (clean_frames, clean_end) = read_stream(FakeReply::ChunkedEnd(vec![frame("start")])).await;
+	let (severed_frames, severed_end) =
+		read_stream(FakeReply::ChunkedTruncated(vec![frame("start")])).await;
+
+	assert_eq!(clean_frames, severed_frames, "same frames delivered");
+	assert!(clean_end.is_none(), "clean end: {clean_end:?}");
+	assert!(severed_end.is_some(), "severed end must be an error");
+}

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -150,6 +150,21 @@ impl PodmanError {
 			Self::Hyper(e) if e.is_canceled() => "canceled",
 			Self::Hyper(e) if e.is_closed() => "closed",
 			Self::Hyper(e) if e.is_timeout() => "hyper-timeout",
+			// A body that stopped short is none of the above. `is_incomplete_message`
+			// is about the message head, so a severed *body* misses every predicate
+			// hyper exposes and used to land in `hyper-other` — the least
+			// informative label, for the likeliest shape.
+			//
+			// Measured against a fake socket that cuts a chunked body deliberately
+			// (`engine::stream_end_tests`), both places a cut can land arrive as a
+			// hyper Body error wrapping `io::ErrorKind::UnexpectedEof`:
+			//
+			//   between chunks  "unexpected EOF during chunk size line"
+			//   mid-payload     IncompleteBody
+			//
+			// The kind is what this keys on; hyper's message text distinguishing the
+			// two is not something to depend on.
+			Self::Hyper(e) if body_ended_early(e) => "body-unexpected-eof",
 			Self::Hyper(_) => "hyper-other",
 			Self::Connect(e) => match e.kind() {
 				std::io::ErrorKind::UnexpectedEof => "io-unexpected-eof",
@@ -235,6 +250,23 @@ impl PodmanError {
 			_ => false,
 		}
 	}
+}
+
+/// Whether a hyper error is a body that ended before it was complete — the shape
+/// a severed stream takes, which none of hyper's own predicates report. Walks the
+/// source chain for an `io::Error` of kind `UnexpectedEof` rather than matching on
+/// message text.
+fn body_ended_early(e: &hyper::Error) -> bool {
+	let mut source: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(e);
+	while let Some(current) = source {
+		if let Some(io) = current.downcast_ref::<std::io::Error>() {
+			if io.kind() == std::io::ErrorKind::UnexpectedEof {
+				return true;
+			}
+		}
+		source = std::error::Error::source(current);
+	}
+	false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Release PR for **3.2.1**. Merge commit, not squash — `main` absorbs `develop` exactly
so the histories stay aligned.

## What ships

- **A diagnostic label.** A severed stream is named `body-unexpected-eof` instead of
  the catch-all `hyper-other`. `IncompleteMessage` — the predicate that sounds like it
  covers this — is about the message *head*; a body cut off mid-flight matched none of
  hyper's own predicates. Measured against a socket that severs a chunked body on
  purpose. **Nothing branches on the label, so no command behaves differently**
  (#1224, toward #1104).
- **clap_complete 4.6.7 → 4.6.8** (#1225).

## What rides along without reaching the binary

- **CI**: both classified lists are empty and both majors gate on identity (#1215); the
  pass-count floor went 115 → 165 against a suite that runs 172; the lane records which
  image each leg booted (#1223) and now recognises a dropped body rather than only a
  dropped head (#1226).
- **Docs**: the benchmark is republished on 3.2.0 with the `secrets` scenario, and three
  harness defects are fixed — the engine label that died with the process, the missing
  scenario order, and `--self-test` overwriting a real report (#1217).
- **Tests**: the fake socket can now frame and sever a chunked body; seven tests pin
  what podup makes of each shape.

## Scope, stated rather than dressed up

This is a thin release. I said so when it was proposed — everything else on `develop` is
CI, docs, bench and test-only code — and the call was made to cut it. The changelog says
the same.

## Verification

Every commit here landed with its own green lane run on both majors: 172 passed, 0
failed, 0 flaky, empty classified list on each. #1228's run additionally proved the
`.deb` builds with the new version, which is the failure mode 1.9.0 shipped.

Tag `v3.2.1` follows on `main`.
