### PR TITLE
chore: bump to 3.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+podup (3.4.1) unstable; urgency=medium
+
+  Fixed
+
+  * `podup top` no longer aborts when a service has already stopped. A project
+    where anything has run to completion — a `migrate` that exits once is the
+    everyday shape — used to lose the services `top` had not reached yet and
+    exit non-zero. It now skips the stopped container and carries on, matching
+    `docker compose top`, which was measured against the same Podman socket.
+
+  Performance
+
+  * Creating a project's secrets makes fewer round trips. A secret that does not
+    exist is no longer deleted before it is created, and the per-secret work now
+    runs concurrently rather than in series. Measured on a six-secret project, a
+    cold `up` drops from 25 API requests to 19.
+
+  * Tearing them down makes fewer still. `down` asked Podman for each secret's
+    ownership label individually and then fetched the whole labelled list anyway;
+    it now takes the list first and uses it. Measured on the same project,
+    `down -v` drops from 18 requests to 12. A secret podup did not create is
+    still never removed.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sat, 01 Aug 2026 15:25:21 -0500
+
 podup (3.4.0) unstable; urgency=medium
 
   Incompatible changes


### PR DESCRIPTION
Patch bump for the four changes on `develop` since 3.4.0.

| commit | kind |
|---|---|
| #1261 `fix(top)` — skip a stopped container instead of aborting | bug fix, user-visible |
| #1262 `perf(secrets)` — stop deleting secrets that are not there, create concurrently | performance |
| #1264 `perf(secrets)` — answer teardown ownership from one list | performance |
| #1260 `chore(ci)` — bump the shared reusables to .github v1.13.0 | CI only |

No new behaviour and nothing incompatible, so PATCH. The `top` change alters an exit code — from 1 to 0 when a service has already stopped — but that was the bug: `docker compose top` exits 0 there, measured against the same Podman socket.

All three files that stamp a version onto a shipped artifact move together:

```
Cargo.toml        3.4.1
Cargo.lock        3.4.1
debian/changelog  3.4.1
```

`debian/changelog` is the one that has gone missing before (1.8.1, inherited by 1.9.0). `dpkg-buildpackage` reads the `.deb` version from there and nowhere else, so dropping it ships a package labelled with the version the user already has — apt then reports nothing to upgrade and the release never reaches them. `dpkg-parsechangelog` reads 3.4.1 back.