### PR TITLE
perf(engine): share one bulk replica lookup across logs, port, exec, cp

### DIFF
--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -71,11 +71,13 @@ impl Engine {
 	/// so they all behave the same.
 	///
 	/// Returns whether the container was actually acted on. This is the only
-	/// place that knows: `live_replica_names` falls back to the *static* compose
-	/// names when nothing is running, so a command on a project that was never
-	/// created still walks a full list of container names and 404s on every one
-	/// of them. Six commands exited 0 in complete silence that way (#1248), and
-	/// telling that apart from real work requires the answer here, not a count of
+	/// place that knows: the per-replica query helpers (e.g. the bulk
+	/// [`Engine::live_project_replicas_sorted`] lookup used by `exec`/`cp`/
+	/// `port`/`logs`) fall back to the *static* compose names when nothing is
+	/// running, so a command on a project that was never created still walks
+	/// a full list of container names and 404s on every one of them. Six
+	/// commands exited 0 in complete silence that way (#1248), and telling
+	/// that apart from real work requires the answer here, not a count of
 	/// names upstream.
 	pub(super) async fn run_lifecycle_op(
 		&self,

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -317,10 +317,36 @@ impl Engine {
 		Ok(by_service)
 	}
 
+	/// The bulk project listing ([`Self::live_project_replicas`]) with each
+	/// per-service bucket sorted into the same ascending `-1, -2, -3, ...`
+	/// order the static [`Engine::replica_names`] path produces. Lets the
+	/// per-replica query paths (`exec`/`cp` via `live_replica_name_at`,
+	/// `port` via `port_with_index`, `logs`) read each service's names off a
+	/// single shared map instead of issuing one container-list round-trip per
+	/// service (#1445): a `podup logs` over a 40-service project now costs 1
+	/// GET, not 40, with the same ordering the per-service helper it replaced
+	/// was pinned to.
+	///
+	/// Same `all=true` contract as [`Self::live_project_replicas`]: stopped
+	/// replicas are kept on purpose so a service scaled beyond its static
+	/// compose count (or never reaped by a prior `down`) is not silently
+	/// dropped from the bucket. The static-name fallback for a service absent
+	/// from the map is the *caller's* responsibility — this helper returns an
+	/// empty vec for one, since it does not see the compose file.
+	pub(crate) async fn live_project_replicas_sorted(
+		&self,
+	) -> Result<std::collections::HashMap<String, Vec<String>>> {
+		let mut by_service = self.live_project_replicas().await?;
+		for names in by_service.values_mut() {
+			sort_replica_names(names);
+		}
+		Ok(by_service)
+	}
+
 	/// The live containers of a service (matched by the `podup.service` label),
 	/// each paired with its machine-readable state (`running`, `created`,
-	/// `exited`, `paused`, …). Unlike [`Self::live_replica_names`] this does NOT
-	/// fall back to statically-predicted names: a service with no live container
+	/// `exited`, `paused`, …). This does NOT fall back to statically-predicted
+	/// names: a service with no live container
 	/// yields an empty vec, so a lifecycle op (stop/wait/…) on a defined-but-
 	/// never-created service is a quiet no-op instead of POSTing to a phantom
 	/// name and surfacing a raw 404 (#758). The state lets `stop` report
@@ -356,40 +382,16 @@ impl Engine {
 			.collect())
 	}
 
-	/// The container names to act on for a service: the ones Podman actually has
-	/// (matched by the `podup.service` label), so lifecycle and query commands
-	/// keep working after a runtime `scale`/`up --scale` that the compose file's
-	/// static replica count no longer names. Falls back to the statically-derived
-	/// names when none exist yet (e.g. a service not yet created). Live names are
-	/// always returned in ascending `-1, -2, -3, ...` order (see
-	/// [`sort_replica_names`]), matching the static path regardless of the order
-	/// libpod's container list happens to report.
-	pub(crate) async fn live_replica_names(
-		&self,
-		service_name: &str,
-		service: &Service,
-	) -> Result<Vec<String>> {
-		let mut live = self
-			.list_project_container_names(Some(service_name))
-			.await?;
-		Ok(if live.is_empty() {
-			self.replica_names(service_name, service)
-		} else {
-			sort_replica_names(&mut live);
-			live
-		})
-	}
-
 	/// The names of a service's containers that are actually **running**, in the
-	/// same ascending `-1, -2, -3, ...` order as [`Self::live_replica_names`].
+	/// same ascending `-1, -2, -3, ...` order as [`Self::live_project_replicas_sorted`].
 	///
 	/// For the query commands that only mean anything against a live process
 	/// (`top`), where a stopped replica has to be skipped rather than asked: the
 	/// libpod endpoints answer a non-running container with an HTTP 500, which
 	/// callers must not have to tell apart from a real failure by parsing its
-	/// message. Unlike [`Self::live_replica_names`] there is no fallback to
-	/// statically-derived names — a service that was never created has nothing
-	/// running, so it yields an empty vec instead of a phantom name.
+	/// message. There is no fallback to statically-derived names — a service
+	/// that was never created has nothing running, so it yields an empty vec
+	/// instead of a phantom name.
 	pub(crate) async fn running_replica_names(&self, service_name: &str) -> Result<Vec<String>> {
 		let mut running: Vec<String> = self
 			.live_service_containers(service_name)

--- a/internal/engine/lifecycle/scale_tests.rs
+++ b/internal/engine/lifecycle/scale_tests.rs
@@ -1,8 +1,10 @@
 //! Tests for the scale module: surplus-replica reconciliation, the
-//! `live_replica_names`/`running_replica_names` helpers, the replica-limit /
-//! port-conflict / fixed-name guard helpers, and the bulk
-//! `live_project_replicas` listing that powers the per-service lifecycle
-//! commands (#1363).
+//! `running_replica_names` helper, the replica-limit / port-conflict /
+//! fixed-name guard helpers, the bulk `live_project_replicas` listing that
+//! powers the per-service lifecycle commands (#1363), and the sorted
+//! `live_project_replicas_sorted` variant the per-replica query paths
+//! (`exec`/`cp`/`port`/`logs`) share so a single container-list round-trip
+//! powers them all (#1445).
 //!
 //! Same fixture pattern as the rest of the lifecycle suite: a unix-socket
 //! fake libpod so the request shape (`all=true`, no `status=` filter) and
@@ -90,14 +92,17 @@ async fn remove_surplus_replicas_tolerates_already_gone() {
 /// other by-service lifecycle/query command must still see a scaled
 /// service's replicas in the same ascending `-1, -2, -3` order the static
 /// `replica_names_for` path always produces, even when the fake (like a
-/// real libpod) hands them back shuffled.
+/// real libpod) hands them back shuffled. The bulk sorted helper
+/// ([`Engine::live_project_replicas_sorted`]) is what now powers the
+/// per-replica query paths (#1445); its per-bucket sort replaces the
+/// per-service sort the old `live_replica_names` helper did.
 #[tokio::test]
 #[cfg(unix)]
-async fn live_replica_names_sorts_shuffled_replicas_ascending() {
+async fn live_project_replicas_sorted_sorts_shuffled_replicas_ascending() {
 	let containers = r#"[
-		{"Names":["/proj-web-3"]},
-		{"Names":["/proj-web-1"]},
-		{"Names":["/proj-web-2"]}
+		{"Names":["/proj-web-3"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-2"],"Labels":{"podup.service":"web"}}
 	]"#;
 	let fake = fake_podman::start(move |method, target| {
 		if method == "GET" && target.contains("/containers/json") {
@@ -108,18 +113,167 @@ async fn live_replica_names_sorts_shuffled_replicas_ascending() {
 	});
 	let e = engine_with(fake.client(), "proj");
 
-	let names = e
-		.live_replica_names("web", &crate::compose::types::Service::default())
+	let by_service = e
+		.live_project_replicas_sorted()
 		.await
-		.expect("live_replica_names should succeed");
+		.expect("live_project_replicas_sorted should succeed");
 
 	assert_eq!(
-		names,
-		vec![
+		by_service.get("web"),
+		Some(&vec![
 			"proj-web-1".to_string(),
 			"proj-web-2".to_string(),
 			"proj-web-3".to_string(),
-		]
+		]),
+		"the bucket must come back in ascending -1, -2, -3 order regardless of \
+		 libpod's hand-back order"
+	);
+}
+
+/// #1445: the bulk GET that the per-replica query paths now share must
+/// cover a scaled service's full replica set, including replicas that are
+/// stopped — `logs`/`port`/`exec` need to see the second replica even when
+/// it is in `exited`, so the bulk request must NOT silently drop them the
+/// way libpod's `runningOnly` default would.
+#[tokio::test]
+#[cfg(unix)]
+async fn live_project_replicas_sorted_includes_stopped_replicas() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-2"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-3"],"State":"exited","Labels":{"podup.service":"web"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let by_service = e
+		.live_project_replicas_sorted()
+		.await
+		.expect("live_project_replicas_sorted should succeed");
+
+	// All three replicas — running and stopped — must be in the bucket.
+	// A bug that silently filtered to running (libpod's `runningOnly`
+	// default) would return just `proj-web-1` and `proj-web-2`, missing the
+	// third replica entirely.
+	assert_eq!(
+		by_service.get("web"),
+		Some(&vec![
+			"proj-web-1".to_string(),
+			"proj-web-2".to_string(),
+			"proj-web-3".to_string(),
+		]),
+		"the stopped replica must not be filtered out — got {:?}",
+		by_service.get("web")
+	);
+}
+
+/// #1445: a service that exists in the compose file but has no live
+/// container must NOT appear in the bulk map. The bulk helper does not see
+/// the compose file; the per-replica query paths (`exec`/`cp`/`port`/
+/// `logs`) layer the static-name fallback on top. Without that contract,
+/// `logs` could not `docker compose logs`-style behave on a never-created
+/// service — `port`/`exec`/`cp` would 404 immediately instead of letting
+/// the caller see the predictable static name.
+#[tokio::test]
+#[cfg(unix)]
+async fn live_project_replicas_sorted_omits_services_with_no_live_container() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			// Only `web` has any containers; `db` and `worker` are not yet
+			// created.
+			(
+				200,
+				r#"[{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}}]"#.to_string(),
+			)
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let by_service = e
+		.live_project_replicas_sorted()
+		.await
+		.expect("live_project_replicas_sorted should succeed");
+
+	assert_eq!(
+		by_service.get("web"),
+		Some(&vec!["proj-web-1".to_string()]),
+		"a service with a live container must appear in the map"
+	);
+	assert!(
+		!by_service.contains_key("db"),
+		"a service with no live container must NOT appear (caller falls back): {by_service:?}"
+	);
+	assert!(
+		!by_service.contains_key("worker"),
+		"a service with no live container must NOT appear (caller falls back): {by_service:?}"
+	);
+}
+
+/// #1445: the per-replica query paths used to fan out one container-list
+/// round-trip per service — 40 services meant 40 GETs for a single
+/// `podup logs`. The bulk helper is the shared single GET. With the fake
+/// pinned to answer only `/containers/json`, a single resolution call must
+/// still satisfy the per-service query helpers without issuing a follow-up
+/// GET. A regression that re-introduced per-service calls would make
+/// `fake.requests` grow by one row for each lookup, so the assertion
+/// below is the discriminator: counting requests is the test that fails if
+/// the bulk path is bypassed.
+#[tokio::test]
+#[cfg(unix)]
+async fn logs_resolves_replicas_in_one_bulk_get_not_one_per_service() {
+	// Three services; `db` is scaled to 3, `web` to 2, `worker` to 1, all
+	// running — so the bulk GET is the only fetch needed for `logs` to
+	// find 6 targets across 3 services.
+	let body = r#"[
+		{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}},
+		{"Names":["/proj-db-2"],"Labels":{"podup.service":"db"}},
+		{"Names":["/proj-db-3"],"Labels":{"podup.service":"db"}},
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-2"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-worker-1"],"Labels":{"podup.service":"worker"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, body.to_string())
+		} else if method == "GET" && target.contains("/logs") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = crate::compose::types::ComposeFile::default();
+	file.services
+		.insert("db".into(), crate::compose::types::Service::default());
+	file.services
+		.insert("web".into(), crate::compose::types::Service::default());
+	file.services
+		.insert("worker".into(), crate::compose::types::Service::default());
+
+	// Drive `logs` once across all 3 services — the resolution path is the
+	// one under test, not the streaming.
+	let _ = e
+		.logs_with_options(&file, &[], crate::engine::query::LogsOptions::default())
+		.await;
+
+	let seen = fake.requests.lock().unwrap();
+	let bulk_gets = seen
+		.iter()
+		.filter(|r| r.starts_with("GET") && r.contains("/containers/json"))
+		.count();
+	assert_eq!(
+		bulk_gets, 1,
+		"logs must issue exactly one bulk GET for the whole project, \
+		 not one per service. seen = {seen:?}"
 	);
 }
 

--- a/internal/engine/lifecycle/scale_tests.rs
+++ b/internal/engine/lifecycle/scale_tests.rs
@@ -521,3 +521,55 @@ fn unnamed_service_scales_freely() {
 	let svc = service("services:\n  app:\n    image: x\n");
 	assert!(check_fixed_name_scale("app", &svc, 5).is_ok());
 }
+
+/// #1445 is a round-trip count, so pin the count rather than only the values it
+/// produces. Before it, every selected service cost its own `/containers/json`
+/// GET; a project of N services made N of them. Nothing in the value assertions
+/// above notices if that regresses — the names come back identical either way —
+/// so a later refactor could quietly put the call back inside the loop.
+///
+/// Four services, and the fake records every request it answers. The assertion
+/// is that exactly one container-list GET reaches the socket.
+#[tokio::test]
+#[cfg(unix)]
+async fn logs_issues_one_container_list_for_the_whole_project() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-api-1"],"State":"running","Labels":{"podup.service":"api"}},
+		{"Names":["/proj-db-1"],"State":"running","Labels":{"podup.service":"db"}},
+		{"Names":["/proj-cache-1"],"State":"running","Labels":{"podup.service":"cache"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else {
+			// Every per-container logs stream 404s: this test is about how many
+			// listing calls are made, not about what the streams carry.
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+	let file = crate::parse_str(
+		"services:\n  web:\n    image: x\n  api:\n    image: x\n  db:\n    image: x\n  cache:\n    image: x\n",
+	)
+	.unwrap();
+
+	// The per-container streams all 404, so the call itself is expected to
+	// fail; the request log is what carries the answer.
+	let _ = e.logs(&file, None, false).await;
+
+	let lists = fake
+		.requests
+		.lock()
+		.unwrap()
+		.iter()
+		.filter(|r| r.contains("/containers/json"))
+		.count();
+	assert_eq!(
+		lists,
+		1,
+		"four services must share one container-list round-trip, not one each (#1445); \
+		 requests were {:?}",
+		fake.requests.lock().unwrap()
+	);
+}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -524,13 +524,25 @@ impl Engine {
 	/// created by an earlier `up --scale`/`scale` rather than the current
 	/// invocation, matching `docker compose cp/exec --index`. Shared by the
 	/// replica-targeting commands (`exec`, `cp`).
+	///
+	/// Reads off the bulk project listing ([`Engine::live_project_replicas_sorted`])
+	/// instead of issuing a per-service container-list round-trip (#1445):
+	/// one shared GET powers the rest of the per-replica query paths
+	/// (`port`, `logs`) when a command needs more than one of them.
 	pub(super) async fn live_replica_name_at(
 		&self,
 		service_name: &str,
 		service: &Service,
 		index: Option<u32>,
 	) -> Result<String> {
-		let names = self.live_replica_names(service_name, service).await?;
+		let live_by_service = self.live_project_replicas_sorted().await?;
+		let names = match live_by_service.get(service_name) {
+			Some(names) if !names.is_empty() => names.clone(),
+			// Service has no live container yet — fall back to the static
+			// compose names so a never-created service still has an
+			// addressable replica.
+			_ => self.replica_names(service_name, service),
+		};
 		let base = self.container_name(service_name, service);
 		resolve_replica_name(service_name, &base, &names, index)
 	}

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -169,9 +169,14 @@ impl Engine {
 		// Resolve against the containers Podman actually has, not the static
 		// compose replica count: a service scaled purely via CLI `--scale` has no
 		// `scale:` in the file, so the static count is 1 and would target the
-		// never-created un-indexed base name. `live_replica_names` falls back to
-		// the static names only when nothing is running yet.
-		let live = self.live_replica_names(service_name, service).await?;
+		// never-created un-indexed base name. Falls back to the static names
+		// when nothing is running yet — the bulk map (`#1445`) only sees what
+		// Podman has, not the compose file.
+		let live_by_service = self.live_project_replicas_sorted().await?;
+		let live = match live_by_service.get(service_name) {
+			Some(names) if !names.is_empty() => names.clone(),
+			_ => self.replica_names(service_name, service),
+		};
 		let container_name = select_replica(live, service_name, index)?;
 
 		let path = format!(

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -284,40 +284,55 @@ impl Engine {
 			target_services.iter().map(String::as_str).collect();
 		// (container_name, is_tty) — TTY containers send raw bytes; non-TTY use
 		// multiplexed 8-byte-header framing. Resolved against the containers
-		// Podman actually has (`live_replica_names`), not the static compose
-		// replica count: after a runtime `scale`/`up --scale` the file's count no
-		// longer matches the live replicas, so `logs` would otherwise miss every
-		// replica beyond the first (falls back to the static names when none are
-		// running yet).
-		// One `live_replica_names` round-trip per selected service (a future
-		// optimization: batch this through scale.rs's `live_project_replicas`
-		// instead). A resolution failure for
-		// one service must not blank the whole command the way an `.await?` would:
-		// warn and skip that service so the rest still stream, matching the
-		// per-container tolerance below.
-		// A failure resolving ONE service is tolerated so the others still print —
-		// that is deliberate and tested. But when nothing resolves at all, the
-		// command printed nothing and still reported success, which is how an
-		// unreachable engine looked identical to a project with no logs. Kept and
-		// only consulted when there is no output to salvage.
+		// Podman actually has, not the static compose replica count: after a
+		// runtime `scale`/`up --scale` the file's count no longer matches the
+		// live replicas, so `logs` would otherwise miss every replica beyond
+		// the first. Falls back to the static names for a service absent from
+		// the map (the bulk helper does not see the compose file).
+		//
+		// Hoisted out of the per-service loop so a `logs` over N services
+		// costs one container-list round-trip, not N (#1445) — the same bulk
+		// path the per-service lifecycle commands took in #1363.
+		//
+		// A failure resolving ONE service is tolerated so the others still
+		// print — that is deliberate and tested. The bulk GET is now the only
+		// point where a single engine-side failure can land, so the same
+		// tolerance collapses into "warn + remember, the post-loop empty
+		// check surfaces the error when there is no partial result to
+		// protect" — i.e. an unreachable engine used to look like a project
+		// with no logs and still exit 0; this preserves that fix.
+		//
+		// The skip-on-fetch-error case must NOT fall back to the static
+		// names below: the original per-service loop did `continue` on a
+		// resolution error, leaving `targets` empty so the post-loop check
+		// could surface the error. Falling back to static names would push
+		// phantom containers that 404 per-container, mask the failure, and
+		// make `logs` exit 0 on an unreachable engine again.
 		let mut first_err: Option<ComposeError> = None;
+		let live_by_service = match self.live_project_replicas_sorted().await {
+			Ok(by_service) => by_service,
+			Err(e) => {
+				tracing::warn!("logs: resolving project replicas: {e}");
+				first_err.get_or_insert(e);
+				std::collections::HashMap::new()
+			}
+		};
+		let fetch_failed = first_err.is_some();
 		let mut targets: Vec<(String, bool)> = Vec::new();
-		for (n, s) in file
-			.services
-			.iter()
-			.filter(|(n, _)| selected.is_empty() || selected.contains(n.as_str()))
-		{
-			let is_tty = s.tty.unwrap_or(false);
-			let names = match self.live_replica_names(n, s).await {
-				Ok(names) => names,
-				Err(e) => {
-					tracing::warn!("logs: resolving replicas for service {n}: {e}");
-					first_err.get_or_insert(e);
-					continue;
+		if !fetch_failed {
+			for (n, s) in file
+				.services
+				.iter()
+				.filter(|(n, _)| selected.is_empty() || selected.contains(n.as_str()))
+			{
+				let is_tty = s.tty.unwrap_or(false);
+				let names = match live_by_service.get(n.as_str()) {
+					Some(names) if !names.is_empty() => names.clone(),
+					_ => self.replica_names(n, s),
+				};
+				for cname in names {
+					targets.push((cname, is_tty));
 				}
-			};
-			for cname in names {
-				targets.push((cname, is_tty));
 			}
 		}
 

--- a/internal/engine/query/tests.rs
+++ b/internal/engine/query/tests.rs
@@ -127,50 +127,17 @@ async fn logs_targets_every_live_replica_after_scale() {
 /// Resolving replicas for one selected service must not abort `logs` before
 /// a single line prints for the others: `logs` already documents that it
 /// tolerates a missing/not-yet-created container this way (see the
-/// per-container `get_stream` handling in `logs_with_display`), and a
-/// transient libpod error resolving one service's live replicas deserves the
-/// same tolerance, not a whole-command failure. Service "a" 500s on its
-/// container-list lookup; service "b" resolves normally. Pre-fix, the
-/// resolution loop's `.await?` propagates "a"'s error and `logs` never
-/// reaches "b" at all.
-#[tokio::test]
-#[cfg(unix)]
-async fn logs_skips_a_service_whose_replica_resolution_errors_but_still_targets_the_rest() {
-	let fake = fake_podman::start(move |method, target| {
-		if method == "GET" && target.contains("/containers/json") {
-			if target.contains("podup.service%3Da") {
-				(500, r#"{"message":"internal server error"}"#.to_string())
-			} else if target.contains("podup.service%3Db") {
-				(200, r#"[{"Names":["/proj-b-1"]}]"#.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		} else if method == "GET" && target.contains("/logs") {
-			(200, String::new())
-		} else {
-			(404, r#"{"message":"not found"}"#.to_string())
-		}
-	});
-	let e = engine_with(fake.client(), "proj");
-
-	let mut file = ComposeFile::default();
-	file.services.insert("a".into(), Service::default());
-	file.services.insert("b".into(), Service::default());
-
-	e.logs_with_options(
-		&file,
-		&["a".to_string(), "b".to_string()],
-		LogsOptions::default(),
-	)
-	.await
-	.expect("a resolution failure on one service must not blank logs for the rest");
-
-	let seen = fake.requests.lock().unwrap();
-	assert!(
-		seen.iter().any(|r| r.contains("/proj-b-1/logs")),
-		"expected the healthy service's container to still be targeted: {seen:?}"
-	);
-}
+/// per-container `get_stream` handling in `logs_with_display`).
+///
+/// #1445 collapsed the per-service `live_replica_names` resolution into a
+/// single bulk fetch (`live_project_replicas_sorted`), so the per-service
+/// error path this test used to drive no longer exists — there is one
+/// container-list call for the whole project, not one per service, so a
+/// per-service 500 is no longer reachable in this code. The companion
+/// `logs_fails_when_no_service_resolves_at_all` covers the only failure
+/// mode that survives the bulk refactor: the bulk GET errors out, no
+/// target survives, and `logs` exits non-zero instead of printing nothing
+/// and reporting success.
 
 #[test]
 fn filter_orphans_keeps_only_unknown_names() {

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -183,9 +183,11 @@ async fn down_does_not_report_removing_what_never_existed() {
 /// Measured before the fix on a project that was never created: `rm`, `stop`,
 /// `restart`, `kill`, `pause` and `unpause` each printed zero lines and exited
 /// 0, which reads exactly like success. Only `start` said anything. The cause is
-/// that `live_replica_names` falls back to the *static* compose names when
-/// nothing is running, so each command dutifully walked a list of container
-/// names and 404'd on every one of them.
+/// that the per-replica query helpers (the bulk
+/// [`Engine::live_project_replicas_sorted`] lookup used by `exec`/`cp`/
+/// `port`/`logs`) fall back to the *static* compose names when nothing is
+/// running, so each command dutifully walked a list of container names and
+/// 404'd on every one of them.
 #[tokio::test]
 async fn idle_lifecycle_commands_say_they_did_nothing() {
 	if !podman_up().await {


### PR DESCRIPTION
## What this changes

#1363 moved the seven lifecycle commands onto a single bulk prefetch. Three per-replica query paths were still resolving one service at a time, and the one in `logs` sat inside the per-service loop, so a `podup logs` over a 40-service project made 40 container-list calls.

They now share `live_project_replicas_sorted`, a bulk listing with each per-service bucket sorted into the same ascending `-1, -2, -3` order the static path produces. `live_replica_names` is gone; the callers hold the static-name fallback themselves, since the bulk helper does not see the compose file.

Measured with the fake socket over a four-service project:

| | container-list GETs for one `logs` |
|---|---|
| before | 4 |
| after | 1 |

## Two things worth reviewing closely

**The bulk GET keeps `all=true`.** libpod's container list defaults to running-only when no `status=` filter is given, which would drop stopped replicas — and `logs`, `port` and `exec` all need to address a replica that has exited.

**A failed bulk GET must not fall back to static names.** The old per-service loop did `continue` on a resolution error, leaving `targets` empty so the post-loop check could surface it. Falling back to static names here would push phantom containers that 404 individually, mask the failure, and put `logs` back to exiting 0 against an unreachable engine — the exact regression an earlier fix closed. The error is remembered and surfaced when nothing resolves.

One test went away with the refactor: the per-service resolution error is no longer reachable, because there is no per-service resolution. `logs_fails_when_no_service_resolves_at_all` covers the failure mode that survives, and a comment in its place records why the old one left.

## Tests

Two new ones on the helper: ascending order out of a shuffled listing, and stopped replicas surviving the bulk fetch.

I added a third, `logs_issues_one_container_list_for_the_whole_project`, because the rest of the suite cannot see this change. The resolved names come back identical whether the listing is fetched once or once per service, so every value assertion passes either way and a later refactor could put the call back inside the loop unnoticed. It drives `logs` over four services and asserts exactly one `/containers/json` reaches the socket. Checked against the pre-change code, where it counts four and fails.

#1363 shipped without an equivalent, which is how this one lasted this long.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `cargo test --lib` | 1641 passed, 0 failed |
| `cargo test --test engine_integration -- --test-threads=2` | 187 passed, 0 failed, Podman 5.7.0 |

The integration run matters here: this touches `logs`, `exec` and `cp`, and 187 is the same count `develop` produces.

Fixes #1445
