### PR TITLE
fix(cli): print the group's own help when a subcommand is missing

### DIFF
--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -233,6 +233,71 @@ fn render_help(rendered: &clap::builder::StyledStr, colour: bool) -> String {
 	}
 }
 
+/// The help of the deepest subcommand the arguments actually reached.
+///
+/// Walks the given command tree along the non-flag arguments, following aliases,
+/// and stops at the first token that is not a subcommand of the current level.
+/// With no subcommand at all it returns the root's help, which is what bare
+/// `podup` should print.
+fn help_for_argv(root: clap::Command) -> clap::builder::StyledStr {
+	help_for(root, std::env::args().skip(1))
+}
+
+/// The tree walk, separated from the process environment so it is testable.
+fn help_for(root: clap::Command, args: impl Iterator<Item = String>) -> clap::builder::StyledStr {
+	// Build first. An unbuilt tree has not propagated the binary name or the
+	// global options down to its subcommands, so a subcommand plucked out of it
+	// renders `Usage: generate <COMMAND>` instead of
+	// `Usage: podup generate [OPTIONS] <COMMAND>` — the same text `--help` on
+	// that group already produces.
+	let mut cmd = root;
+	cmd.build();
+	let mut args = args.peekable();
+	while let Some(arg) = args.next() {
+		if arg.starts_with('-') {
+			// A flag that takes a value consumes the next token, and that token
+			// must not be read as a subcommand: `-p build` names a project, not
+			// the `build` command. `--flag=value` carries its own value, so only
+			// the separated form eats one.
+			if !arg.contains('=') && takes_a_value(&cmd, &arg) {
+				args.next();
+			}
+			continue;
+		}
+		match cmd.find_subcommand(&arg) {
+			Some(sub) => cmd = sub.clone(),
+			// Stop at the first token that is not a subcommand here, so
+			// `podup generate quadlet --bad` stays on `quadlet`.
+			None => break,
+		}
+	}
+	cmd.render_help()
+}
+
+/// Whether `token` names an argument of `cmd` that consumes a following value.
+///
+/// Matches long (`--ansi`), short (`-p`) and clustered-short (`-fp`) forms; for a
+/// cluster only the last letter can take the value, which is how getopt works.
+fn takes_a_value(cmd: &clap::Command, token: &str) -> bool {
+	let wants_value = |a: &clap::Arg| {
+		matches!(
+			a.get_action(),
+			clap::ArgAction::Set | clap::ArgAction::Append
+		)
+	};
+	if let Some(long) = token.strip_prefix("--") {
+		return cmd
+			.get_arguments()
+			.any(|a| a.get_long() == Some(long) && wants_value(a));
+	}
+	match token.strip_prefix('-').and_then(|s| s.chars().last()) {
+		Some(last) => cmd
+			.get_arguments()
+			.any(|a| a.get_short() == Some(last) && wants_value(a)),
+		None => false,
+	}
+}
+
 pub(crate) fn parse_cli() -> Cli {
 	// Apply `--ansi` before clap renders anything: `--help` and clap's own
 	// errors are produced inside the parse call below, so a choice applied
@@ -277,12 +342,90 @@ pub(crate) fn parse_cli() -> Cli {
 				// `MissingSubcommand` error renders as a one-line complaint plus
 				// that subcommand wall, and the help is the useful answer to
 				// both kinds.
-				let help = <Cli as clap::CommandFactory>::command().render_help();
+				//
+				// From the command the user actually reached, not always the root.
+				// `generate` and `autostart` declare `subcommand_required`, so bare
+				// `podup generate` lands here — and rendering the root told them
+				// about the whole tool while withholding the one thing they needed,
+				// which is what `generate` accepts. Their own `--help` already
+				// answers that correctly; this path did not.
+				let help = help_for_argv(<Cli as clap::CommandFactory>::command());
 				eprint!("\n{}\n", render_help(&help, podup::ui::stderr_colored()));
 				process::exit(2);
 			}
 			_ => e.exit(),
 		},
+	}
+}
+
+#[cfg(test)]
+mod help_for_tests {
+	use super::help_for;
+	use crate::cli::Cli;
+	use clap::CommandFactory;
+
+	fn help(args: &[&str]) -> String {
+		help_for(Cli::command(), args.iter().map(|s| (*s).to_string())).to_string()
+	}
+
+	#[test]
+	fn no_subcommand_renders_the_root_help() {
+		assert!(help(&[]).contains("Usage: podup [OPTIONS] <COMMAND>"));
+	}
+
+	#[test]
+	fn a_subcommand_group_renders_its_own_help_not_the_root() {
+		let out = help(&["generate"]);
+		assert!(
+			out.contains("Usage: podup generate"),
+			"expected generate's own usage, got: {out}"
+		);
+		// The point of the fix: the root's usage must NOT be what a user asking
+		// about `generate` is shown.
+		assert!(
+			!out.contains("Usage: podup [OPTIONS] <COMMAND>"),
+			"the root help was rendered instead: {out}"
+		);
+		assert!(
+			out.contains("quadlet"),
+			"the group's subcommands are missing"
+		);
+	}
+
+	#[test]
+	fn an_alias_resolves_to_the_command_it_names() {
+		assert!(help(&["gen"]).contains("Usage: podup generate"));
+	}
+
+	#[test]
+	fn flags_before_the_subcommand_do_not_stop_the_walk() {
+		// `--ansi never generate` must still reach generate. A walk that treated
+		// the flag's value as a subcommand token would stop at `never`.
+		assert!(help(&["--ansi", "never", "autostart"]).contains("Usage: podup autostart"));
+	}
+
+	#[test]
+	fn a_flag_value_that_looks_like_a_subcommand_is_not_walked_into() {
+		// `-p` names a project. A project called "build" is ordinary, and reading
+		// it as the `build` command would render the wrong help for bare
+		// `podup -p build`.
+		let out = help(&["-p", "build"]);
+		assert!(
+			out.contains("Usage: podup [OPTIONS] <COMMAND>"),
+			"a flag's value was walked into as a subcommand: {out}"
+		);
+	}
+
+	#[test]
+	fn the_equals_form_carries_its_own_value() {
+		// `--project-name=build` consumes nothing after it, so `generate` is still
+		// the next token to consider.
+		assert!(help(&["--project-name=build", "generate"]).contains("Usage: podup generate"));
+	}
+
+	#[test]
+	fn an_unknown_token_stops_the_walk_at_the_last_real_command() {
+		assert!(help(&["generate", "nosuchthing"]).contains("Usage: podup generate"));
 	}
 }
 

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -250,20 +250,18 @@ fn missing_subcommand_exits_non_zero() {
 		!gen.status.success(),
 		"generate with no subcommand must exit non-zero"
 	);
-	// Measured 2026-08-02: a subcommand group invoked with no subcommand prints
-	// the ROOT usage, not the group's. `podup generate --help` does render
-	// `Usage: podup generate [OPTIONS] <COMMAND>` and lists `quadlet`, but bare
-	// `podup generate` renders `Usage: podup [OPTIONS] <COMMAND>` and lists every
-	// top-level command instead. `podup autostart` behaves the same way.
-	//
-	// So this asserts what it does, which is still better than asserting only the
-	// exit code: a non-zero exit with an empty stderr would pass that and leave
-	// the user nothing to read. Tightening it to the group's own usage is a
-	// behaviour change, not a test change.
+	// The group's own usage, not the root's. Until #1293 this printed
+	// `Usage: podup [OPTIONS] <COMMAND>` and listed every top-level command,
+	// withholding the one thing the user needed — what `generate` accepts —
+	// which its own `--help` had been answering correctly all along.
 	let gen_err = String::from_utf8_lossy(&gen.stderr);
 	assert!(
-		gen_err.contains("Usage: podup"),
-		"generate with no subcommand printed no usage at all: {gen_err:?}"
+		gen_err.contains("Usage: podup generate"),
+		"generate with no subcommand did not print generate's own usage: {gen_err:?}"
+	);
+	assert!(
+		gen_err.contains("quadlet"),
+		"generate's usage did not list the subcommand it accepts: {gen_err:?}"
 	);
 }
 


### PR DESCRIPTION
Closes #1293. First production change in this run of work — everything before it was tests.

## What it did

| command | before | after |
|---|---|---|
| `podup generate` | `Usage: podup [OPTIONS] <COMMAND>` + every top-level command | `Usage: podup generate [OPTIONS] <COMMAND>` + `quadlet` |
| `podup autostart` | same root wall | `Usage: podup autostart [OPTIONS] <COMMAND>` |
| `podup` (bare) | root help | unchanged |
| `podup generate --help` | already correct | unchanged |

Exit code stays 2 in every case.

## It was not a missing clap attribute

Both groups already declare `subcommand_required` and `arg_required_else_help`, so clap raises the right error. The handler in `startup::parse_cli` renders from `Cli::command()` unconditionally — the **root's** help, whichever group triggered it.

The reason it renders from the command rather than from the error is good and unchanged: a `MissingSubcommand` error renders as a one-line complaint plus a wall of subcommand names, and the help is the useful answer. It just rendered the wrong command's.

## Two things the tests caught, one of them my own first version

**Building the tree matters.** An unbuilt `Command` has not propagated the binary name or the global options to its subcommands, so a subcommand plucked out of it renders `Usage: generate <COMMAND>`. After `build()` it matches `--help` exactly.

**The walk has to know which flags consume a value.** My first version skipped tokens starting with `-` and left the value behind, so `--ansi never autostart` stopped at `never` — caught by the test I had written for that case.

Not walking into unknown tokens at all is not the fix either. `-p build` names a project, and a project called `build` is perfectly ordinary; reading it as the `build` command would render the wrong help for bare `podup -p build`. So value-taking flags are looked up in the built command and their value skipped, with `--flag=value` carrying its own. Both cases have a test.

## Test plan

Seven unit tests over the walk: root with no subcommand, a group rendering its own help and **not** the root's, alias resolution (`gen`), a flag and its value before the subcommand, an unknown token stopping the walk, a flag value that looks like a subcommand, and the `=` form.

`cargo test --lib --bins` is **1444 + 81 passed, 0 failed**. `cli_flags`, `cli_diagnostics` and `cli_aliases` all green. `cargo fmt --check` and clippy clean. `startup/mod.rs` is 392 code lines.

`missing_subcommand_exits_non_zero` now requires generate's own usage and the `quadlet` line rather than any usage at all — that assertion was written yesterday's-way, pinning the old behaviour with the measurement in a comment, and this is the change that comment said would be needed.

Both new functions are private to the crate, so no public API moves.

Closes #1293