### PR TITLE
release: bump to 3.7.0 (develop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.6.1"
+version = "3.7.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.6.1"
+version = "3.7.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,76 @@
+podup (3.7.0) unstable; urgency=medium
+
+  Added
+
+  * A nightly live-Podman coverage gate now runs on the `develop` branch
+    (`podman-lane-develop-nightly` workflow). The `main` nightly was the only
+    signal that a regression landing on `develop` had broken coverage in the
+    half-life before the next release PR; the develop nightly closes that gap
+    with the same 88% floor on the Podman 6 leg.
+  * Per-engine project-label cache. The URL-encoded
+    `{"label":["podup.project={name}"]}` JSON is built once when the engine is
+    constructed; the dynamic sites (those that add a second predicate like
+    `podup.service={svc}`) splice the raw label and re-encode only once. The
+    per-call `format!` + `serde_json::to_string` + `urlencoded` on every
+    container-list / network-list call is gone.
+  * `write_frame` shared helper in the engine: probes `std::str::from_utf8`
+    first and only falls through to `String::from_utf8_lossy` on the rare
+    invalid-byte case, dropping the per-frame `Cow` allocation on the happy
+    `run` path.
+
+  Fixed
+
+  * `interpolate_value` gates the parent mapping rebuild on
+    `mapping_needs_interp`, which only enters the rebuild when a descendant
+    string actually carries a `$`. The 10k key/value pairs on a 100-service
+    file no longer move for free.
+  * The progress ticker re-probed terminal capabilities and queried the
+    window size on every 100 ms tick; both are now cached at `begin()` and
+    re-read only when the size actually matters. `progress_line` also took
+    a global `Mutex` lock per emission, which was paid even when no board
+    was open; an `AtomicBool` short-circuits the hot path.
+  * `identity_style` allocated a `format!("{p}-")` per call; the prefix
+    is now cached in `PROJECT_PREFIX`, set in `set_project` and read by
+    `identity_slot`.
+  * `restart_service_set` returned `(all.clone(), all)` for the
+    empty-targets branch, paying two clones of a 100-service set; it now
+    returns `(Arc<HashSet<String>>, Arc<HashSet<String>>)` so the two halves
+    share one `Arc::clone` and the dependents-included branch is the only
+    place that still allocates.
+  * `is_exec_teardown_noise` matched any stderr line containing
+    `unixpacket` and `connection reset by peer`; a Go program logging
+    `dial unixpacket: connection reset by peer` had its line silently
+    dropped. The match now anchors on the `read unixpacket` system prefix
+    so a real program's log is preserved.
+  * `confirm_lost_response` compared `state == Some("running")` literally;
+    switched to `eq_ignore_ascii_case` so a future libpod returning
+    `Running` or `RUNNING` does not produce a false negative.
+  * `libpod_pull_policy` warned and silently fell back to `missing` for an
+    unknown value; a typo'd `pull_policy: alaways` previously turned into
+    the opposite of what the user wrote (a `never` typo pulled fresh images
+    on every `up`). An unknown value is now a hard error with the accepted
+    list in the message.
+  * `Engine::run_lifecycle_hook` held the stdout lock for the whole
+    stream, serialising the hook behind any other writer for its entire
+    lifetime. The lock is now per-frame, symmetric with stderr.
+  * `libpod/client/mod.rs` and `engine/mod.rs` exceeded the 500-line hard
+    cap that the org's `line-limit` reusable enforces. The libpod client
+    methods are now split into per-verb files (`get.rs`, `post.rs`,
+    `put.rs`, `delete.rs`, `misc.rs`); the engine helpers
+    (`walk_dir`/`walk_collect`, the interactive-detection, the replica
+    name resolution, the project-label filter cache) each moved to
+    their own module. Both files are now under 500 code lines, so the
+    per-PR lane is no longer red on the `line-limit` check.
+
+  Changed
+
+  * The Podman baseline moved to **6.0.2** (was 6.0.1). Re-validated via
+    the live-Podman lane on a fresh Fedora rawhide cloud image;
+    `PODUP_SUMMARY pass=179 fail=0 flaky=0` on the Podman 6 leg, no new
+    identities on the per-major known-failures list.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 09 Aug 2026 13:00:00 -0500
+
 podup (3.6.1) unstable; urgency=medium
 
   Fixed


### PR DESCRIPTION
## Summary

Bump podup to **3.7.0** in lockstep (the release workflow's `verify` job fails closed if any of the three drifts):
- `Cargo.toml`: `3.6.1` → `3.7.0`
- `Cargo.lock`: regenerated to match
- `debian/changelog`: new entry at the top with the same version, full cycle changelog

Changelog covers everything merged into `develop` since 3.6.1:
- **Added** — `podman-lane-develop-nightly` workflow with 88% coverage floor on Podman 6 leg; per-engine project-label filter cache; `write_frame` shared helper.
- **Fixed** — `interpolate_value` gates parent mapping rebuild on `mapping_needs_interp`; progress ticker caches terminal + window probes at `begin`; `progress_line` short-circuits on `SESSION_OPEN` `AtomicBool`; `identity_style` caches `PROJECT_PREFIX`; `restart_service_set` returns `Arc<HashSet<String>>` halves; `is_exec_teardown_noise` anchors on `read unixpacket`; `confirm_lost_response` uses `eq_ignore_ascii_case`; `libpod_pull_policy` hard-errors on unknown values; `Engine::run_lifecycle_hook` takes stdout lock per-frame; `libpod/client/mod.rs` and `engine/mod.rs` both under 500-line cap.
- **Changed** — Podman baseline moved to **6.0.2** (re-validated via live lane on fresh Fedora rawhide cloud image; `PODUP_SUMMARY pass=179 fail=0 flaky=0` on Podman 6 leg).

## Validation

- `cargo build --locked --bin podup --features test-helpers`
- `cargo test --locked --lib --features test-helpers` — 1605 passed, 0 failed
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

## Release flow (follow-up)

After this lands on `develop`, the release flow is:
1. PR `develop` → `main` (merge commit) — that is the per-CLAUDE release PR. Head will be `develop`, so `develop-only` passes.
2. Push the tag `v3.7.0` to `main` (or `gh workflow run release -f tag=v3.7.0 -R Glyndor/podup`). The `verify` job re-checks the three version files match, audits dependencies, then the build matrix produces the 7 targets; the release job signs, builds provenance, and publishes.