### PR TITLE
fix(ui): give the cursor back when a live command is interrupted

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -69,6 +69,11 @@ podup (3.4.0) unstable; urgency=medium
     0.02% looked exactly like one at 69%. Four bands now, with idle rows dimmed.
     `PIDS` was the only unstyled column of the six.
 
+  * Ctrl-C out of a command drawing a live region left the cursor hidden. The
+    restore ran from `Drop`, which covers a command that returns and nothing
+    else — Rust terminates on SIGINT without unwinding. `stats` is where it bit
+    hardest, since Ctrl-C is the normal way to leave it.
+
   * `down` reported removing networks and volumes that never existed. On a
     project name that had never been created it announced three removals,
     including a data volume — naming data the operator is told is gone.

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -74,6 +74,7 @@ impl Region {
 	/// Start a region on `target`, hiding the cursor.
 	pub fn new(target: Target) -> Self {
 		target.write(HIDE_CURSOR);
+		restore_cursor_on_interrupt(target);
 		Self { painted: 0, target }
 	}
 
@@ -108,9 +109,87 @@ impl Drop for Region {
 	}
 }
 
+/// Give the cursor back if the command is interrupted rather than returning.
+///
+/// `Drop` covers a command that ends on its own, and nothing else: Rust's
+/// default SIGINT handling terminates the process without unwinding, so
+/// Ctrl-C out of a region left the caret hidden until the user ran `reset`.
+/// Measured on a 100x30 pty before the fix — one `\e[?25l`, zero `\e[?25h`.
+///
+/// `stats` is where it bit hardest, because Ctrl-C is the *normal* way to leave
+/// it rather than an error path, but a long `up` interrupted part-way had the
+/// same hole.
+///
+/// Exits 130 (128 + SIGINT), the shell convention this binary already documents
+/// for an interrupted command. Installed per region rather than globally, so it
+/// cannot disturb the commands that handle their own interrupt — attached `up`,
+/// `exec`, `watch` — none of which open one.
+fn restore_cursor_on_interrupt(target: Target) {
+	if !claim_install() {
+		return;
+	}
+	// A tokio signal task, not a raw handler: the same shape `attach` and
+	// `watch` already use, and it runs ordinary code rather than being bound by
+	// async-signal-safety.
+	tokio::spawn(async move {
+		wait_for_interrupt().await;
+		target.write(SHOW_CURSOR);
+		std::process::exit(130);
+	});
+}
+
+/// Take the right to install the interrupt handler, once per process.
+///
+/// Two regions in one invocation — a `stats` after an `up` inside an embedding
+/// crate — must not stack handlers, since each would race to call
+/// `process::exit`. Split out of the installer so the latch is testable without
+/// spawning anything.
+fn claim_install() -> bool {
+	static INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+	!INSTALLED.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Resolve when the process is asked to stop.
+#[cfg(unix)]
+async fn wait_for_interrupt() {
+	use tokio::signal::unix::{signal, SignalKind};
+	let mut term = match signal(SignalKind::terminate()) {
+		Ok(s) => s,
+		// Without a SIGTERM handler, Ctrl-C alone is still worth catching.
+		Err(_) => {
+			let _ = tokio::signal::ctrl_c().await;
+			return;
+		}
+	};
+	tokio::select! {
+		_ = tokio::signal::ctrl_c() => {}
+		_ = term.recv() => {}
+	}
+}
+
+/// Windows has no SIGTERM; Ctrl-C is the interrupt that matters.
+#[cfg(not(unix))]
+async fn wait_for_interrupt() {
+	let _ = tokio::signal::ctrl_c().await;
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// The interrupt handler is claimed once per process, however many regions a
+	/// run opens. Two in one invocation — a `stats` after an `up` inside an
+	/// embedding crate — must not stack handlers, since each would race to call
+	/// `process::exit`.
+	///
+	/// The only test in the crate that may call this: the latch is
+	/// process-global, so a second caller would see whatever this one left.
+	#[test]
+	fn the_interrupt_handler_is_claimed_once() {
+		assert!(claim_install(), "the first caller installs");
+		assert!(!claim_install(), "the second must not");
+		assert!(!claim_install());
+	}
 
 	/// The four sequences are what the repaint arithmetic is built on, so they
 	/// are pinned rather than left to a typo. `\x1b[3A` moves up three; `\x1b[J`


### PR DESCRIPTION
Closes #1255.

`podup stats` on a terminal hid the cursor and did not give it back when I pressed Ctrl-C, leaving me typing into my shell with no caret until I ran `reset`.

I introduced this in the live board (#1252) and inherited it in the live `stats` view (#1254). Both hide the cursor with `\e[?25l` and restore it from `Drop` — correct for a command that returns, and never reached by one that is interrupted, because Rust's default SIGINT handling terminates the process without unwinding.

## Measured

Real Podman 5.7.0, a 100×30 pty, `stats` on a project with two running containers, SIGINT after five seconds:

| | before | after |
|---|---|---|
| `\e[?25l` | 1 | 1 |
| `\e[?25h` | 0 | 1 |

`stats` is where it bit hardest, since Ctrl-C is the *normal* way to leave it rather than an error path. A long `up` interrupted part-way had the same hole.

## The fix

A tokio signal task — the same shape `attach` (`inspect.rs:539-558`) and `watch` (`watch/mod.rs:157`) already use, so it runs ordinary code rather than being bound by async-signal-safety. It restores the cursor and exits 130, the convention `main.rs` already documents for an interrupted command.

Installed per region and claimed once per process. Per region so it cannot disturb the commands that handle their own interrupt — attached `up`, `exec`, `watch` — none of which open one. Once per process so two regions in a single invocation (a `stats` after an `up`, inside an embedding crate) cannot stack handlers racing each other to call `process::exit`.

## Test plan

- `cargo test` — **1995 pass, 0 fail**, including the 155-test integration suite against real Podman 5.7.0. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean.
- The once-per-process latch is a pure function with its own test, mutation-verified: a latch that never blocks turns it red.
- **The signal path itself is verified by hand, not by the suite**, and I want to be plain about that. Reaching it needs a real pty *and* a real signal — without a terminal no region is created at all, so no in-process test can get there. What I ran is the table above: a forked pty sized with `TIOCSWINSZ`, SIGINT delivered to the child, the raw output counted for both sequences. I also confirmed the normal exit still restores (`up -d` on the same pty: one hide, one show).
