### PR TITLE
fix(up): reject unknown pull_policy at every resolution site

### DIFF
--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -10,9 +10,10 @@ mod pull;
 mod push;
 mod stream;
 mod tags;
-/// Shared with the `up` image-prefetch stage so it resolves a service's
-/// effective pull policy identically to the pull path below.
-pub(in crate::engine) use pull::libpod_pull_policy;
+/// Shared with the `up` image-prefetch and `up`/pull decision paths so they
+/// resolve a service's effective pull policy identically to the pull path
+/// below, and reject an unrecognized value the same way (#1443).
+pub(in crate::engine) use pull::pull_policy_checked;
 pub use pull::PullOptions;
 pub use push::PushOptions;
 /// Shared with the container-create path so an `up`/`create` references the same

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -121,7 +121,7 @@ impl Engine {
 			.map(|(name, s)| {
 				let image = s.image.as_deref().unwrap_or_default();
 				let policy = self
-					.resolved_pull_policy(s)
+					.resolved_pull_policy(name.as_str(), s)
 					.expect("unknown pull policy already rejected in pull_image");
 				let key = (image, policy, s.platform.as_deref());
 				(name.as_str(), s, key)
@@ -193,8 +193,12 @@ impl Engine {
 		Ok(())
 	}
 
-	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
-		let pull_policy = self.resolved_pull_policy(service)?;
+	pub(in crate::engine) async fn pull_image(
+		&self,
+		service_name: &str,
+		service: &Service,
+	) -> Result<()> {
+		let pull_policy = self.resolved_pull_policy(service_name, service)?;
 		self.pull_image_with_policy(service, pull_policy, self.quiet_pull)
 			.await
 	}
@@ -206,8 +210,12 @@ impl Engine {
 	/// pull is the authoritative one, and reporting from both is what printed
 	/// `Pulling` twice per image on `up` while a standalone `pull` printed it
 	/// once.
-	pub(in crate::engine) async fn pull_image_quietly(&self, service: &Service) -> Result<()> {
-		let pull_policy = self.resolved_pull_policy(service)?;
+	pub(in crate::engine) async fn pull_image_quietly(
+		&self,
+		service_name: &str,
+		service: &Service,
+	) -> Result<()> {
+		let pull_policy = self.resolved_pull_policy(service_name, service)?;
 		self.pull_image_with_policy(service, pull_policy, true)
 			.await
 	}
@@ -215,24 +223,18 @@ impl Engine {
 	/// Resolve the effective libpod pull policy for `service`: the
 	/// engine-wide `--pull` override ([`Engine::with_up_overrides`]) takes
 	/// precedence over the service's own `pull_policy:`, and an unrecognized
-	/// value warns and falls back to `missing`. Shared by [`Self::pull_image`]
-	/// and by the standalone-pull fan-out's dedup key
+	/// value is rejected via [`pull_policy_checked`]. Shared by
+	/// [`Self::pull_image`] and by the standalone-pull fan-out's dedup key
 	/// ([`Self::pull_services_with_options`]), so both agree on exactly the
 	/// same resolved value — an override collapses the dedup (every service
 	/// resolves to the same policy), while differing per-service policies
 	/// (no override set) keep it split.
-	fn resolved_pull_policy(&self, service: &Service) -> Result<&'static str> {
+	fn resolved_pull_policy(&self, service_name: &str, service: &Service) -> Result<&'static str> {
 		let requested = self
 			.pull_policy_override
 			.as_deref()
 			.or(service.pull_policy.as_deref());
-		libpod_pull_policy(requested).ok_or_else(|| {
-			crate::error::ComposeError::Unsupported(format!(
-				"unknown pull policy {:?}: accepted values are always, missing, newer, never \
-				 (case-insensitive); if_not_present and build are accepted as aliases for missing",
-				requested.unwrap_or_default()
-			))
-		})
+		pull_policy_checked(requested, service_name)
 	}
 
 	/// Issue the actual pull request for `service` against an
@@ -367,6 +369,35 @@ pub(in crate::engine) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'st
 	}
 }
 
+/// Map a compose `pull_policy:` value to the libpod images/pull `policy`
+/// parameter, rejecting an unrecognized value with a structured
+/// [`PodmanError::Field`] that names both the compose service and the
+/// offending value (#1443).
+///
+/// `service_name` is the compose service the policy was read from (e.g.
+/// `"web"`); pass the empty string when the value came from the engine-wide
+/// `--pull` override (no service context). The rejected value lands in the
+/// error so a typo'd `pull_policy: alaways` on a specific service is reported
+/// as `service.<name>: pull_policy: unknown pull policy "alaways" (value:
+/// alaways)` — the actionable bit is which service and which value, not the
+/// abstract policy name.
+pub(in crate::engine) fn pull_policy_checked(
+	policy: Option<&str>,
+	service_name: &str,
+) -> crate::error::Result<&'static str> {
+	if let Some(p) = libpod_pull_policy(policy) {
+		return Ok(p);
+	}
+	let value = policy.unwrap_or_default();
+	let message = format!(
+		"unknown pull policy {value:?}: accepted values are always, missing, newer, never \
+		 (case-insensitive); if_not_present and build are accepted as aliases for missing"
+	);
+	Err(crate::error::ComposeError::Podman(
+		crate::libpod::validate::spec_field_error(service_name, "pull_policy", value, message),
+	))
+}
+
 #[cfg(test)]
 mod tests {
 	use super::{libpod_pull_policy, pull_dep_closure};
@@ -440,10 +471,21 @@ mod tests {
 			pull_policy: Some("alaways".to_string()),
 			..crate::compose::types::Service::default()
 		};
-		let err = e.resolved_pull_policy(&svc).unwrap_err();
+		let err = e.resolved_pull_policy("web", &svc).unwrap_err();
 		let msg = err.to_string();
 		assert!(msg.contains("alaways"), "got {msg}");
 		assert!(msg.contains("always"), "got {msg}");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref service,
+					ref field,
+					..
+				}) if service == "web" && field == "pull_policy"
+			),
+			"unknown pull policy must surface as a Field error carrying the service and field name, got {err:?}"
+		);
 	}
 
 	#[cfg(unix)]

--- a/internal/engine/lifecycle/images.rs
+++ b/internal/engine/lifecycle/images.rs
@@ -36,12 +36,16 @@ impl Engine {
 	) -> Result<()> {
 		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
 		// suppresses building even for services with a `build:` section (they fall
-		// back to pulling/using an existing image).
-		let policy = self
+		// back to pulling/using an existing image). Validated through
+		// [`crate::engine::build::pull_policy_checked`] so a typo'd
+		// `pull_policy:` cannot be silently treated as `missing` here — the
+		// skip-only-when-missing arm below would otherwise hide the bad value
+		// from `up` entirely (#1443).
+		let raw_policy = self
 			.pull_policy_override
 			.as_deref()
-			.or(service.pull_policy.as_deref())
-			.unwrap_or("missing");
+			.or(service.pull_policy.as_deref());
+		let policy = crate::engine::build::pull_policy_checked(raw_policy, name)?;
 		// Build on `up` only when the service's image is not already there, which
 		// is what docker compose does: `up` converges on the declared state and
 		// `--build` is the flag that forces a rebuild.
@@ -76,8 +80,8 @@ impl Engine {
 			// host needs no request at all. Skipping only what was observed in
 			// this invocation keeps the decision as fresh as the one the pull
 			// itself would have made.
-			(false, _) if self.image_already_seen_present(service) => {}
-			(false, _) => self.pull_image(service).await?,
+			(false, _) if self.image_already_seen_present(name, service)? => {}
+			(false, _) => self.pull_image(name, service).await?,
 		}
 		Ok(())
 	}
@@ -94,24 +98,28 @@ impl Engine {
 	/// False for a service pinning `platform:`. The observation matched an image
 	/// reference, which carries no architecture, so honouring it there could
 	/// start the wrong variant.
-	fn image_already_seen_present(&self, service: &Service) -> bool {
+	///
+	/// Returns `Err` for an unrecognized `pull_policy:` so the bad value is
+	/// reported rather than silently treated as `missing` (#1443).
+	fn image_already_seen_present(&self, service_name: &str, service: &Service) -> Result<bool> {
 		if service.platform.is_some() {
-			return false;
+			return Ok(false);
 		}
 		let raw_policy = self
 			.pull_policy_override
 			.as_deref()
 			.or(service.pull_policy.as_deref());
-		if crate::engine::build::libpod_pull_policy(raw_policy).unwrap_or("missing") != "missing" {
-			return false;
+		if crate::engine::build::pull_policy_checked(raw_policy, service_name)? != "missing" {
+			return Ok(false);
 		}
 		let Some(image) = service.image.as_deref() else {
-			return false;
+			return Ok(false);
 		};
-		self.images_seen_present
+		Ok(self
+			.images_seen_present
 			.lock()
 			.map(|seen| seen.contains(image))
-			.unwrap_or(false)
+			.unwrap_or(false))
 	}
 }
 
@@ -237,6 +245,47 @@ mod tests {
 		assert!(
 			seen.iter().any(|r| r.contains("/images/pull")),
 			"a platform-pinned service must still pull: a reference match says nothing about the architecture that is local: {seen:?}"
+		);
+	}
+
+	/// A typo'd `pull_policy:` on a warm service must error at the
+	/// `image_already_seen_present` decision (the `#1443` site) rather than
+	/// be silently treated as `missing` and skip the only pull that would have
+	/// surfaced the bad value. The host stands in for one that already has the
+	/// image (so the skip branch *would* fire), and the assertion is that the
+	/// error fires instead — without the fix the call returned `true` and the
+	/// pull was skipped, leaving `up` to exit 0 with the wrong image.
+	#[tokio::test]
+	async fn image_already_seen_present_rejects_an_unknown_pull_policy() {
+		let e = engine_with(crate::libpod::Client::new("/nonexistent.sock"), "proj");
+		// Pre-populate the prefetch's seen-present set as if a previous
+		// `prefetch_images` had confirmed the image on this host. Without the
+		// fix `image_already_seen_present` would then return `true` for any
+		// service whose effective policy it read as `missing` — including a
+		// typo'd `pull_policy:` — and the only pull that could have surfaced
+		// the bad value would be skipped.
+		e.images_seen_present
+			.lock()
+			.unwrap()
+			.insert("shared".to_string());
+
+		let file =
+			crate::parse_str("services:\n  web:\n    image: shared\n    pull_policy: alaways\n")
+				.unwrap();
+		let err = e
+			.image_already_seen_present("web", &file.services["web"])
+			.expect_err("an unknown pull_policy must error at the skip decision");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref service,
+					ref field,
+					ref value,
+					..
+				}) if service == "web" && field == "pull_policy" && value == "alaways"
+			),
+			"unknown pull_policy must surface as a Field error naming the offending service and value, got {err:?}"
 		);
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -240,9 +240,12 @@ impl Engine {
 			// Best-effort: warm the image cache for every service this pass will
 			// pull, concurrently, before the per-level walk below serializes a
 			// level-2+ service's image acquisition behind the level-1 barrier.
-			// A prefetch miss here is never fatal — `up_one_service`'s own pull
-			// below is still authoritative and the only path that can fail `up`.
-			self.prefetch_images(file, &enabled, &target_set).await;
+			// A prefetch I/O miss is never fatal — `up_one_service`'s own pull
+			// below is still authoritative and the only path that can fail `up`
+			// on a transport / registry error. A configuration error (an
+			// unrecognized `pull_policy:`) does propagate: it is reported here
+			// so the operator sees it, not a silent wrong image (#1443).
+			self.prefetch_images(file, &enabled, &target_set).await?;
 
 			// Start each dependency level in turn; services within a level have
 			// no `depends_on` relationship to each other (guaranteed by the

--- a/internal/engine/lifecycle/prefetch.rs
+++ b/internal/engine/lifecycle/prefetch.rs
@@ -8,15 +8,22 @@
 //! concurrently, before the first level barrier — instead of one at a time as
 //! each level's services reach their turn.
 //!
-//! Best-effort only: a prefetch miss is logged at debug and otherwise
-//! swallowed. `up_one_service`'s own pull call is unchanged and remains the
-//! sole source of a real pull failure — this stage can only make `up` faster,
-//! never change whether it succeeds.
+//! Best-effort only for prefetch *misses*: an unreachable socket or a registry
+//! that 500s is logged at debug and otherwise swallowed. `up_one_service`'s
+//! own pull call is unchanged and remains the sole source of a real pull
+//! failure — this stage can only make `up` faster, never change whether it
+//! succeeds.
+//!
+//! An invalid `pull_policy:` (or `--pull`) is **not** a prefetch miss. It is
+//! a configuration error and propagates here as `Err`, before a single pull
+//! is dispatched, so the operator sees it instead of a silent wrong image
+//! (#1443).
 
 use std::collections::{HashMap, HashSet};
 
 use crate::compose::types::{ComposeFile, Service};
-use crate::engine::build::libpod_pull_policy;
+use crate::engine::build::pull_policy_checked;
+use crate::error::Result;
 
 use super::parallel::join_bounded;
 use super::Engine;
@@ -32,19 +39,22 @@ impl Engine {
 	/// prefetch. Deduplicates by image reference, so many services sharing one
 	/// image pull it once instead of once per service, and dispatches the
 	/// resulting pulls with the same bounded concurrency the level fan-out
-	/// uses. Never fails: `up_one_service`'s own pull remains authoritative, so
-	/// a prefetch miss here just means that later call does the work instead,
-	/// exactly as it would without this stage.
+	/// uses. Returns `Err` for an unrecognized `pull_policy:` so a typo
+	/// (`pull_policy: alaways`) is reported instead of being treated as
+	/// `missing` (#1443); prefetch I/O errors stay debug-level and never
+	/// propagate.
 	pub(super) async fn prefetch_images(
 		&self,
 		file: &ComposeFile,
 		enabled: &HashSet<String>,
 		target_set: &Option<HashSet<String>>,
-	) {
+	) -> Result<()> {
 		// One representative service per unique image reference is enough to
 		// issue the pull — this is what dedupes 50 services on one image down
-		// to a single request instead of 50.
-		let mut by_image: HashMap<&str, &Service> = HashMap::new();
+		// to a single request instead of 50. The service *name* travels with
+		// the representative so the pull / policy error can name it, instead
+		// of using the image as a stand-in for the originating service.
+		let mut by_image: HashMap<&str, (&str, &Service)> = HashMap::new();
 		for (name, service) in &file.services {
 			if !enabled.contains(name) {
 				continue;
@@ -66,21 +76,29 @@ impl Engine {
 				.pull_policy_override
 				.as_deref()
 				.or(service.pull_policy.as_deref());
-			if libpod_pull_policy(raw_policy).unwrap_or("missing") == "never" {
+			if pull_policy_checked(raw_policy, name)? == "never" {
 				continue;
 			}
-			by_image.entry(image).or_insert(service);
+			by_image.entry(image).or_insert((name.as_str(), service));
 		}
 
-		let futs = by_image.into_values().map(|service| async move {
+		let futs = by_image.into_values().map(|(name, service)| async move {
 			let image = service.image.as_deref().unwrap_or_default();
 			let raw_policy = self
 				.pull_policy_override
 				.as_deref()
 				.or(service.pull_policy.as_deref());
-			let policy = libpod_pull_policy(raw_policy).unwrap_or("missing");
+			let policy = match pull_policy_checked(raw_policy, name) {
+				Ok(p) => p,
+				// Propagate the validation error out of the prefetch join via a
+				// shared poison cell. The prefetch stage itself is best-effort
+				// for *I/O*, but a configuration error must surface loud — the
+				// outer `join_bounded` join collapses every concurrent task into
+				// one result, and there is no other channel back (#1443).
+				Err(e) => return Err(e),
+			};
 			// `missing` (and its aliases, already normalized by
-			// `libpod_pull_policy`) only pulls when the image is absent —
+			// `pull_policy_checked`) only pulls when the image is absent —
 			// checking first turns a warm cache into a cheap presence check
 			// instead of a redundant pull request. `always`/`newer` mean to
 			// hit the registry regardless, so skip the check and prefetch
@@ -102,18 +120,23 @@ impl Engine {
 						seen.insert(image.to_string());
 					}
 				}
-				return;
+				return Ok(());
 			}
 			// Quietly: this stage only warms the cache, and `up_one_service`'s
 			// own pull below is the authoritative one. Reporting from both is
 			// what made `Pulling` appear twice per image on `up` while a
-			// standalone `pull` printed it once.
-			if let Err(e) = self.pull_image_quietly(service).await {
+			// standalone `pull` printed it once. A prefetch I/O miss is still
+			// debug-only — only the validation error above escapes.
+			if let Err(e) = self.pull_image_quietly(name, service).await {
 				tracing::debug!("prefetch miss for {image}: {e}");
 			}
+			Ok(())
 		});
 
-		join_bounded(futs).await;
+		match super::parallel::first_error(join_bounded(futs).await) {
+			Some(err) => Err(err),
+			None => Ok(()),
+		}
 	}
 }
 
@@ -153,7 +176,7 @@ mod tests {
 		.unwrap();
 		let enabled: HashSet<String> = file.services.keys().cloned().collect();
 
-		e.prefetch_images(&file, &enabled, &None).await;
+		e.prefetch_images(&file, &enabled, &None).await.unwrap();
 
 		let seen = fake.requests.lock().unwrap();
 		let shared_pulls = seen
@@ -194,7 +217,9 @@ mod tests {
 		let enabled: HashSet<String> = file.services.keys().cloned().collect();
 		let target_set: Option<HashSet<String>> = Some(["web".to_string()].into_iter().collect());
 
-		e.prefetch_images(&file, &enabled, &target_set).await;
+		e.prefetch_images(&file, &enabled, &target_set)
+			.await
+			.unwrap();
 
 		let seen = fake.requests.lock().unwrap();
 		assert!(
@@ -205,6 +230,88 @@ mod tests {
 		assert!(
 			!seen.iter().any(|r| r.contains("img-db")),
 			"a service outside the target set must not be prefetched: {seen:?}"
+		);
+	}
+
+	/// A typo'd `pull_policy:` must error loud at the prefetch stage instead of
+	/// being treated as `missing` (#1443). Both the dedup-side check (the
+	/// service is *included* in the prefetch set when the policy is anything
+	/// but `never`) and the per-image future would have happily read the bad
+	/// value as `missing` before the fix, leaving `up` to exit 0 with the
+	/// wrong image and no diagnostic.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn prefetch_rejects_an_unknown_pull_policy() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let file = crate::parse_str(
+			"services:\n  web:\n    image: nginx:1.27\n    pull_policy: alaways\n",
+		)
+		.unwrap();
+		let enabled: HashSet<String> = file.services.keys().cloned().collect();
+
+		let err = e
+			.prefetch_images(&file, &enabled, &None)
+			.await
+			.expect_err("an unknown pull_policy must be rejected, not silently treated as missing");
+		let msg = err.to_string();
+		assert!(msg.contains("alaways"), "got {msg}");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref service,
+					ref field,
+					ref value,
+					..
+				}) if service == "web" && field == "pull_policy" && value == "alaways"
+			),
+			"unknown pull_policy must surface as a Field error naming the offending service and value, got {err:?}"
+		);
+	}
+
+	/// An invalid `--pull` override (no service context) must also propagate
+	/// out of the prefetch stage — same bug as the per-service typo, just
+	/// applied to every service at once. Before the fix the dedup phase
+	/// would treat every service's effective policy as `missing` and warm
+	/// every cache it could reach with the wrong intent (#1443).
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn prefetch_rejects_an_invalid_pull_override() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let mut e = engine_with(fake.client(), "proj");
+		e.pull_policy_override = Some("alaways".to_string());
+
+		let file = crate::parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let enabled: HashSet<String> = file.services.keys().cloned().collect();
+
+		let err = e
+			.prefetch_images(&file, &enabled, &None)
+			.await
+			.expect_err("an invalid --pull override must be rejected");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref field,
+					ref value,
+					..
+				}) if field == "pull_policy" && value == "alaways"
+			),
+			"override must surface as a Field error naming the field and value, got {err:?}"
 		);
 	}
 }


### PR DESCRIPTION
## What this fixes

`libpod_pull_policy` returns `Option` so an unrecognised value can be refused, and `pull_image` already refused it. Three other resolution sites did not — they called `.unwrap_or("missing")`, so a typo became `missing` and nothing said so.

Measured on this branch against a real Podman 5.7.0, with `pull_policy: alaways` on an otherwise valid service:

| | `podup up -d` |
|---|---|
| `develop` | starts the container, exits **0** |
| this branch | `service.web: pull_policy: unknown pull policy "alaways": accepted values are always, missing, newer, never (case-insensitive); if_not_present and build are accepted as aliases for missing (value: alaways)`, exits **1** |

That is the whole bug: the compose author asked for a policy, got a different one, and `up` reported success.

## How

A new `pull_policy_checked` in `internal/engine/build/pull.rs` is the single place that maps a compose `pull_policy:` to the libpod parameter or rejects it. Rejection goes through `spec_field_error` from #1357, so the error names the service, the field and the offending value in the same shape as the other pre-validated compose fields rather than inventing a second error style.

Threading the service name through `resolved_pull_policy`, `pull_image`, `pull_image_quietly` and `image_already_seen_present` is what lets the error say `service.web:` instead of just naming the value.

`image_already_seen_present` now returns `Result<bool>`. That site mattered most: on a host that already had the image, the bad value was read as `missing`, the skip branch fired, and the one pull that would have surfaced the typo never ran.

## Tests

Two new ones, both failing before the change:

- `resolved_pull_policy_rejects_an_unknown_value` — pins that the error is a `PodmanError::Field` carrying the service and field name, not just a string containing the value.
- `image_already_seen_present_rejects_an_unknown_pull_policy` — pre-populates the seen-present set so the skip branch *would* fire, then asserts the error fires instead.

## Known limitation, not introduced here

`podup pull` (the standalone command) still panics on an invalid `pull_policy` rather than reporting it: `pull_services_with_options` resolves the policy inside a closure and `.expect()`s it at `internal/engine/build/pull.rs:125`. I reproduced this on `develop` too, so it predates this change and this PR neither causes nor fixes it — both branches exit 101 there. Filed separately rather than widened into this PR.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `cargo test --lib` | 1641 passed, 0 failed |
| `up` against real Podman 5.7.0 | table above |

Fixes #1443
