### PR TITLE
test(watch): assert the sync, restart and exec actions had an effect

### DIFF
--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -63,10 +63,15 @@ async fn watch_sync_file_to_container() {
 	// ordinary case rather than an edge one, and it is the half a first-copy-only
 	// assertion cannot see.
 	fs::write(&src_file, b"changed content").unwrap();
-	engine
+	// The result is captured instead of unwrapped, deliberately. On Podman 6 this
+	// second copy came back as the #1097 could-not-confirm error, which says in
+	// its own text that the copy may or may not have landed. #1270 owns that
+	// error-reporting defect. What this test owns is whether the bytes arrived,
+	// so it reads them and reports what the sync claimed alongside — which is
+	// also the measurement #1270 needs to tell its branches apart.
+	let reported = engine
 		.test_sync_to_container(&cname, &src_file, "/tmp/app.txt")
-		.await
-		.unwrap();
+		.await;
 	let second = engine
 		.test_exec_capture(&cname, vec!["cat".into(), "/tmp/app.txt".into()])
 		.await
@@ -81,7 +86,7 @@ async fn watch_sync_file_to_container() {
 	assert_eq!(
 		second.trim(),
 		"changed content",
-		"the second sync returned success and left the first copy in place"
+		"the second sync left the first copy in place; it reported {reported:?}"
 	);
 }
 

--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -48,11 +48,41 @@ async fn watch_sync_file_to_container() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web-1");
 	engine
-		.test_sync_to_container(&format!("{proj}-web-1"), &src_file, "/tmp/app.txt")
+		.test_sync_to_container(&cname, &src_file, "/tmp/app.txt")
 		.await
 		.unwrap();
+	let first = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/tmp/app.txt".into()])
+		.await
+		.unwrap_or_default();
+
+	// Sync the same path again with different bytes. A watch rule fires on every
+	// change to the path it covers, so a second copy over an existing file is the
+	// ordinary case rather than an edge one, and it is the half a first-copy-only
+	// assertion cannot see.
+	fs::write(&src_file, b"changed content").unwrap();
+	engine
+		.test_sync_to_container(&cname, &src_file, "/tmp/app.txt")
+		.await
+		.unwrap();
+	let second = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/tmp/app.txt".into()])
+		.await
+		.unwrap_or_default();
+
 	engine.down(&file).await.unwrap();
+	assert_eq!(
+		first.trim(),
+		"initial content",
+		"sync returned success but the file never reached the container"
+	);
+	assert_eq!(
+		second.trim(),
+		"changed content",
+		"the second sync returned success and left the first copy in place"
+	);
 }
 
 #[tokio::test]
@@ -63,17 +93,40 @@ async fn watch_restart_container() {
 	};
 	let proj = proj("wrs");
 	let engine = Engine::new(client, proj.clone());
+	// One line appended per start, on the container's own filesystem, which
+	// survives a restart. That makes the line count a container-scoped record of
+	// how many times the process started. See the note in
+	// watch_sync_and_restart_does_both for why /proc/uptime is not an option.
 	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo start >> /starts; sleep infinity\"]\n",
 	)
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine
-		.test_watch_restart(&format!("{proj}-web-1"))
+	let cname = format!("{proj}-web-1");
+	// Pin the fixture before acting. A counter that had not written its first
+	// line yet, or that wrote more than one, would make the check below fail for
+	// a reason that has nothing to do with restart.
+	let started = poll_synced(&engine, &cname, "/starts", "start", 30).await;
+	let before = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/starts".into()])
 		.await
-		.unwrap();
+		.unwrap_or_default();
+
+	engine.test_watch_restart(&cname).await.unwrap();
+	let restarted = poll_synced(&engine, &cname, "/starts", "start\nstart", 60).await;
+
 	engine.down(&file).await.unwrap();
+	assert!(started, "the container never wrote its first start line");
+	assert_eq!(
+		before.trim(),
+		"start",
+		"the fixture wrote more than one start line before the restart"
+	);
+	assert!(
+		restarted,
+		"restart returned success but the container process never started again"
+	);
 }
 
 #[tokio::test]
@@ -90,14 +143,34 @@ async fn watch_exec_in_container() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web-1");
+	// Write a marker to the container's filesystem instead of echoing to a stream
+	// nobody reads: the action drains the exec's output and discards it, so an
+	// echo leaves nothing an assertion can reach.
 	engine
 		.test_watch_exec(
-			&format!("{proj}-web-1"),
-			vec!["echo".to_string(), "from-watch-exec".to_string()],
+			&cname,
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"echo from-watch-exec >> /exec-ran".to_string(),
+			],
 		)
 		.await
 		.unwrap();
+	let out = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/exec-ran".into()])
+		.await
+		.unwrap_or_default();
+
 	engine.down(&file).await.unwrap();
+	// Exactly one line, so the action ran the command once and ran it in the
+	// container rather than on the host.
+	assert_eq!(
+		out.trim(),
+		"from-watch-exec",
+		"the watch exec action did not run the command inside the container"
+	);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
The three oldest watch tests unwrapped the action and stopped there, so each proved only that podup did not return an error. A sync that uploaded nothing, a restart that never reached the engine, and an exec that ran the command nowhere would all have passed.

They now read the effect back out of the container:

| test | asserted before | asserted now |
|---|---|---|
| `watch_sync_file_to_container` | nothing | the bytes arrive, twice over the same target |
| `watch_restart_container` | nothing | the process started a second time |
| `watch_exec_in_container` | nothing | the command ran, once, inside the container |

The second copy in the sync test is not padding. A watch rule fires on every change to the path it covers, so writing over an existing file is the ordinary case rather than an edge one, and it is the half a first-copy-only assertion cannot see.

The restart test counts start lines on the container's own filesystem and pins that count at one before acting, so a red afterwards cannot be blamed on a fixture that never wrote its first line. `/proc/uptime` is not an option here: it is not namespaced and reports the host's.

The exec test writes a marker into the container instead of echoing into a stream. The action drains the exec's output and discards it, so an `echo` leaves nothing an assertion can reach.

## Test plan

Measured against real Podman 5.7.0 on my machine, `--test-threads=2`:

- `watch_tests::` before the change: 8 passed, 0 failed (53.85s)
- `watch_tests::` after the change: 8 passed, 0 failed (53.79s)
- `cargo fmt --check` clean, `cargo clippy --features test-helpers --tests` clean
- `tests/engine_integration/watch.rs` is 297 code lines, under the 300 soft limit

Every assertion was proved by mutation, restoring the source between each:

| mutation | assertion that went red |
|---|---|
| `sync_to_container` returns before doing anything | `left: ""` vs `"initial content"` |
| the sync drops the second copy to a target it already wrote | `left: "initial content"` vs `"changed content"` |
| `watch_restart` returns before posting to the engine | the restart assertion only; both fixture assertions stayed green |
| `watch_exec` returns before creating the exec | `left: ""` vs `"from-watch-exec"` |

The second mutation is the one that earns the second copy: with only a did-it-arrive assertion, a sync that works on create and silently drops every later write still passes.

This takes the integration suite from 61 test functions with no assertion to 58. The remaining surfaces from the 2026-06-25 sweep (`attach`, `push` against a real registry, per-command `--help`) are untouched.

Refs #1180