### PR TITLE
test(networking): assert pause, scaled restart and scaled exec had an effect

### DIFF
--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -19,9 +19,30 @@ async fn pause_and_unpause() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web-1");
+	// A paused container refuses new exec sessions: Podman answers "can only
+	// create exec sessions on running containers". That refusal is the observable
+	// difference between a pause that happened and one that returned Ok having
+	// done nothing, which is all this test used to check.
+	let before = engine.test_exec_capture(&cname, vec!["true".into()]).await;
 	engine.pause(&file, &[]).await.unwrap();
+	let while_paused = engine.test_exec_capture(&cname, vec!["true".into()]).await;
 	engine.unpause(&file, &[]).await.unwrap();
+	let after = engine.test_exec_capture(&cname, vec!["true".into()]).await;
 	engine.down(&file).await.unwrap();
+
+	assert!(
+		before.is_ok(),
+		"the container did not accept an exec before being paused: {before:?}"
+	);
+	assert!(
+		while_paused.is_err(),
+		"pause returned success but the container still accepted an exec"
+	);
+	assert!(
+		after.is_ok(),
+		"unpause did not return the container to running: {after:?}"
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -239,14 +260,31 @@ async fn restart_scaled_service_all_replicas() {
 	let proj = proj("rsr");
 	let engine = Engine::new(client, proj.clone());
 	let file = parse_str(
-		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo start >> /starts; sleep infinity\"]\n    deploy:\n      replicas: 2\n",
 	)
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	// Both replicas must be reachable for restart to succeed.
+	let one = format!("{proj}-worker-1");
+	let two = format!("{proj}-worker-2");
+	let started = poll_container_file(&engine, &two, "/starts", "start", 30).await;
+
+	// Both replicas must be reachable for restart to succeed. "All replicas" is
+	// the claim, and restarting only the first satisfied the old version.
 	engine.restart(&file, Some("worker")).await.unwrap();
+	let first_restarted = poll_container_file(&engine, &one, "/starts", "start\nstart", 60).await;
+	let second_restarted = poll_container_file(&engine, &two, "/starts", "start\nstart", 60).await;
+
 	engine.down(&file).await.unwrap();
+	assert!(
+		started,
+		"the second replica never wrote its first start line"
+	);
+	assert!(first_restarted, "the first replica did not restart");
+	assert!(
+		second_restarted,
+		"restart stopped at the first replica and left the second running"
+	);
 }
 
 #[tokio::test]
@@ -338,16 +376,48 @@ async fn exec_scaled_service_targets_first_replica() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
+	// Leave a mark instead of echoing, and read it from BOTH replicas. "targets
+	// the first replica" has two halves, and an exec that hit replica 2 — or one
+	// that somehow hit both — returned Ok just as happily as the right one.
 	engine
 		.exec_with_options(
 			&file,
 			"worker",
-			vec!["echo".to_string(), "ok".to_string()],
+			vec![
+				"sh".to_string(),
+				"-c".to_string(),
+				"echo reached > /which".to_string(),
+			],
 			podup::ExecOptions::default(),
 		)
 		.await
 		.unwrap();
+	let first = engine
+		.test_exec_capture(
+			&format!("{proj}-worker-1"),
+			vec!["cat".into(), "/which".into()],
+		)
+		.await
+		.unwrap_or_default();
+	let second = engine
+		.test_exec_capture(
+			&format!("{proj}-worker-2"),
+			vec!["cat".into(), "/which".into()],
+		)
+		.await
+		.unwrap_or_default();
 	engine.down(&file).await.unwrap();
+
+	assert_eq!(
+		first.trim(),
+		"reached",
+		"exec on a scaled service did not run in the first replica"
+	);
+	assert_ne!(
+		second.trim(),
+		"reached",
+		"exec on a scaled service ran in the second replica too"
+	);
 }
 
 #[tokio::test]

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -267,7 +267,14 @@ async fn restart_scaled_service_all_replicas() {
 	engine.up(&file).await.unwrap();
 	let one = format!("{proj}-worker-1");
 	let two = format!("{proj}-worker-2");
-	let started = poll_container_file(&engine, &two, "/starts", "start", 30).await;
+	// Wait for BOTH replicas to have written their first line before restarting.
+	// Waiting on only one of them is a race: the other can still be starting when
+	// the restart fires, and then it ends up with one line instead of two and the
+	// check below fails for a reason that has nothing to do with restart. It
+	// passed alone and failed under the load of the whole file, which is the
+	// shape that makes this kind of fixture bug look like flakiness.
+	let started_one = poll_container_file(&engine, &one, "/starts", "start", 30).await;
+	let started_two = poll_container_file(&engine, &two, "/starts", "start", 30).await;
 
 	// Both replicas must be reachable for restart to succeed. "All replicas" is
 	// the claim, and restarting only the first satisfied the old version.
@@ -277,8 +284,8 @@ async fn restart_scaled_service_all_replicas() {
 
 	engine.down(&file).await.unwrap();
 	assert!(
-		started,
-		"the second replica never wrote its first start line"
+		started_one && started_two,
+		"a replica never wrote its first start line (one: {started_one}, two: {started_two})"
 	);
 	assert!(first_restarted, "the first replica did not restart");
 	assert!(


### PR DESCRIPTION
Three of the eleven bare tests in `commands_networking.rs`.

| test | asserted before | asserted now |
|---|---|---|
| `pause_and_unpause` | nothing | an exec is refused while paused and accepted again after |
| `exec_scaled_service_targets_first_replica` | nothing | the mark lands in replica 1 and **not** in replica 2 |
| `restart_scaled_service_all_replicas` | nothing | both replicas started a second time |

I measured the pause behaviour before writing the assertion rather than assuming it: Podman answers `can only create exec sessions on running containers`. The exec is attempted before, during and after, so a pause that returned Ok having done nothing is separated from a real one.

`restart_scaled_service_all_replicas` waits for **both** replicas to have written their first start line before restarting. Waiting on only one is a race — the other can still be starting when the restart fires, and then it ends up with one line and the check fails for a reason unrelated to restart. That version passed alone and failed under the load of the whole file, which is how this kind of fixture bug disguises itself as flakiness.

I left `top`, `images` and `port` alone. Those commands return `Result<()>` and write to stdout, which the library does not expose; `engine_port_resolves_a_published_port` already documents that and points at the CLI test where the binding is observable.

## Test plan

Podman 5.7.0, `--test-threads=2`: `commands_networking::` is **19 passed, 0 failed** (103s). `cargo fmt --check` and `cargo clippy --features test-helpers --tests` clean. The file is 479 code lines, under the 500 hard limit.

Mutations, sources restored between rounds:

| mutation | assertion that went red |
|---|---|
| `pause` stubbed to a no-op | the paused-exec assertion |
| `live_replica_names` truncated to one entry | both scaled tests |

## A caution worth recording

That second script restored the sources but did not rebuild, so `target/debug/podup` kept the truncation. Every measurement I took by hand afterwards ran against it, and I read the result as a real defect in `restart` and `kill`: they enumerate through `live_replica_names`, which I had truncated, while `stop` goes through `live_service_containers` and looked correct.

I filed that asymmetry as a bug and used "the defect is not uniform, so it cannot be one broken shared resolver" as the argument that it was real. It was a map of which code my patch had reached. Ten runs against a clean rebuild restart both replicas every time, and the issue is closed with the correction.

Restoring the source is not restoring the artifact. A stale binary runs, prints, and everything it says looks like data.

Refs #1180