### PR TITLE
feat(volumes): add opt-in SIZE and RECLAIMABLE columns

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -275,7 +275,7 @@ the raw byte count, not the rendered string.
 | `-q, --quiet` | Print image IDs only. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
 
-### `ps` columns
+### The ps CREATED and STATUS columns
 
 `STATUS` reports how long a running container has been up (`Up 2h 5m 3s`), with
 its health in parentheses when it has a healthcheck (`Up 13h (healthy)`). A
@@ -302,7 +302,27 @@ empty — `1y 2mo 3d`, `1h 5m 3s`, `5s`. A year is 365 days and a month is 30.
 Under `--format json` the raw wire values are passed through instead: `Created`
 is the RFC 3339 string and `StartedAt` is Unix seconds.
 
-### `events` timestamps
+### Volume size accounting
+
+`SIZE` is what the volume occupies; `RECLAIMABLE` is what removing it would free.
+The two differ and both are worth seeing: a volume a container still uses reports
+its full size and **zero** reclaimable, which is the fact that matters when you
+are clearing disk space.
+
+A volume declared in the compose file but never created renders both cells empty
+rather than `0B` — an empty cell says it is not there, while `0B` would claim it
+exists and holds nothing.
+
+**It is opt-in because it is slow, not because it is verbose.** No libpod
+endpoint reports a single volume's size; the only one that knows is `system/df`,
+which accounts for every image, container and volume on the host. Measured on
+Podman 5.7.0 with 46 volumes: 1.2 s, against 10 ms for the plain list. podup
+makes that call once per table, never once per row.
+
+Under `--format json` each entry gains a `Usage` object with the raw byte counts
+and the container link count, and `Usage` is `null` when `--size` was not given.
+
+### Event timestamps
 
 The `TIME` column is the reader's own wall clock, with the offset that applied at
 that instant: `2026-08-02 23:43:35 -05:00`. That matches what `podman events`
@@ -325,6 +345,7 @@ neither creates nor deletes an external volume, so those are the ones a
 | Flag | Description | Default |
 |---|---|---|
 | `-q, --quiet` | Print volume names only. | off |
+| `-s, --size` | Add SIZE and RECLAIMABLE columns. Slow — see below. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
 
 ## Container operations

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -487,6 +487,11 @@ pub(crate) enum Commands {
 		/// Only display volume names. Mutually exclusive with `--format`.
 		#[arg(short, long, conflicts_with = "format")]
 		quiet: bool,
+		/// Show each volume's size and how much removing it would reclaim.
+		/// Slow: the only endpoint carrying a volume's size accounts for the
+		/// whole host, which measured 1.2s against 10ms for the plain list.
+		#[arg(short = 's', long)]
+		size: bool,
 		/// Output format.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Table)]
 		format: OutputFormat,

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -187,17 +187,19 @@ pub(super) async fn dispatch_rest(
 		}
 		Commands::Volumes {
 			quiet,
+			size,
 			format,
 			services,
 		} => {
 			engine
-				.list_volumes(
+				.list_volumes_with_display(
 					file,
 					&services,
 					podup::VolumesOptions {
 						quiet,
 						json: format == OutputFormat::Json,
 					},
+					podup::VolumesDisplayOptions::default().with_size(size),
 				)
 				.await?
 		}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -64,7 +64,7 @@ mod stats;
 pub use staging::is_safe_project_name;
 pub use stats::StatsOptions;
 mod volume;
-pub use volume::VolumesOptions;
+pub use volume::{VolumesDisplayOptions, VolumesOptions};
 mod volume_mounts;
 #[cfg(feature = "watch")]
 mod watch;

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -9,8 +9,46 @@ use std::collections::BTreeSet;
 
 use crate::compose::types::{ComposeFile, VolumeMount};
 use crate::error::Result;
+use crate::libpod::types::volume::SystemDf;
+use crate::libpod::API_PREFIX;
+use crate::units::{format_bytes, SizeFormat};
 
 use super::super::Engine;
+
+/// How `volumes` renders a size: decimal units at three significant digits.
+///
+/// Three rather than the four `podman system df -v` prints (`193.2MB`,
+/// `67.33MB`, measured on Podman 5.7.0). podman is not self-consistent here —
+/// `podman images` and `podman ps -s` both use three — and matching podup's own
+/// other size columns is worth more than reproducing that split.
+const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
+
+/// Options for `volumes` added after the crate's API froze.
+///
+/// `#[non_exhaustive]` from birth: [`VolumesOptions`] is externally
+/// constructible with a struct literal, so adding a field to it requires a
+/// MAJOR — `cargo semver-checks` reports `constructible_struct_adds_field`.
+/// Same reasoning, and the same shape, as `PsDisplayOptions`.
+#[derive(Default, Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct VolumesDisplayOptions {
+	/// Show SIZE and RECLAIMABLE, `-s/--size`.
+	///
+	/// Off by default and expensive when on: the only endpoint carrying a
+	/// volume's size is `system/df`, which accounts for every image, container
+	/// and volume on the host. Measured at **1.2 s against 10 ms** for the plain
+	/// volume list, on a host with 46 volumes.
+	pub size: bool,
+}
+
+impl VolumesDisplayOptions {
+	/// Ask for the size columns.
+	#[must_use]
+	pub fn with_size(mut self, size: bool) -> Self {
+		self.size = size;
+		self
+	}
+}
 
 /// Options for [`Engine::list_volumes`], mirroring `docker compose volumes`.
 #[derive(Default)]
@@ -29,6 +67,20 @@ impl Engine {
 		file: &ComposeFile,
 		services: &[String],
 		opts: VolumesOptions,
+	) -> Result<()> {
+		self.list_volumes_with_display(file, services, opts, VolumesDisplayOptions::default())
+			.await
+	}
+
+	/// Like [`Engine::list_volumes`], plus the options added after the API froze
+	/// ([`VolumesDisplayOptions`]). A separate entry point rather than a fourth
+	/// parameter on the old one, so existing callers keep compiling.
+	pub async fn list_volumes_with_display(
+		&self,
+		file: &ComposeFile,
+		services: &[String],
+		opts: VolumesOptions,
+		display: VolumesDisplayOptions,
 	) -> Result<()> {
 		// Reject an unknown service name (docker compose errors with "no such
 		// service") instead of silently filtering it out and printing nothing.
@@ -63,11 +115,36 @@ impl Engine {
 			}
 			return Ok(());
 		}
+		// One `system/df` for the whole table when the size was asked for, never
+		// per row: the call accounts for the entire host, so asking once per
+		// volume would multiply a 1.2 s answer by the number of rows.
+		let usage = if display.size {
+			self.volume_disk_usage().await?
+		} else {
+			std::collections::HashMap::new()
+		};
+
 		if opts.json {
 			let arr: Vec<_> = rows
 				.iter()
 				.map(|(_, name, driver, external)| {
-					serde_json::json!({ "Name": name, "Driver": driver, "External": external })
+					// Raw byte counts, and absent entirely when the size was not
+					// requested — a consumer can tell "not asked" from "empty",
+					// the same distinction the table draws.
+					let size = display.size.then(|| {
+						let u = usage.get(name.as_str());
+						serde_json::json!({
+							"Size": u.map(|u| u.size).unwrap_or(0),
+							"ReclaimableSize": u.map(|u| u.reclaimable).unwrap_or(0),
+							"Links": u.map(|u| u.links).unwrap_or(0),
+						})
+					});
+					serde_json::json!({
+						"Name": name,
+						"Driver": driver,
+						"External": external,
+						"Usage": size,
+					})
 				})
 				.collect();
 			println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
@@ -92,19 +169,53 @@ impl Engine {
 		// the table was the least visible one. `caution_col` rather than
 		// `status_col`: green would say "healthy", and an external volume is not
 		// healthy or unhealthy — it is the one podup will not delete.
-		let mut table = crate::ui::Table::new(&["NAME", "DRIVER", "EXTERNAL"])
+		//
+		// SIZE and RECLAIMABLE are appended rather than inserted, so a reader's
+		// existing column positions do not move when the flag is off.
+		let mut headers: Vec<&str> = vec!["NAME", "DRIVER", "EXTERNAL"];
+		if display.size {
+			headers.push("SIZE");
+			headers.push("RECLAIMABLE");
+		}
+		let mut table = crate::ui::Table::new(&headers)
 			.cap(0, 48)
 			.identity_col(0)
 			.caution_col(2);
 		for (_, name, driver, external) in &rows {
-			table.push(vec![
+			let mut row = vec![
 				name.clone(),
 				driver.clone(),
 				if *external { "yes" } else { "no" }.to_string(),
-			]);
+			];
+			if display.size {
+				let (size, reclaimable) = size_cells(usage.get(name.as_str()));
+				row.push(size);
+				row.push(reclaimable);
+			}
+			table.push(row);
 		}
 		table.print();
 		Ok(())
+	}
+
+	/// Per-volume disk usage from `system/df`, keyed by on-host volume name.
+	///
+	/// One call for the whole table. libpod has no per-volume size endpoint —
+	/// this one walks the entire installation — so the cost is paid once or not
+	/// at all.
+	async fn volume_disk_usage(
+		&self,
+	) -> Result<std::collections::HashMap<String, crate::libpod::types::volume::VolumeDiskUsage>> {
+		let df: SystemDf = self
+			.client
+			.get_json(&format!("{API_PREFIX}/system/df"))
+			.await
+			.map_err(crate::error::ComposeError::Podman)?;
+		Ok(df
+			.volumes
+			.into_iter()
+			.map(|v| (v.name.clone(), v))
+			.collect())
 	}
 
 	/// The top-level volume keys to list: all of them, or just those mounted by
@@ -170,3 +281,28 @@ mod tests {
 		assert_eq!(mount_source_name(&VolumeMount::Short("/data".into())), None);
 	}
 }
+
+/// The SIZE and RECLAIMABLE cells for one volume.
+///
+/// A volume the accounting does not mention renders empty rather than `0B`:
+/// libpod lists what exists on the host, and a compose file can declare a volume
+/// that has never been created. An empty cell says "not there"; `0B` would claim
+/// it exists and is empty.
+///
+/// RECLAIMABLE is shown next to SIZE rather than instead of it because the two
+/// answer different questions: a volume still linked by a container reports its
+/// full size and **zero** reclaimable, which is the fact someone clearing disk
+/// space actually needs.
+fn size_cells(usage: Option<&crate::libpod::types::volume::VolumeDiskUsage>) -> (String, String) {
+	match usage {
+		Some(u) => (
+			format_bytes(u.size, &SIZE_FORMAT),
+			format_bytes(u.reclaimable, &SIZE_FORMAT),
+		),
+		None => (String::new(), String::new()),
+	}
+}
+
+#[cfg(test)]
+#[path = "list_tests.rs"]
+mod size_tests;

--- a/internal/engine/volume/list_tests.rs
+++ b/internal/engine/volume/list_tests.rs
@@ -1,0 +1,55 @@
+use super::size_cells;
+use crate::libpod::types::volume::VolumeDiskUsage;
+
+fn usage(size: u64, reclaimable: u64) -> VolumeDiskUsage {
+	VolumeDiskUsage {
+		name: "vol".into(),
+		size,
+		reclaimable,
+		links: 1,
+	}
+}
+
+/// The byte counts `system/df` really reported on this host, rendered the way
+/// podup renders every other size: decimal, three significant digits.
+///
+/// `podman system df -v` prints four (`193.2MB`, `67.33MB`, measured 2026-08-03)
+/// while `podman images` and `podman ps -s` print three. podman is not
+/// self-consistent, so matching podup's own columns wins — recorded here so the
+/// divergence is a decision rather than an accident somebody later "fixes".
+#[test]
+fn the_size_cells_render_at_three_significant_digits() {
+	assert_eq!(size_cells(Some(&usage(193_243_902, 0))).0, "193MB");
+	assert_eq!(size_cells(Some(&usage(67_331_781, 0))).0, "67.3MB");
+	assert_eq!(size_cells(Some(&usage(0, 0))).0, "0B");
+}
+
+/// A volume the host accounting never mentions renders empty, not `0B`.
+///
+/// A compose file can declare a volume that has never been created, and libpod
+/// only reports what exists. An empty cell says it is not there; `0B` would
+/// claim it exists and holds nothing — two different answers a reader would act
+/// on differently.
+#[test]
+fn a_volume_that_does_not_exist_yet_renders_empty() {
+	assert_eq!(size_cells(None), (String::new(), String::new()));
+}
+
+/// A volume that exists and is genuinely empty renders `0B`, so the blank above
+/// is keyed on absence and not on size.
+#[test]
+fn an_existing_empty_volume_renders_zero() {
+	assert_eq!(size_cells(Some(&usage(0, 0))), ("0B".into(), "0B".into()));
+}
+
+/// SIZE and RECLAIMABLE are different numbers and both are shown. A volume a
+/// container still links reports its full size and zero reclaimable, which is
+/// the fact someone clearing disk space needs — collapsing the two would hide
+/// exactly the case worth seeing.
+#[test]
+fn reclaimable_is_reported_separately_from_size() {
+	let linked = size_cells(Some(&usage(193_243_902, 0)));
+	assert_eq!(linked, ("193MB".into(), "0B".into()));
+	let unlinked = size_cells(Some(&usage(193_243_902, 193_243_902)));
+	assert_eq!(unlinked, ("193MB".into(), "193MB".into()));
+}

--- a/internal/engine/volume/mod.rs
+++ b/internal/engine/volume/mod.rs
@@ -15,7 +15,7 @@ use crate::libpod::{urlencoded, API_PREFIX};
 use super::Engine;
 
 mod list;
-pub use list::VolumesOptions;
+pub use list::{VolumesDisplayOptions, VolumesOptions};
 
 impl Engine {
 	/// Pre-create every declared (non-external) named volume before containers

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -56,7 +56,7 @@ pub use engine::{
 	AttachOutcome, BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions,
 	ImagesOptions, LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsDisplayOptions,
 	PsFilterOptions, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions,
-	VolumesOptions,
+	VolumesDisplayOptions, VolumesOptions,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/libpod/types/volume.rs
+++ b/internal/libpod/types/volume.rs
@@ -49,3 +49,36 @@ mod tests {
 		assert_eq!(v["Options"]["type"], "nfs");
 	}
 }
+
+/// The `system/df` response, reduced to the part `volumes --size` needs.
+///
+/// **This is the only endpoint that knows a volume's size.** The volume list
+/// carries no size field at all, so answering "how big is this volume" means
+/// asking libpod to account for every image, container and volume it owns —
+/// measured at 1.2 s against 10 ms for the plain list on a host with 46
+/// volumes. That cost is why the column is opt-in rather than default.
+#[derive(serde::Deserialize, Default)]
+pub struct SystemDf {
+	/// Per-volume disk accounting.
+	#[serde(rename = "Volumes", default)]
+	pub volumes: Vec<VolumeDiskUsage>,
+}
+
+/// One volume's disk usage, as `system/df` reports it.
+#[derive(serde::Deserialize, Clone)]
+pub struct VolumeDiskUsage {
+	/// The on-host volume name, which is what the list endpoint calls `Name`.
+	#[serde(rename = "VolumeName", default)]
+	pub name: String,
+	/// Bytes the volume occupies.
+	#[serde(rename = "Size", default)]
+	pub size: u64,
+	/// Bytes that would be freed by removing it — zero while a container still
+	/// links the volume, which is what makes it worth showing next to the size
+	/// rather than instead of it.
+	#[serde(rename = "ReclaimableSize", default)]
+	pub reclaimable: u64,
+	/// How many containers reference the volume.
+	#[serde(rename = "Links", default)]
+	pub links: u64,
+}


### PR DESCRIPTION
Closes #1304.

## Live, on this host

```
$ podup volumes
NAME                   DRIVER EXTERNAL
volcheck_data          local  no

$ podup volumes -s
NAME                   DRIVER EXTERNAL SIZE   RECLAIMABLE
volcheck_data          local  no       12.6MB 0B
```

`podman system df -v` reports `12.58MB` for the same volume. The difference is
deliberate — see the precision note below.

## Why it is opt-in

No libpod endpoint reports a single volume's size. The only one that knows is
`system/df`, which accounts for **every image, container and volume on the
host**. Measured through podup itself:

| | wall clock |
|---|---|
| `podup volumes` | 0.00 s |
| `podup volumes -s` | 1.18 s |

The call is made once per table, never once per row.

## I changed my mind about the shape, and here is why

The issue records me leaning toward a separate `podup system df`. **That was
wrong about the product.** `system/df` is host-wide data, and podup is a
project-scoped tool: the question a compose user has is "what do *my* volumes
cost", not "what does this machine hold". A flag on `volumes` answers that and is
symmetric with the `ps --size` that just landed. Recorded here rather than
silently switched.

## Both numbers, not one

A volume a container still links reports its **full size and zero reclaimable** —
exactly the case above. That is the fact someone clearing disk space needs, and
collapsing the two columns would hide it.

A volume declared in the compose file but never created renders **empty rather
than `0B`**: libpod reports what exists, so a blank says it is not there while
`0B` would claim it exists and holds nothing.

## Three significant digits, against podman's four here

`podman system df -v` prints `193.2MB` and `67.33MB` — four. `podman images` and
`podman ps -s` print three. **podman is not self-consistent**, so matching
podup's own other size columns wins. Pinned by a test whose comment says so, and
by a mutation that switches to four and dies, so nobody later "fixes" it.

## The frozen-API wall again

`VolumesOptions` is externally constructible, so adding a field to it requires a
MAJOR. Same measured reason as `PsDisplayOptions`, same shape: a new
`#[non_exhaustive] VolumesDisplayOptions` reached through
`list_volumes_with_display`, with the old entry point delegating.
`cargo semver-checks`: **223 pass, no update required.**

## A gate that gave a wrong answer, and what caused it

`docs_flags` reported `volumes: --quiet` undocumented while it was plainly in the
table. Cause, confirmed by reproducing it in both directions: I had added a prose
section titled ``### `volumes --size` ``, and the gate matches a section by the
first backticked word of its heading. Mine sat **before** the real `volumes`
section, so the parser found it first and read a section with no flags in it.

Renamed to "Volume size accounting". The two prose headings I introduced earlier
(``### `ps` columns``, ``### `events` timestamps``) had the same latent shape and
only escaped because they happened to sit *after* their commands' real sections —
both renamed too, so the gate no longer depends on ordering.

## Test plan

- 6 volume unit tests; the byte counts are the ones `system/df` really reported.
- **4 mutations, 4 killed:** absent rendered as `0B`, reclaimable mirroring size,
  four significant digits, and the binary ladder.
- `cargo semver-checks` 223 pass; clippy and fmt clean with the CI's own flags.
- Full lib suite 1511; `output_contract` and `docs_flags` green.

## One thing I could not close out

One integration run reported **2 failures out of 177** and I did not capture the
output, so the identities are lost. Two subsequent full runs are clean
(177/177). The failing run took **230 s against the usual ~121 s**, so host load
is the first suspect — but that is a guess, and I am reporting it as an
unidentified flake rather than calling it noise. If it recurs on this branch's
CI, that is the thread to pull.