### PR TITLE
feat(ui): give every service its own colour, readable on light and dark terminals

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,30 @@
+podup (3.4.0) unstable; urgency=medium
+
+  Changed
+
+  * Each service now gets its own identity colour. The palette holds twenty
+    colours instead of six and is assigned in sorted order rather than hashed,
+    so two services in a project no longer share a colour — measured on a
+    four-service project, two of them did. Every colour reads on a light
+    terminal and a dark one alike, and sits away from the red, green and yellow
+    that carry status meaning.
+
+  * Terminals that do not announce 256-colour support fall back to the previous
+    six colours. `--ansi`, `NO_COLOR` and TTY detection are unchanged: if colour
+    is off, none is emitted.
+
+  * `--help` no longer uses green for headings and cyan for literals. Green is
+    the healthy colour everywhere else in podup and cyan is an identity colour,
+    so the two most-read surfaces were competing for one vocabulary.
+
+  Fixed
+
+  * `podup --ansi never --help` emitted colour. Help is rendered inside the
+    argument parse, so the colour choice arrived too late for it; `--ansi` is
+    now read before parsing.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Wed, 29 Jul 2026 22:16:36 -0500
+
 podup (3.3.0) unstable; urgency=medium
 
   Changed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,6 +22,27 @@ These appear before the subcommand and may also come from the environment.
 | `--ansi <WHEN>` | | Colour output: `auto`, `always` or `never`. `always` forces colour even into a pipe or file. | 
 | `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it — when this is given, `.env` is not read. The process environment still takes precedence over both. |
 
+**Identity colours.** Each service gets its own colour, so a name is
+recognisable across `ps`, `logs`, `images`, `stats` and the progress lines.
+Twenty colours are available, assigned in sorted order, so no two services in
+a project share one until the twenty-first. Each was picked to stay readable
+on a light terminal and a dark one alike, and to sit away from the red, green
+and yellow that carry status meaning, so a service name never reads as a
+state.
+
+The wide palette needs a terminal that announces 256-colour support through
+`COLORTERM` or `TERM` (or Windows, where virtual-terminal processing is
+enabled directly). Where it does not, podup falls back to six basic ANSI
+colours (cyan, magenta, blue and their bright variants), which render
+everywhere but cannot fully clear that bar: of the sixteen standard ANSI
+colours, only cyan and bright magenta stay readable on both a light and a dark
+background, and two of the fallback's own six fall short (blue against black,
+bright cyan against white). The fallback stays anyway, on the view that
+distinguishing six services imperfectly beats distinguishing two well, and any
+terminal from the last decade qualifies for the wide palette instead. Both
+palettes obey `--ansi`, `NO_COLOR` and TTY detection: if colour is off,
+neither is emitted.
+
 ## Lifecycle
 
 ### `up`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,8 +36,12 @@ enabled directly). Where it does not, podup falls back to six basic ANSI
 colours (cyan, magenta, blue and their bright variants), which render
 everywhere but cannot fully clear that bar: of the sixteen standard ANSI
 colours, only cyan and bright magenta stay readable on both a light and a dark
-background, and two of the fallback's own six fall short (blue against black,
-bright cyan against white). The fallback stays anyway, on the view that
+background, and four of the fallback's own six fall short (magenta and blue
+against black, bright cyan against white, bright blue against black). ANSI-16
+colours have no fixed RGB — a terminal theme picks its own — so these figures,
+like the wide palette's, are relative to the reference palette this branch's
+tests pin (`internal/ui/palette_tests.rs`, the standard VGA 16-colour set),
+not a universal guarantee. The fallback stays anyway, on the view that
 distinguishing six services imperfectly beats distinguishing two well, and any
 terminal from the last decade qualifies for the wide palette instead. Both
 palettes obey `--ansi`, `NO_COLOR` and TTY detection: if colour is off,

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -17,30 +17,34 @@ pub(crate) use types::{
 ///
 /// Deliberately avoids green and cyan. Green is the "healthy" colour everywhere
 /// else in podup and cyan is an identity colour, so using them here put the two
-/// most-read surfaces in competition for one vocabulary. Help uses weight and
-/// white, which mean nothing elsewhere.
+/// most-read surfaces in competition for one vocabulary. Help uses weight
+/// (bold, underline, dim) and no explicit foreground colour, which means
+/// nothing elsewhere.
 ///
-/// All eight slots are set. Starting from `plain()` and overriding four left
-/// clap's own `error:` unstyled while podup's printed bold red — one binary,
-/// two answers to the same question.
+/// No slot sets an explicit `AnsiColor`, `error`/`invalid` excepted — those are
+/// status colours (red), not identity, and stay. An explicit `White` was tried
+/// first, on the reasoning that *some* colour should mark headings; measured
+/// against the same reference palette this branch's tests pin
+/// (`ui::palette_tests`), it read 1.82:1 on a white terminal background — worse
+/// than the green/cyan it replaced — and bold commonly promotes `White` to the
+/// terminal's bright-white ANSI code, which measured 1.00:1 on white, i.e.
+/// invisible. Leaving the foreground unset uses the terminal's own default
+/// text colour instead, which is readable on both themes by construction: it
+/// is what the terminal owner already chose for their body text.
+///
+/// All eight slots are still explicitly set, even where that means an empty
+/// style — clap's own `plain()` already leaves `error:` unstyled while podup
+/// printed it bold red, so nothing here may silently fall back to a starting
+/// point that disagreed with the rest of the binary.
 const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
-	.header(
-		clap::builder::styling::AnsiColor::White
-			.on_default()
-			.bold()
-			.underline(),
-	)
-	.usage(clap::builder::styling::AnsiColor::White.on_default().bold())
-	.literal(clap::builder::styling::AnsiColor::White.on_default().bold())
-	.placeholder(
-		clap::builder::styling::AnsiColor::White
-			.on_default()
-			.dimmed(),
-	)
+	.header(clap::builder::styling::Style::new().bold().underline())
+	.usage(clap::builder::styling::Style::new().bold())
+	.literal(clap::builder::styling::Style::new().bold())
+	.placeholder(clap::builder::styling::Style::new().dimmed())
 	.error(clap::builder::styling::AnsiColor::Red.on_default().bold())
-	.valid(clap::builder::styling::AnsiColor::White.on_default().bold())
+	.valid(clap::builder::styling::Style::new().bold())
 	.invalid(clap::builder::styling::AnsiColor::Red.on_default())
-	.context(clap::builder::styling::AnsiColor::White.on_default());
+	.context(clap::builder::styling::Style::new());
 
 /// Read `--ansi` straight off argv, before clap parses anything.
 ///

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -13,14 +13,72 @@ pub(crate) use types::{
 	OutputFormat, RmiScope,
 };
 
-/// Help-screen colours (clap honours its own TTY/`NO_COLOR`/`CLICOLOR` detection
-/// for these, since help is rendered before `--ansi` is parsed): green-bold
-/// section headers and usage, cyan-bold flag/command literals, plain placeholders.
+/// Help-screen colours.
+///
+/// Deliberately avoids green and cyan. Green is the "healthy" colour everywhere
+/// else in podup and cyan is an identity colour, so using them here put the two
+/// most-read surfaces in competition for one vocabulary. Help uses weight and
+/// white, which mean nothing elsewhere.
+///
+/// All eight slots are set. Starting from `plain()` and overriding four left
+/// clap's own `error:` unstyled while podup's printed bold red — one binary,
+/// two answers to the same question.
 const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
-	.header(clap::builder::styling::AnsiColor::Green.on_default().bold())
-	.usage(clap::builder::styling::AnsiColor::Green.on_default().bold())
-	.literal(clap::builder::styling::AnsiColor::Cyan.on_default().bold())
-	.placeholder(clap::builder::styling::AnsiColor::Cyan.on_default());
+	.header(
+		clap::builder::styling::AnsiColor::White
+			.on_default()
+			.bold()
+			.underline(),
+	)
+	.usage(clap::builder::styling::AnsiColor::White.on_default().bold())
+	.literal(clap::builder::styling::AnsiColor::White.on_default().bold())
+	.placeholder(
+		clap::builder::styling::AnsiColor::White
+			.on_default()
+			.dimmed(),
+	)
+	.error(clap::builder::styling::AnsiColor::Red.on_default().bold())
+	.valid(clap::builder::styling::AnsiColor::White.on_default().bold())
+	.invalid(clap::builder::styling::AnsiColor::Red.on_default())
+	.context(clap::builder::styling::AnsiColor::White.on_default());
+
+/// Read `--ansi` straight off argv, before clap parses anything.
+///
+/// clap renders `--help` inside the parse call, and the colour choice was only
+/// applied after it returned — so `podup --ansi never --help` came out coloured
+/// while `NO_COLOR=1 podup --help` did not. One flag, two answers.
+///
+/// Accepts both spellings clap does (`--ansi never`, `--ansi=never`) and is
+/// deliberately forgiving: an unrecognised value yields `None` and leaves the
+/// real parser to produce the error message.
+pub(crate) fn ansi_from_argv<I: Iterator<Item = String>>(args: I) -> Option<AnsiMode> {
+	let mut args = args.peekable();
+	while let Some(arg) = args.next() {
+		// `--` ends podup's own options: `run`/`exec`/`help` forward everything
+		// after it to the container's command with `allow_hyphen_values`, so a
+		// passthrough argument may legitimately read `--ansi always` and must not
+		// be mistaken for podup's flag. clap already stops here; before this, the
+		// pre-scan did not, and `NO_COLOR=1 podup <typo> exec svc -- --ansi always`
+		// painted clap's error in colour.
+		if arg == "--" {
+			return None;
+		}
+		let value = if let Some(v) = arg.strip_prefix("--ansi=") {
+			v.to_string()
+		} else if arg == "--ansi" {
+			args.next()?
+		} else {
+			continue;
+		};
+		return match value.as_str() {
+			"auto" => Some(AnsiMode::Auto),
+			"always" => Some(AnsiMode::Always),
+			"never" => Some(AnsiMode::Never),
+			_ => None,
+		};
+	}
+	None
+}
 
 /// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
 //
@@ -86,4 +144,82 @@ pub(crate) struct Cli {
 
 	#[command(subcommand)]
 	pub(crate) command: Commands,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{ansi_from_argv, AnsiMode};
+
+	fn argv(args: &[&str]) -> impl Iterator<Item = String> + use<> {
+		args.iter()
+			.map(|s| s.to_string())
+			.collect::<Vec<_>>()
+			.into_iter()
+	}
+
+	/// clap renders help before the parsed `--ansi` is applied, so the flag has
+	/// to be read straight off argv or `podup --ansi never --help` comes out
+	/// coloured — which it did, while `NO_COLOR=1 podup --help` did not.
+	#[test]
+	fn ansi_is_found_before_the_subcommand() {
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "--ansi", "never", "--help"])),
+			Some(AnsiMode::Never)
+		);
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "--ansi=always", "up"])),
+			Some(AnsiMode::Always)
+		);
+	}
+
+	/// It is a global flag, so it is equally valid after the subcommand.
+	#[test]
+	fn ansi_is_found_after_the_subcommand() {
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "up", "--ansi", "never"])),
+			Some(AnsiMode::Never)
+		);
+	}
+
+	/// No flag means no opinion; the existing auto-detection decides.
+	#[test]
+	fn absent_ansi_yields_none() {
+		assert_eq!(ansi_from_argv(argv(&["podup", "up", "-d"])), None);
+		assert_eq!(ansi_from_argv(argv(&["podup", "--ansi"])), None);
+		assert_eq!(ansi_from_argv(argv(&["podup", "--ansi", "sideways"])), None);
+	}
+
+	/// `--` ends podup's options. Everything after it is the container's command,
+	/// which `run`/`exec` forward verbatim with `allow_hyphen_values`, so a
+	/// passthrough argument reading `--ansi always` is not podup's flag.
+	#[test]
+	fn ansi_after_a_double_dash_is_not_ours() {
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "exec", "svc", "--", "--ansi", "always"])),
+			None
+		);
+		assert_eq!(
+			ansi_from_argv(argv(&[
+				"podup",
+				"exec",
+				"svc",
+				"--",
+				"sh",
+				"-c",
+				"--ansi=never"
+			])),
+			None
+		);
+	}
+
+	/// A flag before the `--` is still ours.
+	#[test]
+	fn ansi_before_a_double_dash_is_ours() {
+		assert_eq!(
+			ansi_from_argv(argv(&[
+				"podup", "--ansi", "never", "exec", "svc", "--", "true"
+			])),
+			Some(AnsiMode::Never)
+		);
+	}
 }

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -47,7 +47,19 @@ impl Engine {
 		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);
 		let mut first_err: Option<crate::error::ComposeError> = None;
 
-		let containers = self.list_project_container_names(None).await?;
+		// With no compose file, the service names are not known statically — but
+		// the labelled containers we are about to tear down carry `podup.service`,
+		// so list them grouped by service instead of the flat name list, and
+		// register the result before any teardown progress line is printed.
+		// Without this every container here fell back to the per-label hash
+		// instead of the sequential identity colour `ps` and the compose-file
+		// `down` path use — the same class of defect fixed for `logs` (#1082).
+		let by_service = self.list_project_containers_by_service().await?;
+		let mut service_names: Vec<String> = by_service.keys().cloned().collect();
+		service_names.sort();
+		crate::ui::set_services(&service_names);
+
+		let containers: Vec<String> = by_service.into_values().flatten().collect();
 		let futs = containers.iter().map(|container_name| {
 			self.teardown_one_container(container_name, grace, &[], remove_volumes)
 		});
@@ -209,7 +221,10 @@ mod tests {
 	#[tokio::test]
 	#[cfg(unix)]
 	async fn down_by_label_propagates_a_real_removal_failure_after_completing_the_rest() {
-		let containers = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-db-1"]}]"#;
+		let containers = r#"[
+			{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+			{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}}
+		]"#;
 		let fake = fake_podman::start(move |method, target| {
 			if method == "GET" && target.contains("/containers/json") {
 				(200, containers.to_string())

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -9,26 +9,40 @@ use std::io::Write;
 /// held in memory forever.
 const MAX_PENDING: usize = 64 * 1024;
 
-/// The identity colour for a log-prefix label.
+/// The palette slot for a log-prefix label.
 ///
-/// Delegates to [`crate::ui::identity_style`], never `crate::ui::service_style`
+/// Delegates to [`crate::ui::identity_slot`], never `crate::ui::service_slot`
 /// directly: the label reaching this module still carries its replica suffix
-/// (`web-1`, from `display_label`), and only `identity_style` strips that (and
+/// (`web-1`, from `display_label`), and only `identity_slot` strips that (and
 /// a project prefix) before resolving through the per-project colour registry
-/// `set_services` fills. Calling `service_style` on the raw label bypassed the
-/// registry entirely — that key was never in it — so every log prefix silently
-/// fell back to the per-label hash instead of the sequential colour `ps` uses.
-/// Measured on an 8-service project: `ps` gave 8 distinct colours, `logs` only
-/// 6, before this indirection existed.
+/// `set_services` fills. Resolving `service_slot` against the raw label
+/// bypassed the registry entirely — that key was never in it — so every log
+/// prefix silently fell back to the per-label hash instead of the sequential
+/// colour `ps` uses. Measured on an 8-service project: `ps` gave 8 distinct
+/// colours, `logs` only 6, before this indirection existed.
 ///
-/// Kept as its own function (rather than calling `identity_style` inline in
-/// [`LinePrefixer::new`]) so the routing choice is unit-testable on its own:
-/// [`LinePrefixer::new`]'s final output is gated by `stdout_colored`, which is
-/// false under the test harness (stdout is not a TTY there), so no test that
-/// only inspects a built `LinePrefixer`'s output can ever observe which style
-/// function was called.
+/// [`prefix_style`] renders this into a [`crate::ui::Style`] and nothing else
+/// — so the routing choice this function makes is the one thing a regression
+/// test needs to pin down, and it can compare the slot directly rather than a
+/// rendered `Style`. That distinction matters: the narrow (6-colour) fallback
+/// wraps a slot index mod 6, so two different wide-palette slots can render
+/// identically there, which would silently swallow a routing regression that
+/// a `Style` comparison alone could not see.
+fn prefix_slot(label: &str) -> usize {
+	crate::ui::identity_slot(label)
+}
+
+/// The identity colour for a log-prefix label. See [`prefix_slot`] for the
+/// routing decision this renders.
+///
+/// Kept as its own function (rather than calling [`crate::ui::identity_style`]
+/// inline in [`LinePrefixer::new`]) so the routing choice is unit-testable on
+/// its own: [`LinePrefixer::new`]'s final output is gated by `stdout_colored`,
+/// which is false under the test harness (stdout is not a TTY there), so no
+/// test that only inspects a built `LinePrefixer`'s output can ever observe
+/// which slot function was called.
 fn prefix_style(label: &str) -> crate::ui::Style {
-	crate::ui::identity_style(label)
+	crate::ui::style_for_slot(prefix_slot(label))
 }
 
 /// Tags each complete log line with `{label} | `, the way `docker compose logs`
@@ -116,28 +130,43 @@ impl LinePrefixer {
 
 #[cfg(test)]
 mod tests {
-	use super::{prefix_style, LinePrefixer};
+	use super::{prefix_slot, prefix_style, LinePrefixer};
 
-	/// The regression this guards: `new` used to call `service_style(label)`
-	/// directly on the raw, replica-suffixed label, which is never a key in the
-	/// per-project registry `identity_style` resolves against — every log
+	/// The regression this guards: `new` used to resolve `service_slot(label)`
+	/// directly against the raw, replica-suffixed label, which is never a key
+	/// in the per-project registry `identity_slot` resolves against — every log
 	/// prefix silently fell back to the hash instead of the sequential colour
-	/// `ps` uses for the same container. `identity_style` strips the `-N`
-	/// replica suffix before resolving, so `prefix_style("web-1")` must land on
-	/// the exact same colour as `identity_style("web")` applied to the same
-	/// container — and, since the raw hash of the two strings differs, must
-	/// disagree with `service_style("web-1")` applied to the untouched label.
+	/// `ps` uses for the same container.
+	///
+	/// Both checks are on `prefix_slot`, the actual routing decision, not the
+	/// `Style` [`prefix_style`] renders it into: the narrow (6-colour) fallback
+	/// wraps a slot index mod 6, and for these two labels slot 1 ("web") and
+	/// slot 19 ("web-1") both land on Magenta there. A `Style` comparison here
+	/// was red on any terminal that never announces the wide palette (no
+	/// `TERM`/`COLORTERM`, which is every Linux/macOS CI leg today) whether or
+	/// not the regression it guards was present. The slot itself never wraps,
+	/// so it stays a real, palette-independent assertion — and since
+	/// `prefix_style` does nothing but render `prefix_slot`'s output (see its
+	/// doc comment), pinning the slot pins the `Style` too.
 	#[test]
 	fn prefix_style_routes_through_identity_style_not_service_style() {
 		assert_eq!(
-			prefix_style("web-1"),
-			crate::ui::identity_style("web"),
+			prefix_slot("web-1"),
+			crate::ui::identity_slot("web"),
 			"the replica suffix must be stripped before resolving the colour"
 		);
 		assert_ne!(
-			prefix_style("web-1"),
-			crate::ui::service_style("web-1"),
+			prefix_slot("web-1"),
+			crate::ui::service_slot("web-1"),
 			"the raw, suffixed label must not be hashed directly"
+		);
+		// `prefix_style` is a pure rendering of `prefix_slot`, so its `Style`
+		// still agrees with `identity_style` on a wide-palette terminal — kept
+		// as a smoke test that the rendering step itself is wired up.
+		assert_eq!(
+			prefix_style("web-1"),
+			crate::ui::identity_style("web"),
+			"prefix_style must render the same slot identity_style does"
 		);
 	}
 

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -9,6 +9,28 @@ use std::io::Write;
 /// held in memory forever.
 const MAX_PENDING: usize = 64 * 1024;
 
+/// The identity colour for a log-prefix label.
+///
+/// Delegates to [`crate::ui::identity_style`], never `crate::ui::service_style`
+/// directly: the label reaching this module still carries its replica suffix
+/// (`web-1`, from `display_label`), and only `identity_style` strips that (and
+/// a project prefix) before resolving through the per-project colour registry
+/// `set_services` fills. Calling `service_style` on the raw label bypassed the
+/// registry entirely — that key was never in it — so every log prefix silently
+/// fell back to the per-label hash instead of the sequential colour `ps` uses.
+/// Measured on an 8-service project: `ps` gave 8 distinct colours, `logs` only
+/// 6, before this indirection existed.
+///
+/// Kept as its own function (rather than calling `identity_style` inline in
+/// [`LinePrefixer::new`]) so the routing choice is unit-testable on its own:
+/// [`LinePrefixer::new`]'s final output is gated by `stdout_colored`, which is
+/// false under the test harness (stdout is not a TTY there), so no test that
+/// only inspects a built `LinePrefixer`'s output can ever observe which style
+/// function was called.
+fn prefix_style(label: &str) -> crate::ui::Style {
+	crate::ui::identity_style(label)
+}
+
 /// Tags each complete log line with `{label} | `, the way `docker compose logs`
 /// labels multi-service output. Bytes arrive as stream frames that may split a
 /// line across frames, so a partial line is buffered until its newline arrives
@@ -39,7 +61,7 @@ impl LinePrefixer {
 		// prefix had to accept both. docker compose uses one space too.
 		let plain = format!("{label} | ");
 		let label = crate::ui::paint(
-			crate::ui::service_style(label),
+			prefix_style(label),
 			&plain,
 			allow_color && crate::ui::stdout_colored(),
 		);
@@ -94,7 +116,30 @@ impl LinePrefixer {
 
 #[cfg(test)]
 mod tests {
-	use super::LinePrefixer;
+	use super::{prefix_style, LinePrefixer};
+
+	/// The regression this guards: `new` used to call `service_style(label)`
+	/// directly on the raw, replica-suffixed label, which is never a key in the
+	/// per-project registry `identity_style` resolves against — every log
+	/// prefix silently fell back to the hash instead of the sequential colour
+	/// `ps` uses for the same container. `identity_style` strips the `-N`
+	/// replica suffix before resolving, so `prefix_style("web-1")` must land on
+	/// the exact same colour as `identity_style("web")` applied to the same
+	/// container — and, since the raw hash of the two strings differs, must
+	/// disagree with `service_style("web-1")` applied to the untouched label.
+	#[test]
+	fn prefix_style_routes_through_identity_style_not_service_style() {
+		assert_eq!(
+			prefix_style("web-1"),
+			crate::ui::identity_style("web"),
+			"the replica suffix must be stripped before resolving the colour"
+		);
+		assert_ne!(
+			prefix_style("web-1"),
+			crate::ui::service_style("web-1"),
+			"the raw, suffixed label must not be hashed directly"
+		);
+	}
 
 	/// #1082: one space before the bar. Attached `up` already used one, so the
 	/// same container was tagged two different ways by two commands in the same

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -328,6 +328,11 @@ async fn run() -> podup::Result<()> {
 		// Identity colours key on the project-stripped label, so every command
 		// tints the same container the same way.
 		podup::ui::set_project(&project);
+		// Register the service names so each gets its own identity colour. The
+		// hash this replaces could not know how many services existed, so two
+		// could share one. The `down`-by-label path has no compose file and
+		// keeps the hash fallback.
+		podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
 		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 		let engine = podup::Engine::with_base_dir(client, project, base_dir);
 		return engine
@@ -440,6 +445,7 @@ async fn run() -> podup::Result<()> {
 		// Identity colours key on the project-stripped label, so every command
 		// tints the same container the same way.
 		podup::ui::set_project(&project);
+		podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
 		// `file` is already parsed with the correct interpolation setting above.
 		let parsed = file;
 		// `--resolve-image-digests` pins each image to its registry digest, which
@@ -491,6 +497,7 @@ async fn run() -> podup::Result<()> {
 	// the progress lines all tint the same container the same way. This is the
 	// path every lifecycle command takes.
 	podup::ui::set_project(&project);
+	podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
 
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -330,8 +330,9 @@ async fn run() -> podup::Result<()> {
 		podup::ui::set_project(&project);
 		// Register the service names so each gets its own identity colour. The
 		// hash this replaces could not know how many services existed, so two
-		// could share one. The `down`-by-label path has no compose file and
-		// keeps the hash fallback.
+		// could share one. The `down`-by-label path has no compose file to read
+		// service names from up front; it registers them itself, from the live
+		// container listing it fetches immediately before tearing down.
 		podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
 		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 		let engine = podup::Engine::with_base_dir(client, project, base_dir);

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -234,6 +234,12 @@ fn render_help(rendered: &clap::builder::StyledStr, colour: bool) -> String {
 }
 
 pub(crate) fn parse_cli() -> Cli {
+	// Apply `--ansi` before clap renders anything: `--help` and clap's own
+	// errors are produced inside the parse call below, so a choice applied
+	// afterwards arrives too late for them.
+	if let Some(mode) = crate::cli::ansi_from_argv(std::env::args()) {
+		podup::ui::set_color_choice(mode.into());
+	}
 	match Cli::try_parse() {
 		Ok(cli) => cli,
 		Err(e) => match e.kind() {

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -113,6 +113,12 @@ pub fn set_services(names: &[String]) {
 /// the same colour for the same container, which is what makes `ps`, `logs`,
 /// `stats` and the progress lines agree.
 pub fn identity_style(label: &str) -> Style {
+	slot_to_style(identity_slot(label), palette::wide_palette_available())
+}
+
+/// The palette slot backing [`identity_style`]. See [`service_slot`] for why
+/// this exists as its own, unrendered step.
+pub(crate) fn identity_slot(label: &str) -> usize {
 	let key = PROJECT
 		.read()
 		.ok()
@@ -122,7 +128,7 @@ pub fn identity_style(label: &str) -> Style {
 				.flatten()
 		})
 		.unwrap_or_else(|| label.to_string());
-	service_style(strip_replica_suffix(&key))
+	service_slot(strip_replica_suffix(&key))
 }
 
 /// Drop a trailing `-N` replica index, so every surface hashes the same key.
@@ -338,14 +344,26 @@ const SERVICE_PALETTE: [AnsiColor; 6] = [
 	AnsiColor::BrightBlue,
 ];
 
-/// The stable colour for a service's aggregated-log prefix.
-pub fn service_style(name: &str) -> Style {
-	let index = SERVICES
+/// The palette slot backing [`service_style`], before it is rendered into a
+/// [`Style`] for whichever palette the terminal supports.
+///
+/// Split out so a routing regression can be asserted on the slot itself: the
+/// narrow (6-colour) fallback wraps a slot index mod 6, so two different
+/// wide-palette slots can render as the same `Style` there. A test comparing
+/// rendered `Style`s can miss exactly the collision it exists to catch on a
+/// terminal that never announces the wide palette; the slot never wraps, so
+/// it stays a real comparison on both.
+pub(crate) fn service_slot(name: &str) -> usize {
+	SERVICES
 		.read()
 		.ok()
 		.and_then(|slot| slot.as_ref().map(|map| palette::colour_for(name, map)))
-		.unwrap_or_else(|| palette::colour_for(name, &std::collections::HashMap::new()));
-	slot_to_style(index, palette::wide_palette_available())
+		.unwrap_or_else(|| palette::colour_for(name, &std::collections::HashMap::new()))
+}
+
+/// The stable colour for a service's aggregated-log prefix.
+pub fn service_style(name: &str) -> Style {
+	slot_to_style(service_slot(name), palette::wide_palette_available())
 }
 
 /// The style for a palette slot, from whichever palette the terminal supports.
@@ -363,6 +381,18 @@ fn slot_to_style(slot: usize, wide: bool) -> Style {
 	} else {
 		Style::new().fg_color(Some(SERVICE_PALETTE[slot % SERVICE_PALETTE.len()].into()))
 	}
+}
+
+/// Render a palette slot (from [`identity_slot`]/[`service_slot`]) into a
+/// [`Style`] for whichever palette the terminal supports right now.
+///
+/// The `pub(crate)` counterpart to [`identity_style`]/[`service_style`] for a
+/// caller that needs to resolve its *own* slot (e.g. the log-prefix module,
+/// which must never let its routing collapse into a raw per-label hash — see
+/// `engine::query::log_prefix::prefix_slot`) rather than one of the two
+/// label-keyed lookups here.
+pub(crate) fn style_for_slot(slot: usize) -> Style {
+	slot_to_style(slot, palette::wide_palette_available())
 }
 
 /// Whether an `Exited (N)` / `exited(N)` label reports a clean finish.

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -17,6 +17,7 @@ pub use anstyle::{AnsiColor, Style};
 
 pub use anstream::ColorChoice;
 
+mod palette;
 mod table;
 pub use table::{fit_cell, sanitize_cell, Table};
 

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -89,6 +89,23 @@ pub fn set_project(name: &str) {
 	}
 }
 
+/// The service-to-colour map for this invocation, filled once the compose file
+/// has been resolved. Empty until then, which is why `colour_for` falls back to
+/// a hash rather than requiring registration.
+static SERVICES: std::sync::RwLock<Option<std::collections::HashMap<String, usize>>> =
+	std::sync::RwLock::new(None);
+
+/// Record this project's service names so each gets its own identity colour.
+///
+/// Call once per invocation, after the compose file is parsed. Without it every
+/// label falls back to the hash, which still works — it just cannot promise two
+/// services differ.
+pub fn set_services(names: &[String]) {
+	if let Ok(mut slot) = SERVICES.write() {
+		*slot = Some(palette::assign(names));
+	}
+}
+
 /// The stable identity colour for a container or service label, keyed on the
 /// label with the project prefix removed.
 ///
@@ -321,20 +338,31 @@ const SERVICE_PALETTE: [AnsiColor; 6] = [
 	AnsiColor::BrightBlue,
 ];
 
-/// Stable palette index for a service name — the same name always maps to the
-/// same colour (FNV-1a over the bytes, modulo the palette size).
-fn palette_index(name: &str) -> usize {
-	let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-	for b in name.bytes() {
-		h ^= u64::from(b);
-		h = h.wrapping_mul(0x0100_0000_01b3);
-	}
-	(h % SERVICE_PALETTE.len() as u64) as usize
-}
-
 /// The stable colour for a service's aggregated-log prefix.
 pub fn service_style(name: &str) -> Style {
-	Style::new().fg_color(Some(SERVICE_PALETTE[palette_index(name)].into()))
+	let index = SERVICES
+		.read()
+		.ok()
+		.and_then(|slot| slot.as_ref().map(|map| palette::colour_for(name, map)))
+		.unwrap_or_else(|| palette::colour_for(name, &std::collections::HashMap::new()));
+	slot_to_style(index, palette::wide_palette_available())
+}
+
+/// The style for a palette slot, from whichever palette the terminal supports.
+///
+/// Split out of [`service_style`] so both branches are testable: the real
+/// decision reads a process-cached environment probe, and a test that flipped
+/// it would pass or fail on test scheduling.
+///
+/// The narrow branch takes a slot assigned against the WIDE palette's size, so
+/// it must wrap again — indexing a six-element array with a slot up to 19 is
+/// the out-of-bounds bug the old hash's `assert!` used to guard.
+fn slot_to_style(slot: usize, wide: bool) -> Style {
+	if wide {
+		Style::new().fg_color(Some(palette::wide_colour(slot)))
+	} else {
+		Style::new().fg_color(Some(SERVICE_PALETTE[slot % SERVICE_PALETTE.len()].into()))
+	}
 }
 
 /// Whether an `Exited (N)` / `exited(N)` label reports a clean finish.

--- a/internal/ui/mod_tests.rs
+++ b/internal/ui/mod_tests.rs
@@ -61,20 +61,6 @@ fn systemd_states_are_coloured() {
 }
 
 #[test]
-fn service_colour_is_stable_per_name() {
-	// Same name → same index every call; different names spread across the
-	// palette (not all collapsed to one colour).
-	assert_eq!(palette_index("web"), palette_index("web"));
-	let distinct: std::collections::HashSet<usize> =
-		["web", "db", "cache", "worker", "proxy", "queue"]
-			.iter()
-			.map(|n| palette_index(n))
-			.collect();
-	assert!(distinct.len() > 1, "palette should spread service names");
-	assert!(palette_index("web") < SERVICE_PALETTE.len());
-}
-
-#[test]
 fn paint_gates_on_enabled() {
 	let plain = paint(bold(), "hi", false);
 	assert_eq!(plain, "hi");
@@ -155,4 +141,44 @@ fn an_unprefixed_label_is_keyed_on_itself() {
 		identity_style("web").render().to_string(),
 		service_style("web").render().to_string()
 	);
+}
+
+/// `set_services` is what makes `service_style` disagree with the plain hash:
+/// once a project's names are registered, sequential assignment guarantees
+/// they spread across the palette, rather than each colliding independently
+/// under the hash the way `palette_index` used to.
+#[test]
+fn set_services_makes_registered_names_distinct() {
+	set_services(&[
+		"colourreg-alpha".to_string(),
+		"colourreg-beta".to_string(),
+		"colourreg-gamma".to_string(),
+	]);
+	let a = service_style("colourreg-alpha").render().to_string();
+	let b = service_style("colourreg-beta").render().to_string();
+	let g = service_style("colourreg-gamma").render().to_string();
+	assert_ne!(a, b, "registered names must not share a colour");
+	assert_ne!(b, g, "registered names must not share a colour");
+	assert_ne!(a, g, "registered names must not share a colour");
+}
+
+/// The guard `palette_index("web") < SERVICE_PALETTE.len()` used to provide
+/// before it was deleted: `service_style`'s narrow-terminal fallback receives
+/// whatever slot `palette::assign` produced (0 through `WIDE_PALETTE.len() -
+/// 1`, since `assign` itself wraps at the wide palette's size), and must wrap
+/// that again to index the six-entry `SERVICE_PALETTE` safely.
+///
+/// Calls `slot_to_style` itself — the real narrow-branch code, not a
+/// reimplementation of its modulo — for every slot the assignment can
+/// produce, on both the wide and narrow branches. Confirmed this fails: with
+/// the `% SERVICE_PALETTE.len()` removed from `slot_to_style`'s narrow arm,
+/// this test panics with an index-out-of-bounds on slot 6 (`index out of
+/// bounds: the len is 6 but the index is 6`), then passes again once the
+/// modulo is restored.
+#[test]
+fn every_wide_palette_slot_indexes_the_narrow_palette_safely() {
+	for slot in 0..palette::WIDE_PALETTE.len() {
+		let _ = slot_to_style(slot, false);
+		let _ = slot_to_style(slot, true);
+	}
 }

--- a/internal/ui/palette.rs
+++ b/internal/ui/palette.rs
@@ -1,0 +1,32 @@
+//! The identity palette: which colour a service is drawn in.
+//!
+//! Colour here is identity, never status. Red, green and yellow are reserved for
+//! state everywhere in podup, so no identity colour may sit near one.
+
+/// Identity colours, as xterm-256 indices.
+///
+/// Chosen so each clears 3:1 contrast against both white and black, sits at
+/// least deltaE 40 from the semantic red/green/yellow, and is at least deltaE 22
+/// from every other entry. `palette_tests.rs` recomputes all three from the sRGB
+/// values, so an edit that adds a pretty but unreadable colour fails the build
+/// rather than shipping.
+///
+/// Twenty is what survives those three filters, not a round number: of the 256
+/// colours only 80 clear 3:1 against both backgrounds at all, and 61 of those
+/// are far enough from the status colours. At the stricter 4.5:1 text bar only
+/// six qualify anywhere in the 256-colour space, which is why the wide palette
+/// targets the 3:1 interface bar instead.
+pub(crate) const WIDE_PALETTE: [u8; 20] = [
+	6, 13, 32, 33, 59, 61, 62, 65, 67, 93, 99, 128, 133, 138, 139, 163, 168, 170, 197, 198,
+];
+
+/// The palette entry at `index`, wrapping when a project has more services than
+/// the palette has colours. Repeating past the twentieth is better than running
+/// out of colour.
+pub(crate) fn wide_colour(index: usize) -> anstyle::Color {
+	anstyle::Ansi256Color(WIDE_PALETTE[index % WIDE_PALETTE.len()]).into()
+}
+
+#[cfg(test)]
+#[path = "palette_tests.rs"]
+mod tests;

--- a/internal/ui/palette.rs
+++ b/internal/ui/palette.rs
@@ -27,6 +27,59 @@ pub(crate) fn wide_colour(index: usize) -> anstyle::Color {
 	anstyle::Ansi256Color(WIDE_PALETTE[index % WIDE_PALETTE.len()]).into()
 }
 
+/// Whether the terminal can render the wide palette, from the values that
+/// describe it.
+///
+/// Pure so all four tiers are tested without a terminal. First match wins:
+/// - `COLORTERM` announcing truecolor or 24bit
+/// - `TERM` carrying the conventional `256color` marker
+/// - on Windows, unconditionally: the console there takes 256 colours in every
+///   modern host, and Windows commonly sets neither variable, so without this
+///   tier every Windows user would fall back
+/// - anything else falls back to the six ANSI basics
+///
+/// Guessing wider paints escape codes into the output of a terminal that cannot
+/// decode them.
+pub(crate) fn supports_wide_palette(
+	colorterm: Option<&str>,
+	term: Option<&str>,
+	windows_vt: bool,
+) -> bool {
+	if matches!(colorterm, Some("truecolor" | "24bit")) {
+		return true;
+	}
+	if term.is_some_and(|t| t.contains("256color")) {
+		return true;
+	}
+	windows_vt
+}
+
+/// [`supports_wide_palette`] against this process's environment.
+///
+/// Read once and cached: the environment does not change under a running
+/// command, and every styled cell would otherwise pay two `var_os` calls.
+///
+/// The Windows argument is `cfg!(windows)` — the target, not a runtime probe of
+/// virtual-terminal processing. That is sufficient because this is only ever
+/// consulted after the colour gate has decided to emit colour at all, which
+/// already required a terminal and a permitting `--ansi`/`NO_COLOR`; and on a
+/// console that genuinely lacks VT, anstream's wincon path converts the escapes
+/// rather than printing them raw.
+///
+/// Cached for the process, so tests must exercise [`supports_wide_palette`]
+/// rather than this: two tests varying the environment around this function
+/// would see whichever answer was cached first and pass or fail on test
+/// scheduling.
+pub(crate) fn wide_palette_available() -> bool {
+	use std::sync::OnceLock;
+	static AVAILABLE: OnceLock<bool> = OnceLock::new();
+	*AVAILABLE.get_or_init(|| {
+		let colorterm = std::env::var("COLORTERM").ok();
+		let term = std::env::var("TERM").ok();
+		supports_wide_palette(colorterm.as_deref(), term.as_deref(), cfg!(windows))
+	})
+}
+
 #[cfg(test)]
 #[path = "palette_tests.rs"]
 mod tests;

--- a/internal/ui/palette.rs
+++ b/internal/ui/palette.rs
@@ -80,6 +80,49 @@ pub(crate) fn wide_palette_available() -> bool {
 	})
 }
 
+use std::collections::HashMap;
+
+/// Give each name its own palette slot, walking them in sorted order.
+///
+/// Sequential rather than hashed: a hash does not know how many services exist,
+/// so it collides well before the palette is full — measured on a four-service
+/// project, two came out the same colour, and over twenty colours five services
+/// still collide about 42% of the time.
+///
+/// Sorting is what keeps it deterministic. Assigning in order of appearance
+/// would repaint everything when a service moved in the compose file; sorted,
+/// the same file always renders the same and adding a service only shifts those
+/// that sort after it. Nothing is written to disk.
+pub(crate) fn assign(names: &[String]) -> HashMap<String, usize> {
+	let mut sorted: Vec<&String> = names.iter().collect();
+	sorted.sort();
+	sorted.dedup();
+	sorted
+		.into_iter()
+		.enumerate()
+		.map(|(i, name)| (name.clone(), i % WIDE_PALETTE.len()))
+		.collect()
+}
+
+/// The palette slot for `label`, falling back to a hash for a label that was
+/// never registered.
+///
+/// The fallback matters for anything podup renders but did not resolve from the
+/// compose file — an orphan container, a project listed by `ls`. A stable wrong
+/// colour reads better than no colour at all, and the hash is what guarantees
+/// the same label always lands on the same slot.
+pub(crate) fn colour_for(label: &str, map: &HashMap<String, usize>) -> usize {
+	if let Some(&index) = map.get(label) {
+		return index;
+	}
+	let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+	for b in label.bytes() {
+		h ^= u64::from(b);
+		h = h.wrapping_mul(0x0100_0000_01b3);
+	}
+	(h % WIDE_PALETTE.len() as u64) as usize
+}
+
 #[cfg(test)]
 #[path = "palette_tests.rs"]
 mod tests;

--- a/internal/ui/palette_tests.rs
+++ b/internal/ui/palette_tests.rs
@@ -1,0 +1,166 @@
+use super::{wide_colour, WIDE_PALETTE};
+
+/// The xterm-256 index to its sRGB triple. The first 16 are the ANSI basics,
+/// then a 6x6x6 cube, then a 24-step grey ramp.
+fn srgb(index: u8) -> (u8, u8, u8) {
+	const BASE: [(u8, u8, u8); 16] = [
+		(0, 0, 0),
+		(128, 0, 0),
+		(0, 128, 0),
+		(128, 128, 0),
+		(0, 0, 128),
+		(128, 0, 128),
+		(0, 128, 128),
+		(192, 192, 192),
+		(128, 128, 128),
+		(255, 0, 0),
+		(0, 255, 0),
+		(255, 255, 0),
+		(0, 0, 255),
+		(255, 0, 255),
+		(0, 255, 255),
+		(255, 255, 255),
+	];
+	const STEP: [u8; 6] = [0, 95, 135, 175, 215, 255];
+	match index {
+		0..=15 => BASE[index as usize],
+		16..=231 => {
+			let i = index - 16;
+			(
+				STEP[(i / 36) as usize],
+				STEP[((i / 6) % 6) as usize],
+				STEP[(i % 6) as usize],
+			)
+		}
+		_ => {
+			let v = 8 + (index - 232) * 10;
+			(v, v, v)
+		}
+	}
+}
+
+/// Relative luminance, WCAG 2.1.
+fn luminance((r, g, b): (u8, u8, u8)) -> f64 {
+	fn channel(c: u8) -> f64 {
+		let c = f64::from(c) / 255.0;
+		if c <= 0.03928 {
+			c / 12.92
+		} else {
+			((c + 0.055) / 1.055).powf(2.4)
+		}
+	}
+	0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+/// WCAG contrast ratio between two colours.
+fn contrast(a: (u8, u8, u8), b: (u8, u8, u8)) -> f64 {
+	let (la, lb) = (luminance(a), luminance(b));
+	let (hi, lo) = if la > lb { (la, lb) } else { (lb, la) };
+	(hi + 0.05) / (lo + 0.05)
+}
+
+/// CIE L*a*b*, D65, for perceptual distance.
+fn lab(c: (u8, u8, u8)) -> (f64, f64, f64) {
+	fn linear(c: u8) -> f64 {
+		let c = f64::from(c) / 255.0;
+		if c <= 0.03928 {
+			c / 12.92
+		} else {
+			((c + 0.055) / 1.055).powf(2.4)
+		}
+	}
+	let (r, g, b) = (linear(c.0), linear(c.1), linear(c.2));
+	let x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
+	let y = r * 0.2126 + g * 0.7152 + b * 0.0722;
+	let z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
+	fn f(t: f64) -> f64 {
+		if t > 0.008856 {
+			t.cbrt()
+		} else {
+			7.787 * t + 16.0 / 116.0
+		}
+	}
+	let (fx, fy, fz) = (f(x), f(y), f(z));
+	(116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz))
+}
+
+/// Euclidean distance in Lab (CIE76).
+fn delta_e(a: (u8, u8, u8), b: (u8, u8, u8)) -> f64 {
+	let (la, aa, ba) = lab(a);
+	let (lb, ab, bb) = lab(b);
+	((la - lb).powi(2) + (aa - ab).powi(2) + (ba - bb).powi(2)).sqrt()
+}
+
+const WHITE: (u8, u8, u8) = (255, 255, 255);
+const BLACK: (u8, u8, u8) = (0, 0, 0);
+
+/// Every identity colour must be readable on a light terminal and a dark one.
+///
+/// 3:1 is the WCAG AA bar for interface components. The stricter 4.5:1 text bar
+/// is unreachable here: only six of the 256 colours clear it against both
+/// backgrounds, which is why this wide palette targets the 3:1 bar instead.
+#[test]
+fn every_palette_colour_reads_on_both_backgrounds() {
+	for &index in &WIDE_PALETTE {
+		let c = srgb(index);
+		let on_white = contrast(c, WHITE);
+		let on_black = contrast(c, BLACK);
+		assert!(
+			on_white >= 3.0,
+			"colour {index} scores {on_white:.2} against white, below the 3:1 bar"
+		);
+		assert!(
+			on_black >= 3.0,
+			"colour {index} scores {on_black:.2} against black, below the 3:1 bar"
+		);
+	}
+}
+
+/// Two services must never be given colours a reader cannot tell apart.
+#[test]
+fn palette_colours_are_distinguishable_from_each_other() {
+	for (i, &a) in WIDE_PALETTE.iter().enumerate() {
+		for &b in &WIDE_PALETTE[i + 1..] {
+			let d = delta_e(srgb(a), srgb(b));
+			assert!(
+				d >= 22.0,
+				"colours {a} and {b} are only deltaE {d:.1} apart; a reader sees one colour"
+			);
+		}
+	}
+}
+
+/// Red, green and yellow carry status meaning everywhere in podup. An identity
+/// colour close to one of them would read as a state.
+#[test]
+fn palette_avoids_the_semantic_colours() {
+	const SEMANTIC: [(u8, u8, u8); 6] = [
+		(255, 0, 0),
+		(128, 0, 0),
+		(0, 255, 0),
+		(0, 128, 0),
+		(255, 255, 0),
+		(128, 128, 0),
+	];
+	for &index in &WIDE_PALETTE {
+		for sem in SEMANTIC {
+			let d = delta_e(srgb(index), sem);
+			assert!(
+				d > 40.0,
+				"colour {index} is deltaE {d:.1} from a status colour; it would read as a state"
+			);
+		}
+	}
+}
+
+/// `wide_colour` wraps rather than panicking past the palette size, and returns
+/// the palette entry rather than the raw index.
+#[test]
+fn wide_colour_wraps_at_the_palette_size() {
+	assert_eq!(wide_colour(0), wide_colour(WIDE_PALETTE.len()));
+	assert_eq!(
+		wide_colour(3),
+		anstyle::Ansi256Color(WIDE_PALETTE[3]).into(),
+		"the returned colour must be the palette entry, not the index"
+	);
+}

--- a/internal/ui/palette_tests.rs
+++ b/internal/ui/palette_tests.rs
@@ -1,4 +1,4 @@
-use super::{supports_wide_palette, wide_colour, WIDE_PALETTE};
+use super::{assign, colour_for, supports_wide_palette, wide_colour, WIDE_PALETTE};
 
 /// The xterm-256 index to its sRGB triple. The first 16 are the ANSI basics,
 /// then a 6x6x6 cube, then a 24-step grey ramp.
@@ -193,4 +193,84 @@ fn an_unannounced_terminal_falls_back() {
 	assert!(!supports_wide_palette(None, None, false));
 	assert!(!supports_wide_palette(None, Some("vt100"), false));
 	assert!(!supports_wide_palette(Some(""), Some("dumb"), false));
+}
+
+/// Every service in a project gets its own colour. This is the whole point:
+/// the hash it replaces collided on a four-service project.
+#[test]
+fn services_up_to_the_palette_size_never_share_a_colour() {
+	let names: Vec<String> = (0..20).map(|i| format!("svc{i:02}")).collect();
+	let map = assign(&names);
+	let mut seen = std::collections::HashSet::new();
+	for name in &names {
+		let idx = map.get(name).copied().expect("every service is assigned");
+		assert!(seen.insert(idx), "{name} reuses a colour already given out");
+	}
+	assert_eq!(seen.len(), 20);
+}
+
+/// Past the palette size the assignment wraps rather than failing. Repeating a
+/// colour at the twenty-first service is better than running out.
+#[test]
+fn assignment_wraps_past_the_palette_size() {
+	let names: Vec<String> = (0..25).map(|i| format!("svc{i:02}")).collect();
+	let map = assign(&names);
+	assert_eq!(
+		map.len(),
+		25,
+		"every service is assigned even past the palette"
+	);
+	assert_eq!(
+		map["svc00"], map["svc20"],
+		"the twenty-first wraps onto the first"
+	);
+}
+
+/// Sorting is what makes this deterministic: the order services appear in the
+/// compose file must not change what colour they get.
+#[test]
+fn assignment_ignores_the_order_names_arrive_in() {
+	let forward: Vec<String> = ["web", "api", "db"].iter().map(|s| s.to_string()).collect();
+	let backward: Vec<String> = ["db", "api", "web"].iter().map(|s| s.to_string()).collect();
+	assert_eq!(assign(&forward), assign(&backward));
+}
+
+/// A label podup never resolved from the compose file — an orphan container,
+/// say — still gets a stable colour rather than none.
+#[test]
+fn an_unregistered_service_still_gets_a_stable_colour() {
+	let map = assign(&["web".to_string()]);
+	let a = colour_for("stranger", &map);
+	let b = colour_for("stranger", &map);
+	assert_eq!(
+		a, b,
+		"the same unknown label must always give the same colour"
+	);
+}
+
+/// `colour_for` must answer from the registry, not the hash, once a label is
+/// registered — otherwise `set_services` would be a no-op and every label
+/// would still collide exactly as before this task. `"db"` is chosen because
+/// its registered slot (1, from sorting alongside `web`/`cache`/`worker`/
+/// `queue`) provably differs from its own unregistered hash (11 against a
+/// 20-entry palette), so this cannot pass by the two coincidentally agreeing.
+#[test]
+fn colour_for_prefers_the_registered_slot_over_the_hash() {
+	let map = assign(&[
+		"web".to_string(),
+		"db".to_string(),
+		"cache".to_string(),
+		"worker".to_string(),
+		"queue".to_string(),
+	]);
+	let registered = colour_for("db", &map);
+	let unregistered = colour_for("db", &std::collections::HashMap::new());
+	assert_eq!(
+		registered, map["db"],
+		"a registered label must return its own slot"
+	);
+	assert_ne!(
+		registered, unregistered,
+		"registration must change the answer, not just agree with the hash"
+	);
 }

--- a/internal/ui/palette_tests.rs
+++ b/internal/ui/palette_tests.rs
@@ -1,4 +1,4 @@
-use super::{wide_colour, WIDE_PALETTE};
+use super::{supports_wide_palette, wide_colour, WIDE_PALETTE};
 
 /// The xterm-256 index to its sRGB triple. The first 16 are the ANSI basics,
 /// then a 6x6x6 cube, then a 24-step grey ramp.
@@ -163,4 +163,34 @@ fn wide_colour_wraps_at_the_palette_size() {
 		anstyle::Ansi256Color(WIDE_PALETTE[3]).into(),
 		"the returned colour must be the palette entry, not the index"
 	);
+}
+
+/// A terminal announcing truecolor can certainly render 256 colours.
+#[test]
+fn colorterm_truecolor_gets_the_wide_palette() {
+	assert!(supports_wide_palette(Some("truecolor"), None, false));
+	assert!(supports_wide_palette(Some("24bit"), None, false));
+}
+
+/// The conventional TERM marker.
+#[test]
+fn term_256color_gets_the_wide_palette() {
+	assert!(supports_wide_palette(None, Some("xterm-256color"), false));
+	assert!(supports_wide_palette(None, Some("screen-256color"), false));
+}
+
+/// Windows commonly sets neither variable while rendering 256 colours fine.
+/// Without this tier every Windows user would fall back to six.
+#[test]
+fn windows_with_vt_enabled_gets_the_wide_palette() {
+	assert!(supports_wide_palette(None, None, true));
+}
+
+/// A terminal that announces nothing gets the six ANSI basics, which render
+/// everywhere. Guessing wider would paint escape codes into its output.
+#[test]
+fn an_unannounced_terminal_falls_back() {
+	assert!(!supports_wide_palette(None, None, false));
+	assert!(!supports_wide_palette(None, Some("vt100"), false));
+	assert!(!supports_wide_palette(Some(""), Some("dumb"), false));
 }

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -444,3 +444,43 @@ fn bare_podup_prints_the_same_help_with_env_globals_set() {
 		);
 	}
 }
+
+// --- Machine output never carries colour, even when forced ------------------
+
+/// Machine-readable output must never carry colour, even when colour is
+/// forced. A script parsing `--format json` or `-q` reads stdout, so any
+/// escape landing there is data corruption, not decoration.
+///
+/// Forced with `--ansi always` on purpose: the auto-detection would suppress
+/// colour in the test harness anyway, so a weaker version of this test would
+/// pass without proving anything. Only stdout is checked: a connection
+/// failure prints its `error:` banner to stderr, which is a human diagnostic
+/// and is allowed to be coloured like any other podup error — the guarantee
+/// under test is about the machine-parseable stream, not every byte podup
+/// writes.
+#[test]
+fn machine_output_carries_no_escapes_even_with_colour_forced() {
+	let dir = std::env::temp_dir().join(format!("podup-cflags-machine-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("compose.yaml");
+	fs::write(&compose, "services:\n  web:\n    image: nginx:1.27\n").unwrap();
+	let c = compose.to_str().unwrap();
+
+	for args in [
+		vec!["-f", c, "--ansi", "always", "config"],
+		vec!["-f", c, "--ansi", "always", "ps", "--format", "json"],
+		vec!["-f", c, "--ansi", "always", "ps", "-q"],
+	] {
+		let out = Command::new(bin())
+			.args(&args)
+			.output()
+			.unwrap_or_else(|e| panic!("run podup {args:?}: {e}"));
+		let stdout = String::from_utf8_lossy(&out.stdout);
+		assert!(
+			!stdout.contains('\u{1b}'),
+			"{args:?} emitted an escape into machine output: {stdout:?}"
+		);
+	}
+
+	let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Phase 1 of four in the terminal-experience work. Six commits, built and reviewed
task by task, with a whole-branch review at the end that found two blockers the
per-task reviews structurally could not see.

## The problem, measured

The identity palette held **six colours**, assigned by hashing the label modulo
six. A hash does not know how many services exist, so collisions landed early —
measured on a four-service project, `migrate` and `broken` came out identical.

There was **no terminal capability detection anywhere in the tree**: `grep` for
`TERM` and `COLORTERM` across `internal/ui` and `internal/cli` returned nothing.
The palette was small because nothing had ever established that a wider one was
safe to emit.

## What a wider palette costs

The requirement is that colours read on a light terminal and a dark one alike,
and that constrains the set far more than its size does:

| threshold | colours passing against **both** white and black |
|---|---|
| 4.5:1 (AA, normal text) | **6 of 256** |
| 3:1 (AA, interface) | **80 of 256** |
| 2.5:1 | 113 of 256 |

At the strict bar there are six usable colours in the whole 256-colour space.
That coincides with the six podup shipped, and the coincidence means nothing —
the two sets do not overlap at all. The palette was six because six is what
ANSI-16 leaves after removing black, white, the greys and the red/green/yellow
families.

This branch adopts the 3:1 interface bar. From those 80, dropping everything
within ΔE 40 of the semantic colours leaves 61; selecting greedily for mutual
distance down to ΔE 22 yields **20**. Twenty is what survives the filters, not a
round number.

**Every one of those three properties is recomputed in tests from the sRGB
values**, so a future edit that adds a pretty-but-unreadable colour fails the
build instead of shipping.

## Assignment

Sequential over **sorted** service names. Not hashed: over 20 colours a hash
still collides about 42% of the time at five services. Sorting keeps it
deterministic — the same compose file always renders the same, adding a service
only shifts those sorting after it, and nothing is written to disk.

Measured on an 8-service project: **8 distinct colours, identical across `ps`,
`logs`, `images` and `stats`** — per name, not merely per set.

## The fallback is honest about what it cannot do

Terminals that do not announce 256-colour support keep the previous six. Those
six **cannot** meet the dual-theme bar: measured across ANSI-16, after the
reservations, exactly two clear 3:1 against both backgrounds — Cyan and
BrightMagenta. `Blue` scores 1.31 on black, `BrightCyan` 1.25 on white.

Six services distinguished imperfectly beats two distinguished well, and any
terminal of the last decade takes the wide palette. The documentation states the
limitation and names the reference palette, since ANSI-16 colours have no fixed
RGB.

## `--help`

It used green for headings and cyan for literals — green means "healthy"
everywhere else and cyan is an identity colour, so the two most-read surfaces
competed for one vocabulary. Help now carries weight, dim and underline with **no
forced foreground**, so it cannot fail in either theme. All eight clap style
slots are set, which is why clap's own `error:` no longer prints unstyled while
podup's prints bold red.

`--ansi` is now read off argv before clap parses. `podup --ansi never --help`
emitted colour, because clap renders help inside the parse call and the choice
was applied after it returned, while `NO_COLOR=1 podup --help` correctly did not.

## What the reviews caught

Worth recording, because none of it was visible from the plan:

- **`logs` bypassed the whole fix.** It passed the suffixed label to a function
  that never consults the registry, so it still gave 6 colours where `ps` gave 8,
  with none matching. Found by measurement, not by reading.
- **A test that could not fail.** The guard for the six-colour path re-derived
  its arithmetic from constants; removing the real production guard left the
  suite green at 1384/1384. Fixed by extracting a pure function and verified by
  mutation.
- **The `--ansi` pre-scan ignored `--`**, so a passthrough argument meant for the
  container could defeat `NO_COLOR` on clap's error path. Reproduced, then closed.
- **The regression test for the `logs` fix broke CI.** It passed only where
  `TERM` announced 256 colours, and no workflow sets `TERM` — so it was red on
  the Linux and macOS legs, and under the narrow palette it failed whether or not
  the defect was present.
- **The `--help` restyle initially made light terminals worse**, using a colour
  at 1.82:1 on white to replace two that cleared the bar — inside the branch
  whose justification is dual-theme contrast.

## Verified

1384 library tests, 74 binary tests, 19 CLI tests, and the 155-test integration
suite. `cargo test --lib` passes **with and without `TERM`**. `clippy
--all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean.
Machine output — `config`, `ps --format json`, `ps -q` — emits no escapes even
with `--ansi always`, and that is now pinned by a test rather than by a manual
sweep. Degradation holds: piped, `NO_COLOR`, `--ansi never` all silent.

`Cargo.toml` and `Cargo.lock` are deliberately untouched; the bump is a separate
release step. `debian/changelog` carries the 3.4.0 stanza.
