### PR TITLE
ci(release): verify every file the installers fetch is staged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,7 +453,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Glyndor/.github
-          ref: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # main (pre-tag)
+          ref: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
           persist-credentials: false
           path: upstream
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,7 +453,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Glyndor/.github
-          ref: e429f62795b09d17452c6d45db8018390d606483 # ci/installer-contract-verify-substance
+          ref: 69a553aa1b3fb26a0ddc13051c2f5713ca1db07f # ci/installer-contract-verify-substance
           persist-credentials: false
           path: upstream
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,6 +449,31 @@ jobs:
             "$venv_py" .github/scripts/verify-signing-key.py "$base" "$sig"
           done
 
+      - name: Check out Glyndor/.github for the asset-existence script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: Glyndor/.github
+          ref: e429f62795b09d17452c6d45db8018390d606483 # ci/installer-contract-verify-substance
+          persist-credentials: false
+          path: upstream
+
+      - name: Verify every file the installers fetch is staged
+        run: |
+          set -euo pipefail
+          # The asset-contract gate compares install.sh against this file and
+          # answers "do the two agree on the names". It cannot answer "does the
+          # release produce them" — a workflow file is a statement of intent,
+          # not proof that a step ran. This is where that question is
+          # answerable: everything is built, signed and checksummed, and the
+          # release is not immutable yet. The script derives what to look for
+          # from install.sh's own ${BASE_URL} fetches, so it covers
+          # SHA256SUMS.sig too — install.sh aborts without it, and nothing
+          # upstream of here ever checked it was produced.
+          python3 upstream/scripts/verify-release-assets.py \
+            --workdir . \
+            --install-script install.sh \
+            --install-ps1 install.ps1
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,7 +453,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Glyndor/.github
-          ref: 69a553aa1b3fb26a0ddc13051c2f5713ca1db07f # ci/installer-contract-verify-substance
+          ref: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # main (pre-tag)
           persist-credentials: false
           path: upstream
 


### PR DESCRIPTION
Consumer side of Glyndor/.github#133. **Draft on purpose — see Blocked below.**

## Why

The asset-contract gate compares `install.sh` against `release.yml` and answers *"do the two agree on the asset names"*. It cannot answer *"does the release produce them"* — a workflow file is a statement of intent, not proof that a step ran.

`Glyndor/.github` carried a check that tried to answer it anyway, by looking for `SHA256SUMS` among the parsed `asset:` keys. Those keys are the build matrix, and the manifest is computed *from* the matrix outputs in a later step, so it can never match. **That is the false positive on #1425** — the gate fails this repo for doing it correctly.

## What this does

Adds one step to the `release` job, between "Verify every signature against the keys consumers embed" and "Create GitHub Release". At that point everything is built, signed and checksummed, and the release is not immutable yet — so existence is a stat call rather than an inference.

What it requires is derived from `install.sh`'s own `${BASE_URL}` fetches, not hardcoded. That matters: **the old check never looked at `SHA256SUMS.sig`**, which `install.sh` downloads and without which it aborts. A release missing only the signature would have passed a gate whose stated purpose was making downloads verifiable.

## Verified, and not

Run locally against this repo's real `install.sh`, `install.ps1` and `release.yml`:

| case | result |
|---|---|
| complete staging dir | `OK: all 8 files the install scripts fetch are staged` |
| `SHA256SUMS.sig` removed | fails — the case the old check could not see |
| `SHA256SUMS` removed | fails, naming both missing files |
| the amended gate, against this repo | passes (it did not before) |

**Not verified:** the workflow wiring itself. `release.yml` only runs on a tag push, and dispatching it would cut a real release, so the step order and the `upstream/` checkout path are unexercised until the next release actually runs. I am not claiming otherwise.

## Blocked

The `ref:` currently pins the branch SHA of Glyndor/.github#133. That SHA becomes unreachable once #133 is squash-merged, so **this must not merge as it stands**. Order:

1. Glyndor/.github#133 merges.
2. `.github` cuts a tag.
3. #1425 bumps the `installer-contract` pin to that tag — that run is what proves the gate fix green.
4. This PR's `ref:` moves to the tag, and comes out of draft.