### PR TITLE
chore: bump to 3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.2.1"
+version = "3.3.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"


### PR DESCRIPTION
Version bump for the 3.3.0 release.

`Cargo.toml` and `Cargo.lock`; `debian/changelog` already carries the 3.3.0
stanza, written alongside the audit fixes so the exit-code changes reached the
surface a Debian user actually reads.

Reproduced the release gate locally before pushing — tag, `Cargo.toml`,
`debian/changelog` and `Cargo.lock` all read 3.3.0, and `cargo build --locked`
succeeds. That gate exists because 1.9.0 shipped `podup_1.8.0_*.deb`: apt saw a
version it already had, and the same release rotated the signing key so
self-update refused too, leaving Debian users with no path at all.

## What 3.3.0 contains

- All five streaming commands report a stream that died instead of exiting 0
  (#1104) — `logs`, `stats`, an attached `up`, `run`, `events`
- `up --wait` implies `-d`, so the health-gated CI invocation returns instead of
  hanging
- `up` no longer pulls an image it already has, once per service (#1218) — a
  42-service project drops from 88 requests to 46
- `top` escapes control characters from process `argv`
- A service keeps one identity colour across every command
- The benchmark instrument resolves below 10 ms and every published table was
  re-measured (#1227)
- Documentation: a false containment claim in the security model, a phantom
  Podman 6 limitation live since 3.0.2, and the exit-code surfaces