### PR TITLE
fix(top): skip a stopped container instead of aborting on it

### DIFF
--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -363,6 +363,28 @@ impl Engine {
 			live
 		})
 	}
+
+	/// The names of a service's containers that are actually **running**, in the
+	/// same ascending `-1, -2, -3, ...` order as [`Self::live_replica_names`].
+	///
+	/// For the query commands that only mean anything against a live process
+	/// (`top`), where a stopped replica has to be skipped rather than asked: the
+	/// libpod endpoints answer a non-running container with an HTTP 500, which
+	/// callers must not have to tell apart from a real failure by parsing its
+	/// message. Unlike [`Self::live_replica_names`] there is no fallback to
+	/// statically-derived names — a service that was never created has nothing
+	/// running, so it yields an empty vec instead of a phantom name.
+	pub(crate) async fn running_replica_names(&self, service_name: &str) -> Result<Vec<String>> {
+		let mut running: Vec<String> = self
+			.live_service_containers(service_name)
+			.await?
+			.into_iter()
+			.filter(|c| c.state.eq_ignore_ascii_case("running"))
+			.map(|c| c.name)
+			.collect();
+		sort_replica_names(&mut running);
+		Ok(running)
+	}
 }
 
 #[cfg(test)]
@@ -474,6 +496,70 @@ mod tests {
 				"proj-web-2".to_string(),
 				"proj-web-3".to_string(),
 			]
+		);
+	}
+
+	/// #1250: `top` aborted on a project with a stopped service because it asked
+	/// every container that exists for its process list, and libpod answers a
+	/// non-running one with an HTTP 500. The exited replica must be dropped
+	/// before the call, and the survivors must keep the ascending order every
+	/// other by-service command produces — so this asserts both, on a listing
+	/// that is shuffled and mixed-state at once.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn running_replica_names_drops_non_running_and_keeps_ascending_order() {
+		let containers = r#"[
+			{"Names":["/proj-web-3"],"State":"running"},
+			{"Names":["/proj-web-4"],"State":"created"},
+			{"Names":["/proj-web-1"],"State":"running"},
+			{"Names":["/proj-web-5"],"State":"paused"},
+			{"Names":["/proj-web-2"],"State":"exited"}
+		]"#;
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, containers.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let names = e
+			.running_replica_names("web")
+			.await
+			.expect("running_replica_names should succeed");
+
+		assert_eq!(
+			names,
+			vec!["proj-web-1".to_string(), "proj-web-3".to_string()],
+			"only the running replicas, in ascending order"
+		);
+	}
+
+	/// The sibling half of the rule above: a service that exists in the compose
+	/// file but was never created has nothing running, so `top` must render
+	/// nothing for it rather than fall back to a statically-derived name and
+	/// then have to swallow the 404 that name earns.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn running_replica_names_does_not_fall_back_to_static_names() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, "[]".to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let names = e
+			.running_replica_names("web")
+			.await
+			.expect("running_replica_names should succeed");
+
+		assert!(
+			names.is_empty(),
+			"a never-created service yields no names, got {names:?}"
 		);
 	}
 

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -69,8 +69,14 @@ impl Engine {
 
 		let mut json_rows: Vec<serde_json::Value> = Vec::new();
 		for name in &names {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
+			// Only running containers are asked for their process list, so a
+			// stopped replica is skipped before the call rather than after it
+			// fails: `/top` answers a non-running container with an HTTP 500, and
+			// the rule below — that a non-404 must surface — is deliberate and
+			// stays. Measured against `docker compose top` v5.1.3 on the same
+			// Podman socket: it omits a stopped service, prints the rest and exits
+			// 0 (#1250).
+			for container_name in self.running_replica_names(name).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/top",
 					urlencoded(&container_name),
@@ -94,10 +100,11 @@ impl Engine {
 						let processes = result.processes.clone().unwrap_or_default();
 						Self::print_process_table(&titles, &processes);
 					}
-					// A not-created container (404) is tolerated; any other failure
-					// (e.g. a stopped container's HTTP 500, or an unreachable socket)
-					// is a real error that must surface with a non-zero exit instead
-					// of being swallowed into a warning.
+					// A container removed between the listing above and this call
+					// (404) is tolerated; any other failure — an unreachable socket,
+					// a container that died in that same window — is a real error
+					// that must surface with a non-zero exit instead of being
+					// swallowed into a warning.
 					Err(e) if e.is_status(404) => {
 						tracing::debug!("top {container_name}: {e}")
 					}

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -286,6 +286,44 @@ async fn top_scaled_service_all_replicas() {
 	engine.down(&file).await.unwrap();
 }
 
+/// #1250: a project where one service has already run to completion — a
+/// `migrate` that exits 0 is the everyday shape — used to abort `top` on the
+/// stopped container, losing the services it had not reached yet and exiting
+/// non-zero. Measured against `docker compose top` v5.1.3 on the same Podman
+/// socket: it omits the stopped service, prints the rest and exits 0.
+#[tokio::test]
+async fn top_skips_a_stopped_service_and_reports_the_rest() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("tss");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n  migrate:\n    image: alpine:latest\n    command: [\"true\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+
+	// `migrate` has to have actually exited before `top` runs, or this passes for
+	// the wrong reason — `up` returns once the container is started, not once it
+	// is done, so without this the test could exercise two running services and
+	// prove nothing. `wait` blocks until it stops, which is deterministic where
+	// a sleep is not.
+	engine
+		.wait_services(&file, &["migrate".to_string()])
+		.await
+		.unwrap();
+
+	engine
+		.top(&file, &[])
+		.await
+		.expect("top must skip the stopped service rather than abort on it");
+
+	engine.down(&file).await.unwrap();
+}
+
 #[tokio::test]
 async fn exec_scaled_service_targets_first_replica() {
 	let client = match podman().await {


### PR DESCRIPTION
Closes #1250.

`top` asked every container a service has for its process list, and libpod answers a non-running one with an HTTP 500. On a project where anything had already exited — a `migrate` that runs once is the everyday shape — that killed the command partway through, losing the services it had not reached yet and exiting non-zero.

### What I measured first

The issue asserted that docker compose skips a non-running container and carries on, so I checked rather than took it. `docker compose` v5.1.3 pointed at the same Podman socket, same compose file, one service already exited:

```
SERVICE  #   UID   PID  PPID  C   STIME  TTY  TIME      CMD
api      1   root  1    0     0   11:31  ?    00:00:00  sleep 300
web      1   root  1    0     0   11:31  ?    00:00:00  sleep 300
EXIT=0
```

`migrate` is absent, the rest print, exit 0. `docker compose top migrate` — naming only the stopped service — prints nothing and exits 0 too. Both now match.

One thing that nearly gave me a wrong answer: my first run had docker compose print nothing at all, including the running services. That was not `top`'s behaviour — podup labels with `podup.project`/`podup.service`, so docker compose could not see a project podup had created. The comparison only means anything when the client being measured is the one that created the project.

### The fix

New `running_replica_names` in `internal/engine/lifecycle/scale.rs` enumerates with the state already carried by `live_service_containers` — which `top` was fetching a name-only view of and discarding — and returns only the running replicas, sorted into the same ascending `-1, -2, -3` order every other by-service command produces.

The stopped container is therefore skipped **before** the call rather than after it fails. That matters for two reasons:

- **The existing ruling stands untouched.** The code carries an explicit decision that a non-404 failure must surface rather than be swallowed into a warning, and the issue was right that reversing it deserved its own evidence. This does not reverse it — a stopped container simply never reaches that branch. An unreachable socket still errors exactly as before.
- **No error-message parsing.** Telling "stopped" apart from a real failure by matching the text of a 500 would be fragile in a way a state field is not.

`live_replica_names` is left alone: it returns the containers that *exist*, which is what `start`, `rm` and `logs` need.

### Proof

Every assertion was proved by mutation rather than assumed:

| mutation | result |
|---|---|
| drop the running-state filter | `running_replica_names_drops_non_running…` red |
| drop the sort | same test red |
| reintroduce the static-name fallback | `running_replica_names_does_not_fall_back…` red |
| revert `top` to the pre-fix enumeration | integration test red with `top can only be used on running containers` |

That last one is the regression test proper: it reproduces the reported failure against the old code. It also blocks the way this test could pass for the wrong reason — `up` returns once a container is *started*, not once it is *done*, so it calls `wait` on `migrate` first to guarantee there really is a non-running container by the time `top` runs.

Full suite green (1998 tests), `cargo fmt --check` clean, `cargo clippy --locked --all-targets --all-features -- -D warnings` clean. Verified end to end with the release binary against real Podman 5.7.0.

### Deliberately not in this PR

- **Output shape.** docker compose prints one table with `SERVICE` and `#` columns, sorted alphabetically; podup prints a per-container header and a table each, in compose order. #1250 exists because that was kept out of #1248, so folding it back in here would undo the reason it was filed separately.
- **Unknown service name.** docker compose exits 0 silently; podup returns `ServiceNotFound`. I think podup is right — a mistyped service that appears to succeed is worse than the divergence — so this stays as it is.