### PR TITLE
chore: bump to 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,28 @@
 podup (3.4.0) unstable; urgency=medium
 
+  Incompatible changes
+
+  If a script of yours reads any of these, read this list before upgrading.
+  The library API is unchanged; every item here is command-line output.
+
+  * `podup build` writes its output to **stderr**, not stdout. `podup build >
+    build.log` now captures nothing — redirect stderr instead (`2> build.log`,
+    or `> build.log 2>&1`). stdout was documented as a clean pipe and `build`
+    was the one command contradicting it.
+
+  * `podup wait` prints one line per container — its name and exit code in
+    aligned columns — instead of a bare exit code per service. Use the new
+    `--format json` for a stable machine-readable form.
+
+  * `podup --version` prints `podup version v3.4.0`, matching `podup version`,
+    where it used to print `podup 3.4.0`. `podup version --short` still prints
+    the bare number.
+
+  * `stats`, `events` and `top` changed their table layouts: `stats`' header now
+    matches its columns, `events` gained a header and fixed column widths, and
+    `top` moved onto the shared table. Anything parsing those by byte offset
+    needs updating; `--format json` is unaffected in all three.
+
   Changed
 
   * Each service now gets its own identity colour. The palette holds twenty


### PR DESCRIPTION
Version bump for the release. Three files, not one — `Cargo.toml`, `Cargo.lock` and `debian/changelog` — because `dpkg-buildpackage` reads the `.deb` version from the changelog and nothing derives it from `Cargo.toml`. Missing it is what shipped `podup_1.8.0_*.deb` in the 1.9.0 release and left apt users with nothing to upgrade to; `release.yml`'s verify job now gates all three.

The stanza leads with the incompatible changes. Every one is command-line output — the library API is unchanged and semver-checks passed on all four PRs in the range — but `podup build > build.log` captures nothing now that `build` writes to stderr, and that is the item most likely to be sitting in somebody's script already.

I raised MAJOR versus MINOR before doing this and the call was 3.4.0. Recording that here so the choice is visible rather than looking like an oversight: the breaking items are CLI rendering, not API, and they are called out at the top of the notes where an upgrader will see them.

Contents (`main..develop`): the four terminal-experience phases (#1247, #1249, #1252, #1254) and the interrupted-cursor fix (#1256).

Verified: `cargo build --locked` clean at 3.4.0, `podup --version` reports `podup version v3.4.0`, 1433 library tests pass, `cargo audit` clean, and all three version files agree.