### PR TITLE
test(cli): assert which rejection, not just that one happened

### DIFF
--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -213,6 +213,14 @@ fn create_rejects_no_recreate_with_force_recreate() {
 		!output.status.success(),
 		"conflicting recreate flags must be rejected"
 	);
+	// Which rejection, not just that one happened. A non-zero exit here is
+	// satisfied by any failure — a missing compose file, an unreachable Podman,
+	// a panic — none of which exercise the flag conflict this test is named for.
+	let err = String::from_utf8_lossy(&output.stderr);
+	assert!(
+		err.contains("--no-recreate") && err.contains("--force-recreate"),
+		"the rejection did not name the two conflicting flags: {err:?}"
+	);
 }
 
 #[test]

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -235,6 +235,13 @@ fn missing_subcommand_exits_non_zero() {
 		.output()
 		.expect("run podup with no args");
 	assert!(!none.status.success(), "no args must exit non-zero");
+	// Exiting non-zero with nothing on stderr would satisfy the check above and
+	// leave the user with no idea what to type. clap prints usage; assert it.
+	let none_err = String::from_utf8_lossy(&none.stderr);
+	assert!(
+		none_err.contains("Usage: podup"),
+		"running with no arguments printed no usage: {none_err:?}"
+	);
 	let gen = Command::new(bin())
 		.arg("generate")
 		.output()
@@ -242,6 +249,21 @@ fn missing_subcommand_exits_non_zero() {
 	assert!(
 		!gen.status.success(),
 		"generate with no subcommand must exit non-zero"
+	);
+	// Measured 2026-08-02: a subcommand group invoked with no subcommand prints
+	// the ROOT usage, not the group's. `podup generate --help` does render
+	// `Usage: podup generate [OPTIONS] <COMMAND>` and lists `quadlet`, but bare
+	// `podup generate` renders `Usage: podup [OPTIONS] <COMMAND>` and lists every
+	// top-level command instead. `podup autostart` behaves the same way.
+	//
+	// So this asserts what it does, which is still better than asserting only the
+	// exit code: a non-zero exit with an empty stderr would pass that and leave
+	// the user nothing to read. Tightening it to the group's own usage is a
+	// behaviour change, not a test change.
+	let gen_err = String::from_utf8_lossy(&gen.stderr);
+	assert!(
+		gen_err.contains("Usage: podup"),
+		"generate with no subcommand printed no usage at all: {gen_err:?}"
 	);
 }
 

--- a/tests/engine_integration/cli_commands.rs
+++ b/tests/engine_integration/cli_commands.rs
@@ -90,6 +90,17 @@ async fn cli_push_to_unreachable_registry_errors() {
 		])
 		.output()
 		.unwrap();
+	// Which failure, not just that one happened. A non-zero exit is satisfied by
+	// a missing compose file or an unreachable Podman, neither of which reaches
+	// the registry. #1076 is the reason this matters: a failed pull used to be
+	// reported as success, and push shares that in-band-error shape — a test that
+	// only reads the exit code cannot tell a real registry failure from podup
+	// falling over before it tried.
+	let err = String::from_utf8_lossy(&push.stderr);
+	assert!(
+		err.contains("localhost:1/podup-nope"),
+		"the failure did not name the image it could not push: {err:?}"
+	);
 	assert!(
 		!push.status.success(),
 		"push to an unreachable registry must fail"


### PR DESCRIPTION
Three of the four tests in #1286. The fourth turned out not to need it.

## Why "it failed" is not enough

The testing standard is explicit:

> A rejection test asserts *which* rejection. `if err == nil { t.Fatal }` is satisfied by any failure, including the one you did not mean.

Five of the seventeen dead controls found in authcore were exactly that shape.

| test | what satisfied it before | what it requires now |
|---|---|---|
| `create_rejects_no_recreate_with_force_recreate` | any non-zero exit — a missing compose file, an unreachable Podman | both flag names in the message |
| `cli_push_to_unreachable_registry_errors` | any non-zero exit | the image name it could not push |
| `missing_subcommand_exits_non_zero` | a non-zero exit with **empty stderr** | usage on stderr |

`cli_push_to_unreachable_registry_errors` is the one that matters most, and #1076 is why: a failed pull used to be reported as success, and `push` shares that in-band-error shape. An exit code alone cannot tell a real registry failure from podup falling over before it tried. A mutation that returns a generic error without naming the image reddens it.

## A UX gap the third one turned up

`podup generate --help` renders `Usage: podup generate [OPTIONS] <COMMAND>` and lists `quadlet`. But bare `podup generate` renders the **root** usage and lists every top-level command instead — and `podup autostart` does the same. The user typed a group name and got told about the whole tool.

The assertion matches what it does today, with the measurement in a comment. Tightening it to the group's own usage is a behaviour change, not a test change, so it is recorded rather than smuggled in here.

## The fourth needed nothing

`cli_stats_flags_truncate_all_and_format` already asserts the full container name under `--no-trunc` and its absence under the default. It reads output through a `run()` helper that returns a `String`, which is why my scan for "captures output and never reads it" flagged it — the scan looks for `.stdout`/`.stderr` in the body and the helper hides them.

**Third false positive from that detector today**, after `.expect("msg")` and `cli_top_subcommand`. Worth stating plainly: the scan finds the *shape* of a missing assertion, and the shape is not the thing.

## Test plan

`cli_diagnostics` 11 passed, `cli_flags` 19 passed, `cli_commands::` 13 passed, `stats_flags::` 5 passed. `cargo fmt --check` and clippy clean.

Refs #1286