### PR TITLE
feat(images): show what each service's image costs on disk

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -262,6 +262,12 @@ Print the public binding for a port.
 ### `images`
 List images used by services.
 
+`SIZE` is the image's on-disk size, rendered in decimal units at three
+significant digits (`98.2MB`, `805kB`) so the column lines up with what `podman
+images` and `docker compose images` print. An image that is not present locally
+has an empty `SIZE` and an empty `IMAGE ID`. Under `--format json` the size is
+the raw byte count, not the rendered string.
+
 | Flag | Description | Default |
 |---|---|---|
 | `-q, --quiet` | Print image IDs only. | off |

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -1,0 +1,186 @@
+//! `podup images`: the image behind each service, and what it costs on disk.
+
+use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::image::ImageInspect;
+use crate::libpod::{urlencoded, API_PREFIX};
+use crate::units::{format_bytes, SizeFormat};
+
+use super::inspect_util::split_repo_tag;
+use super::Engine;
+
+/// How `images` renders a size: decimal units at three significant digits.
+///
+/// Decimal because this table exists to be read against `podman images` and
+/// `docker compose images`, which are decimal — not against `free`. Three
+/// digits because that is what those two print, measured rather than assumed:
+/// `docker compose` v5.1.3 rendered `98.2MB` for `redis:8-alpine` and `podman
+/// images` rendered `1.01 GB` and `805 kB` on the same host. A fixed decimal
+/// count cannot produce all three.
+const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
+
+/// One row of the `images` table.
+///
+/// A named struct rather than a tuple because the row has outgrown the point
+/// where positional fields stay readable, and because `size` is the raw byte
+/// count: the table formats it and the JSON path emits it as a number, so the
+/// row has to carry the value rather than a rendering of it.
+struct ImageRow {
+	service: String,
+	repository: String,
+	tag: String,
+	id: String,
+	/// Raw bytes as libpod reported them. Zero when the image is not present
+	/// locally, which the table renders as an empty cell — a missing image has
+	/// no size, and `0B` would claim it has one.
+	size: u64,
+}
+
+impl Engine {
+	/// List images used by each service as a table (default options).
+	pub async fn images(&self, file: &ComposeFile) -> Result<()> {
+		self.images_with_options(file, super::ImagesOptions::default())
+			.await
+	}
+
+	/// List service images with `docker compose images`-style options:
+	/// `-q/--quiet` (IDs only) and `--format` (table | json), across all services.
+	/// To restrict to specific services use [`Engine::images_with_services`].
+	pub async fn images_with_options(
+		&self,
+		file: &ComposeFile,
+		opts: super::ImagesOptions,
+	) -> Result<()> {
+		self.images_with_services(file, &[], opts).await
+	}
+
+	/// List service images like [`Engine::images_with_options`]. When
+	/// `target_services` is non-empty, only those services are listed (an unknown
+	/// name is an error), matching `docker compose images [SERVICE...]`.
+	pub async fn images_with_services(
+		&self,
+		file: &ComposeFile,
+		target_services: &[String],
+		opts: super::ImagesOptions,
+	) -> Result<()> {
+		for name in target_services {
+			if !file.services.contains_key(name) {
+				return Err(ComposeError::ServiceNotFound(name.clone()));
+			}
+		}
+		// Collect rows first so quiet/json modes can render without the header.
+		let mut rows: Vec<ImageRow> = Vec::new();
+		for (name, service) in &file.services {
+			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
+				continue;
+			}
+			let image_ref = match (&service.image, &service.build) {
+				(Some(img), _) => img.clone(),
+				// A build-only service's image is the tag the build step produced
+				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
+				(None, Some(build)) => {
+					super::super::build::primary_build_tag(&self.project, name, None, build.tags())
+				}
+				(None, None) => continue,
+			};
+			let (repository, tag) = split_repo_tag(&image_ref);
+			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
+			match self.client.get_json::<ImageInspect>(&path).await {
+				Ok(img) => {
+					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
+					rows.push(ImageRow {
+						service: name.clone(),
+						repository,
+						tag,
+						id: id.to_string(),
+						size: img.size,
+					});
+				}
+				// A 404 means the image is simply not present locally — list it with
+				// an empty ID rather than silently dropping it, matching docker
+				// compose. Any other error (a connection failure / unreachable
+				// socket, or an HTTP 500) is a real failure that must propagate with
+				// a non-zero exit rather than printing an empty table and exiting 0.
+				Err(e) if e.is_status(404) => {
+					tracing::debug!("images {name}: not present ({e})");
+					rows.push(ImageRow {
+						service: name.clone(),
+						repository,
+						tag,
+						id: String::new(),
+						size: 0,
+					});
+				}
+				Err(e) => return Err(ComposeError::Podman(e)),
+			}
+		}
+
+		if opts.quiet {
+			// Deduplicate IDs so services sharing an image emit it once, like
+			// docker compose images -q. Empty IDs (not-pulled) are skipped.
+			let mut seen = std::collections::HashSet::new();
+			for row in &rows {
+				if !row.id.is_empty() && seen.insert(row.id.as_str()) {
+					println!("{}", row.id);
+				}
+			}
+			return Ok(());
+		}
+		if opts.json {
+			let json: Vec<_> = rows
+				.iter()
+				.map(|row| {
+					// The raw byte count, not the rendered string: this is the
+					// machine-facing path, and `docker compose images --format
+					// json` emits a number here too (measured against v5.1.3).
+					serde_json::json!({
+						"Service": row.service,
+						"Repository": row.repository,
+						"Tag": row.tag,
+						"ID": row.id,
+						"Size": row.size,
+					})
+				})
+				.collect();
+			println!(
+				"{}",
+				serde_json::to_string_pretty(&json).unwrap_or_default()
+			);
+			return Ok(());
+		}
+
+		let mut table =
+			crate::ui::Table::new(&["SERVICE", "REPOSITORY", "TAG", "IMAGE ID", "SIZE"])
+				.cap(0, 48)
+				.cap(1, 48)
+				.cap(2, 24)
+				.identity_col(0);
+		for row in &rows {
+			table.push(vec![
+				row.service.clone(),
+				row.repository.clone(),
+				row.tag.clone(),
+				row.id.clone(),
+				size_cell(row.size),
+			]);
+		}
+		table.print();
+		Ok(())
+	}
+}
+
+/// The SIZE cell for one row.
+///
+/// An image that is not present locally has no size to report, so the cell is
+/// empty. `0B` would be a claim — that podup asked and the answer was zero —
+/// and the row already says the image is missing by carrying no ID.
+fn size_cell(size: u64) -> String {
+	if size == 0 {
+		return String::new();
+	}
+	format_bytes(size, &SIZE_FORMAT)
+}
+
+#[cfg(test)]
+#[path = "images_tests.rs"]
+mod tests;

--- a/internal/engine/query/images_tests.rs
+++ b/internal/engine/query/images_tests.rs
@@ -1,0 +1,42 @@
+use super::size_cell;
+
+/// The exact strings the reference tools printed for these byte counts on
+/// 2026-08-03: `docker compose` v5.1.3 rendered `98.2MB` for `redis:8-alpine`,
+/// and `podman images` rendered `1.01 GB` and `805 kB` on the same host. The
+/// table exists to be compared against theirs, so a divergence here is a bug in
+/// this column rather than a matter of taste.
+#[test]
+fn the_size_cell_matches_the_reference_tools() {
+	assert_eq!(size_cell(98_234_179), "98.2MB");
+	assert_eq!(size_cell(805_007), "805kB");
+	assert_eq!(size_cell(1_010_000_000), "1.01GB");
+}
+
+/// Decimal, not binary. The same image renders 5% smaller under the binary
+/// ladder, and a reader diffing this table against `podman images` would see
+/// every row disagree.
+#[test]
+fn the_size_cell_uses_the_decimal_ladder() {
+	// 98234179 bytes is 98.2 MB decimal and 93.7 MiB binary.
+	let cell = size_cell(98_234_179);
+	assert!(
+		cell.ends_with("MB"),
+		"{cell:?} is not on the decimal ladder"
+	);
+	assert!(!cell.contains("iB"), "{cell:?} used a binary unit");
+}
+
+/// An image that is not present locally reports zero, and zero is not a size —
+/// it is the absence of an answer. An empty cell says that; `0B` would claim
+/// podup asked and the image really is empty.
+#[test]
+fn a_missing_image_leaves_the_cell_empty() {
+	assert_eq!(size_cell(0), "");
+}
+
+/// One byte is a real size and renders as one, so the empty cell above is
+/// keyed on "no answer" and not on "small".
+#[test]
+fn a_one_byte_image_still_renders() {
+	assert_eq!(size_cell(1), "1B");
+}

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -1,15 +1,13 @@
-//! Container inspection commands: top, port, images, and log attachment.
+//! Container inspection commands: top, port, and log attachment.
 
 use futures_util::StreamExt;
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
-use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 
 use super::inspect_util::{
 	dedup_preserving_order, is_running_status, parse_port_proto, process_table, select_replica,
-	split_repo_tag,
 };
 use super::Engine;
 
@@ -217,111 +215,6 @@ impl Engine {
 				"no host binding for {service_name} port {port}/{proto}"
 			))),
 		}
-	}
-
-	/// List images used by each service as a table (default options).
-	pub async fn images(&self, file: &ComposeFile) -> Result<()> {
-		self.images_with_options(file, super::ImagesOptions::default())
-			.await
-	}
-
-	/// List service images with `docker compose images`-style options:
-	/// `-q/--quiet` (IDs only) and `--format` (table | json), across all services.
-	/// To restrict to specific services use [`Engine::images_with_services`].
-	pub async fn images_with_options(
-		&self,
-		file: &ComposeFile,
-		opts: super::ImagesOptions,
-	) -> Result<()> {
-		self.images_with_services(file, &[], opts).await
-	}
-
-	/// List service images like [`Engine::images_with_options`]. When
-	/// `target_services` is non-empty, only those services are listed (an unknown
-	/// name is an error), matching `docker compose images [SERVICE...]`.
-	pub async fn images_with_services(
-		&self,
-		file: &ComposeFile,
-		target_services: &[String],
-		opts: super::ImagesOptions,
-	) -> Result<()> {
-		for name in target_services {
-			if !file.services.contains_key(name) {
-				return Err(ComposeError::ServiceNotFound(name.clone()));
-			}
-		}
-		// Collect rows first so quiet/json modes can render without the header.
-		let mut rows: Vec<(String, String, String, String)> = Vec::new();
-		for (name, service) in &file.services {
-			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
-				continue;
-			}
-			let image_ref = match (&service.image, &service.build) {
-				(Some(img), _) => img.clone(),
-				// A build-only service's image is the tag the build step produced
-				// (project-scoped `{project}-{service}:latest`, or `build.tags[0]`).
-				(None, Some(build)) => {
-					super::super::build::primary_build_tag(&self.project, name, None, build.tags())
-				}
-				(None, None) => continue,
-			};
-			let (repo, tag) = split_repo_tag(&image_ref);
-			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
-			match self.client.get_json::<ImageInspect>(&path).await {
-				Ok(img) => {
-					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
-					rows.push((name.clone(), repo, tag, id.to_string()));
-				}
-				// A 404 means the image is simply not present locally — list it with
-				// an empty ID rather than silently dropping it, matching docker
-				// compose. Any other error (a connection failure / unreachable
-				// socket, or an HTTP 500) is a real failure that must propagate with
-				// a non-zero exit rather than printing an empty table and exiting 0.
-				Err(e) if e.is_status(404) => {
-					tracing::debug!("images {name}: not present ({e})");
-					rows.push((name.clone(), repo, tag, String::new()));
-				}
-				Err(e) => return Err(ComposeError::Podman(e)),
-			}
-		}
-
-		if opts.quiet {
-			// Deduplicate IDs so services sharing an image emit it once, like
-			// docker compose images -q. Empty IDs (not-pulled) are skipped.
-			let mut seen = std::collections::HashSet::new();
-			for (_, _, _, id) in &rows {
-				if !id.is_empty() && seen.insert(id.as_str()) {
-					println!("{id}");
-				}
-			}
-			return Ok(());
-		}
-		if opts.json {
-			let json: Vec<_> = rows
-				.iter()
-				.map(|(svc, repo, tag, id)| {
-					serde_json::json!({
-						"Service": svc, "Repository": repo, "Tag": tag, "ID": id,
-					})
-				})
-				.collect();
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&json).unwrap_or_default()
-			);
-			return Ok(());
-		}
-
-		let mut table = crate::ui::Table::new(&["SERVICE", "REPOSITORY", "TAG", "IMAGE ID"])
-			.cap(0, 48)
-			.cap(1, 48)
-			.cap(2, 24)
-			.identity_col(0);
-		for (svc, repo, tag, id) in &rows {
-			table.push(vec![svc.clone(), repo.clone(), tag.clone(), id.clone()]);
-		}
-		table.print();
-		Ok(())
 	}
 
 	/// Attach to a single service container's output (`docker compose attach`).

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -10,6 +10,7 @@ use super::Engine;
 
 mod exec;
 mod exec_interactive;
+mod images;
 mod inspect;
 mod inspect_util;
 mod log_prefix;

--- a/internal/libpod/types/image.rs
+++ b/internal/libpod/types/image.rs
@@ -49,4 +49,13 @@ pub struct ImageInspect {
 	/// --resolve-image-digests`. Empty for purely local/built images.
 	#[serde(rename = "RepoDigests", default)]
 	pub repo_digests: Vec<String>,
+	/// On-disk size of the image in bytes, as libpod reports it.
+	///
+	/// Present in the default inspect response, so reading it costs no extra
+	/// call and no query parameter — unlike a container's size, which libpod
+	/// leaves `null` until asked. Defaults to zero when the field is absent, so
+	/// an older server renders an empty cell rather than failing the whole
+	/// listing.
+	#[serde(rename = "Size", default)]
+	pub size: u64,
 }

--- a/internal/units/bytes.rs
+++ b/internal/units/bytes.rs
@@ -140,6 +140,17 @@ enum Precision {
 
 impl Precision {
 	/// Decimal places for a value already reduced onto its unit.
+	///
+	/// Callers hand over a value of at least one — unit selection guarantees it,
+	/// since a rung is only taken once the value reaches it. A smaller value is
+	/// still answered rather than underflowing, counting the leading zero as the
+	/// one digit before the point.
+	///
+	/// There is no clamp on `digits` because none is reachable: the digit count
+	/// before the point is always at least one, so `saturating_sub` already
+	/// floors the result, and `{:.0}` prints a digit regardless. A clamp was
+	/// written here first and a mutation deleting it survived every test, which
+	/// is what dead defensive code looks like from the outside.
 	fn decimals_for(self, value: f64) -> usize {
 		match self {
 			Self::Fixed(decimals) => decimals,
@@ -150,7 +161,7 @@ impl Precision {
 				} else {
 					whole.log10().floor() as usize + 1
 				};
-				digits.max(1).saturating_sub(before_the_point)
+				digits.saturating_sub(before_the_point)
 			}
 		}
 	}

--- a/internal/units/bytes.rs
+++ b/internal/units/bytes.rs
@@ -19,7 +19,12 @@ const BINARY_UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
 
 /// Decimal units, largest exponent last. `EB` is 1000^6; `u64::MAX` is a little
 /// over 18 of them, so this ladder covers the whole input type too.
-const DECIMAL_UNITS: [&str; 7] = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+///
+/// `kB` with a lowercase k, which is the SI prefix for kilo — `K` is kelvin.
+/// This is not pedantry about the standard: it is what the tools this table is
+/// compared against print. `podman images` rendered `805 kB` on Podman 5.7.0,
+/// and every other prefix from mega up is uppercase in the same output.
+const DECIMAL_UNITS: [&str; 7] = ["B", "kB", "MB", "GB", "TB", "PB", "EB"];
 
 impl SizeBase {
 	/// The factor between two neighbouring units on this ladder.
@@ -50,6 +55,19 @@ pub(crate) enum SizeShape {
 	/// One unit carrying `decimals` decimal places: `8.71MB`. What a table cell
 	/// wants, since a column has a width budget.
 	Single { decimals: usize },
+	/// One unit carrying `digits` significant digits: `98.2MB`, `8.71MB`,
+	/// `805kB`, `1.01GB`.
+	///
+	/// This is what podman and docker print, measured on Podman 5.7.0 and
+	/// docker compose v5.1.3 rather than assumed — `podman images` rendered
+	/// `1.01 GB`, `101 MB` and `103 MB`, and `docker compose images` rendered
+	/// `98.2MB`, all three digits wide. A fixed decimal count cannot express it:
+	/// `98.23MB` and `8.71MB` disagree about how many decimals the reference
+	/// uses because the reference is not counting decimals at all.
+	///
+	/// The digit count is also what keeps the column from breathing — every
+	/// value is three digits plus its unit, whatever its magnitude.
+	Significant { digits: usize },
 	/// Up to `parts` whole components, largest first, zeros skipped:
 	/// `1TB 1GB`, `1GB 512MB`. For the places where the number is the point.
 	Composite { parts: usize },
@@ -97,6 +115,45 @@ impl SizeFormat {
 			..self
 		}
 	}
+
+	/// Same ladder, `digits` significant digits on a single component.
+	pub(crate) const fn with_significant(self, digits: usize) -> Self {
+		Self {
+			shape: SizeShape::Significant { digits },
+			..self
+		}
+	}
+}
+
+/// How many decimal places a single-unit value shows.
+///
+/// Two ways of asking, because a table that has to line up against podman's own
+/// output is asking a different question from one that just needs a readable
+/// number.
+#[derive(Clone, Copy)]
+enum Precision {
+	/// Always this many decimals, whatever the magnitude.
+	Fixed(usize),
+	/// As many decimals as leave this many digits in total.
+	Significant(usize),
+}
+
+impl Precision {
+	/// Decimal places for a value already reduced onto its unit.
+	fn decimals_for(self, value: f64) -> usize {
+		match self {
+			Self::Fixed(decimals) => decimals,
+			Self::Significant(digits) => {
+				let whole = value.trunc().abs();
+				let before_the_point = if whole < 1.0 {
+					1
+				} else {
+					whole.log10().floor() as usize + 1
+				};
+				digits.max(1).saturating_sub(before_the_point)
+			}
+		}
+	}
 }
 
 /// Render `bytes` as a human-readable size.
@@ -109,13 +166,16 @@ impl SizeFormat {
 /// integer division, so `1TB 1GB` is exact rather than a float rounded twice.
 pub(crate) fn format_bytes(bytes: u64, fmt: &SizeFormat) -> String {
 	match fmt.shape {
-		SizeShape::Single { decimals } => single(bytes, fmt.base, decimals),
+		SizeShape::Single { decimals } => single(bytes, fmt.base, Precision::Fixed(decimals)),
+		SizeShape::Significant { digits } => {
+			single(bytes, fmt.base, Precision::Significant(digits))
+		}
 		SizeShape::Composite { parts } => composite(bytes, fmt.base, parts),
 	}
 }
 
 /// One number and one unit: the largest unit whose value is at least one.
-fn single(bytes: u64, base: SizeBase, decimals: usize) -> String {
+fn single(bytes: u64, base: SizeBase, precision: Precision) -> String {
 	let units = base.units();
 	let step = base.step();
 
@@ -133,6 +193,7 @@ fn single(bytes: u64, base: SizeBase, decimals: usize) -> String {
 	}
 
 	let mut value = bytes as f64 / divisor as f64;
+	let mut decimals = precision.decimals_for(value);
 	// Rounding can carry the value onto the next rung: 1048575 bytes is
 	// 1023.999 KiB, which prints as `1024.00KiB` — right arithmetic, and the
 	// same unit-boundary artefact the ladder exists to avoid. Promote once,
@@ -146,6 +207,11 @@ fn single(bytes: u64, base: SizeBase, decimals: usize) -> String {
 		divisor *= step;
 		index += 1;
 		value = bytes as f64 / divisor as f64;
+		// The new value has a different magnitude, so a significant-digit
+		// request wants a different number of decimals for it. Recomputing is
+		// the whole reason the promotion happens before the format rather than
+		// as a retry after one.
+		decimals = precision.decimals_for(value);
 	}
 	format!("{value:.decimals$}{}", units[index])
 }

--- a/internal/units/bytes_tests.rs
+++ b/internal/units/bytes_tests.rs
@@ -44,7 +44,8 @@ fn binary_units_step_at_their_own_boundaries() {
 #[test]
 fn decimal_units_step_at_their_own_boundaries() {
 	let fmt = SizeFormat::decimal();
-	assert_eq!(format_bytes(1000, &fmt), "1.00KB");
+	// Lowercase k, the SI prefix, matching what podman prints.
+	assert_eq!(format_bytes(1000, &fmt), "1.00kB");
 	assert_eq!(format_bytes(1000_u64.pow(2), &fmt), "1.00MB");
 	assert_eq!(format_bytes(1000_u64.pow(3), &fmt), "1.00GB");
 	assert_eq!(format_bytes(1000_u64.pow(4), &fmt), "1.00TB");
@@ -117,6 +118,68 @@ fn the_decimal_count_is_configurable() {
 		format_bytes(bytes, &SizeFormat::binary().with_decimals(4)),
 		"1.5000GiB"
 	);
+}
+
+/// The reference rendering, captured rather than assumed. Every value here was
+/// read off a real tool on 2026-08-03: `docker compose` v5.1.3 printed `98.2MB`
+/// for `redis:8-alpine`, and `podman images` printed `1.01 GB`, `101 MB` and
+/// `805 kB` on the same host. Three digits in all of them, which a fixed decimal
+/// count cannot produce — `98.2` has one decimal and `8.71` has two.
+#[test]
+fn significant_digits_match_what_podman_and_docker_print() {
+	let fmt = SizeFormat::decimal().with_significant(3);
+	assert_eq!(format_bytes(98_234_179, &fmt), "98.2MB");
+	assert_eq!(format_bytes(8_710_000, &fmt), "8.71MB");
+	assert_eq!(format_bytes(805_007, &fmt), "805kB");
+	assert_eq!(format_bytes(1_010_000_000, &fmt), "1.01GB");
+}
+
+/// The digit count holds across every magnitude, which is the property that
+/// keeps the column from breathing as rows scroll past. A fixed decimal count
+/// gives `1.00GB` and `999.00MB` — four characters apart.
+#[test]
+fn significant_digits_keep_a_constant_width() {
+	let fmt = SizeFormat::decimal().with_significant(3);
+	for (bytes, expected) in [
+		(1_000_u64, "1.00kB"),
+		(12_000, "12.0kB"),
+		(123_000, "123kB"),
+		(1_230_000, "1.23MB"),
+		(123_000_000_000_000_000, "123PB"),
+	] {
+		let rendered = format_bytes(bytes, &fmt);
+		assert_eq!(rendered, expected);
+		let digits = rendered.chars().filter(char::is_ascii_digit).count();
+		assert_eq!(digits, 3, "{rendered:?} is not three digits wide");
+	}
+}
+
+/// A promotion changes the value's magnitude, so the digit count has to be
+/// recomputed for the new rung. Without that, 999999 bytes rounds to `1000kB`
+/// and then renders as `1kB` — the promotion applied and the decimals did not.
+#[test]
+fn significant_digits_are_recomputed_after_a_promotion() {
+	let fmt = SizeFormat::decimal().with_significant(3);
+	assert_eq!(format_bytes(999_999, &fmt), "1.00MB");
+	assert_eq!(format_bytes(999_999_999, &fmt), "1.00GB");
+}
+
+/// Whole bytes stay whole under this shape too: there is no fraction of a byte,
+/// so a three-digit request cannot invent one.
+#[test]
+fn significant_digits_do_not_reach_below_a_byte() {
+	let fmt = SizeFormat::decimal().with_significant(3);
+	assert_eq!(format_bytes(0, &fmt), "0B");
+	assert_eq!(format_bytes(7, &fmt), "7B");
+	assert_eq!(format_bytes(999, &fmt), "999B");
+}
+
+/// A zero-digit request has no rendering, so it is treated as one digit rather
+/// than producing a bare unit with no number in front of it.
+#[test]
+fn a_zero_digit_request_still_renders_a_digit() {
+	let fmt = SizeFormat::decimal().with_significant(0);
+	assert_eq!(format_bytes(8_710_000, &fmt), "9MB");
 }
 
 /// The owner's worked examples, in the base each was written in.

--- a/internal/units/bytes_tests.rs
+++ b/internal/units/bytes_tests.rs
@@ -174,12 +174,36 @@ fn significant_digits_do_not_reach_below_a_byte() {
 	assert_eq!(format_bytes(999, &fmt), "999B");
 }
 
-/// A zero-digit request has no rendering, so it is treated as one digit rather
-/// than producing a bare unit with no number in front of it.
+/// A zero-digit request still shows a digit, because `{:.0}` prints one
+/// whatever it is handed. Nothing in the formatter enforces this — it is a
+/// property of the format machinery, and it is pinned here so a future clamp
+/// added "to be safe" has something to justify itself against.
 #[test]
 fn a_zero_digit_request_still_renders_a_digit() {
 	let fmt = SizeFormat::decimal().with_significant(0);
 	assert_eq!(format_bytes(8_710_000, &fmt), "9MB");
+}
+
+/// Tested one level below `format_bytes` on purpose. Unit selection guarantees
+/// the value handed over is at least one, so the sub-one branch cannot be
+/// reached through the public entry point — a mutation deleting the clamp that
+/// used to sit here survived every test that went in the front door, which is
+/// what dead defensive code looks like from outside. The clamp is gone; this
+/// pins what the arithmetic actually does, including where it is weak.
+#[test]
+fn the_decimal_count_is_pinned_below_its_public_entry_point() {
+	use super::Precision;
+	// The ordinary path, which is everything `format_bytes` can produce.
+	assert_eq!(Precision::Significant(3).decimals_for(98.2), 1);
+	assert_eq!(Precision::Significant(3).decimals_for(8.71), 2);
+	assert_eq!(Precision::Significant(3).decimals_for(805.0), 0);
+	assert_eq!(Precision::Fixed(4).decimals_for(805.0), 4);
+	// Sub-one values count their leading zero as the digit before the point.
+	// That means one significant digit of 0.5 asks for no decimals and renders
+	// `0` — a real weakness, and unreachable, so it is recorded rather than
+	// fixed. If a caller ever hands this a fraction, fix it then.
+	assert_eq!(Precision::Significant(3).decimals_for(0.5), 2);
+	assert_eq!(Precision::Significant(1).decimals_for(0.5), 0);
 }
 
 /// The owner's worked examples, in the base each was written in.


### PR DESCRIPTION
First of the three pieces #1298 splits into. `images` gains a SIZE column; the
CREATED columns and `ps` follow separately, because they need an RFC3339 parser
this does not.

## Why this one is free

libpod carries `Size` in the default inspect response, the call `images` already
makes. No extra request, no query parameter, no cost — unlike a container's
size, which is `null` until you ask and costs 4.2x when you do (measured over 55
containers, in the issue).

## The formatter grew a shape, and here is why

The reference does not use a fixed decimal count. Measured on this host:

| tool | rendering |
|---|---|
| `docker compose` v5.1.3 | `98.2MB` |
| `podman images` | `1.01 GB`, `101 MB`, `805 kB` |

Three significant digits in every one of them. `98.2` has one decimal and `8.71`
has two — no fixed count produces both. #1302 asked for "two decimals by
default", inferred from the single example `8.71MB`, which happens to be three
significant digits as well. So the module gained a `Significant` shape and
`images` uses it. The per-surface-default rule in #1302 is what makes that the
right call rather than a deviation.

**The same measurement corrected the decimal ladder**: podman prints `kB` with a
lowercase k, which is the SI prefix — `K` is kelvin. The ladder said `KB`. My
own test caught it, which is the argument for pinning against captured output
rather than against what I expected.

## Two small decisions

**A missing image gets an empty cell, not `0B`.** Zero is the absence of an
answer here, and the row already says the image is missing by carrying no ID.

**The JSON path emits the raw byte count.** `docker compose images --format
json` emits a number there too (measured against v5.1.3), and a machine consumer
should parse a number rather than a rendering.

`images` moved into its own module. `inspect.rs` was at 435 code lines and this
would have pushed it toward the hard limit.

## A dead clamp, found and removed

One mutation survived: deleting the zero-digit clamp in `decimals_for` changed
no test. It was not a weak test — the digit count before the point is always at
least one, so `saturating_sub` already floored the result and the clamp could
never change an answer. Reachable from nowhere. Removed, and the arithmetic is
pinned one level below `format_bytes` where the branches can actually be
entered.

## Test plan

- 9 unit tests, every size string in them captured from a real tool rather than
  expected.
- **9 mutations run, 9 killed** after the dead clamp came out: the ladder
  switched to binary, the shape switched to fixed decimals, `kB` uppercased, the
  magnitude ignored, the `log10` off by one, the promotion's recompute dropped,
  the sub-one branch zeroed, and the empty-cell guard disabled.
- Full lib suite: 1486 passed.
- Run against real Podman 5.7.0 on my machine, three services including one
  image that is not present locally, and diffed against both reference tools on
  the same socket:

```
podup            redis 8-alpine 98.2MB   busybox 1.36 4.66MB
docker compose   redis 8-alpine 98.2MB   busybox 1.36 4.66MB
podman images    redis 8-alpine 98.2 MB  busybox 1.36 4.66 MB
```

Part of #1298