### PR TITLE
fix(engine): send log rotation via libpod's typed size field, not options

### DIFF
--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -125,7 +125,7 @@ impl Engine {
 		let (restart_policy, restart_tries) = build_restart_policy(service);
 
 		// --- Logging ---
-		let log_configuration = build_log_config(service.logging.as_ref());
+		let log_configuration = build_log_config(service_name, service.logging.as_ref())?;
 
 		// --- Networks ---
 		let (netns, networks) = resolve_network_mode(service_name, service, file, &self.project);

--- a/internal/engine/container_config/log_config_tests.rs
+++ b/internal/engine/container_config/log_config_tests.rs
@@ -1,0 +1,175 @@
+//! Tests for `build_log_config` — the bridge between compose `logging:` and
+//! libpod's `LogConfig`. Split from `mod.rs` so the production file stays under
+//! the 500-line cap and each surface (struct vs wire JSON vs malformed input
+//! vs `max-file` drop) gets its own focused case (#1417).
+
+use super::*;
+use crate::compose::types::LoggingConfig;
+
+#[test]
+fn log_config_applies_the_default_when_absent() {
+	// A service with no `logging:` block gets the rotation default so
+	// containers cannot run with unbounded log growth (#1354). libpod
+	// reads rotation from `size`, not from options.max-size, so the
+	// default must travel in the typed field (#1417).
+	let cfg = build_log_config("web", None)
+		.expect("absent -> default, not error")
+		.expect("absent -> default, not None");
+	assert_eq!(cfg.driver.as_deref(), Some("k8s-file"));
+	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
+	// `max-size`/`max-file` no longer travel inside options — libpod would
+	// ignore them there, leaving the container with -1B.
+	assert!(!cfg.options.contains_key("max-size"));
+	assert!(!cfg.options.contains_key("max-file"));
+}
+
+#[test]
+fn log_config_default_serializes_size_as_bytes() {
+	// Struct-level assertions passed before #1417 was filed and the
+	// defect still shipped. The wire format is what libpod parses, so the
+	// fix has to be anchored on the serialized JSON.
+	let cfg = build_log_config("web", None).unwrap().unwrap();
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["driver"], "k8s-file");
+	assert_eq!(v["size"], 10 * 1024 * 1024);
+	assert!(
+		v.get("options").is_none(),
+		"empty options must be elided, got {v}"
+	);
+}
+
+#[test]
+fn log_config_driver_only() {
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: Default::default(),
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.driver.as_deref(), Some("json-file"));
+	assert!(cfg.size.is_none());
+	assert!(cfg.options.is_empty());
+}
+
+#[test]
+fn log_config_with_max_size_parses_into_typed_field() {
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "10m".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
+	// And on the wire — what libpod actually parses — the key is `size`
+	// and the value is a number, not the suffixed string under options.
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["size"], 10 * 1024 * 1024);
+	assert_eq!(v["size"].as_i64().unwrap(), 10_485_760);
+	assert!(
+		v["options"].get("max-size").is_none(),
+		"max-size must not also travel in options: {v}"
+	);
+}
+
+#[test]
+fn log_config_max_size_minus_one_disables_rotation() {
+	// libpod treats `size: -1` as unlimited, mirroring Docker's
+	// `--log-opt max-size=-1` convention. Compose users reach for the
+	// same string, so the parser must surface it rather than drop it.
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "-1".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(-1));
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["size"], -1);
+}
+
+#[test]
+fn log_config_max_size_plain_bytes() {
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "1048576".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(1_048_576));
+}
+
+#[test]
+fn log_config_max_file_is_dropped_with_warning() {
+	// libpod does not implement `max-file` on any path; forwarding it as
+	// a `LogOpt` would silently disappear. The unit test asserts the
+	// struct shape; the warning side is exercised by the engine path
+	// and surfaced separately.
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "10m".into());
+	opts.insert("max-file".into(), "5".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
+	assert!(
+		!cfg.options.contains_key("max-file"),
+		"max-file must be dropped, got {v}",
+		v = serde_json::to_string(&cfg).unwrap()
+	);
+	// And nothing carrying the dead key reached the wire.
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert!(
+		v.get("options").is_none(),
+		"options leaked onto the wire: {v}"
+	);
+}
+
+#[test]
+fn log_config_max_size_malformed_returns_field_error() {
+	// libpod would answer this with a 500 ("cannot unmarshal string into
+	// size of type int64"); surfacing it as a PodmanError::Field points
+	// the user at the compose key they wrote, not at libpod's Go type
+	// (#1417).
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "diez megas".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let err = build_log_config("web", Some(&logging)).unwrap_err();
+	match err {
+		ComposeError::Podman(crate::libpod::error::PodmanError::Field {
+			service,
+			field,
+			value,
+			..
+		}) => {
+			assert_eq!(service, "web");
+			assert_eq!(field, "logging.options.max-size");
+			assert_eq!(value, "diez megas");
+		}
+		other => panic!("expected PodmanError::Field, got {other:?}"),
+	}
+}
+
+#[test]
+fn log_config_unsupported_options_pass_through() {
+	// `path` and `tag` are the only options libpod honours for the
+	// built-in drivers (see `man podman-run`); they must reach the wire
+	// unchanged when the user sets them.
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("path".into(), "/var/log/app.log".into());
+	opts.insert("tag".into(), "{{.Name}}".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["options"]["path"], "/var/log/app.log");
+	assert_eq!(v["options"]["tag"], "{{.Name}}");
+}

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -3,9 +3,12 @@
 //!
 //! Device, blkio, tmpfs, and label-file helpers live in `super::container::fields`.
 
+use std::collections::HashMap;
+
 use crate::compose::types::{
 	Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart, Service,
 };
+use crate::error::ComposeError;
 use crate::libpod::types::container::{HealthConfig, LogConfig};
 use crate::size;
 
@@ -78,33 +81,78 @@ pub(super) fn build_restart_policy(service: &Service) -> (Option<String>, Option
 /// Default log rotation applied when a compose file does not carry a
 /// `logging:` block. `k8s-file` is the libpod default since Podman 4; pinning
 /// it explicitly here stops the answer from drifting between podman versions
-/// and distros, and the 10 MB / 5-file shape gives ~50 MB per container —
-/// enough for a week of typical service output, small enough that a runaway
-/// loop will not exhaust the host. The user can override by writing their
-/// own `logging:` in compose.
+/// and distros. The 10 MB cap is enough for a week of typical service output
+/// and small enough that a runaway loop will not exhaust the host. libpod
+/// does not honour `max-file` on any path (see `man podman-run`), so it is
+/// not part of the default; the user can override by writing their own
+/// `logging:` in compose (#1417).
 pub(crate) fn default_log_config() -> LogConfig {
 	LogConfig {
 		driver: Some("k8s-file".into()),
-		options: [
-			("max-size".to_string(), "10m".to_string()),
-			("max-file".to_string(), "5".to_string()),
-		]
-		.into_iter()
-		.collect(),
+		size: Some(10 * 1024 * 1024),
+		options: HashMap::new(),
 	}
 }
 
 /// Resolve the `logging:` block into libpod's `LogConfig`. An absent compose
 /// `logging:` maps to [`default_log_config`] so every container podup creates
-/// has a rotation policy without the user having to set one. The user's
-/// `Some(LoggingConfig)` value is passed through unchanged.
-pub(crate) fn build_log_config(logging: Option<&LoggingConfig>) -> Option<LogConfig> {
-	Some(match logging {
-		Some(l) => LogConfig {
-			driver: l.driver.clone(),
-			options: l.options.clone(),
+/// has a rotation policy without the user having to set one. When the user
+/// supplies a block, `max-size` is parsed into the typed [`LogConfig::size`]
+/// field libpod actually reads rotation from (passing it inside `options` is
+/// silently ignored — #1417); `max-file` is dropped with a warning because
+/// libpod does not implement it. A malformed `max-size` is rejected with a
+/// `PodmanError::Field` so the user gets a compose-flavoured error instead of
+/// a 500 from libpod's JSON unmarshal.
+pub(crate) fn build_log_config(
+	service_name: &str,
+	logging: Option<&LoggingConfig>,
+) -> Result<Option<LogConfig>, ComposeError> {
+	match logging {
+		Some(l) => Ok(Some(translate_user_logging(service_name, l)?)),
+		None => Ok(Some(default_log_config())),
+	}
+}
+
+/// Translate a user-supplied `logging:` block into libpod's [`LogConfig`].
+///
+/// `max-size` is moved into the typed `size` field. `max-file` is dropped
+/// with a warning — libpod does not implement it and would silently ignore
+/// it if forwarded. The user-supplied value of `max-size` is parsed with the
+/// same memory parser used elsewhere in the engine (`10m`, `1g`, plain
+/// bytes); a malformed value is rejected with the service field name so the
+/// error points at the compose key the user wrote (#1417).
+fn translate_user_logging(
+	service_name: &str,
+	l: &LoggingConfig,
+) -> Result<LogConfig, ComposeError> {
+	let mut options = l.options.clone();
+	let size = match options.remove("max-size") {
+		Some(v) => match size::parse_memory(&v) {
+			Some(bytes) => Some(bytes),
+			None => {
+				return Err(ComposeError::Podman(
+					crate::libpod::validate::spec_field_error(
+						service_name,
+						"logging.options.max-size",
+						&v,
+						"must be a byte count (e.g. '10m', '1024', '1g'); \
+						 libpod rejects an invalid `size` outright",
+					),
+				));
+			}
 		},
-		None => default_log_config(),
+		None => None,
+	};
+	if options.remove("max-file").is_some() {
+		tracing::warn!(
+			"logging.options.max-file is ignored by libpod; \
+			 remove it from your compose file or expect unbounded log growth"
+		);
+	}
+	Ok(LogConfig {
+		driver: l.driver.clone(),
+		size,
+		options,
 	})
 }
 
@@ -163,8 +211,7 @@ pub(super) fn build_healthcheck(hc: &HealthCheck) -> HealthConfig {
 mod tests {
 	use super::*;
 	use crate::compose::types::{
-		Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart,
-		Service,
+		Command as ComposeCommand, HealthCheck, RestartPolicy as ComposeRestart, Service,
 	};
 
 	fn default_service() -> Service {
@@ -347,41 +394,6 @@ mod tests {
 		assert_eq!(tries, Some(3));
 	}
 
-	// --- log config ---
-
-	#[test]
-	fn log_config_applies_the_default_when_absent() {
-		// A service with no `logging:` block gets the rotation default so
-		// containers cannot run with unbounded log growth (#1354).
-		let cfg = build_log_config(None).expect("absent -> default, not None");
-		assert_eq!(cfg.driver.as_deref(), Some("k8s-file"));
-		assert_eq!(cfg.options.get("max-size").map(String::as_str), Some("10m"));
-		assert_eq!(cfg.options.get("max-file").map(String::as_str), Some("5"));
-	}
-
-	#[test]
-	fn log_config_driver_only() {
-		let logging = LoggingConfig {
-			driver: Some("json-file".into()),
-			options: Default::default(),
-		};
-		let cfg = build_log_config(Some(&logging)).unwrap();
-		assert_eq!(cfg.driver.as_deref(), Some("json-file"));
-		assert!(cfg.options.is_empty());
-	}
-
-	#[test]
-	fn log_config_with_options() {
-		let mut opts = std::collections::HashMap::new();
-		opts.insert("max-size".into(), "10m".into());
-		let logging = LoggingConfig {
-			driver: Some("json-file".into()),
-			options: opts,
-		};
-		let cfg = build_log_config(Some(&logging)).unwrap();
-		assert_eq!(cfg.options["max-size"], "10m");
-	}
-
 	// --- healthcheck ---
 
 	#[test]
@@ -457,3 +469,7 @@ mod tests {
 		assert_eq!(cfg.retries, Some(7));
 	}
 }
+
+#[cfg(test)]
+#[path = "log_config_tests.rs"]
+mod log_config_tests;

--- a/internal/libpod/types/container/spec/parts.rs
+++ b/internal/libpod/types/container/spec/parts.rs
@@ -421,13 +421,23 @@ pub struct StartupHealthCheck {
 }
 
 /// Container log driver configuration.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct LogConfig {
 	/// Log driver name (e.g. `"json-file"`, `"journald"`, `"k8s-file"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
-	/// Driver-specific options (e.g. `max-size`, `max-file`).
+	/// Maximum log file size in **bytes**. libpod reads rotation from this
+	/// sibling field and ignores `max-size` keys inside [`options`](Self::options)
+	/// (#1417). `-1` disables rotation, matching the Docker `--log-opt max-size=-1`
+	/// convention.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub size: Option<i64>,
+
+	/// Driver-specific options. The only keys libpod honours for the built-in
+	/// log drivers are `path` and `tag` (see `man podman-run`); `max-file` is
+	/// silently dropped by libpod regardless of where it appears, and `max-size`
+	/// must travel as the typed [`size`](Self::size) field above.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub options: HashMap<String, String>,
 }

--- a/internal/quadlet/tests/fields_logging.rs
+++ b/internal/quadlet/tests/fields_logging.rs
@@ -13,6 +13,13 @@ use crate::quadlet::generate_at;
 /// generated quadlet units ship the same rotation policy that `up` would
 /// apply at runtime (#1354). Without this, `generate quadlet` would emit a
 /// unit that runs without rotation, diverging from `up` behaviour.
+///
+/// The cap is rendered as a byte count rather than `10m` since #1417 moved
+/// it into libpod's typed `size` field; `podman run --log-opt
+/// max-size=10485760` was measured to produce the same cap as `max-size=10m`
+/// on Podman 5.7.0. `max-file` is deliberately absent: it was measured to be
+/// dropped by both the API and the CLI, so emitting it promised a rotation
+/// nothing performed.
 #[test]
 fn logging_default_is_emitted_when_logging_block_is_absent() {
 	let yaml = r#"
@@ -28,12 +35,13 @@ services:
 		"missing default LogDriver in:\n{c}"
 	);
 	assert!(
-		c.contains("LogOpt=max-size=10m"),
+		c.contains("LogOpt=max-size=10485760"),
 		"missing max-size LogOpt in:\n{c}"
 	);
 	assert!(
-		c.contains("LogOpt=max-file=5"),
-		"missing max-file LogOpt in:\n{c}"
+		!c.contains("max-file"),
+		"max-file is honoured by neither the API nor the CLI; emitting it \
+		 promises a rotation nothing performs:\n{c}"
 	);
 }
 
@@ -62,11 +70,7 @@ services:
 		"user options not applied:\n{c}"
 	);
 	assert!(
-		!c.contains("max-size=10m"),
-		"default leaked through override:\n{c}"
-	);
-	assert!(
-		!c.contains("max-file=5"),
+		!c.contains("max-size"),
 		"default leaked through override:\n{c}"
 	);
 }

--- a/internal/quadlet/tests/mod.rs
+++ b/internal/quadlet/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::quadlet::{QuadletOutput, QuadletUnit};
 
 mod fields;
+mod fields_logging;
 mod health;
 mod network_volume;
 mod units;

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -381,12 +381,30 @@ pub(crate) fn container_unit(
 	// `LogDriver=` / `LogOpt=` set on the generated unit (#1354). The render
 	// path is the same as the live engine's, so `up` and `generate quadlet`
 	// produce equivalent rotation policy.
-	if let Some(logging) = build_log_config(service.logging.as_ref()) {
-		if let Some(driver) = &logging.driver {
-			container.add("LogDriver", driver.clone());
+	match build_log_config(name, service.logging.as_ref()) {
+		Ok(Some(logging)) => {
+			if let Some(driver) = &logging.driver {
+				container.add("LogDriver", driver.clone());
+			}
+			for (key, val) in sorted_label_pairs(logging.options) {
+				container.add("LogOpt", format!("{key}={val}"));
+			}
 		}
-		for (key, val) in sorted_label_pairs(logging.options) {
-			container.add("LogOpt", format!("{key}={val}"));
+		Ok(None) => {}
+		Err(e) => {
+			// A malformed `max-size` does not abort generation; render the
+			// default rotation and surface the parse error as a warning so the
+			// user sees it before `up` rejects the same value outright.
+			warnings.push(format!("{name}: {e}"));
+			let logging = build_log_config(name, None)
+				.expect("default log config is infallible")
+				.expect("default returns Some");
+			if let Some(driver) = &logging.driver {
+				container.add("LogDriver", driver.clone());
+			}
+			for (key, val) in sorted_label_pairs(logging.options) {
+				container.add("LogOpt", format!("{key}={val}"));
+			}
 		}
 	}
 	if let Some(pull) = &service.pull_policy {

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -382,14 +382,7 @@ pub(crate) fn container_unit(
 	// path is the same as the live engine's, so `up` and `generate quadlet`
 	// produce equivalent rotation policy.
 	match build_log_config(name, service.logging.as_ref()) {
-		Ok(Some(logging)) => {
-			if let Some(driver) = &logging.driver {
-				container.add("LogDriver", driver.clone());
-			}
-			for (key, val) in sorted_label_pairs(logging.options) {
-				container.add("LogOpt", format!("{key}={val}"));
-			}
-		}
+		Ok(Some(logging)) => emit_log_config(&mut container, logging),
 		Ok(None) => {}
 		Err(e) => {
 			// A malformed `max-size` does not abort generation; render the
@@ -399,12 +392,7 @@ pub(crate) fn container_unit(
 			let logging = build_log_config(name, None)
 				.expect("default log config is infallible")
 				.expect("default returns Some");
-			if let Some(driver) = &logging.driver {
-				container.add("LogDriver", driver.clone());
-			}
-			for (key, val) in sorted_label_pairs(logging.options) {
-				container.add("LogOpt", format!("{key}={val}"));
-			}
+			emit_log_config(&mut container, logging);
 		}
 	}
 	if let Some(pull) = &service.pull_policy {
@@ -489,5 +477,30 @@ pub(crate) fn container_unit(
 	QuadletUnit {
 		filename: format!("{}.container", unit_stem(project, name)),
 		contents,
+	}
+}
+
+/// Render a resolved [`LogConfig`] onto a Quadlet `[Container]` section.
+///
+/// Quadlet units run through the podman CLI, which reads rotation from
+/// `--log-opt max-size=` — not from the typed `size` field the libpod API
+/// takes. #1417 moved `max-size` out of `options` into that typed field for
+/// the live path, and rendering `options` alone here dropped rotation from
+/// every generated unit: measured before this helper, a default project
+/// emitted `LogDriver=k8s-file` and no `LogOpt` at all, where it used to
+/// carry `LogOpt=max-size=10m`.
+///
+/// The byte count is emitted verbatim; `podman run --log-opt
+/// max-size=10485760` was measured to produce the same `10.49MB` cap as
+/// `max-size=10m` on Podman 5.7.0, so no suffix has to be reconstructed.
+fn emit_log_config(container: &mut Section, logging: crate::libpod::types::container::LogConfig) {
+	if let Some(driver) = &logging.driver {
+		container.add("LogDriver", driver.clone());
+	}
+	if let Some(size) = logging.size {
+		container.add("LogOpt", format!("max-size={size}"));
+	}
+	for (key, val) in sorted_label_pairs(logging.options) {
+		container.add("LogOpt", format!("{key}={val}"));
 	}
 }

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -62,8 +62,7 @@ Network=proj-frontend.network
 Label=podup.project=proj
 Label=podup.service=web
 LogDriver=k8s-file
-LogOpt=max-file=5
-LogOpt=max-size=10m
+LogOpt=max-size=10485760
 
 [Service]
 Restart=always


### PR DESCRIPTION
## What this fixes

Every container podup creates has unlimited logs. The rotation default from #1354 and any user `logging:` block both wrote `max-size` into `LogConfig.options`, and libpod reads rotation from a sibling typed `size` field instead.

End-to-end on Podman 5.7.0, a compose file with no `logging:` block at all, reading the container `up` actually created:

| | `.HostConfig.LogConfig.Size` |
|---|---|
| `develop` | `-1B` (unlimited) |
| this branch | `10.49MB` |

`3.7.0` is on `main` but not released, so this is still catchable before it ships.

## How

`LogConfig` gains the typed `size` field, and `build_log_config` moves `max-size` into it, parsing the suffix with the engine's existing `size::parse_memory` (`10m`, `1g`, plain bytes) rather than a second suffix table. A malformed value is rejected with a `PodmanError::Field` naming `logging.options.max-size`, in the same shape as the other pre-validated compose fields, instead of reaching libpod and coming back as a 500.

`LogConfig` is reachable only through `pub(crate) mod libpod`, so adding a field is not a public-API change and carries no semver impact.

## `max-file` is dropped, measured rather than assumed

Neither path honours it. On Podman 5.7.0:

- API: `{"log_configuration":{"driver":"k8s-file","size":10485760,"options":{"max-file":"5"}}}` → `"Size": "10.49MB"`, `"Config": null`
- CLI: `podman run --log-opt max-size=10m --log-opt max-file=5` → `"Size": "10MB"`, `"Config": null`

It is out of the default and dropped from a user block with a warning. Emitting it promised a rotation nothing performed.

## A regression in the Quadlet export, and the test that should have caught it

Moving `max-size` out of `options` silently emptied the Quadlet export, which renders `LogOpt` from `options` alone. Measured on a default project:

| | generated `.container` |
|---|---|
| `develop` | `LogDriver=k8s-file`, `LogOpt=max-file=5`, `LogOpt=max-size=10m` |
| first commit here | `LogDriver=k8s-file`, nothing else |

Quadlet units run through the podman CLI, which reads rotation from `--log-opt`, so the typed field never reaches them. Both call sites now render through one `emit_log_config` that writes the byte count as `max-size`; `podman run --log-opt max-size=10485760` was measured to cap at the same `10.49MB` as `max-size=10m`, so no suffix is reconstructed.

`internal/quadlet/tests/fields_logging.rs` asserts exactly this and would have caught it. It was added by #1355 alongside the feature it guards, and `mod fields_logging;` was never added to `tests/mod.rs` — so it had never compiled or run, not once. Its own header explains how: it was split out of `fields.rs` because that file was near the line cap, and the declaration did not follow.

It is declared now, its assertions updated to the measured behaviour, and I confirmed the first one fails when the `max-size` line is removed again.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `cargo test --lib` | 1658 passed, 0 failed |
| `cargo test --test engine_integration -- --test-threads=2` | 187 passed, 0 failed, Podman 5.7.0 |
| `up` then `podman inspect` | table at the top |
| `generate quadlet` | table above |

Fixes #1417
