### PR TITLE
ci(asset-contract): bump installer-contract to v1.16.0

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the


### PR DESCRIPTION
Supersedes #1425.

## What this unblocks

`#1425` bumps `installer-contract` from v1.13.0 to v1.14.1 and fails. The failure is not this repository's: v1.14.1 added a check that looks for `SHA256SUMS` among the `asset:` keys parsed out of `release.yml`. Those keys are the build matrix, and the manifest is computed *from* the matrix outputs in a later step — so it can never be one of them. Failing it is the normal state of a correct release workflow.

Glyndor/.github#133 removed it and shipped v1.16.0. This bump is the first run of the amended gate against a real repository, so it is the proof the fix works.

## What replaces the check

`Glyndor/.github` v1.16.0 adds `scripts/verify-release-assets.py`, which answers the same question where it is answerable: against the staged files at release time, before `gh release create` makes them immutable. #1431 wires it into `release.yml` — currently draft, waiting on this.

## Why not just update #1425

v1.14.1 is two minors behind now, and it still carries the broken clause. Merging it would reintroduce the failure.