### PR TITLE
refactor(engine): split walk helpers out of mod.rs

### DIFF
--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 
+use crate::engine::walk;
 use crate::error::{ComposeError, Result};
 
 /// Append the build context to `tar`, honoring `.dockerignore`.
@@ -30,7 +31,7 @@ fn append_context<W: std::io::Write>(
 	// an SSH key — into the image. Store the link itself instead, matching the
 	// watch-sync and cp paths.
 	tar.follow_symlinks(false);
-	for abs in super::super::walk_dir(context).map_err(ComposeError::Io)? {
+	for abs in walk::walk_dir(context).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -67,6 +67,7 @@ pub use stats::StatsOptions;
 mod volume;
 pub use volume::{VolumesDisplayOptions, VolumesOptions};
 mod volume_mounts;
+mod walk;
 #[cfg(feature = "watch")]
 mod watch;
 
@@ -622,29 +623,8 @@ fn order_replicas(base: &str, names: &[String]) -> Vec<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Filesystem helpers
+// Filesystem helpers (see `walk.rs`)
 // ---------------------------------------------------------------------------
-
-fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
-	let mut out = Vec::new();
-	walk_collect(root, &mut out)?;
-	Ok(out)
-}
-
-fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
-	entries.sort_by_key(|e| e.file_name());
-	for entry in entries {
-		let path = entry.path();
-		let file_type = entry.file_type()?;
-		out.push(path.clone());
-		if file_type.is_dir() {
-			walk_collect(&path, out)?;
-		}
-	}
-	Ok(())
-}
-
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------

--- a/internal/engine/walk.rs
+++ b/internal/engine/walk.rs
@@ -1,0 +1,51 @@
+//! Filesystem walking helpers used by the engine to discover build contexts
+//! and other recursively-resolved paths.
+//!
+//! Kept in its own module so `engine::mod` stays within the 500-line hard cap
+//! that the org's `line-limit` reusable enforces. Pure and total so the
+//! recursion is unit-testable without standing up a real build context.
+
+use std::path::PathBuf;
+
+/// Recursive walk rooted at `root`, returning every entry (file or directory)
+/// in deterministic path order. Pure helper; used by the build-context
+/// materialisation paths to stage a tree before `podman build`.
+pub(in crate::engine) fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
+	let mut out = Vec::new();
+	walk_collect(root, &mut out)?;
+	Ok(out)
+}
+
+fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
+	entries.sort_by_key(|e| e.file_name());
+	for entry in entries {
+		let path = entry.path();
+		let file_type = entry.file_type()?;
+		out.push(path.clone());
+		if file_type.is_dir() {
+			walk_collect(&path, out)?;
+		}
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::walk_dir;
+	use std::path::PathBuf;
+
+	#[test]
+	fn walk_dir_returns_every_entry_in_sorted_order() {
+		let dir = tempfile::tempdir().unwrap();
+		std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+		std::fs::write(dir.path().join("a"), b"a").unwrap();
+		std::fs::write(dir.path().join("sub/b"), b"b").unwrap();
+		let got: Vec<PathBuf> = walk_dir(dir.path()).unwrap();
+		let names: Vec<String> = got
+			.iter()
+			.map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+			.collect();
+		assert_eq!(names, vec!["a", "sub", "b"]);
+	}
+}

--- a/internal/engine/watch/sync.rs
+++ b/internal/engine/watch/sync.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 
+use crate::engine::walk;
 use crate::error::{ComposeError, Result};
 
 /// Pack `src` into a gzipped tar, storing its top-level entry under
@@ -31,7 +32,7 @@ pub(super) fn build_sync_tar(src: &Path, entry_name: &Path) -> Result<Vec<u8>> {
 	tar.follow_symlinks(false);
 
 	if src.is_dir() {
-		for abs in super::super::walk_dir(src).map_err(ComposeError::Io)? {
+		for abs in walk::walk_dir(src).map_err(ComposeError::Io)? {
 			let rel = abs
 				.strip_prefix(src)
 				.map_err(|_| ComposeError::Build("path strip".into()))?;


### PR DESCRIPTION
## Summary

I split the `walk_dir` / `walk_collect` filesystem helpers out of `internal/engine/mod.rs` into a new `internal/engine/walk.rs` module so `mod.rs` falls under the 500-line hard cap the org's `line-limit` reusable enforces (#1386 follow-up; this same check was the one that blocked merging #1390 — the per-PR lane flagged the regression after the `Engine` field additions in the #1364 cache PR pushed it to 503 code lines).

The change is mechanical: the two functions move verbatim, with the same semantics and the same private-in-crate visibility, and one new unit test pins the sorted order on a tempdir. `internal/engine/build/context.rs` and `internal/engine/watch/sync.rs` updated to import from the new module.

## Validation

- `cargo build --locked --bin podup --features test-helpers`
- `cargo test --locked --lib --features test-helpers` (1594 passed, 0 failed)
- `cargo test --locked --bins --features test-helpers` (87 passed, 0 failed)
- `cargo fmt --all --check`
- The `line-limit` check the per-PR lane runs now reports `mod.rs` at 486 code lines (under the 500 hard cap), down from 503.

The real-Podman integration lane is the final runtime check for both supported Podman majors.

Closes the merge blocker on #1390 (the `Engine` field additions for the cached project label filter in the #1364 PR pushed `mod.rs` over the line cap, which the per-PR lane then flagged as a required-check failure).

## Out of scope (deferred)

The next-largest files — `internal/engine/lifecycle/mod.rs` (497) and `internal/engine/copy/archive.rs` (478) — are within the hard cap; they stay.