### PR TITLE
fix(cp): confirm an upload by matching what was sent, not by the mtime moving

### DIFF
--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -7,6 +7,7 @@ use http_body_util::{BodyExt, Limited};
 
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
+use crate::libpod::client::PathStat;
 use crate::libpod::urlencoded;
 use crate::libpod::API_PREFIX;
 
@@ -207,8 +208,21 @@ impl Engine {
 				.map(|n| n.to_string_lossy().into_owned())
 				.unwrap_or_default()
 		});
-		self.put_archive_verified(&container_name, &extract_dir, &entry, tar_bytes)
-			.await
+		// The size the destination entry must end up with. Only a regular file
+		// has one to compare; a directory upload stays unverifiable and
+		// fail-closed, as it was before.
+		let uploaded_size = std::fs::metadata(src)
+			.ok()
+			.filter(std::fs::Metadata::is_file)
+			.map(|m| m.len());
+		self.put_archive_verified(
+			&container_name,
+			&extract_dir,
+			&entry,
+			tar_bytes,
+			uploaded_size,
+		)
+		.await
 	}
 
 	/// PUT a gzipped tar to a container's archive endpoint at `dir`, extracting
@@ -221,23 +235,30 @@ impl Engine {
 	/// measured on 6.0.1; every raw request to the same endpoint gets a clean
 	/// 200, so the trigger is client-side and could not be stripped out). To tell
 	/// that apply-then-close apart from a *genuine* upload failure (a dropped
-	/// socket, a truncated body), capture `dir/entry`'s mtime before the PUT and,
-	/// on an `IncompleteMessage`, treat the copy as landed only if that mtime
-	/// moved — the extracted file takes the source's mtime, so an unchanged one
-	/// means a failed upload left the old entry in place. Fails, rather than
-	/// guessing, when the entry has no name (`cp . svc:/`), when the pre- or
-	/// post-PUT stat cannot be read, or when the mtime did not move.
+	/// socket, a truncated body), read `dir/entry` after the PUT and treat the
+	/// copy as landed only if it now **matches what was uploaded**, which is what
+	/// `uploaded_size` carries.
 	///
-	/// Known limit: the mtime of a *directory* entry moves only when its own
-	/// children are added or removed, so re-syncing a tree whose only change is
-	/// deeper than the top level is reported as unverifiable (fail-closed, never a
-	/// false success). Inert on Podman 5, which returns a normal response.
+	/// This used to compare the entry's mtime before and after and require it to
+	/// move. That signal cannot express the question: Podman 6 reports the mtime
+	/// to whole seconds, so two copies inside one second look identical
+	/// (#1270 — three failures in six back-to-back copies, measured), and
+	/// re-copying an *unchanged* file is undetectable at any resolution because
+	/// the extracted file takes the source's own mtime.
+	///
+	/// Fails, rather than guessing, when the entry has no name (`cp . svc:/`),
+	/// when the source size is unknown, or when the post-PUT stat cannot be read.
+	///
+	/// Known limit: a *directory* entry has no size to compare, so re-syncing a
+	/// tree is reported as unverifiable (fail-closed, never a false success).
+	/// Inert on Podman 5, which returns a normal response.
 	pub(super) async fn put_archive_verified(
 		&self,
 		container: &str,
 		dir: &str,
 		entry: &str,
 		tar_bytes: Vec<u8>,
+		uploaded_size: Option<u64>,
 	) -> Result<()> {
 		let path = format!(
 			"{API_PREFIX}/containers/{}/archive?path={}",
@@ -251,13 +272,24 @@ impl Engine {
 				urlencoded(&join_archive_path(dir, entry)),
 			)
 		});
-		// The pre-PUT mtime, only when it can be read cleanly. `None` means
-		// "unknown" (no verifiable entry, or the stat failed) and forces a later
-		// IncompleteMessage to fail rather than guess.
-		let pre_mtime = match &verify_path {
-			Some(p) => self.client.head_path_mtime(p).await.ok(),
-			None => None,
-		};
+		// What the destination entry must look like once the archive is applied.
+		//
+		// This used to read the entry's mtime *before* the PUT and check that it
+		// moved afterwards. That cannot work: Podman 6 reports the mtime to
+		// whole seconds, so two copies inside one second are indistinguishable
+		// — measured at three failures in six back-to-back copies (#1270) — and
+		// copying an unchanged file twice is undetectable at any resolution,
+		// because the extracted file takes the source's own mtime.
+		//
+		// The question the confirmation should ask is not "did the entry
+		// change" but "does the entry now match what was uploaded". `None`
+		// means the answer is unknowable (no verifiable entry, or the source
+		// could not be stat'd) and forces a later IncompleteMessage to fail
+		// rather than guess.
+		let expected = verify_path
+			.as_ref()
+			.and(uploaded_size)
+			.map(|size| ExpectedEntry { size });
 
 		// `application/gzip` is the honest label for the gzipped tar; Podman
 		// sniffs the magic bytes and forgives either.
@@ -273,9 +305,9 @@ impl Engine {
 		if !e.is_incomplete_message() {
 			return Err(ComposeError::Podman(e));
 		}
-		let landed = match (&verify_path, pre_mtime) {
-			(Some(p), Some(pre)) => match self.client.head_path_mtime(p).await {
-				Ok(post) => copy_landed(pre.as_deref(), post.as_deref()),
+		let landed = match (&verify_path, &expected) {
+			(Some(p), Some(want)) => match self.client.head_path_stat(p).await {
+				Ok(post) => copy_landed(want, post.as_ref()),
 				Err(stat_err) => {
 					tracing::debug!(
 						"cp: could not re-verify {p} after an incomplete PUT: {stat_err}"
@@ -298,15 +330,38 @@ impl Engine {
 	}
 }
 
+/// What the destination entry must look like for the upload to have landed.
+///
+/// Only the size for now. The mtime is deliberately not part of it: the archive
+/// sets it from the source, but Podman reports it to whole seconds while the
+/// source's own mtime carries sub-second precision, so comparing the two would
+/// re-introduce a resolution mismatch — this time as a false *negative* on a
+/// copy that did land.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ExpectedEntry {
+	size: u64,
+}
+
 /// Whether a `cp`/sync whose archive PUT ended in an `IncompleteMessage`
-/// actually landed, from the destination entry's mtime before and after the
-/// PUT. The entry must exist now (`post` is `Some`) and its mtime must differ
-/// from before — the extracted file takes the source's mtime, so an unchanged
-/// mtime means a failed upload left the old entry in place. A vanished entry, or
-/// one whose mtime did not move, is "did not land". Pure so the decision is
-/// unit-tested without a container.
-fn copy_landed(pre: Option<&str>, post: Option<&str>) -> bool {
-	post.is_some() && post != pre
+/// actually landed, by comparing the destination entry against what was
+/// uploaded.
+///
+/// The entry must exist and its size must equal the source's. **Not "did it
+/// change"**, which is what this asked before: Podman 6's mtime has one-second
+/// resolution, so a second copy inside the same second reported an unchanged
+/// mtime and a copy that had landed was called a failure (#1270, measured at
+/// three failures in six). Copying an unchanged file twice was undetectable at
+/// any resolution, since the extracted file takes the source's own mtime.
+///
+/// The residual false positive is a failed upload onto an entry that already
+/// happened to be the same size. It is benign in a way the old false negative
+/// was not: the destination already holds bytes of the length the caller
+/// intended, and the caller is told the copy succeeded rather than being told a
+/// successful copy failed.
+///
+/// Pure so the decision is unit-tested without a container.
+fn copy_landed(expected: &ExpectedEntry, post: Option<&PathStat>) -> bool {
+	post.is_some_and(|entry| entry.size == expected.size)
 }
 
 /// Join a container directory and an entry name into one path, without doubling
@@ -380,7 +435,7 @@ fn parse_endpoint(s: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-	use super::{copy_landed, join_archive_path, parse_endpoint};
+	use super::{copy_landed, join_archive_path, parse_endpoint, ExpectedEntry, PathStat};
 
 	#[test]
 	fn join_archive_path_does_not_double_the_separator() {
@@ -393,23 +448,61 @@ mod tests {
 	}
 
 	#[test]
-	fn copy_landed_requires_the_entry_to_exist_and_its_mtime_to_move() {
-		// A brand-new destination: absent before, present after -> landed.
-		assert!(copy_landed(None, Some("2026-01-01T00:00:00Z")));
-		// An overwrite that applied: the entry's mtime changed to the source's.
-		assert!(copy_landed(
-			Some("2026-01-01T00:00:00Z"),
-			Some("2026-06-01T00:00:00Z")
-		));
-		// An overwrite whose PUT actually failed: the old entry is still there,
-		// unchanged. This is the silent-success the mtime check exists to prevent.
-		assert!(!copy_landed(
-			Some("2026-01-01T00:00:00Z"),
-			Some("2026-01-01T00:00:00Z")
-		));
-		// The entry vanished (or never appeared): not landed.
-		assert!(!copy_landed(Some("2026-01-01T00:00:00Z"), None));
-		assert!(!copy_landed(None, None));
+	fn copy_landed_asks_whether_the_entry_matches_what_was_uploaded() {
+		let want = ExpectedEntry { size: 42 };
+		let stat = |size: u64| PathStat {
+			size,
+			..PathStat::default()
+		};
+		// The entry is there and is the size that was sent -> landed.
+		assert!(copy_landed(&want, Some(&stat(42))));
+		// A failed PUT leaves the old entry, which is a different size.
+		assert!(!copy_landed(&want, Some(&stat(41))));
+		assert!(!copy_landed(&want, Some(&stat(0))));
+		// The entry vanished, or never appeared.
+		assert!(!copy_landed(&want, None));
+	}
+
+	/// The case the previous signal could not express, and the reason it
+	/// changed: copying the **same** file twice.
+	///
+	/// The old check required the destination's mtime to move. The archive sets
+	/// that mtime from the source, so re-copying an unchanged file leaves it
+	/// identical by construction — no resolution would have helped — and the
+	/// second copy was reported as a failure. Matching against what was uploaded
+	/// answers correctly.
+	#[test]
+	fn copying_an_unchanged_file_twice_is_confirmed() {
+		let want = ExpectedEntry { size: 42 };
+		let already_there = PathStat {
+			size: 42,
+			..PathStat::default()
+		};
+		assert!(copy_landed(&want, Some(&already_there)));
+	}
+
+	/// Two copies inside one second, which is what #1270 measured on Podman 6:
+	/// the mtime string is identical either side of the PUT because the runtime
+	/// reports whole seconds, while the size moved. Under the old signal this
+	/// was three failures in six back-to-back copies.
+	#[test]
+	fn two_copies_in_the_same_second_are_told_apart_by_size() {
+		let same_second = "2026-08-03T18:36:05Z";
+		let before = PathStat {
+			size: 14,
+			mtime: same_second.into(),
+			..PathStat::default()
+		};
+		let after = PathStat {
+			size: 15,
+			mtime: same_second.into(),
+			..PathStat::default()
+		};
+		assert_eq!(before.mtime, after.mtime, "the fixture must share an mtime");
+		// What was uploaded is the 15-byte version.
+		assert!(copy_landed(&ExpectedEntry { size: 15 }, Some(&after)));
+		// And the pre-PUT entry would not have satisfied it.
+		assert!(!copy_landed(&ExpectedEntry { size: 15 }, Some(&before)));
 	}
 
 	#[test]

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -208,13 +208,7 @@ impl Engine {
 				.map(|n| n.to_string_lossy().into_owned())
 				.unwrap_or_default()
 		});
-		// The size the destination entry must end up with. Only a regular file
-		// has one to compare; a directory upload stays unverifiable and
-		// fail-closed, as it was before.
-		let uploaded_size = std::fs::metadata(src)
-			.ok()
-			.filter(std::fs::Metadata::is_file)
-			.map(|m| m.len());
+		let uploaded_size = uploaded_entry_size(src);
 		self.put_archive_verified(
 			&container_name,
 			&extract_dir,
@@ -330,6 +324,25 @@ impl Engine {
 	}
 }
 
+/// The size the destination entry must end up with, or `None` when there is
+/// nothing to compare.
+///
+/// Only a regular file has a size the archive preserves. A directory upload
+/// stays unverifiable and therefore fail-closed, which is what it was before —
+/// a directory entry's own size says nothing about whether its children
+/// arrived. A source that cannot be stat'd is `None` for the same reason:
+/// unknown must not become a guess.
+///
+/// Extracted so it is reachable from a test. Inside the async upload it was
+/// covered only by running against a real container, and a mutation replacing
+/// the real length with a constant survived the whole unit suite.
+pub(super) fn uploaded_entry_size(src: &std::path::Path) -> Option<u64> {
+	std::fs::metadata(src)
+		.ok()
+		.filter(std::fs::Metadata::is_file)
+		.map(|m| m.len())
+}
+
 /// What the destination entry must look like for the upload to have landed.
 ///
 /// Only the size for now. The mtime is deliberately not part of it: the archive
@@ -435,7 +448,10 @@ fn parse_endpoint(s: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-	use super::{copy_landed, join_archive_path, parse_endpoint, ExpectedEntry, PathStat};
+	use super::{
+		copy_landed, join_archive_path, parse_endpoint, uploaded_entry_size, ExpectedEntry,
+		PathStat,
+	};
 
 	#[test]
 	fn join_archive_path_does_not_double_the_separator() {
@@ -479,6 +495,32 @@ mod tests {
 			..PathStat::default()
 		};
 		assert!(copy_landed(&want, Some(&already_there)));
+	}
+
+	/// The size that goes into the comparison is the source file's real length,
+	/// and a directory has none.
+	///
+	/// A mutation replacing the length with a constant survived every other test
+	/// here, because they all build `ExpectedEntry` by hand — this is the only
+	/// one that goes through the filesystem.
+	#[test]
+	fn the_expected_size_comes_from_the_source_file() {
+		let dir = tempfile::tempdir().unwrap();
+		let file = dir.path().join("payload.bin");
+		std::fs::write(&file, vec![7u8; 1234]).unwrap();
+		assert_eq!(uploaded_entry_size(&file), Some(1234));
+
+		std::fs::write(&file, b"").unwrap();
+		assert_eq!(
+			uploaded_entry_size(&file),
+			Some(0),
+			"an empty file has a size"
+		);
+
+		// A directory upload has nothing comparable, so it stays unverifiable
+		// and fail-closed rather than confirming on the directory's own size.
+		assert_eq!(uploaded_entry_size(dir.path()), None);
+		assert_eq!(uploaded_entry_size(&dir.path().join("absent")), None);
 	}
 
 	/// Two copies inside one second, which is what #1270 measured on Podman 6:

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -322,10 +322,7 @@ impl Engine {
 		// without a response; the upload is confirmed by the entry matching what
 		// was sent). `watch` used to have its own copy of this PUT, which is how
 		// the two drifted apart and left sync unfixed on Podman 6.
-		let uploaded_size = std::fs::metadata(changed)
-			.ok()
-			.filter(std::fs::Metadata::is_file)
-			.map(|m| m.len());
+		let uploaded_size = crate::engine::copy::uploaded_entry_size(changed);
 		self.put_archive_verified(container, &dest_dir, &entry_name, tar_bytes, uploaded_size)
 			.await?;
 

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -319,10 +319,14 @@ impl Engine {
 
 		// Shared with `cp`: the same archive upload, and the same #1097 Podman-6
 		// apply-then-close handling (the endpoint applies the tar then closes
-		// without a response; the upload is confirmed by the entry's mtime moving).
-		// `watch` used to have its own copy of this PUT, which is how the two
-		// drifted apart and left sync unfixed on Podman 6.
-		self.put_archive_verified(container, &dest_dir, &entry_name, tar_bytes)
+		// without a response; the upload is confirmed by the entry matching what
+		// was sent). `watch` used to have its own copy of this PUT, which is how
+		// the two drifted apart and left sync unfixed on Podman 6.
+		let uploaded_size = std::fs::metadata(changed)
+			.ok()
+			.filter(std::fs::Metadata::is_file)
+			.map(|m| m.len());
+		self.put_archive_verified(container, &dest_dir, &entry_name, tar_bytes, uploaded_size)
 			.await?;
 
 		info!("synced {} -> {target}", changed.display());

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -60,16 +60,22 @@ pub struct Client {
 	socket_path: String,
 }
 
-/// The decoded `X-Docker-Container-Path-Stat` header — a container path's Go
-/// file `mode` and `mtime`. `mtime` is an RFC3339 string compared only for
-/// equality (did a `cp` change the entry?), never parsed into a time. The
-/// runtime's JSON uses lowercase keys (`{"name":…,"size":…,"mode":…,"mtime":…}`).
-#[derive(serde::Deserialize, Default)]
-struct PathStat {
+/// The decoded `X-Docker-Container-Path-Stat` header — a container path's name,
+/// size, Go file `mode` and `mtime`.
+///
+/// `mtime` is an RFC3339 string compared only for equality, never parsed into a
+/// time. **Podman 6 reports it to whole seconds** — `2026-08-03T18:36:05Z`, no
+/// fractional part, measured on `podman-6.0.1-1.fc45` — which is why `size` is
+/// carried here too: two writes inside one second are indistinguishable by mtime
+/// alone. The runtime's JSON uses lowercase keys.
+#[derive(serde::Deserialize, Default, Clone, PartialEq, Eq, Debug)]
+pub(crate) struct PathStat {
 	#[serde(default)]
-	mode: u64,
+	pub(crate) size: u64,
 	#[serde(default)]
-	mtime: String,
+	pub(crate) mode: u64,
+	#[serde(default)]
+	pub(crate) mtime: String,
 }
 
 /// Attach the socket path and a way forward to a connection failure.
@@ -558,7 +564,7 @@ impl Client {
 	/// header, returning `Some(stat)` when the path exists or `None` on 404. The
 	/// header is base64 JSON carrying the Go file `mode`, `size` and `mtime`.
 	/// Shared by [`head_path_is_dir`](Self::head_path_is_dir) and
-	/// [`head_path_mtime`](Self::head_path_mtime).
+	/// [`head_path_stat`](Self::head_path_stat).
 	async fn head_container_path_stat(&self, path: &str) -> Result<Option<PathStat>> {
 		use base64::Engine as _;
 
@@ -606,13 +612,14 @@ impl Client {
 			.map(|s| s.mode & (1 << 31) != 0))
 	}
 
-	/// `HEAD` a container-archive path, returning its `mtime` string when it
-	/// exists or `None` on 404. `cp` uses this to tell a copy actually *landed*
-	/// (the entry's mtime changed to the source's) from a stale entry that was
-	/// already there, when the Podman-6 archive PUT closes without a response
-	/// (#1097). The value is compared as an opaque string, not parsed.
-	pub(crate) async fn head_path_mtime(&self, path: &str) -> Result<Option<String>> {
-		Ok(self.head_container_path_stat(path).await?.map(|s| s.mtime))
+	/// The full decoded stat for a container path, or `None` when it does not
+	/// exist.
+	///
+	/// `cp` needs the size as well as the mtime: Podman 6's mtime has
+	/// one-second resolution, so a second copy inside the same second cannot be
+	/// told from a failed one by mtime alone.
+	pub(crate) async fn head_path_stat(&self, path: &str) -> Result<Option<PathStat>> {
+		self.head_container_path_stat(path).await
 	}
 
 	/// `DELETE` → `Ok(true)` if the resource existed and was removed, `Ok(false)`


### PR DESCRIPTION
Closes #1270. Diagnosed and verified on the Podman 6 VM.

## Reproduced, and the branch is measured rather than inferred

The issue named three possible branches and said which one it was could not be
told apart from the lane's log level. `podup cp` of a changing file onto the same
path, six times back to back, reading the archive stat either side of each:

```
copy 1  rc=0   before: (absent)                 after: 2026-08-03T18:36:05Z 14
copy 2  rc=1   before: 2026-08-03T18:36:05Z 14  after: 2026-08-03T18:36:05Z 15
copy 3  rc=0   before: 2026-08-03T18:36:05Z 15  after: 2026-08-03T18:36:06Z 16
copy 4  rc=1   before: 2026-08-03T18:36:06Z 16  after: 2026-08-03T18:36:06Z 17
copy 5  rc=0   before: 2026-08-03T18:36:07Z 17  after: 2026-08-03T18:36:07Z 18
copy 6  rc=1   before: 2026-08-03T18:36:07Z 18  after: 2026-08-03T18:36:07Z 19
```

**Three of six**, and every failure is a pair whose mtime is byte-identical
across the PUT. **Podman 6 reports that mtime to whole seconds** — no fractional
part — so two copies inside one second cannot be told apart by it. The size moved
on all six, and it is in the same stat object the mtime came from.

It only looked intermittent in the lane because it depends on which side of a
second boundary the two copies land.

## The signal was wrong, not merely coarse

`copy_landed` asked *did the entry change*. The question is *does the entry now
match what was uploaded*.

That also fixes what no resolution could have: **re-copying an unchanged file**.
The archive sets the extracted mtime from the source, so a second copy of an
unchanged file is identical by construction and was always reported as a failure.

The residual false positive is a failed upload onto an entry that happened to be
the same size. It is benign in a way the false negative was not — the
destination already holds bytes of the length intended — and telling a user that
a successful copy failed is the worse error, especially for `watch` sync, which
fires on every write to a watched path.

`head_path_mtime` lost its last caller and is removed rather than left behind.

## A wrong conclusion I nearly recorded

My first probe was `curl -X PUT` with a plain tar and `Content-Length`. It
returned **HTTP 200 both times** — no apply-then-close at all — which would have
meant Podman had fixed #1097 upstream and this issue was moot.

Wrong. podup sends a **gzipped, streamed** body, so the request is chunked, and
that is the path that gets applied-then-closed. Same trap as measuring the image
*list* endpoint instead of the *inspect* one in #1298: the neighbour of the
caller's path gives a confident wrong answer.

## Verified

- **Podman 6.0.1 VM, the exact reproducer: 0 failures in 12** back-to-back
  copies, where it was 3 in 6 before. Content matched every time.
- **The same unchanged file five times: 0 failures.** That case could not pass at
  all before.
- **Podman 5.7.0 host, full integration suite: 178/178.**
- 32 `copy` unit tests; **4 mutations, 4 killed** — the size comparison replaced
  by mere existence, inverted, made to accept an absent entry, and the source
  length replaced by a constant.
- That last one survived at first: every other test builds `ExpectedEntry` by
  hand, and the one place the length is read sat inside the async upload.
  Extracted to `uploaded_entry_size`, which also removed the duplicate stat the
  `watch` caller carried, and pinned against a real file, an empty file, a
  directory and an absent path.

## What I found that is not this bug, and is not mine

The full suite on Podman 6 fails **8 of 178** with my change and **9 of 178**
without it — overlapping but not identical sets, every one an
`IncompleteMessage` or a chunked-EOF on `up`, not on the copy path. On the
Podman 5 host, one run failed `watch_sync_and_restart_does_both` and that same
test then passed **6 of 6 in isolation, with and without my change**.

So the suite is load-flaky on both majors, pre-existing, and the VM is a plain
KVM guest rather than nested virt — which is where the product context currently
attributes this. Filing it separately rather than folding it in here.