### PR TITLE
ci: close the silent slack in the coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,22 @@ jobs:
       # It is deliberately NOT the measured 78.96%: a floor set exactly at
       # today's number turns any unrelated refactor that moves one region into a
       # failed build.
-      coverage-threshold: 75
+      # 79, not the org standard's 90, and not because podup is short of it.
+      #
+      # Measured 2026-08-03: the full suite covers **91.52%** of lines. This job
+      # cannot run it — the integration tests need a live Podman and skip
+      # themselves on a runner without one — so what it measures is `--lib
+      # --bins` alone, which is **79.39%**. The two numbers describe different
+      # things and only one of them is checkable here.
+      #
+      # 75 left four points of silent slack on a figure that is already a
+      # subset: coverage could fall from 79 to 75 with nothing saying so. This
+      # locks in what holds today rather than demanding new work, which is what
+      # the testing standard asks for when adopting a floor.
+      #
+      # The 90 gate belongs where the tests can actually run — the `podman-vm`
+      # lane — and that is tracked separately rather than papered over here.
+      coverage-threshold: 79
       msrv: "1.85"
       package-check: true
       semver-check: true


### PR DESCRIPTION
Part of #1326.

## The numbers

| what | lines |
|---|---|
| `cargo llvm-cov --lib --bins` — what the CI job can see | **79.39%** |
| `cargo llvm-cov --all-features` — the full suite | **91.52%** |
| the gate | **75** → **79** |

**podup is not short of the org standard's 90%.** It clears it. The coverage job
just cannot see that: it runs on a plain runner, every integration test begins
`if podman().await.is_none() { return; }`, and with them skip the coverage of
`dispatch.rs`, `dispatch/rest.rs` and `autostart_cmd.rs` — all reading 0.00%
under `--lib --bins` and all exercised heavily by the suite that cannot run
there.

## What this PR does and does not do

It closes four points of **silent slack**: coverage could fall from 79 to 75 with
nothing saying so. Ratcheting to what holds today is what the testing standard
asks when adopting a floor — *"locks in a state that holds rather than demanding
new work"*.

It does **not** claim to enforce 90. Nothing does, and that is #1326: the lane
that can run the integration tests measures no coverage at all, so the standard's
number is satisfied by the code and checked nowhere.

The threshold carries a comment saying which number is which, so the next person
does not read 79 as a failure to reach 90 and go looking for tests that already
exist.

## Test plan

- Both figures measured with `cargo llvm-cov` on this tree today, not inferred.
- YAML validated.
- No source changed.