### PR TITLE
feat(build): map build.ulimits, which libpod does support

### DIFF
--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -107,7 +107,6 @@ pub(super) fn ignored_build_fields(file: &ComposeFile, out: &mut Vec<String>) {
 	for (service, def) in &file.services {
 		let Some(BuildConfig::Config {
 			privileged,
-			ulimits,
 			isolation,
 			entitlements,
 			provenance,
@@ -124,9 +123,6 @@ pub(super) fn ignored_build_fields(file: &ComposeFile, out: &mut Vec<String>) {
 		}
 		if !ssh.is_empty() {
 			unmapped.push("ssh");
-		}
-		if !ulimits.is_empty() {
-			unmapped.push("ulimits");
 		}
 		if isolation.is_some() {
 			unmapped.push("isolation");

--- a/internal/compose/diagnostics/tests.rs
+++ b/internal/compose/diagnostics/tests.rs
@@ -240,17 +240,21 @@ fn warns_on_remaining_unmapped_build_fields() {
 	let msgs = diagnostics_for(
 			"services:\n  web:\n    build:\n      context: .\n      ulimits:\n        nofile: 1024\n      entitlements: [\"security.insecure\"]\n      provenance: true\n      sbom: true\n",
 		);
-	for field in [
-		"build.ulimits",
-		"build.entitlements",
-		"build.provenance",
-		"build.sbom",
-	] {
+	for field in ["build.entitlements", "build.provenance", "build.sbom"] {
 		assert!(
 			msgs.iter().any(|m| m.contains(field)),
 			"missing {field}; got: {msgs:?}"
 		);
 	}
+	// `build.ulimits` was on this list, wrongly: the libpod build endpoint takes
+	// a `ulimits` parameter and applies it. Measured on podman 5.7.0 — the same
+	// build saw `ulimit -n` of 524288 without it and 1234 with it. Reporting it
+	// as unmapped now would send the reader looking for a workaround that is not
+	// needed.
+	assert!(
+		!msgs.iter().any(|m| m.contains("build.ulimits")),
+		"build.ulimits is mapped now and must not be reported as ignored; got: {msgs:?}"
+	);
 }
 
 #[test]

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -246,6 +246,16 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the per-build ulimits.
+	pub fn ulimits(&self) -> &IndexMap<String, UlimitConfig> {
+		static EMPTY: std::sync::LazyLock<IndexMap<String, UlimitConfig>> =
+			std::sync::LazyLock::new(IndexMap::new);
+		match self {
+			BuildConfig::Context(_) => &EMPTY,
+			BuildConfig::Config { ulimits, .. } => ulimits,
+		}
+	}
+
 	/// Returns the inline Dockerfile contents, if set.
 	pub fn dockerfile_inline(&self) -> Option<&str> {
 		match self {

--- a/internal/engine/build/build_tests.rs
+++ b/internal/engine/build/build_tests.rs
@@ -4,7 +4,9 @@
 //! Split out of `build/mod.rs` so the production code stays under the
 //! source-line limit.
 
-use super::Engine;
+use crate::compose::types::{BuildConfig, UlimitConfig};
+
+use super::{render_build_ulimits, Engine};
 use crate::libpod::Client;
 
 fn engine(base: std::path::PathBuf) -> Engine {
@@ -105,4 +107,59 @@ fn build_secret_undefined_errors() {
 	let file = crate::compose::parse_str(yaml).unwrap();
 	let e = engine(std::env::temp_dir());
 	assert!(e.resolve_build_secrets(build_of(&file), &file).is_err());
+}
+
+/// `build.ulimits` was reported as having no libpod mapping. It has one:
+/// measured on podman 5.7.0, a build with `ulimits=["nofile=1234:1234"]` saw
+/// 1234 where the same build without it saw 524288.
+#[test]
+fn a_pair_renders_as_soft_colon_hard() {
+	let build = build_with_ulimits(&[("nofile", UlimitConfig::Pair { soft: 1, hard: 2 })]);
+	assert_eq!(render_build_ulimits(&build), vec!["nofile=1:2"]);
+}
+
+/// A single value is both limits.
+#[test]
+fn a_single_value_fills_both_limits() {
+	let build = build_with_ulimits(&[("nproc", UlimitConfig::Single(64))]);
+	assert_eq!(render_build_ulimits(&build), vec!["nproc=64:64"]);
+}
+
+/// The value reaches a query string, so an unrecognised name is a typo or an
+/// injection attempt and is dropped rather than forwarded.
+#[test]
+fn an_unknown_resource_name_is_dropped() {
+	let build = build_with_ulimits(&[
+		("bogus,inject=1", UlimitConfig::Single(1)),
+		("nofile", UlimitConfig::Single(2)),
+	]);
+	assert_eq!(render_build_ulimits(&build), vec!["nofile=2:2"]);
+}
+
+/// Podman rejects a soft limit above the hard one. The container path clamps
+/// instead of failing, so the build path matches it.
+#[test]
+fn a_soft_limit_above_the_hard_one_is_clamped() {
+	let build = build_with_ulimits(&[("nofile", UlimitConfig::Pair { soft: 99, hard: 5 })]);
+	assert_eq!(render_build_ulimits(&build), vec!["nofile=5:5"]);
+}
+
+/// A short-form `build: .` has no options block at all.
+#[test]
+fn a_context_only_build_renders_nothing() {
+	let build = BuildConfig::Context(".".into());
+	assert!(render_build_ulimits(&build).is_empty());
+}
+
+fn build_with_ulimits(entries: &[(&str, UlimitConfig)]) -> BuildConfig {
+	let yaml = entries
+		.iter()
+		.map(|(name, cfg)| match cfg {
+			UlimitConfig::Single(v) => format!("  {name}: {v}\n"),
+			UlimitConfig::Pair { soft, hard } => {
+				format!("  {name}:\n    soft: {soft}\n    hard: {hard}\n")
+			}
+		})
+		.collect::<String>();
+	serde_yaml::from_str(&format!("context: .\nulimits:\n{yaml}")).expect("build config parses")
 }

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -25,6 +25,7 @@ use futures_util::StreamExt;
 use tracing::{info, warn};
 
 use crate::compose::types::{BuildConfig, Service};
+use crate::engine::container_config::resources::is_known_ulimit;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::BuildOutput;
 use crate::libpod::urlencoded;
@@ -118,6 +119,37 @@ impl BuildOptions {
 		self.quiet = quiet;
 		self
 	}
+}
+
+/// Render `build.ulimits` into the `name=soft:hard` strings the libpod build
+/// endpoint takes.
+///
+/// podup used to report this field as having no libpod mapping. It does.
+/// Measured on podman 5.7.0 by building the same Containerfile twice through
+/// the API, with a `RUN` that prints `ulimit -n`: without the parameter the
+/// build saw 524288, with `ulimits=["nofile=1234:1234"]` it saw 1234.
+///
+/// An unrecognised name is dropped rather than forwarded. The value reaches a
+/// query string, so an unknown name is either a typo or an injection attempt —
+/// the same reasoning the container-side `build_ulimits` applies.
+fn render_build_ulimits(build: &BuildConfig) -> Vec<String> {
+	build
+		.ulimits()
+		.iter()
+		.filter_map(|(name, cfg)| {
+			if !is_known_ulimit(name) {
+				tracing::warn!(
+					"build.ulimits '{name}' is not a recognized resource name and is ignored"
+				);
+				return None;
+			}
+			let (soft, hard) = (cfg.soft(), cfg.hard());
+			// Podman rejects a soft limit above the hard one; the container
+			// path clamps rather than failing the build, so match it.
+			let soft = soft.min(hard);
+			Some(format!("{name}={soft}:{hard}"))
+		})
+		.collect()
 }
 
 impl Engine {
@@ -358,6 +390,12 @@ impl Engine {
 		} else {
 			Some(super::to_query_json("build.labels", &labels)?)
 		};
+		let build_ulimits = render_build_ulimits(build);
+		let ulimits_json = if build_ulimits.is_empty() {
+			None
+		} else {
+			Some(super::to_query_json("build.ulimits", &build_ulimits)?)
+		};
 
 		let mut qs = format!(
 			"t={}&rm=true&nocache={}",
@@ -388,6 +426,9 @@ impl Engine {
 		}
 		if let Some(l) = &labels_json {
 			qs.push_str(&format!("&labels={}", urlencoded(l)));
+		}
+		if let Some(u) = &ulimits_json {
+			qs.push_str(&format!("&ulimits={}", urlencoded(u)));
 		}
 		if let Some(target) = build.target() {
 			qs.push_str(&format!("&target={}", urlencoded(target)));

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -12,7 +12,7 @@ use crate::error::ComposeError;
 use crate::libpod::types::container::{HealthConfig, LogConfig};
 use crate::size;
 
-mod resources;
+pub(crate) mod resources;
 pub(super) use resources::{build_resource_limits, build_ulimits, cdi_devices};
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -155,7 +155,7 @@ pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 /// The Linux rlimit resource names Podman accepts (without the `RLIMIT_`
 /// prefix). A name outside this set is a typo or an injection attempt and is
 /// rejected rather than forwarded verbatim to the API.
-fn is_known_ulimit(name: &str) -> bool {
+pub(crate) fn is_known_ulimit(name: &str) -> bool {
 	const KNOWN: [&str; 16] = [
 		"core",
 		"cpu",


### PR DESCRIPTION
podup listed `build.ulimits` among the BuildKit-only options with "no libpod build-API mapping", and dropped the field with a diagnostic saying so. The claim is wrong.

## Measured

podman 5.7.0, the same context posted to `/libpod/build` twice, with a `RUN` that prints `ulimit -n`:

| build | `ulimit -n` inside |
|---|---|
| without the parameter | 524288 |
| with `ulimits=["nofile=1234:1234"]` | **1234** |

The control is what makes this evidence rather than a coincidence: the number moves *because of* the parameter.

## What changed

`build.ulimits` renders into the `name=soft:hard` strings the endpoint takes:

* a single value fills both limits (`nproc: 64` → `nproc=64:64`)
* a soft limit above the hard one is clamped rather than failing the build, matching what the container path already does
* an unrecognised resource name is dropped with a warning instead of being forwarded — the value lands in a query string, so an unknown name is a typo or an injection attempt. `is_known_ulimit` already encoded that judgement for the container side, so it is reused rather than duplicated.

`ulimits` is removed from the unmapped-field diagnostic, since it is mapped now.

**Verified end to end**: a compose file declaring `build.ulimits.nofile` of 1234 produces a build whose `RUN` sees 1234.

## On `start_interval`

Looked at in the same pass and deliberately left alone. Quadlet does emit `HealthStartupInterval=` even without a `HealthStartupCmd=`, so that part of the comment is loose — but that key drives podman's separate *startup healthcheck*, and nothing I measured contradicts the substance of the claim. Changing it would need evidence I do not have.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>