### PR TITLE
fix(lifecycle): cover the remaining three endpoints the drops were measured on

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -3,6 +3,7 @@
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 
+use super::drop_recheck::LifecycleGoal;
 use super::filter_services;
 use super::parallel::{
 	filter_levels, first_error, join_bounded, restart_service_set, retain_levels,
@@ -18,30 +19,6 @@ use crate::libpod::API_PREFIX;
 /// typical `<project>-<service>-<n>`; a longer name truncates the way every
 /// other capped column in the binary does.
 const WAIT_NAME_WIDTH: usize = 32;
-
-/// What a lifecycle operation was trying to achieve.
-///
-/// The transport cannot say whether a dropped response means the operation
-/// failed or completed and lost only its reply — the two are indistinguishable
-/// at HTTP (#1104). This names the observable that answers it out of band.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum LifecycleGoal {
-	/// `start`, `restart` — the container should be running afterwards.
-	Running,
-	/// `kill` — the container should not be running afterwards.
-	NotRunning,
-}
-
-impl LifecycleGoal {
-	/// Whether libpod's `State` satisfies this goal. `None` means the container
-	/// no longer exists, which reaches `NotRunning` and fails `Running`.
-	pub(super) fn reached(self, state: Option<&str>) -> bool {
-		match self {
-			Self::Running => state == Some("running"),
-			Self::NotRunning => state != Some("running"),
-		}
-	}
-}
 
 /// `wait`'s header row.
 fn wait_header() -> String {
@@ -129,67 +106,10 @@ impl Engine {
 			// the transport cannot see. If the container reached the state the
 			// operation was for, it succeeded.
 			Err(e) if e.is_incomplete_message() => {
-				match self.container_state(container).await {
-					Ok(state) if goal.reached(state.as_deref()) => {
-						tracing::warn!(
-							"{container}: {done} lost its response [{}] but the container \
-							 reached {goal:?}, so the operation landed",
-							e.stream_end_kind()
-						);
-						crate::ui::progress_line("Container", container, done);
-						Ok(true)
-					}
-					// Fail closed on both remaining shapes: a container that did
-					// not reach the goal, and a re-check that could not be read.
-					// Neither is confirmation, and reporting success without one
-					// is the failure this exists to prevent.
-					Ok(state) => {
-						tracing::warn!(
-							"{container}: {done} lost its response [{}] and the container \
-							 is {state:?}, not {goal:?}",
-							e.stream_end_kind()
-						);
-						Err(ComposeError::Podman(e))
-					}
-					Err(recheck) => {
-						tracing::warn!(
-							"{container}: {done} lost its response [{}] and the state \
-							 could not be re-checked: {recheck}",
-							e.stream_end_kind()
-						);
-						Err(ComposeError::Podman(e))
-					}
-				}
+				self.confirm_lost_response(container, done, goal, e).await
 			}
 			Err(e) => Err(ComposeError::Podman(e)),
 		}
-	}
-
-	/// libpod's `State` for one container, or `None` when it no longer exists.
-	///
-	/// Listed rather than inspected: the list carries `State` directly and the
-	/// inspect response is several times the size for the one field wanted here
-	/// (#1298). libpod's `name` filter matches on substring, so the exact name is
-	/// picked out of the results rather than trusted from the query.
-	pub(super) async fn container_state(&self, container: &str) -> Result<Option<String>> {
-		let filters = serde_json::json!({ "name": [container] });
-		let path = format!(
-			"{API_PREFIX}/containers/json?all=true&filters={}",
-			crate::libpod::urlencoded(&filters.to_string()),
-		);
-		let entries = self
-			.client
-			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
-			.await
-			.map_err(ComposeError::Podman)?;
-		Ok(entries
-			.into_iter()
-			.find(|e| {
-				e.names
-					.iter()
-					.any(|n| n.trim_start_matches('/') == container)
-			})
-			.map(|e| e.state))
 	}
 
 	/// Like [`Self::run_lifecycle_op`] but also treats a "container state
@@ -245,6 +165,13 @@ impl Engine {
 				tracing::debug!("{container}: stop skipped ({e})");
 				Ok(())
 			}
+			// `stop` is one of the four state-changing calls the drops were
+			// measured on (#1339), and it does not go through `run_lifecycle_op`,
+			// so it needs the re-check on its own.
+			Err(e) if e.is_incomplete_message() => self
+				.confirm_lost_response(container, "Stopped", LifecycleGoal::NotRunning, e)
+				.await
+				.map(|_| ()),
 			Err(e) if e.is_timeout() => {
 				tracing::warn!(
 					"{container}: stop did not complete within the grace window; escalating to SIGKILL"

--- a/internal/engine/lifecycle/drop_recheck.rs
+++ b/internal/engine/lifecycle/drop_recheck.rs
@@ -1,0 +1,121 @@
+//! Deciding whether an operation whose response was dropped actually landed.
+//!
+//! The transport cannot answer it. A libpod call that is severed before its
+//! response completes looks identical whether the operation ran or not (#1104),
+//! and on Podman 6 under concurrency that happens on exactly the state-changing
+//! calls — `exec`, `restart`, `stop`, container `DELETE` — after a slow one
+//! (#1339). It is not a client deadline and not a pooled-connection race; both
+//! were ruled out by measurement.
+//!
+//! So it is answered the way `cp` and `stats` already answer theirs: by asking
+//! the observable the transport cannot see.
+
+use crate::error::{ComposeError, Result};
+
+use crate::engine::Engine;
+use crate::libpod::API_PREFIX;
+
+/// What a lifecycle operation was trying to achieve.
+///
+/// The transport cannot say whether a dropped response means the operation
+/// failed or completed and lost only its reply — the two are indistinguishable
+/// at HTTP (#1104). This names the observable that answers it out of band.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum LifecycleGoal {
+	/// `start`, `restart` — the container should be running afterwards.
+	Running,
+	/// `kill`, `stop` — the container should not be running afterwards.
+	NotRunning,
+	/// `rm` — the container should not exist afterwards. Distinct from
+	/// [`Self::NotRunning`]: a stopped-but-present container satisfies that one
+	/// and would read a failed removal as a success.
+	Gone,
+}
+
+impl LifecycleGoal {
+	/// Whether libpod's `State` satisfies this goal. `None` means the container
+	/// no longer exists — which reaches `NotRunning` and `Gone`, and fails
+	/// `Running`.
+	pub(super) fn reached(self, state: Option<&str>) -> bool {
+		match self {
+			Self::Running => state == Some("running"),
+			Self::NotRunning => state != Some("running"),
+			Self::Gone => state.is_none(),
+		}
+	}
+}
+
+impl Engine {
+	/// Decide whether an operation whose response was dropped actually landed.
+	///
+	/// Shared by every state-changing call that can lose its reply, so they
+	/// cannot drift into different answers to the same question — the way the
+	/// lane's retry list and its flake counter drifted apart in #1104.
+	///
+	/// Success requires the container to have reached `goal`. Both other shapes
+	/// fail closed: a container that did not reach it, and a re-check that could
+	/// not be read. Neither is confirmation, and reporting success without one is
+	/// the failure this exists to prevent.
+	pub(super) async fn confirm_lost_response(
+		&self,
+		container: &str,
+		done: &str,
+		goal: LifecycleGoal,
+		e: crate::libpod::PodmanError,
+	) -> Result<bool> {
+		match self.container_state(container).await {
+			Ok(state) if goal.reached(state.as_deref()) => {
+				tracing::warn!(
+					"{container}: {done} lost its response [{}] but the container reached \
+					 {goal:?}, so the operation landed",
+					e.stream_end_kind()
+				);
+				crate::ui::progress_line("Container", container, done);
+				Ok(true)
+			}
+			Ok(state) => {
+				tracing::warn!(
+					"{container}: {done} lost its response [{}] and the container is \
+					 {state:?}, not {goal:?}",
+					e.stream_end_kind()
+				);
+				Err(ComposeError::Podman(e))
+			}
+			Err(recheck) => {
+				tracing::warn!(
+					"{container}: {done} lost its response [{}] and the state could not be \
+					 re-checked: {recheck}",
+					e.stream_end_kind()
+				);
+				Err(ComposeError::Podman(e))
+			}
+		}
+	}
+
+	/// libpod's `State` for one container, or `None` when it no longer exists.
+	///
+	/// Listed rather than inspected: the list carries `State` directly and the
+	/// inspect response is several times the size for the one field wanted here
+	/// (#1298). libpod's `name` filter matches on substring, so the exact name is
+	/// picked out of the results rather than trusted from the query.
+	pub(super) async fn container_state(&self, container: &str) -> Result<Option<String>> {
+		let filters = serde_json::json!({ "name": [container] });
+		let path = format!(
+			"{API_PREFIX}/containers/json?all=true&filters={}",
+			crate::libpod::urlencoded(&filters.to_string()),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		Ok(entries
+			.into_iter()
+			.find(|e| {
+				e.names
+					.iter()
+					.any(|n| n.trim_start_matches('/') == container)
+			})
+			.map(|e| e.state))
+	}
+}

--- a/internal/engine/lifecycle/drop_recheck_tests.rs
+++ b/internal/engine/lifecycle/drop_recheck_tests.rs
@@ -10,7 +10,7 @@
 //! These pin the three answers: the container reached the goal, it did not, and
 //! the re-check itself could not be read. Only the first is success.
 
-use super::commands::LifecycleGoal;
+use super::drop_recheck::LifecycleGoal;
 
 #[test]
 fn a_goal_is_reached_only_by_the_state_that_satisfies_it() {
@@ -27,20 +27,25 @@ fn a_goal_is_reached_only_by_the_state_that_satisfies_it() {
 
 #[cfg(unix)]
 mod over_the_wire {
-	use super::super::commands::LifecycleGoal;
+	use super::super::drop_recheck::LifecycleGoal;
 	use crate::engine::fake_podman::{self, FakeReply};
 	use crate::engine::Engine;
 	use crate::libpod::API_PREFIX;
 
-	fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+	pub(super) fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
 	}
 
 	/// Drop the response to the lifecycle POST, and answer the state re-check
 	/// with `state`. `None` reports the container as absent.
-	fn fake_dropping_the_op(state: Option<&'static str>) -> fake_podman::FakePodman {
+	pub(super) fn fake_dropping_the_op(state: Option<&'static str>) -> fake_podman::FakePodman {
 		fake_podman::start_replying(move |method, target| {
-			if method == "POST" && target.contains("/proj-web-1/") {
+			// Both shapes the drops were measured on: the state-changing POSTs
+			// and the container DELETE. Dropping only the POSTs let a removal
+			// fall through to the 404 arm and be read as an idempotent no-op,
+			// which is a test that measures nothing.
+			let touches_it = target.contains("/proj-web-1");
+			if touches_it && (method == "POST" || method == "DELETE") {
 				// Accept, then hang up without a response — the one shape that
 				// produces hyper's `IncompleteMessage`.
 				return FakeReply::ClosedWithoutResponse;
@@ -132,5 +137,65 @@ mod over_the_wire {
 			.await
 			.expect("the container is gone, so the kill landed");
 		assert!(acted);
+	}
+}
+
+/// `Gone` is not `NotRunning`. A removal that lost its response must not be read
+/// as success just because the container stopped — it has to be absent.
+#[test]
+fn gone_needs_absence_not_merely_a_stopped_container() {
+	assert!(LifecycleGoal::Gone.reached(None));
+	assert!(!LifecycleGoal::Gone.reached(Some("exited")));
+	assert!(!LifecycleGoal::Gone.reached(Some("running")));
+	// The distinction that matters: `exited` satisfies NotRunning and not Gone.
+	assert!(LifecycleGoal::NotRunning.reached(Some("exited")));
+}
+
+#[cfg(unix)]
+mod stop_and_remove {
+	use super::over_the_wire::{engine_with, fake_dropping_the_op};
+
+	/// `stop` does not go through `run_lifecycle_op`, so it carries the re-check
+	/// itself. A container that is no longer running confirms the stop landed.
+	#[tokio::test]
+	async fn a_lost_stop_response_succeeds_when_the_container_is_not_running() {
+		let fake = fake_dropping_the_op(Some("exited"));
+		let engine = engine_with(fake.client(), "proj");
+		engine
+			.stop_container("proj-web-1", 10)
+			.await
+			.expect("the container is not running, so the stop landed");
+	}
+
+	#[tokio::test]
+	async fn a_lost_stop_response_fails_while_the_container_still_runs() {
+		let fake = fake_dropping_the_op(Some("running"));
+		let engine = engine_with(fake.client(), "proj");
+		engine
+			.stop_container("proj-web-1", 10)
+			.await
+			.expect_err("still running is not a stop");
+	}
+
+	/// And removal, which needs the container **absent** — a stopped-but-present
+	/// container would satisfy `NotRunning` and read a failed removal as success.
+	#[tokio::test]
+	async fn a_lost_removal_response_fails_when_the_container_is_merely_stopped() {
+		let fake = fake_dropping_the_op(Some("exited"));
+		let engine = engine_with(fake.client(), "proj");
+		engine
+			.teardown_one_container("proj-web-1", 10, &[], false)
+			.await
+			.expect_err("a container that is still there was not removed");
+	}
+
+	#[tokio::test]
+	async fn a_lost_removal_response_succeeds_when_the_container_is_gone() {
+		let fake = fake_dropping_the_op(None);
+		let engine = engine_with(fake.client(), "proj");
+		engine
+			.teardown_one_container("proj-web-1", 10, &[], false)
+			.await
+			.expect("the container is absent, so the removal landed");
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod down_label;
+mod drop_recheck;
 mod images;
 // Visible within the engine, not beyond it: the secret pre-creation stage
 // (#1219) fans out against the same `MAX_LIFECYCLE_CONCURRENCY` ceiling rather

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -18,7 +18,7 @@ use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
-use super::commands::LifecycleGoal;
+use super::drop_recheck::LifecycleGoal;
 use super::targets::{stop_deadline, stop_timeout_param};
 
 /// Upper bound on the number of same-level services a lifecycle command acts on
@@ -383,6 +383,13 @@ impl Engine {
 				Ok(())
 			}
 			Err(e) if e.is_status(404) => Ok(()),
+			// The other state-changing call the drops were measured on (#1339).
+			// `Gone` rather than `NotRunning`: a stopped-but-present container
+			// would satisfy the latter and read a failed removal as a success.
+			Err(e) if e.is_incomplete_message() => self
+				.confirm_lost_response(container_name, "Removed", LifecycleGoal::Gone, e)
+				.await
+				.map(|_| ()),
 			Err(e) => {
 				tracing::warn!("could not remove {container_name}: {e}");
 				Err(ComposeError::Podman(e))

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -258,11 +258,35 @@ impl Engine {
 			"{API_PREFIX}/containers/{}/exec",
 			urlencoded(&container_name),
 		);
-		let resp: ExecCreateResponse = self
-			.client
-			.post_json(&create_path, &exec_cfg)
-			.await
-			.map_err(|e| map_not_running(e, service_name))?;
+		let resp: ExecCreateResponse = match self.client.post_json(&create_path, &exec_cfg).await {
+			Ok(resp) => resp,
+			// The exec create is where the drops measured in #1339 land most
+			// often — twice of six, more than any other endpoint. Unlike the
+			// lifecycle calls, a lost response here cannot be resolved by looking
+			// at the container: what is lost is the exec id, and a container
+			// running several execs at once cannot say which of its `ExecIDs` was
+			// this one.
+			//
+			// Retrying is safe instead, because creating an exec changes nothing.
+			// Measured on Podman 5.7.0: five execs created and never started leave
+			// the container `running` on the same pid with no extra process
+			// inside — they are inert handles that die with it. So the worst case
+			// of a retry is one leaked handle, against an `exec` that fails for a
+			// reason that was never about the command.
+			//
+			// Once only: a second drop is a daemon problem, not a transient.
+			Err(e) if e.is_incomplete_message() => {
+				tracing::warn!(
+					"{container_name}: the exec create lost its response [{}]; retrying once",
+					e.stream_end_kind()
+				);
+				self.client
+					.post_json(&create_path, &exec_cfg)
+					.await
+					.map_err(|e| map_not_running(e, service_name))?
+			}
+			Err(e) => return Err(map_not_running(e, service_name)),
+		};
 		let exec_id = resp.id;
 
 		// `-d/--detach`: start the exec and return without streaming output or
@@ -571,5 +595,94 @@ mod tests {
 			}
 			other => panic!("expected Podman passthrough, got {other:?}"),
 		}
+	}
+}
+
+/// The exec create is the endpoint the #1339 drops land on most, and a lost
+/// response there cannot be resolved by looking at the container — what is lost
+/// is the exec id. Retrying is safe because creating an exec changes nothing:
+/// measured on Podman 5.7.0, five unstarted execs leave the container running on
+/// the same pid with no extra process inside.
+#[cfg(all(test, unix))]
+mod exec_create_retry_tests {
+	use std::sync::atomic::{AtomicUsize, Ordering};
+	use std::sync::Arc;
+
+	use super::ExecOptions;
+	use crate::compose::parse_str;
+	use crate::engine::fake_podman::{self, FakeReply};
+	use crate::engine::Engine;
+
+	/// Answer the exec create by dropping the connection the first `drops` times
+	/// and replying normally after that. Returns the fake and the call counter.
+	fn fake_dropping_creates(drops: usize) -> (fake_podman::FakePodman, Arc<AtomicUsize>) {
+		let creates = Arc::new(AtomicUsize::new(0));
+		let seen = creates.clone();
+		let fake = fake_podman::start_replying(move |method, target| {
+			if method == "POST" && target.ends_with("/exec") {
+				let n = seen.fetch_add(1, Ordering::SeqCst);
+				if n < drops {
+					return FakeReply::ClosedWithoutResponse;
+				}
+				return FakeReply::Body(201, r#"{"Id":"exec-1"}"#.to_string());
+			}
+			if method == "POST" && target.contains("/exec/") {
+				return FakeReply::Body(200, String::new());
+			}
+			if method == "GET" && target.contains("/containers/json") {
+				return FakeReply::Body(
+					200,
+					r#"[{"Id":"c1","Names":["/proj-web-1"],"Image":"i","Status":"","State":"running"}]"#
+						.to_string(),
+				);
+			}
+			FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
+		});
+		(fake, creates)
+	}
+
+	/// Drive the real `exec` entry point, detached so the hijacked streaming path
+	/// is out of the picture — the retry under test is on the CREATE, which both
+	/// paths share. Driving `test_exec_capture` instead would have measured
+	/// nothing: it builds its own request and never reaches this code.
+	async fn run_exec(fake: &fake_podman::FakePodman) -> crate::error::Result<()> {
+		let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+		let file = parse_str("services:\n  web:\n    image: alpine:latest\n").unwrap();
+		engine
+			.exec_with_options(
+				&file,
+				"web",
+				vec!["true".to_string()],
+				ExecOptions::default()
+					.with_no_tty_for_test(true)
+					.with_detach_for_test(true),
+			)
+			.await
+	}
+
+	#[tokio::test]
+	async fn a_dropped_exec_create_is_retried_once_and_succeeds() {
+		let (fake, creates) = fake_dropping_creates(1);
+		run_exec(&fake).await.expect("the retry answers");
+		assert_eq!(
+			creates.load(Ordering::SeqCst),
+			2,
+			"the create must be attempted twice: once dropped, once retried"
+		);
+	}
+
+	/// Once only. A second drop is a daemon problem, not a transient, and
+	/// retrying forever would turn a broken socket into a hang.
+	#[tokio::test]
+	async fn a_second_dropped_exec_create_is_not_retried_again() {
+		let (fake, creates) = fake_dropping_creates(2);
+		run_exec(&fake)
+			.await
+			.expect_err("two drops in a row is a failure, not something to keep retrying");
+		assert_eq!(
+			creates.load(Ordering::SeqCst),
+			2,
+			"exactly two attempts, never a third"
+		);
 	}
 }


### PR DESCRIPTION
Stacked on #1343 — its commit shows here until it merges, after which this diff
stands alone.

#1339's measurement named four state-changing calls. #1343 covered `restart`,
`start` and `kill` (all three share `run_lifecycle_op`). This covers the other
three: **`stop`, container `DELETE`, and `exec`** — the last of which the
measurement named *most*, twice of six.

| endpoint | how it is resolved | why |
|---|---|---|
| `stop` | re-check → `NotRunning` | own call site, not via `run_lifecycle_op` |
| `rm` | re-check → **`Gone`** | absence, not merely stopped |
| `exec` create | **retry once** | the lost thing is the exec id, not a container state |

## `rm` needed a goal of its own

`NotRunning` is satisfied by a container that stopped but is **still there**,
which would read a failed removal as a success. Mutating `Gone` to behave like
`NotRunning` turns two tests red, so the distinction bites.

## `exec` could not use the same trick, and does not

A lost create response leaves no id to ask about, and a container running
several execs at once cannot say which of its `ExecIDs` was this one.

Retrying works instead, **because creating an exec changes nothing** — measured
on Podman 5.7.0 rather than assumed:

```
5 execs created and never started
container:  running, same pid
ExecIDs:    5
processes:  no extra process inside
```

Inert handles that die with the container. The worst case of a retry is one
leaked handle, against an `exec` that currently fails for a reason that was never
about the command.

**Once only** — a second drop is a daemon problem, not a transient, and an
unbounded retry turns a broken socket into a hang. **Local to `exec`** — the same
retry in the client would apply to container create, where it means two
containers.

## Two holes the tests found in themselves

- The fake dropped only `POST`s, so the container `DELETE` fell through to the
  404 arm and was read as an idempotent no-op — **a removal test measuring
  nothing**. It now drops both methods.
- The first `exec` test drove `test_exec_capture`, which **builds its own request
  and never reaches this code**. It would have passed while testing nothing. The
  test drives `exec_with_options` now.

## Where the code lives

The re-check moved out of `commands.rs` into `drop_recheck.rs` with the goal enum
and the state lookup. `commands.rs` was at **493** code lines against the
standard's 500; it is **424** now.

## Verified by mutation

| mutation | result |
|---|---|
| `Gone` behaves like `NotRunning` | pure test + merely-stopped wire test red |
| `stop` loses its re-check arm | its success test red |
| `exec` retry removed | both exec tests red |
| `exec` retry loops instead of running once | the bounded-retry test red |

## Test plan

- lib 1537, bins 81; full integration suite `178 passed; 0 failed` in 120s.
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets --all-features
  -- -D warnings`.
- `exec.rs` 472 code lines, `commands.rs` 424 — both under the standard's 500.

Refs #1339