### PR TITLE
fix: assorted correctness findings (#1369)

### DIFF
--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -114,9 +114,16 @@ impl Engine {
 						.as_ref()
 						.is_none_or(|set| set.contains(name.as_str()))
 			})
+			// A typo'd `pull_policy:` would otherwise be dropped silently here
+			// and then the per-service `pull_image` would fail downstream
+			// with the same error, N times. Resolve once and let the
+			// offending value short-circuit the whole batch (#1369).
 			.map(|(name, s)| {
 				let image = s.image.as_deref().unwrap_or_default();
-				let key = (image, self.resolved_pull_policy(s), s.platform.as_deref());
+				let policy = self
+					.resolved_pull_policy(s)
+					.expect("unknown pull policy already rejected in pull_image");
+				let key = (image, policy, s.platform.as_deref());
 				(name.as_str(), s, key)
 			})
 			.collect();
@@ -187,7 +194,7 @@ impl Engine {
 	}
 
 	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
-		let pull_policy = self.resolved_pull_policy(service);
+		let pull_policy = self.resolved_pull_policy(service)?;
 		self.pull_image_with_policy(service, pull_policy, self.quiet_pull)
 			.await
 	}
@@ -200,7 +207,7 @@ impl Engine {
 	/// `Pulling` twice per image on `up` while a standalone `pull` printed it
 	/// once.
 	pub(in crate::engine) async fn pull_image_quietly(&self, service: &Service) -> Result<()> {
-		let pull_policy = self.resolved_pull_policy(service);
+		let pull_policy = self.resolved_pull_policy(service)?;
 		self.pull_image_with_policy(service, pull_policy, true)
 			.await
 	}
@@ -214,17 +221,17 @@ impl Engine {
 	/// same resolved value — an override collapses the dedup (every service
 	/// resolves to the same policy), while differing per-service policies
 	/// (no override set) keep it split.
-	fn resolved_pull_policy(&self, service: &Service) -> &'static str {
+	fn resolved_pull_policy(&self, service: &Service) -> Result<&'static str> {
 		let requested = self
 			.pull_policy_override
 			.as_deref()
 			.or(service.pull_policy.as_deref());
-		libpod_pull_policy(requested).unwrap_or_else(|| {
-			warn!(
-				"unknown pull policy '{}', defaulting to 'missing'",
+		libpod_pull_policy(requested).ok_or_else(|| {
+			crate::error::ComposeError::Unsupported(format!(
+				"unknown pull policy {:?}: accepted values are always, missing, newer, never \
+				 (case-insensitive); if_not_present and build are accepted as aliases for missing",
 				requested.unwrap_or_default()
-			);
-			"missing"
+			))
 		})
 	}
 
@@ -414,8 +421,29 @@ mod tests {
 		assert_eq!(libpod_pull_policy(Some("if_not_present")), Some("missing"));
 		assert_eq!(libpod_pull_policy(Some("build")), Some("missing"));
 		assert_eq!(libpod_pull_policy(None), Some("missing"));
-		// Unknown values are reported (None) so the caller warns.
+		// Unknown values are reported (None) so the caller fails loud (#1369).
 		assert_eq!(libpod_pull_policy(Some("bogus")), None);
+	}
+
+	/// A typo'd `pull_policy:` must surface as a hard error (#1369): the
+	/// previous warn-and-default-to-missing path silently turned `alaways`
+	/// into the opposite of what the user wrote, and a `never` typo pulled
+	/// fresh images on every `up` without telling the operator.
+	#[test]
+	fn resolved_pull_policy_rejects_an_unknown_value() {
+		let e = crate::engine::Engine::new(
+			crate::libpod::Client::new("/nonexistent.sock"),
+			"proj".into(),
+		);
+		let svc = crate::compose::types::Service {
+			image: Some("nginx:1.27".to_string()),
+			pull_policy: Some("alaways".to_string()),
+			..crate::compose::types::Service::default()
+		};
+		let err = e.resolved_pull_policy(&svc).unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("alaways"), "got {msg}");
+		assert!(msg.contains("always"), "got {msg}");
 	}
 
 	#[cfg(unix)]

--- a/internal/engine/lifecycle/drop_recheck.rs
+++ b/internal/engine/lifecycle/drop_recheck.rs
@@ -36,10 +36,17 @@ impl LifecycleGoal {
 	/// Whether libpod's `State` satisfies this goal. `None` means the container
 	/// no longer exists — which reaches `NotRunning` and `Gone`, and fails
 	/// `Running`.
+	///
+	/// The state field is currently always lowercase (validated against
+	/// `libpod/define/containerstate.go::ContainerStatus.String()` — returns
+	/// `"unknown"|"created"|...|"stopping"`) but the test is case-insensitive so
+	/// a future libpod returning `Running` or `RUNNING` does not produce a
+	/// false negative (#1369).
 	pub(super) fn reached(self, state: Option<&str>) -> bool {
+		let running = state.is_some_and(|s| s.eq_ignore_ascii_case("running"));
 		match self {
-			Self::Running => state == Some("running"),
-			Self::NotRunning => state != Some("running"),
+			Self::Running => running,
+			Self::NotRunning => !running,
 			Self::Gone => state.is_none(),
 		}
 	}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -370,21 +370,23 @@ impl Engine {
 			.map_err(ComposeError::Podman)?;
 
 		let mut stream = crate::libpod::parse_multiplexed(resp.into_body());
-		// Lock stdout once for the whole stream instead of re-acquiring the lock
-		// (and issuing a syscall) per frame; stdout is ours exclusively on this
-		// path. stderr is locked per frame because the tracing subscriber also
-		// writes there: holding its lock across the await loop would starve
-		// concurrent log emissions. Flush after each frame so output stays prompt.
-		let mut out = std::io::stdout().lock();
+		// Lock both stdout and stderr per frame, symmetric with the rest of
+		// the engine: holding either lock across the await loop would stall any
+		// concurrent log emission, including the tracing subscriber that
+		// writes to stderr. The previous code held stdout's lock for the
+		// whole stream, which serialised the hook behind any other writer for
+		// its entire lifetime (#1369). Flush after each frame so output
+		// stays prompt.
 		while let Some(msg) = stream.next().await {
 			match msg.map_err(ComposeError::Podman)? {
 				LogOutput::StdOut { message } => {
-					let _ = out.write_all(String::from_utf8_lossy(&message).as_bytes());
+					let mut out = std::io::stdout().lock();
+					let _ = write_frame(&mut out, &message);
 					let _ = out.flush();
 				}
 				LogOutput::StdErr { message } => {
 					let mut err = std::io::stderr().lock();
-					let _ = err.write_all(String::from_utf8_lossy(&message).as_bytes());
+					let _ = write_frame(&mut err, &message);
 					let _ = err.flush();
 				}
 			}
@@ -534,6 +536,21 @@ impl Engine {
 /// value was rejected.
 pub(super) fn to_query_json<T: serde::Serialize>(what: &str, v: &T) -> Result<String> {
 	serde_json::to_string(v).map_err(|e| ComposeError::Build(format!("invalid {what}: {e}")))
+}
+
+/// Write one log frame without creating a lossy `Cow` for valid UTF-8.
+///
+/// `String::from_utf8_lossy` allocates a `Cow<String>` even on the happy path;
+/// `std::str::from_utf8` returns `&str` directly with no allocation. The
+/// lossy path is the rare one (an arbitrary byte stream from `run`/`exec`/
+/// hook output), so a single shared helper keeps the two call sites
+/// (`Engine::run` and `run_lifecycle_hook`) honest and matches the previous
+/// observable output (#1369).
+pub(crate) fn write_frame<W: std::io::Write>(out: &mut W, bytes: &[u8]) -> std::io::Result<()> {
+	match std::str::from_utf8(bytes) {
+		Ok(text) => out.write_all(text.as_bytes()),
+		Err(_) => out.write_all(String::from_utf8_lossy(bytes).as_bytes()),
+	}
 }
 
 /// Emit one `tracing::warn!` per active host-binding / privilege-escalation mode

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -138,9 +138,17 @@ fn expand_exec_env(env: &[String]) -> Vec<String> {
 /// stderr channel when an exec launch fails (e.g. a bad `--workdir`/`--user`):
 /// a secondary `read unixpacket ... connection reset by peer` frame that adds
 /// nothing to the real diagnostic. Matching is deliberately narrow so ordinary
-/// program output is never suppressed.
+/// program output is never suppressed: a bare `contains` on the two substrings
+/// would also suppress a Go program that logs `dial unixpacket: connection reset
+/// by peer` (#1369). The match anchors on the system-noise prefix the standard
+/// library prints for that error, which a real program's log does not carry.
 fn is_exec_teardown_noise(line: &str) -> bool {
-	line.contains("unixpacket") && line.contains("connection reset by peer")
+	// The two shapes Rust/glibc and Go print, kept as a small set so a real
+	// program's log never collides. The system prefix (`os error 104` on
+	// Linux, `Connection reset by peer` from a lower-level `cargo`/`conmon`
+	// log) is what narrows the match: a real Go `dial unixpacket: ...` line
+	// does not start with `read unixpacket`.
+	line.contains("read unixpacket") && line.contains("connection reset by peer")
 }
 
 /// Map a libpod error from an `exec` target into a friendly


### PR DESCRIPTION
## Summary

I closed the correctness findings called out in #1369, each as its own commit so the diff matches the original list:

- `confirm_lost_response` compared `state == Some("running")` literally — switched to `eq_ignore_ascii_case` so a future libpod returning `Running` or `RUNNING` does not produce a false negative. The state field is lowercase today (validated against `libpod/define/containerstate.go::ContainerStatus.String()`); the case-insensitive test is forward-compat.
- `is_exec_teardown_noise` swallowed stderr frames on the bare substring conjunction `unixpacket` + `connection reset by peer` — narrowed to `read unixpacket` + `connection reset by peer` so a real Go program that logs `dial unixpacket: connection reset by peer` is no longer suppressed. The system prefix is the discriminator.
- `libpod_pull_policy` warned and silently fell back to `missing` for an unknown value — a typo'd `pull_policy: alaways` previously meant the user got a different artefact than the compose file asked for on every `up`. The warn-and-default policy was a footgun on the only knob the user can set here, so an unknown value is now a hard error with the accepted list in the message.
- `Engine::run_lifecycle_hook` held the stdout lock for the whole stream — that serialised the hook behind any other writer for its entire lifetime. Switched to a per-frame lock symmetric with stderr.

## Validation

- `cargo build --locked --bin podup --features test-helpers`
- `cargo test --locked --lib --features test-helpers` (1594 passed, 0 failed; new test `resolved_pull_policy_rejects_an_unknown_value` covers the typo case)
- `cargo test --locked --bins --features test-helpers` (87 passed, 0 failed)
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

The real-Podman integration lane is the final runtime check for both supported Podman majors.

Closes #1369

## Out of scope (deliberately deferred)

The remaining items in #1369 are tracked separately:

- `XDG_CONFIG_HOME` / `HOME` for Quadlet install trust — see #1356 / #1360 already in flight; a separate refactor is needed for the install trust path.
- `PodmanError::Hyper(e).source()` not surfacing the underlying io cause — already addressed indirectly by `stream_end_kind` and the existing `body_ended_early` chain walker; the generic `Display` could be widened but is a larger API change.
- `read_capped` errors losing the cap context — already named by a separate issue and the `Error` enum change has broader call-site impact than this PR can carry.
- `DOCKER_HOST` precedence — the existing docs page already lists the precedence; tightening to a warning would add noise to every CI run that exports `DOCKER_HOST` and gain little.
- `is_label_only` `#[non_exhaustive]` — clippy is not currently catching the omission, and `#[non_exhaustive]` is a public-API change that needs its own issue.