### PR TITLE
feat(ps): add an opt-in SIZE column

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -176,6 +176,7 @@ List project containers.
 | `--status <STATE>` | Show only containers in this state. Repeatable; folded together with any `status=` from `--filter`. | all |
 | `--filter <KEY=VAL>` | `name=<NAME>` or `status=<STATE>`. An unknown key is an error. | none |
 | `--services` | Print service names only. | off |
+| `-s, --size` | Add a SIZE column with each container's on-disk footprint. | off |
 
 ### `ls`
 List podup compose projects on the host. Needs no compose file.
@@ -283,6 +284,18 @@ stopped container reports its exit code instead (`Exited (7)`).
 `CREATED` is how long ago the container was made. It differs from `STATUS` after
 a restart, which is the point of having both: a container created three days ago
 and started four seconds ago reads `3d` / `Up 4s`.
+
+`SIZE` appears only with `-s/--size`. It reads `143kB (virtual 225MB)`: the bytes
+the container has written on top of its image, then the image's own size — the
+same shape `podman ps -s` and `docker ps -s` print, and `virtual` is the image
+size rather than the total of the two.
+
+It is opt-in because libpod has to walk each container's writable layer to
+answer, which costs real time as a project grows: measured across 59 containers
+on Podman 5.7.0, asking for it took the underlying call from 21 ms to 109 ms. On
+a small project the difference is below noise. Under `--format json` the field is
+`null` when the size was not requested, so a consumer can tell "not asked" from
+"empty".
 
 Both spans are largest-first and up to three components, skipping units that are
 empty — `1y 2mo 3d`, `1h 5m 3s`, `5s`. A year is 365 days and a month is 30.

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -333,6 +333,11 @@ pub(crate) enum Commands {
 		/// Print the service names, one per line, instead of the container table.
 		#[arg(long = "services")]
 		services_only: bool,
+		/// Show each container's on-disk size. Off by default: the server has
+		/// to walk each container's writable layer to answer, which measured
+		/// 21ms to 109ms over 59 containers.
+		#[arg(short = 's', long)]
+		size: bool,
 		/// Filter containers by predicate: status=<running|exited> or
 		/// name=<NAME> (repeatable).
 		#[arg(long)]

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -42,7 +42,8 @@ fn wants_interactive_with(no_tty: bool, detach: bool, stdin_tty: bool, stdout_tt
 }
 
 pub use query::{
-	AttachOutcome, ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsFilterOptions, PsOptions,
+	AttachOutcome, ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsDisplayOptions,
+	PsFilterOptions, PsOptions,
 };
 mod container_config;
 #[cfg(test)]

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -17,7 +17,7 @@ mod log_prefix;
 mod ps;
 pub(crate) mod terminal;
 
-pub use ps::{PsFilterOptions, PsOptions};
+pub use ps::{PsDisplayOptions, PsFilterOptions, PsOptions};
 
 pub use exec::ExecOptions;
 pub(crate) use exec::{stdin_is_terminal, stdout_is_terminal};

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -124,6 +124,27 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 	}
 }
 
+/// The libpod list request `ps` makes, as a URL.
+///
+/// Pure so the query it builds can be asserted without a server. The `size`
+/// parameter is the one worth pinning: `size=true` is not a bigger payload, it
+/// is work — libpod walks each container's writable layer to answer, measured
+/// at 21 ms against 109 ms over 59 containers on Podman 5.7.0 — so asking for it
+/// unconditionally would make every `ps` pay for a column most readers do not
+/// look at. `docker ps -s` is opt-in for the same reason.
+///
+/// Extracted after a mutation that hard-coded `size=true` survived every test:
+/// the string was built inside an async method that needs a live socket, so
+/// nothing could reach it.
+fn containers_path(project: &str, all: bool, size: bool) -> String {
+	let label = format!("podup.project={project}");
+	let filters = serde_json::json!({ "label": [label] });
+	format!(
+		"{API_PREFIX}/containers/json?all={all}&size={size}&filters={}",
+		urlencoded(&filters.to_string()),
+	)
+}
+
 /// How `ps` renders a size: decimal units at three significant digits.
 ///
 /// The same shape `images` uses, and for the same reason — this column is read
@@ -442,18 +463,7 @@ impl Engine {
 		// below still narrows the result to the requested status(es); this only
 		// widens what libpod itself is asked for.
 		let all = opts.all || !status_filter.is_empty();
-		let label = format!("podup.project={}", self.project);
-		let filters = serde_json::json!({ "label": [label] });
-		// `size=true` only when the column was asked for. It is not a bigger
-		// payload, it is work: libpod walks each container's writable layer to
-		// answer, measured at 21 ms → 109 ms over 59 containers on Podman
-		// 5.7.0. `docker ps -s` is opt-in for the same reason.
-		let path = format!(
-			"{API_PREFIX}/containers/json?all={}&size={}&filters={}",
-			all,
-			display.size,
-			urlencoded(&filters.to_string()),
-		);
+		let path = containers_path(&self.project, all, display.size);
 
 		let all_containers = self
 			.client

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -7,7 +7,7 @@ use crate::libpod::types::container::{ContainerListEntry, ContainerPort};
 use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::Engine;
-use crate::units::{format_duration, DurationFormat};
+use crate::units::{format_bytes, format_duration, DurationFormat, SizeFormat};
 
 /// Options for [`Engine::ps_with_options`], mirroring `docker compose ps`.
 #[derive(Default)]
@@ -18,6 +18,39 @@ pub struct PsOptions {
 	pub quiet: bool,
 	/// Emit JSON instead of the table, `--format json`.
 	pub json: bool,
+}
+
+/// Options for `ps` added after the crate's API froze.
+///
+/// **`#[non_exhaustive]` from birth, and that is the whole point.** Both
+/// [`PsOptions`] and [`PsFilterOptions`] are externally constructible with a
+/// struct literal, so adding a field to either requires a MAJOR — measured with
+/// `cargo semver-checks`, which reports `constructible_struct_adds_field`, not
+/// assumed from the rules. `PsFilterOptions` was itself introduced to keep
+/// `PsOptions` stable and inherited the same problem, so a third frozen struct
+/// would only move the wall.
+///
+/// Construct it with [`Default::default`] and the builder below; a struct
+/// literal is refused outside this crate, which is what buys the room to grow.
+#[derive(Default, Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct PsDisplayOptions {
+	/// Ask the server for each container's on-disk size and show the SIZE
+	/// column, `-s/--size`.
+	///
+	/// Off by default because it is not free: libpod walks each container's
+	/// writable layer to answer, measured at 21 ms → 109 ms over 59 containers
+	/// on Podman 5.7.0. `docker ps -s` is opt-in for the same reason.
+	pub size: bool,
+}
+
+impl PsDisplayOptions {
+	/// Ask for the SIZE column.
+	#[must_use]
+	pub fn with_size(mut self, size: bool) -> Self {
+		self.size = size;
+		self
+	}
 }
 
 /// Service/status/name filters for [`Engine::ps_filtered`] (`docker compose ps`
@@ -89,6 +122,34 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 		"" => format!("Up {uptime}"),
 		health => format!("Up {uptime} ({health})"),
 	}
+}
+
+/// How `ps` renders a size: decimal units at three significant digits.
+///
+/// The same shape `images` uses, and for the same reason — this column is read
+/// against `podman ps -s`, which prints `143kB (virtual 225MB)`. Measured
+/// against it rather than assumed.
+const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
+
+/// Table SIZE cell: the writable layer, then the image behind it.
+///
+/// `143kB (virtual 225MB)`, matching `podman ps -s` and `docker ps -s`.
+/// **`virtual` is the image's own size, not the sum** — verified on three
+/// containers whose two readings differ at three significant digits, because on
+/// a container with a small writable layer the two are indistinguishable and a
+/// wrong choice would never show.
+///
+/// Empty when the server sent no size, which is what it does unless the request
+/// asked. A blank cell says podup did not ask; `0B` would claim it did.
+fn table_size(c: &ContainerListEntry) -> String {
+	let Some(size) = &c.size else {
+		return String::new();
+	};
+	format!(
+		"{} (virtual {})",
+		format_bytes(size.rw, &SIZE_FORMAT),
+		format_bytes(size.root_fs, &SIZE_FORMAT)
+	)
 }
 
 /// Table CREATED cell, as of `now`: how long ago the container was created.
@@ -280,6 +341,12 @@ fn ps_json_row(c: &ContainerListEntry) -> serde_json::Value {
 		// wants an instant it can compute with rather than `2mo 1d`.
 		"Created": c.created,
 		"StartedAt": c.started_at,
+		// Raw byte counts, and null when the size was not requested — the same
+		// distinction the table draws between an empty cell and a zero.
+		"Size": c.size.map(|s| serde_json::json!({
+			"RwSize": s.rw,
+			"RootFsSize": s.root_fs,
+		})),
 		"ID": c.id,
 	})
 }
@@ -307,6 +374,20 @@ impl Engine {
 		file: &ComposeFile,
 		opts: PsOptions,
 		filters: PsFilterOptions,
+	) -> Result<()> {
+		self.ps_filtered_with_display(file, opts, filters, PsDisplayOptions::default())
+			.await
+	}
+
+	/// Like [`Engine::ps_filtered`], plus the options added after the API froze
+	/// ([`PsDisplayOptions`]). A separate entry point rather than a fourth
+	/// parameter on the old one, so existing callers keep compiling.
+	pub async fn ps_filtered_with_display(
+		&self,
+		file: &ComposeFile,
+		opts: PsOptions,
+		filters: PsFilterOptions,
+		display: PsDisplayOptions,
 	) -> Result<()> {
 		for name in &filters.services {
 			if !file.services.contains_key(name) {
@@ -363,9 +444,14 @@ impl Engine {
 		let all = opts.all || !status_filter.is_empty();
 		let label = format!("podup.project={}", self.project);
 		let filters = serde_json::json!({ "label": [label] });
+		// `size=true` only when the column was asked for. It is not a bigger
+		// payload, it is work: libpod walks each container's writable layer to
+		// answer, measured at 21 ms → 109 ms over 59 containers on Podman
+		// 5.7.0. `docker ps -s` is opt-in for the same reason.
 		let path = format!(
-			"{API_PREFIX}/containers/json?all={}&filters={}",
+			"{API_PREFIX}/containers/json?all={}&size={}&filters={}",
 			all,
+			display.size,
 			urlencoded(&filters.to_string()),
 		);
 
@@ -410,19 +496,30 @@ impl Engine {
 		// One clock read for the whole table, so two rows created in the same
 		// second cannot render different ages.
 		let now = now_unix();
-		let mut table = crate::ui::Table::new(&["NAME", "IMAGE", "CREATED", "STATUS", "PORTS"])
+		// SIZE is appended rather than inserted, so a reader's existing column
+		// positions do not move when the flag is off — and `docker ps -s` puts
+		// it last too.
+		let mut headers: Vec<&str> = vec!["NAME", "IMAGE", "CREATED", "STATUS", "PORTS"];
+		if display.size {
+			headers.push("SIZE");
+		}
+		let mut table = crate::ui::Table::new(&headers)
 			.cap(0, 48)
 			.cap(1, 48)
 			.status_col(3)
 			.identity_col(0);
 		for c in &containers {
-			table.push(vec![
+			let mut row = vec![
 				name_of(c),
 				c.image.clone(),
 				table_created(c, now),
 				table_status(c, now),
 				format_ports(&c.ports),
-			]);
+			];
+			if display.size {
+				row.push(table_size(c));
+			}
+			table.push(row);
 		}
 		table.print();
 

--- a/internal/engine/query/ps/tests.rs
+++ b/internal/engine/query/ps/tests.rs
@@ -349,6 +349,30 @@ fn an_unparseable_created_leaves_the_cell_blank() {
 	}
 }
 
+/// The request only asks for the size when the column was asked for.
+///
+/// Tested at this level because the string is built inside an async method that
+/// needs a live socket: a mutation hard-coding `size=true` survived every test
+/// that went in the front door. Asking unconditionally would make every `ps`
+/// pay for a filesystem walk per container.
+#[test]
+fn the_request_asks_for_the_size_only_when_the_column_was_asked_for() {
+	assert!(
+		containers_path("demo", false, true).contains("size=true"),
+		"{}",
+		containers_path("demo", false, true)
+	);
+	assert!(
+		containers_path("demo", false, false).contains("size=false"),
+		"{}",
+		containers_path("demo", false, false)
+	);
+	// The other parameters still travel, so the extraction did not drop any.
+	let path = containers_path("demo", true, false);
+	assert!(path.contains("all=true"), "{path}");
+	assert!(path.contains("podup.project%3Ddemo"), "{path}");
+}
+
 /// The exact strings `podman ps -s` printed for these containers on
 /// 2026-08-03. The column exists to be read against that output, so a
 /// divergence here is a bug rather than a matter of taste.

--- a/internal/engine/query/ps/tests.rs
+++ b/internal/engine/query/ps/tests.rs
@@ -23,6 +23,9 @@ fn entry(status: &str, state: &str) -> ContainerListEntry {
 		// the ones that render an age set these explicitly.
 		started_at: 0,
 		created: String::new(),
+		// Absent by default: libpod only fills this when the request asked, and
+		// the tests that render the cell set it explicitly.
+		size: None,
 	}
 }
 
@@ -346,6 +349,93 @@ fn an_unparseable_created_leaves_the_cell_blank() {
 	}
 }
 
+/// The exact strings `podman ps -s` printed for these containers on
+/// 2026-08-03. The column exists to be read against that output, so a
+/// divergence here is a bug rather than a matter of taste.
+#[test]
+fn the_size_cell_matches_what_podman_prints() {
+	let cases = [
+		// (rw, rootFs, what podman rendered)
+		(143_362_u64, 224_997_461_u64, "143kB (virtual 225MB)"),
+		(11_671, 134_251_404, "11.7kB (virtual 134MB)"),
+		(577_461_099, 2_082_961_972, "577MB (virtual 2.08GB)"),
+		(2_084_486, 364_639_122, "2.08MB (virtual 365MB)"),
+	];
+	for (rw, root_fs, expected) in cases {
+		let c = ContainerListEntry {
+			size: Some(crate::libpod::types::container::ContainerSize { rw, root_fs }),
+			..entry("", "running")
+		};
+		assert_eq!(table_size(&c), expected, "rw={rw} rootFs={root_fs}");
+	}
+}
+
+/// `virtual` is the image's own size, **not** the sum of the two. On a
+/// container with a small writable layer the two are indistinguishable at three
+/// significant digits, so this uses the three real containers whose readings
+/// actually differ — otherwise the test passes under either reading and pins
+/// nothing.
+#[test]
+fn virtual_is_the_image_size_and_not_the_total() {
+	let rw = 577_461_099;
+	let root_fs = 2_082_961_972;
+	let c = ContainerListEntry {
+		size: Some(crate::libpod::types::container::ContainerSize { rw, root_fs }),
+		..entry("", "running")
+	};
+	let cell = table_size(&c);
+	assert!(
+		cell.contains("2.08GB"),
+		"{cell:?} should report the image size"
+	);
+	assert!(
+		!cell.contains("2.66GB"),
+		"{cell:?} reported the sum, which is not what podman calls virtual"
+	);
+}
+
+/// A container whose size was never requested renders an empty cell rather than
+/// a zero. libpod omits the field unless the query asked, so a zero here would
+/// claim podup asked and the answer was nothing.
+#[test]
+fn a_size_that_was_not_requested_leaves_the_cell_empty() {
+	assert_eq!(table_size(&entry("", "running")), "");
+}
+
+/// A genuinely empty writable layer still renders, so the blank above is keyed
+/// on "not asked" and not on "small".
+#[test]
+fn a_zero_byte_writable_layer_still_renders() {
+	let c = ContainerListEntry {
+		size: Some(crate::libpod::types::container::ContainerSize {
+			rw: 0,
+			root_fs: 1_000_000,
+		}),
+		..entry("", "running")
+	};
+	assert_eq!(table_size(&c), "0B (virtual 1.00MB)");
+}
+
+/// The JSON path carries the raw counts, and `null` when the size was not
+/// requested — the same distinction the table draws, so a machine consumer can
+/// tell "not asked" from "empty" too.
+#[test]
+fn the_json_row_distinguishes_an_absent_size_from_a_zero() {
+	let absent = ps_json_row(&entry("", "running"));
+	assert!(absent["Size"].is_null(), "{}", absent["Size"]);
+
+	let c = ContainerListEntry {
+		size: Some(crate::libpod::types::container::ContainerSize {
+			rw: 143_362,
+			root_fs: 224_997_461,
+		}),
+		..entry("", "running")
+	};
+	let row = ps_json_row(&c);
+	assert_eq!(row["Size"]["RwSize"], serde_json::json!(143_362));
+	assert_eq!(row["Size"]["RootFsSize"], serde_json::json!(224_997_461));
+}
+
 /// The JSON path passes the wire values through rather than a rendering. A
 /// machine consumer wants an instant it can compute with, and `docker compose ps
 /// --format json` passes the RFC 3339 string through too.
@@ -386,6 +476,7 @@ fn ps_json_row_surfaces_state_exitcode_and_publishers() {
 		labels,
 		started_at: 1_785_728_082,
 		created: "2026-08-02T22:34:41.982670-05:00".into(),
+		size: None,
 	};
 	let row = ps_json_row(&c);
 	assert_eq!(row["Name"], "demo-web-1");

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -54,8 +54,9 @@ pub use engine::{
 	is_safe_project_name, list_projects, list_projects_filtered, resolve_image_digests,
 	retain_active_profiles, retain_active_profiles_with_targets, validate_stop_timeout,
 	AttachOutcome, BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions,
-	ImagesOptions, LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsFilterOptions, PsOptions,
-	PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesOptions,
+	ImagesOptions, LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsDisplayOptions,
+	PsFilterOptions, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions,
+	VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/libpod/types/container/mod.rs
+++ b/internal/libpod/types/container/mod.rs
@@ -5,8 +5,8 @@ mod spec;
 
 #[allow(unused_imports)]
 pub use response::{
-	ContainerInspect, ContainerListEntry, ContainerPort, ContainerState, HealthState, HostBinding,
-	NetworkSettings, TopResponse,
+	ContainerInspect, ContainerListEntry, ContainerPort, ContainerSize, ContainerState,
+	HealthState, HostBinding, NetworkSettings, TopResponse,
 };
 #[allow(unused_imports)]
 pub use spec::{

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -60,6 +60,13 @@ pub struct ContainerListEntry {
 	/// state rather than on this being non-zero.
 	#[serde(rename = "StartedAt", default)]
 	pub started_at: i64,
+	/// On-disk size, present only when the request carried `size=true`.
+	///
+	/// `None` is the ordinary case: libpod leaves it out unless asked, because
+	/// producing it means walking the container's writable layer. Callers render
+	/// an empty cell rather than a zero, so "not asked" never reads as "empty".
+	#[serde(rename = "Size", default)]
+	pub size: Option<ContainerSize>,
 	/// When the container was created, as an RFC 3339 string.
 	///
 	/// Not the docker-compatible `CreatedAt`, which libpod also sends and leaves
@@ -67,6 +74,19 @@ pub struct ContainerListEntry {
 	/// blank column, the same trap as `Status` versus `State` above.
 	#[serde(rename = "Created", default)]
 	pub created: String,
+}
+
+/// A container's on-disk footprint, as `containers/json?size=true` reports it.
+#[derive(Deserialize, Clone, Copy, Debug)]
+pub struct ContainerSize {
+	/// Bytes the container has written on top of its image.
+	#[serde(rename = "rwSize", default)]
+	pub rw: u64,
+	/// The image's own size. This is what `podman ps -s` prints as `virtual`,
+	/// and it is **not** the sum of the two — verified against three containers
+	/// whose two readings differ at three significant digits.
+	#[serde(rename = "rootFsSize", default)]
+	pub root_fs: u64,
 }
 
 /// Port mapping entry in container list response.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -297,6 +297,7 @@ async fn run() -> podup::Result<()> {
 		all,
 		quiet,
 		services_only,
+		size,
 		filter,
 		status,
 		format,
@@ -337,7 +338,7 @@ async fn run() -> podup::Result<()> {
 		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
 		let engine = podup::Engine::with_base_dir(client, project, base_dir);
 		return engine
-			.ps_filtered(
+			.ps_filtered_with_display(
 				&file,
 				podup::PsOptions {
 					all: *all,
@@ -350,6 +351,7 @@ async fn run() -> podup::Result<()> {
 					status: status.clone(),
 					filters: filter.clone(),
 				},
+				podup::PsDisplayOptions::default().with_size(*size),
 			)
 			.await;
 	}

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -503,6 +503,7 @@ mod tests {
 			all: false,
 			quiet: false,
 			services_only: false,
+			size: false,
 			filter: vec![],
 			status: vec![],
 			format: OutputFormat::Table,


### PR DESCRIPTION
Closes #1312. Third of the non-VM issues.

## The column, against the reference

```
podup ps -s      refimages-plain-1  11.3kB (virtual 4.67MB)
podman ps -s     refimages-plain-1  11.3kB (virtual 4.67MB)
```

Byte-identical, measured on the same socket.

**`virtual` is the image's own size, not the sum of the two.** That took finding
three containers with a large writable layer to establish — on an ordinary one
the two readings are indistinguishable at three significant digits, so a wrong
choice would never have shown:

| container | podman prints | `rootFsSize` | sum |
|---|---|---|---|
| api | `577MB (virtual 2.08GB)` | **2.08GB** | 2.66GB |
| bari | `2.08MB (virtual 365MB)` | **365MB** | 367MB |
| petguia | `1.44MB (virtual 664MB)` | **664MB** | 665MB |

## Why it is opt-in

`size=true` is not a bigger payload, it is work: libpod walks each container's
writable layer to answer. Over 59 containers on Podman 5.7.0 the call went from
21 ms to 109 ms. `docker ps -s` is opt-in for the same reason.

**Honest scope on that number:** `podup ps` is project-scoped, so on the
two-service project I tested the difference is below noise. The cost scales with
containers in the project, and the 5x figure is the whole-host measurement, not
what a small project pays. The PR does not claim otherwise.

## A frozen API, and the wall the existing escape hatch hits

`PsFilterOptions` carries a doc comment saying it exists "so the published
library API stays stable across minors". **It does not work for that**, and I
measured rather than assumed: adding a field to it makes `cargo semver-checks`
report `constructible_struct_adds_field — semver requires new major version`. It
is externally constructible with a struct literal, exactly like the `PsOptions`
it was meant to protect, so it only moved the wall.

So the option went into a new `PsDisplayOptions`, **`#[non_exhaustive]` from
birth**, reached through a new `ps_filtered_with_display` that the old
`ps_filtered` delegates into. semver-checks: **223 pass, no semver update
required.**

SIZE is appended rather than inserted, so existing column positions do not move
when the flag is off — and `docker ps -s` puts it last too.

## Absent is not zero

An empty cell means the size was never requested; the JSON field is `null` in
that case and carries raw counts otherwise. A consumer can tell "not asked" from
a genuinely empty writable layer, which a `0` would erase.

## Two mutation rounds, and a driver that lied

First round: **all five survived** — which was the driver, not the code. An
in-place `sed` had mangled its command into `2>cargo test ...`, redirecting the
output to a file, so nothing ever matched `test result: FAILED` and every
mutation looked alive. It also left a stray file in the repo root.

The driver now refuses to run unless a baseline pass reports a non-zero test
count under its own filter. With that guard: **5 of 5 killed** — `virtual` as
the sum, the two numbers swapped, an absent size rendered as zero, the binary
ladder, and the request hard-coded to `size=true`.

That last one survived legitimately at first: the URL was built inside an async
method needing a live socket, so no test could reach it. Extracted to a pure
`containers_path` and pinned.

## Test plan

- 31 `ps` unit tests; every size string captured from `podman ps -s` rather than
  computed by hand.
- 5 mutations, 5 killed, under a driver whose own command is now verified.
- `cargo semver-checks`: 223 pass, no update required.
- Full lib suite 1513; integration **177/177 against real Podman 5.7.0**;
  `output_contract`, `docs_flags` and `cli_flags` green.
- `docs_flags` caught the undocumented flag before CI did; `docs/commands.md`
  now describes the column, its units, the cost and the JSON `null`.