### PR TITLE
release: 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -69,6 +69,11 @@ podup (3.4.0) unstable; urgency=medium
     0.02% looked exactly like one at 69%. Four bands now, with idle rows dimmed.
     `PIDS` was the only unstyled column of the six.
 
+  * Ctrl-C out of a command drawing a live region left the cursor hidden. The
+    restore ran from `Drop`, which covers a command that returns and nothing
+    else — Rust terminates on SIGINT without unwinding. `stats` is where it bit
+    hardest, since Ctrl-C is the normal way to leave it.
+
   * `down` reported removing networks and volumes that never existed. On a
     project name that had never been created it announced three removals,
     including a data volume — naming data the operator is told is gone.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,30 @@
+podup (3.4.0) unstable; urgency=medium
+
+  Changed
+
+  * Each service now gets its own identity colour. The palette holds twenty
+    colours instead of six and is assigned in sorted order rather than hashed,
+    so two services in a project no longer share a colour — measured on a
+    four-service project, two of them did. Every colour reads on a light
+    terminal and a dark one alike, and sits away from the red, green and yellow
+    that carry status meaning.
+
+  * Terminals that do not announce 256-colour support fall back to the previous
+    six colours. `--ansi`, `NO_COLOR` and TTY detection are unchanged: if colour
+    is off, none is emitted.
+
+  * `--help` no longer uses green for headings and cyan for literals. Green is
+    the healthy colour everywhere else in podup and cyan is an identity colour,
+    so the two most-read surfaces were competing for one vocabulary.
+
+  Fixed
+
+  * `podup --ansi never --help` emitted colour. Help is rendered inside the
+    argument parse, so the colour choice arrived too late for it; `--ansi` is
+    now read before parsing.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Wed, 29 Jul 2026 22:16:36 -0500
+
 podup (3.3.0) unstable; urgency=medium
 
   Changed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,28 @@
 podup (3.4.0) unstable; urgency=medium
 
+  Incompatible changes
+
+  If a script of yours reads any of these, read this list before upgrading.
+  The library API is unchanged; every item here is command-line output.
+
+  * `podup build` writes its output to **stderr**, not stdout. `podup build >
+    build.log` now captures nothing — redirect stderr instead (`2> build.log`,
+    or `> build.log 2>&1`). stdout was documented as a clean pipe and `build`
+    was the one command contradicting it.
+
+  * `podup wait` prints one line per container — its name and exit code in
+    aligned columns — instead of a bare exit code per service. Use the new
+    `--format json` for a stable machine-readable form.
+
+  * `podup --version` prints `podup version v3.4.0`, matching `podup version`,
+    where it used to print `podup 3.4.0`. `podup version --short` still prints
+    the bare number.
+
+  * `stats`, `events` and `top` changed their table layouts: `stats`' header now
+    matches its columns, `events` gained a header and fixed column widths, and
+    `top` moved onto the shared table. Anything parsing those by byte offset
+    needs updating; `--format json` is unaffected in all three.
+
   Changed
 
   * Each service now gets its own identity colour. The palette holds twenty

--- a/debian/changelog
+++ b/debian/changelog
@@ -17,7 +17,46 @@ podup (3.4.0) unstable; urgency=medium
     the healthy colour everywhere else in podup and cyan is an identity colour,
     so the two most-read surfaces were competing for one vocabulary.
 
+  * `wait` prints one line per container — its name and exit code, in aligned
+    columns — instead of a bare exit code per service. A scaled service now
+    reports each replica separately, which is the granularity docker compose
+    reports at. New `--format json` emits one NDJSON object per container as
+    that container exits.
+
+  * `push` reports each image as it starts and finishes. It used to print
+    nothing at all: both of its lines sat below the log floor, so a push that
+    genuinely uploaded the image gave no sign it had done anything, and
+    `--quiet` suppressed output that never appeared.
+
+  * `up` reports the networks and volumes it creates, the way `down` has always
+    reported removing them.
+
+  * Every lifecycle command says so when it did nothing. `rm`, `stop`,
+    `restart`, `kill`, `pause` and `unpause` all exited 0 in silence on a
+    project that was never created, which reads exactly like success.
+
+  * `events` prints a header and lines its columns up; `top` dims the process
+    bookkeeping columns so the command line stands out; `volumes` highlights an
+    external volume; `ls` gives each project name its own colour.
+
   Fixed
+
+  * `down` reported removing networks and volumes that never existed. On a
+    project name that had never been created it announced three removals,
+    including a data volume — naming data the operator is told is gone.
+
+  * `podup --version` printed `podup 3.3.0` while `podup version` printed
+    `podup version v3.4.0`, so a script probing the binary got a different
+    string depending on the spelling it used.
+
+  * `autostart status` coloured `enabled: not-found` red while `installed: no`
+    was dim, though both report the same uninstalled unit and neither is a
+    failure. A unit that is on disk while systemd cannot find it still reports
+    red — that one is a broken install.
+
+  * `events` painted an event's actor name without escaping it. Names come from
+    outside podup, so an escape sequence in one repainted the reader's terminal
+    and desynchronised podup's own colour resets for every line after it.
 
   * `podup --ansi never --help` emitted colour. Help is rendered inside the
     argument parse, so the colour choice arrived too late for it; `--ansi` is

--- a/debian/changelog
+++ b/debian/changelog
@@ -55,7 +55,19 @@ podup (3.4.0) unstable; urgency=medium
   * `build` writes its output to stderr. It used stdout, contradicting the
     promise that stdout stays a clean pipe.
 
+  * `stats` repaints its table in place on a terminal instead of reprinting a
+    fresh frame every second. Redirected output, and `--format json` on any
+    terminal, still get plain appended frames.
+
   Fixed
+
+  * `stats`' header had drifted off its own columns. It was a hand-written
+    constant kept separately from the row layout, and the `PIDS` label began
+    exactly where its data stopped. Both are now built from one set of widths.
+
+  * `stats` coloured everything below 70% the same green, so a container at
+    0.02% looked exactly like one at 69%. Four bands now, with idle rows dimmed.
+    `PIDS` was the only unstyled column of the six.
 
   * `down` reported removing networks and volumes that never existed. On a
     project name that had never been created it announced three removals,

--- a/debian/changelog
+++ b/debian/changelog
@@ -39,6 +39,22 @@ podup (3.4.0) unstable; urgency=medium
     bookkeeping columns so the command line stands out; `volumes` highlights an
     external volume; `ls` gives each project name its own colour.
 
+  * `up`, `down`, `pull` and `build` show a live board on a terminal: the whole
+    resource set up front, repainted as work proceeds, with finished rows
+    scrolling up and staying. In a pipe, a file, CI, under `NO_COLOR` or with
+    `--ansi never`, the same events come out as plain append-only lines and no
+    escape sequences. Both carry the intermediate transitions (`Creating` then
+    `Created`), which no renderer emitted before — so a log now says more than
+    it used to, never less.
+
+  * `pull` reports through the progress layer and emits a matching `Pulled`. It
+    used a bare `eprintln!` that bypassed the output layer entirely, ignoring
+    the switch an embedding crate uses to silence podup, and it printed twice
+    per image on `up` while printing once on a standalone `pull`.
+
+  * `build` writes its output to stderr. It used stdout, contradicting the
+    promise that stdout stays a clean pipe.
+
   Fixed
 
   * `down` reported removing networks and volumes that never existed. On a

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,6 +22,31 @@ These appear before the subcommand and may also come from the environment.
 | `--ansi <WHEN>` | | Colour output: `auto`, `always` or `never`. `always` forces colour even into a pipe or file. | 
 | `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it — when this is given, `.env` is not read. The process environment still takes precedence over both. |
 
+**Identity colours.** Each service gets its own colour, so a name is
+recognisable across `ps`, `logs`, `images`, `stats` and the progress lines.
+Twenty colours are available, assigned in sorted order, so no two services in
+a project share one until the twenty-first. Each was picked to stay readable
+on a light terminal and a dark one alike, and to sit away from the red, green
+and yellow that carry status meaning, so a service name never reads as a
+state.
+
+The wide palette needs a terminal that announces 256-colour support through
+`COLORTERM` or `TERM` (or Windows, where virtual-terminal processing is
+enabled directly). Where it does not, podup falls back to six basic ANSI
+colours (cyan, magenta, blue and their bright variants), which render
+everywhere but cannot fully clear that bar: of the sixteen standard ANSI
+colours, only cyan and bright magenta stay readable on both a light and a dark
+background, and four of the fallback's own six fall short (magenta and blue
+against black, bright cyan against white, bright blue against black). ANSI-16
+colours have no fixed RGB — a terminal theme picks its own — so these figures,
+like the wide palette's, are relative to the reference palette this branch's
+tests pin (`internal/ui/palette_tests.rs`, the standard VGA 16-colour set),
+not a universal guarantee. The fallback stays anyway, on the view that
+distinguishing six services imperfectly beats distinguishing two well, and any
+terminal from the last decade qualifies for the wide palette instead. Both
+palettes obey `--ansi`, `NO_COLOR` and TTY detection: if colour is off,
+neither is emitted.
+
 ## Lifecycle
 
 ### `up`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -224,7 +224,17 @@ stands out.
 
 ### `stats [SERVICE...]`
 Live resource usage (CPU, memory, network, block I/O, PIDs) for service
-containers.
+containers. On a terminal the table repaints in place; anywhere else each frame
+is appended, so a redirected `stats` stays a file of readable frames rather than
+a file of cursor moves.
+
+CPU and memory percentages are coloured by band — dim below 5%, green to 50,
+yellow to 85, red above — so an idle container recedes and the one in trouble is
+the one that catches the eye. The absolute figures and the PID count are
+secondary detail and stay dim.
+
+`--format json` never repaints, whatever the terminal is: NDJSON while
+streaming, one pretty array with `--no-stream`.
 
 | Flag | Description | Default |
 |---|---|---|

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -570,21 +570,49 @@ prints the same.
 
 ## Progress output
 
-Lifecycle commands report each resource they act on as a line on **stderr**, so
-stdout stays a clean pipe:
+`up`, `down`, `pull` and `build` report every resource they touch, on
+**stderr**, so stdout stays a clean pipe. What that looks like depends on where
+it is going.
+
+**On a terminal**, a live region at the tail of the output shows the whole set
+up front and repaints it as work proceeds. Finished rows scroll up and stay:
 
 ```
+[+] Running 3/6
+ ✔ Network   myapp_default  Created        0.1s
+ ⠹ Image     postgres:16    Pulling        2.9s
+ ⠹ Container myapp-db-1     Starting       2.9s
+ ⠸ Container myapp-api-1    Creating       0.4s
+ ⠿ Container myapp-web-1    Pending
+```
+
+A tail region rather than a full-screen takeover, deliberately: `up` is a
+command that finishes, and handing the screen back blank would destroy the
+record of what it did.
+
+**Anywhere else** — a pipe, a file, CI, `NO_COLOR`, `--ansi never` — the same
+events come out as plain append-only lines with no escape sequences at all:
+
+```
+ Network myapp_default  Creating
  Network myapp_default  Created
- Volume myapp_data  Created
+ Container myapp-web-1  Starting
  Container myapp-web-1  Started
 ```
 
-The name carries its identity colour and the verb its meaning colour. Only what
-actually happened is reported: re-running `up` over existing resources reports
-no creation, and `down` on a project whose networks or volumes were never
-created reports no removal. A command that acted on nothing says so —
+Both renderers see every event, so a log says *more* than it used to rather than
+less. Animation in a CI log is a defect, and so is a CI log missing what the
+terminal showed.
+
+Only what actually happened is reported: re-running `up` over existing
+resources reports no creation, and `down` on a project whose networks or volumes
+were never created reports no removal. A command that acted on nothing says so —
 `no containers to stop`, `no containers to start (project not created)` — rather
 than exiting silently, which is indistinguishable from success.
+
+The live region needs stderr to be a terminal, colour to be on, and the terminal
+size to be readable. If any of those is missing it falls back to the plain
+lines, which is also what `--ansi never` and `NO_COLOR` select.
 
 ## Diagnostics
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,6 +47,14 @@ terminal from the last decade qualifies for the wide palette instead. Both
 palettes obey `--ansi`, `NO_COLOR` and TTY detection: if colour is off,
 neither is emitted.
 
+Colour elsewhere carries meaning rather than identity, and each family is used
+for one thing only: green for something that now exists or is healthy, red for
+something gone or failed, yellow for something stopped that survives, dim for a
+default or unremarkable answer. That is why `volumes` marks an external volume
+yellow rather than green — it is not healthy or unhealthy, it is the one podup
+will not delete — and why `autostart status` reports an uninstalled unit dim
+throughout instead of colouring systemd's `not-found` red.
+
 ## Lifecycle
 
 ### `up`
@@ -185,7 +193,9 @@ View container output for the named services (or all).
 | `--no-log-prefix` | Drop the `{service} \| ` tag entirely. | off |
 
 ### `events`
-Stream Podman events for this project's containers.
+Stream Podman events for this project's containers, under a `TYPE ACTION NAME`
+header with the columns aligned to a fixed width (rows arrive over time, so
+there is no complete set to size against). `--format json` prints no header.
 
 | Flag | Description | Default |
 |---|---|---|
@@ -203,7 +213,10 @@ when `--until` is given without `--since`. This also decides the exit code — s
 [Exit status](#exit-status).
 
 ### `top [SERVICE...]`
-Show the running processes of service containers.
+Show the running processes of service containers. Each block is headed by the
+container name in its identity colour; within the table the bookkeeping columns
+(`UID`, `PPID`, `C`, `STIME`, `TTY`, `TIME`) are dimmed so the command line
+stands out.
 
 | Flag | Description | Default |
 |---|---|---|
@@ -238,7 +251,9 @@ List images used by services.
 
 ### `volumes [SERVICE...]`
 List the project's named volumes (a trailing service list narrows it to volumes
-those services mount).
+those services mount). `EXTERNAL` is highlighted when it reads `yes`: podup
+neither creates nor deletes an external volume, so those are the ones a
+`down -v` leaves standing.
 
 | Flag | Description | Default |
 |---|---|---|
@@ -373,8 +388,16 @@ Pause running service containers, or resume paused ones. `resume` is an alias
 for `unpause`.
 
 ### `wait [SERVICE...]`
-Block until the named service containers (default: all) stop, printing each
-container's exit code as it does.
+Block until the named service containers (default: all) stop, printing one line
+per container as it exits — the container's name and its exit code, in aligned
+columns, with a non-zero code in red. A scaled service reports each replica
+separately. The command's own exit status is the last non-zero code it saw.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FORMAT>` | `table` for the aligned columns, or `json` for one NDJSON object (`Container`, `ExitCode`) per container, emitted as that container exits rather than after the last one. | table |
+
+A project with nothing to wait on prints nothing and exits 0.
 
 ### `scale <SERVICE=N>...`
 Set the number of running containers for one or more services, creating missing
@@ -417,7 +440,8 @@ Pull images for the named services, or all services if none are given.
 
 ### `push [SERVICE...]`
 Push each service's `image:` to its registry (services without an image are
-skipped). Credentials come from `podman login`.
+skipped). Credentials come from `podman login`. Each image is reported on stderr
+as it starts and finishes, leaving stdout a clean pipe.
 
 | Flag | Description | Default |
 |---|---|---|
@@ -543,6 +567,24 @@ prints the same.
 |---|---|---|
 | `--short` | Print only the version number. | off |
 | `--format <FMT>` | `pretty` or `json`. | `pretty` |
+
+## Progress output
+
+Lifecycle commands report each resource they act on as a line on **stderr**, so
+stdout stays a clean pipe:
+
+```
+ Network myapp_default  Created
+ Volume myapp_data  Created
+ Container myapp-web-1  Started
+```
+
+The name carries its identity colour and the verb its meaning colour. Only what
+actually happened is reported: re-running `up` over existing resources reports
+no creation, and `down` on a project whose networks or volumes were never
+created reports no removal. A command that acted on nothing says so —
+`no containers to stop`, `no containers to start (project not created)` — rather
+than exiting silently, which is indistinguishable from success.
 
 ## Diagnostics
 

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -451,8 +451,21 @@ pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	if let Some(mode) = r.unit_mode {
 		row("mode", &format!("{:04o}", mode & 0o7777));
 	}
-	row("active", &r.is_active);
-	row("enabled", &r.is_enabled);
+	// With no unit file on disk, systemd's answers to both questions are the same
+	// negative the `installed: no` line above already gave, and neither is a
+	// failure — but `is-enabled` returns the word `not-found`, which the status
+	// vocabulary reads as an error and paints red. So an uninstalled project
+	// reported one dim `no` and one red `not-found` about the same unit.
+	//
+	// A unit that *is* on disk while systemd still cannot find it stays red: that
+	// is a genuinely broken install, and the two cases must not look alike.
+	if r.unit_exists {
+		row("active", &r.is_active);
+		row("enabled", &r.is_enabled);
+	} else {
+		crate::ui::print_labelled_neutral("active", &r.is_active);
+		crate::ui::print_labelled_neutral("enabled", &r.is_enabled);
+	}
 	row("linger", if r.linger { "enabled" } else { "disabled" });
 	// Prose, not a state word, so the meaning is stated rather than inferred.
 	crate::ui::print_labelled_with(

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -414,6 +414,10 @@ pub(crate) enum Commands {
 	},
 	/// Block until service containers stop, printing each exit code.
 	Wait {
+		/// Output format. `json` emits one NDJSON object per container as it
+		/// exits, rather than after every container has.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+		format: OutputFormat,
 		/// Wait on these services (default: all).
 		services: Vec<String>,
 	},

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -91,7 +91,15 @@ pub(crate) fn ansi_from_argv<I: Iterator<Item = String>>(args: I) -> Option<Ansi
 #[derive(Parser)]
 #[command(
 	name = "podup",
-	version,
+	// clap renders `--version` as `{name} {version}`, so the derived default gave
+	// `podup 3.3.0` while the `version` subcommand gave `podup version v3.3.0` —
+	// two answers to the same question, and neither caller can tell which one it
+	// is going to get. Measured on docker-compose v5.1.3: `version` and
+	// `--version` are byte-identical (`Docker Compose version v5.1.3`) and only
+	// `--short` drops the `v`. Folding the word and the prefix into the version
+	// string is what makes clap emit the same line the subcommand does; the
+	// subcommand still owns `--short` and `--format json`.
+	version = concat!("version v", env!("CARGO_PKG_VERSION")),
 	about = "Run Compose projects on Podman.",
 	styles = HELP_STYLES,
 	// No subcommand prints help and exits non-zero (like docker compose), and the

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -13,14 +13,76 @@ pub(crate) use types::{
 	OutputFormat, RmiScope,
 };
 
-/// Help-screen colours (clap honours its own TTY/`NO_COLOR`/`CLICOLOR` detection
-/// for these, since help is rendered before `--ansi` is parsed): green-bold
-/// section headers and usage, cyan-bold flag/command literals, plain placeholders.
+/// Help-screen colours.
+///
+/// Deliberately avoids green and cyan. Green is the "healthy" colour everywhere
+/// else in podup and cyan is an identity colour, so using them here put the two
+/// most-read surfaces in competition for one vocabulary. Help uses weight
+/// (bold, underline, dim) and no explicit foreground colour, which means
+/// nothing elsewhere.
+///
+/// No slot sets an explicit `AnsiColor`, `error`/`invalid` excepted — those are
+/// status colours (red), not identity, and stay. An explicit `White` was tried
+/// first, on the reasoning that *some* colour should mark headings; measured
+/// against the same reference palette this branch's tests pin
+/// (`ui::palette_tests`), it read 1.82:1 on a white terminal background — worse
+/// than the green/cyan it replaced — and bold commonly promotes `White` to the
+/// terminal's bright-white ANSI code, which measured 1.00:1 on white, i.e.
+/// invisible. Leaving the foreground unset uses the terminal's own default
+/// text colour instead, which is readable on both themes by construction: it
+/// is what the terminal owner already chose for their body text.
+///
+/// All eight slots are still explicitly set, even where that means an empty
+/// style — clap's own `plain()` already leaves `error:` unstyled while podup
+/// printed it bold red, so nothing here may silently fall back to a starting
+/// point that disagreed with the rest of the binary.
 const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
-	.header(clap::builder::styling::AnsiColor::Green.on_default().bold())
-	.usage(clap::builder::styling::AnsiColor::Green.on_default().bold())
-	.literal(clap::builder::styling::AnsiColor::Cyan.on_default().bold())
-	.placeholder(clap::builder::styling::AnsiColor::Cyan.on_default());
+	.header(clap::builder::styling::Style::new().bold().underline())
+	.usage(clap::builder::styling::Style::new().bold())
+	.literal(clap::builder::styling::Style::new().bold())
+	.placeholder(clap::builder::styling::Style::new().dimmed())
+	.error(clap::builder::styling::AnsiColor::Red.on_default().bold())
+	.valid(clap::builder::styling::Style::new().bold())
+	.invalid(clap::builder::styling::AnsiColor::Red.on_default())
+	.context(clap::builder::styling::Style::new());
+
+/// Read `--ansi` straight off argv, before clap parses anything.
+///
+/// clap renders `--help` inside the parse call, and the colour choice was only
+/// applied after it returned — so `podup --ansi never --help` came out coloured
+/// while `NO_COLOR=1 podup --help` did not. One flag, two answers.
+///
+/// Accepts both spellings clap does (`--ansi never`, `--ansi=never`) and is
+/// deliberately forgiving: an unrecognised value yields `None` and leaves the
+/// real parser to produce the error message.
+pub(crate) fn ansi_from_argv<I: Iterator<Item = String>>(args: I) -> Option<AnsiMode> {
+	let mut args = args.peekable();
+	while let Some(arg) = args.next() {
+		// `--` ends podup's own options: `run`/`exec`/`help` forward everything
+		// after it to the container's command with `allow_hyphen_values`, so a
+		// passthrough argument may legitimately read `--ansi always` and must not
+		// be mistaken for podup's flag. clap already stops here; before this, the
+		// pre-scan did not, and `NO_COLOR=1 podup <typo> exec svc -- --ansi always`
+		// painted clap's error in colour.
+		if arg == "--" {
+			return None;
+		}
+		let value = if let Some(v) = arg.strip_prefix("--ansi=") {
+			v.to_string()
+		} else if arg == "--ansi" {
+			args.next()?
+		} else {
+			continue;
+		};
+		return match value.as_str() {
+			"auto" => Some(AnsiMode::Auto),
+			"always" => Some(AnsiMode::Always),
+			"never" => Some(AnsiMode::Never),
+			_ => None,
+		};
+	}
+	None
+}
 
 /// Top-level clap parser for the `podup` CLI; fields carry the per-flag docs.
 //
@@ -86,4 +148,82 @@ pub(crate) struct Cli {
 
 	#[command(subcommand)]
 	pub(crate) command: Commands,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{ansi_from_argv, AnsiMode};
+
+	fn argv(args: &[&str]) -> impl Iterator<Item = String> + use<> {
+		args.iter()
+			.map(|s| s.to_string())
+			.collect::<Vec<_>>()
+			.into_iter()
+	}
+
+	/// clap renders help before the parsed `--ansi` is applied, so the flag has
+	/// to be read straight off argv or `podup --ansi never --help` comes out
+	/// coloured — which it did, while `NO_COLOR=1 podup --help` did not.
+	#[test]
+	fn ansi_is_found_before_the_subcommand() {
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "--ansi", "never", "--help"])),
+			Some(AnsiMode::Never)
+		);
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "--ansi=always", "up"])),
+			Some(AnsiMode::Always)
+		);
+	}
+
+	/// It is a global flag, so it is equally valid after the subcommand.
+	#[test]
+	fn ansi_is_found_after_the_subcommand() {
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "up", "--ansi", "never"])),
+			Some(AnsiMode::Never)
+		);
+	}
+
+	/// No flag means no opinion; the existing auto-detection decides.
+	#[test]
+	fn absent_ansi_yields_none() {
+		assert_eq!(ansi_from_argv(argv(&["podup", "up", "-d"])), None);
+		assert_eq!(ansi_from_argv(argv(&["podup", "--ansi"])), None);
+		assert_eq!(ansi_from_argv(argv(&["podup", "--ansi", "sideways"])), None);
+	}
+
+	/// `--` ends podup's options. Everything after it is the container's command,
+	/// which `run`/`exec` forward verbatim with `allow_hyphen_values`, so a
+	/// passthrough argument reading `--ansi always` is not podup's flag.
+	#[test]
+	fn ansi_after_a_double_dash_is_not_ours() {
+		assert_eq!(
+			ansi_from_argv(argv(&["podup", "exec", "svc", "--", "--ansi", "always"])),
+			None
+		);
+		assert_eq!(
+			ansi_from_argv(argv(&[
+				"podup",
+				"exec",
+				"svc",
+				"--",
+				"sh",
+				"-c",
+				"--ansi=never"
+			])),
+			None
+		);
+	}
+
+	/// A flag before the `--` is still ours.
+	#[test]
+	fn ansi_before_a_double_dash_is_ours() {
+		assert_eq!(
+			ansi_from_argv(argv(&[
+				"podup", "--ansi", "never", "exec", "svc", "--", "true"
+			])),
+			Some(AnsiMode::Never)
+		);
+	}
 }

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -111,9 +111,11 @@ pub(super) async fn dispatch_rest(
 			sig_proxy: _,
 			detach_keys: _,
 		} => engine.attach_with_index(file, &service, index).await?,
-		Commands::Wait { services } => {
+		Commands::Wait { format, services } => {
 			let file = &profile_filtered(file, profile, &services);
-			engine.wait_services(file, &services).await?
+			engine
+				.wait_services_with_options(file, &services, matches!(format, OutputFormat::Json))
+				.await?
 		}
 		Commands::Commit {
 			service,

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -394,8 +394,13 @@ impl Engine {
 		while let Some(result) = stream.next().await {
 			match result {
 				Ok(output) => {
+					// stderr, not stdout. Build output went to stdout via `print!`,
+					// which contradicted the documented promise that stdout stays
+					// a clean pipe — the one thing a caller redirecting `podup
+					// build > log` relies on, and the same promise `config` and
+					// `generate quadlet` are built around.
 					if !opts.quiet && !output.stream.is_empty() {
-						print!("{}", output.stream);
+						eprint!("{}", output.stream);
 					}
 					if let Some(err) = output.error_detail.and_then(|e| e.message) {
 						return Err(ComposeError::Build(err));

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -145,7 +145,7 @@ impl Engine {
 			// reuse it here instead of letting `pull_image` resolve (and
 			// potentially re-warn about) it a second time.
 			let pull_err = self
-				.pull_image_with_policy(service, key.1)
+				.pull_image_with_policy(service, key.1, self.quiet_pull)
 				.await
 				.err()
 				.map(|e| e.to_string());
@@ -188,7 +188,21 @@ impl Engine {
 
 	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
 		let pull_policy = self.resolved_pull_policy(service);
-		self.pull_image_with_policy(service, pull_policy).await
+		self.pull_image_with_policy(service, pull_policy, self.quiet_pull)
+			.await
+	}
+
+	/// [`Self::pull_image`] with no user-facing progress, whatever `--quiet-pull`
+	/// says.
+	///
+	/// For the `up` prefetch, which only warms the cache: `up_one_service`'s own
+	/// pull is the authoritative one, and reporting from both is what printed
+	/// `Pulling` twice per image on `up` while a standalone `pull` printed it
+	/// once.
+	pub(in crate::engine) async fn pull_image_quietly(&self, service: &Service) -> Result<()> {
+		let pull_policy = self.resolved_pull_policy(service);
+		self.pull_image_with_policy(service, pull_policy, true)
+			.await
 	}
 
 	/// Resolve the effective libpod pull policy for `service`: the
@@ -220,19 +234,26 @@ impl Engine {
 	/// which must resolve the policy anyway to compute its dedup key — can
 	/// reuse that value instead of resolving (and potentially re-warning
 	/// about an unrecognized one) a second time.
-	async fn pull_image_with_policy(&self, service: &Service, pull_policy: &str) -> Result<()> {
+	async fn pull_image_with_policy(
+		&self,
+		service: &Service,
+		pull_policy: &str,
+		quiet: bool,
+	) -> Result<()> {
 		let image = match &service.image {
 			Some(img) => img.clone(),
 			None => return Ok(()),
 		};
 
-		// Progress goes to stderr so it shows at default verbosity (the non-watch
-		// log floor is WARN, so info!/debug! would print nothing) and `--quiet`
-		// actually suppresses it, matching `docker compose pull`.
-		if self.quiet_pull {
+		// Through the progress layer, not a bare `eprintln!`. This was the one
+		// user-facing line in the binary that bypassed `ui` entirely, so it
+		// ignored `PROGRESS_ENABLED` and an embedder that asked podup to stay
+		// silent got it anyway — and there was never a matching `Pulled`, so a
+		// pull that finished looked exactly like one that hung.
+		if quiet {
 			debug!("pulling {image}");
 		} else {
-			eprintln!("Pulling {image}");
+			crate::ui::progress::start("Image", &image, "Pulling");
 		}
 
 		let mut query = format!("reference={}&policy={}", urlencoded(&image), pull_policy);
@@ -274,7 +295,12 @@ impl Engine {
 
 		match pull_err {
 			Some(e) => Err(ComposeError::Build(format!("pull {image} failed: {e}"))),
-			None => Ok(()),
+			None => {
+				if !quiet {
+					crate::ui::progress_line("Image", &image, "Pulled");
+				}
+				Ok(())
+			}
 		}
 	}
 

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -63,7 +63,7 @@ where
 			if quiet {
 				tracing::debug!("pushed {image}");
 			} else {
-				info!("pushed {image}");
+				crate::ui::progress_line("Image", image, "Pushed");
 			}
 			Ok(())
 		}
@@ -132,11 +132,20 @@ impl Engine {
 
 	/// Push a single image ref and drain its progress stream, surfacing a
 	/// mid-stream `error` line as a failure.
+	///
+	/// The two user-facing lines go through `ui::progress_line`, not `tracing`.
+	/// They were `info!` until #1248, and the CLI floors tracing at `warn`
+	/// everywhere except `watch` — so a successful `podup push` wrote **zero
+	/// bytes** to stdout and stderr while the image really did land in the
+	/// registry, and `--quiet` suppressed output that never appeared. Routing
+	/// through the progress layer also honours `PROGRESS_ENABLED`, which is the
+	/// switch an embedder actually controls; a tracing line is gated only by the
+	/// log floor, which it does not.
 	async fn push_image(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<()> {
 		if quiet {
 			tracing::debug!("pushing {image}");
 		} else {
-			info!("pushing {image}");
+			crate::ui::progress_line("Image", image, "Pushing");
 		}
 		let mut query = format!("destination={}", urlencoded(image));
 		if let Some(tls) = opts.tls_verify {

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -108,6 +108,10 @@ impl Engine {
 				 Pass both to bound a window."
 			);
 		}
+		// No header on the machine path: `--format json` is what a parser reads.
+		if !json {
+			crate::ui::print_bold_header(&events_header());
+		}
 		let mut broke: Option<crate::libpod::PodmanError> = None;
 		while let Some(event) = stream.next().await {
 			match event {
@@ -195,6 +199,28 @@ fn format_event(value: &Value, json: bool) -> String {
 	format_event_line(typ, action, name, crate::ui::stdout_colored() && !json)
 }
 
+/// Display width of the `TYPE` column. `container` is the longest type libpod
+/// emits (`network`, `volume`, `image`, `secret`, `pod` are all shorter).
+const TYPE_WIDTH: usize = 9;
+
+/// Display width of the `ACTION` column. `health_status` is the longest verb
+/// seen on the feed.
+const ACTION_WIDTH: usize = 14;
+
+/// The header `events` prints once, before the first event.
+///
+/// Fixed widths, not content-sized like every other table here: rows arrive over
+/// time, so there is nothing to measure up front. `events` was the only stream
+/// with no header and no padding at all — three fields joined by single spaces,
+/// so `NAME` sat in a different column on every line and nothing named what the
+/// fields were.
+fn events_header() -> String {
+	format!(
+		"{:<TYPE_WIDTH$} {:<ACTION_WIDTH$} {}",
+		"TYPE", "ACTION", "NAME"
+	)
+}
+
 /// Join an event's three fields, tinting the two that carry meaning.
 ///
 /// A `--follow` stream is a wall of near-identical lines; `ACTION` is what
@@ -202,14 +228,29 @@ fn format_event(value: &Value, json: bool) -> String {
 /// happened to. The type (`container`, `network`) repeats on almost every line
 /// and is dimmed so it stops competing.
 fn format_event_line(typ: &str, action: &str, name: &str, colour: bool) -> String {
-	use crate::ui::{identity_style, paint, Style};
-	let typ = paint(Style::new().dimmed(), typ, colour);
-	let action = match crate::ui::action_or_status_style(action) {
-		Some(style) => paint(style, action, colour),
-		None => action.to_string(),
+	use crate::ui::{fit_cell, identity_style, paint, Style};
+	// `fit_cell` pads *and* escapes. The escaping is not incidental here: an
+	// event's actor name comes from outside podup, this line painted it raw, and
+	// every other table in the binary has run cells through `sanitize_cell` since
+	// the colour work landed. A `\x1b[` in a container name repainted the
+	// reader's terminal and desynchronised podup's own resets for every line
+	// after it.
+	let typ_cell = fit_cell(typ, TYPE_WIDTH);
+	let action_cell = fit_cell(action, ACTION_WIDTH);
+	let name_cell = fit_cell(name, 0);
+	let typ_out = paint(Style::new().dimmed(), &typ_cell, colour);
+	let action_out = match crate::ui::action_or_status_style(action) {
+		Some(style) => paint(style, &action_cell, colour),
+		None => action_cell,
 	};
-	let name = paint(identity_style(name), name, colour && !name.is_empty());
-	format!("{typ} {action} {name}").trim().to_string()
+	let name_out = paint(
+		identity_style(&name_cell),
+		&name_cell,
+		colour && !name_cell.is_empty(),
+	);
+	format!("{typ_out} {action_out} {name_out}")
+		.trim_end()
+		.to_string()
 }
 
 #[cfg(test)]
@@ -261,13 +302,15 @@ mod tests {
 			"Action": "start",
 			"Actor": { "Attributes": { "name": "web-1" } },
 		});
-		assert_eq!(format_event(&ev, false), "container start web-1");
+		// Columns are fixed-width now (#1248): `container` fills TYPE exactly,
+		// `start` is padded out to ACTION, and NAME is the trailing raw column.
+		assert_eq!(format_event(&ev, false), "container start          web-1");
 	}
 
 	#[test]
 	fn formats_libpod_native_shape() {
 		let ev = json!({ "Type": "container", "status": "die", "id": "abc123" });
-		assert_eq!(format_event(&ev, false), "container die abc123");
+		assert_eq!(format_event(&ev, false), "container die            abc123");
 	}
 
 	#[test]
@@ -286,11 +329,41 @@ mod event_colour_tests {
 	/// Without a colour sink the line is byte-identical to what it always was,
 	/// so `--json`, a pipe and the output contract are untouched.
 	#[test]
-	fn plain_output_is_unchanged() {
+	fn plain_output_carries_no_escapes() {
+		let out = format_event_line("container", "start", "proj-web-1", false);
+		assert!(!out.contains('\u{1b}'), "{out:?}");
+		assert_eq!(out, "container start          proj-web-1");
+	}
+
+	/// The three fields line up under the header, whatever their lengths, so
+	/// NAME does not move column on every line the way it used to.
+	#[test]
+	fn columns_align_under_the_header() {
+		let header = super::events_header();
+		let short = format_event_line("pod", "die", "a", false);
+		let long = format_event_line("container", "health_status", "b", false);
+		let name_col = |line: &str| line.rfind(' ').map(|i| i + 1);
 		assert_eq!(
-			format_event_line("container", "start", "proj-web-1", false),
-			"container start proj-web-1"
+			name_col(&header),
+			name_col(&short),
+			"header {header:?} vs {short:?}"
 		);
+		assert_eq!(
+			name_col(&header),
+			name_col(&long),
+			"header {header:?} vs {long:?}"
+		);
+	}
+
+	/// An actor name comes from outside podup. This line painted it raw while
+	/// every other table escaped its cells, so an escape sequence in a container
+	/// name repainted the reader's terminal.
+	#[test]
+	fn an_actor_name_cannot_drive_the_terminal() {
+		let out = format_event_line("container", "start", "evil\u{1b}[31m\u{7}name", false);
+		assert!(!out.contains('\u{1b}'), "{out:?}");
+		assert!(!out.contains('\u{7}'), "{out:?}");
+		assert!(out.contains("name"), "{out:?}");
 	}
 
 	/// The two fields that distinguish one line from the next carry colour; the

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -11,6 +11,55 @@ use super::targets::{stop_deadline, stop_timeout_param};
 use crate::engine::Engine;
 use crate::libpod::API_PREFIX;
 
+/// Display width of `wait`'s NAME column.
+///
+/// Fixed rather than content-sized: `wait` blocks and prints each container as
+/// it exits, so there is no complete set of rows to measure. Wide enough for a
+/// typical `<project>-<service>-<n>`; a longer name truncates the way every
+/// other capped column in the binary does.
+const WAIT_NAME_WIDTH: usize = 32;
+
+/// `wait`'s header row.
+fn wait_header() -> String {
+	format!("{:<WAIT_NAME_WIDTH$} EXIT", "NAME")
+}
+
+/// One `wait` result line: the container, then its exit code coloured by whether
+/// it is a failure.
+///
+/// The name goes through `fit_cell`, so it is escaped as well as padded — a
+/// container name is not podup's own string.
+fn wait_row(container: &str, code: i64) -> String {
+	let cell = crate::ui::fit_cell(container, WAIT_NAME_WIDTH);
+	let style = if code == 0 {
+		crate::ui::Style::new().dimmed()
+	} else {
+		crate::ui::Style::new().fg_color(Some(crate::ui::AnsiColor::Red.into()))
+	};
+	let coloured = crate::ui::stdout_colored();
+	format!(
+		"{} {}",
+		crate::ui::paint(crate::ui::identity_style(container), &cell, coloured),
+		crate::ui::paint(style, &code.to_string(), coloured)
+	)
+}
+
+/// Say so when a command finished having done nothing.
+///
+/// `start` already did this — *"no containers to start (project not created)"* —
+/// and the other six lifecycle commands did not: `rm`, `stop`, `restart`, `kill`,
+/// `pause` and `unpause` all exited 0 in complete silence on a project that was
+/// never created, which reads exactly like success. Measured before the fix, all
+/// six printed zero lines.
+///
+/// One helper rather than a literal per command, so the wording cannot drift into
+/// seven dialects of the same sentence.
+fn note_if_idle(acted: &std::sync::atomic::AtomicBool, verb: &str) {
+	if !acted.load(std::sync::atomic::Ordering::Relaxed) {
+		crate::ui::progress_note(&format!("no containers to {verb}"));
+	}
+}
+
 impl Engine {
 	/// Run a lifecycle POST against one container with a consistent outcome:
 	/// success prints a `Container {container}  {done}` progress line; "already
@@ -19,20 +68,28 @@ impl Engine {
 	/// a real error that propagates (setting a non-zero exit) instead of being
 	/// swallowed into a warning. Shared by stop/start/restart/kill/pause/unpause
 	/// so they all behave the same.
+	///
+	/// Returns whether the container was actually acted on. This is the only
+	/// place that knows: `live_replica_names` falls back to the *static* compose
+	/// names when nothing is running, so a command on a project that was never
+	/// created still walks a full list of container names and 404s on every one
+	/// of them. Six commands exited 0 in complete silence that way (#1248), and
+	/// telling that apart from real work requires the answer here, not a count of
+	/// names upstream.
 	pub(super) async fn run_lifecycle_op(
 		&self,
 		path: &str,
 		container: &str,
 		done: &str,
-	) -> Result<()> {
+	) -> Result<bool> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				crate::ui::progress_line("Container", container, done);
-				Ok(())
+				Ok(true)
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
-				Ok(())
+				Ok(false)
 			}
 			Err(e) => Err(ComposeError::Podman(e)),
 		}
@@ -48,15 +105,15 @@ impl Engine {
 		path: &str,
 		container: &str,
 		done: &str,
-	) -> Result<()> {
+	) -> Result<bool> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				crate::ui::progress_line("Container", container, done);
-				Ok(())
+				Ok(true)
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_state_conflict() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
-				Ok(())
+				Ok(false)
 			}
 			Err(e) => Err(ComposeError::Podman(e)),
 		}
@@ -153,6 +210,7 @@ impl Engine {
 		// Attempt every service and surface the first error (in service order) at
 		// the end rather than aborting mid-batch and leaving later services
 		// unrestarted.
+		let acted = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
@@ -162,7 +220,7 @@ impl Engine {
 				} else {
 					"Restarted (dependency)"
 				};
-				self.restart_one_service(name, service, done)
+				self.restart_one_service(name, service, done, &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -172,6 +230,7 @@ impl Engine {
 		if let Some(e) = first_err {
 			return Err(e);
 		}
+		note_if_idle(&acted, "restart");
 		Ok(())
 	}
 
@@ -182,6 +241,23 @@ impl Engine {
 		&self,
 		file: &ComposeFile,
 		target_services: &[String],
+	) -> Result<()> {
+		self.wait_services_with_options(file, target_services, false)
+			.await
+	}
+
+	/// [`Engine::wait_services`] with `--format json`, which emits one NDJSON
+	/// object per container instead of the table.
+	///
+	/// NDJSON rather than a trailing array because `wait` blocks: a script that
+	/// only learns anything once every container has exited has been handed the
+	/// answer at the one moment it is least useful. It is also the rule `stats`
+	/// already follows for its streaming output.
+	pub async fn wait_services_with_options(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		json: bool,
 	) -> Result<()> {
 		// `docker compose wait` prints each service's exit code in the order the
 		// services were given on the command line (deduplicated). Only fall back to
@@ -203,17 +279,22 @@ impl Engine {
 				.collect::<Vec<_>>()
 		};
 
+		// One line per container, which is the granularity the reference reports
+		// at — measured against docker compose v5.1.3 with a service scaled to 3
+		// replicas, it printed three lines, one per container id. The comment this
+		// replaces asserted the opposite ("a single exit code for each service"),
+		// and a bare `0` per service was built on it: with more than one container
+		// nothing said which code belonged to which.
+		//
+		// What is deliberately *not* copied is the rendering. The reference prints
+		// `container "<64-char hex id>" exited with status code 0` — an id nobody
+		// can map back to a service, the same sentence repeated on every line, and
+		// no machine path at all. Same information, said better: the container
+		// name podup already has, aligned columns, and the code coloured by
+		// whether it is a failure.
 		let mut last_nonzero = 0i64;
+		let mut printed_header = false;
 		for name in &order {
-			// One line per service, not per replica. docker compose prints a single
-			// exit code for each service it was asked to wait on, so a caller can
-			// pair its input list with the output line for line; printing per
-			// replica made a service scaled to 3 return 3 lines and silently broke
-			// that pairing. A scaled service reports the last non-zero code it saw,
-			// falling back to 0 when every replica exited cleanly — the same rule
-			// the command already used for its own exit status.
-			let mut service_code = 0i64;
-			let mut waited = false;
 			// Only wait on containers Podman actually has. The static-name fallback
 			// would POST `/wait` to a never-created predicted name and surface a raw
 			// HTTP 404; docker compose treats "nothing to wait on" as an idempotent
@@ -231,16 +312,24 @@ impl Engine {
 					.post_empty_json_unbounded::<i64>(&path)
 					.await
 					.map_err(ComposeError::Podman)?;
-				waited = true;
 				if code != 0 {
-					service_code = code;
 					last_nonzero = code;
 				}
-			}
-			// A service with no containers stays the idempotent no-op it was: it
-			// contributes no line at all, rather than a spurious 0.
-			if waited {
-				println!("{service_code}");
+				if json {
+					println!(
+						"{}",
+						serde_json::json!({ "Container": container_name, "ExitCode": code })
+					);
+				} else {
+					// The header is printed lazily, with the first result: a project
+					// where nothing was waited on stays the silent no-op it was,
+					// rather than emitting a header over an empty table.
+					if !printed_header {
+						crate::ui::print_bold_header(&wait_header());
+						printed_header = true;
+					}
+					println!("{}", wait_row(&container_name, code));
+				}
 			}
 		}
 		if last_nonzero != 0 {
@@ -266,15 +355,17 @@ impl Engine {
 		// than a phantom stop. Report "stopped" solely for containers actually
 		// running/paused — stopping a Created/Exited one is a harmless no-op and
 		// must not claim it stopped (#876), matching docker compose.
+		let acted = std::sync::atomic::AtomicBool::new(false);
 		for level in &levels {
 			let futs = level.iter().map(|name| {
 				let grace = self.grace_period_secs(&file.services[name]);
-				self.stop_one_service(name, grace)
+				self.stop_one_service(name, grace, &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				return Err(e);
 			}
 		}
+		note_if_idle(&acted, "stop");
 		Ok(())
 	}
 
@@ -307,9 +398,10 @@ impl Engine {
 		if let Some(e) = first_err {
 			return Err(e);
 		}
-		if !any_live.load(std::sync::atomic::Ordering::Relaxed) {
-			crate::ui::progress_note("no containers to start (project not created)");
-		}
+		// `start`'s flag answers a narrower question than the others' — whether any
+		// container existed at all, not whether anything changed — so it can name
+		// the cause, and the extra clause rides in the verb.
+		note_if_idle(&any_live, "start (project not created)");
 		Ok(())
 	}
 
@@ -329,14 +421,16 @@ impl Engine {
 		let levels = crate::compose::resolve_levels(file)?;
 		let levels = filter_levels(file, levels, target_services)?;
 
+		let acted = std::sync::atomic::AtomicBool::new(false);
 		for level in &levels {
 			let futs = level
 				.iter()
-				.map(|name| self.kill_one_service(name, &file.services[name], signal));
+				.map(|name| self.kill_one_service(name, &file.services[name], signal, &acted));
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				return Err(e);
 			}
 		}
+		note_if_idle(&acted, "signal");
 		Ok(())
 	}
 
@@ -369,11 +463,12 @@ impl Engine {
 		levels.reverse();
 		let levels = filter_levels(file, levels, target_services)?;
 
+		let acted = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
-			let futs = level
-				.iter()
-				.map(|name| self.rm_one_service(name, &file.services[name], force, remove_volumes));
+			let futs = level.iter().map(|name| {
+				self.rm_one_service(name, &file.services[name], force, remove_volumes, &acted)
+			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
 			}
@@ -381,6 +476,7 @@ impl Engine {
 		if let Some(e) = first_err {
 			return Err(e);
 		}
+		note_if_idle(&acted, "remove");
 		Ok(())
 	}
 
@@ -395,10 +491,11 @@ impl Engine {
 		// container is a no-op, and one state-mismatched service must not abort the
 		// batch and leave the rest in an inconsistent partial state. Services in a
 		// level are paused concurrently (#757).
+		let acted = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(name, &file.services[name], "pause", "Paused")
+				self.idempotent_state_service(name, &file.services[name], "pause", "Paused", &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -407,6 +504,7 @@ impl Engine {
 		if let Some(e) = first_err {
 			return Err(e);
 		}
+		note_if_idle(&acted, "pause");
 		Ok(())
 	}
 
@@ -420,10 +518,17 @@ impl Engine {
 		// Idempotent + best-effort, mirroring `pause`: unpausing a not-paused
 		// container is a no-op, and a single mismatch must not abort the batch.
 		// Services in a level are unpaused concurrently (#757).
+		let acted = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(name, &file.services[name], "unpause", "Unpaused")
+				self.idempotent_state_service(
+					name,
+					&file.services[name],
+					"unpause",
+					"Unpaused",
+					&acted,
+				)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -432,6 +537,7 @@ impl Engine {
 		if let Some(e) = first_err {
 			return Err(e);
 		}
+		note_if_idle(&acted, "unpause");
 		Ok(())
 	}
 
@@ -447,5 +553,64 @@ impl Engine {
 			Err(e) if e.is_status(404) => Ok(false),
 			Err(e) => Err(ComposeError::Podman(e)),
 		}
+	}
+}
+
+#[cfg(test)]
+mod wait_output_tests {
+	use super::{wait_header, wait_row, WAIT_NAME_WIDTH};
+
+	/// The exit code sits in one column, header included, whatever the container
+	/// name's length. `wait` prints as each container exits, so it cannot size
+	/// columns to a set it has not finished collecting.
+	#[test]
+	fn the_exit_column_is_in_one_place() {
+		let code_col = |line: &str| {
+			let plain: String = strip_ansi(line);
+			plain.rfind(' ').map(|i| i + 1)
+		};
+		let header = wait_header();
+		let short = wait_row("a", 0);
+		let long = wait_row("project-service-name-12", 7);
+		assert_eq!(code_col(&header), code_col(&short));
+		assert_eq!(code_col(&header), code_col(&long));
+		assert_eq!(code_col(&header), Some(WAIT_NAME_WIDTH + 1));
+	}
+
+	/// A name longer than the column truncates rather than shoving the code out
+	/// of alignment.
+	#[test]
+	fn an_over_long_name_truncates() {
+		let row = strip_ansi(&wait_row(&"x".repeat(WAIT_NAME_WIDTH + 20), 0));
+		assert_eq!(row.chars().count(), WAIT_NAME_WIDTH + 2);
+	}
+
+	/// A container name is not podup's own string, so it is escaped like every
+	/// other cell in the binary.
+	#[test]
+	fn a_container_name_cannot_drive_the_terminal() {
+		// Colour is off in the test process, so any escape left in the output
+		// came from the name rather than from the styling.
+		let row = wait_row("evil\u{1b}[31m\u{7}name", 0);
+		assert!(!row.contains('\u{1b}'), "{row:?}");
+		assert!(!row.contains('\u{7}'), "{row:?}");
+		assert!(row.contains("name"), "{row:?}");
+	}
+
+	fn strip_ansi(s: &str) -> String {
+		let mut out = String::new();
+		let mut chars = s.chars();
+		while let Some(c) = chars.next() {
+			if c == '\u{1b}' {
+				for c in chars.by_ref() {
+					if c == 'm' {
+						break;
+					}
+				}
+			} else {
+				out.push(c);
+			}
+		}
+		out
 	}
 }

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -123,9 +123,11 @@ impl Engine {
 				continue;
 			};
 			let del = format!("{API_PREFIX}/networks/{}", urlencoded(net_name));
-			match self.client.delete_ok(&del).await {
-				Ok(_) => crate::ui::progress_line("Network", net_name, "Removed"),
-				Err(e) if e.is_status(404) => {}
+			// A 404 here means the object disappeared between the list and the
+			// delete, so this sweep did not remove it and must not say it did.
+			match self.client.delete_existed(&del).await {
+				Ok(true) => crate::ui::progress_line("Network", net_name, "Removed"),
+				Ok(false) => {}
 				Err(e) => {
 					tracing::warn!("could not remove network {net_name}: {e}");
 					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
@@ -159,9 +161,11 @@ impl Engine {
 				continue;
 			};
 			let del = format!("{API_PREFIX}/volumes/{}", urlencoded(name));
-			match self.client.delete_ok(&del).await {
-				Ok(_) => crate::ui::progress_line("Volume", name, "Removed"),
-				Err(e) if e.is_status(404) => {}
+			// A 404 here means the object disappeared between the list and the
+			// delete, so this sweep did not remove it and must not say it did.
+			match self.client.delete_existed(&del).await {
+				Ok(true) => crate::ui::progress_line("Volume", name, "Removed"),
+				Ok(false) => {}
 				Err(e) => {
 					tracing::warn!("could not remove volume {name}: {e}");
 					first_err.get_or_insert(crate::error::ComposeError::Podman(e));

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -47,7 +47,19 @@ impl Engine {
 		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);
 		let mut first_err: Option<crate::error::ComposeError> = None;
 
-		let containers = self.list_project_container_names(None).await?;
+		// With no compose file, the service names are not known statically — but
+		// the labelled containers we are about to tear down carry `podup.service`,
+		// so list them grouped by service instead of the flat name list, and
+		// register the result before any teardown progress line is printed.
+		// Without this every container here fell back to the per-label hash
+		// instead of the sequential identity colour `ps` and the compose-file
+		// `down` path use — the same class of defect fixed for `logs` (#1082).
+		let by_service = self.list_project_containers_by_service().await?;
+		let mut service_names: Vec<String> = by_service.keys().cloned().collect();
+		service_names.sort();
+		crate::ui::set_services(&service_names);
+
+		let containers: Vec<String> = by_service.into_values().flatten().collect();
 		let futs = containers.iter().map(|container_name| {
 			self.teardown_one_container(container_name, grace, &[], remove_volumes)
 		});
@@ -209,7 +221,10 @@ mod tests {
 	#[tokio::test]
 	#[cfg(unix)]
 	async fn down_by_label_propagates_a_real_removal_failure_after_completing_the_rest() {
-		let containers = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-db-1"]}]"#;
+		let containers = r#"[
+			{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+			{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}}
+		]"#;
 		let fake = fake_podman::start(move |method, target| {
 			if method == "GET" && target.contains("/containers/json") {
 				(200, containers.to_string())

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -601,9 +601,18 @@ impl Engine {
 				"{API_PREFIX}/networks/{}",
 				crate::libpod::urlencoded(&network_name),
 			);
-			match self.client.delete_ok(&net_path).await {
-				Ok(_) => crate::ui::progress_line("Network", &network_name, "Removed"),
-				Err(e) if e.is_status(404) => {}
+			// `delete_existed`, not `delete_ok`: this loop walks the networks the
+			// compose file *declares*, which is not the same set as the networks
+			// that exist. `delete_ok` throws away the boolean that tells the two
+			// apart, so every 404 arrived here as `Ok(())` and was announced as a
+			// removal — measured on a project that had never been created,
+			// `down -v` reported removing two networks and a volume, none of
+			// which had ever existed. The `Err(404)` arm below was unreachable
+			// for the same reason: the layer underneath had already turned the
+			// 404 into a success.
+			match self.client.delete_existed(&net_path).await {
+				Ok(true) => crate::ui::progress_line("Network", &network_name, "Removed"),
+				Ok(false) => {}
 				Err(e) => {
 					tracing::warn!("could not remove network {network_name}: {e}");
 					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
@@ -637,9 +646,13 @@ impl Engine {
 					"{API_PREFIX}/volumes/{}",
 					crate::libpod::urlencoded(&volume_name),
 				);
-				match self.client.delete_ok(&vol_path).await {
-					Ok(_) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
-					Err(e) if e.is_status(404) => {}
+				// See the network loop above: only a delete that found something
+				// may be reported, and a volume is the object where a false
+				// "Removed" is worst — it names data the operator believes is
+				// gone.
+				match self.client.delete_existed(&vol_path).await {
+					Ok(true) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
+					Ok(false) => {}
 					Err(e) => {
 						tracing::warn!("could not remove volume {volume_name}: {e}");
 						first_err.get_or_insert(crate::error::ComposeError::Podman(e));

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -10,6 +10,7 @@ mod run;
 mod run_attached;
 mod scale;
 mod schedule;
+mod seed;
 mod signal;
 mod targets;
 
@@ -159,7 +160,7 @@ impl Engine {
 		no_deps: bool,
 		start: bool,
 	) -> Result<()> {
-		async {
+		let result = async {
 			// Reject any volume/network/container name Podman's regex would refuse
 			// before issuing a single create, so a bad name surfaces as a clear
 			// client-side error (not an opaque HTTP 500) with nothing created.
@@ -218,6 +219,14 @@ impl Engine {
 					}
 				}
 			}
+
+			// Seed the board before any work starts. This is the whole point of
+			// the phase: the resource set is knowable here — `levels` is already
+			// resolved above, and the networks and volumes come straight off the
+			// compose file — while every progress event in the tree fires once
+			// its work is already over. A board grown from those events would be
+			// a transcript with extra steps.
+			crate::ui::progress::begin(self.up_resources(file, &enabled, &target_set));
 
 			self.create_networks(file).await?;
 			self.create_volumes(file).await?;
@@ -279,7 +288,14 @@ impl Engine {
 
 			Ok(())
 		}
-		.await
+		.await;
+
+		// Close the board on every exit, not just the happy one: the region
+		// hides the cursor, and a `?` that returned early through the block
+		// above would otherwise leave the terminal without a caret. `end` is
+		// idempotent and a no-op when no board was opened.
+		crate::ui::progress::end();
+		result
 	}
 
 	/// Bring up a single service: honor profile/target filters, wait on its
@@ -494,6 +510,11 @@ impl Engine {
 				return Ok(());
 			}
 		}
+		crate::ui::progress::start(
+			"Container",
+			&container_name,
+			if start { "Starting" } else { "Creating" },
+		);
 		self.create_and_start(&container_name, name, service, file, start)
 			.await?;
 		crate::ui::progress_line(
@@ -529,6 +550,20 @@ impl Engine {
 		// Prefetch every project container once and group by service, instead of
 		// one container-list round-trip per service (S+1 → 1 for the level walk).
 		let live_by_service = self.list_project_containers_by_service().await?;
+
+		// Seed from the containers Podman actually has, walked in the same
+		// reversed level order the teardown below uses, so the board predicts
+		// what will happen rather than what the file describes. A service in the
+		// file that was never created must not sit on the board as a row that
+		// never moves.
+		let live_order: Vec<String> = levels
+			.iter()
+			.flatten()
+			.filter_map(|svc| live_by_service.get(svc))
+			.flatten()
+			.cloned()
+			.collect();
+		crate::ui::progress::begin(self.down_resources(file, &live_order, remove_volumes));
 
 		// Best-effort across every level/container/network/volume so one failure
 		// never leaves the rest of the teardown undone, but the first real
@@ -610,6 +645,7 @@ impl Engine {
 			// which had ever existed. The `Err(404)` arm below was unreachable
 			// for the same reason: the layer underneath had already turned the
 			// 404 into a success.
+			crate::ui::progress::start("Network", &network_name, "Removing");
 			match self.client.delete_existed(&net_path).await {
 				Ok(true) => crate::ui::progress_line("Network", &network_name, "Removed"),
 				Ok(false) => {}
@@ -650,6 +686,7 @@ impl Engine {
 				// may be reported, and a volume is the object where a false
 				// "Removed" is worst — it names data the operator believes is
 				// gone.
+				crate::ui::progress::start("Volume", &volume_name, "Removing");
 				match self.client.delete_existed(&vol_path).await {
 					Ok(true) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
 					Ok(false) => {}
@@ -663,7 +700,12 @@ impl Engine {
 
 		// Internal native secrets are podup-owned (not user data), so remove
 		// them unconditionally — independent of `remove_volumes`.
-		self.remove_internal_secrets(file).await?;
+		let secrets = self.remove_internal_secrets(file).await;
+
+		// Close the board before returning, on every path: the region hides the
+		// cursor and an early `?` would leave the terminal without one.
+		crate::ui::progress::end();
+		secrets?;
 
 		if let Some(e) = first_err {
 			return Err(e);

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -131,9 +131,15 @@ pub(super) fn restart_service_set(
 impl Engine {
 	/// Stop a single service's live containers (only those actually running), as
 	/// one unit of work in a concurrent level. See [`Engine::stop`].
-	pub(super) async fn stop_one_service(&self, service_name: &str, grace: i32) -> Result<()> {
+	pub(super) async fn stop_one_service(
+		&self,
+		service_name: &str,
+		grace: i32,
+		acted: &std::sync::atomic::AtomicBool,
+	) -> Result<()> {
 		for container in self.live_service_containers(service_name).await? {
 			if super::scale::state_is_active(&container.state) {
+				acted.store(true, std::sync::atomic::Ordering::Relaxed);
 				self.stop_container(&container.name, grace).await?;
 			} else {
 				tracing::debug!(
@@ -183,6 +189,7 @@ impl Engine {
 		service_name: &str,
 		service: &Service,
 		done: &str,
+		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
 		let grace = self.grace_period_secs(service);
 		let mut first_err: Option<ComposeError> = None;
@@ -194,11 +201,15 @@ impl Engine {
 				urlencoded(&container_name),
 				stop_timeout_param(grace),
 			);
-			if let Err(e) = self
+			match self
 				.run_lifecycle_op(&restart_path, &container_name, done)
 				.await
 			{
-				first_err.get_or_insert(e);
+				Ok(true) => acted.store(true, std::sync::atomic::Ordering::Relaxed),
+				Ok(false) => {}
+				Err(e) => {
+					first_err.get_or_insert(e);
+				}
 			}
 		}
 		first_err.map_or(Ok(()), Err)
@@ -210,6 +221,7 @@ impl Engine {
 		service_name: &str,
 		service: &Service,
 		signal: &str,
+		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
 		let mut first_err: Option<ComposeError> = None;
 		for container_name in self.live_replica_names(service_name, service).await? {
@@ -218,11 +230,15 @@ impl Engine {
 				urlencoded(&container_name),
 				urlencoded(signal),
 			);
-			if let Err(e) = self
+			match self
 				.run_lifecycle_op(&path, &container_name, "Killed")
 				.await
 			{
-				first_err.get_or_insert(e);
+				Ok(true) => acted.store(true, std::sync::atomic::Ordering::Relaxed),
+				Ok(false) => {}
+				Err(e) => {
+					first_err.get_or_insert(e);
+				}
 			}
 		}
 		first_err.map_or(Ok(()), Err)
@@ -235,6 +251,7 @@ impl Engine {
 		service: &Service,
 		force: bool,
 		remove_volumes: bool,
+		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
 		let mut first_err: Option<ComposeError> = None;
 		for container_name in self.live_replica_names(service_name, service).await? {
@@ -247,7 +264,10 @@ impl Engine {
 				// Only report a removal that actually happened — a phantom
 				// (never-created) container 404s and must not be logged as
 				// "removed".
-				Ok(true) => crate::ui::progress_line("Container", &container_name, "Removed"),
+				Ok(true) => {
+					acted.store(true, std::sync::atomic::Ordering::Relaxed);
+					crate::ui::progress_line("Container", &container_name, "Removed");
+				}
 				Ok(false) => {}
 				// Without `--force`, a running container 409s. docker compose rm
 				// skips running containers rather than aborting, so warn and keep
@@ -273,6 +293,7 @@ impl Engine {
 		service: &Service,
 		endpoint: &str,
 		done: &str,
+		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
 		let mut first_err: Option<ComposeError> = None;
 		for container_name in self.live_replica_names(service_name, service).await? {
@@ -280,11 +301,15 @@ impl Engine {
 				"{API_PREFIX}/containers/{}/{endpoint}",
 				urlencoded(&container_name),
 			);
-			if let Err(e) = self
+			match self
 				.run_idempotent_state_op(&path, &container_name, done)
 				.await
 			{
-				first_err.get_or_insert(e);
+				Ok(true) => acted.store(true, std::sync::atomic::Ordering::Relaxed),
+				Ok(false) => {}
+				Err(e) => {
+					first_err.get_or_insert(e);
+				}
 			}
 		}
 		first_err.map_or(Ok(()), Err)

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -336,6 +336,7 @@ impl Engine {
 		pre_stop: &[LifecycleHook],
 		remove_volumes: bool,
 	) -> Result<()> {
+		crate::ui::progress::start("Container", container_name, "Stopping");
 		for hook in pre_stop {
 			if let Err(e) = self.run_lifecycle_hook(container_name, hook).await {
 				tracing::debug!("pre_stop hook {container_name}: {e}");

--- a/internal/engine/lifecycle/prefetch.rs
+++ b/internal/engine/lifecycle/prefetch.rs
@@ -104,7 +104,11 @@ impl Engine {
 				}
 				return;
 			}
-			if let Err(e) = self.pull_image(service).await {
+			// Quietly: this stage only warms the cache, and `up_one_service`'s
+			// own pull below is the authoritative one. Reporting from both is
+			// what made `Pulling` appear twice per image on `up` while a
+			// standalone `pull` printed it once.
+			if let Err(e) = self.pull_image_quietly(service).await {
 				tracing::debug!("prefetch miss for {image}: {e}");
 			}
 		});

--- a/internal/engine/lifecycle/seed.rs
+++ b/internal/engine/lifecycle/seed.rs
@@ -1,0 +1,140 @@
+//! What a lifecycle command is about to work through, worked out before it
+//! starts.
+//!
+//! The board needs the resource set up front, and nothing in the tree produced
+//! it: every progress event fires once its own work is over, so a board grown
+//! from those events would only ever show the past. This is the missing half,
+//! and it is derivable — `resolve_levels` already runs before the walk begins,
+//! and the networks and volumes come straight off the compose file.
+//!
+//! Deliberately a *prediction*, not a promise. It is computed from the compose
+//! file before Podman is asked anything, so it can be wrong in both directions:
+//! a service whose container already exists still gets a row (it will report
+//! `Running` rather than `Started`), and a resource the file does not mention
+//! is appended by the board when its event arrives. Being approximately right
+//! before the work starts beats being exactly right after it finished.
+
+use std::collections::HashSet;
+
+use crate::compose::types::ComposeFile;
+use crate::ui::progress::Kind;
+
+use super::super::network::resolve_network_name;
+use super::super::Engine;
+
+impl Engine {
+	/// Every resource an `up`/`create` pass will touch, in the order it will
+	/// touch them: networks, then volumes, then containers by dependency level.
+	///
+	/// The order matters as much as the contents — the board's completed rows
+	/// scroll away in this order, and that scrollback is the record the command
+	/// leaves behind.
+	pub(super) fn up_resources(
+		&self,
+		file: &ComposeFile,
+		enabled: &HashSet<String>,
+		target_set: &Option<HashSet<String>>,
+	) -> Vec<(Kind, String)> {
+		let mut out = Vec::new();
+
+		// External networks and volumes are never created by podup, so they are
+		// not work this command will do and must not appear as rows waiting to
+		// happen.
+		for (key, cfg) in &file.networks {
+			if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
+				continue;
+			}
+			out.push((
+				Kind::Network,
+				resolve_network_name(key, file, &self.project),
+			));
+		}
+		for (key, cfg) in &file.volumes {
+			let cfg = cfg.as_ref();
+			if cfg.and_then(|c| c.external).unwrap_or(false) {
+				continue;
+			}
+			let name = cfg
+				.and_then(|c| c.name.as_deref())
+				.map(str::to_string)
+				.unwrap_or_else(|| format!("{}_{}", self.project, key));
+			out.push((Kind::Volume, name));
+		}
+
+		// Containers in dependency order, which is the order they will start.
+		// Falls back to the file's own order if the graph cannot be resolved —
+		// a cycle is a real error, but it is `run_up`'s to report, and seeding
+		// must not be the thing that surfaces it.
+		let levels = crate::compose::resolve_levels(file)
+			.unwrap_or_else(|_| vec![file.services.keys().cloned().collect::<Vec<_>>()]);
+		for level in levels {
+			for name in level {
+				// The same two conditions `up_one_service` applies, in the same
+				// order. Any drift here puts a row on the board that will never
+				// move, which is worse than no row at all: a permanently
+				// `Pending` line reads as something hung.
+				if target_set.as_ref().is_some_and(|set| !set.contains(&name)) {
+					continue;
+				}
+				if !enabled.contains(&name) {
+					continue;
+				}
+				let Some(service) = file.services.get(&name) else {
+					continue;
+				};
+				for container in self.replica_names(&name, service) {
+					out.push((Kind::Container, container));
+				}
+			}
+		}
+		out
+	}
+
+	/// Every resource a `down` pass will remove, in teardown order: containers
+	/// first (dependents before their dependencies, the inversion `down` itself
+	/// walks), then networks, then volumes.
+	///
+	/// Containers come from what Podman actually has, not from the compose file:
+	/// `down` removes what exists, and a file listing a service that was never
+	/// created would put a row on the board that never moves.
+	pub(super) fn down_resources(
+		&self,
+		file: &ComposeFile,
+		live: &[String],
+		remove_volumes: bool,
+	) -> Vec<(Kind, String)> {
+		let mut out: Vec<(Kind, String)> = live
+			.iter()
+			.map(|name| (Kind::Container, name.clone()))
+			.collect();
+		for (key, cfg) in &file.networks {
+			if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
+				continue;
+			}
+			out.push((
+				Kind::Network,
+				resolve_network_name(key, file, &self.project),
+			));
+		}
+		// Volumes survive a `down` without `-v`, so they are not work this pass
+		// will do.
+		if remove_volumes {
+			for (key, cfg) in &file.volumes {
+				let cfg = cfg.as_ref();
+				if cfg.and_then(|c| c.external).unwrap_or(false) {
+					continue;
+				}
+				let name = cfg
+					.and_then(|c| c.name.as_deref())
+					.map(str::to_string)
+					.unwrap_or_else(|| format!("{}_{}", self.project, key));
+				out.push((Kind::Volume, name));
+			}
+		}
+		out
+	}
+}
+
+#[cfg(all(test, unix))]
+#[path = "seed_tests.rs"]
+mod tests;

--- a/internal/engine/lifecycle/seed_tests.rs
+++ b/internal/engine/lifecycle/seed_tests.rs
@@ -1,0 +1,127 @@
+use super::*;
+use crate::compose::parse_str;
+
+/// `up_resources` never touches the client — it reads the compose file and the
+/// project name — but an `Engine` needs one, so the tests borrow the same fake
+/// the rest of the lifecycle suite uses. That fake is a unix socket, which is
+/// why this module is `cfg(unix)`.
+fn engine(fake: &crate::engine::fake_podman::FakePodman) -> Engine {
+	Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir())
+}
+
+async fn seeded(yaml: &str, targets: &[&str]) -> Vec<(Kind, String)> {
+	let file = parse_str(yaml).unwrap();
+	let enabled: HashSet<String> = file.services.keys().cloned().collect();
+	let set = (!targets.is_empty()).then(|| {
+		targets
+			.iter()
+			.map(|s| (*s).to_string())
+			.collect::<HashSet<_>>()
+	});
+	let fake = crate::engine::fake_podman::start(|_, _| (404, "{}".to_string()));
+	engine(&fake).up_resources(&file, &enabled, &set)
+}
+
+const TWO_SERVICES: &str = "\
+services:
+  db:
+    image: alpine
+  web:
+    image: alpine
+    depends_on:
+      - db
+volumes:
+  data:
+networks:
+  extra:
+";
+
+/// Networks and volumes come first, then containers: that is the order the work
+/// happens in, and the board's completed rows scroll away in the same order.
+#[tokio::test]
+async fn resources_are_seeded_in_the_order_the_work_happens() {
+	let out = seeded(TWO_SERVICES, &[]).await;
+	let kinds: Vec<Kind> = out.iter().map(|(k, _)| *k).collect();
+	let first_container = kinds.iter().position(|k| *k == Kind::Container).unwrap();
+	assert!(
+		kinds[..first_container]
+			.iter()
+			.all(|k| matches!(k, Kind::Network | Kind::Volume)),
+		"{kinds:?}"
+	);
+}
+
+/// Containers follow the dependency graph, so the board predicts the order the
+/// user will actually see them start in.
+#[tokio::test]
+async fn containers_follow_the_dependency_order() {
+	let out = seeded(TWO_SERVICES, &[]).await;
+	let names: Vec<&str> = out
+		.iter()
+		.filter(|(k, _)| *k == Kind::Container)
+		.map(|(_, n)| n.as_str())
+		.collect();
+	assert_eq!(names, vec!["proj-db-1", "proj-web-1"]);
+}
+
+/// podup never creates an external network or volume, so it is not work this
+/// command will do and must not sit on the board waiting to happen.
+#[tokio::test]
+async fn external_resources_are_not_seeded() {
+	let yaml = "\
+services:
+  web:
+    image: alpine
+volumes:
+  theirs:
+    external: true
+networks:
+  shared:
+    external: true
+";
+	let out = seeded(yaml, &[]).await;
+	assert!(
+		out.iter().all(|(k, _)| *k == Kind::Container),
+		"external resources must not be seeded: {out:?}"
+	);
+}
+
+/// A targeted `up web` seeds only what it will touch. Rows for services this
+/// pass will never start would sit `Pending` forever.
+#[tokio::test]
+async fn a_targeted_up_seeds_only_its_targets() {
+	let out = seeded(TWO_SERVICES, &["web"]).await;
+	let names: Vec<&str> = out
+		.iter()
+		.filter(|(k, _)| *k == Kind::Container)
+		.map(|(_, n)| n.as_str())
+		.collect();
+	assert_eq!(names, vec!["proj-web-1"]);
+}
+
+/// A scaled service gets one row per replica, because the board tracks
+/// containers rather than services — that is the granularity every progress
+/// event in the tree already reports at.
+#[tokio::test]
+async fn a_scaled_service_seeds_one_row_per_replica() {
+	let yaml = "\
+services:
+  web:
+    image: alpine
+    deploy:
+      replicas: 3
+";
+	let out = seeded(yaml, &[]).await;
+	let names: Vec<&str> = out.iter().map(|(_, n)| n.as_str()).collect();
+	assert_eq!(names, vec!["proj-web-1", "proj-web-2", "proj-web-3"]);
+}
+
+/// Volume and network names are the resolved on-host ones, not the compose
+/// keys, so a row matches the event that will later arrive for it.
+#[tokio::test]
+async fn names_are_the_resolved_on_host_ones() {
+	let out = seeded(TWO_SERVICES, &[]).await;
+	let names: Vec<&str> = out.iter().map(|(_, n)| n.as_str()).collect();
+	assert!(names.contains(&"proj_data"), "{names:?}");
+	assert!(names.contains(&"proj_extra"), "{names:?}");
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -56,7 +56,7 @@ mod profiles;
 pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};
 mod projects;
 pub use projects::{list_projects, list_projects_filtered, LsOptions};
-mod query;
+pub(crate) mod query;
 mod secrets;
 mod staging;
 mod stats;

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -67,6 +67,7 @@ impl Engine {
 				subnets,
 			};
 
+			crate::ui::progress::start("Network", &network_name, "Creating");
 			match self
 				.client
 				.post_json::<_, serde_json::Value>(

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -2,8 +2,6 @@
 
 use std::collections::HashMap;
 
-use tracing::info;
-
 use crate::compose::types::{ComposeFile, IpamConfig, Service, ServiceNetworkConfig};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::{Namespace, PerNetworkOptions};
@@ -77,7 +75,7 @@ impl Engine {
 				)
 				.await
 			{
-				Ok(_) => info!("created network {network_name}"),
+				Ok(_) => crate::ui::progress_line("Network", &network_name, "Created"),
 				// An existing network is not an error on re-`up`; accept any
 				// already-exists conflict (network-create returns 409, but share
 				// the same predicate as volume-create for consistency).

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -165,8 +165,19 @@ pub async fn list_projects_filtered(
 		return Ok(());
 	}
 
+	// `ls` was the only list whose first column carried no identity colour, so
+	// the one command whose whole job is to name projects rendered them all in
+	// the same plain text. Each project now gets its own stable colour, which is
+	// what makes a long list scannable.
+	//
+	// Not the same colour as that project's containers, and it cannot be: an
+	// identity colour is keyed on the label with the project prefix stripped, so
+	// `proj-web-1` keys on `web` while the row here keys on `proj`. What is
+	// promised is per-project stability, not cross-command agreement with the
+	// services inside it.
 	let mut table = crate::ui::Table::new(&["NAME", "STATUS"])
 		.cap(0, 48)
+		.identity_col(0)
 		.status_col(1);
 	for (name, t) in &rows {
 		table.push(vec![name.to_string(), status_label(t)]);

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -8,7 +8,7 @@ use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::inspect_util::{
-	align_top_columns, dedup_preserving_order, is_running_status, parse_port_proto, select_replica,
+	dedup_preserving_order, is_running_status, parse_port_proto, process_table, select_replica,
 	split_repo_tag,
 };
 use super::Engine;
@@ -90,17 +90,9 @@ impl Engine {
 						// are listed, so it carries the same identity colour it has in
 						// `ps` and `logs` rather than being merely bold.
 						crate::ui::print_identity_header(&container_name);
-						// Space-pad columns to the widest cell (header + rows) rather
-						// than tab-joining, so the table is aligned as the help promises.
 						let titles = result.titles.clone().unwrap_or_default();
 						let processes = result.processes.clone().unwrap_or_default();
-						let aligned = align_top_columns(&titles, &processes);
-						if let Some((header, rows)) = aligned.split_first() {
-							crate::ui::print_bold_header(header);
-							for row in rows {
-								println!("{row}");
-							}
-						}
+						Self::print_process_table(&titles, &processes);
 					}
 					// A not-created container (404) is tolerated; any other failure
 					// (e.g. a stopped container's HTTP 500, or an unreachable socket)
@@ -120,6 +112,23 @@ impl Engine {
 			);
 		}
 		Ok(())
+	}
+
+	/// Render one container's process list.
+	///
+	/// On `ui::Table` rather than the hand-rolled aligner it replaces: cells are
+	/// escaped and columns sized in one place, so `top` stops being a third
+	/// layout dialect that has to be fixed separately every time. The escaping
+	/// is not incidental — these cells hold a process `argv` read out of a
+	/// container, which is attacker-controlled.
+	///
+	/// The bookkeeping columns are dimmed so the command line is what the eye
+	/// lands on. Before this, `top` styled its two header lines and left every
+	/// process row flat, which on a busy container is the whole output.
+	fn print_process_table(titles: &[String], processes: &[Vec<String>]) {
+		if let Some(table) = process_table(titles, processes) {
+			table.print();
+		}
 	}
 
 	/// Print the public port for a given private port of a service container.

--- a/internal/engine/query/inspect_util.rs
+++ b/internal/engine/query/inspect_util.rs
@@ -135,50 +135,52 @@ pub(super) fn split_repo_tag(image_ref: &str) -> (String, String) {
 	}
 }
 
-/// Align a `top` table (the title row followed by process rows) into
-/// space-padded columns sized to the widest cell, returning one rendered line
-/// per input row (titles first). All but the last column are left-padded; the
-/// last is left ragged to avoid trailing whitespace.
-pub(super) fn align_top_columns(titles: &[String], processes: &[Vec<String>]) -> Vec<String> {
-	// Escaped before anything is measured. These cells hold a process `argv`
-	// read out of a container, which is attacker-controlled: without this a
-	// process can name itself with ANSI and repaint the reader's terminal. Every
-	// other table in podup goes through `fit_cell`, which sanitizes; `top`
-	// formats by hand and was the one that did not. Escaping first also keeps
-	// the width honest, since an escaped control character is wider than the
-	// byte it replaces.
-	let sanitize = |row: &[String]| -> Vec<String> {
-		row.iter().map(|c| crate::ui::sanitize_cell(c)).collect()
-	};
-	let mut rows: Vec<Vec<String>> = Vec::with_capacity(processes.len() + 1);
-	if !titles.is_empty() {
-		rows.push(sanitize(titles));
-	}
-	for p in processes {
-		rows.push(sanitize(p));
-	}
-	let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
-	let mut widths = vec![0usize; col_count];
-	for r in &rows {
-		for (i, cell) in r.iter().enumerate() {
-			widths[i] = widths[i].max(cell.chars().count());
-		}
-	}
-	rows.iter()
-		.map(|r| {
-			r.iter()
-				.enumerate()
-				.map(|(i, cell)| {
-					if i + 1 == r.len() {
-						cell.clone()
-					} else {
-						format!("{cell:<width$}", width = widths[i])
-					}
-				})
-				.collect::<Vec<_>>()
-				.join("  ")
-		})
+/// Column titles that are process bookkeeping rather than the answer.
+///
+/// Matched by title, not by index: libpod chooses the column set, so a
+/// positional list would silently dim the wrong things if that set ever
+/// changed. PID and CMD are what a reader of `top` is looking for; an
+/// unrecognised title is left alone.
+const TOP_SCAFFOLDING: [&str; 6] = ["UID", "PPID", "C", "STIME", "TTY", "TIME"];
+
+/// Which of `titles` are bookkeeping and should be dimmed.
+///
+/// Pure and separate from the table so the choice is testable: a dimming that
+/// selects nothing renders identically to no dimming at all, so without this the
+/// control could be deleted with the suite staying green.
+pub(super) fn top_dim_columns(titles: &[String]) -> Vec<usize> {
+	titles
+		.iter()
+		.enumerate()
+		.filter(|(_, t)| TOP_SCAFFOLDING.contains(&t.as_str()))
+		.map(|(i, _)| i)
 		.collect()
+}
+
+/// Build the table for one container's process list, or `None` when libpod sent
+/// no titles.
+///
+/// On `ui::Table` rather than a hand-rolled aligner: cells are escaped and
+/// columns sized in one place, so `top` stops being a third layout dialect that
+/// has to be fixed separately every time. The escaping is not incidental — these
+/// cells hold a process `argv` read out of a container, which is
+/// attacker-controlled, and a process can name itself.
+///
+/// Pure (returns the table instead of printing it) so both properties stay
+/// testable without a live container.
+pub(super) fn process_table(
+	titles: &[String],
+	processes: &[Vec<String>],
+) -> Option<crate::ui::Table> {
+	if titles.is_empty() {
+		return None;
+	}
+	let headers: Vec<&str> = titles.iter().map(String::as_str).collect();
+	let mut table = crate::ui::Table::new(&headers).dim_cols(&top_dim_columns(titles));
+	for row in processes {
+		table.push(row.clone());
+	}
+	Some(table)
 }
 
 #[cfg(test)]
@@ -191,7 +193,7 @@ mod tests {
 	fn top_escapes_control_characters_from_process_argv() {
 		let titles = vec!["PID".to_string(), "COMMAND".to_string()];
 		let processes = vec![vec!["1".to_string(), "\u{1b}[31mevil".to_string()]];
-		let out = super::align_top_columns(&titles, &processes);
+		let out = super::process_table(&titles, &processes).unwrap().render();
 		assert!(
 			!out.iter().any(|line| line.contains('\u{1b}')),
 			"no raw escape may reach the terminal: {out:?}"
@@ -203,8 +205,7 @@ mod tests {
 	}
 
 	use super::{
-		align_top_columns, dedup_preserving_order, is_running_status, parse_port_proto,
-		select_replica, split_repo_tag,
+		dedup_preserving_order, is_running_status, parse_port_proto, select_replica, split_repo_tag,
 	};
 
 	#[test]
@@ -299,19 +300,57 @@ mod tests {
 	}
 
 	#[test]
-	fn align_top_columns_pads_to_widest_cell() {
+	fn top_pads_columns_to_the_widest_cell() {
 		let titles = vec!["PID".to_string(), "CMD".to_string()];
 		let processes = vec![
 			vec!["1".to_string(), "bash".to_string()],
 			vec!["12345".to_string(), "node".to_string()],
 		];
-		let lines = align_top_columns(&titles, &processes);
+		let lines = super::process_table(&titles, &processes).unwrap().render();
 		assert_eq!(lines.len(), 3);
-		// First column is padded to the widest value ("12345" = 5 chars).
-		assert!(lines[0].starts_with("PID  "));
-		assert!(lines[1].starts_with("1      "));
+		// The invariant is that the second column starts at one offset on every
+		// line, header included — not any particular prefix. Asserting a literal
+		// `"1      "` pinned the old hand-rolled aligner's two-space join, so it
+		// failed when `top` moved onto the shared table for no reason a reader of
+		// `top` would care about.
+		let second_col = |line: &str| {
+			line.find(|c: char| !c.is_whitespace()).map(|_| {
+				let first = line.split_whitespace().next().unwrap_or("");
+				line.find(first).unwrap_or(0)
+					+ first.len() + line[line.find(first).unwrap_or(0) + first.len()..]
+					.chars()
+					.take_while(|c| *c == ' ')
+					.count()
+			})
+		};
+		assert_eq!(second_col(&lines[0]), second_col(&lines[1]));
+		assert_eq!(second_col(&lines[0]), second_col(&lines[2]));
+		// The widest cell ("12345") is what sets that offset.
+		assert_eq!(second_col(&lines[0]), Some("12345".len() + 1));
 		// No tabs in the aligned output.
 		assert!(lines.iter().all(|l| !l.contains('\t')));
+	}
+
+	/// `top` dims the bookkeeping columns so the command line is what the eye
+	/// lands on. Selected by title, so libpod reordering or renaming a column
+	/// cannot silently dim the wrong one.
+	#[test]
+	fn top_dims_the_bookkeeping_columns_only() {
+		let titles: Vec<String> = ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"]
+			.iter()
+			.map(|s| (*s).to_string())
+			.collect();
+		let dim = super::top_dim_columns(&titles);
+		// PID (1) and CMD (7) are the answer, everything else is scaffolding.
+		assert_eq!(dim, vec![0, 2, 3, 4, 5, 6]);
+	}
+
+	/// A title libpod might add in future is left at normal weight rather than
+	/// dimmed on a guess.
+	#[test]
+	fn top_leaves_an_unknown_column_alone() {
+		let titles = vec!["PID".to_string(), "RSS".to_string(), "CMD".to_string()];
+		assert!(super::top_dim_columns(&titles).is_empty());
 	}
 
 	#[test]

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -9,6 +9,42 @@ use std::io::Write;
 /// held in memory forever.
 const MAX_PENDING: usize = 64 * 1024;
 
+/// The palette slot for a log-prefix label.
+///
+/// Delegates to [`crate::ui::identity_slot`], never `crate::ui::service_slot`
+/// directly: the label reaching this module still carries its replica suffix
+/// (`web-1`, from `display_label`), and only `identity_slot` strips that (and
+/// a project prefix) before resolving through the per-project colour registry
+/// `set_services` fills. Resolving `service_slot` against the raw label
+/// bypassed the registry entirely — that key was never in it — so every log
+/// prefix silently fell back to the per-label hash instead of the sequential
+/// colour `ps` uses. Measured on an 8-service project: `ps` gave 8 distinct
+/// colours, `logs` only 6, before this indirection existed.
+///
+/// [`prefix_style`] renders this into a [`crate::ui::Style`] and nothing else
+/// — so the routing choice this function makes is the one thing a regression
+/// test needs to pin down, and it can compare the slot directly rather than a
+/// rendered `Style`. That distinction matters: the narrow (6-colour) fallback
+/// wraps a slot index mod 6, so two different wide-palette slots can render
+/// identically there, which would silently swallow a routing regression that
+/// a `Style` comparison alone could not see.
+fn prefix_slot(label: &str) -> usize {
+	crate::ui::identity_slot(label)
+}
+
+/// The identity colour for a log-prefix label. See [`prefix_slot`] for the
+/// routing decision this renders.
+///
+/// Kept as its own function (rather than calling [`crate::ui::identity_style`]
+/// inline in [`LinePrefixer::new`]) so the routing choice is unit-testable on
+/// its own: [`LinePrefixer::new`]'s final output is gated by `stdout_colored`,
+/// which is false under the test harness (stdout is not a TTY there), so no
+/// test that only inspects a built `LinePrefixer`'s output can ever observe
+/// which slot function was called.
+fn prefix_style(label: &str) -> crate::ui::Style {
+	crate::ui::style_for_slot(prefix_slot(label))
+}
+
 /// Tags each complete log line with `{label} | `, the way `docker compose logs`
 /// labels multi-service output. Bytes arrive as stream frames that may split a
 /// line across frames, so a partial line is buffered until its newline arrives
@@ -39,7 +75,7 @@ impl LinePrefixer {
 		// prefix had to accept both. docker compose uses one space too.
 		let plain = format!("{label} | ");
 		let label = crate::ui::paint(
-			crate::ui::service_style(label),
+			prefix_style(label),
 			&plain,
 			allow_color && crate::ui::stdout_colored(),
 		);
@@ -94,7 +130,45 @@ impl LinePrefixer {
 
 #[cfg(test)]
 mod tests {
-	use super::LinePrefixer;
+	use super::{prefix_slot, prefix_style, LinePrefixer};
+
+	/// The regression this guards: `new` used to resolve `service_slot(label)`
+	/// directly against the raw, replica-suffixed label, which is never a key
+	/// in the per-project registry `identity_slot` resolves against — every log
+	/// prefix silently fell back to the hash instead of the sequential colour
+	/// `ps` uses for the same container.
+	///
+	/// Both checks are on `prefix_slot`, the actual routing decision, not the
+	/// `Style` [`prefix_style`] renders it into: the narrow (6-colour) fallback
+	/// wraps a slot index mod 6, and for these two labels slot 1 ("web") and
+	/// slot 19 ("web-1") both land on Magenta there. A `Style` comparison here
+	/// was red on any terminal that never announces the wide palette (no
+	/// `TERM`/`COLORTERM`, which is every Linux/macOS CI leg today) whether or
+	/// not the regression it guards was present. The slot itself never wraps,
+	/// so it stays a real, palette-independent assertion — and since
+	/// `prefix_style` does nothing but render `prefix_slot`'s output (see its
+	/// doc comment), pinning the slot pins the `Style` too.
+	#[test]
+	fn prefix_style_routes_through_identity_style_not_service_style() {
+		assert_eq!(
+			prefix_slot("web-1"),
+			crate::ui::identity_slot("web"),
+			"the replica suffix must be stripped before resolving the colour"
+		);
+		assert_ne!(
+			prefix_slot("web-1"),
+			crate::ui::service_slot("web-1"),
+			"the raw, suffixed label must not be hashed directly"
+		);
+		// `prefix_style` is a pure rendering of `prefix_slot`, so its `Style`
+		// still agrees with `identity_style` on a wide-palette terminal — kept
+		// as a smoke test that the rendering step itself is wired up.
+		assert_eq!(
+			prefix_style("web-1"),
+			crate::ui::identity_style("web"),
+			"prefix_style must render the same slot identity_style does"
+		);
+	}
 
 	/// #1082: one space before the bar. Attached `up` already used one, so the
 	/// same container was tagged two different ways by two commands in the same

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -44,7 +44,8 @@ impl StatsOptions {
 
 /// Width of the table NAME column; long names are truncated to this width (with
 /// a trailing ellipsis) unless `--no-trunc` is given, so a long container name
-/// no longer overflows and shifts every following column. Matches [`HEADER`].
+/// no longer overflows and shifts every following column. The header is built
+/// from this same constant, so the two cannot drift apart.
 const NAME_WIDTH: usize = 32;
 
 /// Build the query fragment scoping a stats request to the `wanted` containers,
@@ -180,9 +181,17 @@ fn truncate_name(name: &str, no_trunc: bool) -> String {
 /// so should be the one that catches the eye.
 fn load_style(pct: f64) -> crate::ui::Style {
 	use crate::ui::AnsiColor;
-	let colour = if pct >= 90.0 {
+	// Four bands, not three, and the lowest one is dim rather than green.
+	// Everything under 70% used to be the same green, so a container at 0.02%
+	// looked exactly like one at 69% — colour that does not vary with the value
+	// carries no information, and the whole reason to read `stats` is to find
+	// the row in trouble. Idle rows now recede instead of competing.
+	if pct < 5.0 {
+		return crate::ui::Style::new().dimmed();
+	}
+	let colour = if pct >= 85.0 {
 		AnsiColor::Red
-	} else if pct >= 70.0 {
+	} else if pct >= 50.0 {
 		AnsiColor::Yellow
 	} else {
 		AnsiColor::Green
@@ -205,10 +214,14 @@ fn format_row_with(s: &ContainerStat, no_trunc: bool, colour: bool) -> String {
 
 	let name = format!("{:<NAME_WIDTH$}", truncate_name(&s.name, no_trunc));
 	let name = paint(identity_style(s.name.trim()), &name, colour);
-	let cpu = paint(load_style(s.cpu), &format!("{:>7.2}%", s.cpu), colour);
+	let cpu = paint(
+		load_style(s.cpu),
+		&format!("{:>width$.2}%", s.cpu, width = CPU_WIDTH - 1),
+		colour,
+	);
 	let mem_pct = paint(
 		load_style(s.mem_perc),
-		&format!("{:>6.2}%", s.mem_perc),
+		&format!("{:>width$.2}%", s.mem_perc, width = MEM_PCT_WIDTH - 1),
 		colour,
 	);
 	// Secondary detail: the absolute figures matter once a percentage has drawn
@@ -216,27 +229,38 @@ fn format_row_with(s: &ContainerStat, no_trunc: bool, colour: bool) -> String {
 	let mem = paint(
 		dim,
 		&format!(
-			"{:>10} / {:<10}",
+			"{:>width$} / {:<width$}",
 			format_bytes(s.mem_usage),
-			format_bytes(s.mem_limit)
+			format_bytes(s.mem_limit),
+			width = (MEM_WIDTH - 3) / 2
 		),
 		colour,
 	);
 	let net = paint(
 		dim,
-		&format!("{:>9} / {:<9}", format_bytes(rx), format_bytes(tx)),
+		&format!(
+			"{:>width$} / {:<width$}",
+			format_bytes(rx),
+			format_bytes(tx),
+			width = (NET_WIDTH - 3) / 2
+		),
 		colour,
 	);
 	let block = paint(
 		dim,
 		&format!(
-			"{:>9} / {:<9}",
+			"{:>width$} / {:<width$}",
 			format_bytes(s.block_in),
-			format_bytes(s.block_out)
+			format_bytes(s.block_out),
+			width = (BLOCK_WIDTH - 3) / 2
 		),
 		colour,
 	);
-	format!("{name} {cpu} {mem} {mem_pct} {net} {block} {:>5}", s.pids)
+	// PIDS was the only unstyled column of the six. It is secondary detail like
+	// the absolute byte figures beside it, so it takes the same dim treatment
+	// rather than a colour of its own.
+	let pids = paint(dim, &format!("{:>PIDS_WIDTH$}", s.pids), colour);
+	format!("{name} {cpu} {mem} {mem_pct} {net} {block} {pids}")
 }
 
 /// Build one `stats --format json` row with numeric values (raw bytes/percent),
@@ -258,7 +282,35 @@ fn stat_json_row(s: &ContainerStat) -> serde_json::Value {
 	})
 }
 
-const HEADER: &str = "NAME                                 CPU %       MEM USAGE / LIMIT        MEM %    NET I/O             BLOCK I/O           PIDS";
+/// Width of each column after NAME, in the order they are printed.
+///
+/// One source for the header and the rows. They used to be two hand-maintained
+/// layouts that nothing checked against each other, and they had drifted:
+/// measured against a representative row, the `MEM %` label sat one column past
+/// where its own data ended and `PIDS` started exactly where its data *stopped*,
+/// so the label was entirely off its column. Patching the constant would have
+/// fixed it until the next edit.
+const CPU_WIDTH: usize = 8;
+const MEM_WIDTH: usize = 23;
+const MEM_PCT_WIDTH: usize = 7;
+const NET_WIDTH: usize = 21;
+const BLOCK_WIDTH: usize = 21;
+const PIDS_WIDTH: usize = 5;
+
+/// The table header, built from the same widths the rows are.
+///
+/// Fixed widths rather than `ui::Table`'s content sizing, deliberately: this
+/// table repaints every second, and a column that resizes itself as the numbers
+/// change makes every row jump sideways while you are trying to read it. The
+/// shared table is right for a list printed once; a live view wants columns that
+/// stay put.
+fn header() -> String {
+	format!(
+		"{:<NAME_WIDTH$} {:>CPU_WIDTH$} {:<MEM_WIDTH$} {:>MEM_PCT_WIDTH$} \
+		 {:<NET_WIDTH$} {:<BLOCK_WIDTH$} {:>PIDS_WIDTH$}",
+		"NAME", "CPU %", "MEM USAGE / LIMIT", "MEM %", "NET I/O", "BLOCK I/O", "PIDS"
+	)
+}
 
 impl Engine {
 	/// Stream resource usage for the project's service containers (docker
@@ -337,7 +389,7 @@ impl Engine {
 					.await
 					.map_err(ComposeError::Podman)?
 			};
-			print_frame(&report, &running, &stopped, &opts);
+			print_frame(&report, &running, &stopped, &opts, None);
 			return Ok(());
 		}
 
@@ -349,9 +401,17 @@ impl Engine {
 			.await
 			.map_err(ComposeError::Podman)?;
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
+
+		// A live region only where one belongs: stdout a terminal, colour on, the
+		// width readable — the same three conditions the lifecycle board uses,
+		// asked of stdout rather than stderr because `stats` *is* its output. A
+		// `--format json` stream is a machine path and never repaints.
+		let mut region = wants_region(opts.json, live_stats_allowed())
+			.then(|| crate::ui::progress::Region::new(crate::ui::progress::Target::Stdout));
+
 		while let Some(frame) = frames.next().await {
 			match frame {
-				Ok(report) => print_frame(&report, &running, &stopped, &opts),
+				Ok(report) => print_frame(&report, &running, &stopped, &opts, region.as_mut()),
 				Err(e) => {
 					// A `stats --stream` stream lives as long as any sampled
 					// container is running, and ends once none remain. libpod
@@ -495,6 +555,31 @@ fn frame_rows(
 	rows
 }
 
+/// Whether a streaming `stats` frame should repaint in place.
+///
+/// Pure, and separate from the terminal probe, so the `--format json` half is
+/// testable: a piped test cannot exercise it at all, because the terminal probe
+/// is already false there — a version that let JSON repaint on a tty passed
+/// every integration test in the suite.
+fn wants_region(json: bool, live_terminal: bool) -> bool {
+	// Never for the machine path, whatever the terminal says. A parser reading
+	// NDJSON would otherwise get cursor moves interleaved with its documents.
+	!json && live_terminal
+}
+
+/// Whether `stats` may repaint in place.
+///
+/// Asked of **stdout**, unlike the lifecycle board's stderr: `stats` renders its
+/// table to stdout, so that is the stream that has to be a terminal for a
+/// repaint to make sense. `stats > file` on a terminal must still produce a file
+/// of readable frames rather than a file of cursor moves.
+fn live_stats_allowed() -> bool {
+	use std::io::IsTerminal;
+	std::io::stdout().is_terminal()
+		&& crate::ui::stdout_colored()
+		&& crate::engine::query::terminal::window_size().is_some()
+}
+
 /// Print one stats frame: the table (a bold header plus one row per container)
 /// or a JSON array when `--format json`. Table frames end with a blank line.
 fn print_frame(
@@ -502,6 +587,7 @@ fn print_frame(
 	running: &HashSet<String>,
 	stopped: &[String],
 	opts: &StatsOptions,
+	region: Option<&mut crate::ui::progress::Region>,
 ) {
 	let rows = frame_rows(report, running, stopped);
 
@@ -522,10 +608,22 @@ fn print_frame(
 		return;
 	}
 
-	crate::ui::print_bold_header(HEADER);
 	let colour = crate::ui::stdout_colored();
-	for s in &rows {
-		println!("{}", format_row_with(s, opts.no_trunc, colour));
+	let mut lines = vec![crate::ui::paint(crate::ui::bold(), &header(), colour)];
+	lines.extend(
+		rows.iter()
+			.map(|s| format_row_with(s, opts.no_trunc, colour)),
+	);
+
+	// A live region only while streaming. `--no-stream` prints one frame and
+	// exits, so there is nothing to repaint over and a region would only hide
+	// the cursor for no reason.
+	if let Some(region) = region {
+		region.show(&[], &lines);
+		return;
+	}
+	for line in lines {
+		println!("{line}");
 	}
 	println!();
 }

--- a/internal/engine/stats_tests.rs
+++ b/internal/engine/stats_tests.rs
@@ -4,6 +4,25 @@
 
 use super::*;
 
+/// A representative row: values wide enough that a column mis-sized by a couple
+/// of characters shows up, rather than a zeroed struct where every cell happens
+/// to be short.
+fn sample_stat() -> ContainerStat {
+	let mut network = HashMap::new();
+	network.insert("eth0".to_string(), NetStat { rx: 1024, tx: 2048 });
+	ContainerStat {
+		name: "proj-web-1".into(),
+		cpu: 12.5,
+		mem_usage: 1024 * 1024,
+		mem_limit: 60 * 1024 * 1024 * 1024,
+		mem_perc: 0.06,
+		block_in: 4096,
+		block_out: 8192,
+		pids: 3,
+		network,
+	}
+}
+
 #[test]
 fn format_bytes_scales_units() {
 	assert_eq!(format_bytes(512), "512B");
@@ -214,4 +233,74 @@ fn first_unknown_service_flags_typos() {
 		first_unknown_service(&file, &["web".into(), "bogus".into()]),
 		Some("bogus")
 	);
+}
+
+/// The header and the rows are built from one set of widths, so every label
+/// sits over its own column.
+///
+/// They were two hand-maintained layouts that nothing checked against each
+/// other, and they had drifted: measured against a representative row, `MEM %`
+/// sat one column past where its data ended and `PIDS` began exactly where its
+/// data stopped, so the label was entirely off the column it named.
+#[test]
+fn the_header_lines_up_with_the_rows() {
+	let row = format_row_with(&sample_stat(), false, false);
+	let header = header();
+	assert_eq!(
+		header.chars().count(),
+		row.chars().count(),
+		"header and row must be the same width\nH: {header:?}\nR: {row:?}"
+	);
+	// Each label ends no later than its column does, which is what "over its own
+	// column" means for a right-aligned numeric cell.
+	for label in ["CPU %", "MEM %", "PIDS"] {
+		let at = header.find(label).expect("label present");
+		assert!(
+			at + label.len() <= row.chars().count(),
+			"{label} runs past the row\nH: {header:?}\nR: {row:?}"
+		);
+	}
+}
+
+/// A right-aligned label ends where its cell ends. `PIDS` used to start there
+/// instead, which put the whole label past its data.
+#[test]
+fn the_pids_label_sits_over_the_pids_column() {
+	let header = header();
+	assert!(
+		header.trim_end().ends_with("PIDS"),
+		"PIDS is the trailing column: {header:?}"
+	);
+	let row = format_row_with(&sample_stat(), false, false);
+	assert_eq!(
+		header.rfind("PIDS").unwrap() + "PIDS".len(),
+		row.chars().count(),
+		"the label must end where the column does"
+	);
+}
+
+/// Colour has to vary with the value or it says nothing. Everything under 70%
+/// used to be the same green, so a container at 0.02% looked exactly like one
+/// at 69%.
+#[test]
+fn the_load_bands_separate_idle_from_busy() {
+	let idle = load_style(0.02);
+	let moderate = load_style(40.0);
+	let warm = load_style(60.0);
+	let hot = load_style(95.0);
+	assert_ne!(idle, moderate, "0.02% must not look like 40%");
+	assert_ne!(moderate, warm, "40% must not look like 60%");
+	assert_ne!(warm, hot, "60% must not look like 95%");
+}
+
+/// `--format json` never repaints, whatever the terminal is. Asserted on the
+/// pure predicate because no piped test can reach it: with stdout not a
+/// terminal the other half of the condition is already false, so a version that
+/// let JSON repaint on a tty passed the whole suite.
+#[test]
+fn the_machine_path_never_repaints() {
+	assert!(wants_region(false, true), "a table on a terminal repaints");
+	assert!(!wants_region(true, true), "json on a terminal must not");
+	assert!(!wants_region(false, false), "nor a table off a terminal");
+	assert!(!wants_region(true, false));
 }

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -87,9 +87,15 @@ impl Engine {
 		// On `ui::Table` rather than a hand-rolled `{:<40} {:<12}`: cells are
 		// escaped and columns sized in one place, so this stops being a third
 		// layout dialect that has to be fixed separately every time.
+		// EXTERNAL printed `yes`/`no` in plain text while every other meaningful
+		// column in the binary carried colour, so the most consequential fact in
+		// the table was the least visible one. `caution_col` rather than
+		// `status_col`: green would say "healthy", and an external volume is not
+		// healthy or unhealthy — it is the one podup will not delete.
 		let mut table = crate::ui::Table::new(&["NAME", "DRIVER", "EXTERNAL"])
 			.cap(0, 48)
-			.identity_col(0);
+			.identity_col(0)
+			.caution_col(2);
 		for (_, name, driver, external) in &rows {
 			table.push(vec![
 				name.clone(),

--- a/internal/engine/volume/mod.rs
+++ b/internal/engine/volume/mod.rs
@@ -65,6 +65,7 @@ impl Engine {
 				labels,
 			};
 
+			crate::ui::progress::start("Volume", &volume_name, "Creating");
 			match self
 				.client
 				.post_json::<_, serde_json::Value>(

--- a/internal/engine/volume/mod.rs
+++ b/internal/engine/volume/mod.rs
@@ -7,8 +7,6 @@
 
 use std::collections::HashMap;
 
-use tracing::info;
-
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::volume::VolumeCreateOptions;
@@ -75,7 +73,7 @@ impl Engine {
 				)
 				.await
 			{
-				Ok(_) => info!("created volume {volume_name}"),
+				Ok(_) => crate::ui::progress_line("Volume", &volume_name, "Created"),
 				// Podman's libpod volume-create returns 500 (not 409) for an
 				// existing name; treat an already-exists conflict as success so a
 				// re-`up` over an existing named volume stays idempotent.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -328,6 +328,12 @@ async fn run() -> podup::Result<()> {
 		// Identity colours key on the project-stripped label, so every command
 		// tints the same container the same way.
 		podup::ui::set_project(&project);
+		// Register the service names so each gets its own identity colour. The
+		// hash this replaces could not know how many services existed, so two
+		// could share one. The `down`-by-label path has no compose file to read
+		// service names from up front; it registers them itself, from the live
+		// container listing it fetches immediately before tearing down.
+		podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
 		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 		let engine = podup::Engine::with_base_dir(client, project, base_dir);
 		return engine
@@ -440,6 +446,7 @@ async fn run() -> podup::Result<()> {
 		// Identity colours key on the project-stripped label, so every command
 		// tints the same container the same way.
 		podup::ui::set_project(&project);
+		podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
 		// `file` is already parsed with the correct interpolation setting above.
 		let parsed = file;
 		// `--resolve-image-digests` pins each image to its registry digest, which
@@ -491,6 +498,7 @@ async fn run() -> podup::Result<()> {
 	// the progress lines all tint the same container the same way. This is the
 	// path every lifecycle command takes.
 	podup::ui::set_project(&project);
+	podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
 
 	// `generate` produces declarative artifacts from the compose file alone; it
 	// neither contacts Podman nor mutates project state.

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -234,6 +234,12 @@ fn render_help(rendered: &clap::builder::StyledStr, colour: bool) -> String {
 }
 
 pub(crate) fn parse_cli() -> Cli {
+	// Apply `--ansi` before clap renders anything: `--help` and clap's own
+	// errors are produced inside the parse call below, so a choice applied
+	// afterwards arrives too late for them.
+	if let Some(mode) = crate::cli::ansi_from_argv(std::env::args()) {
+		podup::ui::set_color_choice(mode.into());
+	}
 	match Cli::try_parse() {
 		Ok(cli) => cli,
 		Err(e) => match e.kind() {

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -285,6 +285,32 @@ pub fn print_labelled_with(label: &str, value: &str, good: Option<bool>) {
 	);
 }
 
+/// [`print_labelled`] with the value dimmed, for an answer that is negative but
+/// not a failure.
+///
+/// `autostart status` needed it: with no unit file on disk, systemd's
+/// `is-enabled` answers `not-found`, which the status vocabulary reads as an
+/// error and paints red — while the `installed: no` line directly above it says
+/// the same thing about the same unit and was dim. Two colours for one fact, and
+/// the alarming one belonged to the case where nothing is wrong.
+///
+/// Separate from [`print_labelled_with`] rather than a third state added to its
+/// `Option<bool>`: `ui` is public API and podup is 1.0.0, so the existing
+/// signature may not move.
+pub fn print_labelled_neutral(label: &str, value: &str) {
+	use std::io::Write;
+	let dim = Style::new().dimmed();
+	let padded = format!("{label}:");
+	let _ = writeln!(
+		anstream::stdout(),
+		"{}{padded:<11}{} {}{value}{}",
+		dim.render(),
+		dim.render_reset(),
+		dim.render(),
+		dim.render_reset()
+	);
+}
+
 /// Bold — table headers and emphasis.
 pub fn bold() -> Style {
 	Style::new().bold()

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -17,6 +17,7 @@ pub use anstyle::{AnsiColor, Style};
 
 pub use anstream::ColorChoice;
 
+mod palette;
 mod table;
 pub use table::{fit_cell, sanitize_cell, Table};
 
@@ -88,6 +89,23 @@ pub fn set_project(name: &str) {
 	}
 }
 
+/// The service-to-colour map for this invocation, filled once the compose file
+/// has been resolved. Empty until then, which is why `colour_for` falls back to
+/// a hash rather than requiring registration.
+static SERVICES: std::sync::RwLock<Option<std::collections::HashMap<String, usize>>> =
+	std::sync::RwLock::new(None);
+
+/// Record this project's service names so each gets its own identity colour.
+///
+/// Call once per invocation, after the compose file is parsed. Without it every
+/// label falls back to the hash, which still works — it just cannot promise two
+/// services differ.
+pub fn set_services(names: &[String]) {
+	if let Ok(mut slot) = SERVICES.write() {
+		*slot = Some(palette::assign(names));
+	}
+}
+
 /// The stable identity colour for a container or service label, keyed on the
 /// label with the project prefix removed.
 ///
@@ -95,6 +113,12 @@ pub fn set_project(name: &str) {
 /// the same colour for the same container, which is what makes `ps`, `logs`,
 /// `stats` and the progress lines agree.
 pub fn identity_style(label: &str) -> Style {
+	slot_to_style(identity_slot(label), palette::wide_palette_available())
+}
+
+/// The palette slot backing [`identity_style`]. See [`service_slot`] for why
+/// this exists as its own, unrendered step.
+pub(crate) fn identity_slot(label: &str) -> usize {
 	let key = PROJECT
 		.read()
 		.ok()
@@ -104,7 +128,7 @@ pub fn identity_style(label: &str) -> Style {
 				.flatten()
 		})
 		.unwrap_or_else(|| label.to_string());
-	service_style(strip_replica_suffix(&key))
+	service_slot(strip_replica_suffix(&key))
 }
 
 /// Drop a trailing `-N` replica index, so every surface hashes the same key.
@@ -320,20 +344,55 @@ const SERVICE_PALETTE: [AnsiColor; 6] = [
 	AnsiColor::BrightBlue,
 ];
 
-/// Stable palette index for a service name — the same name always maps to the
-/// same colour (FNV-1a over the bytes, modulo the palette size).
-fn palette_index(name: &str) -> usize {
-	let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-	for b in name.bytes() {
-		h ^= u64::from(b);
-		h = h.wrapping_mul(0x0100_0000_01b3);
-	}
-	(h % SERVICE_PALETTE.len() as u64) as usize
+/// The palette slot backing [`service_style`], before it is rendered into a
+/// [`Style`] for whichever palette the terminal supports.
+///
+/// Split out so a routing regression can be asserted on the slot itself: the
+/// narrow (6-colour) fallback wraps a slot index mod 6, so two different
+/// wide-palette slots can render as the same `Style` there. A test comparing
+/// rendered `Style`s can miss exactly the collision it exists to catch on a
+/// terminal that never announces the wide palette; the slot never wraps, so
+/// it stays a real comparison on both.
+pub(crate) fn service_slot(name: &str) -> usize {
+	SERVICES
+		.read()
+		.ok()
+		.and_then(|slot| slot.as_ref().map(|map| palette::colour_for(name, map)))
+		.unwrap_or_else(|| palette::colour_for(name, &std::collections::HashMap::new()))
 }
 
 /// The stable colour for a service's aggregated-log prefix.
 pub fn service_style(name: &str) -> Style {
-	Style::new().fg_color(Some(SERVICE_PALETTE[palette_index(name)].into()))
+	slot_to_style(service_slot(name), palette::wide_palette_available())
+}
+
+/// The style for a palette slot, from whichever palette the terminal supports.
+///
+/// Split out of [`service_style`] so both branches are testable: the real
+/// decision reads a process-cached environment probe, and a test that flipped
+/// it would pass or fail on test scheduling.
+///
+/// The narrow branch takes a slot assigned against the WIDE palette's size, so
+/// it must wrap again — indexing a six-element array with a slot up to 19 is
+/// the out-of-bounds bug the old hash's `assert!` used to guard.
+fn slot_to_style(slot: usize, wide: bool) -> Style {
+	if wide {
+		Style::new().fg_color(Some(palette::wide_colour(slot)))
+	} else {
+		Style::new().fg_color(Some(SERVICE_PALETTE[slot % SERVICE_PALETTE.len()].into()))
+	}
+}
+
+/// Render a palette slot (from [`identity_slot`]/[`service_slot`]) into a
+/// [`Style`] for whichever palette the terminal supports right now.
+///
+/// The `pub(crate)` counterpart to [`identity_style`]/[`service_style`] for a
+/// caller that needs to resolve its *own* slot (e.g. the log-prefix module,
+/// which must never let its routing collapse into a raw per-label hash — see
+/// `engine::query::log_prefix::prefix_slot`) rather than one of the two
+/// label-keyed lookups here.
+pub(crate) fn style_for_slot(slot: usize) -> Style {
+	slot_to_style(slot, palette::wide_palette_available())
 }
 
 /// Whether an `Exited (N)` / `exited(N)` label reports a clean finish.

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -18,6 +18,7 @@ pub use anstyle::{AnsiColor, Style};
 pub use anstream::ColorChoice;
 
 mod palette;
+pub mod progress;
 mod table;
 pub use table::{fit_cell, sanitize_cell, Table};
 
@@ -171,10 +172,27 @@ pub fn progress_enabled() -> bool {
 /// …), tinted green on a colour sink. A no-op unless [`set_progress`] enabled
 /// progress output, so stdout consumers and machine output are never polluted.
 pub fn progress_line(kind: &str, name: &str, action: &str) {
-	use std::io::Write;
 	if !progress_enabled() {
 		return;
 	}
+	// A board, when one is open, owns the rendering: it needs the event as a
+	// state change rather than as a line, and it decides where on screen the
+	// row goes. Routing here rather than at each site is what let the board
+	// arrive without touching the 21 call sites that report an ending.
+	if progress::finish(kind, name, action) {
+		return;
+	}
+	write_progress_line(kind, name, action);
+}
+
+/// Write one progress line to stderr, with no board routing.
+///
+/// Split out of [`progress_line`] because the plain sink has to emit exactly
+/// this and cannot go back through the routing that sent it here — that would
+/// be a loop. It is also the reason the two sinks cannot drift: there is one
+/// line format, used by both.
+pub(crate) fn write_progress_line(kind: &str, name: &str, action: &str) {
+	use std::io::Write;
 	let verb = action_style(action);
 	let ident = identity_style(name);
 	// anstream::stderr strips the ANSI codes itself when colour is off.

--- a/internal/ui/mod_tests.rs
+++ b/internal/ui/mod_tests.rs
@@ -61,20 +61,6 @@ fn systemd_states_are_coloured() {
 }
 
 #[test]
-fn service_colour_is_stable_per_name() {
-	// Same name → same index every call; different names spread across the
-	// palette (not all collapsed to one colour).
-	assert_eq!(palette_index("web"), palette_index("web"));
-	let distinct: std::collections::HashSet<usize> =
-		["web", "db", "cache", "worker", "proxy", "queue"]
-			.iter()
-			.map(|n| palette_index(n))
-			.collect();
-	assert!(distinct.len() > 1, "palette should spread service names");
-	assert!(palette_index("web") < SERVICE_PALETTE.len());
-}
-
-#[test]
 fn paint_gates_on_enabled() {
 	let plain = paint(bold(), "hi", false);
 	assert_eq!(plain, "hi");
@@ -155,4 +141,44 @@ fn an_unprefixed_label_is_keyed_on_itself() {
 		identity_style("web").render().to_string(),
 		service_style("web").render().to_string()
 	);
+}
+
+/// `set_services` is what makes `service_style` disagree with the plain hash:
+/// once a project's names are registered, sequential assignment guarantees
+/// they spread across the palette, rather than each colliding independently
+/// under the hash the way `palette_index` used to.
+#[test]
+fn set_services_makes_registered_names_distinct() {
+	set_services(&[
+		"colourreg-alpha".to_string(),
+		"colourreg-beta".to_string(),
+		"colourreg-gamma".to_string(),
+	]);
+	let a = service_style("colourreg-alpha").render().to_string();
+	let b = service_style("colourreg-beta").render().to_string();
+	let g = service_style("colourreg-gamma").render().to_string();
+	assert_ne!(a, b, "registered names must not share a colour");
+	assert_ne!(b, g, "registered names must not share a colour");
+	assert_ne!(a, g, "registered names must not share a colour");
+}
+
+/// The guard `palette_index("web") < SERVICE_PALETTE.len()` used to provide
+/// before it was deleted: `service_style`'s narrow-terminal fallback receives
+/// whatever slot `palette::assign` produced (0 through `WIDE_PALETTE.len() -
+/// 1`, since `assign` itself wraps at the wide palette's size), and must wrap
+/// that again to index the six-entry `SERVICE_PALETTE` safely.
+///
+/// Calls `slot_to_style` itself — the real narrow-branch code, not a
+/// reimplementation of its modulo — for every slot the assignment can
+/// produce, on both the wide and narrow branches. Confirmed this fails: with
+/// the `% SERVICE_PALETTE.len()` removed from `slot_to_style`'s narrow arm,
+/// this test panics with an index-out-of-bounds on slot 6 (`index out of
+/// bounds: the len is 6 but the index is 6`), then passes again once the
+/// modulo is restored.
+#[test]
+fn every_wide_palette_slot_indexes_the_narrow_palette_safely() {
+	for slot in 0..palette::WIDE_PALETTE.len() {
+		let _ = slot_to_style(slot, false);
+		let _ = slot_to_style(slot, true);
+	}
 }

--- a/internal/ui/palette.rs
+++ b/internal/ui/palette.rs
@@ -1,0 +1,128 @@
+//! The identity palette: which colour a service is drawn in.
+//!
+//! Colour here is identity, never status. Red, green and yellow are reserved for
+//! state everywhere in podup, so no identity colour may sit near one.
+
+/// Identity colours, as xterm-256 indices.
+///
+/// Chosen so each clears 3:1 contrast against both white and black, sits at
+/// least deltaE 40 from the semantic red/green/yellow, and is at least deltaE 22
+/// from every other entry. `palette_tests.rs` recomputes all three from the sRGB
+/// values, so an edit that adds a pretty but unreadable colour fails the build
+/// rather than shipping.
+///
+/// Twenty is what survives those three filters, not a round number: of the 256
+/// colours only 80 clear 3:1 against both backgrounds at all, and 61 of those
+/// are far enough from the status colours. At the stricter 4.5:1 text bar only
+/// six qualify anywhere in the 256-colour space, which is why the wide palette
+/// targets the 3:1 interface bar instead.
+pub(crate) const WIDE_PALETTE: [u8; 20] = [
+	6, 13, 32, 33, 59, 61, 62, 65, 67, 93, 99, 128, 133, 138, 139, 163, 168, 170, 197, 198,
+];
+
+/// The palette entry at `index`, wrapping when a project has more services than
+/// the palette has colours. Repeating past the twentieth is better than running
+/// out of colour.
+pub(crate) fn wide_colour(index: usize) -> anstyle::Color {
+	anstyle::Ansi256Color(WIDE_PALETTE[index % WIDE_PALETTE.len()]).into()
+}
+
+/// Whether the terminal can render the wide palette, from the values that
+/// describe it.
+///
+/// Pure so all four tiers are tested without a terminal. First match wins:
+/// - `COLORTERM` announcing truecolor or 24bit
+/// - `TERM` carrying the conventional `256color` marker
+/// - on Windows, unconditionally: the console there takes 256 colours in every
+///   modern host, and Windows commonly sets neither variable, so without this
+///   tier every Windows user would fall back
+/// - anything else falls back to the six ANSI basics
+///
+/// Guessing wider paints escape codes into the output of a terminal that cannot
+/// decode them.
+pub(crate) fn supports_wide_palette(
+	colorterm: Option<&str>,
+	term: Option<&str>,
+	windows_vt: bool,
+) -> bool {
+	if matches!(colorterm, Some("truecolor" | "24bit")) {
+		return true;
+	}
+	if term.is_some_and(|t| t.contains("256color")) {
+		return true;
+	}
+	windows_vt
+}
+
+/// [`supports_wide_palette`] against this process's environment.
+///
+/// Read once and cached: the environment does not change under a running
+/// command, and every styled cell would otherwise pay two `var_os` calls.
+///
+/// The Windows argument is `cfg!(windows)` — the target, not a runtime probe of
+/// virtual-terminal processing. That is sufficient because this is only ever
+/// consulted after the colour gate has decided to emit colour at all, which
+/// already required a terminal and a permitting `--ansi`/`NO_COLOR`; and on a
+/// console that genuinely lacks VT, anstream's wincon path converts the escapes
+/// rather than printing them raw.
+///
+/// Cached for the process, so tests must exercise [`supports_wide_palette`]
+/// rather than this: two tests varying the environment around this function
+/// would see whichever answer was cached first and pass or fail on test
+/// scheduling.
+pub(crate) fn wide_palette_available() -> bool {
+	use std::sync::OnceLock;
+	static AVAILABLE: OnceLock<bool> = OnceLock::new();
+	*AVAILABLE.get_or_init(|| {
+		let colorterm = std::env::var("COLORTERM").ok();
+		let term = std::env::var("TERM").ok();
+		supports_wide_palette(colorterm.as_deref(), term.as_deref(), cfg!(windows))
+	})
+}
+
+use std::collections::HashMap;
+
+/// Give each name its own palette slot, walking them in sorted order.
+///
+/// Sequential rather than hashed: a hash does not know how many services exist,
+/// so it collides well before the palette is full — measured on a four-service
+/// project, two came out the same colour, and over twenty colours five services
+/// still collide about 42% of the time.
+///
+/// Sorting is what keeps it deterministic. Assigning in order of appearance
+/// would repaint everything when a service moved in the compose file; sorted,
+/// the same file always renders the same and adding a service only shifts those
+/// that sort after it. Nothing is written to disk.
+pub(crate) fn assign(names: &[String]) -> HashMap<String, usize> {
+	let mut sorted: Vec<&String> = names.iter().collect();
+	sorted.sort();
+	sorted.dedup();
+	sorted
+		.into_iter()
+		.enumerate()
+		.map(|(i, name)| (name.clone(), i % WIDE_PALETTE.len()))
+		.collect()
+}
+
+/// The palette slot for `label`, falling back to a hash for a label that was
+/// never registered.
+///
+/// The fallback matters for anything podup renders but did not resolve from the
+/// compose file — an orphan container, a project listed by `ls`. A stable wrong
+/// colour reads better than no colour at all, and the hash is what guarantees
+/// the same label always lands on the same slot.
+pub(crate) fn colour_for(label: &str, map: &HashMap<String, usize>) -> usize {
+	if let Some(&index) = map.get(label) {
+		return index;
+	}
+	let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+	for b in label.bytes() {
+		h ^= u64::from(b);
+		h = h.wrapping_mul(0x0100_0000_01b3);
+	}
+	(h % WIDE_PALETTE.len() as u64) as usize
+}
+
+#[cfg(test)]
+#[path = "palette_tests.rs"]
+mod tests;

--- a/internal/ui/palette_tests.rs
+++ b/internal/ui/palette_tests.rs
@@ -1,0 +1,276 @@
+use super::{assign, colour_for, supports_wide_palette, wide_colour, WIDE_PALETTE};
+
+/// The xterm-256 index to its sRGB triple. The first 16 are the ANSI basics,
+/// then a 6x6x6 cube, then a 24-step grey ramp.
+fn srgb(index: u8) -> (u8, u8, u8) {
+	const BASE: [(u8, u8, u8); 16] = [
+		(0, 0, 0),
+		(128, 0, 0),
+		(0, 128, 0),
+		(128, 128, 0),
+		(0, 0, 128),
+		(128, 0, 128),
+		(0, 128, 128),
+		(192, 192, 192),
+		(128, 128, 128),
+		(255, 0, 0),
+		(0, 255, 0),
+		(255, 255, 0),
+		(0, 0, 255),
+		(255, 0, 255),
+		(0, 255, 255),
+		(255, 255, 255),
+	];
+	const STEP: [u8; 6] = [0, 95, 135, 175, 215, 255];
+	match index {
+		0..=15 => BASE[index as usize],
+		16..=231 => {
+			let i = index - 16;
+			(
+				STEP[(i / 36) as usize],
+				STEP[((i / 6) % 6) as usize],
+				STEP[(i % 6) as usize],
+			)
+		}
+		_ => {
+			let v = 8 + (index - 232) * 10;
+			(v, v, v)
+		}
+	}
+}
+
+/// Relative luminance, WCAG 2.1.
+fn luminance((r, g, b): (u8, u8, u8)) -> f64 {
+	fn channel(c: u8) -> f64 {
+		let c = f64::from(c) / 255.0;
+		if c <= 0.03928 {
+			c / 12.92
+		} else {
+			((c + 0.055) / 1.055).powf(2.4)
+		}
+	}
+	0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+/// WCAG contrast ratio between two colours.
+fn contrast(a: (u8, u8, u8), b: (u8, u8, u8)) -> f64 {
+	let (la, lb) = (luminance(a), luminance(b));
+	let (hi, lo) = if la > lb { (la, lb) } else { (lb, la) };
+	(hi + 0.05) / (lo + 0.05)
+}
+
+/// CIE L*a*b*, D65, for perceptual distance.
+fn lab(c: (u8, u8, u8)) -> (f64, f64, f64) {
+	fn linear(c: u8) -> f64 {
+		let c = f64::from(c) / 255.0;
+		if c <= 0.03928 {
+			c / 12.92
+		} else {
+			((c + 0.055) / 1.055).powf(2.4)
+		}
+	}
+	let (r, g, b) = (linear(c.0), linear(c.1), linear(c.2));
+	let x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
+	let y = r * 0.2126 + g * 0.7152 + b * 0.0722;
+	let z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
+	fn f(t: f64) -> f64 {
+		if t > 0.008856 {
+			t.cbrt()
+		} else {
+			7.787 * t + 16.0 / 116.0
+		}
+	}
+	let (fx, fy, fz) = (f(x), f(y), f(z));
+	(116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz))
+}
+
+/// Euclidean distance in Lab (CIE76).
+fn delta_e(a: (u8, u8, u8), b: (u8, u8, u8)) -> f64 {
+	let (la, aa, ba) = lab(a);
+	let (lb, ab, bb) = lab(b);
+	((la - lb).powi(2) + (aa - ab).powi(2) + (ba - bb).powi(2)).sqrt()
+}
+
+const WHITE: (u8, u8, u8) = (255, 255, 255);
+const BLACK: (u8, u8, u8) = (0, 0, 0);
+
+/// Every identity colour must be readable on a light terminal and a dark one.
+///
+/// 3:1 is the WCAG AA bar for interface components. The stricter 4.5:1 text bar
+/// is unreachable here: only six of the 256 colours clear it against both
+/// backgrounds, which is why this wide palette targets the 3:1 bar instead.
+#[test]
+fn every_palette_colour_reads_on_both_backgrounds() {
+	for &index in &WIDE_PALETTE {
+		let c = srgb(index);
+		let on_white = contrast(c, WHITE);
+		let on_black = contrast(c, BLACK);
+		assert!(
+			on_white >= 3.0,
+			"colour {index} scores {on_white:.2} against white, below the 3:1 bar"
+		);
+		assert!(
+			on_black >= 3.0,
+			"colour {index} scores {on_black:.2} against black, below the 3:1 bar"
+		);
+	}
+}
+
+/// Two services must never be given colours a reader cannot tell apart.
+#[test]
+fn palette_colours_are_distinguishable_from_each_other() {
+	for (i, &a) in WIDE_PALETTE.iter().enumerate() {
+		for &b in &WIDE_PALETTE[i + 1..] {
+			let d = delta_e(srgb(a), srgb(b));
+			assert!(
+				d >= 22.0,
+				"colours {a} and {b} are only deltaE {d:.1} apart; a reader sees one colour"
+			);
+		}
+	}
+}
+
+/// Red, green and yellow carry status meaning everywhere in podup. An identity
+/// colour close to one of them would read as a state.
+#[test]
+fn palette_avoids_the_semantic_colours() {
+	const SEMANTIC: [(u8, u8, u8); 6] = [
+		(255, 0, 0),
+		(128, 0, 0),
+		(0, 255, 0),
+		(0, 128, 0),
+		(255, 255, 0),
+		(128, 128, 0),
+	];
+	for &index in &WIDE_PALETTE {
+		for sem in SEMANTIC {
+			let d = delta_e(srgb(index), sem);
+			assert!(
+				d > 40.0,
+				"colour {index} is deltaE {d:.1} from a status colour; it would read as a state"
+			);
+		}
+	}
+}
+
+/// `wide_colour` wraps rather than panicking past the palette size, and returns
+/// the palette entry rather than the raw index.
+#[test]
+fn wide_colour_wraps_at_the_palette_size() {
+	assert_eq!(wide_colour(0), wide_colour(WIDE_PALETTE.len()));
+	assert_eq!(
+		wide_colour(3),
+		anstyle::Ansi256Color(WIDE_PALETTE[3]).into(),
+		"the returned colour must be the palette entry, not the index"
+	);
+}
+
+/// A terminal announcing truecolor can certainly render 256 colours.
+#[test]
+fn colorterm_truecolor_gets_the_wide_palette() {
+	assert!(supports_wide_palette(Some("truecolor"), None, false));
+	assert!(supports_wide_palette(Some("24bit"), None, false));
+}
+
+/// The conventional TERM marker.
+#[test]
+fn term_256color_gets_the_wide_palette() {
+	assert!(supports_wide_palette(None, Some("xterm-256color"), false));
+	assert!(supports_wide_palette(None, Some("screen-256color"), false));
+}
+
+/// Windows commonly sets neither variable while rendering 256 colours fine.
+/// Without this tier every Windows user would fall back to six.
+#[test]
+fn windows_with_vt_enabled_gets_the_wide_palette() {
+	assert!(supports_wide_palette(None, None, true));
+}
+
+/// A terminal that announces nothing gets the six ANSI basics, which render
+/// everywhere. Guessing wider would paint escape codes into its output.
+#[test]
+fn an_unannounced_terminal_falls_back() {
+	assert!(!supports_wide_palette(None, None, false));
+	assert!(!supports_wide_palette(None, Some("vt100"), false));
+	assert!(!supports_wide_palette(Some(""), Some("dumb"), false));
+}
+
+/// Every service in a project gets its own colour. This is the whole point:
+/// the hash it replaces collided on a four-service project.
+#[test]
+fn services_up_to_the_palette_size_never_share_a_colour() {
+	let names: Vec<String> = (0..20).map(|i| format!("svc{i:02}")).collect();
+	let map = assign(&names);
+	let mut seen = std::collections::HashSet::new();
+	for name in &names {
+		let idx = map.get(name).copied().expect("every service is assigned");
+		assert!(seen.insert(idx), "{name} reuses a colour already given out");
+	}
+	assert_eq!(seen.len(), 20);
+}
+
+/// Past the palette size the assignment wraps rather than failing. Repeating a
+/// colour at the twenty-first service is better than running out.
+#[test]
+fn assignment_wraps_past_the_palette_size() {
+	let names: Vec<String> = (0..25).map(|i| format!("svc{i:02}")).collect();
+	let map = assign(&names);
+	assert_eq!(
+		map.len(),
+		25,
+		"every service is assigned even past the palette"
+	);
+	assert_eq!(
+		map["svc00"], map["svc20"],
+		"the twenty-first wraps onto the first"
+	);
+}
+
+/// Sorting is what makes this deterministic: the order services appear in the
+/// compose file must not change what colour they get.
+#[test]
+fn assignment_ignores_the_order_names_arrive_in() {
+	let forward: Vec<String> = ["web", "api", "db"].iter().map(|s| s.to_string()).collect();
+	let backward: Vec<String> = ["db", "api", "web"].iter().map(|s| s.to_string()).collect();
+	assert_eq!(assign(&forward), assign(&backward));
+}
+
+/// A label podup never resolved from the compose file — an orphan container,
+/// say — still gets a stable colour rather than none.
+#[test]
+fn an_unregistered_service_still_gets_a_stable_colour() {
+	let map = assign(&["web".to_string()]);
+	let a = colour_for("stranger", &map);
+	let b = colour_for("stranger", &map);
+	assert_eq!(
+		a, b,
+		"the same unknown label must always give the same colour"
+	);
+}
+
+/// `colour_for` must answer from the registry, not the hash, once a label is
+/// registered — otherwise `set_services` would be a no-op and every label
+/// would still collide exactly as before this task. `"db"` is chosen because
+/// its registered slot (1, from sorting alongside `web`/`cache`/`worker`/
+/// `queue`) provably differs from its own unregistered hash (11 against a
+/// 20-entry palette), so this cannot pass by the two coincidentally agreeing.
+#[test]
+fn colour_for_prefers_the_registered_slot_over_the_hash() {
+	let map = assign(&[
+		"web".to_string(),
+		"db".to_string(),
+		"cache".to_string(),
+		"worker".to_string(),
+		"queue".to_string(),
+	]);
+	let registered = colour_for("db", &map);
+	let unregistered = colour_for("db", &std::collections::HashMap::new());
+	assert_eq!(
+		registered, map["db"],
+		"a registered label must return its own slot"
+	);
+	assert_ne!(
+		registered, unregistered,
+		"registration must change the answer, not just agree with the hash"
+	);
+}

--- a/internal/ui/progress/board.rs
+++ b/internal/ui/progress/board.rs
@@ -1,0 +1,210 @@
+//! The resource set a lifecycle command is working through, and where each one
+//! has got to.
+//!
+//! Pure: no terminal, no clock reading of its own, no I/O. A renderer asks it
+//! what to draw and it answers; that is what makes the state machine testable
+//! without a tty, which matters because the two things most likely to be wrong
+//! here — a row that never leaves `Working`, and a count that disagrees with the
+//! rows — are invisible in a screenshot.
+
+use std::time::{Duration, Instant};
+
+/// What kind of thing a row is about. The noun printed in the first column, and
+/// the same vocabulary `progress_line` has always used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Kind {
+	Network,
+	Volume,
+	Secret,
+	Image,
+	Container,
+}
+
+impl Kind {
+	/// The displayed noun.
+	pub fn noun(self) -> &'static str {
+		match self {
+			Kind::Network => "Network",
+			Kind::Volume => "Volume",
+			Kind::Secret => "Secret",
+			Kind::Image => "Image",
+			Kind::Container => "Container",
+		}
+	}
+
+	/// Parse the noun back, so `progress_line`'s existing `&str` callers can feed
+	/// the board without all 21 of them changing shape.
+	pub fn from_noun(noun: &str) -> Option<Self> {
+		match noun {
+			"Network" => Some(Kind::Network),
+			"Volume" => Some(Kind::Volume),
+			"Secret" => Some(Kind::Secret),
+			"Image" => Some(Kind::Image),
+			"Container" => Some(Kind::Container),
+			_ => None,
+		}
+	}
+}
+
+/// Where a resource has got to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum State {
+	/// Seeded, nothing has happened to it yet.
+	Pending,
+	/// Work is under way; the verb is the present participle (`Creating`).
+	Working(String),
+	/// Work finished; the verb is the past tense (`Created`).
+	Done(String),
+}
+
+/// One resource's row.
+#[derive(Debug, Clone)]
+pub struct Row {
+	pub kind: Kind,
+	pub name: String,
+	pub state: State,
+	/// When this row last entered `Working`, for the elapsed column. `None`
+	/// while `Pending`, since nothing has taken any time yet.
+	pub started: Option<Instant>,
+	/// How long the row spent working, frozen when it reached `Done` so a
+	/// finished row stops counting up.
+	pub elapsed: Option<Duration>,
+}
+
+impl Row {
+	/// How long to show against this row, or `None` when there is nothing to
+	/// show yet.
+	pub fn duration(&self, now: Instant) -> Option<Duration> {
+		match (&self.state, self.elapsed, self.started) {
+			(State::Done(_), Some(d), _) => Some(d),
+			(State::Working(_), _, Some(start)) => Some(now.saturating_duration_since(start)),
+			_ => None,
+		}
+	}
+}
+
+/// Every resource one command is working through, in the order it was seeded.
+///
+/// Seeded up front rather than grown as events arrive: a board whose rows appear
+/// one at a time is a transcript with extra steps, and the whole point is to
+/// show what is still to come.
+#[derive(Debug, Default)]
+pub struct Board {
+	rows: Vec<Row>,
+	/// Rows already handed to the renderer as permanent history, so they are
+	/// drawn once and never repainted. Counted from the front: rows leave the
+	/// live region in order.
+	flushed: usize,
+}
+
+impl Board {
+	/// A board seeded with `resources` in the order they will be worked through.
+	pub fn new(resources: impl IntoIterator<Item = (Kind, String)>) -> Self {
+		Self {
+			rows: resources
+				.into_iter()
+				.map(|(kind, name)| Row {
+					kind,
+					name,
+					state: State::Pending,
+					started: None,
+					elapsed: None,
+				})
+				.collect(),
+			flushed: 0,
+		}
+	}
+
+	/// Mark a resource as being worked on. Unknown resources are appended rather
+	/// than dropped: the seed is the best guess available before the work starts,
+	/// and a compose file can grow a container the seed did not predict (an
+	/// implicit `_default` network, a `--scale` override). Losing the row would
+	/// be worse than a board that grows by one.
+	pub fn start(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
+		let idx = self.index_of(kind, name).unwrap_or_else(|| {
+			self.rows.push(Row {
+				kind,
+				name: name.to_string(),
+				state: State::Pending,
+				started: None,
+				elapsed: None,
+			});
+			self.rows.len() - 1
+		});
+		let row = &mut self.rows[idx];
+		row.state = State::Working(verb.to_string());
+		row.started.get_or_insert(now);
+	}
+
+	/// Mark a resource as finished. Also tolerates a resource that was never
+	/// seeded or started — most of the 21 existing call sites report only an
+	/// ending, so this has to work without a matching `start`.
+	pub fn finish(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
+		let idx = self.index_of(kind, name).unwrap_or_else(|| {
+			self.rows.push(Row {
+				kind,
+				name: name.to_string(),
+				state: State::Pending,
+				started: None,
+				elapsed: None,
+			});
+			self.rows.len() - 1
+		});
+		let row = &mut self.rows[idx];
+		row.elapsed = row.started.map(|s| now.saturating_duration_since(s));
+		row.state = State::Done(verb.to_string());
+	}
+
+	/// Rows that are finished *and* sit at the front of the un-flushed range, so
+	/// they can be printed once as permanent history and dropped from the region
+	/// that gets repainted.
+	///
+	/// Only a contiguous run from the front is eligible. A finished row with an
+	/// unfinished one before it has to stay in the live region, or the permanent
+	/// history would print out of order — which is exactly the record `up` exists
+	/// to leave behind.
+	pub fn take_completed_prefix(&mut self) -> Vec<Row> {
+		let mut out = Vec::new();
+		while let Some(row) = self.rows.get(self.flushed) {
+			if !matches!(row.state, State::Done(_)) {
+				break;
+			}
+			out.push(row.clone());
+			self.flushed += 1;
+		}
+		out
+	}
+
+	/// The rows still in the live region: everything not yet flushed.
+	pub fn live_rows(&self) -> &[Row] {
+		&self.rows[self.flushed.min(self.rows.len())..]
+	}
+
+	/// How many resources have finished, and how many there are in total — the
+	/// `3/6` in the summary line.
+	pub fn tally(&self) -> (usize, usize) {
+		(
+			self.rows
+				.iter()
+				.filter(|r| matches!(r.state, State::Done(_)))
+				.count(),
+			self.rows.len(),
+		)
+	}
+
+	/// Whether every seeded resource has finished.
+	pub fn is_complete(&self) -> bool {
+		let (done, total) = self.tally();
+		done == total
+	}
+
+	fn index_of(&self, kind: Kind, name: &str) -> Option<usize> {
+		self.rows
+			.iter()
+			.position(|r| r.kind == kind && r.name == name)
+	}
+}
+
+#[cfg(test)]
+#[path = "board_tests.rs"]
+mod tests;

--- a/internal/ui/progress/board_tests.rs
+++ b/internal/ui/progress/board_tests.rs
@@ -1,0 +1,199 @@
+use super::*;
+
+fn t0() -> Instant {
+	Instant::now()
+}
+
+fn seeded() -> Board {
+	Board::new([
+		(Kind::Network, "proj_default".to_string()),
+		(Kind::Container, "proj-web-1".to_string()),
+		(Kind::Container, "proj-db-1".to_string()),
+	])
+}
+
+/// The whole point of seeding is that the board shows what is still to come, so
+/// a fresh board already knows its total.
+#[test]
+fn a_seeded_board_knows_its_total_before_anything_happens() {
+	assert_eq!(seeded().tally(), (0, 3));
+}
+
+/// The counter tracks finished rows, not started ones. A row being worked on is
+/// not progress the user can rely on.
+#[test]
+fn only_finished_rows_count_towards_the_tally() {
+	let mut b = seeded();
+	let now = t0();
+	b.start(Kind::Container, "proj-web-1", "Creating", now);
+	assert_eq!(b.tally(), (0, 3));
+	b.finish(Kind::Container, "proj-web-1", "Created", now);
+	assert_eq!(b.tally(), (1, 3));
+}
+
+/// Most of the existing call sites report only an ending. The board has to
+/// accept that rather than requiring a matching start it will never get.
+#[test]
+fn a_finish_without_a_start_still_lands() {
+	let mut b = seeded();
+	b.finish(Kind::Network, "proj_default", "Created", t0());
+	assert_eq!(b.tally(), (1, 3));
+}
+
+/// A resource the seed did not predict — an implicit network, a `--scale`
+/// override — is appended rather than dropped. Losing the row is worse than a
+/// board that grows by one.
+#[test]
+fn an_unseeded_resource_is_appended_not_dropped() {
+	let mut b = seeded();
+	b.finish(Kind::Volume, "proj_data", "Created", t0());
+	assert_eq!(b.tally(), (1, 4));
+}
+
+/// Kind and name together identify a row: a network and a container may share a
+/// name without sharing a row.
+#[test]
+fn a_row_is_identified_by_kind_and_name_together() {
+	let mut b = Board::new([
+		(Kind::Network, "same".to_string()),
+		(Kind::Container, "same".to_string()),
+	]);
+	b.finish(Kind::Network, "same", "Created", t0());
+	assert_eq!(b.tally(), (1, 2));
+}
+
+/// Completed rows leave the live region in order, so the permanent history
+/// reads in the order the work happened.
+#[test]
+fn completed_rows_flush_from_the_front_in_order() {
+	let mut b = seeded();
+	let now = t0();
+	b.finish(Kind::Network, "proj_default", "Created", now);
+	let flushed = b.take_completed_prefix();
+	assert_eq!(flushed.len(), 1);
+	assert_eq!(flushed[0].name, "proj_default");
+	assert_eq!(b.live_rows().len(), 2);
+}
+
+/// A finished row behind an unfinished one stays put. Flushing it would print
+/// the permanent history out of order, and that record is what `up` leaves
+/// behind.
+#[test]
+fn a_finished_row_behind_an_unfinished_one_does_not_flush() {
+	let mut b = seeded();
+	let now = t0();
+	b.finish(Kind::Container, "proj-db-1", "Created", now);
+	assert!(b.take_completed_prefix().is_empty());
+	assert_eq!(b.live_rows().len(), 3);
+
+	// Once the rows ahead of it finish, the whole run leaves together.
+	b.finish(Kind::Network, "proj_default", "Created", now);
+	b.finish(Kind::Container, "proj-web-1", "Created", now);
+	let flushed = b.take_completed_prefix();
+	assert_eq!(flushed.len(), 3);
+	assert!(b.live_rows().is_empty());
+}
+
+/// A row is never flushed twice, however often the renderer asks.
+#[test]
+fn flushing_is_not_repeatable() {
+	let mut b = seeded();
+	b.finish(Kind::Network, "proj_default", "Created", t0());
+	assert_eq!(b.take_completed_prefix().len(), 1);
+	assert!(b.take_completed_prefix().is_empty());
+}
+
+/// A finished row stops counting up. Without freezing the elapsed time, a
+/// completed row would keep ticking for as long as the command runs.
+#[test]
+fn a_finished_row_freezes_its_elapsed_time() {
+	let mut b = seeded();
+	let start = t0();
+	b.start(Kind::Container, "proj-web-1", "Creating", start);
+	let end = start + Duration::from_millis(250);
+	b.finish(Kind::Container, "proj-web-1", "Created", end);
+	let row = b
+		.live_rows()
+		.iter()
+		.find(|r| r.name == "proj-web-1")
+		.unwrap()
+		.clone();
+	let much_later = start + Duration::from_secs(30);
+	assert_eq!(row.duration(much_later), Some(Duration::from_millis(250)));
+}
+
+/// A working row counts up from when it started, not from when the board did.
+#[test]
+fn a_working_row_counts_from_its_own_start() {
+	let mut b = seeded();
+	let t = t0();
+	b.start(
+		Kind::Container,
+		"proj-web-1",
+		"Creating",
+		t + Duration::from_secs(2),
+	);
+	let row = b.live_rows()[1].clone();
+	assert_eq!(
+		row.duration(t + Duration::from_secs(5)),
+		Some(Duration::from_secs(3))
+	);
+}
+
+/// A pending row shows no time, because nothing has taken any.
+#[test]
+fn a_pending_row_has_no_duration() {
+	let b = seeded();
+	assert_eq!(b.live_rows()[0].duration(t0()), None);
+}
+
+/// Re-starting a row that is already working keeps its original start, so a
+/// retry does not reset the clock and hide how long it really took.
+#[test]
+fn restarting_a_working_row_keeps_the_original_start() {
+	let mut b = seeded();
+	let t = t0();
+	b.start(Kind::Container, "proj-web-1", "Creating", t);
+	b.start(
+		Kind::Container,
+		"proj-web-1",
+		"Starting",
+		t + Duration::from_secs(4),
+	);
+	let row = b.live_rows()[1].clone();
+	assert_eq!(
+		row.duration(t + Duration::from_secs(6)),
+		Some(Duration::from_secs(6))
+	);
+}
+
+#[test]
+fn completion_is_every_row_finished() {
+	let mut b = seeded();
+	let now = t0();
+	assert!(!b.is_complete());
+	for (kind, name) in [
+		(Kind::Network, "proj_default"),
+		(Kind::Container, "proj-web-1"),
+		(Kind::Container, "proj-db-1"),
+	] {
+		b.finish(kind, name, "Created", now);
+	}
+	assert!(b.is_complete());
+}
+
+/// The noun round-trips, because `progress_line`'s callers pass a `&str` and the
+/// board has to map it back without those 21 sites changing shape.
+#[test]
+fn every_kind_round_trips_through_its_noun() {
+	for kind in [
+		Kind::Network,
+		Kind::Volume,
+		Kind::Secret,
+		Kind::Image,
+		Kind::Container,
+	] {
+		assert_eq!(Kind::from_noun(kind.noun()), Some(kind));
+	}
+	assert_eq!(Kind::from_noun("Sandwich"), None);
+}

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -1,0 +1,135 @@
+//! The tail-region renderer.
+//!
+//! Completed rows are printed once, as ordinary scrollback, and never touched
+//! again. Only the rows still in flight live in the region below them, and only
+//! that region is erased and repainted. A tail region rather than an alternate
+//! screen, decided by the owner for every command including `stats`: `up` is a
+//! command that *finishes*, and taking the screen and handing it back blank
+//! destroys the record of what happened.
+//!
+//! Four escape sequences, no dependency.
+
+use std::io::Write;
+use std::time::Instant;
+
+use super::{row, Board};
+
+/// Hide the cursor. Without it the caret sits at the end of whichever row was
+/// painted last and jumps around on every repaint.
+const HIDE_CURSOR: &str = "\x1b[?25l";
+
+/// Restore the cursor. Emitted on drop, including the drop that runs while the
+/// process is unwinding, so a panic mid-`up` cannot leave the terminal without
+/// a caret.
+const SHOW_CURSOR: &str = "\x1b[?25h";
+
+/// Erase from the cursor to the end of the screen.
+const CLEAR_BELOW: &str = "\x1b[J";
+
+/// Move the cursor up `n` rows.
+fn cursor_up(n: usize) -> String {
+	format!("\x1b[{n}A")
+}
+
+/// A tail region being repainted on a real terminal.
+///
+/// Owns the count of rows it last painted, which is the only state the repaint
+/// arithmetic needs — and the reason every line is truncated to the terminal
+/// width first. A line that wraps makes the terminal count two rows where this
+/// counted one, and from then on every repaint erases the wrong lines.
+pub struct LiveRegion {
+	/// Rows painted by the previous repaint, to be walked back over.
+	painted: usize,
+	/// Terminal width at the last repaint.
+	width: usize,
+	/// Width of the name column, sized from the seeded rows so it does not jump
+	/// as rows come and go.
+	name_width: usize,
+}
+
+impl LiveRegion {
+	/// Start a region, hiding the cursor.
+	pub fn new(name_width: usize, width: usize) -> Self {
+		let mut err = std::io::stderr();
+		let _ = err.write_all(HIDE_CURSOR.as_bytes());
+		let _ = err.flush();
+		Self {
+			painted: 0,
+			width,
+			name_width,
+		}
+	}
+
+	/// Re-read the terminal width. Called on each repaint so a resize mid-`up`
+	/// does not leave every later line wrapping.
+	pub fn refresh_width(&mut self, width: usize) {
+		self.width = width;
+	}
+
+	/// Walk back over the previous region, print whatever has finished as
+	/// permanent scrollback, then paint the rows still in flight.
+	pub fn repaint(&mut self, board: &mut Board, frame: usize, now: Instant) {
+		let mut out = String::new();
+		if self.painted > 0 {
+			out.push_str(&cursor_up(self.painted));
+		}
+		out.push_str(CLEAR_BELOW);
+
+		// Finished rows leave the region and become scrollback. `take_completed_prefix`
+		// only releases a contiguous run from the front, so this record stays in
+		// the order the work happened.
+		for done in board.take_completed_prefix() {
+			out.push_str(&row::render(&done, self.name_width, frame, now, self.width));
+			out.push('\n');
+		}
+
+		let (done, total) = board.tally();
+		let mut painted = 0;
+		let live = board.live_rows();
+		if !live.is_empty() {
+			out.push_str(&row::summary(done, total));
+			out.push('\n');
+			painted += 1;
+			for r in live {
+				out.push_str(&row::render(r, self.name_width, frame, now, self.width));
+				out.push('\n');
+				painted += 1;
+			}
+		}
+		self.painted = painted;
+
+		let mut err = std::io::stderr();
+		let _ = err.write_all(out.as_bytes());
+		let _ = err.flush();
+	}
+
+	/// Final repaint with the region emptied, so the last thing on screen is the
+	/// permanent record rather than a half-drawn board.
+	pub fn finish(&mut self, board: &mut Board, now: Instant) {
+		self.repaint(board, 0, now);
+	}
+}
+
+impl Drop for LiveRegion {
+	fn drop(&mut self) {
+		let mut err = std::io::stderr();
+		let _ = err.write_all(SHOW_CURSOR.as_bytes());
+		let _ = err.flush();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The four sequences are what the repaint arithmetic is built on, so they
+	/// are pinned rather than left to a typo. `\x1b[3A` moves up three; `\x1b[J`
+	/// erases from the cursor down.
+	#[test]
+	fn the_cursor_moves_are_what_they_claim() {
+		assert_eq!(cursor_up(3), "\u{1b}[3A");
+		assert_eq!(CLEAR_BELOW, "\u{1b}[J");
+		assert_eq!(HIDE_CURSOR, "\u{1b}[?25l");
+		assert_eq!(SHOW_CURSOR, "\u{1b}[?25h");
+	}
+}

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -74,6 +74,7 @@ impl Region {
 	/// Start a region on `target`, hiding the cursor.
 	pub fn new(target: Target) -> Self {
 		target.write(HIDE_CURSOR);
+		restore_cursor_on_interrupt(target);
 		Self { painted: 0, target }
 	}
 
@@ -108,9 +109,87 @@ impl Drop for Region {
 	}
 }
 
+/// Give the cursor back if the command is interrupted rather than returning.
+///
+/// `Drop` covers a command that ends on its own, and nothing else: Rust's
+/// default SIGINT handling terminates the process without unwinding, so
+/// Ctrl-C out of a region left the caret hidden until the user ran `reset`.
+/// Measured on a 100x30 pty before the fix — one `\e[?25l`, zero `\e[?25h`.
+///
+/// `stats` is where it bit hardest, because Ctrl-C is the *normal* way to leave
+/// it rather than an error path, but a long `up` interrupted part-way had the
+/// same hole.
+///
+/// Exits 130 (128 + SIGINT), the shell convention this binary already documents
+/// for an interrupted command. Installed per region rather than globally, so it
+/// cannot disturb the commands that handle their own interrupt — attached `up`,
+/// `exec`, `watch` — none of which open one.
+fn restore_cursor_on_interrupt(target: Target) {
+	if !claim_install() {
+		return;
+	}
+	// A tokio signal task, not a raw handler: the same shape `attach` and
+	// `watch` already use, and it runs ordinary code rather than being bound by
+	// async-signal-safety.
+	tokio::spawn(async move {
+		wait_for_interrupt().await;
+		target.write(SHOW_CURSOR);
+		std::process::exit(130);
+	});
+}
+
+/// Take the right to install the interrupt handler, once per process.
+///
+/// Two regions in one invocation — a `stats` after an `up` inside an embedding
+/// crate — must not stack handlers, since each would race to call
+/// `process::exit`. Split out of the installer so the latch is testable without
+/// spawning anything.
+fn claim_install() -> bool {
+	static INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+	!INSTALLED.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Resolve when the process is asked to stop.
+#[cfg(unix)]
+async fn wait_for_interrupt() {
+	use tokio::signal::unix::{signal, SignalKind};
+	let mut term = match signal(SignalKind::terminate()) {
+		Ok(s) => s,
+		// Without a SIGTERM handler, Ctrl-C alone is still worth catching.
+		Err(_) => {
+			let _ = tokio::signal::ctrl_c().await;
+			return;
+		}
+	};
+	tokio::select! {
+		_ = tokio::signal::ctrl_c() => {}
+		_ = term.recv() => {}
+	}
+}
+
+/// Windows has no SIGTERM; Ctrl-C is the interrupt that matters.
+#[cfg(not(unix))]
+async fn wait_for_interrupt() {
+	let _ = tokio::signal::ctrl_c().await;
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// The interrupt handler is claimed once per process, however many regions a
+	/// run opens. Two in one invocation — a `stats` after an `up` inside an
+	/// embedding crate — must not stack handlers, since each would race to call
+	/// `process::exit`.
+	///
+	/// The only test in the crate that may call this: the latch is
+	/// process-global, so a second caller would see whatever this one left.
+	#[test]
+	fn the_interrupt_handler_is_claimed_once() {
+		assert!(claim_install(), "the first caller installs");
+		assert!(!claim_install(), "the second must not");
+		assert!(!claim_install());
+	}
 
 	/// The four sequences are what the repaint arithmetic is built on, so they
 	/// are pinned rather than left to a typo. `\x1b[3A` moves up three; `\x1b[J`

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -10,9 +10,6 @@
 //! Four escape sequences, no dependency.
 
 use std::io::Write;
-use std::time::Instant;
-
-use super::{row, Board};
 
 /// Hide the cursor. Without it the caret sits at the end of whichever row was
 /// painted last and jumps around on every repaint.
@@ -34,87 +31,80 @@ fn cursor_up(n: usize) -> String {
 /// A tail region being repainted on a real terminal.
 ///
 /// Owns the count of rows it last painted, which is the only state the repaint
-/// arithmetic needs — and the reason every line is truncated to the terminal
-/// width first. A line that wraps makes the terminal count two rows where this
-/// counted one, and from then on every repaint erases the wrong lines.
-pub struct LiveRegion {
-	/// Rows painted by the previous repaint, to be walked back over.
-	painted: usize,
-	/// Terminal width at the last repaint.
-	width: usize,
-	/// Width of the name column, sized from the seeded rows so it does not jump
-	/// as rows come and go.
-	name_width: usize,
+/// arithmetic needs — and the reason every line handed to it must already be
+/// truncated to the terminal width. A line that wraps makes the terminal count
+/// two rows where this counted one, and from then on every repaint erases the
+/// wrong lines.
+///
+/// Deliberately knows nothing about what it is drawing. It takes two blocks of
+/// finished text: lines that become permanent scrollback, and lines that are
+/// erased on the next call. That is what lets the board and `stats` share it —
+/// they disagree about everything except needing a block of text repainted in
+/// place.
+/// Which stream a region draws on.
+///
+/// Not always stderr. The lifecycle board goes there so stdout stays a clean
+/// pipe, but `stats` *is* its output — its table is the thing a user redirects —
+/// so its region belongs on stdout. Getting this wrong would put cursor moves in
+/// one stream and the content in the other.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+	Stdout,
+	Stderr,
 }
 
-impl LiveRegion {
-	/// Start a region, hiding the cursor.
-	pub fn new(name_width: usize, width: usize) -> Self {
-		let mut err = std::io::stderr();
-		let _ = err.write_all(HIDE_CURSOR.as_bytes());
-		let _ = err.flush();
-		Self {
-			painted: 0,
-			width,
-			name_width,
-		}
+impl Target {
+	fn write(self, text: &str) {
+		let mut out: Box<dyn Write> = match self {
+			Target::Stdout => Box::new(std::io::stdout()),
+			Target::Stderr => Box::new(std::io::stderr()),
+		};
+		let _ = out.write_all(text.as_bytes());
+		let _ = out.flush();
+	}
+}
+
+pub struct Region {
+	/// Rows painted by the previous repaint, to be walked back over.
+	painted: usize,
+	target: Target,
+}
+
+impl Region {
+	/// Start a region on `target`, hiding the cursor.
+	pub fn new(target: Target) -> Self {
+		target.write(HIDE_CURSOR);
+		Self { painted: 0, target }
 	}
 
-	/// Re-read the terminal width. Called on each repaint so a resize mid-`up`
-	/// does not leave every later line wrapping.
-	pub fn refresh_width(&mut self, width: usize) {
-		self.width = width;
-	}
-
-	/// Walk back over the previous region, print whatever has finished as
-	/// permanent scrollback, then paint the rows still in flight.
-	pub fn repaint(&mut self, board: &mut Board, frame: usize, now: Instant) {
+	/// Walk back over the previous region, emit `scrollback` as permanent
+	/// history, then paint `live` as the new region.
+	///
+	/// Both are already-rendered lines: fitting them to the terminal width is
+	/// the caller's job, because the caller is the one that knows which cell may
+	/// be truncated without losing the point of the row.
+	pub fn show(&mut self, scrollback: &[String], live: &[String]) {
 		let mut out = String::new();
 		if self.painted > 0 {
 			out.push_str(&cursor_up(self.painted));
 		}
 		out.push_str(CLEAR_BELOW);
-
-		// Finished rows leave the region and become scrollback. `take_completed_prefix`
-		// only releases a contiguous run from the front, so this record stays in
-		// the order the work happened.
-		for done in board.take_completed_prefix() {
-			out.push_str(&row::render(&done, self.name_width, frame, now, self.width));
+		for line in scrollback {
+			out.push_str(line);
 			out.push('\n');
 		}
-
-		let (done, total) = board.tally();
-		let mut painted = 0;
-		let live = board.live_rows();
-		if !live.is_empty() {
-			out.push_str(&row::summary(done, total));
+		for line in live {
+			out.push_str(line);
 			out.push('\n');
-			painted += 1;
-			for r in live {
-				out.push_str(&row::render(r, self.name_width, frame, now, self.width));
-				out.push('\n');
-				painted += 1;
-			}
 		}
-		self.painted = painted;
-
-		let mut err = std::io::stderr();
-		let _ = err.write_all(out.as_bytes());
-		let _ = err.flush();
-	}
-
-	/// Final repaint with the region emptied, so the last thing on screen is the
-	/// permanent record rather than a half-drawn board.
-	pub fn finish(&mut self, board: &mut Board, now: Instant) {
-		self.repaint(board, 0, now);
+		self.painted = live.len();
+		self.target.write(&out);
 	}
 }
 
-impl Drop for LiveRegion {
+impl Drop for Region {
 	fn drop(&mut self) {
-		let mut err = std::io::stderr();
-		let _ = err.write_all(SHOW_CURSOR.as_bytes());
-		let _ = err.flush();
+		self.target.write(SHOW_CURSOR);
 	}
 }
 

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -1,0 +1,267 @@
+//! The live board: what a lifecycle command is working through, and where it
+//! has got to.
+//!
+//! One model, two renderers. Which one runs is decided from the terminal and the
+//! colour choice, never from the command: `up` on a tty repaints a tail region,
+//! `up` in a pipe emits the same events as plain append-only lines. **Animation
+//! in a CI log is a defect**, and so is a CI log that says less than the
+//! terminal did — both renderers see every event, including the intermediate
+//! transitions the old output dropped entirely.
+//!
+//! Everything goes to stderr. stdout stays a clean pipe, which is what lets
+//! `run -d` keep printing its container id there.
+
+use std::sync::Mutex;
+use std::time::Instant;
+
+mod board;
+mod live;
+mod row;
+
+pub use board::{Board, Kind, Row, State};
+
+/// How often the region repaints while nothing is happening, so the spinner
+/// turns during a long pull instead of looking like a hang. The same cadence
+/// `terminal::windows`'s resize poll already uses.
+const TICK: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// The board for the command currently running, if one asked for it.
+///
+/// Process-global for the same reason the colour choice is: one CLI invocation
+/// runs one lifecycle command, and threading a handle through every engine call
+/// site would change 21 signatures to say something none of them decides. A
+/// library embedder never gets one — [`begin`] is a no-op unless the CLI turned
+/// progress on.
+static SESSION: Mutex<Option<Session>> = Mutex::new(None);
+
+/// The repaint ticker, kept so it can be stopped when the board ends.
+static TICKER: Mutex<Option<tokio::task::JoinHandle<()>>> = Mutex::new(None);
+
+struct Session {
+	board: Board,
+	/// `None` when the sink is plain: not a terminal, colour off, or the
+	/// terminal size could not be read.
+	region: Option<live::LiveRegion>,
+	frame: usize,
+}
+
+/// Whether a live region is allowed right now.
+///
+/// Three conditions, all required. stderr must be a terminal — `--ansi always |
+/// tee` is a log, not a terminal, and repainting into it writes cursor moves
+/// into a file. The colour choice must not be `Never`, because someone who asked
+/// for no escapes means it. And the width must be readable, since every line is
+/// truncated to it and the repaint arithmetic depends on that truncation.
+fn live_allowed() -> Option<usize> {
+	use std::io::IsTerminal;
+	if !std::io::stderr().is_terminal() || !super::stderr_colored() {
+		return None;
+	}
+	width_from(crate::engine::query::terminal::window_size())
+}
+
+/// The usable width from a `window_size()` answer.
+///
+/// Split out so the one thing that can silently be wrong here is testable:
+/// `window_size` returns **`(rows, cols)`**, in that order, and reading the
+/// first element as the width truncated every board line to the terminal's
+/// *height* instead. Measured on a 100x30 pty, every verb came out as `Pen…`,
+/// and nothing in the type system or the suite objected.
+fn width_from(size: Option<(u16, u16)>) -> Option<usize> {
+	size.map(|(_rows, cols)| cols as usize)
+}
+
+/// Start a board over `resources`, in the order they will be worked through.
+///
+/// A no-op when progress output is off, so an embedding crate never gets a
+/// board it did not ask for.
+pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
+	if !super::progress_enabled() {
+		return;
+	}
+	let board = Board::new(resources);
+	let name_width = board
+		.live_rows()
+		.iter()
+		.map(|r| r.name.chars().count())
+		.max()
+		.unwrap_or(0)
+		.clamp(12, 40);
+	let region = live_allowed().map(|width| live::LiveRegion::new(name_width, width));
+	let live = region.is_some();
+	if let Ok(mut slot) = SESSION.lock() {
+		*slot = Some(Session {
+			board,
+			region,
+			frame: 0,
+		});
+	}
+	if live {
+		spawn_ticker();
+	}
+	repaint();
+}
+
+/// Report that work on a resource has begun.
+///
+/// This is the event the tree could not previously produce: every one of the 21
+/// existing progress sites fires once the work is already over.
+pub fn start(kind: &str, name: &str, verb: &str) {
+	let Some(kind) = Kind::from_noun(kind) else {
+		return;
+	};
+	let sink = {
+		let Ok(mut slot) = SESSION.lock() else {
+			return;
+		};
+		match slot.as_mut() {
+			Some(session) => {
+				session.board.start(kind, name, verb, Instant::now());
+				if session.region.is_some() {
+					Sink::Live
+				} else {
+					Sink::Plain
+				}
+			}
+			None => Sink::None,
+		}
+	};
+	emit(sink, kind, name, verb);
+}
+
+/// Which renderer a just-recorded event belongs to.
+enum Sink {
+	/// A region is open; the event shows up on the next repaint.
+	Live,
+	/// A board is open but not on a terminal, so the event is a line.
+	Plain,
+	/// No board at all.
+	None,
+}
+
+/// Hand a recorded event to whichever renderer owns it.
+///
+/// The plain sink writes the same line the tree has always written, through
+/// [`super::write_progress_line`] rather than `progress_line` — going back
+/// through the routing that sent the event here would be a loop, and it is what
+/// made a piped `up` print nothing at all the first time this was wired up: the
+/// board swallowed every line and no renderer put one back.
+fn emit(sink: Sink, kind: Kind, name: &str, verb: &str) {
+	match sink {
+		Sink::Live => repaint(),
+		Sink::Plain => super::write_progress_line(kind.noun(), name, verb),
+		// No board open, but the caller still asked to report a transition, so
+		// the line is still owed — this is the "a pipe says more than it used
+		// to, never less" half of the contract.
+		Sink::None => {
+			if super::progress_enabled() {
+				super::write_progress_line(kind.noun(), name, verb);
+			}
+		}
+	}
+}
+
+/// Report that work on a resource has finished. Returns whether a board took it;
+/// `false` leaves the caller to print its own line, which is what keeps every
+/// existing `progress_line` call site working unchanged.
+pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
+	let Some(kind) = Kind::from_noun(kind) else {
+		return false;
+	};
+	let sink = {
+		let Ok(mut slot) = SESSION.lock() else {
+			return false;
+		};
+		match slot.as_mut() {
+			Some(session) => {
+				session.board.finish(kind, name, verb, Instant::now());
+				if session.region.is_some() {
+					Sink::Live
+				} else {
+					Sink::Plain
+				}
+			}
+			None => Sink::None,
+		}
+	};
+	// `Sink::None` means no board took it, so the caller prints its own line as
+	// it always has. The other two mean the event is accounted for here.
+	if matches!(sink, Sink::None) {
+		return false;
+	}
+	emit(sink, kind, name, verb);
+	true
+}
+
+/// Close the board: stop the ticker, draw the finished state, restore the
+/// cursor.
+///
+/// Idempotent, because the commands that open a board have several exits.
+pub fn end() {
+	if let Ok(mut slot) = TICKER.lock() {
+		if let Some(handle) = slot.take() {
+			handle.abort();
+		}
+	}
+	let Ok(mut slot) = SESSION.lock() else {
+		return;
+	};
+	if let Some(mut session) = slot.take() {
+		if let Some(region) = session.region.as_mut() {
+			region.finish(&mut session.board, Instant::now());
+		}
+	}
+}
+
+/// Repaint the region, if there is one. A plain sink does nothing here: its
+/// lines are emitted by the event calls themselves.
+fn repaint() {
+	let Ok(mut slot) = SESSION.lock() else {
+		return;
+	};
+	let Some(session) = slot.as_mut() else {
+		return;
+	};
+	let frame = session.frame;
+	let Session { board, region, .. } = session;
+	if let Some(region) = region.as_mut() {
+		if let Some(width) = live_allowed() {
+			region.refresh_width(width);
+		}
+		region.repaint(board, frame, Instant::now());
+	}
+}
+
+/// Advance the spinner and repaint, so a long pull turns rather than freezing.
+fn spawn_ticker() {
+	let handle = tokio::spawn(async {
+		let mut interval = tokio::time::interval(TICK);
+		loop {
+			interval.tick().await;
+			{
+				let Ok(mut slot) = SESSION.lock() else { return };
+				match slot.as_mut() {
+					Some(session) => session.frame = session.frame.wrapping_add(1),
+					None => return,
+				}
+			}
+			repaint();
+		}
+	});
+	if let Ok(mut slot) = TICKER.lock() {
+		*slot = Some(handle);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::width_from;
+
+	/// `window_size` answers `(rows, cols)`. Getting this backwards is invisible
+	/// on a square-ish terminal and mangles every line on a normal one.
+	#[test]
+	fn the_width_is_the_columns_not_the_rows() {
+		assert_eq!(width_from(Some((30, 100))), Some(100));
+		assert_eq!(width_from(None), None);
+	}
+}

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -19,6 +19,7 @@ mod live;
 mod row;
 
 pub use board::{Board, Kind, Row, State};
+pub use live::{Region, Target};
 
 /// How often the region repaints while nothing is happening, so the spinner
 /// turns during a long pull instead of looking like a hang. The same cadence
@@ -41,8 +42,11 @@ struct Session {
 	board: Board,
 	/// `None` when the sink is plain: not a terminal, colour off, or the
 	/// terminal size could not be read.
-	region: Option<live::LiveRegion>,
+	region: Option<live::Region>,
 	frame: usize,
+	/// Width of the name column, sized from the seeded rows so it does not jump
+	/// as rows come and go.
+	name_width: usize,
 }
 
 /// Whether a live region is allowed right now.
@@ -87,13 +91,14 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 		.max()
 		.unwrap_or(0)
 		.clamp(12, 40);
-	let region = live_allowed().map(|width| live::LiveRegion::new(name_width, width));
+	let region = live_allowed().map(|_| live::Region::new(live::Target::Stderr));
 	let live = region.is_some();
 	if let Ok(mut slot) = SESSION.lock() {
 		*slot = Some(Session {
 			board,
 			region,
 			frame: 0,
+			name_width,
 		});
 	}
 	if live {
@@ -207,8 +212,26 @@ pub fn end() {
 		return;
 	};
 	if let Some(mut session) = slot.take() {
-		if let Some(region) = session.region.as_mut() {
-			region.finish(&mut session.board, Instant::now());
+		// One last paint with the region emptied, so the last thing on screen is
+		// the permanent record rather than a half-drawn board.
+		if session.region.is_some() {
+			let width = live_allowed().unwrap_or(0);
+			let now = Instant::now();
+			let scrollback: Vec<String> = session
+				.board
+				.take_completed_prefix()
+				.iter()
+				.map(|r| row::render(r, session.name_width, 0, now, width))
+				.collect();
+			let leftover: Vec<String> = session
+				.board
+				.live_rows()
+				.iter()
+				.map(|r| row::render(r, session.name_width, 0, now, width))
+				.collect();
+			if let Some(region) = session.region.as_mut() {
+				region.show(&scrollback, &leftover);
+			}
 		}
 	}
 }
@@ -223,13 +246,31 @@ fn repaint() {
 		return;
 	};
 	let frame = session.frame;
+	let name_width = session.name_width;
 	let Session { board, region, .. } = session;
-	if let Some(region) = region.as_mut() {
-		if let Some(width) = live_allowed() {
-			region.refresh_width(width);
-		}
-		region.repaint(board, frame, Instant::now());
+	let Some(region) = region.as_mut() else {
+		return;
+	};
+	// Re-read the width every repaint, so a resize mid-command does not leave
+	// every later line wrapping — and wrapping is what breaks the arithmetic.
+	let width = live_allowed().unwrap_or(0);
+	let now = Instant::now();
+	let scrollback: Vec<String> = board
+		.take_completed_prefix()
+		.iter()
+		.map(|r| row::render(r, name_width, frame, now, width))
+		.collect();
+	let mut lines = Vec::new();
+	let rows = board.live_rows();
+	if !rows.is_empty() {
+		let (done, total) = board.tally();
+		lines.push(row::summary(done, total));
+		lines.extend(
+			rows.iter()
+				.map(|r| row::render(r, name_width, frame, now, width)),
+		);
 	}
+	region.show(&scrollback, &lines);
 }
 
 /// Advance the spinner and repaint, so a long pull turns rather than freezing.

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -1,0 +1,119 @@
+//! Turning one [`Row`](super::Row) into one line of text.
+//!
+//! Pure, and separate from the terminal driver on purpose: the arithmetic that
+//! decides how wide a line is, is the same arithmetic the cursor-up repaint
+//! depends on. A line that is one column too long wraps, the terminal counts two
+//! rows where the renderer counted one, and every subsequent repaint erases the
+//! wrong lines. So the width rule is tested on its own rather than inferred from
+//! a screenshot.
+
+use std::time::{Duration, Instant};
+
+use super::{Row, State};
+use crate::ui::{fit_cell, identity_style, paint, AnsiColor, Style};
+
+/// Frames of the working marker. Ten braille cells, so no dependency and no font
+/// assumption beyond what every terminal that reports 256 colours already has.
+pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Marker for a finished row.
+const DONE_MARK: &str = "✔";
+
+/// Marker for a row nothing has happened to yet.
+const PENDING_MARK: &str = "⠿";
+
+/// Width of the resource-noun column. `Container` is the longest of the five.
+const KIND_WIDTH: usize = 9;
+
+/// Width reserved for the elapsed time, right-aligned so the digits line up
+/// rather than drifting with each value's length.
+const TIME_WIDTH: usize = 6;
+
+/// The marker for a row, and the style it carries.
+///
+/// Colour here is state, not identity: a finished row is green because something
+/// now exists, a pending one is dim because nothing has happened to it. The name
+/// beside it keeps its identity colour, which is why the marker must not reuse
+/// that palette.
+fn marker(row: &Row, frame: usize) -> (&'static str, Style) {
+	match row.state {
+		State::Done(_) => (
+			DONE_MARK,
+			Style::new().fg_color(Some(AnsiColor::Green.into())),
+		),
+		State::Working(_) => (SPINNER[frame % SPINNER.len()], Style::new()),
+		State::Pending => (PENDING_MARK, Style::new().dimmed()),
+	}
+}
+
+/// The verb shown for a row.
+fn verb(row: &Row) -> &str {
+	match &row.state {
+		State::Done(v) | State::Working(v) => v,
+		State::Pending => "Pending",
+	}
+}
+
+/// `0.4s`, `12.9s`, `1m03s`. Sub-minute values keep a decimal because the
+/// interesting range for a container start is fractions of a second; past a
+/// minute the decimal is noise.
+pub fn format_elapsed(d: Duration) -> String {
+	let secs = d.as_secs_f64();
+	if secs < 60.0 {
+		format!("{secs:.1}s")
+	} else {
+		format!("{}m{:02}s", d.as_secs() / 60, d.as_secs() % 60)
+	}
+}
+
+/// One board line, fitted to `width` columns.
+///
+/// `width` is the terminal's, and the returned line never exceeds it: the
+/// cursor-up repaint counts one terminal row per line it wrote, and a line that
+/// wraps makes that count wrong for every repaint afterwards.
+pub fn render(row: &Row, name_width: usize, frame: usize, now: Instant, width: usize) -> String {
+	let (mark, mark_style) = marker(row, frame);
+	let time = row.duration(now).map(format_elapsed).unwrap_or_default();
+	let plain = format!(
+		" {mark} {:<KIND_WIDTH$} {} {:<12} {time:>TIME_WIDTH$}",
+		row.kind.noun(),
+		fit_cell(&row.name, name_width),
+		verb(row),
+	);
+	let plain = fit_cell(plain.trim_end(), 0);
+	let plain = if width > 0 && plain.chars().count() > width {
+		fit_cell(&plain, width)
+	} else {
+		plain
+	};
+	colourise(&plain, row, mark, mark_style)
+}
+
+/// Re-apply colour to an already-fitted line.
+///
+/// Deliberately done after fitting rather than before: the escape sequences are
+/// zero-width, so measuring a coloured line counts characters the terminal never
+/// draws, and the truncation would cut in the middle of an escape and leave the
+/// terminal painted.
+fn colourise(plain: &str, row: &Row, mark: &str, mark_style: Style) -> String {
+	let mut out = plain.to_string();
+	if let Some(pos) = out.find(mark) {
+		let styled = paint(mark_style, mark, true);
+		out.replace_range(pos..pos + mark.len(), &styled);
+	}
+	if let Some(pos) = out.find(&row.name) {
+		let styled = paint(identity_style(&row.name), &row.name, true);
+		out.replace_range(pos..pos + row.name.len(), &styled);
+	}
+	out
+}
+
+/// The summary line above the region: how many resources are done out of how
+/// many.
+pub fn summary(done: usize, total: usize) -> String {
+	format!("[+] Running {done}/{total}")
+}
+
+#[cfg(test)]
+#[path = "row_tests.rs"]
+mod tests;

--- a/internal/ui/progress/row_tests.rs
+++ b/internal/ui/progress/row_tests.rs
@@ -1,0 +1,152 @@
+use super::*;
+use crate::ui::progress::Kind;
+
+fn row(state: State) -> Row {
+	Row {
+		kind: Kind::Container,
+		name: "proj-web-1".to_string(),
+		state,
+		started: None,
+		elapsed: None,
+	}
+}
+
+fn plain(line: &str) -> String {
+	let mut out = String::new();
+	let mut chars = line.chars();
+	while let Some(c) = chars.next() {
+		if c == '\u{1b}' {
+			for c in chars.by_ref() {
+				if c == 'm' {
+					break;
+				}
+			}
+		} else {
+			out.push(c);
+		}
+	}
+	out
+}
+
+/// The width promise, which the whole repaint rests on: a line that wraps makes
+/// the terminal count two rows where the renderer counted one, and every repaint
+/// afterwards erases the wrong lines.
+#[test]
+fn a_line_never_exceeds_the_terminal_width() {
+	for width in [10, 20, 40, 80] {
+		let r = Row {
+			name: "a-very-long-container-name-that-will-not-fit-anywhere".to_string(),
+			..row(State::Working("Creating".into()))
+		};
+		let line = plain(&render(&r, 40, 0, Instant::now(), width));
+		assert!(
+			line.chars().count() <= width,
+			"width {width}: got {} chars: {line:?}",
+			line.chars().count()
+		);
+	}
+}
+
+/// A width of zero means "do not truncate" — the caller could not read the
+/// terminal size. The line is still produced rather than collapsing to nothing.
+#[test]
+fn width_zero_leaves_the_line_intact() {
+	let line = plain(&render(&row(State::Pending), 20, 0, Instant::now(), 0));
+	assert!(line.contains("proj-web-1"), "{line:?}");
+}
+
+/// The three states are visually distinct without reading the words, which is
+/// the entire reason for a marker column.
+#[test]
+fn each_state_gets_its_own_marker() {
+	let now = Instant::now();
+	let done = plain(&render(&row(State::Done("Created".into())), 20, 0, now, 80));
+	let working = plain(&render(
+		&row(State::Working("Creating".into())),
+		20,
+		0,
+		now,
+		80,
+	));
+	let pending = plain(&render(&row(State::Pending), 20, 0, now, 80));
+	assert!(done.contains(DONE_MARK), "{done:?}");
+	assert!(working.contains(SPINNER[0]), "{working:?}");
+	assert!(pending.contains(PENDING_MARK), "{pending:?}");
+}
+
+/// The spinner advances with the frame, or a slow pull looks like a hang.
+#[test]
+fn the_working_marker_advances_with_the_frame() {
+	let now = Instant::now();
+	let r = row(State::Working("Pulling".into()));
+	let a = plain(&render(&r, 20, 0, now, 80));
+	let b = plain(&render(&r, 20, 1, now, 80));
+	assert_ne!(a, b);
+}
+
+/// The frame wraps rather than panicking: the ticker counts up without bound.
+#[test]
+fn the_frame_index_wraps() {
+	let now = Instant::now();
+	let r = row(State::Working("Pulling".into()));
+	let wrapped = plain(&render(&r, 20, SPINNER.len() * 7 + 3, now, 80));
+	let direct = plain(&render(&r, 20, 3, now, 80));
+	assert_eq!(wrapped, direct);
+}
+
+/// A pending row shows no time. Nothing has taken any, and a `0.0s` there reads
+/// as "this was instant" rather than "this has not started".
+#[test]
+fn a_pending_row_shows_no_time() {
+	let line = plain(&render(&row(State::Pending), 20, 0, Instant::now(), 80));
+	assert!(!line.contains('s'), "{line:?}");
+	assert!(line.contains("Pending"), "{line:?}");
+}
+
+/// Sub-minute times keep a decimal, because the interesting range for starting
+/// a container is fractions of a second. Past a minute the decimal is noise.
+#[test]
+fn elapsed_switches_units_at_a_minute() {
+	assert_eq!(format_elapsed(Duration::from_millis(100)), "0.1s");
+	assert_eq!(format_elapsed(Duration::from_millis(12_900)), "12.9s");
+	assert_eq!(format_elapsed(Duration::from_secs(63)), "1m03s");
+	assert_eq!(format_elapsed(Duration::from_secs(600)), "10m00s");
+}
+
+/// Colour is applied after the line has been fitted. Applied before, the
+/// zero-width escapes would be counted as visible columns and the truncation
+/// could cut through one, leaving the terminal painted with whatever it set.
+#[test]
+fn truncation_never_cuts_through_an_escape() {
+	let r = Row {
+		name: "x".repeat(60),
+		..row(State::Working("Creating".into()))
+	};
+	let line = render(&r, 60, 0, Instant::now(), 24);
+	let escapes = line.matches('\u{1b}').count();
+	let resets = line.matches("\u{1b}[0m").count();
+	assert_eq!(
+		escapes,
+		resets * 2,
+		"every opening escape needs its reset: {line:?}"
+	);
+}
+
+/// A name carrying an escape sequence cannot repaint the reader's terminal. The
+/// name comes from a compose file, which is trusted input, but the row goes
+/// through the same `fit_cell` every other table uses rather than trusting that.
+#[test]
+fn a_name_cannot_drive_the_terminal() {
+	let r = Row {
+		name: "evil\u{1b}[31m\u{7}name".to_string(),
+		..row(State::Pending)
+	};
+	let line = render(&r, 30, 0, Instant::now(), 80);
+	assert!(!line.contains('\u{7}'), "{line:?}");
+	assert!(line.contains("name"), "{line:?}");
+}
+
+#[test]
+fn the_summary_counts_done_over_total() {
+	assert_eq!(summary(3, 6), "[+] Running 3/6");
+}

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -50,6 +50,20 @@ pub fn sanitize_cell(s: &str) -> String {
 		.collect()
 }
 
+/// The style for a [`Table::caution_col`] cell: yellow for the answer that
+/// warrants a second look, dim for the default one, and nothing for a value that
+/// is neither.
+///
+/// Pure and taking the cell text, so the mapping is unit-testable without
+/// rendering a table or reading the process-global colour choice.
+fn caution_style(cell: &str) -> super::Style {
+	match cell.trim() {
+		"yes" => super::Style::new().fg_color(Some(super::AnsiColor::Yellow.into())),
+		"no" => super::Style::new().dimmed(),
+		_ => super::Style::new(),
+	}
+}
+
 /// A list-command table whose columns size to their content (capped, so a
 /// pathologically long cell truncates with an ellipsis rather than pushing every
 /// later column past its header). The trailing column is emitted raw.
@@ -63,6 +77,12 @@ pub struct Table {
 	/// The column (if any) carrying an identity — a service or container name —
 	/// tinted with that identity's stable colour.
 	identity_col: Option<usize>,
+	/// The column (if any) holding a yes/no answer where `yes` is the one worth
+	/// noticing. See [`Table::caution_col`].
+	caution_col: Option<usize>,
+	/// Columns rendered dim, so the ones left at normal weight are what the eye
+	/// lands on. See [`Table::dim_cols`].
+	dim_cols: Vec<usize>,
 	rows: Vec<Vec<String>>,
 	/// Per-row identity key, parallel to `rows`. `None` falls back to the
 	/// identity cell's own text.
@@ -78,6 +98,8 @@ impl Table {
 			caps: vec![None; headers.len()],
 			status_col: None,
 			identity_col: None,
+			caution_col: None,
+			dim_cols: Vec::new(),
 			rows: Vec::new(),
 			keys: Vec::new(),
 		}
@@ -110,6 +132,32 @@ impl Table {
 		self
 	}
 
+	/// Mark column `col` as a yes/no answer where `yes` is the one worth noticing:
+	/// `yes` takes the yellow band, `no` is dimmed as the unremarkable default.
+	///
+	/// Deliberately not [`Table::status_col`], which would paint `yes` green.
+	/// Green means healthy/up everywhere else in this CLI, and the column this
+	/// was written for — `volumes`' `EXTERNAL` — is not reporting health. It
+	/// reports the one volume podup will refuse to delete, so a `down -v` that
+	/// leaves something standing is explicable. That is a caution, and yellow is
+	/// already the band this CLI uses for *survives*.
+	pub fn caution_col(mut self, col: usize) -> Self {
+		self.caution_col = Some(col);
+		self
+	}
+
+	/// Dim the given columns, leaving the rest at normal weight.
+	///
+	/// For a table where most columns are scaffolding and one or two carry the
+	/// answer. `top` is the case: eight columns of process bookkeeping around the
+	/// command line, which is the reason anyone runs it. Dimming is not a
+	/// meaning — unlike the status and caution colours it says nothing about the
+	/// value — so it composes with them rather than competing.
+	pub fn dim_cols(mut self, cols: &[usize]) -> Self {
+		self.dim_cols = cols.to_vec();
+		self
+	}
+
 	/// Append one data row. The cell count should match the header count; missing
 	/// cells render blank and extra cells are ignored.
 	pub fn push(&mut self, cells: Vec<String>) {
@@ -128,6 +176,18 @@ impl Table {
 	pub fn push_keyed(&mut self, cells: Vec<String>, key: String) {
 		self.rows.push(cells);
 		self.keys.push(Some(key));
+	}
+
+	/// Whether any column marker is set, i.e. whether rendering with colour could
+	/// differ from rendering without it.
+	///
+	/// Kept as one predicate so adding a marker is a single edit: the gate in
+	/// [`Table::print`] and the marker list cannot drift apart.
+	fn colours_any_column(&self) -> bool {
+		self.status_col.is_some()
+			|| self.identity_col.is_some()
+			|| self.caution_col.is_some()
+			|| !self.dim_cols.is_empty()
 	}
 
 	/// Content-sized width of each column: the widest of the header and its cells,
@@ -185,11 +245,11 @@ impl Table {
 					// either way, so alignment is untouched.
 					return super::paint(super::identity_style(key.unwrap_or(cell)), &padded, true);
 				}
-				if colour && Some(i) == self.identity_col && !cell.trim().is_empty() {
-					// The padding is inside the paint so the colour does not stop
-					// at the name and leave the gap bare; the codes are zero-width
-					// either way, so alignment is untouched.
-					return super::paint(super::identity_style(key.unwrap_or(cell)), &padded, true);
+				if colour && Some(i) == self.caution_col {
+					return super::paint(caution_style(cell), &padded, true);
+				}
+				if colour && self.dim_cols.contains(&i) {
+					return super::paint(super::Style::new().dimmed(), &padded, true);
 				}
 				padded
 			})
@@ -215,8 +275,11 @@ impl Table {
 	pub fn print(&self) {
 		let widths = self.widths();
 		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
-		let colour =
-			(self.status_col.is_some() || self.identity_col.is_some()) && super::stdout_colored();
+		// Every column marker that can tint a cell has to appear here, or a table
+		// that uses only that marker renders plain. `caution_col` was added
+		// without being listed, and it went unnoticed because its first caller —
+		// `volumes` — also sets `identity_col`, so the gate happened to be open.
+		let colour = self.colours_any_column() && super::stdout_colored();
 		for (i, row) in self.rows.iter().enumerate() {
 			let key = self.keys.get(i).and_then(Option::as_deref);
 			println!("{}", self.format_row_keyed(row, &widths, colour, key));
@@ -239,6 +302,54 @@ mod tests {
 		assert!(!out.contains('\x07'), "{out:?}");
 		assert!(!out.contains('\t'), "{out:?}");
 		assert!(out.contains("name"), "{out:?}");
+	}
+
+	/// A caution column separates its two answers, and `yes` is not the same as
+	/// `no` with a different word. Asserted as "the two styles differ" rather
+	/// than against a literal escape sequence: re-deriving the expected code from
+	/// the same constant the renderer reads would pass whether or not the
+	/// renderer consulted it.
+	#[test]
+	fn caution_style_distinguishes_yes_from_no() {
+		assert_ne!(caution_style("yes"), caution_style("no"));
+		// Padding must not change the answer — cells reach it already padded.
+		assert_eq!(caution_style("yes  "), caution_style("yes"));
+	}
+
+	/// A value that is neither answer is left alone rather than given an
+	/// arbitrary colour, matching how `status_style` treats an unknown word.
+	#[test]
+	fn caution_style_leaves_an_unknown_value_alone() {
+		assert_eq!(caution_style("maybe"), super::super::Style::new());
+	}
+
+	/// The caution column reaches the rendered row. `render` is the uncoloured
+	/// path, so this pins that the column is *declared*; the colour itself is
+	/// asserted on `caution_style` above.
+	#[test]
+	fn caution_col_survives_rendering() {
+		let mut t = Table::new(&["NAME", "EXTERNAL"]).caution_col(1);
+		t.push(vec!["theirs".into(), "yes".into()]);
+		let rows = t.render();
+		assert!(rows[1].contains("yes"), "{rows:?}");
+	}
+
+	/// A table whose only marker is `caution_col` still colours. The gate in
+	/// `print` listed `status_col` and `identity_col` only, and the first caution
+	/// caller set `identity_col` too — so the omission was invisible.
+	#[test]
+	fn a_caution_only_table_still_colours() {
+		let t = Table::new(&["NAME", "EXTERNAL"]).caution_col(1);
+		assert!(t.colours_any_column());
+	}
+
+	/// Dimming is a column property, so it reaches the gate the same way the
+	/// meaning-carrying markers do.
+	#[test]
+	fn a_dim_only_table_still_colours() {
+		let t = Table::new(&["PID", "CMD"]).dim_cols(&[0]);
+		assert!(t.colours_any_column());
+		assert!(!Table::new(&["PID", "CMD"]).colours_any_column());
 	}
 
 	/// Printable text is untouched.

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -444,3 +444,43 @@ fn bare_podup_prints_the_same_help_with_env_globals_set() {
 		);
 	}
 }
+
+// --- Machine output never carries colour, even when forced ------------------
+
+/// Machine-readable output must never carry colour, even when colour is
+/// forced. A script parsing `--format json` or `-q` reads stdout, so any
+/// escape landing there is data corruption, not decoration.
+///
+/// Forced with `--ansi always` on purpose: the auto-detection would suppress
+/// colour in the test harness anyway, so a weaker version of this test would
+/// pass without proving anything. Only stdout is checked: a connection
+/// failure prints its `error:` banner to stderr, which is a human diagnostic
+/// and is allowed to be coloured like any other podup error — the guarantee
+/// under test is about the machine-parseable stream, not every byte podup
+/// writes.
+#[test]
+fn machine_output_carries_no_escapes_even_with_colour_forced() {
+	let dir = std::env::temp_dir().join(format!("podup-cflags-machine-{}", std::process::id()));
+	fs::create_dir_all(&dir).unwrap();
+	let compose = dir.join("compose.yaml");
+	fs::write(&compose, "services:\n  web:\n    image: nginx:1.27\n").unwrap();
+	let c = compose.to_str().unwrap();
+
+	for args in [
+		vec!["-f", c, "--ansi", "always", "config"],
+		vec!["-f", c, "--ansi", "always", "ps", "--format", "json"],
+		vec!["-f", c, "--ansi", "always", "ps", "-q"],
+	] {
+		let out = Command::new(bin())
+			.args(&args)
+			.output()
+			.unwrap_or_else(|e| panic!("run podup {args:?}: {e}"));
+		let stdout = String::from_utf8_lossy(&out.stdout);
+		assert!(
+			!stdout.contains('\u{1b}'),
+			"{args:?} emitted an escape into machine output: {stdout:?}"
+		);
+	}
+
+	let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/engine_integration/niche.rs
+++ b/tests/engine_integration/niche.rs
@@ -10,7 +10,7 @@ fn run(args: &[&str]) -> std::process::Output {
 	Command::new(bin()).args(args).output().unwrap()
 }
 #[tokio::test]
-async fn cli_wait_prints_exit_code() {
+async fn cli_wait_names_the_container_and_its_exit_code() {
 	if super::podman().await.is_none() {
 		return;
 	}
@@ -27,11 +27,15 @@ async fn cli_wait_prints_exit_code() {
 	run(&["-f", c, "-p", &proj, "up", "-d"]);
 	let out = run(&["-f", c, "-p", &proj, "wait", "job"]);
 	assert!(out.status.success(), "wait failed: {:?}", out.stderr);
+	// One line per container, naming it (#1248). This used to assert a line
+	// that was exactly `"0"` — a bare code with nothing saying whose it was,
+	// which is what the change replaced.
+	let stdout = String::from_utf8_lossy(&out.stdout);
 	assert!(
-		String::from_utf8_lossy(&out.stdout)
+		stdout
 			.lines()
-			.any(|l| l.trim() == "0"),
-		"wait must print the exit code 0"
+			.any(|l| l.contains(&format!("{proj}-job-1")) && l.trim().ends_with('0')),
+		"wait must name the container and its exit code; got:\n{stdout}"
 	);
 	run(&["-f", c, "-p", &proj, "down"]);
 }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -1,0 +1,86 @@
+//! Shared fixtures for the two output-contract suites.
+//!
+//! Every integration test file is its own crate, so this is a module each of
+//! them declares rather than something either imports from the other. Both
+//! suites drive the real binary against a real Podman, which is the only layer
+//! that can see a wrong exit code or an empty line (see the testing standard's
+//! capability matrix).
+
+#![allow(dead_code)]
+
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+pub fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Whether a Podman podup can actually drive is reachable.
+///
+/// This is the integration suite's guard, not a `podman info` probe. The CI
+/// runner ships a podman binary that is *below podup's floor* with no socket
+/// running, so `podman info` succeeds while every command here fails — the
+/// weaker check let these run in the main CI job and fail for the environment
+/// rather than the code.
+pub async fn podman_up() -> bool {
+	match podup::podman::connect_from_env().or_else(|_| podup::podman::connect(None)) {
+		Ok(client) => client.ping().await.is_ok(),
+		Err(_) => false,
+	}
+}
+
+pub struct Project {
+	pub _dir: tempfile::TempDir,
+	pub compose: String,
+	pub name: String,
+}
+
+impl Project {
+	pub fn start(tag: &str) -> Self {
+		let dir = tempdir().unwrap();
+		let compose = dir.path().join("compose.yaml");
+		fs::write(
+			&compose,
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    \
+			 ports:\n      - \"0:80\"\n    volumes:\n      - data:/data\nvolumes:\n  data:\n",
+		)
+		.unwrap();
+		let p = Project {
+			compose: compose.to_string_lossy().into_owned(),
+			name: format!("t{}-{tag}", std::process::id()),
+			_dir: dir,
+		};
+		p.run(&["up", "-d"]);
+		p
+	}
+
+	pub fn run(&self, args: &[&str]) -> String {
+		let out = Command::new(bin())
+			.args(["-f", &self.compose, "-p", &self.name])
+			.args(args)
+			.output()
+			.expect("run podup");
+		String::from_utf8_lossy(&out.stdout).into_owned()
+	}
+
+	/// The progress stream, which lifecycle commands write to stderr so stdout
+	/// stays a clean pipe. [`Project::run`] returns stdout and therefore cannot
+	/// see any of it.
+	pub fn progress(&self, args: &[&str]) -> String {
+		let out = Command::new(bin())
+			.args(["-f", &self.compose, "-p", &self.name])
+			.args(args)
+			.output()
+			.expect("run podup");
+		String::from_utf8_lossy(&out.stderr).into_owned()
+	}
+}
+
+impl Drop for Project {
+	fn drop(&mut self) {
+		let _ = Command::new(bin())
+			.args(["-f", &self.compose, "-p", &self.name, "down", "-v"])
+			.output();
+	}
+}

--- a/tests/output_contract.rs
+++ b/tests/output_contract.rs
@@ -305,3 +305,63 @@ async fn top_styles_its_process_rows() {
 		"process rows must carry the dim styling, not just the two headers; got:\n{text}"
 	);
 }
+
+/// A piped `stats` stays a readable transcript, and its machine paths are never
+/// repainted.
+///
+/// The live view is gated on **stdout** rather than stderr, because `stats` is
+/// its own output — `stats > file` on a terminal must still produce a file of
+/// frames rather than a file of cursor moves. `--format json` never repaints at
+/// all, whatever the terminal says, and keeps the split it already had: NDJSON
+/// while streaming, one pretty array for `--no-stream`.
+#[tokio::test]
+async fn piped_stats_is_frames_and_json_never_repaints() {
+	if !podman_up().await {
+		return;
+	}
+	let p = Project::start("stt");
+
+	let table = p.run(&["stats", "--no-stream"]);
+	assert!(
+		!table.contains('\u{1b}'),
+		"a piped stats table must carry no escapes; got:\n{table:?}"
+	);
+	assert!(
+		table.contains("NAME") && table.contains("PIDS"),
+		"and it must still be the table; got:\n{table}"
+	);
+
+	let json = p.run(&["stats", "--no-stream", "--format", "json"]);
+	assert!(
+		!json.contains('\u{1b}'),
+		"the machine path must carry no escapes; got:\n{json:?}"
+	);
+	let parsed: serde_json::Value =
+		serde_json::from_str(&json).expect("--no-stream --format json stays one pretty document");
+	assert!(parsed.is_array(), "and it stays an array: {parsed}");
+}
+
+/// The header sits over its own columns.
+///
+/// It was a hand-written constant kept separately from the row layout, and the
+/// two had drifted: `PIDS` began exactly where its data stopped, so the label
+/// was entirely off the column it named. Asserted against the rendered output
+/// rather than against a literal, so it measures what a reader sees.
+#[tokio::test]
+async fn the_stats_header_matches_its_rows() {
+	if !podman_up().await {
+		return;
+	}
+	let p = Project::start("stthdr");
+	let out = p.run(&["stats", "--no-stream"]);
+	let mut lines = out.lines().filter(|l| !l.trim().is_empty());
+	let header = lines.next().unwrap_or_default();
+	let Some(row) = lines.next() else {
+		return; // nothing sampled yet; the width rule is asserted in the unit tests
+	};
+	assert_eq!(
+		header.chars().count(),
+		row.chars().count(),
+		"header and row must be the same width\nH: {header:?}\nR: {row:?}"
+	);
+}

--- a/tests/output_contract.rs
+++ b/tests/output_contract.rs
@@ -1,4 +1,5 @@
-//! Table headers and JSON keys are a contract with users' scripts.
+//! Table headers, JSON keys and the styling of a command's output are a
+//! contract with users' scripts and eyes.
 //!
 //! #1082's closing observation is that nothing protected them: not one test
 //! asserted `NAME`, `STATUS`, or an `images` JSON key, so every drift in that
@@ -9,71 +10,15 @@
 //!
 //! Deliberately narrow: presence and shape, never values. A test that pinned
 //! actual container names would fail for the wrong reason and get deleted.
+//!
+//! Whether a command reports what it *did* lives in `reporting_contract.rs`.
 
+mod harness;
+
+use harness::{bin, podman_up, Project};
 use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
-
-fn bin() -> &'static str {
-	env!("CARGO_BIN_EXE_podup")
-}
-
-/// Whether a Podman podup can actually drive is reachable.
-///
-/// This is the integration suite's guard, not a `podman info` probe. The CI
-/// runner ships a podman binary that is *below podup's floor* with no socket
-/// running, so `podman info` succeeds while every command here fails — the
-/// weaker check let these run in the main CI job and fail for the environment
-/// rather than the code.
-async fn podman_up() -> bool {
-	match podup::podman::connect_from_env().or_else(|_| podup::podman::connect(None)) {
-		Ok(client) => client.ping().await.is_ok(),
-		Err(_) => false,
-	}
-}
-
-struct Project {
-	_dir: tempfile::TempDir,
-	compose: String,
-	name: String,
-}
-
-impl Project {
-	fn start(tag: &str) -> Self {
-		let dir = tempdir().unwrap();
-		let compose = dir.path().join("compose.yaml");
-		fs::write(
-			&compose,
-			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    \
-			 ports:\n      - \"0:80\"\n    volumes:\n      - data:/data\nvolumes:\n  data:\n",
-		)
-		.unwrap();
-		let p = Project {
-			compose: compose.to_string_lossy().into_owned(),
-			name: format!("t{}-{tag}", std::process::id()),
-			_dir: dir,
-		};
-		p.run(&["up", "-d"]);
-		p
-	}
-
-	fn run(&self, args: &[&str]) -> String {
-		let out = Command::new(bin())
-			.args(["-f", &self.compose, "-p", &self.name])
-			.args(args)
-			.output()
-			.expect("run podup");
-		String::from_utf8_lossy(&out.stdout).into_owned()
-	}
-}
-
-impl Drop for Project {
-	fn drop(&mut self) {
-		let _ = Command::new(bin())
-			.args(["-f", &self.compose, "-p", &self.name, "down", "-v"])
-			.output();
-	}
-}
 
 /// Every list command prints its header, including on an empty result. `volumes`
 /// used to be the exception, so a script locating its columns from the header
@@ -182,5 +127,181 @@ async fn logs_prefix_is_service_and_index_with_one_space() {
 	assert!(
 		!line.contains(&format!("{}-web-1", p.name)),
 		"the project prefix must be stripped: {line:?}"
+	);
+}
+
+/// `podup version` and `podup --version` answer the same question, so they emit
+/// the same line.
+///
+/// They did not: clap's derived `--version` rendered `podup 3.3.0` while the
+/// subcommand rendered `podup version v3.3.0`, so a script probing the binary
+/// got a different string depending on which spelling it happened to use — and
+/// the `v` prefix, which is what the tags and the release assets carry, appeared
+/// in only one of them. Measured on docker-compose v5.1.3, both spellings return
+/// `Docker Compose version v5.1.3` byte for byte.
+#[test]
+fn version_subcommand_and_flag_agree() {
+	let sub = Command::new(bin()).arg("version").output().unwrap();
+	let flag = Command::new(bin()).arg("--version").output().unwrap();
+	let sub = String::from_utf8_lossy(&sub.stdout).trim().to_string();
+	let flag = String::from_utf8_lossy(&flag.stdout).trim().to_string();
+	assert_eq!(sub, flag, "`version` and `--version` must emit one line");
+	assert!(
+		sub.starts_with("podup version v"),
+		"expected `podup version v<semver>`, got {sub:?}"
+	);
+}
+
+/// `version --short` is the one spelling that drops the `v`, so a script can get
+/// a bare semver without parsing the sentence. The reference behaves the same
+/// way (`docker-compose version --short` returns `5.1.3`).
+#[test]
+fn version_short_is_a_bare_semver() {
+	let out = Command::new(bin())
+		.args(["version", "--short"])
+		.output()
+		.unwrap();
+	let line = String::from_utf8_lossy(&out.stdout).trim().to_string();
+	assert!(
+		!line.starts_with('v') && line.starts_with(|c: char| c.is_ascii_digit()),
+		"expected a bare semver with no `v`, got {line:?}"
+	);
+}
+
+/// `ls` tints the project name, and two different projects get two different
+/// colours. It was the only list command whose first column was bare.
+///
+/// The assertion is on *distinctness*, not on a particular escape sequence: a
+/// test that re-derived the expected code from the same palette constant the
+/// renderer reads would pass whether or not the renderer consulted it.
+#[tokio::test]
+async fn ls_tints_each_project_name() {
+	if !podman_up().await {
+		return;
+	}
+	let a = Project::start("lsa");
+	let b = Project::start("lsb");
+	let out = Command::new(bin())
+		.args(["-f", &a.compose, "--ansi", "always", "ls"])
+		.output()
+		.expect("run podup ls");
+	let text = String::from_utf8_lossy(&out.stdout);
+	let colour_of = |name: &str| -> Option<String> {
+		text.lines()
+			.find(|l| l.contains(name))
+			.and_then(|l| l.split_once(&format!("m{name}")))
+			.map(|(head, _)| head.rsplit('\u{1b}').next().unwrap_or("").to_string())
+	};
+	let (ca, cb) = (colour_of(&a.name), colour_of(&b.name));
+	assert!(
+		ca.is_some() && cb.is_some(),
+		"both project names must carry a colour; got:\n{text}"
+	);
+	assert_ne!(
+		ca, cb,
+		"two projects must not share one colour, or the column says nothing:\n{text}"
+	);
+}
+
+/// `autostart status` gives one answer one colour.
+///
+/// With no unit file on disk it gave two: `installed: no` was dim while
+/// `enabled: not-found` was red, though both report the same fact about the same
+/// uninstalled unit and neither is a failure. The red one belonged to the case
+/// where nothing is wrong, which is the reading an operator scanning six
+/// consecutive yes/no lines will act on first.
+///
+/// Compares the two lines' value styles against each other rather than against a
+/// literal escape sequence, so the test cannot pass by re-deriving what the
+/// renderer was going to emit anyway.
+#[test]
+fn autostart_status_renders_one_negative_one_way() {
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(&compose, "services:\n  web:\n    image: alpine:latest\n").unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"-p",
+			&format!("t{}-nounit", std::process::id()),
+			"--ansi",
+			"always",
+			"autostart",
+			"status",
+		])
+		.output()
+		.expect("run podup autostart status");
+	let text = String::from_utf8_lossy(&out.stdout);
+
+	// The style applied to a line's value: everything after the label's own reset.
+	let value_style = |label: &str| -> Option<String> {
+		text.lines()
+			.find(|l| l.contains(&format!("{label}:")))
+			.and_then(|l| l.split_once("\u{1b}[0m "))
+			.map(|(_, rest)| {
+				// The whole leading SGR sequence, terminator included. Stopping at
+				// the first non-alphanumeric char instead truncates `\x1b[2m` and
+				// `\x1b[31m` to the same `\x1b[`, which made an earlier version of
+				// this test pass with the control deleted.
+				let mut style = String::new();
+				for c in rest.chars() {
+					style.push(c);
+					if c == 'm' {
+						break;
+					}
+				}
+				style
+			})
+	};
+
+	let installed = value_style("installed");
+	let enabled = value_style("enabled");
+	assert!(
+		installed.is_some() && enabled.is_some(),
+		"both lines must be present; got:\n{text}"
+	);
+	assert_eq!(
+		installed, enabled,
+		"`installed: no` and `enabled: not-found` report the same uninstalled \
+		 unit, so they must not be styled differently; got:\n{text}"
+	);
+}
+
+/// `top`'s process rows carry styling, and the dimming really reaches them.
+///
+/// Two header lines were styled and every process row was flat, which on a busy
+/// container is the whole output. The bookkeeping columns are now dimmed so the
+/// command line is what the eye lands on.
+///
+/// This is deliberately an end-to-end assertion rather than a unit test of the
+/// column choice. Both exist, because they fail for different reasons: the unit
+/// test catches a wrong choice, and only this one catches the choice being
+/// computed correctly and then not passed to the table — which is exactly the
+/// shape of the `logs` defect that survived every per-task review in #1247.
+#[tokio::test]
+async fn top_styles_its_process_rows() {
+	if !podman_up().await {
+		return;
+	}
+	let p = Project::start("topsty");
+	let out = Command::new(bin())
+		.args([
+			"-f", &p.compose, "-p", &p.name, "--ansi", "always", "top", "web",
+		])
+		.output()
+		.expect("run podup top");
+	let text = String::from_utf8_lossy(&out.stdout);
+	let process_rows: Vec<&str> = text
+		.lines()
+		.filter(|l| l.contains("sleep") || l.contains("root"))
+		.collect();
+	assert!(
+		!process_rows.is_empty(),
+		"expected at least one process row; got:\n{text}"
+	);
+	assert!(
+		process_rows.iter().any(|l| l.contains("\u{1b}[2m")),
+		"process rows must carry the dim styling, not just the two headers; got:\n{text}"
 	);
 }

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -299,3 +299,247 @@ async fn wait_names_each_container_and_its_code() {
 		"the failing containers' code must survive: {ndjson}"
 	);
 }
+
+/// A pipe gets the events, never the animation.
+///
+/// This is the contract that protects CI logs. The live region only exists when
+/// stderr is a terminal and colour is on; anywhere else the same event model
+/// comes out as append-only lines. **Animation in a CI log is a defect** — and
+/// so is a CI log that says less than the terminal did, which is why the
+/// intermediate transitions are asserted here too. Before the board they did
+/// not exist at all: `up` reported only the finished state of each resource.
+#[tokio::test]
+async fn a_piped_up_gets_transitions_and_no_escapes() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-pipe", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["up", "-d"]);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"a pipe must get no escape sequences at all; got:\n{stderr:?}"
+	);
+	// Asserted per resource, not as "some line somewhere says Creating". A
+	// looser version of this passed with the container's start event deleted,
+	// because the network's own `Creating` satisfied it.
+	let has = |name: &str, verbs: &[&str]| {
+		stderr
+			.lines()
+			.any(|l| l.contains(name) && verbs.iter().any(|v| l.contains(v)))
+	};
+	let container = format!("{}-web-1", p.name);
+	assert!(
+		has(&container, &["Starting", "Creating"]),
+		"the container needs its own transition, not only its ending; got:\n{stderr}"
+	);
+	assert!(
+		has(&container, &["Started", "Created", "Running"]),
+		"and it must still get its ending; got:\n{stderr}"
+	);
+	let network = format!("{}_default", p.name);
+	assert!(
+		has(&network, &["Creating"]),
+		"the network needs one too; got:\n{stderr}"
+	);
+}
+
+/// `--ansi never` means it. The board is gated on the colour choice as well as
+/// on the terminal, because someone who asked for no escapes did not ask for a
+/// quieter kind of escape.
+#[tokio::test]
+async fn ansi_never_gets_no_board() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(&compose, "services:\n  web:\n    image: alpine:latest\n").unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-noansi", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["--ansi", "never", "up", "-d"]);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"--ansi never must emit nothing to repaint with; got:\n{stderr:?}"
+	);
+}
+
+/// The board writes to stderr only. stdout stays a clean pipe, which is what
+/// lets `run -d` keep printing its container id there and `config` keep piping
+/// into a file.
+#[tokio::test]
+async fn the_board_never_touches_stdout() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-stdout", std::process::id()),
+		_dir: dir,
+	};
+	let stdout = p.run(&["up", "-d"]);
+	assert!(
+		stdout.trim().is_empty(),
+		"up must leave stdout empty; got:\n{stdout}"
+	);
+}
+
+/// `down` gets a board too, seeded from what Podman actually has rather than
+/// from what the compose file describes — a service the file lists but that was
+/// never created would sit on the board as a row that never moves.
+#[tokio::test]
+async fn a_piped_down_gets_transitions_for_what_exists() {
+	if !podman_up().await {
+		return;
+	}
+	let p = Project::start("dwn");
+	let stderr = p.progress(&["down", "-v"]);
+	assert!(
+		!stderr.contains('\u{1b}'),
+		"a pipe must get no escape sequences; got:\n{stderr:?}"
+	);
+	let has = |name: &str, verb: &str| stderr.lines().any(|l| l.contains(name) && l.contains(verb));
+	let container = format!("{}-web-1", p.name);
+	assert!(
+		has(&container, "Stopping"),
+		"the container needs its transition; got:\n{stderr}"
+	);
+	assert!(has(&container, "Removed"), "and its ending; got:\n{stderr}");
+	let network = format!("{}_default", p.name);
+	assert!(
+		has(&network, "Removing") && has(&network, "Removed"),
+		"the network needs both; got:\n{stderr}"
+	);
+}
+
+/// `build` writes its output to stderr, leaving stdout a clean pipe.
+///
+/// It used `print!`, contradicting the documented promise that stdout stays
+/// pipeable — the one thing a caller redirecting `podup build > log` relies on,
+/// and the same promise `config` and `generate quadlet` are built around.
+#[tokio::test]
+async fn build_leaves_stdout_a_clean_pipe() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	fs::write(
+		dir.path().join("Dockerfile"),
+		"FROM alpine:latest\nRUN true\n",
+	)
+	.unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  tiny:\n    image: podup-build-probe:1\n    build:\n      context: .\n",
+	)
+	.unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"-p",
+			&format!("t{}-bld", std::process::id()),
+			"build",
+		])
+		.output()
+		.expect("run podup build");
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		stdout.trim().is_empty(),
+		"build must not write to stdout; got:\n{stdout}"
+	);
+	assert!(
+		!String::from_utf8_lossy(&out.stderr).trim().is_empty(),
+		"the build output has to go somewhere, and that somewhere is stderr"
+	);
+}
+
+/// `pull` reports through the progress layer, with a matching `Pulled`.
+///
+/// It used a bare `eprintln!` — the one user-facing line in the binary that
+/// bypassed `ui` entirely, so it ignored `PROGRESS_ENABLED` and an embedder
+/// asking podup to stay silent got it anyway. There was never a `Pulled` at all,
+/// so a pull that finished looked exactly like one that hung.
+#[tokio::test]
+async fn pull_reports_both_ends() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(&compose, "services:\n  x:\n    image: alpine:latest\n").unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-pull", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["pull"]);
+	assert!(
+		stderr.contains("Pulling") && stderr.contains("Pulled"),
+		"pull must report starting and finishing; got:\n{stderr}"
+	);
+	assert_eq!(
+		stderr.matches("Pulling").count(),
+		1,
+		"one image, one Pulling; got:\n{stderr}"
+	);
+}
+
+/// One image, one `Pulling`, even on the `up` path.
+///
+/// `up` warms the image cache before the per-level walk and then pulls again
+/// inside it, and both reported — so `Pulling` appeared twice per image on `up`
+/// while a standalone `pull` printed it once. The prefetch is best-effort
+/// warming and the walk's own pull is the authoritative one, so only the second
+/// speaks.
+///
+/// `pull_policy: always` is what forces both stages to actually issue a pull for
+/// an image that is already local; with the default `missing` the prefetch would
+/// short-circuit and the duplication could not appear whether or not the control
+/// exists.
+#[tokio::test]
+async fn up_pulls_an_image_once() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    pull_policy: always\n    command: \
+		 [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-once", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["up", "-d"]);
+	let pulls = stderr.matches("Pulling").count();
+	assert!(
+		pulls <= 1,
+		"one image must produce at most one Pulling on up; got {pulls} in:\n{stderr}"
+	);
+}

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -1,0 +1,301 @@
+//! Whether a command tells you what it did.
+//!
+//! The sibling of `output_contract.rs`: that file pins the *shape* of output,
+//! this one pins that there is any. #1248 found six lifecycle commands exiting
+//! 0 in complete silence on a project that was never created, a `push` that
+//! uploaded an image and wrote zero bytes, an `up` that created three resources
+//! and named none of them, and a `down` that announced destroying a data volume
+//! which had never existed.
+//!
+//! Silence and a false report are the two failure modes, and each needs an
+//! acceptance twin: a test that only asserts a note appears is equally
+//! satisfied by a note that always appears.
+
+mod harness;
+
+use harness::{bin, podman_up, Project};
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+/// `push` says something. It used to say nothing at all.
+///
+/// Its only two user-facing lines were `tracing::info!`, and the CLI floors
+/// tracing at `warn`, so a push that genuinely uploaded the image wrote zero
+/// bytes to stdout and stderr and exited 0 — measured against a real local
+/// registry, which afterwards listed the repository. This asserts the line is
+/// back and that it goes to stderr, leaving stdout a clean pipe.
+///
+/// Deliberately pointed at a registry that cannot exist (port 1) with an image
+/// that is not present locally: the progress line is emitted before the API
+/// call, so the assertion needs no registry and no build, and the command still
+/// fails afterwards — which is also what pins the line as *progress* rather
+/// than a success message.
+#[tokio::test]
+async fn push_reports_the_image_it_is_pushing() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  x:\n    image: localhost:1/absent:1\n",
+	)
+	.unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"push",
+			"--tls-verify=false",
+		])
+		.output()
+		.expect("run podup push");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		stderr.contains("localhost:1/absent:1") && stderr.contains("Pushing"),
+		"push must report the image on stderr; got stderr:\n{stderr}"
+	);
+	assert!(
+		stdout.trim().is_empty(),
+		"push must leave stdout a clean pipe; got stdout:\n{stdout}"
+	);
+}
+
+/// `push --quiet` suppresses the progress lines. The flag existed while there
+/// was no output for it to suppress, so nothing had ever exercised it.
+#[tokio::test]
+async fn push_quiet_suppresses_the_progress_lines() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  x:\n    image: localhost:1/absent:1\n",
+	)
+	.unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"push",
+			"--quiet",
+			"--tls-verify=false",
+		])
+		.output()
+		.expect("run podup push --quiet");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		!stderr.contains("Pushing"),
+		"--quiet must suppress the progress line; got stderr:\n{stderr}"
+	);
+}
+
+/// `up` reports the networks and volumes it creates, the way `down` has always
+/// reported removing them.
+///
+/// It did not: measured on a four-object project, `up` created `p4_default`,
+/// `p4_extra` and `p4_data` and named none of them, while `down -v` on the same
+/// project listed all three as `Removed`. Creation went through
+/// `tracing::info!` under the CLI's `warn` floor, so the two halves of the same
+/// lifecycle disagreed about whether resources were worth mentioning.
+///
+/// Asserted on a fresh project name, because the create is idempotent: a second
+/// `up` correctly reports nothing, so a reused project would pass this whether
+/// or not the control exists.
+#[tokio::test]
+async fn up_reports_the_networks_and_volumes_it_creates() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    \
+		 volumes:\n      - data:/data\nvolumes:\n  data:\nnetworks:\n  extra:\n",
+	)
+	.unwrap();
+	let compose = compose.to_string_lossy().into_owned();
+	let name = format!("t{}-mk", std::process::id());
+	let out = Command::new(bin())
+		.args(["-f", &compose, "-p", &name, "up", "-d"])
+		.output()
+		.expect("run podup up");
+	let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+	let _ = Command::new(bin())
+		.args(["-f", &compose, "-p", &name, "down", "-v"])
+		.output();
+	for needle in [
+		&format!("Network {name}_default"),
+		&format!("Network {name}_extra"),
+		&format!("Volume {name}_data"),
+	] {
+		assert!(
+			stderr.contains(needle.as_str()) && stderr.contains("Created"),
+			"up must report creating {needle}; got stderr:\n{stderr}"
+		);
+	}
+}
+
+/// `down` only reports removals that happened.
+///
+/// It reported three that had not: measured on a project name that had never
+/// been created, `down -v` printed `Network …_extra Removed`, `Network
+/// …_default Removed` and `Volume …_data Removed`. The cause was `delete_ok`
+/// discarding the boolean `delete_existed` returns — the very distinction that
+/// method exists to preserve, and which the container path had always used — so
+/// a 404 reached the caller as `Ok(())` and was announced as a deletion.
+///
+/// A volume is where this is worst: it names data the operator is being told is
+/// gone. The reference prints nothing at all here and exits 0.
+#[tokio::test]
+async fn down_does_not_report_removing_what_never_existed() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    volumes:\n      - data:/data\nvolumes:\n  \
+		 data:\nnetworks:\n  extra:\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-ghost", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["down", "-v"]);
+	assert!(
+		!stderr.contains("Removed"),
+		"nothing existed, so nothing may be reported as removed; got stderr:\n{stderr}"
+	);
+}
+
+/// Every lifecycle command says so when it did nothing.
+///
+/// Measured before the fix on a project that was never created: `rm`, `stop`,
+/// `restart`, `kill`, `pause` and `unpause` each printed zero lines and exited
+/// 0, which reads exactly like success. Only `start` said anything. The cause is
+/// that `live_replica_names` falls back to the *static* compose names when
+/// nothing is running, so each command dutifully walked a list of container
+/// names and 404'd on every one of them.
+#[tokio::test]
+async fn idle_lifecycle_commands_say_they_did_nothing() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(&compose, "services:\n  web:\n    image: alpine:latest\n").unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-idle", std::process::id()),
+		_dir: dir,
+	};
+	for (args, verb) in [
+		(vec!["rm", "-f"], "remove"),
+		(vec!["stop"], "stop"),
+		(vec!["start"], "start"),
+		(vec!["restart"], "restart"),
+		(vec!["kill"], "signal"),
+		(vec!["pause"], "pause"),
+		(vec!["unpause"], "unpause"),
+	] {
+		let stderr = p.progress(&args);
+		assert!(
+			stderr.contains(&format!("no containers to {verb}")),
+			"`{}` on an uncreated project must say it did nothing; got stderr:\n{stderr}",
+			args.join(" ")
+		);
+	}
+}
+
+/// The acceptance twin of the test above: when the command really does act, the
+/// note must not appear. Without this pairing, a `note_if_idle` that fired
+/// unconditionally would satisfy the rejection test and prove nothing.
+#[tokio::test]
+async fn lifecycle_commands_stay_quiet_when_they_did_act() {
+	if !podman_up().await {
+		return;
+	}
+	let p = Project::start("acted");
+	for (args, verb) in [
+		(vec!["restart"], "restart"),
+		(vec!["stop"], "stop"),
+		(vec!["rm", "-f"], "remove"),
+	] {
+		let stderr = p.progress(&args);
+		assert!(
+			!stderr.contains(&format!("no containers to {verb}")),
+			"`{}` acted, so it must not claim there was nothing to do; got stderr:\n{stderr}",
+			args.join(" ")
+		);
+	}
+}
+
+/// `wait` names the container each exit code belongs to, one line per container,
+/// and offers a machine path.
+///
+/// It printed a bare `0` per service. With more than one container nothing said
+/// which code was whose, and a service scaled to three collapsed to one line.
+/// Measured on docker compose v5.1.3 with three replicas: it reports per
+/// container, so the granularity here follows the reference — the rendering
+/// deliberately does not, since the reference prints a 64-character hex id, the
+/// same sentence on every line, and nothing a parser can read.
+#[tokio::test]
+async fn wait_names_each_container_and_its_code() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  ok:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"exit 0\"]\n  \
+		 bad:\n    image: alpine:latest\n    deploy:\n      replicas: 2\n    command: [\"sh\", \
+		 \"-c\", \"exit 3\"]\n",
+	)
+	.unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-wait", std::process::id()),
+		_dir: dir,
+	};
+	p.run(&["up", "-d"]);
+
+	let table = p.run(&["wait"]);
+	assert!(
+		table.contains("NAME") && table.contains("EXIT"),
+		"wait must print its header; got:\n{table}"
+	);
+	for needle in ["-ok-1", "-bad-1", "-bad-2"] {
+		assert!(
+			table.contains(needle),
+			"every container gets its own line, including each replica; \
+			 missing {needle} in:\n{table}"
+		);
+	}
+
+	let ndjson = p.run(&["wait", "--format", "json"]);
+	let rows: Vec<serde_json::Value> = ndjson
+		.lines()
+		.filter(|l| !l.trim().is_empty())
+		.map(|l| serde_json::from_str(l).expect("each wait json line must parse on its own"))
+		.collect();
+	assert_eq!(rows.len(), 3, "one NDJSON object per container: {ndjson}");
+	for row in &rows {
+		assert!(row.get("Container").is_some(), "missing Container: {row}");
+		assert!(row.get("ExitCode").is_some(), "missing ExitCode: {row}");
+	}
+	assert!(
+		rows.iter().any(|r| r["ExitCode"] == 3),
+		"the failing containers' code must survive: {ndjson}"
+	);
+}


### PR DESCRIPTION
Release 3.4.0. Contents of `main..develop`: the four terminal-experience phases and the interrupted-cursor fix that followed them.

- #1247 — twenty identity colours, one per service, readable on a light terminal and a dark one alike
- #1249 — the commands that finished their work and told me nothing
- #1252 — a live board while `up`, `down`, `pull` and `build` work
- #1254 — `stats` repaints instead of scrolling
- #1256 — the cursor comes back when a live command is interrupted

## Incompatible changes

All command-line output. The library API is unchanged and semver-checks passed on every PR in the range.

- **`podup build` writes to stderr, not stdout.** `podup build > build.log` now captures nothing; redirect stderr instead. stdout was documented as a clean pipe and `build` was the one command contradicting it.
- **`podup wait` prints one line per container** — name and exit code in aligned columns — instead of a bare exit code per service. `--format json` is new and is the stable machine form.
- **`podup --version`** prints `podup version v3.4.0`, matching `podup version`. `version --short` still prints the bare number.
- **`stats`, `events` and `top` changed their table layouts.** Anything parsing them by byte offset needs updating; `--format json` is unaffected in all three.

I raised MAJOR versus MINOR before the bump and the call was 3.4.0: these are CLI rendering rather than API. Recording it here so the choice is visible rather than looking like an oversight, and the items are at the top of the notes where an upgrader will see them.

## Verified before tagging

- `cargo test` — 1995 pass, 0 fail, including the 155-test integration suite against real Podman 5.7.0.
- `cargo audit` clean, which is what `release.yml`'s verify job gates on.
- All three version files agree at 3.4.0 — `Cargo.toml`, `Cargo.lock` and `debian/changelog`. The third is the one that shipped `podup_1.8.0_*.deb` in 1.9.0 and left apt users with nothing to upgrade to; verify now gates all three before anything is built.
- `cargo build --locked` at 3.4.0, and the built binary reports `podup version v3.4.0`.
- `embedded_key_verifies_real_release` passes, so the embedded trust anchor still verifies a real published `SHA256SUMS`.

Merge commit, not squash: `main` absorbs `develop` exactly so the histories stay aligned and the next release PR only shows new work.
