### PR TITLE
chore(ci): close the rollback-attack window in the shell installers (#1356)

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/asset-contract.yml"
       - ".github/scripts/verify-signing-key.py"
+      - "internal/update/install.rs"
       - "tests/fixtures/releases/**"
   pull_request:
     branches:
@@ -21,6 +22,7 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/asset-contract.yml"
       - ".github/scripts/verify-signing-key.py"
+      - "internal/update/install.rs"
       - "tests/fixtures/releases/**"
 
 permissions:
@@ -85,3 +87,46 @@ jobs:
         run: |
           $env:PATH = "$env:RUNNER_TEMP\fixturevenv\Scripts;$env:PATH"
           pwsh -NoProfile -File tests/fixtures/releases/test.ps1
+  # Version self-test in the shell installer (issue #1356). The Rust
+  # `podup update` already pins the staged binary's --version to the
+  # resolved tag (internal/update/install.rs:152-205) and refuses a
+  # rollback. The shell installer path was missing the equivalent gate
+  # - a CDN or transparent proxy could replay an older, *legitimately*
+  # signed binary and matching SHA256SUMS and the install would accept
+  # it. The fixture exercises verify_version_self_test in install.sh
+  # directly with stub binaries (matching version, older version, -dev
+  # suffix, garbage, non-zero exit, missing file) so a regression in
+  # the strict-equality-with-optional-v comparison fails here.
+  shell-version-self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run the version-self-test shell fixture
+        run: bash tests/fixtures/releases/version-self-test.sh
+  # Same fixture on Windows so install.ps1's Test-StagedVersion is
+  # covered. The PowerShell script extracts the function via AST and
+  # runs it against .cmd stubs, so a regression in the strict-equality
+  # comparison or in the staged-file-removal on failure fails here.
+  powershell-version-self-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run the version-self-test PowerShell fixture
+        shell: pwsh
+        run: pwsh -NoProfile -File tests/fixtures/releases/version-self-test.ps1
+  # Rust reference test for the self_test in internal/update/install.rs.
+  # Gates against the shell-side regression by pinning the canonical
+  # behaviour: the shell installer mirrors this test token-for-token.
+  # Installs rustup directly (dtolnay/rust-toolchain is not on the
+  # org's allowed-actions list) at the project's MSRV, the same way
+  # release.yml sets up the release build.
+  rust-self-test-reference:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Rust toolchain
+        env:
+          RUST_TOOLCHAIN: "1.85"
+        run: rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+      - name: Run the install self-test
+        run: cargo test --locked -p podup install::tests::self_test

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -634,7 +634,13 @@ Replace the running binary with the latest signed release.
 | `--force` | Reinstall even if the latest release is not newer. | off |
 
 Verification fails closed: a missing key, bad Ed25519 signature, or SHA-256
-mismatch aborts before the installed binary is touched. See
+mismatch aborts before the installed binary is touched. After the binary is
+written, a self-test runs `<binary> --version` and refuses the install if the
+reported version does not match the resolved release tag (strict equality,
+optional single `v` prefix) — a CDN or proxy that replays an older,
+*legitimately* signed release passes the signature and digest checks but fails
+this one, and the previous binary is restored. The shell installers
+(`install.sh`, `install.ps1`) run the same gate. See
 [self-update.md](self-update.md) for the trust model.
 
 ### `autostart` (alias `boot`)

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -65,6 +65,28 @@ release public key is configured. There is **no opt-out**: a checksum alone is
 not a trust anchor. The `--apt` path likewise verifies the keyring package's
 Ed25519 signature before installing it as root.
 
+### Version self-test (rollback gate)
+
+The signed manifest binds the asset bytes but **not** the release tag — a CDN
+or transparent proxy able to spoof release metadata could replay an older,
+*legitimately* signed binary and matching `SHA256SUMS`, and both would still
+verify. Both `install.sh` and `install.ps1` therefore run the staged binary's
+`--version` and pin it to the resolved tag (resolved via the GitHub releases
+API when `PODUP_VERSION=latest`, or used as-is when an explicit `vX.Y.Z` is
+given). The comparison is **strict equality with one optional `v` prefix**, so
+a `3.7.0-dev` report does not slip past a `3.7.0` check — that is the rollback
+case this gate exists to reject. A mismatch removes the staged file and aborts
+the install with exit code `1`; the operator sees:
+
+```
+[fail] Staged binary reports 'podup version v3.6.0', expected v3.7.0
+Refusing to install: staged binary's --version does not match the resolved
+release tag (possible rollback) - the staged file has been removed
+```
+
+The same gate runs inside `podup update` (`internal/update/install.rs:152-205`)
+and a failed self-test there rolls back to the previous binary.
+
 `install.sh` and `install.ps1` are themselves listed in the signed `SHA256SUMS`
 manifest and carry their own `install.sh.sig` / `install.ps1.sig`, so a user
 pinning a version can verify the script before piping it to a shell — the script

--- a/install.ps1
+++ b/install.ps1
@@ -89,6 +89,80 @@ try {
 		return $dest
 	}
 
+	# Resolve the actual release tag from the GitHub releases API when the
+	# caller leaves the version at its default ('latest'). The signature over
+	# SHA256SUMS binds the asset bytes but not the release tag, so a CDN or
+	# transparent-proxy replay can serve an older, *legitimately* signed
+	# binary and matching manifest - both still verify cryptographically. We
+	# pin the staged binary's reported --version to this resolved tag in
+	# the self-test (Test-StagedVersion) to close that window. Without this
+	# resolution we cannot self-test against the literal string 'latest',
+	# and using the binary's own --version as the truth would be circular
+	# (that is exactly the attack).
+	function Resolve-ReleaseTag {
+		$apiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+		try {
+			$resp = Invoke-WebRequest -Uri $apiUrl -Headers @{ 'Accept' = 'application/vnd.github+json' } -UseBasicParsing -TimeoutSec 60
+		} catch {
+			Fail "Cannot resolve latest release tag from $apiUrl"
+		}
+		# Use ErrorAction to surface a bad response as a fatal condition rather
+		# than silently emitting $null and moving on.
+		try {
+			$json = $resp.Content | ConvertFrom-Json -ErrorAction Stop
+		} catch {
+			Fail "Malformed GitHub releases JSON from /releases/latest"
+		}
+		if (-not $json.tag_name) {
+			Fail "GitHub releases response missing tag_name"
+		}
+		return [string]$json.tag_name
+	}
+
+	# Confirm the staged binary's --version reports the resolved release
+	# tag. This closes the signed-release rollback window: a replayed older
+	# binary passes the Ed25519 signature, the SHA-256 digest, and the build
+	# provenance (the manifest and the asset are both legitimately signed),
+	# but its --version still reports the old release. The self-test refuses
+	# such an install the same way the Rust `podup update` does
+	# (internal/update/install.rs:152-205).
+	#
+	# Strict equality, with one optional leading 'v'. Each whitespace-
+	# delimited token in the staged binary's --version output is compared
+	# in full; a starts_with / substring match would let `3.7.0-dev` slip
+	# past the `3.7.0` check, which is the rollback case this gate exists
+	# to reject. Matches the Rust behaviour token-for-token.
+	function Test-StagedVersion {
+		param(
+			[string]$StagedPath,
+			[string]$ResolvedTag
+		)
+		$expected = if ($ResolvedTag.StartsWith('v')) { $ResolvedTag.Substring(1) } else { $ResolvedTag }
+		# Run the staged binary's --version. A non-zero exit (or a missing
+		# file) fails closed.
+		try {
+			$reported = & $StagedPath --version 2>&1
+		} catch {
+			Remove-Item -Path $StagedPath -Force -ErrorAction SilentlyContinue
+			Fail "Could not run $StagedPath --version to self-test the staged binary"
+		}
+		if ($LASTEXITCODE -ne 0) {
+			Remove-Item -Path $StagedPath -Force -ErrorAction SilentlyContinue
+			Fail "Could not run $StagedPath --version to self-test the staged binary"
+		}
+		$reportedStr = ($reported | Out-String).TrimEnd()
+		$tokens = $reportedStr -split '\s+'
+		foreach ($token in $tokens) {
+			if (($token -eq $expected) -or ($token -eq "v$expected")) {
+				Write-LogOk "Reported --version matches $ResolvedTag"
+				return
+			}
+		}
+		Remove-Item -Path $StagedPath -Force -ErrorAction SilentlyContinue
+		Write-LogError "Staged binary reports `"$reportedStr`", expected $ResolvedTag"
+		Fail "Refusing to install: staged binary's --version does not match the resolved release tag (possible rollback) - the staged file has been removed"
+	}
+
 	Write-LogInfo "Downloading $Artifact ($Version) ..."
 	$artifactPath = Get-ReleaseFile $Artifact
 	$sumsPath = Get-ReleaseFile 'SHA256SUMS'
@@ -220,6 +294,19 @@ sys.exit(1)
 	if ($expected -ne $actual) { Fail "Checksum verification failed for $Artifact" }
 	Write-LogOk 'Checksum verified'
 
+	# Resolve the actual release tag for the self-test. With an explicit
+	# PODUP_VERSION=vX.Y.Z this is just that tag; with the default 'latest'
+	# we hit the GitHub releases API to discover it. The signed manifest
+	# binds asset bytes but not the release tag, so we cannot use the
+	# staged binary's --version as the source of truth - that would be
+	# the attack vector.
+	$ResolvedTag = if ($Version -eq 'latest') {
+		Write-LogInfo 'Resolving latest release tag ...'
+		Resolve-ReleaseTag
+	} else {
+		$Version
+	}
+
 	# --- Install -------------------------------------------------------------
 
 	if (-not (Test-Path $InstallDir)) {
@@ -230,6 +317,16 @@ sys.exit(1)
 	# can never leave a partial yet executable binary on PATH.
 	$staged = Join-Path $InstallDir ".podup.install-$PID.exe"
 	Copy-Item -Path $artifactPath -Destination $staged -Force
+
+	# Self-test against the staged binary BEFORE the move into place. The
+	# signed manifest binds the asset bytes but not the release tag, so a
+	# CDN or transparent-proxy replay can serve an older, *legitimately*
+	# signed binary and matching SHA256SUMS - both still verify. The
+	# staged binary's --version still reports the old release, and we
+	# refuse. Mirrors the Rust self_test at
+	# internal/update/install.rs:152-205.
+	Test-StagedVersion -StagedPath $staged -ResolvedTag $ResolvedTag
+
 	Move-Item -Path $staged -Destination $target -Force
 
 	# Add the install dir to the user PATH if it is not already there.

--- a/install.sh
+++ b/install.sh
@@ -184,6 +184,82 @@ run_root() {
 	fi
 }
 
+# Resolve the actual release tag from the GitHub releases API when the
+# caller leaves the version at its default ("latest"). The signature over
+# SHA256SUMS binds the asset bytes but not the release tag, so a CDN or
+# transparent-proxy replay can serve an older, *legitimately* signed
+# binary and matching manifest - both still verify cryptographically.
+# We pin the staged binary's reported --version to this resolved tag in
+# the self-test (verify_version_self_test) to close that window. Without
+# this resolution we cannot self-test against the literal string
+# "latest", and using the binary's own --version as the truth would be
+# circular (that is exactly the attack).
+#
+# Echoes the tag with the `v` prefix (the convention every published
+# release follows). python3 is already required for the Ed25519
+# signature check, so leaning on it for JSON parsing here does not add
+# a new dependency.
+resolve_release_tag() {
+	local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+	local body
+	body="$(curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+		--max-time 60 -fsSL \
+		-H 'Accept: application/vnd.github+json' \
+		"$api_url")" || fail "Cannot resolve latest release tag from ${api_url}"
+	python3 - "$body" <<'PYEOF' || fail "Malformed GitHub releases JSON from /releases/latest"
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+except (json.JSONDecodeError, ValueError) as exc:
+    sys.exit(f"malformed GitHub releases JSON: {exc}")
+tag = data.get("tag_name", "")
+if not isinstance(tag, str) or not tag:
+    sys.exit(f"GitHub releases response missing tag_name: {tag!r}")
+print(tag)
+PYEOF
+}
+
+# Confirm the staged binary's --version reports the resolved release
+# tag. This closes the signed-release rollback window: a replayed older
+# binary passes the Ed25519 signature, the SHA-256 digest, and the build
+# provenance (the manifest and the asset are both legitimately signed),
+# but its --version still reports the old release. The self-test refuses
+# such an install the same way the Rust `podup update` does
+# (internal/update/install.rs:152-205).
+#
+# Strict equality, with one optional leading `v`. Each whitespace-
+# delimited token in the staged binary's --version output is compared
+# in full; a starts_with / substring match would let `3.7.0-dev` slip
+# past the `3.7.0` check, which is the rollback case this gate exists
+# to reject. Matches the Rust behaviour token-for-token.
+#
+#   verify_version_self_test <staged-path> <resolved-tag>
+verify_version_self_test() {
+	local staged="$1" expected_tag="$2"
+	local expected="${expected_tag#v}"
+
+	local reported
+	# The staged file lives in INSTALL_DIR (possibly sudo-owned) with a
+	# hidden name; reading --version requires execute permission but no
+	# read/ownership on the parent.
+	if ! reported="$("$staged" --version 2>/dev/null)"; then
+		rm -f "$staged" 2>/dev/null || true
+		fail "Could not run ${staged} --version to self-test the staged binary"
+	fi
+
+	local token
+	# shellcheck disable=SC2086  # word-splitting is intentional: $reported is the raw --version line.
+	for token in $reported; do
+		if [[ "$token" == "$expected" || "$token" == "v$expected" ]]; then
+			log_ok "Reported --version matches ${expected_tag}"
+			return 0
+		fi
+	done
+	rm -f "$staged" 2>/dev/null || true
+	log_error "Staged binary reports '${reported}', expected ${expected_tag}"
+	fail "Refusing to install: staged binary's --version does not match the resolved release tag (possible rollback) - the staged file has been removed"
+}
+
 # --- apt mode ----------------------------------------------------------------
 
 install_apt() {
@@ -283,18 +359,43 @@ or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, the
 
 	verify_checksum "$ARTIFACT"
 
+	# Resolve the actual release tag for the self-test. With an explicit
+	# PODUP_VERSION=vX.Y.Z this is just that tag; with the default
+	# "latest" we hit the GitHub releases API to discover it. The signed
+	# manifest binds asset bytes but not the release tag, so we cannot
+	# use the staged binary's --version as the source of truth - that
+	# would be the attack vector.
+	local resolved_tag
+	if [[ "$VERSION" == "latest" ]]; then
+		log_info "Resolving latest release tag ..."
+		resolved_tag="$(resolve_release_tag)"
+	else
+		resolved_tag="$VERSION"
+	fi
+
 	# Stage next to the target and rename into place, so a kill mid-install can
-	# never leave a partial yet executable binary on PATH.
+	# never leave a partial yet executable binary on PATH. The version
+	# self-test runs against the staged binary before the move: a failed
+	# self-test removes the staged file and aborts the install the same
+	# way the Rust self_test does.
 	local staged="${INSTALL_DIR}/.podup.install-$$"
 	local install_cmd=(install -m 0755 "${TMP_DIR}/${ARTIFACT}" "$staged")
 	local move_cmd=(mv -f "$staged" "${INSTALL_DIR}/podup")
 	if [[ -w "$INSTALL_DIR" ]]; then
-		"${install_cmd[@]}" && "${move_cmd[@]}"
+		"${install_cmd[@]}"
 	elif command -v sudo >/dev/null 2>&1; then
 		log_info "Installing to ${INSTALL_DIR} (requires sudo) ..."
-		sudo "${install_cmd[@]}" && sudo "${move_cmd[@]}"
+		sudo "${install_cmd[@]}"
 	else
 		fail "Cannot write to ${INSTALL_DIR} and sudo is not available. Set PODUP_INSTALL_DIR to a writable directory."
+	fi
+
+	verify_version_self_test "$staged" "$resolved_tag"
+
+	if [[ -w "$INSTALL_DIR" ]]; then
+		"${move_cmd[@]}"
+	elif command -v sudo >/dev/null 2>&1; then
+		sudo "${move_cmd[@]}"
 	fi
 
 	log_ok "podup installed: $("${INSTALL_DIR}/podup" --version)"

--- a/tests/fixtures/releases/version-self-test.ps1
+++ b/tests/fixtures/releases/version-self-test.ps1
@@ -1,0 +1,157 @@
+#requires -Version 5.1
+<#
+Version self-test regression for issue #1356, PowerShell side.
+
+Mirrors the bash test in version-self-test.sh:
+  1. A stub that reports the resolved tag with v prefix passes the
+     self-test.
+  2. A stub that reports the resolved tag without v prefix also passes.
+  3. A stub that reports an older tag is rejected.
+  4. A stub that reports a -dev suffix is rejected (the rollback case:
+     a partial token would let `3.7.0-dev` slip past `3.7.0`).
+  5. A stub that reports garbage is rejected.
+  6. A stub that exits non-zero on --version is rejected.
+  7. A staged file that does not exist is rejected.
+  8. On any failed self-test the staged file is removed.
+
+The actual Test-StagedVersion function lives in install.ps1; this
+script extracts it via AST and loads it in this scope so the regression
+runs against the real code, not a copy. (The bash test uses
+`sed + source`, which PowerShell cannot mirror directly; AST parsing
+is the equivalent and stays robust to surrounding code.)
+
+Test-StagedVersion calls the top-level `Fail` helper on a mismatch.
+`Fail` does `exit 1` and that would terminate the whole test process.
+`Invoke-Expression` binds the extracted function to the test's scope,
+so its reference to `Fail` resolves to a test-local override that
+throws - the test catches the throw and reports a clean refusal.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$InstallerPath = Join-Path $RepoRoot 'install.ps1'
+
+# Override the helpers Test-StagedVersion calls: route the refusal to a
+# throw instead of `exit 1`, and silence the side-effect log lines so
+# the test output stays readable. The overrides shadow install.ps1's
+# top-level definitions; Invoke-Expression binds the extracted
+# function to this scope, so its references resolve here.
+function Write-LogInfo { param($msg) Write-Host "[info] $msg" -ForegroundColor Blue }
+function Write-LogOk { param($msg) Write-Host "[ ok ] $msg" -ForegroundColor Green }
+function Write-LogError { param($msg) Write-Host "[fail] $msg" -ForegroundColor Red }
+function Fail { param($msg) throw [System.Exception]::new("Refused: $msg") }
+
+# Extract Test-StagedVersion via AST so we test the real code, not a
+# copy. Fail closed if the function is missing: a regression that
+# removes the gate from install.ps1 must break this test.
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+	$InstallerPath, [ref]$null, [ref]$null)
+$testFn = $ast.Find({ param($n)
+	$n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+	$n.Name -eq 'Test-StagedVersion'
+}, $true)
+if (-not $testFn) {
+	Write-Host 'FAIL: Test-StagedVersion not found in install.ps1' -ForegroundColor Red
+	exit 1
+}
+Invoke-Expression $testFn.Extent.Text
+
+function Assert-True {
+	param([bool] $Condition, [string] $Message)
+	if (-not $Condition) {
+		Write-Host "FAIL: $Message" -ForegroundColor Red
+		exit 1
+	}
+}
+
+# Stub directory: write platform-appropriate executable stubs that
+# print specific --version outputs. On Windows we use .cmd files
+# (natively executable). On Linux/macOS we use bash scripts with a
+# shebang, since .cmd files have no kernel handler there. The test
+# fixture's logical contract is the same in both cases - what matters
+# is what `& <stub> --version` prints and the exit code it returns.
+$stubsDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $stubsDir | Out-Null
+try {
+	$script:useWindowsStubs = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+		[System.Runtime.InteropServices.OSPlatform]::Windows)
+	$stubExt = if ($script:useWindowsStubs) { '.cmd' } else { '.sh' }
+	# The .sh stub template runs the body and exits with the requested
+	# code. The .cmd stub uses cmd.exe semantics.
+	function New-Stub {
+		param([string] $Name, [string] $Body, [string] $ExitCode = '0')
+		$path = Join-Path $stubsDir ("$Name$stubExt")
+		if ($script:useWindowsStubs) {
+			$content = "@echo off`r`n$Body`r`nexit /b $ExitCode"
+			Set-Content -LiteralPath $path -Value $content -Encoding ASCII -NoNewline
+		} else {
+			$content = "#!/bin/sh`n$Body`nexit $ExitCode"
+			Set-Content -LiteralPath $path -Value $content -Encoding ASCII
+			& chmod +x $path
+		}
+		return $path
+	}
+
+	function Invoke-Pass {
+		param([string] $StubPath, [string] $Tag)
+		try {
+			Test-StagedVersion -StagedPath $StubPath -ResolvedTag $Tag
+		} catch {
+			# Test-StagedVersion's success path is silent apart from the
+			# info line routed through Write-LogInfo (now silenced). A
+			# throw here means the test override threw via Fail - that
+			# is the refusal case, which Invoke-Fail handles.
+			Write-Host "  FAIL  $StubPath should have passed but was refused: $_" -ForegroundColor Red
+			exit 1
+		}
+		Write-Host "  OK    $StubPath reports the resolved tag"
+	}
+
+	function Invoke-Fail {
+		param([string] $StubPath, [string] $Tag)
+		$refused = $false
+		try {
+			Test-StagedVersion -StagedPath $StubPath -ResolvedTag $Tag
+		} catch {
+			$refused = $true
+		}
+		Assert-True $refused "$StubPath should have been refused but the self-test accepted it"
+		Assert-True (-not (Test-Path -LiteralPath $StubPath)) "staged file $StubPath was not removed after the failed self-test"
+		Write-Host "  OK    $StubPath was refused and the staged file was removed"
+	}
+
+	$Tag = 'v3.7.0'
+
+	Write-Host 'Part 1: --version reports the resolved tag (with v prefix)' -ForegroundColor Cyan
+	$stub = New-Stub -Name 'pass_v' -Body 'echo podup version v3.7.0'
+	Invoke-Pass -StubPath $stub -Tag $Tag
+
+	Write-Host 'Part 2: --version reports the resolved tag (without v prefix)' -ForegroundColor Cyan
+	$stub = New-Stub -Name 'pass_plain' -Body 'echo podup 3.7.0'
+	Invoke-Pass -StubPath $stub -Tag $Tag
+
+	Write-Host 'Part 3: --version reports an older tag (rollback)' -ForegroundColor Cyan
+	$stub = New-Stub -Name 'fail_older' -Body 'echo podup version v3.6.0'
+	Invoke-Fail -StubPath $stub -Tag $Tag
+
+	Write-Host 'Part 4: --version reports a -dev suffix on the resolved version' -ForegroundColor Cyan
+	$stub = New-Stub -Name 'fail_dev' -Body 'echo podup version v3.7.0-dev'
+	Invoke-Fail -StubPath $stub -Tag $Tag
+
+	Write-Host 'Part 5: --version reports garbage' -ForegroundColor Cyan
+	$stub = New-Stub -Name 'fail_garbage' -Body 'echo definitely not a podup'
+	Invoke-Fail -StubPath $stub -Tag $Tag
+
+	Write-Host 'Part 6: --version exits non-zero' -ForegroundColor Cyan
+	$stub = New-Stub -Name 'fail_exit' -Body 'echo podup version v3.7.0' -ExitCode '1'
+	Invoke-Fail -StubPath $stub -Tag $Tag
+
+	Write-Host 'Part 7: staged file does not exist' -ForegroundColor Cyan
+	Invoke-Fail -StubPath (Join-Path $stubsDir "does-not-exist$stubExt") -Tag $Tag
+
+	Write-Host ''
+	Write-Host 'All parts passed.' -ForegroundColor Green
+} finally {
+	Remove-Item -LiteralPath $stubsDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/fixtures/releases/version-self-test.sh
+++ b/tests/fixtures/releases/version-self-test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Regression test for the version self-test in install.sh (issue #1356).
+#
+# Closes the rollback window in the shell installer: a CDN or
+# transparent-proxy replay can serve an older, *legitimately* signed
+# binary and matching SHA256SUMS - both still verify. The version
+# self-test pins the staged binary's reported --version to the resolved
+# tag, refusing installs a Rust reference already refuses
+# (internal/update/install.rs:152-205).
+#
+# Cases:
+#   1. Reports the resolved tag with v prefix -> self-test passes.
+#   2. Reports the resolved tag without v prefix -> self-test passes.
+#   3. Reports an older tag -> self-test fails.
+#   4. Reports a -dev suffix on the right version -> self-test fails
+#      (the rollback case: a partial matches a full token but not the
+#      exact one).
+#   5. Reports garbage -> self-test fails.
+#   6. Exits non-zero on --version -> self-test fails.
+#   7. The staged file does not exist -> self-test fails.
+#   8. On any failed self-test the staged file is removed.
+#
+# Run from the repo root:
+#   bash tests/fixtures/releases/version-self-test.sh
+set -euo pipefail
+
+# __file__ is tests/fixtures/releases/version-self-test.sh; walk three
+# levels up to land on the repo root regardless of where the script is
+# invoked from.
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+# Source the helpers (verify_version_self_test, fail, log_info, log_ok,
+# log_error, REPO, ...) by stripping the Dispatch section. Everything
+# before the dispatch is pure function definitions and constants; sourcing
+# it does not touch the network or write to the filesystem. Same pattern
+# the existing test.sh uses.
+TMP_HELPERS="$(mktemp)"
+trap 'rm -f "$TMP_HELPERS"' EXIT
+sed '/^# --- Dispatch /,$d' "$INSTALL_SH" > "$TMP_HELPERS"
+# shellcheck disable=SC1090
+source "$TMP_HELPERS"
+
+# Stub directory: tiny executables that print specific --version outputs.
+STUBS="$(mktemp -d)"
+trap 'rm -rf "$TMP_HELPERS" "$STUBS"' EXIT
+
+write_stub() {
+	local name="$1" body="$2"
+	local path="$STUBS/$name"
+	printf '%s\n' "$body" > "$path"
+	chmod +x "$path"
+	printf '%s' "$path"
+}
+
+# Run verify_version_self_test against a stub that is expected to PASS.
+# The function calls `fail` (which does `exit 1`) on any unexpected
+# failure, so a passing run is the only path that reaches the next assertion.
+assert_pass() {
+	local stub_path="$1" tag="$2"
+	if verify_version_self_test "$stub_path" "$tag"; then
+		echo "  OK    $stub_path reports the resolved tag"
+	else
+		echo "  FAIL  $stub_path should have passed but was refused" >&2
+		exit 1
+	fi
+}
+
+# Run verify_version_self_test against a stub that is expected to FAIL.
+# We run inside a subshell so the function's `exit 1` only kills the
+# subshell, not the test script, and we can read $? afterwards. After
+# the run we also confirm the staged file is gone (the rollback path
+# removes the staged binary so a kill at this point cannot leave a
+# partial yet executable binary on PATH).
+assert_fail() {
+	local stub_path="$1" tag="$2"
+	set +e
+	(verify_version_self_test "$stub_path" "$tag") >/dev/null 2>&1
+	rc=$?
+	set -e
+	if [[ $rc -eq 0 ]]; then
+		echo "  FAIL  $stub_path should have been refused but the self-test accepted it" >&2
+		exit 1
+	fi
+	if [[ -e "$stub_path" ]]; then
+		echo "  FAIL  staged file $stub_path was not removed after the failed self-test" >&2
+		exit 1
+	fi
+	echo "  OK    $stub_path was refused and the staged file was removed"
+}
+
+TAG="v3.7.0"
+
+echo "Part 1: --version reports the resolved tag (with v prefix)"
+stub="$(write_stub 'pass_v' \
+	'#!/bin/sh
+echo "podup version v3.7.0"
+exit 0')"
+assert_pass "$stub" "$TAG"
+
+echo "Part 2: --version reports the resolved tag (without v prefix)"
+stub="$(write_stub 'pass_plain' \
+	'#!/bin/sh
+echo "podup 3.7.0"
+exit 0')"
+assert_pass "$stub" "$TAG"
+
+echo "Part 3: --version reports an older tag (rollback)"
+stub="$(write_stub 'fail_older' \
+	'#!/bin/sh
+echo "podup version v3.6.0"
+exit 0')"
+assert_fail "$stub" "$TAG"
+
+echo "Part 4: --version reports a -dev suffix on the resolved version"
+stub="$(write_stub 'fail_dev' \
+	'#!/bin/sh
+echo "podup version v3.7.0-dev"
+exit 0')"
+assert_fail "$stub" "$TAG"
+
+echo "Part 5: --version reports garbage"
+stub="$(write_stub 'fail_garbage' \
+	'#!/bin/sh
+echo "definitely not a podup"
+exit 0')"
+assert_fail "$stub" "$TAG"
+
+echo "Part 6: --version exits non-zero"
+stub="$(write_stub 'fail_exit' \
+	'#!/bin/sh
+echo "podup version v3.7.0"
+exit 1')"
+assert_fail "$stub" "$TAG"
+
+echo "Part 7: staged file does not exist"
+assert_fail "$STUBS/does-not-exist" "$TAG"
+
+echo
+echo "All parts passed."


### PR DESCRIPTION
## Test plan

- **Shell fixture**: a stub `podup` binary that prints different `--version` outputs. Two cases:
  - Reports the resolved tag (with or without leading `v`) → installer proceeds.
  - Reports anything else (older tag, `-dev` suffix, garbage) → installer refuses with non-zero exit and the staged file is removed.
- **CI**: extend `.github/workflows/asset-contract.yml` (or its underlying reusable in `Glyndor/.github`) with a step that runs the shell fixture on Linux, a Windows-runner step for `install.ps1`, and the existing Rust reference test for parity. The fixture should live in `tests/fixtures/releases/` or similar.

## Validation

- `shellcheck install.sh` clean.
- `PSScriptAnalyzer install.ps1` clean.
- The new CI job passes on push.
- The Rust reference test (`internal/update/install.rs`) still passes — no regression.