### PR TITLE
perf(client): introduce HTTP connection reuse in the libpod client (#1362)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,6 +17,7 @@ These appear before the subcommand and may also come from the environment.
 | `-f, --file <PATH>` | `COMPOSE_FILE` | Compose file. Repeatable; later files merge over earlier ones. When unset, the compose-spec precedence list is probed: `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml`. |
 | `-p, --project <NAME>` | `COMPOSE_PROJECT_NAME` | Project name, prefixing container/network/volume names. When unset: the top-level `name:`, then the sanitized project-directory basename. |
 | `--socket <PATH>` | `PODMAN_SOCKET` | Podman socket path; overrides auto-detection. |
+| `--connection-pool-size <N>` | `PODUP_LIBCOD_POOL` | Maximum HTTP/1.1 connections the libpod client keeps open to the Podman socket for reuse. Streaming calls each take a dedicated connection outside this cap. Default: 8. |
 | `--profile <NAMES>` | `COMPOSE_PROFILES` | Active profiles, comma-separated. |
 
 | `--project-directory <PATH>` | | Base directory for relative paths (env_file, build context, bind mounts, config/secret sources). Defaults to the compose file's directory. |
@@ -733,6 +734,7 @@ when both are set.
 | `COMPOSE_PROJECT_NAME` | Default project name (`--project`). |
 | `COMPOSE_PROFILES` | Default active profiles (`--profile`). |
 | `PODMAN_SOCKET` | Podman socket path (`--socket`). |
+| `PODUP_LIBCOD_POOL` | HTTP/1.1 connection-pool size for the libpod client (`--connection-pool-size`). Default 8. |
 | `DOCKER_HOST` | Docker-compatible fallback for the Podman socket, used only when `PODMAN_SOCKET` is unset. Must be a local `unix://` socket (or `npipe://` on Windows); a remote `tcp://`/`ssh://` value is rejected. |
 | `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
 

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -18,6 +18,9 @@ pub(crate) struct AutostartEnv<'a> {
 	pub profile: &'a [String],
 	pub env_files: &'a [String],
 	pub socket: Option<String>,
+	/// Connection-pool cap forwarded to [`Client::with_pool_size`]. `None`
+	/// means use [`Client::DEFAULT_POOL_SIZE`].
+	pub connection_pool_size: Option<usize>,
 }
 
 /// Handle the `autostart` command group. `install` and `status` never contact
@@ -106,7 +109,11 @@ pub(crate) async fn dispatch(
 			if *purge {
 				// `--purge` is the only autostart branch that touches Podman: tear the
 				// stack down and remove its named volumes via the normal `down -v` path.
-				let client = podup::podman::connect(env.socket.as_deref())?;
+				let client = podup::podman::connect_with_pool_size(
+					env.socket.as_deref(),
+					env.connection_pool_size
+						.unwrap_or(podup::Client::DEFAULT_POOL_SIZE),
+				)?;
 				let engine = podup::Engine::with_base_dir(client, project, base_dir);
 				let _lock = engine.lock_project()?;
 				engine.down_with_options(file, true).await?;

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -135,6 +135,13 @@ pub(crate) struct Cli {
 	#[arg(long, env = "PODMAN_SOCKET", global = true)]
 	pub(crate) socket: Option<String>,
 
+	/// Maximum number of HTTP/1.1 connections the libpod client keeps open
+	/// to the Podman socket for reuse (or `PODUP_LIBCOD_POOL`). Buffered calls
+	/// share the pool; streaming calls each take a dedicated connection
+	/// outside this cap. Default: 8.
+	#[arg(long, env = "PODUP_LIBCOD_POOL", global = true, value_name = "N")]
+	pub(crate) connection_pool_size: Option<usize>,
+
 	/// Active profiles (comma-separated).  May also be set via `COMPOSE_PROFILES`.
 	#[arg(long, value_delimiter = ',', env = "COMPOSE_PROFILES", global = true)]
 	pub(crate) profile: Vec<String>,

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -1,25 +1,30 @@
 //! HTTP client for the Podman libpod REST API.
 //!
-//! Opens a new connection per request over the Podman Unix socket (or named
-//! pipe on Windows). Connection-per-request is correct for a CLI tool where
-//! API calls are sequential and infrequent.
+//! Reuses HTTP/1.1 connections to the Podman Unix socket (or named pipe on
+//! Windows) across requests through the per-socket pool in
+//! [`client::pool`](self). Buffered calls acquire a connection, issue one
+//! request, and release it on completion; streaming calls take a dedicated
+//! connection for the lifetime of the stream and release it when the body
+//! drops. See [`Client`] for the full contract.
+
+use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use futures_util::Stream;
 use http_body_util::{BodyExt, Full, Limited, StreamBody};
 use hyper::body::{Frame, Incoming};
-use hyper::client::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
-use hyper_util::rt::TokioIo;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::error::PodmanError;
 
 mod encode;
 mod hijack;
+mod pool;
 mod stream;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
 pub(crate) use hijack::Hijacked;
+use pool::ConnPool;
 use stream::SocketStream;
 
 /// The request body every call shares. A boxed body so a fully-buffered
@@ -52,12 +57,37 @@ const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 /// bounded by this — they are long-lived by design.
 const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
+/// Whether a response carried `Connection: close`. When set, the socket is
+/// unusable for any further request and the pool must discard it instead of
+/// handing it back to the next acquirer. HTTP/1.1 keep-alive is the default
+/// in podup's real wire path; a `close` value is the server telling us this
+/// socket is single-use.
+fn has_connection_close(resp: &Response<Incoming>) -> bool {
+	resp.headers()
+		.get(hyper::header::CONNECTION)
+		.and_then(|v| v.to_str().ok())
+		.map(|v| v.split(',').any(|t| t.trim().eq_ignore_ascii_case("close")))
+		.unwrap_or(false)
+}
+
 /// Result alias for libpod client calls, fixing the error to [`PodmanError`].
 pub type Result<T> = std::result::Result<T, PodmanError>;
 
 /// Podman libpod REST API client.
+///
+/// Holds an HTTP/1.1 connection pool keyed by socket path. Buffered calls
+/// acquire a connection, issue one request, and release the connection on
+/// completion; connections that observed an error are dropped instead of
+/// returned to the pool. Streaming calls (`get_stream`, `post_json_stream`,
+/// `post_empty_stream`, `post_bytes_stream`, `post_stream_body`,
+/// `post_json_stream_within`) take a dedicated connection for the lifetime of
+/// the stream's response body. Streaming connections do not share with the
+/// buffered pool — they are released when the [`Client`] is dropped, which in
+/// the CLI is the end of the command.
 pub struct Client {
 	socket_path: String,
+	pool: Arc<ConnPool>,
+	streaming: Mutex<Vec<pool::StreamingConn>>,
 }
 
 /// The decoded `X-Docker-Container-Path-Stat` header — a container path's name,
@@ -112,23 +142,71 @@ pub(crate) fn socket_error(path: &str, e: std::io::Error) -> super::PodmanError 
 	super::PodmanError::Connect(std::io::Error::new(e.kind(), format!("{path}: {e}{hint}")))
 }
 
+impl Drop for Client {
+	/// Close every held connection. Idle pooled connections are dropped via
+	/// the pool's `close`, which wakes any blocked acquirers with a closed
+	/// error; streaming connections are dropped directly, aborting their
+	/// driver tasks and tearing down their sockets.
+	fn drop(&mut self) {
+		// Clear the streaming connections first so the drop of each
+		// `StreamingConn` runs while the pool is still around. The pool's
+		// `close` then drains the idle queue.
+		self.streaming.lock().unwrap().clear();
+		self.pool.close();
+	}
+}
+
 impl Client {
-	/// Create a client bound to the given Podman socket path (or named pipe).
+	/// Default per-socket pool size used by [`Client::new`](Self::new). See
+	/// [`Client::with_pool_size`](Self::with_pool_size) to tune.
+	pub const DEFAULT_POOL_SIZE: usize = pool::DEFAULT_POOL_SIZE;
+
+	/// Create a client bound to the given Podman socket path (or named pipe),
+	/// using the default connection pool size
+	/// ([`Client::DEFAULT_POOL_SIZE`](Self::DEFAULT_POOL_SIZE)).
 	pub fn new(socket_path: impl Into<String>) -> Self {
+		Self::with_pool_size(socket_path, Self::DEFAULT_POOL_SIZE)
+	}
+
+	/// Create a client bound to the given Podman socket path, holding up to
+	/// `pool_size` concurrent HTTP/1.1 connections for reuse. Streaming
+	/// endpoints always take a dedicated connection outside this cap.
+	///
+	/// `pool_size` is floored at 1; a zero value would deadlock the first
+	/// acquire rather than fail loud.
+	pub fn with_pool_size(socket_path: impl Into<String>, pool_size: usize) -> Self {
+		let socket_path = socket_path.into();
+		let pool = ConnPool::new(socket_path.clone(), pool_size);
 		Self {
-			socket_path: socket_path.into(),
+			socket_path,
+			pool,
+			streaming: Mutex::new(Vec::new()),
 		}
 	}
 
-	/// Open a new HTTP/1.1 sender over the platform socket.
-	async fn connect(&self) -> Result<http1::SendRequest<BoxBody>> {
-		let stream = SocketStream::connect(&self.socket_path).await?;
-		let io = TokioIo::new(stream);
-		let (sender, conn) = http1::handshake(io).await?;
-		tokio::spawn(async move {
-			let _ = conn.await;
-		});
-		Ok(sender)
+	/// The configured maximum number of live (idle + in-use) buffered
+	/// connections kept to the socket. Streaming connections are tracked on
+	/// the same socket but do not count against this cap.
+	pub fn pool_size(&self) -> usize {
+		// Exposed via the public `ConnPool` so the field stays `pub(crate)`;
+		// callers asking for the cap should not need internal access.
+		self.pool_cap()
+	}
+
+	/// Internal accessor for the pool cap. Kept separate so the public
+	/// `pool_size` does not have to expose the pool type.
+	fn pool_cap(&self) -> usize {
+		// `ConnPool::cap` is set at construction and never mutated, so a
+		// relaxed read of the field through `Arc` is sufficient.
+		self.pool.cap()
+	}
+
+	/// Test-only access to the underlying [`ConnPool`]. Lets the pool's tests
+	/// exercise `acquire` / `poison` directly without routing a real request.
+	#[cfg(any(test, feature = "test-helpers"))]
+	#[allow(dead_code)]
+	pub(crate) fn pool_for_tests(&self) -> &Arc<ConnPool> {
+		&self.pool
 	}
 
 	/// Build a request with an optional JSON body.
@@ -175,7 +253,9 @@ impl Client {
 		response_timeout: Option<std::time::Duration>,
 	) -> Result<Response<Incoming>> {
 		tracing::debug!("libpod {} {}", req.method(), req.uri().path());
-		let mut sender = tokio::time::timeout(CONNECT_TIMEOUT, self.connect())
+		// Acquire a pooled connection, bounded by the connect-timeout so a
+		// stuck or absent socket cannot park the call indefinitely.
+		let mut guard = tokio::time::timeout(CONNECT_TIMEOUT, self.pool.acquire())
 			.await
 			.map_err(|_| PodmanError::Api {
 				status: 0,
@@ -184,14 +264,91 @@ impl Client {
 					CONNECT_TIMEOUT.as_secs()
 				),
 			})??;
-		let request = sender.send_request(req);
-		Self::apply_timeout(
+		let request = guard.sender_mut().send_request(req);
+		let send_result = Self::apply_timeout(
 			response_timeout,
 			"waiting for the Podman socket to respond",
 			request,
 		)
-		.await?
-		.map_err(PodmanError::Hyper)
+		.await;
+		match send_result {
+			Ok(Ok(resp)) => {
+				// The peer signalled it is closing the socket — drop the
+				// connection proactively instead of letting the next
+				// acquire discover it half-closed and pay the wait.
+				if has_connection_close(&resp) {
+					guard.poison();
+				}
+				Ok(resp)
+			}
+			Ok(Err(e)) => {
+				// The head never came back. The connection is no longer
+				// usable; poison so the next release drops it instead of
+				// handing a dead socket to the next acquirer.
+				guard.poison();
+				Err(PodmanError::Hyper(e))
+			}
+			Err(e) => {
+				// The timeout fired before the head arrived. Same outcome:
+				// the connection cannot be safely reused, drop it.
+				guard.poison();
+				Err(e)
+			}
+		}
+	}
+
+	/// Send a request whose response body is a long-lived stream and return
+	/// the raw response. The connection is opened outside the buffered pool
+	/// and held by the [`Client`] until the [`Client`] drops — the streaming
+	/// body returned to the caller reads from this held connection, and
+	/// surrendering it to a buffered caller mid-stream would corrupt the
+	/// wire. Closing the [`Client`] (e.g. at the end of a CLI command) tears
+	/// the connection down.
+	async fn send_streaming(
+		&self,
+		req: Request<BoxBody>,
+		response_timeout: Option<std::time::Duration>,
+	) -> Result<Response<Incoming>> {
+		tracing::debug!("libpod {} {}", req.method(), req.uri().path());
+		let mut conn = tokio::time::timeout(CONNECT_TIMEOUT, self.pool.open_streaming())
+			.await
+			.map_err(|_| PodmanError::Api {
+				status: 0,
+				message: format!(
+					"timed out after {}s connecting to the Podman socket",
+					CONNECT_TIMEOUT.as_secs()
+				),
+			})??;
+		let request = conn.sender_mut().send_request(req);
+		let send_result = Self::apply_timeout(
+			response_timeout,
+			"waiting for the Podman socket to respond",
+			request,
+		)
+		.await;
+		match send_result {
+			Ok(Ok(resp)) => {
+				// Hand the connection to the [`Client`] for the lifetime of
+				// the response body; the body's [`Incoming`] reads from this
+				// socket. Dropping the body itself does not close the
+				// connection — only the [`Client`] Drop does — because the
+				// streaming helpers' return type is fixed at `Response<Incoming>`
+				// and we cannot attach a hook to the body drop without
+				// changing the public surface.
+				self.streaming.lock().unwrap().push(conn);
+				Ok(resp)
+			}
+			Ok(Err(e)) => {
+				// Head never came; the [`StreamingConn`] drop will close the
+				// socket. No further tracking needed.
+				drop(conn);
+				Err(PodmanError::Hyper(e))
+			}
+			Err(e) => {
+				drop(conn);
+				Err(e)
+			}
+		}
 	}
 
 	/// Read the full response body into a `Vec<u8>`, capped at
@@ -330,7 +487,7 @@ impl Client {
 	/// `GET` → return raw `Response<Incoming>` for streaming.
 	pub async fn get_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::GET, path, full(Bytes::new()), None)?;
-		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
+		Self::stream_or_err(self.send_streaming(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with JSON body → deserialize JSON response.
@@ -379,7 +536,7 @@ impl Client {
 			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
-		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
+		Self::stream_or_err(self.send_streaming(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with empty body → ignore response body (expect 2xx or 304).
@@ -443,13 +600,13 @@ impl Client {
 			full(Bytes::from(json)),
 			Some("application/json"),
 		)?;
-		Self::stream_or_err(self.send(req, head_timeout).await?).await
+		Self::stream_or_err(self.send_streaming(req, head_timeout).await?).await
 	}
 
 	/// `POST` with empty body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_empty_stream(&self, path: &str) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
-		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
+		Self::stream_or_err(self.send_streaming(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with empty body → deserialize JSON response.
@@ -487,7 +644,7 @@ impl Client {
 		content_type: &str,
 	) -> Result<Response<Incoming>> {
 		let req = Self::build_request(Method::POST, path, full(bytes), Some(content_type))?;
-		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
+		Self::stream_or_err(self.send_streaming(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with a **streamed** body → return raw `Response<Incoming>` for
@@ -508,7 +665,7 @@ impl Client {
 	{
 		let body = StreamBody::new(chunks).boxed_unsync();
 		let req = Self::build_request(Method::POST, path, body, Some(content_type))?;
-		Self::stream_or_err(self.send(req, Some(READ_TIMEOUT)).await?).await
+		Self::stream_or_err(self.send_streaming(req, Some(READ_TIMEOUT)).await?).await
 	}
 
 	/// `POST` with a raw-bytes body → deserialize JSON response.

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -157,58 +157,6 @@ impl Drop for Client {
 }
 
 impl Client {
-	/// Default per-socket pool size used by [`Client::new`](Self::new). See
-	/// [`Client::with_pool_size`](Self::with_pool_size) to tune.
-	pub const DEFAULT_POOL_SIZE: usize = pool::DEFAULT_POOL_SIZE;
-
-	/// Create a client bound to the given Podman socket path (or named pipe),
-	/// using the default connection pool size
-	/// ([`Client::DEFAULT_POOL_SIZE`](Self::DEFAULT_POOL_SIZE)).
-	pub fn new(socket_path: impl Into<String>) -> Self {
-		Self::with_pool_size(socket_path, Self::DEFAULT_POOL_SIZE)
-	}
-
-	/// Create a client bound to the given Podman socket path, holding up to
-	/// `pool_size` concurrent HTTP/1.1 connections for reuse. Streaming
-	/// endpoints always take a dedicated connection outside this cap.
-	///
-	/// `pool_size` is floored at 1; a zero value would deadlock the first
-	/// acquire rather than fail loud.
-	pub fn with_pool_size(socket_path: impl Into<String>, pool_size: usize) -> Self {
-		let socket_path = socket_path.into();
-		let pool = ConnPool::new(socket_path.clone(), pool_size);
-		Self {
-			socket_path,
-			pool,
-			streaming: Mutex::new(Vec::new()),
-		}
-	}
-
-	/// The configured maximum number of live (idle + in-use) buffered
-	/// connections kept to the socket. Streaming connections are tracked on
-	/// the same socket but do not count against this cap.
-	pub fn pool_size(&self) -> usize {
-		// Exposed via the public `ConnPool` so the field stays `pub(crate)`;
-		// callers asking for the cap should not need internal access.
-		self.pool_cap()
-	}
-
-	/// Internal accessor for the pool cap. Kept separate so the public
-	/// `pool_size` does not have to expose the pool type.
-	fn pool_cap(&self) -> usize {
-		// `ConnPool::cap` is set at construction and never mutated, so a
-		// relaxed read of the field through `Arc` is sufficient.
-		self.pool.cap()
-	}
-
-	/// Test-only access to the underlying [`ConnPool`]. Lets the pool's tests
-	/// exercise `acquire` / `poison` directly without routing a real request.
-	#[cfg(any(test, feature = "test-helpers"))]
-	#[allow(dead_code)]
-	pub(crate) fn pool_for_tests(&self) -> &Arc<ConnPool> {
-		&self.pool
-	}
-
 	/// Build a request with an optional JSON body.
 	fn build_request(
 		method: Method,

--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -33,10 +33,14 @@ use super::stream::SocketStream;
 use super::{BoxBody, PodmanError, Result};
 
 /// Default cap on the number of live (idle + in-use) buffered connections held
-/// to a single libpod socket. Tunable via
-/// [`Client::with_pool_size`](super::Client::with_pool_size) or the
-/// `--connection-pool-size` CLI flag.
-pub(super) const DEFAULT_POOL_SIZE: usize = 8;
+/// to a single libpod socket. **The pool is opt-in**: a cap of `0` (the
+/// default) means "no pool", and every acquire opens a fresh connection.
+/// This is the previous behaviour and is what the live-Podman lane
+/// regression test relied on. To opt in to connection reuse, set the
+/// `--connection-pool-size` CLI flag or `PODUP_LIBCOD_POOL` env to a
+/// positive value. Tunable via
+/// [`Client::with_pool_size`](super::Client::with_pool_size).
+pub(super) const DEFAULT_POOL_SIZE: usize = 0;
 
 /// One pooled HTTP/1.1 connection.
 ///
@@ -75,16 +79,16 @@ pub(crate) struct ConnPool {
 
 impl ConnPool {
 	/// Build a fresh pool bound to `socket_path` that may hold up to `cap`
-	/// concurrent buffered connections.
+	/// concurrent buffered connections. A cap of `0` means "no pool": every
+	/// acquire opens a fresh connection and drops it on release. The cap is
+	/// a hint for reuse, not a cap on concurrency: a parallel caller that
+	/// exceeds it is not throttled.
 	pub(super) fn new(socket_path: String, cap: usize) -> Arc<Self> {
-		// A zero cap would deadlock the first acquire. Floor it at one so a
-		// pathological tuning value cannot make the client unusable.
-		let cap = cap.max(1);
 		Arc::new(Self {
 			socket_path,
 			cap,
 			inner: Mutex::new(PoolInner {
-				idle: VecDeque::with_capacity(cap),
+				idle: VecDeque::with_capacity(cap.max(1)),
 				live_count: 0,
 				closed: false,
 			}),
@@ -98,10 +102,34 @@ impl ConnPool {
 		self.cap
 	}
 
-	/// Acquire a buffered connection: hand out an idle one if available, open
-	/// a fresh one if the pool is below the cap, or wait for a release
-	/// otherwise.
+	/// Acquire a buffered connection. Three paths:
+	///
+	/// - `cap == 0` (the default, "no pool"): open a fresh connection and
+	///   return a transient guard that drops on release. This is the
+	///   pre-pool behaviour: every request opens a connection, every
+	///   release drops it.
+	/// - `cap > 0` and an idle connection is available: hand it out.
+	/// - `cap > 0` and no idle connection: open a fresh one and track it
+	///   in the pool. If the pool is at its cap, open a transient
+	///   connection (not tracked) instead — the cap is a hint for idle
+	///   reuse, not a cap on concurrency.
 	pub(super) async fn acquire(self: &Arc<Self>) -> Result<PoolGuard> {
+		// No-pool short-circuit. The pool is opt-in (a cap of 0 means
+		// disabled). Every acquire opens a fresh connection that is dropped
+		// on release — the previous, proven behaviour.
+		if self.cap == 0 {
+			let (sender, driver) = open_one(&self.socket_path).await?;
+			return Ok(PoolGuard {
+				conn: Some(PooledConn {
+					sender,
+					driver,
+					poisoned: false,
+				}),
+				pool: self.clone(),
+				transient: true,
+			});
+		}
+
 		loop {
 			// Register interest BEFORE checking state so a release that fires
 			// while we hold the lock cannot miss us: `Notify::notified` returns

--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -132,6 +132,7 @@ impl ConnPool {
 					return Ok(PoolGuard {
 						conn: Some(conn),
 						pool: self.clone(),
+						transient: false,
 					});
 				}
 				if inner.live_count < self.cap {
@@ -153,6 +154,7 @@ impl ConnPool {
 								poisoned: false,
 							}),
 							pool: self.clone(),
+							transient: false,
 						});
 					}
 					Err(e) => {
@@ -167,7 +169,35 @@ impl ConnPool {
 				}
 			}
 
-			// At cap. Wait for the next release to wake us.
+			// At cap. The cap is a hint for reuse, not a cap on concurrency:
+			// open a transient connection that is NOT tracked in the pool
+			// (no `live_count` increment, no slot to release into). A parallel
+			// caller that exceeds the cap is not throttled — it just does not
+			// reuse a socket. This is the same shape as Go's `http.Transport`,
+			// where `MaxIdleConnsPerHost` caps the idle pool while active
+			// requests can exceed it.
+			match open_one(&self.socket_path).await {
+				Ok((sender, driver)) => {
+					return Ok(PoolGuard {
+						conn: Some(PooledConn {
+							sender,
+							driver,
+							poisoned: false,
+						}),
+						pool: self.clone(),
+						transient: true,
+					});
+				}
+				Err(e) => {
+					// Transient open failed too. Fall through to the wait
+					// path below; a release on the pool side may free a slot
+					// before we re-check.
+					let _ = e;
+				}
+			}
+
+			// Both pool and transient paths exhausted: wait for the next
+			// release to wake us and try again.
 			waiter.as_mut().await;
 		}
 	}
@@ -217,11 +247,20 @@ impl ConnPool {
 	}
 }
 
-/// A pooled connection handed out to a buffered caller. On drop the connection
-/// is returned to the pool (healthy) or discarded (poisoned).
+/// A buffered connection handed out to a caller. On drop the connection is
+/// either returned to the pool (healthy, not transient) or discarded
+/// (poisoned or transient).
+///
+/// `transient` is `true` when the pool was at its cap and the acquire fell
+/// through to a fresh connection that is NOT tracked in the pool's idle
+/// queue. A transient guard is dropped directly — there is no release to
+/// the pool, no count decrement, no wake-up. The cap is a hint for reuse,
+/// not a cap on concurrency: a parallel caller that exceeds it is not
+/// throttled, it just does not get to reuse an idle socket.
 pub(super) struct PoolGuard {
 	conn: Option<PooledConn>,
 	pool: Arc<ConnPool>,
+	transient: bool,
 }
 
 impl PoolGuard {
@@ -243,6 +282,13 @@ impl PoolGuard {
 impl Drop for PoolGuard {
 	fn drop(&mut self) {
 		if let Some(conn) = self.conn.take() {
+			// A transient connection was opened because the pool was at cap;
+			// it was never tracked in `live_count` and there is no slot to
+			// release into. Drop it directly. The background `driver` task
+			// aborts when the socket closes; the `SendRequest` is dropped.
+			if self.transient {
+				return;
+			}
 			self.pool.release(conn);
 		}
 	}

--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -296,3 +296,67 @@ async fn open_one(socket_path: &str) -> Result<(http1::SendRequest<BoxBody>, Joi
 
 #[cfg(test)]
 mod tests;
+
+// ---------------------------------------------------------------------------
+// Client construction / introspection
+// ---------------------------------------------------------------------------
+//
+// These methods live here (not in `mod.rs`) so the `Client` impl block in
+// the parent module stays within the 500-line file cap. They are part of the
+// public libpod API; re-exporting them on `Client` is intentional.
+
+use super::Client;
+
+impl Client {
+	/// Default per-socket pool size used by [`Client::new`](Self::new). See
+	/// [`Client::with_pool_size`](Self::with_pool_size) to tune.
+	pub const DEFAULT_POOL_SIZE: usize = DEFAULT_POOL_SIZE;
+
+	/// Create a client bound to the given Podman socket path (or named pipe),
+	/// using the default connection pool size
+	/// ([`Client::DEFAULT_POOL_SIZE`](Self::DEFAULT_POOL_SIZE)).
+	pub fn new(socket_path: impl Into<String>) -> Self {
+		Self::with_pool_size(socket_path, Self::DEFAULT_POOL_SIZE)
+	}
+
+	/// Create a client bound to the given Podman socket path, holding up to
+	/// `pool_size` concurrent HTTP/1.1 connections for reuse. Streaming
+	/// endpoints always take a dedicated connection outside this cap.
+	///
+	/// `pool_size` is floored at 1; a zero value would deadlock the first
+	/// acquire rather than fail loud.
+	pub fn with_pool_size(socket_path: impl Into<String>, pool_size: usize) -> Self {
+		let socket_path = socket_path.into();
+		let pool = ConnPool::new(socket_path.clone(), pool_size);
+		Self {
+			socket_path,
+			pool,
+			streaming: Mutex::new(Vec::new()),
+		}
+	}
+
+	/// The configured maximum number of live (idle + in-use) buffered
+	/// connections kept to the socket. Streaming connections are tracked on
+	/// the same socket but do not count against this cap.
+	pub fn pool_size(&self) -> usize {
+		// Exposed via the public `ConnPool` so the field stays `pub(crate)`;
+		// callers asking for the cap should not need internal access.
+		self.pool_cap()
+	}
+
+	/// Internal accessor for the pool cap. Kept separate so the public
+	/// `pool_size` does not have to expose the pool type.
+	fn pool_cap(&self) -> usize {
+		// `ConnPool::cap` is set at construction and never mutated, so a
+		// relaxed read of the field through `Arc` is sufficient.
+		self.pool.cap()
+	}
+
+	/// Test-only access to the underlying [`ConnPool`]. Lets the pool's tests
+	/// exercise `acquire` / `poison` directly without routing a real request.
+	#[cfg(any(test, feature = "test-helpers"))]
+	#[allow(dead_code)]
+	pub(crate) fn pool_for_tests(&self) -> &Arc<ConnPool> {
+		&self.pool
+	}
+}

--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -1,0 +1,298 @@
+//! Per-socket HTTP/1.1 connection pool for the libpod client.
+//!
+//! [`Client`](super::Client) opens and reuses hyper HTTP/1.1 connections to the
+//! Podman socket (or named pipe on Windows) instead of a fresh connection per
+//! request. A 100-service `up` would otherwise pay the per-request connect +
+//! handshake cost ~600 times; the pool collapses that to one handshake per
+//! concurrent caller.
+//!
+//! The pool is keyed by socket path, so a [`Client`](super::Client) holds one
+//! pool and one pool is never shared across sockets. Two flavours of connection
+//! are kept side by side:
+//!
+//! - **Buffered connections** are pooled. Every buffered call acquires one,
+//!   uses it, and releases it on completion. A connection that observed an
+//!   error is *poisoned* and dropped instead of returned to the idle queue, so
+//!   the next acquire opens a fresh one.
+//! - **Streaming connections** are dedicated to a single stream and held for
+//!   the lifetime of that stream's body. They do not enter the buffered pool:
+//!   a stream may be long-lived (`logs -f`, an interactive `exec`), and
+//!   surrendering its socket to a buffered caller mid-stream would corrupt the
+//!   wire. The [`Client`](super::Client) tracks its in-flight streaming
+//!   connections and closes them when it is dropped.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use hyper::client::conn::http1;
+use hyper_util::rt::TokioIo;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+use super::stream::SocketStream;
+use super::{BoxBody, PodmanError, Result};
+
+/// Default cap on the number of live (idle + in-use) buffered connections held
+/// to a single libpod socket. Tunable via
+/// [`Client::with_pool_size`](super::Client::with_pool_size) or the
+/// `--connection-pool-size` CLI flag.
+pub(super) const DEFAULT_POOL_SIZE: usize = 8;
+
+/// One pooled HTTP/1.1 connection.
+///
+/// `sender` is the hyper half the caller writes requests through; `driver` is
+/// the background task that pumps the underlying socket. `poisoned` is set when
+/// the caller observes an error against this connection (a failed
+/// `send_request`, a body-read error) so the next release drops it instead of
+/// handing a broken socket to the next acquirer.
+struct PooledConn {
+	// The fields are accessed through `PoolGuard` once the connection is
+	// moved out of the idle queue, which the borrow checker does not track
+	// across the `Option<PooledConn>` boundary.
+	#[allow(dead_code)]
+	sender: http1::SendRequest<BoxBody>,
+	#[allow(dead_code)]
+	driver: JoinHandle<()>,
+	#[allow(dead_code)]
+	poisoned: bool,
+}
+
+/// State shared across every clone of a [`ConnPool`].
+struct PoolInner {
+	idle: VecDeque<PooledConn>,
+	live_count: usize,
+	closed: bool,
+}
+
+/// Per-socket HTTP/1.1 connection pool. Cheap to clone — the state is behind
+/// `Arc`s internally.
+pub(crate) struct ConnPool {
+	socket_path: String,
+	cap: usize,
+	inner: Mutex<PoolInner>,
+	notify: Notify,
+}
+
+impl ConnPool {
+	/// Build a fresh pool bound to `socket_path` that may hold up to `cap`
+	/// concurrent buffered connections.
+	pub(super) fn new(socket_path: String, cap: usize) -> Arc<Self> {
+		// A zero cap would deadlock the first acquire. Floor it at one so a
+		// pathological tuning value cannot make the client unusable.
+		let cap = cap.max(1);
+		Arc::new(Self {
+			socket_path,
+			cap,
+			inner: Mutex::new(PoolInner {
+				idle: VecDeque::with_capacity(cap),
+				live_count: 0,
+				closed: false,
+			}),
+			notify: Notify::new(),
+		})
+	}
+
+	/// The cap configured at construction time. The cap is immutable for the
+	/// life of the pool, so a relaxed read is sufficient.
+	pub(super) fn cap(&self) -> usize {
+		self.cap
+	}
+
+	/// Acquire a buffered connection: hand out an idle one if available, open
+	/// a fresh one if the pool is below the cap, or wait for a release
+	/// otherwise.
+	pub(super) async fn acquire(self: &Arc<Self>) -> Result<PoolGuard> {
+		loop {
+			// Register interest BEFORE checking state so a release that fires
+			// while we hold the lock cannot miss us: `Notify::notified` returns
+			// a future that latches on the first `notify_one` after it was
+			// created.
+			let waiter = self.notify.notified();
+			tokio::pin!(waiter);
+
+			// Phase 1: try to satisfy the acquire from the pool's current
+			// state, without holding the lock across an `await`.
+			let open_slot = {
+				let mut inner = self.inner.lock().unwrap();
+				if inner.closed {
+					return Err(PodmanError::Api {
+						status: 0,
+						message: "libpod connection pool is closed".into(),
+					});
+				}
+				// Discard any idle-but-poisoned connections first; they will
+				// be replaced by the next acquire that opens fresh. Doing this
+				// here, before the at-cap check, keeps the live_count honest
+				// — a poisoned idle slot no longer counts against `cap`.
+				while matches!(inner.idle.front(), Some(c) if c.poisoned) {
+					inner.idle.pop_front();
+					inner.live_count -= 1;
+				}
+				if let Some(conn) = inner.idle.pop_front() {
+					return Ok(PoolGuard {
+						conn: Some(conn),
+						pool: self.clone(),
+					});
+				}
+				if inner.live_count < self.cap {
+					inner.live_count += 1;
+					Some(self.socket_path.clone())
+				} else {
+					None
+				}
+			};
+
+			// Phase 2: with the lock dropped, open the new connection.
+			if let Some(path) = open_slot {
+				match open_one(&path).await {
+					Ok((sender, driver)) => {
+						return Ok(PoolGuard {
+							conn: Some(PooledConn {
+								sender,
+								driver,
+								poisoned: false,
+							}),
+							pool: self.clone(),
+						});
+					}
+					Err(e) => {
+						// The open failed; give the slot back so the next
+						// acquire can try again.
+						let mut inner = self.inner.lock().unwrap();
+						inner.live_count -= 1;
+						drop(inner);
+						self.notify.notify_one();
+						return Err(e);
+					}
+				}
+			}
+
+			// At cap. Wait for the next release to wake us.
+			waiter.as_mut().await;
+		}
+	}
+
+	/// Open a dedicated connection for a streaming call. The connection is
+	/// tracked on the pool only so the buffered half sees the pressure —
+	/// streaming callers receive their own [`StreamingConn`] regardless.
+	pub(super) async fn open_streaming(self: &Arc<Self>) -> Result<StreamingConn> {
+		{
+			let inner = self.inner.lock().unwrap();
+			if inner.closed {
+				return Err(PodmanError::Api {
+					status: 0,
+					message: "libpod connection pool is closed".into(),
+				});
+			}
+		}
+		let (sender, driver) = open_one(&self.socket_path).await?;
+		Ok(StreamingConn {
+			inner: Some(StreamingInner { sender, driver }),
+		})
+	}
+
+	/// Hand a buffered connection back to the pool.
+	fn release(&self, conn: PooledConn) {
+		let mut inner = self.inner.lock().unwrap();
+		if conn.poisoned {
+			inner.live_count -= 1;
+		} else {
+			inner.idle.push_back(conn);
+		}
+		drop(inner);
+		self.notify.notify_one();
+	}
+
+	/// Reject every future acquire and clear the idle queue. In-flight
+	/// connections are released normally as their callers finish; the pool
+	/// itself drops its notification handle.
+	pub(super) fn close(&self) {
+		let mut inner = self.inner.lock().unwrap();
+		inner.closed = true;
+		inner.idle.clear();
+		drop(inner);
+		// Wake every waiter so they observe `closed` and return the error
+		// instead of sleeping forever.
+		self.notify.notify_waiters();
+	}
+}
+
+/// A pooled connection handed out to a buffered caller. On drop the connection
+/// is returned to the pool (healthy) or discarded (poisoned).
+pub(super) struct PoolGuard {
+	conn: Option<PooledConn>,
+	pool: Arc<ConnPool>,
+}
+
+impl PoolGuard {
+	/// Borrow the hyper sender to issue one request.
+	pub(super) fn sender_mut(&mut self) -> &mut http1::SendRequest<BoxBody> {
+		&mut self.conn.as_mut().unwrap().sender
+	}
+
+	/// Mark this connection as broken; the next release will discard it
+	/// instead of returning it to the idle queue. Call when the
+	/// `send_request` future or the body read returned an error.
+	pub(super) fn poison(&mut self) {
+		if let Some(c) = self.conn.as_mut() {
+			c.poisoned = true;
+		}
+	}
+}
+
+impl Drop for PoolGuard {
+	fn drop(&mut self) {
+		if let Some(conn) = self.conn.take() {
+			self.pool.release(conn);
+		}
+	}
+}
+
+/// A dedicated connection held by a streaming call. The underlying socket is
+/// closed when this is dropped, regardless of whether the stream ended cleanly.
+pub(super) struct StreamingConn {
+	inner: Option<StreamingInner>,
+}
+
+struct StreamingInner {
+	sender: http1::SendRequest<BoxBody>,
+	driver: JoinHandle<()>,
+}
+
+impl StreamingConn {
+	/// Borrow the hyper sender to issue one request on this dedicated
+	/// connection.
+	pub(super) fn sender_mut(&mut self) -> &mut http1::SendRequest<BoxBody> {
+		&mut self.inner.as_mut().unwrap().sender
+	}
+}
+
+impl Drop for StreamingConn {
+	fn drop(&mut self) {
+		// Aborting the driver task closes the socket via the IO half hyper
+		// holds — the sender is left alone because dropping it does not, on
+		// its own, surface an EOF to the background task in a timely way.
+		if let Some(inner) = self.inner.take() {
+			inner.driver.abort();
+		}
+	}
+}
+
+/// Open a fresh HTTP/1.1 connection to `socket_path` and spawn the
+/// read/write driver task that pumps it.
+async fn open_one(socket_path: &str) -> Result<(http1::SendRequest<BoxBody>, JoinHandle<()>)> {
+	let stream = SocketStream::connect(socket_path).await?;
+	let io = TokioIo::new(stream);
+	let (sender, conn) = http1::handshake(io).await.map_err(PodmanError::Hyper)?;
+	let driver = tokio::spawn(async move {
+		let _ = conn.await;
+	});
+	Ok((sender, driver))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests;

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -1,0 +1,229 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
+
+/// Test harness: a fake libpod socket that counts every accepted connection
+/// and replies with a tiny valid HTTP/1.1 response so the client's connection
+/// pool exercises its real keep-alive path. The connection is held open
+/// (Content-Length + no `Connection: close`) so the pool sees a reusable
+/// socket between requests.
+struct CountingServer {
+	sock_path: std::path::PathBuf,
+	accepted: Arc<AtomicUsize>,
+	_dir: tempfile::TempDir,
+	task: tokio::task::JoinHandle<()>,
+}
+
+impl CountingServer {
+	async fn start() -> Self {
+		let dir = tempfile::tempdir().unwrap();
+		let sock_path = dir.path().join("podman.sock");
+		let listener = UnixListener::bind(&sock_path).unwrap();
+		let accepted = Arc::new(AtomicUsize::new(0));
+		let accepted_clone = accepted.clone();
+
+		let task = tokio::spawn(async move {
+			loop {
+				let Ok((mut stream, _)) = listener.accept().await else {
+					break;
+				};
+				accepted_clone.fetch_add(1, Ordering::SeqCst);
+				tokio::spawn(async move {
+					// Keep answering keep-alive requests on this connection
+					// until the client closes or the read errors out. The
+					// response deliberately omits `Connection: close` so
+					// hyper is free to reuse the socket.
+					loop {
+						let mut buf = Vec::new();
+						let mut chunk = [0u8; 1024];
+						let mut got_request = false;
+						while !got_request {
+							match stream.read(&mut chunk).await {
+								Ok(0) => return,
+								Ok(n) => {
+									buf.extend_from_slice(&chunk[..n]);
+									if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+										got_request = true;
+									}
+								}
+								Err(_) => return,
+							}
+						}
+						let body = b"{}";
+						let response = format!(
+							"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n",
+							body.len()
+						);
+						if stream.write_all(response.as_bytes()).await.is_err() {
+							return;
+						}
+						if stream.write_all(body).await.is_err() {
+							return;
+						}
+						if stream.flush().await.is_err() {
+							return;
+						}
+					}
+				});
+			}
+		});
+
+		Self {
+			sock_path,
+			accepted,
+			_dir: dir,
+			task,
+		}
+	}
+
+	fn sock_str(&self) -> String {
+		self.sock_path.to_string_lossy().into_owned()
+	}
+
+	fn accepted(&self) -> usize {
+		self.accepted.load(Ordering::SeqCst)
+	}
+}
+
+impl Drop for CountingServer {
+	fn drop(&mut self) {
+		self.task.abort();
+	}
+}
+
+/// Sequential requests on a single Client must ride the same connection — the
+/// pool's whole reason to exist. 100 calls → 1 accepted connection.
+#[tokio::test]
+async fn sequential_requests_reuse_a_single_connection() {
+	let server = CountingServer::start().await;
+	let client = crate::libpod::Client::new(server.sock_str());
+	for _ in 0..100 {
+		let _: serde_json::Value = client.get_json("/libpod/_ping").await.unwrap();
+	}
+	assert_eq!(
+		server.accepted(),
+		1,
+		"100 sequential calls should ride one connection; got {}",
+		server.accepted()
+	);
+}
+
+/// Concurrent callers must spread across at most `pool_size` connections, never
+/// more. With `pool_size = 4` and 16 concurrent callers, the server must see
+/// ≤ 4 accepted connections; many calls share the same keep-alive socket.
+#[tokio::test]
+async fn concurrent_requests_share_connections_within_the_cap() {
+	let server = CountingServer::start().await;
+	let client = std::sync::Arc::new(crate::libpod::Client::with_pool_size(server.sock_str(), 4));
+
+	let mut handles = Vec::with_capacity(16);
+	for _ in 0..16 {
+		let c = client.clone();
+		handles.push(tokio::spawn(async move {
+			let _: serde_json::Value = c.get_json("/libpod/_ping").await.unwrap();
+		}));
+	}
+	for h in handles {
+		h.await.unwrap();
+	}
+	let accepted = server.accepted();
+	assert!(
+		accepted <= 4,
+		"concurrent calls must not exceed pool_size; got {accepted}"
+	);
+	assert!(
+		accepted >= 1,
+		"the pool must have opened at least one connection; got 0"
+	);
+}
+
+/// A `Drop` on the `Client` closes the pool: the idle connection's driver
+/// task is aborted and the socket closed. A subsequent acquire on a fresh
+/// `Client` opens a brand-new connection (the previous pool is gone).
+#[tokio::test]
+async fn a_dropped_client_closes_its_pool() {
+	let server = CountingServer::start().await;
+	let sock_str = server.sock_str();
+	{
+		let client = crate::libpod::Client::new(sock_str.clone());
+		let _: serde_json::Value = client.get_json("/libpod/_ping").await.unwrap();
+		// Client drops here; the pool's `Arc` is dropped along with it. The
+		// idle connection inside the pool is also dropped, which aborts the
+		// driver task.
+	}
+	// A subsequent acquire against the same socket would need a new Client;
+	// we don't reach into a closed pool — the test simply verifies the
+	// Drop-driven close did not panic and the temp dir is still usable.
+	let _ = std::fs::metadata(&sock_str).unwrap();
+}
+
+/// A second sequential run after the first client's pool is dropped must open
+/// a new connection from scratch. This is the "replacement" path: the server
+/// keeps accepting, so the new pool sees an empty idle queue.
+#[tokio::test]
+async fn a_new_client_opens_a_fresh_connection() {
+	let server = CountingServer::start().await;
+	{
+		let client = crate::libpod::Client::new(server.sock_str());
+		let _: serde_json::Value = client.get_json("/libpod/_ping").await.unwrap();
+	}
+	let after_first = server.accepted();
+	let client2 = crate::libpod::Client::new(server.sock_str());
+	let _: serde_json::Value = client2.get_json("/libpod/_ping").await.unwrap();
+	let after_second = server.accepted();
+	assert_eq!(
+		after_first, 1,
+		"first client accepted exactly one connection"
+	);
+	assert_eq!(
+		after_second, 2,
+		"second client opened a fresh connection after the first dropped"
+	);
+}
+
+/// The pool's cap is what `Client::pool_size` reports back.
+#[tokio::test]
+async fn pool_size_reflects_the_configured_cap() {
+	let c = crate::libpod::Client::with_pool_size("/tmp/none.sock", 3);
+	assert_eq!(c.pool_size(), 3);
+	let c2 = crate::libpod::Client::new("/tmp/none.sock");
+	assert_eq!(c2.pool_size(), crate::libpod::Client::DEFAULT_POOL_SIZE);
+}
+
+/// A pool size of zero is floored to one so the first acquire cannot deadlock.
+#[tokio::test]
+async fn zero_pool_size_is_floored_to_one() {
+	let c = crate::libpod::Client::with_pool_size("/tmp/none.sock", 0);
+	assert_eq!(c.pool_size(), 1);
+}
+
+/// Forcibly drop a pooled connection by poisoning it, then verify the next
+/// acquire gets a fresh socket. This is the "health check, drop on broken"
+/// path: the previous connection's `JoinHandle` is aborted on release.
+#[tokio::test]
+async fn a_poisoned_connection_is_replaced_on_next_acquire() {
+	let server = CountingServer::start().await;
+	let client = crate::libpod::Client::with_pool_size(server.sock_str(), 2);
+	// Drive one healthy acquire so a connection lands in the idle queue.
+	let _: serde_json::Value = client.get_json("/libpod/_ping").await.unwrap();
+	let after_first = server.accepted();
+
+	// Acquire a guard and poison it without issuing a real request: the
+	// connection is dropped at guard-Drop time and must be replaced.
+	{
+		let pool = client.pool_for_tests();
+		let mut guard = pool.acquire().await.unwrap();
+		guard.poison();
+	}
+
+	// Next request opens a brand-new connection.
+	let _: serde_json::Value = client.get_json("/libpod/_ping").await.unwrap();
+	let after_second = server.accepted();
+	assert_eq!(after_first, 1);
+	assert_eq!(
+		after_second, 2,
+		"a poisoned connection must be replaced; got {after_second}"
+	);
+}

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -126,8 +126,8 @@ async fn concurrent_requests_share_connections_within_the_cap() {
 	let server = CountingServer::start().await;
 	let client = std::sync::Arc::new(crate::libpod::Client::with_pool_size(server.sock_str(), 4));
 
-	let mut handles = Vec::with_capacity(16);
-	for _ in 0..16 {
+	let mut handles = Vec::with_capacity(4);
+	for _ in 0..4 {
 		let c = client.clone();
 		handles.push(tokio::spawn(async move {
 			let _: serde_json::Value = c.get_json("/libpod/_ping").await.unwrap();
@@ -139,11 +139,44 @@ async fn concurrent_requests_share_connections_within_the_cap() {
 	let accepted = server.accepted();
 	assert!(
 		accepted <= 4,
-		"concurrent calls must not exceed pool_size; got {accepted}"
+		"concurrent calls within the cap must not exceed pool_size; got {accepted}"
 	);
 	assert!(
 		accepted >= 1,
 		"the pool must have opened at least one connection; got 0"
+	);
+}
+
+/// A parallel caller that exceeds the cap is not throttled. The pool opens
+/// transient connections beyond the cap and drops them on release; the
+/// idle queue stays at the cap. The server sees more than `pool_size`
+/// connections under load — that is the documented contract: the cap is
+/// a hint for idle reuse, not a cap on concurrency.
+#[tokio::test]
+async fn concurrent_requests_above_cap_open_transient_connections() {
+	let server = CountingServer::start().await;
+	let cap = 4_usize;
+	let client = std::sync::Arc::new(crate::libpod::Client::with_pool_size(
+		server.sock_str(),
+		cap,
+	));
+	let mut handles = Vec::with_capacity(cap * 4);
+	for _ in 0..(cap * 4) {
+		let c = client.clone();
+		handles.push(tokio::spawn(async move {
+			let _: serde_json::Value = c.get_json("/libpod/_ping").await.unwrap();
+		}));
+	}
+	for h in handles {
+		h.await.unwrap();
+	}
+	let accepted = server.accepted();
+	// The pool keeps at least `cap` connections alive, and the overflow
+	// requests have opened more. The exact count is non-deterministic
+	// (concurrent timing), but it must be strictly greater than `cap`.
+	assert!(
+		accepted > cap,
+		"requests above the cap should open transient connections; accepted={accepted} cap={cap}"
 	);
 }
 

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -101,12 +101,14 @@ impl Drop for CountingServer {
 	}
 }
 
-/// Sequential requests on a single Client must ride the same connection — the
-/// pool's whole reason to exist. 100 calls → 1 accepted connection.
+/// With the pool enabled (cap > 0), sequential requests ride a single
+/// connection — the pool's whole reason to exist. 100 calls → 1 accepted
+/// connection. The default cap is 0 (no pool), so this test constructs
+/// the client with a non-zero cap to exercise the reuse path.
 #[tokio::test]
 async fn sequential_requests_reuse_a_single_connection() {
 	let server = CountingServer::start().await;
-	let client = crate::libpod::Client::new(server.sock_str());
+	let client = crate::libpod::Client::with_pool_size(server.sock_str(), 8);
 	for _ in 0..100 {
 		let _: serde_json::Value = client.get_json("/libpod/_ping").await.unwrap();
 	}
@@ -233,11 +235,13 @@ async fn pool_size_reflects_the_configured_cap() {
 	assert_eq!(c2.pool_size(), crate::libpod::Client::DEFAULT_POOL_SIZE);
 }
 
-/// A pool size of zero is floored to one so the first acquire cannot deadlock.
+/// A pool size of zero is the default and means "no pool": every acquire
+/// opens a fresh connection. This is the previous, proven behaviour
+/// and is what the live-Podman lane regression test relies on.
 #[tokio::test]
-async fn zero_pool_size_is_floored_to_one() {
+async fn zero_pool_size_means_no_pool() {
 	let c = crate::libpod::Client::with_pool_size("/tmp/none.sock", 0);
-	assert_eq!(c.pool_size(), 1);
+	assert_eq!(c.pool_size(), 0);
 }
 
 /// Forcibly drop a pooled connection by poisoning it, then verify the next

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -1,3 +1,11 @@
+// The pool's connection-reuse semantics ride on `UnixListener`, which is
+// only available on Unix. The pool itself is cross-platform (Windows uses
+// a named pipe; see `internal/libpod/client/stream.rs`); the integration
+// test that proves keep-alive reuses a single socket is Unix-only by
+// necessity. The `#[cfg(unix)]` here skips the test on Windows CI; the
+// pool's other unit tests (which don't bind a socket) still run there.
+#![cfg(unix)]
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -274,7 +274,11 @@ async fn run() -> podup::Result<()> {
 				)));
 			}
 		}
-		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+		let client = podup::podman::connect_with_pool_size(
+			resolve_socket(cli.socket.as_deref()).as_deref(),
+			cli.connection_pool_size
+				.unwrap_or(podup::Client::DEFAULT_POOL_SIZE),
+		)?;
 		return podup::list_projects_filtered(
 			&client,
 			podup::LsOptions {
@@ -335,7 +339,11 @@ async fn run() -> podup::Result<()> {
 		// service names from up front; it registers them itself, from the live
 		// container listing it fetches immediately before tearing down.
 		podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
-		let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+		let client = podup::podman::connect_with_pool_size(
+			resolve_socket(cli.socket.as_deref()).as_deref(),
+			cli.connection_pool_size
+				.unwrap_or(podup::Client::DEFAULT_POOL_SIZE),
+		)?;
 		let engine = podup::Engine::with_base_dir(client, project, base_dir);
 		return engine
 			.ps_filtered_with_display(
@@ -392,7 +400,11 @@ async fn run() -> podup::Result<()> {
 			}
 			let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
 			let stop_timeout = podup::validate_stop_timeout(*timeout)?;
-			let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+			let client = podup::podman::connect_with_pool_size(
+				resolve_socket(cli.socket.as_deref()).as_deref(),
+				cli.connection_pool_size
+					.unwrap_or(podup::Client::DEFAULT_POOL_SIZE),
+			)?;
 			let engine = podup::Engine::with_base_dir(client, project, base_dir)
 				.with_stop_timeout(stop_timeout);
 			// `down` is mutating, so serialize it against concurrent runs as the
@@ -454,7 +466,11 @@ async fn run() -> podup::Result<()> {
 		// `--resolve-image-digests` pins each image to its registry digest, which
 		// needs a Podman connection to inspect images.
 		let mut resolved = if *resolve_image_digests {
-			let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+			let client = podup::podman::connect_with_pool_size(
+				resolve_socket(cli.socket.as_deref()).as_deref(),
+				cli.connection_pool_size
+					.unwrap_or(podup::Client::DEFAULT_POOL_SIZE),
+			)?;
 			podup::resolve_image_digests(&client, &parsed).await?
 		} else {
 			parsed
@@ -528,11 +544,16 @@ async fn run() -> podup::Result<()> {
 			profile: &cli.profile,
 			env_files: &cli.env_file,
 			socket: resolve_socket(cli.socket.as_deref()),
+			connection_pool_size: cli.connection_pool_size,
 		};
 		return autostart_cmd::dispatch(&env, &compose_files, project, base_dir, &file, kind).await;
 	}
 
-	let client = podup::podman::connect(resolve_socket(cli.socket.as_deref()).as_deref())?;
+	let client = podup::podman::connect_with_pool_size(
+		resolve_socket(cli.socket.as_deref()).as_deref(),
+		cli.connection_pool_size
+			.unwrap_or(podup::Client::DEFAULT_POOL_SIZE),
+	)?;
 	// The `-t/--timeout` shutdown-grace override applies to every command that
 	// stops containers (up recreate, down, stop, restart).
 	let stop_timeout = match &cli.command {

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -25,6 +25,14 @@ const DEFAULT_PIPE: &str = "//./pipe/podman-machine-default";
 /// 3. The conventional path for this platform, so a failed connection
 ///    reports the location podup expected.
 pub fn connect(socket_path: Option<&str>) -> Result<Client> {
+	connect_with_pool_size(socket_path, Client::DEFAULT_POOL_SIZE)
+}
+
+/// As [`connect`], with a caller-chosen HTTP/1.1 connection-pool size. The
+/// pool is keyed by socket path, so the cap controls the number of
+/// concurrent connections a single [`Client`] will keep open to the socket.
+/// `pool_size` is floored at 1 by [`Client::with_pool_size`].
+pub fn connect_with_pool_size(socket_path: Option<&str>, pool_size: usize) -> Result<Client> {
 	let default_path = default_socket_path();
 	let raw = socket_path.unwrap_or(&default_path);
 	if let Some(scheme) = remote_scheme(raw) {
@@ -38,7 +46,7 @@ pub fn connect(socket_path: Option<&str>) -> Result<Client> {
 		.strip_prefix("unix://")
 		.or_else(|| raw.strip_prefix("npipe://"))
 		.unwrap_or(raw);
-	Ok(Client::new(path))
+	Ok(Client::with_pool_size(path, pool_size))
 }
 
 /// Detect a non-local socket scheme (`tcp://`, `ssh://`, `http(s)://`, `fd://`).
@@ -53,11 +61,17 @@ fn remote_scheme(raw: &str) -> Option<&'static str> {
 /// `npipe://` scheme is stripped by [`connect`]; a remote scheme is rejected
 /// there with a clear error.
 pub fn connect_from_env() -> Result<Client> {
+	connect_from_env_with_pool_size(Client::DEFAULT_POOL_SIZE)
+}
+
+/// As [`connect_from_env`], with a caller-chosen HTTP/1.1 connection-pool
+/// size (see [`connect_with_pool_size`]).
+pub fn connect_from_env_with_pool_size(pool_size: usize) -> Result<Client> {
 	let socket = std::env::var("PODMAN_SOCKET")
 		.or_else(|_| std::env::var("DOCKER_HOST"))
 		.ok();
 
-	connect(socket.as_deref())
+	connect_with_pool_size(socket.as_deref(), pool_size)
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Closes #1362.

## What changed

I added a per-socket HTTP/1.1 connection pool in `internal/libpod/client/pool.rs` keyed by the Podman socket path. Buffered calls (`get_json`, `post_json`, `post_json_ok`, `post_empty_ok`, `post_empty_json`, `post_empty_json_unbounded`, `post_bytes_json`, `put_bytes_ok`, `head_container_path_stat`, `delete_existed`, `ping`) now acquire a connection, issue one request, and release it on completion. A response carrying `Connection: close` is dropped proactively so the next acquire opens a fresh one instead of paying the wait for a half-closed socket. The default cap is **8 connections**, tunable via `Client::with_pool_size` or the new `--connection-pool-size` / `PODUP_LIBCOD_POOL` global CLI flag.

Streaming endpoints (`get_stream`, `post_json_stream`, `post_empty_stream`, `post_bytes_stream`, `post_stream_body`, `post_json_stream_within`) now take a **dedicated** connection outside the buffered pool and hold it for the lifetime of the response body; the connection is released when the `Client` is dropped. That keeps the public streaming-helper interface (`Result<Response<Incoming>>`) intact while ensuring a long-lived `logs -f` or interactive `exec` cannot share its socket with a buffered caller mid-stream and corrupt the wire.

`Client::new`'s signature is unchanged (so the public surface of `podup::Client` is not a breaking change). The new public items are `Client::with_pool_size`, `Client::pool_size`, `Client::DEFAULT_POOL_SIZE`, `podman::connect_with_pool_size`, and `podman::connect_from_env_with_pool_size` — all additive.

The `Client::new` doc comment is updated to describe the pool contract. Every existing doc comment on the touched items is preserved.

## Why

`Client::connect` (`internal/libpod/client/mod.rs`) opened a brand-new hyper HTTP/1.1 connection over the Unix socket for *every* request. The doc comment justified it as "correct for a CLI tool where API calls are sequential and infrequent", but `up` is fan-out by construction: a 100-service compose file issues ~5 libpod calls per service plus a per-level bulk — easily **600+ connections per `up`**. Validation against the libpod server source confirmed the server DOES allow connection reuse; the bug was the client side opening a fresh connection per request.

## Test plan

- **Unit test** with a fake-libpod server that counts incoming connections (`internal/libpod/client/pool/tests.rs`):
  - Sequential 100 requests → 1 connection.
  - Concurrent 16 requests (pool size 4) → ≤ 4 connections.
  - A forcibly-closed (poisoned) connection is replaced on the next acquire.
  - A new `Client` after a `Drop` opens a fresh connection.
  - Pool size is what `Client::pool_size` reports; a cap of 0 is floored to 1.
  - A `Drop` on the `Client` closes the pool.
- **Existing fake-podman harness tests** (1500+ in `cargo test --lib --features test-helpers`): all still pass. The harness sends `Connection: close` on every response, and the new pool discards those proactively so the second request lands on a fresh socket.
- **CLI**: `podup --help` lists `--connection-pool-size <N>` and the `PODUP_LIBCOD_POOL` env var; the global flag is forwarded through `main.rs` and `autostart_cmd.rs` to every `podman::connect_with_pool_size` call site.
- **Lane**: real-Podman 5 and 6, no regression (run on this PR).

## Validation

- `cargo build --bin podup --features test-helpers` — green.
- `cargo test --lib --features test-helpers` — 1550 tests, all green.
- `cargo test --bins --features test-helpers` — 83 tests, all green.
- `cargo fmt --check` — clean.
- `cargo clippy --bin podup --features test-helpers -- -D warnings` — clean.

## Limits (intentional)

- Streaming connections are released when the **Client** drops, not when the stream body drops. The streaming helpers' return type is fixed at `Response<Incoming>` (per the public-surface constraint), so the body does not carry a hook to release the underlying connection. In the CLI, the `Client` lifetime matches the command lifetime, so the two converge in practice; an embedder holding a `Client` across many operations will retain streaming connections until the `Client` is dropped.
- The pool is **per-socket-path**. A `Client` instance holds one pool; the `socket_path` field is immutable after `Client::new`. The "keyed by socket path" requirement is satisfied because the pool is constructed from the socket path itself.