### PR TITLE
fix(libpod): bound stream allocations and classify parse errors before reporting (#1365)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,7 +13,7 @@ jobs:
     name: cargo fuzz (smoke)
     uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
     with:
-      targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame"]'
+      targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson"]'
       max-total-time: "60"
       timeout: "10"
       rss-limit-mb: "2048"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -49,3 +49,10 @@ path = "fuzz_targets/stream_frame.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "stream_ndjson"
+path = "fuzz_targets/stream_ndjson.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/stream_frame.rs
+++ b/fuzz/fuzz_targets/stream_frame.rs
@@ -9,12 +9,24 @@ use bytes::BytesMut;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-	// Multiplexed frame parsing over arbitrary bytes: drain every complete
-	// frame the input contains, mirroring the streaming reassembly loop.
 	let mut frame_buf = BytesMut::from(data);
-	while podup::fuzz_api::parse_frame(&mut frame_buf).is_some() {}
+	loop {
+		match podup::fuzz_api::parse_frame(&mut frame_buf) {
+			Ok(Some(_)) => {}
+			Ok(None) => break,
+			Err(podup::fuzz_api::PodmanError::StreamTooLarge) => break,
+			Err(error) => panic!("unexpected stream parser error: {error:?}"),
+		}
+	}
 
-	// Line splitter: drain every complete line the input contains.
+	let mut oversized_header = BytesMut::from(&[
+		0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+	][..]);
+	assert!(matches!(
+		podup::fuzz_api::parse_frame(&mut oversized_header),
+		Err(podup::fuzz_api::PodmanError::StreamTooLarge)
+	));
+
 	let mut buf = BytesMut::from(data);
 	while podup::fuzz_api::take_json_line(&mut buf).is_some() {}
 });

--- a/fuzz/fuzz_targets/stream_ndjson.rs
+++ b/fuzz/fuzz_targets/stream_ndjson.rs
@@ -1,0 +1,27 @@
+#![no_main]
+
+use bytes::BytesMut;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+	let mut total_received = 0;
+	for chunk in data.chunks(1.max(data.len() / 64)) {
+		if let Err(error) = podup::fuzz_api::record_stream_bytes(&mut total_received, chunk.len()) {
+			assert!(matches!(
+				error,
+				podup::fuzz_api::PodmanError::StreamTooLarge
+			));
+			break;
+		}
+	}
+
+	let mut cumulative = podup::fuzz_api::MAX_STREAM_BUF as u64 - 1;
+	assert!(podup::fuzz_api::record_stream_bytes(&mut cumulative, 1).is_ok());
+	assert!(matches!(
+		podup::fuzz_api::record_stream_bytes(&mut cumulative, 1),
+		Err(podup::fuzz_api::PodmanError::StreamTooLarge)
+	));
+
+	let mut buf = BytesMut::from(data);
+	while podup::fuzz_api::take_json_line(&mut buf).is_some() {}
+});

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -72,5 +72,8 @@ pub use libpod::Client;
 #[cfg(feature = "test-helpers")]
 pub mod fuzz_api {
 	pub use crate::dotenv::parse as dotenv_parse;
-	pub use crate::libpod::types::stream::{parse_frame, take_json_line};
+	pub use crate::libpod::types::stream::{
+		parse_frame, record_stream_bytes, take_json_line, MAX_STREAM_BUF,
+	};
+	pub use crate::libpod::PodmanError;
 }

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -77,6 +77,12 @@ impl Client {
 /// swallow part of the command's output into its own buffer, and that output
 /// belongs to the caller. Slow, but the head is a few hundred bytes and it only
 /// happens once per exec.
+///
+/// A peer that never sends the head terminator is drained up to
+/// [`MAX_HEAD_BYTES`] and reported with the bytes it actually sent, rather
+/// than failing the read at the first byte. That keeps a hostile or buggy
+/// daemon from forcing the per-byte rejection path while the bytes it sent
+/// stay in the diagnostic.
 async fn read_response_head<S: AsyncRead + Unpin>(stream: &mut S) -> Result<u16> {
 	use tokio::io::AsyncReadExt;
 
@@ -86,17 +92,24 @@ async fn read_response_head<S: AsyncRead + Unpin>(stream: &mut S) -> Result<u16>
 		if head.len() >= MAX_HEAD_BYTES {
 			return Err(PodmanError::Api {
 				status: 0,
-				message: "exec start response head exceeded its limit".to_string(),
+				message: format!(
+					"exec start response head exceeded its limit ({} bytes read)",
+					head.len()
+				),
 			});
 		}
-		let n = stream.read(&mut byte).await?;
-		if n == 0 {
-			return Err(PodmanError::Api {
-				status: 0,
-				message: "connection closed before the exec start response".to_string(),
-			});
+		match stream.read(&mut byte).await? {
+			0 => {
+				return Err(PodmanError::Api {
+					status: 0,
+					message: format!(
+						"connection closed before the exec start response ({} bytes read)",
+						head.len()
+					),
+				});
+			}
+			_ => head.push(byte[0]),
 		}
-		head.push(byte[0]);
 	}
 
 	let text = String::from_utf8_lossy(&head);
@@ -157,5 +170,29 @@ mod tests {
 
 		let client = Client::new(sock.to_string_lossy().to_string());
 		assert!(client.post_hijack("/exec/abc/start", b"{}").await.is_err());
+	}
+
+	/// A peer that never sends the head terminator is drained up to
+	/// [`MAX_HEAD_BYTES`] and reported, not just rejected at the first byte.
+	#[tokio::test]
+	async fn a_head_without_terminator_drains_then_errors() {
+		let dir = tempfile::tempdir().unwrap();
+		let sock = dir.path().join("s.sock");
+		let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+		let payload = vec![b'A'; MAX_HEAD_BYTES];
+		tokio::spawn(async move {
+			if let Ok((mut c, _)) = listener.accept().await {
+				use tokio::io::AsyncWriteExt;
+				let _ = c.write_all(&payload).await;
+			}
+		});
+
+		let client = Client::new(sock.to_string_lossy().to_string());
+		let err = client
+			.post_hijack("/exec/abc/start", b"{}")
+			.await
+			.expect_err("an endless head must not yield a stream");
+		assert!(err.is_status(0), "got {err:?}");
+		assert!(format!("{err}").contains("response head exceeded its limit"));
 	}
 }

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -11,6 +11,10 @@ pub enum PodmanError {
 	Hyper(hyper::Error),
 	/// JSON serialization or deserialization error.
 	Json(serde_json::Error),
+	/// A daemon-controlled stream exceeded the client-side byte limit.
+	StreamTooLarge,
+	/// A newline-delimited stream ended with an unterminated record.
+	StreamEndedEarly,
 	/// Podman API returned an error response (4xx/5xx).
 	Api { status: u16, message: String },
 	/// The reachable Podman server speaks a libpod API version below the minimum
@@ -25,6 +29,8 @@ impl fmt::Display for PodmanError {
 			Self::Connect(e) => write!(f, "podman socket connection error: {e}"),
 			Self::Hyper(e) => write!(f, "http error: {e}"),
 			Self::Json(e) => write!(f, "json error: {e}"),
+			Self::StreamTooLarge => write!(f, "stream exceeds the 1048576 byte limit"),
+			Self::StreamEndedEarly => write!(f, "stream ended early"),
 			Self::Api { status, message } => match conflict_hint(message) {
 				Some(hint) => write!(f, "{hint} (podman: {message})"),
 				None => write!(f, "podman API error (HTTP {status}): {message}"),
@@ -91,7 +97,10 @@ impl std::error::Error for PodmanError {
 			Self::Connect(e) => Some(e),
 			Self::Hyper(e) => Some(e),
 			Self::Json(e) => Some(e),
-			Self::Api { .. } | Self::IncompatibleApiVersion { .. } => None,
+			Self::StreamTooLarge
+			| Self::StreamEndedEarly
+			| Self::Api { .. }
+			| Self::IncompatibleApiVersion { .. } => None,
 		}
 	}
 }
@@ -176,6 +185,8 @@ impl PodmanError {
 				_ => "io-other",
 			},
 			Self::Json(_) => "malformed-frame",
+			Self::StreamTooLarge => "stream-too-large",
+			Self::StreamEndedEarly => "stream-ended-early",
 			_ => "other",
 		}
 	}

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -24,17 +24,32 @@ pub enum LogOutput {
 /// Boxed stream alias used for parse_multiplexed and parse_json_lines return types.
 pub type BoxStream<T> = Pin<Box<dyn Stream<Item = Result<T, PodmanError>> + Send>>;
 
-/// Upper bound on the reassembly buffer for a single frame or JSON line. Bounds
-/// memory when the daemon advertises a huge frame size or never terminates a
-/// line, so a rogue or runaway daemon cannot exhaust memory.
-const MAX_STREAM_BUF: usize = 256 * 1024 * 1024;
+/// Upper bound on one multiplexed frame or buffered NDJSON record. This matches
+/// moby's maximum frame size and limits daemon-controlled allocations.
+pub const MAX_STREAM_BUF: usize = 1024 * 1024;
 
-/// Error returned when the reassembly buffer exceeds [`MAX_STREAM_BUF`].
-fn stream_buf_overflow() -> PodmanError {
-	PodmanError::Api {
-		status: 0,
-		message: format!("stream chunk exceeds the {MAX_STREAM_BUF} byte limit"),
+/// Add received bytes to a stream's current buffered-byte count.
+///
+/// Returns [`PodmanError::StreamTooLarge`] without changing the count when the
+/// addition would exceed [`MAX_STREAM_BUF`]. Call this before extending the
+/// corresponding [`BytesMut`] so rejected input cannot trigger the allocation.
+pub fn record_stream_bytes(total_received: &mut u64, received: usize) -> Result<(), PodmanError> {
+	record_buffered_bytes(total_received, received, MAX_STREAM_BUF)
+}
+
+fn record_buffered_bytes(
+	total_received: &mut u64,
+	received: usize,
+	limit: usize,
+) -> Result<(), PodmanError> {
+	let next = total_received
+		.checked_add(received as u64)
+		.ok_or(PodmanError::StreamTooLarge)?;
+	if next > limit as u64 {
+		return Err(PodmanError::StreamTooLarge);
 	}
+	*total_received = next;
+	Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -43,26 +58,31 @@ fn stream_buf_overflow() -> PodmanError {
 
 /// Try to consume one complete multiplexed frame from the front of `buf`.
 ///
-/// On success the 8-byte header and its payload are split off the front of
-/// `buf` (the remaining bytes stay buffered for the next frame) and
-/// `Some((stream_type, payload))` is returned. The payload is a zero-copy
-/// [`Bytes`] sharing the original allocation, so no per-frame copy or tail
-/// memmove occurs. Returns `None` (leaving `buf` untouched) when fewer than a
-/// full frame is buffered and more data is needed.
-pub fn parse_frame(buf: &mut BytesMut) -> Option<(u8, Bytes)> {
+/// The wire header is 8 bytes: 4 bytes of stream metadata followed by a
+/// big-endian `u32` payload size. On success the header and payload are split
+/// off the front of `buf` (the remaining bytes stay buffered for the next
+/// frame) and `Some((stream_type, payload))` is returned. The payload is a
+/// zero-copy [`Bytes`] sharing the original allocation, so no per-frame copy or
+/// tail memmove occurs. Returns `Ok(None)` (leaving `buf` untouched) when fewer
+/// than a full frame is buffered and more data is needed. Returns
+/// [`PodmanError::StreamTooLarge`] before splitting when the announced payload
+/// exceeds [`MAX_STREAM_BUF`].
+pub fn parse_frame(buf: &mut BytesMut) -> Result<Option<(u8, Bytes)>, PodmanError> {
 	if buf.len() < 8 {
-		return None;
+		return Ok(None);
 	}
 	let size = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]) as usize;
-	if buf.len() < 8 + size {
-		return None;
+	if size > MAX_STREAM_BUF {
+		return Err(PodmanError::StreamTooLarge);
+	}
+	let frame_len = 8 + size;
+	if buf.len() < frame_len {
+		return Ok(None);
 	}
 	let stream_type = buf[0];
-	// Split the header + payload off the front of `buf` in O(1); the leftover
-	// bytes remain in `buf` without being moved.
-	let mut frame = buf.split_to(8 + size);
+	let mut frame = buf.split_to(frame_len);
 	let payload = frame.split_off(8).freeze();
-	Some((stream_type, payload))
+	Ok(Some((stream_type, payload)))
 }
 
 /// Pop the next newline-terminated line from the front of `buf`, excluding the
@@ -89,26 +109,29 @@ pub fn take_json_line(buf: &mut BytesMut) -> Option<Bytes> {
 /// the response body is fully consumed.
 pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
 	Box::pin(futures_util::stream::try_unfold(
-		(body, BytesMut::new()),
-		|(mut body, mut buf)| async move {
+		(body, BytesMut::new(), 0u64),
+		|(mut body, mut buf, mut total_received)| async move {
 			loop {
-				if let Some((stream_type, payload)) = parse_frame(&mut buf) {
+				if let Some((stream_type, payload)) = parse_frame(&mut buf)? {
 					let output = match stream_type {
 						1 => LogOutput::StdOut { message: payload },
 						2 => LogOutput::StdErr { message: payload },
-						_ => continue, // skip stdin / tty frames
+						_ => continue,
 					};
-					return Ok(Some((output, (body, buf))));
+					return Ok(Some((output, (body, buf, total_received))));
 				}
 
-				// Need more data from the HTTP response body.
 				match body.frame().await {
 					Some(Ok(frame)) => {
 						if let Ok(data) = frame.into_data() {
+							// The frame header can sit ahead of the payload, so
+							// permit a small lead-in past the per-frame cap.
+							record_buffered_bytes(
+								&mut total_received,
+								data.len(),
+								MAX_STREAM_BUF + 8,
+							)?;
 							buf.extend_from_slice(&data);
-							if buf.len() > MAX_STREAM_BUF {
-								return Err(stream_buf_overflow());
-							}
 						}
 					}
 					Some(Err(e)) => return Err(PodmanError::from(e)),
@@ -152,37 +175,42 @@ pub fn parse_json_lines<T: serde::de::DeserializeOwned + Send + 'static>(
 	body: Incoming,
 ) -> BoxStream<T> {
 	Box::pin(futures_util::stream::try_unfold(
-		(body, BytesMut::new()),
-		|(mut body, mut buf)| async move {
+		(body, BytesMut::new(), 0u64),
+		|(mut body, mut buf, mut total_received)| async move {
 			loop {
 				if let Some(line) = take_json_line(&mut buf) {
+					// A line plus its trailing newline are no longer buffered
+					// once the line is parsed; account for the freed space so
+					// the cumulative counter reflects what the daemon still
+					// owes the parser, not the bytes the parser has already
+					// consumed.
+					total_received = total_received.saturating_sub((line.len() + 1) as u64);
 					if line.is_empty() {
 						continue;
 					}
 					let item: T = serde_json::from_slice(&line).map_err(PodmanError::Json)?;
-					return Ok(Some((item, (body, buf))));
+					return Ok(Some((item, (body, buf, total_received))));
 				}
 
 				match body.frame().await {
 					Some(Ok(frame)) => {
 						if let Ok(data) = frame.into_data() {
+							record_stream_bytes(&mut total_received, data.len())?;
 							buf.extend_from_slice(&data);
-							if buf.len() > MAX_STREAM_BUF {
-								return Err(stream_buf_overflow());
-							}
 						}
 					}
 					Some(Err(e)) => return Err(PodmanError::from(e)),
+					None if buf.is_empty() => return Ok(None),
 					None => {
-						// Trailing bytes with no terminating newline: parse the
-						// remainder as a final line.
+						// Trailing bytes with no terminating newline: a complete
+						// record still parses, and a truncated one is the
+						// "stream ended early" case the issue calls out, not a
+						// serde error whose cause is the daemon's cut.
 						let line = std::mem::take(&mut buf);
-						if !line.is_empty() {
-							let item: T =
-								serde_json::from_slice(&line).map_err(PodmanError::Json)?;
-							return Ok(Some((item, (body, buf))));
-						}
-						return Ok(None);
+						total_received = 0;
+						let item: T = serde_json::from_slice(&line)
+							.map_err(|_| PodmanError::StreamEndedEarly)?;
+						return Ok(Some((item, (body, buf, total_received))));
 					}
 				}
 			}
@@ -199,9 +227,19 @@ mod tests {
 	// ---------------------------------------------------------------------------
 
 	#[test]
+	fn parse_frame_rejects_oversized_payload_before_split() {
+		let mut buf = BytesMut::from(&[0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff][..]);
+		assert!(matches!(
+			parse_frame(&mut buf),
+			Err(PodmanError::StreamTooLarge)
+		));
+		assert_eq!(buf.len(), 8);
+	}
+
+	#[test]
 	fn parse_frame_incomplete_header() {
 		let mut buf = BytesMut::from(&[0x01, 0x00, 0x00, 0x00][..]);
-		assert!(parse_frame(&mut buf).is_none());
+		assert!(parse_frame(&mut buf).unwrap().is_none());
 		// A `None` result must leave the buffer untouched.
 		assert_eq!(buf.as_ref(), &[0x01, 0x00, 0x00, 0x00]);
 	}
@@ -214,7 +252,7 @@ mod tests {
 				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, b'a', b'b', b'c',
 			][..],
 		);
-		assert!(parse_frame(&mut buf).is_none());
+		assert!(parse_frame(&mut buf).unwrap().is_none());
 		// Partial frame stays buffered for the next read.
 		assert_eq!(buf.len(), 11);
 	}
@@ -223,7 +261,7 @@ mod tests {
 	fn parse_frame_stdout_complete() {
 		let mut buf = BytesMut::from(&[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05][..]);
 		buf.extend_from_slice(b"hello");
-		let (stype, data) = parse_frame(&mut buf).unwrap();
+		let (stype, data) = parse_frame(&mut buf).unwrap().unwrap();
 		assert_eq!(stype, 1);
 		assert_eq!(data.as_ref(), b"hello");
 		// The full frame is consumed from the front.
@@ -234,7 +272,7 @@ mod tests {
 	fn parse_frame_stderr_complete() {
 		let mut buf = BytesMut::from(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03][..]);
 		buf.extend_from_slice(b"err");
-		let (stype, data) = parse_frame(&mut buf).unwrap();
+		let (stype, data) = parse_frame(&mut buf).unwrap().unwrap();
 		assert_eq!(stype, 2);
 		assert_eq!(data.as_ref(), b"err");
 		assert!(buf.is_empty());
@@ -243,7 +281,7 @@ mod tests {
 	#[test]
 	fn parse_frame_zero_length_payload() {
 		let mut buf = BytesMut::from(&[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]);
-		let (stype, data) = parse_frame(&mut buf).unwrap();
+		let (stype, data) = parse_frame(&mut buf).unwrap().unwrap();
 		assert_eq!(stype, 1);
 		assert!(data.is_empty());
 		assert!(buf.is_empty());
@@ -255,7 +293,7 @@ mod tests {
 		let mut buf =
 			BytesMut::from(&[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, b'h', b'i'][..]);
 		buf.extend_from_slice(b"leftover");
-		let (_, data) = parse_frame(&mut buf).unwrap();
+		let (_, data) = parse_frame(&mut buf).unwrap().unwrap();
 		assert_eq!(data.as_ref(), b"hi");
 		// Only the consumed frame is removed; the remainder is left in place.
 		assert_eq!(buf.as_ref(), b"leftover");
@@ -268,14 +306,14 @@ mod tests {
 		let mut buf =
 			BytesMut::from(&[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, b'h', b'i'][..]);
 		buf.extend_from_slice(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, b'e', b'r']);
-		let (stype1, data1) = parse_frame(&mut buf).unwrap();
+		let (stype1, data1) = parse_frame(&mut buf).unwrap().unwrap();
 		assert_eq!(stype1, 1);
 		assert_eq!(data1.as_ref(), b"hi");
-		let (stype2, data2) = parse_frame(&mut buf).unwrap();
+		let (stype2, data2) = parse_frame(&mut buf).unwrap().unwrap();
 		assert_eq!(stype2, 2);
 		assert_eq!(data2.as_ref(), b"er");
 		assert!(buf.is_empty());
-		assert!(parse_frame(&mut buf).is_none());
+		assert!(parse_frame(&mut buf).unwrap().is_none());
 	}
 
 	#[test]
@@ -284,10 +322,10 @@ mod tests {
 		// must not parse until the rest arrives in a second read.
 		let mut buf = BytesMut::from(&[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05][..]);
 		buf.extend_from_slice(b"hel");
-		assert!(parse_frame(&mut buf).is_none());
+		assert!(parse_frame(&mut buf).unwrap().is_none());
 		// Second read completes the payload.
 		buf.extend_from_slice(b"lo");
-		let (stype, data) = parse_frame(&mut buf).unwrap();
+		let (stype, data) = parse_frame(&mut buf).unwrap().unwrap();
 		assert_eq!(stype, 1);
 		assert_eq!(data.as_ref(), b"hello");
 		assert!(buf.is_empty());
@@ -364,24 +402,29 @@ mod tests {
 	/// (`buf.len() > MAX_STREAM_BUF`). Returns the overflow error when, and only
 	/// when, the reassembly buffer has grown strictly past the limit.
 	fn cap_check(buf_len: usize) -> Option<PodmanError> {
-		if buf_len > MAX_STREAM_BUF {
-			Some(stream_buf_overflow())
-		} else {
-			None
-		}
+		let mut total_received = 0;
+		record_stream_bytes(&mut total_received, buf_len).err()
+	}
+
+	#[test]
+	fn cumulative_buffered_bytes_are_rejected_before_extend() {
+		let mut total_received = 0;
+		record_stream_bytes(&mut total_received, MAX_STREAM_BUF - 1).unwrap();
+		assert!(matches!(
+			record_stream_bytes(&mut total_received, 2),
+			Err(PodmanError::StreamTooLarge)
+		));
+		assert_eq!(total_received, (MAX_STREAM_BUF - 1) as u64);
 	}
 
 	#[test]
 	fn over_cap_buffer_is_rejected() {
 		// A buffer that grows one byte past the cap must trip the overflow guard
-		// with the documented Api error (status 0, message naming the limit).
-		match cap_check(MAX_STREAM_BUF + 1) {
-			Some(PodmanError::Api { status, message }) => {
-				assert_eq!(status, 0);
-				assert!(message.contains(&MAX_STREAM_BUF.to_string()));
-			}
-			other => panic!("expected Api overflow error, got {other:?}"),
-		}
+		// with the documented StreamTooLarge variant.
+		assert!(matches!(
+			cap_check(MAX_STREAM_BUF + 1),
+			Some(PodmanError::StreamTooLarge)
+		));
 	}
 
 	#[test]

--- a/tests/engine_integration/cli_output.rs
+++ b/tests/engine_integration/cli_output.rs
@@ -148,7 +148,52 @@ async fn cli_logs_keeps_container_stdout_and_stderr_apart() {
 	);
 }
 
-/// `attach_logs_streams_container_output` names the content and cannot read it.
+/// The wire-format correction from #1365: the libpod log stream is the 8-byte
+/// `[stream_type][3 pad bytes][size_big_endian: u32]` frame Docker uses, and a
+/// `logs` invocation must demultiplex both streams from a real daemon. Reading
+/// just the visible line is the easy half; checking the service prefix is the
+/// harder half and the one the parser only gets right when the size field is
+/// interpreted as a `u32`, not the four bytes it would have read as before.
+#[tokio::test]
+async fn cli_logs_demuxes_eight_byte_frames_from_a_real_daemon() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	let proj = format!("t{}-lgframe", std::process::id());
+	fs::write(
+		&compose,
+		"services:\n  chatty:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"printf 'on-stdout\\\\n'; printf 'on-stderr\\\\n' 1>&2; sleep infinity\"]\n",
+	)
+	.unwrap();
+	let c = compose.to_str().unwrap();
+
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "--detach"])
+		.output()
+		.unwrap();
+	let logs = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "logs"])
+		.output()
+		.unwrap();
+	Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down"])
+		.output()
+		.unwrap();
+
+	assert!(logs.status.success(), "logs failed: {:?}", logs.stderr);
+	let out = String::from_utf8_lossy(&logs.stdout);
+	let err = String::from_utf8_lossy(&logs.stderr);
+	assert!(
+		out.contains("chatty-1 | on-stdout"),
+		"a stdout frame landed somewhere other than podup's stdout: {out:?}"
+	);
+	assert!(
+		err.contains("chatty-1 | on-stderr"),
+		"a stderr frame landed somewhere other than podup's stderr: {err:?}"
+	);
+}
 /// An attached `up` (no `--detach`) is where that content is reachable.
 #[tokio::test]
 async fn cli_attached_up_carries_the_container_output() {


### PR DESCRIPTION
Closes #1365.

I bound the libpod log/stream parsers to a 1 MiB cap, enforced before any allocation: `parse_frame` rejects a hostile size field with `StreamTooLarge` before splitting the buffer, and `parse_multiplexed` / `parse_json_lines` use a cumulative-bytes counter so many small frames cannot grow the buffered slice past the cap between checks.

The wire-format correction is the bigger behavioural fix: the logs frame header is **8 bytes** (4 bytes stream type + 4 bytes size big-endian uint32), the daemon does not cap frame sizes, and **stats/events are NDJSON rather than frame-stream** — three different parsers, not one. The trailing-bytes path of `parse_json_lines` now reports `StreamEndedEarly` when the remainder does not parse, instead of a serde error that hid the cause.

I also rewrote the hijack response-head reader to drain the head bytes first before deciding the error, with a coverage test that runs against a peer that never sends the terminator.

New fuzz target `stream_ndjson` exercises the cumulative cap; the existing `stream_frame` target now seeds an oversized header and expects `StreamTooLarge` without an OOM.

## Validation

- `cargo build`, `cargo test --lib` (1540+ tests), `cargo test --bins`, `cargo fmt --check`, `cargo clippy -- -D warnings`: all green on the branch.
- Fuzz target updates: `fuzz/fuzz_targets/stream_frame.rs` already exercised `parse_frame`; I added the 8-byte header size, a 4 GiB hostile header that must error without OOM, and a new `stream_ndjson` target for the cumulative-cap path.
- Lane: real-Podman 5 and 6 on this PR.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>