### PR TITLE
fix(events): decide an unexpected feed end by intent, the last of the five

### DIFF
--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -117,7 +117,10 @@ pub(crate) async fn dispatch(
 				// exited 0 — measured on 5.4.2 by restarting the libpod socket
 				// underneath an attached `up`.
 				if outcome == podup::AttachOutcome::StreamBroke {
-					return Err(podup::ComposeError::StreamTruncated);
+					return Err(podup::ComposeError::StreamTruncated(
+					"log stream ended while the container was still running: output is incomplete"
+						.to_string(),
+				));
 				}
 			}
 		}

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -50,22 +50,52 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut stream = crate::libpod::parse_json_lines::<Value>(resp.into_body());
-		// Warned, never fatal. The parser only yields `Err` on a transport
-		// failure or an unparseable frame — but "transport failure" turns out to
-		// include how libpod ends a finished stream on some versions:
-		// `engine_events_stream_connects` went red on the live lane's Podman
-		// 5.8.1 when this was treated as a command failure, while the same suite
-		// is green on 5.4.2. Until podup can tell that apart from a socket that
-		// genuinely died, reporting it would fail commands that worked.
+		// Intent decides whether the end was expected, not the shape of the end.
+		//
+		// The other streaming commands re-check the container they followed
+		// (#1169, #1204, #1242). An events feed is project-scoped and follows no
+		// single container, so there is nothing to re-check — but the client
+		// already knows what it asked for, at no API cost. Without `--until` the
+		// feed is unbounded: libpod does not end it, only the client does, so any
+		// end is unexpected. With `--until` the window closes on its own and an
+		// end is what was asked for.
+		//
+		// Deliberately keyed on intent rather than on `Err` versus a clean `None`.
+		// Measured on 5.4.2: a fully past `--until` window ends the feed cleanly
+		// (`None`), so an unbounded feed reaching `None` is the same anomaly as
+		// one reaching `Err` — and the previous code exited 0 for both.
+		//
+		// Measured too, and worth knowing before trusting the flag: an `--until`
+		// in the FUTURE does not close the feed. libpod keeps it open past that
+		// time, with `stream=true` and `stream=false` alike, confirmed with curl
+		// against the socket with no podup involved. Only an already-elapsed
+		// window ends on its own.
+		let bounded = opts.until.is_some();
+		let mut broke: Option<crate::libpod::PodmanError> = None;
 		while let Some(event) = stream.next().await {
 			match event {
 				Ok(value) => println!("{}", format_event(&value, json)),
 				Err(e) => {
-					tracing::warn!("events: stream ended early [{}]: {e}", e.stream_end_kind())
+					tracing::warn!("events: stream ended early [{}]: {e}", e.stream_end_kind());
+					broke = Some(e);
+					break;
 				}
 			}
 		}
-		Ok(())
+		if bounded {
+			return Ok(());
+		}
+		// An unbounded feed that returned at all lost its connection: report it,
+		// carrying the transport error when there was one so the operator sees
+		// the cause rather than only the verdict.
+		match broke {
+			Some(e) => Err(ComposeError::Podman(e)),
+			None => Err(ComposeError::StreamTruncated(
+				"events stream ended on its own: an unbounded feed only ends when the client \
+				 stops it"
+					.to_string(),
+			)),
+		}
 	}
 }
 
@@ -242,5 +272,88 @@ mod event_colour_tests {
 			out.ends_with("create\u{1b}[0m") || !out.ends_with("\u{1b}[0m "),
 			"{out:?}"
 		);
+	}
+}
+
+/// Whether an events feed that ended did so because it was asked to.
+///
+/// The four other streaming commands re-check the container they followed. An
+/// events feed follows none, so the discriminator is intent — which the client
+/// knows without an API call.
+#[cfg(test)]
+#[cfg(unix)]
+mod stream_end_tests {
+	use crate::engine::fake_podman::{self, FakeReply};
+	use crate::engine::{Engine, EventsOptions};
+
+	fn engine(fake: &fake_podman::FakePodman) -> Engine {
+		Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir())
+	}
+
+	/// One event, then the body ends the way the server chose.
+	fn fake(reply: fn() -> FakeReply) -> fake_podman::FakePodman {
+		fake_podman::start_replying(move |_method, _target| reply())
+	}
+
+	fn one_event() -> Vec<String> {
+		vec![r#"{"Type":"container","Action":"start","id":"abc"}"#.to_string()]
+	}
+
+	fn bounded() -> EventsOptions {
+		EventsOptions {
+			until: Some("2026-01-01T00:00:00Z".to_string()),
+			..Default::default()
+		}
+	}
+
+	#[tokio::test]
+	async fn an_unbounded_feed_that_ends_cleanly_is_still_a_failure() {
+		// The case no error-shaped check could catch: the server closed the body
+		// properly, so the parser reports a clean end, and this used to exit 0.
+		let fake = fake(|| FakeReply::ChunkedEnd(one_event()));
+		let err = engine(&fake)
+			.stream_events_with_options(false, &EventsOptions::default())
+			.await
+			.expect_err("only the client ends an unbounded feed, so any end is unexpected");
+		assert!(
+			matches!(err, crate::error::ComposeError::StreamTruncated(_)),
+			"expected the intent verdict, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn an_unbounded_feed_cut_mid_body_is_a_failure() {
+		let fake = fake(|| FakeReply::ChunkedTruncated(one_event()));
+		let err = engine(&fake)
+			.stream_events_with_options(false, &EventsOptions::default())
+			.await
+			.expect_err("a severed unbounded feed is a failure too");
+		assert!(
+			matches!(err, crate::error::ComposeError::Podman(_)),
+			"the transport error must survive so the operator sees the cause, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn a_bounded_feed_that_ends_is_success() {
+		// `--until` is the client saying the window closes on its own, so the end
+		// is what was asked for. Measured on 5.4.2: an already-elapsed window does
+		// end the feed cleanly.
+		let fake = fake(|| FakeReply::ChunkedEnd(one_event()));
+		engine(&fake)
+			.stream_events_with_options(false, &bounded())
+			.await
+			.expect("a bounded feed reaching the end of its window succeeded");
+	}
+
+	#[tokio::test]
+	async fn a_bounded_feed_cut_mid_body_is_still_success() {
+		// Intent decides, not the shape of the end: a lost terminator on a window
+		// that was closing anyway must not fail the command.
+		let fake = fake(|| FakeReply::ChunkedTruncated(one_event()));
+		engine(&fake)
+			.stream_events_with_options(false, &bounded())
+			.await
+			.expect("a bounded feed's end is expected however the body finished");
 	}
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -61,11 +61,11 @@ pub enum ComposeError {
 	/// mapping; it is not printed, because the operator who pressed Ctrl-C does
 	/// not need to be told what they just did.
 	Interrupted,
-	/// An attached `up` lost a log stream while its container was still running,
-	/// so the output the user was watching is truncated rather than finished
-	/// (#1104). Which container is named in a warning as it happens; this only
-	/// carries the failure to the exit status.
-	StreamTruncated,
+	/// A stream ended when it should not have: an attached `up` whose container
+	/// was still running, or an unbounded `events` feed that returned at all
+	/// (#1104). Carries a short description of which, since the detail (the
+	/// container, the transport error) is already warned as it happens.
+	StreamTruncated(String),
 	/// `podup update` (self-update) failed.
 	Update(String),
 	/// An `external: true` secret/config/network/volume is absent.
@@ -229,10 +229,7 @@ impl fmt::Display for ComposeError {
 			Self::Unsupported(s) => write!(f, "unsupported feature: {s}"),
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
 			Self::Interrupted => write!(f, "interrupted"),
-			Self::StreamTruncated => write!(
-				f,
-				"log stream ended while the container was still running: output is incomplete"
-			),
+			Self::StreamTruncated(what) => write!(f, "{what}"),
 			Self::Update(s) => write!(f, "update error: {s}"),
 			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
 			Self::ScalePortConflict {


### PR DESCRIPTION
`events` was the one streaming command #1104 could not solve with the pattern the
other four use. They re-check the container they followed; an events feed is
project-scoped and follows none, so there is nothing to re-check.

The discriminator is **intent**, and the client already knows it at no API cost:

- **without `--until`** the feed is unbounded. libpod does not end it, only the
  client does, so any end is unexpected.
- **with `--until`** the window closes on its own and an end is what was asked
  for.

## Why intent and not the shape of the end

Measured on 5.4.2: a fully past `--until` window ends the feed **cleanly**. So an
unbounded feed reaching a clean `None` is exactly the same anomaly as one
reaching `Err` — and both used to exit 0. No predicate on the error shape could
have caught the first, which is the case a `logs`-style check would have missed
entirely.

## A measurement worth having before trusting the flag

**An `--until` in the future does not close the feed.** libpod keeps it open past
that time, with `stream=true` and `stream=false` alike. Confirmed with curl
straight at the socket, no podup involved:

```
until=+3s, stream=true   -> still open at 15s, killed by timeout
until=+3s, stream=false  -> still open at 15s, killed by timeout
since=-2h until=-1h      -> 1567 events, closes immediately
```

Only an already-elapsed window ends on its own. `podup events --until 3s` and
`docker compose events --until 3s` both sit there until killed — measured, same
socket. So the flag is real but narrower than it reads, and the rule above is
exercised exactly where it works.

## The comment this replaces was out of date

It blamed Podman 5.8.1 for ending a finished stream early, on the evidence of
`engine_events_stream_connects` reddening the lane. That entry is gone from
`.github/podman-known-failures-5`, and the removal note records the real cause:
the journald log driver could not open its library in that image, so every logs
request returned HTTP 500. The version-specific behaviour this code was written
around has no evidence behind it any more.

## Tests

Four, each dying under mutation **in both directions**: restoring the old
always-`Ok` behaviour kills both unbounded cases, and ignoring intent kills both
bounded ones. Real chunked bodies through the fake, both a clean end and a cut.

`ComposeError::StreamTruncated` gains a payload instead of growing a sibling
variant, now that `attach` and `events` reach it with different causes. It has
not shipped in a release, so nothing downstream is affected — and the enum is
`#[non_exhaustive]` regardless.

## Measured against real Podman 5.4.2

- an elapsed `--until` window → exits **0**
- an unbounded feed killed by SIGTERM → dies by signal, no invented error
- integration suite: **155 passed, 0 failed**

With this, all five streaming commands report a broken stream: `stats` (#1169),
`logs` (#1204), `attach` and `run` (#1242), and `events` here.

Closes #1104
