### PR TITLE
test(cli): cover the output that only the binary can show

### DIFF
--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -163,6 +163,8 @@ mod cli_commands;
 mod cli_flags;
 #[path = "engine_integration/cli_lifecycle.rs"]
 mod cli_lifecycle;
+#[path = "engine_integration/cli_output.rs"]
+mod cli_output;
 #[path = "engine_integration/create_ls.rs"]
 mod create_ls;
 #[path = "engine_integration/lifecycle_output.rs"]

--- a/tests/engine_integration/cli_output.rs
+++ b/tests/engine_integration/cli_output.rs
@@ -1,0 +1,185 @@
+//! CLI tests for output the library-level tests cannot reach.
+//!
+//! `logs`, `top` and an attached `up` all write to stdout and return
+//! `Result<()>`, so their engine-level counterparts can only assert the absence
+//! of an error. These drive the binary, where the bytes are readable. Split out
+//! of `cli_commands.rs` when the additions took it past the 500 code-line limit.
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use super::*;
+
+/// `logs_scaled_service_all_replicas` promises every replica is included and
+/// cannot check it. This does. The regression it guards is real history: #592
+/// was by-service commands failing to resolve replicas after a scale.
+#[tokio::test]
+async fn cli_logs_covers_every_replica_of_a_scaled_service() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-lgscale", std::process::id());
+	// Each replica prints, so a `logs` that reached only the first one is visible
+	// as a missing prefix rather than as shorter output nobody counts.
+	fs::write(
+		&compose,
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo hello-from-worker; sleep infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "--detach"])
+		.output()
+		.unwrap();
+	let logs = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "logs"])
+		.output()
+		.unwrap();
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+
+	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
+	let out = String::from_utf8_lossy(&logs.stdout);
+	assert!(
+		out.contains("worker-1 | hello-from-worker"),
+		"logs missed the first replica: {out:?}"
+	);
+	assert!(
+		out.contains("worker-2 | hello-from-worker"),
+		"logs stopped at the first replica: {out:?}"
+	);
+}
+
+/// The `top` half of the same gap: `cli_top_subcommand` drives one service, so
+/// "all replicas" was asserted nowhere.
+#[tokio::test]
+async fn cli_top_covers_every_replica_of_a_scaled_service() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-tpscale", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  worker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    deploy:\n      replicas: 2\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "--detach"])
+		.output()
+		.unwrap();
+	let top = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "top"])
+		.output()
+		.unwrap();
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+
+	assert!(top.status.success(), "top failed: {:?}", top.stderr);
+	let out = String::from_utf8_lossy(&top.stdout);
+	assert!(
+		out.contains(&format!("{proj}-worker-1")),
+		"top missed the first replica: {out:?}"
+	);
+	assert!(
+		out.contains(&format!("{proj}-worker-2")),
+		"top stopped at the first replica: {out:?}"
+	);
+}
+
+/// `logs_with_stderr_output` names the stderr path and cannot read it. Measured
+/// while writing this: podup keeps the streams apart — the container's stdout
+/// reaches podup's stdout and its stderr reaches podup's stderr, both carrying
+/// the service prefix. That separation is the contract, and it is finer than
+/// "the line appears somewhere": folding stderr into stdout would satisfy a
+/// laxer check while breaking `podup logs 2>/dev/null` for anyone filtering.
+#[tokio::test]
+async fn cli_logs_keeps_container_stdout_and_stderr_apart() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-lgerr", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  noisy:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo on-stdout; echo on-stderr 1>&2; sleep infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "--detach"])
+		.output()
+		.unwrap();
+	let logs = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "logs"])
+		.output()
+		.unwrap();
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+
+	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
+	let out = String::from_utf8_lossy(&logs.stdout);
+	let err = String::from_utf8_lossy(&logs.stderr);
+	assert!(
+		out.contains("noisy-1 | on-stdout"),
+		"the container's stdout did not reach podup's stdout: {out:?}"
+	);
+	assert!(
+		err.contains("noisy-1 | on-stderr"),
+		"the container's stderr did not reach podup's stderr: {err:?}"
+	);
+	assert!(
+		!out.contains("on-stderr"),
+		"stderr was folded into stdout, so `podup logs 2>/dev/null` would carry it: {out:?}"
+	);
+}
+
+/// `attach_logs_streams_container_output` names the content and cannot read it.
+/// An attached `up` (no `--detach`) is where that content is reachable.
+#[tokio::test]
+async fn cli_attached_up_carries_the_container_output() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-attach", std::process::id());
+	// The command exits on its own, so the attached `up` returns without needing
+	// a signal — no timeout standing in for synchronisation.
+	fs::write(
+		&compose,
+		"services:\n  chatty:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo attached-output; sleep 2\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	let up = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up"])
+		.output()
+		.unwrap();
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+
+	assert!(up.status.success(), "attached up failed: {:?}", up.stderr);
+	let out = String::from_utf8_lossy(&up.stdout);
+	assert!(
+		out.contains("chatty-1 | attached-output"),
+		"the attached up did not carry the container's output: {out:?}"
+	);
+}


### PR DESCRIPTION
Closes the three gaps #1285 records. **These are the first tests added today** — everything before this strengthened one that already existed.

## Why they belong at the CLI level

`logs`, `top` and an attached `up` write to stdout and return `Result<()>`. The engine-level tests named for these behaviours cannot read a thing; driving the binary is where the bytes are.

| new test | what was unverified |
|---|---|
| `cli_logs_covers_every_replica_of_a_scaled_service` | `logs_scaled_service_all_replicas` promises "all replicas" and cannot check it |
| `cli_top_covers_every_replica_of_a_scaled_service` | same for `top_scaled_service_all_replicas` |
| `cli_logs_keeps_container_stdout_and_stderr_apart` | `logs_with_stderr_output` names the stderr path |
| `cli_attached_up_carries_the_container_output` | `attach_logs_streams_container_output` names the content |

The replica pair matters because **#592 was exactly that**: by-service commands failing to resolve replicas after a scale. Each replica prints, so reaching only the first shows up as a missing prefix rather than as shorter output nobody counts.

## The stderr one is finer than I expected

Measured while writing it: podup **keeps the streams separate** — the container's stdout reaches podup's stdout, its stderr reaches podup's stderr, both carrying the service prefix.

So the test asserts the separation in both directions, including that stdout does **not** carry the stderr line. Folding them would satisfy a laxer "the line appears somewhere" check while breaking `podup logs 2>/dev/null` for anyone filtering.

I nearly measured this wrong. My first probe piped `2>/dev/null` and the stderr line vanished — which looked like podup dropping it. It was my own redirection.

## Mutations

| mutation | assertion that fired |
|---|---|
| `logs` enumerates one replica | `worker-2`, with `worker-1` still green |
| `top` enumerates one replica | `worker-2` |
| the error prefix writes to stdout | the stderr check |

## Test plan

Podman 5.7.0, `--test-threads=2`: `cli_output::` + `cli_commands::` is **17 passed, 0 failed** (90s). `cargo fmt --check` and clippy clean.

The additions took `cli_commands.rs` to 585 code lines, past the hard limit, so they moved to `cli_output.rs` — 440 and 149. **Checked before pushing this time**, unlike the two files earlier today where the gate caught it for me.

Closes #1285