### PR TITLE
ci(lane): give the coverage path timeout headroom before it runs out

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -23,7 +23,16 @@ jobs:
     runs-on: ubuntu-24.04
     # Raised for the one-thread experiment: serialising the suite costs wall
     # clock, and a run that dies on the timeout answers nothing (#1039).
-    timeout-minutes: 75
+    #
+    # Raised again for the coverage path. Capping the coverage run to the same
+    # thread count as the gating run (#1338) means the Podman 6 leg now runs two
+    # serialised suites, and it came in at 66m27s of the 75 on run 30879785232 —
+    # 89% of the budget. That is not a failure yet, which is the only useful
+    # moment to change it: a slower runner or a heavier rawhide image tips it
+    # over, and the run that dies tells you nothing about the coverage it was
+    # measuring. Costs nothing on the pull-request path, where coverage is off
+    # and the leg finishes in about half this.
+    timeout-minutes: 95
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Capping the coverage run to the gating run's thread count (#1338) means the
Podman 6 leg now runs **two serialised suites**. Measured on run `30879785232`:

| leg | started | gating suite done | coverage done | total | budget used |
|---|---|---|---|---|---|
| Podman 6 | 05:08:53 | 05:40:27 | 06:15:13 | **66m27s** | **89%** of 75 |
| Podman 5 | 05:08:58 | 05:26:15 | 05:45:20 | 36m28s | 49% |

It has not failed, which is the only useful moment to change this. A slower
runner or a heavier rawhide image tips it over, and **a job killed on the
timeout tells you nothing about the coverage it was measuring** — the same
reason the timeout was raised for the one-thread experiment in #1039.

95 rather than 90 so a bad-luck run still lands.

Costs nothing on the pull-request path: coverage is off there by design, and the
leg finishes in roughly half the time.

## Also, the number arrived

Same run, both legs, with #1337 and #1338 in place:

| leg | coverage |
|---|---|
| Podman 5.8.1 | **91.56%** |
| Podman 6.0.1 | **91.59%** |

Three samples now sit within 0.03pp of each other, against the CI job's 79.39%
and the standard's 90%. Podman 6 previously reported `no-total-line`; the thread
cap fixed it, which is the confirmation #1338 was waiting for.

## Test plan

- YAML parses.
- Nothing else in the file changes — this is the `timeout-minutes` value and the
  comment recording why.