### PR TITLE
test(filesystem): pin the 16 MiB read cap on both paths it guards

### DIFF
--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -318,3 +318,143 @@ fn update_rejects_compose_only_global_flags() {
 		);
 	}
 }
+
+/// The `-f -` form enforces the same 16 MiB read cap the file path does.
+///
+/// The cap exists so a pathological compose document cannot exhaust memory, and
+/// the generic reader that implements it is unit-tested — but with an explicit
+/// limit passed in. **Nothing checked that the stdin call site passes
+/// `MAX_FILE_BYTES` rather than something larger**, which a mutation replacing it
+/// with `u64::MAX` proved by surviving the whole suite.
+///
+/// It cannot be closed at unit level: the function reads the real stdin, so the
+/// only honest test is the one a user would perform. This feeds the binary more
+/// than the cap through a pipe and asserts it is refused.
+#[test]
+fn stdin_is_refused_past_the_read_cap() {
+	use std::io::Write;
+	use std::process::Stdio;
+
+	// One byte over 16 MiB, and valid YAML up to the point it is rejected, so a
+	// refusal cannot be mistaken for a parse error. The padding lives in a
+	// comment for the same reason.
+	const CAP: usize = 16 * 1024 * 1024;
+	let mut document = String::from("services:\n  web:\n    image: alpine\n# ");
+	document.push_str(&"x".repeat(CAP + 1 - document.len()));
+	document.push('\n');
+	assert!(document.len() > CAP, "the fixture must exceed the cap");
+
+	let mut child = Command::new(bin())
+		.args(["-f", "-", "config"])
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.unwrap();
+	// A refused read closes the pipe, so the write can fail with EPIPE before
+	// the whole document is sent. That is the success path, not an error.
+	let _ = child.stdin.take().unwrap().write_all(document.as_bytes());
+	let out = child.wait_with_output().unwrap();
+
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		!out.status.success(),
+		"oversized stdin was accepted: stdout {} bytes, stderr {stderr:?}",
+		out.stdout.len()
+	);
+	assert!(
+		stderr.contains("larger than") && stderr.contains("limit"),
+		"refused for some other reason than the cap: {stderr:?}"
+	);
+}
+
+/// The same document one byte under the cap is accepted, so the test above
+/// pins a threshold rather than "big inputs fail".
+#[test]
+fn stdin_just_under_the_cap_is_accepted() {
+	use std::io::Write;
+	use std::process::Stdio;
+
+	const CAP: usize = 16 * 1024 * 1024;
+	let mut document = String::from("services:\n  web:\n    image: alpine\n# ");
+	document.push_str(&"x".repeat(CAP - document.len() - 1));
+	document.push('\n');
+	assert!(document.len() <= CAP, "the fixture must fit under the cap");
+
+	let mut child = Command::new(bin())
+		.args(["-f", "-", "config"])
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.unwrap();
+	child
+		.stdin
+		.take()
+		.unwrap()
+		.write_all(document.as_bytes())
+		.unwrap();
+	let out = child.wait_with_output().unwrap();
+	assert!(
+		out.status.success(),
+		"a document under the cap was refused: {}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+}
+
+/// A compose file past the 16 MiB cap is refused, the same as stdin.
+///
+/// The cap is a bound on what a single trusted-but-unbounded input can make
+/// podup allocate. `read_capped_from` implements it and is unit-tested — with an
+/// explicit limit passed in — so **what was untested is that the real call sites
+/// pass `MAX_FILE_BYTES`**. A mutation raising the constant to a terabyte left
+/// the whole lib and bins suite green, which is what a control nothing exercises
+/// looks like from outside.
+#[test]
+fn a_compose_file_past_the_read_cap_is_refused() {
+	const CAP: usize = 16 * 1024 * 1024;
+	let dir = TempDir::new().unwrap();
+	let path = dir.path().join("docker-compose.yml");
+	let mut document = String::from("services:\n  web:\n    image: alpine\n# ");
+	document.push_str(&"x".repeat(CAP + 1 - document.len()));
+	document.push('\n');
+	fs::write(&path, &document).unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", path.to_str().unwrap(), "config"])
+		.output()
+		.unwrap();
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		!out.status.success(),
+		"an oversized compose file was accepted: {} bytes of stdout",
+		out.stdout.len()
+	);
+	assert!(
+		stderr.contains("larger than") && stderr.contains("limit"),
+		"refused for some other reason than the cap: {stderr:?}"
+	);
+}
+
+/// The same file one byte under the cap is accepted, so the test above pins the
+/// threshold rather than "large files fail".
+#[test]
+fn a_compose_file_just_under_the_read_cap_is_accepted() {
+	const CAP: usize = 16 * 1024 * 1024;
+	let dir = TempDir::new().unwrap();
+	let path = dir.path().join("docker-compose.yml");
+	let mut document = String::from("services:\n  web:\n    image: alpine\n# ");
+	document.push_str(&"x".repeat(CAP - document.len() - 1));
+	document.push('\n');
+	fs::write(&path, &document).unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", path.to_str().unwrap(), "config"])
+		.output()
+		.unwrap();
+	assert!(
+		out.status.success(),
+		"a compose file under the cap was refused: {}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+}


### PR DESCRIPTION
Found by a security-control mutation campaign: **the cap was a dead control.**

## What the campaign did

Ten security controls, each deleted or weakened to see whether anything went
red. Nine were alive — the zip-slip guard, the extracted-mode sanitiser, the
systemd control-character rejection, the quadlet filter, the error-message
escaping, the signature verification (three ways), the project-name sanitiser.

**The 16 MiB read cap was not.** Raising `MAX_FILE_BYTES` to a terabyte left the
whole lib and bins suite green.

## Why it was dead

`read_capped_from` implements the cap and *is* unit-tested — but with an
explicit limit passed in. So the mechanism was proven and **the call sites'
choice of limit was not**. Neither `-f <file>` nor `-f -` had anything asserting
they pass `MAX_FILE_BYTES` rather than something larger.

Neither can be closed at unit level: one reads the real stdin, and the constant's
effect is only observable through the binary. So these are CLI tests that feed a
document either side of the cap — a file for `-f`, a pipe for `-f -` — and assert
the refusal.

## Verified by watching it fail

With the constant raised to a terabyte, exactly the two refusal tests go red and
the two acceptance tests stay green. Restored, all four pass.

## Two things I got wrong first, both worth recording

**My first mutation of this control looked like a kill and was not.** Replacing
the constant with `u64::MAX` makes `take(max + 1)` overflow and panic, so every
test fails for the wrong reason — and I nearly recorded the control as alive on
that basis. The commit message carries the warning for whoever mutates it next.

**Three other controls looked dead and were not.** `sanitize_project_name` and
the zip-slip guard survived until I noticed the driver only ran `cargo test
--lib`, and `resolve` is a module of `main.rs`. Its four tests exist and run —
under `--bins`. The driver now runs both, which is the same trap the product
context already records for `startup`.

## Test plan

- 4 new CLI tests, both sides of the threshold on both paths.
- The clean mutation (1 TiB, no overflow) kills exactly the two refusal tests.
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets --all-features
  -- -D warnings`, and every test target green: lib 1524, bins 81, and all
  integration targets.