### PR TITLE
test: check the setup command worked before asserting on its effect

### DIFF
--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -72,6 +72,40 @@ fn bin() -> &'static str {
 	env!("CARGO_BIN_EXE_podup")
 }
 
+/// Run the built `podup` and hand back whatever it did, checking nothing.
+///
+/// For calls whose outcome the test does not depend on — teardown, mostly. When
+/// a later assertion depends on this command having worked, use [`run_ok`].
+#[allow(dead_code)]
+fn run(args: &[&str]) -> std::process::Output {
+	std::process::Command::new(bin())
+		.args(args)
+		.output()
+		.unwrap()
+}
+
+/// Run the built `podup` and fail with its own words if it did not succeed.
+///
+/// Setting a test up with [`run`] and then asserting on the effect throws away
+/// the evidence of what went wrong. `create_makes_containers_without_starting_them`
+/// discarded an `up -d` and reported `left: 0, right: 1` — true, and unable to
+/// say whether `up` failed or whether it worked and the container died (#1340).
+///
+/// The failure is invisible while the environment is healthy and surfaces
+/// exactly when something else is already broken, which is when the diagnosis
+/// is worth the most.
+#[allow(dead_code)]
+fn run_ok(args: &[&str]) -> std::process::Output {
+	let out = run(args);
+	assert!(
+		out.status.success(),
+		"podup {args:?} exited {}: {}",
+		out.status,
+		String::from_utf8_lossy(&out.stderr)
+	);
+	out
+}
+
 /// Poll until reading `path` inside `container` yields exactly `expect` once
 /// trimmed, or `secs` elapse. Returns whether it matched.
 ///

--- a/tests/engine_integration/cli_flags.rs
+++ b/tests/engine_integration/cli_flags.rs
@@ -60,10 +60,6 @@ async fn cli_logs_tail_limits_output() {
 		.unwrap();
 }
 
-fn run(args: &[&str]) -> std::process::Output {
-	Command::new(bin()).args(args).output().unwrap()
-}
-
 fn ps_all_count(compose: &str, proj: &str) -> usize {
 	String::from_utf8_lossy(&run(&["-f", compose, "-p", proj, "ps", "-a", "-q"]).stdout)
 		.lines()
@@ -89,7 +85,7 @@ async fn cli_down_remove_orphans_drops_undeclared_containers() {
 	fs::write(&one, format!("services:\n  web:\n    {svc}\n")).unwrap();
 	let (two, one) = (two.to_str().unwrap(), one.to_str().unwrap());
 
-	run(&["-f", two, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", two, "-p", &proj, "up", "-d"]);
 	assert_eq!(ps_all_count(two, &proj), 2);
 
 	// Down against the one-service file: --remove-orphans must also drop `extra`.
@@ -117,7 +113,7 @@ async fn cli_restart_no_deps_succeeds() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	let restart = run(&["-f", c, "-p", &proj, "restart", "--no-deps", "web"]);
 	assert!(
 		restart.status.success(),
@@ -170,7 +166,7 @@ async fn cli_up_pull_never_starts_present_image() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 	// Ensure the image is present, then `--pull never` must still start it.
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	run(&["-f", c, "-p", &proj, "down"]);
 	let up = run(&["-f", c, "-p", &proj, "up", "-d", "--pull", "never"]);
 	assert!(
@@ -220,7 +216,7 @@ async fn cli_down_rmi_all_succeeds_and_removes_containers() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	let down = run(&["-f", c, "-p", &proj, "down", "--rmi", "all"]);
 	assert!(
 		down.status.success(),
@@ -259,7 +255,7 @@ async fn cli_rm_volumes_removes_container() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	run(&["-f", c, "-p", &proj, "stop"]);
 	let rm = run(&["-f", c, "-p", &proj, "rm", "-v", "-f"]);
 	assert!(rm.status.success(), "rm -v failed: {:?}", rm.stderr);
@@ -284,7 +280,7 @@ async fn cli_kill_remove_orphans_drops_undeclared() {
 	fs::write(&one, format!("services:\n  web:\n    {svc}\n")).unwrap();
 	let (two, one) = (two.to_str().unwrap(), one.to_str().unwrap());
 
-	run(&["-f", two, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", two, "-p", &proj, "up", "-d"]);
 	let kill = run(&["-f", one, "-p", &proj, "kill", "--remove-orphans"]);
 	assert!(kill.status.success(), "kill failed: {:?}", kill.stderr);
 	// The orphan `extra` is removed; the declared `web` is killed but remains.
@@ -367,7 +363,7 @@ async fn cli_rm_stop_removes_running_container() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	assert_eq!(ps_all_count(c, &proj), 1, "container should exist after up");
 
 	// `rm -s` (no -f) must stop the running container first, then remove it.
@@ -399,7 +395,7 @@ async fn cli_start_wait_returns_after_starting() {
 
 	// Create the container without starting, then `start --wait` must start it
 	// and return (no healthcheck → ready once started).
-	run(&["-f", c, "-p", &proj, "up", "--no-start"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "--no-start"]);
 	let start = run(&[
 		"-f",
 		c,

--- a/tests/engine_integration/create_ls.rs
+++ b/tests/engine_integration/create_ls.rs
@@ -1,14 +1,9 @@
 //! Integration tests for `create` (containers without starting) and `ls`
 //! (project discovery) against a real Podman daemon. Skip when unreachable.
 use std::fs;
-use std::process::Command;
 use tempfile::tempdir;
 
 use super::*;
-
-fn run(args: &[&str]) -> std::process::Output {
-	Command::new(bin()).args(args).output().unwrap()
-}
 
 /// Count non-empty lines of a `-q` listing.
 fn count(out: &std::process::Output) -> usize {
@@ -48,7 +43,7 @@ async fn create_makes_containers_without_starting_them() {
 	);
 
 	// `up` then starts the already-created container.
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	assert_eq!(count(&run(&["-f", c, "-p", &proj, "ps", "-q"])), 1);
 
 	run(&["-f", c, "-p", &proj, "down"]);
@@ -69,7 +64,7 @@ async fn ls_lists_running_projects() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	// `ls -q` (running only) lists the project by name.
 	let names = String::from_utf8_lossy(&run(&["-p", &proj, "ls", "-q"]).stdout).into_owned();
 	assert!(

--- a/tests/engine_integration/niche.rs
+++ b/tests/engine_integration/niche.rs
@@ -1,14 +1,10 @@
 //! Niche-command CLI integration tests (wait/export/commit), split for the
 //! source line limit.
 use std::fs;
-use std::process::Command;
 use tempfile::tempdir;
 
 use super::*;
 
-fn run(args: &[&str]) -> std::process::Output {
-	Command::new(bin()).args(args).output().unwrap()
-}
 #[tokio::test]
 async fn cli_wait_names_the_container_and_its_exit_code() {
 	if super::podman().await.is_none() {
@@ -24,7 +20,7 @@ async fn cli_wait_names_the_container_and_its_exit_code() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	let out = run(&["-f", c, "-p", &proj, "wait", "job"]);
 	assert!(out.status.success(), "wait failed: {:?}", out.stderr);
 	// One line per container, naming it (#1248). This used to assert a line
@@ -56,7 +52,7 @@ async fn cli_export_writes_tar() {
 	let c = compose.to_str().unwrap();
 	let tar = dir.path().join("rootfs.tar");
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	let out = run(&[
 		"-f",
 		c,
@@ -89,7 +85,7 @@ async fn cli_commit_creates_image() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	let out = run(&["-f", c, "-p", &proj, "commit", "web", &img]);
 	run(&["-f", c, "-p", &proj, "down"]);
 	let exists = std::process::Command::new("podman")
@@ -126,7 +122,7 @@ async fn cli_attach_streams_output_until_exit() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "-d"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "-d"]);
 	let out = run(&["-f", c, "-p", &proj, "attach", "web"]);
 	run(&["-f", c, "-p", &proj, "down"]);
 	assert!(out.status.success(), "attach failed: {:?}", out.stderr);

--- a/tests/engine_integration/scale.rs
+++ b/tests/engine_integration/scale.rs
@@ -18,10 +18,6 @@ fn running_count(compose: &str, proj: &str) -> usize {
 		.count()
 }
 
-fn run(args: &[&str]) -> std::process::Output {
-	Command::new(bin()).args(args).output().unwrap()
-}
-
 /// Podman container id for `name`, or empty when it does not exist.
 fn container_id(name: &str) -> String {
 	let out = Command::new("podman")
@@ -80,7 +76,7 @@ async fn scale_subcommand_scales_up_then_down() {
 	.unwrap();
 	let c = compose.to_str().unwrap();
 
-	run(&["-f", c, "-p", &proj, "up", "--detach"]);
+	run_ok(&["-f", c, "-p", &proj, "up", "--detach"]);
 	assert_eq!(running_count(c, &proj), 1);
 
 	let up = run(&["-f", c, "-p", &proj, "scale", "worker=3"]);

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -129,7 +129,15 @@ async fn cli_stats_streaming_json_is_ndjson() {
 			.output()
 			.expect("run podup")
 	};
-	run(&["up", "-d"]);
+	// The closure above only checks that podup started, not that it exited 0,
+	// so a failed `up` would surface as a confusing assertion further down
+	// (#1340).
+	let up = run(&["up", "-d"]);
+	assert!(
+		up.status.success(),
+		"up -d failed: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
 
 	// Take a couple of frames, then stop: the stream never ends on its own.
 	let out = Command::new("timeout")
@@ -187,7 +195,15 @@ async fn cli_port_without_a_binding_exits_nonzero() {
 			.output()
 			.expect("run podup")
 	};
-	run(&["up", "-d"]);
+	// The closure above only checks that podup started, not that it exited 0,
+	// so a failed `up` would surface as a confusing assertion further down
+	// (#1340).
+	let up = run(&["up", "-d"]);
+	assert!(
+		up.status.success(),
+		"up -d failed: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
 
 	let out = run(&["port", "web", "80"]);
 	assert!(
@@ -229,7 +245,15 @@ async fn cli_port_prints_the_published_binding() {
 			.output()
 			.expect("run podup")
 	};
-	run(&["up", "-d"]);
+	// The closure above only checks that podup started, not that it exited 0,
+	// so a failed `up` would surface as a confusing assertion further down
+	// (#1340).
+	let up = run(&["up", "-d"]);
+	assert!(
+		up.status.success(),
+		"up -d failed: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
 
 	let out = run(&["port", "web", "80"]);
 	let stdout = String::from_utf8_lossy(&out.stdout).to_string();


### PR DESCRIPTION
Closes #1340. Found while bisecting the thread threshold for #1339.

A two-thread run reported this, and it took reading the test source to learn
what it meant:

```
create_ls::create_makes_containers_without_starting_them
assertion `left == right` failed
  left: 0
 right: 1
```

The assertion is correct. The message cannot say whether `up -d` **failed** or
succeeded and the container died, because the line above threw the answer away:

```rust
run(&["-f", c, "-p", &proj, "up", "-d"]);   // result discarded
```

## Scope, measured

41 discarded results:

| command | discarded | verdict |
|---|---|---|
| `down` | 21 | teardown — the test is over, fine |
| **`up`** | **18** | **everything after depends on it** |
| `stop` / `pull` | 2 | left alone |

## Two causes, both fixed

**Four identical copies of an unchecked helper.** `cli_flags`, `create_ls`,
`niche` and `scale` each defined

```rust
fn run(args: &[&str]) -> std::process::Output {
    Command::new(bin()).args(args).output().unwrap()
}
```

which is how they drifted from `stats_flags`'s version — the only one that
already asserted. The four copies are gone, replaced by one `run` (unchecked,
for teardown) and one `run_ok` (asserts, with the command and its stderr) at
the crate root, where every submodule already reaches via `use super::*`.

**Local closures that check the wrong thing.** `stats_flags` keeps its checked
module-level helper, but three of its tests define a local closure that only
`.expect("run podup")`s the *spawn*. A process that starts and exits 1 passes
that. Those three `up` calls now assert.

## Verified by making an `up` fail on purpose

```
run_ok →  podup [... "up", "-d", "--flag-que-no-existe"] exited exit status: 2:
          error: unexpected argument '--flag-que-no-existe' found

run    →  left: 0
          right: 1
```

Same test, same failure, two messages. The mutation was reverted and the file
confirmed clean.

## Why it is worth doing now

This is invisible while the environment is healthy — a green suite never
exercises it — and surfaces exactly when something else is already broken,
which is when the diagnosis is worth the most. Today it turned "is podup's `up`
failing under concurrency?" into an assertion about a count.

Same shape as #1330, where a DNS test blamed podup for the runtime's dead
resolver. A test that discards the evidence of its own precondition reports the
wrong thing with total confidence.

## Test plan

- Full integration suite: `178 passed; 0 failed` in 120.56s.
- lib 1525, bins 81.
- `cargo fmt --all --check` and `cargo clippy --locked --all-targets
  --all-features -- -D warnings`; the two imports orphaned by deleting the
  duplicate helpers are removed, so the build is warning-free.