### PR TITLE
test(top): assert what top prints, document what cannot be asserted

### DIFF
--- a/tests/engine_integration/cli_commands.rs
+++ b/tests/engine_integration/cli_commands.rs
@@ -323,6 +323,23 @@ async fn cli_top_subcommand() {
 		.output()
 		.unwrap();
 	assert!(top.status.success(), "top failed: {:?}", top.stderr);
+	// The exit code was the whole check, and passing `top.stderr` into the failure
+	// message made it look like the output was being read when nothing asserted
+	// anything about it. `top` exists to print processes: the container it belongs
+	// to, the column header, and the command actually running inside.
+	let out = String::from_utf8_lossy(&top.stdout);
+	assert!(
+		out.contains(&format!("{proj}-web-1")),
+		"top did not name the container the processes belong to: {out:?}"
+	);
+	assert!(
+		out.contains("PID") && out.contains("CMD"),
+		"top printed no process table header: {out:?}"
+	);
+	assert!(
+		out.contains("sleep infinity"),
+		"top did not report the process running in the container: {out:?}"
+	);
 
 	Command::new(bin())
 		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down"])

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -104,6 +104,10 @@ async fn engine_run_nonzero_exit_returns_run_exited() {
 // Top
 // ---------------------------------------------------------------------------
 
+/// `Engine::top` returns `Result<()>` and writes the process table to stdout, so
+/// at this level the only thing to assert is that asking a running project does
+/// not error. What it prints is checked in `cli_commands::cli_top_subcommand`,
+/// which reads the container name, the header and the process actually running.
 #[tokio::test]
 async fn engine_top_running_container() {
 	let client = match podman().await {
@@ -126,6 +130,8 @@ async fn engine_top_running_container() {
 // Images
 // ---------------------------------------------------------------------------
 
+/// Same shape: `Engine::images` prints and returns `Result<()>`. The output is
+/// asserted in `cli_commands::cli_images_subcommand`.
 #[tokio::test]
 async fn engine_images_lists_service_images() {
 	let client = match podman().await {
@@ -294,6 +300,11 @@ async fn restart_scaled_service_all_replicas() {
 	);
 }
 
+/// Unassertable here, and — unlike `top` and `images` — **not covered anywhere
+/// else either**. `logs` on a scaled service prints, so the library returns
+/// nothing to check, and no CLI test drives a scaled project through it. The
+/// claim in the name, that every replica is included, is currently unverified.
+/// Closing that needs a CLI-level test over `replicas: 2`, not an assertion here.
 #[tokio::test]
 async fn logs_scaled_service_all_replicas() {
 	let client = match podman().await {
@@ -313,6 +324,8 @@ async fn logs_scaled_service_all_replicas() {
 	engine.down(&file).await.unwrap();
 }
 
+/// Same gap as the scaled `logs` above: `cli_top_subcommand` drives a
+/// single-service project, so "all replicas" is asserted nowhere.
 #[tokio::test]
 async fn top_scaled_service_all_replicas() {
 	let client = match podman().await {


### PR DESCRIPTION
**This slice does not move the assertion-less count.** That is the honest outcome rather than a shortfall: four of the five remaining tests in this file cannot be asserted where they sit, and one that *looked* fine was not.

## The one that was hiding

`cli_top_subcommand` asserted only the exit code — and passed `top.stderr` into the failure message, which made my scan for "captures output and never reads it" walk straight past it. Syntactically it does touch the bytes. Nothing checked them.

It now reads the three things `top` exists to print:

```
tp-…-web-1
UID  PID PPID C STIME TTY TIME     CMD
root 1   0    0 15:03 ?   00:00:00 sleep infinity
```

the container the processes belong to, the table header, and the process actually running inside.

## Proving it took three anchors

| what I stubbed | result |
|---|---|
| `Engine::top` | **green** — nothing calls it; it is a thin wrapper |
| `Engine::top_with_options` (what `dispatch/rest.rs` uses) | **red** on the container-name assertion |

Third time today that mutating the wrapper instead of the path the caller takes produced a misleading green. A surviving mutation and an unreachable one look identical from outside.

## What the doc comments record

`top`, `images` and the two scaled variants all return `Result<()>` and write to stdout, so there is nothing for the library-level test to read. Each now says so and names where the output *is* checked.

Two of them record something worse than a documentation gap:

> **`logs` and `top` on a scaled service are asserted nowhere at all.**

`cli_top_subcommand` and `cli_logs_subcommand` both drive single-service projects, so "all replicas" — which is exactly what `logs_scaled_service_all_replicas` and `top_scaled_service_all_replicas` promise in their names — is currently unverified. Closing that needs CLI-level coverage over `replicas: 2`, not an assertion at a level where there is nothing to read.

## Test plan

Podman 5.7.0, `--test-threads=2`: `commands_networking::` + `cli_commands::` is **32 passed, 0 failed** (144s). `cargo fmt --check` and clippy clean. 479 and 440 code lines, both under the limit — checked before pushing.

The branch was rebased onto current `develop` before running any of this: it had been cut before #1278 merged, and the stale base made four already-fixed tests reappear in my count.

Refs #1180