### PR TITLE
fix(release): check the .github helper out of the workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,13 +449,17 @@ jobs:
             "$venv_py" .github/scripts/verify-signing-key.py "$base" "$sig"
           done
 
+      # Checked out under RUNNER_TEMP, not into the workspace: `cargo publish`
+      # refuses a dirty tree, and this helper's 83 files are untracked as far
+      # as podup's git is concerned. v3.7.1 published its release and then
+      # failed at the publish step for exactly that reason (#1462).
       - name: Check out Glyndor/.github for the asset-existence script
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Glyndor/.github
           ref: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
           persist-credentials: false
-          path: upstream
+          path: ${{ runner.temp }}/upstream
 
       - name: Verify every file the installers fetch is staged
         run: |
@@ -469,7 +473,7 @@ jobs:
           # from install.sh's own ${BASE_URL} fetches, so it covers
           # SHA256SUMS.sig too — install.sh aborts without it, and nothing
           # upstream of here ever checked it was produced.
-          python3 upstream/scripts/verify-release-assets.py \
+          python3 "$RUNNER_TEMP/upstream/scripts/verify-release-assets.py" \
             --workdir . \
             --install-script install.sh \
             --install-ps1 install.ps1
@@ -511,6 +515,23 @@ jobs:
 
       - name: Remove release artifacts
         run: rm -f podup-* podup_* NOTICES.html* SHA256SUMS SHA256SUMS.sig install.sh.sig install.ps1.sig
+
+      # `cargo publish` refuses a dirty tree, and it does so *after* the
+      # release already exists — which is unrecoverable in place, since
+      # `gh release create` will not accept a tag that has one. Checking here
+      # turns that into a named failure before anything is published. v3.7.1
+      # lost its crates.io publish to a helper checked out into the workspace
+      # (#1462); this is the guard that would have named it.
+      - name: Working tree must be clean before publishing
+        run: |
+          set -euo pipefail
+          dirty="$(git status --porcelain)"
+          if [ -n "$dirty" ]; then
+            echo "::error::working tree is not clean; cargo publish would refuse it"
+            echo "$dirty" | head -20
+            exit 1
+          fi
+          echo "Working tree is clean."
 
       - name: Publish to crates.io
         env:


### PR DESCRIPTION
## What happened

v3.7.1 published its GitHub release with all 40 signed assets, then failed on the last step:

```
error: 83 files in the working directory contain changes that were not yet committed into git:
upstream/.editorconfig
upstream/.github/FUNDING.yml
...
```

crates.io was never reached. The version is **not burned** — it can still be published under its own number.

## Cause

The asset-existence helper was checked out with `path: upstream`, which lands inside podup's own working tree. `cargo publish` refuses a dirty tree, and those 83 files are untracked as far as podup's git is concerned.

Every release before that gate was added published fine, so it arrived with the gate rather than being longstanding.

The checkout now goes to `RUNNER_TEMP` — the same place the signing venv in this workflow already uses — and the one caller reads it from there.

## The guard that was missing

`cargo publish` notices a dirty tree *after* the release exists, and that is unrecoverable in place: `gh release create` will not take a tag that already has a release, so the only remedy was to burn the version.

A `git status --porcelain` check before the publish step turns that into a named error while it is still cheap. Verified it sees an untracked directory, which is the exact shape this failure had.

Together with #1479's re-entrant workflow, this closes both halves: the cause, and the recovery path if something else ever fails there.

## What it unblocks

3.7.1 can be published to crates.io under its own number. Consumers declaring `podup = "3.7.1"` cannot resolve it today, and helmly-agent and epistle will be exactly those consumers.

Fixes #1462