### PR TITLE
feat(cli)!: change podup logs default to last 100 lines

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -194,7 +194,7 @@ View container output for the named services (or all).
 | Flag | Description | Default |
 |---|---|---|
 | `-f, --follow` | Stream new output. | off |
-| `-n, --tail <N>` | Show the last N lines. | all |
+| `-n, --tail <N>` | Show the last N lines. `all` opts back into the full stream. | 100 |
 | `--since <TIME>` | Show logs since a timestamp or relative time (e.g. `10m`). | start |
 | `--until <TIME>` | Show logs before a timestamp or relative time. | end |
 | `-t, --timestamps` | Prefix each line with an RFC3339 timestamp. | off |

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -516,7 +516,7 @@ pub(crate) enum Commands {
 		/// Follow log output.
 		#[arg(short, long)]
 		follow: bool,
-		/// Number of lines to show from the end of the logs (default: all).
+		/// Number of lines to show from the end of the logs (default: 100; `all` for the full stream).
 		#[arg(short = 'n', long)]
 		tail: Option<String>,
 		/// Show logs since a timestamp or relative time (e.g.

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -4,11 +4,22 @@
 //! Reached via the catch-all arm in [`super::dispatch`]; the arms here move
 //! their fields exactly as before.
 
-use podup::{Engine, StatsOptions};
+use podup::{Engine, StatsOptions, DEFAULT_LOG_TAIL};
 
 use crate::cli::*;
 
 use super::profile_filtered;
+
+/// Substitute the CLI default for `--tail` when the user did not pass one.
+///
+/// `docker compose logs` defaults to "all lines from the start"; podup's CLI
+/// defaults to the last [`DEFAULT_LOG_TAIL`] lines (see the constant's doc for
+/// why). The library `LogsOptions` stays at "None = all" so helmly-agent and
+/// any other direct caller keeps its current behaviour; the change happens at
+/// the CLI boundary. `--tail all` is the user's explicit opt-in to "all".
+fn cli_logs_tail_default(tail: Option<String>) -> Option<String> {
+	Some(tail.unwrap_or_else(|| DEFAULT_LOG_TAIL.to_string()))
+}
 
 /// Handle the commands not matched in [`super::dispatch`]. Behaviour-preserving
 /// continuation of the same match (the arms are a verbatim move).
@@ -236,7 +247,7 @@ pub(super) async fn dispatch_rest(
 					&services,
 					podup::LogsOptions {
 						follow,
-						tail,
+						tail: cli_logs_tail_default(tail),
 						since,
 						until,
 						timestamps,
@@ -312,4 +323,30 @@ pub(super) async fn dispatch_rest(
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::cli_logs_tail_default;
+
+	/// The CLI default is bounded. Without `--tail`, the dispatch substitutes
+	/// the constant so the wire query carries `&tail=100`. Library callers that
+	/// build `LogsOptions` directly keep `None` (= all) — see the issue.
+	#[test]
+	fn cli_logs_tail_default_substitutes_the_bounded_default_when_missing() {
+		assert_eq!(cli_logs_tail_default(None).as_deref(), Some("100"));
+	}
+
+	/// `--tail all` and `--tail <N>` are user intent and pass through unchanged.
+	#[test]
+	fn cli_logs_tail_default_preserves_an_explicit_value() {
+		assert_eq!(
+			cli_logs_tail_default(Some("all".into())).as_deref(),
+			Some("all")
+		);
+		assert_eq!(
+			cli_logs_tail_default(Some("42".into())).as_deref(),
+			Some("42")
+		);
+	}
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -43,7 +43,7 @@ fn wants_interactive_with(no_tty: bool, detach: bool, stdin_tty: bool, stdout_tt
 
 pub use query::{
 	AttachOutcome, ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, PsDisplayOptions,
-	PsFilterOptions, PsOptions,
+	PsFilterOptions, PsOptions, DEFAULT_LOG_TAIL,
 };
 mod container_config;
 #[cfg(test)]

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -34,6 +34,14 @@ pub struct ImagesOptions {
 	pub json: bool,
 }
 
+/// Default for `podup logs` when the user does not pass `--tail`: show the last
+/// 100 lines. `docker compose logs` defaults to "all"; podup's bounded default
+/// keeps the inspection case ("what just happened?") from flooding the
+/// terminal and stops CI scripts that capture `podup logs` from silently
+/// missing errors that landed before the window. Pass `--tail all` to opt
+/// back into the previous behaviour.
+pub const DEFAULT_LOG_TAIL: &str = "100";
+
 /// Options for [`Engine::logs_with_options`], mirroring `docker compose logs`.
 #[derive(Default)]
 pub struct LogsOptions {

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -56,7 +56,7 @@ pub use engine::{
 	AttachOutcome, BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions,
 	ImagesOptions, LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsDisplayOptions,
 	PsFilterOptions, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions,
-	VolumesDisplayOptions, VolumesOptions,
+	VolumesDisplayOptions, VolumesOptions, DEFAULT_LOG_TAIL,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.


### PR DESCRIPTION
Closes #1351.

podup logs today returns every line from the start of each container's log stream -- the same behaviour docker compose logs has, and a wall of output for the inspection case ("what just happened?"). This flips the CLI default to the last 100 lines; --tail all is the explicit opt-in to the previous behaviour. The default also applies to podup logs -f, so the two modes share one rule.

The library LogsOptions stays at "None = all" so helmly-agent and any other direct caller keeps its current behaviour. The substitution lives at the CLI dispatch boundary in internal/dispatch/rest.rs and reads from a new public DEFAULT_LOG_TAIL constant in internal/engine/query/.

## BREAKING CHANGE

podup logs (and podup logs -f) now show only the last 100 lines by default. Pass --tail all for the previous behaviour. The change applies at the CLI layer only; the LogsOptions library API and its Default impl are unchanged.

## What's in the PR

- New pub const DEFAULT_LOG_TAIL = "100" next to LogsOptions; re-exported through engine/mod.rs and lib.rs.
- New fn cli_logs_tail_default(tail: Option<String>) -> Option<String> in dispatch/rest.rs, called from the Logs arm to substitute the default when --tail was not passed. Two unit tests cover the substitution and the explicit-passthrough cases.
- CLI doc string on --tail updated from "default: all" to "default: 100; 'all' for the full stream".
- docs/commands.md logs table: --tail row default changes from 'all' to '100' with a note about --tail all.
- Engine attach_logs is unaffected (its own query string, no LogsOptions involvement).

## Validation

- cargo build / clippy -D warnings / fmt --check: clean.
- 1540 lib tests pass (including the existing log_query tests that assert the library default still produces no &tail=).
- 83 binary tests pass (the two new dispatch tests are part of that set).
- Real-Podman coverage via the lane (Podman 5 + 6) on this PR.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>