### PR TITLE
fix(build): the integration suite requires test-helpers, so declare it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,22 @@ path = "internal/main.rs"
 name = "podup"
 path = "internal/lib.rs"
 
+# The engine integration suite drives the library through test-only seams
+# (`test_exec_capture`, `test_project_container_names`) that live behind the
+# `test-helpers` feature so they never reach a release build. Without the
+# feature the target does not compile, and `debian/rules` builds with
+# `--no-default-features --features watch,completions` — so it broke there while
+# every other caller passed either `--all-features` or `--features test-helpers`
+# and stayed green.
+#
+# `required-features` makes cargo skip the target instead of failing to build it.
+# Nothing is lost: the suite needs a reachable Podman, which a package builder
+# does not have, and the lane that gates merges always passes the feature.
+[[test]]
+name = "engine_integration"
+path = "tests/engine_integration.rs"
+required-features = ["test-helpers"]
+
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "net", "io-util", "io-std"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
**`develop` does not compile its tests without `--features test-helpers`, and has not for several days.** 43 errors, all `no method named test_exec_capture`.

I broke it, and this fixes it.

## What happened

The seams the suite drives — `test_exec_capture`, `test_project_container_names` — live behind `#[cfg(feature = "test-helpers")]` so they never reach a release build. The assertions I added over the last day call them from modules that compile unconditionally. `watch.rs` was already gated in `engine_integration.rs` for exactly this reason, and I did not carry that across.

## Why nothing caught it for twenty pull requests

| caller | flags | outcome |
|---|---|---|
| `podman-lane.yml` | `--features test-helpers` | compiles |
| `rust / Test` | `--all-features` | compiles |
| **`debian/rules`** | `--no-default-features --features watch,completions` | **43 errors** |

And `debian-build.yml` is path-filtered:

```yaml
paths: [ "debian/**", "Cargo.toml", "Cargo.lock", "internal/**", ... ]
```

A test-only change never triggers it. Every pull request I opened yesterday and today touched `tests/` alone — until #1294, the first to touch `internal/`, which went red immediately **on a break that had nothing to do with it**.

That is worth recording beyond this fix: a path filter is a gate that does not run, and a gate that does not run is indistinguishable from a gate that passes. Twenty green pull requests said nothing about a build that had been broken since roughly the fourth.

## The fix

`required-features` on the test target. Cargo skips it rather than failing to build it.

Nothing is lost. The suite needs a reachable Podman, which a package builder does not have, and every gate that matters already passes the feature.

## Verified on all four invocations

| invocation | errors | integration target |
|---|---|---|
| Debian's flags | 0 | skipped |
| `--all-features` | 0 | built |
| the lane's | 0 | built |
| bare `cargo test` | 0 | skipped |

The other suites still run unaffected under Debian's flags: **1386 + 70 + 11 + 10 + 19 + 3 passing**.

## Follow-up worth considering, not done here

`debian-build.yml`'s path filter is why this hid. Adding `tests/**` to it would have caught this on the first pull request. That is a change to a workflow's trigger and belongs in its own review, not smuggled into a build fix.