### PR TITLE
fix(attach,run): decide a dead stream out of band, like logs and stats

### DIFF
--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -111,6 +111,14 @@ pub(crate) async fn dispatch(
 				if outcome == podup::AttachOutcome::Interrupted {
 					return Err(podup::ComposeError::Interrupted);
 				}
+				// Same ordering rule as the interrupt above: reported after the
+				// teardown, never instead of it. docker compose exits 1 when an
+				// attached stream dies with the container still running, and we
+				// exited 0 — measured on 5.4.2 by restarting the libpod socket
+				// underneath an attached `up`.
+				if outcome == podup::AttachOutcome::StreamBroke {
+					return Err(podup::ComposeError::StreamTruncated);
+				}
 			}
 		}
 		Commands::Down {

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -241,21 +241,48 @@ impl Engine {
 			// writes there: holding its lock across the await loop would starve
 			// concurrent log emissions. Flush after each frame so `run` streams
 			// promptly.
-			{
+			// Held across the loop but dropped before the recheck below, which
+			// awaits: keeping stdout locked across that await would block any
+			// concurrent writer for the length of an API round trip.
+			let broke = {
 				let mut out = std::io::stdout().lock();
+				let mut broke = None;
 				while let Some(msg) = log_stream.next().await {
-					match msg.map_err(ComposeError::Podman)? {
-						crate::libpod::LogOutput::StdOut { message } => {
+					match msg {
+						Ok(crate::libpod::LogOutput::StdOut { message }) => {
 							let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
 							let _ = out.flush();
 						}
-						crate::libpod::LogOutput::StdErr { message } => {
+						Ok(crate::libpod::LogOutput::StdErr { message }) => {
 							let mut err = std::io::stderr().lock();
 							let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
 							let _ = err.flush();
 						}
+						// This arm used to abort the run. A lost chunked terminator
+						// is indistinguishable at the transport layer from a real
+						// mid-stream break (#1104), so aborting here fails a run
+						// whose command actually succeeded, on any version that
+						// drops it. Deciding out of band instead: the container's
+						// own state answers what the transport cannot.
+						Err(e) => {
+							broke = Some(e);
+							break;
+						}
 					}
 				}
+				broke
+			};
+			if let Some(e) = broke {
+				// Still running means the output really was truncated and the
+				// stream failed. Stopped means the command finished and only the
+				// terminator went missing, so fall through to `wait`, which
+				// reports the exit code the run actually produced.
+				if super::super::query::stream_broke_mid_output(
+					self.container_still_running(&run_name).await,
+				) {
+					return Err(ComposeError::Podman(e));
+				}
+				tracing::debug!("run {run_name}: log stream ended as the container stopped: {e}");
 			}
 
 			let wait_path = format!(
@@ -357,5 +384,79 @@ mod tests {
 		assert_eq!(lookup(&list, "A"), Some("a"));
 		assert_eq!(lookup(&list, "B"), Some("b"));
 		assert_eq!(lookup(&list, "C"), Some("c"));
+	}
+}
+
+/// What a non-interactive `run` does when its log stream dies under it.
+///
+/// The stream arm used to abort the run on any error. A lost chunked terminator
+/// is indistinguishable at the transport layer from a real break (#1104), so
+/// that failed a `run` whose command had succeeded. The container's state is the
+/// out-of-band answer, and `wait` then reports the real exit code.
+#[cfg(test)]
+#[cfg(unix)]
+mod stream_end_tests {
+	use crate::engine::fake_podman::{self, FakeReply};
+	use crate::engine::Engine;
+
+	fn compose() -> crate::compose::types::ComposeFile {
+		crate::parse_str("services:\n  app:\n    image: img\n").unwrap()
+	}
+
+	/// A fake whose log stream is cut with no terminating chunk, whose container
+	/// listing reports `state`, and whose `wait` reports `code`.
+	fn fake(state: &'static str, code: i64) -> fake_podman::FakePodman {
+		fake_podman::start_replying(move |method, target| {
+			if target.contains("/logs") {
+				FakeReply::ChunkedTruncated(vec!["output\n".to_string()])
+			} else if target.contains("/wait") {
+				FakeReply::Body(200, code.to_string())
+			} else if target.contains("/containers/json") {
+				FakeReply::Body(
+					200,
+					format!(r#"[{{"Names":["/proj-app-run-1"],"State":"{state}"}}]"#),
+				)
+			} else if method == "POST" {
+				FakeReply::Body(200, r#"{"Id":"cafe"}"#.to_string())
+			} else {
+				FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
+			}
+		})
+	}
+
+	fn options() -> crate::engine::RunOptions {
+		crate::engine::RunOptions {
+			cmd: vec![],
+			rm: false,
+			detach: false,
+			env_overrides: vec![],
+			name_override: Some("proj-app-run-1".to_string()),
+			service_ports: false,
+		}
+	}
+
+	#[tokio::test]
+	async fn a_cut_stream_after_the_container_stopped_reports_the_real_exit_code() {
+		let fake = fake("exited", 0);
+		let e = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+
+		e.run(&compose(), "app", options())
+			.await
+			.expect("the command finished; only the terminator went missing");
+	}
+
+	#[tokio::test]
+	async fn a_cut_stream_while_the_container_runs_is_a_failure() {
+		let fake = fake("running", 0);
+		let e = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+
+		let err = e
+			.run(&compose(), "app", options())
+			.await
+			.expect_err("output was truncated with the container still up: that is a failed read");
+		assert!(
+			matches!(err, crate::error::ComposeError::Podman(_)),
+			"expected the transport error to survive, got {err:?}"
+		);
 	}
 }

--- a/internal/engine/query/attach_stream_tests.rs
+++ b/internal/engine/query/attach_stream_tests.rs
@@ -1,0 +1,71 @@
+//! What an attached `up` does when a log stream dies under it.
+//!
+//! The transport cannot say whether a body that stopped without its terminator
+//! finished or broke (#1104, and `stream_end_tests` pins that both cuts arrive
+//! the same way). The container's own state is the second, independent
+//! observation that answers it, so these drive a real severed body against the
+//! fake and vary only the container listing.
+
+#![cfg(unix)]
+
+use super::inspect::AttachOutcome;
+use super::Engine;
+use crate::engine::fake_podman::{self, FakeReply};
+
+/// One `tty: true` service, so attach reads the raw byte stream rather than the
+/// multiplexed framing. The cut is what matters here, not the framing.
+fn compose() -> crate::compose::types::ComposeFile {
+	crate::parse_str("services:\n  app:\n    image: img\n    tty: true\n").unwrap()
+}
+
+/// A fake whose log stream is cut with no terminating chunk, and whose container
+/// listing reports `state`.
+fn fake_with_state(state: &'static str) -> fake_podman::FakePodman {
+	fake_podman::start_replying(move |_method, target| {
+		if target.contains("/logs") {
+			FakeReply::ChunkedTruncated(vec!["hello from the container\n".to_string()])
+		} else if target.contains("/containers/json") {
+			FakeReply::Body(
+				200,
+				format!(r#"[{{"Names":["/proj-app-1"],"State":"{state}"}}]"#),
+			)
+		} else {
+			FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
+		}
+	})
+}
+
+fn engine(fake: &fake_podman::FakePodman) -> Engine {
+	Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir())
+}
+
+#[tokio::test]
+async fn a_stream_cut_while_the_container_runs_is_a_broken_stream() {
+	let fake = fake_with_state("running");
+	let outcome = engine(&fake)
+		.attach_logs_with_options(&compose(), false)
+		.await
+		.expect("attach itself must not error; the outcome carries the verdict");
+
+	assert_eq!(
+		outcome,
+		AttachOutcome::StreamBroke,
+		"a cut body with the container still running truncated live output"
+	);
+}
+
+#[tokio::test]
+async fn a_stream_cut_as_the_container_stopped_is_a_clean_end() {
+	let fake = fake_with_state("exited");
+	let outcome = engine(&fake)
+		.attach_logs_with_options(&compose(), false)
+		.await
+		.expect("attach itself must not error");
+
+	assert_eq!(
+		outcome,
+		AttachOutcome::StreamsEnded,
+		"the container stopped, so the stream had every reason to end: a missing \
+		 terminator must not fail an `up` that finished"
+	);
+}

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -31,6 +31,9 @@ pub enum AttachOutcome {
 	StreamsEnded,
 	/// SIGINT or SIGTERM arrived while streaming.
 	Interrupted,
+	/// At least one stream ended while its container was still running, so live
+	/// output was truncated rather than finished (#1104).
+	StreamBroke,
 }
 
 impl Engine {
@@ -457,12 +460,13 @@ impl Engine {
 				);
 				let client = &self.client;
 				let is_tty = *is_tty;
+				let cname = cname.clone();
 				async move {
 					let resp = match client.get_stream(&path).await {
 						Ok(r) => r,
 						Err(e) => {
 							tracing::warn!("attach_logs {prefix}: {e}");
-							return;
+							return false;
 						}
 					};
 					// TTY containers produce raw bytes (stdout/stderr merged).
@@ -480,9 +484,37 @@ impl Engine {
 							Ok(LogOutput::StdErr { message }) => {
 								eprint!("{prefix} | {}", String::from_utf8_lossy(&message));
 							}
-							Err(_) => break,
+							// An attach stream lives as long as its container and
+							// ends when the container stops, so a lost chunked
+							// terminator is indistinguishable at the transport
+							// layer from a real mid-stream break (#1104). The
+							// container answers what the transport cannot: still
+							// running means live output was truncated.
+							//
+							// This arm used to discard the error without even a
+							// warning, so `up` in the foreground could lose its
+							// connection to the engine and still exit 0.
+							Err(e) => {
+								let kind = e.stream_end_kind();
+								let broke = super::stream_broke_mid_output(
+									self.container_still_running(&cname).await,
+								);
+								if broke {
+									tracing::warn!(
+										"attach {prefix}: stream ended while the container was \
+										 still running [{kind}]: {e}"
+									);
+								} else {
+									tracing::warn!(
+										"attach {prefix}: stream ended as the container stopped \
+										 [{kind}]"
+									);
+								}
+								return broke;
+							}
 						}
 					}
+					false
 				}
 			})
 			.collect();
@@ -497,7 +529,15 @@ impl Engine {
 			use tokio::signal::unix::{signal, SignalKind};
 			let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
 			tokio::select! {
-				_ = futures_util::future::join_all(streams) => AttachOutcome::StreamsEnded,
+				broke = futures_util::future::join_all(streams) => {
+					// One truncated stream is enough: the output the user was
+					// watching is incomplete whatever the others did.
+					if broke.into_iter().any(|b| b) {
+						AttachOutcome::StreamBroke
+					} else {
+						AttachOutcome::StreamsEnded
+					}
+				}
 				_ = tokio::signal::ctrl_c() => AttachOutcome::Interrupted,
 				_ = sigterm.recv() => AttachOutcome::Interrupted,
 			}
@@ -542,5 +582,14 @@ mod attach_outcome_tests {
 	#[test]
 	fn the_two_endings_are_not_equal() {
 		assert_ne!(AttachOutcome::StreamsEnded, AttachOutcome::Interrupted);
+	}
+
+	/// A truncated stream is its own ending, not either of the first two. Folding
+	/// it into `StreamsEnded` is what let an attached `up` lose its connection to
+	/// the engine and still exit 0.
+	#[test]
+	fn a_broken_stream_is_neither_of_the_other_two() {
+		assert_ne!(AttachOutcome::StreamBroke, AttachOutcome::StreamsEnded);
+		assert_ne!(AttachOutcome::StreamBroke, AttachOutcome::Interrupted);
 	}
 }

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -187,7 +187,7 @@ fn stop_on_write_error(container_name: &str, result: std::io::Result<()>) -> boo
 /// as stopped.
 ///
 /// Pure so the rule is pinned without a live socket.
-fn log_stream_broke_mid_output(still_running: Option<bool>) -> bool {
+pub(super) fn stream_broke_mid_output(still_running: Option<bool>) -> bool {
 	!matches!(still_running, Some(false))
 }
 
@@ -403,7 +403,7 @@ impl Engine {
 								// them and the container is gone either way.
 								Err(e) => {
 									let kind = e.stream_end_kind();
-									match log_stream_broke_mid_output(
+									match stream_broke_mid_output(
 										self.container_still_running(&container_name).await,
 									) {
 										true => {
@@ -488,7 +488,7 @@ impl Engine {
 						// truncated live output (#1104).
 						Err(e) => {
 							let kind = e.stream_end_kind();
-							match log_stream_broke_mid_output(
+							match stream_broke_mid_output(
 								self.container_still_running(&container_name).await,
 							) {
 								true => {
@@ -542,7 +542,7 @@ impl Engine {
 	/// `Ok(None)` is "could not tell" — an unreadable state is not confirmation
 	/// the end was expected, so the caller keeps the original error rather than
 	/// masking a possible failure. Mirrors the fail-closed rule `stats` uses.
-	async fn container_still_running(&self, container_name: &str) -> Option<bool> {
+	pub(super) async fn container_still_running(&self, container_name: &str) -> Option<bool> {
 		let filters = serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
 		let path = format!(
 			"{API_PREFIX}/containers/json?all=true&filters={}",
@@ -647,5 +647,8 @@ fn filter_orphans(names: Vec<String>, known: &std::collections::HashSet<String>)
 	names.into_iter().filter(|n| !known.contains(n)).collect()
 }
 
+/// Kept out of `inspect.rs`, which is 11 lines under the 500-line limit.
+#[cfg(test)]
+mod attach_stream_tests;
 #[cfg(test)]
 mod tests;

--- a/internal/engine/query/tests.rs
+++ b/internal/engine/query/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-	filter_orphans, is_valid_log_time, log_query, log_stream_broke_mid_output,
-	validate_log_filters, LogsOptions,
+	filter_orphans, is_valid_log_time, log_query, stream_broke_mid_output, validate_log_filters,
+	LogsOptions,
 };
 use std::collections::HashSet;
 
@@ -342,13 +342,13 @@ async fn logs_tolerates_one_container_that_will_not_stream() {
 #[test]
 fn a_stream_ending_while_the_container_runs_is_a_break() {
 	// The container outlived its own log stream, so output was truncated.
-	assert!(log_stream_broke_mid_output(Some(true)));
+	assert!(stream_broke_mid_output(Some(true)));
 }
 
 #[test]
 fn a_stream_ending_after_the_container_stopped_is_clean() {
 	// The stream is supposed to end here; libpod just did not get to say so.
-	assert!(!log_stream_broke_mid_output(Some(false)));
+	assert!(!stream_broke_mid_output(Some(false)));
 }
 
 #[test]
@@ -359,5 +359,5 @@ fn an_unreadable_state_counts_as_a_break() {
 	// transport failure back into exit 0. Measured — the permissive version
 	// reported a still-running container as stopped when the socket restarted
 	// under an attached `logs -f`.
-	assert!(log_stream_broke_mid_output(None));
+	assert!(stream_broke_mid_output(None));
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -61,6 +61,11 @@ pub enum ComposeError {
 	/// mapping; it is not printed, because the operator who pressed Ctrl-C does
 	/// not need to be told what they just did.
 	Interrupted,
+	/// An attached `up` lost a log stream while its container was still running,
+	/// so the output the user was watching is truncated rather than finished
+	/// (#1104). Which container is named in a warning as it happens; this only
+	/// carries the failure to the exit status.
+	StreamTruncated,
 	/// `podup update` (self-update) failed.
 	Update(String),
 	/// An `external: true` secret/config/network/volume is absent.
@@ -224,6 +229,10 @@ impl fmt::Display for ComposeError {
 			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
 			Self::Interrupted => write!(f, "interrupted"),
+			Self::StreamTruncated => write!(
+				f,
+				"log stream ended while the container was still running: output is incomplete"
+			),
 			Self::Update(s) => write!(f, "update error: {s}"),
 			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
 			Self::ScalePortConflict {


### PR DESCRIPTION
#1104 asked whether a finished libpod stream can be told from a broken one at the
transport layer. It cannot — `stream_end_tests` already pins that both places a
body can be cut arrive identically — so `stats` (#1169) and `logs` (#1204)
stopped asking the transport and asked the container instead. `attach` and `run`
were the two left.

## attach could lose the engine and still exit 0

The error arm discarded the error without even a warning, and the closure
returned nothing, so no failure could reach the caller:

```rust
Err(_) => break,
```

It now re-checks the container. Still running means live output was truncated,
which surfaces as `AttachOutcome::StreamBroke` and, after the teardown, a
non-zero exit. `AttachOutcome` was already `#[non_exhaustive]`, and its doc said
why: "a later ending — a stream that died rather than finished — is a variant".

Reported **after** the teardown and never instead of it, the same ordering the
interrupt already uses: returning early would leave the project running, which is
a worse bug than the exit code.

## run had the opposite bug

Its stream arm aborted on any error (`msg.map_err(...)?`), so a lost terminator
fails a run whose command succeeded. It now re-checks too, and when the container
has stopped it falls through to `wait`, which reports the exit code the run
actually produced.

**The interactive path needed no change.** It already waits on
`condition=stopped` and propagates that error, which is a stronger out-of-band
answer than a state re-check: it does not ask "is it still up", it waits for the
real result. Verified by reading it and by running it, not assumed.

## Tests

Four, each dying under mutation **in both directions** — a truncated body with
the container running must be a break, and the same body with the container
stopped must be a clean end. They drive a real severed chunked body through the
fake (`FakeReply::ChunkedTruncated`), not a stand-in error.

The `run` pair is worth singling out: mutating the check back to "abort on any
error" reproduces the exact previous behaviour, and the test catches it.

## Measured

Against real Podman 5.4.2 with the built binary:

- `run` exit 0 → 0, `run` exit 7 → **7**, so `wait` still reports the real code
- an attached `up` whose container finishes on its own → **0**, no false break
- the integration suite: **155 passed, 0 failed**

**What is not verified here**: a genuinely severed socket against a live daemon.
That needs restarting libpod under an attached `up`, and this host has eight
unrelated containers of the owner's running, so I did not. The fake covers the
wire shape; the live severance is the one gap.

## Note on the issue's framing

Both known-failure lists are empty now, and the 2026-07-20 entry in
`podman-known-failures-5` records why: the six `run`/`attach` tests that reddened
the 5.8.1 leg were the journald log driver returning HTTP 500, not a version that
drops the terminator. So the original hypothesis behind this issue was measured
and refuted — which does not change that the ambiguity is real, only where it
came from.

`events` stays open. It has no container whose state answers the question, and
its discriminator is intent (`--until` present or not), which is a separate
change.

Refs #1104
