### PR TITLE
release: 3.4.1

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -24,4 +24,4 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/dco.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+podup (3.4.1) unstable; urgency=medium
+
+  Fixed
+
+  * `podup top` no longer aborts when a service has already stopped. A project
+    where anything has run to completion — a `migrate` that exits once is the
+    everyday shape — used to lose the services `top` had not reached yet and
+    exit non-zero. It now skips the stopped container and carries on, matching
+    `docker compose top`, which was measured against the same Podman socket.
+
+  Performance
+
+  * Creating a project's secrets makes fewer round trips. A secret that does not
+    exist is no longer deleted before it is created, and the per-secret work now
+    runs concurrently rather than in series. Measured on a six-secret project, a
+    cold `up` drops from 25 API requests to 19.
+
+  * Tearing them down makes fewer still. `down` asked Podman for each secret's
+    ownership label individually and then fetched the whole labelled list anyway;
+    it now takes the list first and uses it. Measured on the same project,
+    `down -v` drops from 18 requests to 12. A secret podup did not create is
+    still never removed.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sat, 01 Aug 2026 15:25:21 -0500
+
 podup (3.4.0) unstable; urgency=medium
 
   Incompatible changes

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -3,7 +3,11 @@
 mod commands;
 mod down_label;
 mod images;
-mod parallel;
+// Visible within the engine, not beyond it: the secret pre-creation stage
+// (#1219) fans out against the same `MAX_LIFECYCLE_CONCURRENCY` ceiling rather
+// than growing a second concurrency limit that could silently drift from this
+// one.
+pub(in crate::engine) mod parallel;
 mod prefetch;
 mod readiness;
 mod run;

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -24,7 +24,7 @@ use super::targets::{stop_deadline, stop_timeout_param};
 /// concurrently. Services within a dependency level have no ordering between
 /// them, so they run in parallel; the cap keeps a very wide compose file from
 /// opening an unbounded number of simultaneous libpod connections at once.
-pub(super) const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
+pub(in crate::engine) const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
 
 /// Run a batch of independent per-service futures concurrently, bounded by
 /// [`MAX_LIFECYCLE_CONCURRENCY`], and return their outputs in the *input*
@@ -34,6 +34,14 @@ pub(super) const MAX_LIFECYCLE_CONCURRENCY: usize = 16;
 /// (`Result<()>`, reduced via [`first_error`]) and a best-effort one that
 /// never fails (`()`, e.g. the image-prefetch stage) share this one bounded
 /// dispatcher.
+///
+/// Not reachable from every stage that wants a fan-out: this is built on
+/// `buffer_unordered`, whose `FuturesUnordered` is `Send` only if its future is
+/// `Send` for *every* lifetime. A caller whose futures borrow `&self` therefore
+/// acquires a higher-ranked bound that propagates out to its own callers, which
+/// is why the secret pre-creation stage (#1219) chunks `join_all` against
+/// [`MAX_LIFECYCLE_CONCURRENCY`] instead of calling this. The cap is shared; the
+/// dispatcher is not.
 pub(super) async fn join_bounded<F, T>(futs: impl IntoIterator<Item = F>) -> Vec<T>
 where
 	F: std::future::Future<Output = T>,
@@ -55,7 +63,7 @@ where
 /// Reduce a level's per-service results to the first error in service order, so
 /// one failing service is still reported clearly while the rest of the level is
 /// allowed to complete.
-pub(super) fn first_error(results: Vec<Result<()>>) -> Option<ComposeError> {
+pub(in crate::engine) fn first_error(results: Vec<Result<()>>) -> Option<ComposeError> {
 	results.into_iter().find_map(Result::err)
 }
 

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -363,6 +363,28 @@ impl Engine {
 			live
 		})
 	}
+
+	/// The names of a service's containers that are actually **running**, in the
+	/// same ascending `-1, -2, -3, ...` order as [`Self::live_replica_names`].
+	///
+	/// For the query commands that only mean anything against a live process
+	/// (`top`), where a stopped replica has to be skipped rather than asked: the
+	/// libpod endpoints answer a non-running container with an HTTP 500, which
+	/// callers must not have to tell apart from a real failure by parsing its
+	/// message. Unlike [`Self::live_replica_names`] there is no fallback to
+	/// statically-derived names — a service that was never created has nothing
+	/// running, so it yields an empty vec instead of a phantom name.
+	pub(crate) async fn running_replica_names(&self, service_name: &str) -> Result<Vec<String>> {
+		let mut running: Vec<String> = self
+			.live_service_containers(service_name)
+			.await?
+			.into_iter()
+			.filter(|c| c.state.eq_ignore_ascii_case("running"))
+			.map(|c| c.name)
+			.collect();
+		sort_replica_names(&mut running);
+		Ok(running)
+	}
 }
 
 #[cfg(test)]
@@ -474,6 +496,70 @@ mod tests {
 				"proj-web-2".to_string(),
 				"proj-web-3".to_string(),
 			]
+		);
+	}
+
+	/// #1250: `top` aborted on a project with a stopped service because it asked
+	/// every container that exists for its process list, and libpod answers a
+	/// non-running one with an HTTP 500. The exited replica must be dropped
+	/// before the call, and the survivors must keep the ascending order every
+	/// other by-service command produces — so this asserts both, on a listing
+	/// that is shuffled and mixed-state at once.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn running_replica_names_drops_non_running_and_keeps_ascending_order() {
+		let containers = r#"[
+			{"Names":["/proj-web-3"],"State":"running"},
+			{"Names":["/proj-web-4"],"State":"created"},
+			{"Names":["/proj-web-1"],"State":"running"},
+			{"Names":["/proj-web-5"],"State":"paused"},
+			{"Names":["/proj-web-2"],"State":"exited"}
+		]"#;
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, containers.to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let names = e
+			.running_replica_names("web")
+			.await
+			.expect("running_replica_names should succeed");
+
+		assert_eq!(
+			names,
+			vec!["proj-web-1".to_string(), "proj-web-3".to_string()],
+			"only the running replicas, in ascending order"
+		);
+	}
+
+	/// The sibling half of the rule above: a service that exists in the compose
+	/// file but was never created has nothing running, so `top` must render
+	/// nothing for it rather than fall back to a statically-derived name and
+	/// then have to swallow the 404 that name earns.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn running_replica_names_does_not_fall_back_to_static_names() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/containers/json") {
+				(200, "[]".to_string())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let names = e
+			.running_replica_names("web")
+			.await
+			.expect("running_replica_names should succeed");
+
+		assert!(
+			names.is_empty(),
+			"a never-created service yields no names, got {names:?}"
 		);
 	}
 

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -69,8 +69,14 @@ impl Engine {
 
 		let mut json_rows: Vec<serde_json::Value> = Vec::new();
 		for name in &names {
-			let service = &file.services[name];
-			for container_name in self.live_replica_names(name, service).await? {
+			// Only running containers are asked for their process list, so a
+			// stopped replica is skipped before the call rather than after it
+			// fails: `/top` answers a non-running container with an HTTP 500, and
+			// the rule below — that a non-404 must surface — is deliberate and
+			// stays. Measured against `docker compose top` v5.1.3 on the same
+			// Podman socket: it omits a stopped service, prints the rest and exits
+			// 0 (#1250).
+			for container_name in self.running_replica_names(name).await? {
 				let path = format!(
 					"{API_PREFIX}/containers/{}/top",
 					urlencoded(&container_name),
@@ -94,10 +100,11 @@ impl Engine {
 						let processes = result.processes.clone().unwrap_or_default();
 						Self::print_process_table(&titles, &processes);
 					}
-					// A not-created container (404) is tolerated; any other failure
-					// (e.g. a stopped container's HTTP 500, or an unreachable socket)
-					// is a real error that must surface with a non-zero exit instead
-					// of being swallowed into a warning.
+					// A container removed between the listing above and this call
+					// (404) is tolerated; any other failure — an unreachable socket,
+					// a container that died in that same window — is a real error
+					// that must surface with a non-zero exit instead of being
+					// swallowed into a warning.
 					Err(e) if e.is_status(404) => {
 						tracing::debug!("top {container_name}: {e}")
 					}

--- a/internal/engine/secrets/create.rs
+++ b/internal/engine/secrets/create.rs
@@ -1,0 +1,352 @@
+//! Creating the project's Podman-native secrets at `up`.
+//!
+//! The union of every `content:`/`environment:`/`file:` source across all
+//! services is created once up front, before services start concurrently, so a
+//! name two services share is never raced through the non-atomic
+//! delete-then-create. Why `file:` sources are copied into native secrets at
+//! all is in the module docs of [`super`].
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::plan::{check_secret_size, Payload};
+use super::{collect_payload_union, Engine};
+
+impl Engine {
+	/// Create the union of the `content:`/`environment:`/`file:` secrets and
+	/// configs declared across *all* services in the project, once, before the
+	/// per-level start loop — mirroring how [`Engine::create_networks`] and
+	/// [`Engine::create_volumes`] pre-create their resources.
+	///
+	/// Doing this up front fixes the race in which two services in the same
+	/// dependency level (started concurrently) both ran the non-atomic
+	/// delete-then-create for the same project-scoped secret name, so one could
+	/// delete the secret the other had just created. The same scoped name is
+	/// created exactly once here (later services share it), and each created
+	/// secret carries the `podup.project=<proj>` label so the label-guarded
+	/// teardown on `down` still only removes secrets podup owns.
+	pub(in crate::engine) async fn create_project_secrets(&self, file: &ComposeFile) -> Result<()> {
+		let mut work: Vec<(String, Vec<u8>)> = Vec::new();
+		for (name, payload) in collect_payload_union(&self.project, file, &self.base_dir)? {
+			let bytes = match payload {
+				Payload::Inline(bytes) => bytes,
+				// Read here rather than in the planner, which stays free of I/O so
+				// the compose→plan mapping remains unit-testable. The cap is the
+				// same bounded read the compose-adjacent files get; Podman's own
+				// 512 kB secret limit is enforced right after, in `create_secret`.
+				Payload::File(path) => crate::filesystem::read_capped(&path).map_err(|e| {
+					ComposeError::Unsupported(format!(
+						"secret/config source {} could not be read: {e}",
+						path.display()
+					))
+				})?,
+			};
+			work.push((name, bytes));
+		}
+		// The union is a `HashMap`, so its iteration order is arbitrary and not
+		// stable between runs. Sorting by name is what makes "the first error
+		// wins" mean something: without it, which of several failing secrets got
+		// reported would vary run to run, and so would the test asserting it.
+		work.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+		// Fanned out over the union, never per service (#1219). The union holds
+		// distinct scoped names, so these chains cannot collide with each other;
+		// parallelising per service instead would put two services in one
+		// dependency level back to racing the same scoped name through a
+		// non-atomic delete-then-create, which pre-creating the union once is
+		// exactly what settles.
+		//
+		// Chunked `join_all` against the lifecycle's ceiling rather than its
+		// `join_bounded`, and that is a compiler limitation rather than a
+		// preference. `join_bounded` is built on `buffer_unordered`, whose
+		// `FuturesUnordered` is `Send` only if its future is `Send` for *every*
+		// lifetime. Reaching it from here — where the futures borrow `self` —
+		// makes that bound higher-ranked and propagates out through `up` until an
+		// unrelated `tokio::spawn(engine.watch(…))` stops compiling with
+		// "implementation of `Send` is not general enough", reported in a test
+		// file that never touches secrets. Owning the payloads and boxing the
+		// futures were both tried; neither clears it. `join_all` over fixed-size
+		// chunks carries no such bound, holds the same ceiling on simultaneous
+		// libpod connections, and returns results in input order, so the error
+		// reported is still the first by name.
+		//
+		// Note the behaviour change this carries: previously the first failing
+		// secret aborted before the rest were touched, and now every secret in
+		// its chunk is attempted. Nothing leaks — `down` sweeps by label — but a
+		// failed `up` can leave later secrets created where it used to leave none.
+		let mut results: Vec<Result<()>> = Vec::with_capacity(work.len());
+		for chunk in work.chunks(crate::engine::lifecycle::parallel::MAX_LIFECYCLE_CONCURRENCY) {
+			results.extend(
+				futures_util::future::join_all(
+					chunk
+						.iter()
+						.map(|(name, bytes)| self.create_secret(name, bytes)),
+				)
+				.await,
+			);
+		}
+		match crate::engine::lifecycle::parallel::first_error(results) {
+			Some(e) => Err(e),
+			None => Ok(()),
+		}
+	}
+
+	/// Create a Podman-native secret named `name` holding `payload`, labelled
+	/// `podup.project=<proj>` so it can be cleaned up on `down`. The payload size
+	/// is checked up front to turn Podman's opaque 500 into a clear message.
+	///
+	/// Idempotent across re-`up`s: rather than `replace=true` (which some Podman
+	/// 5.x builds reject when the secret does not yet exist — the internal delete
+	/// fails with "no secret data with ID"), the existing secret of this name is
+	/// removed first (a 404 is fine) and then created fresh.
+	async fn create_secret(&self, name: &str, payload: &[u8]) -> Result<()> {
+		check_secret_size(name, payload.len())?;
+		// Guard the delete-then-create: if a secret of this name already exists and
+		// is not labelled as ours, refuse rather than clobber a foreign secret.
+		// Our own secret (or a 404) is replaced fresh, keeping re-`up` idempotent.
+		let inspect = format!("{API_PREFIX}/secrets/{}/json", urlencoded(name));
+		let existed = match self.client.get_json::<serde_json::Value>(&inspect).await {
+			Ok(info) => {
+				let owned = info
+					.get("Spec")
+					.and_then(|spec| spec.get("Labels"))
+					.and_then(|labels| labels.get("podup.project"))
+					.and_then(|v| v.as_str())
+					== Some(self.project.as_str());
+				if !owned {
+					return Err(ComposeError::Unsupported(format!(
+						"a secret named '{name}' already exists and is not labelled \
+						 podup.project={} — refusing to overwrite a secret podup did \
+						 not create",
+						self.project
+					)));
+				}
+				true
+			}
+			Err(e) if e.is_status(404) => false,
+			Err(e) => return Err(ComposeError::Podman(e)),
+		};
+		// Only delete something that is actually there (#1219). On a first `up`
+		// every secret is a 404, so this was a round trip per secret spent
+		// removing nothing.
+		if existed {
+			let delete_path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
+			self.client
+				.delete_ok(&delete_path)
+				.await
+				.map_err(ComposeError::Podman)?;
+		}
+		let labels = serde_json::json!({ "podup.project": self.project }).to_string();
+		let path = format!(
+			"{API_PREFIX}/secrets/create?name={}&labels={}",
+			urlencoded(name),
+			urlencoded(&labels),
+		);
+		// The response is `{"ID": "..."}`; we don't need the id, only success.
+		self.client
+			.post_bytes_json::<serde_json::Value>(
+				&path,
+				bytes::Bytes::copy_from_slice(payload),
+				"application/octet-stream",
+			)
+			.await
+			.map(|_| ())
+			.map_err(|e| {
+				// Skipping the delete opens a window: the inspect said the name was
+				// free, and something claimed it before the create landed. `up` now
+				// fails there instead of clobbering whatever arrived — the better
+				// outcome, but only if it is legible. Podman's own message for this
+				// is an opaque 500, so it is named here rather than passed through.
+				if !existed {
+					ComposeError::Unsupported(format!(
+						"secret '{name}' did not exist when podup checked but could not \
+						 be created: {e} — something else created a secret of that name \
+						 in between. Re-run `up`, or remove it if it is not wanted."
+					))
+				} else {
+					ComposeError::Podman(e)
+				}
+			})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+	#[cfg(unix)]
+	use crate::engine::secrets::tests_support::{engine_on, file_with_content_secrets};
+
+	/// #1219: on a first `up` every secret inspect is a 404, so there is nothing
+	/// to remove — the delete-then-create was spending a round trip per secret
+	/// deleting a secret that does not exist. Measured on the six-secret bench
+	/// scenario, this is what takes a cold `up` from 25 requests to 19.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn create_skips_the_delete_when_the_secret_does_not_exist() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.create_project_secrets(&file_with_content_secrets(3))
+			.await
+			.expect("creating fresh secrets should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		let deletes: Vec<&String> = seen.iter().filter(|r| r.starts_with("DELETE")).collect();
+		assert!(
+			deletes.is_empty(),
+			"no delete should be issued for a secret that does not exist, got {deletes:?}"
+		);
+		assert_eq!(
+			seen.iter()
+				.filter(|r| r.contains("/secrets/create"))
+				.count(),
+			3,
+			"every secret is still created"
+		);
+	}
+
+	/// The other half of the same rule: a secret that IS there still has to be
+	/// removed before the create, because `replace=true` is rejected on some
+	/// Podman 5.x builds. Skipping the delete unconditionally would break
+	/// re-`up` idempotence, which is the reason the delete exists at all.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn create_still_deletes_a_secret_that_already_exists() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(
+					200,
+					r#"{"Spec":{"Labels":{"podup.project":"proj"}}}"#.to_string(),
+				)
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.create_project_secrets(&file_with_content_secrets(2))
+			.await
+			.expect("replacing our own secrets should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		assert_eq!(
+			seen.iter().filter(|r| r.starts_with("DELETE")).count(),
+			2,
+			"each existing secret is removed before being recreated, got {seen:?}"
+		);
+	}
+
+	/// The behaviour change the fan-out carries, stated in #1219 and asserted
+	/// here rather than left to the reader: the pass no longer stops at the
+	/// first failure, so every secret is attempted, and the error that surfaces
+	/// is the first *by name* — not whichever chain happened to lose the race.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn fan_out_attempts_every_secret_and_reports_the_first_by_name() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else if method == "POST" && (target.contains("s2") || target.contains("s3")) {
+				(500, r#"{"message":"boom"}"#.to_string())
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(4))
+			.await
+			.expect_err("a failing secret must still fail the stage");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		for i in 1..=4 {
+			assert!(
+				seen.iter().any(|r| r.contains(&format!("s{i}"))),
+				"secret s{i} should have been attempted despite an earlier failure, got {seen:?}"
+			);
+		}
+		assert!(
+			err.to_string().contains("s2"),
+			"the first failure by name should be the one reported, got: {err}"
+		);
+	}
+
+	/// Skipping the delete opens a window between the inspect and the create.
+	/// If something claims the name in it, `up` fails rather than clobbering
+	/// what arrived — but Podman's own message for that is an opaque 500, so
+	/// the failure has to name the race or the operator cannot act on it.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_name_claimed_after_the_inspect_fails_with_a_legible_message() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else {
+				(500, r#"{"message":"secret name in use"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(1))
+			.await
+			.expect_err("a name claimed in the window must fail")
+			.to_string();
+
+		assert!(
+			err.contains("in between"),
+			"the message must explain the race, got: {err}"
+		);
+		assert!(
+			err.contains("proj_secret_s1"),
+			"the message must name which secret, got: {err}"
+		);
+		// The engine's own error is kept as the cause — it is useful — but it must
+		// not be the whole of what the operator is handed, which is what the bare
+		// `ComposeError::Podman` passthrough would have given them.
+		assert!(
+			!err.starts_with("podman API error"),
+			"the raw engine error must not be the message itself, got: {err}"
+		);
+	}
+
+	/// The ownership guard is untouched by any of the above: a secret of the
+	/// same name that podup did not create is still refused, never deleted.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_foreign_secret_is_still_refused_and_never_deleted() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(
+					200,
+					r#"{"Spec":{"Labels":{"podup.project":"someone-else"}}}"#.to_string(),
+				)
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(1))
+			.await
+			.expect_err("a foreign secret must not be overwritten")
+			.to_string();
+
+		assert!(err.contains("refusing to overwrite"), "got: {err}");
+		let seen = fake.requests.lock().unwrap().clone();
+		assert!(
+			!seen.iter().any(|r| r.starts_with("DELETE")),
+			"a foreign secret must never be deleted, got {seen:?}"
+		);
+	}
+}

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -106,6 +106,7 @@ impl Engine {
 	/// secret carries the `podup.project=<proj>` label so the label-guarded
 	/// teardown on `down` still only removes secrets podup owns.
 	pub(super) async fn create_project_secrets(&self, file: &ComposeFile) -> Result<()> {
+		let mut work: Vec<(String, Vec<u8>)> = Vec::new();
 		for (name, payload) in collect_payload_union(&self.project, file, &self.base_dir)? {
 			let bytes = match payload {
 				Payload::Inline(bytes) => bytes,
@@ -120,9 +121,54 @@ impl Engine {
 					))
 				})?,
 			};
-			self.create_secret(&name, &bytes).await?;
+			work.push((name, bytes));
 		}
-		Ok(())
+		// The union is a `HashMap`, so its iteration order is arbitrary and not
+		// stable between runs. Sorting by name is what makes "the first error
+		// wins" mean something: without it, which of several failing secrets got
+		// reported would vary run to run, and so would the test asserting it.
+		work.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+		// Fanned out over the union, never per service (#1219). The union holds
+		// distinct scoped names, so these chains cannot collide with each other;
+		// parallelising per service instead would put two services in one
+		// dependency level back to racing the same scoped name through a
+		// non-atomic delete-then-create, which pre-creating the union once is
+		// exactly what settles.
+		//
+		// Chunked `join_all` against the lifecycle's ceiling rather than its
+		// `join_bounded`, and that is a compiler limitation rather than a
+		// preference. `join_bounded` is built on `buffer_unordered`, whose
+		// `FuturesUnordered` is `Send` only if its future is `Send` for *every*
+		// lifetime. Reaching it from here — where the futures borrow `self` —
+		// makes that bound higher-ranked and propagates out through `up` until an
+		// unrelated `tokio::spawn(engine.watch(…))` stops compiling with
+		// "implementation of `Send` is not general enough", reported in a test
+		// file that never touches secrets. Owning the payloads and boxing the
+		// futures were both tried; neither clears it. `join_all` over fixed-size
+		// chunks carries no such bound, holds the same ceiling on simultaneous
+		// libpod connections, and returns results in input order, so the error
+		// reported is still the first by name.
+		//
+		// Note the behaviour change this carries: previously the first failing
+		// secret aborted before the rest were touched, and now every secret in
+		// its chunk is attempted. Nothing leaks — `down` sweeps by label — but a
+		// failed `up` can leave later secrets created where it used to leave none.
+		let mut results: Vec<Result<()>> = Vec::with_capacity(work.len());
+		for chunk in work.chunks(crate::engine::lifecycle::parallel::MAX_LIFECYCLE_CONCURRENCY) {
+			results.extend(
+				futures_util::future::join_all(
+					chunk
+						.iter()
+						.map(|(name, bytes)| self.create_secret(name, bytes)),
+				)
+				.await,
+			);
+		}
+		match crate::engine::lifecycle::parallel::first_error(results) {
+			Some(e) => Err(e),
+			None => Ok(()),
+		}
 	}
 
 	/// Create a Podman-native secret named `name` holding `payload`, labelled
@@ -139,7 +185,7 @@ impl Engine {
 		// is not labelled as ours, refuse rather than clobber a foreign secret.
 		// Our own secret (or a 404) is replaced fresh, keeping re-`up` idempotent.
 		let inspect = format!("{API_PREFIX}/secrets/{}/json", urlencoded(name));
-		match self.client.get_json::<serde_json::Value>(&inspect).await {
+		let existed = match self.client.get_json::<serde_json::Value>(&inspect).await {
 			Ok(info) => {
 				let owned = info
 					.get("Spec")
@@ -155,15 +201,21 @@ impl Engine {
 						self.project
 					)));
 				}
+				true
 			}
-			Err(e) if e.is_status(404) => {}
+			Err(e) if e.is_status(404) => false,
 			Err(e) => return Err(ComposeError::Podman(e)),
+		};
+		// Only delete something that is actually there (#1219). On a first `up`
+		// every secret is a 404, so this was a round trip per secret spent
+		// removing nothing.
+		if existed {
+			let delete_path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
+			self.client
+				.delete_ok(&delete_path)
+				.await
+				.map_err(ComposeError::Podman)?;
 		}
-		let delete_path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
-		self.client
-			.delete_ok(&delete_path)
-			.await
-			.map_err(ComposeError::Podman)?;
 		let labels = serde_json::json!({ "podup.project": self.project }).to_string();
 		let path = format!(
 			"{API_PREFIX}/secrets/create?name={}&labels={}",
@@ -179,7 +231,22 @@ impl Engine {
 			)
 			.await
 			.map(|_| ())
-			.map_err(ComposeError::Podman)
+			.map_err(|e| {
+				// Skipping the delete opens a window: the inspect said the name was
+				// free, and something claimed it before the create landed. `up` now
+				// fails there instead of clobbering whatever arrived — the better
+				// outcome, but only if it is legible. Podman's own message for this
+				// is an opaque 500, so it is named here rather than passed through.
+				if !existed {
+					ComposeError::Unsupported(format!(
+						"secret '{name}' did not exist when podup checked but could not \
+						 be created: {e} — something else created a secret of that name \
+						 in between. Re-run `up`, or remove it if it is not wanted."
+					))
+				} else {
+					ComposeError::Podman(e)
+				}
+			})
 	}
 
 	/// Remove the project-scoped native secrets created on `up` for the
@@ -321,6 +388,200 @@ mod tests {
 	use super::*;
 	use crate::libpod::Client;
 	use std::path::PathBuf;
+
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+
+	/// A compose file with `n` `content:` secrets named `s1..sn`, all on one
+	/// service — the shape the union deduplicates and then fans out over.
+	#[cfg(unix)]
+	fn file_with_content_secrets(n: usize) -> ComposeFile {
+		let refs: String = (1..=n).map(|i| format!("      - s{i}\n")).collect();
+		let defs: String = (1..=n)
+			.map(|i| format!("  s{i}: {{content: \"v{i}\"}}\n"))
+			.collect();
+		crate::compose::parse_str(&format!(
+			"services:\n  app:\n    image: alpine\n    secrets:\n{refs}secrets:\n{defs}"
+		))
+		.expect("fixture compose file should parse")
+	}
+
+	#[cfg(unix)]
+	fn engine_on(fake: &fake_podman::FakePodman) -> Engine {
+		Engine::with_base_dir(fake.client(), "proj".to_string(), std::env::temp_dir())
+	}
+
+	/// #1219: on a first `up` every secret inspect is a 404, so there is nothing
+	/// to remove — the delete-then-create was spending a round trip per secret
+	/// deleting a secret that does not exist. Measured on the six-secret bench
+	/// scenario, this is what takes a cold `up` from 25 requests to 19.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn create_skips_the_delete_when_the_secret_does_not_exist() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.create_project_secrets(&file_with_content_secrets(3))
+			.await
+			.expect("creating fresh secrets should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		let deletes: Vec<&String> = seen.iter().filter(|r| r.starts_with("DELETE")).collect();
+		assert!(
+			deletes.is_empty(),
+			"no delete should be issued for a secret that does not exist, got {deletes:?}"
+		);
+		assert_eq!(
+			seen.iter()
+				.filter(|r| r.contains("/secrets/create"))
+				.count(),
+			3,
+			"every secret is still created"
+		);
+	}
+
+	/// The other half of the same rule: a secret that IS there still has to be
+	/// removed before the create, because `replace=true` is rejected on some
+	/// Podman 5.x builds. Skipping the delete unconditionally would break
+	/// re-`up` idempotence, which is the reason the delete exists at all.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn create_still_deletes_a_secret_that_already_exists() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(
+					200,
+					r#"{"Spec":{"Labels":{"podup.project":"proj"}}}"#.to_string(),
+				)
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.create_project_secrets(&file_with_content_secrets(2))
+			.await
+			.expect("replacing our own secrets should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		assert_eq!(
+			seen.iter().filter(|r| r.starts_with("DELETE")).count(),
+			2,
+			"each existing secret is removed before being recreated, got {seen:?}"
+		);
+	}
+
+	/// The behaviour change the fan-out carries, stated in #1219 and asserted
+	/// here rather than left to the reader: the pass no longer stops at the
+	/// first failure, so every secret is attempted, and the error that surfaces
+	/// is the first *by name* — not whichever chain happened to lose the race.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn fan_out_attempts_every_secret_and_reports_the_first_by_name() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else if method == "POST" && (target.contains("s2") || target.contains("s3")) {
+				(500, r#"{"message":"boom"}"#.to_string())
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(4))
+			.await
+			.expect_err("a failing secret must still fail the stage");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		for i in 1..=4 {
+			assert!(
+				seen.iter().any(|r| r.contains(&format!("s{i}"))),
+				"secret s{i} should have been attempted despite an earlier failure, got {seen:?}"
+			);
+		}
+		assert!(
+			err.to_string().contains("s2"),
+			"the first failure by name should be the one reported, got: {err}"
+		);
+	}
+
+	/// Skipping the delete opens a window between the inspect and the create.
+	/// If something claims the name in it, `up` fails rather than clobbering
+	/// what arrived — but Podman's own message for that is an opaque 500, so
+	/// the failure has to name the race or the operator cannot act on it.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_name_claimed_after_the_inspect_fails_with_a_legible_message() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else {
+				(500, r#"{"message":"secret name in use"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(1))
+			.await
+			.expect_err("a name claimed in the window must fail")
+			.to_string();
+
+		assert!(
+			err.contains("in between"),
+			"the message must explain the race, got: {err}"
+		);
+		assert!(
+			err.contains("proj_secret_s1"),
+			"the message must name which secret, got: {err}"
+		);
+		// The engine's own error is kept as the cause — it is useful — but it must
+		// not be the whole of what the operator is handed, which is what the bare
+		// `ComposeError::Podman` passthrough would have given them.
+		assert!(
+			!err.starts_with("podman API error"),
+			"the raw engine error must not be the message itself, got: {err}"
+		);
+	}
+
+	/// The ownership guard is untouched by any of the above: a secret of the
+	/// same name that podup did not create is still refused, never deleted.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_foreign_secret_is_still_refused_and_never_deleted() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/") {
+				(
+					200,
+					r#"{"Spec":{"Labels":{"podup.project":"someone-else"}}}"#.to_string(),
+				)
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_content_secrets(1))
+			.await
+			.expect_err("a foreign secret must not be overwritten")
+			.to_string();
+
+		assert!(err.contains("refusing to overwrite"), "got: {err}");
+		let seen = fake.requests.lock().unwrap().clone();
+		assert!(
+			!seen.iter().any(|r| r.starts_with("DELETE")),
+			"a foreign secret must never be deleted, got {seen:?}"
+		);
+	}
 
 	fn engine_with_base(base: &str) -> Engine {
 		Engine::with_base_dir(

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -31,20 +31,18 @@
 //!
 //! The pure compose→plan mapping lives in [`plan`].
 
+mod create;
 mod plan;
+mod remove;
 
 use std::collections::HashMap;
 use std::path::Path;
 
 use crate::compose::types::{ComposeFile, Service};
-use crate::error::{ComposeError, Result};
+use crate::error::Result;
 use crate::libpod::types::container::Secret;
-use crate::libpod::{urlencoded, API_PREFIX};
 
-use plan::{
-	check_secret_size, collect_native_plans, host_file_secret_mode, is_podup_created_source,
-	scoped_name, Payload,
-};
+use plan::{collect_native_plans, host_file_secret_mode, Payload};
 
 use super::Engine;
 
@@ -92,271 +90,6 @@ impl Engine {
 		}
 		Ok(secrets)
 	}
-
-	/// Create the union of the `content:`/`environment:`/`file:` secrets and
-	/// configs declared across *all* services in the project, once, before the
-	/// per-level start loop — mirroring how [`Engine::create_networks`] and
-	/// [`Engine::create_volumes`] pre-create their resources.
-	///
-	/// Doing this up front fixes the race in which two services in the same
-	/// dependency level (started concurrently) both ran the non-atomic
-	/// delete-then-create for the same project-scoped secret name, so one could
-	/// delete the secret the other had just created. The same scoped name is
-	/// created exactly once here (later services share it), and each created
-	/// secret carries the `podup.project=<proj>` label so the label-guarded
-	/// teardown on `down` still only removes secrets podup owns.
-	pub(super) async fn create_project_secrets(&self, file: &ComposeFile) -> Result<()> {
-		let mut work: Vec<(String, Vec<u8>)> = Vec::new();
-		for (name, payload) in collect_payload_union(&self.project, file, &self.base_dir)? {
-			let bytes = match payload {
-				Payload::Inline(bytes) => bytes,
-				// Read here rather than in the planner, which stays free of I/O so
-				// the compose→plan mapping remains unit-testable. The cap is the
-				// same bounded read the compose-adjacent files get; Podman's own
-				// 512 kB secret limit is enforced right after, in `create_secret`.
-				Payload::File(path) => crate::filesystem::read_capped(&path).map_err(|e| {
-					ComposeError::Unsupported(format!(
-						"secret/config source {} could not be read: {e}",
-						path.display()
-					))
-				})?,
-			};
-			work.push((name, bytes));
-		}
-		// The union is a `HashMap`, so its iteration order is arbitrary and not
-		// stable between runs. Sorting by name is what makes "the first error
-		// wins" mean something: without it, which of several failing secrets got
-		// reported would vary run to run, and so would the test asserting it.
-		work.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-		// Fanned out over the union, never per service (#1219). The union holds
-		// distinct scoped names, so these chains cannot collide with each other;
-		// parallelising per service instead would put two services in one
-		// dependency level back to racing the same scoped name through a
-		// non-atomic delete-then-create, which pre-creating the union once is
-		// exactly what settles.
-		//
-		// Chunked `join_all` against the lifecycle's ceiling rather than its
-		// `join_bounded`, and that is a compiler limitation rather than a
-		// preference. `join_bounded` is built on `buffer_unordered`, whose
-		// `FuturesUnordered` is `Send` only if its future is `Send` for *every*
-		// lifetime. Reaching it from here — where the futures borrow `self` —
-		// makes that bound higher-ranked and propagates out through `up` until an
-		// unrelated `tokio::spawn(engine.watch(…))` stops compiling with
-		// "implementation of `Send` is not general enough", reported in a test
-		// file that never touches secrets. Owning the payloads and boxing the
-		// futures were both tried; neither clears it. `join_all` over fixed-size
-		// chunks carries no such bound, holds the same ceiling on simultaneous
-		// libpod connections, and returns results in input order, so the error
-		// reported is still the first by name.
-		//
-		// Note the behaviour change this carries: previously the first failing
-		// secret aborted before the rest were touched, and now every secret in
-		// its chunk is attempted. Nothing leaks — `down` sweeps by label — but a
-		// failed `up` can leave later secrets created where it used to leave none.
-		let mut results: Vec<Result<()>> = Vec::with_capacity(work.len());
-		for chunk in work.chunks(crate::engine::lifecycle::parallel::MAX_LIFECYCLE_CONCURRENCY) {
-			results.extend(
-				futures_util::future::join_all(
-					chunk
-						.iter()
-						.map(|(name, bytes)| self.create_secret(name, bytes)),
-				)
-				.await,
-			);
-		}
-		match crate::engine::lifecycle::parallel::first_error(results) {
-			Some(e) => Err(e),
-			None => Ok(()),
-		}
-	}
-
-	/// Create a Podman-native secret named `name` holding `payload`, labelled
-	/// `podup.project=<proj>` so it can be cleaned up on `down`. The payload size
-	/// is checked up front to turn Podman's opaque 500 into a clear message.
-	///
-	/// Idempotent across re-`up`s: rather than `replace=true` (which some Podman
-	/// 5.x builds reject when the secret does not yet exist — the internal delete
-	/// fails with "no secret data with ID"), the existing secret of this name is
-	/// removed first (a 404 is fine) and then created fresh.
-	async fn create_secret(&self, name: &str, payload: &[u8]) -> Result<()> {
-		check_secret_size(name, payload.len())?;
-		// Guard the delete-then-create: if a secret of this name already exists and
-		// is not labelled as ours, refuse rather than clobber a foreign secret.
-		// Our own secret (or a 404) is replaced fresh, keeping re-`up` idempotent.
-		let inspect = format!("{API_PREFIX}/secrets/{}/json", urlencoded(name));
-		let existed = match self.client.get_json::<serde_json::Value>(&inspect).await {
-			Ok(info) => {
-				let owned = info
-					.get("Spec")
-					.and_then(|spec| spec.get("Labels"))
-					.and_then(|labels| labels.get("podup.project"))
-					.and_then(|v| v.as_str())
-					== Some(self.project.as_str());
-				if !owned {
-					return Err(ComposeError::Unsupported(format!(
-						"a secret named '{name}' already exists and is not labelled \
-						 podup.project={} — refusing to overwrite a secret podup did \
-						 not create",
-						self.project
-					)));
-				}
-				true
-			}
-			Err(e) if e.is_status(404) => false,
-			Err(e) => return Err(ComposeError::Podman(e)),
-		};
-		// Only delete something that is actually there (#1219). On a first `up`
-		// every secret is a 404, so this was a round trip per secret spent
-		// removing nothing.
-		if existed {
-			let delete_path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
-			self.client
-				.delete_ok(&delete_path)
-				.await
-				.map_err(ComposeError::Podman)?;
-		}
-		let labels = serde_json::json!({ "podup.project": self.project }).to_string();
-		let path = format!(
-			"{API_PREFIX}/secrets/create?name={}&labels={}",
-			urlencoded(name),
-			urlencoded(&labels),
-		);
-		// The response is `{"ID": "..."}`; we don't need the id, only success.
-		self.client
-			.post_bytes_json::<serde_json::Value>(
-				&path,
-				bytes::Bytes::copy_from_slice(payload),
-				"application/octet-stream",
-			)
-			.await
-			.map(|_| ())
-			.map_err(|e| {
-				// Skipping the delete opens a window: the inspect said the name was
-				// free, and something claimed it before the create landed. `up` now
-				// fails there instead of clobbering whatever arrived — the better
-				// outcome, but only if it is legible. Podman's own message for this
-				// is an opaque 500, so it is named here rather than passed through.
-				if !existed {
-					ComposeError::Unsupported(format!(
-						"secret '{name}' did not exist when podup checked but could not \
-						 be created: {e} — something else created a secret of that name \
-						 in between. Re-run `up`, or remove it if it is not wanted."
-					))
-				} else {
-					ComposeError::Podman(e)
-				}
-			})
-	}
-
-	/// Remove the project-scoped native secrets created on `up` for the
-	/// `content:`/`environment:`/`file:` secrets and configs, mirroring the volume
-	/// and network teardown on `down`. `external:` references own no podup-created
-	/// secret and are left untouched; a missing secret is ignored (`delete_ok`
-	/// swallows a 404). Best-effort: a delete failure is logged, not fatal, so the
-	/// rest of teardown proceeds.
-	pub(super) async fn remove_internal_secrets(&self, file: &ComposeFile) -> Result<()> {
-		for (name, def) in &file.secrets {
-			if is_podup_created_source(
-				def.external,
-				def.content.as_deref(),
-				def.environment.as_deref(),
-				def.file.as_deref(),
-			) {
-				self.delete_secret(&scoped_name(&self.project, "secret", name))
-					.await;
-			}
-		}
-		for (name, def) in &file.configs {
-			if is_podup_created_source(
-				def.external,
-				def.content.as_deref(),
-				def.environment.as_deref(),
-				def.file.as_deref(),
-			) {
-				self.delete_secret(&scoped_name(&self.project, "config", name))
-					.await;
-			}
-		}
-		// Catch orphans: a secret podup created on a previous `up` whose compose key
-		// was since renamed/removed (or a `down` run without the original file) is
-		// not reached by the loops above. Sweep every secret carrying this project's
-		// label and remove it, so no podup-created secret is left behind.
-		for name in self.list_project_secret_names().await {
-			self.delete_secret(&name).await;
-		}
-		Ok(())
-	}
-
-	/// Names of all native secrets labelled `podup.project=<proj>` — the secrets
-	/// podup created for this project. libpod's `/secrets/json` rejects a `label`
-	/// filter (HTTP 500 `invalid filter "label"`), so the full list is fetched and
-	/// filtered client-side by the `podup.project` label. Best-effort: a list
-	/// failure yields an empty set so teardown still proceeds via the
-	/// compose-driven deletes above.
-	async fn list_project_secret_names(&self) -> Vec<String> {
-		let path = format!("{API_PREFIX}/secrets/json");
-		match self.client.get_json::<Vec<serde_json::Value>>(&path).await {
-			Ok(list) => list
-				.iter()
-				.filter_map(|s| {
-					let spec = s.get("Spec")?;
-					let owned = spec
-						.get("Labels")
-						.and_then(|l| l.get("podup.project"))
-						.and_then(|v| v.as_str())
-						== Some(self.project.as_str());
-					if owned {
-						spec.get("Name")
-							.and_then(|n| n.as_str())
-							.map(str::to_string)
-					} else {
-						None
-					}
-				})
-				.collect(),
-			Err(e) => {
-				tracing::debug!("could not list project secrets for orphan cleanup: {e}");
-				Vec::new()
-			}
-		}
-	}
-
-	/// Delete a project-scoped secret, but only after confirming it carries our
-	/// `podup.project=<proj>` label — so a same-named secret the user created by
-	/// hand (and which podup never created) is never destroyed on `down`. A
-	/// missing secret (404) is a no-op.
-	async fn delete_secret(&self, name: &str) {
-		let inspect = format!("{API_PREFIX}/secrets/{}/json", urlencoded(name));
-		match self.client.get_json::<serde_json::Value>(&inspect).await {
-			Ok(info) => {
-				let owned = info
-					.get("Spec")
-					.and_then(|spec| spec.get("Labels"))
-					.and_then(|labels| labels.get("podup.project"))
-					.and_then(|v| v.as_str())
-					== Some(self.project.as_str());
-				if !owned {
-					tracing::warn!(
-						"secret {name} is not labelled podup.project={} — \
-						 leaving it untouched (not created by podup)",
-						self.project
-					);
-					return;
-				}
-			}
-			Err(e) if e.is_status(404) => return,
-			Err(e) => {
-				tracing::warn!("could not inspect secret {name} before removal: {e}");
-				return;
-			}
-		}
-		let path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
-		match self.client.delete_ok(&path).await {
-			Ok(()) => tracing::info!("removed secret {name}"),
-			Err(e) => tracing::warn!("could not remove secret {name}: {e}"),
-		}
-	}
 }
 
 /// Collect the project's podup-created secret/config payloads, deduplicated by
@@ -383,19 +116,17 @@ fn collect_payload_union(
 	Ok(payloads)
 }
 
+/// Helpers the `create` and `remove` test modules share.
 #[cfg(test)]
-mod tests {
+pub(super) mod tests_support {
 	use super::*;
-	use crate::libpod::Client;
-	use std::path::PathBuf;
-
 	#[cfg(unix)]
 	use crate::engine::fake_podman;
 
 	/// A compose file with `n` `content:` secrets named `s1..sn`, all on one
 	/// service — the shape the union deduplicates and then fans out over.
 	#[cfg(unix)]
-	fn file_with_content_secrets(n: usize) -> ComposeFile {
+	pub(in crate::engine::secrets) fn file_with_content_secrets(n: usize) -> ComposeFile {
 		let refs: String = (1..=n).map(|i| format!("      - s{i}\n")).collect();
 		let defs: String = (1..=n)
 			.map(|i| format!("  s{i}: {{content: \"v{i}\"}}\n"))
@@ -407,181 +138,16 @@ mod tests {
 	}
 
 	#[cfg(unix)]
-	fn engine_on(fake: &fake_podman::FakePodman) -> Engine {
+	pub(in crate::engine::secrets) fn engine_on(fake: &fake_podman::FakePodman) -> Engine {
 		Engine::with_base_dir(fake.client(), "proj".to_string(), std::env::temp_dir())
 	}
+}
 
-	/// #1219: on a first `up` every secret inspect is a 404, so there is nothing
-	/// to remove — the delete-then-create was spending a round trip per secret
-	/// deleting a secret that does not exist. Measured on the six-secret bench
-	/// scenario, this is what takes a cold `up` from 25 requests to 19.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn create_skips_the_delete_when_the_secret_does_not_exist() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "GET" && target.contains("/secrets/") {
-				(404, r#"{"message":"no such secret"}"#.to_string())
-			} else {
-				(201, r#"{"ID":"abc"}"#.to_string())
-			}
-		});
-		let e = engine_on(&fake);
-
-		e.create_project_secrets(&file_with_content_secrets(3))
-			.await
-			.expect("creating fresh secrets should succeed");
-
-		let seen = fake.requests.lock().unwrap().clone();
-		let deletes: Vec<&String> = seen.iter().filter(|r| r.starts_with("DELETE")).collect();
-		assert!(
-			deletes.is_empty(),
-			"no delete should be issued for a secret that does not exist, got {deletes:?}"
-		);
-		assert_eq!(
-			seen.iter()
-				.filter(|r| r.contains("/secrets/create"))
-				.count(),
-			3,
-			"every secret is still created"
-		);
-	}
-
-	/// The other half of the same rule: a secret that IS there still has to be
-	/// removed before the create, because `replace=true` is rejected on some
-	/// Podman 5.x builds. Skipping the delete unconditionally would break
-	/// re-`up` idempotence, which is the reason the delete exists at all.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn create_still_deletes_a_secret_that_already_exists() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "GET" && target.contains("/secrets/") {
-				(
-					200,
-					r#"{"Spec":{"Labels":{"podup.project":"proj"}}}"#.to_string(),
-				)
-			} else {
-				(201, r#"{"ID":"abc"}"#.to_string())
-			}
-		});
-		let e = engine_on(&fake);
-
-		e.create_project_secrets(&file_with_content_secrets(2))
-			.await
-			.expect("replacing our own secrets should succeed");
-
-		let seen = fake.requests.lock().unwrap().clone();
-		assert_eq!(
-			seen.iter().filter(|r| r.starts_with("DELETE")).count(),
-			2,
-			"each existing secret is removed before being recreated, got {seen:?}"
-		);
-	}
-
-	/// The behaviour change the fan-out carries, stated in #1219 and asserted
-	/// here rather than left to the reader: the pass no longer stops at the
-	/// first failure, so every secret is attempted, and the error that surfaces
-	/// is the first *by name* — not whichever chain happened to lose the race.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn fan_out_attempts_every_secret_and_reports_the_first_by_name() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "GET" && target.contains("/secrets/") {
-				(404, r#"{"message":"no such secret"}"#.to_string())
-			} else if method == "POST" && (target.contains("s2") || target.contains("s3")) {
-				(500, r#"{"message":"boom"}"#.to_string())
-			} else {
-				(201, r#"{"ID":"abc"}"#.to_string())
-			}
-		});
-		let e = engine_on(&fake);
-
-		let err = e
-			.create_project_secrets(&file_with_content_secrets(4))
-			.await
-			.expect_err("a failing secret must still fail the stage");
-
-		let seen = fake.requests.lock().unwrap().clone();
-		for i in 1..=4 {
-			assert!(
-				seen.iter().any(|r| r.contains(&format!("s{i}"))),
-				"secret s{i} should have been attempted despite an earlier failure, got {seen:?}"
-			);
-		}
-		assert!(
-			err.to_string().contains("s2"),
-			"the first failure by name should be the one reported, got: {err}"
-		);
-	}
-
-	/// Skipping the delete opens a window between the inspect and the create.
-	/// If something claims the name in it, `up` fails rather than clobbering
-	/// what arrived — but Podman's own message for that is an opaque 500, so
-	/// the failure has to name the race or the operator cannot act on it.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn a_name_claimed_after_the_inspect_fails_with_a_legible_message() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "GET" && target.contains("/secrets/") {
-				(404, r#"{"message":"no such secret"}"#.to_string())
-			} else {
-				(500, r#"{"message":"secret name in use"}"#.to_string())
-			}
-		});
-		let e = engine_on(&fake);
-
-		let err = e
-			.create_project_secrets(&file_with_content_secrets(1))
-			.await
-			.expect_err("a name claimed in the window must fail")
-			.to_string();
-
-		assert!(
-			err.contains("in between"),
-			"the message must explain the race, got: {err}"
-		);
-		assert!(
-			err.contains("proj_secret_s1"),
-			"the message must name which secret, got: {err}"
-		);
-		// The engine's own error is kept as the cause — it is useful — but it must
-		// not be the whole of what the operator is handed, which is what the bare
-		// `ComposeError::Podman` passthrough would have given them.
-		assert!(
-			!err.starts_with("podman API error"),
-			"the raw engine error must not be the message itself, got: {err}"
-		);
-	}
-
-	/// The ownership guard is untouched by any of the above: a secret of the
-	/// same name that podup did not create is still refused, never deleted.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn a_foreign_secret_is_still_refused_and_never_deleted() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "GET" && target.contains("/secrets/") {
-				(
-					200,
-					r#"{"Spec":{"Labels":{"podup.project":"someone-else"}}}"#.to_string(),
-				)
-			} else {
-				(201, r#"{"ID":"abc"}"#.to_string())
-			}
-		});
-		let e = engine_on(&fake);
-
-		let err = e
-			.create_project_secrets(&file_with_content_secrets(1))
-			.await
-			.expect_err("a foreign secret must not be overwritten")
-			.to_string();
-
-		assert!(err.contains("refusing to overwrite"), "got: {err}");
-		let seen = fake.requests.lock().unwrap().clone();
-		assert!(
-			!seen.iter().any(|r| r.starts_with("DELETE")),
-			"a foreign secret must never be deleted, got {seen:?}"
-		);
-	}
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::libpod::Client;
+	use std::path::PathBuf;
 
 	fn engine_with_base(base: &str) -> Engine {
 		Engine::with_base_dir(

--- a/internal/engine/secrets/remove.rs
+++ b/internal/engine/secrets/remove.rs
@@ -1,0 +1,333 @@
+//! Removing the project's Podman-native secrets at `down`.
+//!
+//! Ownership is answered from one labelled list rather than an inspect per
+//! secret (#1263). That list is also a superset of what the compose file names,
+//! since every secret podup creates carries `podup.project=<proj>`, so a single
+//! pass over it sweeps the declared secrets and the orphans alike.
+
+use crate::compose::types::ComposeFile;
+use crate::error::Result;
+use crate::libpod::{urlencoded, API_PREFIX};
+
+use super::plan::{is_podup_created_source, scoped_name};
+use super::Engine;
+
+impl Engine {
+	/// Remove the project-scoped native secrets created on `up` for the
+	/// `content:`/`environment:`/`file:` secrets and configs, mirroring the volume
+	/// and network teardown on `down`. `external:` references own no podup-created
+	/// secret and are left untouched; a missing secret is ignored (`delete_ok`
+	/// swallows a 404). Best-effort: a delete failure is logged, not fatal, so the
+	/// rest of teardown proceeds.
+	pub(in crate::engine) async fn remove_internal_secrets(
+		&self,
+		file: &ComposeFile,
+	) -> Result<()> {
+		// One list answers the ownership question for every name at once (#1263).
+		// It used to be fetched only for the orphan sweep, *after* each
+		// compose-named secret had already been inspected individually for the
+		// same label — so every label was fetched twice, once per secret and once
+		// for all of them.
+		//
+		// The label-carrying list is also a superset of what the compose loops
+		// reach: every secret podup creates carries `podup.project=<proj>`, so
+		// sweeping the labelled set covers the compose-named secrets and the
+		// orphans (a key since renamed, or a `down` run without the original
+		// file) in one pass. A same-named secret the user created by hand is not
+		// in the set, which is exactly the guard this has to keep.
+		match self.list_project_secret_names().await {
+			Some(owned) => {
+				// Ownership is already established by the label on each entry, so
+				// these deletes are not re-inspected. The window between the list
+				// and the last delete is wider than the old per-secret one; `down`
+				// is best-effort here either way (a delete failure is logged, not
+				// fatal), and a secret that changed hands inside it would have been
+				// created by podup moments earlier.
+				for name in owned {
+					self.delete_listed_secret(&name).await;
+				}
+			}
+			// The list failed. Falling through to an empty set would silently
+			// delete nothing and report a clean teardown, so this drops back to
+			// the per-secret guarded path instead — the same requests as before
+			// #1263, only reached when the cheap route is unavailable. The orphan
+			// sweep is not possible without a list, which is also how it behaved
+			// before.
+			None => {
+				for (name, def) in &file.secrets {
+					if is_podup_created_source(
+						def.external,
+						def.content.as_deref(),
+						def.environment.as_deref(),
+						def.file.as_deref(),
+					) {
+						self.delete_secret(&scoped_name(&self.project, "secret", name))
+							.await;
+					}
+				}
+				for (name, def) in &file.configs {
+					if is_podup_created_source(
+						def.external,
+						def.content.as_deref(),
+						def.environment.as_deref(),
+						def.file.as_deref(),
+					) {
+						self.delete_secret(&scoped_name(&self.project, "config", name))
+							.await;
+					}
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Names of all native secrets labelled `podup.project=<proj>` — the secrets
+	/// podup created for this project. libpod's `/secrets/json` rejects a `label`
+	/// filter (HTTP 500 `invalid filter "label"`), so the full list is fetched and
+	/// filtered client-side by the `podup.project` label.
+	///
+	/// `None` means the list could not be fetched, and is deliberately not the
+	/// same value as `Some(vec![])`. Since #1263 this list *is* the ownership
+	/// check for teardown, so collapsing a failure into "no secrets are ours"
+	/// would delete nothing and call it a clean `down`. The caller falls back to
+	/// inspecting each compose-named secret instead.
+	async fn list_project_secret_names(&self) -> Option<Vec<String>> {
+		let path = format!("{API_PREFIX}/secrets/json");
+		match self.client.get_json::<Vec<serde_json::Value>>(&path).await {
+			Ok(list) => Some(
+				list.iter()
+					.filter_map(|s| {
+						let spec = s.get("Spec")?;
+						let owned = spec
+							.get("Labels")
+							.and_then(|l| l.get("podup.project"))
+							.and_then(|v| v.as_str())
+							== Some(self.project.as_str());
+						if owned {
+							spec.get("Name")
+								.and_then(|n| n.as_str())
+								.map(str::to_string)
+						} else {
+							None
+						}
+					})
+					.collect(),
+			),
+			Err(e) => {
+				tracing::debug!(
+					"could not list project secrets, falling back to per-secret inspection: {e}"
+				);
+				None
+			}
+		}
+	}
+
+	/// Delete a secret whose `podup.project=<proj>` label was already confirmed
+	/// by [`Self::list_project_secret_names`], so it carries no inspect of its
+	/// own. Kept separate from [`Self::delete_secret`] rather than adding a flag,
+	/// so that a call site can never accidentally skip a check it was supposed to
+	/// make: this one is only reachable from a name the list vouched for.
+	async fn delete_listed_secret(&self, name: &str) {
+		let path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
+		match self.client.delete_ok(&path).await {
+			Ok(()) => tracing::info!("removed secret {name}"),
+			Err(e) => tracing::warn!("could not remove secret {name}: {e}"),
+		}
+	}
+
+	/// Delete a project-scoped secret, but only after confirming it carries our
+	/// `podup.project=<proj>` label — so a same-named secret the user created by
+	/// hand (and which podup never created) is never destroyed on `down`. A
+	/// missing secret (404) is a no-op.
+	async fn delete_secret(&self, name: &str) {
+		let inspect = format!("{API_PREFIX}/secrets/{}/json", urlencoded(name));
+		match self.client.get_json::<serde_json::Value>(&inspect).await {
+			Ok(info) => {
+				let owned = info
+					.get("Spec")
+					.and_then(|spec| spec.get("Labels"))
+					.and_then(|labels| labels.get("podup.project"))
+					.and_then(|v| v.as_str())
+					== Some(self.project.as_str());
+				if !owned {
+					tracing::warn!(
+						"secret {name} is not labelled podup.project={} — \
+						 leaving it untouched (not created by podup)",
+						self.project
+					);
+					return;
+				}
+			}
+			Err(e) if e.is_status(404) => return,
+			Err(e) => {
+				tracing::warn!("could not inspect secret {name} before removal: {e}");
+				return;
+			}
+		}
+		let path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
+		match self.client.delete_ok(&path).await {
+			Ok(()) => tracing::info!("removed secret {name}"),
+			Err(e) => tracing::warn!("could not remove secret {name}: {e}"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(unix)]
+	use crate::engine::fake_podman;
+	#[cfg(unix)]
+	use crate::engine::secrets::tests_support::{engine_on, file_with_content_secrets};
+
+	/// A `/secrets/json` body holding one entry per `(name, project-label)` pair.
+	#[cfg(unix)]
+	fn secret_list(entries: &[(&str, &str)]) -> String {
+		let items: Vec<String> = entries
+			.iter()
+			.map(|(name, project)| {
+				format!(
+					r#"{{"Spec":{{"Name":"{name}","Labels":{{"podup.project":"{project}"}}}}}}"#
+				)
+			})
+			.collect();
+		format!("[{}]", items.join(","))
+	}
+
+	/// #1263: the labelled list already answers the ownership question for every
+	/// name at once, so teardown must not also inspect each secret individually
+	/// for the same label. Measured on the six-secret bench scenario, dropping
+	/// those takes `down -v` from 18 requests to 12.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn down_uses_the_list_and_inspects_no_secret_individually() {
+		let body = secret_list(&[("proj_secret_s1", "proj"), ("proj_secret_s2", "proj")]);
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/secrets/json") {
+				(200, body.clone())
+			} else {
+				(200, "{}".to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.remove_internal_secrets(&file_with_content_secrets(2))
+			.await
+			.expect("teardown should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		let inspects: Vec<&String> = seen
+			.iter()
+			.filter(|r| r.starts_with("GET") && r.contains("/json") && !r.contains("/secrets/json"))
+			.collect();
+		assert!(
+			inspects.is_empty(),
+			"no per-secret inspect should be issued, got {inspects:?}"
+		);
+		assert_eq!(
+			seen.iter().filter(|r| r.starts_with("DELETE")).count(),
+			2,
+			"both listed secrets are removed, got {seen:?}"
+		);
+	}
+
+	/// The guard the batch has to keep: a secret carrying another project's label
+	/// is not in the owned set, so it is neither inspected nor removed — even
+	/// though the compose file names it.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn down_never_deletes_a_secret_labelled_for_another_project() {
+		let body = secret_list(&[
+			("proj_secret_s1", "proj"),
+			("proj_secret_s2", "someone-else"),
+		]);
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/secrets/json") {
+				(200, body.clone())
+			} else {
+				(200, "{}".to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.remove_internal_secrets(&file_with_content_secrets(2))
+			.await
+			.expect("teardown should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		assert!(
+			seen.iter()
+				.any(|r| r.starts_with("DELETE") && r.contains("proj_secret_s1")),
+			"our own secret is removed, got {seen:?}"
+		);
+		assert!(
+			!seen.iter().any(|r| r.contains("proj_secret_s2")),
+			"a secret labelled for another project must not be touched at all, got {seen:?}"
+		);
+	}
+
+	/// A secret podup created whose compose key was since renamed or removed is
+	/// still swept, because the labelled list — not the compose file — is what
+	/// teardown walks.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn down_sweeps_an_orphan_the_compose_file_no_longer_names() {
+		let body = secret_list(&[("proj_secret_gone", "proj")]);
+		let fake = fake_podman::start(move |method, target| {
+			if method == "GET" && target.contains("/secrets/json") {
+				(200, body.clone())
+			} else {
+				(200, "{}".to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.remove_internal_secrets(&file_with_content_secrets(1))
+			.await
+			.expect("teardown should succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		assert!(
+			seen.iter()
+				.any(|r| r.starts_with("DELETE") && r.contains("proj_secret_gone")),
+			"an orphan carrying our label is still removed, got {seen:?}"
+		);
+	}
+
+	/// The failure mode worth more than the saving. Since the list *is* the
+	/// ownership check now, a failed list must not read as "nothing is ours" —
+	/// that would delete nothing and report a clean `down`. It falls back to the
+	/// per-secret guarded path instead.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn a_failed_list_falls_back_to_per_secret_inspection_not_to_deleting_nothing() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "GET" && target.contains("/secrets/json") {
+				(500, r#"{"message":"boom"}"#.to_string())
+			} else if method == "GET" {
+				(
+					200,
+					r#"{"Spec":{"Labels":{"podup.project":"proj"}}}"#.to_string(),
+				)
+			} else {
+				(200, "{}".to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		e.remove_internal_secrets(&file_with_content_secrets(2))
+			.await
+			.expect("teardown should still succeed");
+
+		let seen = fake.requests.lock().unwrap().clone();
+		assert_eq!(
+			seen.iter().filter(|r| r.starts_with("DELETE")).count(),
+			2,
+			"both compose-named secrets are still removed when the list fails, got {seen:?}"
+		);
+		assert!(
+			seen.iter()
+				.any(|r| r.starts_with("GET") && r.contains("proj_secret_s1/json")),
+			"the fallback re-checks ownership per secret rather than assuming it, got {seen:?}"
+		);
+	}
+}

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -286,6 +286,44 @@ async fn top_scaled_service_all_replicas() {
 	engine.down(&file).await.unwrap();
 }
 
+/// #1250: a project where one service has already run to completion — a
+/// `migrate` that exits 0 is the everyday shape — used to abort `top` on the
+/// stopped container, losing the services it had not reached yet and exiting
+/// non-zero. Measured against `docker compose top` v5.1.3 on the same Podman
+/// socket: it omits the stopped service, prints the rest and exits 0.
+#[tokio::test]
+async fn top_skips_a_stopped_service_and_reports_the_rest() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("tss");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n  migrate:\n    image: alpine:latest\n    command: [\"true\"]\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+
+	// `migrate` has to have actually exited before `top` runs, or this passes for
+	// the wrong reason — `up` returns once the container is started, not once it
+	// is done, so without this the test could exercise two running services and
+	// prove nothing. `wait` blocks until it stops, which is deterministic where
+	// a sleep is not.
+	engine
+		.wait_services(&file, &["migrate".to_string()])
+		.await
+		.unwrap();
+
+	engine
+		.top(&file, &[])
+		.await
+		.expect("top must skip the stopped service rather than abort on it");
+
+	engine.down(&file).await.unwrap();
+}
+
 #[tokio::test]
 async fn exec_scaled_service_targets_first_replica() {
 	let client = match podman().await {


### PR DESCRIPTION
Release 3.4.1. A patch — one bug fix and two performance changes, nothing incompatible and no new behaviour.

### Fixed

**`podup top` no longer aborts when a service has already stopped** (#1250, PR #1261). A project where anything has run to completion — a `migrate` that exits once is the everyday shape — used to print the services it had reached, then die on the stopped one, losing the rest and exiting non-zero.

It now skips the stopped container and carries on. Measured against `docker compose top` v5.1.3 pointed at the same Podman socket before writing anything: it omits the stopped service, prints the rest and exits 0, and `top <stopped-service>` prints nothing and exits 0. Both now match.

The fix enumerates with the container state attached and asks only the running ones, so the existing ruling — that a non-404 failure must surface rather than be swallowed — is untouched: a stopped container simply never reaches that branch.

### Performance

**Creating a project's secrets makes fewer round trips** (#1219, PR #1262). A secret that does not exist is no longer deleted before being created — on a first `up` every one is a 404, so that was a round trip per secret spent removing nothing — and the per-secret work runs concurrently rather than in series.

**Tearing them down makes fewer still** (#1263, PR #1264). `down` asked Podman for each secret's ownership label individually and then fetched the whole labelled list anyway. It now takes the list first and uses it, which is also a superset of what the compose file names, so one pass sweeps the declared secrets and the orphans alike.

Measured on the six-secret bench scenario, Podman 5.7.0:

| | before | after |
|---|---|---|
| `up -d` cold | 25 requests | **19** |
| `down -v` | 18 requests | **12** |

A secret podup did not create is still never removed, and a failed list falls back to the per-secret guarded path rather than reading as "nothing is ours".

### Verified

Both secrets changes were verified on **an SELinux-enforcing host and both Podman majors**, which is what the originating issue required and what the local machine cannot provide — every `file:` and `content:` secret read back from inside the container on Podman 5.8.1 (Fedora 44) and 6.0.1 (Fedora 45 rawhide), across a cold up, a re-up and a teardown, including an unlabelled secret surviving `down` and a labelled orphan still being swept.

Every new assertion was proved by mutation rather than assumed — ten mutations across the three changes, each turning the intended test red.

### Version consistency

```
Cargo.toml        3.4.1
Cargo.lock        3.4.1
debian/changelog  3.4.1
```

All three move together. `dpkg-buildpackage` reads the `.deb` version from `debian/changelog` and nowhere else, so a miss there ships a package labelled with the version the user already has and apt reports nothing to upgrade.

### Also on this branch

`chore(ci)` (PR #1260) moved all twelve reusable-workflow callers to `.github` v1.13.0, which brings the verified shellcheck download into this repository's shell and workflow linting. No product change.