### PR TITLE
test(cli): read the output these tests were already capturing

### DIFF
--- a/tests/engine_integration/cli_lifecycle.rs
+++ b/tests/engine_integration/cli_lifecycle.rs
@@ -99,6 +99,18 @@ async fn cli_ps_subcommand() {
 		.output()
 		.unwrap();
 	assert!(ps.status.success());
+	// The exit code was the whole assertion here, on a command whose entire job
+	// is what it prints. Reading STATUS matters especially: #590 was `ps` leaving
+	// that column empty for every container, which an exit-code check cannot see.
+	let out = String::from_utf8_lossy(&ps.stdout);
+	assert!(
+		out.contains(&format!("{proj}-web-1")),
+		"ps did not list the running container: {out:?}"
+	);
+	assert!(
+		out.contains("running"),
+		"ps printed the container without its status: {out:?}"
+	);
 
 	Command::new(bin())
 		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
@@ -114,9 +126,12 @@ async fn cli_logs_subcommand() {
 	let dir = tempdir().unwrap();
 	let compose = dir.path().join("docker-compose.yml");
 	let proj = format!("t{}-cllg", std::process::id());
+	// The container has to say something. With `sleep infinity` it prints nothing,
+	// so `logs` has no output to be right or wrong about and no assertion on it
+	// could fail.
 	fs::write(
 		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo hello-from-web; sleep infinity\"]\n",
 	)
 	.unwrap();
 
@@ -137,6 +152,18 @@ async fn cli_logs_subcommand() {
 		.output()
 		.unwrap();
 	assert!(logs.status.success());
+	// Both halves of the line are a contract. The container's own output is the
+	// point of the command, and the `service |` prefix was missing entirely once
+	// (#594), which is invisible to a check on the exit code.
+	let out = String::from_utf8_lossy(&logs.stdout);
+	assert!(
+		out.contains("hello-from-web"),
+		"logs did not carry the container's output: {out:?}"
+	);
+	assert!(
+		out.contains("web-1 |"),
+		"logs dropped the per-service prefix: {out:?}"
+	);
 
 	Command::new(bin())
 		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
@@ -184,6 +211,13 @@ async fn cli_exec_subcommand() {
 		.output()
 		.unwrap();
 	assert!(exec.status.success());
+	// The command was chosen to print something and then nobody read it.
+	let out = String::from_utf8_lossy(&exec.stdout);
+	assert_eq!(
+		out.trim(),
+		"cli-exec",
+		"exec did not forward the command's output"
+	);
 
 	Command::new(bin())
 		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
@@ -222,6 +256,15 @@ async fn cli_restart_subcommand() {
 		.output()
 		.unwrap();
 	assert!(restart.status.success());
+	// Progress goes to stderr, measured rather than assumed: asserting stdout here
+	// would fail with nothing wrong. Six lifecycle commands used to exit 0 in
+	// silence on a project that was never created, so naming the container is the
+	// part worth pinning.
+	let err = String::from_utf8_lossy(&restart.stderr);
+	assert!(
+		err.contains(&format!("{proj}-web-1")) && err.contains("Restarted"),
+		"restart did not report which container it restarted: {err:?}"
+	);
 
 	Command::new(bin())
 		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])
@@ -243,6 +286,14 @@ async fn cli_pull_subcommand() {
 		.output()
 		.unwrap();
 	assert!(pull.status.success());
+	// Also stderr, measured. #1076 is the reason the reported outcome matters
+	// here: a failed pull used to arrive as an in-band error line on a 200 and be
+	// dropped, so `pull` exited 0 having pulled nothing.
+	let err = String::from_utf8_lossy(&pull.stderr);
+	assert!(
+		err.contains("alpine:latest") && err.contains("Pulled"),
+		"pull did not report pulling the image: {err:?}"
+	);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Five CLI tests ran the binary with `.output()` — which captures stdout and stderr — and then asserted only `status.success()`. The bytes were sitting there unread.

```rust
let ps = Command::new(bin()).args([..., "ps"]).output().unwrap();
assert!(ps.status.success());
```

This is the blind spot #1180 describes, wearing an assertion. My scan for assertion-less tests walked straight past all five, which is why the issue's count was too low; I posted the corrected measurement there.

## Two of these are regressions that already happened

| assertion | the bug it would have caught |
|---|---|
| `ps` prints a STATUS | **#590** — the column was empty for every container |
| `logs` keeps the `service \|` prefix | **#594** — the prefix was missing entirely |

Neither changes the exit code, so neither was catchable before.

## I measured which stream each command uses

| command | writes to |
|---|---|
| `ps`, `logs`, `exec` | stdout |
| `restart`, `pull` | **stderr** |

Asserting stdout for `restart` and `pull` would have failed with nothing wrong. Worth knowing generally, since 3.4.0 moved `build` from stdout to stderr.

`cli_logs_subcommand` also needed its fixture changed: it ran `sleep infinity`, so the container printed nothing and `logs` had no output to be right or wrong about. No assertion on it could have failed.

## Test plan

Podman 5.7.0 on my machine: `cli_lifecycle::` is **12 passed, 0 failed** (52s). `cargo fmt --check` and `cargo clippy --features test-helpers --tests` clean.

Five mutations, sources restored between each, every one red in its own assertion:

| mutation | what the test read |
|---|---|
| `ps` renders an empty state | `"NAME … STATUS PORTS\nt…-clps-web-1 docker.io/library/alpine:latest        "` — #590 verbatim; the container-name assertion stayed green |
| `display_label` returns nothing | `" \| hello-from-web"` — the content assertion stayed green, only the prefix one fired |
| `pull` stops reporting | `" Image alpine:latest  Pulling"` with no `Pulled` |
| `restart` reports an empty action | the container-naming assertion |
| `exec` sets `attach_stdout: false` | `left: ""`, `right: "cli-exec"` |

Four remaining tests elsewhere capture output and never read it (`cli_push_to_unreachable_registry_errors`, `create_rejects_no_recreate_with_force_recreate`, `missing_subcommand_exits_non_zero`, `cli_stats_flags_truncate_all_and_format`). Two of those are rejection tests that pass on any failure and should assert which one. Left for a follow-up. `cli_run_nonzero_exit_propagates` is deliberately untouched — the exit code is its whole contract.

Refs #1180