### PR TITLE
fix(ci): cap the coverage run's threads too, so it measures the gated suite

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -208,7 +208,16 @@ jobs:
                     # own wording several minutes and one full build later.
                     echo "PODUP_COVERAGE=llvm-tools-missing"
                   elif cargo install cargo-llvm-cov --locked; then
-                    cargo llvm-cov --all-features --summary-only >/tmp/cov.log 2>&1
+                    # Same thread cap as the gating run above. cargo-llvm-cov
+                    # drives its own `cargo test` and does NOT inherit it, which
+                    # is measurable rather than theoretical: on the Podman 6 leg
+                    # the gating run took 1743s and passed 178/178, and the
+                    # coverage run of the same code in the same boot took 441s —
+                    # four times faster because it was parallel — and failed 5
+                    # with hyper IncompleteMessage. Uncapped, this step measures
+                    # a different suite than the one that gates.
+                    cargo llvm-cov --all-features --summary-only \
+                      -- --test-threads=__THREADS__ >/tmp/cov.log 2>&1
                     PCT=$(awk '$1=="TOTAL" { for (i=1;i<=NF;i++) if ($i ~ /%$/) { print $i; exit } }' /tmp/cov.log)
                     if [ -n "$PCT" ]; then
                       echo "PODUP_COVERAGE=$PCT"


### PR DESCRIPTION
`cargo-llvm-cov` drives its **own** `cargo test` and does not inherit the
`--test-threads` cap the gating run uses. Uncapped, the coverage step was
measuring a different suite than the one that decides whether the leg is green.

## The measurement

Podman 6 leg of run `30874830737` — same code, same VM, same boot:

| run | threads | result | duration |
|---|---|---|---|
| gating | **1** | 178 passed, 0 failed | 1743.03s |
| coverage | default | **173 passed, 5 failed** | **441.66s** |

The coverage pass was **four times faster**, which is what gives the
parallelism away. My first reading was that instrumentation had slowed it into
failing — the durations say the opposite, and I would have reported the wrong
cause without pulling them.

All five failures were `hyper::Error(IncompleteMessage)` — the
dropped-connection signature — and **three of them match tests that fail on a
local Podman 6 guest running at six threads**:

```
top_skips_a_stopped_service_and_reports_the_rest
watch_restart_container
watch_sync_creates_missing_target_directory
```

## What that says beyond this fix

Podman 6 still drops connections under concurrency. **The lane is green because
it caps threads to one, not because the defect is gone** (#1039, #1104).

This is the cleanest evidence of that so far, because it is a controlled
comparison *inside a single VM boot* — one variable, same kernel, same podman
build — rather than the two-machine comparison that has produced five dead
hypotheses in #1207.

## Immediate effect

With tests failing, cargo-llvm-cov exits without printing a summary, so the
Podman 6 leg reported no number at all (`no-total-line`). Podman 5, whose cap
is 2, was unaffected and reported **91.58%** — the first real coverage figure
measured where the integration tests actually run, against the CI job's 79.39%.

## Test plan

- YAML parses; the generated `run-suite.sh` passes `bash -n` with both
  placeholders substituted.
- `__THREADS__` substitution verified to reach **both** call sites: the
  workflow's `sed` has no `g` flag, and the two occurrences are on separate
  lines, so each is replaced. Simulated against the real command — zero left.
- Coverage stays report-only, so a leg is green regardless.

Refs #1326