### PR TITLE
ci(release): add a re-entrant path for publishing to crates.io

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,0 +1,100 @@
+name: Publish to crates.io
+
+# The recovery path for a crates.io publish that failed after the GitHub
+# release already exists.
+#
+# `release.yml` creates the release and then publishes to the registry in one
+# job. When the publish step fails, that job cannot be re-run into a useful
+# state: `gh release create` refuses a tag that already has a release, so the
+# only remedy was to burn the version and cut another. v3.7.1 hit exactly that
+# — 40 signed assets published, crates.io left behind at 3.6.1.
+#
+# This workflow does one thing and nothing else: publish an existing tag to
+# crates.io. It never touches the release, the assets, the tag, or the signing
+# key. crates.io rejects a duplicate version, so a second run is a no-op rather
+# than a hazard.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v3.7.1). Defaults to the newest v* tag."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish an existing tag to crates.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # Full history so the fallback can find the newest tag; the checkout is
+      # re-pointed at the resolved tag below rather than guessing here.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve the tag to publish
+        id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$(git tag --list 'v*' --sort=-v:refname | head -1)}"
+          [ -n "$TAG" ] || { echo "::error::no v* tag found and none was given"; exit 1; }
+          git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null \
+            || { echo "::error::tag ${TAG} does not exist in this repository"; exit 1; }
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${TAG}."
+
+      - name: Check out that tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
+          persist-credentials: false
+
+      # Same two gates release.yml runs before it builds anything. A version
+      # published to crates.io can never be replaced, so a tag that disagrees
+      # with the manifest must stop here rather than become permanent.
+      - name: Validate tag format
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag '${TAG}' does not match required format v<major>.<minor>.<patch>."
+            exit 1
+          fi
+
+      - name: Tag must equal Cargo.toml version
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          CRATE_VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "$VERSION" != "$CRATE_VERSION" ]; then
+            echo "::error::Tag ${TAG} does not match Cargo.toml version ${CRATE_VERSION}."
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        env:
+          RUST_TOOLCHAIN: "1.97"
+        run: |
+          set -euo pipefail
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+
+      # `--locked` so the published crate resolves the same dependency versions
+      # the tag was tested with. A duplicate version exits non-zero here, which
+      # is the intended outcome of a second run.
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -n "${CARGO_REGISTRY_TOKEN:-}" ] \
+            || { echo "::error::CARGO_REGISTRY_TOKEN is not available to this workflow"; exit 1; }
+          cargo publish --locked


### PR DESCRIPTION
## Why

`release.yml` creates the GitHub release and then publishes to the registry in the same job. When the publish step fails, that job cannot be re-run into a useful state — `gh release create` refuses a tag that already has a release — so the only remedy was to burn the version and cut another.

**v3.7.1 hit exactly that**: 40 signed assets published, crates.io left at 3.6.1, and a 3.7.2 nobody needed as the only way forward.

The cause of that particular failure is separate (#1462). This is the *recovery path*, which would have been missing for any other failure of that step.

## What it does

One thing: publish an existing tag to crates.io. It never touches the release, the assets, the tag, or the signing key. `workflow_dispatch` only, so it cannot race `release.yml`.

Idempotent by construction — crates.io rejects a duplicate version, so a second run is a no-op rather than a hazard.

## The gates it repeats, and why

It re-runs the two checks `release.yml` does before building anything: tag format, and tag-equals-`Cargo.toml`.

That duplication is deliberate. **A version on crates.io can never be replaced**, so a tag that disagrees with the manifest has to stop here rather than become permanent. The missing-token check is there for the same reason: fail *before* publishing, not during.

## Checked by hand against this checkout

| Path | Result |
|---|---|
| Nonexistent tag | stops with a named error |
| No input given | fallback resolves `v3.7.1` |
| Tag vs `Cargo.toml` | 3.7.1 = 3.7.1 |

## What it unblocks

Once merged, 3.7.1 can be published under its own number — the version is unpublished, not burned. Consumers declaring `podup = "3.7.1"` cannot resolve it today, and helmly-agent and epistle are going to be exactly those consumers.

Fixes #1477