### PR TITLE
fix(ci): give cargo-llvm-cov the LLVM tools, since there is no rustup in the VM

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -184,7 +184,30 @@ jobs:
                   # `install-failed` for exactly that reason: cargo never ran.
                   # stdout and stderr already point at the console, inherited
                   # from the root caller that launched this script.
-                  if cargo install cargo-llvm-cov --locked; then
+                  # cargo-llvm-cov looks for the `llvm-tools-preview` rustup
+                  # component, and there is no rustup here — Rust comes from dnf.
+                  # It accepts the two tools directly instead, and Fedora's `llvm`
+                  # package (already installed above) carries both. Taking them
+                  # from the distribution is also what keeps the versions in step:
+                  # rustc and llvm are built for the same Fedora release, so the
+                  # profile format matches, which a separately-pinned LLVM would
+                  # not guarantee.
+                  #
+                  # Exactly ONE PODUP_COVERAGE line is emitted on every path. Two
+                  # would be worse than none: whoever greps the log gets an answer
+                  # either way and no reason to suspect there was another.
+                  export LLVM_COV=/usr/bin/llvm-cov
+                  export LLVM_PROFDATA=/usr/bin/llvm-profdata
+                  # Print both versions unconditionally. A profile-format mismatch
+                  # is the next thing likely to go wrong here, and it is only
+                  # diagnosable against the pair of numbers that produced it.
+                  echo "llvm tools: $("$LLVM_COV" --version 2>&1 | grep -i version | head -1)"
+                  echo "rustc llvm: $(rustc --version --verbose | grep -i '^LLVM')"
+                  if [ ! -x "$LLVM_COV" ] || [ ! -x "$LLVM_PROFDATA" ]; then
+                    # Say so here rather than letting cargo-llvm-cov fail with its
+                    # own wording several minutes and one full build later.
+                    echo "PODUP_COVERAGE=llvm-tools-missing"
+                  elif cargo install cargo-llvm-cov --locked; then
                     cargo llvm-cov --all-features --summary-only >/tmp/cov.log 2>&1
                     PCT=$(awk '$1=="TOTAL" { for (i=1;i<=NF;i++) if ($i ~ /%$/) { print $i; exit } }' /tmp/cov.log)
                     if [ -n "$PCT" ]; then


### PR DESCRIPTION
Follow-on from #1334. With the console redirect fixed, cargo actually ran — and
said what was wrong all along:

```
error: failed to find llvm-tools-preview, please install llvm-tools-preview,
or set LLVM_COV and LLVM_PROFDATA environment variables
```

That line came from the log dump #1334 added, on the first run after it merged.
The point of that dump was to make the next failure cost a log read instead of
another VM boot, and this is it doing that.

## The cause

`cargo-llvm-cov` looks for the `llvm-tools-preview` **rustup component**, and
this VM has no rustup — Rust comes from dnf. It accepts the two binaries
directly instead, and Fedora's `llvm` package (already in the seed's dnf line)
provides both at `/usr/bin`.

## Why the distribution's copy, specifically

Measured on a Fedora 45 rawhide guest:

| | |
|---|---|
| `rustc --version --verbose` | LLVM **22.1.6** |
| `llvm` package | **22.1.8** |

Same series, because both are built for the same Fedora release. A separately
pinned LLVM would have no such guarantee, and a profile-format mismatch is the
next thing likely to break here — so both versions now print on **every**
coverage run, not only when something fails. A mismatch is only diagnosable
against the pair of numbers that produced it.

## One marker per path, verified

Whoever greps this log gets an answer either way and no reason to suspect a
second one, so emitting two would be worse than emitting none. All four paths
driven against stubs:

```
sin herramientas -> emitidos=1  PODUP_COVERAGE=llvm-tools-missing
install falla    -> emitidos=1  PODUP_COVERAGE=install-failed
sin linea TOTAL  -> emitidos=1  PODUP_COVERAGE=no-total-line
camino bueno     -> emitidos=1  PODUP_COVERAGE=91.52%
```

## Test plan

- YAML parses; the generated `run-suite.sh` passes `bash -n`.
- Dispatched on this branch — the only path that sets `COVERAGE=1`:
  run `30874830737`.
- Coverage stays report-only, so a leg stays green regardless of the outcome.

Refs #1326