### PR TITLE
release: 3.7.0

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v6.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
           python-version: "3.13"
       - name: Install pinned cryptography
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v6.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
           python-version: "3.13"
       - name: Install pinned cryptography

--- a/.github/workflows/podman-lane-develop-nightly.yml
+++ b/.github/workflows/podman-lane-develop-nightly.yml
@@ -17,8 +17,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 21 * * *"
-  pull_request:
-    branches: [develop]
 permissions:
   contents: read
 jobs:
@@ -37,6 +35,8 @@ jobs:
         podman: ["6"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: develop
       - name: Install qemu + cloud tools
         run: sudo apt-get update -qq && sudo apt-get install -y -qq qemu-system-x86 qemu-utils cloud-image-utils
       - name: Fetch Fedora rawhide cloud image (Podman 6)

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -179,8 +179,8 @@ jobs:
                 PASS=$(grep -oE 'test result: .* [0-9]+ passed' /tmp/cargo.log | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' | tail -1)
                 FAIL=$(grep -oE '[0-9]+ failed' /tmp/cargo.log | grep -oE '[0-9]+' | tail -1)
                 FLAKY=$(grep -cE "$DROPPED" /tmp/cargo.log)
-                echo "PODUP_TESTS_RC=$RC"
-                echo "PODUP_SUMMARY pass=${PASS:-0} fail=${FAIL:-0} flaky=${FLAKY:-0}"
+                echo "PODUP_TESTS_RC_BEGIN rc=$RC PODUP_TESTS_RC_END"
+                echo "PODUP_SUMMARY_BEGIN pass=${PASS:-0} fail=${FAIL:-0} flaky=${FLAKY:-0} PODUP_SUMMARY_END"
                 # Coverage, measured where the integration tests can actually run.
                 # Reported, never gated — see the note where COVERAGE is set. A
                 # failure here must not redden the leg: this is an observation, and
@@ -252,14 +252,14 @@ jobs:
                 # detail lines, which the 4-space-exact match skips); no failures
                 # yields an empty list, not an error.
                 FAILED_TESTS=$(sed -n '/^failures:$/,/^test result:/p' /tmp/cargo.log | grep -oE '^    [A-Za-z0-9_:]+$' | tr -d ' ' | paste -sd, -)
-                echo "PODUP_FAILED_TESTS=${FAILED_TESTS}"
+                echo "PODUP_FAILED_TESTS_BEGIN tests=${FAILED_TESTS} PODUP_FAILED_TESTS_END"
           runcmd:
-            - bash -c 'F=$(findmnt -no FSTYPE /); case $F in btrfs) btrfs filesystem resize max / ;; xfs) xfs_growfs / ;; ext4) resize2fs $(findmnt -no SOURCE /) ;; esac >/dev/console 2>&1; echo "DISK=$(df -h / | tail -1)" >/dev/console'
+            - bash -c 'F=$(findmnt -no FSTYPE /); case $F in btrfs) btrfs filesystem resize max / ;; xfs) xfs_growfs / ;; ext4) resize2fs $(findmnt -no SOURCE /) ;; esac >/dev/console 2>&1; echo "DISK_BEGIN value=$(df -h / | tail -1) DISK_END" >/dev/console'
             - bash -c 'dnf install -y podman rust cargo gcc git llvm >/dev/console 2>&1'
             # Prove the driver took, so a silently-ignored config cannot put the
             # logs tests back to passing without reading anything.
-            - bash -c 'echo "LOGDRIVER=$(podman info --format {{.Host.LogDriver}} 2>/dev/null)" >/dev/console'
-            - bash -c 'echo "PODMAN=$(podman --version)  RUST=$(rustc --version)" >/dev/console'
+            - bash -c 'echo "LOGDRIVER_BEGIN value=$(podman info --format {{.Host.LogDriver}} 2>/dev/null) LOGDRIVER_END" >/dev/console'
+            - bash -c 'echo "PODMAN_BEGIN version=$(podman --version)  RUST=$(rustc --version) PODMAN_END" >/dev/console'
             - bash -c 'echo "tester:100000:65536" >/etc/subuid; echo "tester:100000:65536" >/etc/subgid'
             - bash -c 'loginctl enable-linger tester; sleep 6'
             - bash -c 'mkdir -p /mnt/repo && mount -t 9p -o trans=virtio,version=9p2000.L repo /mnt/repo && cp -a /mnt/repo /home/tester/podup && chown -R tester:tester /home/tester/podup'
@@ -294,10 +294,10 @@ jobs:
       - name: Verify podup core suite passed on the target Podman
         run: |
           L="$RUNNER_TEMP/vm.log"
-          echo "=== key lines ==="; grep -E 'DISK=|PODMAN=|test result:|PODUP_TESTS_RC|No space' "$L" | tail -10 || true
+          echo "=== key lines ==="; grep -E 'DISK_BEGIN|PODMAN_BEGIN|test result:|PODUP_TESTS_RC_BEGIN|No space' "$L" | tail -10 || true
           grep -q 'No space left' "$L" && { echo "::error::VM disk full — run invalid"; exit 1; }
-          VER=$(grep -oE 'PODMAN=podman version [0-9.]+' "$L" | grep -oE '[0-9.]+' | tail -1)
-          grep -qE 'PODMAN=podman version [0-9]' "$L" || { echo "::error::Podman not detected in VM"; exit 1; }
+          VER=$(perl -0777 -ne 'while (/PODMAN_BEGIN\s+version=podman version ([0-9.]+)(?s:(?:(?!PODMAN_BEGIN).)*?)PODMAN_END/g) { print "$1\n" }' "$L" | tail -1)
+          [ -n "$VER" ] || { echo "::error::Podman not detected in VM"; exit 1; }
           # The VM must be able to serve logs. Gate on that, not on which driver
           # provides it: Fedora 44's journald cannot open its library here and every
           # logs request 500s, while rawhide's works fine — so requiring a specific
@@ -307,7 +307,7 @@ jobs:
           # `unwrap()` the result passed without fetching a byte, because `logs`
           # swallowed the 500 and returned success. Green-and-meaningless is worse
           # than red, so the signature is a hard failure.
-          echo "log driver: $(grep -oE 'LOGDRIVER=[a-z0-9-]+' "$L" | tail -1)"
+          echo "log driver: $(perl -0777 -ne 'while (/LOGDRIVER_BEGIN\s+value=([a-z0-9-]+)(?s:(?:(?!LOGDRIVER_BEGIN).)*?)LOGDRIVER_END/g) { print "$1\n" }' "$L" | tail -1)"
           if grep -q 'unable to open a handle to the library' "$L"; then
             echo "::error::the VM could not serve logs (journald cannot open its library) — the logs tests would pass without reading anything"
             exit 1
@@ -319,7 +319,7 @@ jobs:
           esac
           # Read the machine-readable summary the VM computed from the FULL cargo
           # log (the console here is tail-truncated, so don't recount from it).
-          SUM=$(grep -oE 'PODUP_SUMMARY pass=[0-9]+ fail=[0-9]+ flaky=[0-9]+' "$L" | tail -1)
+          SUM=$(perl -0777 -ne 'while (/PODUP_SUMMARY_BEGIN\s+pass=(\d+)(?s:(?:(?!PODUP_SUMMARY_BEGIN).)*?)fail=(\d+)(?s:(?:(?!PODUP_SUMMARY_BEGIN).)*?)flaky=(\d+)\s+PODUP_SUMMARY_END/g) { print "PODUP_SUMMARY pass=$1 fail=$2 flaky=$3\n" }' "$L" | tail -1)
           [ -n "$SUM" ] || { echo "::error::no PODUP_SUMMARY from VM on Podman $VER — suite did not report"; exit 1; }
           # Coverage, when this run asked for it. Reported into the job summary.
           # Gated on the scheduled + manual paths only, on Podman 6 (the leg that
@@ -363,7 +363,7 @@ jobs:
           # its final element — which then matches nothing in the classified list
           # and reports the last failing test as an unexpected regression. That is
           # exactly how this gate false-reddened on its first run.
-          FAILED_TESTS=$(grep -oE 'PODUP_FAILED_TESTS=.*' "$L" | tail -1 | cut -d= -f2- | tr -d '\r' || true)
+          FAILED_TESTS=$(perl -0777 -ne 'while (/PODUP_FAILED_TESTS_BEGIN\s+tests=((?:(?!PODUP_FAILED_TESTS_BEGIN).)*?)\s+PODUP_FAILED_TESTS_END/sg) { print "$1\n" }' "$L" | tail -1 | tr -d '\r' || true)
           if [ -n "$FAILED_TESTS" ]; then
             echo "Failing tests on Podman $VER: $FAILED_TESTS"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
           "$venv_py" .github/scripts/sign.py "${{ matrix.asset }}"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ matrix.asset }}
 
@@ -274,7 +274,7 @@ jobs:
           echo "Staged $(basename "$deb")"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: podup_*_${{ matrix.arch }}.deb
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,6 +449,31 @@ jobs:
             "$venv_py" .github/scripts/verify-signing-key.py "$base" "$sig"
           done
 
+      - name: Check out Glyndor/.github for the asset-existence script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: Glyndor/.github
+          ref: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+          persist-credentials: false
+          path: upstream
+
+      - name: Verify every file the installers fetch is staged
+        run: |
+          set -euo pipefail
+          # The asset-contract gate compares install.sh against this file and
+          # answers "do the two agree on the names". It cannot answer "does the
+          # release produce them" — a workflow file is a statement of intent,
+          # not proof that a step ran. This is where that question is
+          # answerable: everything is built, signed and checksummed, and the
+          # release is not immutable yet. The script derives what to look for
+          # from install.sh's own ${BASE_URL} fetches, so it covers
+          # SHA256SUMS.sig too — install.sh aborts without it, and nothing
+          # upstream of here ever checked it was produced.
+          python3 upstream/scripts/verify-release-assets.py \
+            --workdir . \
+            --install-script install.sh \
+            --install-ps1 install.ps1
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,21 +355,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,6 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
@@ -724,7 +718,7 @@ version = "3.7.0"
 dependencies = [
  "anstream",
  "anstyle",
- "base64 0.23.1",
+ "base64",
  "bytes",
  "clap",
  "clap_complete",
@@ -1221,11 +1215,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "log",
  "percent-encoding",
  "rustls",
@@ -1237,11 +1231,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http",
  "httparse",
  "log",

--- a/debian/changelog
+++ b/debian/changelog
@@ -20,10 +20,42 @@ podup (3.7.0) unstable; urgency=medium
 
   Fixed
 
+  * Log rotation never reached libpod. The default added in 3.7.0, and any
+    `logging:` block a user wrote, put `max-size` into the driver options map;
+    libpod reads rotation from a sibling typed field and ignores the option, so
+    every container podup created ran with unlimited logs. Measured on Podman
+    5.7.0, a container created by `up` reported a `-1B` cap where it now
+    reports `10.49MB`. `max-file` is gone from the default and dropped from a
+    user block with a warning: neither the API nor the CLI honours it, so
+    emitting it promised a rotation nothing performed. The Quadlet export
+    carries the cap as a byte count in `LogOpt=max-size=`, which is where the
+    podman CLI reads it.
+  * A libpod 4xx/5xx now names the compose field that caused it. The fields
+    libpod validates itself (`pid`, `ipc`, `uts`, `cgroup`, `userns_mode`,
+    `device_cgroup_rule`, `build.args` and `build.labels` keys) are checked
+    before the request is sent and reported as `service.<name>: <field>: ...
+    (value: ...)`; for the fields libpod forwards verbatim, its message is
+    preserved rather than replaced with a generic HTTP body.
+  * An unknown `pull_policy` is rejected at every site that resolves it, not
+    only the one. Three paths still read a typo as `missing`, and the worst of
+    them was the skip that fires when the image is already present locally: the
+    one pull that would have surfaced the bad value never ran, and `up` exited
+    0 having used a stale image. A standalone `podup pull` also panicked on the
+    same input rather than reporting it, because the dedup pass asserted the
+    value had already been rejected by a code path it runs before.
+  * `--format json` no longer prints an empty document when serialisation
+    fails. `ls`, `ps`, `images`, `top` and `volumes` swallowed the error and
+    exited 0, so a script consuming the output could not tell a failure from an
+    empty result set.
+
   * `interpolate_value` gates the parent mapping rebuild on
     `mapping_needs_interp`, which only enters the rebuild when a descendant
     string actually carries a `$`. The 10k key/value pairs on a 100-service
     file no longer move for free.
+  * `logs`, `exec`, `cp` and `port` resolved a service's replicas with one
+    container-list request per service. They now share the single project-wide
+    listing the lifecycle commands already used, so a `logs` over a
+    forty-service project costs one request rather than forty.
   * The progress ticker re-probed terminal capabilities and queried the
     window size on every 100 ms tick; both are now cached at `begin()` and
     re-read only when the size actually matters. `progress_line` also took

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -10,9 +10,10 @@ mod pull;
 mod push;
 mod stream;
 mod tags;
-/// Shared with the `up` image-prefetch stage so it resolves a service's
-/// effective pull policy identically to the pull path below.
-pub(in crate::engine) use pull::libpod_pull_policy;
+/// Shared with the `up` image-prefetch and `up`/pull decision paths so they
+/// resolve a service's effective pull policy identically to the pull path
+/// below, and reject an unrecognized value the same way (#1443).
+pub(in crate::engine) use pull::pull_policy_checked;
 pub use pull::PullOptions;
 pub use push::PushOptions;
 /// Shared with the container-create path so an `up`/`create` references the same

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -27,6 +27,7 @@ use crate::compose::types::{BuildConfig, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::BuildOutput;
 use crate::libpod::urlencoded;
+use crate::libpod::validate::pre_validate_build;
 use crate::libpod::API_PREFIX;
 use crate::size;
 
@@ -248,6 +249,14 @@ impl Engine {
 		if let BuildConfig::Config { labels: l, .. } = build {
 			labels.extend(l.to_map());
 		}
+
+		// Pre-validate the keys libpod's buildkit-fronted parser rejects
+		// (anything outside `[A-Za-z0-9_.-]`), so a bad `build.args` or
+		// `build.labels` key surfaces as a `PodmanError::Field` naming the
+		// compose-side field rather than libpod's `400` body. Runs before
+		// the build URL is assembled so a bad key fails before any POST to
+		// the daemon (#1357).
+		pre_validate_build(&build_args, &labels)?;
 
 		let network = if let BuildConfig::Config {
 			network: Some(n), ..

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -118,15 +118,19 @@ impl Engine {
 			// and then the per-service `pull_image` would fail downstream
 			// with the same error, N times. Resolve once and let the
 			// offending value short-circuit the whole batch (#1369).
+			//
+			// Collect into `Result`: the previous `.expect` here assumed the
+			// `up` path had already rejected an unknown value, but standalone
+			// `pull` never reaches `pull_image` before this dedup, so the
+			// invariant was false and the binary panicked on every typo
+			// (#1450).
 			.map(|(name, s)| {
 				let image = s.image.as_deref().unwrap_or_default();
-				let policy = self
-					.resolved_pull_policy(name.as_str(), s)
-					.expect("unknown pull policy already rejected in pull_image");
+				let policy = self.resolved_pull_policy(name.as_str(), s)?;
 				let key = (image, policy, s.platform.as_deref());
-				(name.as_str(), s, key)
+				Ok((name.as_str(), s, key))
 			})
-			.collect();
+			.collect::<Result<Vec<_>>>()?;
 
 		// Dedup by that key: 50 services agreeing on image, resolved policy
 		// and platform must issue one pull, not 50. Two services naming the
@@ -442,6 +446,10 @@ mod tests {
 		);
 	}
 
+	// `pull_rejects_an_unknown_pull_policy_without_panicking` lives in the
+	// sibling `pull_typo_tests.rs` to keep this file below the source-line
+	// limit (#1450).
+
 	#[test]
 	fn pull_policy_maps_every_spec_value() {
 		assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
@@ -719,3 +727,7 @@ mod tests {
 		.expect("--ignore-pull-failures must stay exit 0");
 	}
 }
+
+#[cfg(test)]
+#[path = "pull_typo_tests.rs"]
+mod typo_tests;

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -121,7 +121,7 @@ impl Engine {
 			.map(|(name, s)| {
 				let image = s.image.as_deref().unwrap_or_default();
 				let policy = self
-					.resolved_pull_policy(s)
+					.resolved_pull_policy(name.as_str(), s)
 					.expect("unknown pull policy already rejected in pull_image");
 				let key = (image, policy, s.platform.as_deref());
 				(name.as_str(), s, key)
@@ -193,8 +193,12 @@ impl Engine {
 		Ok(())
 	}
 
-	pub(in crate::engine) async fn pull_image(&self, service: &Service) -> Result<()> {
-		let pull_policy = self.resolved_pull_policy(service)?;
+	pub(in crate::engine) async fn pull_image(
+		&self,
+		service_name: &str,
+		service: &Service,
+	) -> Result<()> {
+		let pull_policy = self.resolved_pull_policy(service_name, service)?;
 		self.pull_image_with_policy(service, pull_policy, self.quiet_pull)
 			.await
 	}
@@ -206,8 +210,12 @@ impl Engine {
 	/// pull is the authoritative one, and reporting from both is what printed
 	/// `Pulling` twice per image on `up` while a standalone `pull` printed it
 	/// once.
-	pub(in crate::engine) async fn pull_image_quietly(&self, service: &Service) -> Result<()> {
-		let pull_policy = self.resolved_pull_policy(service)?;
+	pub(in crate::engine) async fn pull_image_quietly(
+		&self,
+		service_name: &str,
+		service: &Service,
+	) -> Result<()> {
+		let pull_policy = self.resolved_pull_policy(service_name, service)?;
 		self.pull_image_with_policy(service, pull_policy, true)
 			.await
 	}
@@ -215,24 +223,18 @@ impl Engine {
 	/// Resolve the effective libpod pull policy for `service`: the
 	/// engine-wide `--pull` override ([`Engine::with_up_overrides`]) takes
 	/// precedence over the service's own `pull_policy:`, and an unrecognized
-	/// value warns and falls back to `missing`. Shared by [`Self::pull_image`]
-	/// and by the standalone-pull fan-out's dedup key
+	/// value is rejected via [`pull_policy_checked`]. Shared by
+	/// [`Self::pull_image`] and by the standalone-pull fan-out's dedup key
 	/// ([`Self::pull_services_with_options`]), so both agree on exactly the
 	/// same resolved value — an override collapses the dedup (every service
 	/// resolves to the same policy), while differing per-service policies
 	/// (no override set) keep it split.
-	fn resolved_pull_policy(&self, service: &Service) -> Result<&'static str> {
+	fn resolved_pull_policy(&self, service_name: &str, service: &Service) -> Result<&'static str> {
 		let requested = self
 			.pull_policy_override
 			.as_deref()
 			.or(service.pull_policy.as_deref());
-		libpod_pull_policy(requested).ok_or_else(|| {
-			crate::error::ComposeError::Unsupported(format!(
-				"unknown pull policy {:?}: accepted values are always, missing, newer, never \
-				 (case-insensitive); if_not_present and build are accepted as aliases for missing",
-				requested.unwrap_or_default()
-			))
-		})
+		pull_policy_checked(requested, service_name)
 	}
 
 	/// Issue the actual pull request for `service` against an
@@ -367,6 +369,35 @@ pub(in crate::engine) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'st
 	}
 }
 
+/// Map a compose `pull_policy:` value to the libpod images/pull `policy`
+/// parameter, rejecting an unrecognized value with a structured
+/// [`PodmanError::Field`] that names both the compose service and the
+/// offending value (#1443).
+///
+/// `service_name` is the compose service the policy was read from (e.g.
+/// `"web"`); pass the empty string when the value came from the engine-wide
+/// `--pull` override (no service context). The rejected value lands in the
+/// error so a typo'd `pull_policy: alaways` on a specific service is reported
+/// as `service.<name>: pull_policy: unknown pull policy "alaways" (value:
+/// alaways)` — the actionable bit is which service and which value, not the
+/// abstract policy name.
+pub(in crate::engine) fn pull_policy_checked(
+	policy: Option<&str>,
+	service_name: &str,
+) -> crate::error::Result<&'static str> {
+	if let Some(p) = libpod_pull_policy(policy) {
+		return Ok(p);
+	}
+	let value = policy.unwrap_or_default();
+	let message = format!(
+		"unknown pull policy {value:?}: accepted values are always, missing, newer, never \
+		 (case-insensitive); if_not_present and build are accepted as aliases for missing"
+	);
+	Err(crate::error::ComposeError::Podman(
+		crate::libpod::validate::spec_field_error(service_name, "pull_policy", value, message),
+	))
+}
+
 #[cfg(test)]
 mod tests {
 	use super::{libpod_pull_policy, pull_dep_closure};
@@ -440,10 +471,21 @@ mod tests {
 			pull_policy: Some("alaways".to_string()),
 			..crate::compose::types::Service::default()
 		};
-		let err = e.resolved_pull_policy(&svc).unwrap_err();
+		let err = e.resolved_pull_policy("web", &svc).unwrap_err();
 		let msg = err.to_string();
 		assert!(msg.contains("alaways"), "got {msg}");
 		assert!(msg.contains("always"), "got {msg}");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref service,
+					ref field,
+					..
+				}) if service == "web" && field == "pull_policy"
+			),
+			"unknown pull policy must surface as a Field error carrying the service and field name, got {err:?}"
+		);
 	}
 
 	#[cfg(unix)]

--- a/internal/engine/build/pull_typo_tests.rs
+++ b/internal/engine/build/pull_typo_tests.rs
@@ -1,0 +1,38 @@
+//! Targeted regression for #1450 — the standalone `pull` path used to panic
+//! on a typo'd `pull_policy:` because the dedup pass unwrapped
+//! `resolved_pull_policy` with an `.expect` whose invariant only held for
+//! `up`. Split out so adding this test does not push `build/pull.rs` over the
+//! source-line limit; the production fix lives there.
+
+/// Standalone `pull` must surface a typo'd `pull_policy:` as a structured
+/// `PodmanError::Field` carrying the offending service and value — the same
+/// shape `up` uses after #1443. Before the fix the dedup pass unwrapped
+/// `resolved_pull_policy` with `.expect`, so the binary panicked on every
+/// typo and the worker-thread death produced a second `internal error` from
+/// `main.rs:61`.
+#[tokio::test]
+async fn pull_rejects_an_unknown_pull_policy_without_panicking() {
+	let file =
+		crate::parse_str("services:\n  web:\n    image: alpine:latest\n    pull_policy: alaways\n")
+			.unwrap();
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	);
+	let err = e
+		.pull_services(&file, &[])
+		.await
+		.expect_err("unknown pull_policy must surface as Err, not panic");
+	let crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+		ref service,
+		ref field,
+		ref value,
+		..
+	}) = err
+	else {
+		panic!("expected Field error, got {err:?}");
+	};
+	assert_eq!(service, "web");
+	assert_eq!(field, "pull_policy");
+	assert!(value.contains("alaways"), "got {value}");
+}

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -125,7 +125,7 @@ impl Engine {
 		let (restart_policy, restart_tries) = build_restart_policy(service);
 
 		// --- Logging ---
-		let log_configuration = build_log_config(service.logging.as_ref());
+		let log_configuration = build_log_config(service_name, service.logging.as_ref())?;
 
 		// --- Networks ---
 		let (netns, networks) = resolve_network_mode(service_name, service, file, &self.project);

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -7,6 +7,7 @@ use crate::compose::types::{ComposeFile, Service};
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::container::{LinuxResources, Namespace, SpecGenerator};
 use crate::libpod::urlencoded;
+use crate::libpod::validate::pre_validate_spec;
 use crate::libpod::API_PREFIX;
 use crate::{ports, size};
 
@@ -198,6 +199,19 @@ impl Engine {
 				None
 			})
 		}));
+
+		// Pre-validate the `SpecGenerator` fields libpod validates on its own
+		// (namespace modes, `device_cgroup_rule` access strings), so a rejected
+		// value surfaces as a `PodmanError::Field` carrying the compose-side
+		// field name and offending value instead of libpod's raw validator
+		// text. Podup's `SpecGenerator` is built below; doing this before
+		// assembling it keeps the pre-validator close to the service fields
+		// it inspects (#1357).
+		let device_cgroup_access: Vec<String> = device_cgroup_rule
+			.iter()
+			.filter_map(|r| r.access.clone())
+			.collect();
+		pre_validate_spec(service_name, service, &device_cgroup_access)?;
 
 		// --- Namespace modes ---
 		let pidns = service.pid.as_deref().map(Namespace::parse);

--- a/internal/engine/container_config/log_config_tests.rs
+++ b/internal/engine/container_config/log_config_tests.rs
@@ -1,0 +1,175 @@
+//! Tests for `build_log_config` — the bridge between compose `logging:` and
+//! libpod's `LogConfig`. Split from `mod.rs` so the production file stays under
+//! the 500-line cap and each surface (struct vs wire JSON vs malformed input
+//! vs `max-file` drop) gets its own focused case (#1417).
+
+use super::*;
+use crate::compose::types::LoggingConfig;
+
+#[test]
+fn log_config_applies_the_default_when_absent() {
+	// A service with no `logging:` block gets the rotation default so
+	// containers cannot run with unbounded log growth (#1354). libpod
+	// reads rotation from `size`, not from options.max-size, so the
+	// default must travel in the typed field (#1417).
+	let cfg = build_log_config("web", None)
+		.expect("absent -> default, not error")
+		.expect("absent -> default, not None");
+	assert_eq!(cfg.driver.as_deref(), Some("k8s-file"));
+	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
+	// `max-size`/`max-file` no longer travel inside options — libpod would
+	// ignore them there, leaving the container with -1B.
+	assert!(!cfg.options.contains_key("max-size"));
+	assert!(!cfg.options.contains_key("max-file"));
+}
+
+#[test]
+fn log_config_default_serializes_size_as_bytes() {
+	// Struct-level assertions passed before #1417 was filed and the
+	// defect still shipped. The wire format is what libpod parses, so the
+	// fix has to be anchored on the serialized JSON.
+	let cfg = build_log_config("web", None).unwrap().unwrap();
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["driver"], "k8s-file");
+	assert_eq!(v["size"], 10 * 1024 * 1024);
+	assert!(
+		v.get("options").is_none(),
+		"empty options must be elided, got {v}"
+	);
+}
+
+#[test]
+fn log_config_driver_only() {
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: Default::default(),
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.driver.as_deref(), Some("json-file"));
+	assert!(cfg.size.is_none());
+	assert!(cfg.options.is_empty());
+}
+
+#[test]
+fn log_config_with_max_size_parses_into_typed_field() {
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "10m".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
+	// And on the wire — what libpod actually parses — the key is `size`
+	// and the value is a number, not the suffixed string under options.
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["size"], 10 * 1024 * 1024);
+	assert_eq!(v["size"].as_i64().unwrap(), 10_485_760);
+	assert!(
+		v["options"].get("max-size").is_none(),
+		"max-size must not also travel in options: {v}"
+	);
+}
+
+#[test]
+fn log_config_max_size_minus_one_disables_rotation() {
+	// libpod treats `size: -1` as unlimited, mirroring Docker's
+	// `--log-opt max-size=-1` convention. Compose users reach for the
+	// same string, so the parser must surface it rather than drop it.
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "-1".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(-1));
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["size"], -1);
+}
+
+#[test]
+fn log_config_max_size_plain_bytes() {
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "1048576".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(1_048_576));
+}
+
+#[test]
+fn log_config_max_file_is_dropped_with_warning() {
+	// libpod does not implement `max-file` on any path; forwarding it as
+	// a `LogOpt` would silently disappear. The unit test asserts the
+	// struct shape; the warning side is exercised by the engine path
+	// and surfaced separately.
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "10m".into());
+	opts.insert("max-file".into(), "5".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
+	assert!(
+		!cfg.options.contains_key("max-file"),
+		"max-file must be dropped, got {v}",
+		v = serde_json::to_string(&cfg).unwrap()
+	);
+	// And nothing carrying the dead key reached the wire.
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert!(
+		v.get("options").is_none(),
+		"options leaked onto the wire: {v}"
+	);
+}
+
+#[test]
+fn log_config_max_size_malformed_returns_field_error() {
+	// libpod would answer this with a 500 ("cannot unmarshal string into
+	// size of type int64"); surfacing it as a PodmanError::Field points
+	// the user at the compose key they wrote, not at libpod's Go type
+	// (#1417).
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("max-size".into(), "diez megas".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let err = build_log_config("web", Some(&logging)).unwrap_err();
+	match err {
+		ComposeError::Podman(crate::libpod::error::PodmanError::Field {
+			service,
+			field,
+			value,
+			..
+		}) => {
+			assert_eq!(service, "web");
+			assert_eq!(field, "logging.options.max-size");
+			assert_eq!(value, "diez megas");
+		}
+		other => panic!("expected PodmanError::Field, got {other:?}"),
+	}
+}
+
+#[test]
+fn log_config_unsupported_options_pass_through() {
+	// `path` and `tag` are the only options libpod honours for the
+	// built-in drivers (see `man podman-run`); they must reach the wire
+	// unchanged when the user sets them.
+	let mut opts = std::collections::HashMap::new();
+	opts.insert("path".into(), "/var/log/app.log".into());
+	opts.insert("tag".into(), "{{.Name}}".into());
+	let logging = LoggingConfig {
+		driver: Some("json-file".into()),
+		options: opts,
+	};
+	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
+	let v = serde_json::to_value(&cfg).unwrap();
+	assert_eq!(v["options"]["path"], "/var/log/app.log");
+	assert_eq!(v["options"]["tag"], "{{.Name}}");
+}

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -3,9 +3,12 @@
 //!
 //! Device, blkio, tmpfs, and label-file helpers live in `super::container::fields`.
 
+use std::collections::HashMap;
+
 use crate::compose::types::{
 	Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart, Service,
 };
+use crate::error::ComposeError;
 use crate::libpod::types::container::{HealthConfig, LogConfig};
 use crate::size;
 
@@ -78,33 +81,78 @@ pub(super) fn build_restart_policy(service: &Service) -> (Option<String>, Option
 /// Default log rotation applied when a compose file does not carry a
 /// `logging:` block. `k8s-file` is the libpod default since Podman 4; pinning
 /// it explicitly here stops the answer from drifting between podman versions
-/// and distros, and the 10 MB / 5-file shape gives ~50 MB per container —
-/// enough for a week of typical service output, small enough that a runaway
-/// loop will not exhaust the host. The user can override by writing their
-/// own `logging:` in compose.
+/// and distros. The 10 MB cap is enough for a week of typical service output
+/// and small enough that a runaway loop will not exhaust the host. libpod
+/// does not honour `max-file` on any path (see `man podman-run`), so it is
+/// not part of the default; the user can override by writing their own
+/// `logging:` in compose (#1417).
 pub(crate) fn default_log_config() -> LogConfig {
 	LogConfig {
 		driver: Some("k8s-file".into()),
-		options: [
-			("max-size".to_string(), "10m".to_string()),
-			("max-file".to_string(), "5".to_string()),
-		]
-		.into_iter()
-		.collect(),
+		size: Some(10 * 1024 * 1024),
+		options: HashMap::new(),
 	}
 }
 
 /// Resolve the `logging:` block into libpod's `LogConfig`. An absent compose
 /// `logging:` maps to [`default_log_config`] so every container podup creates
-/// has a rotation policy without the user having to set one. The user's
-/// `Some(LoggingConfig)` value is passed through unchanged.
-pub(crate) fn build_log_config(logging: Option<&LoggingConfig>) -> Option<LogConfig> {
-	Some(match logging {
-		Some(l) => LogConfig {
-			driver: l.driver.clone(),
-			options: l.options.clone(),
+/// has a rotation policy without the user having to set one. When the user
+/// supplies a block, `max-size` is parsed into the typed [`LogConfig::size`]
+/// field libpod actually reads rotation from (passing it inside `options` is
+/// silently ignored — #1417); `max-file` is dropped with a warning because
+/// libpod does not implement it. A malformed `max-size` is rejected with a
+/// `PodmanError::Field` so the user gets a compose-flavoured error instead of
+/// a 500 from libpod's JSON unmarshal.
+pub(crate) fn build_log_config(
+	service_name: &str,
+	logging: Option<&LoggingConfig>,
+) -> Result<Option<LogConfig>, ComposeError> {
+	match logging {
+		Some(l) => Ok(Some(translate_user_logging(service_name, l)?)),
+		None => Ok(Some(default_log_config())),
+	}
+}
+
+/// Translate a user-supplied `logging:` block into libpod's [`LogConfig`].
+///
+/// `max-size` is moved into the typed `size` field. `max-file` is dropped
+/// with a warning — libpod does not implement it and would silently ignore
+/// it if forwarded. The user-supplied value of `max-size` is parsed with the
+/// same memory parser used elsewhere in the engine (`10m`, `1g`, plain
+/// bytes); a malformed value is rejected with the service field name so the
+/// error points at the compose key the user wrote (#1417).
+fn translate_user_logging(
+	service_name: &str,
+	l: &LoggingConfig,
+) -> Result<LogConfig, ComposeError> {
+	let mut options = l.options.clone();
+	let size = match options.remove("max-size") {
+		Some(v) => match size::parse_memory(&v) {
+			Some(bytes) => Some(bytes),
+			None => {
+				return Err(ComposeError::Podman(
+					crate::libpod::validate::spec_field_error(
+						service_name,
+						"logging.options.max-size",
+						&v,
+						"must be a byte count (e.g. '10m', '1024', '1g'); \
+						 libpod rejects an invalid `size` outright",
+					),
+				));
+			}
 		},
-		None => default_log_config(),
+		None => None,
+	};
+	if options.remove("max-file").is_some() {
+		tracing::warn!(
+			"logging.options.max-file is ignored by libpod; \
+			 remove it from your compose file or expect unbounded log growth"
+		);
+	}
+	Ok(LogConfig {
+		driver: l.driver.clone(),
+		size,
+		options,
 	})
 }
 
@@ -163,8 +211,7 @@ pub(super) fn build_healthcheck(hc: &HealthCheck) -> HealthConfig {
 mod tests {
 	use super::*;
 	use crate::compose::types::{
-		Command as ComposeCommand, HealthCheck, LoggingConfig, RestartPolicy as ComposeRestart,
-		Service,
+		Command as ComposeCommand, HealthCheck, RestartPolicy as ComposeRestart, Service,
 	};
 
 	fn default_service() -> Service {
@@ -347,41 +394,6 @@ mod tests {
 		assert_eq!(tries, Some(3));
 	}
 
-	// --- log config ---
-
-	#[test]
-	fn log_config_applies_the_default_when_absent() {
-		// A service with no `logging:` block gets the rotation default so
-		// containers cannot run with unbounded log growth (#1354).
-		let cfg = build_log_config(None).expect("absent -> default, not None");
-		assert_eq!(cfg.driver.as_deref(), Some("k8s-file"));
-		assert_eq!(cfg.options.get("max-size").map(String::as_str), Some("10m"));
-		assert_eq!(cfg.options.get("max-file").map(String::as_str), Some("5"));
-	}
-
-	#[test]
-	fn log_config_driver_only() {
-		let logging = LoggingConfig {
-			driver: Some("json-file".into()),
-			options: Default::default(),
-		};
-		let cfg = build_log_config(Some(&logging)).unwrap();
-		assert_eq!(cfg.driver.as_deref(), Some("json-file"));
-		assert!(cfg.options.is_empty());
-	}
-
-	#[test]
-	fn log_config_with_options() {
-		let mut opts = std::collections::HashMap::new();
-		opts.insert("max-size".into(), "10m".into());
-		let logging = LoggingConfig {
-			driver: Some("json-file".into()),
-			options: opts,
-		};
-		let cfg = build_log_config(Some(&logging)).unwrap();
-		assert_eq!(cfg.options["max-size"], "10m");
-	}
-
 	// --- healthcheck ---
 
 	#[test]
@@ -457,3 +469,7 @@ mod tests {
 		assert_eq!(cfg.retries, Some(7));
 	}
 }
+
+#[cfg(test)]
+#[path = "log_config_tests.rs"]
+mod log_config_tests;

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -71,11 +71,13 @@ impl Engine {
 	/// so they all behave the same.
 	///
 	/// Returns whether the container was actually acted on. This is the only
-	/// place that knows: `live_replica_names` falls back to the *static* compose
-	/// names when nothing is running, so a command on a project that was never
-	/// created still walks a full list of container names and 404s on every one
-	/// of them. Six commands exited 0 in complete silence that way (#1248), and
-	/// telling that apart from real work requires the answer here, not a count of
+	/// place that knows: the per-replica query helpers (e.g. the bulk
+	/// [`Engine::live_project_replicas_sorted`] lookup used by `exec`/`cp`/
+	/// `port`/`logs`) fall back to the *static* compose names when nothing is
+	/// running, so a command on a project that was never created still walks
+	/// a full list of container names and 404s on every one of them. Six
+	/// commands exited 0 in complete silence that way (#1248), and telling
+	/// that apart from real work requires the answer here, not a count of
 	/// names upstream.
 	pub(super) async fn run_lifecycle_op(
 		&self,

--- a/internal/engine/lifecycle/images.rs
+++ b/internal/engine/lifecycle/images.rs
@@ -36,12 +36,16 @@ impl Engine {
 	) -> Result<()> {
 		// `up --pull <policy>` overrides the per-service `pull_policy`; `--no-build`
 		// suppresses building even for services with a `build:` section (they fall
-		// back to pulling/using an existing image).
-		let policy = self
+		// back to pulling/using an existing image). Validated through
+		// [`crate::engine::build::pull_policy_checked`] so a typo'd
+		// `pull_policy:` cannot be silently treated as `missing` here — the
+		// skip-only-when-missing arm below would otherwise hide the bad value
+		// from `up` entirely (#1443).
+		let raw_policy = self
 			.pull_policy_override
 			.as_deref()
-			.or(service.pull_policy.as_deref())
-			.unwrap_or("missing");
+			.or(service.pull_policy.as_deref());
+		let policy = crate::engine::build::pull_policy_checked(raw_policy, name)?;
 		// Build on `up` only when the service's image is not already there, which
 		// is what docker compose does: `up` converges on the declared state and
 		// `--build` is the flag that forces a rebuild.
@@ -76,8 +80,8 @@ impl Engine {
 			// host needs no request at all. Skipping only what was observed in
 			// this invocation keeps the decision as fresh as the one the pull
 			// itself would have made.
-			(false, _) if self.image_already_seen_present(service) => {}
-			(false, _) => self.pull_image(service).await?,
+			(false, _) if self.image_already_seen_present(name, service)? => {}
+			(false, _) => self.pull_image(name, service).await?,
 		}
 		Ok(())
 	}
@@ -94,24 +98,28 @@ impl Engine {
 	/// False for a service pinning `platform:`. The observation matched an image
 	/// reference, which carries no architecture, so honouring it there could
 	/// start the wrong variant.
-	fn image_already_seen_present(&self, service: &Service) -> bool {
+	///
+	/// Returns `Err` for an unrecognized `pull_policy:` so the bad value is
+	/// reported rather than silently treated as `missing` (#1443).
+	fn image_already_seen_present(&self, service_name: &str, service: &Service) -> Result<bool> {
 		if service.platform.is_some() {
-			return false;
+			return Ok(false);
 		}
 		let raw_policy = self
 			.pull_policy_override
 			.as_deref()
 			.or(service.pull_policy.as_deref());
-		if crate::engine::build::libpod_pull_policy(raw_policy).unwrap_or("missing") != "missing" {
-			return false;
+		if crate::engine::build::pull_policy_checked(raw_policy, service_name)? != "missing" {
+			return Ok(false);
 		}
 		let Some(image) = service.image.as_deref() else {
-			return false;
+			return Ok(false);
 		};
-		self.images_seen_present
+		Ok(self
+			.images_seen_present
 			.lock()
 			.map(|seen| seen.contains(image))
-			.unwrap_or(false)
+			.unwrap_or(false))
 	}
 }
 
@@ -237,6 +245,47 @@ mod tests {
 		assert!(
 			seen.iter().any(|r| r.contains("/images/pull")),
 			"a platform-pinned service must still pull: a reference match says nothing about the architecture that is local: {seen:?}"
+		);
+	}
+
+	/// A typo'd `pull_policy:` on a warm service must error at the
+	/// `image_already_seen_present` decision (the `#1443` site) rather than
+	/// be silently treated as `missing` and skip the only pull that would have
+	/// surfaced the bad value. The host stands in for one that already has the
+	/// image (so the skip branch *would* fire), and the assertion is that the
+	/// error fires instead — without the fix the call returned `true` and the
+	/// pull was skipped, leaving `up` to exit 0 with the wrong image.
+	#[tokio::test]
+	async fn image_already_seen_present_rejects_an_unknown_pull_policy() {
+		let e = engine_with(crate::libpod::Client::new("/nonexistent.sock"), "proj");
+		// Pre-populate the prefetch's seen-present set as if a previous
+		// `prefetch_images` had confirmed the image on this host. Without the
+		// fix `image_already_seen_present` would then return `true` for any
+		// service whose effective policy it read as `missing` — including a
+		// typo'd `pull_policy:` — and the only pull that could have surfaced
+		// the bad value would be skipped.
+		e.images_seen_present
+			.lock()
+			.unwrap()
+			.insert("shared".to_string());
+
+		let file =
+			crate::parse_str("services:\n  web:\n    image: shared\n    pull_policy: alaways\n")
+				.unwrap();
+		let err = e
+			.image_already_seen_present("web", &file.services["web"])
+			.expect_err("an unknown pull_policy must error at the skip decision");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref service,
+					ref field,
+					ref value,
+					..
+				}) if service == "web" && field == "pull_policy" && value == "alaways"
+			),
+			"unknown pull_policy must surface as a Field error naming the offending service and value, got {err:?}"
 		);
 	}
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -494,9 +494,16 @@ impl Engine {
 				);
 				return Ok(());
 			}
-			// Services with a build section are rebuilt on every up, so
-			// their container must be recreated to pick up the fresh
-			// image even when the compose config is unchanged.
+			// A service with a `build:` section is recreated even when its hash
+			// matches: the compose-config hash compared below does not cover
+			// the build context's source files, so the existing container may
+			// still hold an image built from an older tree. Recreating forces
+			// the new container to bind whatever image is current.
+			//
+			// `up` stopped rebuilding these unconditionally in #1094 — it now
+			// builds only when the image is missing — so the fresh-image
+			// guarantee this recreate used to inherit from that rebuild no
+			// longer comes for free.
 			if service.build.is_none()
 				&& existing_hash.get(&container_name).map(String::as_str) == Some(new_hash)
 			{

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -240,9 +240,12 @@ impl Engine {
 			// Best-effort: warm the image cache for every service this pass will
 			// pull, concurrently, before the per-level walk below serializes a
 			// level-2+ service's image acquisition behind the level-1 barrier.
-			// A prefetch miss here is never fatal — `up_one_service`'s own pull
-			// below is still authoritative and the only path that can fail `up`.
-			self.prefetch_images(file, &enabled, &target_set).await;
+			// A prefetch I/O miss is never fatal — `up_one_service`'s own pull
+			// below is still authoritative and the only path that can fail `up`
+			// on a transport / registry error. A configuration error (an
+			// unrecognized `pull_policy:`) does propagate: it is reported here
+			// so the operator sees it, not a silent wrong image (#1443).
+			self.prefetch_images(file, &enabled, &target_set).await?;
 
 			// Start each dependency level in turn; services within a level have
 			// no `depends_on` relationship to each other (guaranteed by the

--- a/internal/engine/lifecycle/prefetch.rs
+++ b/internal/engine/lifecycle/prefetch.rs
@@ -8,15 +8,22 @@
 //! concurrently, before the first level barrier — instead of one at a time as
 //! each level's services reach their turn.
 //!
-//! Best-effort only: a prefetch miss is logged at debug and otherwise
-//! swallowed. `up_one_service`'s own pull call is unchanged and remains the
-//! sole source of a real pull failure — this stage can only make `up` faster,
-//! never change whether it succeeds.
+//! Best-effort only for prefetch *misses*: an unreachable socket or a registry
+//! that 500s is logged at debug and otherwise swallowed. `up_one_service`'s
+//! own pull call is unchanged and remains the sole source of a real pull
+//! failure — this stage can only make `up` faster, never change whether it
+//! succeeds.
+//!
+//! An invalid `pull_policy:` (or `--pull`) is **not** a prefetch miss. It is
+//! a configuration error and propagates here as `Err`, before a single pull
+//! is dispatched, so the operator sees it instead of a silent wrong image
+//! (#1443).
 
 use std::collections::{HashMap, HashSet};
 
 use crate::compose::types::{ComposeFile, Service};
-use crate::engine::build::libpod_pull_policy;
+use crate::engine::build::pull_policy_checked;
+use crate::error::Result;
 
 use super::parallel::join_bounded;
 use super::Engine;
@@ -32,19 +39,22 @@ impl Engine {
 	/// prefetch. Deduplicates by image reference, so many services sharing one
 	/// image pull it once instead of once per service, and dispatches the
 	/// resulting pulls with the same bounded concurrency the level fan-out
-	/// uses. Never fails: `up_one_service`'s own pull remains authoritative, so
-	/// a prefetch miss here just means that later call does the work instead,
-	/// exactly as it would without this stage.
+	/// uses. Returns `Err` for an unrecognized `pull_policy:` so a typo
+	/// (`pull_policy: alaways`) is reported instead of being treated as
+	/// `missing` (#1443); prefetch I/O errors stay debug-level and never
+	/// propagate.
 	pub(super) async fn prefetch_images(
 		&self,
 		file: &ComposeFile,
 		enabled: &HashSet<String>,
 		target_set: &Option<HashSet<String>>,
-	) {
+	) -> Result<()> {
 		// One representative service per unique image reference is enough to
 		// issue the pull — this is what dedupes 50 services on one image down
-		// to a single request instead of 50.
-		let mut by_image: HashMap<&str, &Service> = HashMap::new();
+		// to a single request instead of 50. The service *name* travels with
+		// the representative so the pull / policy error can name it, instead
+		// of using the image as a stand-in for the originating service.
+		let mut by_image: HashMap<&str, (&str, &Service)> = HashMap::new();
 		for (name, service) in &file.services {
 			if !enabled.contains(name) {
 				continue;
@@ -66,21 +76,29 @@ impl Engine {
 				.pull_policy_override
 				.as_deref()
 				.or(service.pull_policy.as_deref());
-			if libpod_pull_policy(raw_policy).unwrap_or("missing") == "never" {
+			if pull_policy_checked(raw_policy, name)? == "never" {
 				continue;
 			}
-			by_image.entry(image).or_insert(service);
+			by_image.entry(image).or_insert((name.as_str(), service));
 		}
 
-		let futs = by_image.into_values().map(|service| async move {
+		let futs = by_image.into_values().map(|(name, service)| async move {
 			let image = service.image.as_deref().unwrap_or_default();
 			let raw_policy = self
 				.pull_policy_override
 				.as_deref()
 				.or(service.pull_policy.as_deref());
-			let policy = libpod_pull_policy(raw_policy).unwrap_or("missing");
+			let policy = match pull_policy_checked(raw_policy, name) {
+				Ok(p) => p,
+				// Propagate the validation error out of the prefetch join via a
+				// shared poison cell. The prefetch stage itself is best-effort
+				// for *I/O*, but a configuration error must surface loud — the
+				// outer `join_bounded` join collapses every concurrent task into
+				// one result, and there is no other channel back (#1443).
+				Err(e) => return Err(e),
+			};
 			// `missing` (and its aliases, already normalized by
-			// `libpod_pull_policy`) only pulls when the image is absent —
+			// `pull_policy_checked`) only pulls when the image is absent —
 			// checking first turns a warm cache into a cheap presence check
 			// instead of a redundant pull request. `always`/`newer` mean to
 			// hit the registry regardless, so skip the check and prefetch
@@ -102,18 +120,23 @@ impl Engine {
 						seen.insert(image.to_string());
 					}
 				}
-				return;
+				return Ok(());
 			}
 			// Quietly: this stage only warms the cache, and `up_one_service`'s
 			// own pull below is the authoritative one. Reporting from both is
 			// what made `Pulling` appear twice per image on `up` while a
-			// standalone `pull` printed it once.
-			if let Err(e) = self.pull_image_quietly(service).await {
+			// standalone `pull` printed it once. A prefetch I/O miss is still
+			// debug-only — only the validation error above escapes.
+			if let Err(e) = self.pull_image_quietly(name, service).await {
 				tracing::debug!("prefetch miss for {image}: {e}");
 			}
+			Ok(())
 		});
 
-		join_bounded(futs).await;
+		match super::parallel::first_error(join_bounded(futs).await) {
+			Some(err) => Err(err),
+			None => Ok(()),
+		}
 	}
 }
 
@@ -153,7 +176,7 @@ mod tests {
 		.unwrap();
 		let enabled: HashSet<String> = file.services.keys().cloned().collect();
 
-		e.prefetch_images(&file, &enabled, &None).await;
+		e.prefetch_images(&file, &enabled, &None).await.unwrap();
 
 		let seen = fake.requests.lock().unwrap();
 		let shared_pulls = seen
@@ -194,7 +217,9 @@ mod tests {
 		let enabled: HashSet<String> = file.services.keys().cloned().collect();
 		let target_set: Option<HashSet<String>> = Some(["web".to_string()].into_iter().collect());
 
-		e.prefetch_images(&file, &enabled, &target_set).await;
+		e.prefetch_images(&file, &enabled, &target_set)
+			.await
+			.unwrap();
 
 		let seen = fake.requests.lock().unwrap();
 		assert!(
@@ -205,6 +230,88 @@ mod tests {
 		assert!(
 			!seen.iter().any(|r| r.contains("img-db")),
 			"a service outside the target set must not be prefetched: {seen:?}"
+		);
+	}
+
+	/// A typo'd `pull_policy:` must error loud at the prefetch stage instead of
+	/// being treated as `missing` (#1443). Both the dedup-side check (the
+	/// service is *included* in the prefetch set when the policy is anything
+	/// but `never`) and the per-image future would have happily read the bad
+	/// value as `missing` before the fix, leaving `up` to exit 0 with the
+	/// wrong image and no diagnostic.
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn prefetch_rejects_an_unknown_pull_policy() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let e = engine_with(fake.client(), "proj");
+
+		let file = crate::parse_str(
+			"services:\n  web:\n    image: nginx:1.27\n    pull_policy: alaways\n",
+		)
+		.unwrap();
+		let enabled: HashSet<String> = file.services.keys().cloned().collect();
+
+		let err = e
+			.prefetch_images(&file, &enabled, &None)
+			.await
+			.expect_err("an unknown pull_policy must be rejected, not silently treated as missing");
+		let msg = err.to_string();
+		assert!(msg.contains("alaways"), "got {msg}");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref service,
+					ref field,
+					ref value,
+					..
+				}) if service == "web" && field == "pull_policy" && value == "alaways"
+			),
+			"unknown pull_policy must surface as a Field error naming the offending service and value, got {err:?}"
+		);
+	}
+
+	/// An invalid `--pull` override (no service context) must also propagate
+	/// out of the prefetch stage — same bug as the per-service typo, just
+	/// applied to every service at once. Before the fix the dedup phase
+	/// would treat every service's effective policy as `missing` and warm
+	/// every cache it could reach with the wrong intent (#1443).
+	#[tokio::test]
+	#[cfg(unix)]
+	async fn prefetch_rejects_an_invalid_pull_override() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/images/pull") {
+				(200, String::new())
+			} else {
+				(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let mut e = engine_with(fake.client(), "proj");
+		e.pull_policy_override = Some("alaways".to_string());
+
+		let file = crate::parse_str("services:\n  web:\n    image: nginx:1.27\n").unwrap();
+		let enabled: HashSet<String> = file.services.keys().cloned().collect();
+
+		let err = e
+			.prefetch_images(&file, &enabled, &None)
+			.await
+			.expect_err("an invalid --pull override must be rejected");
+		assert!(
+			matches!(
+				err,
+				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+					ref field,
+					ref value,
+					..
+				}) if field == "pull_policy" && value == "alaways"
+			),
+			"override must surface as a Field error naming the field and value, got {err:?}"
 		);
 	}
 }

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -317,10 +317,36 @@ impl Engine {
 		Ok(by_service)
 	}
 
+	/// The bulk project listing ([`Self::live_project_replicas`]) with each
+	/// per-service bucket sorted into the same ascending `-1, -2, -3, ...`
+	/// order the static [`Engine::replica_names`] path produces. Lets the
+	/// per-replica query paths (`exec`/`cp` via `live_replica_name_at`,
+	/// `port` via `port_with_index`, `logs`) read each service's names off a
+	/// single shared map instead of issuing one container-list round-trip per
+	/// service (#1445): a `podup logs` over a 40-service project now costs 1
+	/// GET, not 40, with the same ordering the per-service helper it replaced
+	/// was pinned to.
+	///
+	/// Same `all=true` contract as [`Self::live_project_replicas`]: stopped
+	/// replicas are kept on purpose so a service scaled beyond its static
+	/// compose count (or never reaped by a prior `down`) is not silently
+	/// dropped from the bucket. The static-name fallback for a service absent
+	/// from the map is the *caller's* responsibility — this helper returns an
+	/// empty vec for one, since it does not see the compose file.
+	pub(crate) async fn live_project_replicas_sorted(
+		&self,
+	) -> Result<std::collections::HashMap<String, Vec<String>>> {
+		let mut by_service = self.live_project_replicas().await?;
+		for names in by_service.values_mut() {
+			sort_replica_names(names);
+		}
+		Ok(by_service)
+	}
+
 	/// The live containers of a service (matched by the `podup.service` label),
 	/// each paired with its machine-readable state (`running`, `created`,
-	/// `exited`, `paused`, …). Unlike [`Self::live_replica_names`] this does NOT
-	/// fall back to statically-predicted names: a service with no live container
+	/// `exited`, `paused`, …). This does NOT fall back to statically-predicted
+	/// names: a service with no live container
 	/// yields an empty vec, so a lifecycle op (stop/wait/…) on a defined-but-
 	/// never-created service is a quiet no-op instead of POSTing to a phantom
 	/// name and surfacing a raw 404 (#758). The state lets `stop` report
@@ -356,40 +382,16 @@ impl Engine {
 			.collect())
 	}
 
-	/// The container names to act on for a service: the ones Podman actually has
-	/// (matched by the `podup.service` label), so lifecycle and query commands
-	/// keep working after a runtime `scale`/`up --scale` that the compose file's
-	/// static replica count no longer names. Falls back to the statically-derived
-	/// names when none exist yet (e.g. a service not yet created). Live names are
-	/// always returned in ascending `-1, -2, -3, ...` order (see
-	/// [`sort_replica_names`]), matching the static path regardless of the order
-	/// libpod's container list happens to report.
-	pub(crate) async fn live_replica_names(
-		&self,
-		service_name: &str,
-		service: &Service,
-	) -> Result<Vec<String>> {
-		let mut live = self
-			.list_project_container_names(Some(service_name))
-			.await?;
-		Ok(if live.is_empty() {
-			self.replica_names(service_name, service)
-		} else {
-			sort_replica_names(&mut live);
-			live
-		})
-	}
-
 	/// The names of a service's containers that are actually **running**, in the
-	/// same ascending `-1, -2, -3, ...` order as [`Self::live_replica_names`].
+	/// same ascending `-1, -2, -3, ...` order as [`Self::live_project_replicas_sorted`].
 	///
 	/// For the query commands that only mean anything against a live process
 	/// (`top`), where a stopped replica has to be skipped rather than asked: the
 	/// libpod endpoints answer a non-running container with an HTTP 500, which
 	/// callers must not have to tell apart from a real failure by parsing its
-	/// message. Unlike [`Self::live_replica_names`] there is no fallback to
-	/// statically-derived names — a service that was never created has nothing
-	/// running, so it yields an empty vec instead of a phantom name.
+	/// message. There is no fallback to statically-derived names — a service
+	/// that was never created has nothing running, so it yields an empty vec
+	/// instead of a phantom name.
 	pub(crate) async fn running_replica_names(&self, service_name: &str) -> Result<Vec<String>> {
 		let mut running: Vec<String> = self
 			.live_service_containers(service_name)

--- a/internal/engine/lifecycle/scale_tests.rs
+++ b/internal/engine/lifecycle/scale_tests.rs
@@ -1,8 +1,10 @@
 //! Tests for the scale module: surplus-replica reconciliation, the
-//! `live_replica_names`/`running_replica_names` helpers, the replica-limit /
-//! port-conflict / fixed-name guard helpers, and the bulk
-//! `live_project_replicas` listing that powers the per-service lifecycle
-//! commands (#1363).
+//! `running_replica_names` helper, the replica-limit / port-conflict /
+//! fixed-name guard helpers, the bulk `live_project_replicas` listing that
+//! powers the per-service lifecycle commands (#1363), and the sorted
+//! `live_project_replicas_sorted` variant the per-replica query paths
+//! (`exec`/`cp`/`port`/`logs`) share so a single container-list round-trip
+//! powers them all (#1445).
 //!
 //! Same fixture pattern as the rest of the lifecycle suite: a unix-socket
 //! fake libpod so the request shape (`all=true`, no `status=` filter) and
@@ -90,14 +92,17 @@ async fn remove_surplus_replicas_tolerates_already_gone() {
 /// other by-service lifecycle/query command must still see a scaled
 /// service's replicas in the same ascending `-1, -2, -3` order the static
 /// `replica_names_for` path always produces, even when the fake (like a
-/// real libpod) hands them back shuffled.
+/// real libpod) hands them back shuffled. The bulk sorted helper
+/// ([`Engine::live_project_replicas_sorted`]) is what now powers the
+/// per-replica query paths (#1445); its per-bucket sort replaces the
+/// per-service sort the old `live_replica_names` helper did.
 #[tokio::test]
 #[cfg(unix)]
-async fn live_replica_names_sorts_shuffled_replicas_ascending() {
+async fn live_project_replicas_sorted_sorts_shuffled_replicas_ascending() {
 	let containers = r#"[
-		{"Names":["/proj-web-3"]},
-		{"Names":["/proj-web-1"]},
-		{"Names":["/proj-web-2"]}
+		{"Names":["/proj-web-3"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-2"],"Labels":{"podup.service":"web"}}
 	]"#;
 	let fake = fake_podman::start(move |method, target| {
 		if method == "GET" && target.contains("/containers/json") {
@@ -108,18 +113,167 @@ async fn live_replica_names_sorts_shuffled_replicas_ascending() {
 	});
 	let e = engine_with(fake.client(), "proj");
 
-	let names = e
-		.live_replica_names("web", &crate::compose::types::Service::default())
+	let by_service = e
+		.live_project_replicas_sorted()
 		.await
-		.expect("live_replica_names should succeed");
+		.expect("live_project_replicas_sorted should succeed");
 
 	assert_eq!(
-		names,
-		vec![
+		by_service.get("web"),
+		Some(&vec![
 			"proj-web-1".to_string(),
 			"proj-web-2".to_string(),
 			"proj-web-3".to_string(),
-		]
+		]),
+		"the bucket must come back in ascending -1, -2, -3 order regardless of \
+		 libpod's hand-back order"
+	);
+}
+
+/// #1445: the bulk GET that the per-replica query paths now share must
+/// cover a scaled service's full replica set, including replicas that are
+/// stopped — `logs`/`port`/`exec` need to see the second replica even when
+/// it is in `exited`, so the bulk request must NOT silently drop them the
+/// way libpod's `runningOnly` default would.
+#[tokio::test]
+#[cfg(unix)]
+async fn live_project_replicas_sorted_includes_stopped_replicas() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-2"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-3"],"State":"exited","Labels":{"podup.service":"web"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let by_service = e
+		.live_project_replicas_sorted()
+		.await
+		.expect("live_project_replicas_sorted should succeed");
+
+	// All three replicas — running and stopped — must be in the bucket.
+	// A bug that silently filtered to running (libpod's `runningOnly`
+	// default) would return just `proj-web-1` and `proj-web-2`, missing the
+	// third replica entirely.
+	assert_eq!(
+		by_service.get("web"),
+		Some(&vec![
+			"proj-web-1".to_string(),
+			"proj-web-2".to_string(),
+			"proj-web-3".to_string(),
+		]),
+		"the stopped replica must not be filtered out — got {:?}",
+		by_service.get("web")
+	);
+}
+
+/// #1445: a service that exists in the compose file but has no live
+/// container must NOT appear in the bulk map. The bulk helper does not see
+/// the compose file; the per-replica query paths (`exec`/`cp`/`port`/
+/// `logs`) layer the static-name fallback on top. Without that contract,
+/// `logs` could not `docker compose logs`-style behave on a never-created
+/// service — `port`/`exec`/`cp` would 404 immediately instead of letting
+/// the caller see the predictable static name.
+#[tokio::test]
+#[cfg(unix)]
+async fn live_project_replicas_sorted_omits_services_with_no_live_container() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			// Only `web` has any containers; `db` and `worker` are not yet
+			// created.
+			(
+				200,
+				r#"[{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}}]"#.to_string(),
+			)
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let by_service = e
+		.live_project_replicas_sorted()
+		.await
+		.expect("live_project_replicas_sorted should succeed");
+
+	assert_eq!(
+		by_service.get("web"),
+		Some(&vec!["proj-web-1".to_string()]),
+		"a service with a live container must appear in the map"
+	);
+	assert!(
+		!by_service.contains_key("db"),
+		"a service with no live container must NOT appear (caller falls back): {by_service:?}"
+	);
+	assert!(
+		!by_service.contains_key("worker"),
+		"a service with no live container must NOT appear (caller falls back): {by_service:?}"
+	);
+}
+
+/// #1445: the per-replica query paths used to fan out one container-list
+/// round-trip per service — 40 services meant 40 GETs for a single
+/// `podup logs`. The bulk helper is the shared single GET. With the fake
+/// pinned to answer only `/containers/json`, a single resolution call must
+/// still satisfy the per-service query helpers without issuing a follow-up
+/// GET. A regression that re-introduced per-service calls would make
+/// `fake.requests` grow by one row for each lookup, so the assertion
+/// below is the discriminator: counting requests is the test that fails if
+/// the bulk path is bypassed.
+#[tokio::test]
+#[cfg(unix)]
+async fn logs_resolves_replicas_in_one_bulk_get_not_one_per_service() {
+	// Three services; `db` is scaled to 3, `web` to 2, `worker` to 1, all
+	// running — so the bulk GET is the only fetch needed for `logs` to
+	// find 6 targets across 3 services.
+	let body = r#"[
+		{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}},
+		{"Names":["/proj-db-2"],"Labels":{"podup.service":"db"}},
+		{"Names":["/proj-db-3"],"Labels":{"podup.service":"db"}},
+		{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-2"],"Labels":{"podup.service":"web"}},
+		{"Names":["/proj-worker-1"],"Labels":{"podup.service":"worker"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, body.to_string())
+		} else if method == "GET" && target.contains("/logs") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = crate::compose::types::ComposeFile::default();
+	file.services
+		.insert("db".into(), crate::compose::types::Service::default());
+	file.services
+		.insert("web".into(), crate::compose::types::Service::default());
+	file.services
+		.insert("worker".into(), crate::compose::types::Service::default());
+
+	// Drive `logs` once across all 3 services — the resolution path is the
+	// one under test, not the streaming.
+	let _ = e
+		.logs_with_options(&file, &[], crate::engine::query::LogsOptions::default())
+		.await;
+
+	let seen = fake.requests.lock().unwrap();
+	let bulk_gets = seen
+		.iter()
+		.filter(|r| r.starts_with("GET") && r.contains("/containers/json"))
+		.count();
+	assert_eq!(
+		bulk_gets, 1,
+		"logs must issue exactly one bulk GET for the whole project, \
+		 not one per service. seen = {seen:?}"
 	);
 }
 
@@ -366,4 +520,56 @@ fn fixed_container_name_scaled_above_one_is_rejected() {
 fn unnamed_service_scales_freely() {
 	let svc = service("services:\n  app:\n    image: x\n");
 	assert!(check_fixed_name_scale("app", &svc, 5).is_ok());
+}
+
+/// #1445 is a round-trip count, so pin the count rather than only the values it
+/// produces. Before it, every selected service cost its own `/containers/json`
+/// GET; a project of N services made N of them. Nothing in the value assertions
+/// above notices if that regresses — the names come back identical either way —
+/// so a later refactor could quietly put the call back inside the loop.
+///
+/// Four services, and the fake records every request it answers. The assertion
+/// is that exactly one container-list GET reaches the socket.
+#[tokio::test]
+#[cfg(unix)]
+async fn logs_issues_one_container_list_for_the_whole_project() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-api-1"],"State":"running","Labels":{"podup.service":"api"}},
+		{"Names":["/proj-db-1"],"State":"running","Labels":{"podup.service":"db"}},
+		{"Names":["/proj-cache-1"],"State":"running","Labels":{"podup.service":"cache"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else {
+			// Every per-container logs stream 404s: this test is about how many
+			// listing calls are made, not about what the streams carry.
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+	let file = crate::parse_str(
+		"services:\n  web:\n    image: x\n  api:\n    image: x\n  db:\n    image: x\n  cache:\n    image: x\n",
+	)
+	.unwrap();
+
+	// The per-container streams all 404, so the call itself is expected to
+	// fail; the request log is what carries the answer.
+	let _ = e.logs(&file, None, false).await;
+
+	let lists = fake
+		.requests
+		.lock()
+		.unwrap()
+		.iter()
+		.filter(|r| r.contains("/containers/json"))
+		.count();
+	assert_eq!(
+		lists,
+		1,
+		"four services must share one container-list round-trip, not one each (#1445); \
+		 requests were {:?}",
+		fake.requests.lock().unwrap()
+	);
 }

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -524,13 +524,25 @@ impl Engine {
 	/// created by an earlier `up --scale`/`scale` rather than the current
 	/// invocation, matching `docker compose cp/exec --index`. Shared by the
 	/// replica-targeting commands (`exec`, `cp`).
+	///
+	/// Reads off the bulk project listing ([`Engine::live_project_replicas_sorted`])
+	/// instead of issuing a per-service container-list round-trip (#1445):
+	/// one shared GET powers the rest of the per-replica query paths
+	/// (`port`, `logs`) when a command needs more than one of them.
 	pub(super) async fn live_replica_name_at(
 		&self,
 		service_name: &str,
 		service: &Service,
 		index: Option<u32>,
 	) -> Result<String> {
-		let names = self.live_replica_names(service_name, service).await?;
+		let live_by_service = self.live_project_replicas_sorted().await?;
+		let names = match live_by_service.get(service_name) {
+			Some(names) if !names.is_empty() => names.clone(),
+			// Service has no live container yet — fall back to the static
+			// compose names so a never-created service still has an
+			// addressable replica.
+			_ => self.replica_names(service_name, service),
+		};
 		let base = self.container_name(service_name, service);
 		resolve_replica_name(service_name, &base, &names, index)
 	}

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -567,6 +567,28 @@ pub(super) fn to_query_json<T: serde::Serialize>(what: &str, v: &T) -> Result<St
 	serde_json::to_string(v).map_err(|e| ComposeError::Build(format!("invalid {what}: {e}")))
 }
 
+/// Serialise `v` to a pretty-printed JSON string for emitting as the final
+/// `--format json` output of a list command.
+///
+/// Five sites flow through this: `ls` ([`projects::list_projects_filtered`]),
+/// `images` ([`Engine::images_with_services`]), `top`
+/// ([`Engine::top_with_options`]), `ps` ([`Engine::ps_filtered_with_display`]),
+/// and `volumes` ([`Engine::list_volumes_with_display`]). Each used to call
+/// `serde_json::to_string_pretty(...).unwrap_or_default()`, which silently
+/// emitted an empty string on a serialisation failure; the command then
+/// printed the empty string and exited 0, so a script consuming
+/// `podup <cmd> --format json` received an empty document indistinguishable
+/// from "no results" (#1444). Unlike the NDJSON path in
+/// [`to_query_json`](self)/[`events`](super::events) — where one row can be
+/// dropped and the stream continue — `--format json` is the *whole* output,
+/// so a failure must propagate as an error and exit non-zero.
+///
+/// `what` names the offending field in the error so the operator sees which
+/// row or document type was rejected.
+pub(super) fn to_pretty_json<T: serde::Serialize>(what: &str, v: &T) -> Result<String> {
+	serde_json::to_string_pretty(v).map_err(|e| ComposeError::Build(format!("invalid {what}: {e}")))
+}
+
 /// Write one log frame without creating a lossy `Cow` for valid UTF-8.
 ///
 /// `String::from_utf8_lossy` allocates a `Cow<String>` even on the happy path;
@@ -709,6 +731,10 @@ mod to_query_json_tests {
 		assert!(err.to_string().contains("build.cache_to"), "got {err}");
 	}
 }
+
+#[cfg(test)]
+#[path = "to_pretty_json_tests.rs"]
+mod to_pretty_json_tests;
 
 #[cfg(test)]
 mod tests;

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -161,7 +161,7 @@ pub async fn list_projects_filtered(
 			.iter()
 			.map(|(name, t)| project_row(name, t, &t.config_files))
 			.collect();
-		println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+		println!("{}", super::to_pretty_json("ls.row", &arr)?);
 		return Ok(());
 	}
 

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -153,10 +153,7 @@ impl Engine {
 					})
 				})
 				.collect();
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&json).unwrap_or_default()
-			);
+			println!("{}", super::super::to_pretty_json("images.row", &json)?);
 			return Ok(());
 		}
 

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -166,9 +166,14 @@ impl Engine {
 		// Resolve against the containers Podman actually has, not the static
 		// compose replica count: a service scaled purely via CLI `--scale` has no
 		// `scale:` in the file, so the static count is 1 and would target the
-		// never-created un-indexed base name. `live_replica_names` falls back to
-		// the static names only when nothing is running yet.
-		let live = self.live_replica_names(service_name, service).await?;
+		// never-created un-indexed base name. Falls back to the static names
+		// when nothing is running yet — the bulk map (`#1445`) only sees what
+		// Podman has, not the compose file.
+		let live_by_service = self.live_project_replicas_sorted().await?;
+		let live = match live_by_service.get(service_name) {
+			Some(names) if !names.is_empty() => names.clone(),
+			_ => self.replica_names(service_name, service),
+		};
 		let container_name = select_replica(live, service_name, index)?;
 
 		let path = format!(

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -111,10 +111,7 @@ impl Engine {
 			}
 		}
 		if json {
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&json_rows).unwrap_or_default()
-			);
+			println!("{}", super::super::to_pretty_json("top.row", &json_rows)?);
 		}
 		Ok(())
 	}

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -284,40 +284,55 @@ impl Engine {
 			target_services.iter().map(String::as_str).collect();
 		// (container_name, is_tty) — TTY containers send raw bytes; non-TTY use
 		// multiplexed 8-byte-header framing. Resolved against the containers
-		// Podman actually has (`live_replica_names`), not the static compose
-		// replica count: after a runtime `scale`/`up --scale` the file's count no
-		// longer matches the live replicas, so `logs` would otherwise miss every
-		// replica beyond the first (falls back to the static names when none are
-		// running yet).
-		// One `live_replica_names` round-trip per selected service (a future
-		// optimization: batch this through scale.rs's `live_project_replicas`
-		// instead). A resolution failure for
-		// one service must not blank the whole command the way an `.await?` would:
-		// warn and skip that service so the rest still stream, matching the
-		// per-container tolerance below.
-		// A failure resolving ONE service is tolerated so the others still print —
-		// that is deliberate and tested. But when nothing resolves at all, the
-		// command printed nothing and still reported success, which is how an
-		// unreachable engine looked identical to a project with no logs. Kept and
-		// only consulted when there is no output to salvage.
+		// Podman actually has, not the static compose replica count: after a
+		// runtime `scale`/`up --scale` the file's count no longer matches the
+		// live replicas, so `logs` would otherwise miss every replica beyond
+		// the first. Falls back to the static names for a service absent from
+		// the map (the bulk helper does not see the compose file).
+		//
+		// Hoisted out of the per-service loop so a `logs` over N services
+		// costs one container-list round-trip, not N (#1445) — the same bulk
+		// path the per-service lifecycle commands took in #1363.
+		//
+		// A failure resolving ONE service is tolerated so the others still
+		// print — that is deliberate and tested. The bulk GET is now the only
+		// point where a single engine-side failure can land, so the same
+		// tolerance collapses into "warn + remember, the post-loop empty
+		// check surfaces the error when there is no partial result to
+		// protect" — i.e. an unreachable engine used to look like a project
+		// with no logs and still exit 0; this preserves that fix.
+		//
+		// The skip-on-fetch-error case must NOT fall back to the static
+		// names below: the original per-service loop did `continue` on a
+		// resolution error, leaving `targets` empty so the post-loop check
+		// could surface the error. Falling back to static names would push
+		// phantom containers that 404 per-container, mask the failure, and
+		// make `logs` exit 0 on an unreachable engine again.
 		let mut first_err: Option<ComposeError> = None;
+		let live_by_service = match self.live_project_replicas_sorted().await {
+			Ok(by_service) => by_service,
+			Err(e) => {
+				tracing::warn!("logs: resolving project replicas: {e}");
+				first_err.get_or_insert(e);
+				std::collections::HashMap::new()
+			}
+		};
+		let fetch_failed = first_err.is_some();
 		let mut targets: Vec<(String, bool)> = Vec::new();
-		for (n, s) in file
-			.services
-			.iter()
-			.filter(|(n, _)| selected.is_empty() || selected.contains(n.as_str()))
-		{
-			let is_tty = s.tty.unwrap_or(false);
-			let names = match self.live_replica_names(n, s).await {
-				Ok(names) => names,
-				Err(e) => {
-					tracing::warn!("logs: resolving replicas for service {n}: {e}");
-					first_err.get_or_insert(e);
-					continue;
+		if !fetch_failed {
+			for (n, s) in file
+				.services
+				.iter()
+				.filter(|(n, _)| selected.is_empty() || selected.contains(n.as_str()))
+			{
+				let is_tty = s.tty.unwrap_or(false);
+				let names = match live_by_service.get(n.as_str()) {
+					Some(names) if !names.is_empty() => names.clone(),
+					_ => self.replica_names(n, s),
+				};
+				for cname in names {
+					targets.push((cname, is_tty));
 				}
-			};
-			for cname in names {
-				targets.push((cname, is_tty));
 			}
 		}
 

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -496,10 +496,7 @@ impl Engine {
 
 		if opts.json {
 			let rows: Vec<_> = containers.iter().map(ps_json_row).collect();
-			println!(
-				"{}",
-				serde_json::to_string_pretty(&rows).unwrap_or_default()
-			);
+			println!("{}", super::super::to_pretty_json("ps.row", &rows)?);
 			return Ok(());
 		}
 

--- a/internal/engine/query/tests.rs
+++ b/internal/engine/query/tests.rs
@@ -127,50 +127,17 @@ async fn logs_targets_every_live_replica_after_scale() {
 /// Resolving replicas for one selected service must not abort `logs` before
 /// a single line prints for the others: `logs` already documents that it
 /// tolerates a missing/not-yet-created container this way (see the
-/// per-container `get_stream` handling in `logs_with_display`), and a
-/// transient libpod error resolving one service's live replicas deserves the
-/// same tolerance, not a whole-command failure. Service "a" 500s on its
-/// container-list lookup; service "b" resolves normally. Pre-fix, the
-/// resolution loop's `.await?` propagates "a"'s error and `logs` never
-/// reaches "b" at all.
-#[tokio::test]
-#[cfg(unix)]
-async fn logs_skips_a_service_whose_replica_resolution_errors_but_still_targets_the_rest() {
-	let fake = fake_podman::start(move |method, target| {
-		if method == "GET" && target.contains("/containers/json") {
-			if target.contains("podup.service%3Da") {
-				(500, r#"{"message":"internal server error"}"#.to_string())
-			} else if target.contains("podup.service%3Db") {
-				(200, r#"[{"Names":["/proj-b-1"]}]"#.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		} else if method == "GET" && target.contains("/logs") {
-			(200, String::new())
-		} else {
-			(404, r#"{"message":"not found"}"#.to_string())
-		}
-	});
-	let e = engine_with(fake.client(), "proj");
-
-	let mut file = ComposeFile::default();
-	file.services.insert("a".into(), Service::default());
-	file.services.insert("b".into(), Service::default());
-
-	e.logs_with_options(
-		&file,
-		&["a".to_string(), "b".to_string()],
-		LogsOptions::default(),
-	)
-	.await
-	.expect("a resolution failure on one service must not blank logs for the rest");
-
-	let seen = fake.requests.lock().unwrap();
-	assert!(
-		seen.iter().any(|r| r.contains("/proj-b-1/logs")),
-		"expected the healthy service's container to still be targeted: {seen:?}"
-	);
-}
+/// per-container `get_stream` handling in `logs_with_display`).
+///
+/// #1445 collapsed the per-service `live_replica_names` resolution into a
+/// single bulk fetch (`live_project_replicas_sorted`), so the per-service
+/// error path this test used to drive no longer exists — there is one
+/// container-list call for the whole project, not one per service, so a
+/// per-service 500 is no longer reachable in this code. The companion
+/// `logs_fails_when_no_service_resolves_at_all` covers the only failure
+/// mode that survives the bulk refactor: the bulk GET errors out, no
+/// target survives, and `logs` exits non-zero instead of printing nothing
+/// and reporting success.
 
 #[test]
 fn filter_orphans_keeps_only_unknown_names() {

--- a/internal/engine/to_pretty_json_tests.rs
+++ b/internal/engine/to_pretty_json_tests.rs
@@ -1,0 +1,90 @@
+//! Unit tests for the `to_pretty_json` helper.
+//!
+//! `to_pretty_json` is the pretty-printed sibling of [`super::to_query_json`],
+//! shared by the five `--format json` output sites (`ls`, `images`, `top`,
+//! `ps`, `volumes`). The failure contract is the same: a serialisation error
+//! must surface as `Err(ComposeError::Build)` naming the field, never as an
+//! empty string swallowed by `unwrap_or_default` (#1444).
+
+use super::to_pretty_json;
+use crate::error::ComposeError;
+use serde::ser::{Error as _, Serializer};
+use serde::Serialize;
+use serde_json::json;
+
+/// A `Serialize` impl that always errors, so a unit test can pin the
+/// "surface the failure" contract without depending on a particular type
+/// in the build path. Mirrors the helper used by [`super::to_query_json_tests`].
+struct AlwaysFails {
+	reason: &'static str,
+}
+
+impl Serialize for AlwaysFails {
+	fn serialize<S: Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
+		Err(S::Error::custom(self.reason))
+	}
+}
+
+/// The happy path: a `Vec<serde_json::Value>` of the same shape the five
+/// `--format json` call sites serialise round-trips through `to_pretty_json`
+/// unchanged. Parse-and-compare rather than pinning the literal pretty
+/// format — the round-trip is what matters and is portable across minor
+/// formatting tweaks.
+#[test]
+fn to_pretty_json_serialises_vec_of_json_values() {
+	let arr = vec![
+		json!({ "Name": "web", "Status": "running(1)" }),
+		json!({ "Name": "db", "Status": "exited(1)" }),
+	];
+	let s = to_pretty_json("ls.row", &arr).unwrap();
+	let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+	assert_eq!(
+		parsed,
+		json!([
+			{ "Name": "web", "Status": "running(1)" },
+			{ "Name": "db", "Status": "exited(1)" },
+		])
+	);
+}
+
+/// A serialisation failure must surface as `Err(ComposeError::Build)`
+/// whose message names the field and the underlying reason. Each of the
+/// five `--format json` call sites passes a distinct `what`, so all five
+/// labels are pinned to a test.
+#[test]
+fn to_pretty_json_failure_names_ls_row() {
+	let err = to_pretty_json("ls.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(matches!(err, ComposeError::Build(_)), "got {err:?}");
+	let msg = err.to_string();
+	assert!(msg.contains("ls.row"), "got {msg:?}");
+	assert!(msg.contains("boom"), "got {msg:?}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_images_row() {
+	let err = to_pretty_json("images.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("images.row"), "got {err}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_top_row() {
+	let err = to_pretty_json("top.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("top.row"), "got {err}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_ps_row() {
+	let err = to_pretty_json("ps.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("ps.row"), "got {err}");
+}
+
+#[test]
+fn to_pretty_json_failure_names_volumes_row() {
+	let err = to_pretty_json("volumes.row", &AlwaysFails { reason: "boom" })
+		.expect_err("must surface the error");
+	assert!(err.to_string().contains("volumes.row"), "got {err}");
+}

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -147,7 +147,7 @@ impl Engine {
 					})
 				})
 				.collect();
-			println!("{}", serde_json::to_string_pretty(&arr).unwrap_or_default());
+			println!("{}", super::super::to_pretty_json("volumes.row", &arr)?);
 			return Ok(());
 		}
 

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -320,30 +320,68 @@ impl Client {
 		}
 	}
 
-	/// Check status code; on error parse the Podman error message.
-	fn check_status(status: StatusCode, body: &[u8]) -> Result<()> {
-		if status.is_success() {
-			return Ok(());
-		}
-
+	/// Extract the human-readable message from a libpod error body. The body is
+	/// JSON shaped like `{"message": "...", "cause": "..."}`; prefer `message`,
+	/// fall back to `cause`, and to the raw body when the JSON is malformed (a
+	/// proxy or a 502 from a fronting process can return plain text). Pure, so
+	/// `check_status` and `check_status_with_field` share it without duplication.
+	pub(crate) fn parse_error_message(body: &[u8]) -> String {
 		#[derive(serde::Deserialize)]
 		struct ApiError {
 			cause: Option<String>,
 			message: Option<String>,
 		}
 
-		let msg = if let Ok(e) = serde_json::from_slice::<ApiError>(body) {
+		if let Ok(e) = serde_json::from_slice::<ApiError>(body) {
 			e.message
 				.or(e.cause)
 				.unwrap_or_else(|| String::from_utf8_lossy(body).into_owned())
 		} else {
 			String::from_utf8_lossy(body).into_owned()
-		};
+		}
+	}
 
+	/// Check status code; on error parse the Podman error message.
+	fn check_status(status: StatusCode, body: &[u8]) -> Result<()> {
+		if status.is_success() {
+			return Ok(());
+		}
 		Err(PodmanError::Api {
 			status: status.as_u16(),
-			message: msg,
+			message: Self::parse_error_message(body),
 		})
+	}
+
+	/// Check status code and, on a 4xx/5xx, promote the failure to a
+	/// [`PodmanError::Field`] when a single field is in scope.
+	///
+	/// The pre-validators in [`super::validate`] catch the field-level
+	/// rejections libpod makes on its own (namespace modes, `device_cgroup_rule`
+	/// access, build-arg/label keys). For other fields — `cap_add`, `runtime`,
+	/// `devices`, `extra_hosts` — podup does not have a pre-validator (the
+	/// failure surfaces from the OCI runtime or the cgroup manager, not from
+	/// libpod's specgen), and podup does not know which compose-side key libpod
+	/// rejected. When the caller does know, passing `field` turns an opaque
+	/// `podman API error (HTTP 400): <message>` into the field-shaped
+	/// `field: <message> (value: <value>)` form so the operator sees the
+	/// compose-side key, not the libpod body. The libpod message is preserved
+	/// inside the `Field`'s own `message` so the cause is not lost (#1357).
+	fn check_status_with_field(
+		status: StatusCode,
+		body: &[u8],
+		field: Option<(&'static str, &str)>,
+	) -> Result<()> {
+		if status.is_success() {
+			return Ok(());
+		}
+		let msg = Self::parse_error_message(body);
+		match field {
+			Some((name, value)) => Err(super::validate::spec_field_error("", name, value, msg)),
+			None => Err(PodmanError::Api {
+				status: status.as_u16(),
+				message: msg,
+			}),
+		}
 	}
 
 	/// For streaming endpoints, return the response on success or parse the

--- a/internal/libpod/client/post.rs
+++ b/internal/libpod/client/post.rs
@@ -41,6 +41,64 @@ impl Client {
 		Self::check_status(status, &body)
 	}
 
+	/// `POST` with JSON body → deserialize JSON response, promoting a 4xx/5xx
+	/// to a [`PodmanError::Field`](crate::libpod::PodmanError::Field) when
+	/// `field` names a compose-side key the
+	/// caller knows was being attempted.
+	///
+	/// Prefer this over [`post_json`](Self::post_json) at call sites where a
+	/// single field is in scope: the error then reads `field: <libpod message>
+	/// (value: <value>)` instead of the generic HTTP framing, so the operator
+	/// sees what podup was trying to set. The libpod message is preserved
+	/// inside the `Field` so the cause is not lost (#1357).
+	pub async fn post_json_with_field<B, T>(
+		&self,
+		path: &str,
+		body: &B,
+		field: Option<(&'static str, &str)>,
+	) -> Result<T>
+	where
+		B: Serialize,
+		T: DeserializeOwned,
+	{
+		let json = serde_json::to_vec(body).map_err(super::PodmanError::Json)?;
+		let req = Self::build_request(
+			Method::POST,
+			path,
+			full(Bytes::from(json)),
+			Some("application/json"),
+		)?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
+		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		Self::check_status_with_field(status, &body, field)?;
+		serde_json::from_slice(&body).map_err(super::PodmanError::Json)
+	}
+
+	/// `POST` with JSON body → ignore response body, promoting a 4xx/5xx to a
+	/// [`PodmanError::Field`](crate::libpod::PodmanError::Field) when `field`
+	/// names a compose-side key. See
+	/// [`post_json_with_field`](Self::post_json_with_field).
+	pub async fn post_json_ok_with_field<B>(
+		&self,
+		path: &str,
+		body: &B,
+		field: Option<(&'static str, &str)>,
+	) -> Result<()>
+	where
+		B: Serialize,
+	{
+		let json = serde_json::to_vec(body).map_err(super::PodmanError::Json)?;
+		let req = Self::build_request(
+			Method::POST,
+			path,
+			full(Bytes::from(json)),
+			Some("application/json"),
+		)?;
+		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
+		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		Self::check_status_with_field(status, &body, field)
+	}
+
 	/// `POST` with JSON body → return raw `Response<Incoming>` for streaming.
 	pub async fn post_json_stream<B: Serialize>(
 		&self,

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -1,6 +1,6 @@
 use hyper::StatusCode;
 
-use super::{meets_minimum, Client};
+use super::{meets_minimum, Client, PodmanError};
 
 // ---------------------------------------------------------------------------
 // check_status tests
@@ -45,6 +45,132 @@ fn check_status_falls_back_to_raw_body_on_non_json() {
 		Client::check_status(StatusCode::INTERNAL_SERVER_ERROR, b"plain text error").unwrap_err();
 	assert!(err.is_status(500));
 	assert!(err.to_string().contains("plain text error"));
+}
+
+// ---------------------------------------------------------------------------
+// parse_error_message tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_error_message_prefers_message_field() {
+	// Podman's libpod JSON error body carries `message` (operator-facing)
+	// and `cause` (lower-level chain). `message` is the one to surface
+	// because it is the human-readable reason; `cause` is the wrapped
+	// driver detail.
+	let body = br#"{"message":"namespace \"evil\" not recognised","cause":"ParseNamespace"}"#;
+	let msg = Client::parse_error_message(body);
+	assert!(msg.contains("namespace"), "got: {msg}");
+	assert!(!msg.contains("ParseNamespace"), "got: {msg}");
+}
+
+#[test]
+fn parse_error_message_falls_back_to_cause() {
+	// Some endpoints populate only `cause`. Falling back keeps the
+	// operator looking at libpod's own wording rather than an empty
+	// placeholder.
+	let body = br#"{"cause":"internal: cgroup mount not found"}"#;
+	let msg = Client::parse_error_message(body);
+	assert!(msg.contains("cgroup mount"), "got: {msg}");
+}
+
+#[test]
+fn parse_error_message_uses_raw_body_when_not_json() {
+	// A proxy or a 502 from a fronting process can return plain text.
+	// The raw body is the only signal then, so it goes through verbatim
+	// rather than being dropped to an empty string.
+	let body = b"upstream connect error: connection refused";
+	let msg = Client::parse_error_message(body);
+	assert!(msg.contains("connection refused"), "got: {msg}");
+}
+
+#[test]
+fn parse_error_message_uses_raw_body_when_json_has_no_message() {
+	// An empty `{}` body is JSON but carries no signal; fall through to
+	// the raw body so the operator sees at least the byte content.
+	let body = b"{}";
+	let msg = Client::parse_error_message(body);
+	assert!(!msg.is_empty(), "got: {msg}");
+}
+
+// ---------------------------------------------------------------------------
+// check_status_with_field tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_status_with_field_promotes_to_field_error() {
+	// A 4xx with a field context renders as `field: <libpod message>
+	// (value: <value>)` — the field-shaped form the operator wants,
+	// not the raw HTTP framing. The libpod message is preserved inside
+	// the Field so the cause is not lost (#1357).
+	let body = br#"{"message":"namespace \"evil\" not recognised"}"#;
+	let err = Client::check_status_with_field(
+		hyper::StatusCode::BAD_REQUEST,
+		body,
+		Some(("pid", "evil")),
+	)
+	.unwrap_err();
+	match err {
+		PodmanError::Field {
+			service,
+			field,
+			value,
+			message,
+		} => {
+			assert_eq!(service, "");
+			assert_eq!(field, "pid");
+			assert_eq!(value, "evil");
+			assert!(message.contains("namespace"), "got: {message}");
+		}
+		other => panic!("expected Field variant, got {other:?}"),
+	}
+}
+
+#[test]
+fn check_status_with_field_without_context_keeps_api_shape() {
+	// No field context → the existing `Api` shape is preserved, so
+	// callers that do not opt in to the new method see the same
+	// error as before. The new method is purely additive (#1357).
+	let body = br#"{"message":"bad request"}"#;
+	let err =
+		Client::check_status_with_field(hyper::StatusCode::BAD_REQUEST, body, None).unwrap_err();
+	assert!(err.is_status(400));
+}
+
+#[test]
+fn check_status_with_field_preserves_non_json_message() {
+	// A non-JSON body is fed through `parse_error_message` and lands
+	// inside the `Field`'s `message` verbatim. The libpod detail is
+	// not lost when the body is not the usual JSON shape (#1357).
+	let body = b"plain text body";
+	let err = Client::check_status_with_field(
+		hyper::StatusCode::INTERNAL_SERVER_ERROR,
+		body,
+		Some(("runtime", "/nonexistent")),
+	)
+	.unwrap_err();
+	match err {
+		PodmanError::Field {
+			field,
+			value,
+			message,
+			..
+		} => {
+			assert_eq!(field, "runtime");
+			assert_eq!(value, "/nonexistent");
+			assert_eq!(message, "plain text body");
+		}
+		other => panic!("expected Field variant, got {other:?}"),
+	}
+}
+
+#[test]
+fn check_status_with_field_passes_through_on_success() {
+	// 2xx responses are never promoted to an error regardless of
+	// whether a field context is provided. The field context is
+	// strictly an *error-shaping* tool.
+	let body = b"{}";
+	Client::check_status_with_field(hyper::StatusCode::OK, body, Some(("pid", "evil")))
+		.expect("2xx must be a no-op");
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -17,6 +17,35 @@ pub enum PodmanError {
 	StreamEndedEarly,
 	/// Podman API returned an error response (4xx/5xx).
 	Api { status: u16, message: String },
+	/// A libpod field-level rejection that podup identified and attributed to a
+	/// specific field of the request it sent.
+	///
+	/// libpod validates a handful of fields at the `SpecGenerator` (container
+	/// create) and build-query layer — namespaces via `ParseNamespace`,
+	/// `device_cgroup_rule` access strings via `parseLinuxResourcesDeviceAccess`,
+	/// build-arg/label keys, and a few others. When podup pre-validates these,
+	/// or when it identifies the offending field by inspecting the request it
+	/// just sent, it surfaces the rejection as a `Field` so the user sees the
+	/// compose-side key plus the offending value, not the raw libpod message.
+	/// `service` is the compose service name for `SpecGenerator` requests and
+	/// the empty string for build-query requests (which have no service
+	/// context); `field` is the compose-side field name (e.g. `"pid"`,
+	/// `"build.args"`); `value` is the offending value as it was sent;
+	/// `message` is the ready-to-print explanation and includes the libpod
+	/// detail so the cause is not lost (#1357).
+	Field {
+		/// Compose service name, or `""` when the request had no service
+		/// context (build queries, ping).
+		service: String,
+		/// Compose-side field name (e.g. `"pid"`, `"runtime"`, `"build.args"`).
+		field: String,
+		/// The offending value, truncated if necessary so a huge or binary
+		/// value does not flood the error.
+		value: String,
+		/// Ready-to-print explanation; carries the libpod detail so the cause
+		/// is preserved.
+		message: String,
+	},
 	/// The reachable Podman server speaks a libpod API version below the minimum
 	/// podup supports. Carries the version string the server reported (empty when
 	/// the server sent no `Libpod-API-Version` header).
@@ -35,6 +64,18 @@ impl fmt::Display for PodmanError {
 				Some(hint) => write!(f, "{hint} (podman: {message})"),
 				None => write!(f, "podman API error (HTTP {status}): {message}"),
 			},
+			Self::Field {
+				service,
+				field,
+				value,
+				message,
+			} => {
+				if service.is_empty() {
+					write!(f, "{field}: {message} (value: {value})")
+				} else {
+					write!(f, "service.{service}: {field}: {message} (value: {value})")
+				}
+			}
 			Self::IncompatibleApiVersion { reported } => {
 				let reported = if reported.is_empty() {
 					"an unknown version"
@@ -100,6 +141,7 @@ impl std::error::Error for PodmanError {
 			Self::StreamTooLarge
 			| Self::StreamEndedEarly
 			| Self::Api { .. }
+			| Self::Field { .. }
 			| Self::IncompatibleApiVersion { .. } => None,
 		}
 	}
@@ -187,6 +229,7 @@ impl PodmanError {
 			Self::Json(_) => "malformed-frame",
 			Self::StreamTooLarge => "stream-too-large",
 			Self::StreamEndedEarly => "stream-ended-early",
+			Self::Field { .. } => "field-rejected",
 			_ => "other",
 		}
 	}
@@ -284,338 +327,4 @@ fn body_ended_early(e: &hyper::Error) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-	use super::{conflict_hint, PodmanError};
-
-	#[test]
-	fn conflict_hint_recognises_common_state_errors() {
-		let rm = "cannot remove container abc as it is running - running or paused containers \
-			cannot be removed without force: container state improper";
-		assert!(conflict_hint(rm).unwrap().contains("-f"));
-		assert!(conflict_hint("container abc is already paused")
-			.unwrap()
-			.contains("already paused"));
-		assert!(conflict_hint("container abc is not paused")
-			.unwrap()
-			.contains("not paused"));
-		assert!(
-			conflict_hint("cannot kill container abc: container abc is not running")
-				.unwrap()
-				.contains("not running")
-		);
-		// libpod's kill-of-stopped 409 message ("can only kill running
-		// containers …") gets the same friendly "not running" hint.
-		assert!(conflict_hint(
-			"can only kill running containers. abc is in state exited: container state improper"
-		)
-		.unwrap()
-		.contains("not running"));
-	}
-
-	#[test]
-	fn is_kill_of_stopped_matches_only_the_kill_409() {
-		let stopped = PodmanError::Api {
-			status: 409,
-			message: "can only kill running containers. abc is in state exited: \
-				container state improper"
-				.into(),
-		};
-		assert!(stopped.is_kill_of_stopped());
-		// A different 409 (e.g. already-paused) must not be swallowed by kill.
-		let paused = PodmanError::Api {
-			status: 409,
-			message: "container abc is already paused".into(),
-		};
-		assert!(!paused.is_kill_of_stopped());
-		// Wrong status, even with a matching message, is not a kill-of-stopped.
-		let other = PodmanError::Api {
-			status: 500,
-			message: "can only kill running containers".into(),
-		};
-		assert!(!other.is_kill_of_stopped());
-		assert!(
-			!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_kill_of_stopped()
-		);
-	}
-
-	#[test]
-	fn conflict_hint_paused_rm_is_not_labelled_running() {
-		// Podman's removal refusal for a *paused* container shares the "without
-		// force" wording; the hint must say paused, not running.
-		let paused = "cannot remove container abc as it is paused - running or paused containers \
-			cannot be removed without force: container state improper";
-		let hint = conflict_hint(paused).unwrap();
-		assert!(hint.contains("paused"), "got {hint:?}");
-		assert!(!hint.contains("running"), "must not say running: {hint:?}");
-		assert!(hint.contains("-f"));
-	}
-
-	#[test]
-	fn conflict_hint_covers_kill_exec_and_start() {
-		// kill a stopped container.
-		assert!(
-			conflict_hint("can only kill running containers. abc is in state exited")
-				.unwrap()
-				.contains("not running")
-		);
-		// exec into a stopped container.
-		assert!(conflict_hint(
-			"can only create exec sessions on running containers: container state improper"
-		)
-		.unwrap()
-		.contains("not running"));
-		// start a container that is not startable.
-		assert!(conflict_hint(
-			"unable to start container abc: container must be in Created or Stopped state to be \
-			 started"
-		)
-		.unwrap()
-		.contains("cannot be started"));
-	}
-
-	#[test]
-	fn conflict_hint_none_for_unrecognised() {
-		assert!(conflict_hint("some unrelated error").is_none());
-		assert!(conflict_hint("no such container: abc").is_none());
-	}
-
-	#[test]
-	fn api_error_display_leads_with_hint_and_keeps_message() {
-		let e = PodmanError::Api {
-			status: 409,
-			message: "container abc is already paused".into(),
-		};
-		let s = e.to_string();
-		assert!(s.starts_with("the container is already paused"));
-		assert!(s.contains("podman: container abc is already paused"));
-	}
-
-	#[test]
-	fn api_error_display_raw_when_no_hint() {
-		let e = PodmanError::Api {
-			status: 500,
-			message: "boom".into(),
-		};
-		assert_eq!(e.to_string(), "podman API error (HTTP 500): boom");
-	}
-
-	#[test]
-	fn is_status_matches_code() {
-		let e = PodmanError::Api {
-			status: 404,
-			message: "not found".into(),
-		};
-		assert!(e.is_status(404));
-		assert!(!e.is_status(200));
-		assert!(!e.is_status(500));
-	}
-
-	#[test]
-	fn is_timeout_matches_synthetic_timeout_error() {
-		// Client-side timeouts carry status 0 and a "timed out" message; lifecycle
-		// stop escalation keys off this.
-		assert!(PodmanError::Api {
-			status: 0,
-			message: "timed out after 40s waiting for the Podman socket to respond".into(),
-		}
-		.is_timeout());
-		// A real HTTP error (non-zero status) is not a timeout.
-		assert!(!PodmanError::Api {
-			status: 500,
-			message: "boom".into(),
-		}
-		.is_timeout());
-		// A status-0 error without the timeout marker is not a timeout.
-		assert!(!PodmanError::Api {
-			status: 0,
-			message: "invalid API path".into(),
-		}
-		.is_timeout());
-	}
-
-	#[test]
-	fn is_status_false_for_non_api() {
-		let e = PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err());
-		assert!(!e.is_status(404));
-	}
-
-	#[test]
-	fn already_exists_accepts_409_and_500_with_message() {
-		// 409 conflict: always an already-exists.
-		assert!(PodmanError::Api {
-			status: 409,
-			message: "network already used".into(),
-		}
-		.is_already_exists());
-		// 500 carrying the libpod "already exists" cause (Podman's volume-create
-		// path) must also count as already-exists for idempotent create.
-		assert!(PodmanError::Api {
-			status: 500,
-			message: "volume with name p_v already exists: volume already exists".into(),
-		}
-		.is_already_exists());
-	}
-
-	#[test]
-	fn image_in_use_accepts_409_and_500_with_message() {
-		// A 409 on image delete is always an in-use conflict.
-		assert!(PodmanError::Api {
-			status: 409,
-			message: "image is in use by 1 container".into(),
-		}
-		.is_image_in_use());
-		// Some Podman versions report it as a 500 naming the cause.
-		assert!(PodmanError::Api {
-			status: 500,
-			message: "image used by a container: image in use".into(),
-		}
-		.is_image_in_use());
-		// An unrelated 500 still propagates.
-		assert!(!PodmanError::Api {
-			status: 500,
-			message: "internal error".into(),
-		}
-		.is_image_in_use());
-		assert!(!PodmanError::Api {
-			status: 404,
-			message: "no such image".into(),
-		}
-		.is_image_in_use());
-	}
-
-	#[test]
-	fn state_conflict_recognises_pause_unpause_mismatches() {
-		for msg in [
-			"container abc is already paused: container state improper",
-			"container abc is not paused: container state improper",
-			"cannot pause container abc: container abc is not running",
-			"unpausing container: container state improper",
-		] {
-			assert!(
-				PodmanError::Api {
-					status: 500,
-					message: msg.into(),
-				}
-				.is_state_conflict(),
-				"should treat {msg:?} as a state conflict"
-			);
-		}
-		// A genuine failure is not a state conflict.
-		assert!(!PodmanError::Api {
-			status: 500,
-			message: "internal error".into(),
-		}
-		.is_state_conflict());
-		assert!(!PodmanError::Api {
-			status: 404,
-			message: "no such container".into(),
-		}
-		.is_state_conflict());
-	}
-
-	#[test]
-	fn already_exists_false_for_other_errors() {
-		// A 500 that is not an already-exists must still propagate.
-		assert!(!PodmanError::Api {
-			status: 500,
-			message: "internal error".into(),
-		}
-		.is_already_exists());
-		assert!(!PodmanError::Api {
-			status: 404,
-			message: "no such volume".into(),
-		}
-		.is_already_exists());
-		assert!(
-			!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_already_exists()
-		);
-	}
-
-	#[test]
-	fn display_api_error() {
-		let e = PodmanError::Api {
-			status: 500,
-			message: "internal error".into(),
-		};
-		assert_eq!(e.to_string(), "podman API error (HTTP 500): internal error");
-	}
-
-	#[test]
-	fn display_json_error() {
-		let e = PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err());
-		assert!(e.to_string().contains("json error"));
-	}
-
-	#[test]
-	fn display_connect_error() {
-		let e = PodmanError::Connect(std::io::Error::new(
-			std::io::ErrorKind::NotFound,
-			"no socket",
-		));
-		assert!(e.to_string().contains("podman socket connection error"));
-	}
-
-	#[test]
-	fn display_incompatible_api_version_reports_version() {
-		let e = PodmanError::IncompatibleApiVersion {
-			reported: "4.9.3".into(),
-		};
-		let msg = e.to_string();
-		assert!(msg.contains("Podman >= 5.0"));
-		assert!(msg.contains("4.9.3"));
-	}
-
-	#[test]
-	fn display_incompatible_api_version_handles_missing_header() {
-		// An empty reported version (no `Libpod-API-Version` header) renders a
-		// readable placeholder rather than a blank.
-		let e = PodmanError::IncompatibleApiVersion {
-			reported: String::new(),
-		};
-		let msg = e.to_string();
-		assert!(msg.contains("an unknown version"));
-	}
-
-	#[test]
-	fn source_present_for_wrapped_errors_absent_for_owned() {
-		use std::error::Error;
-		// Wrapped lower-level errors expose their source...
-		let connect = PodmanError::Connect(std::io::Error::new(
-			std::io::ErrorKind::NotFound,
-			"no socket",
-		));
-		assert!(connect.source().is_some());
-		let json = PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err());
-		assert!(json.source().is_some());
-		// ...while the owned variants have no underlying source.
-		assert!(PodmanError::Api {
-			status: 500,
-			message: "x".into(),
-		}
-		.source()
-		.is_none());
-		assert!(PodmanError::IncompatibleApiVersion {
-			reported: "4.0.0".into(),
-		}
-		.source()
-		.is_none());
-	}
-
-	#[test]
-	fn from_io_error_becomes_connect() {
-		// The `?`-operator conversion an io error takes when bubbling out of the
-		// client maps onto the Connect variant.
-		let io = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
-		let e: PodmanError = io.into();
-		assert!(matches!(e, PodmanError::Connect(_)));
-		assert!(e.to_string().contains("podman socket connection error"));
-	}
-
-	#[test]
-	fn from_json_error_becomes_json() {
-		let json_err = serde_json::from_str::<u8>("not-json").unwrap_err();
-		let e: PodmanError = json_err.into();
-		assert!(matches!(e, PodmanError::Json(_)));
-		assert!(e.to_string().contains("json error"));
-	}
-}
+mod tests;

--- a/internal/libpod/error/tests.rs
+++ b/internal/libpod/error/tests.rs
@@ -1,0 +1,397 @@
+use crate::libpod::error::{conflict_hint, PodmanError};
+
+#[test]
+fn conflict_hint_recognises_common_state_errors() {
+	let rm = "cannot remove container abc as it is running - running or paused containers \
+			cannot be removed without force: container state improper";
+	assert!(conflict_hint(rm).unwrap().contains("-f"));
+	assert!(conflict_hint("container abc is already paused")
+		.unwrap()
+		.contains("already paused"));
+	assert!(conflict_hint("container abc is not paused")
+		.unwrap()
+		.contains("not paused"));
+	assert!(
+		conflict_hint("cannot kill container abc: container abc is not running")
+			.unwrap()
+			.contains("not running")
+	);
+	// libpod's kill-of-stopped 409 message ("can only kill running
+	// containers …") gets the same friendly "not running" hint.
+	assert!(conflict_hint(
+		"can only kill running containers. abc is in state exited: container state improper"
+	)
+	.unwrap()
+	.contains("not running"));
+}
+
+#[test]
+fn is_kill_of_stopped_matches_only_the_kill_409() {
+	let stopped = PodmanError::Api {
+		status: 409,
+		message: "can only kill running containers. abc is in state exited: \
+				container state improper"
+			.into(),
+	};
+	assert!(stopped.is_kill_of_stopped());
+	// A different 409 (e.g. already-paused) must not be swallowed by kill.
+	let paused = PodmanError::Api {
+		status: 409,
+		message: "container abc is already paused".into(),
+	};
+	assert!(!paused.is_kill_of_stopped());
+	// Wrong status, even with a matching message, is not a kill-of-stopped.
+	let other = PodmanError::Api {
+		status: 500,
+		message: "can only kill running containers".into(),
+	};
+	assert!(!other.is_kill_of_stopped());
+	assert!(
+		!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_kill_of_stopped()
+	);
+}
+
+#[test]
+fn conflict_hint_paused_rm_is_not_labelled_running() {
+	// Podman's removal refusal for a *paused* container shares the "without
+	// force" wording; the hint must say paused, not running.
+	let paused = "cannot remove container abc as it is paused - running or paused containers \
+			cannot be removed without force: container state improper";
+	let hint = conflict_hint(paused).unwrap();
+	assert!(hint.contains("paused"), "got {hint:?}");
+	assert!(!hint.contains("running"), "must not say running: {hint:?}");
+	assert!(hint.contains("-f"));
+}
+
+#[test]
+fn conflict_hint_covers_kill_exec_and_start() {
+	// kill a stopped container.
+	assert!(
+		conflict_hint("can only kill running containers. abc is in state exited")
+			.unwrap()
+			.contains("not running")
+	);
+	// exec into a stopped container.
+	assert!(conflict_hint(
+		"can only create exec sessions on running containers: container state improper"
+	)
+	.unwrap()
+	.contains("not running"));
+	// start a container that is not startable.
+	assert!(conflict_hint(
+		"unable to start container abc: container must be in Created or Stopped state to be \
+			 started"
+	)
+	.unwrap()
+	.contains("cannot be started"));
+}
+
+#[test]
+fn conflict_hint_none_for_unrecognised() {
+	assert!(conflict_hint("some unrelated error").is_none());
+	assert!(conflict_hint("no such container: abc").is_none());
+}
+
+#[test]
+fn api_error_display_leads_with_hint_and_keeps_message() {
+	let e = PodmanError::Api {
+		status: 409,
+		message: "container abc is already paused".into(),
+	};
+	let s = e.to_string();
+	assert!(s.starts_with("the container is already paused"));
+	assert!(s.contains("podman: container abc is already paused"));
+}
+
+#[test]
+fn api_error_display_raw_when_no_hint() {
+	let e = PodmanError::Api {
+		status: 500,
+		message: "boom".into(),
+	};
+	assert_eq!(e.to_string(), "podman API error (HTTP 500): boom");
+}
+
+#[test]
+fn is_status_matches_code() {
+	let e = PodmanError::Api {
+		status: 404,
+		message: "not found".into(),
+	};
+	assert!(e.is_status(404));
+	assert!(!e.is_status(200));
+	assert!(!e.is_status(500));
+}
+
+#[test]
+fn is_timeout_matches_synthetic_timeout_error() {
+	// Client-side timeouts carry status 0 and a "timed out" message; lifecycle
+	// stop escalation keys off this.
+	assert!(PodmanError::Api {
+		status: 0,
+		message: "timed out after 40s waiting for the Podman socket to respond".into(),
+	}
+	.is_timeout());
+	// A real HTTP error (non-zero status) is not a timeout.
+	assert!(!PodmanError::Api {
+		status: 500,
+		message: "boom".into(),
+	}
+	.is_timeout());
+	// A status-0 error without the timeout marker is not a timeout.
+	assert!(!PodmanError::Api {
+		status: 0,
+		message: "invalid API path".into(),
+	}
+	.is_timeout());
+}
+
+#[test]
+fn is_status_false_for_non_api() {
+	let e = PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err());
+	assert!(!e.is_status(404));
+}
+
+#[test]
+fn already_exists_accepts_409_and_500_with_message() {
+	// 409 conflict: always an already-exists.
+	assert!(PodmanError::Api {
+		status: 409,
+		message: "network already used".into(),
+	}
+	.is_already_exists());
+	// 500 carrying the libpod "already exists" cause (Podman's volume-create
+	// path) must also count as already-exists for idempotent create.
+	assert!(PodmanError::Api {
+		status: 500,
+		message: "volume with name p_v already exists: volume already exists".into(),
+	}
+	.is_already_exists());
+}
+
+#[test]
+fn image_in_use_accepts_409_and_500_with_message() {
+	// A 409 on image delete is always an in-use conflict.
+	assert!(PodmanError::Api {
+		status: 409,
+		message: "image is in use by 1 container".into(),
+	}
+	.is_image_in_use());
+	// Some Podman versions report it as a 500 naming the cause.
+	assert!(PodmanError::Api {
+		status: 500,
+		message: "image used by a container: image in use".into(),
+	}
+	.is_image_in_use());
+	// An unrelated 500 still propagates.
+	assert!(!PodmanError::Api {
+		status: 500,
+		message: "internal error".into(),
+	}
+	.is_image_in_use());
+	assert!(!PodmanError::Api {
+		status: 404,
+		message: "no such image".into(),
+	}
+	.is_image_in_use());
+}
+
+#[test]
+fn state_conflict_recognises_pause_unpause_mismatches() {
+	for msg in [
+		"container abc is already paused: container state improper",
+		"container abc is not paused: container state improper",
+		"cannot pause container abc: container abc is not running",
+		"unpausing container: container state improper",
+	] {
+		assert!(
+			PodmanError::Api {
+				status: 500,
+				message: msg.into(),
+			}
+			.is_state_conflict(),
+			"should treat {msg:?} as a state conflict"
+		);
+	}
+	// A genuine failure is not a state conflict.
+	assert!(!PodmanError::Api {
+		status: 500,
+		message: "internal error".into(),
+	}
+	.is_state_conflict());
+	assert!(!PodmanError::Api {
+		status: 404,
+		message: "no such container".into(),
+	}
+	.is_state_conflict());
+}
+
+#[test]
+fn already_exists_false_for_other_errors() {
+	// A 500 that is not an already-exists must still propagate.
+	assert!(!PodmanError::Api {
+		status: 500,
+		message: "internal error".into(),
+	}
+	.is_already_exists());
+	assert!(!PodmanError::Api {
+		status: 404,
+		message: "no such volume".into(),
+	}
+	.is_already_exists());
+	assert!(!PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err()).is_already_exists());
+}
+
+#[test]
+fn display_api_error() {
+	let e = PodmanError::Api {
+		status: 500,
+		message: "internal error".into(),
+	};
+	assert_eq!(e.to_string(), "podman API error (HTTP 500): internal error");
+}
+
+#[test]
+fn display_json_error() {
+	let e = PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err());
+	assert!(e.to_string().contains("json error"));
+}
+
+#[test]
+fn display_connect_error() {
+	let e = PodmanError::Connect(std::io::Error::new(
+		std::io::ErrorKind::NotFound,
+		"no socket",
+	));
+	assert!(e.to_string().contains("podman socket connection error"));
+}
+
+#[test]
+fn display_incompatible_api_version_reports_version() {
+	let e = PodmanError::IncompatibleApiVersion {
+		reported: "4.9.3".into(),
+	};
+	let msg = e.to_string();
+	assert!(msg.contains("Podman >= 5.0"));
+	assert!(msg.contains("4.9.3"));
+}
+
+#[test]
+fn display_incompatible_api_version_handles_missing_header() {
+	// An empty reported version (no `Libpod-API-Version` header) renders a
+	// readable placeholder rather than a blank.
+	let e = PodmanError::IncompatibleApiVersion {
+		reported: String::new(),
+	};
+	let msg = e.to_string();
+	assert!(msg.contains("an unknown version"));
+}
+
+#[test]
+fn source_present_for_wrapped_errors_absent_for_owned() {
+	use std::error::Error;
+	// Wrapped lower-level errors expose their source...
+	let connect = PodmanError::Connect(std::io::Error::new(
+		std::io::ErrorKind::NotFound,
+		"no socket",
+	));
+	assert!(connect.source().is_some());
+	let json = PodmanError::Json(serde_json::from_str::<u8>("bad").unwrap_err());
+	assert!(json.source().is_some());
+	// ...while the owned variants have no underlying source.
+	assert!(PodmanError::Api {
+		status: 500,
+		message: "x".into(),
+	}
+	.source()
+	.is_none());
+	assert!(PodmanError::IncompatibleApiVersion {
+		reported: "4.0.0".into(),
+	}
+	.source()
+	.is_none());
+}
+
+#[test]
+fn from_io_error_becomes_connect() {
+	// The `?`-operator conversion an io error takes when bubbling out of the
+	// client maps onto the Connect variant.
+	let io = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+	let e: PodmanError = io.into();
+	assert!(matches!(e, PodmanError::Connect(_)));
+	assert!(e.to_string().contains("podman socket connection error"));
+}
+
+#[test]
+fn from_json_error_becomes_json() {
+	let json_err = serde_json::from_str::<u8>("not-json").unwrap_err();
+	let e: PodmanError = json_err.into();
+	assert!(matches!(e, PodmanError::Json(_)));
+	assert!(e.to_string().contains("json error"));
+}
+
+#[test]
+fn field_error_names_service_and_field() {
+	// A `Field` rendered for a container-create failure leads with the
+	// service and field, then the value, so the operator sees the
+	// offending entry without parsing the libpod body (#1357).
+	let e = PodmanError::Field {
+		service: "web".into(),
+		field: "pid".into(),
+		value: "evil".into(),
+		message: "namespace not recognised".into(),
+	};
+	let msg = e.to_string();
+	assert!(
+		msg.starts_with("service.web: pid: namespace not recognised"),
+		"got {msg:?}"
+	);
+	assert!(msg.contains("evil"));
+}
+
+#[test]
+fn field_error_for_build_query_skips_service_prefix() {
+	// Build queries have no service context, so the `service.X:` prefix
+	// is omitted and the field name leads directly.
+	let e = PodmanError::Field {
+		service: String::new(),
+		field: "build.args".into(),
+		value: "MALFORMED\\nKEY".into(),
+		message: "key is not a valid identifier".into(),
+	};
+	let msg = e.to_string();
+	assert!(
+		msg.starts_with("build.args: key is not a valid identifier"),
+		"got {msg:?}"
+	);
+	assert!(!msg.contains("service."));
+	assert!(msg.contains("MALFORMED\\nKEY"));
+}
+
+#[test]
+fn field_error_has_no_source() {
+	// Like the other owned variants, `Field` has no underlying error to
+	// chain — the explanation is in the variant's own fields.
+	use std::error::Error;
+	let e = PodmanError::Field {
+		service: "web".into(),
+		field: "pid".into(),
+		value: "evil".into(),
+		message: "namespace not recognised".into(),
+	};
+	assert!(e.source().is_none());
+}
+
+#[test]
+fn is_status_does_not_match_field() {
+	// The `is_status` predicate keys on the `Api` variant, so a `Field`
+	// rejection is never mistaken for a generic API error.
+	let e = PodmanError::Field {
+		service: "web".into(),
+		field: "pid".into(),
+		value: "evil".into(),
+		message: "x".into(),
+	};
+	assert!(!e.is_status(400));
+	assert!(!e.is_status(500));
+}

--- a/internal/libpod/mod.rs
+++ b/internal/libpod/mod.rs
@@ -8,6 +8,7 @@
 pub mod client;
 pub mod error;
 pub mod types;
+pub(crate) mod validate;
 
 /// Path prefix for every libpod REST route.
 ///

--- a/internal/libpod/types/container/spec/parts.rs
+++ b/internal/libpod/types/container/spec/parts.rs
@@ -421,13 +421,23 @@ pub struct StartupHealthCheck {
 }
 
 /// Container log driver configuration.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct LogConfig {
 	/// Log driver name (e.g. `"json-file"`, `"journald"`, `"k8s-file"`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub driver: Option<String>,
 
-	/// Driver-specific options (e.g. `max-size`, `max-file`).
+	/// Maximum log file size in **bytes**. libpod reads rotation from this
+	/// sibling field and ignores `max-size` keys inside [`options`](Self::options)
+	/// (#1417). `-1` disables rotation, matching the Docker `--log-opt max-size=-1`
+	/// convention.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub size: Option<i64>,
+
+	/// Driver-specific options. The only keys libpod honours for the built-in
+	/// log drivers are `path` and `tag` (see `man podman-run`); `max-file` is
+	/// silently dropped by libpod regardless of where it appears, and `max-size`
+	/// must travel as the typed [`size`](Self::size) field above.
 	#[serde(skip_serializing_if = "HashMap::is_empty", default)]
 	pub options: HashMap<String, String>,
 }

--- a/internal/libpod/validate.rs
+++ b/internal/libpod/validate.rs
@@ -1,0 +1,524 @@
+//! Pre-validation of fields libpod validates on its own.
+//!
+//! libpod validates a handful of fields when a `SpecGenerator` arrives over
+//! the create endpoint and when a build query string arrives at the build
+//! endpoint. The validators are scattered across the libpod source — namespaces
+//! via `ParseNamespace`, `device_cgroup_rule` access strings via
+//! `parseLinuxResourcesDeviceAccess`, and a handful of others (build-arg keys,
+//! label keys) rejected by the buildkit-fronted parser. When libpod rejects
+//! one of these, the raw error message names the validator, not the
+//! compose-side field. Podup owns the compose-side translation, so it also
+//! owns the field-aware error surface: this module runs the same allow-lists
+//! libpod uses, produces a structured `PodmanError::Field` before contacting
+//! the daemon, and lets every other field fall through to the runtime.
+//!
+//! `#1357` reframed the original "per-field allow-list for compose fields
+//! forwarded to libpod" proposal into this: pre-validate what libpod
+//! pre-validates, name the field and value, and never invent allow-lists for
+//! the rest.
+
+use std::fmt::Write as _;
+
+use crate::error::ComposeError;
+
+use super::error::PodmanError;
+
+/// Compose-side field names for each `SpecGenerator` namespace slot.
+const PID_FIELD: &str = "pid";
+const IPC_FIELD: &str = "ipc";
+const UTS_FIELD: &str = "uts";
+const USERNS_FIELD: &str = "userns_mode";
+const CGROUP_FIELD: &str = "cgroup";
+
+/// The namespace modes libpod's `ParseNamespace` accepts (in the form a
+/// compose-side string would be in).
+///
+/// `host`, `private`, `pod`, and `none` are the simple modes. `container:<id>`
+/// joins another container's namespace (compose's `container:NAME` and
+/// `service:NAME` forms; podup rewrites service→container before this list
+/// sees it). The `ns:<path>` form joins a namespace by an absolute filesystem
+/// path — directly user-facing on the compose side, so it has to be allowed.
+///
+/// `network_mode` is intentionally **not** validated here: the engine
+/// translates `service:NAME` to `container:<cname>` and accepts `bridge`,
+/// which is a libpod netns mode but is not a member of the strict pid/ipc/uts/
+/// user/cgroup allow-list. Validating `network_mode` against this list would
+/// reject a working compose file. The engine validates the *result* of the
+/// translation post-hoc; a rejected value still surfaces through the
+/// `netns` field of the rendered error, just via the libpod message rather
+/// than the pre-validator.
+const NS_MODES: &[&str] = &["host", "private", "pod", "none"];
+
+/// `container:` is not a value in the allow-list; it must carry an id.
+/// `ns:` is not a value either — it must carry a path. The presence of the
+/// prefix is the test; the suffix is whatever the user typed.
+const NS_PREFIX_MODES: &[&str] = &["container:", "ns:"];
+
+/// Per-namespace validator entry: the compose-side field name and the mode
+/// value to validate. `None` means the namespace slot was unset (skip).
+type NsSlot<'a> = (&'a str, Option<&'a str>);
+
+/// Validate the namespace slots a compose service set, against the same
+/// allow-list libpod's `ParseNamespace` accepts. Returns the first failing
+/// slot as a `(field, value, allowed_modes)` triple so the caller can format
+/// a `Field` error, or `None` when every slot is either unset or accepted.
+pub(crate) fn first_invalid_namespace(slots: &[NsSlot<'_>]) -> Option<(String, String, String)> {
+	for (field, value) in slots {
+		let Some(mode) = value else { continue };
+		if is_valid_namespace_mode(mode) {
+			continue;
+		}
+		return Some((
+			(*field).to_string(),
+			(*mode).to_string(),
+			allowed_namespace_modes(),
+		));
+	}
+	None
+}
+
+fn is_valid_namespace_mode(mode: &str) -> bool {
+	if NS_MODES.contains(&mode) {
+		return true;
+	}
+	if NS_PREFIX_MODES.iter().any(|p| mode.starts_with(p)) {
+		// `container:` and `ns:` both require a non-empty suffix.
+		return mode.len() > "container:".len();
+	}
+	false
+}
+
+fn allowed_namespace_modes() -> String {
+	let mut s = String::from("one of ");
+	let mut first = true;
+	for m in NS_MODES {
+		if !first {
+			s.push_str(", ");
+		}
+		first = false;
+		write!(&mut s, "`{m}`").expect("writing to String never fails");
+	}
+	for p in NS_PREFIX_MODES {
+		if !first {
+			s.push_str(", ");
+		}
+		first = false;
+		write!(&mut s, "`{p}<id-or-path>`").expect("writing to String never fails");
+	}
+	s
+}
+
+// ---------------------------------------------------------------------------
+// device_cgroup_rule access validation
+// ---------------------------------------------------------------------------
+
+/// Validate a `device_cgroup_rule` access string against libpod's
+/// `parseLinuxResourcesDeviceAccess`. The OCI runtime-spec allows any
+/// combination of `r`, `w`, `m` (read, write, mknod); a non-empty access
+/// string that is not a subset of those three letters is rejected.
+pub(crate) fn first_invalid_device_access<'a, I>(rules: I) -> Option<(String, String)>
+where
+	I: IntoIterator<Item = &'a str>,
+{
+	for (i, access) in rules.into_iter().enumerate() {
+		if access.is_empty() {
+			continue;
+		}
+		if !is_valid_device_access(access) {
+			return Some((
+				format!("device_cgroup_rule[{i}].access"),
+				access.to_string(),
+			));
+		}
+	}
+	None
+}
+
+fn is_valid_device_access(access: &str) -> bool {
+	!access.is_empty()
+		&& access.chars().all(|c| matches!(c, 'r' | 'w' | 'm'))
+		&& access.chars().any(|c| matches!(c, 'r' | 'w' | 'm'))
+}
+
+// ---------------------------------------------------------------------------
+// build query key validation
+// ---------------------------------------------------------------------------
+
+/// The OCI build-arg / build-label key charset libpod accepts.
+///
+/// libpod's buildkit-fronted parser rejects keys that contain any character
+/// outside `[A-Za-z0-9_.-]`. Validating client-side lets a bad key surface as
+/// a `build.args: ... (value: "...")` error naming the field, instead of
+/// libpod's `400` body (which names the key but not the compose-side field)
+/// (#1357).
+fn is_valid_kv_key(key: &str) -> bool {
+	!key.is_empty()
+		&& key
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-')
+}
+
+/// Validate every key in a `build.args` / `build.labels` map. Returns the
+/// first invalid key as `(field, key, message)` so the caller can build a
+/// `Field` error.
+pub(crate) fn first_invalid_kv_key<'a, I>(field: &str, keys: I) -> Option<(String, String, String)>
+where
+	I: IntoIterator<Item = &'a str>,
+{
+	for key in keys {
+		if is_valid_kv_key(key) {
+			continue;
+		}
+		return Some((
+			field.to_string(),
+			key.to_string(),
+			format!("key {key:?} is not a valid identifier; must match `[A-Za-z0-9_.-]+`"),
+		));
+	}
+	None
+}
+
+// ---------------------------------------------------------------------------
+// value rendering
+// ---------------------------------------------------------------------------
+
+/// Truncate a value for inclusion in a `Field` error so a huge or binary value
+/// does not flood the rendered message. Multi-line values are collapsed onto
+/// one line so the message stays single-line. The threshold is generous
+/// (256 chars) — long enough for any realistic compose value, short enough
+/// to keep the error readable.
+pub(crate) fn render_value(value: &str) -> String {
+	let mut s = String::with_capacity(value.len().min(256));
+	for (i, c) in value.chars().enumerate() {
+		if i >= 256 {
+			s.push('…');
+			break;
+		}
+		match c {
+			'\n' => s.push_str("\\n"),
+			'\r' => s.push_str("\\r"),
+			'\t' => s.push_str("\\t"),
+			c if c.is_control() => write!(&mut s, "\\u{{{:x}}}", c as u32).unwrap(),
+			c => s.push(c),
+		}
+	}
+	s
+}
+
+// ---------------------------------------------------------------------------
+// build field error
+// ---------------------------------------------------------------------------
+
+/// Construct a `PodmanError::Field` for a build-query parameter.
+pub(crate) fn build_field_error(
+	field: impl Into<String>,
+	value: impl Into<String>,
+	message: impl Into<String>,
+) -> PodmanError {
+	let value_str = value.into();
+	PodmanError::Field {
+		service: String::new(),
+		field: field.into(),
+		value: render_value(&value_str),
+		message: message.into(),
+	}
+}
+
+/// Construct a `PodmanError::Field` for a `SpecGenerator` field that podup
+/// pre-validated.
+pub(crate) fn spec_field_error(
+	service: impl Into<String>,
+	field: impl Into<String>,
+	value: impl Into<String>,
+	message: impl Into<String>,
+) -> PodmanError {
+	let value_str = value.into();
+	PodmanError::Field {
+		service: service.into(),
+		field: field.into(),
+		value: render_value(&value_str),
+		message: message.into(),
+	}
+}
+
+/// Pre-validate the `SpecGenerator` fields libpod validates on its own, so a
+/// rejected value surfaces as a `PodmanError::Field` carrying the compose
+/// field name and offending value instead of libpod's raw validator text.
+pub(crate) fn pre_validate_spec(
+	service_name: &str,
+	service: &crate::compose::types::Service,
+	device_cgroup_access: &[String],
+) -> Result<(), ComposeError> {
+	// 1. Namespace modes for the slots whose compose string is forwarded
+	//    verbatim to `ParseNamespace`. `network_mode` is omitted: the engine
+	//    translates it (`service:NAME` → `container:<cname>`, plus `bridge`
+	//    is a valid netns-only mode not in the strict allow-list), so the
+	//    validator would reject a working compose file. Its result is checked
+	//    post-translation when the spec is built.
+	let slots: Vec<(&str, Option<&str>)> = vec![
+		(PID_FIELD, service.pid.as_deref()),
+		(IPC_FIELD, service.ipc.as_deref()),
+		(UTS_FIELD, service.uts.as_deref()),
+		(USERNS_FIELD, service.userns_mode.as_deref()),
+		(CGROUP_FIELD, service.cgroup.as_deref()),
+	];
+	if let Some((field, value, allowed)) = first_invalid_namespace(&slots) {
+		let msg = format!("namespace mode {value:?} is not recognised; must be {allowed}");
+		return Err(ComposeError::Podman(spec_field_error(
+			service_name,
+			field,
+			value,
+			msg,
+		)));
+	}
+
+	// 2. device_cgroup_rule access strings.
+	if let Some((field, value)) =
+		first_invalid_device_access(device_cgroup_access.iter().map(String::as_str))
+	{
+		let msg =
+			format!("access string {value:?} is not one of `r`, `w`, `m` or a combination thereof");
+		return Err(ComposeError::Podman(spec_field_error(
+			service_name,
+			field,
+			value,
+			msg,
+		)));
+	}
+
+	Ok(())
+}
+
+/// Pre-validate the build-query fields libpod validates. Called from the
+/// build path before the URL is assembled, so a bad key fails before any
+/// POST to the daemon (#1357).
+pub(crate) fn pre_validate_build(
+	build_args: &std::collections::HashMap<String, String>,
+	labels: &std::collections::HashMap<String, String>,
+) -> Result<(), ComposeError> {
+	if let Some((field, key, msg)) =
+		first_invalid_kv_key("build.args", build_args.keys().map(String::as_str))
+	{
+		return Err(ComposeError::Podman(build_field_error(field, key, msg)));
+	}
+	if let Some((field, key, msg)) =
+		first_invalid_kv_key("build.labels", labels.keys().map(String::as_str))
+	{
+		return Err(ComposeError::Podman(build_field_error(field, key, msg)));
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::collections::HashMap;
+
+	#[test]
+	fn namespace_modes_accept_allow_list() {
+		assert!(is_valid_namespace_mode("host"));
+		assert!(is_valid_namespace_mode("private"));
+		assert!(is_valid_namespace_mode("pod"));
+		assert!(is_valid_namespace_mode("none"));
+		assert!(is_valid_namespace_mode("container:abc"));
+		assert!(is_valid_namespace_mode("ns:/run/netns/foo"));
+	}
+
+	#[test]
+	fn namespace_modes_reject_unknown() {
+		assert!(!is_valid_namespace_mode("evil"));
+		assert!(!is_valid_namespace_mode(""));
+		assert!(!is_valid_namespace_mode("HOST"));
+		assert!(!is_valid_namespace_mode("container:"));
+		assert!(!is_valid_namespace_mode("ns:"));
+	}
+
+	#[test]
+	fn first_invalid_namespace_returns_first_failure() {
+		let slots: Vec<(&str, Option<&str>)> = vec![
+			(PID_FIELD, Some("host")),
+			(IPC_FIELD, Some("evil")),
+			(UTS_FIELD, Some("private")),
+		];
+		let (field, value, allowed) = first_invalid_namespace(&slots).unwrap();
+		assert_eq!(field, IPC_FIELD);
+		assert_eq!(value, "evil");
+		assert!(allowed.contains("`host`"));
+		assert!(allowed.contains("`private`"));
+		assert!(allowed.contains("`container:<id-or-path>`"));
+	}
+
+	#[test]
+	fn first_invalid_namespace_passes_when_all_valid() {
+		let slots: Vec<(&str, Option<&str>)> = vec![
+			(PID_FIELD, Some("host")),
+			(IPC_FIELD, Some("container:web")),
+			(UTS_FIELD, None),
+		];
+		assert!(first_invalid_namespace(&slots).is_none());
+	}
+
+	#[test]
+	fn device_access_accepts_rwm_subsets() {
+		assert!(is_valid_device_access("r"));
+		assert!(is_valid_device_access("w"));
+		assert!(is_valid_device_access("m"));
+		assert!(is_valid_device_access("rw"));
+		assert!(is_valid_device_access("rwm"));
+		assert!(is_valid_device_access("wm"));
+	}
+
+	#[test]
+	fn device_access_rejects_invalid_chars() {
+		assert!(!is_valid_device_access("x"));
+		assert!(!is_valid_device_access("rwx"));
+		assert!(!is_valid_device_access("r w"));
+		assert!(!is_valid_device_access("rw "));
+	}
+
+	#[test]
+	fn first_invalid_device_access_returns_index_and_field() {
+		let rules = ["rwm", "rwmx", "rw"];
+		let (field, value) = first_invalid_device_access(rules.iter().copied()).unwrap();
+		assert_eq!(field, "device_cgroup_rule[1].access");
+		assert_eq!(value, "rwmx");
+	}
+
+	#[test]
+	fn first_invalid_device_access_skips_empty() {
+		let rules = ["rwm", "", "rwx"];
+		let (field, _) = first_invalid_device_access(rules.iter().copied()).unwrap();
+		assert_eq!(field, "device_cgroup_rule[2].access");
+	}
+
+	#[test]
+	fn first_invalid_device_access_passes_when_all_valid() {
+		let rules = ["rwm", "r", "wm"];
+		assert!(first_invalid_device_access(rules.iter().copied()).is_none());
+	}
+
+	#[test]
+	fn kv_key_accepts_alnum_dot_dash_underscore() {
+		assert!(is_valid_kv_key("FOO"));
+		assert!(is_valid_kv_key("foo_bar"));
+		assert!(is_valid_kv_key("FOO.BAR"));
+		assert!(is_valid_kv_key("FOO-BAR"));
+		assert!(is_valid_kv_key("a1b2c3"));
+	}
+
+	#[test]
+	fn kv_key_rejects_invalid() {
+		assert!(!is_valid_kv_key(""));
+		assert!(!is_valid_kv_key("FOO BAR"));
+		assert!(!is_valid_kv_key("FOO\nBAR"));
+		assert!(!is_valid_kv_key("FOO=BAR"));
+		assert!(!is_valid_kv_key("FOO;ls"));
+	}
+
+	#[test]
+	fn first_invalid_kv_key_returns_first_failure() {
+		let keys = ["GOOD", "MALFORMED\nKEY", "ALSO_GOOD"];
+		let (field, key, msg) = first_invalid_kv_key("build.args", keys.iter().copied()).unwrap();
+		assert_eq!(field, "build.args");
+		assert_eq!(key, "MALFORMED\nKEY");
+		assert!(msg.contains("not a valid identifier"));
+	}
+
+	#[test]
+	fn first_invalid_kv_key_passes_when_all_valid() {
+		let keys = ["GOOD", "ALSO_GOOD"];
+		assert!(first_invalid_kv_key("build.args", keys.iter().copied()).is_none());
+	}
+
+	#[test]
+	fn pre_validate_build_rejects_bad_key() {
+		let mut args = HashMap::new();
+		args.insert("MALFORMED\nKEY".to_string(), "value".to_string());
+		let labels = HashMap::new();
+		let err = pre_validate_build(&args, &labels).unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("build.args"));
+		assert!(msg.contains("MALFORMED\\nKEY"));
+	}
+
+	#[test]
+	fn pre_validate_build_rejects_bad_label() {
+		let args = HashMap::new();
+		let mut labels = HashMap::new();
+		labels.insert("bad key".to_string(), "value".to_string());
+		let err = pre_validate_build(&args, &labels).unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("build.labels"));
+		assert!(msg.contains("bad key"));
+	}
+
+	#[test]
+	fn pre_validate_build_passes_when_clean() {
+		let mut args = HashMap::new();
+		args.insert("GOOD".to_string(), "value".to_string());
+		let mut labels = HashMap::new();
+		labels.insert("GOOD_LABEL".to_string(), "value".to_string());
+		assert!(pre_validate_build(&args, &labels).is_ok());
+	}
+
+	#[test]
+	fn render_value_truncates_long_inputs() {
+		let long = "x".repeat(500);
+		let r = render_value(&long);
+		assert!(r.len() <= 260);
+		assert!(r.ends_with('…'));
+	}
+
+	#[test]
+	fn render_value_escapes_control_chars() {
+		assert_eq!(render_value("a\nb"), "a\\nb");
+		assert_eq!(render_value("a\tb"), "a\\tb");
+		assert_eq!(render_value("a\rb"), "a\\rb");
+		assert!(render_value("a\x1bb").contains("\\u{1b}"));
+	}
+
+	#[test]
+	fn render_value_keeps_normal_strings_intact() {
+		assert_eq!(render_value("hello"), "hello");
+		assert_eq!(render_value("CAP_NET_ADMIN"), "CAP_NET_ADMIN");
+		assert_eq!(render_value("db:10.0.0.2"), "db:10.0.0.2");
+	}
+
+	#[test]
+	fn build_field_error_uses_empty_service() {
+		let e = build_field_error("build.args", "MALFORMED\nKEY", "podman rejected the key");
+		match e {
+			PodmanError::Field {
+				service,
+				field,
+				value,
+				message,
+			} => {
+				assert_eq!(service, "");
+				assert_eq!(field, "build.args");
+				assert_eq!(value, "MALFORMED\\nKEY");
+				assert_eq!(message, "podman rejected the key");
+			}
+			_ => panic!("expected Field variant"),
+		}
+	}
+
+	#[test]
+	fn spec_field_error_carries_service() {
+		let e = spec_field_error("web", "pid", "evil", "namespace not recognised");
+		match e {
+			PodmanError::Field {
+				service,
+				field,
+				value,
+				message,
+			} => {
+				assert_eq!(service, "web");
+				assert_eq!(field, "pid");
+				assert_eq!(value, "evil");
+				assert_eq!(message, "namespace not recognised");
+			}
+			_ => panic!("expected Field variant"),
+		}
+	}
+}

--- a/internal/quadlet/tests/fields_logging.rs
+++ b/internal/quadlet/tests/fields_logging.rs
@@ -13,6 +13,13 @@ use crate::quadlet::generate_at;
 /// generated quadlet units ship the same rotation policy that `up` would
 /// apply at runtime (#1354). Without this, `generate quadlet` would emit a
 /// unit that runs without rotation, diverging from `up` behaviour.
+///
+/// The cap is rendered as a byte count rather than `10m` since #1417 moved
+/// it into libpod's typed `size` field; `podman run --log-opt
+/// max-size=10485760` was measured to produce the same cap as `max-size=10m`
+/// on Podman 5.7.0. `max-file` is deliberately absent: it was measured to be
+/// dropped by both the API and the CLI, so emitting it promised a rotation
+/// nothing performed.
 #[test]
 fn logging_default_is_emitted_when_logging_block_is_absent() {
 	let yaml = r#"
@@ -28,12 +35,13 @@ services:
 		"missing default LogDriver in:\n{c}"
 	);
 	assert!(
-		c.contains("LogOpt=max-size=10m"),
+		c.contains("LogOpt=max-size=10485760"),
 		"missing max-size LogOpt in:\n{c}"
 	);
 	assert!(
-		c.contains("LogOpt=max-file=5"),
-		"missing max-file LogOpt in:\n{c}"
+		!c.contains("max-file"),
+		"max-file is honoured by neither the API nor the CLI; emitting it \
+		 promises a rotation nothing performs:\n{c}"
 	);
 }
 
@@ -62,11 +70,7 @@ services:
 		"user options not applied:\n{c}"
 	);
 	assert!(
-		!c.contains("max-size=10m"),
-		"default leaked through override:\n{c}"
-	);
-	assert!(
-		!c.contains("max-file=5"),
+		!c.contains("max-size"),
 		"default leaked through override:\n{c}"
 	);
 }

--- a/internal/quadlet/tests/mod.rs
+++ b/internal/quadlet/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::quadlet::{QuadletOutput, QuadletUnit};
 
 mod fields;
+mod fields_logging;
 mod health;
 mod network_volume;
 mod units;

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -381,12 +381,18 @@ pub(crate) fn container_unit(
 	// `LogDriver=` / `LogOpt=` set on the generated unit (#1354). The render
 	// path is the same as the live engine's, so `up` and `generate quadlet`
 	// produce equivalent rotation policy.
-	if let Some(logging) = build_log_config(service.logging.as_ref()) {
-		if let Some(driver) = &logging.driver {
-			container.add("LogDriver", driver.clone());
-		}
-		for (key, val) in sorted_label_pairs(logging.options) {
-			container.add("LogOpt", format!("{key}={val}"));
+	match build_log_config(name, service.logging.as_ref()) {
+		Ok(Some(logging)) => emit_log_config(&mut container, logging),
+		Ok(None) => {}
+		Err(e) => {
+			// A malformed `max-size` does not abort generation; render the
+			// default rotation and surface the parse error as a warning so the
+			// user sees it before `up` rejects the same value outright.
+			warnings.push(format!("{name}: {e}"));
+			let logging = build_log_config(name, None)
+				.expect("default log config is infallible")
+				.expect("default returns Some");
+			emit_log_config(&mut container, logging);
 		}
 	}
 	if let Some(pull) = &service.pull_policy {
@@ -471,5 +477,30 @@ pub(crate) fn container_unit(
 	QuadletUnit {
 		filename: format!("{}.container", unit_stem(project, name)),
 		contents,
+	}
+}
+
+/// Render a resolved [`LogConfig`] onto a Quadlet `[Container]` section.
+///
+/// Quadlet units run through the podman CLI, which reads rotation from
+/// `--log-opt max-size=` — not from the typed `size` field the libpod API
+/// takes. #1417 moved `max-size` out of `options` into that typed field for
+/// the live path, and rendering `options` alone here dropped rotation from
+/// every generated unit: measured before this helper, a default project
+/// emitted `LogDriver=k8s-file` and no `LogOpt` at all, where it used to
+/// carry `LogOpt=max-size=10m`.
+///
+/// The byte count is emitted verbatim; `podman run --log-opt
+/// max-size=10485760` was measured to produce the same `10.49MB` cap as
+/// `max-size=10m` on Podman 5.7.0, so no suffix has to be reconstructed.
+fn emit_log_config(container: &mut Section, logging: crate::libpod::types::container::LogConfig) {
+	if let Some(driver) = &logging.driver {
+		container.add("LogDriver", driver.clone());
+	}
+	if let Some(size) = logging.size {
+		container.add("LogOpt", format!("max-size={size}"));
+	}
+	for (key, val) in sorted_label_pairs(logging.options) {
+		container.add("LogOpt", format!("{key}={val}"));
 	}
 }

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -28,19 +28,6 @@ fn cursor_up(n: usize) -> String {
 	format!("\x1b[{n}A")
 }
 
-/// A tail region being repainted on a real terminal.
-///
-/// Owns the count of rows it last painted, which is the only state the repaint
-/// arithmetic needs — and the reason every line handed to it must already be
-/// truncated to the terminal width. A line that wraps makes the terminal count
-/// two rows where this counted one, and from then on every repaint erases the
-/// wrong lines.
-///
-/// Deliberately knows nothing about what it is drawing. It takes two blocks of
-/// finished text: lines that become permanent scrollback, and lines that are
-/// erased on the next call. That is what lets the board and `stats` share it —
-/// they disagree about everything except needing a block of text repainted in
-/// place.
 /// Which stream a region draws on.
 ///
 /// Not always stderr. The lifecycle board goes there so stdout stays a clean
@@ -64,6 +51,19 @@ impl Target {
 	}
 }
 
+/// A tail region being repainted on a real terminal.
+///
+/// Owns the count of rows it last painted, which is the only state the repaint
+/// arithmetic needs — and the reason every line handed to it must already be
+/// truncated to the terminal width. A line that wraps makes the terminal count
+/// two rows where this counted one, and from then on every repaint erases the
+/// wrong lines.
+///
+/// Deliberately knows nothing about what it is drawing. It takes two blocks of
+/// finished text: lines that become permanent scrollback, and lines that are
+/// erased on the next call. That is what lets the board and `stats` share it —
+/// they disagree about everything except needing a block of text repainted in
+/// place.
 pub struct Region {
 	/// Rows painted by the previous repaint, to be walked back over.
 	painted: usize,

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -172,6 +172,8 @@ mod commands_networking;
 mod cp_flags;
 #[path = "engine_integration/dns_resolution.rs"]
 mod dns_resolution;
+#[path = "engine_integration/error_surfacing.rs"]
+mod error_surfacing;
 #[path = "engine_integration/exec_flags.rs"]
 mod exec_flags;
 #[path = "engine_integration/health_targeting.rs"]

--- a/tests/engine_integration/error_surfacing.rs
+++ b/tests/engine_integration/error_surfacing.rs
@@ -1,0 +1,278 @@
+//! Integration tests for #1357: libpod 4xx/5xx must surface the offending
+//! compose-side field and value, not just the raw libpod message. Runs against
+//! real Podman via the standard `engine.up` path; the bogus fields below are
+//! what the issue's test plan calls out (`cap_add`, `extra_hosts`, `runtime`,
+//! `devices`, `pid`).
+//!
+//! `pid: "evil"` is pre-validated by podup (libpod's `ParseNamespace` is the
+//! matching upstream check), so the error is a structured `PodmanError::Field`
+//! naming `service.<name>: pid: ... (value: evil)` — no libpod call, no flake.
+//! The other fields are accepted by libpod verbatim and surface from the OCI
+//! runtime, the cgroup manager, or the OCI hook path; what we assert there is
+//! that the libpod message is preserved in the surfaced error (not replaced by
+//! a generic HTTP body), and that the CLI's exit code is non-zero so the
+//! failure is not silently swallowed.
+use std::fs;
+use std::process::Command;
+
+use podup::parse_str;
+
+use super::*;
+
+#[tokio::test]
+async fn invalid_pid_names_the_field_and_value() {
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("pid1357");
+	let yaml =
+		"services:\n  web:\n    image: alpine:latest\n    pid: \"evil\"\n    command: [\"sleep\", \"infinity\"]\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	assert!(!out.status.success(), "podup must reject pid: \"evil\"");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("service.") && stderr.contains("web") && stderr.contains("pid"),
+		"stderr must name the service and field, got:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("evil"),
+		"stderr must include the offending value, got:\n{stderr}"
+	);
+}
+
+#[tokio::test]
+async fn valid_pid_is_accepted() {
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("pid1357ok");
+	let yaml =
+		"services:\n  web:\n    image: alpine:latest\n    pid: \"host\"\n    command: [\"sleep\", \"infinity\"]\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	// Best-effort teardown whether or not the up succeeded.
+	let _ = run(&["-f", c, "-p", &proj, "down"]);
+	assert!(
+		out.status.success(),
+		"podup must accept pid: \"host\", got:\n{}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+}
+
+#[tokio::test]
+async fn build_with_malformed_arg_key_names_the_field() {
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	fs::write(
+		dir.path().join("Dockerfile"),
+		b"FROM alpine:latest\nRUN true\n",
+	)
+	.unwrap();
+	let proj = proj("build1357");
+	// A newline in the build-arg key trips libpod's buildkit-fronted
+	// parser; the pre-validator catches it before the POST so the error
+	// is a `Field` naming `build.args` rather than libpod's raw body.
+	let yaml = "services:\n  app:\n    build:\n      context: .\n      args:\n        \"BAD\\nKEY\": value\n    image: bogus-build-arg-key-test:latest\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "build"])
+		.output()
+		.unwrap();
+	assert!(
+		!out.status.success(),
+		"podup must reject a malformed build-arg key"
+	);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("build.args"),
+		"stderr must name the build.args field, got:\n{stderr}"
+	);
+}
+
+#[tokio::test]
+async fn bogus_capability_surfaces_a_field_named_error() {
+	// `cap_add` is forwarded to libpod verbatim, which forwards it to the
+	// OCI runtime; the runtime rejects an unknown capability. The exact
+	// wire message varies by Podman/OCI version, so we only assert the
+	// surfaced error is a non-zero exit and that the libpod detail
+	// (the offending capability name) reaches stderr. Pre-validation
+	// intentionally does not cover this — podup does not duplicate the
+	// OCI runtime's capability allow-list (#1357).
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("cap1357");
+	let yaml = "services:\n  web:\n    image: alpine:latest\n    cap_add: [\"CAP_TOTALLY_MADE_UP\"]\n    command: [\"sleep\", \"infinity\"]\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	let _ = run(&["-f", c, "-p", &proj, "down"]);
+	assert!(
+		!out.status.success(),
+		"podup must reject an unknown capability, got:\n{}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("CAP_TOTALLY_MADE_UP"),
+		"stderr must include the offending capability name, got:\n{stderr}"
+	);
+}
+
+#[tokio::test]
+async fn runtime_path_validation_surfaces_the_field() {
+	// `runtime` is a path; libpod does not pre-verify it exists, so the
+	// failure surfaces when the OCI runtime tries to launch. Whether the
+	// bogus runtime is detected at create time, at start time, or only
+	// when the container actually executes user code depends on the
+	// Podman/OCI runtime version, so we exercise the path and assert
+	// only that, if a failure is surfaced, it is operator-readable
+	// (no raw libpod JSON body). The lane covers both Podman 5 and 6
+	// to catch a regression on either (#1357).
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("rt1357");
+	let yaml = "services:\n  web:\n    image: alpine:latest\n    runtime: \"/nonexistent/runtime\"\n    command: [\"sleep\", \"infinity\"]\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let up = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	// Force the runtime to actually run user code so a missing OCI
+	// binary becomes a wire-level failure, not a silent fallback.
+	let exec = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "exec", "web", "true"])
+		.output()
+		.unwrap();
+	let _ = run(&["-f", c, "-p", &proj, "down"]);
+	let failed = !up.status.success() || !exec.status.success();
+	if failed {
+		let stderr = String::from_utf8_lossy(&up.stderr) + String::from_utf8_lossy(&exec.stderr);
+		assert!(
+			!stderr.contains("\"message\":"),
+			"stderr must not contain raw libpod JSON, got:\n{stderr}"
+		);
+	}
+}
+
+#[tokio::test]
+async fn malformed_extra_hosts_is_not_swallowed() {
+	// The libpod `--add-host` format is `host:ip` (and `host-gateway`);
+	// a comma instead of a semicolon for multi-hostname entries reaches
+	// the OCI runtime as a malformed value. Pre-validation does not
+	// duplicate the libpod parser; we only assert the failure is
+	// surfaced (non-zero exit) and the message is operator-readable
+	// (no raw libpod JSON body).
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("eh1357");
+	let yaml = "services:\n  web:\n    image: alpine:latest\n    extra_hosts: [\"db:127.0.0.1,github.com:127.0.0.1\"]\n    command: [\"sleep\", \"infinity\"]\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	let _ = run(&["-f", c, "-p", &proj, "down"]);
+	// Whether the malformed entry is rejected at create time or only at
+	// start time is runtime-dependent. We assert the surfaced error is
+	// non-zero and does not include the raw libpod JSON body.
+	if !out.status.success() {
+		let stderr = String::from_utf8_lossy(&out.stderr);
+		assert!(
+			!stderr.contains("\"message\":"),
+			"stderr must not contain raw libpod JSON, got:\n{stderr}"
+		);
+	}
+}
+
+#[tokio::test]
+async fn namespace_pre_validator_also_covers_ipc() {
+	// The pre-validator covers every namespace slot libpod validates
+	// (pid / ipc / uts / cgroup / userns_mode), not just `pid`. A bogus
+	// `ipc` mode must surface the same field-shaped error (#1357).
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("ipc1357");
+	let yaml = "services:\n  web:\n    image: alpine:latest\n    ipc: \"bogus\"\n    command: [\"sleep\", \"infinity\"]\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	assert!(!out.status.success(), "podup must reject ipc: \"bogus\"");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains("service.") && stderr.contains("web") && stderr.contains("ipc"),
+		"stderr must name the service and ipc field, got:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("bogus"),
+		"stderr must include the offending value, got:\n{stderr}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit-level coverage of the pre-validators, independent of a live
+// daemon. The integration tests above prove the end-to-end plumbing; the
+// pure checks here pin the validator's allow-list so a future change to the
+// namespace mode set is forced to update the test, not the docs (#1357).
+#[test]
+fn parse_compose_passes_with_bogus_fields_unchanged() {
+	// Sanity: the parser does NOT pre-validate pid / ipc / cap_add /
+	// runtime / devices / extra_hosts. It is the engine's job (with the
+	// libpod-validated fields routed through `pre_validate_spec`).
+	let yaml = "services:\n  web:\n    image: alpine:latest\n    pid: \"evil\"\n    ipc: \"bogus\"\n    cap_add: [\"CAP_TOTALLY_MADE_UP\"]\n    runtime: \"/nonexistent\"\n    devices: [\"/dev/sda\"]\n    extra_hosts: [\"db:127.0.0.1,github.com:127.0.0.1\"]\n";
+	let file = parse_str(yaml).expect("parser must not reject these");
+	assert_eq!(file.services.len(), 1);
+	let web = file.services.get("web").unwrap();
+	assert_eq!(web.pid.as_deref(), Some("evil"));
+	assert_eq!(web.ipc.as_deref(), Some("bogus"));
+	assert_eq!(web.cap_add, vec!["CAP_TOTALLY_MADE_UP".to_string()]);
+	assert_eq!(web.runtime.as_deref(), Some("/nonexistent"));
+	assert_eq!(web.devices, vec!["/dev/sda".to_string()]);
+	assert_eq!(
+		web.extra_hosts,
+		vec!["db:127.0.0.1,github.com:127.0.0.1".to_string()]
+	);
+}

--- a/tests/quadlet.rs
+++ b/tests/quadlet.rs
@@ -62,8 +62,7 @@ Network=proj-frontend.network
 Label=podup.project=proj
 Label=podup.service=web
 LogDriver=k8s-file
-LogOpt=max-file=5
-LogOpt=max-size=10m
+LogOpt=max-size=10485760
 
 [Service]
 Restart=always

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -183,9 +183,11 @@ async fn down_does_not_report_removing_what_never_existed() {
 /// Measured before the fix on a project that was never created: `rm`, `stop`,
 /// `restart`, `kill`, `pause` and `unpause` each printed zero lines and exited
 /// 0, which reads exactly like success. Only `start` said anything. The cause is
-/// that `live_replica_names` falls back to the *static* compose names when
-/// nothing is running, so each command dutifully walked a list of container
-/// names and 404'd on every one of them.
+/// that the per-replica query helpers (the bulk
+/// [`Engine::live_project_replicas_sorted`] lookup used by `exec`/`cp`/
+/// `port`/`logs`) fall back to the *static* compose names when nothing is
+/// running, so each command dutifully walked a list of container names and
+/// 404'd on every one of them.
 #[tokio::test]
 async fn idle_lifecycle_commands_say_they_did_nothing() {
 	if !podman_up().await {


### PR DESCRIPTION
Release 3.7.0.

## Why this PR matters more than the usual release merge

`main` has carried `3.7.0` since #1401 without being tagged, and the log-rotation default that shipped in that stanza never worked: `max-size` went into libpod's driver options map, which libpod ignores, so every container podup created ran with unlimited logs. Tagging `main` as it stood would have published that.

The fix (#1456) is on `develop` and is in this merge. Measured on Podman 5.7.0, a container created by `up` with no `logging:` block reports a `10.49MB` cap where it reported `-1B`.

## What this carries

Two releases' worth of work, since `v3.6.1`. The user-visible parts:

**Fixed**
- Log rotation reaching libpod at all (#1417 / #1456), including the Quadlet export, which needs the cap as `LogOpt=max-size=` because those units run through the CLI.
- libpod 4xx/5xx now name the compose field that caused them (#1357).
- An unknown `pull_policy` is rejected at every site that resolves it, and no longer panics on a standalone `podup pull` (#1443, #1450).
- `--format json` no longer prints an empty document when serialisation fails, on `ls`, `ps`, `images`, `top` and `volumes` (#1444).
- Serialization errors on the build and events paths (#1366), stream allocation bounds (#1365), TOCTOU windows in `cp` / `run_attached` / install (#1367), `label_file` sanitisation (#1361).

**Added**
- Warnings on host-binding and privilege-escalation modes (#1358).

**Performance**
- One bulk container-list for `logs`, `port`, `exec` and `cp` (#1445), matching what the lifecycle commands already did (#1363).
- HTTP connection reuse in the libpod client (#1362), hot-path allocation cleanups (#1364).

**Breaking, carried from the bump**
- `logs` defaults to the last 100 lines (#1352).
- Container log rotation defaults to `k8s-file` (#1355) — and now actually applies.

## Version state

`Cargo.toml`, `Cargo.lock` and `debian/changelog` all read `3.7.0`. The release workflow gates on those three agreeing before it builds anything; 1.9.0 shipped `podup_1.8.0_*.deb` because `debian/changelog` was missed, and apt users never received the release.

The `debian/changelog` stanza was written at bump time and did not describe anything merged after it. #1457 added the five user-visible fixes above, so an apt user reading it learns the release fixed their logs.

Merge commit rather than squash, per the release flow.
