### PR TITLE
feat(quadlet): emit Notify=healthy, making depends_on service_healthy work

### DIFF
--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -267,6 +267,7 @@ pub fn generate_at(file: &ComposeFile, project: &str, base_dir: &std::path::Path
 		declared_networks: &declared_networks,
 		secrets: &file.secrets,
 		base_dir,
+		services: &file.services,
 	};
 	for (name, service) in &file.services {
 		// Emit a `.build` unit first so the systemd generator builds the image

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -32,6 +32,9 @@ pub(crate) struct UnitContext<'a> {
 	/// Directory compose resolves relative paths against — the compose file's
 	/// own directory, not the unit's. See [`abs_against`].
 	pub base_dir: &'a std::path::Path,
+	/// Every service in the file, so a `depends_on` condition can be judged
+	/// against the service it names rather than in the abstract.
+	pub services: &'a IndexMap<String, Service>,
 }
 
 /// Build the `.container` unit for one compose `service`.
@@ -52,6 +55,7 @@ pub(crate) fn container_unit(
 		declared_networks,
 		secrets,
 		base_dir,
+		services,
 	} = ctx;
 	let mut unit = Section::new("Unit");
 	unit.add("Description", format!("{name} (podup)"));
@@ -460,7 +464,7 @@ pub(crate) fn container_unit(
 		}
 	}
 
-	collect_warnings(name, service, warnings);
+	collect_warnings(name, service, services, warnings);
 
 	// The unforgeable ownership marker comes first, as its own comment line;
 	// see `owner_marker` for why it must stay separate from the `Label=` line.

--- a/internal/quadlet/unit/health.rs
+++ b/internal/quadlet/unit/health.rs
@@ -35,6 +35,24 @@ pub(super) fn render_healthcheck(
 		};
 		if !cmd.is_empty() {
 			container.add("HealthCmd", cmd);
+			// Tell systemd the unit is not up until the healthcheck passes.
+			// Quadlet renders this as `--sdnotify=healthy`, and without it
+			// systemd calls the service started the moment the container is
+			// created — so `After=`/`Requires=` order the *creation*, not the
+			// readiness, and a dependant starts against a service that is not
+			// serving yet.
+			//
+			// Measured on podman 5.7.0 with a probe that takes ten seconds to
+			// pass: `systemctl start` on the unit itself returned after 11s
+			// rather than immediately, and a second unit with
+			// `After=`/`Requires=` on it started 10s in. That second number is
+			// the one that matters — it is `depends_on: service_healthy`
+			// actually being honoured.
+			//
+			// Only emitted alongside a command. `--sdnotify=healthy` with
+			// nothing to probe would leave the unit starting until
+			// `TimeoutStartSec` expires.
+			container.add("Notify", "healthy".to_string());
 		}
 	}
 	if let Some(v) = &hc.interval {
@@ -140,5 +158,37 @@ mod tests {
 		// No key is emitted for start_interval, but the user is warned.
 		assert_eq!(warnings.len(), 1);
 		assert!(warnings[0].contains("start_interval"));
+	}
+
+	/// Without this systemd calls the unit started as soon as the container is
+	/// created, so `After=`/`Requires=` order creation rather than readiness.
+	/// Measured on podman 5.7.0: a dependant started 10s into a dependency
+	/// whose probe took 10s, instead of immediately.
+	#[test]
+	fn a_healthcheck_brings_notify_healthy() {
+		let (body, _) = render("image: x\nhealthcheck:\n  test: [\"CMD\", \"true\"]\n");
+		assert!(body.contains("Notify=healthy"), "{body}");
+	}
+
+	/// `--sdnotify=healthy` with nothing to probe would leave the unit starting
+	/// until `TimeoutStartSec` expires, so it must never be emitted alone.
+	#[test]
+	fn no_healthcheck_means_no_notify() {
+		let (body, _) = render("image: x\n");
+		assert!(!body.contains("Notify"), "{body}");
+	}
+
+	#[test]
+	fn a_disabled_healthcheck_means_no_notify() {
+		let (body, _) = render("image: x\nhealthcheck:\n  disable: true\n");
+		assert!(!body.contains("Notify"), "{body}");
+	}
+
+	/// An empty command emits no `HealthCmd`, so there is nothing for systemd
+	/// to wait on and `Notify` must not appear either.
+	#[test]
+	fn an_empty_test_means_no_notify() {
+		let (body, _) = render("image: x\nhealthcheck:\n  test: []\n");
+		assert!(!body.contains("Notify"), "{body}");
 	}
 }

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -1,11 +1,18 @@
 //! Report compose fields that are set but have no Quadlet mapping.
 
-use crate::compose::types::{DependsOn, Service, ServiceCondition};
+use indexmap::IndexMap;
+
+use crate::compose::types::{DependsOn, HealthCheck, Service, ServiceCondition};
 
 /// Warn for fields that are set but have no Quadlet mapping, so the operator
 /// knows the generated unit is incomplete rather than discovering it at run
 /// time.
-pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec<String>) {
+pub(super) fn collect_warnings(
+	name: &str,
+	service: &Service,
+	services: &IndexMap<String, Service>,
+	warnings: &mut Vec<String>,
+) {
 	let mut warn = |field: &str, detail: &str| {
 		warnings.push(format!("{name}: {field} {detail}"));
 	};
@@ -50,16 +57,35 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"hooks have no Quadlet equivalent and are skipped",
 		);
 	}
-	// systemd `After=`/`Requires=` order startup but cannot gate it on a
-	// dependency becoming healthy or completing; those conditions are dropped.
+	// `service_healthy` IS enforceable, as long as the service it names has a
+	// healthcheck: that service's unit carries `Notify=healthy`, so systemd
+	// does not call it started until the probe passes, and `After=`/`Requires=`
+	// then order against readiness rather than creation. Measured on podman
+	// 5.7.0 — a dependant started 10s into a dependency whose probe took 10s.
+	//
+	// So the warning is now about the cases that really cannot work: a
+	// `service_healthy` naming a service with no healthcheck to wait on, and
+	// `service_completed_successfully`, which would need the dependency to be a
+	// `Type=oneshot` unit that exits.
 	if let DependsOn::Map(deps) = &service.depends_on {
-		if deps
-			.values()
-			.any(|c| c.condition != ServiceCondition::ServiceStarted)
-		{
+		let unwaitable: Vec<&str> = deps
+			.iter()
+			.filter(|(dep_name, c)| match c.condition {
+				ServiceCondition::ServiceStarted => false,
+				ServiceCondition::ServiceHealthy => services
+					.get(dep_name.as_str())
+					.is_none_or(|d| d.healthcheck.as_ref().is_none_or(HealthCheck::is_disabled)),
+				_ => true,
+			})
+			.map(|(dep_name, _)| dep_name.as_str())
+			.collect();
+		if !unwaitable.is_empty() {
 			warn(
 				"depends_on",
-				"condition service_healthy/service_completed_successfully is not enforceable in Quadlet; only start ordering is emitted",
+				&format!(
+					"condition on {} is not enforceable in Quadlet and only start ordering is emitted; service_healthy needs the named service to declare a healthcheck, and service_completed_successfully has no equivalent",
+					unwaitable.join(", ")
+				),
 			);
 		}
 	}


### PR DESCRIPTION
The generated units carried no `Notify=`, so systemd called a service started the moment its container was created. `After=`/`Requires=` then ordered *creation*, not readiness, and a dependant started against a service that was not serving yet.

podup said so itself, in a warning:

> condition service_healthy/service_completed_successfully is not enforceable in Quadlet; only start ordering is emitted

**That was not true**, and this fixes both the behaviour and the claim.

## Measured

podman 5.7.0, quadlet unit with `Notify=healthy` and a probe that takes ten seconds to pass:

| | |
|---|---|
| `systemctl start` on the unit itself | returned after **11s**, not immediately |
| a second unit with `After=`/`Requires=` on it | started **10s** in |

The second number is the point: that is `depends_on: service_healthy` actually being honoured by systemd.

## What changed

A service with a healthcheck now gets `Notify=healthy`, which quadlet renders as `--sdnotify=healthy`. Only alongside a real command — the key with nothing to probe would leave the unit starting until `TimeoutStartSec` expires, so a disabled or empty healthcheck emits nothing.

The warning is now scoped to what genuinely cannot work, and names the offending service instead of speaking in the abstract:

* `service_healthy` pointing at a service with **no** healthcheck — nothing to wait on
* `service_completed_successfully` — would need the dependency to be a `Type=oneshot` unit that exits

Judging that needs the sibling services, so `UnitContext` carries them. It is built in one place, so the change does not spread.

## Verified end to end

A four-service file — `db` with a healthcheck, `api` depending on it, `cache` without one, `worker` depending on that:

* `q-db.container` has `Notify=healthy`; `q-cache.container` has no `Notify`
* the only warning emitted is `worker: depends_on condition on cache …`, and nothing is said about `api → db`, which now works

119 quadlet tests pass, up from 115.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>