### PR TITLE
docs: refresh stale build-recreate comment and re-attach Region doc

### DIFF
--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -494,9 +494,16 @@ impl Engine {
 				);
 				return Ok(());
 			}
-			// Services with a build section are rebuilt on every up, so
-			// their container must be recreated to pick up the fresh
-			// image even when the compose config is unchanged.
+			// A service with a `build:` section is recreated even when its hash
+			// matches: the compose-config hash compared below does not cover
+			// the build context's source files, so the existing container may
+			// still hold an image built from an older tree. Recreating forces
+			// the new container to bind whatever image is current.
+			//
+			// `up` stopped rebuilding these unconditionally in #1094 — it now
+			// builds only when the image is missing — so the fresh-image
+			// guarantee this recreate used to inherit from that rebuild no
+			// longer comes for free.
 			if service.build.is_none()
 				&& existing_hash.get(&container_name).map(String::as_str) == Some(new_hash)
 			{

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -28,19 +28,6 @@ fn cursor_up(n: usize) -> String {
 	format!("\x1b[{n}A")
 }
 
-/// A tail region being repainted on a real terminal.
-///
-/// Owns the count of rows it last painted, which is the only state the repaint
-/// arithmetic needs — and the reason every line handed to it must already be
-/// truncated to the terminal width. A line that wraps makes the terminal count
-/// two rows where this counted one, and from then on every repaint erases the
-/// wrong lines.
-///
-/// Deliberately knows nothing about what it is drawing. It takes two blocks of
-/// finished text: lines that become permanent scrollback, and lines that are
-/// erased on the next call. That is what lets the board and `stats` share it —
-/// they disagree about everything except needing a block of text repainted in
-/// place.
 /// Which stream a region draws on.
 ///
 /// Not always stderr. The lifecycle board goes there so stdout stays a clean
@@ -64,6 +51,19 @@ impl Target {
 	}
 }
 
+/// A tail region being repainted on a real terminal.
+///
+/// Owns the count of rows it last painted, which is the only state the repaint
+/// arithmetic needs — and the reason every line handed to it must already be
+/// truncated to the terminal width. A line that wraps makes the terminal count
+/// two rows where this counted one, and from then on every repaint erases the
+/// wrong lines.
+///
+/// Deliberately knows nothing about what it is drawing. It takes two blocks of
+/// finished text: lines that become permanent scrollback, and lines that are
+/// erased on the next call. That is what lets the board and `stats` share it —
+/// they disagree about everything except needing a block of text repainted in
+/// place.
 pub struct Region {
 	/// Rows painted by the previous repaint, to be walked back over.
 	painted: usize,


### PR DESCRIPTION
## What this fixes

Two doc defects, no behaviour change.

**The stale comment in `internal/engine/lifecycle/mod.rs`.** It said services with a `build:` section are rebuilt on every `up`, which stopped being true in #1094. I checked what actually justifies the recreate today before rewriting it: `config_hash` (`internal/engine/container/resolve.rs:178`) serializes the service config plus any inline secret payloads, and never reads the build context's source files. So a `build:` service can hold an image built from an older tree while its hash still matches, and the recreate is still correct — for a different reason than the comment gave.

The rewrite states that reason and keeps the #1094 fact in past tense, which is the shape the style standard asks for. The old wording was present tense, and that is what let it rot.

**The misplaced doc block in `internal/ui/progress/live.rs`.** The block describing `Region` sat above the next item's doc comment, so the two concatenated and the whole thing bound to `Target`. `pub struct Region` had no doc of its own, which the style standard requires on every public item. I moved the block onto the struct and left the `Target` doc untouched. The wrap invariant it carries is unchanged: every line handed to the region must arrive already truncated to terminal width, or each later repaint erases the wrong rows.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `cargo test --lib` | 1638 passed, 0 failed |

Fixes #1446
