### PR TITLE
test(networking): tell podup's half of service-name DNS from the runtime's

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -129,11 +129,18 @@ jobs:
                 # this hypothesis dies too and the search moves elsewhere.
                 #
                 # `--test-threads` caps how many streaming tests hit the libpod
-                # socket at once. The nested-virt (VM-in-runner) transport is what
-                # drops connections mid-stream — measured: on a single-level VM
-                # (Podman 5.8.1 and 6.0.1) the same suite never drops a byte, so the
-                # flake is the double-virt socket under concurrent load, not a podup
-                # or libpod bug. Fewer concurrent streams means less peak pressure,
+                # socket at once.
+                #
+                # This used to say the drops were specific to the nested-virt
+                # (VM-in-runner) transport, and that a single-level VM "never
+                # drops a byte". **That is measured false** (2026-08-03, #1322):
+                # on a plain KVM guest with Podman 6.0.1, the same suite fails
+                # 17 of 27 at eight test threads and 3 at one — a clean
+                # dose-response curve in thread count, reproducible across
+                # repetitions. Nesting makes it worse; it does not cause it.
+                #
+                # What holds is the lever: fewer concurrent streams means less
+                # peak pressure,
                 # which is the lever to shrink Podman 6's variable flaky tail toward
                 # a small, stable set that an identity list can gate (#1039). Kept at
                 # 2 rather than 1 so the suite still fits the VM's time budget.

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -445,6 +445,36 @@ impl Engine {
 		self.list_project_container_names(None).await
 	}
 
+	/// The network aliases a container answers to, flattened across every
+	/// network it is attached to.
+	///
+	/// The seam that lets a test check **podup's** contribution to service-name
+	/// resolution — registering the compose service name as an alias — without
+	/// depending on the runtime's DNS server being up to answer for it. Those
+	/// are two layers, and a test that only measures the second blames podup for
+	/// the first's failures (#1330).
+	pub async fn test_container_aliases(&self, container: &str) -> Result<Vec<String>> {
+		let path = format!(
+			"{}/containers/{}/json",
+			crate::libpod::API_PREFIX,
+			crate::libpod::urlencoded(container)
+		);
+		let inspect: crate::libpod::types::container::ContainerInspect = self
+			.client
+			.get_json(&path)
+			.await
+			.map_err(crate::error::ComposeError::Podman)?;
+		Ok(inspect
+			.network_settings
+			.map(|n| {
+				n.networks
+					.into_values()
+					.flat_map(|a| a.aliases)
+					.collect::<Vec<_>>()
+			})
+			.unwrap_or_default())
+	}
+
 	/// Run a command in the named container and return its captured stdout.
 	///
 	/// Integration tests use this to observe the effect of a watch action (e.g.

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -187,6 +187,23 @@ pub struct NetworkSettings {
 	/// exposed but not published.
 	#[serde(rename = "Ports", default)]
 	pub ports: HashMap<String, Option<Vec<HostBinding>>>,
+	/// Per-network attachment details, keyed by the on-host network name.
+	///
+	/// Carried for the aliases: a compose service is reachable by its service
+	/// name because podup registers that name as a network alias, and that
+	/// registration is the part podup owns. Whether a lookup for it then
+	/// *answers* is the container runtime's DNS, which is a different layer and
+	/// fails for its own reasons (#1330).
+	#[serde(rename = "Networks", default)]
+	pub networks: HashMap<String, NetworkAttachment>,
+}
+
+/// One network a container is attached to.
+#[derive(Deserialize, Default, Clone)]
+pub struct NetworkAttachment {
+	/// Names this container answers to on the network, when DNS is working.
+	#[serde(rename = "Aliases", default, deserialize_with = "null_default")]
+	pub aliases: Vec<String>,
 }
 
 /// Host port binding from container inspect network settings.

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -519,9 +519,17 @@ async fn sibling_resolves_service_by_name_on_shared_network() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	// The client must reach the server by its compose service name (`server`),
-	// not only by the container name — the service name has to be registered as
-	// a network alias. Retry briefly while the server's httpd comes up.
+	// Two layers, asserted separately (#1330).
+	//
+	// **podup's layer**: the compose service name is registered as a network
+	// alias. That is the whole of podup's contribution to service-name
+	// resolution and it is checkable without any DNS.
+	let aliases = engine
+		.test_container_aliases(&format!("{proj}-server-1"))
+		.await
+		.expect("could not read the server's network aliases");
+	// **The runtime's layer**: a lookup for that alias actually answers. Retry
+	// briefly while the server's httpd comes up.
 	let out = engine
 		.test_exec_capture(
 			&format!("{proj}-client-1"),
@@ -533,10 +541,16 @@ async fn sibling_resolves_service_by_name_on_shared_network() {
 		)
 		.await;
 	engine.down(&file).await.unwrap();
+
+	assert!(
+		aliases.iter().any(|a| a == "server"),
+		"podup did not register the service name as a network alias: {aliases:?}"
+	);
 	let out = out.expect("exec in client container failed");
 	assert!(
 		out.contains("ok"),
-		"service `server` was not reachable by its service name: {out:?}"
+		"the alias `server` is registered but the lookup did not answer, so the \
+		 container runtime's DNS is what failed here, not podup: {out:?}"
 	);
 }
 
@@ -568,6 +582,12 @@ async fn sibling_resolves_service_by_name_without_networks_block() {
 	let file = parse_files_with_env_files(&[compose], &[]).unwrap();
 
 	engine.up(&file).await.unwrap();
+	// Same two-layer split as the shared-network case above (#1330): the alias
+	// is podup's, the lookup answering is the runtime's.
+	let aliases = engine
+		.test_container_aliases(&format!("{proj}-server-1"))
+		.await
+		.expect("could not read the server's network aliases");
 	let out = engine
 		.test_exec_capture(
 			&format!("{proj}-client-1"),
@@ -579,10 +599,17 @@ async fn sibling_resolves_service_by_name_without_networks_block() {
 		)
 		.await;
 	engine.down(&file).await.unwrap();
+
+	assert!(
+		aliases.iter().any(|a| a == "server"),
+		"podup did not register the service name as an alias on the synthesized \
+		 default network: {aliases:?}"
+	);
 	let out = out.expect("exec in client container failed");
 	assert!(
 		out.contains("ok"),
-		"service `server` was not reachable by name without a networks: block: {out:?}"
+		"the alias `server` is registered but the lookup did not answer, so the \
+		 container runtime's DNS is what failed here, not podup: {out:?}"
 	);
 }
 


### PR DESCRIPTION
Closes #1330, and corrects a measured-false claim in `podman-lane.yml`.

## The test accused podup of the runtime's failure

On the Podman 6 VM the message was:

```
service `server` was not reachable by its service name
```

which reads as a podup networking defect. Measured, it was not:

| check | result |
|---|---|
| `podup up` | OK |
| alias registered on the network | **`aliases: ['server', ...]`** — podup did its part |
| `wget http://server` | `bad address` |
| `wget http://<container-name>` | `bad address` — not even the container name |
| `aardvark-dns` process | **not running** |
| plain `podman run` + `nslookup`, no podup | `connection timed out; no servers could be reached` |

Container DNS was down at the runtime level. podup registered the alias, nothing
could answer for it, and the test named podup.

That cost real time: the failure was read as a podup networking bug, then folded
into a netns race in #1207, before measuring showed the DNS server was simply not
running.

## The fix is the standard's own rule — assert under the boundary

Two layers, asserted separately:

- **podup's**: the compose service name appears in the container's network
  aliases. Checkable with no DNS at all, through a new `test_container_aliases`
  seam.
- **the runtime's**: a lookup for that alias answers. When the alias is present
  and the lookup fails, the message now says the runtime is what failed.

## Verified both ways

Not just that it passes. With the service-name alias registration disabled in
`build_per_network_options`, the new assertion fires and prints what it actually
found:

```
podup did not register the service name as a network alias: ["75abafa9ddfe"]
```

The old test would have said "not reachable" — indistinguishable from a broken
DNS server.

## The lane comment was wrong

`podman-lane.yml` claimed:

> *measured: on a single-level VM (Podman 5.8.1 and 6.0.1) the same suite never
> drops a byte, so the flake is the double-virt socket under concurrent load*

Measured on exactly that — a plain KVM guest with Podman 6.0.1 — the suite drops
plenty: **17 failures of 27 at eight test threads, 3 at one**, a clean
dose-response curve reproducible across repetitions (#1322). Nesting makes it
worse; it does not cause it. The comment now says so, because a comment that
asserts a measurement nobody re-ran is worse than none.

## Test plan

- Both tests green on the host (Podman 5.7.0, working DNS); full suite 178/178.
- The alias assertion verified by disabling the control and watching it fire.
- `cargo semver-checks`: no update required — the new seam is `#[cfg(feature =
  "test-helpers")]`, off in the published crate.
- fmt and clippy with the CI's own flags.