### PR TITLE
release: 3.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.7.1"
+version = "3.8.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.7.1"
+version = "3.8.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (3.8.0) unstable; urgency=medium
+
+  Added
+
+  * `PodmanError` and the predicates the engine's own retry paths use
+    (`is_timeout`, `is_state_conflict`, `is_already_exists`, `is_image_in_use`,
+    `is_kill_of_stopped`, `is_incomplete_message`, `stream_end_kind`) are part
+    of the public API. `ComposeError::Podman` already carried the type, so a
+    caller could hold the error but not ask it anything: telling a timeout
+    apart from a state conflict meant matching on the `Display` string, which
+    is not a contract I want anyone depending on. A compile-time test now
+    pins the surface so it cannot narrow again by accident.
+
+  Fixed
+
+  * `push` uploaded only the tag named by `image:`, silently skipping every
+    alias declared under `build.tags`. The command still exited zero, so a
+    service that builds three tags and pushes them reported success while two
+    of them were never written to the registry. Every tag is pushed now, and
+    the integration test reads the images back out of a live `registry:2`
+    rather than trusting the exit code.
+  * The release workflow checked the signing helper out on top of the
+    workspace, which left the tree dirty and made `cargo publish` refuse to
+    run. The helper is cloned outside the workspace now, and a gate fails the
+    job before publishing if the tree is not clean.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Wed, 20 Aug 2026 06:55:00 -0500
+
 podup (3.7.1) unstable; urgency=medium
 
   3.7.0 was tagged but never released: its release workflow failed while


### PR DESCRIPTION
Bumps the version across the three files that carry it — `Cargo.toml`, `Cargo.lock` and `debian/changelog` — and adds the 3.8.0 stanza.

This is a MINOR because #1478 widened the public API: `PodmanError` and its retry predicates are exported now, so a library consumer can tell a timeout from a state conflict without matching on the `Display` string.

Why cut it rather than go straight to the next major: crates.io is still serving 3.6.1, which predates the log-rotation fix. Anyone on the 3.x line gets that fix from this release; a major would not reach them until they chose to adopt it.

Once this is on `main`, `crates-publish.yml` becomes dispatchable there and the crates.io publish that 3.7.1 never completed can run against `v3.8.0`.