### PR TITLE
perf(secrets): stop deleting secrets that are not there, and create them concurrently

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -3,7 +3,11 @@
 mod commands;
 mod down_label;
 mod images;
-mod parallel;
+// Visible within the engine, not beyond it: the secret pre-creation stage
+// (#1219) fans out against the same `MAX_LIFECYCLE_CONCURRENCY` ceiling rather
+// than growing a second concurrency limit that could silently drift from this
+// one.
+pub(in crate::engine) mod parallel;
 mod prefetch;
 mod readiness;
 mod run;

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -24,7 +24,7 @@ use super::targets::{stop_deadline, stop_timeout_param};
 /// concurrently. Services within a dependency level have no ordering between
 /// them, so they run in parallel; the cap keeps a very wide compose file from
 /// opening an unbounded number of simultaneous libpod connections at once.
-pub(super) const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
+pub(in crate::engine) const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
 
 /// Run a batch of independent per-service futures concurrently, bounded by
 /// [`MAX_LIFECYCLE_CONCURRENCY`], and return their outputs in the *input*
@@ -34,6 +34,14 @@ pub(super) const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
 /// (`Result<()>`, reduced via [`first_error`]) and a best-effort one that
 /// never fails (`()`, e.g. the image-prefetch stage) share this one bounded
 /// dispatcher.
+///
+/// Not reachable from every stage that wants a fan-out: this is built on
+/// `buffer_unordered`, whose `FuturesUnordered` is `Send` only if its future is
+/// `Send` for *every* lifetime. A caller whose futures borrow `&self` therefore
+/// acquires a higher-ranked bound that propagates out to its own callers, which
+/// is why the secret pre-creation stage (#1219) chunks `join_all` against
+/// [`MAX_LIFECYCLE_CONCURRENCY`] instead of calling this. The cap is shared; the
+/// dispatcher is not.
 pub(super) async fn join_bounded<F, T>(futs: impl IntoIterator<Item = F>) -> Vec<T>
 where
 	F: std::future::Future<Output = T>,
@@ -55,7 +63,7 @@ where
 /// Reduce a level's per-service results to the first error in service order, so
 /// one failing service is still reported clearly while the rest of the level is
 /// allowed to complete.
-pub(super) fn first_error(results: Vec<Result<()>>) -> Option<ComposeError> {
+pub(in crate::engine) fn first_error(results: Vec<Result<()>>) -> Option<ComposeError> {
 	results.into_iter().find_map(Result::err)
 }
 

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -106,6 +106,7 @@ impl Engine {
 	/// secret carries the `podup.project=<proj>` label so the label-guarded
 	/// teardown on `down` still only removes secrets podup owns.
 	pub(super) async fn create_project_secrets(&self, file: &ComposeFile) -> Result<()> {
+		let mut work: Vec<(String, Vec<u8>)> = Vec::new();
 		for (name, payload) in collect_payload_union(&self.project, file, &self.base_dir)? {
 			let bytes = match payload {
 				Payload::Inline(bytes) => bytes,
@@ -120,9 +121,54 @@ impl Engine {
 					))
 				})?,
 			};
-			self.create_secret(&name, &bytes).await?;
+			work.push((name, bytes));
 		}
-		Ok(())
+		// The union is a `HashMap`, so its iteration order is arbitrary and not
+		// stable between runs. Sorting by name is what makes "the first error
+		// wins" mean something: without it, which of several failing secrets got
+		// reported would vary run to run, and so would the test asserting it.
+		work.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+		// Fanned out over the union, never per service (#1219). The union holds
+		// distinct scoped names, so these chains cannot collide with each other;
+		// parallelising per service instead would put two services in one
+		// dependency level back to racing the same scoped name through a
+		// non-atomic delete-then-create, which pre-creating the union once is
+		// exactly what settles.
+		//
+		// Chunked `join_all` against the lifecycle's ceiling rather than its
+		// `join_bounded`, and that is a compiler limitation rather than a
+		// preference. `join_bounded` is built on `buffer_unordered`, whose
+		// `FuturesUnordered` is `Send` only if its future is `Send` for *every*
+		// lifetime. Reaching it from here — where the futures borrow `self` —
+		// makes that bound higher-ranked and propagates out through `up` until an
+		// unrelated `tokio::spawn(engine.watch(…))` stops compiling with
+		// "implementation of `Send` is not general enough", reported in a test
+		// file that never touches secrets. Owning the payloads and boxing the
+		// futures were both tried; neither clears it. `join_all` over fixed-size
+		// chunks carries no such bound, holds the same ceiling on simultaneous
+		// libpod connections, and returns results in input order, so the error
+		// reported is still the first by name.
+		//
+		// Note the behaviour change this carries: previously the first failing
+		// secret aborted before the rest were touched, and now every secret in
+		// its chunk is attempted. Nothing leaks — `down` sweeps by label — but a
+		// failed `up` can leave later secrets created where it used to leave none.
+		let mut results: Vec<Result<()>> = Vec::with_capacity(work.len());
+		for chunk in work.chunks(crate::engine::lifecycle::parallel::MAX_LIFECYCLE_CONCURRENCY) {
+			results.extend(
+				futures_util::future::join_all(
+					chunk
+						.iter()
+						.map(|(name, bytes)| self.create_secret(name, bytes)),
+				)
+				.await,
+			);
+		}
+		match crate::engine::lifecycle::parallel::first_error(results) {
+			Some(e) => Err(e),
+			None => Ok(()),
+		}
 	}
 
 	/// Create a Podman-native secret named `name` holding `payload`, labelled
@@ -139,7 +185,7 @@ impl Engine {
 		// is not labelled as ours, refuse rather than clobber a foreign secret.
 		// Our own secret (or a 404) is replaced fresh, keeping re-`up` idempotent.
 		let inspect = format!("{API_PREFIX}/secrets/{}/json", urlencoded(name));
-		match self.client.get_json::<serde_json::Value>(&inspect).await {
+		let existed = match self.client.get_json::<serde_json::Value>(&inspect).await {
 			Ok(info) => {
 				let owned = info
 					.get("Spec")
@@ -155,15 +201,21 @@ impl Engine {
 						self.project
 					)));
 				}
+				true
 			}
-			Err(e) if e.is_status(404) => {}
+			Err(e) if e.is_status(404) => false,
 			Err(e) => return Err(ComposeError::Podman(e)),
+		};
+		// Only delete something that is actually there (#1219). On a first `up`
+		// every secret is a 404, so this was a round trip per secret spent
+		// removing nothing.
+		if existed {
+			let delete_path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
+			self.client
+				.delete_ok(&delete_path)
+				.await
+				.map_err(ComposeError::Podman)?;
 		}
-		let delete_path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
-		self.client
-			.delete_ok(&delete_path)
-			.await
-			.map_err(ComposeError::Podman)?;
 		let labels = serde_json::json!({ "podup.project": self.project }).to_string();
 		let path = format!(
 			"{API_PREFIX}/secrets/create?name={}&labels={}",
@@ -179,7 +231,22 @@ impl Engine {
 			)
 			.await
 			.map(|_| ())
-			.map_err(ComposeError::Podman)
+			.map_err(|e| {
+				// Skipping the delete opens a window: the inspect said the name was
+				// free, and something claimed it before the create landed. `up` now
+				// fails there instead of clobbering whatever arrived — the better
+				// outcome, but only if it is legible. Podman's own message for this
+				// is an opaque 500, so it is named here rather than passed through.
+				if !existed {
+					ComposeError::Unsupported(format!(
+						"secret '{name}' did not exist when podup checked but could not \
+						 be created: {e} — something else created a secret of that name \
+						 in between. Re-run `up`, or remove it if it is not wanted."
+					))
+				} else {
+					ComposeError::Podman(e)
+				}
+			})
 	}
 
 	/// Remove the project-scoped native secrets created on `up` for the
@@ -321,6 +388,200 @@ mod tests {
 	use super::*;
 	use crate::libpod::Client;
 	use std::path::PathBuf;
+
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+
+	/// A compose file with `n` `content:` secrets named `s1..sn`, all on one
+	/// service — the shape the union deduplicates and then fans out over.
+	#[cfg(unix)]
+	fn file_with_content_secrets(n: usize) -> ComposeFile {
+		let refs: String = (1..=n).map(|i| format!("      - s{i}\n")).collect();
+		let defs: String = (1..=n)
+			.map(|i| format!("  s{i}: {{content: \"v{i}\"}}\n"))
+			.collect();
+		crate::compose::parse_str(&format!(
+			"services:\n  app:\n    image: alpine\n    secrets:\n{refs}secrets:\n{defs}"
+		))
+		.expect("fixture compose file should parse")
+	}
+
+	#[cfg(unix)]
+	fn engine_on(fake: &fake_podman::FakePodman) -> Engine {
+		Engine::with_base_dir(fake.client(), "proj".to_string(), std::env::temp_dir())
+	}
+
+	/// #1219: on a first `up` every secret inspect is a 404, so there is nothing
+	/// to remove — the delete-then-create was spending a round trip per secret
+	/// deleting a secret that does not exist. Measured on the six-secret bench
+	/// scenario, this is what takes a cold `up` from 25 requests to 19.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn create_skips_the_delete_when_the_secret_does_not_exist() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.create_project_secrets(&file_with_content_secrets(3))
+			.await
+			.expect("creating fresh secrets should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		let deletes: Vec<&String> = seen.iter().filter(|r| r.starts_with("DELETE")).collect();
+		assert!(
+			deletes.is_empty(),
+			"no delete should be issued for a secret that does not exist, got {deletes:?}"
+		);
+		assert_eq!(
+			seen.iter()
+				.filter(|r| r.contains("/secrets/create"))
+				.count(),
+			3,
+			"every secret is still created"
+		);
+	}
+
+	/// The other half of the same rule: a secret that IS there still has to be
+	/// removed before the create, because `replace=true` is rejected on some
+	/// Podman 5.x builds. Skipping the delete unconditionally would break
+	/// re-`up` idempotence, which is the reason the delete exists at all.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn create_still_deletes_a_secret_that_already_exists() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(
+					200,
+					r#"{"Spec":{"Labels":{"podup.project":"proj"}}}"#.to_string(),
+				)
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.create_project_secrets(&file_with_content_secrets(2))
+			.await
+			.expect("replacing our own secrets should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		assert_eq!(
+			seen.iter().filter(|r| r.starts_with("DELETE")).count(),
+			2,
+			"each existing secret is removed before being recreated, got {seen:?}"
+		);
+	}
+
+	/// The behaviour change the fan-out carries, stated in #1219 and asserted
+	/// here rather than left to the reader: the pass no longer stops at the
+	/// first failure, so every secret is attempted, and the error that surfaces
+	/// is the first *by name* — not whichever chain happened to lose the race.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn fan_out_attempts_every_secret_and_reports_the_first_by_name() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else if method == "POST" && (target.contains("s2") || target.contains("s3")) {
+				(500, r#"{"message":"boom"}"#.to_string())
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(4))
+			.await
+			.expect_err("a failing secret must still fail the stage");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		for i in 1..=4 {
+			assert!(
+				seen.iter().any(|r| r.contains(&format!("s{i}"))),
+				"secret s{i} should have been attempted despite an earlier failure, got {seen:?}"
+			);
+		}
+		assert!(
+			err.to_string().contains("s2"),
+			"the first failure by name should be the one reported, got: {err}"
+		);
+	}
+
+	/// Skipping the delete opens a window between the inspect and the create.
+	/// If something claims the name in it, `up` fails rather than clobbering
+	/// what arrived — but Podman's own message for that is an opaque 500, so
+	/// the failure has to name the race or the operator cannot act on it.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_name_claimed_after_the_inspect_fails_with_a_legible_message() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else {
+				(500, r#"{"message":"secret name in use"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(1))
+			.await
+			.expect_err("a name claimed in the window must fail")
+			.to_string();
+
+		assert!(
+			err.contains("in between"),
+			"the message must explain the race, got: {err}"
+		);
+		assert!(
+			err.contains("proj_secret_s1"),
+			"the message must name which secret, got: {err}"
+		);
+		// The engine's own error is kept as the cause — it is useful — but it must
+		// not be the whole of what the operator is handed, which is what the bare
+		// `ComposeError::Podman` passthrough would have given them.
+		assert!(
+			!err.starts_with("podman API error"),
+			"the raw engine error must not be the message itself, got: {err}"
+		);
+	}
+
+	/// The ownership guard is untouched by any of the above: a secret of the
+	/// same name that podup did not create is still refused, never deleted.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_foreign_secret_is_still_refused_and_never_deleted() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(
+					200,
+					r#"{"Spec":{"Labels":{"podup.project":"someone-else"}}}"#.to_string(),
+				)
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(1))
+			.await
+			.expect_err("a foreign secret must not be overwritten")
+			.to_string();
+
+		assert!(err.contains("refusing to overwrite"), "got: {err}");
+		let seen = fake.requests.lock().unwrap().clone();
+		assert!(
+			!seen.iter().any(|r| r.starts_with("DELETE")),
+			"a foreign secret must never be deleted, got {seen:?}"
+		);
+	}
 
 	fn engine_with_base(base: &str) -> Engine {
 		Engine::with_base_dir(


### PR DESCRIPTION
Closes #1219.

Native secrets cost three serial API calls each at `up` — an inspect for the ownership guard, a delete, then a create. Both recoveries the issue named are here; neither touches what #1174 bought.

### Recovery 1 — do not delete what is not there

The inspect already knows whether the secret exists; that answer now decides whether the delete is issued. On a first `up` every secret is a 404, so this was a round trip per secret spent removing nothing.

Measured on `bench/scenarios/secrets` (six `file:` secrets), Podman 5.7.0:

| | before | after |
|---|---|---|
| `up -d` cold | 25 | **19** |
| `up -d` warm | 23 | 23 |
| `down -v` | 18 | 18 |

The warm figure is not a miss. There the secrets do exist, and the delete is exactly what keeps a re-`up` idempotent — `replace=true` is rejected on some Podman 5.x builds, which is why delete-then-create exists at all. A test pins both halves.

### Recovery 2 — concurrent, over the union

The per-secret chains now run together rather than in series, over the union and **never per service**. Parallelising per service would put two services in one dependency level back to racing the same scoped name through a non-atomic delete-then-create, which pre-creating the union once is precisely what settles.

One thing the issue could not have anticipated: `collect_payload_union` returns a `HashMap`, so there was no stable input order and "the first error wins" did not mean anything. The work is sorted by name before dispatch, or the test asserting which error surfaces would itself be non-deterministic.

### Wall clock, and a correction

40 iterations, alternating binaries per iteration so drift lands on both arms:

```
before  n=40  median 113.3 ms   min  99.8   p90 120.6
after   n=40  median 111.0 ms   min  93.5   p90 118.1
                     -2.3 ms  (-2.0 %)
```

A first 15-sample run suggested nearly 6 ms. That was noise — the `before` median moved about 5 ms between runs on its own, the same order as the effect. The request count is the deterministic result; the clock gain is modest.

### The two consequences, both tested

- **The pass no longer stops at the first failure.** Every secret is attempted and the first error *by name* is reported. Nothing leaks: `down` sweeps by label. But a failed `up` can now leave later secrets created where it used to leave none, which is a real behaviour change and is asserted rather than left to the reader.
- **Skipping the delete opens a window** between the inspect and the create. If something claims the name in it, `up` fails rather than clobbering what arrived — the better outcome, but only if it is legible, so the error names the race instead of passing through Podman's opaque 500.

### Why chunked `join_all` and not `join_bounded`

A compiler limitation, not a preference, and worth recording because the failure is unrecognisable from where it is reported. `join_bounded` is built on `buffer_unordered`, whose `FuturesUnordered` is `Send` only if its future is `Send` for *every* lifetime. Reaching it from here, where the futures borrow `self`, makes that bound higher-ranked and propagates out through `up` until `tokio::spawn(engine.watch(…))` stops compiling with "implementation of `Send` is not general enough" — reported in `tests/engine_integration/watch.rs`, a file that never touches secrets. Owning the payloads and boxing the futures were both tried; neither clears it. `join_all` over fixed-size chunks carries no such bound, holds the same `MAX_LIFECYCLE_CONCURRENCY` ceiling, and returns results in input order. The cap is shared; the dispatcher is not, and `join_bounded`'s doc comment now says why.

I checked that a clean `develop` reports zero of those errors before concluding it was mine.

### Verified where it counts

The issue is explicit that this does not merge on a green local suite: it needs an enforcing host and both majors. The local machine is Ubuntu with no SELinux at all, which is the environment blind to what #1174 was about.

```
Podman 5.8.1  Fedora 44          SELinux Enforcing   ALL PASS
Podman 6.0.1  Fedora 45 rawhide  SELinux Enforcing   ALL PASS
```

Not "exited 0" — each secret is read back from inside the container and compared, which is the distinction #1174 turned on, where `up` reported success while the container could not read the file. The pass covers a cold `up`, a re-`up`, the ownership guard refusing a foreign secret without destroying it, and a clean teardown.

Full suite green (2003 tests). `cargo fmt --check` and `cargo clippy --locked --all-targets --all-features -- -D warnings` clean. Every new assertion proved by mutation — six mutations, each turning the intended test red.

### Not in this PR

`down` stays at 18 requests. There is a third recovery there that the issue does not name: it makes six per-secret ownership inspects *and* a `GET /secrets/json` that already carries every label. Fetching the list first would make those six redundant. I have filed that separately rather than fold it in, because it changes the ownership guard's mechanism rather than just its pace, and this issue scopes the recoveries to `up`.