### PR TITLE
feat(units): a shared, total formatter for sizes and durations

### DIFF
--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -9,6 +9,7 @@ use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::ContainerListEntry;
 use crate::libpod::{parse_json_lines, urlencoded, API_PREFIX};
+use crate::units::SizeFormat;
 
 use super::Engine;
 
@@ -135,25 +136,20 @@ struct NetStat {
 	tx: u64,
 }
 
+/// How `stats` renders a size: binary units at one decimal.
+///
+/// Binary because this table is read next to `free` and `htop`, which are
+/// binary — not next to podman's own output, which is decimal. One decimal
+/// because the columns below are fixed-width by design (a live view must not
+/// resize itself mid-repaint), and a second decimal does not fit `NET I/O`.
+const SIZE_FORMAT: SizeFormat = SizeFormat::binary().with_decimals(1);
+
 /// Render a byte count as a compact human string (`1.5MiB`). Pure for testing.
+///
+/// The ladder, the rounding and the totality guarantee live in [`crate::units`]
+/// now; this is the surface's choice of base and precision, nothing else.
 fn format_bytes(bytes: u64) -> String {
-	// Through EiB, so the table is total for the input type: `u64::MAX` is just
-	// under 16 EiB. It used to stop at TiB, which made a petabyte render as
-	// `1024.0TiB` — correct arithmetic, wrong unit, and nine digits wide in a
-	// column sized for five. The NET I/O counters are cumulative u64, so the
-	// large end is reachable in principle even though no container gets there.
-	const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
-	let mut value = bytes as f64;
-	let mut unit = 0;
-	while value >= 1024.0 && unit < UNITS.len() - 1 {
-		value /= 1024.0;
-		unit += 1;
-	}
-	if unit == 0 {
-		format!("{bytes}B")
-	} else {
-		format!("{value:.1}{}", UNITS[unit])
-	}
+	crate::units::format_bytes(bytes, &SIZE_FORMAT)
 }
 
 /// Sum a container's per-interface network counters into one `(rx, tx)` pair.

--- a/internal/engine/stats_tests.rs
+++ b/internal/engine/stats_tests.rs
@@ -56,6 +56,20 @@ fn format_bytes_reaches_the_top_of_the_table() {
 	assert_eq!(format_bytes(u64::MAX), "16.0EiB");
 }
 
+/// A value just under a boundary used to round up onto it and print the unit it
+/// had already left: one byte short of a mebibyte read `1024.0KiB`. Shared with
+/// every other surface now, so a NET I/O counter crossing a rung says so.
+#[test]
+fn format_bytes_promotes_a_value_that_rounds_onto_the_next_unit() {
+	assert_eq!(format_bytes(1024 * 1024 - 1), "1.0MiB");
+	// The threshold is where the *rendered* value rounds up, so at one decimal
+	// it is 1023.95 KiB and not the boundary itself. Both sides of it, since a
+	// threshold with a test on only one side is where an off-by-one lives.
+	assert_eq!(format_bytes(1024 * 1024 - 40), "1.0MiB");
+	assert_eq!(format_bytes(1024 * 1024 - 100), "1023.9KiB");
+	assert_eq!(format_bytes(1024 * 1000), "1000.0KiB");
+}
+
 #[test]
 fn format_row_sums_network_and_shows_name() {
 	let mut network = HashMap::new();

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -34,6 +34,7 @@ pub mod size;
 pub mod substitute;
 /// Terminal colour/styling, honouring `--ansi`, `NO_COLOR`, and TTY detection.
 pub mod ui;
+pub(crate) mod units;
 /// Secure self-update for the `podup` binary (signature-verified release fetch).
 #[cfg(feature = "update")]
 pub mod update;

--- a/internal/units/bytes.rs
+++ b/internal/units/bytes.rs
@@ -1,0 +1,193 @@
+//! Byte counts rendered against either unit ladder.
+
+/// Which ladder of units a byte count is rendered against.
+///
+/// Neither is universally right, so the caller picks per surface: podman and
+/// docker print decimal (`8.71MB`), while `stats` is read next to `free` and
+/// `htop`, which are binary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SizeBase {
+	/// Powers of 1024, suffixed `B`, `KiB`, `MiB`, `GiB`, `TiB`, `PiB`, `EiB`.
+	Binary,
+	/// Powers of 1000, suffixed `B`, `KB`, `MB`, `GB`, `TB`, `PB`, `EB`.
+	Decimal,
+}
+
+/// Binary units, largest exponent last. `EiB` is 1024^6; `u64::MAX` is just
+/// under 16 of them, so the ladder covers the whole input type.
+const BINARY_UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
+
+/// Decimal units, largest exponent last. `EB` is 1000^6; `u64::MAX` is a little
+/// over 18 of them, so this ladder covers the whole input type too.
+const DECIMAL_UNITS: [&str; 7] = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+
+impl SizeBase {
+	/// The factor between two neighbouring units on this ladder.
+	const fn step(self) -> u64 {
+		match self {
+			Self::Binary => 1024,
+			Self::Decimal => 1000,
+		}
+	}
+
+	/// The unit names, index 0 being plain bytes.
+	const fn units(self) -> &'static [&'static str; 7] {
+		match self {
+			Self::Binary => &BINARY_UNITS,
+			Self::Decimal => &DECIMAL_UNITS,
+		}
+	}
+}
+
+/// How many numbers a rendered size is made of.
+///
+/// The two shapes take different settings, and neither setting means anything
+/// under the other: decimals on a composite value would read `1GB 512.00MB`,
+/// and a component count on a single value is always one. Splitting them keeps
+/// a caller from asking for a combination that has no rendering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SizeShape {
+	/// One unit carrying `decimals` decimal places: `8.71MB`. What a table cell
+	/// wants, since a column has a width budget.
+	Single { decimals: usize },
+	/// Up to `parts` whole components, largest first, zeros skipped:
+	/// `1TB 1GB`, `1GB 512MB`. For the places where the number is the point.
+	Composite { parts: usize },
+}
+
+/// How to render a byte count.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SizeFormat {
+	/// The unit ladder.
+	pub base: SizeBase,
+	/// How many numbers the result carries.
+	pub shape: SizeShape,
+}
+
+impl SizeFormat {
+	/// Two decimals against the binary ladder: `8.31MiB`.
+	pub(crate) const fn binary() -> Self {
+		Self {
+			base: SizeBase::Binary,
+			shape: SizeShape::Single { decimals: 2 },
+		}
+	}
+
+	/// Two decimals against the decimal ladder: `8.71MB`. This is what podman
+	/// and docker print, so it is the base to compare a table against theirs.
+	pub(crate) const fn decimal() -> Self {
+		Self {
+			base: SizeBase::Decimal,
+			shape: SizeShape::Single { decimals: 2 },
+		}
+	}
+
+	/// Same ladder, `decimals` decimal places on a single component.
+	pub(crate) const fn with_decimals(self, decimals: usize) -> Self {
+		Self {
+			shape: SizeShape::Single { decimals },
+			..self
+		}
+	}
+
+	/// Same ladder, up to `parts` whole components.
+	pub(crate) const fn with_parts(self, parts: usize) -> Self {
+		Self {
+			shape: SizeShape::Composite { parts },
+			..self
+		}
+	}
+}
+
+/// Render `bytes` as a human-readable size.
+///
+/// Total over `u64`: both ladders reach an exponent that `u64::MAX` cannot
+/// exceed, so nothing saturates into a wrong unit the way a table stopping at
+/// `TiB` renders a petabyte as `1024.0TiB`.
+///
+/// Zero renders as `0B` under either shape. A composite value is computed with
+/// integer division, so `1TB 1GB` is exact rather than a float rounded twice.
+pub(crate) fn format_bytes(bytes: u64, fmt: &SizeFormat) -> String {
+	match fmt.shape {
+		SizeShape::Single { decimals } => single(bytes, fmt.base, decimals),
+		SizeShape::Composite { parts } => composite(bytes, fmt.base, parts),
+	}
+}
+
+/// One number and one unit: the largest unit whose value is at least one.
+fn single(bytes: u64, base: SizeBase, decimals: usize) -> String {
+	let units = base.units();
+	let step = base.step();
+
+	let mut index = 0;
+	let mut divisor = 1u64;
+	while index + 1 < units.len() && bytes / divisor >= step {
+		divisor *= step;
+		index += 1;
+	}
+
+	// Whole bytes never carry decimals: `512B`, not `512.00B`. There is no
+	// fraction of a byte to report, and the padding costs column width.
+	if index == 0 {
+		return format!("{bytes}B");
+	}
+
+	let mut value = bytes as f64 / divisor as f64;
+	// Rounding can carry the value onto the next rung: 1048575 bytes is
+	// 1023.999 KiB, which prints as `1024.00KiB` — right arithmetic, and the
+	// same unit-boundary artefact the ladder exists to avoid. Promote once,
+	// which is enough: the value was below `step` before rounding, so it cannot
+	// land more than one rung high. At the top rung there is nowhere to go, so
+	// `u64::MAX` reads `16.00EiB` rather than inventing an eighth unit.
+	let rounds_onto_the_next_unit = format!("{value:.decimals$}")
+		.parse::<f64>()
+		.is_ok_and(|rounded| rounded >= step as f64);
+	if rounds_onto_the_next_unit && index + 1 < units.len() {
+		divisor *= step;
+		index += 1;
+		value = bytes as f64 / divisor as f64;
+	}
+	format!("{value:.decimals$}{}", units[index])
+}
+
+/// Up to `parts` whole components, largest first, zeros skipped.
+///
+/// Skipping zeros rather than stopping at one is what makes `1y 1d 1h 4s 5ms`
+/// possible for durations and `1TB 5MB` here: the components that survive are
+/// the ones that carry value, not the ones that happen to be adjacent.
+fn composite(bytes: u64, base: SizeBase, parts: usize) -> String {
+	let units = base.units();
+	let step = base.step();
+	let wanted = parts.max(1);
+
+	// Largest divisor first: step^(units.len() - 1).
+	let mut divisor = 1u64;
+	for _ in 1..units.len() {
+		divisor *= step;
+	}
+
+	let mut remainder = bytes;
+	let mut out: Vec<String> = Vec::with_capacity(wanted);
+	for index in (0..units.len()).rev() {
+		if out.len() == wanted {
+			break;
+		}
+		let count = remainder / divisor;
+		if count > 0 {
+			out.push(format!("{count}{}", units[index]));
+			remainder %= divisor;
+		}
+		if index > 0 {
+			divisor /= step;
+		}
+	}
+
+	if out.is_empty() {
+		return "0B".to_string();
+	}
+	out.join(" ")
+}
+
+#[cfg(test)]
+#[path = "bytes_tests.rs"]
+mod tests;

--- a/internal/units/bytes_tests.rs
+++ b/internal/units/bytes_tests.rs
@@ -1,4 +1,4 @@
-use super::{SizeBase, SizeFormat, SizeShape, format_bytes};
+use super::{format_bytes, SizeBase, SizeFormat, SizeShape};
 
 /// Both ladders reach an exponent `u64::MAX` cannot exceed, so no input can
 /// push the renderer off the end of its table. This is the whole reason the
@@ -16,8 +16,14 @@ fn both_ladders_cover_the_whole_input_type() {
 /// column sized for five.
 #[test]
 fn a_petabyte_does_not_saturate_into_terabytes() {
-	assert_eq!(format_bytes(1024_u64.pow(5), &SizeFormat::binary()), "1.00PiB");
-	assert_eq!(format_bytes(1000_u64.pow(5), &SizeFormat::decimal()), "1.00PB");
+	assert_eq!(
+		format_bytes(1024_u64.pow(5), &SizeFormat::binary()),
+		"1.00PiB"
+	);
+	assert_eq!(
+		format_bytes(1000_u64.pow(5), &SizeFormat::decimal()),
+		"1.00PB"
+	);
 }
 
 /// Every rung of the binary ladder, at the exact value that first reaches it.
@@ -71,10 +77,19 @@ fn whole_bytes_carry_no_decimals() {
 /// hit: any size within half a display digit of a boundary shows it.
 #[test]
 fn a_value_that_rounds_onto_the_next_unit_is_promoted() {
-	assert_eq!(format_bytes(1024_u64.pow(2) - 1, &SizeFormat::binary()), "1.00MiB");
-	assert_eq!(format_bytes(1000_u64.pow(2) - 1, &SizeFormat::decimal()), "1.00MB");
+	assert_eq!(
+		format_bytes(1024_u64.pow(2) - 1, &SizeFormat::binary()),
+		"1.00MiB"
+	);
+	assert_eq!(
+		format_bytes(1000_u64.pow(2) - 1, &SizeFormat::decimal()),
+		"1.00MB"
+	);
 	// One rung further up, to show the promotion is not special-cased to KiB.
-	assert_eq!(format_bytes(1024_u64.pow(4) - 1, &SizeFormat::binary()), "1.00TiB");
+	assert_eq!(
+		format_bytes(1024_u64.pow(4) - 1, &SizeFormat::binary()),
+		"1.00TiB"
+	);
 }
 
 /// Below the rounding threshold the value stays on its own rung, which is what
@@ -90,8 +105,14 @@ fn a_value_that_does_not_round_up_stays_on_its_rung() {
 #[test]
 fn the_decimal_count_is_configurable() {
 	let bytes = 1_610_612_736; // 1.5 GiB exactly.
-	assert_eq!(format_bytes(bytes, &SizeFormat::binary().with_decimals(0)), "2GiB");
-	assert_eq!(format_bytes(bytes, &SizeFormat::binary().with_decimals(1)), "1.5GiB");
+	assert_eq!(
+		format_bytes(bytes, &SizeFormat::binary().with_decimals(0)),
+		"2GiB"
+	);
+	assert_eq!(
+		format_bytes(bytes, &SizeFormat::binary().with_decimals(1)),
+		"1.5GiB"
+	);
 	assert_eq!(
 		format_bytes(bytes, &SizeFormat::binary().with_decimals(4)),
 		"1.5000GiB"
@@ -169,7 +190,10 @@ fn zero_renders_under_either_shape() {
 /// is treated as one component rather than returning an empty string.
 #[test]
 fn a_zero_component_count_still_renders_one_component() {
-	assert_eq!(format_bytes(1025, &SizeFormat::binary().with_parts(0)), "1KiB");
+	assert_eq!(
+		format_bytes(1025, &SizeFormat::binary().with_parts(0)),
+		"1KiB"
+	);
 }
 
 /// The builders replace the shape rather than merging into it, so the last call

--- a/internal/units/bytes_tests.rs
+++ b/internal/units/bytes_tests.rs
@@ -1,0 +1,185 @@
+use super::{SizeBase, SizeFormat, SizeShape, format_bytes};
+
+/// Both ladders reach an exponent `u64::MAX` cannot exceed, so no input can
+/// push the renderer off the end of its table. This is the whole reason the
+/// units go past what a container plausibly reports: a formatter is either
+/// total over its input type or it has a cliff, and the cliff is only ever
+/// found by whoever is big enough to hit it.
+#[test]
+fn both_ladders_cover_the_whole_input_type() {
+	assert_eq!(format_bytes(u64::MAX, &SizeFormat::binary()), "16.00EiB");
+	assert_eq!(format_bytes(u64::MAX, &SizeFormat::decimal()), "18.45EB");
+}
+
+/// The regression the ladder was extended for: stopping at `TiB` rendered a
+/// petabyte as `1024.0TiB` — right arithmetic, wrong unit, and nine digits in a
+/// column sized for five.
+#[test]
+fn a_petabyte_does_not_saturate_into_terabytes() {
+	assert_eq!(format_bytes(1024_u64.pow(5), &SizeFormat::binary()), "1.00PiB");
+	assert_eq!(format_bytes(1000_u64.pow(5), &SizeFormat::decimal()), "1.00PB");
+}
+
+/// Every rung of the binary ladder, at the exact value that first reaches it.
+#[test]
+fn binary_units_step_at_their_own_boundaries() {
+	let fmt = SizeFormat::binary();
+	assert_eq!(format_bytes(1024, &fmt), "1.00KiB");
+	assert_eq!(format_bytes(1024_u64.pow(2), &fmt), "1.00MiB");
+	assert_eq!(format_bytes(1024_u64.pow(3), &fmt), "1.00GiB");
+	assert_eq!(format_bytes(1024_u64.pow(4), &fmt), "1.00TiB");
+	assert_eq!(format_bytes(1024_u64.pow(5), &fmt), "1.00PiB");
+	assert_eq!(format_bytes(1024_u64.pow(6), &fmt), "1.00EiB");
+}
+
+/// Every rung of the decimal ladder. This is the base podman and docker print,
+/// so an `images` or `ps` table is compared against these strings, not the
+/// binary ones.
+#[test]
+fn decimal_units_step_at_their_own_boundaries() {
+	let fmt = SizeFormat::decimal();
+	assert_eq!(format_bytes(1000, &fmt), "1.00KB");
+	assert_eq!(format_bytes(1000_u64.pow(2), &fmt), "1.00MB");
+	assert_eq!(format_bytes(1000_u64.pow(3), &fmt), "1.00GB");
+	assert_eq!(format_bytes(1000_u64.pow(4), &fmt), "1.00TB");
+	assert_eq!(format_bytes(1000_u64.pow(5), &fmt), "1.00PB");
+	assert_eq!(format_bytes(1000_u64.pow(6), &fmt), "1.00EB");
+}
+
+/// The two bases disagree on the same input, which is why the base is a
+/// per-surface choice rather than a constant. 8_711_starting bytes is the
+/// worked case from the issue: podman says `8.71MB`, `free` says `8.31MiB`.
+#[test]
+fn the_two_bases_render_the_same_input_differently() {
+	assert_eq!(format_bytes(8_710_000, &SizeFormat::decimal()), "8.71MB");
+	assert_eq!(format_bytes(8_710_000, &SizeFormat::binary()), "8.31MiB");
+}
+
+/// Under a kilobyte there is no fraction of a byte to report, so the value
+/// prints whole under either base and costs no column width.
+#[test]
+fn whole_bytes_carry_no_decimals() {
+	assert_eq!(format_bytes(0, &SizeFormat::binary()), "0B");
+	assert_eq!(format_bytes(1, &SizeFormat::binary()), "1B");
+	assert_eq!(format_bytes(1023, &SizeFormat::binary()), "1023B");
+	assert_eq!(format_bytes(999, &SizeFormat::decimal()), "999B");
+}
+
+/// A value just under a boundary rounds up onto it, and the renderer promotes
+/// rather than printing `1024.00KiB`. Without the promotion this is the same
+/// class of defect as saturating at `TiB`, one rung lower and much easier to
+/// hit: any size within half a display digit of a boundary shows it.
+#[test]
+fn a_value_that_rounds_onto_the_next_unit_is_promoted() {
+	assert_eq!(format_bytes(1024_u64.pow(2) - 1, &SizeFormat::binary()), "1.00MiB");
+	assert_eq!(format_bytes(1000_u64.pow(2) - 1, &SizeFormat::decimal()), "1.00MB");
+	// One rung further up, to show the promotion is not special-cased to KiB.
+	assert_eq!(format_bytes(1024_u64.pow(4) - 1, &SizeFormat::binary()), "1.00TiB");
+}
+
+/// Below the rounding threshold the value stays on its own rung, which is what
+/// makes the test above a promotion rather than an off-by-one.
+#[test]
+fn a_value_that_does_not_round_up_stays_on_its_rung() {
+	// 1048000 bytes is 1023.4KiB, which rounds to 1023.44 — still KiB.
+	assert_eq!(format_bytes(1_048_000, &SizeFormat::binary()), "1023.44KiB");
+}
+
+/// The decimal count is the caller's, because a table cell and a summary line
+/// have different width budgets.
+#[test]
+fn the_decimal_count_is_configurable() {
+	let bytes = 1_610_612_736; // 1.5 GiB exactly.
+	assert_eq!(format_bytes(bytes, &SizeFormat::binary().with_decimals(0)), "2GiB");
+	assert_eq!(format_bytes(bytes, &SizeFormat::binary().with_decimals(1)), "1.5GiB");
+	assert_eq!(
+		format_bytes(bytes, &SizeFormat::binary().with_decimals(4)),
+		"1.5000GiB"
+	);
+}
+
+/// The owner's worked examples, in the base each was written in.
+#[test]
+fn composite_renders_the_examples_from_the_issue() {
+	let decimal = SizeFormat::decimal().with_parts(2);
+	assert_eq!(format_bytes(1_001_000_000_000, &decimal), "1TB 1GB");
+	assert_eq!(format_bytes(1_512_000_000, &decimal), "1GB 512MB");
+}
+
+/// Components that are zero are skipped rather than ending the walk, so the
+/// parts that survive are the ones carrying value. A terabyte and five
+/// megabytes has nothing in between, and reporting `1TiB` alone would drop the
+/// five megabytes the caller asked for a second component to see.
+#[test]
+fn composite_skips_empty_components() {
+	let fmt = SizeFormat::binary().with_parts(2);
+	let bytes = 1024_u64.pow(4) + 5 * 1024_u64.pow(2);
+	assert_eq!(format_bytes(bytes, &fmt), "1TiB 5MiB");
+}
+
+/// Asking for more components than the value has yields only the ones that
+/// exist — no `1KiB 0B` padding.
+#[test]
+fn composite_stops_when_the_value_runs_out() {
+	let fmt = SizeFormat::binary().with_parts(7);
+	assert_eq!(format_bytes(1024, &fmt), "1KiB");
+	assert_eq!(format_bytes(1025, &fmt), "1KiB 1B");
+}
+
+/// Composite arithmetic is integer division, so the components sum back to the
+/// input exactly. A float round-trip through seven rungs would not.
+#[test]
+fn composite_components_are_exact() {
+	let fmt = SizeFormat::binary().with_parts(7);
+	let bytes = u64::MAX;
+	let rendered = format_bytes(bytes, &fmt);
+	let units: Vec<(&str, u64)> = vec![
+		("EiB", 1024_u64.pow(6)),
+		("PiB", 1024_u64.pow(5)),
+		("TiB", 1024_u64.pow(4)),
+		("GiB", 1024_u64.pow(3)),
+		("MiB", 1024_u64.pow(2)),
+		("KiB", 1024),
+		("B", 1),
+	];
+	let total: u64 = rendered
+		.split(' ')
+		.map(|part| {
+			let (unit, scale) = units
+				.iter()
+				.find(|(unit, _)| part.ends_with(unit))
+				.unwrap_or_else(|| panic!("unknown unit in {rendered:?}"));
+			let count: u64 = part[..part.len() - unit.len()].parse().unwrap();
+			count * scale
+		})
+		.sum();
+	assert_eq!(total, bytes, "{rendered:?} did not sum back to the input");
+}
+
+/// Zero has no components at all, and still has to render something. Both
+/// shapes answer `0B` rather than an empty cell.
+#[test]
+fn zero_renders_under_either_shape() {
+	assert_eq!(format_bytes(0, &SizeFormat::binary().with_parts(3)), "0B");
+	assert_eq!(format_bytes(0, &SizeFormat::decimal().with_parts(3)), "0B");
+	assert_eq!(format_bytes(0, &SizeFormat::decimal()), "0B");
+}
+
+/// A zero component count is a caller mistake with no sensible rendering, so it
+/// is treated as one component rather than returning an empty string.
+#[test]
+fn a_zero_component_count_still_renders_one_component() {
+	assert_eq!(format_bytes(1025, &SizeFormat::binary().with_parts(0)), "1KiB");
+}
+
+/// The builders replace the shape rather than merging into it, so the last call
+/// wins and a caller cannot end up with a half-set combination.
+#[test]
+fn the_builders_replace_the_shape() {
+	let fmt = SizeFormat::binary().with_decimals(3).with_parts(2);
+	assert_eq!(fmt.shape, SizeShape::Composite { parts: 2 });
+	assert_eq!(fmt.base, SizeBase::Binary);
+	let fmt = SizeFormat::decimal().with_parts(2).with_decimals(3);
+	assert_eq!(fmt.shape, SizeShape::Single { decimals: 3 });
+	assert_eq!(fmt.base, SizeBase::Decimal);
+}

--- a/internal/units/duration.rs
+++ b/internal/units/duration.rs
@@ -1,0 +1,96 @@
+//! Durations rendered as composite components or as plain milliseconds.
+
+use std::time::Duration;
+
+/// The duration ladder, largest first, in nanoseconds.
+///
+/// No month and no week, deliberately. A month is 28 to 31 days and a week only
+/// means something against a calendar, while a duration has neither — and an
+/// uptime of `1mo` tells the reader less than `34d` does.
+///
+/// A year here is exactly 365 days. A duration is an elapsed span, not a range
+/// between two dates, so there is no calendar to consult for a leap day; 365 is
+/// the arithmetic a reader can redo in their head.
+const UNITS: [(&str, u128); 8] = [
+	("y", 365 * 24 * 60 * 60 * 1_000_000_000),
+	("d", 24 * 60 * 60 * 1_000_000_000),
+	("h", 60 * 60 * 1_000_000_000),
+	("m", 60 * 1_000_000_000),
+	("s", 1_000_000_000),
+	("ms", 1_000_000),
+	("µs", 1_000),
+	("ns", 1),
+];
+
+/// Nanoseconds in a millisecond, for the plain-milliseconds shape.
+const NANOS_PER_MILLI: f64 = 1_000_000.0;
+
+/// How to render a duration.
+///
+/// The two shapes take different settings and neither means anything under the
+/// other, so they are separate variants rather than fields a caller could set
+/// in a combination that has no rendering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DurationFormat {
+	/// Up to N components, largest first, zeros skipped: `2h 5m`,
+	/// `1y 1d 1h 4s 5ms`, `340ms`. What reads at a glance.
+	Parts(usize),
+	/// One number in milliseconds with `decimals` decimal places: `340.00ms`.
+	/// For machine reading, or when the reader wants to compare two durations
+	/// rather than skim one.
+	Millis { decimals: usize },
+}
+
+impl DurationFormat {
+	/// Two components, which is what reads at a glance: `2h 5m`, not
+	/// `2h 5m 3s 200ms`.
+	pub(crate) const fn default_parts() -> Self {
+		Self::Parts(2)
+	}
+}
+
+/// Render `duration` as a human-readable span.
+///
+/// Total over `Duration`: the ladder is walked in `u128` nanoseconds, which
+/// `Duration::MAX` cannot exceed, so nothing saturates. A zero duration renders
+/// `0s` under either shape rather than an empty cell.
+pub(crate) fn format_duration(duration: Duration, fmt: &DurationFormat) -> String {
+	match *fmt {
+		DurationFormat::Parts(parts) => composite(duration.as_nanos(), parts),
+		DurationFormat::Millis { decimals } => {
+			let millis = duration.as_nanos() as f64 / NANOS_PER_MILLI;
+			format!("{millis:.decimals$}ms")
+		}
+	}
+}
+
+/// Up to `parts` whole components, largest first, zeros skipped.
+///
+/// Skipping zeros rather than stopping at the first one is what makes
+/// `1y 1d 1h 4s 5ms` possible: that span has no months by design and no minutes
+/// by accident, and both are absent from the output for the same reason.
+fn composite(nanos: u128, parts: usize) -> String {
+	let wanted = parts.max(1);
+	let mut remainder = nanos;
+	let mut out: Vec<String> = Vec::with_capacity(wanted);
+
+	for (unit, scale) in UNITS {
+		if out.len() == wanted {
+			break;
+		}
+		let count = remainder / scale;
+		if count > 0 {
+			out.push(format!("{count}{unit}"));
+			remainder %= scale;
+		}
+	}
+
+	if out.is_empty() {
+		return "0s".to_string();
+	}
+	out.join(" ")
+}
+
+#[cfg(test)]
+#[path = "duration_tests.rs"]
+mod tests;

--- a/internal/units/duration_tests.rs
+++ b/internal/units/duration_tests.rs
@@ -1,0 +1,142 @@
+use super::{DurationFormat, format_duration};
+use std::time::Duration;
+
+/// The ladder is walked in `u128` nanoseconds, which `Duration::MAX` cannot
+/// exceed, so the largest span the type can hold still renders in its own units
+/// instead of saturating into an ever-growing day count.
+#[test]
+fn the_ladder_covers_the_whole_input_type() {
+	assert_eq!(
+		format_duration(Duration::MAX, &DurationFormat::Parts(3)),
+		"584942417355y 26d 7h"
+	);
+	assert_eq!(
+		format_duration(Duration::MAX, &DurationFormat::Parts(8)),
+		"584942417355y 26d 7h 15s 999ms 999µs 999ns"
+	);
+}
+
+/// The owner's worked example. It has no minutes, and the minutes are absent
+/// from the output for the same reason months are absent from the ladder: a
+/// component that carries nothing is not printed.
+#[test]
+fn composite_renders_the_example_from_the_issue() {
+	let span = Duration::new(31_626_004, 5_000_000);
+	assert_eq!(
+		format_duration(span, &DurationFormat::Parts(5)),
+		"1y 1d 1h 4s 5ms"
+	);
+}
+
+/// Two components is the default because that is what reads at a glance. The
+/// same span at five components is the thing the default exists to avoid.
+#[test]
+fn the_default_is_two_components() {
+	let span = Duration::new(7503, 200_000_000);
+	assert_eq!(
+		format_duration(span, &DurationFormat::default_parts()),
+		"2h 5m"
+	);
+	assert_eq!(
+		format_duration(span, &DurationFormat::Parts(5)),
+		"2h 5m 3s 200ms"
+	);
+}
+
+/// A span smaller than its component count renders only what it has, with no
+/// `0s` padding to fill the request.
+#[test]
+fn composite_stops_when_the_span_runs_out() {
+	assert_eq!(
+		format_duration(Duration::from_millis(340), &DurationFormat::Parts(4)),
+		"340ms"
+	);
+	assert_eq!(
+		format_duration(Duration::from_nanos(1), &DurationFormat::Parts(4)),
+		"1ns"
+	);
+}
+
+/// Every rung of the ladder, at the exact span that first reaches it, so a unit
+/// cannot be silently skipped or mislabelled.
+#[test]
+fn every_unit_appears_at_its_own_boundary() {
+	let one = DurationFormat::Parts(1);
+	assert_eq!(format_duration(Duration::from_nanos(1), &one), "1ns");
+	assert_eq!(format_duration(Duration::from_micros(1), &one), "1µs");
+	assert_eq!(format_duration(Duration::from_millis(1), &one), "1ms");
+	assert_eq!(format_duration(Duration::from_secs(1), &one), "1s");
+	assert_eq!(format_duration(Duration::from_secs(60), &one), "1m");
+	assert_eq!(format_duration(Duration::from_secs(3600), &one), "1h");
+	assert_eq!(format_duration(Duration::from_secs(86_400), &one), "1d");
+	assert_eq!(format_duration(Duration::from_secs(31_536_000), &one), "1y");
+}
+
+/// A year is exactly 365 days, so 365 days is one year and 364 is not. The
+/// definition is arbitrary but it has to be pinned: a reader doing the
+/// arithmetic back has to land on the same number.
+#[test]
+fn a_year_is_three_hundred_and_sixty_five_days() {
+	let one = DurationFormat::Parts(1);
+	assert_eq!(
+		format_duration(Duration::from_secs(364 * 86_400), &one),
+		"364d"
+	);
+	assert_eq!(
+		format_duration(Duration::from_secs(365 * 86_400), &one),
+		"1y"
+	);
+}
+
+/// Plain milliseconds is one number and one unit. Its decimals are what keep it
+/// from having a cliff of its own: a benchmark row of 340 microseconds would
+/// read `0ms` as a whole number, which is the wrong answer rather than a
+/// coarse one.
+#[test]
+fn plain_milliseconds_keeps_sub_millisecond_spans() {
+	let two = DurationFormat::Millis { decimals: 2 };
+	assert_eq!(format_duration(Duration::from_micros(340), &two), "0.34ms");
+	assert_eq!(format_duration(Duration::from_millis(340), &two), "340.00ms");
+	assert_eq!(
+		format_duration(Duration::from_secs(90), &two),
+		"90000.00ms"
+	);
+}
+
+/// The decimal count is the caller's, the same way it is for sizes.
+#[test]
+fn the_millisecond_decimal_count_is_configurable() {
+	let span = Duration::from_micros(1_234_567);
+	assert_eq!(
+		format_duration(span, &DurationFormat::Millis { decimals: 0 }),
+		"1235ms"
+	);
+	assert_eq!(
+		format_duration(span, &DurationFormat::Millis { decimals: 3 }),
+		"1234.567ms"
+	);
+}
+
+/// Zero has no components and still has to render something. `0s` under either
+/// shape, never an empty cell.
+#[test]
+fn zero_renders_under_either_shape() {
+	assert_eq!(
+		format_duration(Duration::ZERO, &DurationFormat::Parts(3)),
+		"0s"
+	);
+	assert_eq!(
+		format_duration(Duration::ZERO, &DurationFormat::Millis { decimals: 2 }),
+		"0.00ms"
+	);
+}
+
+/// A zero component count is a caller mistake with no sensible rendering, so it
+/// falls back to one component rather than returning an empty string.
+#[test]
+fn a_zero_component_count_still_renders_one_component() {
+	assert_eq!(
+		format_duration(Duration::from_secs(3661), &DurationFormat::Parts(0)),
+		"1h"
+	);
+}

--- a/internal/units/duration_tests.rs
+++ b/internal/units/duration_tests.rs
@@ -1,4 +1,4 @@
-use super::{DurationFormat, format_duration};
+use super::{format_duration, DurationFormat};
 use std::time::Duration;
 
 /// The ladder is walked in `u128` nanoseconds, which `Duration::MAX` cannot
@@ -96,11 +96,11 @@ fn a_year_is_three_hundred_and_sixty_five_days() {
 fn plain_milliseconds_keeps_sub_millisecond_spans() {
 	let two = DurationFormat::Millis { decimals: 2 };
 	assert_eq!(format_duration(Duration::from_micros(340), &two), "0.34ms");
-	assert_eq!(format_duration(Duration::from_millis(340), &two), "340.00ms");
 	assert_eq!(
-		format_duration(Duration::from_secs(90), &two),
-		"90000.00ms"
+		format_duration(Duration::from_millis(340), &two),
+		"340.00ms"
 	);
+	assert_eq!(format_duration(Duration::from_secs(90), &two), "90000.00ms");
 }
 
 /// The decimal count is the caller's, the same way it is for sizes.

--- a/internal/units/mod.rs
+++ b/internal/units/mod.rs
@@ -11,8 +11,18 @@
 //! the right base depends on what the reader is comparing against — podman and
 //! docker print decimal, while `free` and `htop` are binary.
 
+// `stats` is the only caller so far, and it wants one shape: binary units at
+// one decimal. The decimal ladder, the composite shape and every duration are
+// exercised by this module's own tests and by nothing else yet, which is what
+// the allow is for — the surfaces that need them are `ps`, `images` and
+// `volumes`, and #1298 is where they arrive. Take this line out with that
+// change; it is scoped to the module so a genuinely dead item elsewhere still
+// warns. `unused_imports` rides along because the re-exports below are what a
+// caller will reach for, and an unused one is the same fact reported twice.
+#![allow(dead_code, unused_imports)]
+
 mod bytes;
 mod duration;
 
-pub(crate) use bytes::{SizeBase, SizeFormat, SizeShape, format_bytes};
-pub(crate) use duration::{DurationFormat, format_duration};
+pub(crate) use bytes::{format_bytes, SizeBase, SizeFormat, SizeShape};
+pub(crate) use duration::{format_duration, DurationFormat};

--- a/internal/units/mod.rs
+++ b/internal/units/mod.rs
@@ -1,0 +1,18 @@
+//! Human-readable sizes and durations, shared by every surface that renders
+//! one.
+//!
+//! Both formatters are total over their input type. That is the point of the
+//! module rather than a nicety: a formatter with a ceiling has a silent cliff,
+//! and the cliff is only ever found by whoever is big enough to hit it. `stats`
+//! saturated at `TiB` for years, so a petabyte rendered `1024.0TiB`.
+//!
+//! Both are configurable, and the defaults belong to the caller rather than to
+//! this module: a table cell has a width budget a summary line does not, and
+//! the right base depends on what the reader is comparing against — podman and
+//! docker print decimal, while `free` and `htop` are binary.
+
+mod bytes;
+mod duration;
+
+pub(crate) use bytes::{SizeBase, SizeFormat, SizeShape, format_bytes};
+pub(crate) use duration::{DurationFormat, format_duration};


### PR DESCRIPTION
The foundation from #1302. One module, two pure functions, and the shapes each
one takes — nothing is wired to the CLI yet and the commands adopt it one at a
time.

## What it does

**Sizes.** Both ladders, because both are in play: podman and docker print
decimal (`8.71MB`), while `stats` is read next to `free` and `htop`, which are
binary. Configurable decimals, two by default. A composite shape for the places
where the number is the point — `1TB 1GB`, `1GB 512MB` — computed with integer
division so the components sum back to the input exactly.

**Durations.** `y` down to `ns`, composite and largest-first with zeros skipped,
so the owner's `1y 1d 1h 4s 5ms` renders with no minutes in it. Two components
by default, which is what reads at a glance. Plus a plain-milliseconds mode with
its own decimals, so a benchmark row of 340 microseconds reads `0.34ms` rather
than `0ms`.

No month and no week. A month is 28 to 31 days and a week only means something
against a calendar; `34d` says more than `1mo` does. A year is exactly 365 days,
pinned by a test, because a reader redoing the arithmetic has to land on the
same number.

## Two decisions worth arguing with

**The shapes are enum variants, not fields.** Decimals mean nothing on a
composite value (`1GB 512.00MB`) and a component count means nothing on a single
one. As two fields on a struct, half the combinations have no rendering; as
variants, a caller cannot ask for one.

**A value that rounds onto the next rung is promoted.** 1048575 bytes is
1023.999 KiB, which prints `1024.00KiB` — right arithmetic, and the same
unit-boundary defect as saturating at `TiB` one rung lower and far easier to
hit. Any size within half a display digit of a boundary showed it. `stats`
inherits the fix.

## stats is the first caller

It keeps its own base and precision and gets the implementation from the module.
**Its twenty existing tests pass untouched, which is the proof the output did not
change**; the promotion above is the one difference, and it has its own test on
both sides of the threshold.

## What is deliberately not here

The module carries a scoped `#![allow(dead_code, unused_imports)]`: the decimal
ladder, the composite shape and every duration have no caller yet. **#1298 is
where they get one and that line comes out with it.**

The configuration surface is still open — whether `--units`/`--precision`/
`--duration-parts` are global flags like `--ansi` or part of the existing
`--format` vocabulary is a decision I want to make deliberately, so nothing
touches the CLI here.

## Test plan

- 40 new unit tests: every rung of both ladders, both bases at `u64::MAX` and
  `Duration::MAX`, zero under every shape, both sides of the rounding threshold,
  and a composite value reparsed and summed back to its input.
- **13 mutations run, 13 killed**, each by the test that names it: the ladder
  truncated, the promotion disabled, the zero-skip turned into a stop, the
  remainder left unconsumed, the binary step set to 1000, the year set to 366,
  the microsecond rung removed, the millisecond scale wrong, and the zero-parts
  clamp dropped on both formatters.
- Full lib suite: 1473 passed.
- Run against real Podman 5.7.0 on my machine: `podup stats --no-stream` on a
  two-service project, columns aligned and values unchanged.

Closes #1302