### PR TITLE
fix(push): upload every build.tags alias, not only image:

### DIFF
--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -119,15 +119,37 @@ impl Engine {
 				tracing::debug!("{name}: no image to push, skipping");
 				continue;
 			};
-			if let Err(e) = self.push_image(image, &opts, quiet).await {
-				if opts.ignore_failures {
-					warn!("push {image} failed (ignored): {e}");
-				} else {
-					return Err(e);
+			self.try_push(image, &opts, quiet).await?;
+			// `build.tags` is locally retagged by `apply_extra_tags` after the
+			// build. Push each one too — the registry would otherwise end up
+			// with only the primary `image`, and the other refs a user expects
+			// to deploy would never be published (#1476).
+			if let Some(build) = &service.build {
+				for extra in build.tags() {
+					if extra == image {
+						continue;
+					}
+					self.try_push(extra, &opts, quiet).await?;
 				}
 			}
 		}
 		Ok(())
+	}
+
+	/// Push a single image ref, applying `--ignore-push-failures` semantics:
+	/// warn-and-continue when the flag is set, otherwise surface the error so
+	/// the caller aborts the whole push. Shared by the primary and the extra
+	/// `build.tags` loop in [`Engine::push_with_quiet`] so the two cannot drift
+	/// on how a per-image failure is treated.
+	async fn try_push(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<()> {
+		match self.push_image(image, opts, quiet).await {
+			Ok(()) => Ok(()),
+			Err(e) if opts.ignore_failures => {
+				warn!("push {image} failed (ignored): {e}");
+				Ok(())
+			}
+			Err(e) => Err(e),
+		}
 	}
 
 	/// Push a single image ref and drain its progress stream, surfacing a

--- a/tests/engine_integration/push_registry.rs
+++ b/tests/engine_integration/push_registry.rs
@@ -157,3 +157,117 @@ async fn cli_push_reaches_a_real_registry() {
 		"the registry has the repository but not the tag that was pushed.\ntags: {tags}"
 	);
 }
+
+/// `podup push` uploads every `build.tags` alias, not just the primary `image:`.
+///
+/// `build` retags the freshly built image under every `build.tags` entry, but
+/// the old `push` loop only iterated `service.image` and left the aliases as
+/// local-only tags. The build would exit 0, `podman images` would show them
+/// all, and the registry would receive one. Nobody noticed until a deploy by a
+/// non-primary ref pulled nothing (#1476).
+///
+/// The assertion reads the registry back out: every tag declared in
+/// `build.tags` must appear under `/v2/{repo}/tags/list`. A green exit code
+/// alone is not evidence — the bug it guards against was exactly that.
+#[tokio::test]
+async fn cli_push_uploads_every_build_tags_alias() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let port = free_port();
+	let container = format!("t{}-podup-registry-btags", std::process::id());
+	let repository = "podup-push-btags";
+	let primary_tag = "1";
+	// Two aliases in addition to the primary; both must be uploaded by `push`.
+	let extra_tags = ["latest", "v1"];
+	let repo_ref = format!("127.0.0.1:{port}/{repository}");
+	let image = format!("{repo_ref}:{primary_tag}");
+
+	let start = Command::new("podman")
+		.args([
+			"run",
+			"-d",
+			"--name",
+			&container,
+			"-p",
+			&format!("127.0.0.1:{port}:5000"),
+			"docker.io/library/registry:2",
+		])
+		.output()
+		.unwrap();
+	if !start.status.success() {
+		cleanup(&container, &image);
+		panic!(
+			"could not start the registry: {}",
+			String::from_utf8_lossy(&start.stderr)
+		);
+	}
+	if !wait_until_ready(port) {
+		cleanup(&container, &image);
+		panic!("the registry never answered /v2/ on port {port}");
+	}
+
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// List every tag we want the registry to end up with. The primary tag is
+	// included deliberately: `apply_extra_tags` skips it on the build side, and
+	// `push` must skip it for the same reason — re-listing it here exercises
+	// the dedup branch.
+	let tags_yaml = std::iter::once(format!("        - {image}\n"))
+		.chain(
+			extra_tags
+				.iter()
+				.map(|t| format!("        - {repo_ref}:{t}\n")),
+		)
+		.collect::<String>();
+	fs::write(
+		&compose,
+		format!(
+			"services:\n  app:\n    image: {image}\n    build:\n      context: .\n      \
+			 dockerfile_inline: |\n        FROM docker.io/library/busybox:1.36\n        \
+			 RUN echo pushed > /pushed\n      tags:\n{tags_yaml}"
+		),
+	)
+	.unwrap();
+	let proj = format!("t{}-pushbtags", std::process::id());
+
+	let build = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "build"])
+		.output()
+		.unwrap();
+	if !build.status.success() {
+		cleanup(&container, &image);
+		panic!("build failed: {}", String::from_utf8_lossy(&build.stderr));
+	}
+
+	let push = Command::new(bin())
+		.args([
+			"-f",
+			compose.to_str().unwrap(),
+			"-p",
+			&proj,
+			"push",
+			"--tls-verify",
+			"false",
+		])
+		.output()
+		.unwrap();
+	let push_ok = push.status.success();
+	let push_err = String::from_utf8_lossy(&push.stderr).to_string();
+
+	// Read the registry back out: every alias declared in `build.tags` must be
+	// listed, not just the primary one. This is the bug's exact signature.
+	let tags_response = http_get(port, &format!("/v2/{repository}/tags/list")).unwrap_or_default();
+	cleanup(&container, &image);
+
+	assert!(push_ok, "push exited non-zero: {push_err}");
+	for needle in std::iter::once(primary_tag).chain(extra_tags.iter().copied()) {
+		let json_quoted = format!("\"{needle}\"");
+		assert!(
+			tags_response.contains(&json_quoted),
+			"tag {json_quoted} missing from registry after push.\n\
+			 registry tags response: {tags_response}\n\
+			 push stderr: {push_err}"
+		);
+	}
+}


### PR DESCRIPTION
## What was wrong

`push_with_quiet` pushed `service.image` and moved on. But `apply_extra_tags` does tag every entry in `build.tags` locally after the build.

So the build reported success, `podman images` showed every tag, and the registry received one. Nobody finds out until a deploy pulls a tag that was never published.

## The fix

The extra tags are pushed alongside the primary, skipping the duplicate. Both paths now go through one `try_push` helper so the `--ignore-push-failures` semantics cannot drift between them — a per-image failure is warned and skipped with the flag, and aborts the whole push without it, exactly as before for the primary.

## The test matters as much as the fix

`push` against a real registry is the one integration path that had **never executed** (#1314): four tests name it, none reaches a registry. A loop pushing the wrong set passes all of them.

`tests/engine_integration/push_registry.rs` runs a `registry:2` container on the same rootless Podman the rest of the suite drives, and **reads the image back out of the registry**. That distinction is the point: a zero exit is what `push` returned while writing nothing at all, so the exit code cannot be the evidence.

Two tests, both run here against Podman 5.7.0:

| | Result |
|---|---|
| `cli_push_reaches_a_real_registry` | passes in 8s |
| `cli_push_uploads_every_build_tags_alias` | passes |

And checked in the other direction — with the fix removed, the alias test **fails** at the registry read while the basic one still passes. It discriminates exactly what it should.

## Verified

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-features` | no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc` | clean |
| `push.rs` size | 171 code lines, well under the 500 cap |

Fixes #1476