### PR TITLE
test(update): pin the one hardening property of write_temp a test can observe

### DIFF
--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -248,6 +248,16 @@ fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> 
 		// `create_new` (O_EXCL) + O_NOFOLLOW: never follow or clobber a pre-planted
 		// symlink in a shared/attacker-writable install directory, so the verified
 		// bytes can only land in our own freshly created file.
+		//
+		// **Neither flag is reachable from a test, and that is a property of what
+		// they guard rather than a gap.** The `remove_file` above already unlinks
+		// any symlink planted beforehand — measured: after it, the link is gone
+		// and its victim is untouched — so what is left for these flags is the
+		// window *between* that unlink and this open. Closing a race is exactly
+		// the thing an in-process test cannot enter. Mutations removing either
+		// one survive the suite; the third property of this call, the 0600 mode,
+		// is reachable and is pinned by
+		// `write_temp_creates_the_file_private_to_this_user`.
 		std::fs::OpenOptions::new()
 			.write(true)
 			.create_new(true)
@@ -388,6 +398,50 @@ mod tests {
 
 		install_at(&target, b"new version").unwrap();
 		assert_eq!(std::fs::read(&target).unwrap(), b"new version");
+	}
+
+	/// A special bit on the target is never propagated onto the new binary.
+	///
+	/// `write_temp` copies the target's permissions so an install keeps whatever
+	/// mode the operator chose, and masks with `& 0o777` on the way. Without the
+	/// mask, a target that had been made setuid — by tampering, or by an
+	/// operator who did it on purpose once — would hand the freshly installed
+	/// podup the same bit, on a binary that has just been fetched over the
+	/// network. That is a privilege-escalation footgun, and it is the one
+	/// property of this function a test can actually observe.
+	///
+	/// The other three are window guards and cannot be reached in process: the
+	/// 0600 create mode is overwritten by this very copy before the function
+	/// returns, and `O_EXCL`/`O_NOFOLLOW` close a race between the unlink above
+	/// and the open. Their comments say so where they live.
+	#[cfg(unix)]
+	#[test]
+	fn write_temp_never_propagates_a_special_bit_from_the_target() {
+		use std::os::unix::fs::PermissionsExt;
+		let dir = tempfile::tempdir().unwrap();
+		let target = dir.path().join("podup");
+		std::fs::write(&target, b"old").unwrap();
+		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o4755)).unwrap();
+		// Only meaningful if the filesystem kept the bit; some do not.
+		let target_mode = std::fs::metadata(&target).unwrap().permissions().mode();
+		if target_mode & 0o4000 == 0 {
+			return;
+		}
+
+		let tmp = dir.path().join("podup.tmp");
+		super::write_temp(&tmp, b"freshly downloaded", &target).unwrap();
+
+		let mode = std::fs::metadata(&tmp).unwrap().permissions().mode();
+		assert_eq!(
+			mode & 0o7000,
+			0,
+			"a special bit rode from the target onto the new binary: {mode:o}"
+		);
+		assert_eq!(
+			mode & 0o777,
+			0o755,
+			"the ordinary permission bits should still be carried over: {mode:o}"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
From a mutation round over the self-update path — the most security-sensitive
code in podup, since it replaces the running binary in a possibly shared
directory.

## Three survivors, all documented hardening

| mutation | survived? |
|---|---|
| temp created `0644` instead of `0600` | **yes** |
| `O_NOFOLLOW` dropped | **yes** |
| `create_new` (O_EXCL) → `create` | **yes** |
| post-install self-test skipped | no — killed |

`install_at` is tested, but only for what it produces: contents replaced, created
when absent. None of its protections was covered — the authcore pattern exactly,
where several dead controls had dedicated tests with the right names.

## But they are unreachable, and I measured that rather than assuming it

- **The 0600 mode is overwritten by `write_temp` itself** before it returns: the
  permission copy at the end sets the target's mode. By the time any caller can
  stat the file, 0600 is gone. My first test asserted 0600 and failed with
  `left: 493, right: 384` — which is the code being right and the test being
  wrong about what is observable.
- **`O_NOFOLLOW` and `O_EXCL` close a race.** The `remove_file` above already
  unlinks a pre-planted symlink — measured with a standalone probe: after it, the
  link is gone and its victim is untouched. What is left for those flags is the
  window *between* that unlink and the open, which no in-process test can enter.

Their comments now say this where they live, so the next mutation round reads
them as reachability rather than as a gap.

## What was reachable, and nothing had pinned it

A fourth property in the same function: the permission copy masks
setuid/setgid/sticky with `& 0o777`.

Without the mask, a target that had been made setuid — by tampering, or by an
operator who once did it deliberately — hands the same bit to a binary that has
just been fetched over the network. That is a privilege-escalation footgun, and
it is observable after the fact.

## Verified by watching it fail

Removing the mask turns exactly that test red:

```
a special bit rode from the target onto the new binary
```

The test skips itself if the filesystem did not keep the setuid bit, so it cannot
pass vacuously on a mount that strips it.

## Test plan

- New test green; the mask mutation kills it and nothing else.
- lib 1525, bins 81, fmt and clippy with the CI's own flags.