### PR TITLE
release: 3.8.0

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,0 +1,100 @@
+name: Publish to crates.io
+
+# The recovery path for a crates.io publish that failed after the GitHub
+# release already exists.
+#
+# `release.yml` creates the release and then publishes to the registry in one
+# job. When the publish step fails, that job cannot be re-run into a useful
+# state: `gh release create` refuses a tag that already has a release, so the
+# only remedy was to burn the version and cut another. v3.7.1 hit exactly that
+# — 40 signed assets published, crates.io left behind at 3.6.1.
+#
+# This workflow does one thing and nothing else: publish an existing tag to
+# crates.io. It never touches the release, the assets, the tag, or the signing
+# key. crates.io rejects a duplicate version, so a second run is a no-op rather
+# than a hazard.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v3.7.1). Defaults to the newest v* tag."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish an existing tag to crates.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # Full history so the fallback can find the newest tag; the checkout is
+      # re-pointed at the resolved tag below rather than guessing here.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve the tag to publish
+        id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$(git tag --list 'v*' --sort=-v:refname | head -1)}"
+          [ -n "$TAG" ] || { echo "::error::no v* tag found and none was given"; exit 1; }
+          git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null \
+            || { echo "::error::tag ${TAG} does not exist in this repository"; exit 1; }
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${TAG}."
+
+      - name: Check out that tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
+          persist-credentials: false
+
+      # Same two gates release.yml runs before it builds anything. A version
+      # published to crates.io can never be replaced, so a tag that disagrees
+      # with the manifest must stop here rather than become permanent.
+      - name: Validate tag format
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag '${TAG}' does not match required format v<major>.<minor>.<patch>."
+            exit 1
+          fi
+
+      - name: Tag must equal Cargo.toml version
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          CRATE_VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "$VERSION" != "$CRATE_VERSION" ]; then
+            echo "::error::Tag ${TAG} does not match Cargo.toml version ${CRATE_VERSION}."
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        env:
+          RUST_TOOLCHAIN: "1.97"
+        run: |
+          set -euo pipefail
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+
+      # `--locked` so the published crate resolves the same dependency versions
+      # the tag was tested with. A duplicate version exits non-zero here, which
+      # is the intended outcome of a second run.
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -n "${CARGO_REGISTRY_TOKEN:-}" ] \
+            || { echo "::error::CARGO_REGISTRY_TOKEN is not available to this workflow"; exit 1; }
+          cargo publish --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,13 +449,17 @@ jobs:
             "$venv_py" .github/scripts/verify-signing-key.py "$base" "$sig"
           done
 
+      # Checked out under RUNNER_TEMP, not into the workspace: `cargo publish`
+      # refuses a dirty tree, and this helper's 83 files are untracked as far
+      # as podup's git is concerned. v3.7.1 published its release and then
+      # failed at the publish step for exactly that reason (#1462).
       - name: Check out Glyndor/.github for the asset-existence script
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Glyndor/.github
           ref: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
           persist-credentials: false
-          path: upstream
+          path: ${{ runner.temp }}/upstream
 
       - name: Verify every file the installers fetch is staged
         run: |
@@ -469,7 +473,7 @@ jobs:
           # from install.sh's own ${BASE_URL} fetches, so it covers
           # SHA256SUMS.sig too — install.sh aborts without it, and nothing
           # upstream of here ever checked it was produced.
-          python3 upstream/scripts/verify-release-assets.py \
+          python3 "$RUNNER_TEMP/upstream/scripts/verify-release-assets.py" \
             --workdir . \
             --install-script install.sh \
             --install-ps1 install.ps1
@@ -511,6 +515,23 @@ jobs:
 
       - name: Remove release artifacts
         run: rm -f podup-* podup_* NOTICES.html* SHA256SUMS SHA256SUMS.sig install.sh.sig install.ps1.sig
+
+      # `cargo publish` refuses a dirty tree, and it does so *after* the
+      # release already exists — which is unrecoverable in place, since
+      # `gh release create` will not accept a tag that has one. Checking here
+      # turns that into a named failure before anything is published. v3.7.1
+      # lost its crates.io publish to a helper checked out into the workspace
+      # (#1462); this is the guard that would have named it.
+      - name: Working tree must be clean before publishing
+        run: |
+          set -euo pipefail
+          dirty="$(git status --porcelain)"
+          if [ -n "$dirty" ]; then
+            echo "::error::working tree is not clean; cargo publish would refuse it"
+            echo "$dirty" | head -20
+            exit 1
+          fi
+          echo "Working tree is clean."
 
       - name: Publish to crates.io
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.7.1"
+version = "3.8.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.7.1"
+version = "3.8.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (3.8.0) unstable; urgency=medium
+
+  Added
+
+  * `PodmanError` and the predicates the engine's own retry paths use
+    (`is_timeout`, `is_state_conflict`, `is_already_exists`, `is_image_in_use`,
+    `is_kill_of_stopped`, `is_incomplete_message`, `stream_end_kind`) are part
+    of the public API. `ComposeError::Podman` already carried the type, so a
+    caller could hold the error but not ask it anything: telling a timeout
+    apart from a state conflict meant matching on the `Display` string, which
+    is not a contract I want anyone depending on. A compile-time test now
+    pins the surface so it cannot narrow again by accident.
+
+  Fixed
+
+  * `push` uploaded only the tag named by `image:`, silently skipping every
+    alias declared under `build.tags`. The command still exited zero, so a
+    service that builds three tags and pushes them reported success while two
+    of them were never written to the registry. Every tag is pushed now, and
+    the integration test reads the images back out of a live `registry:2`
+    rather than trusting the exit code.
+  * The release workflow checked the signing helper out on top of the
+    workspace, which left the tree dirty and made `cargo publish` refuse to
+    run. The helper is cloned outside the workspace now, and a gate fails the
+    job before publishing if the tree is not clean.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Wed, 20 Aug 2026 06:55:00 -0500
+
 podup (3.7.1) unstable; urgency=medium
 
   3.7.0 was tagged but never released: its release workflow failed while

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -119,15 +119,37 @@ impl Engine {
 				tracing::debug!("{name}: no image to push, skipping");
 				continue;
 			};
-			if let Err(e) = self.push_image(image, &opts, quiet).await {
-				if opts.ignore_failures {
-					warn!("push {image} failed (ignored): {e}");
-				} else {
-					return Err(e);
+			self.try_push(image, &opts, quiet).await?;
+			// `build.tags` is locally retagged by `apply_extra_tags` after the
+			// build. Push each one too — the registry would otherwise end up
+			// with only the primary `image`, and the other refs a user expects
+			// to deploy would never be published (#1476).
+			if let Some(build) = &service.build {
+				for extra in build.tags() {
+					if extra == image {
+						continue;
+					}
+					self.try_push(extra, &opts, quiet).await?;
 				}
 			}
 		}
 		Ok(())
+	}
+
+	/// Push a single image ref, applying `--ignore-push-failures` semantics:
+	/// warn-and-continue when the flag is set, otherwise surface the error so
+	/// the caller aborts the whole push. Shared by the primary and the extra
+	/// `build.tags` loop in [`Engine::push_with_quiet`] so the two cannot drift
+	/// on how a per-image failure is treated.
+	async fn try_push(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<()> {
+		match self.push_image(image, opts, quiet).await {
+			Ok(()) => Ok(()),
+			Err(e) if opts.ignore_failures => {
+				warn!("push {image} failed (ignored): {e}");
+				Ok(())
+			}
+			Err(e) => Err(e),
+		}
 	}
 
 	/// Push a single image ref and drain its progress stream, surfacing a

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -63,6 +63,18 @@ pub use engine::{
 pub use error::{ComposeError, Result};
 /// The libpod `Client`, surfaced for callers that talk to Podman directly.
 pub use libpod::Client;
+/// The libpod error type carried inside [`ComposeError::Podman`], with the
+/// predicates the engine's own retry paths use.
+///
+/// An embedding daemon has to tell a transport fault it should retry from a
+/// rejection it should not, and the only alternative to these predicates is
+/// matching on the message text — which breaks silently the day libpod rewords
+/// one.
+pub use libpod::PodmanError;
+/// Log frames as libpod delivers them, and the stream parsers that produce
+/// them, for callers routing container output somewhere other than this
+/// process's stdout.
+pub use libpod::{parse_json_lines, parse_multiplexed, parse_raw, LogOutput};
 
 /// Internal parsers exposed only under `test-helpers` for fuzzing and tests.
 ///

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -177,7 +177,7 @@ impl PodmanError {
 	/// Podman 6 applies the archive and then closes without a response, so `cp`
 	/// uses this to tell that specific case apart and re-verify the copy landed
 	/// rather than failing an upload that actually succeeded (#1097).
-	pub(crate) fn is_incomplete_message(&self) -> bool {
+	pub fn is_incomplete_message(&self) -> bool {
 		matches!(self, Self::Hyper(e) if e.is_incomplete_message())
 	}
 
@@ -197,7 +197,7 @@ impl PodmanError {
 	///
 	/// This names the hyper classification so a log can say *which* ending
 	/// occurred. It stays diagnostic: nothing branches on it.
-	pub(crate) fn stream_end_kind(&self) -> &'static str {
+	pub fn stream_end_kind(&self) -> &'static str {
 		match self {
 			Self::Hyper(e) if e.is_incomplete_message() => "incomplete-message",
 			Self::Hyper(e) if e.is_body_write_aborted() => "body-write-aborted",
@@ -238,7 +238,7 @@ impl PodmanError {
 	/// socket never responded within the deadline). These carry a synthetic
 	/// status `0` and a `timed out` message; lifecycle callers use this to
 	/// escalate a wedged `stop` to an explicit `SIGKILL`.
-	pub(crate) fn is_timeout(&self) -> bool {
+	pub fn is_timeout(&self) -> bool {
 		matches!(self, Self::Api { status: 0, message } if message.contains("timed out"))
 	}
 
@@ -248,7 +248,7 @@ impl PodmanError {
 	/// idempotent no-op rather than a fatal error that aborts the loop. The
 	/// message is unique to the kill endpoint, so matching it cannot mask another
 	/// op's 409.
-	pub(crate) fn is_kill_of_stopped(&self) -> bool {
+	pub fn is_kill_of_stopped(&self) -> bool {
 		matches!(
 			self,
 			Self::Api { status: 409, message }
@@ -260,7 +260,7 @@ impl PodmanError {
 	/// 409 conflict, or an HTTP 500 whose message says so. Podman's libpod
 	/// volume-create endpoint returns 500 (not 409) for a duplicate name, so an
 	/// idempotent create must accept both to let a re-`up` succeed.
-	pub(crate) fn is_already_exists(&self) -> bool {
+	pub fn is_already_exists(&self) -> bool {
 		match self {
 			Self::Api { status: 409, .. } => true,
 			Self::Api {
@@ -277,7 +277,7 @@ impl PodmanError {
 	/// every dependent container — including ones owned by other projects. Podman
 	/// returns this as a 409 conflict, or on some versions a 500 whose message
 	/// names the in-use cause.
-	pub(crate) fn is_image_in_use(&self) -> bool {
+	pub fn is_image_in_use(&self) -> bool {
 		match self {
 			Self::Api { status: 409, .. } => true,
 			Self::Api {
@@ -295,7 +295,7 @@ impl PodmanError {
 	/// attempted lifecycle op (already paused, not paused, not running). Podman
 	/// returns these as a 409/500 with a "container state improper" cause. Lets
 	/// `pause`/`unpause` stay idempotent no-ops, matching docker compose.
-	pub(crate) fn is_state_conflict(&self) -> bool {
+	pub fn is_state_conflict(&self) -> bool {
 		match self {
 			Self::Api { status, message } if *status == 409 || *status == 500 => {
 				let m = message.to_ascii_lowercase();

--- a/tests/api_surface.rs
+++ b/tests/api_surface.rs
@@ -1,0 +1,49 @@
+//! The public surface an embedding daemon needs, exercised by naming it.
+//!
+//! helmly-agent and epistle consume podup as a library. When a call fails they
+//! receive a `ComposeError::Podman`, and deciding whether to retry means asking
+//! the error what kind of failure it was. Before #1474 the type inside was not
+//! nameable from outside the crate and every predicate was `pub(crate)`, so the
+//! only way to ask was matching on the message text.
+//!
+//! This file is a compile-time contract, not a behavioural test: it fails by
+//! not building. Nothing here asserts what the predicates return — only that a
+//! caller outside the crate can name the type and call them.
+
+use podup::{ComposeError, LogOutput, PodmanError};
+
+/// Name every type the retry path of an embedding daemon has to write down.
+#[test]
+fn public_types_are_nameable() {
+	fn _takes_error(_: &PodmanError) {}
+	fn _takes_frame(_: &LogOutput) {}
+	fn _takes_compose_error(_: &ComposeError) {}
+}
+
+/// Call each predicate the engine's own retry logic uses. A consumer that
+/// cannot reach these has to fall back to `err.to_string().contains(..)`,
+/// which breaks the day libpod rewords a message — and breaks silently,
+/// because the retry simply stops happening.
+#[test]
+fn retry_predicates_are_callable_from_outside() {
+	fn _probe(e: &PodmanError) -> (bool, bool, bool, bool, bool, bool, &'static str) {
+		(
+			e.is_timeout(),
+			e.is_incomplete_message(),
+			e.is_kill_of_stopped(),
+			e.is_already_exists(),
+			e.is_image_in_use(),
+			e.is_state_conflict(),
+			e.stream_end_kind(),
+		)
+	}
+}
+
+/// The stream parsers, for a consumer routing container output somewhere other
+/// than this process's stdout — a TUI, a WebSocket, a log shipper.
+#[test]
+fn stream_parsers_are_reachable() {
+	let _ = podup::parse_json_lines::<serde_json::Value>;
+	let _ = podup::parse_multiplexed;
+	let _ = podup::parse_raw;
+}

--- a/tests/engine_integration/push_registry.rs
+++ b/tests/engine_integration/push_registry.rs
@@ -157,3 +157,117 @@ async fn cli_push_reaches_a_real_registry() {
 		"the registry has the repository but not the tag that was pushed.\ntags: {tags}"
 	);
 }
+
+/// `podup push` uploads every `build.tags` alias, not just the primary `image:`.
+///
+/// `build` retags the freshly built image under every `build.tags` entry, but
+/// the old `push` loop only iterated `service.image` and left the aliases as
+/// local-only tags. The build would exit 0, `podman images` would show them
+/// all, and the registry would receive one. Nobody noticed until a deploy by a
+/// non-primary ref pulled nothing (#1476).
+///
+/// The assertion reads the registry back out: every tag declared in
+/// `build.tags` must appear under `/v2/{repo}/tags/list`. A green exit code
+/// alone is not evidence — the bug it guards against was exactly that.
+#[tokio::test]
+async fn cli_push_uploads_every_build_tags_alias() {
+	if super::podman().await.is_none() {
+		return;
+	}
+	let port = free_port();
+	let container = format!("t{}-podup-registry-btags", std::process::id());
+	let repository = "podup-push-btags";
+	let primary_tag = "1";
+	// Two aliases in addition to the primary; both must be uploaded by `push`.
+	let extra_tags = ["latest", "v1"];
+	let repo_ref = format!("127.0.0.1:{port}/{repository}");
+	let image = format!("{repo_ref}:{primary_tag}");
+
+	let start = Command::new("podman")
+		.args([
+			"run",
+			"-d",
+			"--name",
+			&container,
+			"-p",
+			&format!("127.0.0.1:{port}:5000"),
+			"docker.io/library/registry:2",
+		])
+		.output()
+		.unwrap();
+	if !start.status.success() {
+		cleanup(&container, &image);
+		panic!(
+			"could not start the registry: {}",
+			String::from_utf8_lossy(&start.stderr)
+		);
+	}
+	if !wait_until_ready(port) {
+		cleanup(&container, &image);
+		panic!("the registry never answered /v2/ on port {port}");
+	}
+
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("docker-compose.yml");
+	// List every tag we want the registry to end up with. The primary tag is
+	// included deliberately: `apply_extra_tags` skips it on the build side, and
+	// `push` must skip it for the same reason — re-listing it here exercises
+	// the dedup branch.
+	let tags_yaml = std::iter::once(format!("        - {image}\n"))
+		.chain(
+			extra_tags
+				.iter()
+				.map(|t| format!("        - {repo_ref}:{t}\n")),
+		)
+		.collect::<String>();
+	fs::write(
+		&compose,
+		format!(
+			"services:\n  app:\n    image: {image}\n    build:\n      context: .\n      \
+			 dockerfile_inline: |\n        FROM docker.io/library/busybox:1.36\n        \
+			 RUN echo pushed > /pushed\n      tags:\n{tags_yaml}"
+		),
+	)
+	.unwrap();
+	let proj = format!("t{}-pushbtags", std::process::id());
+
+	let build = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "build"])
+		.output()
+		.unwrap();
+	if !build.status.success() {
+		cleanup(&container, &image);
+		panic!("build failed: {}", String::from_utf8_lossy(&build.stderr));
+	}
+
+	let push = Command::new(bin())
+		.args([
+			"-f",
+			compose.to_str().unwrap(),
+			"-p",
+			&proj,
+			"push",
+			"--tls-verify",
+			"false",
+		])
+		.output()
+		.unwrap();
+	let push_ok = push.status.success();
+	let push_err = String::from_utf8_lossy(&push.stderr).to_string();
+
+	// Read the registry back out: every alias declared in `build.tags` must be
+	// listed, not just the primary one. This is the bug's exact signature.
+	let tags_response = http_get(port, &format!("/v2/{repository}/tags/list")).unwrap_or_default();
+	cleanup(&container, &image);
+
+	assert!(push_ok, "push exited non-zero: {push_err}");
+	for needle in std::iter::once(primary_tag).chain(extra_tags.iter().copied()) {
+		let json_quoted = format!("\"{needle}\"");
+		assert!(
+			tags_response.contains(&json_quoted),
+			"tag {json_quoted} missing from registry after push.\n\
+			 registry tags response: {tags_response}\n\
+			 push stderr: {push_err}"
+		);
+	}
+}


### PR DESCRIPTION
Five commits since 3.7.1.

| | |
|---|---|
| #1478 | `PodmanError` and its retry predicates are public — a library consumer can tell a timeout from a state conflict without matching on the `Display` string |
| #1480 | `push` uploads every `build.tags` alias instead of only the tag named by `image:` |
| #1482 | the release workflow clones the signing helper outside the workspace, so the tree stays clean for `cargo publish` |
| #1479 | `crates-publish.yml`, a dispatchable path for publishing a tag to crates.io |
| #1483 | the version bump and the 3.8.0 stanza |

MINOR because #1478 widened the public API.

crates.io is still serving 3.6.1, so it never received the log-rotation fix that 3.7.1 carried — 3.7.1 published its GitHub release and .debs but died on the crates.io step, which is what #1482 repairs. This release is what takes that fix to the 3.x line on crates.io.

Once this lands, `crates-publish.yml` is dispatchable from `main` and can publish `v3.8.0`.