### PR TITLE
ci(debian): let the Debian lane see test-only changes

### DIFF
--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -9,6 +9,13 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "internal/**"
+      # debian/rules is the only caller that builds the test targets with
+      # --no-default-features --features watch,completions, so it is the only
+      # place a feature-gating mistake in the test tree is visible. Leaving
+      # tests/ out of this filter hid a broken develop across twenty pull
+      # requests (#1295): every other lane builds with test-helpers or
+      # all-features and compiles the same code fine.
+      - "tests/**"
       - ".github/workflows/debian-build.yml"
   pull_request:
     branches:
@@ -19,6 +26,13 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "internal/**"
+      # debian/rules is the only caller that builds the test targets with
+      # --no-default-features --features watch,completions, so it is the only
+      # place a feature-gating mistake in the test tree is visible. Leaving
+      # tests/ out of this filter hid a broken develop across twenty pull
+      # requests (#1295): every other lane builds with test-helpers or
+      # all-features and compiles the same code fine.
+      - "tests/**"
       - ".github/workflows/debian-build.yml"
 
 permissions:


### PR DESCRIPTION
Closes #1313.

## The blind spot, measured rather than argued

`debian/rules` is the only caller in the repo that builds the test targets with
`--no-default-features --features watch,completions`. Every other lane builds
with `test-helpers` or `--all-features`. So it is the only place a feature-gating
mistake in the test tree can be seen — and `tests/**` was absent from the path
filter on **both** triggers, so a test-only change never reached it.

I proved that before changing anything, by adding a call to a
`test-helpers`-gated export from an ungated test target and running each lane's
own command:

| what it runs | result |
|---|---|
| `debian/rules` feature set | ``error[E0433]: cannot find `fuzz_api` in `podup` `` |
| `--features test-helpers` | 12 passed |
| `--all-features` | 12 passed |

The defect is invisible to every lane except this one, and this one could not
run. That is what hid a broken `develop` across twenty pull requests (#1295) —
which fixed the breakage and left the blind spot.

Fourteen test targets have no `required-features`, so they all compile under the
Debian feature set and all of them can carry this mistake today.

## The audit the issue also asked for

Checked every path filter in the repo, not just this one:

| workflow | filter | verdict |
|---|---|---|
| `asset-contract` | `install.sh`, `install.ps1`, `release.yml`, itself | complete — those are exactly the three files it compares |
| `benchmark` | `bench/**`, itself | by design; the published numbers run on a controlled runner, shared CI is smoke only |
| `lint-shell` / `lint-powershell` | `**.sh` / `**.ps1` | complete |
| `supply-chain` | `Cargo.toml`, `Cargo.lock`, `about.toml`, `about.hbs`, itself | complete — dependencies cannot change elsewhere |

This was the only gap.

## What this PR cannot prove, and where the proof lands

This PR touches `.github/workflows/debian-build.yml`, which was already in the
filter, so the Debian lane runs here regardless of the new entry. **That means
its appearing green below is not evidence the `tests/**` entry works.**

The trigger gets proven by the next test-only pull request: #1314 is a
tests-only change, and `debian / dpkg-buildpackage` appearing in its checks is
the observation. I will check it there and say so rather than assume it.

## Test plan

- The three-way comparison above, run locally.
- The violation restored and the tree confirmed clean before committing.
- YAML validated; both triggers carry the new entry (`grep -c` returns 2).
- No Rust changed.