### PR TITLE
release: 3.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+podup (3.6.1) unstable; urgency=medium
+
+  Fixed
+
+  * A lifecycle operation whose response the daemon drops is no longer reported
+    as a failure when it actually completed. `restart`, `start`, `kill`, `stop`
+    and `rm` now confirm the container reached the state the command was for,
+    and only then report success; a container that did not reach it, or a state
+    that cannot be re-read, still fails. Podman 6 severs these responses under
+    concurrency, which made `up`, `down` and `restart` fail on multi-service
+    projects for a reason that was never the command.
+  * `exec` retries once when the daemon drops the response to its session
+    create. That request is where the drops land most, and it cannot be resolved
+    by re-checking the container, because what is lost is the session id.
+    Retrying is safe: an exec that is created and never started allocates no
+    process and is discarded with the container.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Tue, 04 Aug 2026 04:35:55 -0500
+
 podup (3.6.0) unstable; urgency=medium
 
   Incompatible


### PR DESCRIPTION
A **patch** release. `cargo semver-checks` against `origin/main` agrees:

```
Checking podup v3.6.0 -> v3.6.1 (patch change)
223 checks: 223 pass, 30 skip
Summary no semver update required
```

## What it carries

One user-visible fix, in two halves — everything else in the window is CI and
test work with no runtime effect, plus a clap patch bump.

**A lifecycle operation whose response the daemon drops was reported as a
failure even when it had completed.** Podman 6 severs exactly these responses
under concurrency; measured on the lane, where the same suite passes 178/178 at
one test thread and fails 5 at the default, all dropped connections. So `up`,
`down` and `restart` on a multi-service project could fail for a reason that was
never the command. `restart`, `start`, `kill`, `stop` and `rm` now confirm the
container reached the state the operation was for, and only then report success
— a container that did not reach it, or a state that cannot be re-read, still
fails.

**`exec` retries once** instead, because a dropped create loses the *session id*
rather than a container state, so there is nothing to re-check. Measured before
relying on it: an exec created and never started allocates no process and is
discarded with the container.

## Blocked on #1344

The changelog describes `stop`, `rm` and `exec`, which are in #1344 and not yet
on develop. **This must not merge before that does** — a changelog describing
behaviour that did not ship is worse than a thinner one. If #1344 does not land,
the entry gets trimmed to what #1343 alone delivers.

## Version in all three files

`Cargo.toml`, `Cargo.lock` and `debian/changelog`. Missing the changelog ships
.debs carrying the previous version and strands apt users on the one upgrade
path the release key forces them onto.