### PR TITLE
fix(release): clone the .github helper instead of checking it out

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,17 +449,29 @@ jobs:
             "$venv_py" .github/scripts/verify-signing-key.py "$base" "$sig"
           done
 
-      # Checked out under RUNNER_TEMP, not into the workspace: `cargo publish`
-      # refuses a dirty tree, and this helper's 83 files are untracked as far
-      # as podup's git is concerned. v3.7.1 published its release and then
-      # failed at the publish step for exactly that reason (#1462).
+      # Cloned by hand under RUNNER_TEMP rather than with actions/checkout:
+      # `cargo publish` refuses a dirty tree, and this helper's 83 files are
+      # untracked as far as podup's git is concerned. v3.7.1 published its
+      # release and then failed at the publish step for exactly that reason
+      # (#1462). actions/checkout cannot be the tool here — it rejects any
+      # `path:` outside the workspace ("is not under /home/runner/work/..."),
+      # which is what broke v3.8.0.
+      #
+      # The pin is still the commit SHA, not the tag: the tag is a moving
+      # label and the SHA is the boundary. `git fetch` of one SHA at depth 1
+      # is what keeps that guarantee without a full clone.
       - name: Check out Glyndor/.github for the asset-existence script
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: Glyndor/.github
-          ref: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
-          persist-credentials: false
-          path: ${{ runner.temp }}/upstream
+        env:
+          UPSTREAM_SHA: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+        run: |
+          set -euo pipefail
+          git init -q "$RUNNER_TEMP/upstream"
+          git -C "$RUNNER_TEMP/upstream" remote add origin \
+            https://github.com/Glyndor/.github.git
+          git -C "$RUNNER_TEMP/upstream" fetch -q --depth 1 origin "$UPSTREAM_SHA"
+          git -C "$RUNNER_TEMP/upstream" checkout -q FETCH_HEAD
+          # Fail loudly rather than run a script that silently is not there.
+          test -f "$RUNNER_TEMP/upstream/scripts/verify-release-assets.py"
 
       - name: Verify every file the installers fetch is staged
         run: |


### PR DESCRIPTION
v3.8.0 is tagged, built all nine artefacts, and then died before the release was created:

```
Repository path '/home/runner/work/_temp/upstream' is not under '/home/runner/work/podup/podup'
```

`actions/checkout` refuses any `path:` outside the workspace, so #1482 could never have worked — it moved the helper to `RUNNER_TEMP`, which is precisely what the action rejects. Nothing had exercised that path before, because the release workflow only runs on a tag.

The constraint #1482 was solving is genuine: the helper's 83 files are untracked from podup's point of view and `cargo publish` refuses a dirty tree. That is what killed v3.7.1's publish step (#1462).

A plain clone does what the action will not:

```
git init "$RUNNER_TEMP/upstream"
git -C ... fetch --depth 1 origin "$UPSTREAM_SHA"
git -C ... checkout FETCH_HEAD
```

The pin stays on the commit SHA rather than the tag. `Glyndor/.github` is public, so no credential is involved. I ran the sequence locally: it resolves to the pinned SHA and `scripts/verify-release-assets.py` is present. The step now also fails loudly if the script is ever missing, instead of running a path that is not there.

No tag is moved. Once this reaches `main`, `v3.8.0` can be re-run through `workflow_dispatch`.

Refs #1462.