### PR TITLE
test(stats): pin format_bytes at its edges, extend it to EiB, add a minutes tier

### DIFF
--- a/bench/aggregate.py
+++ b/bench/aggregate.py
@@ -114,6 +114,13 @@ def row_unit(cells, metric):
 		values += [v for v in (s["median"], s["p95"]) if v == v]
 	if values and max(values) < 1.0:
 		return ("ms", 1000.0, 1)
+	# Above a minute, seconds stop being readable at a glance: a scenario that
+	# takes two minutes printed as `120.000 s` makes the reader do the division.
+	# No published row reaches this yet — the slowest is `wide-level up` at 9.7 s
+	# for docker-compose — but the tier belongs here before a long scenario is
+	# added rather than after, when the fix competes with reading the results.
+	if values and max(values) >= 60.0:
+		return ("min", 1.0 / 60.0, 2)
 	return ("s", 1.0, 3)
 
 
@@ -272,6 +279,18 @@ def main():
 		# synthetic, so they are not measured against the real budget — but a gate
 		# nobody has watched fail is decoration, and this is the only place the
 		# shared-CI smoke run can watch it.
+		# The unit tiers, exercised rather than assumed: a row is rendered in one
+		# unit chosen from its largest value, and each boundary decides a report
+		# column nobody re-reads once it is published.
+		def unit_of(seconds):
+			return row_unit([{"seconds": {"median": seconds, "p95": seconds}}], "seconds")[0]
+
+		for value, want in ((0.5, "ms"), (1.0, "s"), (59.9, "s"), (60.0, "min"), (600.0, "min")):
+			got = unit_of(value)
+			if got != want:
+				print(f"self-test FAILED: {value}s rendered in {got}, expected {want}", file=sys.stderr)
+				return 1
+
 		under = {"podup": {"single": {"up": {"rss_mib": {"median": 1.0}}}}}
 		over = {"podup": {"single": {"up": {"rss_mib": {"median": 10_000.0}}}}}
 		if check_memory_budget(under) != 0:

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -137,7 +137,12 @@ struct NetStat {
 
 /// Render a byte count as a compact human string (`1.5MiB`). Pure for testing.
 fn format_bytes(bytes: u64) -> String {
-	const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+	// Through EiB, so the table is total for the input type: `u64::MAX` is just
+	// under 16 EiB. It used to stop at TiB, which made a petabyte render as
+	// `1024.0TiB` — correct arithmetic, wrong unit, and nine digits wide in a
+	// column sized for five. The NET I/O counters are cumulative u64, so the
+	// large end is reachable in principle even though no container gets there.
+	const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
 	let mut value = bytes as f64;
 	let mut unit = 0;
 	while value >= 1024.0 && unit < UNITS.len() - 1 {

--- a/internal/engine/stats_tests.rs
+++ b/internal/engine/stats_tests.rs
@@ -32,6 +32,30 @@ fn format_bytes_scales_units() {
 	assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.0GiB");
 }
 
+/// The edges the scaling test steps over. It goes from 512 straight to 1024, so
+/// the last value that must stay in bytes — and the empty case — were never
+/// pinned, and a threshold with no test on either side of it is where an
+/// off-by-one lives.
+#[test]
+fn format_bytes_pins_both_sides_of_the_first_threshold() {
+	assert_eq!(format_bytes(0), "0B");
+	assert_eq!(format_bytes(1), "1B");
+	assert_eq!(format_bytes(1023), "1023B");
+	assert_eq!(format_bytes(1024), "1.0KiB");
+}
+
+/// Every unit in the table, including the two the counters can only reach in
+/// principle. `u64::MAX` is just under 16 EiB, so this also pins that the
+/// function is total for its input type rather than saturating.
+#[test]
+fn format_bytes_reaches_the_top_of_the_table() {
+	assert_eq!(format_bytes(1u64 << 40), "1.0TiB");
+	assert_eq!(format_bytes(1u64 << 50), "1.0PiB");
+	assert_eq!(format_bytes(1u64 << 60), "1.0EiB");
+	// Before the table grew, this printed 16777216.0TiB.
+	assert_eq!(format_bytes(u64::MAX), "16.0EiB");
+}
+
 #[test]
 fn format_row_sums_network_and_shows_name() {
 	let mut network = HashMap::new();


### PR DESCRIPTION
Closes #1299 — and corrects how I filed it.

## The correction first

I said `format_bytes` had no tests. **It does** — `format_bytes_scales_units` in `stats_tests.rs`, and it is a real test of the scaling, not a token one. I grepped inside `stats.rs`; the tests live in the file it pulls in at the bottom with `#[path = "stats_tests.rs"] mod tests`. The issue carries the correction.

## What that test steps over

It goes from 512 straight to 1024, so **the last value that must stay in bytes was never pinned**, nor was zero, nor the top of the unit table.

```rust
format_bytes(0)    -> "0B"
format_bytes(1)    -> "1B"
format_bytes(1023) -> "1023B"     // the one the old test skipped
format_bytes(1024) -> "1.0KiB"
```

A threshold with no test on either side of it is where an off-by-one lives.

## The table stopped at TiB

A petabyte rendered as `1024.0TiB` — correct arithmetic, wrong unit, and nine digits wide in a column sized for five. Extended through **EiB**, which makes it total for the input type:

```rust
format_bytes(1u64 << 50) -> "1.0PiB"
format_bytes(1u64 << 60) -> "1.0EiB"
format_bytes(u64::MAX)   -> "16.0EiB"   // was 16777216.0TiB
```

The NET I/O counters are cumulative `u64`, so the large end is reachable in principle even though no container gets there.

## The benchmark knew two units

`ms` under a second, `s` above, nothing else — so a scenario crossing a minute would print `120.000 s` and make the reader do the division. There is a minutes tier above 60 s now.

**The real data is byte-identical after the change**, since the slowest published row is `wide-level up` at 9.7 s. That is the point: the tier belongs here before a long scenario is added, not after, when the fix competes with reading the results.

The existing rule is untouched — one unit per row, chosen from the row's largest value including p95. Only the tiers it picks from changed.

## Both are exercised, not assumed

`--self-test` now walks the tier boundaries (0.5, 1.0, 59.9, 60.0, 600.0) and fails if any renders in the wrong unit, the same way the memory budget added in #1296 is exercised in both directions.

A tier nobody has watched choose is the same thing as a gate nobody has watched fail.

## Test plan

`cargo test --lib --bins`: **1446 + 81 passed, 0 failed**. `cargo fmt --check` and clippy clean. Benchmark self-test green; a real aggregate run reproduces the published numbers unchanged and reports `peak median 8.62 MiB, budget 9.00 MiB`.

Closes #1299