### PR TITLE
test(ports): stop three tests fighting over one hard-coded port

### DIFF
--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -171,6 +171,24 @@ mod create_ls;
 mod lifecycle_output;
 #[path = "engine_integration/multi_file.rs"]
 mod multi_file;
+/// A free loopback port, chosen by binding zero and releasing it.
+///
+/// Shared because three tests hard-coded `18081` and a fourth `18080`, so any
+/// two of them running at once fought over the same bind and the loser failed
+/// with `pasta failed ... Address already in use`. That is not flakiness: at
+/// eight test threads it is close to certain.
+///
+/// There is a window between releasing the port and the container binding it.
+/// It is small, and far smaller than the certainty of a shared constant.
+#[allow(dead_code)]
+fn free_port() -> u16 {
+	std::net::TcpListener::bind("127.0.0.1:0")
+		.expect("no loopback port")
+		.local_addr()
+		.unwrap()
+		.port()
+}
+
 #[path = "engine_integration/push_registry.rs"]
 mod push_registry;
 #[path = "engine_integration/scale.rs"]

--- a/tests/engine_integration/cli_commands.rs
+++ b/tests/engine_integration/cli_commands.rs
@@ -413,9 +413,15 @@ async fn cli_port_subcommand() {
 	let dir = tempdir().unwrap();
 	let compose = dir.path().join("docker-compose.yml");
 	let proj = format!("t{}-clprt", std::process::id());
+	// A port chosen at run time, not a constant: three tests shared 18081 and a
+	// fourth 18080, so any two running at once lost the bind and failed with
+	// `pasta failed ... Address already in use`.
+	let port = super::free_port();
 	fs::write(
 		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:18081:80\"\n",
+		format!(
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:{port}:80\"\n"
+		),
 	)
 	.unwrap();
 

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -167,9 +167,13 @@ async fn engine_port_resolves_a_published_port() {
 	};
 	let proj = proj("prt");
 	let engine = Engine::new(client, proj.clone());
-	let file = parse_str(
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:18080:80\"\n",
-	)
+	// A port chosen at run time, not a constant: three tests shared 18081 and a
+	// fourth 18080, so any two running at once lost the bind and failed with
+	// `pasta failed ... Address already in use`.
+	let port = super::free_port();
+	let file = parse_str(&format!(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:{port}:80\"\n"
+	))
 	.unwrap();
 
 	engine.up(&file).await.unwrap();

--- a/tests/engine_integration/push_registry.rs
+++ b/tests/engine_integration/push_registry.rs
@@ -18,17 +18,6 @@ use tempfile::tempdir;
 
 use super::*;
 
-/// A free loopback port, chosen by binding zero and releasing it.
-///
-/// There is a window between releasing and the registry binding it. It is small
-/// and the readiness poll below fails loudly rather than silently if it is lost,
-/// which is the honest trade against hard-coding a port two concurrent runs
-/// would fight over.
-fn free_port() -> u16 {
-	let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("no loopback port");
-	listener.local_addr().unwrap().port()
-}
-
 /// One HTTP GET over a plain TCP socket, returning the body.
 ///
 /// Raw rather than a client library on purpose: this asks a local registry for a

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -210,9 +210,15 @@ async fn cli_port_prints_the_published_binding() {
 	let dir = tempdir().unwrap();
 	let compose = dir.path().join("docker-compose.yml");
 	let proj = format!("t{}-prtb", std::process::id());
+	// A port chosen at run time, not a constant: three tests shared 18081 and a
+	// fourth 18080, so any two running at once lost the bind and failed with
+	// `pasta failed ... Address already in use`.
+	let port = super::free_port();
 	fs::write(
 		&compose,
-		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:18081:80\"\n",
+		format!(
+			"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    ports:\n      - \"127.0.0.1:{port}:80\"\n"
+		),
 	)
 	.unwrap();
 	let c = compose.to_str().unwrap();
@@ -235,7 +241,7 @@ async fn cli_port_prints_the_published_binding() {
 		"port failed for a published port: {stdout:?}"
 	);
 	assert!(
-		stdout.contains("127.0.0.1:18081"),
+		stdout.contains(&format!("127.0.0.1:{port}")),
 		"port did not print the host binding it was asked for: {stdout:?}"
 	);
 }


### PR DESCRIPTION
Part of #1322.

## What it was

Three tests published `127.0.0.1:18081` and a fourth `18080`. Any two running at
once lost the bind:

```
pasta failed with exit code 1:
Listen failed for HOST TCP port 127.0.0.1/18080: Address already in use
```

At eight test threads that is close to certain rather than unlucky. It was **one
of the three failures that survived even at `--test-threads=1`** on the Podman 6
VM, which is how it surfaced: everything else at that level was #1207, and this
one was ours.

## The fix

`free_port` — written this morning for the registry test — moves up to the suite
root, and all four fixtures take a port chosen at run time. There is a window
between releasing the port and the container binding it, and it is far smaller
than the certainty of a shared constant.

## Verified

| | before | after |
|---|---|---|
| Podman 6 VM, `--test-threads=1` | **3 failed** | **2 failed** |
| Podman 5.7.0 host, full suite | 178/178 | 178/178 |

The two that remain are `sibling_resolves_service_by_name_*`, which are #1207 —
reproducible with two plain `podman run` commands and no podup involved.

## What this does not fix

The load-dependent failures. Those track thread count (3 → 17 of 27 from one
thread to eight, measured) and are a different problem, still open on #1322.