### PR TITLE
chore: bump to 3.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.5.0"
+version = "3.6.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,50 @@
+podup (3.6.0) unstable; urgency=medium
+
+  Incompatible
+
+  * `events` prints its TIME column in the reader's own time zone with the
+    offset that applied at that instant — `2026-08-03 09:44:27 -05:00`, matching
+    `podman events`. It was UTC and said so nowhere, which is worse than either
+    alternative: a reader correlating a podup line against `podman events` or
+    `journalctl` read it as their own wall clock and was silently wrong by the
+    offset. The cell is twenty-six characters wide where it was nineteen, so a
+    script slicing it by position needs updating. `--format json` is unchanged
+    and passes libpod's own event object straight through.
+
+  Fixed
+
+  * `cp` and `watch sync` no longer report a failure for a copy that landed. On
+    Podman 6 the archive endpoint applies the upload and closes without a
+    response, and the confirmation asked whether the destination's mtime had
+    moved. That runtime reports the mtime to whole seconds, so two copies inside
+    one second were indistinguishable — three failures in six back-to-back
+    copies, measured — and re-copying an unchanged file could never be confirmed
+    at all, since the extracted file takes the source's own mtime. The
+    confirmation now asks whether the destination matches what was uploaded.
+    This matters most for `watch`, which fires on every write to a watched path.
+
+  Added
+
+  * `ps -s/--size` adds a SIZE column: what the container has written on top of
+    its image, then the image's own size — `143kB (virtual 225MB)`, the same
+    shape `podman ps -s` prints. Opt-in because the runtime walks each
+    container's writable layer to answer it.
+  * `volumes -s/--size` adds SIZE and RECLAIMABLE. A volume a container still
+    uses reports its full size and zero reclaimable, which is the number that
+    matters when clearing space. Opt-in and slow: the only endpoint carrying a
+    volume's size accounts for the whole host, measured at 1.2s against 10ms for
+    the plain list.
+
+  Internal
+
+  * The Debian lane now runs on test-only changes. It is the only caller that
+    builds the test targets with the packaging feature set, and its path filter
+    excluded `tests/`, which hid a broken branch across twenty pull requests.
+  * The release binary has a size budget, and `push` is exercised against a real
+    registry rather than only against an unreachable one.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 03 Aug 2026 14:50:25 -0500
+
 podup (3.5.0) unstable; urgency=medium
 
   Incompatible


### PR DESCRIPTION
One P1 fix, two new flags, and one incompatible rendering change since 3.5.0.

## Why MINOR

The library API did not change and semver-checks passes. The **CLI output** did:
`events` prints its TIME column twenty-six characters wide where it was nineteen,
so anything slicing that column by position needs updating. Same call as 3.4.0
and 3.5.0 — rendering rather than API.

## What it carries

**The P1.** `cp` and `watch sync` stop reporting a failure for a copy that
landed on Podman 6. Diagnosed and verified on the VM: three failures in six
back-to-back copies, because the runtime reports the archive mtime to whole
seconds and the confirmation asked whether it had *moved*. Re-copying an
unchanged file could never be confirmed at all.

**It removes a known limitation 3.5.0 shipped with.** That release documented
`events` printing UTC without saying so. It now prints local time with the
offset that applied at that instant, matching `podman events`.

**Two opt-in columns**, `ps --size` and `volumes --size`, both behind flags
because the runtime does real work to answer them.

## The changelog carries what the release notes cannot

`release.yml` builds the GitHub notes from Conventional Commit titles and none of
the above survives that. The `debian/changelog` stanza leads with
**Incompatible**, and the published notes need that section added by hand
afterwards — as they did for 3.5.0.

## Test plan

- Three version files compared with the same expressions `release.yml` uses: all
  at 3.6.0. `dpkg-parsechangelog` reads the new stanza cleanly.
- `podup --version` reports `v3.6.0` from the built binary.
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets --all-features
  -- -D warnings`, lib suite 1524 — the CI commands, not approximations.