### PR TITLE
feat(cli): show a live board while up, down, pull and build work

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -39,6 +39,22 @@ podup (3.4.0) unstable; urgency=medium
     bookkeeping columns so the command line stands out; `volumes` highlights an
     external volume; `ls` gives each project name its own colour.
 
+  * `up`, `down`, `pull` and `build` show a live board on a terminal: the whole
+    resource set up front, repainted as work proceeds, with finished rows
+    scrolling up and staying. In a pipe, a file, CI, under `NO_COLOR` or with
+    `--ansi never`, the same events come out as plain append-only lines and no
+    escape sequences. Both carry the intermediate transitions (`Creating` then
+    `Created`), which no renderer emitted before — so a log now says more than
+    it used to, never less.
+
+  * `pull` reports through the progress layer and emits a matching `Pulled`. It
+    used a bare `eprintln!` that bypassed the output layer entirely, ignoring
+    the switch an embedding crate uses to silence podup, and it printed twice
+    per image on `up` while printing once on a standalone `pull`.
+
+  * `build` writes its output to stderr. It used stdout, contradicting the
+    promise that stdout stays a clean pipe.
+
   Fixed
 
   * `down` reported removing networks and volumes that never existed. On a

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -570,21 +570,49 @@ prints the same.
 
 ## Progress output
 
-Lifecycle commands report each resource they act on as a line on **stderr**, so
-stdout stays a clean pipe:
+`up`, `down`, `pull` and `build` report every resource they touch, on
+**stderr**, so stdout stays a clean pipe. What that looks like depends on where
+it is going.
+
+**On a terminal**, a live region at the tail of the output shows the whole set
+up front and repaints it as work proceeds. Finished rows scroll up and stay:
 
 ```
+[+] Running 3/6
+ ✔ Network   myapp_default  Created        0.1s
+ ⠹ Image     postgres:16    Pulling        2.9s
+ ⠹ Container myapp-db-1     Starting       2.9s
+ ⠸ Container myapp-api-1    Creating       0.4s
+ ⠿ Container myapp-web-1    Pending
+```
+
+A tail region rather than a full-screen takeover, deliberately: `up` is a
+command that finishes, and handing the screen back blank would destroy the
+record of what it did.
+
+**Anywhere else** — a pipe, a file, CI, `NO_COLOR`, `--ansi never` — the same
+events come out as plain append-only lines with no escape sequences at all:
+
+```
+ Network myapp_default  Creating
  Network myapp_default  Created
- Volume myapp_data  Created
+ Container myapp-web-1  Starting
  Container myapp-web-1  Started
 ```
 
-The name carries its identity colour and the verb its meaning colour. Only what
-actually happened is reported: re-running `up` over existing resources reports
-no creation, and `down` on a project whose networks or volumes were never
-created reports no removal. A command that acted on nothing says so —
+Both renderers see every event, so a log says *more* than it used to rather than
+less. Animation in a CI log is a defect, and so is a CI log missing what the
+terminal showed.
+
+Only what actually happened is reported: re-running `up` over existing
+resources reports no creation, and `down` on a project whose networks or volumes
+were never created reports no removal. A command that acted on nothing says so —
 `no containers to stop`, `no containers to start (project not created)` — rather
 than exiting silently, which is indistinguishable from success.
+
+The live region needs stderr to be a terminal, colour to be on, and the terminal
+size to be readable. If any of those is missing it falls back to the plain
+lines, which is also what `--ansi never` and `NO_COLOR` select.
 
 ## Diagnostics
 

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -394,8 +394,13 @@ impl Engine {
 		while let Some(result) = stream.next().await {
 			match result {
 				Ok(output) => {
+					// stderr, not stdout. Build output went to stdout via `print!`,
+					// which contradicted the documented promise that stdout stays
+					// a clean pipe — the one thing a caller redirecting `podup
+					// build > log` relies on, and the same promise `config` and
+					// `generate quadlet` are built around.
 					if !opts.quiet && !output.stream.is_empty() {
-						print!("{}", output.stream);
+						eprint!("{}", output.stream);
 					}
 					if let Some(err) = output.error_detail.and_then(|e| e.message) {
 						return Err(ComposeError::Build(err));

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -145,7 +145,7 @@ impl Engine {
 			// reuse it here instead of letting `pull_image` resolve (and
 			// potentially re-warn about) it a second time.
 			let pull_err = self
-				.pull_image_with_policy(service, key.1)
+				.pull_image_with_policy(service, key.1, self.quiet_pull)
 				.await
 				.err()
 				.map(|e| e.to_string());
@@ -188,7 +188,21 @@ impl Engine {
 
 	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
 		let pull_policy = self.resolved_pull_policy(service);
-		self.pull_image_with_policy(service, pull_policy).await
+		self.pull_image_with_policy(service, pull_policy, self.quiet_pull)
+			.await
+	}
+
+	/// [`Self::pull_image`] with no user-facing progress, whatever `--quiet-pull`
+	/// says.
+	///
+	/// For the `up` prefetch, which only warms the cache: `up_one_service`'s own
+	/// pull is the authoritative one, and reporting from both is what printed
+	/// `Pulling` twice per image on `up` while a standalone `pull` printed it
+	/// once.
+	pub(in crate::engine) async fn pull_image_quietly(&self, service: &Service) -> Result<()> {
+		let pull_policy = self.resolved_pull_policy(service);
+		self.pull_image_with_policy(service, pull_policy, true)
+			.await
 	}
 
 	/// Resolve the effective libpod pull policy for `service`: the
@@ -220,19 +234,26 @@ impl Engine {
 	/// which must resolve the policy anyway to compute its dedup key — can
 	/// reuse that value instead of resolving (and potentially re-warning
 	/// about an unrecognized one) a second time.
-	async fn pull_image_with_policy(&self, service: &Service, pull_policy: &str) -> Result<()> {
+	async fn pull_image_with_policy(
+		&self,
+		service: &Service,
+		pull_policy: &str,
+		quiet: bool,
+	) -> Result<()> {
 		let image = match &service.image {
 			Some(img) => img.clone(),
 			None => return Ok(()),
 		};
 
-		// Progress goes to stderr so it shows at default verbosity (the non-watch
-		// log floor is WARN, so info!/debug! would print nothing) and `--quiet`
-		// actually suppresses it, matching `docker compose pull`.
-		if self.quiet_pull {
+		// Through the progress layer, not a bare `eprintln!`. This was the one
+		// user-facing line in the binary that bypassed `ui` entirely, so it
+		// ignored `PROGRESS_ENABLED` and an embedder that asked podup to stay
+		// silent got it anyway — and there was never a matching `Pulled`, so a
+		// pull that finished looked exactly like one that hung.
+		if quiet {
 			debug!("pulling {image}");
 		} else {
-			eprintln!("Pulling {image}");
+			crate::ui::progress::start("Image", &image, "Pulling");
 		}
 
 		let mut query = format!("reference={}&policy={}", urlencoded(&image), pull_policy);
@@ -274,7 +295,12 @@ impl Engine {
 
 		match pull_err {
 			Some(e) => Err(ComposeError::Build(format!("pull {image} failed: {e}"))),
-			None => Ok(()),
+			None => {
+				if !quiet {
+					crate::ui::progress_line("Image", &image, "Pulled");
+				}
+				Ok(())
+			}
 		}
 	}
 

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -551,6 +551,20 @@ impl Engine {
 		// one container-list round-trip per service (S+1 → 1 for the level walk).
 		let live_by_service = self.list_project_containers_by_service().await?;
 
+		// Seed from the containers Podman actually has, walked in the same
+		// reversed level order the teardown below uses, so the board predicts
+		// what will happen rather than what the file describes. A service in the
+		// file that was never created must not sit on the board as a row that
+		// never moves.
+		let live_order: Vec<String> = levels
+			.iter()
+			.flatten()
+			.filter_map(|svc| live_by_service.get(svc))
+			.flatten()
+			.cloned()
+			.collect();
+		crate::ui::progress::begin(self.down_resources(file, &live_order, remove_volumes));
+
 		// Best-effort across every level/container/network/volume so one failure
 		// never leaves the rest of the teardown undone, but the first real
 		// REMOVAL failure is remembered and returned at the end instead of being
@@ -631,6 +645,7 @@ impl Engine {
 			// which had ever existed. The `Err(404)` arm below was unreachable
 			// for the same reason: the layer underneath had already turned the
 			// 404 into a success.
+			crate::ui::progress::start("Network", &network_name, "Removing");
 			match self.client.delete_existed(&net_path).await {
 				Ok(true) => crate::ui::progress_line("Network", &network_name, "Removed"),
 				Ok(false) => {}
@@ -671,6 +686,7 @@ impl Engine {
 				// may be reported, and a volume is the object where a false
 				// "Removed" is worst — it names data the operator believes is
 				// gone.
+				crate::ui::progress::start("Volume", &volume_name, "Removing");
 				match self.client.delete_existed(&vol_path).await {
 					Ok(true) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
 					Ok(false) => {}
@@ -684,7 +700,12 @@ impl Engine {
 
 		// Internal native secrets are podup-owned (not user data), so remove
 		// them unconditionally — independent of `remove_volumes`.
-		self.remove_internal_secrets(file).await?;
+		let secrets = self.remove_internal_secrets(file).await;
+
+		// Close the board before returning, on every path: the region hides the
+		// cursor and an early `?` would leave the terminal without one.
+		crate::ui::progress::end();
+		secrets?;
 
 		if let Some(e) = first_err {
 			return Err(e);

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -10,6 +10,7 @@ mod run;
 mod run_attached;
 mod scale;
 mod schedule;
+mod seed;
 mod signal;
 mod targets;
 
@@ -159,7 +160,7 @@ impl Engine {
 		no_deps: bool,
 		start: bool,
 	) -> Result<()> {
-		async {
+		let result = async {
 			// Reject any volume/network/container name Podman's regex would refuse
 			// before issuing a single create, so a bad name surfaces as a clear
 			// client-side error (not an opaque HTTP 500) with nothing created.
@@ -218,6 +219,14 @@ impl Engine {
 					}
 				}
 			}
+
+			// Seed the board before any work starts. This is the whole point of
+			// the phase: the resource set is knowable here — `levels` is already
+			// resolved above, and the networks and volumes come straight off the
+			// compose file — while every progress event in the tree fires once
+			// its work is already over. A board grown from those events would be
+			// a transcript with extra steps.
+			crate::ui::progress::begin(self.up_resources(file, &enabled, &target_set));
 
 			self.create_networks(file).await?;
 			self.create_volumes(file).await?;
@@ -279,7 +288,14 @@ impl Engine {
 
 			Ok(())
 		}
-		.await
+		.await;
+
+		// Close the board on every exit, not just the happy one: the region
+		// hides the cursor, and a `?` that returned early through the block
+		// above would otherwise leave the terminal without a caret. `end` is
+		// idempotent and a no-op when no board was opened.
+		crate::ui::progress::end();
+		result
 	}
 
 	/// Bring up a single service: honor profile/target filters, wait on its

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -510,6 +510,11 @@ impl Engine {
 				return Ok(());
 			}
 		}
+		crate::ui::progress::start(
+			"Container",
+			&container_name,
+			if start { "Starting" } else { "Creating" },
+		);
 		self.create_and_start(&container_name, name, service, file, start)
 			.await?;
 		crate::ui::progress_line(

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -336,6 +336,7 @@ impl Engine {
 		pre_stop: &[LifecycleHook],
 		remove_volumes: bool,
 	) -> Result<()> {
+		crate::ui::progress::start("Container", container_name, "Stopping");
 		for hook in pre_stop {
 			if let Err(e) = self.run_lifecycle_hook(container_name, hook).await {
 				tracing::debug!("pre_stop hook {container_name}: {e}");

--- a/internal/engine/lifecycle/prefetch.rs
+++ b/internal/engine/lifecycle/prefetch.rs
@@ -104,7 +104,11 @@ impl Engine {
 				}
 				return;
 			}
-			if let Err(e) = self.pull_image(service).await {
+			// Quietly: this stage only warms the cache, and `up_one_service`'s
+			// own pull below is the authoritative one. Reporting from both is
+			// what made `Pulling` appear twice per image on `up` while a
+			// standalone `pull` printed it once.
+			if let Err(e) = self.pull_image_quietly(service).await {
 				tracing::debug!("prefetch miss for {image}: {e}");
 			}
 		});

--- a/internal/engine/lifecycle/seed.rs
+++ b/internal/engine/lifecycle/seed.rs
@@ -1,0 +1,96 @@
+//! What a lifecycle command is about to work through, worked out before it
+//! starts.
+//!
+//! The board needs the resource set up front, and nothing in the tree produced
+//! it: every progress event fires once its own work is over, so a board grown
+//! from those events would only ever show the past. This is the missing half,
+//! and it is derivable — `resolve_levels` already runs before the walk begins,
+//! and the networks and volumes come straight off the compose file.
+//!
+//! Deliberately a *prediction*, not a promise. It is computed from the compose
+//! file before Podman is asked anything, so it can be wrong in both directions:
+//! a service whose container already exists still gets a row (it will report
+//! `Running` rather than `Started`), and a resource the file does not mention
+//! is appended by the board when its event arrives. Being approximately right
+//! before the work starts beats being exactly right after it finished.
+
+use std::collections::HashSet;
+
+use crate::compose::types::ComposeFile;
+use crate::ui::progress::Kind;
+
+use super::super::network::resolve_network_name;
+use super::super::Engine;
+
+impl Engine {
+	/// Every resource an `up`/`create` pass will touch, in the order it will
+	/// touch them: networks, then volumes, then containers by dependency level.
+	///
+	/// The order matters as much as the contents — the board's completed rows
+	/// scroll away in this order, and that scrollback is the record the command
+	/// leaves behind.
+	pub(super) fn up_resources(
+		&self,
+		file: &ComposeFile,
+		enabled: &HashSet<String>,
+		target_set: &Option<HashSet<String>>,
+	) -> Vec<(Kind, String)> {
+		let mut out = Vec::new();
+
+		// External networks and volumes are never created by podup, so they are
+		// not work this command will do and must not appear as rows waiting to
+		// happen.
+		for (key, cfg) in &file.networks {
+			if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
+				continue;
+			}
+			out.push((
+				Kind::Network,
+				resolve_network_name(key, file, &self.project),
+			));
+		}
+		for (key, cfg) in &file.volumes {
+			let cfg = cfg.as_ref();
+			if cfg.and_then(|c| c.external).unwrap_or(false) {
+				continue;
+			}
+			let name = cfg
+				.and_then(|c| c.name.as_deref())
+				.map(str::to_string)
+				.unwrap_or_else(|| format!("{}_{}", self.project, key));
+			out.push((Kind::Volume, name));
+		}
+
+		// Containers in dependency order, which is the order they will start.
+		// Falls back to the file's own order if the graph cannot be resolved —
+		// a cycle is a real error, but it is `run_up`'s to report, and seeding
+		// must not be the thing that surfaces it.
+		let levels = crate::compose::resolve_levels(file)
+			.unwrap_or_else(|_| vec![file.services.keys().cloned().collect::<Vec<_>>()]);
+		for level in levels {
+			for name in level {
+				// The same two conditions `up_one_service` applies, in the same
+				// order. Any drift here puts a row on the board that will never
+				// move, which is worse than no row at all: a permanently
+				// `Pending` line reads as something hung.
+				if target_set.as_ref().is_some_and(|set| !set.contains(&name)) {
+					continue;
+				}
+				if !enabled.contains(&name) {
+					continue;
+				}
+				let Some(service) = file.services.get(&name) else {
+					continue;
+				};
+				for container in self.replica_names(&name, service) {
+					out.push((Kind::Container, container));
+				}
+			}
+		}
+		out
+	}
+}
+
+#[cfg(all(test, unix))]
+#[path = "seed_tests.rs"]
+mod tests;

--- a/internal/engine/lifecycle/seed.rs
+++ b/internal/engine/lifecycle/seed.rs
@@ -89,6 +89,50 @@ impl Engine {
 		}
 		out
 	}
+
+	/// Every resource a `down` pass will remove, in teardown order: containers
+	/// first (dependents before their dependencies, the inversion `down` itself
+	/// walks), then networks, then volumes.
+	///
+	/// Containers come from what Podman actually has, not from the compose file:
+	/// `down` removes what exists, and a file listing a service that was never
+	/// created would put a row on the board that never moves.
+	pub(super) fn down_resources(
+		&self,
+		file: &ComposeFile,
+		live: &[String],
+		remove_volumes: bool,
+	) -> Vec<(Kind, String)> {
+		let mut out: Vec<(Kind, String)> = live
+			.iter()
+			.map(|name| (Kind::Container, name.clone()))
+			.collect();
+		for (key, cfg) in &file.networks {
+			if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
+				continue;
+			}
+			out.push((
+				Kind::Network,
+				resolve_network_name(key, file, &self.project),
+			));
+		}
+		// Volumes survive a `down` without `-v`, so they are not work this pass
+		// will do.
+		if remove_volumes {
+			for (key, cfg) in &file.volumes {
+				let cfg = cfg.as_ref();
+				if cfg.and_then(|c| c.external).unwrap_or(false) {
+					continue;
+				}
+				let name = cfg
+					.and_then(|c| c.name.as_deref())
+					.map(str::to_string)
+					.unwrap_or_else(|| format!("{}_{}", self.project, key));
+				out.push((Kind::Volume, name));
+			}
+		}
+		out
+	}
 }
 
 #[cfg(all(test, unix))]

--- a/internal/engine/lifecycle/seed_tests.rs
+++ b/internal/engine/lifecycle/seed_tests.rs
@@ -1,0 +1,127 @@
+use super::*;
+use crate::compose::parse_str;
+
+/// `up_resources` never touches the client — it reads the compose file and the
+/// project name — but an `Engine` needs one, so the tests borrow the same fake
+/// the rest of the lifecycle suite uses. That fake is a unix socket, which is
+/// why this module is `cfg(unix)`.
+fn engine(fake: &crate::engine::fake_podman::FakePodman) -> Engine {
+	Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir())
+}
+
+async fn seeded(yaml: &str, targets: &[&str]) -> Vec<(Kind, String)> {
+	let file = parse_str(yaml).unwrap();
+	let enabled: HashSet<String> = file.services.keys().cloned().collect();
+	let set = (!targets.is_empty()).then(|| {
+		targets
+			.iter()
+			.map(|s| (*s).to_string())
+			.collect::<HashSet<_>>()
+	});
+	let fake = crate::engine::fake_podman::start(|_, _| (404, "{}".to_string()));
+	engine(&fake).up_resources(&file, &enabled, &set)
+}
+
+const TWO_SERVICES: &str = "\
+services:
+  db:
+    image: alpine
+  web:
+    image: alpine
+    depends_on:
+      - db
+volumes:
+  data:
+networks:
+  extra:
+";
+
+/// Networks and volumes come first, then containers: that is the order the work
+/// happens in, and the board's completed rows scroll away in the same order.
+#[tokio::test]
+async fn resources_are_seeded_in_the_order_the_work_happens() {
+	let out = seeded(TWO_SERVICES, &[]).await;
+	let kinds: Vec<Kind> = out.iter().map(|(k, _)| *k).collect();
+	let first_container = kinds.iter().position(|k| *k == Kind::Container).unwrap();
+	assert!(
+		kinds[..first_container]
+			.iter()
+			.all(|k| matches!(k, Kind::Network | Kind::Volume)),
+		"{kinds:?}"
+	);
+}
+
+/// Containers follow the dependency graph, so the board predicts the order the
+/// user will actually see them start in.
+#[tokio::test]
+async fn containers_follow_the_dependency_order() {
+	let out = seeded(TWO_SERVICES, &[]).await;
+	let names: Vec<&str> = out
+		.iter()
+		.filter(|(k, _)| *k == Kind::Container)
+		.map(|(_, n)| n.as_str())
+		.collect();
+	assert_eq!(names, vec!["proj-db-1", "proj-web-1"]);
+}
+
+/// podup never creates an external network or volume, so it is not work this
+/// command will do and must not sit on the board waiting to happen.
+#[tokio::test]
+async fn external_resources_are_not_seeded() {
+	let yaml = "\
+services:
+  web:
+    image: alpine
+volumes:
+  theirs:
+    external: true
+networks:
+  shared:
+    external: true
+";
+	let out = seeded(yaml, &[]).await;
+	assert!(
+		out.iter().all(|(k, _)| *k == Kind::Container),
+		"external resources must not be seeded: {out:?}"
+	);
+}
+
+/// A targeted `up web` seeds only what it will touch. Rows for services this
+/// pass will never start would sit `Pending` forever.
+#[tokio::test]
+async fn a_targeted_up_seeds_only_its_targets() {
+	let out = seeded(TWO_SERVICES, &["web"]).await;
+	let names: Vec<&str> = out
+		.iter()
+		.filter(|(k, _)| *k == Kind::Container)
+		.map(|(_, n)| n.as_str())
+		.collect();
+	assert_eq!(names, vec!["proj-web-1"]);
+}
+
+/// A scaled service gets one row per replica, because the board tracks
+/// containers rather than services — that is the granularity every progress
+/// event in the tree already reports at.
+#[tokio::test]
+async fn a_scaled_service_seeds_one_row_per_replica() {
+	let yaml = "\
+services:
+  web:
+    image: alpine
+    deploy:
+      replicas: 3
+";
+	let out = seeded(yaml, &[]).await;
+	let names: Vec<&str> = out.iter().map(|(_, n)| n.as_str()).collect();
+	assert_eq!(names, vec!["proj-web-1", "proj-web-2", "proj-web-3"]);
+}
+
+/// Volume and network names are the resolved on-host ones, not the compose
+/// keys, so a row matches the event that will later arrive for it.
+#[tokio::test]
+async fn names_are_the_resolved_on_host_ones() {
+	let out = seeded(TWO_SERVICES, &[]).await;
+	let names: Vec<&str> = out.iter().map(|(_, n)| n.as_str()).collect();
+	assert!(names.contains(&"proj_data"), "{names:?}");
+	assert!(names.contains(&"proj_extra"), "{names:?}");
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -56,7 +56,7 @@ mod profiles;
 pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};
 mod projects;
 pub use projects::{list_projects, list_projects_filtered, LsOptions};
-mod query;
+pub(crate) mod query;
 mod secrets;
 mod staging;
 mod stats;

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -67,6 +67,7 @@ impl Engine {
 				subnets,
 			};
 
+			crate::ui::progress::start("Network", &network_name, "Creating");
 			match self
 				.client
 				.post_json::<_, serde_json::Value>(

--- a/internal/engine/volume/mod.rs
+++ b/internal/engine/volume/mod.rs
@@ -65,6 +65,7 @@ impl Engine {
 				labels,
 			};
 
+			crate::ui::progress::start("Volume", &volume_name, "Creating");
 			match self
 				.client
 				.post_json::<_, serde_json::Value>(

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -18,6 +18,7 @@ pub use anstyle::{AnsiColor, Style};
 pub use anstream::ColorChoice;
 
 mod palette;
+pub mod progress;
 mod table;
 pub use table::{fit_cell, sanitize_cell, Table};
 

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -176,6 +176,13 @@ pub fn progress_line(kind: &str, name: &str, action: &str) {
 	if !progress_enabled() {
 		return;
 	}
+	// A board, when one is open, owns the rendering: it needs the event as a
+	// state change rather than as a line, and it decides where on screen the
+	// row goes. Routing here rather than at each site is what let the board
+	// arrive without touching the 21 call sites that report an ending.
+	if progress::finish(kind, name, action) {
+		return;
+	}
 	let verb = action_style(action);
 	let ident = identity_style(name);
 	// anstream::stderr strips the ANSI codes itself when colour is off.

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -172,7 +172,6 @@ pub fn progress_enabled() -> bool {
 /// …), tinted green on a colour sink. A no-op unless [`set_progress`] enabled
 /// progress output, so stdout consumers and machine output are never polluted.
 pub fn progress_line(kind: &str, name: &str, action: &str) {
-	use std::io::Write;
 	if !progress_enabled() {
 		return;
 	}
@@ -183,6 +182,17 @@ pub fn progress_line(kind: &str, name: &str, action: &str) {
 	if progress::finish(kind, name, action) {
 		return;
 	}
+	write_progress_line(kind, name, action);
+}
+
+/// Write one progress line to stderr, with no board routing.
+///
+/// Split out of [`progress_line`] because the plain sink has to emit exactly
+/// this and cannot go back through the routing that sent it here — that would
+/// be a loop. It is also the reason the two sinks cannot drift: there is one
+/// line format, used by both.
+pub(crate) fn write_progress_line(kind: &str, name: &str, action: &str) {
+	use std::io::Write;
 	let verb = action_style(action);
 	let ident = identity_style(name);
 	// anstream::stderr strips the ANSI codes itself when colour is off.

--- a/internal/ui/progress/board.rs
+++ b/internal/ui/progress/board.rs
@@ -1,0 +1,210 @@
+//! The resource set a lifecycle command is working through, and where each one
+//! has got to.
+//!
+//! Pure: no terminal, no clock reading of its own, no I/O. A renderer asks it
+//! what to draw and it answers; that is what makes the state machine testable
+//! without a tty, which matters because the two things most likely to be wrong
+//! here — a row that never leaves `Working`, and a count that disagrees with the
+//! rows — are invisible in a screenshot.
+
+use std::time::{Duration, Instant};
+
+/// What kind of thing a row is about. The noun printed in the first column, and
+/// the same vocabulary `progress_line` has always used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Kind {
+	Network,
+	Volume,
+	Secret,
+	Image,
+	Container,
+}
+
+impl Kind {
+	/// The displayed noun.
+	pub fn noun(self) -> &'static str {
+		match self {
+			Kind::Network => "Network",
+			Kind::Volume => "Volume",
+			Kind::Secret => "Secret",
+			Kind::Image => "Image",
+			Kind::Container => "Container",
+		}
+	}
+
+	/// Parse the noun back, so `progress_line`'s existing `&str` callers can feed
+	/// the board without all 21 of them changing shape.
+	pub fn from_noun(noun: &str) -> Option<Self> {
+		match noun {
+			"Network" => Some(Kind::Network),
+			"Volume" => Some(Kind::Volume),
+			"Secret" => Some(Kind::Secret),
+			"Image" => Some(Kind::Image),
+			"Container" => Some(Kind::Container),
+			_ => None,
+		}
+	}
+}
+
+/// Where a resource has got to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum State {
+	/// Seeded, nothing has happened to it yet.
+	Pending,
+	/// Work is under way; the verb is the present participle (`Creating`).
+	Working(String),
+	/// Work finished; the verb is the past tense (`Created`).
+	Done(String),
+}
+
+/// One resource's row.
+#[derive(Debug, Clone)]
+pub struct Row {
+	pub kind: Kind,
+	pub name: String,
+	pub state: State,
+	/// When this row last entered `Working`, for the elapsed column. `None`
+	/// while `Pending`, since nothing has taken any time yet.
+	pub started: Option<Instant>,
+	/// How long the row spent working, frozen when it reached `Done` so a
+	/// finished row stops counting up.
+	pub elapsed: Option<Duration>,
+}
+
+impl Row {
+	/// How long to show against this row, or `None` when there is nothing to
+	/// show yet.
+	pub fn duration(&self, now: Instant) -> Option<Duration> {
+		match (&self.state, self.elapsed, self.started) {
+			(State::Done(_), Some(d), _) => Some(d),
+			(State::Working(_), _, Some(start)) => Some(now.saturating_duration_since(start)),
+			_ => None,
+		}
+	}
+}
+
+/// Every resource one command is working through, in the order it was seeded.
+///
+/// Seeded up front rather than grown as events arrive: a board whose rows appear
+/// one at a time is a transcript with extra steps, and the whole point is to
+/// show what is still to come.
+#[derive(Debug, Default)]
+pub struct Board {
+	rows: Vec<Row>,
+	/// Rows already handed to the renderer as permanent history, so they are
+	/// drawn once and never repainted. Counted from the front: rows leave the
+	/// live region in order.
+	flushed: usize,
+}
+
+impl Board {
+	/// A board seeded with `resources` in the order they will be worked through.
+	pub fn new(resources: impl IntoIterator<Item = (Kind, String)>) -> Self {
+		Self {
+			rows: resources
+				.into_iter()
+				.map(|(kind, name)| Row {
+					kind,
+					name,
+					state: State::Pending,
+					started: None,
+					elapsed: None,
+				})
+				.collect(),
+			flushed: 0,
+		}
+	}
+
+	/// Mark a resource as being worked on. Unknown resources are appended rather
+	/// than dropped: the seed is the best guess available before the work starts,
+	/// and a compose file can grow a container the seed did not predict (an
+	/// implicit `_default` network, a `--scale` override). Losing the row would
+	/// be worse than a board that grows by one.
+	pub fn start(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
+		let idx = self.index_of(kind, name).unwrap_or_else(|| {
+			self.rows.push(Row {
+				kind,
+				name: name.to_string(),
+				state: State::Pending,
+				started: None,
+				elapsed: None,
+			});
+			self.rows.len() - 1
+		});
+		let row = &mut self.rows[idx];
+		row.state = State::Working(verb.to_string());
+		row.started.get_or_insert(now);
+	}
+
+	/// Mark a resource as finished. Also tolerates a resource that was never
+	/// seeded or started — most of the 21 existing call sites report only an
+	/// ending, so this has to work without a matching `start`.
+	pub fn finish(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
+		let idx = self.index_of(kind, name).unwrap_or_else(|| {
+			self.rows.push(Row {
+				kind,
+				name: name.to_string(),
+				state: State::Pending,
+				started: None,
+				elapsed: None,
+			});
+			self.rows.len() - 1
+		});
+		let row = &mut self.rows[idx];
+		row.elapsed = row.started.map(|s| now.saturating_duration_since(s));
+		row.state = State::Done(verb.to_string());
+	}
+
+	/// Rows that are finished *and* sit at the front of the un-flushed range, so
+	/// they can be printed once as permanent history and dropped from the region
+	/// that gets repainted.
+	///
+	/// Only a contiguous run from the front is eligible. A finished row with an
+	/// unfinished one before it has to stay in the live region, or the permanent
+	/// history would print out of order — which is exactly the record `up` exists
+	/// to leave behind.
+	pub fn take_completed_prefix(&mut self) -> Vec<Row> {
+		let mut out = Vec::new();
+		while let Some(row) = self.rows.get(self.flushed) {
+			if !matches!(row.state, State::Done(_)) {
+				break;
+			}
+			out.push(row.clone());
+			self.flushed += 1;
+		}
+		out
+	}
+
+	/// The rows still in the live region: everything not yet flushed.
+	pub fn live_rows(&self) -> &[Row] {
+		&self.rows[self.flushed.min(self.rows.len())..]
+	}
+
+	/// How many resources have finished, and how many there are in total — the
+	/// `3/6` in the summary line.
+	pub fn tally(&self) -> (usize, usize) {
+		(
+			self.rows
+				.iter()
+				.filter(|r| matches!(r.state, State::Done(_)))
+				.count(),
+			self.rows.len(),
+		)
+	}
+
+	/// Whether every seeded resource has finished.
+	pub fn is_complete(&self) -> bool {
+		let (done, total) = self.tally();
+		done == total
+	}
+
+	fn index_of(&self, kind: Kind, name: &str) -> Option<usize> {
+		self.rows
+			.iter()
+			.position(|r| r.kind == kind && r.name == name)
+	}
+}
+
+#[cfg(test)]
+#[path = "board_tests.rs"]
+mod tests;

--- a/internal/ui/progress/board_tests.rs
+++ b/internal/ui/progress/board_tests.rs
@@ -1,0 +1,199 @@
+use super::*;
+
+fn t0() -> Instant {
+	Instant::now()
+}
+
+fn seeded() -> Board {
+	Board::new([
+		(Kind::Network, "proj_default".to_string()),
+		(Kind::Container, "proj-web-1".to_string()),
+		(Kind::Container, "proj-db-1".to_string()),
+	])
+}
+
+/// The whole point of seeding is that the board shows what is still to come, so
+/// a fresh board already knows its total.
+#[test]
+fn a_seeded_board_knows_its_total_before_anything_happens() {
+	assert_eq!(seeded().tally(), (0, 3));
+}
+
+/// The counter tracks finished rows, not started ones. A row being worked on is
+/// not progress the user can rely on.
+#[test]
+fn only_finished_rows_count_towards_the_tally() {
+	let mut b = seeded();
+	let now = t0();
+	b.start(Kind::Container, "proj-web-1", "Creating", now);
+	assert_eq!(b.tally(), (0, 3));
+	b.finish(Kind::Container, "proj-web-1", "Created", now);
+	assert_eq!(b.tally(), (1, 3));
+}
+
+/// Most of the existing call sites report only an ending. The board has to
+/// accept that rather than requiring a matching start it will never get.
+#[test]
+fn a_finish_without_a_start_still_lands() {
+	let mut b = seeded();
+	b.finish(Kind::Network, "proj_default", "Created", t0());
+	assert_eq!(b.tally(), (1, 3));
+}
+
+/// A resource the seed did not predict — an implicit network, a `--scale`
+/// override — is appended rather than dropped. Losing the row is worse than a
+/// board that grows by one.
+#[test]
+fn an_unseeded_resource_is_appended_not_dropped() {
+	let mut b = seeded();
+	b.finish(Kind::Volume, "proj_data", "Created", t0());
+	assert_eq!(b.tally(), (1, 4));
+}
+
+/// Kind and name together identify a row: a network and a container may share a
+/// name without sharing a row.
+#[test]
+fn a_row_is_identified_by_kind_and_name_together() {
+	let mut b = Board::new([
+		(Kind::Network, "same".to_string()),
+		(Kind::Container, "same".to_string()),
+	]);
+	b.finish(Kind::Network, "same", "Created", t0());
+	assert_eq!(b.tally(), (1, 2));
+}
+
+/// Completed rows leave the live region in order, so the permanent history
+/// reads in the order the work happened.
+#[test]
+fn completed_rows_flush_from_the_front_in_order() {
+	let mut b = seeded();
+	let now = t0();
+	b.finish(Kind::Network, "proj_default", "Created", now);
+	let flushed = b.take_completed_prefix();
+	assert_eq!(flushed.len(), 1);
+	assert_eq!(flushed[0].name, "proj_default");
+	assert_eq!(b.live_rows().len(), 2);
+}
+
+/// A finished row behind an unfinished one stays put. Flushing it would print
+/// the permanent history out of order, and that record is what `up` leaves
+/// behind.
+#[test]
+fn a_finished_row_behind_an_unfinished_one_does_not_flush() {
+	let mut b = seeded();
+	let now = t0();
+	b.finish(Kind::Container, "proj-db-1", "Created", now);
+	assert!(b.take_completed_prefix().is_empty());
+	assert_eq!(b.live_rows().len(), 3);
+
+	// Once the rows ahead of it finish, the whole run leaves together.
+	b.finish(Kind::Network, "proj_default", "Created", now);
+	b.finish(Kind::Container, "proj-web-1", "Created", now);
+	let flushed = b.take_completed_prefix();
+	assert_eq!(flushed.len(), 3);
+	assert!(b.live_rows().is_empty());
+}
+
+/// A row is never flushed twice, however often the renderer asks.
+#[test]
+fn flushing_is_not_repeatable() {
+	let mut b = seeded();
+	b.finish(Kind::Network, "proj_default", "Created", t0());
+	assert_eq!(b.take_completed_prefix().len(), 1);
+	assert!(b.take_completed_prefix().is_empty());
+}
+
+/// A finished row stops counting up. Without freezing the elapsed time, a
+/// completed row would keep ticking for as long as the command runs.
+#[test]
+fn a_finished_row_freezes_its_elapsed_time() {
+	let mut b = seeded();
+	let start = t0();
+	b.start(Kind::Container, "proj-web-1", "Creating", start);
+	let end = start + Duration::from_millis(250);
+	b.finish(Kind::Container, "proj-web-1", "Created", end);
+	let row = b
+		.live_rows()
+		.iter()
+		.find(|r| r.name == "proj-web-1")
+		.unwrap()
+		.clone();
+	let much_later = start + Duration::from_secs(30);
+	assert_eq!(row.duration(much_later), Some(Duration::from_millis(250)));
+}
+
+/// A working row counts up from when it started, not from when the board did.
+#[test]
+fn a_working_row_counts_from_its_own_start() {
+	let mut b = seeded();
+	let t = t0();
+	b.start(
+		Kind::Container,
+		"proj-web-1",
+		"Creating",
+		t + Duration::from_secs(2),
+	);
+	let row = b.live_rows()[1].clone();
+	assert_eq!(
+		row.duration(t + Duration::from_secs(5)),
+		Some(Duration::from_secs(3))
+	);
+}
+
+/// A pending row shows no time, because nothing has taken any.
+#[test]
+fn a_pending_row_has_no_duration() {
+	let b = seeded();
+	assert_eq!(b.live_rows()[0].duration(t0()), None);
+}
+
+/// Re-starting a row that is already working keeps its original start, so a
+/// retry does not reset the clock and hide how long it really took.
+#[test]
+fn restarting_a_working_row_keeps_the_original_start() {
+	let mut b = seeded();
+	let t = t0();
+	b.start(Kind::Container, "proj-web-1", "Creating", t);
+	b.start(
+		Kind::Container,
+		"proj-web-1",
+		"Starting",
+		t + Duration::from_secs(4),
+	);
+	let row = b.live_rows()[1].clone();
+	assert_eq!(
+		row.duration(t + Duration::from_secs(6)),
+		Some(Duration::from_secs(6))
+	);
+}
+
+#[test]
+fn completion_is_every_row_finished() {
+	let mut b = seeded();
+	let now = t0();
+	assert!(!b.is_complete());
+	for (kind, name) in [
+		(Kind::Network, "proj_default"),
+		(Kind::Container, "proj-web-1"),
+		(Kind::Container, "proj-db-1"),
+	] {
+		b.finish(kind, name, "Created", now);
+	}
+	assert!(b.is_complete());
+}
+
+/// The noun round-trips, because `progress_line`'s callers pass a `&str` and the
+/// board has to map it back without those 21 sites changing shape.
+#[test]
+fn every_kind_round_trips_through_its_noun() {
+	for kind in [
+		Kind::Network,
+		Kind::Volume,
+		Kind::Secret,
+		Kind::Image,
+		Kind::Container,
+	] {
+		assert_eq!(Kind::from_noun(kind.noun()), Some(kind));
+	}
+	assert_eq!(Kind::from_noun("Sandwich"), None);
+}

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -1,0 +1,135 @@
+//! The tail-region renderer.
+//!
+//! Completed rows are printed once, as ordinary scrollback, and never touched
+//! again. Only the rows still in flight live in the region below them, and only
+//! that region is erased and repainted. A tail region rather than an alternate
+//! screen, decided by the owner for every command including `stats`: `up` is a
+//! command that *finishes*, and taking the screen and handing it back blank
+//! destroys the record of what happened.
+//!
+//! Four escape sequences, no dependency.
+
+use std::io::Write;
+use std::time::Instant;
+
+use super::{row, Board};
+
+/// Hide the cursor. Without it the caret sits at the end of whichever row was
+/// painted last and jumps around on every repaint.
+const HIDE_CURSOR: &str = "\x1b[?25l";
+
+/// Restore the cursor. Emitted on drop, including the drop that runs while the
+/// process is unwinding, so a panic mid-`up` cannot leave the terminal without
+/// a caret.
+const SHOW_CURSOR: &str = "\x1b[?25h";
+
+/// Erase from the cursor to the end of the screen.
+const CLEAR_BELOW: &str = "\x1b[J";
+
+/// Move the cursor up `n` rows.
+fn cursor_up(n: usize) -> String {
+	format!("\x1b[{n}A")
+}
+
+/// A tail region being repainted on a real terminal.
+///
+/// Owns the count of rows it last painted, which is the only state the repaint
+/// arithmetic needs — and the reason every line is truncated to the terminal
+/// width first. A line that wraps makes the terminal count two rows where this
+/// counted one, and from then on every repaint erases the wrong lines.
+pub struct LiveRegion {
+	/// Rows painted by the previous repaint, to be walked back over.
+	painted: usize,
+	/// Terminal width at the last repaint.
+	width: usize,
+	/// Width of the name column, sized from the seeded rows so it does not jump
+	/// as rows come and go.
+	name_width: usize,
+}
+
+impl LiveRegion {
+	/// Start a region, hiding the cursor.
+	pub fn new(name_width: usize, width: usize) -> Self {
+		let mut err = std::io::stderr();
+		let _ = err.write_all(HIDE_CURSOR.as_bytes());
+		let _ = err.flush();
+		Self {
+			painted: 0,
+			width,
+			name_width,
+		}
+	}
+
+	/// Re-read the terminal width. Called on each repaint so a resize mid-`up`
+	/// does not leave every later line wrapping.
+	pub fn refresh_width(&mut self, width: usize) {
+		self.width = width;
+	}
+
+	/// Walk back over the previous region, print whatever has finished as
+	/// permanent scrollback, then paint the rows still in flight.
+	pub fn repaint(&mut self, board: &mut Board, frame: usize, now: Instant) {
+		let mut out = String::new();
+		if self.painted > 0 {
+			out.push_str(&cursor_up(self.painted));
+		}
+		out.push_str(CLEAR_BELOW);
+
+		// Finished rows leave the region and become scrollback. `take_completed_prefix`
+		// only releases a contiguous run from the front, so this record stays in
+		// the order the work happened.
+		for done in board.take_completed_prefix() {
+			out.push_str(&row::render(&done, self.name_width, frame, now, self.width));
+			out.push('\n');
+		}
+
+		let (done, total) = board.tally();
+		let mut painted = 0;
+		let live = board.live_rows();
+		if !live.is_empty() {
+			out.push_str(&row::summary(done, total));
+			out.push('\n');
+			painted += 1;
+			for r in live {
+				out.push_str(&row::render(r, self.name_width, frame, now, self.width));
+				out.push('\n');
+				painted += 1;
+			}
+		}
+		self.painted = painted;
+
+		let mut err = std::io::stderr();
+		let _ = err.write_all(out.as_bytes());
+		let _ = err.flush();
+	}
+
+	/// Final repaint with the region emptied, so the last thing on screen is the
+	/// permanent record rather than a half-drawn board.
+	pub fn finish(&mut self, board: &mut Board, now: Instant) {
+		self.repaint(board, 0, now);
+	}
+}
+
+impl Drop for LiveRegion {
+	fn drop(&mut self) {
+		let mut err = std::io::stderr();
+		let _ = err.write_all(SHOW_CURSOR.as_bytes());
+		let _ = err.flush();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The four sequences are what the repaint arithmetic is built on, so they
+	/// are pinned rather than left to a typo. `\x1b[3A` moves up three; `\x1b[J`
+	/// erases from the cursor down.
+	#[test]
+	fn the_cursor_moves_are_what_they_claim() {
+		assert_eq!(cursor_up(3), "\u{1b}[3A");
+		assert_eq!(CLEAR_BELOW, "\u{1b}[J");
+		assert_eq!(HIDE_CURSOR, "\u{1b}[?25l");
+		assert_eq!(SHOW_CURSOR, "\u{1b}[?25h");
+	}
+}

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -1,0 +1,12 @@
+//! The live board: what a lifecycle command is working through, and where it
+//! has got to.
+//!
+//! One model, two renderers. Which one runs is decided from the terminal and the
+//! colour choice, never from the command: `up` on a tty repaints a tail region,
+//! `up` in CI emits the same events as plain append-only lines. **Animation in a
+//! CI log is a defect**, and so is a CI log that says less than the terminal
+//! did — both renderers see every event.
+
+mod board;
+
+pub use board::{Board, Kind, Row, State};

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -3,10 +3,205 @@
 //!
 //! One model, two renderers. Which one runs is decided from the terminal and the
 //! colour choice, never from the command: `up` on a tty repaints a tail region,
-//! `up` in CI emits the same events as plain append-only lines. **Animation in a
-//! CI log is a defect**, and so is a CI log that says less than the terminal
-//! did — both renderers see every event.
+//! `up` in a pipe emits the same events as plain append-only lines. **Animation
+//! in a CI log is a defect**, and so is a CI log that says less than the
+//! terminal did — both renderers see every event, including the intermediate
+//! transitions the old output dropped entirely.
+//!
+//! Everything goes to stderr. stdout stays a clean pipe, which is what lets
+//! `run -d` keep printing its container id there.
+
+use std::sync::Mutex;
+use std::time::Instant;
 
 mod board;
+mod live;
+mod row;
 
 pub use board::{Board, Kind, Row, State};
+
+/// How often the region repaints while nothing is happening, so the spinner
+/// turns during a long pull instead of looking like a hang. The same cadence
+/// `terminal::windows`'s resize poll already uses.
+const TICK: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// The board for the command currently running, if one asked for it.
+///
+/// Process-global for the same reason the colour choice is: one CLI invocation
+/// runs one lifecycle command, and threading a handle through every engine call
+/// site would change 21 signatures to say something none of them decides. A
+/// library embedder never gets one — [`begin`] is a no-op unless the CLI turned
+/// progress on.
+static SESSION: Mutex<Option<Session>> = Mutex::new(None);
+
+/// The repaint ticker, kept so it can be stopped when the board ends.
+static TICKER: Mutex<Option<tokio::task::JoinHandle<()>>> = Mutex::new(None);
+
+struct Session {
+	board: Board,
+	/// `None` when the sink is plain: not a terminal, colour off, or the
+	/// terminal size could not be read.
+	region: Option<live::LiveRegion>,
+	frame: usize,
+}
+
+/// Whether a live region is allowed right now.
+///
+/// Three conditions, all required. stderr must be a terminal — `--ansi always |
+/// tee` is a log, not a terminal, and repainting into it writes cursor moves
+/// into a file. The colour choice must not be `Never`, because someone who asked
+/// for no escapes means it. And the width must be readable, since every line is
+/// truncated to it and the repaint arithmetic depends on that truncation.
+fn live_allowed() -> Option<usize> {
+	use std::io::IsTerminal;
+	if !std::io::stderr().is_terminal() || !super::stderr_colored() {
+		return None;
+	}
+	crate::engine::query::terminal::window_size().map(|(cols, _)| cols as usize)
+}
+
+/// Start a board over `resources`, in the order they will be worked through.
+///
+/// A no-op when progress output is off, so an embedding crate never gets a
+/// board it did not ask for.
+pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
+	if !super::progress_enabled() {
+		return;
+	}
+	let board = Board::new(resources);
+	let name_width = board
+		.live_rows()
+		.iter()
+		.map(|r| r.name.chars().count())
+		.max()
+		.unwrap_or(0)
+		.clamp(12, 40);
+	let region = live_allowed().map(|width| live::LiveRegion::new(name_width, width));
+	let live = region.is_some();
+	if let Ok(mut slot) = SESSION.lock() {
+		*slot = Some(Session {
+			board,
+			region,
+			frame: 0,
+		});
+	}
+	if live {
+		spawn_ticker();
+	}
+	repaint();
+}
+
+/// Report that work on a resource has begun.
+///
+/// This is the event the tree could not previously produce: every one of the 21
+/// existing progress sites fires once the work is already over.
+pub fn start(kind: &str, name: &str, verb: &str) {
+	let Some(kind) = Kind::from_noun(kind) else {
+		return;
+	};
+	let handled = {
+		let Ok(mut slot) = SESSION.lock() else {
+			return;
+		};
+		match slot.as_mut() {
+			Some(session) => {
+				session.board.start(kind, name, verb, Instant::now());
+				true
+			}
+			None => false,
+		}
+	};
+	if handled {
+		repaint();
+	} else if super::progress_enabled() {
+		// No board: still emit the transition, so a plain sink says as much as a
+		// live one. This is the "more information than today" half of the
+		// contract, and it must not depend on a board being open.
+		super::progress_line(kind.noun(), name, verb);
+	}
+}
+
+/// Report that work on a resource has finished. Returns whether a board took it;
+/// `false` leaves the caller to print its own line, which is what keeps every
+/// existing `progress_line` call site working unchanged.
+pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
+	let Some(kind) = Kind::from_noun(kind) else {
+		return false;
+	};
+	let handled = {
+		let Ok(mut slot) = SESSION.lock() else {
+			return false;
+		};
+		match slot.as_mut() {
+			Some(session) => {
+				session.board.finish(kind, name, verb, Instant::now());
+				true
+			}
+			None => false,
+		}
+	};
+	if handled {
+		repaint();
+	}
+	handled
+}
+
+/// Close the board: stop the ticker, draw the finished state, restore the
+/// cursor.
+///
+/// Idempotent, because the commands that open a board have several exits.
+pub fn end() {
+	if let Ok(mut slot) = TICKER.lock() {
+		if let Some(handle) = slot.take() {
+			handle.abort();
+		}
+	}
+	let Ok(mut slot) = SESSION.lock() else {
+		return;
+	};
+	if let Some(mut session) = slot.take() {
+		if let Some(region) = session.region.as_mut() {
+			region.finish(&mut session.board, Instant::now());
+		}
+	}
+}
+
+/// Repaint the region, if there is one. A plain sink does nothing here: its
+/// lines are emitted by the event calls themselves.
+fn repaint() {
+	let Ok(mut slot) = SESSION.lock() else {
+		return;
+	};
+	let Some(session) = slot.as_mut() else {
+		return;
+	};
+	let frame = session.frame;
+	let Session { board, region, .. } = session;
+	if let Some(region) = region.as_mut() {
+		if let Some(width) = live_allowed() {
+			region.refresh_width(width);
+		}
+		region.repaint(board, frame, Instant::now());
+	}
+}
+
+/// Advance the spinner and repaint, so a long pull turns rather than freezing.
+fn spawn_ticker() {
+	let handle = tokio::spawn(async {
+		let mut interval = tokio::time::interval(TICK);
+		loop {
+			interval.tick().await;
+			{
+				let Ok(mut slot) = SESSION.lock() else { return };
+				match slot.as_mut() {
+					Some(session) => session.frame = session.frame.wrapping_add(1),
+					None => return,
+				}
+			}
+			repaint();
+		}
+	});
+	if let Ok(mut slot) = TICKER.lock() {
+		*slot = Some(handle);
+	}
+}

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -57,7 +57,18 @@ fn live_allowed() -> Option<usize> {
 	if !std::io::stderr().is_terminal() || !super::stderr_colored() {
 		return None;
 	}
-	crate::engine::query::terminal::window_size().map(|(cols, _)| cols as usize)
+	width_from(crate::engine::query::terminal::window_size())
+}
+
+/// The usable width from a `window_size()` answer.
+///
+/// Split out so the one thing that can silently be wrong here is testable:
+/// `window_size` returns **`(rows, cols)`**, in that order, and reading the
+/// first element as the width truncated every board line to the terminal's
+/// *height* instead. Measured on a 100x30 pty, every verb came out as `Pen…`,
+/// and nothing in the type system or the suite objected.
+fn width_from(size: Option<(u16, u16)>) -> Option<usize> {
+	size.map(|(_rows, cols)| cols as usize)
 }
 
 /// Start a board over `resources`, in the order they will be worked through.
@@ -99,25 +110,54 @@ pub fn start(kind: &str, name: &str, verb: &str) {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return;
 	};
-	let handled = {
+	let sink = {
 		let Ok(mut slot) = SESSION.lock() else {
 			return;
 		};
 		match slot.as_mut() {
 			Some(session) => {
 				session.board.start(kind, name, verb, Instant::now());
-				true
+				if session.region.is_some() {
+					Sink::Live
+				} else {
+					Sink::Plain
+				}
 			}
-			None => false,
+			None => Sink::None,
 		}
 	};
-	if handled {
-		repaint();
-	} else if super::progress_enabled() {
-		// No board: still emit the transition, so a plain sink says as much as a
-		// live one. This is the "more information than today" half of the
-		// contract, and it must not depend on a board being open.
-		super::progress_line(kind.noun(), name, verb);
+	emit(sink, kind, name, verb);
+}
+
+/// Which renderer a just-recorded event belongs to.
+enum Sink {
+	/// A region is open; the event shows up on the next repaint.
+	Live,
+	/// A board is open but not on a terminal, so the event is a line.
+	Plain,
+	/// No board at all.
+	None,
+}
+
+/// Hand a recorded event to whichever renderer owns it.
+///
+/// The plain sink writes the same line the tree has always written, through
+/// [`super::write_progress_line`] rather than `progress_line` — going back
+/// through the routing that sent the event here would be a loop, and it is what
+/// made a piped `up` print nothing at all the first time this was wired up: the
+/// board swallowed every line and no renderer put one back.
+fn emit(sink: Sink, kind: Kind, name: &str, verb: &str) {
+	match sink {
+		Sink::Live => repaint(),
+		Sink::Plain => super::write_progress_line(kind.noun(), name, verb),
+		// No board open, but the caller still asked to report a transition, so
+		// the line is still owed — this is the "a pipe says more than it used
+		// to, never less" half of the contract.
+		Sink::None => {
+			if super::progress_enabled() {
+				super::write_progress_line(kind.noun(), name, verb);
+			}
+		}
 	}
 }
 
@@ -128,22 +168,29 @@ pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return false;
 	};
-	let handled = {
+	let sink = {
 		let Ok(mut slot) = SESSION.lock() else {
 			return false;
 		};
 		match slot.as_mut() {
 			Some(session) => {
 				session.board.finish(kind, name, verb, Instant::now());
-				true
+				if session.region.is_some() {
+					Sink::Live
+				} else {
+					Sink::Plain
+				}
 			}
-			None => false,
+			None => Sink::None,
 		}
 	};
-	if handled {
-		repaint();
+	// `Sink::None` means no board took it, so the caller prints its own line as
+	// it always has. The other two mean the event is accounted for here.
+	if matches!(sink, Sink::None) {
+		return false;
 	}
-	handled
+	emit(sink, kind, name, verb);
+	true
 }
 
 /// Close the board: stop the ticker, draw the finished state, restore the
@@ -203,5 +250,18 @@ fn spawn_ticker() {
 	});
 	if let Ok(mut slot) = TICKER.lock() {
 		*slot = Some(handle);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::width_from;
+
+	/// `window_size` answers `(rows, cols)`. Getting this backwards is invisible
+	/// on a square-ish terminal and mangles every line on a normal one.
+	#[test]
+	fn the_width_is_the_columns_not_the_rows() {
+		assert_eq!(width_from(Some((30, 100))), Some(100));
+		assert_eq!(width_from(None), None);
 	}
 }

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -1,0 +1,119 @@
+//! Turning one [`Row`](super::Row) into one line of text.
+//!
+//! Pure, and separate from the terminal driver on purpose: the arithmetic that
+//! decides how wide a line is, is the same arithmetic the cursor-up repaint
+//! depends on. A line that is one column too long wraps, the terminal counts two
+//! rows where the renderer counted one, and every subsequent repaint erases the
+//! wrong lines. So the width rule is tested on its own rather than inferred from
+//! a screenshot.
+
+use std::time::{Duration, Instant};
+
+use super::{Row, State};
+use crate::ui::{fit_cell, identity_style, paint, AnsiColor, Style};
+
+/// Frames of the working marker. Ten braille cells, so no dependency and no font
+/// assumption beyond what every terminal that reports 256 colours already has.
+pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Marker for a finished row.
+const DONE_MARK: &str = "✔";
+
+/// Marker for a row nothing has happened to yet.
+const PENDING_MARK: &str = "⠿";
+
+/// Width of the resource-noun column. `Container` is the longest of the five.
+const KIND_WIDTH: usize = 9;
+
+/// Width reserved for the elapsed time, right-aligned so the digits line up
+/// rather than drifting with each value's length.
+const TIME_WIDTH: usize = 6;
+
+/// The marker for a row, and the style it carries.
+///
+/// Colour here is state, not identity: a finished row is green because something
+/// now exists, a pending one is dim because nothing has happened to it. The name
+/// beside it keeps its identity colour, which is why the marker must not reuse
+/// that palette.
+fn marker(row: &Row, frame: usize) -> (&'static str, Style) {
+	match row.state {
+		State::Done(_) => (
+			DONE_MARK,
+			Style::new().fg_color(Some(AnsiColor::Green.into())),
+		),
+		State::Working(_) => (SPINNER[frame % SPINNER.len()], Style::new()),
+		State::Pending => (PENDING_MARK, Style::new().dimmed()),
+	}
+}
+
+/// The verb shown for a row.
+fn verb(row: &Row) -> &str {
+	match &row.state {
+		State::Done(v) | State::Working(v) => v,
+		State::Pending => "Pending",
+	}
+}
+
+/// `0.4s`, `12.9s`, `1m03s`. Sub-minute values keep a decimal because the
+/// interesting range for a container start is fractions of a second; past a
+/// minute the decimal is noise.
+pub fn format_elapsed(d: Duration) -> String {
+	let secs = d.as_secs_f64();
+	if secs < 60.0 {
+		format!("{secs:.1}s")
+	} else {
+		format!("{}m{:02}s", d.as_secs() / 60, d.as_secs() % 60)
+	}
+}
+
+/// One board line, fitted to `width` columns.
+///
+/// `width` is the terminal's, and the returned line never exceeds it: the
+/// cursor-up repaint counts one terminal row per line it wrote, and a line that
+/// wraps makes that count wrong for every repaint afterwards.
+pub fn render(row: &Row, name_width: usize, frame: usize, now: Instant, width: usize) -> String {
+	let (mark, mark_style) = marker(row, frame);
+	let time = row.duration(now).map(format_elapsed).unwrap_or_default();
+	let plain = format!(
+		" {mark} {:<KIND_WIDTH$} {} {:<12} {time:>TIME_WIDTH$}",
+		row.kind.noun(),
+		fit_cell(&row.name, name_width),
+		verb(row),
+	);
+	let plain = fit_cell(plain.trim_end(), 0);
+	let plain = if width > 0 && plain.chars().count() > width {
+		fit_cell(&plain, width)
+	} else {
+		plain
+	};
+	colourise(&plain, row, mark, mark_style)
+}
+
+/// Re-apply colour to an already-fitted line.
+///
+/// Deliberately done after fitting rather than before: the escape sequences are
+/// zero-width, so measuring a coloured line counts characters the terminal never
+/// draws, and the truncation would cut in the middle of an escape and leave the
+/// terminal painted.
+fn colourise(plain: &str, row: &Row, mark: &str, mark_style: Style) -> String {
+	let mut out = plain.to_string();
+	if let Some(pos) = out.find(mark) {
+		let styled = paint(mark_style, mark, true);
+		out.replace_range(pos..pos + mark.len(), &styled);
+	}
+	if let Some(pos) = out.find(&row.name) {
+		let styled = paint(identity_style(&row.name), &row.name, true);
+		out.replace_range(pos..pos + row.name.len(), &styled);
+	}
+	out
+}
+
+/// The summary line above the region: how many resources are done out of how
+/// many.
+pub fn summary(done: usize, total: usize) -> String {
+	format!("[+] Running {done}/{total}")
+}
+
+#[cfg(test)]
+#[path = "row_tests.rs"]
+mod tests;

--- a/internal/ui/progress/row_tests.rs
+++ b/internal/ui/progress/row_tests.rs
@@ -1,0 +1,152 @@
+use super::*;
+use crate::ui::progress::Kind;
+
+fn row(state: State) -> Row {
+	Row {
+		kind: Kind::Container,
+		name: "proj-web-1".to_string(),
+		state,
+		started: None,
+		elapsed: None,
+	}
+}
+
+fn plain(line: &str) -> String {
+	let mut out = String::new();
+	let mut chars = line.chars();
+	while let Some(c) = chars.next() {
+		if c == '\u{1b}' {
+			for c in chars.by_ref() {
+				if c == 'm' {
+					break;
+				}
+			}
+		} else {
+			out.push(c);
+		}
+	}
+	out
+}
+
+/// The width promise, which the whole repaint rests on: a line that wraps makes
+/// the terminal count two rows where the renderer counted one, and every repaint
+/// afterwards erases the wrong lines.
+#[test]
+fn a_line_never_exceeds_the_terminal_width() {
+	for width in [10, 20, 40, 80] {
+		let r = Row {
+			name: "a-very-long-container-name-that-will-not-fit-anywhere".to_string(),
+			..row(State::Working("Creating".into()))
+		};
+		let line = plain(&render(&r, 40, 0, Instant::now(), width));
+		assert!(
+			line.chars().count() <= width,
+			"width {width}: got {} chars: {line:?}",
+			line.chars().count()
+		);
+	}
+}
+
+/// A width of zero means "do not truncate" — the caller could not read the
+/// terminal size. The line is still produced rather than collapsing to nothing.
+#[test]
+fn width_zero_leaves_the_line_intact() {
+	let line = plain(&render(&row(State::Pending), 20, 0, Instant::now(), 0));
+	assert!(line.contains("proj-web-1"), "{line:?}");
+}
+
+/// The three states are visually distinct without reading the words, which is
+/// the entire reason for a marker column.
+#[test]
+fn each_state_gets_its_own_marker() {
+	let now = Instant::now();
+	let done = plain(&render(&row(State::Done("Created".into())), 20, 0, now, 80));
+	let working = plain(&render(
+		&row(State::Working("Creating".into())),
+		20,
+		0,
+		now,
+		80,
+	));
+	let pending = plain(&render(&row(State::Pending), 20, 0, now, 80));
+	assert!(done.contains(DONE_MARK), "{done:?}");
+	assert!(working.contains(SPINNER[0]), "{working:?}");
+	assert!(pending.contains(PENDING_MARK), "{pending:?}");
+}
+
+/// The spinner advances with the frame, or a slow pull looks like a hang.
+#[test]
+fn the_working_marker_advances_with_the_frame() {
+	let now = Instant::now();
+	let r = row(State::Working("Pulling".into()));
+	let a = plain(&render(&r, 20, 0, now, 80));
+	let b = plain(&render(&r, 20, 1, now, 80));
+	assert_ne!(a, b);
+}
+
+/// The frame wraps rather than panicking: the ticker counts up without bound.
+#[test]
+fn the_frame_index_wraps() {
+	let now = Instant::now();
+	let r = row(State::Working("Pulling".into()));
+	let wrapped = plain(&render(&r, 20, SPINNER.len() * 7 + 3, now, 80));
+	let direct = plain(&render(&r, 20, 3, now, 80));
+	assert_eq!(wrapped, direct);
+}
+
+/// A pending row shows no time. Nothing has taken any, and a `0.0s` there reads
+/// as "this was instant" rather than "this has not started".
+#[test]
+fn a_pending_row_shows_no_time() {
+	let line = plain(&render(&row(State::Pending), 20, 0, Instant::now(), 80));
+	assert!(!line.contains('s'), "{line:?}");
+	assert!(line.contains("Pending"), "{line:?}");
+}
+
+/// Sub-minute times keep a decimal, because the interesting range for starting
+/// a container is fractions of a second. Past a minute the decimal is noise.
+#[test]
+fn elapsed_switches_units_at_a_minute() {
+	assert_eq!(format_elapsed(Duration::from_millis(100)), "0.1s");
+	assert_eq!(format_elapsed(Duration::from_millis(12_900)), "12.9s");
+	assert_eq!(format_elapsed(Duration::from_secs(63)), "1m03s");
+	assert_eq!(format_elapsed(Duration::from_secs(600)), "10m00s");
+}
+
+/// Colour is applied after the line has been fitted. Applied before, the
+/// zero-width escapes would be counted as visible columns and the truncation
+/// could cut through one, leaving the terminal painted with whatever it set.
+#[test]
+fn truncation_never_cuts_through_an_escape() {
+	let r = Row {
+		name: "x".repeat(60),
+		..row(State::Working("Creating".into()))
+	};
+	let line = render(&r, 60, 0, Instant::now(), 24);
+	let escapes = line.matches('\u{1b}').count();
+	let resets = line.matches("\u{1b}[0m").count();
+	assert_eq!(
+		escapes,
+		resets * 2,
+		"every opening escape needs its reset: {line:?}"
+	);
+}
+
+/// A name carrying an escape sequence cannot repaint the reader's terminal. The
+/// name comes from a compose file, which is trusted input, but the row goes
+/// through the same `fit_cell` every other table uses rather than trusting that.
+#[test]
+fn a_name_cannot_drive_the_terminal() {
+	let r = Row {
+		name: "evil\u{1b}[31m\u{7}name".to_string(),
+		..row(State::Pending)
+	};
+	let line = render(&r, 30, 0, Instant::now(), 80);
+	assert!(!line.contains('\u{7}'), "{line:?}");
+	assert!(line.contains("name"), "{line:?}");
+}
+
+#[test]
+fn the_summary_counts_done_over_total() {
+	assert_eq!(summary(3, 6), "[+] Running 3/6");
+}

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -431,3 +431,115 @@ async fn a_piped_down_gets_transitions_for_what_exists() {
 		"the network needs both; got:\n{stderr}"
 	);
 }
+
+/// `build` writes its output to stderr, leaving stdout a clean pipe.
+///
+/// It used `print!`, contradicting the documented promise that stdout stays
+/// pipeable — the one thing a caller redirecting `podup build > log` relies on,
+/// and the same promise `config` and `generate quadlet` are built around.
+#[tokio::test]
+async fn build_leaves_stdout_a_clean_pipe() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	fs::write(
+		dir.path().join("Dockerfile"),
+		"FROM alpine:latest\nRUN true\n",
+	)
+	.unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  tiny:\n    image: podup-build-probe:1\n    build:\n      context: .\n",
+	)
+	.unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"-p",
+			&format!("t{}-bld", std::process::id()),
+			"build",
+		])
+		.output()
+		.expect("run podup build");
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		stdout.trim().is_empty(),
+		"build must not write to stdout; got:\n{stdout}"
+	);
+	assert!(
+		!String::from_utf8_lossy(&out.stderr).trim().is_empty(),
+		"the build output has to go somewhere, and that somewhere is stderr"
+	);
+}
+
+/// `pull` reports through the progress layer, with a matching `Pulled`.
+///
+/// It used a bare `eprintln!` — the one user-facing line in the binary that
+/// bypassed `ui` entirely, so it ignored `PROGRESS_ENABLED` and an embedder
+/// asking podup to stay silent got it anyway. There was never a `Pulled` at all,
+/// so a pull that finished looked exactly like one that hung.
+#[tokio::test]
+async fn pull_reports_both_ends() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(&compose, "services:\n  x:\n    image: alpine:latest\n").unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-pull", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["pull"]);
+	assert!(
+		stderr.contains("Pulling") && stderr.contains("Pulled"),
+		"pull must report starting and finishing; got:\n{stderr}"
+	);
+	assert_eq!(
+		stderr.matches("Pulling").count(),
+		1,
+		"one image, one Pulling; got:\n{stderr}"
+	);
+}
+
+/// One image, one `Pulling`, even on the `up` path.
+///
+/// `up` warms the image cache before the per-level walk and then pulls again
+/// inside it, and both reported — so `Pulling` appeared twice per image on `up`
+/// while a standalone `pull` printed it once. The prefetch is best-effort
+/// warming and the walk's own pull is the authoritative one, so only the second
+/// speaks.
+///
+/// `pull_policy: always` is what forces both stages to actually issue a pull for
+/// an image that is already local; with the default `missing` the prefetch would
+/// short-circuit and the duplication could not appear whether or not the control
+/// exists.
+#[tokio::test]
+async fn up_pulls_an_image_once() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    pull_policy: always\n    command: \
+		 [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-once", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["up", "-d"]);
+	let pulls = stderr.matches("Pulling").count();
+	assert!(
+		pulls <= 1,
+		"one image must produce at most one Pulling on up; got {pulls} in:\n{stderr}"
+	);
+}

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -403,3 +403,31 @@ async fn the_board_never_touches_stdout() {
 		"up must leave stdout empty; got:\n{stdout}"
 	);
 }
+
+/// `down` gets a board too, seeded from what Podman actually has rather than
+/// from what the compose file describes — a service the file lists but that was
+/// never created would sit on the board as a row that never moves.
+#[tokio::test]
+async fn a_piped_down_gets_transitions_for_what_exists() {
+	if !podman_up().await {
+		return;
+	}
+	let p = Project::start("dwn");
+	let stderr = p.progress(&["down", "-v"]);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"a pipe must get no escape sequences; got:\n{stderr:?}"
+	);
+	let has = |name: &str, verb: &str| stderr.lines().any(|l| l.contains(name) && l.contains(verb));
+	let container = format!("{}-web-1", p.name);
+	assert!(
+		has(&container, "Stopping"),
+		"the container needs its transition; got:\n{stderr}"
+	);
+	assert!(has(&container, "Removed"), "and its ending; got:\n{stderr}");
+	let network = format!("{}_default", p.name);
+	assert!(
+		has(&network, "Removing") && has(&network, "Removed"),
+		"the network needs both; got:\n{stderr}"
+	);
+}

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -299,3 +299,107 @@ async fn wait_names_each_container_and_its_code() {
 		"the failing containers' code must survive: {ndjson}"
 	);
 }
+
+/// A pipe gets the events, never the animation.
+///
+/// This is the contract that protects CI logs. The live region only exists when
+/// stderr is a terminal and colour is on; anywhere else the same event model
+/// comes out as append-only lines. **Animation in a CI log is a defect** — and
+/// so is a CI log that says less than the terminal did, which is why the
+/// intermediate transitions are asserted here too. Before the board they did
+/// not exist at all: `up` reported only the finished state of each resource.
+#[tokio::test]
+async fn a_piped_up_gets_transitions_and_no_escapes() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-pipe", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["up", "-d"]);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"a pipe must get no escape sequences at all; got:\n{stderr:?}"
+	);
+	// Asserted per resource, not as "some line somewhere says Creating". A
+	// looser version of this passed with the container's start event deleted,
+	// because the network's own `Creating` satisfied it.
+	let has = |name: &str, verbs: &[&str]| {
+		stderr
+			.lines()
+			.any(|l| l.contains(name) && verbs.iter().any(|v| l.contains(v)))
+	};
+	let container = format!("{}-web-1", p.name);
+	assert!(
+		has(&container, &["Starting", "Creating"]),
+		"the container needs its own transition, not only its ending; got:\n{stderr}"
+	);
+	assert!(
+		has(&container, &["Started", "Created", "Running"]),
+		"and it must still get its ending; got:\n{stderr}"
+	);
+	let network = format!("{}_default", p.name);
+	assert!(
+		has(&network, &["Creating"]),
+		"the network needs one too; got:\n{stderr}"
+	);
+}
+
+/// `--ansi never` means it. The board is gated on the colour choice as well as
+/// on the terminal, because someone who asked for no escapes did not ask for a
+/// quieter kind of escape.
+#[tokio::test]
+async fn ansi_never_gets_no_board() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(&compose, "services:\n  web:\n    image: alpine:latest\n").unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-noansi", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["--ansi", "never", "up", "-d"]);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"--ansi never must emit nothing to repaint with; got:\n{stderr:?}"
+	);
+}
+
+/// The board writes to stderr only. stdout stays a clean pipe, which is what
+/// lets `run -d` keep printing its container id there and `config` keep piping
+/// into a file.
+#[tokio::test]
+async fn the_board_never_touches_stdout() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-stdout", std::process::id()),
+		_dir: dir,
+	};
+	let stdout = p.run(&["up", "-d"]);
+	assert!(
+		stdout.trim().is_empty(),
+		"up must leave stdout empty; got:\n{stdout}"
+	);
+}


### PR DESCRIPTION
Closes #1251.

Phase 2 of the terminal-experience work — the one I actually asked for. Phase 1 shipped the identity colours in #1247, phase 4 the commands that said nothing in #1249.

On a terminal:

```
[+] Running 3/6
 ✔ Network   myapp_default  Created        0.1s
 ⠹ Image     postgres:16    Pulling        2.9s
 ⠹ Container myapp-db-1     Starting       2.9s
 ⠸ Container myapp-api-1    Creating       0.4s
 ⠿ Container myapp-web-1    Pending
```

Finished rows scroll up and stay; only the rows still in flight are erased and repainted. A tail region rather than a full-screen takeover, because `up` is a command that *finishes* and handing the screen back blank would destroy the record of what it did.

Anywhere else — a pipe, a file, CI, `NO_COLOR`, `--ansi never` — the same events come out as plain append-only lines with no escape sequences at all.

## The work was the event model, not the renderer

Measured before starting: progress was emitted from **21 call sites across 7 files**, and every one fired when its work was already over. Nothing in the tree knew the resource set before the walk began, which is the one thing a board has to show. A board grown from those events would have been a transcript with extra steps.

So the shape is: `Board` is the model, seeded up front and updated by start and finish events, and deliberately pure — no terminal, no clock of its own, no I/O. Two renderers sit behind it. `progress_line` routes into the board when one is open, which is what let this arrive without touching the 21 sites that report an ending.

Seeding applies exactly the two conditions `up_one_service` does, in the same order. Drift there puts a row on the board that never moves, and a permanently `Pending` line reads as something hung — worse than no row at all.

## Both sinks see every event

That is the half worth naming. A pipe now gets the intermediate transitions (`Creating` then `Created`) that no renderer emitted before, so a log says **more** than it used to, never less. Animation in a CI log stays a defect. Same events, different renderer.

## Three things measurement caught that reading did not

- **A piped `up` printed nothing at all.** The board swallowed every event and, with no region open, no renderer put a line back. I only found it by running the binary through a pipe — the suite was green.
- **Every board line was truncated to the terminal's *height*.** `window_size()` answers `(rows, cols)` and I read the first element as the width, so on a 100×30 pty every verb came out as `Pen…`. That one now has its own pure function and its own test, precisely because nothing else could have caught it.
- **`script` allocates a 0×0 pty.** My first attempt at exercising the live path fell back to plain and I nearly concluded the region was broken. Measured all three descriptors: stdout and stderr are ttys reporting 0×0, which `window_size` correctly treats as unknown. The real harness sets `TIOCSWINSZ`.

## The two defects this absorbs

- **`Pulling` was a bare `eprintln!`** — the one user-facing line in the binary that bypassed `ui` entirely, so it ignored `PROGRESS_ENABLED` and an embedder asking podup to stay silent got it anyway. There was never a matching `Pulled`, so a pull that finished looked exactly like one that hung. Measured: it printed **twice per image on `up`** and once on a standalone `pull` — the prefetch stage and the per-level walk both pulled and both reported. The prefetch only warms the cache, so only the authoritative one speaks now.
- **`build` wrote to stdout** via `print!`, contradicting the documented promise that stdout stays a clean pipe.

## The open question from phase 1, answered

Phase 1 left this for me: *with the wide palette a service's colour depends on the whole service set, but the board wants to colour a network before every service is resolved — does it resolve the mapping up front or render those early rows unstyled?*

Neither is needed. `set_services` already runs in `main.rs` before dispatch, so the palette is fully resolved before any board opens. A network row painted before a single container exists gets the same colour it will have in `ps` and `down`. Verified by comparing the escape on `myapp_default` across the board and the teardown lines: identical.

## No new dependencies

A ten-frame braille spinner, four escape sequences, `window_size()` which already existed for `exec`'s pty, and tokio's timer which already runs the resize poll. Not `indicatif`, `ratatui` or `crossterm`.

## Test plan

- `cargo test` — **1949 pass, 0 fail**, including the 155-test integration suite against real Podman 5.7.0.
- `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean.
- **Every control verified by mutation** — deleted, test re-run to confirm red, restored. Two of my own tests were vacuous on the first attempt and had to be rewritten:
  - `a_piped_up_gets_transitions_and_no_escapes` asserted "some line says `Creating`", which the *network's* transition satisfied — so it passed with the container's start event deleted. It now asserts per resource.
  - `pull_reports_both_ends` tests the standalone command, which never goes through the prefetch, so it could not see the duplication it was meant to guard. `up_pulls_an_image_once` covers that, with `pull_policy: always` deliberately — under the default `missing` the prefetch short-circuits and the test would pass either way.
- The board's state machine is tested without a terminal at all: 14 cases on flush ordering, the elapsed freeze, unseeded resources, and finishes with no matching start.
- Measured by hand in both sinks: `up` and `down` piped (transitions present, zero escapes, stdout empty) and on a 100×30 pty (spinner, running clock, counter, cursor restored on exit).

`Cargo.toml` and `Cargo.lock` are untouched — the bump is a release step. `debian/changelog` extends the 3.4.0 stanza.

## Still to come

Phase 3, `stats` as a live view, reuses this renderer.
