### PR TITLE
fix(pull): surface an unknown pull_policy from the dedup pass

### DIFF
--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -118,15 +118,19 @@ impl Engine {
 			// and then the per-service `pull_image` would fail downstream
 			// with the same error, N times. Resolve once and let the
 			// offending value short-circuit the whole batch (#1369).
+			//
+			// Collect into `Result`: the previous `.expect` here assumed the
+			// `up` path had already rejected an unknown value, but standalone
+			// `pull` never reaches `pull_image` before this dedup, so the
+			// invariant was false and the binary panicked on every typo
+			// (#1450).
 			.map(|(name, s)| {
 				let image = s.image.as_deref().unwrap_or_default();
-				let policy = self
-					.resolved_pull_policy(name.as_str(), s)
-					.expect("unknown pull policy already rejected in pull_image");
+				let policy = self.resolved_pull_policy(name.as_str(), s)?;
 				let key = (image, policy, s.platform.as_deref());
-				(name.as_str(), s, key)
+				Ok((name.as_str(), s, key))
 			})
-			.collect();
+			.collect::<Result<Vec<_>>>()?;
 
 		// Dedup by that key: 50 services agreeing on image, resolved policy
 		// and platform must issue one pull, not 50. Two services naming the
@@ -442,6 +446,10 @@ mod tests {
 		);
 	}
 
+	// `pull_rejects_an_unknown_pull_policy_without_panicking` lives in the
+	// sibling `pull_typo_tests.rs` to keep this file below the source-line
+	// limit (#1450).
+
 	#[test]
 	fn pull_policy_maps_every_spec_value() {
 		assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
@@ -719,3 +727,7 @@ mod tests {
 		.expect("--ignore-pull-failures must stay exit 0");
 	}
 }
+
+#[cfg(test)]
+#[path = "pull_typo_tests.rs"]
+mod typo_tests;

--- a/internal/engine/build/pull_typo_tests.rs
+++ b/internal/engine/build/pull_typo_tests.rs
@@ -1,0 +1,38 @@
+//! Targeted regression for #1450 — the standalone `pull` path used to panic
+//! on a typo'd `pull_policy:` because the dedup pass unwrapped
+//! `resolved_pull_policy` with an `.expect` whose invariant only held for
+//! `up`. Split out so adding this test does not push `build/pull.rs` over the
+//! source-line limit; the production fix lives there.
+
+/// Standalone `pull` must surface a typo'd `pull_policy:` as a structured
+/// `PodmanError::Field` carrying the offending service and value — the same
+/// shape `up` uses after #1443. Before the fix the dedup pass unwrapped
+/// `resolved_pull_policy` with `.expect`, so the binary panicked on every
+/// typo and the worker-thread death produced a second `internal error` from
+/// `main.rs:61`.
+#[tokio::test]
+async fn pull_rejects_an_unknown_pull_policy_without_panicking() {
+	let file =
+		crate::parse_str("services:\n  web:\n    image: alpine:latest\n    pull_policy: alaways\n")
+			.unwrap();
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	);
+	let err = e
+		.pull_services(&file, &[])
+		.await
+		.expect_err("unknown pull_policy must surface as Err, not panic");
+	let crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+		ref service,
+		ref field,
+		ref value,
+		..
+	}) = err
+	else {
+		panic!("expected Field error, got {err:?}");
+	};
+	assert_eq!(service, "web");
+	assert_eq!(field, "pull_policy");
+	assert!(value.contains("alaways"), "got {value}");
+}


### PR DESCRIPTION
## What this fixes

`podup pull` panicked on an invalid `pull_policy:` instead of reporting it. Measured with the built binary on a compose file carrying `pull_policy: alaways`:

| | `podup pull` |
|---|---|
| `develop` | two `internal error: panicked` reports, exit 101 |
| this branch | `podup: error: podman error: service.web: pull_policy: unknown pull policy "alaways": ...`, exit 1 |

The `.expect` at `internal/engine/build/pull.rs:125` stated an invariant that did not hold on this path: it claimed the value had "already been rejected in `pull_image`", but `resolved_pull_policy` is called here, inside the `map` that builds the dedup keys, and that runs *before* any `pull_image`. On the standalone `pull` path nothing had rejected it yet, so the `expect` was the first thing to see it. The invariant holds for `up`, which is presumably where it was written.

The error was already well-formed by then — #1443 and #1357 gave it the service, field and value — so the fix is to return it rather than unwrap it. The `map` now collects into `Result`.

## Test

`pull_rejects_an_unknown_pull_policy_without_panicking`. I checked it discriminates rather than assuming: reverting the `?` back to `.expect` turns it red at `pull.rs:129`, and restoring it turns it green.

It lives in a sibling `pull_typo_tests.rs` because `pull.rs` is at 491 code lines against a 500 hard limit. Worth knowing for whoever touches this file next — there is not much room left.

## Not addressed here

The panic surfaced twice, once from the `expect` and once from `internal/main.rs:61` ("podup worker thread panicked"). One panic producing two `internal error` reports is its own defect, and unrelated to which value triggered it. Left alone rather than widened into this PR.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `cargo test --lib` | 1651 passed, 0 failed |
| built binary, `podup pull` | table above |

Fixes #1450
