### PR TITLE
feat(lib): make PodmanError and its retry predicates public

### DIFF
--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -63,6 +63,18 @@ pub use engine::{
 pub use error::{ComposeError, Result};
 /// The libpod `Client`, surfaced for callers that talk to Podman directly.
 pub use libpod::Client;
+/// The libpod error type carried inside [`ComposeError::Podman`], with the
+/// predicates the engine's own retry paths use.
+///
+/// An embedding daemon has to tell a transport fault it should retry from a
+/// rejection it should not, and the only alternative to these predicates is
+/// matching on the message text — which breaks silently the day libpod rewords
+/// one.
+pub use libpod::PodmanError;
+/// Log frames as libpod delivers them, and the stream parsers that produce
+/// them, for callers routing container output somewhere other than this
+/// process's stdout.
+pub use libpod::{parse_json_lines, parse_multiplexed, parse_raw, LogOutput};
 
 /// Internal parsers exposed only under `test-helpers` for fuzzing and tests.
 ///

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -177,7 +177,7 @@ impl PodmanError {
 	/// Podman 6 applies the archive and then closes without a response, so `cp`
 	/// uses this to tell that specific case apart and re-verify the copy landed
 	/// rather than failing an upload that actually succeeded (#1097).
-	pub(crate) fn is_incomplete_message(&self) -> bool {
+	pub fn is_incomplete_message(&self) -> bool {
 		matches!(self, Self::Hyper(e) if e.is_incomplete_message())
 	}
 
@@ -197,7 +197,7 @@ impl PodmanError {
 	///
 	/// This names the hyper classification so a log can say *which* ending
 	/// occurred. It stays diagnostic: nothing branches on it.
-	pub(crate) fn stream_end_kind(&self) -> &'static str {
+	pub fn stream_end_kind(&self) -> &'static str {
 		match self {
 			Self::Hyper(e) if e.is_incomplete_message() => "incomplete-message",
 			Self::Hyper(e) if e.is_body_write_aborted() => "body-write-aborted",
@@ -238,7 +238,7 @@ impl PodmanError {
 	/// socket never responded within the deadline). These carry a synthetic
 	/// status `0` and a `timed out` message; lifecycle callers use this to
 	/// escalate a wedged `stop` to an explicit `SIGKILL`.
-	pub(crate) fn is_timeout(&self) -> bool {
+	pub fn is_timeout(&self) -> bool {
 		matches!(self, Self::Api { status: 0, message } if message.contains("timed out"))
 	}
 
@@ -248,7 +248,7 @@ impl PodmanError {
 	/// idempotent no-op rather than a fatal error that aborts the loop. The
 	/// message is unique to the kill endpoint, so matching it cannot mask another
 	/// op's 409.
-	pub(crate) fn is_kill_of_stopped(&self) -> bool {
+	pub fn is_kill_of_stopped(&self) -> bool {
 		matches!(
 			self,
 			Self::Api { status: 409, message }
@@ -260,7 +260,7 @@ impl PodmanError {
 	/// 409 conflict, or an HTTP 500 whose message says so. Podman's libpod
 	/// volume-create endpoint returns 500 (not 409) for a duplicate name, so an
 	/// idempotent create must accept both to let a re-`up` succeed.
-	pub(crate) fn is_already_exists(&self) -> bool {
+	pub fn is_already_exists(&self) -> bool {
 		match self {
 			Self::Api { status: 409, .. } => true,
 			Self::Api {
@@ -277,7 +277,7 @@ impl PodmanError {
 	/// every dependent container — including ones owned by other projects. Podman
 	/// returns this as a 409 conflict, or on some versions a 500 whose message
 	/// names the in-use cause.
-	pub(crate) fn is_image_in_use(&self) -> bool {
+	pub fn is_image_in_use(&self) -> bool {
 		match self {
 			Self::Api { status: 409, .. } => true,
 			Self::Api {
@@ -295,7 +295,7 @@ impl PodmanError {
 	/// attempted lifecycle op (already paused, not paused, not running). Podman
 	/// returns these as a 409/500 with a "container state improper" cause. Lets
 	/// `pause`/`unpause` stay idempotent no-ops, matching docker compose.
-	pub(crate) fn is_state_conflict(&self) -> bool {
+	pub fn is_state_conflict(&self) -> bool {
 		match self {
 			Self::Api { status, message } if *status == 409 || *status == 500 => {
 				let m = message.to_ascii_lowercase();

--- a/tests/api_surface.rs
+++ b/tests/api_surface.rs
@@ -1,0 +1,49 @@
+//! The public surface an embedding daemon needs, exercised by naming it.
+//!
+//! helmly-agent and epistle consume podup as a library. When a call fails they
+//! receive a `ComposeError::Podman`, and deciding whether to retry means asking
+//! the error what kind of failure it was. Before #1474 the type inside was not
+//! nameable from outside the crate and every predicate was `pub(crate)`, so the
+//! only way to ask was matching on the message text.
+//!
+//! This file is a compile-time contract, not a behavioural test: it fails by
+//! not building. Nothing here asserts what the predicates return — only that a
+//! caller outside the crate can name the type and call them.
+
+use podup::{ComposeError, LogOutput, PodmanError};
+
+/// Name every type the retry path of an embedding daemon has to write down.
+#[test]
+fn public_types_are_nameable() {
+	fn _takes_error(_: &PodmanError) {}
+	fn _takes_frame(_: &LogOutput) {}
+	fn _takes_compose_error(_: &ComposeError) {}
+}
+
+/// Call each predicate the engine's own retry logic uses. A consumer that
+/// cannot reach these has to fall back to `err.to_string().contains(..)`,
+/// which breaks the day libpod rewords a message — and breaks silently,
+/// because the retry simply stops happening.
+#[test]
+fn retry_predicates_are_callable_from_outside() {
+	fn _probe(e: &PodmanError) -> (bool, bool, bool, bool, bool, bool, &'static str) {
+		(
+			e.is_timeout(),
+			e.is_incomplete_message(),
+			e.is_kill_of_stopped(),
+			e.is_already_exists(),
+			e.is_image_in_use(),
+			e.is_state_conflict(),
+			e.stream_end_kind(),
+		)
+	}
+}
+
+/// The stream parsers, for a consumer routing container output somewhere other
+/// than this process's stdout — a TUI, a WebSocket, a log shipper.
+#[test]
+fn stream_parsers_are_reachable() {
+	let _ = podup::parse_json_lines::<serde_json::Value>;
+	let _ = podup::parse_multiplexed;
+	let _ = podup::parse_raw;
+}


### PR DESCRIPTION
## What this unblocks

helmly-agent and epistle are going to consume podup as a library. Today a failed call gives them `ComposeError::Podman(_)` and no way to look inside: `libpod` is `pub(crate)`, so `PodmanError` is a value they receive but cannot write a type for. The seven predicates the engine's own retry paths use are `pub(crate)` as well.

That leaves `err.to_string().contains("timeout")` as the only way to ask — which breaks when libpod rewords a message, and breaks *silently*, because the retry simply stops happening.

## What changed

Twelve lines of re-export in `lib.rs` and seven visibility changes in `libpod/error.rs`. Nothing renamed, nothing removed, no behaviour touched — **additive, so MINOR**.

`PodmanError` was already re-exported under the `test-helpers` feature, which is off in the published crate. The shape was settled; it just never reached the real surface.

## Test

`tests/api_surface.rs` is a compile-time contract, not a behavioural test: it fails by *not building*. Nothing in it asserts what the predicates return — only that a caller outside the crate can name the types and call them.

Checked against the unchanged tree: three visibility errors. With the change, it compiles and passes.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `cargo test --lib` | 1659 passed, 0 failed |
| `cargo test --test api_surface` | 3 passed |

## Timing

helmly-agent currently pins `podup v0.9.0` and calls no podup function yet, so the public surface is not fixed by any consumer. Changes like this one cost nothing today and become MAJOR the moment they start using it.

Fixes #1474