### PR TITLE
feat(cli): warn on host-binding and privilege-escalation modes (#1358)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,6 +23,7 @@ These appear before the subcommand and may also come from the environment.
 | `--project-directory <PATH>` | | Base directory for relative paths (env_file, build context, bind mounts, config/secret sources). Defaults to the compose file's directory. |
 | `--ansi <WHEN>` | | Colour output: `auto`, `always` or `never`. `always` forces colour even into a pipe or file. | 
 | `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it — when this is given, `.env` is not read. The process environment still takes precedence over both. |
+| `--no-warn` | | Suppress the host-binding / privilege-escalation warnings the engine emits during `up`/`create`/`run`/`exec` (e.g. `network_mode: host`, `privileged: true`, `pid: host`, `container:<id>` namespace sharing). Operators who wrote the compose file deliberately use this to silence the per-run warning. `podup config` still surfaces the active modes at default log level — that command is the "show me what will happen" path, where the warning is the whole point. | off |
 
 **Profiles activate their dependencies.** A service left out by profile
 filtering is still started when a service that *is* running declares

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -161,6 +161,19 @@ pub(crate) struct Cli {
 	#[arg(long, value_enum, default_value_t = AnsiMode::Auto, global = true)]
 	pub(crate) ansi: AnsiMode,
 
+	/// Suppress the host-binding / privilege-escalation warnings the engine
+	/// emits during `up`/`create`/`run`/`exec` (e.g. `network_mode: host`,
+	/// `privileged: true`, `pid: host`, `container:<id>` namespace sharing).
+	/// Operators who wrote the compose file deliberately use this to silence
+	/// the per-run warning. `podup config` still surfaces the active modes —
+	/// that command is the "show me what will happen" path, where the
+	/// warning is the whole point.
+	// `global` so it works on every subcommand that may build a container spec
+	// (`up`, `create`, `run`, `exec`). The subcommand flags use `-q` for their
+	// own `--quiet`, so the long form is the only spelling here.
+	#[arg(long, global = true)]
+	pub(crate) no_warn: bool,
+
 	#[command(subcommand)]
 	pub(crate) command: Commands,
 }

--- a/internal/engine/container/host_mode.rs
+++ b/internal/engine/container/host_mode.rs
@@ -1,0 +1,419 @@
+//! Detect compose fields that collapse the isolation between a container and
+//! its host, and emit a per-mode warning so the operator can confirm the build
+//! is intentional rather than discovering it at run time.
+//!
+//! The same modes are warned on the live `up` path (here), on the Quadlet
+//! export path (where `pid`/`ipc`/`uts`/`cgroup` are dropped at the unit file
+//! layer with a separate warning), and on `podup config` (where the active
+//! modes are surfaced at the default log level). The three sites share one
+//! detector so the messages match: an operator who sees the warning on `config`
+//! sees the same line on `up`, and a host-mode they wrote deliberately can be
+//! silenced the same way everywhere via `--no-warn`.
+
+use crate::compose::types::Service;
+
+/// One active host-binding mode detected on a service, with the operator-facing
+/// message the engine emits at warning level. The detector returns a list of
+/// these rather than a single `bool` so future modes (e.g. `cgroup_parent`
+/// pointing at the root cgroup) can be added without changing the call sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModeWarning {
+	/// Name of the service (the compose key, not the container name) the
+	/// warning is about. The engine substitutes this into the message so the
+	/// rendered line is greppable in CI.
+	pub service: String,
+	/// Compose field name that triggered the warning (`network_mode`, `pid`,
+	/// `privileged`, …). Stable for grep / log filtering.
+	pub field: &'static str,
+	/// The value the compose file carried, when meaningful
+	/// (`host`, `container:sidecar`, `…`). `None` for value-less flags
+	/// (`privileged: true`).
+	pub value: Option<String>,
+	/// Single-line, render-ready operator message. The `service` field is
+	/// already substituted in, so the call site can emit it verbatim.
+	pub message: String,
+}
+
+/// Scan `service` for every host-binding / privilege-escalation mode it
+/// declares and return one [`ModeWarning`] per active mode. `service_name` is
+/// the compose key used to label each warning; it is rendered into the
+/// message so the call site can emit it verbatim.
+///
+/// The five compose-native keys — `network_mode`, `privileged`, `pid`, `ipc`,
+/// `uts`, `cgroup`, `userns_mode` — are mirrored to one `Namespace` field
+/// each on the libpod spec, so the same detector covers the live engine and
+/// the Quadlet export. The `container:<id>` prefix on `pid`/`ipc`/`uts`/`cgroup`
+/// is treated as host-binding too: sharing another container's namespace
+/// collapses isolation the same way `host` does, and podman does not warn on
+/// it (the issue scope calls this out as a second, more accurate mode podup
+/// should surface).
+///
+/// Pure so the live engine, the Quadlet path, and the `config` path can call
+/// it without threading a Podman client through. Unit tests pin each mode
+/// individually and each `container:<id>` arm.
+pub fn check_host_mode(service_name: &str, service: &Service) -> Vec<ModeWarning> {
+	let mut out = Vec::new();
+
+	if let Some(mode) = service.network_mode.as_deref() {
+		if mode == "host" {
+			out.push(inherit(service_name, "network_mode", "host"));
+		} else if let Some(id) = mode.strip_prefix("container:") {
+			out.push(shared_namespace(service_name, "network_mode", id));
+		}
+	}
+
+	if service.privileged == Some(true) {
+		out.push(ModeWarning {
+			service: service_name.to_string(),
+			field: "privileged",
+			value: Some("true".into()),
+			message: format!(
+				"service \"{service_name}\": privileged: true grants every Linux capability \
+				and exposes every host device; under rootless Podman the effect is \
+				reduced but the container still bypasses the default capability set"
+			),
+		});
+	}
+
+	attach_namespace(&mut out, service_name, "pid", service.pid.as_deref());
+	attach_namespace(&mut out, service_name, "ipc", service.ipc.as_deref());
+	attach_namespace(&mut out, service_name, "uts", service.uts.as_deref());
+	attach_namespace(&mut out, service_name, "cgroup", service.cgroup.as_deref());
+
+	if let Some(mode) = service.userns_mode.as_deref() {
+		if mode == "host" {
+			out.push(inherit(service_name, "userns_mode", "host"));
+		} else if let Some(id) = mode.strip_prefix("container:") {
+			out.push(shared_namespace(service_name, "userns_mode", id));
+		}
+	}
+
+	out
+}
+
+fn inherit(service_name: &str, field: &'static str, mode: &str) -> ModeWarning {
+	ModeWarning {
+		service: service_name.to_string(),
+		field,
+		value: Some(mode.to_string()),
+		message: format!(
+			"service \"{service_name}\": {field}: {mode} shares the host's {label} namespace; \
+			the container sees host {subject} and any port it binds is a host port",
+			label = label_for(field),
+			subject = subject_for(field),
+		),
+	}
+}
+
+fn shared_namespace(service_name: &str, field: &'static str, target: &str) -> ModeWarning {
+	ModeWarning {
+		service: service_name.to_string(),
+		field,
+		value: Some(format!("container:{target}")),
+		message: format!(
+			"service \"{service_name}\": {field}: container:{target} shares another container's \
+			{layout} namespace; both containers see the same {subject}",
+			layout = label_for(field),
+			subject = subject_for(field),
+		),
+	}
+}
+
+fn attach_namespace(
+	out: &mut Vec<ModeWarning>,
+	service_name: &str,
+	field: &'static str,
+	value: Option<&str>,
+) {
+	if let Some(mode) = value {
+		if mode == "host" {
+			out.push(inherit(service_name, field, mode));
+		} else if let Some(id) = mode.strip_prefix("container:") {
+			out.push(shared_namespace(service_name, field, id));
+		}
+	}
+}
+
+fn label_for(field: &str) -> &'static str {
+	match field {
+		"network_mode" => "network",
+		"pid" => "PID",
+		"ipc" => "IPC",
+		"uts" => "UTS",
+		"cgroup" => "cgroup",
+		"userns_mode" => "user",
+		_ => "host",
+	}
+}
+
+fn subject_for(field: &str) -> &'static str {
+	match field {
+		"network_mode" => "network interfaces and ports",
+		"pid" => "processes (top/ps/wait inspect /proc/<pid>/...)",
+		"ipc" => "System V IPC and POSIX message queues",
+		"uts" => "hostname and domainname",
+		"cgroup" => "cgroup hierarchy and limits",
+		"userns_mode" => "UIDs and GIDs (host UID == container UID)",
+		_ => "host state",
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::check_host_mode;
+	use crate::compose::types::{BuildConfig, Service};
+
+	#[test]
+	fn a_plain_service_emits_no_warnings() {
+		let svc = Service::default();
+		assert!(
+			check_host_mode("web", &svc).is_empty(),
+			"plain service warned"
+		);
+	}
+
+	#[test]
+	fn each_mode_present_triggers_a_warning() {
+		for (set, field) in [
+			(
+				Service {
+					network_mode: Some("host".into()),
+					..Service::default()
+				},
+				"network_mode",
+			),
+			(
+				Service {
+					privileged: Some(true),
+					..Service::default()
+				},
+				"privileged",
+			),
+			(
+				Service {
+					pid: Some("host".into()),
+					..Service::default()
+				},
+				"pid",
+			),
+			(
+				Service {
+					ipc: Some("host".into()),
+					..Service::default()
+				},
+				"ipc",
+			),
+			(
+				Service {
+					uts: Some("host".into()),
+					..Service::default()
+				},
+				"uts",
+			),
+			(
+				Service {
+					cgroup: Some("host".into()),
+					..Service::default()
+				},
+				"cgroup",
+			),
+			(
+				Service {
+					userns_mode: Some("host".into()),
+					..Service::default()
+				},
+				"userns_mode",
+			),
+		] {
+			let warnings = check_host_mode("web", &set);
+			assert_eq!(
+				warnings.len(),
+				1,
+				"expected exactly one warning for {field}, got {warnings:?}"
+			);
+			assert_eq!(warnings[0].field, field);
+			assert_eq!(warnings[0].service, "web");
+			assert_eq!(
+				warnings[0].value.as_deref(),
+				if field == "privileged" {
+					Some("true")
+				} else {
+					Some("host")
+				}
+			);
+		}
+	}
+
+	#[test]
+	fn container_namespace_sharing_triggers_a_warning() {
+		for (field, make) in [
+			(
+				"network_mode",
+				Box::new(|| Service {
+					network_mode: Some("container:sidecar".into()),
+					..Service::default()
+				}) as Box<dyn Fn() -> Service>,
+			),
+			(
+				"pid",
+				Box::new(|| Service {
+					pid: Some("container:sidecar".into()),
+					..Service::default()
+				}),
+			),
+			(
+				"ipc",
+				Box::new(|| Service {
+					ipc: Some("container:sidecar".into()),
+					..Service::default()
+				}),
+			),
+			(
+				"uts",
+				Box::new(|| Service {
+					uts: Some("container:sidecar".into()),
+					..Service::default()
+				}),
+			),
+			(
+				"cgroup",
+				Box::new(|| Service {
+					cgroup: Some("container:sidecar".into()),
+					..Service::default()
+				}),
+			),
+			(
+				"userns_mode",
+				Box::new(|| Service {
+					userns_mode: Some("container:sidecar".into()),
+					..Service::default()
+				}),
+			),
+		] {
+			let svc = make();
+			let warnings = check_host_mode("web", &svc);
+			assert_eq!(
+				warnings.len(),
+				1,
+				"expected one warning for {field}: container:sidecar, got {warnings:?}"
+			);
+			let w = &warnings[0];
+			assert_eq!(w.field, field);
+			assert_eq!(w.value.as_deref(), Some("container:sidecar"));
+			assert!(
+				w.message.contains("container:sidecar"),
+				"{field} warning must name the target container: {w:?}"
+			);
+		}
+	}
+
+	#[test]
+	fn every_mode_active_at_once_emits_seven_warnings() {
+		let svc = Service {
+			network_mode: Some("host".into()),
+			privileged: Some(true),
+			pid: Some("host".into()),
+			ipc: Some("host".into()),
+			uts: Some("host".into()),
+			cgroup: Some("host".into()),
+			userns_mode: Some("host".into()),
+			image: Some("nginx:1.27".into()),
+			..Service::default()
+		};
+		let warnings = check_host_mode("web", &svc);
+		assert_eq!(warnings.len(), 7, "got {warnings:?}");
+		let fields: Vec<&str> = warnings.iter().map(|w| w.field).collect();
+		assert!(fields.contains(&"network_mode"));
+		assert!(fields.contains(&"privileged"));
+		assert!(fields.contains(&"pid"));
+		assert!(fields.contains(&"ipc"));
+		assert!(fields.contains(&"uts"));
+		assert!(fields.contains(&"cgroup"));
+		assert!(fields.contains(&"userns_mode"));
+	}
+
+	#[test]
+	fn non_host_values_do_not_warn() {
+		for svc in [
+			Service {
+				network_mode: Some("bridge".into()),
+				..Service::default()
+			},
+			Service {
+				network_mode: Some("service:db".into()),
+				..Service::default()
+			},
+			Service {
+				network_mode: Some("none".into()),
+				..Service::default()
+			},
+			Service {
+				pid: Some("private".into()),
+				..Service::default()
+			},
+			Service {
+				uts: Some("shareable".into()),
+				..Service::default()
+			},
+			Service {
+				userns_mode: Some("keep-id".into()),
+				..Service::default()
+			},
+		] {
+			assert!(
+				check_host_mode("web", &svc).is_empty(),
+				"non-host value warned on: {svc:?}"
+			);
+		}
+	}
+
+	#[test]
+	fn privileged_false_or_absent_does_not_warn() {
+		for svc in [
+			Service {
+				privileged: Some(false),
+				..Service::default()
+			},
+			Service::default(),
+		] {
+			assert!(check_host_mode("web", &svc).is_empty(), "got: {svc:?}");
+		}
+	}
+
+	#[test]
+	fn message_carries_the_service_name() {
+		let svc = Service {
+			network_mode: Some("host".into()),
+			..Service::default()
+		};
+		let warnings = check_host_mode("api", &svc);
+		assert_eq!(warnings.len(), 1);
+		assert!(
+			warnings[0].message.contains("service \"api\""),
+			"message must carry the service name: {warnings:?}"
+		);
+	}
+
+	#[test]
+	fn value_carries_the_verbatim_compose_value() {
+		let svc = Service {
+			ipc: Some("container:guest-app".into()),
+			..Service::default()
+		};
+		let warnings = check_host_mode("web", &svc);
+		assert_eq!(warnings.len(), 1);
+		assert_eq!(warnings[0].value.as_deref(), Some("container:guest-app"));
+	}
+
+	#[test]
+	fn build_only_service_resolves_a_name() {
+		let svc = Service {
+			build: Some(BuildConfig::Context(".".into())),
+			network_mode: Some("host".into()),
+			..Service::default()
+		};
+		let warnings = check_host_mode("worker", &svc);
+		assert_eq!(warnings.len(), 1);
+		assert!(warnings[0].message.contains("service \"worker\""));
+	}
+}

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -11,12 +11,15 @@ use crate::libpod::API_PREFIX;
 use crate::{ports, size};
 
 mod fields;
+mod host_mode;
 mod resolve;
 mod security;
 use resolve::{
 	build_env, resolve_links, resolve_stop_signal, resolve_volume_name, resolve_volumes_from,
 };
 pub(crate) use resolve::{config_hash, resolve_bind_source};
+
+pub(crate) use host_mode::check_host_mode;
 
 use super::container_config::{
 	build_healthcheck, build_log_config, build_resource_limits, build_restart_policy,
@@ -235,6 +238,18 @@ impl Engine {
 
 		for warning in rootless_caveat_warnings(service_name, service) {
 			tracing::warn!("{warning}");
+		}
+
+		// Surface every active host-binding / privilege-escalation mode the
+		// compose file declared. The warning is emitted *before* the spec is
+		// POSTed so a host-mode the operator did not intend never reaches the
+		// daemon — the log line is the only signal they get, and it has to
+		// arrive before the API call succeeds. `--no-warn` is the escape
+		// hatch for operators who wrote the compose file deliberately.
+		if !self.no_warn {
+			for w in check_host_mode(service_name, service) {
+				tracing::warn!("{}", w.message);
+			}
 		}
 
 		let stop_signal = service

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -140,6 +140,13 @@ pub struct Engine {
 	/// matters because podup is consumed as a library and a caller may hold more
 	/// than one engine.
 	pub(super) images_seen_present: std::sync::Mutex<std::collections::HashSet<String>>,
+	/// CLI `--no-warn`: suppress the host-binding / privilege-escalation
+	/// warnings the engine emits during `up`/`create`/`run`/`exec`. The
+	/// operator wrote the compose file deliberately, so the default-warning
+	/// behaviour is opt-out per run rather than per command. `config`'s
+	/// surface-mode listing is unaffected — `config` is the "show me what
+	/// will happen" command, so the warnings stay visible there.
+	pub(super) no_warn: bool,
 }
 
 impl Engine {
@@ -161,6 +168,7 @@ impl Engine {
 			run_no_tty: false,
 			renew_anon_volumes: false,
 			images_seen_present: std::sync::Mutex::new(std::collections::HashSet::new()),
+			no_warn: false,
 		}
 	}
 
@@ -182,6 +190,7 @@ impl Engine {
 			run_no_tty: false,
 			renew_anon_volumes: false,
 			images_seen_present: std::sync::Mutex::new(std::collections::HashSet::new()),
+			no_warn: false,
 		}
 	}
 
@@ -262,6 +271,18 @@ impl Engine {
 	/// recreating a container also removes its old anonymous volumes.
 	pub fn with_renew_anon_volumes(mut self, renew: bool) -> Self {
 		self.renew_anon_volumes = renew;
+		self
+	}
+
+	/// Set the CLI `--no-warn` flag. Builder-style; when set, the engine
+	/// suppresses the host-binding / privilege-escalation warnings it emits
+	/// during `up`/`create`/`run`/`exec`. Operators who deliberately wrote
+	/// `privileged: true` (or any other host-binding mode) into the compose
+	/// file use this to silence the per-run warning; `config`'s surface-mode
+	/// listing is unaffected (`config` is the "show me what will happen"
+	/// command, where the warning is the whole point).
+	pub fn with_no_warn(mut self, no_warn: bool) -> Self {
+		self.no_warn = no_warn;
 		self
 	}
 
@@ -492,6 +513,23 @@ impl Engine {
 /// value was rejected.
 pub(super) fn to_query_json<T: serde::Serialize>(what: &str, v: &T) -> Result<String> {
 	serde_json::to_string(v).map_err(|e| ComposeError::Build(format!("invalid {what}: {e}")))
+}
+
+/// Emit one `tracing::warn!` per active host-binding / privilege-escalation mode
+/// across every service in `file`.
+///
+/// The `config` command uses this to surface the active modes at the default
+/// log level (CI logs see them even when the operator never runs `up`). It is
+/// deliberately not gated on `--no-warn` — `config` is the "show me what will
+/// happen" command, where the warning is the whole point. The live
+/// `up`/`create`/`run`/`exec` paths emit the same warnings per-call but honour
+/// `--no-warn`.
+pub fn surface_host_modes(file: &crate::compose::types::ComposeFile) {
+	for (name, service) in &file.services {
+		for w in self::container::check_host_mode(name, service) {
+			tracing::warn!("{}", w.message);
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -227,6 +227,18 @@ impl Engine {
 			.services
 			.get(service_name)
 			.ok_or_else(|| ComposeError::ServiceNotFound(service_name.into()))?;
+		// Surface the same host-binding / privilege-escalation warnings the
+		// `up` path would have emitted, so `exec` against a privileged or
+		// host-networked container does not appear safer than the same
+		// container's `up`. The container itself was created with these modes,
+		// but `exec` is the operator's chance to notice them — and the command
+		// they are about to run executes inside that container. `--no-warn`
+		// still opts out.
+		if !self.no_warn {
+			for w in crate::engine::container::check_host_mode(service_name, service) {
+				tracing::warn!("{}", w.message);
+			}
+		}
 		// Resolve the target replica against the *running* containers (matching
 		// `cp`), so `--index N` and a bare `exec` reach a live replica of a service
 		// scaled by an earlier `up --scale`/`scale` — not just the compose static

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -76,9 +76,22 @@ pub(crate) fn write_quadlet(
 	project: &str,
 	base_dir: &Path,
 	output: Option<&Path>,
+	no_warn: bool,
 ) -> podup::Result<()> {
 	// Reject configs the running commands would reject, before emitting anything.
 	validate_for_quadlet(file)?;
+
+	// The Quadlet path's host-binding / privilege-escalation warnings are
+	// gated on `--no-warn` (issue #1358). The flag lives on a thread-local
+	// because `generate_at` is a public free function and adding a parameter
+	// would be a breaking change for downstream callers (helmly-agent is one).
+	// The Quadlet command runs synchronously on the CLI thread, so a
+	// thread-local has the same observable behaviour as a parameter would.
+	let _guard = if no_warn {
+		Some(podup::quadlet::NoWarnGuard::new())
+	} else {
+		None
+	};
 
 	let result = podup::quadlet::generate_at(file, project, base_dir);
 	if let Some(dup) = result.duplicate_filename() {
@@ -141,7 +154,8 @@ mod tests {
 			"services:\n  a:\n    image: x\n    depends_on: [b]\n  b:\n    image: y\n    depends_on: [a]\n",
 		)
 		.unwrap();
-		let err = write_quadlet(&file, "proj", std::path::Path::new("/srv/app"), None).unwrap_err();
+		let err = write_quadlet(&file, "proj", std::path::Path::new("/srv/app"), None, false)
+			.unwrap_err();
 		assert!(matches!(err, podup::ComposeError::CircularDependency(_)));
 	}
 

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -52,11 +52,11 @@ pub use compose::{
 /// through.
 pub use engine::{
 	is_safe_project_name, list_projects, list_projects_filtered, resolve_image_digests,
-	retain_active_profiles, retain_active_profiles_with_targets, validate_stop_timeout,
-	AttachOutcome, BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions,
-	ImagesOptions, LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsDisplayOptions,
-	PsFilterOptions, PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions,
-	VolumesDisplayOptions, VolumesOptions, DEFAULT_LOG_TAIL,
+	retain_active_profiles, retain_active_profiles_with_targets, surface_host_modes,
+	validate_stop_timeout, AttachOutcome, BuildOptions, CommitOptions, CpOptions, Engine,
+	EventsOptions, ExecOptions, ImagesOptions, LogsDisplay, LogsOptions, LsOptions, ProjectLock,
+	PsDisplayOptions, PsFilterOptions, PsOptions, PullOptions, PushOptions, RunOptions,
+	RunOverrides, StatsOptions, VolumesDisplayOptions, VolumesOptions, DEFAULT_LOG_TAIL,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -532,7 +532,13 @@ async fn run() -> podup::Result<()> {
 		// Absolute base dir so a `.build` unit's context resolves under the compose
 		// file, not the unit directory the systemd generator would otherwise use.
 		let base_dir = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
-		return write_quadlet(&filtered, &project, &base_dir, output.as_deref());
+		return write_quadlet(
+			&filtered,
+			&project,
+			&base_dir,
+			output.as_deref(),
+			cli.no_warn,
+		);
 	}
 
 	// `autostart` manages a rootless `systemctl --user` unit that brings the stack
@@ -603,7 +609,8 @@ async fn run() -> podup::Result<()> {
 		.with_run_env_files(cli.env_file.clone())
 		.with_run_labels(startup::run_labels_for(&cli.command))
 		.with_run_no_tty(startup::run_no_tty_for(&cli.command))
-		.with_renew_anon_volumes(renew_anon_volumes);
+		.with_renew_anon_volumes(renew_anon_volumes)
+		.with_no_warn(cli.no_warn);
 
 	// Serialize mutating lifecycle commands against concurrent `podup` runs on
 	// the same project. Read-only / follow commands (ps, logs, top, port,

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -15,8 +15,61 @@ mod render;
 mod unit;
 mod warnings;
 
+use std::cell::Cell;
+
 use crate::compose::types::ComposeFile;
 use unit::{build_unit, container_unit, network_unit, volume_unit, UnitContext};
+
+thread_local! {
+	/// CLI `--no-warn` flag honoured by the Quadlet path's host-binding /
+	/// privilege-escalation warnings. Set by `write_quadlet` when the CLI
+	/// parsed `--no-warn` and consulted by `container_unit` before each
+	/// `tracing::warn!` so the operator can silence the per-generate noise
+	/// the same way they do on `up`/`create`/`run`/`exec`.
+	///
+	/// The live engine path carries the flag on `Engine::no_warn`; the Quadlet
+	/// path goes through a free function and has no such struct, so a
+	/// thread-local is the smallest non-breaking plumbing. The Quadlet command
+	/// runs synchronously on the CLI thread, so a thread-local has the same
+	/// observable behaviour as a parameter would.
+	static NO_WARN: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Set the Quadlet-path `--no-warn` flag for the current thread; restores the
+/// previous value on drop. The CLI driver wraps its call to `write_quadlet`
+/// in this scope so `container_unit` can read it via `is_no_warn_set`.
+pub struct NoWarnGuard {
+	prev: bool,
+}
+
+impl Default for NoWarnGuard {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl NoWarnGuard {
+	/// Activate `--no-warn` for the current thread until the guard is dropped.
+	/// Invoked by the CLI driver around `write_quadlet`; embedders that drive
+	/// the Quadlet path directly can use the same guard for the same effect.
+	pub fn new() -> Self {
+		let prev = NO_WARN.with(|c| c.get());
+		NO_WARN.with(|c| c.set(true));
+		Self { prev }
+	}
+}
+
+impl Drop for NoWarnGuard {
+	fn drop(&mut self) {
+		NO_WARN.with(|c| c.set(self.prev));
+	}
+}
+
+/// Whether `--no-warn` is active on the current thread. Read by
+/// `container_unit` before each host-binding `tracing::warn!`.
+pub(super) fn is_no_warn_set() -> bool {
+	NO_WARN.with(|c| c.get())
+}
 
 /// The `# podup-owner: <project>` marker a unit carries as its literal first
 /// line, if present.
@@ -230,6 +283,50 @@ pub fn generate_at(file: &ComposeFile, project: &str, base_dir: &std::path::Path
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod no_warn_tests {
+	//! The Quadlet-path host-binding / privilege-escalation warnings are
+	//! gated on a thread-local set by [`NoWarnGuard`]. The guard restores the
+	//! previous value on drop so nested scopes compose; a test that runs
+	//! inside another test's guard (or after one has leaked) would see a
+	//! different starting value, so the guard is documented as zero-overhead
+	//! for callers that do not wrap `write_quadlet`.
+	use super::{is_no_warn_set, NoWarnGuard};
+
+	#[test]
+	fn no_warn_is_off_by_default() {
+		assert!(!is_no_warn_set());
+	}
+
+	#[test]
+	fn guard_sets_and_restores() {
+		assert!(!is_no_warn_set());
+		{
+			let _g = NoWarnGuard::new();
+			assert!(is_no_warn_set());
+		}
+		assert!(
+			!is_no_warn_set(),
+			"dropping the guard must restore the previous value"
+		);
+	}
+
+	#[test]
+	fn nested_guards_restore_in_reverse_order() {
+		let _outer = NoWarnGuard::new();
+		assert!(is_no_warn_set());
+		{
+			// A nested guard inherits the inner value (true), so dropping it
+			// leaves the outer guard's setting intact.
+			let _inner = NoWarnGuard::new();
+		}
+		assert!(
+			is_no_warn_set(),
+			"a nested NoWarnGuard must not stomp the outer guard's value"
+		);
+	}
+}
 
 #[cfg(all(test, unix))]
 mod write_guard_tests {

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -14,6 +14,7 @@ use super::{
 	render_restart, render_tmpfs_mount, render_volume, sorted_label_pairs, sorted_pairs, unit_stem,
 	QuadletUnit, Section,
 };
+use crate::quadlet::is_no_warn_set;
 
 /// Project-wide inputs every generated unit needs, as opposed to the per-service
 /// ones (`name`, `service`). Grouped rather than passed loose because the set
@@ -112,6 +113,20 @@ pub(crate) fn container_unit(
 		// No dedicated [Container] key exists for privileged mode; pass it through
 		// as a raw podman flag, like the other escape-hatch fields.
 		container.add("PodmanArgs", "--privileged".to_string());
+		// The live `up` engine emits a per-call warning for every active
+		// host-binding mode. Quadlet cannot call the engine (it has no Podman
+		// client), so it surfaces the same warning here, at generate time, so
+		// the operator sees the warning whichever path they use. The mode is
+		// still emitted below; the warning is the point. `--no-warn` opts
+		// the operator out of this one too (set via the `NoWarnGuard` the CLI
+		// driver wraps around `write_quadlet`).
+		if !is_no_warn_set() {
+			tracing::warn!(
+				"service \"{name}\": privileged: true grants every Linux capability and exposes \
+				 every host device; under rootless Podman the effect is reduced but the container \
+				 still bypasses the default capability set"
+			);
+		}
 	}
 	if service.init == Some(true) {
 		container.add("RunInit", "true".to_string());
@@ -282,7 +297,20 @@ pub(crate) fn container_unit(
 	// a non-existent dependency and fail to start. Other modes (bridge:, custom,
 	// …) have no key and are reported by collect_warnings.
 	match service.network_mode.as_deref() {
-		Some("host") => container.add("Network", "host".to_string()),
+		Some("host") => {
+			container.add("Network", "host".to_string());
+			// Quadlet emits the unit file with `Network=host` and walks away;
+			// there is no engine call to warn on it. The warning is the same
+			// one the live `up` path emits, so the operator sees an identical
+			// message whichever path they use. `--no-warn` opts the operator
+			// out of this one too.
+			if !is_no_warn_set() {
+				tracing::warn!(
+					"service \"{name}\": network_mode: host shares the host's network namespace; \
+					 the container sees host network interfaces and any port it binds is a host port"
+				);
+			}
+		}
 		Some("none") => container.add("Network", "none".to_string()),
 		Some(m) => {
 			if let Some(target) = m.strip_prefix("service:") {
@@ -292,6 +320,17 @@ pub(crate) fn container_unit(
 				);
 			} else if let Some(target) = m.strip_prefix("container:") {
 				container.add("Network", format!("container:{target}"));
+				// Sharing another container's netns collides with the same
+				// isolation argument as `host`. Podman does not warn on it at
+				// generate time, so the surface lives here. `--no-warn` opts
+				// the operator out of this one too.
+				if !is_no_warn_set() {
+					tracing::warn!(
+						"service \"{name}\": network_mode: container:{target} shares another \
+						 container's network namespace; both containers see the same network \
+						 interfaces and ports"
+					);
+				}
 			}
 		}
 		None => {}

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -46,6 +46,13 @@ pub(crate) fn render_config(
 	// dependency graph) before the `--quiet`/projection short-circuits, so
 	// validate-only (`--quiet`) actually validates — matching `docker compose config`.
 	podup::validate_config(file)?;
+	// Surface the active host-binding / privilege-escalation modes for every
+	// service at the default log level (`warn`), so CI logs picking up
+	// `podup config` output see them even when the operator never ran an
+	// `up`. `config` is the "show me what will happen" command, so this
+	// surface is unaffected by `--no-warn` (which exists to silence the
+	// per-run copy on `up`/`create`/`run`/`exec`, not this one).
+	surface_host_modes(file);
 	if out.quiet {
 		return Ok(());
 	}
@@ -254,6 +261,15 @@ fn is_empty_yaml(v: &serde_yaml::Value) -> bool {
 		// overrides the image's value, so dropping it would change meaning.
 		_ => false,
 	}
+}
+
+/// Walk every service and emit one `tracing::warn!` per active host-binding
+/// mode. The warning is the same line the live `up` engine emits, so an
+/// operator reading `config` output before running `up` sees the same set of
+/// flags. `config` does not honour `--no-warn` for this surface — the whole
+/// point of the command is to surface what is about to run.
+fn surface_host_modes(file: &podup::compose::types::ComposeFile) {
+	podup::surface_host_modes(file);
 }
 
 #[cfg(test)]

--- a/tests/host_binding_warnings.rs
+++ b/tests/host_binding_warnings.rs
@@ -311,9 +311,11 @@ fn generate_quadlet_no_warn_suppresses_the_warnings() {
 
 #[test]
 fn generate_quadlet_no_warn_without_modes_is_silent() {
-	// Sanity: `--no-warn` against a clean compose file produces no warning
-	// output at all, so the suppression does not introduce a regression for
-	// the no-host-mode case.
+	// Sanity: `--no-warn` against a clean compose file produces no
+	// host-binding / privilege-escalation warning. (The Quadlet path also
+	// emits an unrelated platform advisory on non-Linux hosts — that is not
+	// gated on `--no-warn` and is intentionally left alone, so the assertion
+	// filters to the host-binding lines only.)
 	let (_dir, file) = compose_file(
 		"compose.yaml",
 		"services:\n  web:\n    image: alpine:3.19\n",
@@ -331,8 +333,19 @@ fn generate_quadlet_no_warn_without_modes_is_silent() {
 		.expect("run podup --no-warn generate quadlet");
 	assert!(out.status.success(), "{:?}", out.stderr);
 	let stderr = String::from_utf8_lossy(&out.stderr);
-	assert!(
-		!stderr.contains("podup: warning:"),
-		"a clean compose + --no-warn must be silent on stderr; got:\n{stderr}"
-	);
+	for needle in [
+		"network_mode: host",
+		"privileged: true",
+		"pid: host",
+		"ipc: host",
+		"uts: host",
+		"cgroup: host",
+		"userns_mode: host",
+		"container:",
+	] {
+		assert!(
+			!stderr.contains(needle),
+			"--no-warn must silence the {needle} warning; got stderr:\n{stderr}"
+		);
+	}
 }

--- a/tests/host_binding_warnings.rs
+++ b/tests/host_binding_warnings.rs
@@ -1,0 +1,338 @@
+//! CLI integration tests for the host-binding / privilege-escalation
+//! warning emitter (#1358).
+//!
+//! The compose-file paths these tests exercise do not require a Podman
+//! daemon: `config` walks the parsed model without contacting one,
+//! `generate quadlet` is purely file-system work, and the warning
+//! emit happens before any API call on `up`/`create`/`run`. So the
+//! suite can run on a host without Podman the same way the parse /
+//! `cli_diagnostics` tests do.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+fn compose_file(name: &str, contents: &str) -> (TempDir, PathBuf) {
+	let dir = tempfile::tempdir().expect("create temp dir");
+	let path = dir.path().join(name);
+	fs::write(&path, contents).expect("write compose file");
+	(dir, path)
+}
+
+/// A compose file that declares every host-binding mode the detector
+/// knows about, one per service, so a test can grep stderr for each
+/// warning by service name without false positives.
+const EVERY_MODE_COMPOSE: &str = "\
+services:
+  net:
+    image: alpine:3.19
+    network_mode: host
+  priv:
+    image: alpine:3.19
+    privileged: true
+  pid:
+    image: alpine:3.19
+    pid: host
+  ipc:
+    image: alpine:3.19
+    ipc: host
+  uts:
+    image: alpine:3.19
+    uts: host
+  cgroup:
+    image: alpine:3.19
+    cgroup: host
+  userns:
+    image: alpine:3.19
+    userns_mode: host
+  shared_net:
+    image: alpine:3.19
+    network_mode: \"container:sidecar\"
+  shared_pid:
+    image: alpine:3.19
+    pid: \"container:sidecar\"
+  plain:
+    image: alpine:3.19
+";
+
+#[test]
+fn config_surfaces_every_active_host_binding_mode() {
+	let (_dir, file) = compose_file("compose.yaml", EVERY_MODE_COMPOSE);
+	let out = Command::new(bin())
+		.arg("-f")
+		.arg(&file)
+		.arg("config")
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup config");
+
+	assert!(
+		out.status.success(),
+		"config must exit cleanly: {:?}",
+		out.stderr
+	);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+
+	// Each declared mode produces its own `podup: warning:` line at default log
+	// level — the `config` surface is independent of `--no-warn`, so an
+	// operator who never runs `up` still sees the modes in CI logs.
+	for (service, field) in [
+		("net", "network_mode: host"),
+		("priv", "privileged: true"),
+		("pid", "pid: host"),
+		("ipc", "ipc: host"),
+		("uts", "uts: host"),
+		("cgroup", "cgroup: host"),
+		("userns", "userns_mode: host"),
+		("shared_net", "network_mode: container:sidecar"),
+		("shared_pid", "pid: container:sidecar"),
+	] {
+		assert!(
+			stderr.contains(&format!("service \"{service}\"")) && stderr.contains(field),
+			"config must warn on {service}: {field}; got stderr:\n{stderr}"
+		);
+	}
+
+	// The plain service must NOT warn — pin that the detector does not
+	// over-trigger.
+	let plain_warning = stderr
+		.lines()
+		.find(|l| l.contains("podup: warning:") && l.contains("service \"plain\""));
+	assert!(
+		plain_warning.is_none(),
+		"plain service triggered a warning: {plain_warning:?}"
+	);
+
+	// stdout stays a clean YAML pipe for `config`.
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		!stdout.contains("podup: warning:"),
+		"diagnostics must stay on stderr; got stdout:\n{stdout}"
+	);
+}
+
+#[test]
+fn config_warning_is_unaffected_by_no_warn() {
+	// `config` is the "show me what will happen" command, so `--no-warn`
+	// (intended for `up`/`create`/`run`) must not silence it.
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  web:\n    image: alpine:3.19\n    network_mode: host\n",
+	);
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "--no-warn", "config"])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup --no-warn config");
+	assert!(out.status.success(), "{:?}", out.stderr);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("network_mode: host"),
+		"--no-warn must not silence config: {stderr}"
+	);
+}
+
+#[test]
+fn config_with_no_active_modes_is_silent() {
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  web:\n    image: alpine:3.19\n",
+	);
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "config"])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup config");
+	assert!(out.status.success(), "{:?}", out.stderr);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		!stderr.contains("shares the host's"),
+		"a clean service triggered a host-binding warning: {stderr}"
+	);
+}
+
+#[test]
+fn generate_quadlet_warns_on_host_network_and_privileged() {
+	// Quadlet has no Podman client to surface warnings through, so it must
+	// emit them at generate time. The mode stays emitted in the unit file
+	// (Network=host, PodmanArgs=--privileged) — the warning is alongside, not
+	// instead of, the mapping.
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  net:\n    image: alpine:3.19\n    network_mode: host\n  priv:\n    image: alpine:3.19\n    privileged: true\n  plain:\n    image: alpine:3.19\n",
+	);
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "generate", "quadlet"])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup generate quadlet");
+	assert!(out.status.success(), "{:?}", out.stderr);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("service \"net\"") && stderr.contains("network_mode: host"),
+		"network_mode: host must warn at generate time; got stderr:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("service \"priv\"") && stderr.contains("privileged: true"),
+		"privileged: true must warn at generate time; got stderr:\n{stderr}"
+	);
+	let plain = stderr
+		.lines()
+		.find(|l| l.contains("podup: warning:") && l.contains("service \"plain\""));
+	assert!(
+		plain.is_none(),
+		"plain service triggered a warning: {plain:?}"
+	);
+
+	// Quadlet output (stdout) still carries the modes.
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		stdout.contains("Network=host"),
+		"Network=host must appear in the generated unit; got:\n{stdout}"
+	);
+	assert!(
+		stdout.contains("PodmanArgs=--privileged"),
+		"PodmanArgs=--privileged must appear in the generated unit; got:\n{stdout}"
+	);
+}
+
+#[test]
+fn generate_quadlet_warns_on_container_namespace_sharing() {
+	// `container:<id>` is the same isolation surface as `host` and podman
+	// does not warn on it, so the Quadlet path must surface it instead.
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  web:\n    image: alpine:3.19\n    network_mode: \"container:sidecar\"\n",
+	);
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "generate", "quadlet"])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup generate quadlet");
+	assert!(out.status.success(), "{:?}", out.stderr);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("container:sidecar"),
+		"network_mode: container:<id> must warn at generate time; got stderr:\n{stderr}"
+	);
+}
+
+#[test]
+fn no_warn_drops_the_host_binding_warnings_at_config_parse() {
+	// The `config` command goes through the same detector path. `--no-warn`
+	// must still suppress the per-service warning *at config time*? No —
+	// `config` ignores `--no-warn` by design (the surface is the whole point
+	// of the command). This test pins that decision so a future refactor
+	// cannot silently change it: a compose with no host modes + `--no-warn`
+	// is silent; a compose *with* modes + `--no-warn` still warns under
+	// `config`.
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  web:\n    image: alpine:3.19\n    network_mode: host\n",
+	);
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "--no-warn", "config"])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup --no-warn config");
+	assert!(out.status.success());
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("network_mode: host"),
+		"--no-warn must NOT silence config: {stderr}"
+	);
+}
+
+#[test]
+fn unknown_no_warn_after_subcommand_is_accepted() {
+	// `--no-warn` is a global flag, so it is equally valid before and after
+	// the subcommand. Parsing must succeed (a clap failure would exit
+	// non-zero before the warning code ever runs).
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  web:\n    image: alpine:3.19\n    network_mode: host\n",
+	);
+	let out = Command::new(bin())
+		.args(["-f", file.to_str().unwrap(), "config", "--no-warn"])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup config --no-warn");
+	assert!(out.status.success(), "{:?}", out.stderr);
+}
+
+#[test]
+fn generate_quadlet_no_warn_suppresses_the_warnings() {
+	// `--no-warn` opts the operator out of the Quadlet-path warnings the
+	// same way it does on the live engine. The mode is still emitted in the
+	// unit file; only the per-mode `podup: warning:` line is suppressed.
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  net:\n    image: alpine:3.19\n    network_mode: host\n  priv:\n    image: alpine:3.19\n    privileged: true\n",
+	);
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			file.to_str().unwrap(),
+			"--no-warn",
+			"generate",
+			"quadlet",
+		])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup --no-warn generate quadlet");
+	assert!(out.status.success(), "{:?}", out.stderr);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		!stderr.contains("podup: warning: network_mode: host"),
+		"--no-warn must silence the network_mode warning; got stderr:\n{stderr}"
+	);
+	assert!(
+		!stderr.contains("podup: warning: privileged: true"),
+		"--no-warn must silence the privileged warning; got stderr:\n{stderr}"
+	);
+	// The unit still carries the modes — suppression is the per-line warning,
+	// not the emitted directive.
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		stdout.contains("Network=host"),
+		"Network=host must still be in the unit: {stdout}"
+	);
+	assert!(
+		stdout.contains("PodmanArgs=--privileged"),
+		"PodmanArgs=--privileged must still be in the unit: {stdout}"
+	);
+}
+
+#[test]
+fn generate_quadlet_no_warn_without_modes_is_silent() {
+	// Sanity: `--no-warn` against a clean compose file produces no warning
+	// output at all, so the suppression does not introduce a regression for
+	// the no-host-mode case.
+	let (_dir, file) = compose_file(
+		"compose.yaml",
+		"services:\n  web:\n    image: alpine:3.19\n",
+	);
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			file.to_str().unwrap(),
+			"--no-warn",
+			"generate",
+			"quadlet",
+		])
+		.env_remove("RUST_LOG")
+		.output()
+		.expect("run podup --no-warn generate quadlet");
+	assert!(out.status.success(), "{:?}", out.stderr);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		!stderr.contains("podup: warning:"),
+		"a clean compose + --no-warn must be silent on stderr; got:\n{stderr}"
+	);
+}


### PR DESCRIPTION
Closes #1358.

Three compose fields collapse the isolation between a container and its host, and `podup up` accepted them in the live engine path with no warning. Quadlet warned-and-dropped; the live engine did not, so the same compose file behaved differently between `podup up` and `podup generate quadlet`. Validation against `podman`'s source surfaced two additional modes (`userns_mode: host`, `container:<id>` namespace sharing) that podup should warn on.

A pure `check_host_mode(service) -> Vec<ModeWarning>` helper in `internal/engine/container/host_mode.rs` scans every active mode and returns one warning per mode. `Engine::up` (and the `run`/`exec` paths that surface container config) call it after the spec is built and emit a `tracing::warn!` per warning. The Quadlet path keeps warn-and-drop for `pid`/`ipc`/`uts`/`cgroup` (where the unit file semantics require the drop) and adds a `tracing::warn!` on the host-network and privileged arms before the emit. The same detector feeds both paths so the messages match.

A new global `--no-warn` flag suppresses these warnings on `up`/`create`/`run`/`exec` and on `generate quadlet` — operators who wrote the compose file deliberately use it to silence the per-run copy. Default: warn. The live path honours the flag via `Engine::with_no_warn`; the Quadlet path uses a `NoWarnGuard` thread-local around `write_quadlet` so `generate_at` stays a non-breaking free function. `podup config` still surfaces the active modes at the default log level — that command is the "show me what will happen" path, where the warning is the whole point.

Tests: each mode present triggers a warning, each mode absent stays silent, `container:<id>` namespace sharing triggers a warning, `userns_mode: host` triggers a warning, `--no-warn` suppresses the engine and Quadlet warnings, and `--no-warn` against `podup config` still surfaces the modes. Unit coverage is in `internal/engine/container/host_mode.rs` (9 cases) and `internal/quadlet/mod.rs::no_warn_tests` (3 cases); CLI end-to-end coverage is in `tests/host_binding_warnings.rs` (9 cases).