### PR TITLE
chore: bump to 3.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.4.1"
+version = "3.5.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.4.1"
+version = "3.5.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,50 @@
+podup (3.5.0) unstable; urgency=medium
+
+  Incompatible
+
+  * Three tables changed shape, so a script slicing their columns by position
+    needs updating. `ps` gained a CREATED column between IMAGE and STATUS, and
+    its STATUS now reads `Up 2h 5m` rather than the bare word `running`.
+    `images` gained SIZE and CREATED. `events` gained a TIME column, in 3.4.x
+    it had none. The `--format json` output of each is a superset of what it
+    was: existing keys keep their names and meaning, and the new ones carry raw
+    wire values rather than rendered strings.
+
+  Added
+
+  * `ps` reports how long a running container has been up, with its health in
+    parentheses when it has a healthcheck. The state alone answered "is it on";
+    the span answers "did it just restart", which is what CREATED next to it
+    makes visible.
+  * `ps` and `images` report when things were created, and `images` reports what
+    each image costs on disk. Sizes there render the way `podman images` and
+    `docker compose images` render them, measured against both rather than
+    assumed.
+  * `events` reports when each event happened. The feed carried the timestamp
+    all along and printed nothing, so nothing could be correlated against it.
+
+  Changed
+
+  * Sizes and durations now come from one formatter that is total over its input
+    type. `stats` used to saturate at TiB, rendering a petabyte as `1024.0TiB` —
+    right arithmetic, wrong unit. Its own output is otherwise unchanged.
+  * Durations read as up to three components whose units follow the magnitude:
+    `5s`, `1h 5m 3s`, `1y 1mo 5d`. A year is 365 days and a month is 30.
+
+  Fixed
+
+  * `podup generate` and `podup autostart` print their own usage when a
+    subcommand is missing, instead of the root usage.
+  * A value one byte short of a unit boundary no longer prints the unit it has
+    already left, so 1048575 bytes reads `1.0MiB` and not `1024.0KiB`.
+
+  Known limitation
+
+  * The `events` TIME column is UTC and does not say so, while `podman events`
+    prints local time with its offset. Tracked; the fix is a later release.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 03 Aug 2026 04:43:42 -0500
+
 podup (3.4.1) unstable; urgency=medium
 
   Fixed


### PR DESCRIPTION
Five features and two fixes since 3.4.1, and three tables changed shape.

## Why MINOR and not MAJOR

The library API did not break and semver-checks passes. The **CLI output** did:
anything slicing these tables by column position needs updating.

| table | change |
|---|---|
| `ps` | gained CREATED between IMAGE and STATUS; STATUS now reads `Up 2h 5m` rather than the bare word `running` |
| `images` | gained SIZE and CREATED |
| `events` | gained TIME; in 3.4.x it had no timestamp column at all |

`--format json` is a superset in each case — existing keys keep their names and
meaning, and the new ones carry raw wire values rather than rendered strings, so
a machine consumer parses an instant it can compute with.

Same call as 3.4.0, which shipped four incompatible CLI changes as a MINOR on
the grounds that they are rendering rather than API. Recorded here so the
decision is visible rather than inferred later.

## The changelog carries what the release notes cannot

`release.yml` builds the GitHub notes from Conventional Commit titles, which
carry none of the above. The `debian/changelog` stanza leads with an
**Incompatible** section, and the release notes need that section added by hand
after publishing.

It also carries a **Known limitation**: the new `events` TIME column is UTC and
does not say so, while `podman events` prints local time with its offset
(#1309). Shipping it stated rather than silent — the support policy is
latest-only with no back-ports, so users live with it until the next release.

## Three files, not one

`Cargo.toml`, `Cargo.lock` and `debian/changelog`, all at 3.5.0. `dpkg-
buildpackage` reads the `.deb` version from the changelog and nowhere else;
1.9.0 shipped `podup_1.8.0_*.deb` for exactly that reason and stranded every apt
user. `release.yml`'s verify job gates all three, and I ran the same three
comparisons locally before pushing.

## Test plan

- The three versions compared with the same expressions `release.yml` uses: all
  agree at 3.5.0.
- `dpkg-parsechangelog` reads the new stanza: `Version: 3.5.0`, well-formed.
- `podup --version` reports `v3.5.0` from the built binary.
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets --all-features
  -- -D warnings`, lib suite 1508 passed — the CI commands themselves, not
  approximations of them.