### PR TITLE
test(targeting): assert profiles and target filtering picked the right services

### DIFF
--- a/tests/engine_integration/health_targeting.rs
+++ b/tests/engine_integration/health_targeting.rs
@@ -52,7 +52,20 @@ fn active_profiles_via_env() {
 				.up_with_options(&file, false, &[], &[], false, false, false)
 				.await
 				.unwrap();
+			let mut names = engine
+				.test_project_container_names()
+				.await
+				.unwrap_or_default();
+			names.sort();
 			engine.down(&file).await.unwrap();
+
+			// COMPOSE_PROFILES=prod must not enable the "debug" profile. Reading it
+			// and then starting everything anyway returned Ok just as happily.
+			assert_eq!(
+				names,
+				vec![format!("{proj}-web-1")],
+				"COMPOSE_PROFILES=prod started the debug-profiled service"
+			);
 		});
 	});
 }
@@ -237,7 +250,18 @@ async fn target_services_skips_non_dep() {
 		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
+	let mut names = engine
+		.test_project_container_names()
+		.await
+		.unwrap_or_default();
+	names.sort();
 	engine.down(&file).await.unwrap();
+
+	assert_eq!(
+		names,
+		vec![format!("{proj}-web-1")],
+		"targeting web started extra as well, which nothing depends on"
+	);
 }
 
 #[tokio::test]
@@ -260,7 +284,24 @@ async fn dep_on_profile_filtered_service() {
 		.up_with_options(&file, false, &[], &[], false, false, false)
 		.await
 		.unwrap();
+	let mut names = engine
+		.test_project_container_names()
+		.await
+		.unwrap_or_default();
+	names.sort();
 	engine.down(&file).await.unwrap();
+
+	// This pins what podup does today, which is not what the comment above it
+	// claimed and not what the reference does. Measured 2026-08-02: podup starts
+	// BOTH, while docker compose v5.1.3 refuses the project outright with
+	// `service "web" depends on undefined service "db": invalid compose project`.
+	// Filed as #1276; the assertion changes with the fix. Asserting the divergence
+	// is worth more than asserting nothing, which is where this test was.
+	assert_eq!(
+		names,
+		vec![format!("{proj}-db-1"), format!("{proj}-web-1")],
+		"the profile-gated dependency behaviour changed; see #1276 before editing this"
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -343,7 +384,21 @@ async fn optional_dep_not_in_file() {
 		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
 		.await
 		.unwrap();
+	let mut names = engine
+		.test_project_container_names()
+		.await
+		.unwrap_or_default();
+	names.sort();
 	engine.down(&file).await.unwrap();
+
+	// web has to actually come up. An optional dependency that is not in the file
+	// must be skipped, not turned into a container and not made to block the
+	// service that named it.
+	assert_eq!(
+		names,
+		vec![format!("{proj}-web-1")],
+		"an optional dependency missing from the file did not resolve to exactly web"
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -377,7 +432,20 @@ async fn target_services_duplicate_entry() {
 		)
 		.await
 		.unwrap();
+	let names = engine
+		.test_project_container_names()
+		.await
+		.unwrap_or_default();
 	engine.down(&file).await.unwrap();
+
+	// One container, not two. The deduplication is the whole point of the test,
+	// and a second pass over the same service would have shown up here rather
+	// than in the return value.
+	assert_eq!(
+		names,
+		vec![format!("{proj}-web-1")],
+		"naming the same service twice did not resolve to a single container"
+	);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Five of the ten bare tests in `health_targeting.rs`. All five observe the same thing the commands cannot report through their return value: which containers the project ended up with.

## One of them found a three-way disagreement

`dep_on_profile_filtered_service` says in its own comment that a profile-gated dependency is skipped. Measuring it:

| | what happens with `db` behind `profiles: ["debug"]` and `web` depending on it |
|---|---|
| **docker compose v5.1.3** (parity reference, on Podman's socket) | refuses the project: `service "web" depends on undefined service "db": invalid compose project` |
| **podup** | starts **both** |
| the test's comment | claims `db` is skipped |

Filed as #1276. Plain profile filtering is fine — `profile_filtered_service_skipped` asserts a profiled service with nothing depending on it stays out, and passes. The divergence is specific to a profiled service being a `depends_on` target.

The test now pins what podup actually does, with the measurement in a comment pointing at the issue. Asserting the divergence beats asserting nothing, which is where it was.

## Test plan

Podman 5.7.0, `--test-threads=2`: `health_targeting::` is **14 passed, 0 failed** (83s). `cargo fmt --check` and clippy clean. 356 code lines, under the limit.

Two mutations, sources restored between rounds, and the binary verified free of mutation markers afterwards:

| mutation | assertion that went red |
|---|---|
| profile gating enables everything | `active_profiles_via_env` — `["…-apv-debug-1", "…-apv-web-1"]` against just web |
| `target_services` blanked inside `up_with_options` | `target_services_skips_non_dep` — `["…-tsk-extra-1", "…-tsk-web-1"]` against just web |

**Three assertions did not go red under either, and I am not calling them proved.** `optional_dep_not_in_file` and `target_services_duplicate_entry` declare a single service, so ignoring the targeting produces the same one container — they are regression detectors if those files ever grow a second service, not assertions I have watched fail. `dep_on_profile_filtered_service` is unaffected by the profile mutation because it already expects both containers.

## On the mutation driver

The driver now rebuilds after restoring and proves the marker is gone from `target/debug/podup` before anything else is measured. That guard exists because its absence cost me a false bug report earlier today: a round left a truncated replica list inside the built binary, and every hand measurement afterwards ran against it.

Refs #1180