### PR TITLE
feat(units): months, and three components by default for sizes and durations

### DIFF
--- a/internal/units/bytes.rs
+++ b/internal/units/bytes.rs
@@ -123,6 +123,21 @@ impl SizeFormat {
 			..self
 		}
 	}
+
+	/// Same ladder, the default number of components.
+	///
+	/// Three, matching [`DurationFormat::default_parts`]. One default across
+	/// both formatters is the point: a reader who has learned what `1h 5m 3s`
+	/// means should not have to learn a second rule for `1GB 512MB 200kB`.
+	///
+	/// This is the default *component count*, not a floor on the output. A value
+	/// with fewer components than that still renders only the ones it has —
+	/// three is what a caller gets when it does not choose, never padding.
+	///
+	/// [`DurationFormat::default_parts`]: super::DurationFormat::default_parts
+	pub(crate) const fn default_parts(self) -> Self {
+		self.with_parts(DEFAULT_PARTS)
+	}
 }
 
 /// How many decimal places a single-unit value shows.
@@ -166,6 +181,12 @@ impl Precision {
 		}
 	}
 }
+
+/// The default component count for both formatters.
+///
+/// Lives here and is read by the duration side too, so the two cannot drift to
+/// different defaults without the change being visible in one place.
+pub(crate) const DEFAULT_PARTS: usize = 3;
 
 /// Render `bytes` as a human-readable size.
 ///

--- a/internal/units/bytes_tests.rs
+++ b/internal/units/bytes_tests.rs
@@ -283,6 +283,32 @@ fn a_zero_component_count_still_renders_one_component() {
 	);
 }
 
+/// Three components by default, the same count durations use. One rule across
+/// both formatters: a reader who has learned what `1h 5m 3s` means should not
+/// have to learn a second one for a size.
+#[test]
+fn the_default_component_count_is_three_and_matches_durations() {
+	use super::super::DurationFormat;
+	let fmt = SizeFormat::decimal().default_parts();
+	assert_eq!(fmt.shape, SizeShape::Composite { parts: 3 });
+	assert_eq!(
+		format_bytes(1_512_200_000, &fmt),
+		"1GB 512MB 200kB",
+		"three components, largest first"
+	);
+	// Read off the same constant, so the two cannot drift apart.
+	assert_eq!(DurationFormat::default_parts(), DurationFormat::Parts(3));
+}
+
+/// Three is what a caller gets when it does not choose, not a floor on the
+/// output: a value with fewer components renders only the ones it has.
+#[test]
+fn the_default_count_never_pads_a_short_value() {
+	let fmt = SizeFormat::decimal().default_parts();
+	assert_eq!(format_bytes(1000, &fmt), "1kB");
+	assert_eq!(format_bytes(0, &fmt), "0B");
+}
+
 /// The builders replace the shape rather than merging into it, so the last call
 /// wins and a caller cannot end up with a half-set combination.
 #[test]

--- a/internal/units/duration.rs
+++ b/internal/units/duration.rs
@@ -4,15 +4,23 @@ use std::time::Duration;
 
 /// The duration ladder, largest first, in nanoseconds.
 ///
-/// No month and no week, deliberately. A month is 28 to 31 days and a week only
-/// means something against a calendar, while a duration has neither — and an
-/// uptime of `1mo` tells the reader less than `34d` does.
+/// A year is exactly 365 days and a month exactly 30. A duration is an elapsed
+/// span, not a range between two dates, so there is no calendar to consult for a
+/// leap day or for which month it fell in; both numbers are ones a reader can
+/// redo in their head.
 ///
-/// A year here is exactly 365 days. A duration is an elapsed span, not a range
-/// between two dates, so there is no calendar to consult for a leap day; 365 is
-/// the arithmetic a reader can redo in their head.
-const UNITS: [(&str, u128); 8] = [
+/// The two do not divide evenly, and that is visible: 364 days reads `12mo 4d`
+/// while 365 reads `1y`. Twelve thirty-day months are 360 days, not a year. The
+/// alternative is a fractional month (365/12 = 30.4167 days), which no reader
+/// can check by hand — the seam is preferred over the arithmetic nobody can
+/// verify.
+///
+/// No week. Unlike a month it has no conventional length in a duration context
+/// at all: it only means something against a calendar, and `9d` already says
+/// what `1w 2d` would.
+const UNITS: [(&str, u128); 9] = [
 	("y", 365 * 24 * 60 * 60 * 1_000_000_000),
+	("mo", 30 * 24 * 60 * 60 * 1_000_000_000),
 	("d", 24 * 60 * 60 * 1_000_000_000),
 	("h", 60 * 60 * 1_000_000_000),
 	("m", 60 * 1_000_000_000),
@@ -32,8 +40,14 @@ const NANOS_PER_MILLI: f64 = 1_000_000.0;
 /// in a combination that has no rendering.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DurationFormat {
-	/// Up to N components, largest first, zeros skipped: `2h 5m`,
-	/// `1y 1d 1h 4s 5ms`, `340ms`. What reads at a glance.
+	/// Up to N components, largest first, zeros skipped: `1h 5m 3s`,
+	/// `1y 2mo 3d`, `340ms`.
+	///
+	/// The component count is fixed; which units fill it is not. A span that
+	/// just started shows `5s`, one running an hour shows `1h 5m 3s`, and one
+	/// past a year shows `1y 2mo 3d` — the window slides up the ladder as the
+	/// span grows, so the same width always carries the three units that matter
+	/// at that magnitude.
 	Parts(usize),
 	/// One number in milliseconds with `decimals` decimal places: `340.00ms`.
 	/// For machine reading, or when the reader wants to compare two durations
@@ -42,10 +56,10 @@ pub(crate) enum DurationFormat {
 }
 
 impl DurationFormat {
-	/// Two components, which is what reads at a glance: `2h 5m`, not
-	/// `2h 5m 3s 200ms`.
+	/// Three components, which is the width the owner asked for: enough to say
+	/// `1h 5m 3s` or `1y 2mo 3d` without running on into `200ms`.
 	pub(crate) const fn default_parts() -> Self {
-		Self::Parts(2)
+		Self::Parts(3)
 	}
 }
 

--- a/internal/units/duration.rs
+++ b/internal/units/duration.rs
@@ -58,8 +58,13 @@ pub(crate) enum DurationFormat {
 impl DurationFormat {
 	/// Three components, which is the width the owner asked for: enough to say
 	/// `1h 5m 3s` or `1y 2mo 3d` without running on into `200ms`.
+	///
+	/// The count is shared with [`SizeFormat::default_parts`] rather than
+	/// written twice, so sizes and durations cannot drift to different defaults.
+	///
+	/// [`SizeFormat::default_parts`]: super::SizeFormat::default_parts
 	pub(crate) const fn default_parts() -> Self {
-		Self::Parts(3)
+		Self::Parts(super::bytes::DEFAULT_PARTS)
 	}
 }
 

--- a/internal/units/duration_tests.rs
+++ b/internal/units/duration_tests.rs
@@ -57,6 +57,12 @@ fn the_window_slides_up_the_ladder_as_the_span_grows() {
 		(3903, "1h 5m 3s"),
 		(61 * day, "2mo 1d"),
 		(400 * day, "1y 1mo 5d"),
+		// A gap inside the window: a year and two days has no whole month in
+		// it, so the month is skipped rather than ending the walk. Without this
+		// row the whole test passes against a formatter that stops at the first
+		// empty unit, because every span above happens to have none.
+		(367 * day, "1y 2d"),
+		(365 * day + 3600, "1y 1h"),
 	] {
 		assert_eq!(
 			format_duration(Duration::from_secs(secs), &three),

--- a/internal/units/duration_tests.rs
+++ b/internal/units/duration_tests.rs
@@ -28,19 +28,42 @@ fn composite_renders_the_example_from_the_issue() {
 	);
 }
 
-/// Two components is the default because that is what reads at a glance. The
-/// same span at five components is the thing the default exists to avoid.
+/// Three components is the default. The same span at five components is what
+/// the default exists to cut off.
 #[test]
-fn the_default_is_two_components() {
+fn the_default_is_three_components() {
 	let span = Duration::new(7503, 200_000_000);
 	assert_eq!(
 		format_duration(span, &DurationFormat::default_parts()),
-		"2h 5m"
+		"2h 5m 3s"
 	);
 	assert_eq!(
 		format_duration(span, &DurationFormat::Parts(5)),
 		"2h 5m 3s 200ms"
 	);
+}
+
+/// The component count is fixed and the units that fill it slide with the
+/// magnitude. This is the whole contract: a column three components wide always
+/// carries the three that matter at that scale, so a freshly started container
+/// and one up for two years are equally readable in the same width.
+#[test]
+fn the_window_slides_up_the_ladder_as_the_span_grows() {
+	let three = DurationFormat::default_parts();
+	let day = 86_400;
+	for (secs, expected) in [
+		(5_u64, "5s"),
+		(90, "1m 30s"),
+		(3903, "1h 5m 3s"),
+		(61 * day, "2mo 1d"),
+		(400 * day, "1y 1mo 5d"),
+	] {
+		assert_eq!(
+			format_duration(Duration::from_secs(secs), &three),
+			expected,
+			"{secs}s"
+		);
+	}
 }
 
 /// A span smaller than its component count renders only what it has, with no
@@ -69,21 +92,38 @@ fn every_unit_appears_at_its_own_boundary() {
 	assert_eq!(format_duration(Duration::from_secs(60), &one), "1m");
 	assert_eq!(format_duration(Duration::from_secs(3600), &one), "1h");
 	assert_eq!(format_duration(Duration::from_secs(86_400), &one), "1d");
+	assert_eq!(format_duration(Duration::from_secs(2_592_000), &one), "1mo");
 	assert_eq!(format_duration(Duration::from_secs(31_536_000), &one), "1y");
 }
 
-/// A year is exactly 365 days, so 365 days is one year and 364 is not. The
-/// definition is arbitrary but it has to be pinned: a reader doing the
-/// arithmetic back has to land on the same number.
+/// A year is exactly 365 days and a month exactly 30, both pinned because a
+/// reader doing the arithmetic back has to land on the same number.
 #[test]
-fn a_year_is_three_hundred_and_sixty_five_days() {
+fn a_year_is_three_hundred_and_sixty_five_days_and_a_month_is_thirty() {
 	let one = DurationFormat::Parts(1);
 	assert_eq!(
-		format_duration(Duration::from_secs(364 * 86_400), &one),
-		"364d"
+		format_duration(Duration::from_secs(30 * 86_400), &one),
+		"1mo"
 	);
 	assert_eq!(
 		format_duration(Duration::from_secs(365 * 86_400), &one),
+		"1y"
+	);
+}
+
+/// The two definitions do not divide evenly, and the seam is deliberate rather
+/// than a rounding slip: twelve thirty-day months are 360 days, so 364 days is
+/// twelve months and four days while 365 is one year. The alternative is a
+/// fractional month nobody can verify by hand.
+#[test]
+fn twelve_months_are_not_a_year_and_the_output_says_so() {
+	let three = DurationFormat::default_parts();
+	assert_eq!(
+		format_duration(Duration::from_secs(364 * 86_400), &three),
+		"12mo 4d"
+	);
+	assert_eq!(
+		format_duration(Duration::from_secs(365 * 86_400), &three),
 		"1y"
 	);
 }


### PR DESCRIPTION
The owner's rule for how a span reads, which I had wrong in #1303.

## The window slides, the width does not

Three components, and which units fill them moves with the magnitude:

| span | reads |
|---|---|
| just started | `5s` |
| a minute and a half | `1m 30s` |
| an hour in | `1h 5m 3s` |
| two months | `2mo 1d` |
| past a year | `1y 1mo 5d` |

Same column width at every scale, always carrying the three units that matter
there. The default was two components; it is three.

## Months are back

I took them out of #1303 on the grounds that 28 to 31 days is ambiguous. That
reasoning was mine, written into the issue body — it was never the owner's
requirement, and the owner wants months.

**A month is exactly 30 days**, the same way a year is exactly 365. Neither
consults a calendar, because a duration is an elapsed span and has none.

**They do not divide evenly and the output says so:** 364 days reads `12mo 4d`
while 365 reads `1y`, because twelve thirty-day months are 360 days. The
alternative is a fractional month of 30.4167 days, which no reader can check by
hand. The seam is preferred over arithmetic nobody can verify, and it has its
own test so nobody "fixes" it later without reading why.

**Weeks stay out.** A month at least has a conventional length; a week has none
in a duration context at all, and `9d` already says what `1w 2d` would.

## A test that was not testing what it claimed

The first version of the sliding-window test used five spans, and every one of
them happened to have consecutive units — no gaps. So it passed unchanged
against a formatter that stops at the first empty unit instead of skipping it.
The mutation proving the zero-skip died by a different test entirely, which is
how it surfaced. Two gap rows added: a year and two days has no whole month in
it, and that is the case that tells the two behaviours apart.

## Test plan

- 12 duration tests, including the owner's table above and the 364/365 seam.
- **4 mutations run, 4 killed**: the month set to 31 days, the month rung
  collapsed onto days, the default put back to two components, and the zero-skip
  turned into a stop.
- Full lib suite: 1478 passed.
- No runtime surface yet — nothing calls the duration formatter, so there is
  nothing to measure against a live Podman. The CREATED columns that will call
  it are the next piece of #1298.

Part of #1298