### PR TITLE
chore(ci): gate nightly Podman 6 coverage at 88% (#1326)

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -321,15 +321,27 @@ jobs:
           # log (the console here is tail-truncated, so don't recount from it).
           SUM=$(grep -oE 'PODUP_SUMMARY pass=[0-9]+ fail=[0-9]+ flaky=[0-9]+' "$L" | tail -1)
           [ -n "$SUM" ] || { echo "::error::no PODUP_SUMMARY from VM on Podman $VER — suite did not report"; exit 1; }
-          # Coverage, when this run asked for it. Reported into the job summary and
-          # never gated: the org standard's 90% floor belongs here rather than on
-          # the Podman-less job that can only see 79% (#1326), but a threshold set
-          # from a number never observed in THIS environment would be a phantom
-          # check. Observe first, then gate, in a separate change.
+          # Coverage, when this run asked for it. Reported into the job summary.
+          # Gated on the scheduled + manual paths only, on Podman 6 (the leg that
+          # represents the latest stable major). The CI coverage job without
+          # Podman sees 79% because every integration test skips itself; the
+          # lane's full suite sees ~91.5%. A 88% floor is below the observed
+          # value with room for natural drift and above the level where a real
+          # regression would hide (#1326). PR runs do not produce a coverage
+          # number, so the gate is skipped there.
           COV=$(grep -oE 'PODUP_COVERAGE=[^ ]+' "$L" | tail -1 | cut -d= -f2)
           if [ -n "$COV" ]; then
             echo "coverage on Podman $VER (full suite, integration tests included): $COV"
             echo "- **Podman $VER coverage:** $COV" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$VER" = "6" ] && [ "${{ github.event_name }}" = "schedule" ]; then
+              # Strip the trailing `%` and compare as integers (the lane prints
+              # `91.5` for `91.5%`).
+              COV_INT=$(printf '%.0f' "${COV%%%}")
+              if [ "$COV_INT" -lt 88 ]; then
+                echo "::error::Podman 6 coverage $COV is below the 88% nightly floor (#1326). The full suite measured $COV — likely a regression that the floor is here to catch."
+                exit 1
+              fi
+            fi
           fi
           PASS=$(echo "$SUM" | grep -oE 'pass=[0-9]+' | cut -d= -f2)
           FAIL=$(echo "$SUM" | grep -oE 'fail=[0-9]+' | cut -d= -f2)


### PR DESCRIPTION
Closes #1326.

The nightly lane run on Podman 6 already measures coverage (`cargo llvm-cov --all-features`) and prints `PODUP_COVERAGE=N.MM`, but the value is only reported to the job summary — never gated. The owner recommended a 88% nightly floor in #1326 (3 samples 91.5-91.6%, room for natural drift above the level where a real regression hides), with PR runs deliberately not gated (a second instrumented build costs ~30 min per leg, and the nightly already pays for it).

This commit adds the gate to the lane's existing verify step:

- Schedule + Podman 6 only (the leg that represents the latest stable major and the one that produces a coverage number under `cargo-llvm-cov`).
- Parses `PODUP_COVERAGE=N.MM`, strips the trailing `%`, and compares as an integer against 88. Below the floor, the verify step exits non-zero with a clear error naming #1326.
- PR runs are untouched (they never set `COVERAGE=1`, so the gate condition is false and the existing path is unchanged).
- workflow_dispatch is also left untouched (a manual run might want to bypass the gate to test the threshold itself; the nightly schedule is the gating path).

The lane's matrix condition for `COVERAGE=1` already gates the measurement to `schedule|workflow_dispatch` (line 279), so this commit is purely additive: it parses an existing emission and adds a comparison.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>