### PR TITLE
feat(events): print the time in the reader's own zone, with its offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ libc = "0.2"
 # Console raw mode and window size for interactive exec/run: GetConsoleMode/
 # SetConsoleMode and the screen-buffer query. Already in the tree transitively
 # (tokio pulls the same version), so this adds features, not a crate.
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Console"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Console", "Win32_System_Time"] }
 
 [features]
 default = ["watch", "completions", "update"]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -289,6 +289,20 @@ empty — `1y 2mo 3d`, `1h 5m 3s`, `5s`. A year is 365 days and a month is 30.
 Under `--format json` the raw wire values are passed through instead: `Created`
 is the RFC 3339 string and `StartedAt` is Unix seconds.
 
+### `events` timestamps
+
+The `TIME` column is the reader's own wall clock, with the offset that applied at
+that instant: `2026-08-02 23:43:35 -05:00`. That matches what `podman events`
+prints, so a podup line and a podman line for the same event read the same.
+
+The offset is resolved per event rather than once, so a `--since` window
+spanning a daylight-saving change renders each side correctly. If the platform
+cannot determine a zone, the time is shown in UTC and marked `Z` rather than
+left ambiguous.
+
+`--format json` is untouched: it passes libpod's own event object straight
+through.
+
 ### `volumes [SERVICE...]`
 List the project's named volumes (a trailing service list narrows it to volumes
 those services mount). `EXTERNAL` is highlighted when it reads `yes`: podup

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -208,46 +208,25 @@ fn format_event(value: &Value, json: bool) -> String {
 		crate::ui::stdout_colored() && !json,
 	)
 }
-
-/// Render a Unix timestamp as `YYYY-MM-DD HH:MM:SS` in UTC.
+/// Render an event's timestamp in the reader's own time zone, with the offset
+/// that applied at that instant.
 ///
-/// UTC, not local, and the reason is not that it is cheaper. An event log exists
-/// to be correlated — against another host's log, against a metric, against the
-/// same file read next year — and a bare local timestamp carries no offset, so
-/// it is ambiguous across a DST boundary and unreadable anywhere else. docker
-/// compose prints local without an offset; this is the case its rendering is
-/// adequate rather than right.
-///
-/// It also avoids a dependency. podup has never formatted a wall-clock time and
-/// carries no date crate; local time would need the tz database and therefore
-/// one, for a single column.
-///
-/// The civil-from-days conversion is Howard Hinnant's, shifted to a March-based
-/// year so the leap day lands at the end and no month-length table is needed.
+/// The calendar arithmetic used to live here as its own civil-from-days walk.
+/// It moved to `crate::timestamp`, which already held the inverse for parsing —
+/// the two halves are one thing, and a round-trip test between them only means
+/// something while neither can be edited without the other in view.
 pub(crate) fn format_event_time(unix_secs: i64) -> String {
-	let days = unix_secs.div_euclid(86_400);
-	let secs = unix_secs.rem_euclid(86_400);
-	// Shift the epoch to 0000-03-01, which puts February last.
-	let z = days + 719_468;
-	let era = z.div_euclid(146_097);
-	let doe = z.rem_euclid(146_097);
-	let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-	let y = yoe + era * 400;
-	let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-	let mp = (5 * doy + 2) / 153;
-	let d = doy - (153 * mp + 2) / 5 + 1;
-	let m = if mp < 10 { mp + 3 } else { mp - 9 };
-	let y = if m <= 2 { y + 1 } else { y };
-	format!(
-		"{y:04}-{m:02}-{d:02} {:02}:{:02}:{:02}",
-		secs / 3600,
-		(secs % 3600) / 60,
-		secs % 60
-	)
+	crate::timestamp::format_local(unix_secs)
 }
 
-/// Display width of the `TIME` column: `YYYY-MM-DD HH:MM:SS` is nineteen.
-const TIME_WIDTH: usize = 19;
+/// Display width of the `TIME` column.
+///
+/// `YYYY-MM-DD HH:MM:SS -05:00` is twenty-six. It was nineteen while the column
+/// rendered UTC and said nothing about it; adding the offset without widening
+/// truncated every row to `...19:00:0…`, which the tests caught. The two belong
+/// in one edit — a width that describes a format it no longer holds is the same
+/// class of bug as the `stats` header that had drifted off its own columns.
+const TIME_WIDTH: usize = 26;
 
 /// Display width of the `TYPE` column. `container` is the longest type libpod
 /// emits (`network`, `volume`, `image`, `secret`, `pod` are all shorter).
@@ -315,7 +294,7 @@ fn format_event_line(
 
 #[cfg(test)]
 mod tests {
-	use super::{build_event_filters, format_event};
+	use super::{build_event_filters, format_event, TIME_WIDTH};
 	use serde_json::json;
 
 	#[test]
@@ -366,18 +345,28 @@ mod tests {
 		// Columns are fixed-width now (#1248): TIME leads, `container` fills TYPE
 		// exactly, `start` is padded out to ACTION, and NAME is the trailing raw
 		// column.
+		//
+		// The TIME cell is asserted by width rather than by value: it renders
+		// the reader's wall clock, so a fixed string would pass on a machine at
+		// -05:00 and fail on a runner at UTC. `crate::timestamp` pins what goes
+		// in the cell; this pins that the columns after it land where the header
+		// says.
+		let out = format_event(&ev, false);
 		assert_eq!(
-			format_event(&ev, false),
-			"1970-01-01 00:00:00 container start          web-1"
+			&out[TIME_WIDTH..],
+			" container start          web-1",
+			"columns after TIME drifted: {out:?}"
 		);
 	}
 
 	#[test]
 	fn formats_libpod_native_shape() {
 		let ev = json!({ "Type": "container", "status": "die", "id": "abc123", "time": 0 });
+		let out = format_event(&ev, false);
 		assert_eq!(
-			format_event(&ev, false),
-			"1970-01-01 00:00:00 container die            abc123"
+			&out[TIME_WIDTH..],
+			" container die            abc123",
+			"columns after TIME drifted: {out:?}"
 		);
 	}
 
@@ -392,38 +381,11 @@ mod tests {
 
 #[cfg(test)]
 mod event_colour_tests {
-	use super::{format_event_line, format_event_time};
+	use super::{format_event_line, TIME_WIDTH};
 
-	/// Known instants, including the ones the arithmetic can get wrong: the epoch
-	/// itself, a leap day, the day after one, a century that is not a leap year
-	/// and one that is, and the end of a year. The conversion is a March-based
-	/// civil-from-days, so February and the year boundary are where it earns its
-	/// keep.
-	#[test]
-	fn format_event_time_pins_known_instants() {
-		assert_eq!(format_event_time(0), "1970-01-01 00:00:00");
-		assert_eq!(format_event_time(1), "1970-01-01 00:00:01");
-		// 1972 was a leap year: 29 February exists.
-		assert_eq!(format_event_time(68_169_600), "1972-02-29 00:00:00");
-		assert_eq!(format_event_time(68_256_000), "1972-03-01 00:00:00");
-		// 1900 is divisible by 4 and NOT a leap year; 2000 is divisible by 400
-		// and is one. The second is the case a naive rule gets wrong.
-		assert_eq!(format_event_time(951_782_400), "2000-02-29 00:00:00");
-		// Last second of a year, then the first of the next.
-		assert_eq!(format_event_time(1_735_689_599), "2024-12-31 23:59:59");
-		assert_eq!(format_event_time(1_735_689_600), "2025-01-01 00:00:00");
-		// The event this column was added for, captured from libpod.
-		assert_eq!(format_event_time(1_785_718_245), "2026-08-03 00:50:45");
-	}
-
-	/// Before the epoch. `div_euclid`/`rem_euclid` are used rather than `/` and
-	/// `%` precisely so a negative input floors instead of truncating toward
-	/// zero; with the plain operators this would render an hour of -1.
-	#[test]
-	fn format_event_time_handles_dates_before_the_epoch() {
-		assert_eq!(format_event_time(-1), "1969-12-31 23:59:59");
-		assert_eq!(format_event_time(-86_400), "1969-12-31 00:00:00");
-	}
+	// The instant-by-instant pinning that used to live here moved to
+	// `crate::timestamp` with the arithmetic itself. Keeping a copy next to the
+	// caller would be two places to update and one of them would rot.
 
 	/// An event with no `time` renders the column blank rather than inventing a
 	/// value. A timestamp that looks real and is not is worse than none.
@@ -431,7 +393,7 @@ mod event_colour_tests {
 	fn an_event_without_a_time_leaves_the_column_empty() {
 		let line = format_event_line(None, "container", "start", "web-1", false);
 		assert!(
-			line.starts_with("                    container"),
+			line.starts_with(&" ".repeat(TIME_WIDTH)),
 			"expected a blank time cell, got: {line:?}"
 		);
 	}
@@ -443,8 +405,9 @@ mod event_colour_tests {
 		let out = format_event_line(Some(0), "container", "start", "proj-web-1", false);
 		assert!(!out.contains('\u{1b}'), "{out:?}");
 		assert_eq!(
-			out,
-			"1970-01-01 00:00:00 container start          proj-web-1"
+			&out[TIME_WIDTH..],
+			" container start          proj-web-1",
+			"{out:?}"
 		);
 	}
 

--- a/internal/timestamp/mod.rs
+++ b/internal/timestamp/mod.rs
@@ -149,12 +149,11 @@ const fn days_in_month(year: i64, month: i64) -> i64 {
 
 /// Days since the Unix epoch for a civil date.
 ///
-/// The exact inverse of the civil-from-days walk in `engine::events`, which
-/// turns Unix seconds back into a date. Both shift the epoch to 0000-03-01 so
-/// February — the month whose length varies — lands last and the leap-day case
-/// needs no branch of its own. Round-tripping one through the other is the test
-/// that matters here: for both to agree and both be wrong, they would have to be
-/// wrong in the same direction.
+/// The exact inverse of [`civil_from_days`]. Both shift the epoch to 0000-03-01
+/// so February — the month whose length varies — lands last and the leap-day
+/// case needs no branch of its own. Round-tripping one through the other is the
+/// test that matters here: for both to agree and both be wrong, they would have
+/// to be wrong in the same direction.
 fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
 	let year = year - i64::from(month <= 2);
 	let era = if year >= 0 { year } else { year - 399 } / 400;
@@ -165,6 +164,126 @@ fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
 	era * 146_097 + day_of_era - 719_468
 }
 
+/// The civil date for a count of days since the Unix epoch, as
+/// `(year, month, day)`.
+///
+/// The exact inverse of [`days_from_civil`]. This used to live in
+/// `engine::events` as half of its timestamp formatter; the two halves are one
+/// thing and belong next to each other, and the round-trip test between them is
+/// only honest while neither can be edited without the other in view.
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+	let shifted = days + 719_468;
+	let era = shifted.div_euclid(146_097);
+	let day_of_era = shifted.rem_euclid(146_097);
+	let year_of_era =
+		(day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+	let year = year_of_era + era * 400;
+	let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+	let month_shifted = (5 * day_of_year + 2) / 153;
+	let day = day_of_year - (153 * month_shifted + 2) / 5 + 1;
+	let month = if month_shifted < 10 {
+		month_shifted + 3
+	} else {
+		month_shifted - 9
+	};
+	let year = if month <= 2 { year + 1 } else { year };
+	(year, month, day)
+}
+
+/// Render `unix_secs` as a wall-clock timestamp in the reader's own time zone,
+/// with the offset that applies **at that instant**: `2026-08-02 23:43:35 -05:00`.
+///
+/// Matching what `podman events` prints. Before this, podup rendered UTC and did
+/// not say so, which is worse than either alternative: a reader correlating a
+/// podup line against `podman events` or `journalctl` reads it as their own wall
+/// clock and is silently wrong by the offset.
+///
+/// The offset is resolved per instant rather than once, so an event from July
+/// and one from January render correctly wherever daylight saving applies. When
+/// the platform cannot say what the offset is, the value is rendered in UTC and
+/// labelled `Z` — an unlabelled guess is the failure this replaced.
+pub(crate) fn format_local(unix_secs: i64) -> String {
+	match local_offset_seconds(unix_secs) {
+		Some(offset) => {
+			let sign = if offset < 0 { '-' } else { '+' };
+			let magnitude = offset.abs();
+			format!(
+				"{} {sign}{:02}:{:02}",
+				format_civil(unix_secs + offset),
+				magnitude / 3600,
+				(magnitude % 3600) / 60
+			)
+		}
+		None => format!("{}Z", format_civil(unix_secs)),
+	}
+}
+
+/// `YYYY-MM-DD HH:MM:SS` for a count of seconds, with no zone of its own.
+///
+/// `div_euclid`/`rem_euclid` rather than `/` and `%` so a negative input floors
+/// instead of truncating toward zero; with the plain operators a pre-epoch
+/// instant renders an hour of -1.
+fn format_civil(secs_total: i64) -> String {
+	let days = secs_total.div_euclid(SECS_PER_DAY);
+	let secs = secs_total.rem_euclid(SECS_PER_DAY);
+	let (year, month, day) = civil_from_days(days);
+	format!(
+		"{year:04}-{month:02}-{day:02} {:02}:{:02}:{:02}",
+		secs / 3600,
+		(secs % 3600) / 60,
+		secs % 60
+	)
+}
+
+#[cfg(unix)]
+#[path = "offset_unix.rs"]
+mod offset;
+#[cfg(windows)]
+#[path = "offset_windows.rs"]
+mod offset;
+
+/// Offset from UTC in seconds at `unix_secs`, or `None` when the platform
+/// cannot say.
+///
+/// Split per platform because the two ask entirely different questions of the
+/// OS, and both need FFI: there is no portable way to reach a timezone database
+/// from the standard library.
+fn local_offset_seconds(unix_secs: i64) -> Option<i64> {
+	offset::local_offset_seconds(unix_secs)
+}
+
+/// Build a Win32 `SYSTEMTIME` from Unix seconds.
+///
+/// Lives here rather than in the Windows module so it is compiled — and
+/// therefore type-checked and unit-tested — on every platform. A conversion
+/// that only builds on the one machine nobody develops on is a conversion
+/// nobody has checked.
+#[cfg(windows)]
+fn to_system_time(unix_secs: i64) -> Option<windows_sys::Win32::Foundation::SYSTEMTIME> {
+	let days = unix_secs.div_euclid(SECS_PER_DAY);
+	let secs = unix_secs.rem_euclid(SECS_PER_DAY);
+	let (year, month, day) = civil_from_days(days);
+	Some(windows_sys::Win32::Foundation::SYSTEMTIME {
+		wYear: u16::try_from(year).ok()?,
+		wMonth: u16::try_from(month).ok()?,
+		wDayOfWeek: 0,
+		wDay: u16::try_from(day).ok()?,
+		wHour: u16::try_from(secs / 3600).ok()?,
+		wMinute: u16::try_from((secs % 3600) / 60).ok()?,
+		wSecond: u16::try_from(secs % 60).ok()?,
+		wMilliseconds: 0,
+	})
+}
+
+/// Unix seconds from a Win32 `SYSTEMTIME`, ignoring milliseconds.
+#[cfg(windows)]
+fn from_system_time(t: &windows_sys::Win32::Foundation::SYSTEMTIME) -> i64 {
+	let days = days_from_civil(i64::from(t.wYear), i64::from(t.wMonth), i64::from(t.wDay));
+	days * SECS_PER_DAY
+		+ i64::from(t.wHour) * 3600
+		+ i64::from(t.wMinute) * 60
+		+ i64::from(t.wSecond)
+}
+
 #[cfg(test)]
-#[path = "timestamp_tests.rs"]
 mod tests;

--- a/internal/timestamp/mod.rs
+++ b/internal/timestamp/mod.rs
@@ -203,19 +203,30 @@ fn civil_from_days(days: i64) -> (i64, i64, i64) {
 /// the platform cannot say what the offset is, the value is rendered in UTC and
 /// labelled `Z` — an unlabelled guess is the failure this replaced.
 pub(crate) fn format_local(unix_secs: i64) -> String {
-	match local_offset_seconds(unix_secs) {
-		Some(offset) => {
-			let sign = if offset < 0 { '-' } else { '+' };
-			let magnitude = offset.abs();
-			format!(
-				"{} {sign}{:02}:{:02}",
-				format_civil(unix_secs + offset),
-				magnitude / 3600,
-				(magnitude % 3600) / 60
-			)
-		}
-		None => format!("{}Z", format_civil(unix_secs)),
-	}
+	render_with_offset(unix_secs, local_offset_seconds(unix_secs))
+}
+
+/// The rendering half, split from the lookup so both of its branches can be
+/// entered from a test.
+///
+/// Two things follow from the split, and both are why it exists. The `None`
+/// branch is unreachable through [`format_local`] on any machine whose libc
+/// resolves a zone — mutations deleting it survived every test that went in the
+/// front door, which is what an untestable control looks like from outside. And
+/// the rendered string stops depending on the machine's own zone, so it can be
+/// pinned exactly instead of only by shape.
+fn render_with_offset(unix_secs: i64, offset: Option<i64>) -> String {
+	let Some(offset) = offset else {
+		return format!("{}Z", format_civil(unix_secs));
+	};
+	let sign = if offset < 0 { '-' } else { '+' };
+	let magnitude = offset.abs();
+	format!(
+		"{} {sign}{:02}:{:02}",
+		format_civil(unix_secs + offset),
+		magnitude / 3600,
+		(magnitude % 3600) / 60
+	)
 }
 
 /// `YYYY-MM-DD HH:MM:SS` for a count of seconds, with no zone of its own.

--- a/internal/timestamp/offset_unix.rs
+++ b/internal/timestamp/offset_unix.rs
@@ -1,0 +1,37 @@
+//! The reader's UTC offset on Unix, from libc.
+//!
+//! Rust's standard library has no local time, deliberately: resolving one needs
+//! a timezone database, and the C function that reads the system's has a
+//! documented race. podup already depends on `libc` and already carries FFI in
+//! five other modules, so this is that pattern rather than a new dependency or
+//! an in-tree tzfile parser.
+
+// libc FFI (localtime_r) is needed here; the block carries a soundness comment.
+#![allow(unsafe_code)]
+
+/// Offset from UTC in seconds at `unix_secs`, or `None` when libc refuses.
+///
+/// Resolved per instant rather than once, so an instant on the far side of a
+/// daylight-saving transition gets the offset that applied then.
+pub(super) fn local_offset_seconds(unix_secs: i64) -> Option<i64> {
+	let time = libc::time_t::try_from(unix_secs).ok()?;
+	let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+
+	// SAFETY: `localtime_r` writes a `struct tm` through the pointer it is
+	// given and reads nothing else of ours. `tm` is a live, correctly typed,
+	// exclusively borrowed local; `&time` is a live `time_t`. The reentrant
+	// form is used precisely because it writes to the caller's buffer instead
+	// of a shared static, so nothing here can be clobbered by another thread.
+	//
+	// The known hazard with this family is `tzset`, which reads the `TZ`
+	// environment variable and races a concurrent `setenv`. podup never sets an
+	// environment variable at runtime — the only writes are in test processes,
+	// and no test calls this — so the race has no second party. A returned null
+	// means libc could not resolve a zone at all and is handled rather than
+	// assumed away.
+	let result = unsafe { libc::localtime_r(&time, &mut tm) };
+	if result.is_null() {
+		return None;
+	}
+	Some(tm.tm_gmtoff as i64)
+}

--- a/internal/timestamp/offset_unix.rs
+++ b/internal/timestamp/offset_unix.rs
@@ -30,6 +30,14 @@ pub(super) fn local_offset_seconds(unix_secs: i64) -> Option<i64> {
 	// means libc could not resolve a zone at all and is handled rather than
 	// assumed away.
 	let result = unsafe { libc::localtime_r(&time, &mut tm) };
+	// Deleting this check survives the whole suite, and that is a statement
+	// about reach rather than about the tests: `localtime_r` returns null only
+	// when libc cannot resolve a zone at all — a missing or corrupt
+	// `/etc/localtime`, or a `TZ` it cannot parse — and no in-process test can
+	// produce that without replacing libc. The branch it guards is reachable in
+	// production and is exercised from the caller side instead:
+	// `render_with_offset(_, None)` has its own test, so what happens when the
+	// offset is unknown is pinned even though this line cannot be.
 	if result.is_null() {
 		return None;
 	}

--- a/internal/timestamp/offset_windows.rs
+++ b/internal/timestamp/offset_windows.rs
@@ -1,0 +1,45 @@
+//! The reader's UTC offset on Windows, from the Win32 time API.
+//!
+//! `SystemTimeToTzSpecificLocalTime` rather than `GetTimeZoneInformation`'s
+//! bias: the bias describes the zone *now*, while this converts a specific
+//! instant and so applies the daylight rule that was in force then. An events
+//! feed is mostly live, but a `--since` window can reach across a transition,
+//! and a formatter that is right only for today is the kind of defect nobody
+//! notices until October.
+
+// Win32 FFI is needed here; each block carries a soundness comment.
+#![allow(unsafe_code)]
+
+use windows_sys::Win32::Foundation::SYSTEMTIME;
+use windows_sys::Win32::System::Time::SystemTimeToTzSpecificLocalTime;
+
+/// Offset from UTC in seconds at `unix_secs`, or `None` when Windows refuses.
+pub(super) fn local_offset_seconds(unix_secs: i64) -> Option<i64> {
+	let utc = super::to_system_time(unix_secs)?;
+	let mut local = SYSTEMTIME {
+		wYear: 0,
+		wMonth: 0,
+		wDayOfWeek: 0,
+		wDay: 0,
+		wHour: 0,
+		wMinute: 0,
+		wSecond: 0,
+		wMilliseconds: 0,
+	};
+
+	// SAFETY: both pointers are to live, correctly typed, exclusively borrowed
+	// locals for the duration of the call, and the function writes only through
+	// the out parameter. A null first argument asks for the machine's current
+	// time zone, which is what the reader's wall clock means here. The call is
+	// documented to return zero on failure, which is handled rather than
+	// assumed away.
+	let ok = unsafe { SystemTimeToTzSpecificLocalTime(std::ptr::null(), &utc, &mut local) };
+	if ok == 0 {
+		return None;
+	}
+	// The difference of the two wall clocks *is* the offset: the same instant
+	// expressed twice. Computing it this way rather than reading a bias field
+	// means the daylight rule is applied by Windows for that instant, not
+	// re-implemented here.
+	Some(super::from_system_time(&local) - unix_secs)
+}

--- a/internal/timestamp/tests.rs
+++ b/internal/timestamp/tests.rs
@@ -102,6 +102,47 @@ fn format_local_renders_a_fixed_width_shape() {
 	);
 }
 
+/// The rendering, pinned exactly. Possible because the offset is a parameter
+/// here rather than a reading of the machine's own zone, so these strings are
+/// the same on a laptop at -05:00 and a runner at UTC.
+#[test]
+fn the_rendering_is_pinned_for_every_offset_shape() {
+	let t = 1_785_718_245; // 2026-08-03 00:50:45 UTC
+	assert_eq!(
+		super::render_with_offset(t, Some(-5 * 3600)),
+		"2026-08-02 19:50:45 -05:00"
+	);
+	assert_eq!(
+		super::render_with_offset(t, Some(5 * 3600 + 30 * 60)),
+		"2026-08-03 06:20:45 +05:30"
+	);
+	assert_eq!(
+		super::render_with_offset(t, Some(0)),
+		"2026-08-03 00:50:45 +00:00"
+	);
+	// A negative offset with minutes, so the sign is not carried by the hours
+	// alone: -09:30 is a real zone (Marquesas).
+	assert_eq!(
+		super::render_with_offset(t, Some(-(9 * 3600 + 30 * 60))),
+		"2026-08-02 15:20:45 -09:30"
+	);
+}
+
+/// When the platform cannot say what the offset is, the value renders in UTC
+/// and says so. An unlabelled guess is the defect this whole change replaced,
+/// so the fallback must not quietly become one.
+///
+/// Only reachable at this level: on any machine whose libc resolves a zone,
+/// `format_local` never takes this branch.
+#[test]
+fn an_unknown_offset_renders_utc_and_labels_it() {
+	assert_eq!(
+		super::render_with_offset(1_785_718_245, None),
+		"2026-08-03 00:50:45Z"
+	);
+	assert_eq!(super::render_with_offset(0, None), "1970-01-01 00:00:00Z");
+}
+
 /// The calendar half, pinned absolutely because it has no zone in it. This is
 /// what the round-trip cannot check on its own: two inverse functions can agree
 /// while both being shifted by the same amount.

--- a/internal/timestamp/tests.rs
+++ b/internal/timestamp/tests.rs
@@ -39,12 +39,18 @@ fn the_offset_moves_the_instant_the_right_way() {
 	);
 }
 
-/// Round-trip against the formatter that already lives in the tree. This is the
-/// test the two functions exist to give each other: `format_event_time` walks
-/// civil-from-days and this walks days-from-civil, so for both to agree and both
-/// be wrong they would have to be wrong in the same direction.
+/// Round-trip through the formatter that lives beside this parser. The two are
+/// inverses — days-from-civil here, civil-from-days there — so for both to agree
+/// and both be wrong they would have to be wrong in the same direction.
+///
+/// **Zone-independent on purpose.** `format_local` renders the reader's wall
+/// clock, so pinning its exact output would pass on a machine at -05:00 and fail
+/// on a CI runner at UTC. Reading the rendered offset back and undoing it must
+/// return the instant that went in, on any machine, which is the stronger claim
+/// anyway: it checks the offset is applied in the right direction as well as
+/// that the calendar arithmetic holds.
 #[test]
-fn it_round_trips_against_the_event_formatter() {
+fn format_local_round_trips_on_any_machine() {
 	for unix in [
 		0_i64,
 		1,
@@ -55,14 +61,74 @@ fn it_round_trips_against_the_event_formatter() {
 		1_709_164_800, // 2024-02-29
 		1_735_689_599, // last second of 2024
 		1_735_689_600, // first of 2025
-		1_785_718_245, // the instant #1301 was built for
+		1_785_718_245, // the instant the TIME column was added for
 		4_102_444_800, // 2100-01-01, a century that is not a leap year
 	] {
-		let printed = crate::engine::events::format_event_time(unix);
-		let reparsed = parse_rfc3339(&format!("{printed}Z"))
-			.unwrap_or_else(|| panic!("could not reparse {printed:?} (from {unix})"));
-		assert_eq!(reparsed, unix, "{printed:?} did not round-trip");
+		let rendered = super::format_local(unix);
+		let reparsed = reparse(&rendered)
+			.unwrap_or_else(|| panic!("could not reparse {rendered:?} (from {unix})"));
+		assert_eq!(reparsed, unix, "{rendered:?} did not round-trip");
 	}
+}
+
+/// Turn what `format_local` prints back into an RFC 3339 string this module can
+/// parse: `YYYY-MM-DD HH:MM:SS ±HH:MM` differs from RFC 3339 only by the space
+/// before the offset, and `Z` needs no change at all.
+fn reparse(rendered: &str) -> Option<i64> {
+	let normalised = match rendered.rsplit_once(' ') {
+		Some((instant, zone)) if zone.starts_with(['+', '-']) => format!("{instant}{zone}"),
+		_ => rendered.to_string(),
+	};
+	parse_rfc3339(&normalised)
+}
+
+/// The rendered shape itself, which the round-trip above would tolerate being
+/// wrong about: twenty-six characters, and an offset that is `Z` or `±HH:MM`.
+/// The `events` TIME column is sized from this, so a change here that nothing
+/// notices truncates every row.
+#[test]
+fn format_local_renders_a_fixed_width_shape() {
+	let rendered = super::format_local(1_785_718_245);
+	assert_eq!(
+		rendered.len(),
+		26,
+		"{rendered:?} is not the width the TIME column is sized for"
+	);
+	let (instant, zone) = rendered.rsplit_once(' ').expect("no zone in {rendered:?}");
+	assert_eq!(instant.len(), 19, "{instant:?}");
+	assert!(
+		zone == "Z" || (zone.len() == 6 && zone.starts_with(['+', '-']) && &zone[3..4] == ":"),
+		"{zone:?} is not Z or ±HH:MM"
+	);
+}
+
+/// The calendar half, pinned absolutely because it has no zone in it. This is
+/// what the round-trip cannot check on its own: two inverse functions can agree
+/// while both being shifted by the same amount.
+#[test]
+fn the_civil_rendering_is_pinned_to_known_instants() {
+	assert_eq!(super::format_civil(0), "1970-01-01 00:00:00");
+	assert_eq!(super::format_civil(1), "1970-01-01 00:00:01");
+	// 1972 was a leap year: 29 February exists.
+	assert_eq!(super::format_civil(68_169_600), "1972-02-29 00:00:00");
+	assert_eq!(super::format_civil(68_256_000), "1972-03-01 00:00:00");
+	// 1900 is divisible by 4 and NOT a leap year; 2000 is divisible by 400 and
+	// is one. The second is the case a naive rule gets wrong.
+	assert_eq!(super::format_civil(951_782_400), "2000-02-29 00:00:00");
+	// Last second of a year, then the first of the next.
+	assert_eq!(super::format_civil(1_735_689_599), "2024-12-31 23:59:59");
+	assert_eq!(super::format_civil(1_735_689_600), "2025-01-01 00:00:00");
+	// The event the column was added for, captured from libpod.
+	assert_eq!(super::format_civil(1_785_718_245), "2026-08-03 00:50:45");
+}
+
+/// Before the epoch. `div_euclid`/`rem_euclid` are used rather than `/` and `%`
+/// precisely so a negative input floors instead of truncating toward zero; with
+/// the plain operators this renders an hour of -1.
+#[test]
+fn the_civil_rendering_handles_dates_before_the_epoch() {
+	assert_eq!(super::format_civil(-1), "1969-12-31 23:59:59");
+	assert_eq!(super::format_civil(-86_400), "1969-12-31 00:00:00");
 }
 
 /// Dates before the epoch parse to negative seconds rather than wrapping. The


### PR DESCRIPTION
Closes #1309.

## Before and after, against the reference on the same instant

```
podup (before)   2026-08-03 04:43:35
podup (after)    2026-08-03 09:44:27 -05:00
podman events    2026-08-03 09:44:27.006054234 -0500 -05
```

Five hours apart, with nothing saying which zone the old one was in. Ambiguous
is worse than either alternative: a reader correlating a podup line against
`podman events` or `journalctl` reads it as their own wall clock and is silently
wrong by the offset.

The offset is resolved **for the instant being rendered**, not once at startup,
so an event either side of a daylight-saving transition is right. Using a single
captured offset would quietly shift half the year.

## No date crate, no tzfile parser

Rust std has no local time on purpose — resolving one needs a timezone database,
and the C function that reads the system's has a documented race. Neither a
dependency nor an in-tree TZif parser was needed: `libc` and `windows-sys` are
already dependencies, and five modules already carry `#![allow(unsafe_code)]`
with a per-block soundness comment. This is that pattern.

- **Unix:** `localtime_r`, `tm_gmtoff`.
- **Windows:** `SystemTimeToTzSpecificLocalTime` rather than
  `GetTimeZoneInformation`'s bias — the bias describes the zone *now*, while
  this converts a specific instant and so applies the daylight rule in force
  then.

The soundness comment names the actual hazard rather than waving at it: the race
is `tzset` reading `TZ` against a concurrent `setenv`, and podup never sets an
environment variable at runtime.

## The calendar arithmetic is one thing now

`days_from_civil` lived in `timestamp.rs` for parsing and its inverse lived in
`events.rs` for formatting. They are two halves of one thing, and the round-trip
test between them only means something while neither can be edited without the
other in view. Both are in `crate::timestamp`; `events.rs` calls it.

## What the tests caught, and what the mutations caught

**The TIME column was still 19 wide.** Adding the offset without widening
truncated every row to `...19:00:0…`. The width and the format have to move in
one edit — a constant that describes a format it no longer holds is the same
class of bug as the `stats` header that had drifted off its own columns.

**Rendering local time makes output tests machine-dependent.** A test pinning
the exact string passes here at -05:00 and fails on a runner at UTC. Two
answers, both applied: the `events` tests assert the columns *after* TIME by
slicing at `TIME_WIDTH`, and the rendering itself was split from the OS lookup
so it takes the offset as a parameter — deterministic everywhere, and pinned
exactly for `-05:00`, `+05:30`, `+00:00` and `-09:30`.

**That split was forced by a mutation, not by taste.** Deleting the UTC fallback
and ignoring a null from `localtime_r` both survived the whole suite: on any
machine whose libc resolves a zone, `format_local` never enters those branches.
Not weak tests — unreachable controls, the same shape as the dead clamp in
#1305.

## Test plan

- **8 mutations run, 7 killed:** offset applied backwards, sign character
  flipped, offset minutes dropped, zone suffix removed, `div_euclid` replaced by
  truncating division, the leap-year branch dropped, and `TIME_WIDTH` put back
  to 19.
- **The eighth survives and is documented in place:** `localtime_r` returns null
  only when libc cannot resolve a zone at all, which no in-process test can
  produce without replacing libc. Its *effect* is pinned from the caller side —
  `render_with_offset(_, None)` has its own test — so the behaviour is covered
  even though the line is not.
- Full lib suite 1511 passed; integration suite **177/177 against real Podman
  5.7.0**; `output_contract` 10 passed.
- **Windows type-checked**, not assumed: `cargo check --target
  x86_64-pc-windows-gnu` passes, and I verified the check actually reaches the
  file by introducing a typo in a `SYSTEMTIME` field and watching it error at
  `offset_windows.rs:27`.

## What is still unverified

Whether `SystemTimeToTzSpecificLocalTime` returns what this expects on a real
Windows machine. It compiles and the arithmetic is unit-tested, but the offset
has not been observed on Windows hardware. Same posture as the console work in
#1154.