### PR TITLE
chore(ci): bump the shared reusables to .github v1.13.0

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/dco.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0


### PR DESCRIPTION
Closes #1259.

All twelve callers under `.github/workflows/` move from `7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1` to `e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0`. One line each, no other change.

### Why one pull request instead of the ten open ones

Dependabot has #1231–#1240 open against `develop`, all proposing `v1.12.0`. They are a release behind — `v1.13.0` shipped 2026-07-31, they were opened 2026-07-29 — and the `v1.10.1..v1.12.0` diff over `.github/workflows/` only touches `docs-current.yml`, `go-ci.yml`, `go-fuzz.yml` and `schedule-freshness.yml`, none of which this repository calls. Merging all ten would move twelve SHAs and change no behaviour.

The two reusables that did change for us are only in `v1.13.0`:

- `shell-ci.yml` — the shellcheck tarball is written to disk and verified with `sha256sum -c` before extraction, instead of being piped into `tar` as it arrives.
- `workflow-lint.yml` — the same, and the pinned binary is now passed to `actionlint -shellcheck` rather than letting the embedded pass fall back to whatever the runner image ships.

Neither had a viable route in. `shell-ci.yml` and `line-limit.yml` have no Dependabot pull request at all, because `open-pull-requests-limit` is 10 and the ten above filled the queue; `workflow-lint.yml` has #1231, but at a version that predates the fix.

### Caller impact

`lint-shell.yml` and `workflow-lint.yml` both call their reusable with no `with:` block, so the new `shellcheck-sha256` input resolves to its default — the hash of the pinned `v0.11.0` tarball — and nothing on this side needs to change. If we ever pin `shellcheck-version` here, the hash has to be set alongside it.

I will close #1231–#1240 once this is green.