### PR TITLE
chore: tighten install path integrity (.old swap, dpkg-query fail-closed, file: secret cleanup) (#1360)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 #
 # podup installer for Windows - downloads a release binary, verifies it and
 # installs it.
@@ -313,9 +313,20 @@ sys.exit(1)
 		New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
 	}
 	$target = Join-Path $InstallDir 'podup.exe'
-	# Stage next to the target and rename into place, so an interrupted install
-	# can never leave a partial yet executable binary on PATH.
-	$staged = Join-Path $InstallDir ".podup.install-$PID.exe"
+	# A running .exe cannot be overwritten, but it can be renamed. Unify
+	# with the Rust updater (internal/update/install.rs:307-325): rename
+	# the in-use target aside to *.old, move the staged binary in, then
+	# best-effort remove the leftover. If the staged → target rename
+	# fails, the old binary is restored from *.old so the user is never
+	# left without a working podup. The *.old path follows the target's
+	# basename rather than a PID-suffix, so a kill between the two
+	# renames leaves a single recoverable sibling rather than a
+	# stale partial.
+	$backup = [System.IO.Path]::ChangeExtension($target, '.old')
+	$staged = Join-Path $InstallDir '.podup.install.exe'
+	if (Test-Path -LiteralPath $staged) {
+		Remove-Item -LiteralPath $staged -Force
+	}
 	Copy-Item -Path $artifactPath -Destination $staged -Force
 
 	# Self-test against the staged binary BEFORE the move into place. The
@@ -327,7 +338,34 @@ sys.exit(1)
 	# internal/update/install.rs:152-205.
 	Test-StagedVersion -StagedPath $staged -ResolvedTag $ResolvedTag
 
-	Move-Item -Path $staged -Destination $target -Force
+	# Move the in-use target aside. Drop any stale leftover from a prior
+	# interrupted install (a best-effort removal we still clean up at the
+	# start of the next run, but the install path itself should not blow
+	# up on it).
+	if (Test-Path -LiteralPath $backup) {
+		Remove-Item -LiteralPath $backup -Force
+	}
+	if (Test-Path -LiteralPath $target) {
+		Move-Item -LiteralPath $target -Destination $backup -Force
+	}
+	# Move the verified staged binary into place. If this fails (target
+	# directory read-only, AV scanner has the file open, …) restore the
+	# old binary so podup is not uninstalled by a failed upgrade.
+	try {
+		Move-Item -LiteralPath $staged -Destination $target -Force
+	} catch {
+		if (Test-Path -LiteralPath $backup) {
+			try {
+				Move-Item -LiteralPath $backup -Destination $target -Force
+			} catch {
+				Fail "Failed to install the new binary AND to restore the previous one from $backup - re-run the installer: $($_.Exception.Message)"
+			}
+		}
+		Fail "Failed to install the new binary, restored the previous one from $backup: $($_.Exception.Message)"
+	}
+	# Best-effort remove the *.old: it may still be locked by the running
+	# process, in which case the next updater run reaps it on entry.
+	Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
 
 	# Add the install dir to the user PATH if it is not already there.
 	$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')

--- a/install.sh
+++ b/install.sh
@@ -378,14 +378,54 @@ or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, the
 	# self-test runs against the staged binary before the move: a failed
 	# self-test removes the staged file and aborts the install the same
 	# way the Rust self_test does.
+	#
+	# The staged binary is created private (0600) under a 077 umask so the
+	# verified bytes are never world-readable in a shared directory like
+	# /usr/local/bin during the window before the rename. The target's mode
+	# is then applied explicitly, masked with ~0o777 so a setuid/setgid/
+	# sticky bit on the target (planted or inherited) cannot ride onto the
+	# freshly installed binary — the same discipline the Rust updater
+	# follows at internal/update/install.rs:237-298. Mirrors what the
+	# Rust `install_at` does, with `install` swapped for the equivalent
+	# `cp + chmod` because `-m` only sets the mode of the *new* file and
+	# cannot start private then widen.
 	local staged="${INSTALL_DIR}/.podup.install-$$"
-	local install_cmd=(install -m 0755 "${TMP_DIR}/${ARTIFACT}" "$staged")
-	local move_cmd=(mv -f "$staged" "${INSTALL_DIR}/podup")
+	local target="${INSTALL_DIR}/podup"
+	# Read the target's mode if it exists, so the new binary takes over
+	# whatever mode the operator chose. A default install lands at 0755.
+	# stat -c %a prints the mode as an octal string ("755", "4755"…); strip
+	# the special bits explicitly rather than relying on arithmetic, so
+	# the value fed to chmod is always a plain permission string.
+	local target_mode
+	if [[ -e "$target" ]]; then
+		target_mode="$(stat -c '%a' "$target")"
+		# 4 digits → setuid/setgid/sticky + perm; 3 digits → perm only.
+		# Strip the leading digit and any special bits from the value the
+		# operator set, so a tampered planted setuid bit never propagates.
+		local perm="${target_mode: -3}"
+		# final sanity: only octal digits 0-7 survive.
+		if [[ "$perm" =~ ^[0-7]{3}$ ]]; then
+			target_mode="$perm"
+		else
+			target_mode="755"
+		fi
+	else
+		target_mode="755"
+	fi
+	# Stage next to the target: copy under a 077 umask so the verified bytes
+	# are never world-readable in a shared directory (e.g. /usr/local/bin)
+	# during the window before the chmod applies the target's mode. The
+	# chmod then widens the file to the target's ordinary permission bits,
+	# with the special bits stripped — same discipline the Rust updater
+	# follows at internal/update/install.rs:237-298.
+	local copy_cmd=(install -m 0600 "${TMP_DIR}/${ARTIFACT}" "$staged")
+	local perms_cmd=(chmod "$target_mode" "$staged")
+	local move_cmd=(mv -f "$staged" "$target")
 	if [[ -w "$INSTALL_DIR" ]]; then
-		"${install_cmd[@]}"
+		(umask 077 && "${copy_cmd[@]}" && "${perms_cmd[@]}")
 	elif command -v sudo >/dev/null 2>&1; then
 		log_info "Installing to ${INSTALL_DIR} (requires sudo) ..."
-		sudo "${install_cmd[@]}"
+		sudo sh -c "umask 077 && $(printf '%q ' "${copy_cmd[@]}") && $(printf '%q ' "${perms_cmd[@]}")"
 	else
 		fail "Cannot write to ${INSTALL_DIR} and sudo is not available. Set PODUP_INSTALL_DIR to a writable directory."
 	fi
@@ -398,7 +438,7 @@ or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, the
 		sudo "${move_cmd[@]}"
 	fi
 
-	log_ok "podup installed: $("${INSTALL_DIR}/podup" --version)"
+	log_ok "podup installed: $("${target}" --version)"
 }
 
 # --- Dispatch ----------------------------------------------------------------

--- a/internal/engine/secrets/remove.rs
+++ b/internal/engine/secrets/remove.rs
@@ -4,6 +4,16 @@
 //! secret (#1263). That list is also a superset of what the compose file names,
 //! since every secret podup creates carries `podup.project=<proj>`, so a single
 //! pass over it sweeps the declared secrets and the orphans alike.
+//!
+//! Every secret podup creates — including `file:` sources, whose bytes are
+//! copied into a Podman-native secret at `up` time and **persist independently
+//! of any container** (`podman-secret-rm(1)`: the secret lives in the podman
+//! store, not in container state) — is removed on `down`. Without this sweep
+//! the bytes from a `file:` source survive a `down`/`up` cycle until the next
+//! `up` overwrites them, which is a defence-in-depth gap (#1360): a stale
+//! secret payload outlives the container that read it. A summary log line
+//! names the secrets that were removed, so the operator can see the teardown
+//! actually happened.
 
 use crate::compose::types::ComposeFile;
 use crate::error::Result;
@@ -35,6 +45,11 @@ impl Engine {
 		// orphans (a key since renamed, or a `down` run without the original
 		// file) in one pass. A same-named secret the user created by hand is not
 		// in the set, which is exactly the guard this has to keep.
+		//
+		// Both paths emit a single summary log line so the operator can see
+		// which secrets were removed (#1360 L6). The per-secret `info` lines
+		// stay; the summary is the closure the user is actually looking for
+		// when the teardown finishes.
 		match self.list_project_secret_names().await {
 			Some(owned) => {
 				// Ownership is already established by the label on each entry, so
@@ -43,9 +58,13 @@ impl Engine {
 				// is best-effort here either way (a delete failure is logged, not
 				// fatal), and a secret that changed hands inside it would have been
 				// created by podup moments earlier.
+				let mut removed = Vec::with_capacity(owned.len());
 				for name in owned {
-					self.delete_listed_secret(&name).await;
+					if self.delete_listed_secret(&name).await {
+						removed.push(name);
+					}
 				}
+				log_removed_secrets(&self.project, &removed);
 			}
 			// The list failed. Falling through to an empty set would silently
 			// delete nothing and report a clean teardown, so this drops back to
@@ -54,6 +73,7 @@ impl Engine {
 			// sweep is not possible without a list, which is also how it behaved
 			// before.
 			None => {
+				let mut removed = Vec::new();
 				for (name, def) in &file.secrets {
 					if is_podup_created_source(
 						def.external,
@@ -61,8 +81,10 @@ impl Engine {
 						def.environment.as_deref(),
 						def.file.as_deref(),
 					) {
-						self.delete_secret(&scoped_name(&self.project, "secret", name))
-							.await;
+						let scoped = scoped_name(&self.project, "secret", name);
+						if self.delete_secret(&scoped).await {
+							removed.push(scoped);
+						}
 					}
 				}
 				for (name, def) in &file.configs {
@@ -72,10 +94,13 @@ impl Engine {
 						def.environment.as_deref(),
 						def.file.as_deref(),
 					) {
-						self.delete_secret(&scoped_name(&self.project, "config", name))
-							.await;
+						let scoped = scoped_name(&self.project, "config", name);
+						if self.delete_secret(&scoped).await {
+							removed.push(scoped);
+						}
 					}
 				}
+				log_removed_secrets(&self.project, &removed);
 			}
 		}
 		Ok(())
@@ -127,11 +152,21 @@ impl Engine {
 	/// own. Kept separate from [`Self::delete_secret`] rather than adding a flag,
 	/// so that a call site can never accidentally skip a check it was supposed to
 	/// make: this one is only reachable from a name the list vouched for.
-	async fn delete_listed_secret(&self, name: &str) {
+	///
+	/// Returns `true` when the secret was actually removed (or was already
+	/// absent — a 404 still counts as teardown success). The caller collects
+	/// the names for the summary log line.
+	async fn delete_listed_secret(&self, name: &str) -> bool {
 		let path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
 		match self.client.delete_ok(&path).await {
-			Ok(()) => tracing::info!("removed secret {name}"),
-			Err(e) => tracing::warn!("could not remove secret {name}: {e}"),
+			Ok(()) => {
+				tracing::info!("removed secret {name}");
+				true
+			}
+			Err(e) => {
+				tracing::warn!("could not remove secret {name}: {e}");
+				false
+			}
 		}
 	}
 
@@ -139,7 +174,11 @@ impl Engine {
 	/// `podup.project=<proj>` label — so a same-named secret the user created by
 	/// hand (and which podup never created) is never destroyed on `down`. A
 	/// missing secret (404) is a no-op.
-	async fn delete_secret(&self, name: &str) {
+	///
+	/// Returns `true` when the secret was actually removed, `false` when the
+	/// inspect failed (404, transport error, or a foreign label) and the
+	/// caller should not count it as teardown.
+	async fn delete_secret(&self, name: &str) -> bool {
 		let inspect = format!("{API_PREFIX}/secrets/{}/json", urlencoded(name));
 		match self.client.get_json::<serde_json::Value>(&inspect).await {
 			Ok(info) => {
@@ -155,21 +194,44 @@ impl Engine {
 						 leaving it untouched (not created by podup)",
 						self.project
 					);
-					return;
+					return false;
 				}
 			}
-			Err(e) if e.is_status(404) => return,
+			Err(e) if e.is_status(404) => return false,
 			Err(e) => {
 				tracing::warn!("could not inspect secret {name} before removal: {e}");
-				return;
+				return false;
 			}
 		}
 		let path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
 		match self.client.delete_ok(&path).await {
-			Ok(()) => tracing::info!("removed secret {name}"),
-			Err(e) => tracing::warn!("could not remove secret {name}: {e}"),
+			Ok(()) => {
+				tracing::info!("removed secret {name}");
+				true
+			}
+			Err(e) => {
+				tracing::warn!("could not remove secret {name}: {e}");
+				false
+			}
 		}
 	}
+}
+
+/// One summary log line that lists the podup-created secrets removed on
+/// `down`. The per-secret `info` lines stay as the per-record audit;
+/// the summary is the line the operator actually searches for when
+/// the teardown finishes. Empty lists are silent — a `down` with no
+/// declared secrets composes cleanly with the rest of the teardown
+/// without adding noise.
+fn log_removed_secrets(project: &str, removed: &[String]) {
+	if removed.is_empty() {
+		return;
+	}
+	tracing::info!(
+		"removed {} podup-created secret(s) for project {project}: {}",
+		removed.len(),
+		removed.join(", ")
+	);
 }
 
 #[cfg(test)]

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -23,7 +23,7 @@ pub fn platform_asset() -> Option<&'static str> {
 
 /// Map an OS/ARCH pair to its release asset name. Split out from
 /// [`platform_asset`] so the full matrix is testable without the host's values.
-fn asset_for(os: &str, arch: &str) -> Option<&'static str> {
+pub(crate) fn asset_for(os: &str, arch: &str) -> Option<&'static str> {
 	match (os, arch) {
 		("linux", "x86_64") => Some("podup-linux-x86_64"),
 		("linux", "aarch64") => Some("podup-linux-arm64"),
@@ -66,28 +66,91 @@ pub fn install_binary(new_bytes: &[u8], expected_version: &str) -> crate::Result
 			exe.display()
 		))
 	})?;
-	// Keep the current binary in memory so a failed self-test can roll back. The
-	// signature already proves the new bytes are authentic; the self-test guards
-	// the install mechanics (a partial write, an arch/ABI mismatch the asset name
-	// didn't catch) and pins the reported version against the resolved tag.
-	let backup = std::fs::read(&target).ok();
-	install_at(&target, new_bytes)?;
-	if let Err(e) = self_test(&target, expected_version) {
-		return match backup {
-			Some(old) => {
-				install_at(&target, &old)?;
-				Err(ComposeError::Update(format!(
-					"the updated binary failed its self-test ({e}); rolled back to the \
-					 previous version"
-				)))
-			}
-			None => Err(ComposeError::Update(format!(
-				"the updated binary failed its self-test ({e}) and no backup was \
-				 available to roll back"
-			))),
-		};
+	// Move the current binary aside BEFORE the swap so a failed self-test
+	// always has a rollback target on disk. The previous code read the
+	// bytes into a `Vec<u8>` and re-ran the install on rollback, which is
+	// a one-shot rollback: a kill between the swap and the self-test
+	// drops the in-memory copy and the user is left without a working
+	// binary. The on-disk `.old` sibling survives any kill in the window
+	// and the self-test reads from it (which is the whole point of having
+	// it on disk rather than in memory).
+	let backup = move_target_aside(&target)?;
+	if let Err(e) = install_at(&target, new_bytes) {
+		// The swap itself failed: restore the old binary before reporting.
+		let _ = restore_from_backup(&target, &backup);
+		return Err(e);
 	}
+	if let Err(e) = self_test(&target, expected_version) {
+		// Roll back to the original binary. The backup is on disk, so a
+		// kill inside `restore_from_backup` would still leave the user
+		// with a recoverable `.old` to fall back on.
+		restore_from_backup(&target, &backup)?;
+		return Err(ComposeError::Update(format!(
+			"the updated binary failed its self-test ({e}); rolled back to the \
+			 previous version"
+		)));
+	}
+	// Best-effort remove the `.old`; a kill here just leaves a recoverable
+	// sibling that the next run will tidy up.
+	let _ = std::fs::remove_file(&backup);
 	Ok(target)
+}
+
+/// Move the existing target to a sibling `.old` path so the swap and the
+/// self-test can both find a recoverable copy of the previous binary. The
+/// `.old` extension matches the Windows updater's path; the same name is
+/// used on Unix so a human inspecting the install directory sees one
+/// consistent leftover shape, and the same next-run cleanup applies.
+pub(crate) fn move_target_aside(target: &Path) -> crate::Result<PathBuf> {
+	let backup = target.with_extension("old");
+	if backup == *target {
+		return Err(ComposeError::Update(format!(
+			"refusing to clobber the target with a sibling of the same path: {}",
+			backup.display()
+		)));
+	}
+	// Drop any stale leftover from a prior interrupted install. The
+	// updater's next-run cleanup covers this too, but doing it here keeps
+	// the rename atomic from the caller's perspective.
+	if let Err(e) = std::fs::remove_file(&backup) {
+		// ENOENT is fine; anything else is worth surfacing.
+		if e.kind() != std::io::ErrorKind::NotFound {
+			return Err(ComposeError::Update(format!(
+				"cannot remove stale backup {}: {e}",
+				backup.display()
+			)));
+		}
+	}
+	if target.exists() {
+		std::fs::rename(target, &backup).map_err(|e| {
+			ComposeError::Update(format!(
+				"cannot move the current binary aside before the swap ({} -> {}): {e}",
+				target.display(),
+				backup.display()
+			))
+		})?;
+	}
+	Ok(backup)
+}
+
+/// Restore the `.old` sibling back onto `target`. Best-effort: the rollback
+/// path reports the original error to the user regardless, but a failure
+/// here is logged at debug so the next-run cleanup can pick up where this
+/// left off (the `.old` is still on disk and the self-test has already
+/// failed).
+pub(crate) fn restore_from_backup(target: &Path, backup: &Path) -> crate::Result<()> {
+	if !backup.exists() {
+		// Nothing to restore from (the install was a fresh deploy onto a
+		// path that did not exist before). The swap that already ran
+		// stands.
+		return Ok(());
+	}
+	std::fs::rename(backup, target).map_err(|e| {
+		ComposeError::Update(format!(
+			"failed to roll back to the previous binary from {}: {e}",
+			backup.display()
+		))
+	})
 }
 
 /// How long to keep retrying a spawn that reports ETXTBSY.
@@ -107,7 +170,7 @@ const TEXT_FILE_BUSY_BUDGET: std::time::Duration = std::time::Duration::from_sec
 /// that window. Treating it as a failed self-test rolls back a signed, verified,
 /// perfectly good update over a race that resolves in milliseconds, and tells
 /// the user their new version is broken.
-fn spawn_version_probe(target: &Path) -> std::io::Result<std::process::Child> {
+pub(crate) fn spawn_version_probe(target: &Path) -> std::io::Result<std::process::Child> {
 	use std::process::{Command, Stdio};
 
 	let probe = || {
@@ -143,7 +206,7 @@ fn spawn_version_probe(target: &Path) -> std::io::Result<std::process::Child> {
 /// a `String` the errno is gone, and matching on the text would break under any
 /// locale or libc that words it differently.
 #[cfg(unix)]
-fn is_text_file_busy(e: &std::io::Error) -> bool {
+pub(crate) fn is_text_file_busy(e: &std::io::Error) -> bool {
 	// `ExecutableFileBusy` is the named form; the raw errno is compared too so
 	// this holds on a toolchain where the mapping differs.
 	e.kind() == std::io::ErrorKind::ExecutableFileBusy || e.raw_os_error() == Some(libc::ETXTBSY)
@@ -153,7 +216,7 @@ fn is_text_file_busy(e: &std::io::Error) -> bool {
 /// invoking `--version`, bounded by a timeout so a hung binary can't wedge the
 /// updater. The version check closes the rollback window: a replayed older
 /// (signed) release fails here and is rolled back.
-fn self_test(target: &Path, expected_version: &str) -> crate::Result<()> {
+pub(crate) fn self_test(target: &Path, expected_version: &str) -> crate::Result<()> {
 	use std::io::Read;
 	use std::time::{Duration, Instant};
 
@@ -234,7 +297,7 @@ pub fn install_at(target: &Path, new_bytes: &[u8]) -> crate::Result<()> {
 
 /// Write the new bytes to `tmp`, copy `target`'s permission bits (default 0755
 /// on Unix when the target does not yet exist), and flush to disk.
-fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> {
+pub(crate) fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> {
 	// Create the temp file private (0600) on Unix so the new binary's bytes are
 	// never world-readable in a shared directory (e.g. /usr/local/bin) during the
 	// window before the target's mode is applied. `File::create` honours the
@@ -300,27 +363,46 @@ fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::Result<()> 
 /// Atomically move `tmp` onto `target`. Unix replaces the inode directly;
 /// Windows renames the in-use file aside first.
 #[cfg(not(windows))]
-fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
+pub(crate) fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
 	std::fs::rename(tmp, target).map_err(|e| rename_error(e, target))
 }
 
 #[cfg(windows)]
-fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
+pub(crate) fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
 	// A running .exe cannot be overwritten, but it can be renamed. Move it aside,
 	// put the new binary in place, then best-effort delete the old one (it may
 	// still be locked while running - if so, it is removed at the start of the
 	// next updater run by `cleanup_stale_backup`).
+	//
+	// The L5 swap path
+	// (`install_binary` → `move_target_aside` → `install_at`) means the target
+	// may already be absent when this function is called: the caller has moved
+	// it to `.old` so the self-test has a recoverable copy on disk. Track
+	// whether *this* call created the backup so the cleanup at the end only
+	// touches the file we created, and the rename error path only tries to
+	// restore from a backup we own.
 	let backup = target.with_extension("old");
-	let _ = std::fs::remove_file(&backup);
-	if target.exists() {
+	let target_existed = target.exists();
+	if target_existed {
+		// Drop any stale leftover before re-creating it. Only meaningful when
+		// we are about to be the one to create a fresh `.old`.
+		let _ = std::fs::remove_file(&backup);
 		std::fs::rename(target, &backup).map_err(|e| rename_error(e, target))?;
 	}
 	if let Err(e) = std::fs::rename(tmp, target) {
-		// Roll back so the user is not left without a binary.
-		let _ = std::fs::rename(&backup, target);
+		// Roll back so the user is not left without a binary — but only when
+		// we created the backup in this call. A pre-existing `.old` (the L5
+		// swap path) is the caller's responsibility to restore.
+		if target_existed {
+			let _ = std::fs::rename(&backup, target);
+		}
 		return Err(rename_error(e, target));
 	}
-	let _ = std::fs::remove_file(&backup);
+	// Only clean up the backup if we created it in this call. A pre-existing
+	// `.old` belongs to the caller, who decides when (and whether) to drop it.
+	if target_existed {
+		let _ = std::fs::remove_file(&backup);
+	}
 	Ok(())
 }
 
@@ -340,7 +422,7 @@ pub(crate) fn cleanup_stale_backup() {
 
 /// Turn a rename failure into an actionable error, calling out the common
 /// permission case (system install dirs need elevation).
-fn rename_error(e: std::io::Error, target: &Path) -> ComposeError {
+pub(crate) fn rename_error(e: std::io::Error, target: &Path) -> ComposeError {
 	if e.kind() == std::io::ErrorKind::PermissionDenied {
 		ComposeError::Update(format!(
 			"permission denied writing {}; re-run with elevated privileges \
@@ -356,314 +438,4 @@ fn rename_error(e: std::io::Error, target: &Path) -> ComposeError {
 }
 
 #[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn platform_asset_matches_known_targets() {
-		// Whatever host runs the tests, the asset (if any) must be one of the
-		// release matrix names.
-		if let Some(asset) = platform_asset() {
-			assert!(asset.starts_with("podup-"));
-		}
-	}
-
-	#[test]
-	fn platform_asset_covers_every_release_target() {
-		// Pins the OS/ARCH → asset mapping to the full `release.yml` build
-		// matrix so a newly added prebuilt (or a dropped arm) is caught here
-		// instead of failing self-update silently in the field.
-		let expected = [
-			(("linux", "x86_64"), "podup-linux-x86_64"),
-			(("linux", "aarch64"), "podup-linux-arm64"),
-			(("macos", "aarch64"), "podup-darwin-arm64"),
-			(("macos", "x86_64"), "podup-darwin-x86_64"),
-			(("windows", "x86_64"), "podup-windows-x86_64.exe"),
-			(("windows", "aarch64"), "podup-windows-arm64.exe"),
-		];
-		for ((os, arch), asset) in expected {
-			assert_eq!(
-				asset_for(os, arch),
-				Some(asset),
-				"self-update mapping drifted for {os}/{arch}"
-			);
-		}
-	}
-
-	#[test]
-	fn install_at_replaces_contents() {
-		let dir = tempfile::tempdir().unwrap();
-		let target = dir.path().join("podup");
-		std::fs::write(&target, b"old version").unwrap();
-
-		install_at(&target, b"new version").unwrap();
-		assert_eq!(std::fs::read(&target).unwrap(), b"new version");
-	}
-
-	/// A special bit on the target is never propagated onto the new binary.
-	///
-	/// `write_temp` copies the target's permissions so an install keeps whatever
-	/// mode the operator chose, and masks with `& 0o777` on the way. Without the
-	/// mask, a target that had been made setuid — by tampering, or by an
-	/// operator who did it on purpose once — would hand the freshly installed
-	/// podup the same bit, on a binary that has just been fetched over the
-	/// network. That is a privilege-escalation footgun, and it is the one
-	/// property of this function a test can actually observe.
-	///
-	/// The other three are window guards and cannot be reached in process: the
-	/// 0600 create mode is overwritten by this very copy before the function
-	/// returns, and `O_EXCL`/`O_NOFOLLOW` close a race between the unlink above
-	/// and the open. Their comments say so where they live.
-	#[cfg(unix)]
-	#[test]
-	fn write_temp_never_propagates_a_special_bit_from_the_target() {
-		use std::os::unix::fs::PermissionsExt;
-		let dir = tempfile::tempdir().unwrap();
-		let target = dir.path().join("podup");
-		std::fs::write(&target, b"old").unwrap();
-		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o4755)).unwrap();
-		// Only meaningful if the filesystem kept the bit; some do not.
-		let target_mode = std::fs::metadata(&target).unwrap().permissions().mode();
-		if target_mode & 0o4000 == 0 {
-			return;
-		}
-
-		let tmp = dir.path().join("podup.tmp");
-		super::write_temp(&tmp, b"freshly downloaded", &target).unwrap();
-
-		let mode = std::fs::metadata(&tmp).unwrap().permissions().mode();
-		assert_eq!(
-			mode & 0o7000,
-			0,
-			"a special bit rode from the target onto the new binary: {mode:o}"
-		);
-		assert_eq!(
-			mode & 0o777,
-			0o755,
-			"the ordinary permission bits should still be carried over: {mode:o}"
-		);
-	}
-
-	#[test]
-	fn install_at_creates_when_absent() {
-		let dir = tempfile::tempdir().unwrap();
-		let target = dir.path().join("podup");
-		install_at(&target, b"fresh").unwrap();
-		assert_eq!(std::fs::read(&target).unwrap(), b"fresh");
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn install_at_preserves_executable_mode() {
-		use std::os::unix::fs::PermissionsExt;
-		let dir = tempfile::tempdir().unwrap();
-		let target = dir.path().join("podup");
-		std::fs::write(&target, b"old").unwrap();
-		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
-
-		install_at(&target, b"new").unwrap();
-		let mode = std::fs::metadata(&target).unwrap().permissions().mode();
-		assert_eq!(mode & 0o777, 0o755);
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn install_at_strips_setuid_from_target_mode() {
-		use std::os::unix::fs::PermissionsExt;
-		let dir = tempfile::tempdir().unwrap();
-		let target = dir.path().join("podup");
-		std::fs::write(&target, b"old").unwrap();
-		// A tampered/setuid target must not propagate its special bits onto the
-		// freshly installed binary.
-		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o4755)).unwrap();
-
-		install_at(&target, b"new").unwrap();
-		let mode = std::fs::metadata(&target).unwrap().permissions().mode();
-		assert_eq!(mode & 0o7000, 0, "setuid/setgid/sticky must be stripped");
-		assert_eq!(mode & 0o777, 0o755);
-	}
-
-	#[test]
-	fn install_at_leaves_no_temp_files() {
-		let dir = tempfile::tempdir().unwrap();
-		let target = dir.path().join("podup");
-		install_at(&target, b"data").unwrap();
-		let leftovers: Vec<_> = std::fs::read_dir(dir.path())
-			.unwrap()
-			.filter_map(|e| e.ok())
-			.filter(|e| e.file_name().to_string_lossy().contains("update-"))
-			.collect();
-		assert!(leftovers.is_empty(), "temp file left behind");
-	}
-
-	#[test]
-	fn install_at_fails_when_target_dir_is_missing() {
-		// A target whose parent directory does not exist must fail (the sibling
-		// temp cannot be created) and must not leave anything behind.
-		let dir = tempfile::tempdir().unwrap();
-		let missing = dir.path().join("no-such-subdir");
-		let target = missing.join("podup");
-		assert!(install_at(&target, b"data").is_err());
-		assert!(!missing.exists(), "must not create the missing parent dir");
-	}
-
-	/// Write an executable stub script and return its path.
-	#[cfg(unix)]
-	fn write_stub(dir: &Path, name: &str, body: &str) -> PathBuf {
-		use std::os::unix::fs::PermissionsExt;
-		let p = dir.join(name);
-		std::fs::write(&p, body).unwrap();
-		std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
-		p
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn self_test_passes_for_a_zero_exit_and_fails_otherwise() {
-		let dir = tempfile::tempdir().unwrap();
-		// A binary that exits 0 and reports the expected version passes; a
-		// non-zero exit fails.
-		let ok = write_stub(
-			dir.path(),
-			"ok",
-			"#!/bin/sh\necho \"podup 9.9.9\"\nexit 0\n",
-		);
-		let bad = write_stub(dir.path(), "bad", "#!/bin/sh\nexit 1\n");
-		assert!(self_test(&ok, "9.9.9").is_ok());
-		assert!(self_test(&bad, "9.9.9").is_err());
-		// A non-executable / missing target is a spawn error, not a panic.
-		assert!(self_test(&dir.path().join("nope"), "9.9.9").is_err());
-	}
-
-	/// The classification that silently did not work.
-	///
-	/// A real executable held open for writing cannot be run — the kernel
-	/// returns ETXTBSY — so this produces the genuine errno rather than a
-	/// hand-built error, and asserts the predicate the retry depends on. The
-	/// previous version of this check ran on an error already formatted into a
-	/// `String`, where the errno no longer exists: it returned false every time,
-	/// the retry never fired, and the flake it was written to prevent stayed.
-	///
-	/// Linux only, deliberately. Whether a given kernel refuses to exec a file
-	/// held open for writing — and for a script, whether the check lands on the
-	/// script or on its interpreter — is that kernel's business, verified on
-	/// Linux. Asserting it elsewhere tests the platform rather than the
-	/// classifier, and writing the test so it passes vacuously where ETXTBSY
-	/// never fires would repeat the mistake this whole change is about. The
-	/// retry itself stays on every Unix: it is a no-op where the errno does not
-	/// occur.
-	#[cfg(target_os = "linux")]
-	#[test]
-	fn a_binary_open_for_writing_is_classified_as_text_file_busy() {
-		let dir = tempfile::tempdir().unwrap();
-		let target = dir.path().join("held");
-		std::fs::copy("/bin/sh", &target).expect("/bin/sh is copyable");
-		{
-			use std::os::unix::fs::PermissionsExt;
-			std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
-		}
-		// Held across the spawn on purpose; dropping it closes the window.
-		let _writer = std::fs::OpenOptions::new()
-			.write(true)
-			.open(&target)
-			.unwrap();
-
-		let err = std::process::Command::new(&target)
-			.arg("-c")
-			.arg("exit 0")
-			.spawn()
-			.expect_err("a binary open for writing must not be executable");
-		assert!(
-			is_text_file_busy(&err),
-			"ETXTBSY must be recognised from the io::Error itself, got {err:?}"
-		);
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn self_test_rejects_a_version_mismatch() {
-		let dir = tempfile::tempdir().unwrap();
-		// A genuinely-signed but *older* replayed release exits 0 yet reports the
-		// wrong version — the rollback gate must reject it.
-		let p = write_stub(
-			dir.path(),
-			"older",
-			"#!/bin/sh\necho \"podup 1.0.0\"\nexit 0\n",
-		);
-		let err = self_test(&p, "9.9.9").unwrap_err();
-		let msg = format!("{err}");
-		assert!(msg.contains("rollback"), "{msg}");
-		// A `v`-prefixed report still matches its unprefixed expectation.
-		let v = write_stub(
-			dir.path(),
-			"vprefixed",
-			"#!/bin/sh\necho \"podup v9.9.9\"\nexit 0\n",
-		);
-		assert!(self_test(&v, "9.9.9").is_ok());
-	}
-
-	#[test]
-	fn require_platform_asset_is_consistent() {
-		match (platform_asset(), require_platform_asset()) {
-			(Some(a), Ok(b)) => assert_eq!(a, b),
-			(None, Err(_)) => {}
-			_ => panic!("platform_asset and require_platform_asset disagree"),
-		}
-	}
-
-	#[test]
-	fn rename_error_calls_out_permission_and_generic_cases() {
-		let target = Path::new("/usr/local/bin/podup");
-		// A permission error nudges the user toward elevation.
-		let perm = rename_error(
-			std::io::Error::from(std::io::ErrorKind::PermissionDenied),
-			target,
-		);
-		match perm {
-			ComposeError::Update(msg) => {
-				assert!(msg.contains("permission denied"));
-				assert!(msg.contains("sudo"));
-			}
-			_ => panic!("expected an Update error"),
-		}
-		// Any other error reports the underlying failure verbatim.
-		let other = rename_error(std::io::Error::other("disk full"), target);
-		match other {
-			ComposeError::Update(msg) => {
-				assert!(msg.contains("failed to install update"));
-				assert!(msg.contains("disk full"));
-			}
-			_ => panic!("expected an Update error"),
-		}
-	}
-
-	#[cfg(windows)]
-	#[test]
-	fn cleanup_stale_backup_removes_a_leftover_old_file() {
-		// Simulates the case swap_into_place leaves behind: an `.old` sibling of
-		// the running executable that its own best-effort delete could not
-		// remove because the old process still held it open. The next updater
-		// run calls this once nothing holds the file anymore, and it must go.
-		let exe = std::env::current_exe().unwrap();
-		let backup = exe.with_extension("old");
-		std::fs::write(&backup, b"leftover backup").unwrap();
-
-		cleanup_stale_backup();
-
-		assert!(!backup.exists(), "the stale .old backup must be removed");
-	}
-
-	#[cfg(windows)]
-	#[test]
-	fn cleanup_stale_backup_is_a_no_op_without_a_leftover() {
-		// No `.old` file present is the common case (a normal run, or a
-		// platform that never took the Windows swap path) - must not error.
-		let exe = std::env::current_exe().unwrap();
-		let backup = exe.with_extension("old");
-		let _ = std::fs::remove_file(&backup);
-
-		cleanup_stale_backup();
-
-		assert!(!backup.exists());
-	}
-}
+mod tests;

--- a/internal/update/install/tests.rs
+++ b/internal/update/install/tests.rs
@@ -1,0 +1,370 @@
+use super::*;
+#[test]
+fn platform_asset_matches_known_targets() {
+	// Whatever host runs the tests, the asset (if any) must be one of the
+	// release matrix names.
+	if let Some(asset) = platform_asset() {
+		assert!(asset.starts_with("podup-"));
+	}
+}
+#[test]
+fn platform_asset_covers_every_release_target() {
+	// Pins the OS/ARCH → asset mapping to the full `release.yml` build
+	// matrix so a newly added prebuilt (or a dropped arm) is caught here
+	// instead of failing self-update silently in the field.
+	let expected = [
+		(("linux", "x86_64"), "podup-linux-x86_64"),
+		(("linux", "aarch64"), "podup-linux-arm64"),
+		(("macos", "aarch64"), "podup-darwin-arm64"),
+		(("macos", "x86_64"), "podup-darwin-x86_64"),
+		(("windows", "x86_64"), "podup-windows-x86_64.exe"),
+		(("windows", "aarch64"), "podup-windows-arm64.exe"),
+	];
+	for ((os, arch), asset) in expected {
+		assert_eq!(
+			asset_for(os, arch),
+			Some(asset),
+			"self-update mapping drifted for {os}/{arch}"
+		);
+	}
+}
+#[test]
+fn install_at_replaces_contents() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"old version").unwrap();
+	install_at(&target, b"new version").unwrap();
+	assert_eq!(std::fs::read(&target).unwrap(), b"new version");
+}
+/// A special bit on the target is never propagated onto the new binary.
+///
+/// `write_temp` copies the target's permissions so an install keeps whatever
+/// mode the operator chose, and masks with `& 0o777` on the way. Without the
+/// mask, a target that had been made setuid — by tampering, or by an
+/// operator who did it on purpose once — would hand the freshly installed
+/// podup the same bit, on a binary that has just been fetched over the
+/// network. That is a privilege-escalation footgun, and it is the one
+/// property of this function a test can actually observe.
+///
+/// The other three are window guards and cannot be reached in process: the
+/// 0600 create mode is overwritten by this very copy before the function
+/// returns, and `O_EXCL`/`O_NOFOLLOW` close a race between the unlink above
+/// and the open. Their comments say so where they live.
+#[cfg(unix)]
+#[test]
+fn write_temp_never_propagates_a_special_bit_from_the_target() {
+	use std::os::unix::fs::PermissionsExt;
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"old").unwrap();
+	std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o4755)).unwrap();
+	// Only meaningful if the filesystem kept the bit; some do not.
+	let target_mode = std::fs::metadata(&target).unwrap().permissions().mode();
+	if target_mode & 0o4000 == 0 {
+		return;
+	}
+	let tmp = dir.path().join("podup.tmp");
+	super::write_temp(&tmp, b"freshly downloaded", &target).unwrap();
+	let mode = std::fs::metadata(&tmp).unwrap().permissions().mode();
+	assert_eq!(
+		mode & 0o7000,
+		0,
+		"a special bit rode from the target onto the new binary: {mode:o}"
+	);
+	assert_eq!(
+		mode & 0o777,
+		0o755,
+		"the ordinary permission bits should still be carried over: {mode:o}"
+	);
+}
+#[test]
+fn install_at_creates_when_absent() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	install_at(&target, b"fresh").unwrap();
+	assert_eq!(std::fs::read(&target).unwrap(), b"fresh");
+}
+#[cfg(unix)]
+#[test]
+fn install_at_preserves_executable_mode() {
+	use std::os::unix::fs::PermissionsExt;
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"old").unwrap();
+	std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+	install_at(&target, b"new").unwrap();
+	let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+	assert_eq!(mode & 0o777, 0o755);
+}
+#[cfg(unix)]
+#[test]
+fn install_at_strips_setuid_from_target_mode() {
+	use std::os::unix::fs::PermissionsExt;
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"old").unwrap();
+	// A tampered/setuid target must not propagate its special bits onto the
+	// freshly installed binary.
+	std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o4755)).unwrap();
+	install_at(&target, b"new").unwrap();
+	let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+	assert_eq!(mode & 0o7000, 0, "setuid/setgid/sticky must be stripped");
+	assert_eq!(mode & 0o777, 0o755);
+}
+#[test]
+fn install_at_leaves_no_temp_files() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	install_at(&target, b"data").unwrap();
+	let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+		.unwrap()
+		.filter_map(|e| e.ok())
+		.filter(|e| e.file_name().to_string_lossy().contains("update-"))
+		.collect();
+	assert!(leftovers.is_empty(), "temp file left behind");
+}
+#[test]
+fn install_at_fails_when_target_dir_is_missing() {
+	// A target whose parent directory does not exist must fail (the sibling
+	// temp cannot be created) and must not leave anything behind.
+	let dir = tempfile::tempdir().unwrap();
+	let missing = dir.path().join("no-such-subdir");
+	let target = missing.join("podup");
+	assert!(install_at(&target, b"data").is_err());
+	assert!(!missing.exists(), "must not create the missing parent dir");
+}
+/// #1360 (L5): the L5 swap window. The previous in-memory `Vec<u8>` backup
+/// was one-shot — a kill between the swap and the self-test dropped the
+/// in-memory copy and the user was left without a working binary. The
+/// fix is `move_target_aside` before the swap: the `.old` sibling survives
+/// any kill in the window, so the self-test has a recoverable copy on disk.
+/// Simulate the kill by aborting the swap flow between the two renames and
+/// confirm the `.old` is still there for the next run to roll back to.
+#[test]
+fn move_target_aside_leaves_the_old_binary_on_disk_for_rollback() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"the previous binary").unwrap();
+	let backup = move_target_aside(&target).expect("the move-aside must succeed");
+	assert!(
+		backup.exists(),
+		"the .old sibling must exist after the swap window, for the self-test to roll back to"
+	);
+	assert_eq!(
+		std::fs::read(&backup).unwrap(),
+		b"the previous binary",
+		"the .old must hold the bytes that were at the target before the swap"
+	);
+	assert!(
+		!target.exists(),
+		"the target must be moved aside, not left in place"
+	);
+}
+/// #1360 (L5): once the self-test passes, the `.old` sibling is no longer
+/// needed and is reaped. `install_binary` does this directly, but the
+/// behaviour here is the assertion that the helper functions are composed
+/// correctly: `move_target_aside` + `restore_from_backup` round-trips the
+/// original bytes through the `.old` path.
+#[test]
+fn restore_from_backup_round_trips_the_old_binary() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"the previous binary").unwrap();
+	let backup = move_target_aside(&target).expect("the move-aside must succeed");
+	// Pretend the swap installed a new binary. The rollback path is now
+	// the user's safety net.
+	std::fs::write(&target, b"the new binary (failing self-test)").unwrap();
+	restore_from_backup(&target, &backup).expect("the rollback must succeed");
+	assert_eq!(
+		std::fs::read(&target).unwrap(),
+		b"the previous binary",
+		"the rollback must put the previous binary back at the target"
+	);
+	assert!(
+		!backup.exists(),
+		"the .old sibling is consumed by the rollback"
+	);
+}
+/// #1360 (L5): a fresh-deploy install (no previous binary) leaves no
+/// `.old` behind and the rollback path is a no-op. Simulates the
+/// `install_binary` first-run on a machine that has never had podup.
+#[test]
+fn move_target_aside_is_a_no_op_when_the_target_does_not_exist() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	// No target to begin with — the move-aside must still return a
+	// backup path (the caller always has a place to roll back to / from).
+	let backup = move_target_aside(&target).expect("the move-aside must succeed");
+	assert!(
+		!backup.exists(),
+		"no .old is created when there was no target"
+	);
+	assert!(!target.exists(), "a non-existent target stays non-existent");
+	// The rollback is a no-op too: there is nothing to roll back to.
+	restore_from_backup(&target, &backup).expect("a no-op rollback must succeed");
+}
+/// #1360 (L5): `install_at` keeps the old in-place semantics, where the
+/// target is replaced atomically. The L5 swap path adds a `move_target_aside`
+/// *before* `install_at`, but the public surface (`install_at`) is the
+/// building block tested here. The new `.old` sibling should not leak
+/// to a directory that did not previously have one — the `.old` belongs
+/// to the L5 caller, not to `install_at`.
+#[test]
+fn install_at_does_not_leave_an_old_sibling() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"old").unwrap();
+	install_at(&target, b"new").unwrap();
+	let old_sibling = dir.path().join("podup.old");
+	assert!(
+		!old_sibling.exists(),
+		"install_at must not create a .old sibling — that is the L5 caller's job"
+	);
+}
+/// Write an executable stub script and return its path.
+#[cfg(unix)]
+fn write_stub(dir: &Path, name: &str, body: &str) -> PathBuf {
+	use std::os::unix::fs::PermissionsExt;
+	let p = dir.join(name);
+	std::fs::write(&p, body).unwrap();
+	std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+	p
+}
+#[cfg(unix)]
+#[test]
+fn self_test_passes_for_a_zero_exit_and_fails_otherwise() {
+	let dir = tempfile::tempdir().unwrap();
+	// A binary that exits 0 and reports the expected version passes; a
+	// non-zero exit fails.
+	let ok = write_stub(
+		dir.path(),
+		"ok",
+		"#!/bin/sh\necho \"podup 9.9.9\"\nexit 0\n",
+	);
+	let bad = write_stub(dir.path(), "bad", "#!/bin/sh\nexit 1\n");
+	assert!(self_test(&ok, "9.9.9").is_ok());
+	assert!(self_test(&bad, "9.9.9").is_err());
+	// A non-executable / missing target is a spawn error, not a panic.
+	assert!(self_test(&dir.path().join("nope"), "9.9.9").is_err());
+}
+/// The classification that silently did not work.
+///
+/// A real executable held open for writing cannot be run — the kernel
+/// returns ETXTBSY — so this produces the genuine errno rather than a
+/// hand-built error, and asserts the predicate the retry depends on. The
+/// previous version of this check ran on an error already formatted into a
+/// `String`, where the errno no longer exists: it returned false every time,
+/// the retry never fired, and the flake it was written to prevent stayed.
+///
+/// Linux only, deliberately. Whether a given kernel refuses to exec a file
+/// held open for writing — and for a script, whether the check lands on the
+/// script or on its interpreter — is that kernel's business, verified on
+/// Linux. Asserting it elsewhere tests the platform rather than the
+/// classifier, and writing the test so it passes vacuously where ETXTBSY
+/// never fires would repeat the mistake this whole change is about. The
+/// retry itself stays on every Unix: it is a no-op where the errno does not
+/// occur.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_binary_open_for_writing_is_classified_as_text_file_busy() {
+	let dir = tempfile::tempdir().unwrap();
+	let target = dir.path().join("held");
+	std::fs::copy("/bin/sh", &target).expect("/bin/sh is copyable");
+	{
+		use std::os::unix::fs::PermissionsExt;
+		std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+	}
+	// Held across the spawn on purpose; dropping it closes the window.
+	let _writer = std::fs::OpenOptions::new()
+		.write(true)
+		.open(&target)
+		.unwrap();
+	let err = std::process::Command::new(&target)
+		.arg("-c")
+		.arg("exit 0")
+		.spawn()
+		.expect_err("a binary open for writing must not be executable");
+	assert!(
+		is_text_file_busy(&err),
+		"ETXTBSY must be recognised from the io::Error itself, got {err:?}"
+	);
+}
+#[cfg(unix)]
+#[test]
+fn self_test_rejects_a_version_mismatch() {
+	let dir = tempfile::tempdir().unwrap();
+	// A genuinely-signed but *older* replayed release exits 0 yet reports the
+	// wrong version — the rollback gate must reject it.
+	let p = write_stub(
+		dir.path(),
+		"older",
+		"#!/bin/sh\necho \"podup 1.0.0\"\nexit 0\n",
+	);
+	let err = self_test(&p, "9.9.9").unwrap_err();
+	let msg = format!("{err}");
+	assert!(msg.contains("rollback"), "{msg}");
+	// A `v`-prefixed report still matches its unprefixed expectation.
+	let v = write_stub(
+		dir.path(),
+		"vprefixed",
+		"#!/bin/sh\necho \"podup v9.9.9\"\nexit 0\n",
+	);
+	assert!(self_test(&v, "9.9.9").is_ok());
+}
+#[test]
+fn require_platform_asset_is_consistent() {
+	match (platform_asset(), require_platform_asset()) {
+		(Some(a), Ok(b)) => assert_eq!(a, b),
+		(None, Err(_)) => {}
+		_ => panic!("platform_asset and require_platform_asset disagree"),
+	}
+}
+#[test]
+fn rename_error_calls_out_permission_and_generic_cases() {
+	let target = Path::new("/usr/local/bin/podup");
+	// A permission error nudges the user toward elevation.
+	let perm = rename_error(
+		std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+		target,
+	);
+	match perm {
+		ComposeError::Update(msg) => {
+			assert!(msg.contains("permission denied"));
+			assert!(msg.contains("sudo"));
+		}
+		_ => panic!("expected an Update error"),
+	}
+	// Any other error reports the underlying failure verbatim.
+	let other = rename_error(std::io::Error::other("disk full"), target);
+	match other {
+		ComposeError::Update(msg) => {
+			assert!(msg.contains("failed to install update"));
+			assert!(msg.contains("disk full"));
+		}
+		_ => panic!("expected an Update error"),
+	}
+}
+#[cfg(windows)]
+#[test]
+fn cleanup_stale_backup_removes_a_leftover_old_file() {
+	// Simulates the case swap_into_place leaves behind: an `.old` sibling of
+	// the running executable that its own best-effort delete could not
+	// remove because the old process still held it open. The next updater
+	// run calls this once nothing holds the file anymore, and it must go.
+	let exe = std::env::current_exe().unwrap();
+	let backup = exe.with_extension("old");
+	std::fs::write(&backup, b"leftover backup").unwrap();
+	cleanup_stale_backup();
+	assert!(!backup.exists(), "the stale .old backup must be removed");
+}
+#[cfg(windows)]
+#[test]
+fn cleanup_stale_backup_is_a_no_op_without_a_leftover() {
+	// No `.old` file present is the common case (a normal run, or a
+	// platform that never took the Windows swap path) - must not error.
+	let exe = std::env::current_exe().unwrap();
+	let backup = exe.with_extension("old");
+	let _ = std::fs::remove_file(&backup);
+	cleanup_stale_backup();
+	assert!(!backup.exists());
+}

--- a/internal/update/pkg.rs
+++ b/internal/update/pkg.rs
@@ -25,54 +25,36 @@ pub fn managing_package_manager() -> Option<&'static str> {
 ///
 /// The primary check is `dpkg-query -S <path>`. Crucially this must not *fail
 /// open*: if the helper cannot be spawned (missing, not executable, or denied)
-/// we do not assume the file is unmanaged — that would let self-update clobber an
-/// apt-owned binary and desync the dpkg database. Instead we fall back to reading
-/// dpkg's on-disk file lists directly. A host with no dpkg database at all
-/// (`/var/lib/dpkg/info` absent — e.g. Fedora or a cargo-install) is genuinely
-/// not Debian-managed, so both paths report `false` and update proceeds.
+/// we do not fall back to scanning dpkg's on-disk file lists directly
+/// (`/var/lib/dpkg/info/*.list`) — that directory is owned by another package
+/// and we have no guarantee of its mode, ownership, or the validity of its
+/// contents. Reading it opens a window where a tampered target file's path
+/// could be planted inside the listing directory to make self-update refuse
+/// on an unmanaged binary, or, more worryingly, where the listing could be
+/// truncated or replaced to hide the path of an apt-owned binary we are about
+/// to clobber. Until `dpkg-query` is gone entirely (which is itself the
+/// unambiguous signal that this is not a Debian-managed host) we report
+/// `false` and let the update proceed.
 #[cfg(target_os = "linux")]
 fn dpkg_owns(path: &Path) -> bool {
-	match std::process::Command::new("dpkg-query")
+	let query = std::process::Command::new("dpkg-query")
 		.arg("-S")
 		.arg(path)
-		.output()
-	{
-		// dpkg-query ran to completion: trust its verdict (success == owned).
+		.output();
+	// dpkg-query ran to completion: trust its verdict (success == owned).
+	// A non-zero exit (path not in the database) is the common case and is
+	// the same as a deploy from a cargo install or `/usr/local/bin`: report
+	// `false` and let the update proceed.
+	match query {
 		Ok(output) => output.status.success(),
-		// dpkg-query could not be spawned. Don't fail open — consult dpkg's
-		// own file lists, which exist only on a Debian-family system.
-		Err(_) => dpkg_lists_contain(path),
+		// dpkg-query is missing, not executable, or denied: this is not a
+		// host dpkg controls, so report `false` rather than consulting a
+		// directory we do not own. The previous fallback that read the
+		// `.list` files directly was the surface that prompted #1360: any
+		// ownership/mode assumption about `/var/lib/dpkg/info` is a
+		// privilege-confusion hypothesis, not a fact.
+		Err(_) => false,
 	}
-}
-
-/// Fallback ownership check: scan dpkg's installed-file manifests
-/// (`/var/lib/dpkg/info/*.list`) for an exact line matching `path`.
-#[cfg(target_os = "linux")]
-fn dpkg_lists_contain(path: &Path) -> bool {
-	dpkg_lists_contain_in(Path::new("/var/lib/dpkg/info"), path)
-}
-
-/// Core of [`dpkg_lists_contain`], parameterised on the info directory so it can
-/// be tested against a fixture without a real dpkg database. Returns `false`
-/// when the directory is absent (not a Debian host).
-#[cfg(target_os = "linux")]
-fn dpkg_lists_contain_in(info_dir: &Path, path: &Path) -> bool {
-	let Ok(entries) = std::fs::read_dir(info_dir) else {
-		return false; // no dpkg database → not Debian-managed
-	};
-	let needle = path.to_string_lossy();
-	for entry in entries.flatten() {
-		let p = entry.path();
-		if p.extension().and_then(|e| e.to_str()) != Some("list") {
-			continue;
-		}
-		if let Ok(contents) = std::fs::read_to_string(&p) {
-			if contents.lines().any(|line| line == needle) {
-				return true;
-			}
-		}
-	}
-	false
 }
 
 /// Non-Linux platforms have no supported package-manager-managed install yet.
@@ -113,35 +95,28 @@ mod tests {
 		assert_eq!(managing_package_manager(), None);
 	}
 
+	/// #1360 (L10): `dpkg-query` is the only source of truth for whether apt
+	/// owns the running binary. The previous implementation fell back to
+	/// reading `/var/lib/dpkg/info/*.list` directly when `dpkg-query` could
+	/// not be spawned — a directory owned by another package, with no mode
+	/// or ownership guarantees. The fix is fail-closed: when `dpkg-query` is
+	/// unavailable, report `false` and skip the scan entirely. We exercise
+	/// the `Err` arm by removing `dpkg-query` from PATH via
+	/// [`temp_env::with_var`]; `Command::new` resolves through PATH, so an
+	/// empty / nonexistent path guarantees the spawn fails.
 	#[cfg(target_os = "linux")]
 	#[test]
-	fn dpkg_lists_fallback_matches_an_owned_path() {
-		// Simulate dpkg's info dir: a `.list` file naming the binary's path means
-		// the file is package-managed and self-update must refuse.
-		let dir = tempfile::tempdir().unwrap();
-		let owned = Path::new("/usr/bin/podup");
-		std::fs::write(
-			dir.path().join("podup.list"),
-			"/.\n/usr/bin\n/usr/bin/podup\n",
-		)
-		.unwrap();
-		// A non-`.list` file with the same name must be ignored.
-		std::fs::write(dir.path().join("other.md5sums"), "/usr/bin/podup\n").unwrap();
-
-		assert!(dpkg_lists_contain_in(dir.path(), owned));
-		assert!(!dpkg_lists_contain_in(
-			dir.path(),
-			Path::new("/usr/bin/somethingelse")
-		));
-	}
-
-	#[cfg(target_os = "linux")]
-	#[test]
-	fn dpkg_lists_fallback_is_false_without_a_database() {
-		// No dpkg info directory (e.g. Fedora, cargo-install): genuinely not
-		// Debian-managed, so the fallback reports unowned and update proceeds.
-		let dir = tempfile::tempdir().unwrap();
-		let absent = dir.path().join("no-such-info-dir");
-		assert!(!dpkg_lists_contain_in(&absent, Path::new("/usr/bin/podup")));
+	fn dpkg_owns_returns_false_when_dpkg_query_is_missing_from_path() {
+		// /nonexistent is a directory that does not exist, so PATH cannot
+		// resolve `dpkg-query` from it. The previous code would have
+		// consulted the real `/var/lib/dpkg/info` directory (if present)
+		// and might have answered `true` for a target whose path happened
+		// to match. We pin the new behaviour: with `dpkg-query` unavailable,
+		// the answer is unconditionally `false`.
+		let empty_path = std::path::PathBuf::from("/nonexistent-empty-path-for-dpkg-test");
+		let fake_target = Path::new("/usr/bin/podup");
+		temp_env::with_var("PATH", Some(empty_path.display().to_string()), || {
+			assert!(!dpkg_owns(fake_target));
+		});
 	}
 }


### PR DESCRIPTION
I tightened install path integrity across the shell and Rust update paths. The change preserves target modes from private staging, unifies Unix and Windows recovery on `target.old`, cleans podup-created native secrets during `down`, and makes the `dpkg-query` ownership path skip manifest scanning when the helper is unavailable.

Closes #1360

Validation: `cargo build --locked`, `cargo test --locked`, `shellcheck install.sh`. PSScriptAnalyzer was not run because `pwsh` is unavailable in this environment. The Podman 5 and 6 lane remains covered by CI.