### PR TITLE
feat(network): isolate bridge networks by default, matching docker

### DIFF
--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -45,10 +45,11 @@ impl Engine {
 				.unwrap_or_default();
 			labels.insert("podup.project".to_string(), self.project.clone());
 
-			let driver_opts: HashMap<String, String> = config
+			let mut driver_opts: HashMap<String, String> = config
 				.as_ref()
 				.map(|c| c.driver_opts.clone())
 				.unwrap_or_default();
+			apply_default_isolation(&driver, &mut driver_opts);
 
 			let ipam = config.as_ref().and_then(|c| c.ipam.as_ref());
 			let subnets = ipam.map(build_subnets).unwrap_or_default();
@@ -153,6 +154,51 @@ pub(super) fn build_per_network_options(
 	}
 
 	opts
+}
+
+/// The netavark option that stops a bridge network from reaching another one.
+const ISOLATE_OPT: &str = "isolate";
+
+/// Ask netavark to isolate a bridge network unless the compose file said
+/// otherwise.
+///
+/// Docker isolates its bridge networks from each other and podman does not, so
+/// without this a service reaches ports on a neighbouring network that were
+/// never published. Measured on 2026-08-20 with the same experiment on both
+/// engines — a listener on an unpublished port in network B, and a container in
+/// network A dialling its address:
+///
+/// | engine | result |
+/// |---|---|
+/// | docker 29.6.2 | refused |
+/// | podman 5.7.0 | connected |
+///
+/// The control matters: inside the *same* network docker connects, so the
+/// refusal is isolation rather than a broken dial.
+///
+/// Also measured on podman 5.7.0 with the option set: traffic within one
+/// network still flows (compose keeps working) and outbound internet still
+/// works.
+///
+/// **The option only bites when both networks carry it.** Measured three ways:
+/// isolated → isolated is refused, isolated → plain connects, and plain →
+/// isolated connects. So this does not harden a network against the world; it
+/// makes networks that share the default stop seeing each other. Since podup
+/// now sets it on every bridge network it creates, the effect is that two
+/// podup projects no longer reach each other's unpublished ports — verified
+/// end to end with two projects — while a network created outside podup
+/// without the option still can. Being a default rather than opt-in is the
+/// whole point: one project opting in would protect nobody.
+///
+/// A compose file that sets `isolate` in `driver_opts` wins, including setting
+/// it to `false`, which is the escape hatch for a project that deliberately
+/// spans networks.
+fn apply_default_isolation(driver: &str, opts: &mut HashMap<String, String>) {
+	if driver != "bridge" {
+		return;
+	}
+	opts.entry(ISOLATE_OPT.to_string())
+		.or_insert_with(|| "true".to_string());
 }
 
 /// Resolve a service's networking into a netns `Namespace` and per-network

--- a/internal/engine/network/tests.rs
+++ b/internal/engine/network/tests.rs
@@ -356,3 +356,46 @@ fn lease_range_ipv6_zero_prefix_spans_whole_space() {
 fn lease_range_ipv6_rejects_oversized_prefix() {
 	assert!(lease_range_from_cidr("2001:db8::/129").is_none());
 }
+
+/// Docker isolates bridge networks from each other and podman does not, so a
+/// podup project used to let one service reach unpublished ports on another
+/// network. Measured on both engines; see `apply_default_isolation`.
+#[test]
+fn a_bridge_network_is_isolated_by_default() {
+	let mut opts = HashMap::new();
+	apply_default_isolation("bridge", &mut opts);
+	assert_eq!(opts.get("isolate").map(String::as_str), Some("true"));
+}
+
+/// The option is netavark's bridge plugin. Setting it on a driver that does
+/// not read it would be noise at best and a create failure at worst.
+#[test]
+fn only_bridge_networks_get_the_option() {
+	for driver in ["macvlan", "ipvlan", "host"] {
+		let mut opts = HashMap::new();
+		apply_default_isolation(driver, &mut opts);
+		assert!(opts.is_empty(), "{driver} should not be given isolate");
+	}
+}
+
+/// The escape hatch for a project that deliberately spans networks. A default
+/// that cannot be turned off is not a default, it is a policy.
+#[test]
+fn an_explicit_driver_opt_wins_in_both_directions() {
+	let mut off = HashMap::from([("isolate".to_string(), "false".to_string())]);
+	apply_default_isolation("bridge", &mut off);
+	assert_eq!(off.get("isolate").map(String::as_str), Some("false"));
+
+	let mut strict = HashMap::from([("isolate".to_string(), "strict".to_string())]);
+	apply_default_isolation("bridge", &mut strict);
+	assert_eq!(strict.get("isolate").map(String::as_str), Some("strict"));
+}
+
+/// Whatever else the compose file asked for has to survive.
+#[test]
+fn other_driver_opts_are_left_alone() {
+	let mut opts = HashMap::from([("mtu".to_string(), "9000".to_string())]);
+	apply_default_isolation("bridge", &mut opts);
+	assert_eq!(opts.get("mtu").map(String::as_str), Some("9000"));
+	assert_eq!(opts.get("isolate").map(String::as_str), Some("true"));
+}


### PR DESCRIPTION
Docker isolates its bridge networks from each other; podman does not. So a podup service could reach ports on a neighbouring network that were **never published**. This is a parity gap with `docker compose` — podup's stated target — and a security one.

## Measured, both engines, same experiment

A listener on an unpublished port in network B; a container in network A dialling its address.

| engine | result |
|---|---|
| docker 29.6.2 | **refused** |
| podman 5.7.0 | **connected** |

The control is what makes this evidence rather than a guess: inside the *same* network docker connects. The refusal is isolation, not a broken dial.

## What the fix does

podup passes netavark's `isolate` on every bridge network it creates. Measured on podman 5.7.0:

* traffic **inside** one network still flows — compose keeps working
* outbound **internet** still works (checked against a plain network as control)
* the option **only bites when both networks carry it**: isolated→isolated is refused, while isolated→plain and plain→isolated both connect

That last measurement is why this is a default and not an opt-in. A single project opting in would protect nobody — the neighbour has to have it too. With it on by default, two podup projects stop seeing each other's unpublished ports, which I verified end to end by bringing up two projects and dialling across. A network created outside podup without the option can still reach in; this narrows the exposure, it does not seal the host.

## Escape hatch

`driver_opts.isolate` in the compose file wins, including setting it to `false`, for a project that deliberately spans networks. Only `bridge` networks get it — the option belongs to that netavark plugin, and macvlan/ipvlan do not read it.

## Compatibility

This changes behaviour for anyone relying on cross-network reachability between podup projects, which is why it belongs in 4.0.0. The failure mode is a connection that stops working rather than a silent wrong answer, and the compose-level opt-out restores the old behaviour.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>