### PR TITLE
feat(cli)!: default container log rotation to k8s-file 10m/5

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,6 +63,15 @@ yellow rather than green — it is not healthy or unhealthy, it is the one podup
 will not delete — and why `autostart status` reports an uninstalled unit dim
 throughout instead of colouring systemd's `not-found` red.
 
+## Defaults
+
+Defaults podup applies when a compose file does not specify them. Override
+each with the compose-spec field shown.
+
+| Compose key | Default | Notes |
+|---|---|---|
+| `logging` | `driver: k8s-file` + `max-size: 10m` + `max-file: 5` | Rotation policy on every container podup creates. Without an explicit `logging:` block, libpod logs would grow unbounded and eventually fill the host. To delegate rotation to journald instead: `logging: { driver: journald }`. To opt out of rotation: `logging: { driver: k8s-file, options: { max-file: "0" } }`. The same default is applied by `generate quadlet`, so a generated unit behaves the same as an `up`-managed container. |
+
 ## Lifecycle
 
 ### `up`

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -75,10 +75,36 @@ pub(super) fn build_restart_policy(service: &Service) -> (Option<String>, Option
 // Logging
 // ---------------------------------------------------------------------------
 
-pub(super) fn build_log_config(logging: Option<&LoggingConfig>) -> Option<LogConfig> {
-	logging.map(|l| LogConfig {
-		driver: l.driver.clone(),
-		options: l.options.clone(),
+/// Default log rotation applied when a compose file does not carry a
+/// `logging:` block. `k8s-file` is the libpod default since Podman 4; pinning
+/// it explicitly here stops the answer from drifting between podman versions
+/// and distros, and the 10 MB / 5-file shape gives ~50 MB per container —
+/// enough for a week of typical service output, small enough that a runaway
+/// loop will not exhaust the host. The user can override by writing their
+/// own `logging:` in compose.
+pub(crate) fn default_log_config() -> LogConfig {
+	LogConfig {
+		driver: Some("k8s-file".into()),
+		options: [
+			("max-size".to_string(), "10m".to_string()),
+			("max-file".to_string(), "5".to_string()),
+		]
+		.into_iter()
+		.collect(),
+	}
+}
+
+/// Resolve the `logging:` block into libpod's `LogConfig`. An absent compose
+/// `logging:` maps to [`default_log_config`] so every container podup creates
+/// has a rotation policy without the user having to set one. The user's
+/// `Some(LoggingConfig)` value is passed through unchanged.
+pub(crate) fn build_log_config(logging: Option<&LoggingConfig>) -> Option<LogConfig> {
+	Some(match logging {
+		Some(l) => LogConfig {
+			driver: l.driver.clone(),
+			options: l.options.clone(),
+		},
+		None => default_log_config(),
 	})
 }
 
@@ -324,8 +350,13 @@ mod tests {
 	// --- log config ---
 
 	#[test]
-	fn log_config_none_when_absent() {
-		assert!(build_log_config(None).is_none());
+	fn log_config_applies_the_default_when_absent() {
+		// A service with no `logging:` block gets the rotation default so
+		// containers cannot run with unbounded log growth (#1354).
+		let cfg = build_log_config(None).expect("absent -> default, not None");
+		assert_eq!(cfg.driver.as_deref(), Some("k8s-file"));
+		assert_eq!(cfg.options.get("max-size").map(String::as_str), Some("10m"));
+		assert_eq!(cfg.options.get("max-file").map(String::as_str), Some("5"));
 	}
 
 	#[test]

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -46,6 +46,7 @@ pub use query::{
 	PsFilterOptions, PsOptions, DEFAULT_LOG_TAIL,
 };
 mod container_config;
+pub(crate) use container_config::build_log_config;
 #[cfg(test)]
 mod fake_podman;
 mod health;

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -267,6 +267,68 @@ networks:
 	}
 }
 
+/// A service with no `logging:` block gets the rotation default so the
+/// generated quadlet units ship the same rotation policy that `up` would
+/// apply at runtime (#1354). Without this, `generate quadlet` would emit a
+/// unit that runs without rotation, diverging from `up` behaviour.
+#[test]
+fn logging_default_is_emitted_when_logging_block_is_absent() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-s.container").contents;
+	assert!(
+		c.contains("LogDriver=k8s-file"),
+		"missing default LogDriver in:\n{c}"
+	);
+	assert!(
+		c.contains("LogOpt=max-size=10m"),
+		"missing max-size LogOpt in:\n{c}"
+	);
+	assert!(
+		c.contains("LogOpt=max-file=5"),
+		"missing max-file LogOpt in:\n{c}"
+	);
+}
+
+/// An explicit `logging:` block overrides the default — the rendered unit
+/// carries the user's driver and options, not the default (#1354).
+#[test]
+fn logging_user_override_replaces_the_default() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    logging:
+      driver: journald
+      options:
+        tag: mytag
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-s.container").contents;
+	assert!(
+		c.contains("LogDriver=journald"),
+		"user override not applied:\n{c}"
+	);
+	assert!(
+		c.contains("LogOpt=tag=mytag"),
+		"user options not applied:\n{c}"
+	);
+	assert!(
+		!c.contains("max-size=10m"),
+		"default leaked through override:\n{c}"
+	);
+	assert!(
+		!c.contains("max-file=5"),
+		"default leaked through override:\n{c}"
+	);
+}
+
 #[test]
 fn memory_and_apparmor_render_as_podman_args() {
 	// `Memory=` and `AppArmor=` are not recognised [Container] keys in

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -267,68 +267,6 @@ networks:
 	}
 }
 
-/// A service with no `logging:` block gets the rotation default so the
-/// generated quadlet units ship the same rotation policy that `up` would
-/// apply at runtime (#1354). Without this, `generate quadlet` would emit a
-/// unit that runs without rotation, diverging from `up` behaviour.
-#[test]
-fn logging_default_is_emitted_when_logging_block_is_absent() {
-	let yaml = r#"
-services:
-  s:
-    image: x
-"#;
-	let file = parse_str(yaml).unwrap();
-	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
-	let c = &unit_named(&out, "p-s.container").contents;
-	assert!(
-		c.contains("LogDriver=k8s-file"),
-		"missing default LogDriver in:\n{c}"
-	);
-	assert!(
-		c.contains("LogOpt=max-size=10m"),
-		"missing max-size LogOpt in:\n{c}"
-	);
-	assert!(
-		c.contains("LogOpt=max-file=5"),
-		"missing max-file LogOpt in:\n{c}"
-	);
-}
-
-/// An explicit `logging:` block overrides the default — the rendered unit
-/// carries the user's driver and options, not the default (#1354).
-#[test]
-fn logging_user_override_replaces_the_default() {
-	let yaml = r#"
-services:
-  s:
-    image: x
-    logging:
-      driver: journald
-      options:
-        tag: mytag
-"#;
-	let file = parse_str(yaml).unwrap();
-	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
-	let c = &unit_named(&out, "p-s.container").contents;
-	assert!(
-		c.contains("LogDriver=journald"),
-		"user override not applied:\n{c}"
-	);
-	assert!(
-		c.contains("LogOpt=tag=mytag"),
-		"user options not applied:\n{c}"
-	);
-	assert!(
-		!c.contains("max-size=10m"),
-		"default leaked through override:\n{c}"
-	);
-	assert!(
-		!c.contains("max-file=5"),
-		"default leaked through override:\n{c}"
-	);
-}
-
 #[test]
 fn memory_and_apparmor_render_as_podman_args() {
 	// `Memory=` and `AppArmor=` are not recognised [Container] keys in

--- a/internal/quadlet/tests/fields_logging.rs
+++ b/internal/quadlet/tests/fields_logging.rs
@@ -1,0 +1,72 @@
+//! Log-rotation rendering tests for the Quadlet export.
+//!
+//! `internal/quadlet/tests/fields.rs` carries the rest of the field-mapping
+//! coverage; the log-rotation tests are pulled out into this file because
+//! `fields.rs` was already near the per-file line cap and these two tests
+//! alone were enough to push it over (#1354).
+
+use super::unit_named;
+use crate::parse_str;
+use crate::quadlet::generate_at;
+
+/// A service with no `logging:` block gets the rotation default so the
+/// generated quadlet units ship the same rotation policy that `up` would
+/// apply at runtime (#1354). Without this, `generate quadlet` would emit a
+/// unit that runs without rotation, diverging from `up` behaviour.
+#[test]
+fn logging_default_is_emitted_when_logging_block_is_absent() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-s.container").contents;
+	assert!(
+		c.contains("LogDriver=k8s-file"),
+		"missing default LogDriver in:\n{c}"
+	);
+	assert!(
+		c.contains("LogOpt=max-size=10m"),
+		"missing max-size LogOpt in:\n{c}"
+	);
+	assert!(
+		c.contains("LogOpt=max-file=5"),
+		"missing max-file LogOpt in:\n{c}"
+	);
+}
+
+/// An explicit `logging:` block overrides the default — the rendered unit
+/// carries the user's driver and options, not the default (#1354).
+#[test]
+fn logging_user_override_replaces_the_default() {
+	let yaml = r#"
+services:
+  s:
+    image: x
+    logging:
+      driver: journald
+      options:
+        tag: mytag
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-s.container").contents;
+	assert!(
+		c.contains("LogDriver=journald"),
+		"user override not applied:\n{c}"
+	);
+	assert!(
+		c.contains("LogOpt=tag=mytag"),
+		"user options not applied:\n{c}"
+	);
+	assert!(
+		!c.contains("max-size=10m"),
+		"default leaked through override:\n{c}"
+	);
+	assert!(
+		!c.contains("max-file=5"),
+		"default leaked through override:\n{c}"
+	);
+}

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -3,6 +3,7 @@
 use indexmap::IndexMap;
 
 use crate::compose::types::{RestartPolicy, SecretConfig, Service};
+use crate::engine::build_log_config;
 use crate::ports::parse_ports;
 use crate::size::parse_duration_secs;
 
@@ -336,11 +337,16 @@ pub(crate) fn container_unit(
 	for opt in &service.security_opt {
 		map_security_opt(opt, &mut container, name, warnings);
 	}
-	if let Some(logging) = &service.logging {
+	// `build_log_config` substitutes the rotation default when `service.logging`
+	// is None, so an absent `logging:` block in compose still produces a
+	// `LogDriver=` / `LogOpt=` set on the generated unit (#1354). The render
+	// path is the same as the live engine's, so `up` and `generate quadlet`
+	// produce equivalent rotation policy.
+	if let Some(logging) = build_log_config(service.logging.as_ref()) {
 		if let Some(driver) = &logging.driver {
 			container.add("LogDriver", driver.clone());
 		}
-		for (key, val) in sorted_label_pairs(logging.options.clone()) {
+		for (key, val) in sorted_label_pairs(logging.options) {
 			container.add("LogOpt", format!("{key}={val}"));
 		}
 	}

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -61,6 +61,9 @@ Volume=proj-data.volume:/var/lib/data
 Network=proj-frontend.network
 Label=podup.project=proj
 Label=podup.service=web
+LogDriver=k8s-file
+LogOpt=max-file=5
+LogOpt=max-size=10m
 
 [Service]
 Restart=always


### PR DESCRIPTION
Closes #1354.

podup today leaves log rotation to whatever podman picks by default when a compose file has no `logging:` block. That default has shifted between podman versions and distros -- a long-running service that prints more than a few megabytes a day will fill the disk eventually.

This sets an explicit rotation default: `k8s-file` with `max-size: 10m` and `max-file: 5`, applied by `build_log_config` when the compose `logging:` block is absent. The user's value still wins when present. The same default is threaded into the Quadlet export so `generate quadlet` and `up` produce equivalent units.

The override surface is the existing `logging:` compose block:

```
logging: { driver: journald }                              # hand off to journald
logging: { driver: k8s-file, options: { max-file: "0" } } # disable rotation
logging: { driver: k8s-file, options: { max-size: 50m, max-file: 10 } } # custom
```

## What is in the PR

- `internal/engine/container_config/mod.rs`: new `pub(crate) fn default_log_config()` returning `LogConfig { driver: Some("k8s-file"), options: { max-size: "10m", max-file: "5" } }`. `build_log_config` now returns `Some(default_log_config())` when the input is `None`.
- `internal/engine/mod.rs`: re-export `build_log_config` as `pub(crate)` so the Quadlet path can call it.
- `internal/quadlet/unit/container.rs`: the inline `if let Some(logging) = &service.logging` block is replaced with `if let Some(logging) = build_log_config(service.logging.as_ref())`, so a generated unit carries the same default a live `up` would. Single source of truth for the policy.
- Tests: `log_config_applies_the_default_when_absent` (engine), `logging_default_is_emitted_when_logging_block_is_absent` and `logging_user_override_replaces_the_default` (Quadlet). The two pre-existing engine tests (`log_config_driver_only`, `log_config_with_options`) still pin the user-override path.
- `docs/commands.md`: new "Defaults" section documenting the log-rotation default and how to override or disable it.
- `ai-context/context/podup/index.md`: log-rotation default added to the "Default values (tunable)" section.

## Validation

- 1542 lib tests pass.
- 83 binary tests pass.
- `cargo fmt --check` clean.
- `cargo clippy -- -D warnings` clean.
- Real-Podman coverage via the lane (Podman 5 + 6) on this PR.

## Breaking

Per the project's stance on the public API, a 4.0 MAJOR bump is the right way to flag this. The change is observable in two ways: a workflow that tails `/var/log/containers/<project>-<service>-<n>.log` directly will see the file get renamed under it as podman rotates (use `podup logs` instead, which queries the libpod endpoint and survives rotation), and a CI script that `grep -r` across `/var/log/containers/` for a one-off error string will only see the last ~50 MB per container. Both are soft breaks -- the ability to read logs is unchanged, only the rolling-window shape.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>