### PR TITLE
docs: record that a profile-gated depends_on target is started

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,9 +18,17 @@ These appear before the subcommand and may also come from the environment.
 | `-p, --project <NAME>` | `COMPOSE_PROJECT_NAME` | Project name, prefixing container/network/volume names. When unset: the top-level `name:`, then the sanitized project-directory basename. |
 | `--socket <PATH>` | `PODMAN_SOCKET` | Podman socket path; overrides auto-detection. |
 | `--profile <NAMES>` | `COMPOSE_PROFILES` | Active profiles, comma-separated. |
+
 | `--project-directory <PATH>` | | Base directory for relative paths (env_file, build context, bind mounts, config/secret sources). Defaults to the compose file's directory. |
 | `--ansi <WHEN>` | | Colour output: `auto`, `always` or `never`. `always` forces colour even into a pipe or file. | 
 | `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it — when this is given, `.env` is not read. The process environment still takes precedence over both. |
+
+**Profiles activate their dependencies.** A service left out by profile
+filtering is still started when a service that *is* running declares
+`depends_on` on it, transitively — so a retained service never points at a
+dropped one. docker compose rejects that file instead. Give the dependant the
+same profile if you want neither to start. See
+[docker-migration.md](docker-migration.md#a-depends_on-target-behind-an-inactive-profile).
 
 **Identity colours.** Each service gets its own colour, so a name is
 recognisable across `ps`, `logs`, `images`, `stats` and the progress lines.

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -222,11 +222,20 @@ Both forms of `depends_on` behave this way, short and long. When **both**
 services carry the profile, podup agrees with docker compose and starts neither
 — the profile is doing its job and nothing contradicts it.
 
+**The Compose Specification does not decide this.** It says only that a service
+with `profiles` "is only started if the profile is activated", and says nothing
+about a dependency whose profile is inactive. Docker's own documentation treats
+it as something the author must fix — the dependency has to be "in the same
+profile, started separately, or not assigned to any profile" — so its rejection
+is an implementation choice in a case the specification leaves open, not a rule
+podup is breaking.
+
 **What this means for you.** A compose file relying on this runs under podup and
 is rejected by docker compose, so it is not portable back. If you want the
-dependency to stay out, give the dependant the same profile; then neither
-starts, in both tools. Note also that docker compose's message is misleading —
-`db` is not undefined, it is defined and filtered.
+dependency to stay out, or you need the file to work under both tools, give the
+dependant the same profile; then neither starts, everywhere. Note also that
+docker compose's message is misleading — `db` is not undefined, it is defined
+and filtered.
 
 ## Accepted but has no effect
 

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -189,6 +189,45 @@ services:
         mac_address: "02:42:ac:11:00:02"
 ```
 
+## Accepted, and podup is more permissive
+
+### A `depends_on` target behind an inactive profile
+
+A service can declare `profiles:` so it stays out of a default `up`. If another
+service that *is* being started declares `depends_on` on it, the two
+declarations contradict each other: one says keep it out, the other says it is
+required.
+
+docker compose refuses the project:
+
+```
+service "web" depends on undefined service "db": invalid compose project
+```
+
+podup **starts the dependency**, and every service transitively reached that
+way, so a service that is kept never points at one that was dropped.
+
+```yaml
+services:
+  db:
+    image: postgres:18-alpine
+    profiles: ["debug"]      # not started by a plain `up`...
+  web:
+    image: nginx:alpine
+    depends_on:
+      - db                   # ...but web needs it, so podup starts it
+```
+
+Both forms of `depends_on` behave this way, short and long. When **both**
+services carry the profile, podup agrees with docker compose and starts neither
+— the profile is doing its job and nothing contradicts it.
+
+**What this means for you.** A compose file relying on this runs under podup and
+is rejected by docker compose, so it is not portable back. If you want the
+dependency to stay out, give the dependant the same profile; then neither
+starts, in both tools. Note also that docker compose's message is misleading —
+`db` is not undefined, it is defined and filtered.
+
 ## Accepted but has no effect
 
 These fields parse cleanly so existing compose files validate, but podup cannot


### PR DESCRIPTION
Part of #1276, which I filed as a bug before reading the implementation. **It is not one** — the behaviour is deliberate and its rationale is in `internal/engine/profiles.rs:61`:

> Implicit activation: pull in profiled `depends_on` targets of enabled services, transitively, so a retained service never references a dropped dependency.

What was missing is that a user had no way to learn this. `docs/commands.md` documents `--profile` and `COMPOSE_PROFILES` and says nothing about it; `docs/docker-migration.md` exists precisely for differences like this and did not carry it either.

## What the divergence is

| | with `db` gated behind an inactive profile and `web` depending on it |
|---|---|
| **docker compose** | rejects the project: `service "web" depends on undefined service "db"` |
| **podup** | starts `db`, and anything transitively reached that way |
| both services carry the profile | **agree** — neither starts |

Measured on Podman 5.7.0 against docker-compose v5.1.3 on the same socket, for both the short and long `depends_on` forms.

## Why podup's behaviour is defensible

The owner's ruling, recorded in `context/podup`: *where docker does not do it well and podman does, podup improves on it.* Resolving a situation that is satisfiable, instead of erroring on it, is that. And docker compose's diagnostic is separately wrong — `db` is **not** undefined, it is defined and filtered, which sends the reader looking for a typo in a service that exists.

## What the docs now say

A new section in the migration guide under a new heading, *"Accepted, and podup is more permissive"*, with a worked example, both `depends_on` forms, the shared-profile case that agrees, and the practical consequence: **a file relying on this is not portable back to docker compose**, and giving the dependant the same profile makes both tools agree.

Plus a short note next to `--profile` in `docs/commands.md` linking to it.

## What is still open on #1276

Two things this does not do, listed there:

- `dep_on_profile_filtered_service`'s comment still claims the dependency is *skipped*, which is the opposite of what the code does. That file is being touched by #1289 right now, so it is a follow-up rather than a conflict.
- Nothing pins the choice as intentional, so a future reader who finds it surprising can revert it toward docker compose with nothing going red.

I have also still not read the Compose Specification on this point. If the spec names the case, it decides whether this is an improvement or a deviation, and the wording above should quote it.

Refs #1276