### PR TITLE
feat(ps,images): report how old things are, and how long they have been up

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -262,7 +262,8 @@ Print the public binding for a port.
 ### `images`
 List images used by services.
 
-`SIZE` is the image's on-disk size, rendered in decimal units at three
+`CREATED` is how long ago the image was built, largest-first and up to three
+components (`2mo 27d 10h`). `SIZE` is the image's on-disk size, rendered in decimal units at three
 significant digits (`98.2MB`, `805kB`) so the column lines up with what `podman
 images` and `docker compose images` print. An image that is not present locally
 has an empty `SIZE` and an empty `IMAGE ID`. Under `--format json` the size is
@@ -272,6 +273,21 @@ the raw byte count, not the rendered string.
 |---|---|---|
 | `-q, --quiet` | Print image IDs only. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
+
+### `ps` columns
+
+`STATUS` reports how long a running container has been up (`Up 2h 5m 3s`), with
+its health in parentheses when it has a healthcheck (`Up 13h (healthy)`). A
+stopped container reports its exit code instead (`Exited (7)`).
+
+`CREATED` is how long ago the container was made. It differs from `STATUS` after
+a restart, which is the point of having both: a container created three days ago
+and started four seconds ago reads `3d` / `Up 4s`.
+
+Both spans are largest-first and up to three components, skipping units that are
+empty — `1y 2mo 3d`, `1h 5m 3s`, `5s`. A year is 365 days and a month is 30.
+Under `--format json` the raw wire values are passed through instead: `Created`
+is the RFC 3339 string and `StartedAt` is Unix seconds.
 
 ### `volumes [SERVICE...]`
 List the project's named volumes (a trailing service list narrows it to volumes

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -224,7 +224,7 @@ fn format_event(value: &Value, json: bool) -> String {
 ///
 /// The civil-from-days conversion is Howard Hinnant's, shifted to a March-based
 /// year so the leap day lands at the end and no month-length table is needed.
-fn format_event_time(unix_secs: i64) -> String {
+pub(crate) fn format_event_time(unix_secs: i64) -> String {
 	let days = unix_secs.div_euclid(86_400);
 	let secs = unix_secs.rem_euclid(86_400);
 	// Shift the epoch to 0000-03-01, which puts February last.

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -5,7 +5,7 @@
 mod build;
 mod container;
 mod copy;
-mod events;
+pub(crate) mod events;
 mod terminal_pump;
 pub use events::EventsOptions;
 mod image;

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -4,7 +4,7 @@ use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, API_PREFIX};
-use crate::units::{format_bytes, SizeFormat};
+use crate::units::{format_bytes, format_duration, DurationFormat, SizeFormat};
 
 use super::inspect_util::split_repo_tag;
 use super::Engine;
@@ -18,6 +18,9 @@ use super::Engine;
 /// images` rendered `1.01 GB` and `805 kB` on the same host. A fixed decimal
 /// count cannot produce all three.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
+
+/// How `images` renders an age: the shared default, three components.
+const AGE_FORMAT: DurationFormat = DurationFormat::default_parts();
 
 /// One row of the `images` table.
 ///
@@ -34,6 +37,9 @@ struct ImageRow {
 	/// locally, which the table renders as an empty cell — a missing image has
 	/// no size, and `0B` would claim it has one.
 	size: u64,
+	/// The RFC 3339 string libpod sent, kept raw so the table can render an age
+	/// and the JSON path can pass the instant through unchanged.
+	created: String,
 }
 
 impl Engine {
@@ -94,6 +100,7 @@ impl Engine {
 						tag,
 						id: id.to_string(),
 						size: img.size,
+						created: img.created,
 					});
 				}
 				// A 404 means the image is simply not present locally — list it with
@@ -109,6 +116,7 @@ impl Engine {
 						tag,
 						id: String::new(),
 						size: 0,
+						created: String::new(),
 					});
 				}
 				Err(e) => return Err(ComposeError::Podman(e)),
@@ -139,6 +147,9 @@ impl Engine {
 						"Tag": row.tag,
 						"ID": row.id,
 						"Size": row.size,
+						// The raw instant, like the reference: a machine
+						// consumer wants something it can compute with.
+						"Created": row.created,
 					})
 				})
 				.collect();
@@ -149,12 +160,21 @@ impl Engine {
 			return Ok(());
 		}
 
-		let mut table =
-			crate::ui::Table::new(&["SERVICE", "REPOSITORY", "TAG", "IMAGE ID", "SIZE"])
-				.cap(0, 48)
-				.cap(1, 48)
-				.cap(2, 24)
-				.identity_col(0);
+		// One clock read for the whole table, so two rows built in the same
+		// second cannot render different ages.
+		let now = super::ps::now_unix();
+		let mut table = crate::ui::Table::new(&[
+			"SERVICE",
+			"REPOSITORY",
+			"TAG",
+			"IMAGE ID",
+			"SIZE",
+			"CREATED",
+		])
+		.cap(0, 48)
+		.cap(1, 48)
+		.cap(2, 24)
+		.identity_col(0);
 		for row in &rows {
 			table.push(vec![
 				row.service.clone(),
@@ -162,6 +182,7 @@ impl Engine {
 				row.tag.clone(),
 				row.id.clone(),
 				size_cell(row.size),
+				age_cell(&row.created, now),
 			]);
 		}
 		table.print();
@@ -179,6 +200,18 @@ fn size_cell(size: u64) -> String {
 		return String::new();
 	}
 	format_bytes(size, &SIZE_FORMAT)
+}
+
+/// The CREATED cell: how long ago the image was built.
+///
+/// Empty when libpod sent nothing or something this cannot parse. A blank cell
+/// says podup could not tell; a plausible wrong date is the one a reader acts on.
+fn age_cell(created: &str, now: i64) -> String {
+	let Some(built) = crate::timestamp::parse_rfc3339(created) else {
+		return String::new();
+	};
+	let elapsed = now.saturating_sub(built).max(0);
+	format_duration(std::time::Duration::from_secs(elapsed as u64), &AGE_FORMAT)
 }
 
 #[cfg(test)]

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -7,6 +7,7 @@ use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::Engine;
+use crate::units::{format_duration, DurationFormat};
 
 /// Options for [`Engine::ps_with_options`], mirroring `docker compose ps`.
 #[derive(Default)]
@@ -45,11 +46,29 @@ fn display_status(c: &ContainerListEntry) -> &str {
 	}
 }
 
-/// Table STATUS cell. Podman's list endpoint reports an exited container with a
-/// bare `exited` state and no code, which is indistinguishable from a clean exit;
-/// surface the exit code the way `docker compose ps` does (`Exited (0)` /
-/// `Exited (7)`). For every other state fall back to [`display_status`].
-fn table_status(c: &ContainerListEntry) -> String {
+/// How `ps` renders a span: the shared default, three components.
+const SPAN_FORMAT: DurationFormat = DurationFormat::default_parts();
+
+/// Table STATUS cell, as of `now` (Unix seconds).
+///
+/// A running container says how long it has been up, which is what both
+/// reference tools do and what podup did not: `podman ps` renders `Up 13 hours
+/// (healthy)` and `docker compose ps` renders `Up 2 minutes`, while podup
+/// rendered the bare word `running`. The state alone answers "is it on"; the
+/// span answers "did it just restart", which is the question someone runs `ps`
+/// to settle.
+///
+/// The health suffix only appears when the container has a healthcheck —
+/// libpod leaves `Status` empty otherwise, measured on Podman 5.7.0, so there is
+/// nothing to append rather than an unknown to invent.
+///
+/// Podman's list endpoint reports an exited container with a bare `exited` state
+/// and no code, which is indistinguishable from a clean exit; surface the exit
+/// code the way `docker compose ps` does (`Exited (0)` / `Exited (7)`).
+///
+/// `now` is a parameter rather than a clock read so the rendering is pure and
+/// its tests are deterministic.
+fn table_status(c: &ContainerListEntry, now: i64) -> String {
 	let status = display_status(c);
 	let exited = c.state.eq_ignore_ascii_case("exited") || c.state.eq_ignore_ascii_case("dead");
 	// Only synthesize when the status text doesn't already carry the code, so a
@@ -57,7 +76,60 @@ fn table_status(c: &ContainerListEntry) -> String {
 	if exited && !status.contains("Exited (") {
 		return format!("Exited ({})", c.exit_code.unwrap_or(0));
 	}
-	status.to_string()
+	if !c.state.eq_ignore_ascii_case("running") {
+		return status.to_string();
+	}
+	let Some(uptime) = span_since(c.started_at, now) else {
+		return status.to_string();
+	};
+	// `health_from_status` answers with an empty string when the container has
+	// no healthcheck, which is the same case as libpod sending an empty
+	// `Status` — nothing to append rather than an unknown to invent.
+	match health_from_status(status) {
+		"" => format!("Up {uptime}"),
+		health => format!("Up {uptime} ({health})"),
+	}
+}
+
+/// Table CREATED cell, as of `now`: how long ago the container was created.
+///
+/// Empty when libpod sent no timestamp or one this cannot parse. A blank cell
+/// says podup could not tell; a cell holding a plausible wrong age does not, and
+/// the wrong age is the one a reader acts on.
+fn table_created(c: &ContainerListEntry, now: i64) -> String {
+	crate::timestamp::parse_rfc3339(&c.created)
+		.and_then(|created| span_since(created, now))
+		.unwrap_or_default()
+}
+
+/// Render the span from `then` to `now`, or `None` when there is nothing to
+/// render.
+///
+/// A zero `then` means the field was absent, not that the instant was the epoch.
+/// A `then` in the future is clock skew between this process and the server —
+/// clamped to zero rather than rendered as a negative age, since `Up 0s` on a
+/// container that just started is right and `Up -3s` is never right.
+fn span_since(then: i64, now: i64) -> Option<String> {
+	if then <= 0 {
+		return None;
+	}
+	let elapsed = now.saturating_sub(then).max(0);
+	Some(format_duration(
+		std::time::Duration::from_secs(elapsed as u64),
+		&SPAN_FORMAT,
+	))
+}
+
+/// The wall clock as Unix seconds, for the cells that render an age.
+///
+/// Before the epoch is not a state this can reach on any host that boots, so a
+/// failure floors at zero and every cell renders blank rather than the call
+/// site handling an error it cannot act on.
+pub(super) fn now_unix() -> i64 {
+	std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.map(|d| d.as_secs() as i64)
+		.unwrap_or(0)
 }
 
 /// The container's display name (leading slash stripped).
@@ -203,6 +275,11 @@ fn ps_json_row(c: &ContainerListEntry) -> serde_json::Value {
 		"Health": health_from_status(display_status(c)),
 		"ExitCode": c.exit_code.unwrap_or(0),
 		"Publishers": publishers(&c.ports),
+		// The raw wire values, not a rendering. `docker compose ps --format
+		// json` passes the RFC 3339 string through too, and a machine consumer
+		// wants an instant it can compute with rather than `2mo 1d`.
+		"Created": c.created,
+		"StartedAt": c.started_at,
 		"ID": c.id,
 	})
 }
@@ -330,16 +407,20 @@ impl Engine {
 			return Ok(());
 		}
 
-		let mut table = crate::ui::Table::new(&["NAME", "IMAGE", "STATUS", "PORTS"])
+		// One clock read for the whole table, so two rows created in the same
+		// second cannot render different ages.
+		let now = now_unix();
+		let mut table = crate::ui::Table::new(&["NAME", "IMAGE", "CREATED", "STATUS", "PORTS"])
 			.cap(0, 48)
 			.cap(1, 48)
-			.status_col(2)
+			.status_col(3)
 			.identity_col(0);
 		for c in &containers {
 			table.push(vec![
 				name_of(c),
 				c.image.clone(),
-				table_status(c),
+				table_created(c, now),
+				table_status(c, now),
 				format_ports(&c.ports),
 			]);
 		}

--- a/internal/engine/query/ps/tests.rs
+++ b/internal/engine/query/ps/tests.rs
@@ -290,15 +290,34 @@ fn a_start_time_in_the_future_clamps_to_zero() {
 	assert_eq!(table_status(&c, NOW), "Up 0s");
 }
 
-/// Only a running container gets an age. A stopped one keeps the exit code it
-/// already reported, which is the more useful fact about it.
+/// Only a running container gets an age.
+///
+/// A stopped one keeps the exit code it already reported, which is the more
+/// useful fact about it. The case that actually exercises the guard is
+/// **paused**: it has a real `StartedAt` and is not running, so without the
+/// check it would claim `Up 1h` for a container that is doing nothing. The
+/// first version of this test used an exited container and proved nothing —
+/// that path returns from the exit-code branch before the guard is reached, so
+/// deleting the guard left it green.
 #[test]
 fn only_a_running_container_reports_an_age() {
-	let c = ContainerListEntry {
+	let exited = ContainerListEntry {
 		started_at: NOW - 3600,
 		..entry_exit("exited", Some(7))
 	};
-	assert_eq!(table_status(&c, NOW), "Exited (7)");
+	assert_eq!(table_status(&exited, NOW), "Exited (7)");
+
+	let paused = ContainerListEntry {
+		started_at: NOW - 3600,
+		..entry("paused", "paused")
+	};
+	assert_eq!(table_status(&paused, NOW), "paused");
+
+	let created = ContainerListEntry {
+		started_at: NOW - 3600,
+		..entry("", "created")
+	};
+	assert_eq!(table_status(&created, NOW), "created");
 }
 
 /// CREATED is how long ago the container was made, parsed from the RFC 3339

--- a/internal/engine/query/ps/tests.rs
+++ b/internal/engine/query/ps/tests.rs
@@ -19,8 +19,16 @@ fn entry(status: &str, state: &str) -> ContainerListEntry {
 		ports: vec![],
 		exit_code: None,
 		labels: HashMap::new(),
+		// Absent by default: the fixtures below exercise the fallback path, and
+		// the ones that render an age set these explicitly.
+		started_at: 0,
+		created: String::new(),
 	}
 }
+
+/// A fixed `now` for the cells that render an age, so the tests are
+/// deterministic. 2026-08-03 00:58:45 UTC, the instant captured from libpod.
+const NOW: i64 = 1_785_718_725;
 
 #[test]
 fn status_matches_empty_filter_matches_all() {
@@ -74,27 +82,36 @@ fn entry_exit(state: &str, code: Option<i32>) -> ContainerListEntry {
 fn table_status_shows_exit_code_for_bare_exited() {
 	// A crash (non-zero) and a clean exit (zero) must be distinguishable,
 	// even though libpod reports both as a bare `exited` state.
-	assert_eq!(table_status(&entry_exit("exited", Some(7))), "Exited (7)");
-	assert_eq!(table_status(&entry_exit("exited", Some(0))), "Exited (0)");
+	assert_eq!(
+		table_status(&entry_exit("exited", Some(7)), NOW),
+		"Exited (7)"
+	);
+	assert_eq!(
+		table_status(&entry_exit("exited", Some(0)), NOW),
+		"Exited (0)"
+	);
 	// Missing exit code defaults to 0 rather than rendering a bare word.
-	assert_eq!(table_status(&entry_exit("exited", None)), "Exited (0)");
+	assert_eq!(table_status(&entry_exit("exited", None), NOW), "Exited (0)");
 	// `dead` is treated like an exit too.
-	assert_eq!(table_status(&entry_exit("dead", Some(255))), "Exited (255)");
+	assert_eq!(
+		table_status(&entry_exit("dead", Some(255)), NOW),
+		"Exited (255)"
+	);
 }
 
 #[test]
 fn table_status_keeps_running_and_rich_status_text() {
 	assert_eq!(
-		table_status(&entry("Up 2 seconds", "running")),
+		table_status(&entry("Up 2 seconds", "running"), NOW),
 		"Up 2 seconds"
 	);
-	assert_eq!(table_status(&entry("", "running")), "running");
+	assert_eq!(table_status(&entry("", "running"), NOW), "running");
 	// A Docker-style status that already carries the code is left untouched.
 	let c = ContainerListEntry {
 		exit_code: Some(7),
 		..entry("Exited (7) 4 seconds ago", "exited")
 	};
-	assert_eq!(table_status(&c), "Exited (7) 4 seconds ago");
+	assert_eq!(table_status(&c, NOW), "Exited (7) 4 seconds ago");
 }
 
 #[test]
@@ -213,6 +230,121 @@ fn health_is_derived_from_status_text() {
 	assert_eq!(health_from_status("Restarting (1) 3 seconds ago"), "");
 }
 
+/// A running container says how long it has been up, which is what both
+/// reference tools do and what podup did not. Measured the same day: `podman ps`
+/// renders `Up 13 hours (healthy)` and `docker compose ps` renders
+/// `Up 2 minutes`, while podup rendered the bare word `running`.
+#[test]
+fn a_running_container_reports_how_long_it_has_been_up() {
+	let c = ContainerListEntry {
+		started_at: NOW - (2 * 3600 + 5 * 60 + 3),
+		..entry("", "running")
+	};
+	assert_eq!(table_status(&c, NOW), "Up 2h 5m 3s");
+}
+
+/// The health suffix appears only when the container has a healthcheck. libpod
+/// leaves `Status` empty otherwise, so there is nothing to append rather than an
+/// unknown to invent.
+#[test]
+fn the_health_suffix_appears_only_when_there_is_a_healthcheck() {
+	let started = NOW - 13 * 3600;
+	let healthy = ContainerListEntry {
+		started_at: started,
+		..entry("healthy", "running")
+	};
+	let unhealthy = ContainerListEntry {
+		started_at: started,
+		..entry("unhealthy", "running")
+	};
+	let plain = ContainerListEntry {
+		started_at: started,
+		..entry("", "running")
+	};
+	assert_eq!(table_status(&healthy, NOW), "Up 13h (healthy)");
+	assert_eq!(table_status(&unhealthy, NOW), "Up 13h (unhealthy)");
+	assert_eq!(table_status(&plain, NOW), "Up 13h");
+}
+
+/// A zero `StartedAt` means the field was absent, not that the container
+/// started at the epoch. Rendering `Up 56y` for a container that has never run
+/// is worse than saying nothing, so the cell falls back to the state.
+#[test]
+fn an_absent_start_time_does_not_become_an_age() {
+	let c = ContainerListEntry {
+		started_at: 0,
+		..entry("", "running")
+	};
+	assert_eq!(table_status(&c, NOW), "running");
+}
+
+/// A start time in the future is clock skew between this process and the
+/// server, not a negative age. `Up 0s` on a container that just started is
+/// right; `Up -3s` is never right.
+#[test]
+fn a_start_time_in_the_future_clamps_to_zero() {
+	let c = ContainerListEntry {
+		started_at: NOW + 3,
+		..entry("", "running")
+	};
+	assert_eq!(table_status(&c, NOW), "Up 0s");
+}
+
+/// Only a running container gets an age. A stopped one keeps the exit code it
+/// already reported, which is the more useful fact about it.
+#[test]
+fn only_a_running_container_reports_an_age() {
+	let c = ContainerListEntry {
+		started_at: NOW - 3600,
+		..entry_exit("exited", Some(7))
+	};
+	assert_eq!(table_status(&c, NOW), "Exited (7)");
+}
+
+/// CREATED is how long ago the container was made, parsed from the RFC 3339
+/// string libpod sends in `Created`.
+#[test]
+fn the_created_cell_reports_the_age_of_the_container() {
+	let c = ContainerListEntry {
+		// 2026-08-02 22:34:41 at -05:00 is 2026-08-03 03:34:41Z, which is two
+		// hours and change after NOW... so use a value comfortably before it.
+		created: "2026-08-01T00:58:45Z".into(),
+		..entry("", "running")
+	};
+	assert_eq!(table_created(&c, NOW), "2d");
+}
+
+/// A timestamp podup cannot parse leaves the cell blank rather than showing a
+/// plausible wrong age. The wrong age is the one a reader would act on.
+#[test]
+fn an_unparseable_created_leaves_the_cell_blank() {
+	for bad in ["", "not a timestamp", "2026-13-01T00:00:00Z"] {
+		let c = ContainerListEntry {
+			created: bad.into(),
+			..entry("", "running")
+		};
+		assert_eq!(table_created(&c, NOW), "", "{bad:?}");
+	}
+}
+
+/// The JSON path passes the wire values through rather than a rendering. A
+/// machine consumer wants an instant it can compute with, and `docker compose ps
+/// --format json` passes the RFC 3339 string through too.
+#[test]
+fn the_json_row_carries_the_raw_instants() {
+	let c = ContainerListEntry {
+		started_at: 1_785_728_082,
+		created: "2026-08-02T22:34:41.982670-05:00".into(),
+		..entry("", "running")
+	};
+	let row = ps_json_row(&c);
+	assert_eq!(row["StartedAt"], serde_json::json!(1_785_728_082_i64));
+	assert_eq!(
+		row["Created"],
+		serde_json::json!("2026-08-02T22:34:41.982670-05:00")
+	);
+}
+
 #[test]
 fn ps_json_row_surfaces_state_exitcode_and_publishers() {
 	let mut labels = HashMap::new();
@@ -233,6 +365,8 @@ fn ps_json_row_surfaces_state_exitcode_and_publishers() {
 		}],
 		exit_code: Some(137),
 		labels,
+		started_at: 1_785_728_082,
+		created: "2026-08-02T22:34:41.982670-05:00".into(),
 	};
 	let row = ps_json_row(&c);
 	assert_eq!(row["Name"], "demo-web-1");

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -32,6 +32,7 @@ pub mod quadlet;
 pub mod size;
 /// Docker Compose `${VAR}`/`$VAR` substitution over raw YAML before parsing.
 pub mod substitute;
+pub(crate) mod timestamp;
 /// Terminal colour/styling, honouring `--ansi`, `NO_COLOR`, and TTY detection.
 pub mod ui;
 pub(crate) mod units;

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -55,6 +55,18 @@ pub struct ContainerListEntry {
 	/// Container labels (key/value), including compose project/service labels.
 	#[serde(rename = "Labels", default, deserialize_with = "null_default")]
 	pub labels: HashMap<String, String>,
+	/// When the container was last started, in Unix seconds. Zero for one that
+	/// has never run, which is why `ps` keys "how long has this been up" on the
+	/// state rather than on this being non-zero.
+	#[serde(rename = "StartedAt", default)]
+	pub started_at: i64,
+	/// When the container was created, as an RFC 3339 string.
+	///
+	/// Not the docker-compatible `CreatedAt`, which libpod also sends and leaves
+	/// **empty** — measured on Podman 5.7.0. Reading the familiar name gets a
+	/// blank column, the same trap as `Status` versus `State` above.
+	#[serde(rename = "Created", default)]
+	pub created: String,
 }
 
 /// Port mapping entry in container list response.

--- a/internal/libpod/types/image.rs
+++ b/internal/libpod/types/image.rs
@@ -58,4 +58,12 @@ pub struct ImageInspect {
 	/// listing.
 	#[serde(rename = "Size", default)]
 	pub size: u64,
+	/// When the image was built, as an RFC 3339 string.
+	///
+	/// Note the shape: the image **list** endpoint reports this as Unix seconds,
+	/// the **inspect** endpoint this code calls reports it as RFC 3339. Measured
+	/// on Podman 5.7.0; reading the list's documentation and applying it here
+	/// yields a parse failure and a blank column.
+	#[serde(rename = "Created", default)]
+	pub created: String,
 }

--- a/internal/timestamp.rs
+++ b/internal/timestamp.rs
@@ -1,0 +1,170 @@
+//! RFC 3339 timestamps, as libpod puts them on the wire.
+//!
+//! podup has no date library and does not want one. The three fields that need
+//! this — a container's `Created`, a volume's `CreatedAt`, and an image's
+//! `Created` from the inspect endpoint — all arrive as RFC 3339 strings, and
+//! everything else libpod reports (`StartedAt`, the event feed) is already Unix
+//! seconds.
+//!
+//! Two flavours appear in practice, measured on Podman 5.7.0: the image inspect
+//! response ends in `Z`, and the container list carries an explicit offset
+//! (`-05:00`). A parser that handles one and not the other fails on exactly half
+//! the columns, so both are covered here and by tests built from captured
+//! strings rather than from the specification.
+//!
+//! Parsing is fail-closed: anything that is not a well-formed timestamp in range
+//! returns `None`, and callers render an empty cell. A cell that is blank tells
+//! the reader podup could not say; a cell holding a plausible wrong date does
+//! not.
+
+/// Seconds in a day.
+const SECS_PER_DAY: i64 = 86_400;
+
+/// Parse an RFC 3339 timestamp into Unix seconds.
+///
+/// Accepts `YYYY-MM-DDTHH:MM:SS` followed by an optional fractional part and a
+/// mandatory offset of `Z` or `±HH:MM`. The date/time separator may be `T`, `t`
+/// or a space, which RFC 3339 permits and which keeps this usable for the
+/// `--since` values a user types by hand.
+///
+/// Returns `None` for anything malformed or out of range, including a date that
+/// does not exist (31 February) and an offset beyond ±24 hours. The fractional
+/// part is validated but discarded: every consumer here renders whole seconds at
+/// coarsest, and keeping sub-second precision would only widen the type.
+pub(crate) fn parse_rfc3339(input: &str) -> Option<i64> {
+	let bytes = input.as_bytes();
+	// `YYYY-MM-DDTHH:MM:SS` is nineteen characters, and an offset always
+	// follows, so anything shorter than twenty cannot be complete.
+	if bytes.len() < 20 {
+		return None;
+	}
+
+	let year: i64 = digits(&input[0..4])?;
+	if bytes[4] != b'-' {
+		return None;
+	}
+	let month: i64 = digits(&input[5..7])?;
+	if bytes[7] != b'-' {
+		return None;
+	}
+	let day: i64 = digits(&input[8..10])?;
+	if !matches!(bytes[10], b'T' | b't' | b' ') {
+		return None;
+	}
+	let hour: i64 = digits(&input[11..13])?;
+	if bytes[13] != b':' {
+		return None;
+	}
+	let minute: i64 = digits(&input[14..16])?;
+	if bytes[16] != b':' {
+		return None;
+	}
+	let second: i64 = digits(&input[17..19])?;
+
+	// A leap second is reported as :60 and is not a distinct instant here, so it
+	// is folded onto the following second rather than rejected: refusing a
+	// timestamp the server legitimately sent would blank the cell.
+	if !(1..=12).contains(&month) || day < 1 || hour > 23 || minute > 59 || second > 60 {
+		return None;
+	}
+	if day > days_in_month(year, month) {
+		return None;
+	}
+
+	let offset = parse_offset(&input[19..])?;
+
+	let days = days_from_civil(year, month, day);
+	let secs = days * SECS_PER_DAY + hour * 3600 + minute * 60 + second;
+	Some(secs - offset)
+}
+
+/// Parse the fractional part and the zone suffix into an offset in seconds.
+///
+/// The offset is what has to be *subtracted* to reach UTC: a timestamp written
+/// at `-05:00` is five hours behind, so its UTC instant is five hours later.
+fn parse_offset(rest: &str) -> Option<i64> {
+	let bytes = rest.as_bytes();
+	let mut i = 0;
+
+	// Optional fractional seconds. Validated so `.` alone or `.abc` is rejected
+	// rather than silently treated as a zone that is not there.
+	if bytes.first() == Some(&b'.') {
+		i = 1;
+		let start = i;
+		while i < bytes.len() && bytes[i].is_ascii_digit() {
+			i += 1;
+		}
+		if i == start {
+			return None;
+		}
+	}
+
+	match bytes.get(i) {
+		Some(b'Z' | b'z') if i + 1 == bytes.len() => Some(0),
+		Some(sign @ (b'+' | b'-')) => {
+			// `±HH:MM`, exactly six characters, nothing after it.
+			let zone = rest.get(i + 1..)?;
+			if zone.len() != 5 || zone.as_bytes()[2] != b':' {
+				return None;
+			}
+			let hours: i64 = digits(&zone[0..2])?;
+			let minutes: i64 = digits(&zone[3..5])?;
+			if hours > 23 || minutes > 59 {
+				return None;
+			}
+			let magnitude = hours * 3600 + minutes * 60;
+			Some(if *sign == b'-' { -magnitude } else { magnitude })
+		}
+		_ => None,
+	}
+}
+
+/// Parse a run of ASCII digits, rejecting a sign, spaces or anything else
+/// `str::parse` would otherwise accept.
+///
+/// `"+1"` and `" 1"` both parse as one through the standard parser, which would
+/// let `20 6-08-02` through the field checks above.
+fn digits(s: &str) -> Option<i64> {
+	if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+		return None;
+	}
+	s.parse().ok()
+}
+
+/// Whether `year` is a leap year in the proleptic Gregorian calendar.
+const fn is_leap_year(year: i64) -> bool {
+	year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+/// Days in `month` of `year`.
+const fn days_in_month(year: i64, month: i64) -> i64 {
+	match month {
+		1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+		4 | 6 | 9 | 11 => 30,
+		2 if is_leap_year(year) => 29,
+		2 => 28,
+		_ => 0,
+	}
+}
+
+/// Days since the Unix epoch for a civil date.
+///
+/// The exact inverse of the civil-from-days walk in `engine::events`, which
+/// turns Unix seconds back into a date. Both shift the epoch to 0000-03-01 so
+/// February — the month whose length varies — lands last and the leap-day case
+/// needs no branch of its own. Round-tripping one through the other is the test
+/// that matters here: for both to agree and both be wrong, they would have to be
+/// wrong in the same direction.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+	let year = year - i64::from(month <= 2);
+	let era = if year >= 0 { year } else { year - 399 } / 400;
+	let year_of_era = year - era * 400;
+	let month_shifted = if month > 2 { month - 3 } else { month + 9 };
+	let day_of_year = (153 * month_shifted + 2) / 5 + day - 1;
+	let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+	era * 146_097 + day_of_era - 719_468
+}
+
+#[cfg(test)]
+#[path = "timestamp_tests.rs"]
+mod tests;

--- a/internal/timestamp_tests.rs
+++ b/internal/timestamp_tests.rs
@@ -1,0 +1,162 @@
+use super::parse_rfc3339;
+
+/// The two strings libpod actually sent, captured from Podman 5.7.0 on
+/// 2026-08-03 rather than written from the specification. One ends in `Z` (the
+/// image inspect response), the other carries an explicit offset (the container
+/// list). A parser that handles one and not the other blanks half the columns.
+#[test]
+fn the_two_shapes_libpod_really_sends_both_parse() {
+	// `docker.io/library/redis:8-alpine`, from `images/{ref}/json`.
+	assert_eq!(
+		parse_rfc3339("2026-05-07T17:41:42.866453985Z"),
+		Some(1_778_175_702)
+	);
+	// A running container, from `containers/json`. Written at -05:00, so its
+	// UTC instant is five hours later than the wall clock in the string:
+	// 2026-08-03 00:58:45Z. Both constants here were checked against an
+	// independent parser rather than worked out by hand — the first version of
+	// this one was an hour off, and the code was right.
+	assert_eq!(
+		parse_rfc3339("2026-08-02T19:58:45.39802971-05:00"),
+		Some(1_785_718_725)
+	);
+}
+
+/// The offset is applied in the right direction, which is the single easiest
+/// thing to get backwards. The same wall clock at three zones is three
+/// different instants, five hours apart in each direction.
+#[test]
+fn the_offset_moves_the_instant_the_right_way() {
+	let utc = parse_rfc3339("2026-01-01T12:00:00Z").unwrap();
+	let behind = parse_rfc3339("2026-01-01T12:00:00-05:00").unwrap();
+	let ahead = parse_rfc3339("2026-01-01T12:00:00+05:00").unwrap();
+	assert_eq!(behind - utc, 5 * 3600, "a negative offset is behind UTC");
+	assert_eq!(utc - ahead, 5 * 3600, "a positive offset is ahead of UTC");
+	// And a half-hour zone, since minutes are a separate field.
+	assert_eq!(
+		parse_rfc3339("2026-01-01T12:00:00+05:30").unwrap(),
+		utc - (5 * 3600 + 30 * 60)
+	);
+}
+
+/// Round-trip against the formatter that already lives in the tree. This is the
+/// test the two functions exist to give each other: `format_event_time` walks
+/// civil-from-days and this walks days-from-civil, so for both to agree and both
+/// be wrong they would have to be wrong in the same direction.
+#[test]
+fn it_round_trips_against_the_event_formatter() {
+	for unix in [
+		0_i64,
+		1,
+		-1,
+		-86_400,
+		68_169_600,    // 1972-02-29, a leap day
+		951_782_400,   // 2000-02-29, the century leap a naive rule misses
+		1_709_164_800, // 2024-02-29
+		1_735_689_599, // last second of 2024
+		1_735_689_600, // first of 2025
+		1_785_718_245, // the instant #1301 was built for
+		4_102_444_800, // 2100-01-01, a century that is not a leap year
+	] {
+		let printed = crate::engine::events::format_event_time(unix);
+		let reparsed = parse_rfc3339(&format!("{printed}Z"))
+			.unwrap_or_else(|| panic!("could not reparse {printed:?} (from {unix})"));
+		assert_eq!(reparsed, unix, "{printed:?} did not round-trip");
+	}
+}
+
+/// Dates before the epoch parse to negative seconds rather than wrapping. The
+/// era arithmetic has to floor for negative years, which is the same reason the
+/// formatter uses `div_euclid`.
+#[test]
+fn dates_before_the_epoch_parse_negative() {
+	assert_eq!(parse_rfc3339("1969-12-31T23:59:59Z"), Some(-1));
+	assert_eq!(parse_rfc3339("1969-12-31T00:00:00Z"), Some(-86_400));
+}
+
+/// A date that does not exist is rejected rather than silently rolling into the
+/// next month. This is the check that makes the cell blank instead of showing a
+/// plausible wrong day.
+#[test]
+fn impossible_dates_are_rejected() {
+	assert_eq!(parse_rfc3339("2026-02-30T00:00:00Z"), None);
+	assert_eq!(
+		parse_rfc3339("2026-02-29T00:00:00Z"),
+		None,
+		"2026 is not a leap year"
+	);
+	assert_eq!(parse_rfc3339("2026-04-31T00:00:00Z"), None);
+	assert_eq!(parse_rfc3339("2026-13-01T00:00:00Z"), None);
+	assert_eq!(parse_rfc3339("2026-00-01T00:00:00Z"), None);
+	assert_eq!(parse_rfc3339("2026-01-00T00:00:00Z"), None);
+	assert_eq!(parse_rfc3339("2026-01-01T24:00:00Z"), None);
+	assert_eq!(parse_rfc3339("2026-01-01T00:60:00Z"), None);
+}
+
+/// The leap-year rule has to be the full one. 2024 is a leap year, 2100 is not
+/// despite being divisible by four, and 2000 is despite being a century.
+#[test]
+fn the_leap_year_rule_is_the_whole_rule() {
+	assert!(parse_rfc3339("2024-02-29T00:00:00Z").is_some());
+	assert!(parse_rfc3339("2000-02-29T00:00:00Z").is_some());
+	assert!(parse_rfc3339("2100-02-29T00:00:00Z").is_none());
+	assert!(parse_rfc3339("1900-02-29T00:00:00Z").is_none());
+}
+
+/// Malformed input returns `None` rather than a wrong instant. Every one of
+/// these is a shape that a laxer parser accepts: `str::parse` takes a leading
+/// sign and leading spaces, a missing zone would default to UTC, and a stray
+/// suffix would be ignored.
+#[test]
+fn malformed_input_is_refused() {
+	for bad in [
+		"",
+		"not a timestamp",
+		"2026-05-07T17:41:42",          // no zone at all
+		"2026-05-07T17:41:42.",         // a dot with no digits
+		"2026-05-07T17:41:42.Z",        // same, with a zone after it
+		"2026-05-07T17:41:42Zextra",    // trailing junk after Z
+		"2026-05-07T17:41:42+05",       // truncated offset
+		"2026-05-07T17:41:42+0500",     // offset with no colon
+		"2026-05-07T17:41:42+05:00:00", // offset with seconds
+		"2026-05-07T17:41:42+99:00",    // offset out of range
+		"2026-05-07T17:41:42+05:99",    // offset minutes out of range
+		"20 6-05-07T17:41:42Z",         // a space where a digit belongs
+		"+026-05-07T17:41:42Z",         // a sign where a digit belongs
+		"2026/05/07T17:41:42Z",         // wrong date separators
+		"2026-05-07X17:41:42Z",         // wrong date/time separator
+		"2026-05-07T17-41-42Z",         // wrong time separators
+	] {
+		assert_eq!(parse_rfc3339(bad), None, "{bad:?} should not parse");
+	}
+}
+
+/// The separator may be `T`, lowercase `t`, or a space. RFC 3339 permits all
+/// three, and a user typing a `--since` by hand reaches for the space.
+#[test]
+fn every_permitted_separator_is_accepted() {
+	let expected = parse_rfc3339("2026-05-07T17:41:42Z");
+	assert!(expected.is_some());
+	assert_eq!(parse_rfc3339("2026-05-07t17:41:42Z"), expected);
+	assert_eq!(parse_rfc3339("2026-05-07 17:41:42Z"), expected);
+	assert_eq!(parse_rfc3339("2026-05-07T17:41:42z"), expected);
+}
+
+/// A leap second is folded onto the following second rather than refused. The
+/// server can legitimately send `:60`, and blanking the cell over it would lose
+/// a timestamp that is very nearly right.
+#[test]
+fn a_leap_second_is_accepted() {
+	let ordinary = parse_rfc3339("2016-12-31T23:59:59Z").unwrap();
+	assert_eq!(parse_rfc3339("2016-12-31T23:59:60Z"), Some(ordinary + 1));
+}
+
+/// The fractional part is validated and discarded, whatever its length. Every
+/// consumer renders whole seconds at coarsest.
+#[test]
+fn the_fractional_part_is_ignored_at_any_length() {
+	let whole = parse_rfc3339("2026-05-07T17:41:42Z");
+	assert_eq!(parse_rfc3339("2026-05-07T17:41:42.9Z"), whole);
+	assert_eq!(parse_rfc3339("2026-05-07T17:41:42.866453985Z"), whole);
+	assert_eq!(parse_rfc3339("2026-05-07T17:41:42.000000000000Z"), whole);
+}

--- a/internal/units/bytes.rs
+++ b/internal/units/bytes.rs
@@ -70,6 +70,12 @@ pub(crate) enum SizeShape {
 	Significant { digits: usize },
 	/// Up to `parts` whole components, largest first, zeros skipped:
 	/// `1TB 1GB`, `1GB 512MB`. For the places where the number is the point.
+	///
+	/// No caller yet: the surfaces that want it are `ps --size` and the volume
+	/// accounting in #1304. Exercised by this module's tests meanwhile, which is
+	/// what the allow covers — it is scoped to the three composite items rather
+	/// than the module, so anything else going dead here still warns.
+	#[allow(dead_code)]
 	Composite { parts: usize },
 }
 
@@ -109,6 +115,7 @@ impl SizeFormat {
 	}
 
 	/// Same ladder, up to `parts` whole components.
+	#[allow(dead_code)]
 	pub(crate) const fn with_parts(self, parts: usize) -> Self {
 		Self {
 			shape: SizeShape::Composite { parts },
@@ -135,6 +142,7 @@ impl SizeFormat {
 	/// three is what a caller gets when it does not choose, never padding.
 	///
 	/// [`DurationFormat::default_parts`]: super::DurationFormat::default_parts
+	#[allow(dead_code)]
 	pub(crate) const fn default_parts(self) -> Self {
 		self.with_parts(DEFAULT_PARTS)
 	}

--- a/internal/units/duration.rs
+++ b/internal/units/duration.rs
@@ -52,6 +52,12 @@ pub(crate) enum DurationFormat {
 	/// One number in milliseconds with `decimals` decimal places: `340.00ms`.
 	/// For machine reading, or when the reader wants to compare two durations
 	/// rather than skim one.
+	///
+	/// No caller yet — the benchmark aggregation is where it lands, and that is
+	/// Python today (`bench/aggregate.py`). Exercised by this module's tests
+	/// meanwhile; the allow is on this variant alone so anything else going dead
+	/// here still warns.
+	#[allow(dead_code)]
 	Millis { decimals: usize },
 }
 

--- a/internal/units/mod.rs
+++ b/internal/units/mod.rs
@@ -11,18 +11,8 @@
 //! the right base depends on what the reader is comparing against — podman and
 //! docker print decimal, while `free` and `htop` are binary.
 
-// `stats` is the only caller so far, and it wants one shape: binary units at
-// one decimal. The decimal ladder, the composite shape and every duration are
-// exercised by this module's own tests and by nothing else yet, which is what
-// the allow is for — the surfaces that need them are `ps`, `images` and
-// `volumes`, and #1298 is where they arrive. Take this line out with that
-// change; it is scoped to the module so a genuinely dead item elsewhere still
-// warns. `unused_imports` rides along because the re-exports below are what a
-// caller will reach for, and an unused one is the same fact reported twice.
-#![allow(dead_code, unused_imports)]
-
 mod bytes;
 mod duration;
 
-pub(crate) use bytes::{format_bytes, SizeBase, SizeFormat, SizeShape};
+pub(crate) use bytes::{format_bytes, SizeFormat};
 pub(crate) use duration::{format_duration, DurationFormat};

--- a/tests/engine_integration/cli_lifecycle.rs
+++ b/tests/engine_integration/cli_lifecycle.rs
@@ -118,9 +118,9 @@ async fn cli_ps_subcommand() {
 		.position(|c| *c == "Up")
 		.unwrap_or_else(|| panic!("ps printed the container without its status: {row:?}"));
 	assert!(
-		cells.get(up + 1).is_some_and(|span| {
-			span.chars().next().is_some_and(|c| c.is_ascii_digit())
-		}),
+		cells
+			.get(up + 1)
+			.is_some_and(|span| { span.chars().next().is_some_and(|c| c.is_ascii_digit()) }),
 		"the uptime after `Up` is missing or not a span: {row:?}"
 	);
 	// CREATED sits between the image and STATUS. It is only ever filled by
@@ -128,7 +128,11 @@ async fn cli_ps_subcommand() {
 	// parser failing against the live server — which no unit test can see,
 	// because every fixture it has was written by hand.
 	assert!(
-		up >= 3 && cells[up - 1].chars().next().is_some_and(|c| c.is_ascii_digit()),
+		up >= 3
+			&& cells[up - 1]
+				.chars()
+				.next()
+				.is_some_and(|c| c.is_ascii_digit()),
 		"ps printed no CREATED age, so the timestamp did not parse: {row:?}"
 	);
 

--- a/tests/engine_integration/cli_lifecycle.rs
+++ b/tests/engine_integration/cli_lifecycle.rs
@@ -102,14 +102,34 @@ async fn cli_ps_subcommand() {
 	// The exit code was the whole assertion here, on a command whose entire job
 	// is what it prints. Reading STATUS matters especially: #590 was `ps` leaving
 	// that column empty for every container, which an exit-code check cannot see.
+	//
+	// This used to look for the bare word `running`. STATUS reports the uptime
+	// now (`Up 4s`), matching what podman and docker compose print, so the check
+	// moved to that shape — and it is stricter than the old one rather than
+	// looser: an empty STATUS has no `Up`, so #590 would still turn this red.
 	let out = String::from_utf8_lossy(&ps.stdout);
+	let row = out
+		.lines()
+		.find(|line| line.contains(&format!("{proj}-web-1")))
+		.unwrap_or_else(|| panic!("ps did not list the running container: {out:?}"));
+	let cells: Vec<&str> = row.split_whitespace().collect();
+	let up = cells
+		.iter()
+		.position(|c| *c == "Up")
+		.unwrap_or_else(|| panic!("ps printed the container without its status: {row:?}"));
 	assert!(
-		out.contains(&format!("{proj}-web-1")),
-		"ps did not list the running container: {out:?}"
+		cells.get(up + 1).is_some_and(|span| {
+			span.chars().next().is_some_and(|c| c.is_ascii_digit())
+		}),
+		"the uptime after `Up` is missing or not a span: {row:?}"
 	);
+	// CREATED sits between the image and STATUS. It is only ever filled by
+	// parsing the RFC 3339 string libpod really sends, so a blank here is the
+	// parser failing against the live server — which no unit test can see,
+	// because every fixture it has was written by hand.
 	assert!(
-		out.contains("running"),
-		"ps printed the container without its status: {out:?}"
+		up >= 3 && cells[up - 1].chars().next().is_some_and(|c| c.is_ascii_digit()),
+		"ps printed no CREATED age, so the timestamp did not parse: {row:?}"
 	);
 
 	Command::new(bin())


### PR DESCRIPTION
Closes #1298. Supersedes #1307, which GitHub closed when its stacked base
(#1306) merged and its branch was deleted; same work, rebased onto `develop`.

## What changed, measured against both reference tools

| | before | after | podman |
|---|---|---|---|
| `ps` STATUS | `running` | `Up 8s (healthy)` | `Up 8 seconds (healthy)` |
| `ps` CREATED | absent | `3d` | — |
| `images` CREATED | absent | `2mo 27d 10h` | — |

The state alone answers "is it on". The span answers "did it just restart",
which is the question someone runs `ps` to settle — and it is why `CREATED` and
`STATUS` are both worth having. A container created nine minutes ago and started
four seconds ago reads `9m 3s` / `Up 4s`, which is a restart, visible.

The health suffix appears only when the container has a healthcheck. libpod
leaves `Status` empty otherwise, measured, so there is nothing to append rather
than an unknown to invent.

## An RFC 3339 parser, in-tree

podup has no date library and does not want one. The parser is the exact inverse
of the civil-from-days walk #1301 added for `events`, so **the two round-trip
through each other** — for both to agree and both be wrong they would have to be
wrong in the same direction. That test covers leap days, the 1900/2000/2100
century rule, and dates before the epoch.

Parsing is fail-closed. A malformed timestamp leaves the cell blank rather than
showing a plausible wrong date, because the wrong date is the one a reader acts
on. Sixteen malformed shapes are refused by test, including the ones a laxer
parser accepts: `str::parse` takes a leading sign and leading spaces, so
`20 6-05-07` and `+026-05-07` are checked explicitly.

## Three wire shapes I would have got wrong from the documentation

- The image **list** endpoint sends `Created` as Unix seconds; the **inspect**
  endpoint this code calls sends RFC 3339. I measured the list first and wrote
  "images needs no parser" on the issue, which was wrong about the code.
- `containers/json` carries the value in `Created`. The docker-compatible
  `CreatedAt` is present and **empty** — the same trap as #590, where `Status`
  was empty and `State` held the answer.
- Container `Size` is `null` until asked and costs 4.2x, which is why it is not
  in this PR.

## Two tests that were not testing what they claimed

**`only_a_running_container_reports_an_age`** used an exited container. That path
returns from the exit-code branch *before* the guard it was meant to exercise, so
deleting the guard left it green. Paused is the case that reaches it: a real
`StartedAt` on a container that is not running, which without the check claims
`Up 1h` for something doing nothing.

**A constant I worked out by hand was an hour off**, and the code was right. Both
timestamp constants are now checked against an independent parser.

## The dead-code allow

#1303 left `#![allow(dead_code, unused_imports)]` on the whole `units` module.
Durations have callers now, so **that line is gone**. What is left is scoped to
the three composite-size items and the milliseconds variant, each carrying the
issue that gives it a caller (`ps --size`, #1304, and the benchmark aggregation,
which is Python today).

## Test plan

- 30 new tests: the parser, the two new `ps` cells, the JSON pass-through.
- **13 mutations run, 13 killed** after the paused-container fix: the offset sign
  flipped, the offset added instead of subtracted, the leap rule reduced to
  `%4`, the day-of-month check removed, `digits` made permissive, trailing junk
  allowed after `Z`, an empty fraction accepted, the absent-start guard removed,
  the clock-skew clamp removed, the health suffix always appended, the running
  guard removed, a parse failure rendered as `0s`, and the JSON instant
  stringified. Re-run after the rebase rather than assumed.
- Full lib suite: 1508 passed.
- Run against real Podman 5.7.0 on my machine, one service with a healthcheck
  and one without:

```
podup    refimages-plain-1  Up 8s              refimages-cache-1  Up 8s (healthy)
podman   refimages-plain-1  Up 8 seconds       refimages-cache-1  Up 8 seconds (healthy)
```

## One deliberate divergence

`docker compose images` renders CREATED as `2 months ago`. podup renders
`2mo 27d 10h` — the sliding-window rule, three components, and more precise than
a phrase that covers anywhere from 59 to 62 days.