### PR TITLE
fix: the audit findings that block 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,14 @@ release's Ed25519 signature and SHA-256 checksum, failing closed otherwise. See
 ### Podman version
 
 podup tracks the **latest stable Podman** and supports its **last two majors,
-Podman 5.x and 6.x**. It talks to Podman's native libpod API (still versioned
-5.x, at 5.2.0 on Podman 6), so it needs **Podman ≥ 5.0**. Both supported majors
+Podman 5.x and 6.x**. It talks to Podman's native libpod API, requesting the
+`/v5.0.0/libpod` path that Podman 6 still serves; the gate is the major version
+the engine reports, so it needs **Podman ≥ 5.0**. Both supported majors
 run the integration suite in CI on every engine change (Fedora 44 for the
 latest 5.x, rawhide for 6.x). Many distributions still ship 4.x, so check
 `podman --version` and upgrade if needed. Fedora, Debian trixie/sid and recent
 Ubuntu releases carry 5.x; on an older release, install or upgrade Podman
 following the official guide: <https://podman.io/docs/installation>.
-
-**Known limitation on Podman 6.** Copying *into* a container (`podup cp
-./file web:/path`) and `watch` rules whose action includes `sync` fail with a
-transport error. Copying *out* of a container works on both majors, and both
-directions work on Podman 5. Fedora, Arch and Manjaro ship Podman 6 today, so
-this affects them now; it is tracked in
-[#1097](https://github.com/Glyndor/podup/issues/1097).
 
 ### Platforms
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -9,10 +9,12 @@ A podup loss is published exactly like a podup win.
 - **podup** and **podman-compose** both drive **Podman**, so comparing them is a
   pure *tool* comparison — same engine, only the orchestrator differs. This is the
   apples-to-apples result.
-- **docker-compose** drives **dockerd**, a different daemon. Any number that
-  includes it is an end-to-end *stack* comparison, not a pure-tool one, and is
-  labelled as such. It is only measured when a Docker Engine is available on the
-  benchmark host; otherwise it is left blank, never estimated.
+- **docker-compose** is pointed at the **Podman socket** through `DOCKER_HOST`,
+  which is what makes it comparable: same engine, so the only difference left is
+  the orchestrator. Run against a Docker daemon instead, its numbers fold in the
+  engine difference and become an end-to-end *stack* comparison; the harness
+  detects which engine it drove and labels the report accordingly, so a reader
+  is never left guessing. It is never estimated when absent.
 
 ## Fairness rules (non-negotiable)
 
@@ -89,7 +91,7 @@ against 0.50 ms here.
 
 ```sh
 # build the release binary first; point the harness at it
-PODUP_BIN=target/release/podup bench/run.sh --iters 12 --warmup 2 --cores 2-9
+PODUP_BIN=target/release/podup bash bench/run.sh --iters 12 --warmup 2 --cores 2-9
 python3 bench/aggregate.py
 # -> bench/results/report.md and bench/results/summary.json
 ```
@@ -101,8 +103,9 @@ python3 bench/aggregate.py
 `run.sh` writes one raw row per timed run to `results/raw.csv`; `aggregate.py`
 discards warm-up and failed runs and computes the statistics into
 `results/report.md` + `results/summary.json`. Raw, host-specific results are not
-committed; the published numbers live in the repository `README.md`, with the
-methodology and host details alongside them.
+committed; the published numbers live in `docs/benchmarks.md`, with the
+methodology and host details alongside them, and a short summary in the
+repository `README.md`.
 
 The harness is reviewed by `podup-benchmark-fairness-auditor` (the harness is
 equitable) and `podup-benchmark-results-reviewer` (the published claims are

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,48 @@
+podup (3.3.0) unstable; urgency=medium
+
+  Changed
+
+  * All five streaming commands now report a stream that died instead of
+    exiting 0. An attached `up` whose log stream dies while its container is
+    still running exits 1, `run` reports the transport error rather than a
+    missing exit code, and `events` exits 1 when an unbounded feed ends at all.
+    `logs` and `stats` already did this. A stream that ends because its
+    container stopped still exits 0. The transport cannot tell a finished
+    stream from a broken one, so each command asks something else: the four
+    container-scoped ones re-check whether the container is still running, and
+    `events`, which follows no single container, keys on whether a bounded
+    window was asked for. Scripts gating on these exit codes should expect a
+    non-zero where they previously saw success on a lost connection.
+
+  * `up --wait` now implies `-d`, matching `docker compose up --wait`. It
+    previously ran the health wait and then attached to the logs, so the
+    canonical health-gated CI invocation never returned.
+
+  * `up` no longer pulls an image it already has, once per service. Under the
+    effective `missing` policy the image is checked once per invocation and the
+    pull is skipped for every service using it, so a warm `up` prints no
+    `Pulling` line and issues no pull request. A 42-service project on one
+    image dropped from 88 requests to 46. `always` and `newer` still go to the
+    registry, and a service pinning `platform:` still pulls.
+
+  * `events --since` and `--until`, and `logs --since` and `--until`, accept a
+    leading hyphen, so relative times such as `--until -30m` parse instead of
+    being read as an unknown flag. Bounding an events feed needs both flags,
+    both already elapsed; podup now warns when `--until` is given alone.
+
+  Fixed
+
+  * `top` escapes control characters in the process table. A process inside a
+    container can name itself, and that name was printed unescaped, so it could
+    emit ANSI into the reader's terminal. Every other table already escaped.
+
+  * A service now keeps one identity colour across every command. `ps` keyed on
+    the container name and `images` on the service name, so the same service
+    could appear in two different colours depending on which command printed
+    it.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Wed, 29 Jul 2026 10:18:37 -0500
+
 podup (3.2.1) unstable; urgency=medium
 
   Changed

--- a/debian/podup.1
+++ b/debian/podup.1
@@ -1,4 +1,4 @@
-.TH PODUP 1 "July 2026" "podup 3.0.1" "User Commands"
+.TH PODUP 1 "July 2026" "podup 3.3.0" "User Commands"
 .SH NAME
 podup \- run docker-compose files on rootless Podman
 .SH SYNOPSIS
@@ -170,8 +170,13 @@ Print the public binding for a container port. \fB\-\-proto\fR sets the protocol
 (default \fBtcp\fR).
 .TP
 .B events
-Stream Podman events for this project's containers. \fB\-\-json\fR emits each
-event as a JSON line instead of a summary.
+Stream Podman events for this project's containers.
+\fB\-\-format\fR \fItable\fR|\fIjson\fR selects the output shape (json emits one
+object per line, not an array); \fB\-\-json\fR is a deprecated alias for it.
+\fB\-\-filter\fR \fIKEY=VALUE\fR keeps only matching events and is repeatable.
+\fB\-\-since\fR and \fB\-\-until\fR bound the window and must be given
+together to end the feed \- either alone, or an \fB\-\-until\fR in the future,
+leaves it following indefinitely.
 .TP
 .B images
 List images used by services.
@@ -284,9 +289,20 @@ A usage error (invalid arguments or flags).
 .TP
 .B 127
 \fBrun\fR/\fBexec\fR: the command was not found.
+.TP
+.B 130
+An attached \fBup\fR was ended by SIGINT or SIGTERM. 130 for both, matching
+\fBdocker compose\fR; the project is still torn down before the code is
+returned.
 .PP
 \fBrun\fR propagates the container's own exit code verbatim, so any other
 non-zero status comes from the container that was run.
+.PP
+A streaming command whose connection dies exits 1 rather than reporting success.
+This covers \fBlogs\fR, \fBstats\fR, an attached \fBup\fR, \fBrun\fR and
+\fBevents\fR. A stream that ends because its container stopped still exits 0.
+For \fBevents\fR, an unbounded feed that ends at all exits 1; bounding one
+needs \fB--since\fR and \fB--until\fR together, both already elapsed.
 .SH FILES
 .TP
 .B docker-compose.yml

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -44,6 +44,18 @@ Create and start all services (or only the named ones, plus their transitive
 | `--quiet-pull` | Suppress image-pull progress output. | off |
 | `--wait` | Wait until services are running/healthy before returning. | off |
 | `--wait-timeout <SECS>` | Maximum seconds to wait with `--wait` before giving up. | no limit |
+
+**`--wait` implies `-d`.** The flag means "return once the services are up", so
+`up --wait` does not stay attached to the logs afterwards — matching
+`docker compose up --wait`.
+
+**Under `missing`, an image already present is not pulled again.** The effective
+policy is `missing` unless `--pull` or a service's `pull_policy` says otherwise;
+in that case podup checks the image once per invocation and skips the pull for
+every service using it, so a warm `up` prints no `Pulling` line and issues no
+pull request. `always` and `newer` always go to the registry, and a service
+pinning `platform:` always pulls, because presence is matched on the image
+reference and that carries no architecture.
 | `--no-start` | Create the containers but do not start them. | off |
 | `--timestamps` | Prefix attached log lines with a timestamp (ignored with `-d`). | off |
 | `-V, --renew-anon-volumes` | Recreate anonymous volumes instead of keeping the previous ones. | off |
@@ -154,10 +166,16 @@ Stream Podman events for this project's containers.
 |---|---|---|
 | `--format <FMT>` | `table` (a `TYPE ACTION NAME` summary) or `json` (one object per line). | `table` |
 | `--filter <FILTER>` | Keep only events matching a predicate (`KEY=VALUE`, e.g. `event=start`). Repeatable. | none |
-| `--since <TIME>` | Only stream events at or after this timestamp or relative time. | stream start |
-| `--until <TIME>` | Only stream events up to this timestamp or relative time. | no end |
+| `--since <TIME>` | Only stream events at or after this timestamp or relative time (e.g. `-30m`). | stream start |
+| `--until <TIME>` | End of the window. Only closes the feed when paired with `--since` and already elapsed. | no end |
 
 `--json` is a hidden deprecated alias for `--format json`.
+
+**Bounding a feed needs both flags.** Measured against Podman 5.4.2:
+`--since -2h --until -1h` ends the feed; `--until` alone, `--since` alone, and
+any `--until` in the future all leave it following indefinitely. podup warns
+when `--until` is given without `--since`. This also decides the exit code — see
+[Exit status](#exit-status).
 
 ### `top [SERVICE...]`
 Show the running processes of service containers.
@@ -297,10 +315,6 @@ container side, e.g. `podup cp web:/app/data ./local`.
 | `-L, --follow-link` | Follow symlinks in the host source before copying into the container. | off |
 | `-a, --archive` | Accepted for compatibility (no effect under rootless Podman). | off |
 
-> **Podman 6:** copying *into* a container fails with a transport error.
-> Copying *out* works on both majors, and both directions work on Podman 5.
-> Tracked in [#1097](https://github.com/Glyndor/podup/issues/1097).
-
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
 container exits or you detach. Output only — stdin is never attached.
@@ -418,11 +432,6 @@ The `action` of each rule may be:
 | `restart` | Restart the container without rebuilding. |
 | `sync+restart` | Sync the files, then restart the container. |
 | `sync+exec` | Sync the files, then run the rule's `exec` command in the container. |
-
-> **Podman 6:** the `sync` step copies into the container through the same path
-> as `cp`, so `sync`, `sync+restart` and `sync+exec` fail there. `rebuild` and
-> `restart` are unaffected, and every action works on Podman 5. Tracked in
-> [#1097](https://github.com/Glyndor/podup/issues/1097).
 
 ## Maintenance
 
@@ -624,6 +633,10 @@ returns the whole set, which a script reads as a match.
 | `130` | An attached `up` was ended by SIGINT or SIGTERM. |
 | other | `run` propagates the container's own exit code verbatim. |
 
+An attached `up` also exits `1` when a log stream dies while its container is
+still running, and `events` exits `1` when an unbounded feed ends at all. Both
+are new in 3.3.0 and both used to exit `0`; see the streaming rule below.
+
 `exec` propagates the command's exit code the same way `run` does, and `wait`
 returns the last non-zero code it saw.
 
@@ -644,13 +657,16 @@ splits `NetIO`/`BlockIO` into separate input/output fields. Raw numbers are
 exact and need no parsing, but it does mean a docker-compose JSON consumer needs
 adapting rather than working unchanged.
 
-**A streaming command that loses its connection fails.** `logs` and `stats` end
-when the containers they follow stop, and libpod marks that end with a chunked
-terminator. A lost terminator — a dropped connection, or a version that omits it
-— is indistinguishable from a real mid-stream break at the transport layer, so
-both commands resolve it out of band: they re-check whether the containers are
-still running. Still running means live output was truncated, and the command
-exits `1`.
+**A streaming command that loses its connection fails.** This covers five
+commands: `logs`, `stats`, an attached `up`, `run`, and `events`.
+
+A stream ends when the container it follows stops, and libpod marks that end
+with a chunked terminator. A lost terminator — a dropped connection, or a
+version that omits it — is indistinguishable from a real mid-stream break at the
+transport layer, so the transport is not asked. Four of the five re-check
+whether the container is still running: still running means live output was
+truncated, and the command exits `1`. `run` reports the transport error instead
+of an exit code, since the command it was running never produced one.
 
 This matters for anything scraping them. `logs -f` used to return success after
 losing its socket, so a monitor could not tell "the container finished" from "my
@@ -664,6 +680,26 @@ A stream that ends because its containers stopped still exits `0`, as does
 When the re-check itself cannot be made — usually because the same severed
 connection is needed for it — the command fails rather than assuming the end was
 clean.
+
+**`events` decides it differently**, because a feed is project-scoped and
+follows no single container, so there is nothing to re-check. What the caller
+asked for answers it instead:
+
+- **A bounded window** — `--since` and `--until` together, both already elapsed
+  — closes on its own, so reaching the end exits `0`.
+- **Anything else** is an unbounded feed. libpod never ends one, so *any* end
+  means the stream was lost and the command exits `1` — including a clean end,
+  which no check on the error shape could have caught.
+- **A transport failure always fails**, bounded or not. A severed socket is not
+  made expected by having asked for a window.
+- Ctrl-C or SIGTERM kills the process by signal, as before; no error is
+  invented.
+
+Note that a window needs **both** ends and both must already have elapsed.
+Measured against Podman 5.4.2: `--since -2h --until -1h` closes the feed, while
+either flag alone leaves it open, as does any `--until` in the future. So
+`--until 5m` follows indefinitely rather than stopping in five minutes. podup
+warns when `--until` is passed without `--since`.
 
 **`watch` is the exception.** A sync, rebuild, restart or exec that fails during
 a watch session is reported as a warning and the session keeps going; `watch`

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -44,8 +44,9 @@ A compose file is treated like a Makefile: running podup on one is equivalent to
 trusting its author. Path-valued keys the spec resolves relative to the compose
 file (`extends.file`, `env_file`, `label_file`, `include`) may reference paths
 outside the project directory, including `../`. Do **not** run podup on a compose
-file from an untrusted source. (`include` still rejects absolute paths as
-non-portable, but this is hardening, not a security guarantee.)
+file from an untrusted source. `include` accepts an absolute path and uses it as
+given, the same as `extends.file` and `env_file` — there is no containment here
+to rely on.
 
 ## Container hardening (compose security keys)
 

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -363,11 +363,17 @@ pub(crate) enum Commands {
 		/// object per line (NDJSON, not a JSON array).
 		#[arg(long, value_enum, default_value_t = EventsFormat::Table)]
 		format: EventsFormat,
-		/// Only stream events at or after this timestamp/relative time.
-		#[arg(long)]
+		/// Only stream events at or after this timestamp/relative time (e.g.
+		/// -30m, 2026-01-01T00:00:00).
+		///
+		/// `allow_hyphen_values` because a relative time is written with a
+		/// leading `-`; without it clap reads `-30m` as an unknown flag.
+		#[arg(long, allow_hyphen_values = true)]
 		since: Option<String>,
-		/// Only stream events up to this timestamp/relative time.
-		#[arg(long)]
+		/// Only stream events up to this timestamp/relative time. Only an
+		/// already-elapsed window ends the feed: libpod keeps a stream open past
+		/// a future time, so `--until -5m` bounds it and `--until 5m` does not.
+		#[arg(long, allow_hyphen_values = true)]
 		until: Option<String>,
 		/// Filter events by predicate (KEY=VALUE, e.g. event=start); repeatable.
 		#[arg(long)]
@@ -499,11 +505,12 @@ pub(crate) enum Commands {
 		/// Number of lines to show from the end of the logs (default: all).
 		#[arg(short = 'n', long)]
 		tail: Option<String>,
-		/// Show logs since a timestamp or relative time (e.g. 2024-01-01T00:00:00, 10m).
-		#[arg(long)]
+		/// Show logs since a timestamp or relative time (e.g.
+		/// 2024-01-01T00:00:00, -10m).
+		#[arg(long, allow_hyphen_values = true)]
 		since: Option<String>,
-		/// Show logs before a timestamp or relative time.
-		#[arg(long)]
+		/// Show logs before a timestamp or relative time (e.g. -5m).
+		#[arg(long, allow_hyphen_values = true)]
 		until: Option<String>,
 		/// Prefix each line with an RFC3339 timestamp.
 		#[arg(short = 't', long)]

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -97,9 +97,15 @@ pub(crate) async fn dispatch(
 					None => fut.await?,
 				}
 			}
+			// `--wait` implies detach, as it does in docker compose: the flag
+			// means "return once the services are up", so attaching afterwards
+			// would block forever on a command whose whole point is to finish.
+			// Measured against v5.1.3 on the same socket: `docker compose up
+			// --wait` exits 0, and `podup up --wait` hung until killed — which is
+			// the canonical health-gated CI idiom, so it hung the job.
 			if watch {
 				engine.watch(file).await?;
-			} else if !detach {
+			} else if !detach && !wait {
 				let outcome = engine.attach_logs_with_options(file, timestamps).await?;
 				// A failed teardown must surface as a non-zero exit, not be
 				// swallowed after the log streams end.

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -22,9 +22,12 @@ pub struct EventsOptions {
 }
 
 impl Engine {
-	/// Stream events for this project's containers until interrupted. With
-	/// `json`, each event is printed as a compact JSON line; otherwise as
-	/// `TYPE ACTION NAME`.
+	/// Stream events for this project's containers. With `json`, each event is
+	/// printed as a compact JSON line; otherwise as `TYPE ACTION NAME`.
+	///
+	/// The feed is unbounded, so it normally ends only when the caller stops it.
+	/// Returning at all therefore means the stream was lost, and this returns
+	/// `Err` — see [`Engine::stream_events_with_options`] for the bounded case.
 	pub async fn stream_events(&self, json: bool) -> Result<()> {
 		self.stream_events_with_options(json, &EventsOptions::default())
 			.await
@@ -32,6 +35,29 @@ impl Engine {
 
 	/// [`Engine::stream_events`] with `docker compose events`-style `--since`,
 	/// `--until`, and `--filter` options.
+	///
+	/// # Errors
+	///
+	/// A transport failure always returns the underlying error, whatever was
+	/// asked for. Beyond that, whether a *clean* ending is an error depends on
+	/// what the caller asked for:
+	///
+	/// - **`since` and `until` both set, both already elapsed** — the window
+	///   closes on its own, so a clean ending is what was asked for. Returns
+	///   `Ok(())`.
+	/// - **anything else** — the feed is unbounded and libpod never ends it, so
+	///   any ending means the stream was lost. Returns
+	///   [`ComposeError::StreamTruncated`](crate::ComposeError::StreamTruncated).
+	///
+	/// Also returns `Err` if a `--filter` is malformed or the stream cannot be
+	/// opened.
+	///
+	/// A window needs **both** ends to close, and both must already have
+	/// elapsed. Measured against Podman 5.4.2: `since` and `until` together
+	/// close the feed, whether absolute or relative (`-2h`..`-1h`); either one
+	/// alone leaves it open, as does any `until` in the future. So `--until 5m`
+	/// follows indefinitely rather than stopping in five minutes, and `--until
+	/// -5m` alone does too.
 	pub async fn stream_events_with_options(&self, json: bool, opts: &EventsOptions) -> Result<()> {
 		let filters = build_event_filters(&self.project, &opts.filters)?;
 		let mut path = format!(
@@ -50,27 +76,38 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut stream = crate::libpod::parse_json_lines::<Value>(resp.into_body());
-		// Intent decides whether the end was expected, not the shape of the end.
+		// Whether a clean end was expected is decided by what was asked for, not
+		// by the shape of the end.
 		//
 		// The other streaming commands re-check the container they followed
 		// (#1169, #1204, #1242). An events feed is project-scoped and follows no
-		// single container, so there is nothing to re-check — but the client
-		// already knows what it asked for, at no API cost. Without `--until` the
-		// feed is unbounded: libpod does not end it, only the client does, so any
-		// end is unexpected. With `--until` the window closes on its own and an
-		// end is what was asked for.
+		// single container, so there is nothing to re-check. What the client
+		// asked for answers it instead, at no API cost.
 		//
-		// Deliberately keyed on intent rather than on `Err` versus a clean `None`.
-		// Measured on 5.4.2: a fully past `--until` window ends the feed cleanly
-		// (`None`), so an unbounded feed reaching `None` is the same anomaly as
-		// one reaching `Err` — and the previous code exited 0 for both.
+		// Keying on the request rather than on `Err` versus a clean `None`
+		// matters: a closed window ends the feed *cleanly*, so an unbounded feed
+		// reaching `None` is the same anomaly as one reaching `Err`, and the
+		// previous code exited 0 for both.
 		//
-		// Measured too, and worth knowing before trusting the flag: an `--until`
-		// in the FUTURE does not close the feed. libpod keeps it open past that
-		// time, with `stream=true` and `stream=false` alike, confirmed with curl
-		// against the socket with no podup involved. Only an already-elapsed
-		// window ends on its own.
-		let bounded = opts.until.is_some();
+		// A window needs BOTH ends to close. Measured against 5.4.2 with curl,
+		// no podup involved, `stream=true`:
+		//
+		//   since + until, both past, absolute   closes
+		//   since + until, relative (-2h..-1h)   closes
+		//   until alone, past                    stays open
+		//   since alone, past                    stays open
+		//
+		// So `--until` on its own does not bound anything, whatever the user
+		// meant by it, and treating it as intent-to-bound would call an unbounded
+		// feed bounded. A future `until` never closes either, with or without
+		// `since`.
+		let bounded = opts.since.is_some() && opts.until.is_some();
+		if opts.until.is_some() && opts.since.is_none() {
+			tracing::warn!(
+				"events: --until without --since does not bound the feed; libpod keeps it open. \
+				 Pass both to bound a window."
+			);
+		}
 		let mut broke: Option<crate::libpod::PodmanError> = None;
 		while let Some(event) = stream.next().await {
 			match event {
@@ -82,20 +119,25 @@ impl Engine {
 				}
 			}
 		}
+		// A transport failure is never expected, whatever was asked for. Intent
+		// says whether an *ending* was expected; it cannot make a severed socket
+		// expected. Reading it as "bounded means always fine" inverted the whole
+		// point of #1104 on the scriptable path: `--until` with `--format json`
+		// is what a script uses, and it would have truncated its window and
+		// reported success, while the interactive unbounded form got the strict
+		// check.
+		if let Some(e) = broke {
+			return Err(ComposeError::Podman(e));
+		}
 		if bounded {
 			return Ok(());
 		}
-		// An unbounded feed that returned at all lost its connection: report it,
-		// carrying the transport error when there was one so the operator sees
-		// the cause rather than only the verdict.
-		match broke {
-			Some(e) => Err(ComposeError::Podman(e)),
-			None => Err(ComposeError::StreamTruncated(
-				"events stream ended on its own: an unbounded feed only ends when the client \
-				 stops it"
-					.to_string(),
-			)),
-		}
+		// An unbounded feed that ended cleanly still lost its connection: libpod
+		// does not end one, so reaching here at all is the anomaly.
+		Err(ComposeError::StreamTruncated(
+			"events stream ended on its own: an unbounded feed only ends when the client stops it"
+				.to_string(),
+		))
 	}
 }
 
@@ -299,9 +341,11 @@ mod stream_end_tests {
 		vec![r#"{"Type":"container","Action":"start","id":"abc"}"#.to_string()]
 	}
 
+	/// Both ends of an elapsed window, which is the only form libpod closes.
 	fn bounded() -> EventsOptions {
 		EventsOptions {
-			until: Some("2026-01-01T00:00:00Z".to_string()),
+			since: Some("2026-01-01T00:00:00Z".to_string()),
+			until: Some("2026-01-01T01:00:00Z".to_string()),
 			..Default::default()
 		}
 	}
@@ -346,14 +390,42 @@ mod stream_end_tests {
 			.expect("a bounded feed reaching the end of its window succeeded");
 	}
 
+	/// `--until` alone does not bound anything: measured against 5.4.2, libpod
+	/// leaves the feed open without a `since` to pair it with. Treating it as
+	/// bounded would call an unbounded feed bounded and hand back a success.
 	#[tokio::test]
-	async fn a_bounded_feed_cut_mid_body_is_still_success() {
-		// Intent decides, not the shape of the end: a lost terminator on a window
-		// that was closing anyway must not fail the command.
+	async fn until_without_since_is_not_a_bounded_feed() {
+		let fake = fake(|| FakeReply::ChunkedEnd(one_event()));
+		let opts = EventsOptions {
+			until: Some("2026-01-01T00:00:00Z".to_string()),
+			..Default::default()
+		};
+		let err = engine(&fake)
+			.stream_events_with_options(false, &opts)
+			.await
+			.expect_err("until alone leaves the feed unbounded, so any end is unexpected");
+		assert!(
+			matches!(err, crate::error::ComposeError::StreamTruncated(_)),
+			"expected the unbounded verdict, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn a_bounded_feed_cut_mid_body_is_a_failure() {
+		// Intent says whether an *ending* was expected. It cannot make a severed
+		// socket expected, and this is the case that matters most: `--until` with
+		// `--format json` is the scriptable form, so swallowing the error here
+		// would truncate a window and report success on exactly the path a script
+		// trusts, while the interactive unbounded form kept the strict check.
+		// That inverts #1104 rather than completing it.
 		let fake = fake(|| FakeReply::ChunkedTruncated(one_event()));
-		engine(&fake)
+		let err = engine(&fake)
 			.stream_events_with_options(false, &bounded())
 			.await
-			.expect("a bounded feed's end is expected however the body finished");
+			.expect_err("a severed window is a failed read, bounded or not");
+		assert!(
+			matches!(err, crate::error::ComposeError::Podman(_)),
+			"the transport error must survive so the operator sees the cause, got {err:?}"
+		);
 	}
 }

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -17,7 +17,19 @@ impl Engine {
 	/// Run a one-off command in a new container for a service.
 	///
 	/// The container is started, its output streamed, and it is removed when done
-	/// (unless `opts.rm` is false). Non-zero exit codes surface as `ComposeError::RunExited`.
+	/// (unless `opts.rm` is false).
+	///
+	/// # Errors
+	///
+	/// A command that ran and exited non-zero surfaces as
+	/// [`ComposeError::RunExited`](crate::ComposeError::RunExited), carrying its
+	/// code.
+	///
+	/// A stream that dies while the container is still running is a failed read,
+	/// not a finished command: it returns the transport error and never reaches
+	/// the exit-code wait, so there is no code to carry. A stream that ends after
+	/// the container has stopped is treated as finished, whether or not its body
+	/// was terminated properly, and the exit code is reported as usual.
 	pub async fn run(
 		&self,
 		file: &ComposeFile,

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -15,15 +15,16 @@ use super::Engine;
 
 /// How an attached `up` stopped streaming.
 ///
-/// The distinction has to survive back to the caller because the two endings
-/// mean opposite things to a script: the containers finishing on their own is
-/// success, and the operator pressing Ctrl-C is not. The caller still tears the
-/// project down either way — reporting the interrupt as an error from `attach`
+/// The distinction has to survive back to the caller because the three endings
+/// mean different things to a script: the containers finishing on their own is
+/// success, the operator pressing Ctrl-C is not, and a stream that died under a
+/// container still running is a failed read. The caller still tears the project
+/// down in every case. Reporting an ending as an error from `attach` itself
 /// would short-circuit that and leave the containers running, which is a worse
 /// bug than the exit code this exists to fix.
-/// `#[non_exhaustive]` for the same reason the other public types in this
-/// release gained it: a later ending — a stream that died rather than finished
-/// — is a variant, and without this it would be a major bump to add one.
+///
+/// `#[non_exhaustive]` since 3.0.0, so a further ending can be added without a
+/// major bump. `StreamBroke` (3.3.0) is one that already was.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttachOutcome {

--- a/internal/engine/query/inspect_util.rs
+++ b/internal/engine/query/inspect_util.rs
@@ -140,12 +140,22 @@ pub(super) fn split_repo_tag(image_ref: &str) -> (String, String) {
 /// per input row (titles first). All but the last column are left-padded; the
 /// last is left ragged to avoid trailing whitespace.
 pub(super) fn align_top_columns(titles: &[String], processes: &[Vec<String>]) -> Vec<String> {
-	let mut rows: Vec<&[String]> = Vec::with_capacity(processes.len() + 1);
+	// Escaped before anything is measured. These cells hold a process `argv`
+	// read out of a container, which is attacker-controlled: without this a
+	// process can name itself with ANSI and repaint the reader's terminal. Every
+	// other table in podup goes through `fit_cell`, which sanitizes; `top`
+	// formats by hand and was the one that did not. Escaping first also keeps
+	// the width honest, since an escaped control character is wider than the
+	// byte it replaces.
+	let sanitize = |row: &[String]| -> Vec<String> {
+		row.iter().map(|c| crate::ui::sanitize_cell(c)).collect()
+	};
+	let mut rows: Vec<Vec<String>> = Vec::with_capacity(processes.len() + 1);
 	if !titles.is_empty() {
-		rows.push(titles);
+		rows.push(sanitize(titles));
 	}
 	for p in processes {
-		rows.push(p);
+		rows.push(sanitize(p));
 	}
 	let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
 	let mut widths = vec![0usize; col_count];
@@ -173,6 +183,25 @@ pub(super) fn align_top_columns(titles: &[String], processes: &[Vec<String>]) ->
 
 #[cfg(test)]
 mod tests {
+	/// A process can name itself, and `top` prints that name. Without escaping,
+	/// a container process called `\x1b[31mevil` repaints the reader's terminal
+	/// — the one table in podup that formatted by hand rather than through
+	/// `fit_cell`, which has sanitized since it was written.
+	#[test]
+	fn top_escapes_control_characters_from_process_argv() {
+		let titles = vec!["PID".to_string(), "COMMAND".to_string()];
+		let processes = vec![vec!["1".to_string(), "\u{1b}[31mevil".to_string()]];
+		let out = super::align_top_columns(&titles, &processes);
+		assert!(
+			!out.iter().any(|line| line.contains('\u{1b}')),
+			"no raw escape may reach the terminal: {out:?}"
+		);
+		assert!(
+			out[1].contains("\\u{1b}") || out[1].contains("\\x1b") || out[1].contains("\\e"),
+			"the sequence must survive as visible text, not vanish: {out:?}"
+		);
+	}
+
 	use super::{
 		align_top_columns, dedup_preserving_order, is_running_status, parse_port_proto,
 		select_replica, split_repo_tag,

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -130,19 +130,22 @@ impl PodmanError {
 		matches!(self, Self::Hyper(e) if e.is_incomplete_message())
 	}
 
-	/// How a streaming read ended, for the one question podup cannot currently
+	/// How a streaming read ended, for the one question the *transport* cannot
 	/// answer: was the stream *finished* or *broken*?
 	///
 	/// The parsers return `Ok(None)` on a clean body end, so in principle every
-	/// `Err` is a fault. In practice it is not — treating a mid-stream `Err` as a
-	/// command failure reddened fifteen tests on the lane's Podman 5.8.1 leg
-	/// while real 5.4.2 stayed green on the identical commit (#1104). Something
-	/// about how libpod ends a finished stream differs by version, and podup has
-	/// no way to tell which.
+	/// `Err` is a fault. In practice it is not, and the two cases are not
+	/// separable here: a body cut between chunks and one cut mid-payload arrive
+	/// alike, and a finished stream whose terminator went missing is
+	/// indistinguishable from either (#1104, pinned by `stream_end_tests`).
 	///
-	/// This names the hyper classification so a lane run can say *which* one
-	/// occurs, instead of the question being argued from the source. It is
-	/// diagnostic, not yet a decision: nothing branches on it.
+	/// Every streaming command therefore answers it out of band instead, by
+	/// asking something the transport cannot see — whether the container it was
+	/// following is still running, or whether the caller asked for a bounded
+	/// stream at all.
+	///
+	/// This names the hyper classification so a log can say *which* ending
+	/// occurred. It stays diagnostic: nothing branches on it.
 	pub(crate) fn stream_end_kind(&self) -> &'static str {
 		match self {
 			Self::Hyper(e) if e.is_incomplete_message() => "incomplete-message",

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -18,7 +18,7 @@ pub use anstyle::{AnsiColor, Style};
 pub use anstream::ColorChoice;
 
 mod table;
-pub use table::{fit_cell, Table};
+pub use table::{fit_cell, sanitize_cell, Table};
 
 /// Apply the resolved colour choice process-wide and enable Windows VT once.
 ///
@@ -104,7 +104,28 @@ pub fn identity_style(label: &str) -> Style {
 				.flatten()
 		})
 		.unwrap_or_else(|| label.to_string());
-	service_style(&key)
+	service_style(strip_replica_suffix(&key))
+}
+
+/// Drop a trailing `-N` replica index, so every surface hashes the same key.
+///
+/// Without this the promise above held only within one command: `ps` keys a
+/// container as `web-1` while `images` keys the same service as `web`, so one
+/// service came out in two different colours depending on which command printed
+/// it. Measured before the fix, one project, one invocation: `migrate` was blue
+/// in `ps` and light magenta in `images`.
+///
+/// Only an all-digit suffix is stripped, so a service genuinely named `api-2`
+/// keeps its own identity rather than colliding with `api`.
+fn strip_replica_suffix(key: &str) -> &str {
+	match key.rsplit_once('-') {
+		Some((head, tail))
+			if !head.is_empty() && !tail.is_empty() && tail.bytes().all(|b| b.is_ascii_digit()) =>
+		{
+			head
+		}
+		_ => key,
+	}
 }
 
 /// Enable or disable user-facing lifecycle progress output process-wide. The CLI
@@ -152,7 +173,13 @@ pub fn progress_line(kind: &str, name: &str, action: &str) {
 /// changed (dim).
 fn action_style(action: &str) -> Style {
 	let a = action.to_ascii_lowercase();
-	if a.starts_with("remov") || a.starts_with("kill") || a.starts_with("delet") {
+	// `unpaused` is checked before `paus` on purpose. It reaches the green arm
+	// either way — a container resuming is a thing becoming active, which is what
+	// green means here — but only by falling through, and adding `unpause` to the
+	// yellow arm's prefixes would silently invert it. Naming it pins the intent.
+	if a.starts_with("unpaus") {
+		Style::new().fg_color(Some(AnsiColor::Green.into()))
+	} else if a.starts_with("remov") || a.starts_with("kill") || a.starts_with("delet") {
 		Style::new().fg_color(Some(AnsiColor::Red.into()))
 	} else if a.starts_with("stop") || a.starts_with("paus") || a.starts_with("restart") {
 		Style::new().fg_color(Some(AnsiColor::Yellow.into()))

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -38,7 +38,7 @@ pub fn fit_cell(cell: &str, width: usize) -> String {
 /// Escaping happens before padding, so the width the column reserves is the
 /// width actually printed. Doing it after would let an escaped cell overflow its
 /// column and break every row's alignment.
-fn sanitize_cell(s: &str) -> String {
+pub fn sanitize_cell(s: &str) -> String {
 	s.chars()
 		.flat_map(|c| {
 			if c.is_control() {


### PR DESCRIPTION
A four-agent audit ahead of the release — code doc comments, markdown docs, CLI
ergonomics, visual experience — turned up four things that would have shipped
wrong. This is the blocking subset; the rest is going to issues.

## The one in code I had just merged

`events` **swallowed a transport failure inside a bounded window and returned
success.** Intent says whether an *ending* was expected; it cannot make a severed
socket expected. That inverted #1104 on the path where it matters most: `--until`
with `--format json` is the scriptable form, so it would have truncated its
window and reported success, while the interactive unbounded form kept the strict
check. The test that pinned the wrong behaviour is rewritten.

**And the bound itself was wrong.** Measured with curl against 5.4.2, no podup
involved:

```
since + until, both past, absolute   closes
since + until, relative (-2h..-1h)   closes
until alone, past                    stays open
since alone, past                    stays open
```

A window needs **both** ends. `--until` alone was being read as intent-to-bound
while libpod kept streaming. It now takes both, and podup warns when `--until` is
passed alone. Neither relative form parsed at all before this — `--until -30m`
died as an unknown flag — so `allow_hyphen_values` is set here and on `logs
--since`/`--until`.

## Two blockers that predate this work

**`up --wait` did not imply detach.** After the health wait, control fell into the
log attach and never returned. Measured: `timeout 25 podup up --wait` → 124,
`docker compose up --wait` → 0, same file and socket. That is the canonical
health-gated CI invocation, and it hung the job.

**`top` printed the process table without escaping.** A process inside a container
names itself, so it could emit ANSI into the reader's terminal. Every other table
goes through `fit_cell`, which has sanitized since it was written; `top` formatted
by hand. Escaping happens before the widths are measured, or an escaped cell
overflows its column. Dies under mutation.

## Visual

A service now keeps **one identity colour everywhere**. `ps` keyed on the
container name (`web-1`) and `images` on the service name (`web`), so the same
service came out in two colours depending on which command printed it — breaking
the promise the module makes in its own doc. Only an all-digit suffix is
stripped, so a service genuinely named `api-2` keeps its own identity.

`action_style` names `unpaused` explicitly. It already reached the green arm,
which is the right colour — a container resuming is a thing becoming active — but
by falling through, and adding `unpause` to the yellow prefixes would have
silently inverted it.

## Documentation

The reference had drifted behind the code, and one entry was actively harmful:

- **`security-model.md` claimed `include` rejects absolute paths.** The code uses
  an absolute path as given and `docker-migration.md` documents the real
  behaviour. A containment guarantee that does not exist, in the security
  document.
- **The Podman 6 `cp`/`watch` limitation is deleted from three places.** Fixed by
  #1170, released in **3.0.2**, and it had been telling Fedora, Arch and Manjaro
  users ever since that a working capability was broken.
- The exit-status table and streaming rule now cover all five commands and both
  new non-zero paths; the events window, the `up` pull skip and `--wait` implying
  `-d` are documented.
- **The man page** moves to 3.3.0 and gains exit code 130, the streaming rule and
  the `events` options. It is the reference `.deb` users actually get, and it was
  on 3.0.1.
- **The 3.3.0 changelog stanza** is written — where a user finds an exit-code
  change, and version-load-bearing for the `.deb`.
- `bench/README.md` described a methodology the harness no longer uses, its run
  snippet omitted `bash` for a non-executable script, and it pointed at the wrong
  file for the published numbers.
- The public doc comments on `AttachOutcome`, `stream_events`, `run` and
  `stream_end_kind` described the pre-#1104 system. `AttachOutcome` cited the
  variant added eleven lines below it as hypothetical, and said "this release" on
  a docs.rs surface.
- The README's libpod API claim said the version stays 5.x. The header reports
  the engine's own version — measured `Libpod-Api-Version: 5.4.2` here — and the
  gate is the major.

## Verified

Against real Podman 5.4.2: `up --wait` returns 0, a bounded `events` window exits
0, `--until` alone warns and keeps following, the man page renders without
warnings, `dpkg-parsechangelog` reads 3.3.0. **1369 unit tests and the 155-test
integration suite pass.**

Refs #1104
