### PR TITLE
fix(engine): surface --format json serialisation failures in five list commands

### DIFF
--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -567,6 +567,28 @@ pub(super) fn to_query_json<T: serde::Serialize>(what: &str, v: &T) -> Result<St
 	serde_json::to_string(v).map_err(|e| ComposeError::Build(format!("invalid {what}: {e}")))
 }
 
+/// Serialise `v` to a pretty-printed JSON string for emitting as the final
+/// `--format json` output of a list command.
+///
+/// Five sites flow through this: `ls` ([`projects::list_projects_filtered`]),
+/// `images` ([`Engine::images_with_services`]), `top`
+/// ([`Engine::top_with_options`]), `ps` ([`Engine::ps_filtered_with_display`]),
+/// and `volumes` ([`Engine::list_volumes_with_display`]). Each used to call
+/// `serde_json::to_string_pretty(...).unwrap_or_default()`, which silently
+/// emitted an empty string on a serialisation failure; the command then
+/// printed the empty string and exited 0, so a script consuming
+/// `podup <cmd> --format json` received an empty document indistinguishable
+/// from "no results" (#1444). Unlike the NDJSON path in
+/// [`to_query_json`](self)/[`events`](super::events) — where one row can be
+/// dropped and the stream continue — `--format json` is the *whole* output,
+/// so a failure must propagate as an error and exit non-zero.
+///
+/// `what` names the offending field in the error so the operator sees which
+/// row or document type was rejected.
+pub(super) fn to_pretty_json<T: serde::Serialize>(what: &str, v: &T) -> Result<String> {
+	serde_json::to_string_pretty(v).map_err(|e| ComposeError::Build(format!("invalid {what}: {e}")))
+}
+
 /// Write one log frame without creating a lossy `Cow` for valid UTF-8.
 ///
 /// `String::from_utf8_lossy` allocates a `Cow<String>` even on the happy path;
@@ -709,6 +731,10 @@ mod to_query_json_tests {
 		assert!(err.to_string().contains("build.cache_to"), "got {err}");
 	}
 }
+
+#[cfg(test)]
+#[path = "to_pretty_json_tests.rs"]
+mod to_pretty_json_tests;
 
 #[cfg(test)]
 mod tests;

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -161,7 +161,7 @@ pub async fn list_projects_filtered(
 			.iter()
 			.map(|(name, t)| project_row(name, t, &t.config_files))
 			.collect();
-		println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+		println!("{}", super::to_pretty_json("ls.row", &arr)?);
 		return Ok(());
 	}
 

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -153,10 +153,7 @@ impl Engine {
 					})
 				})
 				.collect();
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&json).unwrap_or_default()
-			);
+			println!("{}", super::super::to_pretty_json("images.row", &json)?);
 			return Ok(());
 		}
 

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -111,10 +111,7 @@ impl Engine {
 			}
 		}
 		if json {
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&json_rows).unwrap_or_default()
-			);
+			println!("{}", super::super::to_pretty_json("top.row", &json_rows)?);
 		}
 		Ok(())
 	}

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -496,10 +496,7 @@ impl Engine {
 
 		if opts.json {
 			let rows: Vec<_> = containers.iter().map(ps_json_row).collect();
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&rows).unwrap_or_default()
-			);
+			println!("{}", super::super::to_pretty_json("ps.row", &rows)?);
 			return Ok(());
 		}
 

--- a/internal/engine/to_pretty_json_tests.rs
+++ b/internal/engine/to_pretty_json_tests.rs
@@ -1,0 +1,90 @@
+//! Unit tests for the `to_pretty_json` helper.
+//!
+//! `to_pretty_json` is the pretty-printed sibling of [`super::to_query_json`],
+//! shared by the five `--format json` output sites (`ls`, `images`, `top`,
+//! `ps`, `volumes`). The failure contract is the same: a serialisation error
+//! must surface as `Err(ComposeError::Build)` naming the field, never as an
+//! empty string swallowed by `unwrap_or_default` (#1444).
+
+use super::to_pretty_json;
+use crate::error::ComposeError;
+use serde::ser::{Error as _, Serializer};
+use serde::Serialize;
+use serde_json::json;
+
+/// A `Serialize` impl that always errors, so a unit test can pin the
+/// "surface the failure" contract without depending on a particular type
+/// in the build path. Mirrors the helper used by [`super::to_query_json_tests`].
+struct AlwaysFails {
+	reason: &'static str,
+}
+
+impl Serialize for AlwaysFails {
+	fn serialize<S: Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
+		Err(S::Error::custom(self.reason))
+	}
+}
+
+/// The happy path: a `Vec<serde_json::Value>` of the same shape the five
+/// `--format json` call sites serialise round-trips through `to_pretty_json`
+/// unchanged. Parse-and-compare rather than pinning the literal pretty
+/// format — the round-trip is what matters and is portable across minor
+/// formatting tweaks.
+#[test]
+fn to_pretty_json_serialises_vec_of_json_values() {
+	let arr = vec![
+		json!({ "Name": "web", "Status": "running(1)" }),
+		json!({ "Name": "db", "Status": "exited(1)" }),
+	];
+	let s = to_pretty_json("ls.row", &arr).unwrap();
+	let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+	assert_eq!(
+		parsed,
+		json!([
+			{ "Name": "web", "Status": "running(1)" },
+			{ "Name": "db", "Status": "exited(1)" },
+		])
+	);
+}
+
+/// A serialisation failure must surface as `Err(ComposeError::Build)`
+/// whose message names the field and the underlying reason. Each of the
+/// five `--format json` call sites passes a distinct `what`, so all five
+/// labels are pinned to a test.
+#[test]
+fn to_pretty_json_failure_names_ls_row() {
+	let err = to_pretty_json("ls.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(matches!(err, ComposeError::Build(_)), "got {err:?}");
+	let msg = err.to_string();
+	assert!(msg.contains("ls.row"), "got {msg:?}");
+	assert!(msg.contains("boom"), "got {msg:?}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_images_row() {
+	let err = to_pretty_json("images.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("images.row"), "got {err}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_top_row() {
+	let err = to_pretty_json("top.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("top.row"), "got {err}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_ps_row() {
+	let err = to_pretty_json("ps.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("ps.row"), "got {err}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_volumes_row() {
+	let err = to_pretty_json("volumes.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("volumes.row"), "got {err}");
+}

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -147,7 +147,7 @@ impl Engine {
 					})
 				})
 				.collect();
-			println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+			println!("{}", super::super::to_pretty_json("volumes.row", &arr)?);
 			return Ok(());
 		}
 


### PR DESCRIPTION
## What this fixes

#1366 removed the swallowed `serde_json::to_string` failures on the build and events paths. The same shape was still on five `--format json` output sites, where it is worse: `--format json` is the whole output, not one row of a stream, so an empty string is indistinguishable from "no results" and the command still exits 0.

All five now go through a new `to_pretty_json` helper next to `to_query_json`, which returns `Result<String>` and names the offending row type in the error:

| Command | Site | Label |
|---|---|---|
| `ls` | `internal/engine/projects.rs:164` | `ls.row` |
| `ps` | `internal/engine/query/ps.rs:499` | `ps.row` |
| `volumes` | `internal/engine/volume/list.rs:150` | `volumes.row` |
| `images` | `internal/engine/query/images.rs:156` | `images.row` |
| `top` | `internal/engine/query/inspect.rs:114` | `top.row` |

The last one is labelled `top.row` rather than `inspect.row` because that line lives inside `top_with_options`, not in an inspect path. The issue text called it inspect; the file name was misleading.

No `to_string_pretty(..).unwrap_or_default()` remains in the tree.

## Tests

Six new tests in `internal/engine/to_pretty_json_tests.rs`, using an always-failing `Serialize` impl in the same shape as the existing `to_query_json_tests`: one round-trip on the happy path, and one per label pinning that a failure surfaces as `ComposeError::Build` naming that field.

I checked they discriminate rather than assuming it: reverting the helper body to `unwrap_or_default` turns all five failure tests red, and restoring it turns them green.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `cargo test --lib` | 1644 passed, 0 failed |

Fixes #1444
