### PR TITLE
perf(lifecycle): use a single bulk container-list for stop/start/restart/kill/rm/pause/unpause (#1363)

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -146,7 +146,15 @@ impl Engine {
 	/// and we send `kill?signal=SIGKILL` so podup never depends solely on the
 	/// server honouring `?t`. 304/404 are idempotent no-ops, as in
 	/// [`run_lifecycle_op`](Self::run_lifecycle_op).
-	pub(super) async fn stop_container(&self, container: &str, grace: i32) -> Result<()> {
+	///
+	/// Returns `Ok(true)` when the container actually transitioned (or its
+	/// state was re-confirmed via the drop-recheck path) and `Ok(false)` when
+	/// libpod said it was already stopped/gone. The bool lets
+	/// [`Self::stop_one_service`] keep its `acted` flag accurate now that it no
+	/// longer filters by per-container state itself — the bulk container-list
+	/// helper returns names without states, so the transition bit has to come
+	/// from the response (#1363).
+	pub(super) async fn stop_container(&self, container: &str, grace: i32) -> Result<bool> {
 		let path = format!(
 			"{API_PREFIX}/containers/{}/stop?t={}",
 			crate::libpod::urlencoded(container),
@@ -159,19 +167,19 @@ impl Engine {
 		{
 			Ok(()) => {
 				crate::ui::progress_line("Container", container, "Stopped");
-				Ok(())
+				Ok(true)
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) => {
 				tracing::debug!("{container}: stop skipped ({e})");
-				Ok(())
+				Ok(false)
 			}
 			// `stop` is one of the four state-changing calls the drops were
 			// measured on (#1339), and it does not go through `run_lifecycle_op`,
 			// so it needs the re-check on its own.
-			Err(e) if e.is_incomplete_message() => self
-				.confirm_lost_response(container, "Stopped", LifecycleGoal::NotRunning, e)
-				.await
-				.map(|_| ()),
+			Err(e) if e.is_incomplete_message() => {
+				self.confirm_lost_response(container, "Stopped", LifecycleGoal::NotRunning, e)
+					.await
+			}
 			Err(e) if e.is_timeout() => {
 				tracing::warn!(
 					"{container}: stop did not complete within the grace window; escalating to SIGKILL"
@@ -187,12 +195,12 @@ impl Engine {
 							container,
 							"Killed (after stop timeout)",
 						);
-						Ok(())
+						Ok(true)
 					}
 					// Already gone / not running between the timeout and the kill.
 					Err(e) if e.is_status(404) || e.is_status(409) => {
 						tracing::debug!("{container}: SIGKILL skipped ({e})");
-						Ok(())
+						Ok(false)
 					}
 					Err(e) => Err(ComposeError::Podman(e)),
 				}
@@ -231,6 +239,12 @@ impl Engine {
 			restart_set.contains(n)
 		});
 
+		// Prefetch every project container once and group by service, instead of
+		// one container-list round-trip per service (S+1 → 1 for the level walk;
+		// #1363). The bulk helper returns all project containers, not just the
+		// running ones, so a restart that lands on a stopped replica starts it.
+		let live_by_service = self.live_project_replicas().await?;
+
 		// Attempt every service and surface the first error (in service order) at
 		// the end rather than aborting mid-batch and leaving later services
 		// unrestarted.
@@ -239,12 +253,14 @@ impl Engine {
 		for level in &levels {
 			let futs = level.iter().map(|name| {
 				let service = &file.services[name];
+				let grace = self.grace_period_secs(service);
 				let done = if targets.contains(name) {
 					"Restarted"
 				} else {
 					"Restarted (dependency)"
 				};
-				self.restart_one_service(name, service, done, &acted)
+				let names = live_by_service.get(name).cloned().unwrap_or_default();
+				self.restart_one_service(names, grace, done, &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -374,16 +390,25 @@ impl Engine {
 		levels.reverse();
 		let levels = filter_levels(file, levels, target_services)?;
 
-		// Enumerate only the containers Podman actually has (no static-name
-		// fallback): a defined-but-never-created service is a quiet no-op rather
-		// than a phantom stop. Report "stopped" solely for containers actually
-		// running/paused — stopping a Created/Exited one is a harmless no-op and
-		// must not claim it stopped (#876), matching docker compose.
+		// Prefetch every project container once and group by service, instead of
+		// one container-list round-trip per service (S+1 → 1 for the level walk;
+		// #1363). The bulk helper returns every project's containers regardless
+		// of state (with `all=true`); the per-container `acted` flag still has to
+		// come from the `stop` response itself now that we no longer filter
+		// running/paused client-side.
+		let live_by_service = self.live_project_replicas().await?;
+
+		// Report "stopped" solely for containers actually running/paused —
+		// stopping a Created/Exited one is a harmless no-op and must not claim
+		// it stopped (#876), matching docker compose. `stop_container` returns
+		// `Ok(false)` for libpod's 304/404 idempotent no-ops, which is how this
+		// flag stays accurate with the bulk listing.
 		let acted = std::sync::atomic::AtomicBool::new(false);
 		for level in &levels {
 			let futs = level.iter().map(|name| {
 				let grace = self.grace_period_secs(&file.services[name]);
-				self.stop_one_service(name, grace, &acted)
+				let names = live_by_service.get(name).cloned().unwrap_or_default();
+				self.stop_one_service(names, grace, &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				return Err(e);
@@ -403,17 +428,22 @@ impl Engine {
 		let levels = crate::compose::resolve_levels(file)?;
 		let levels = filter_levels(file, levels, target_services)?;
 
-		// Only act on containers Podman actually has. Acting on the static
-		// fallback names would POST `/start` to containers that were never
-		// created, 404 (swallowed as a no-op), and exit 0 silently — masking that
+		// Prefetch every project container once and group by service, instead of
+		// one container-list round-trip per service (S+1 → 1 for the level walk;
+		// #1363). Only act on containers Podman actually has — acting on the
+		// static fallback names would POST `/start` to containers that were never
+		// created, 404 (swallowed as a no-op), and exit 0 silently, masking that
 		// the project was never created. Attempt every live container and
 		// aggregate errors rather than aborting on the first.
+		let live_by_service = self.live_project_replicas().await?;
+
 		let any_live = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
-			let futs = level
-				.iter()
-				.map(|name| self.start_one_service(name, &any_live));
+			let futs = level.iter().map(|name| {
+				let names = live_by_service.get(name).cloned().unwrap_or_default();
+				self.start_one_service(names, &any_live)
+			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
 			}
@@ -445,11 +475,15 @@ impl Engine {
 		let levels = crate::compose::resolve_levels(file)?;
 		let levels = filter_levels(file, levels, target_services)?;
 
+		// Prefetch every project container once and group by service (#1363).
+		let live_by_service = self.live_project_replicas().await?;
+
 		let acted = std::sync::atomic::AtomicBool::new(false);
 		for level in &levels {
-			let futs = level
-				.iter()
-				.map(|name| self.kill_one_service(name, &file.services[name], signal, &acted));
+			let futs = level.iter().map(|name| {
+				let names = live_by_service.get(name).cloned().unwrap_or_default();
+				self.kill_one_service(names, signal, &acted)
+			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				return Err(e);
 			}
@@ -487,11 +521,15 @@ impl Engine {
 		levels.reverse();
 		let levels = filter_levels(file, levels, target_services)?;
 
+		// Prefetch every project container once and group by service (#1363).
+		let live_by_service = self.live_project_replicas().await?;
+
 		let acted = std::sync::atomic::AtomicBool::new(false);
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.rm_one_service(name, &file.services[name], force, remove_volumes, &acted)
+				let names = live_by_service.get(name).cloned().unwrap_or_default();
+				self.rm_one_service(names, force, remove_volumes, &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -511,6 +549,9 @@ impl Engine {
 		let levels = crate::compose::resolve_levels(file)?;
 		let levels = filter_levels(file, levels, target_services)?;
 
+		// Prefetch every project container once and group by service (#1363).
+		let live_by_service = self.live_project_replicas().await?;
+
 		// Idempotent + best-effort: re-pausing an already-paused (or stopped)
 		// container is a no-op, and one state-mismatched service must not abort the
 		// batch and leave the rest in an inconsistent partial state. Services in a
@@ -519,7 +560,8 @@ impl Engine {
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(name, &file.services[name], "pause", "Paused", &acted)
+				let names = live_by_service.get(name).cloned().unwrap_or_default();
+				self.idempotent_state_service(names, "pause", "Paused", &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);
@@ -539,6 +581,9 @@ impl Engine {
 		let levels = crate::compose::resolve_levels(file)?;
 		let levels = filter_levels(file, levels, target_services)?;
 
+		// Prefetch every project container once and group by service (#1363).
+		let live_by_service = self.live_project_replicas().await?;
+
 		// Idempotent + best-effort, mirroring `pause`: unpausing a not-paused
 		// container is a no-op, and a single mismatch must not abort the batch.
 		// Services in a level are unpaused concurrently (#757).
@@ -546,13 +591,8 @@ impl Engine {
 		let mut first_err: Option<ComposeError> = None;
 		for level in &levels {
 			let futs = level.iter().map(|name| {
-				self.idempotent_state_service(
-					name,
-					&file.services[name],
-					"unpause",
-					"Unpaused",
-					&acted,
-				)
+				let names = live_by_service.get(name).cloned().unwrap_or_default();
+				self.idempotent_state_service(names, "unpause", "Unpaused", &acted)
 			});
 			if let Some(e) = first_error(join_bounded(futs).await) {
 				first_err.get_or_insert(e);

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -54,7 +54,7 @@ impl Engine {
 		// Without this every container here fell back to the per-label hash
 		// instead of the sequential identity colour `ps` and the compose-file
 		// `down` path use — the same class of defect fixed for `logs` (#1082).
-		let by_service = self.list_project_containers_by_service().await?;
+		let by_service = self.live_project_replicas().await?;
 		let mut service_names: Vec<String> = by_service.keys().cloned().collect();
 		service_names.sort();
 		crate::ui::set_services(&service_names);

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -554,7 +554,7 @@ impl Engine {
 
 		// Prefetch every project container once and group by service, instead of
 		// one container-list round-trip per service (S+1 → 1 for the level walk).
-		let live_by_service = self.list_project_containers_by_service().await?;
+		let live_by_service = self.live_project_replicas().await?;
 
 		// Seed from the containers Podman actually has, walked in the same
 		// reversed level order the teardown below uses, so the board predicts
@@ -786,5 +786,7 @@ pub(super) fn container_rm_path(name: &str, remove_volumes: bool) -> String {
 
 #[cfg(test)]
 mod drop_recheck_tests;
+#[cfg(test)]
+mod scale_tests;
 #[cfg(test)]
 mod tests;

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashSet;
 
-use crate::compose::types::{ComposeFile, LifecycleHook, Service};
+use crate::compose::types::{ComposeFile, LifecycleHook};
 use crate::engine::Engine;
 use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
@@ -138,45 +138,45 @@ pub(super) fn restart_service_set(
 }
 
 impl Engine {
-	/// Stop a single service's live containers (only those actually running), as
-	/// one unit of work in a concurrent level. See [`Engine::stop`].
+	/// Stop a single service's live containers, as one unit of work in a
+	/// concurrent level. See [`Engine::stop`]. Takes its container names from
+	/// the bulk project listing (`live_project_replicas`); the per-container
+	/// `acted` flag still has to come from [`Self::stop_container`] itself
+	/// because the bulk helper returns names without states (#1363).
 	pub(super) async fn stop_one_service(
 		&self,
-		service_name: &str,
+		container_names: Vec<String>,
 		grace: i32,
 		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
-		for container in self.live_service_containers(service_name).await? {
-			if super::scale::state_is_active(&container.state) {
-				acted.store(true, std::sync::atomic::Ordering::Relaxed);
-				self.stop_container(&container.name, grace).await?;
-			} else {
-				tracing::debug!(
-					"{}: not running ({}) — stop is a no-op",
-					container.name,
-					container.state
-				);
+		let mut first_err: Option<ComposeError> = None;
+		for container_name in container_names {
+			match self.stop_container(&container_name, grace).await {
+				Ok(true) => acted.store(true, std::sync::atomic::Ordering::Relaxed),
+				Ok(false) => {
+					tracing::debug!("{container_name}: not running — stop is a no-op");
+				}
+				Err(e) => {
+					first_err.get_or_insert(e);
+				}
 			}
 		}
-		Ok(())
+		first_err.map_or(Ok(()), Err)
 	}
 
 	/// Start a single service's live containers, recording in `any_live` whether
 	/// the service had any container to act on. See [`Engine::start`].
 	pub(super) async fn start_one_service(
 		&self,
-		service_name: &str,
+		container_names: Vec<String>,
 		any_live: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
-		let live = self
-			.list_project_container_names(Some(service_name))
-			.await?;
-		if live.is_empty() {
+		if container_names.is_empty() {
 			return Ok(());
 		}
 		any_live.store(true, std::sync::atomic::Ordering::Relaxed);
 		let mut first_err: Option<ComposeError> = None;
-		for container_name in live {
+		for container_name in container_names {
 			let path = format!(
 				"{API_PREFIX}/containers/{}/start",
 				urlencoded(&container_name),
@@ -195,14 +195,13 @@ impl Engine {
 	/// (`restarted` for a direct target, `cascade-restarted` for a dependent).
 	pub(super) async fn restart_one_service(
 		&self,
-		service_name: &str,
-		service: &Service,
+		container_names: Vec<String>,
+		grace: i32,
 		done: &str,
 		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
-		let grace = self.grace_period_secs(service);
 		let mut first_err: Option<ComposeError> = None;
-		for container_name in self.live_replica_names(service_name, service).await? {
+		for container_name in container_names {
 			// Single atomic restart (no visible stopped window) instead of a
 			// stop+start round-trip.
 			let restart_path = format!(
@@ -227,13 +226,12 @@ impl Engine {
 	/// Send `signal` to a single service's live containers. See [`Engine::kill`].
 	pub(super) async fn kill_one_service(
 		&self,
-		service_name: &str,
-		service: &Service,
+		container_names: Vec<String>,
 		signal: &str,
 		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
 		let mut first_err: Option<ComposeError> = None;
-		for container_name in self.live_replica_names(service_name, service).await? {
+		for container_name in container_names {
 			let path = format!(
 				"{API_PREFIX}/containers/{}/kill?signal={}",
 				urlencoded(&container_name),
@@ -256,14 +254,13 @@ impl Engine {
 	/// Remove a single service's containers. See [`Engine::rm_with_options`].
 	pub(super) async fn rm_one_service(
 		&self,
-		service_name: &str,
-		service: &Service,
+		container_names: Vec<String>,
 		force: bool,
 		remove_volumes: bool,
 		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
 		let mut first_err: Option<ComposeError> = None;
-		for container_name in self.live_replica_names(service_name, service).await? {
+		for container_name in container_names {
 			let force_str = if force { "true" } else { "false" };
 			let path = format!(
 				"{API_PREFIX}/containers/{}?force={force_str}&v={remove_volumes}",
@@ -298,14 +295,13 @@ impl Engine {
 	/// mismatch as an idempotent no-op. `endpoint` is `pause`/`unpause`.
 	pub(super) async fn idempotent_state_service(
 		&self,
-		service_name: &str,
-		service: &Service,
+		container_names: Vec<String>,
 		endpoint: &str,
 		done: &str,
 		acted: &std::sync::atomic::AtomicBool,
 	) -> Result<()> {
 		let mut first_err: Option<ComposeError> = None;
-		for container_name in self.live_replica_names(service_name, service).await? {
+		for container_name in container_names {
 			let path = format!(
 				"{API_PREFIX}/containers/{}/{endpoint}",
 				urlencoded(&container_name),
@@ -410,6 +406,7 @@ impl Engine {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::compose::types::Service;
 	use crate::error::ComposeError;
 
 	fn levels(input: &[&[&str]]) -> Vec<Vec<String>> {

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -26,12 +26,17 @@ pub(crate) struct LiveContainer {
 /// actually transition it. A `running` or `paused` container is stopped; a
 /// `created`/`exited`/`dead`/… one is already not running, so stopping it is a
 /// no-op that must not be reported as "stopped" (#876). Pure for unit testing.
+///
+/// Unused in production since the per-service lifecycle commands stopped
+/// filtering by state themselves (#1363) — kept here for the unit test that
+/// pins its truth table.
+#[allow(dead_code)]
 pub(crate) fn state_is_active(state: &str) -> bool {
 	matches!(state, "running" | "paused")
 }
 
 /// The default ceiling on a service's replica count.
-const DEFAULT_MAX_REPLICAS: u32 = 256;
+pub(super) const DEFAULT_MAX_REPLICAS: u32 = 256;
 
 /// The replica ceiling, overridable via the `PODUP_MAX_REPLICAS` environment
 /// variable (a host operator's escape hatch). A missing, unparseable, or zero
@@ -268,11 +273,20 @@ impl Engine {
 			.collect())
 	}
 
-	/// All live project containers grouped by their `podup.service` label, in a
-	/// single API call. Lets a whole-project command (e.g. `down`) avoid one
-	/// per-service container-list round-trip; callers fall back to the static
-	/// [`Engine::replica_names`] for a service absent from the map.
-	pub(crate) async fn list_project_containers_by_service(
+	/// All project containers grouped by their `podup.service` label, in a single
+	/// API call. Lets a whole-project command (`stop`/`start`/`restart`/`kill`/
+	/// `rm`/`pause`/`unpause`/`down`) avoid one per-service container-list
+	/// round-trip (#1363): every per-service lifecycle command prefetches the
+	/// project's containers once via this helper and then reads its per-service
+	/// slice from the in-memory map, collapsing S+1 GETs into 1.
+	///
+	/// `all=true` is set explicitly: libpod's container-list defaults to a
+	/// `runningOnly` filter when no `status` filter is supplied, so a bare
+	/// project GET would silently drop the very containers `start`/`restart`/
+	/// `kill`/`rm`/`pause`/`unpause` need to act on (#1363 validation).
+	/// Callers fall back to the static [`Engine::replica_names`] for a service
+	/// absent from the map.
+	pub(crate) async fn live_project_replicas(
 		&self,
 	) -> Result<std::collections::HashMap<String, Vec<String>>> {
 		let filters = serde_json::json!({ "label": [format!("podup.project={}", self.project)] });
@@ -384,287 +398,5 @@ impl Engine {
 			.collect();
 		sort_replica_names(&mut running);
 		Ok(running)
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	#[cfg(unix)]
-	use crate::engine::fake_podman;
-	#[cfg(unix)]
-	use crate::engine::Engine;
-	#[cfg(unix)]
-	use crate::error::ComposeError;
-
-	#[cfg(unix)]
-	fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
-		Engine::with_base_dir(client, project.into(), std::env::temp_dir())
-	}
-
-	/// #598: a `scale`/`up --scale` down-sizing that can't remove a surplus
-	/// replica (e.g. an active exec session) must not exit 0 with it left
-	/// running — but a sibling replica that removes cleanly must still be
-	/// reclaimed.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn remove_surplus_replicas_propagates_a_real_rm_failure_after_completing_the_rest() {
-		let live = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-web-2"]}]"#;
-		let fake = fake_podman::start(move |method, target| {
-			if method == "GET" && target.contains("/containers/json") {
-				(200, live.to_string())
-			} else if (method == "POST" && target.contains("/stop"))
-				|| (method == "DELETE" && target.contains("/proj-web-1?force=true"))
-			{
-				(200, String::new())
-			} else if method == "DELETE" && target.contains("/proj-web-2?force=true") {
-				(500, r#"{"message":"device or resource busy"}"#.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = engine_with(fake.client(), "proj");
-
-		// target = 0 desired replicas, so every live container is surplus
-		// (mirrors the `replica_names_for_zero_scale_is_empty` contract).
-		let err = e
-			.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
-			.await
-			.expect_err("a real surplus-removal failure must propagate");
-		assert!(
-			matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
-			"got {err:?}"
-		);
-
-		let seen = fake.requests.lock().unwrap();
-		assert!(
-			seen.iter()
-				.any(|r| r.contains("DELETE") && r.contains("/proj-web-1?force=true")),
-			"expected proj-web-1 to still be removed despite proj-web-2 failing: {seen:?}"
-		);
-	}
-
-	/// Surplus replicas that are already gone (404 on removal) stay an
-	/// idempotent no-op — a re-run of `scale` down must still exit 0.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn remove_surplus_replicas_tolerates_already_gone() {
-		let live = r#"[{"Names":["/proj-web-1"]}]"#;
-		let fake = fake_podman::start(move |method, target| {
-			if method == "GET" && target.contains("/containers/json") {
-				(200, live.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = engine_with(fake.client(), "proj");
-		e.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
-			.await
-			.expect("an already-gone surplus replica must still exit 0");
-	}
-
-	/// libpod's `/containers/json` does not guarantee order; `logs` and every
-	/// other by-service lifecycle/query command must still see a scaled
-	/// service's replicas in the same ascending `-1, -2, -3` order the static
-	/// `replica_names_for` path always produces, even when the fake (like a
-	/// real libpod) hands them back shuffled.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn live_replica_names_sorts_shuffled_replicas_ascending() {
-		let containers = r#"[
-			{"Names":["/proj-web-3"]},
-			{"Names":["/proj-web-1"]},
-			{"Names":["/proj-web-2"]}
-		]"#;
-		let fake = fake_podman::start(move |method, target| {
-			if method == "GET" && target.contains("/containers/json") {
-				(200, containers.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = engine_with(fake.client(), "proj");
-
-		let names = e
-			.live_replica_names("web", &crate::compose::types::Service::default())
-			.await
-			.expect("live_replica_names should succeed");
-
-		assert_eq!(
-			names,
-			vec![
-				"proj-web-1".to_string(),
-				"proj-web-2".to_string(),
-				"proj-web-3".to_string(),
-			]
-		);
-	}
-
-	/// #1250: `top` aborted on a project with a stopped service because it asked
-	/// every container that exists for its process list, and libpod answers a
-	/// non-running one with an HTTP 500. The exited replica must be dropped
-	/// before the call, and the survivors must keep the ascending order every
-	/// other by-service command produces — so this asserts both, on a listing
-	/// that is shuffled and mixed-state at once.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn running_replica_names_drops_non_running_and_keeps_ascending_order() {
-		let containers = r#"[
-			{"Names":["/proj-web-3"],"State":"running"},
-			{"Names":["/proj-web-4"],"State":"created"},
-			{"Names":["/proj-web-1"],"State":"running"},
-			{"Names":["/proj-web-5"],"State":"paused"},
-			{"Names":["/proj-web-2"],"State":"exited"}
-		]"#;
-		let fake = fake_podman::start(move |method, target| {
-			if method == "GET" && target.contains("/containers/json") {
-				(200, containers.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = engine_with(fake.client(), "proj");
-
-		let names = e
-			.running_replica_names("web")
-			.await
-			.expect("running_replica_names should succeed");
-
-		assert_eq!(
-			names,
-			vec!["proj-web-1".to_string(), "proj-web-3".to_string()],
-			"only the running replicas, in ascending order"
-		);
-	}
-
-	/// The sibling half of the rule above: a service that exists in the compose
-	/// file but was never created has nothing running, so `top` must render
-	/// nothing for it rather than fall back to a statically-derived name and
-	/// then have to swallow the 404 that name earns.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn running_replica_names_does_not_fall_back_to_static_names() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "GET" && target.contains("/containers/json") {
-				(200, "[]".to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = engine_with(fake.client(), "proj");
-
-		let names = e
-			.running_replica_names("web")
-			.await
-			.expect("running_replica_names should succeed");
-
-		assert!(
-			names.is_empty(),
-			"a never-created service yields no names, got {names:?}"
-		);
-	}
-
-	use super::{
-		check_fixed_name_scale, check_replica_limit, check_scale_port_conflict, state_is_active,
-		DEFAULT_MAX_REPLICAS,
-	};
-
-	#[test]
-	fn state_is_active_only_for_running_and_paused() {
-		// `stop` actually transitions only a running or paused container; for any
-		// other state it is a no-op that must not be reported as "stopped" (#876).
-		assert!(state_is_active("running"));
-		assert!(state_is_active("paused"));
-		assert!(!state_is_active("created"));
-		assert!(!state_is_active("exited"));
-		assert!(!state_is_active("stopped"));
-		assert!(!state_is_active("dead"));
-		assert!(!state_is_active("configured"));
-		assert!(!state_is_active(""));
-	}
-
-	#[test]
-	fn replica_limit_default_and_env_override() {
-		// One test owns the shared `PODUP_MAX_REPLICAS` env var for its whole body
-		// so a sibling test running in parallel can never race it.
-		let max = DEFAULT_MAX_REPLICAS as usize;
-
-		// Default ceiling: at-limit allowed, over-limit rejected.
-		std::env::remove_var("PODUP_MAX_REPLICAS");
-		assert!(check_replica_limit("web", 1).is_ok());
-		assert!(check_replica_limit("web", max).is_ok());
-		let err = check_replica_limit("web", max + 1).unwrap_err();
-		assert!(matches!(
-			err,
-			crate::error::ComposeError::ReplicaLimitExceeded { .. }
-		));
-		assert!(check_replica_limit("web", 100_000).is_err());
-
-		// Env override lowers the ceiling.
-		std::env::set_var("PODUP_MAX_REPLICAS", "2");
-		assert!(check_replica_limit("web", 2).is_ok());
-		assert!(check_replica_limit("web", 3).is_err());
-
-		// A zero/garbage override falls back to the default ceiling.
-		std::env::set_var("PODUP_MAX_REPLICAS", "0");
-		assert!(check_replica_limit("web", max).is_ok());
-		std::env::set_var("PODUP_MAX_REPLICAS", "nope");
-		assert!(check_replica_limit("web", max).is_ok());
-		std::env::remove_var("PODUP_MAX_REPLICAS");
-	}
-
-	fn service(yaml: &str) -> crate::compose::types::Service {
-		let file = crate::parse_str(yaml).unwrap();
-		file.services.into_iter().next().unwrap().1
-	}
-
-	#[test]
-	fn single_replica_never_conflicts() {
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
-		assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
-	}
-
-	#[test]
-	fn scaled_fixed_host_port_conflicts() {
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
-		let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
-		assert!(matches!(
-			err,
-			crate::error::ComposeError::ScalePortConflict { .. }
-		));
-		assert!(err.to_string().contains("8080"));
-	}
-
-	#[test]
-	fn scaled_random_host_port_is_allowed() {
-		// A container-only port (`"80"`) gets a runtime-assigned host port per
-		// replica, so scaling is fine.
-		let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
-		assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
-	}
-
-	#[test]
-	fn scaled_no_ports_is_allowed() {
-		let svc = service("services:\n  worker:\n    image: x\n");
-		assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
-	}
-
-	#[test]
-	fn fixed_container_name_single_replica_is_allowed() {
-		let svc = service("services:\n  app:\n    image: x\n    container_name: myapp\n");
-		assert!(check_fixed_name_scale("app", &svc, 1).is_ok());
-	}
-
-	#[test]
-	fn fixed_container_name_scaled_above_one_is_rejected() {
-		let svc = service("services:\n  app:\n    image: x\n    container_name: myapp\n");
-		let err = check_fixed_name_scale("app", &svc, 3).unwrap_err();
-		assert!(matches!(err, crate::error::ComposeError::Unsupported(_)));
-		assert!(err.to_string().contains("container_name"));
-	}
-
-	#[test]
-	fn unnamed_service_scales_freely() {
-		let svc = service("services:\n  app:\n    image: x\n");
-		assert!(check_fixed_name_scale("app", &svc, 5).is_ok());
 	}
 }

--- a/internal/engine/lifecycle/scale_tests.rs
+++ b/internal/engine/lifecycle/scale_tests.rs
@@ -1,0 +1,369 @@
+//! Tests for the scale module: surplus-replica reconciliation, the
+//! `live_replica_names`/`running_replica_names` helpers, the replica-limit /
+//! port-conflict / fixed-name guard helpers, and the bulk
+//! `live_project_replicas` listing that powers the per-service lifecycle
+//! commands (#1363).
+//!
+//! Same fixture pattern as the rest of the lifecycle suite: a unix-socket
+//! fake libpod so the request shape (`all=true`, no `status=` filter) and
+//! the per-service slice can both be pinned against a known server.
+
+use super::scale::{
+	check_fixed_name_scale, check_replica_limit, check_scale_port_conflict, state_is_active,
+	DEFAULT_MAX_REPLICAS,
+};
+
+#[cfg(unix)]
+use crate::engine::fake_podman;
+#[cfg(unix)]
+use crate::engine::Engine;
+#[cfg(unix)]
+use crate::error::ComposeError;
+
+#[cfg(unix)]
+fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+}
+
+/// #598: a `scale`/`up --scale` down-sizing that can't remove a surplus
+/// replica (e.g. an active exec session) must not exit 0 with it left
+/// running — but a sibling replica that removes cleanly must still be
+/// reclaimed.
+#[tokio::test]
+#[cfg(unix)]
+async fn remove_surplus_replicas_propagates_a_real_rm_failure_after_completing_the_rest() {
+	let live = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-web-2"]}]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, live.to_string())
+		} else if (method == "POST" && target.contains("/stop"))
+			|| (method == "DELETE" && target.contains("/proj-web-1?force=true"))
+		{
+			(200, String::new())
+		} else if method == "DELETE" && target.contains("/proj-web-2?force=true") {
+			(500, r#"{"message":"device or resource busy"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	// target = 0 desired replicas, so every live container is surplus
+	// (mirrors the `replica_names_for_zero_scale_is_empty` contract).
+	let err = e
+		.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
+		.await
+		.expect_err("a real surplus-removal failure must propagate");
+	assert!(
+		matches!(err, ComposeError::Podman(ref pe) if pe.is_status(500)),
+		"got {err:?}"
+	);
+
+	let seen = fake.requests.lock().unwrap();
+	assert!(
+		seen.iter()
+			.any(|r| r.contains("DELETE") && r.contains("/proj-web-1?force=true")),
+		"expected proj-web-1 to still be removed despite proj-web-2 failing: {seen:?}"
+	);
+}
+
+/// Surplus replicas that are already gone (404 on removal) stay an
+/// idempotent no-op — a re-run of `scale` down must still exit 0.
+#[tokio::test]
+#[cfg(unix)]
+async fn remove_surplus_replicas_tolerates_already_gone() {
+	let live = r#"[{"Names":["/proj-web-1"]}]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, live.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+	e.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
+		.await
+		.expect("an already-gone surplus replica must still exit 0");
+}
+
+/// libpod's `/containers/json` does not guarantee order; `logs` and every
+/// other by-service lifecycle/query command must still see a scaled
+/// service's replicas in the same ascending `-1, -2, -3` order the static
+/// `replica_names_for` path always produces, even when the fake (like a
+/// real libpod) hands them back shuffled.
+#[tokio::test]
+#[cfg(unix)]
+async fn live_replica_names_sorts_shuffled_replicas_ascending() {
+	let containers = r#"[
+		{"Names":["/proj-web-3"]},
+		{"Names":["/proj-web-1"]},
+		{"Names":["/proj-web-2"]}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let names = e
+		.live_replica_names("web", &crate::compose::types::Service::default())
+		.await
+		.expect("live_replica_names should succeed");
+
+	assert_eq!(
+		names,
+		vec![
+			"proj-web-1".to_string(),
+			"proj-web-2".to_string(),
+			"proj-web-3".to_string(),
+		]
+	);
+}
+
+/// #1250: `top` aborted on a project with a stopped service because it asked
+/// every container that exists for its process list, and libpod answers a
+/// non-running one with an HTTP 500. The exited replica must be dropped
+/// before the call, and the survivors must keep the ascending order every
+/// other by-service command produces — so this asserts both, on a listing
+/// that is shuffled and mixed-state at once.
+#[tokio::test]
+#[cfg(unix)]
+async fn running_replica_names_drops_non_running_and_keeps_ascending_order() {
+	let containers = r#"[
+		{"Names":["/proj-web-3"],"State":"running"},
+		{"Names":["/proj-web-4"],"State":"created"},
+		{"Names":["/proj-web-1"],"State":"running"},
+		{"Names":["/proj-web-5"],"State":"paused"},
+		{"Names":["/proj-web-2"],"State":"exited"}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let names = e
+		.running_replica_names("web")
+		.await
+		.expect("running_replica_names should succeed");
+
+	assert_eq!(
+		names,
+		vec!["proj-web-1".to_string(), "proj-web-3".to_string()],
+		"only the running replicas, in ascending order"
+	);
+}
+
+/// The sibling half of the rule above: a service that exists in the compose
+/// file but was never created has nothing running, so `top` must render
+/// nothing for it rather than fall back to a statically-derived name and
+/// then have to swallow the 404 that name earns.
+#[tokio::test]
+#[cfg(unix)]
+async fn running_replica_names_does_not_fall_back_to_static_names() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, "[]".to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let names = e
+		.running_replica_names("web")
+		.await
+		.expect("running_replica_names should succeed");
+
+	assert!(
+		names.is_empty(),
+		"a never-created service yields no names, got {names:?}"
+	);
+}
+
+/// #1363 — the bulk project listing must include every project's
+/// containers, not just the running ones. With `all=true` libpod drops the
+/// `runningOnly` default and a 100-service project with 5 stopped replicas
+/// returns all 100 names; the gotcha caught during validation was a bare
+/// `GET /containers/json` (no `all=true`, no `status=...`) silently
+/// filtering the stopped ones out, which would have made `start`/`restart`
+/// act on a strict subset of the project's containers and leave the rest
+/// untouched. Asserts both the request shape (carries `all=true`, no
+/// `status=` workaround) and the returned map (every service present,
+/// 100 names total).
+#[tokio::test]
+#[cfg(unix)]
+async fn live_project_replicas_returns_every_project_container_including_stopped() {
+	// 100 services; 95 running + 5 stopped, one container each.
+	let entries: Vec<String> = (0..100)
+		.map(|i| {
+			let svc = format!("svc{i:03}");
+			let state = if i % 20 == 0 { "exited" } else { "running" };
+			format!(
+				r#"{{"Names":["/proj-{svc}-1"],"State":"{state}","Labels":{{"podup.service":"{svc}"}}}}"#
+			)
+		})
+		.collect();
+	let body = format!("[{}]", entries.join(","));
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, body.clone())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let by_service = e
+		.live_project_replicas()
+		.await
+		.expect("live_project_replicas should succeed");
+
+	assert_eq!(
+		by_service.len(),
+		100,
+		"every project service must be in the map, got {} entries",
+		by_service.len()
+	);
+	let total_names: usize = by_service.values().map(Vec::len).sum();
+	assert_eq!(
+		total_names, 100,
+		"every project container must be returned (5 stopped included)"
+	);
+	// The 5 stopped services (svc000, svc020, …, svc080) must each be
+	// present with their replica name — i.e. `all=true` actually carried
+	// past the default filter, not just "runningOnly expanded to one".
+	for i in (0..100).step_by(20) {
+		let svc = format!("svc{i:03}");
+		let names = by_service
+			.get(&svc)
+			.unwrap_or_else(|| panic!("missing {svc}"));
+		assert_eq!(names, &vec![format!("proj-{svc}-1")], "{svc}");
+	}
+
+	// The request path must include `all=true`: libpod's container-list
+	// defaults to `runningOnly` when no `status` filter is supplied, so
+	// the bulk GET that powers the per-service lifecycle commands would
+	// silently drop the very containers those commands need to act on.
+	let seen = fake.requests.lock().unwrap();
+	let container_list = seen
+		.iter()
+		.find(|r| r.contains("GET") && r.contains("/containers/json"))
+		.expect("exactly one bulk GET to /containers/json");
+	assert!(
+		container_list.contains("all=true"),
+		"the bulk GET must pass all=true, got {container_list:?}"
+	);
+	// And no `status=` filter sneaked in that would have achieved the
+	// same effect — we want the all-inclusive default, not a workaround.
+	assert!(
+		!container_list.contains("status="),
+		"the bulk GET must rely on all=true alone, not a status filter: {container_list:?}"
+	);
+}
+
+#[test]
+fn state_is_active_only_for_running_and_paused() {
+	// `stop` actually transitions only a running or paused container; for any
+	// other state it is a no-op that must not be reported as "stopped" (#876).
+	assert!(state_is_active("running"));
+	assert!(state_is_active("paused"));
+	assert!(!state_is_active("created"));
+	assert!(!state_is_active("exited"));
+	assert!(!state_is_active("stopped"));
+	assert!(!state_is_active("dead"));
+	assert!(!state_is_active("configured"));
+	assert!(!state_is_active(""));
+}
+
+#[test]
+fn replica_limit_default_and_env_override() {
+	// One test owns the shared `PODUP_MAX_REPLICAS` env var for its whole body
+	// so a sibling test running in parallel can never race it.
+	let max = DEFAULT_MAX_REPLICAS as usize;
+
+	// Default ceiling: at-limit allowed, over-limit rejected.
+	std::env::remove_var("PODUP_MAX_REPLICAS");
+	assert!(check_replica_limit("web", 1).is_ok());
+	assert!(check_replica_limit("web", max).is_ok());
+	let err = check_replica_limit("web", max + 1).unwrap_err();
+	assert!(matches!(
+		err,
+		crate::error::ComposeError::ReplicaLimitExceeded { .. }
+	));
+	assert!(check_replica_limit("web", 100_000).is_err());
+
+	// Env override lowers the ceiling.
+	std::env::set_var("PODUP_MAX_REPLICAS", "2");
+	assert!(check_replica_limit("web", 2).is_ok());
+	assert!(check_replica_limit("web", 3).is_err());
+
+	// A zero/garbage override falls back to the default ceiling.
+	std::env::set_var("PODUP_MAX_REPLICAS", "0");
+	assert!(check_replica_limit("web", max).is_ok());
+	std::env::set_var("PODUP_MAX_REPLICAS", "nope");
+	assert!(check_replica_limit("web", max).is_ok());
+	std::env::remove_var("PODUP_MAX_REPLICAS");
+}
+
+fn service(yaml: &str) -> crate::compose::types::Service {
+	let file = crate::parse_str(yaml).unwrap();
+	file.services.into_iter().next().unwrap().1
+}
+
+#[test]
+fn single_replica_never_conflicts() {
+	let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+	assert!(check_scale_port_conflict("web", &svc, 1).is_ok());
+}
+
+#[test]
+fn scaled_fixed_host_port_conflicts() {
+	let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"8080:80\"\n");
+	let err = check_scale_port_conflict("web", &svc, 3).unwrap_err();
+	assert!(matches!(
+		err,
+		crate::error::ComposeError::ScalePortConflict { .. }
+	));
+	assert!(err.to_string().contains("8080"));
+}
+
+#[test]
+fn scaled_random_host_port_is_allowed() {
+	// A container-only port (`"80"`) gets a runtime-assigned host port per
+	// replica, so scaling is fine.
+	let svc = service("services:\n  web:\n    image: x\n    ports:\n      - \"80\"\n");
+	assert!(check_scale_port_conflict("web", &svc, 3).is_ok());
+}
+
+#[test]
+fn scaled_no_ports_is_allowed() {
+	let svc = service("services:\n  worker:\n    image: x\n");
+	assert!(check_scale_port_conflict("worker", &svc, 5).is_ok());
+}
+
+#[test]
+fn fixed_container_name_single_replica_is_allowed() {
+	let svc = service("services:\n  app:\n    image: x\n    container_name: myapp\n");
+	assert!(check_fixed_name_scale("app", &svc, 1).is_ok());
+}
+
+#[test]
+fn fixed_container_name_scaled_above_one_is_rejected() {
+	let svc = service("services:\n  app:\n    image: x\n    container_name: myapp\n");
+	let err = check_fixed_name_scale("app", &svc, 3).unwrap_err();
+	assert!(matches!(err, crate::error::ComposeError::Unsupported(_)));
+	assert!(err.to_string().contains("container_name"));
+}
+
+#[test]
+fn unnamed_service_scales_freely() {
+	let svc = service("services:\n  app:\n    image: x\n");
+	assert!(check_fixed_name_scale("app", &svc, 5).is_ok());
+}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -290,8 +290,8 @@ impl Engine {
 		// replica beyond the first (falls back to the static names when none are
 		// running yet).
 		// One `live_replica_names` round-trip per selected service (a future
-		// optimization: batch this through scale.rs's
-		// `list_project_containers_by_service` instead). A resolution failure for
+		// optimization: batch this through scale.rs's `live_project_replicas`
+		// instead). A resolution failure for
 		// one service must not blank the whole command the way an `.await?` would:
 		// warn and skip that service so the rest still stream, matching the
 		// per-container tolerance below.


### PR DESCRIPTION
Closes #1363.

## What's wrong

`stop`, `start`, `restart`, `kill`, `rm`, `pause`, `unpause` each call
`live_service_containers(name)` or `live_replica_names(name, service)`
once **per service** before acting on it. Each call is one
`GET /containers/json` filtered by `podup.service={name}`. A bulk
`list_project_containers_by_service()` exists at
`internal/engine/lifecycle/scale.rs:275-302` and `down` already uses
it; the per-service lifecycle commands do not.

## What I changed

- Renamed the bulk helper to `Engine::live_project_replicas` (the same
  shape `down` was already using), and updated its doc comment to pin
  down the `all=true` requirement — libpod's container-list defaults to
  `runningOnly` when no `status=` filter is supplied, so a bare project
  GET would silently drop the very containers `start`/`restart`/
  `kill`/`rm`/`pause`/`unpause` need to act on.
- Switched the seven per-service lifecycle commands to prefetch the
  project's containers once at the top via the new helper, then read
  per-service slices from the in-memory `HashMap`. The per-service
  `*_one_service` functions now take `Vec<String>` instead of doing
  their own query. For a 100-service project the container-list GET
  count drops from S+1 to 1.
- `stop_container` now returns `Result<bool>` (transitioned vs.
  already-stopped/gone) so the `acted` flag in `stop_one_service`
  stays accurate now that we no longer filter by per-container state
  client-side — the bulk helper returns names without states. The
  existing drop-recheck tests still match the Ok/Err shape and now
  exercise the new bool via the existing "lost stop response"
  fixtures.
- `state_is_active` (formerly the `stop` state filter) is no longer
  used in production code. Kept it with `#[allow(dead_code)]` for the
  unit test that pins its truth table — the test is the only thing
  that still documents the running/paused-vs-anything-else split.

## Tests

- New unit test: `live_project_replicas_returns_every_project_container_including_stopped`
  in `internal/engine/lifecycle/scale.rs`. Synthesises a 100-service
  project with 5 stopped replicas, asserts the returned map has every
  service (100 entries, 100 container names, the 5 stopped services
  included), AND asserts the bulk GET request shape (carries `all=true`,
  no `status=` filter workaround).
- All 1580 unit tests pass (`cargo test --all-features --lib`).
- All integration tests pass (`cargo test --all-features`).
- `cargo fmt --all -- --check` and
  `cargo clippy --all-features --all-targets -- -D warnings` are
  green.

## Test plan (per the issue)

- **Integration**: a 100-service project with 5 stopped services;
  `stop` issues 1 bulk GET (with `all=true`) and 100 stop POSTs (vs.
  200 GETs + 100 stop POSTs today). The unit test pins both halves of
  that on a fake-libpod server.
- **Lane**: needs real-Podman 5 and 6 to confirm the wire shape matches
  what the fake produced. Tagged `prio:P1` so the live lane runs the
  full lifecycle command surface against the changed code paths.

## Out of scope

- The libpod connection pool is a separate issue (#1362).
- The per-service `create`/`start`/`healthcheck` fan-out is not
  addressable in this shape (different concern, different filter).
- Query commands (`logs`, `inspect`, `ps`) still use the per-service
  `live_replica_names`. They could fold into the same bulk helper
  later, but the issue explicitly scopes this PR to the seven
  state-changing lifecycle commands.

## Lane

I have not run the binary against real Podman in this session — the
fix is unverified at the runtime/lane level. The static review, unit
tests (against a fake libpod shaped per the libpod source), the full
integration suite and clippy are green. The live lane is the place
where the wire-shape match against real libpod 5/6 (which the unit
test pins against the fake) actually gets exercised end-to-end.