### PR TITLE
fix(ci): the lane's coverage step never ran cargo, it failed to open the console

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -177,10 +177,26 @@ jobs:
                 # failure here must not redden the leg: this is an observation, and
                 # the suite's own result above is what gates.
                 if [ "$COVERAGE" = "1" ]; then
-                  if cargo install cargo-llvm-cov --locked >/dev/console 2>&1; then
-                    PCT=$(cargo llvm-cov --all-features --summary-only 2>/dev/console \
-                          | awk '$1=="TOTAL" { for (i=1;i<=NF;i++) if ($i ~ /%$/) { print $i; exit } }')
-                    echo "PODUP_COVERAGE=${PCT:-unknown}"
+                  # Nothing here redirects to /dev/console. This script runs as
+                  # `tester`, which may not open that device, and a denied
+                  # redirection aborts the command it was attached to and is
+                  # reported as that command's own failure. The first run said
+                  # `install-failed` for exactly that reason: cargo never ran.
+                  # stdout and stderr already point at the console, inherited
+                  # from the root caller that launched this script.
+                  if cargo install cargo-llvm-cov --locked; then
+                    cargo llvm-cov --all-features --summary-only >/tmp/cov.log 2>&1
+                    PCT=$(awk '$1=="TOTAL" { for (i=1;i<=NF;i++) if ($i ~ /%$/) { print $i; exit } }' /tmp/cov.log)
+                    if [ -n "$PCT" ]; then
+                      echo "PODUP_COVERAGE=$PCT"
+                    else
+                      # Ran, produced nothing parseable. Print what it actually
+                      # said: a second 15-minute boot is an expensive way to
+                      # find out, and each distinct marker below names one
+                      # cause instead of collapsing every failure into one word.
+                      echo "PODUP_COVERAGE=no-total-line"
+                      tail -30 /tmp/cov.log
+                    fi
                   else
                     echo "PODUP_COVERAGE=install-failed"
                   fi


### PR DESCRIPTION
The first lane run with coverage enabled (#1332) reported `install-failed` on
**both** legs. The console said why one line earlier:

```
/usr/local/bin/run-suite.sh: line 93: /dev/console: Permission denied
PODUP_COVERAGE=install-failed
```

## The install did not fail — the redirection did

`run-suite.sh` runs as `tester` (the runcmd is `sudo -iu tester ...`), which may
not open the console device. A denied redirection **aborts the command it was
attached to before it executes**, and the shell reports that as the command's
own failure. So `cargo install ... >/dev/console` never ran cargo at all.

I checked the semantics rather than inferring them from the log:

```
$ if echo RAN-THE-COMMAND >/root/not-writable 2>&1; then echo then; else echo "else rc=$?"; fi
bash: /root/not-writable: Permission denied
else rc=1
$ ... | grep -c RAN-THE-COMMAND
0
```

The command leaves no trace of having run, and the `if` takes the else — exactly
the shape in the log.

The script's other lines reach the log because they **inherit** stdout from the
root caller that launched the script; they never open the device themselves.
That is why `PODUP_TESTS_RC` and `PODUP_SUMMARY` printed fine three lines above.
Both redirects were unnecessary, and both are gone.

## The message was the second defect

`install-failed` named the only cause its author imagined, which was not the one
that happened. A marker that can describe exactly one failure is a hypothesis
wearing the clothes of a diagnosis. The measurement step now has its own marker
and dumps what the tool actually said, so the next distinct failure costs a log
read instead of another 15-minute VM boot.

## Report-only earned its keep

The legs were **green** the whole time this was broken — coverage is observed,
never gated, so nothing was blocked by an observation that could not observe.
Same run, Podman 5: `178 passed; 0 failed; 0 flaky` in 882s.

## Test plan

- YAML parses; the generated `run-suite.sh` extracted from the cloud-init seed
  passes `bash -n`; zero `/dev/console` redirects remain in it.
- Dispatched on this branch, which is the only path that sets `COVERAGE=1`:
  run `30872834999`. A pull_request run cannot prove this — it runs with
  coverage off by design.

Refs #1326