### PR TITLE
test(query): assert down --volumes and the empty attach, document the rest

### DIFF
--- a/tests/engine_integration/lifecycle.rs
+++ b/tests/engine_integration/lifecycle.rs
@@ -160,6 +160,26 @@ async fn down_with_remove_volumes() {
 
 	engine.up(&file).await.unwrap();
 	engine.down_with_options(&file, true).await.unwrap();
+	// `down --volumes` has to take the volume with it. Whether it exists is not
+	// something the library returns, so read it the way the sibling tests read
+	// container config: out of band, through the podman CLI.
+	let volumes = String::from_utf8_lossy(
+		&std::process::Command::new("podman")
+			.args(["volume", "ls", "--format", "{{.Name}}"])
+			.output()
+			.expect("podman volume ls")
+			.stdout,
+	)
+	.to_string();
+
+	// Match on the project prefix, not the declared name. podup namespaces a
+	// declared volume as `{project}_{name}`, so an equality check against
+	// `{proj}-data` can never match and the assertion would hold whatever `down`
+	// did — which is how the first version of this line survived its mutation.
+	assert!(
+		!volumes.lines().any(|v| v.contains(proj.as_str())),
+		"down --volumes left a volume belonging to the project behind: {volumes:?}"
+	);
 }
 
 #[tokio::test]

--- a/tests/engine_integration/lifecycle_query.rs
+++ b/tests/engine_integration/lifecycle_query.rs
@@ -8,6 +8,11 @@ use super::*;
 // Query
 // ---------------------------------------------------------------------------
 
+/// `Engine::ps` returns `Result<()>` and writes the table to stdout, so at this
+/// level the only thing to assert is that listing a running project does not
+/// error. What it prints is checked where it is reachable, in
+/// `cli_lifecycle::cli_ps_subcommand`, which reads the container name and the
+/// STATUS column — the column #590 left empty for every container.
 #[tokio::test]
 async fn ps_shows_running_container() {
 	let client = match podman().await {
@@ -26,6 +31,10 @@ async fn ps_shows_running_container() {
 	engine.down(&file).await.unwrap();
 }
 
+/// Same shape as `ps`: `Engine::logs` streams to stdout and returns
+/// `Result<()>`. The output contract — the container's own line, carrying the
+/// `service |` prefix that #594 dropped — is asserted in
+/// `cli_lifecycle::cli_logs_subcommand`.
 #[tokio::test]
 async fn logs_from_named_service() {
 	let client = match podman().await {
@@ -44,6 +53,8 @@ async fn logs_from_named_service() {
 	engine.down(&file).await.unwrap();
 }
 
+/// The all-services variant of the above, and unassertable here for the same
+/// reason. Kept because it exercises the no-target branch of the same call.
 #[tokio::test]
 async fn logs_all_services() {
 	let client = match podman().await {
@@ -258,6 +269,12 @@ async fn exec_nonexistent_user_fails_fast() {
 	engine.down(&file).await.unwrap();
 }
 
+/// `Engine::pull` reports progress on stderr and returns `Result<()>`. Asserting
+/// that the image is present afterwards would prove nothing: `alpine:latest` is
+/// already local in every environment this suite runs in, so the assertion would
+/// hold with the pull removed entirely. Removing it first would make the test
+/// depend on the network, which the testing standard rules out. What `pull`
+/// reports is asserted in `cli_lifecycle::cli_pull_subcommand`.
 #[tokio::test]
 async fn pull_images() {
 	let client = match podman().await {
@@ -355,8 +372,26 @@ async fn attach_logs_empty_attach_returns() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	engine.attach_logs(&file).await.unwrap();
+	// "Returns immediately" is the claim, and it is the one thing here that can be
+	// checked without reading the stream: attaching to a service marked
+	// `attach: false` would follow the container's output and never come back, so
+	// the test would hang rather than fail. A bound turns that into a red.
+	let started = tokio::time::Instant::now();
+	let attached = tokio::time::timeout(
+		std::time::Duration::from_secs(10),
+		engine.attach_logs(&file),
+	)
+	.await;
+	let elapsed = started.elapsed();
 	engine.down(&file).await.unwrap();
+
+	let attached =
+		attached.expect("attach_logs did not return within 10s on an attach: false service");
+	attached.unwrap();
+	assert!(
+		elapsed < std::time::Duration::from_secs(5),
+		"attach_logs took {elapsed:?} on a service with attach: false; it has no targets and must not wait"
+	);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Six bare tests left across the two lifecycle files. **Two can be asserted and four cannot**, and pretending otherwise would be worse than the gap.

## The two

`down_with_remove_volumes` checks the volume is gone.

My first version of that assertion was itself vacuous. It compared against the declared name `{proj}-data`, and podup namespaces a declared volume as `{project}_{name}` — so the equality could never match and the assertion held whatever `down` did. The mutation caught it. That is the entire argument for running one rather than reading the line and nodding.

`attach_logs_empty_attach_returns` claims in its own name that it returns immediately. That is checkable without reading the stream: attaching to a service marked `attach: false` would follow the container's output and never come back, so the test would **hang** rather than fail. It is now bounded.

| mutation | result |
|---|---|
| `down_with_options` forces `remove_volumes = false` | red (after fixing my vacuous assertion; the first version survived) |
| an 8s wait inside `attach_logs` | red on the bound |

## The four

`ps`, both `logs`, and `pull_images` return `Result<()>` and write to stdout or stderr, which the library does not expose. Each now carries a doc comment saying so and naming the CLI test that does assert the output:

| library test | where the output is asserted | what that catches |
|---|---|---|
| `ps_shows_running_container` | `cli_ps_subcommand` | the STATUS column #590 left empty |
| `logs_from_named_service` | `cli_logs_subcommand` | the `service \|` prefix #594 dropped |
| `pull_images` | `cli_pull_subcommand` | what pull actually reported |

`pull_images` deserves the explicit note it now has. Asserting the image is present afterwards would prove nothing — `alpine:latest` is already local in every environment this suite runs in, so the assertion would hold with the pull removed entirely. Removing the image first would make the test depend on the network, which the testing standard rules out.

## Test plan

Podman 5.7.0, `--test-threads=2`: `lifecycle::` + `lifecycle_query::` is **33 passed, 0 failed** (195s). `cargo fmt --check` and clippy clean. 245 and 383 code lines, both under the limit — checked before pushing this time.

Refs #1180