### PR TITLE
fix(lifecycle): resolve a dropped lifecycle response out of band instead of failing

### DIFF
--- a/internal/engine/fake_podman.rs
+++ b/internal/engine/fake_podman.rs
@@ -42,6 +42,19 @@ pub(super) enum FakeReply {
 	/// closes. The other place a severed stream can land, and — measured — hyper
 	/// classifies the two differently, which is why both exist here.
 	ChunkedCutMidPayload(String),
+	/// The request is read and accepted, and then the connection closes with **no
+	/// response at all** — not even a status line.
+	///
+	/// This is the shape `PodmanError::is_incomplete_message` names: hyper's
+	/// `IncompleteMessage` is about the message *head*, so it is the one reply
+	/// here that produces it, and the severed-body variants above do not.
+	///
+	/// It is what libpod does on Podman 6 to the container-archive PUT (#1097,
+	/// applies the archive then hangs up) and to state-changing POSTs under
+	/// concurrency (#1339). Both are handled by re-checking the observable out of
+	/// band, and until this existed neither discriminator had a test that could
+	/// reach it.
+	ClosedWithoutResponse,
 }
 
 /// A test's routing rule: `(method, target) -> reply`, where `target` is the
@@ -180,6 +193,9 @@ async fn serve_one(
 				.write_all(format!("{:x}\r\n{}", chunk.len(), &chunk[..half]).as_bytes())
 				.await?;
 			stream.flush().await?;
+		}
+		FakeReply::ClosedWithoutResponse => {
+			// Write nothing. The shutdown below is the entire reply.
 		}
 	}
 	stream.shutdown().await?;

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -19,6 +19,30 @@ use crate::libpod::API_PREFIX;
 /// other capped column in the binary does.
 const WAIT_NAME_WIDTH: usize = 32;
 
+/// What a lifecycle operation was trying to achieve.
+///
+/// The transport cannot say whether a dropped response means the operation
+/// failed or completed and lost only its reply — the two are indistinguishable
+/// at HTTP (#1104). This names the observable that answers it out of band.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum LifecycleGoal {
+	/// `start`, `restart` — the container should be running afterwards.
+	Running,
+	/// `kill` — the container should not be running afterwards.
+	NotRunning,
+}
+
+impl LifecycleGoal {
+	/// Whether libpod's `State` satisfies this goal. `None` means the container
+	/// no longer exists, which reaches `NotRunning` and fails `Running`.
+	pub(super) fn reached(self, state: Option<&str>) -> bool {
+		match self {
+			Self::Running => state == Some("running"),
+			Self::NotRunning => state != Some("running"),
+		}
+	}
+}
+
 /// `wait`'s header row.
 fn wait_header() -> String {
 	format!("{:<WAIT_NAME_WIDTH$} EXIT", "NAME")
@@ -81,6 +105,7 @@ impl Engine {
 		path: &str,
 		container: &str,
 		done: &str,
+		goal: LifecycleGoal,
 	) -> Result<bool> {
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
@@ -91,8 +116,80 @@ impl Engine {
 				tracing::debug!("{container}: {done} skipped ({e})");
 				Ok(false)
 			}
+			// The server closed before completing the response. That is not an
+			// answer: the operation may have run to completion and lost only its
+			// reply. Measured on Podman 6 under concurrency, where the drops land
+			// on exactly these state-changing POSTs and follow a slow one — a
+			// restart that burned its full stop grace, then a drop on the next
+			// (#1339). It is not a client deadline (READ_TIMEOUT is 120s) and not
+			// a pooled-connection race (there is no pool; every request gets a
+			// fresh socket), so the transport genuinely cannot say.
+			//
+			// Resolve it the way `cp` and `stats` already do: ask the observable
+			// the transport cannot see. If the container reached the state the
+			// operation was for, it succeeded.
+			Err(e) if e.is_incomplete_message() => {
+				match self.container_state(container).await {
+					Ok(state) if goal.reached(state.as_deref()) => {
+						tracing::warn!(
+							"{container}: {done} lost its response [{}] but the container \
+							 reached {goal:?}, so the operation landed",
+							e.stream_end_kind()
+						);
+						crate::ui::progress_line("Container", container, done);
+						Ok(true)
+					}
+					// Fail closed on both remaining shapes: a container that did
+					// not reach the goal, and a re-check that could not be read.
+					// Neither is confirmation, and reporting success without one
+					// is the failure this exists to prevent.
+					Ok(state) => {
+						tracing::warn!(
+							"{container}: {done} lost its response [{}] and the container \
+							 is {state:?}, not {goal:?}",
+							e.stream_end_kind()
+						);
+						Err(ComposeError::Podman(e))
+					}
+					Err(recheck) => {
+						tracing::warn!(
+							"{container}: {done} lost its response [{}] and the state \
+							 could not be re-checked: {recheck}",
+							e.stream_end_kind()
+						);
+						Err(ComposeError::Podman(e))
+					}
+				}
+			}
 			Err(e) => Err(ComposeError::Podman(e)),
 		}
+	}
+
+	/// libpod's `State` for one container, or `None` when it no longer exists.
+	///
+	/// Listed rather than inspected: the list carries `State` directly and the
+	/// inspect response is several times the size for the one field wanted here
+	/// (#1298). libpod's `name` filter matches on substring, so the exact name is
+	/// picked out of the results rather than trusted from the query.
+	pub(super) async fn container_state(&self, container: &str) -> Result<Option<String>> {
+		let filters = serde_json::json!({ "name": [container] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			crate::libpod::urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		Ok(entries
+			.into_iter()
+			.find(|e| {
+				e.names
+					.iter()
+					.any(|n| n.trim_start_matches('/') == container)
+			})
+			.map(|e| e.state))
 	}
 
 	/// Like [`Self::run_lifecycle_op`] but also treats a "container state

--- a/internal/engine/lifecycle/drop_recheck_tests.rs
+++ b/internal/engine/lifecycle/drop_recheck_tests.rs
@@ -1,0 +1,136 @@
+//! A lifecycle POST whose response is dropped is resolved out of band (#1339).
+//!
+//! Measured on Podman 6 under concurrency: the drops land on state-changing
+//! POSTs — `exec`, `restart`, `stop`, container `DELETE` — and follow a slow
+//! one, a restart that burned its full stop grace before the next request lost
+//! its response. It is not a client deadline (`READ_TIMEOUT` is 120s) and not a
+//! pooled-connection race (there is no pool; every request opens a fresh
+//! socket), so the transport genuinely cannot say whether the operation ran.
+//!
+//! These pin the three answers: the container reached the goal, it did not, and
+//! the re-check itself could not be read. Only the first is success.
+
+use super::commands::LifecycleGoal;
+
+#[test]
+fn a_goal_is_reached_only_by_the_state_that_satisfies_it() {
+	assert!(LifecycleGoal::Running.reached(Some("running")));
+	assert!(!LifecycleGoal::Running.reached(Some("exited")));
+	assert!(!LifecycleGoal::Running.reached(Some("paused")));
+	// A container that no longer exists never satisfies `Running`, and always
+	// satisfies `NotRunning` — `rm` and a lost `kill` response both land here.
+	assert!(!LifecycleGoal::Running.reached(None));
+	assert!(LifecycleGoal::NotRunning.reached(None));
+	assert!(LifecycleGoal::NotRunning.reached(Some("exited")));
+	assert!(!LifecycleGoal::NotRunning.reached(Some("running")));
+}
+
+#[cfg(unix)]
+mod over_the_wire {
+	use super::super::commands::LifecycleGoal;
+	use crate::engine::fake_podman::{self, FakeReply};
+	use crate::engine::Engine;
+	use crate::libpod::API_PREFIX;
+
+	fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+	}
+
+	/// Drop the response to the lifecycle POST, and answer the state re-check
+	/// with `state`. `None` reports the container as absent.
+	fn fake_dropping_the_op(state: Option<&'static str>) -> fake_podman::FakePodman {
+		fake_podman::start_replying(move |method, target| {
+			if method == "POST" && target.contains("/proj-web-1/") {
+				// Accept, then hang up without a response — the one shape that
+				// produces hyper's `IncompleteMessage`.
+				return FakeReply::ClosedWithoutResponse;
+			}
+			if method == "GET" && target.contains("/containers/json") {
+				let body = match state {
+					Some(s) => format!(
+						r#"[{{"Id":"abc","Names":["/proj-web-1"],"Image":"i","Status":"","State":"{s}"}}]"#
+					),
+					None => "[]".to_string(),
+				};
+				return FakeReply::Body(200, body);
+			}
+			FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
+		})
+	}
+
+	fn start_path() -> String {
+		format!("{API_PREFIX}/containers/proj-web-1/start")
+	}
+
+	#[tokio::test]
+	async fn a_lost_response_succeeds_when_the_container_reached_the_goal() {
+		let fake = fake_dropping_the_op(Some("running"));
+		let engine = engine_with(fake.client(), "proj");
+		let acted = engine
+			.run_lifecycle_op(
+				&start_path(),
+				"proj-web-1",
+				"Started",
+				LifecycleGoal::Running,
+			)
+			.await
+			.expect("the container is running, so the operation landed");
+		assert!(acted, "a confirmed operation counts as having acted");
+	}
+
+	#[tokio::test]
+	async fn a_lost_response_fails_when_the_container_did_not_reach_the_goal() {
+		let fake = fake_dropping_the_op(Some("exited"));
+		let engine = engine_with(fake.client(), "proj");
+		engine
+			.run_lifecycle_op(
+				&start_path(),
+				"proj-web-1",
+				"Started",
+				LifecycleGoal::Running,
+			)
+			.await
+			.expect_err("the container is not running, so nothing confirms the start");
+	}
+
+	/// Fail closed. An unreadable re-check is not confirmation, and reporting
+	/// success without one is the defect this whole path exists to prevent.
+	#[tokio::test]
+	async fn a_lost_response_fails_when_the_state_cannot_be_re_checked() {
+		let fake = fake_podman::start_replying(|method, target| {
+			if method == "POST" && target.contains("/proj-web-1/") {
+				return FakeReply::ClosedWithoutResponse;
+			}
+			// The re-check itself errors.
+			FakeReply::Body(500, r#"{"message":"boom"}"#.to_string())
+		});
+		let engine = engine_with(fake.client(), "proj");
+		engine
+			.run_lifecycle_op(
+				&start_path(),
+				"proj-web-1",
+				"Started",
+				LifecycleGoal::Running,
+			)
+			.await
+			.expect_err("an unreadable re-check must not be read as success");
+	}
+
+	/// A gone container satisfies `NotRunning`, which is what a lost `kill`
+	/// response looks like when the kill actually worked.
+	#[tokio::test]
+	async fn a_lost_kill_response_succeeds_when_the_container_is_gone() {
+		let fake = fake_dropping_the_op(None);
+		let engine = engine_with(fake.client(), "proj");
+		let acted = engine
+			.run_lifecycle_op(
+				&format!("{API_PREFIX}/containers/proj-web-1/kill?signal=SIGKILL"),
+				"proj-web-1",
+				"Killed",
+				LifecycleGoal::NotRunning,
+			)
+			.await
+			.expect("the container is gone, so the kill landed");
+		assert!(acted);
+	}
+}

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -772,4 +772,6 @@ pub(super) fn container_rm_path(name: &str, remove_volumes: bool) -> String {
 }
 
 #[cfg(test)]
+mod drop_recheck_tests;
+#[cfg(test)]
 mod tests;

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -18,6 +18,7 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
+use super::commands::LifecycleGoal;
 use super::targets::{stop_deadline, stop_timeout_param};
 
 /// Upper bound on the number of same-level services a lifecycle command acts on
@@ -181,7 +182,7 @@ impl Engine {
 				urlencoded(&container_name),
 			);
 			if let Err(e) = self
-				.run_lifecycle_op(&path, &container_name, "Started")
+				.run_lifecycle_op(&path, &container_name, "Started", LifecycleGoal::Running)
 				.await
 			{
 				first_err.get_or_insert(e);
@@ -210,7 +211,7 @@ impl Engine {
 				stop_timeout_param(grace),
 			);
 			match self
-				.run_lifecycle_op(&restart_path, &container_name, done)
+				.run_lifecycle_op(&restart_path, &container_name, done, LifecycleGoal::Running)
 				.await
 			{
 				Ok(true) => acted.store(true, std::sync::atomic::Ordering::Relaxed),
@@ -239,7 +240,7 @@ impl Engine {
 				urlencoded(signal),
 			);
 			match self
-				.run_lifecycle_op(&path, &container_name, "Killed")
+				.run_lifecycle_op(&path, &container_name, "Killed", LifecycleGoal::NotRunning)
 				.await
 			{
 				Ok(true) => acted.store(true, std::sync::atomic::Ordering::Relaxed),

--- a/internal/engine/stream_end_tests.rs
+++ b/internal/engine/stream_end_tests.rs
@@ -38,6 +38,10 @@ async fn read_stream(reply: FakeReply) -> (Vec<serde_json::Value>, Option<String
 		FakeReply::ChunkedEnd(c) => FakeReply::ChunkedEnd(c.clone()),
 		FakeReply::ChunkedTruncated(c) => FakeReply::ChunkedTruncated(c.clone()),
 		FakeReply::ChunkedCutMidPayload(c) => FakeReply::ChunkedCutMidPayload(c.clone()),
+		// Not a stream *ending* — it never becomes a stream. `get_stream` fails
+		// at the response head rather than reaching the parser this measures, so
+		// this shape belongs to the lifecycle re-check tests instead.
+		FakeReply::ClosedWithoutResponse => FakeReply::ClosedWithoutResponse,
 	});
 	let client = fake.client();
 	let resp = client


### PR DESCRIPTION
The fix #1339's step 3 pointed at, and it is podup-side, so it waits on nothing
upstream.

## What the measurement said

Instrumenting the suite at three threads (`RUST_LOG=podup=debug`, every libpod
request logged) showed the drops land on **state-changing POSTs** — `exec`,
`restart`, `stop`, container `DELETE` — never on the reads. And the timestamps
inside one failing test's own captured block:

```
06:24:06.700679  POST …/containers/t3812-rsr-worker-1/restart
06:24:16.826346  POST …/containers/t3812-rsr-worker-2/restart    ← 10.1s later
                 panicked … Podman(Hyper(hyper::Error(IncompleteMessage)))
```

Everything else in that trace runs in **milliseconds**. The gap is the first
restart burning its full stop grace; the drop lands on the request after it.

Two explanations that suggested, both ruled out by reading the client rather
than guessing:

| candidate | why not |
|---|---|
| a client deadline | `READ_TIMEOUT` 120s, `CONNECT_TIMEOUT` 30s — nowhere near 10s |
| a keep-alive race on a pooled connection | there is no pool; `http1::handshake` runs per request on a fresh socket |

So the server severed the response, and the transport cannot say whether the
operation ran. That is #1104's undecidable question, arriving from the other end.

## The fix is the pattern podup already has

`cp` verifies the destination entry moved (#1097); `stats` re-checks the running
set (#1080). `run_lifecycle_op` now does the same — and because `start`,
`restart` and `kill` already share it, one change covers all three.

A `LifecycleGoal` names what the operation was for, and **only a container that
reached it counts as success**. Both other shapes fail closed:

- reached the goal → success, with a `warn!` recording that the response was lost
- did not reach it → the original error
- re-check unreadable → the original error

## The harness could not produce this shape at all

`FakeReply`'s four variants all send *something*, and `is_incomplete_message` is
about the message **head** — so nothing in the tree could reach that
discriminator, **including the one `cp` has relied on since #1097**.
`ClosedWithoutResponse` fills that: request accepted, connection closed, no
status line.

## Verified by mutation, not by reading

| mutation | result |
|---|---|
| remove the re-check branch | the **2 success tests** go red |
| make the re-check always agree | the **did-not-reach-the-goal** test goes red |

The unreadable-re-check test stays green under the second, because it lives in a
different arm — so the tests tell the two fail-closed shapes apart rather than
conflating them.

## Test plan

- lib 1530, bins 81; full integration suite `178 passed; 0 failed` in 120s.
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets --all-features
  -- -D warnings`.
- `commands.rs` at 478 code lines, under the standard's 500; the new tests are
  their own file rather than pushing it over.

Refs #1339