### PR TITLE
release: 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "3.8.0"
+version = "4.0.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "3.8.0"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,58 @@
 podup (4.0.0) unstable; urgency=medium
 
+  Breaking
+
+  * Bridge networks are isolated from each other now. Docker does this and
+    podman does not, so a service could reach ports on a neighbouring network
+    that were never published. Measured with the same experiment on both
+    engines — a listener on an unpublished port in network B, a container in
+    network A dialling its address: docker 29.6.2 refused, podman 5.7.0
+    connected. Inside one network docker connects, which is what makes that a
+    measurement of isolation rather than of a broken dial.
+
+    podup passes netavark's `isolate` on every bridge network it creates.
+    Traffic within a network still flows and outbound internet still works,
+    both checked against a plain network. The option only bites when both
+    networks carry it, so this is a default rather than something to opt into:
+    one project opting in would protect nobody. Two podup projects no longer
+    reach each other's unpublished ports; a network created outside podup
+    without the option still can.
+
+    `driver_opts.isolate` wins if the compose file sets it, including to
+    `false`, for a project that deliberately spans networks.
+
+  Added
+
+  * Quadlet units carry `Notify=healthy` for a service with a healthcheck, so
+    `depends_on: condition: service_healthy` is honoured. Without it systemd
+    called a service started the moment its container was created, so
+    `After=`/`Requires=` ordered creation rather than readiness and a
+    dependant started against a service that was not serving yet. podup used
+    to warn that the condition "is not enforceable in Quadlet"; measured on
+    podman 5.7.0 with a probe that takes ten seconds to pass, a dependant now
+    starts ten seconds in rather than immediately. The warning is scoped to
+    what genuinely cannot work — a `service_healthy` naming a service with no
+    healthcheck, and `service_completed_successfully` — and names the service
+    at fault.
+
+  * `build.ulimits` reaches the build. It was reported as having no libpod
+    mapping; it has one. Measured on podman 5.7.0 by posting the same context
+    twice with a `RUN` that prints `ulimit -n`: 524288 without the parameter,
+    1234 with `ulimits=["nofile=1234:1234"]`. An unrecognised resource name is
+    dropped with a warning rather than forwarded into a query string.
+
+  Fixed
+
+  * Namespace validation is per-slot. One allow-list served `pid`, `ipc`,
+    `uts`, `cgroup` and `userns_mode`, which made it wrong for four of them.
+    It refused what podman accepts — `ipc: shareable`, and every
+    `userns_mode` value podman offers (`keep-id`, `auto`, `nomap`, and the
+    `keep-id:uid=…` and `auto:size=…` forms) — and accepted what podman
+    refuses, `none` on four slots, which then came back as a libpod error
+    naming no field. The error text now lists the modes the slot in hand
+    accepts. A short but legal `ns:/x` was also rejected for being shorter
+    than `"container:"`, which the check measured every prefix against.
+
   Breaking (library only; the CLI is unchanged)
 
   * Sixteen more public option structs are #[non_exhaustive] now:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+podup (4.0.0) unstable; urgency=medium
+
+  Breaking (library only; the CLI is unchanged)
+
+  * Sixteen more public option structs are #[non_exhaustive] now:
+    BuildOptions, CommitOptions, CpOptions, EventsOptions, ImagesOptions,
+    LogsDisplay, LogsOptions, LsOptions, PsFilterOptions, PsOptions,
+    PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions and
+    VolumesOptions. That brings every published options struct under the same
+    rule, joining ExecOptions, PsDisplayOptions and VolumesDisplayOptions,
+    which already carried it.
+
+    A struct literal no longer compiles outside the crate. Each one gains a
+    `new(...)` taking every field plus a `with_<field>` builder per field, so
+    the replacement is `PsOptions::new(..)` or
+    `PsOptions::default().with_all(true)`.
+
+    This is the same trade 3.0.0 made for the compose option blocks. Adding a
+    field to a struct an external caller can build with a literal is a
+    breaking change, so every one of these structs was frozen: the surface
+    could not grow without a major. It can grow in a minor now.
+
+    A compile-time test (tests/semver_constructible_structs.rs) walks every
+    constructor and builder through the public API, so a new options struct
+    that skips the convention stops the build.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Thu, 20 Aug 2026 08:20:00 -0500
+
 podup (3.8.0) unstable; urgency=medium
 
   Added

--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -107,7 +107,6 @@ pub(super) fn ignored_build_fields(file: &ComposeFile, out: &mut Vec<String>) {
 	for (service, def) in &file.services {
 		let Some(BuildConfig::Config {
 			privileged,
-			ulimits,
 			isolation,
 			entitlements,
 			provenance,
@@ -124,9 +123,6 @@ pub(super) fn ignored_build_fields(file: &ComposeFile, out: &mut Vec<String>) {
 		}
 		if !ssh.is_empty() {
 			unmapped.push("ssh");
-		}
-		if !ulimits.is_empty() {
-			unmapped.push("ulimits");
 		}
 		if isolation.is_some() {
 			unmapped.push("isolation");

--- a/internal/compose/diagnostics/tests.rs
+++ b/internal/compose/diagnostics/tests.rs
@@ -240,17 +240,21 @@ fn warns_on_remaining_unmapped_build_fields() {
 	let msgs = diagnostics_for(
 			"services:\n  web:\n    build:\n      context: .\n      ulimits:\n        nofile: 1024\n      entitlements: [\"security.insecure\"]\n      provenance: true\n      sbom: true\n",
 		);
-	for field in [
-		"build.ulimits",
-		"build.entitlements",
-		"build.provenance",
-		"build.sbom",
-	] {
+	for field in ["build.entitlements", "build.provenance", "build.sbom"] {
 		assert!(
 			msgs.iter().any(|m| m.contains(field)),
 			"missing {field}; got: {msgs:?}"
 		);
 	}
+	// `build.ulimits` was on this list, wrongly: the libpod build endpoint takes
+	// a `ulimits` parameter and applies it. Measured on podman 5.7.0 — the same
+	// build saw `ulimit -n` of 524288 without it and 1234 with it. Reporting it
+	// as unmapped now would send the reader looking for a workaround that is not
+	// needed.
+	assert!(
+		!msgs.iter().any(|m| m.contains("build.ulimits")),
+		"build.ulimits is mapped now and must not be reported as ignored; got: {msgs:?}"
+	);
 }
 
 #[test]

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -246,6 +246,16 @@ impl BuildConfig {
 		}
 	}
 
+	/// Returns the per-build ulimits.
+	pub fn ulimits(&self) -> &IndexMap<String, UlimitConfig> {
+		static EMPTY: std::sync::LazyLock<IndexMap<String, UlimitConfig>> =
+			std::sync::LazyLock::new(IndexMap::new);
+		match self {
+			BuildConfig::Context(_) => &EMPTY,
+			BuildConfig::Config { ulimits, .. } => ulimits,
+		}
+	}
+
 	/// Returns the inline Dockerfile contents, if set.
 	pub fn dockerfile_inline(&self) -> Option<&str> {
 		match self {

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -219,12 +219,7 @@ pub(crate) async fn dispatch(
 				.build_all_with_options(
 					file,
 					&services,
-					&podup::BuildOptions {
-						no_cache,
-						pull,
-						build_args: build_arg,
-						quiet,
-					},
+					&podup::BuildOptions::new(no_cache, pull, build_arg, quiet),
 				)
 				.await?;
 			// `--push` pushes each freshly built image to its registry.

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -61,16 +61,16 @@ pub(super) async fn dispatch_rest(
 				.run(
 					file,
 					&service,
-					podup::RunOptions {
+					podup::RunOptions::new(
 						cmd,
 						// Remove the one-off container after exit unless the user
 						// asked to keep it with `--no-rm`.
-						rm: !no_rm,
+						!no_rm,
 						detach,
 						env_overrides,
-						name_override: name,
+						name,
 						service_ports,
-					},
+					),
 				)
 				.await?
 		}
@@ -86,11 +86,7 @@ pub(super) async fn dispatch_rest(
 					file,
 					&src,
 					&dst,
-					podup::CpOptions {
-						index,
-						follow_link,
-						archive,
-					},
+					podup::CpOptions::new(index, follow_link, archive),
 				)
 				.await?
 		}
@@ -111,14 +107,7 @@ pub(super) async fn dispatch_rest(
 			// with an explicit `--format`); either selects JSON-line output.
 			let json = json || format == EventsFormat::Json;
 			engine
-				.stream_events_with_options(
-					json,
-					&podup::EventsOptions {
-						since,
-						until,
-						filters: filter,
-					},
-				)
+				.stream_events_with_options(json, &podup::EventsOptions::new(since, until, filter))
 				.await?
 		}
 		Commands::Attach {
@@ -149,12 +138,7 @@ pub(super) async fn dispatch_rest(
 					&service,
 					&image,
 					index,
-					podup::CommitOptions {
-						message,
-						author,
-						pause: Some(pause),
-						changes: change,
-					},
+					podup::CommitOptions::new(message, author, Some(pause), change),
 				)
 				.await?
 		}
@@ -184,10 +168,7 @@ pub(super) async fn dispatch_rest(
 				.push_with_quiet(
 					file,
 					&services,
-					podup::PushOptions {
-						ignore_failures: ignore_push_failures,
-						tls_verify,
-					},
+					podup::PushOptions::new(ignore_push_failures, tls_verify),
 					quiet,
 				)
 				.await?
@@ -212,10 +193,7 @@ pub(super) async fn dispatch_rest(
 				.list_volumes_with_display(
 					file,
 					&services,
-					podup::VolumesOptions {
-						quiet,
-						json: format == OutputFormat::Json,
-					},
+					podup::VolumesOptions::new(quiet, format == OutputFormat::Json),
 					podup::VolumesDisplayOptions::default().with_size(size),
 				)
 				.await?
@@ -230,10 +208,7 @@ pub(super) async fn dispatch_rest(
 				.images_with_services(
 					file,
 					&services,
-					podup::ImagesOptions {
-						quiet,
-						json: format == OutputFormat::Json,
-					},
+					podup::ImagesOptions::new(quiet, format == OutputFormat::Json),
 				)
 				.await?
 		}
@@ -251,17 +226,14 @@ pub(super) async fn dispatch_rest(
 				.logs_with_display(
 					file,
 					&services,
-					podup::LogsOptions {
+					podup::LogsOptions::new(
 						follow,
-						tail: cli_logs_tail_default(tail),
+						cli_logs_tail_default(tail),
 						since,
 						until,
 						timestamps,
-					},
-					podup::LogsDisplay {
-						no_color,
-						no_log_prefix,
-					},
+					),
+					podup::LogsDisplay::new(no_color, no_log_prefix),
 				)
 				.await?
 		}
@@ -297,10 +269,7 @@ pub(super) async fn dispatch_rest(
 				.pull_services_with_options(
 					file,
 					&services,
-					podup::PullOptions {
-						ignore_failures: ignore_pull_failures,
-						include_deps,
-					},
+					podup::PullOptions::new(ignore_pull_failures, include_deps),
 				)
 				.await?
 		}

--- a/internal/engine/build/build_tests.rs
+++ b/internal/engine/build/build_tests.rs
@@ -1,0 +1,108 @@
+//! Tests for the build path: secret resolution, build-arg and `shm_size`
+//! validation, and the tar payload a file-backed secret ships.
+//!
+//! Split out of `build/mod.rs` so the production code stays under the
+//! source-line limit.
+
+use super::Engine;
+use crate::libpod::Client;
+
+fn engine(base: std::path::PathBuf) -> Engine {
+	Engine::with_base_dir(Client::new("/nonexistent.sock"), "p".into(), base)
+}
+
+fn build_of(file: &crate::compose::types::ComposeFile) -> &crate::compose::types::BuildConfig {
+	file.services["app"].build.as_ref().unwrap()
+}
+
+#[test]
+fn build_secret_from_file_shipped_in_tar() {
+	let dir = tempfile::tempdir().unwrap();
+	std::fs::write(dir.path().join("token.txt"), b"s3cr3t").unwrap();
+	let yaml = "services:\n  app:\n    build:\n      context: .\n      secrets:\n        - tok\nsecrets:\n  tok:\n    file: token.txt\n";
+	let file = crate::compose::parse_str(yaml).unwrap();
+	let e = engine(dir.path().to_path_buf());
+	let (files, specs) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
+	assert_eq!(
+		specs,
+		vec!["id=tok,src=.podup-build-secret-tok".to_string()]
+	);
+	assert_eq!(files.len(), 1);
+	assert_eq!(files[0].0, ".podup-build-secret-tok");
+	assert_eq!(files[0].1, b"s3cr3t");
+}
+
+#[test]
+fn build_secret_content_inlined() {
+	let yaml = "services:\n  app:\n    build:\n      context: .\n      secrets:\n        - c\nsecrets:\n  c:\n    content: inline-value\n";
+	let file = crate::compose::parse_str(yaml).unwrap();
+	let e = engine(std::env::temp_dir());
+	let (files, _) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
+	assert_eq!(files[0].1, b"inline-value");
+}
+
+#[test]
+fn build_secret_external_is_skipped() {
+	let yaml = "services:\n  app:\n    build:\n      context: .\n      secrets:\n        - ext\nsecrets:\n  ext:\n    external: true\n";
+	let file = crate::compose::parse_str(yaml).unwrap();
+	let e = engine(std::env::temp_dir());
+	let (files, specs) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
+	assert!(files.is_empty());
+	assert!(specs.is_empty());
+}
+
+#[tokio::test]
+async fn empty_build_arg_key_is_rejected() {
+	// `--build-arg =value` is a user typo Podman would silently ignore; we
+	// reject it before contacting the daemon.
+	let dir = tempfile::tempdir().unwrap();
+	std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	let yaml = "services:\n  app:\n    build:\n      context: .\n";
+	let file = crate::compose::parse_str(yaml).unwrap();
+	let e = engine(dir.path().to_path_buf());
+	let opts = super::BuildOptions {
+		build_args: vec!["=orphan".to_string()],
+		..Default::default()
+	};
+	let err = e
+		.build_service("app", &file.services["app"], &file, &opts)
+		.await
+		.expect_err("empty build-arg key must be rejected");
+	assert!(
+		err.to_string().contains("build-arg"),
+		"unexpected error: {err}"
+	);
+}
+
+#[tokio::test]
+async fn invalid_shm_size_is_rejected() {
+	// A malformed `build.shm_size` must error rather than silently fall back to
+	// the default shm size.
+	let dir = tempfile::tempdir().unwrap();
+	std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	let yaml = "services:\n  app:\n    build:\n      context: .\n      shm_size: \"64mb!\"\n";
+	let file = crate::compose::parse_str(yaml).unwrap();
+	let e = engine(dir.path().to_path_buf());
+	let err = e
+		.build_service(
+			"app",
+			&file.services["app"],
+			&file,
+			&super::BuildOptions::default(),
+		)
+		.await
+		.expect_err("malformed shm_size must be rejected");
+	assert!(
+		err.to_string().contains("shm_size"),
+		"unexpected error: {err}"
+	);
+}
+
+#[test]
+fn build_secret_undefined_errors() {
+	let yaml =
+		"services:\n  app:\n    build:\n      context: .\n      secrets:\n        - missing\n";
+	let file = crate::compose::parse_str(yaml).unwrap();
+	let e = engine(std::env::temp_dir());
+	assert!(e.resolve_build_secrets(build_of(&file), &file).is_err());
+}

--- a/internal/engine/build/build_tests.rs
+++ b/internal/engine/build/build_tests.rs
@@ -4,7 +4,9 @@
 //! Split out of `build/mod.rs` so the production code stays under the
 //! source-line limit.
 
-use super::Engine;
+use crate::compose::types::{BuildConfig, UlimitConfig};
+
+use super::{render_build_ulimits, Engine};
 use crate::libpod::Client;
 
 fn engine(base: std::path::PathBuf) -> Engine {
@@ -105,4 +107,59 @@ fn build_secret_undefined_errors() {
 	let file = crate::compose::parse_str(yaml).unwrap();
 	let e = engine(std::env::temp_dir());
 	assert!(e.resolve_build_secrets(build_of(&file), &file).is_err());
+}
+
+/// `build.ulimits` was reported as having no libpod mapping. It has one:
+/// measured on podman 5.7.0, a build with `ulimits=["nofile=1234:1234"]` saw
+/// 1234 where the same build without it saw 524288.
+#[test]
+fn a_pair_renders_as_soft_colon_hard() {
+	let build = build_with_ulimits(&[("nofile", UlimitConfig::Pair { soft: 1, hard: 2 })]);
+	assert_eq!(render_build_ulimits(&build), vec!["nofile=1:2"]);
+}
+
+/// A single value is both limits.
+#[test]
+fn a_single_value_fills_both_limits() {
+	let build = build_with_ulimits(&[("nproc", UlimitConfig::Single(64))]);
+	assert_eq!(render_build_ulimits(&build), vec!["nproc=64:64"]);
+}
+
+/// The value reaches a query string, so an unrecognised name is a typo or an
+/// injection attempt and is dropped rather than forwarded.
+#[test]
+fn an_unknown_resource_name_is_dropped() {
+	let build = build_with_ulimits(&[
+		("bogus,inject=1", UlimitConfig::Single(1)),
+		("nofile", UlimitConfig::Single(2)),
+	]);
+	assert_eq!(render_build_ulimits(&build), vec!["nofile=2:2"]);
+}
+
+/// Podman rejects a soft limit above the hard one. The container path clamps
+/// instead of failing, so the build path matches it.
+#[test]
+fn a_soft_limit_above_the_hard_one_is_clamped() {
+	let build = build_with_ulimits(&[("nofile", UlimitConfig::Pair { soft: 99, hard: 5 })]);
+	assert_eq!(render_build_ulimits(&build), vec!["nofile=5:5"]);
+}
+
+/// A short-form `build: .` has no options block at all.
+#[test]
+fn a_context_only_build_renders_nothing() {
+	let build = BuildConfig::Context(".".into());
+	assert!(render_build_ulimits(&build).is_empty());
+}
+
+fn build_with_ulimits(entries: &[(&str, UlimitConfig)]) -> BuildConfig {
+	let yaml = entries
+		.iter()
+		.map(|(name, cfg)| match cfg {
+			UlimitConfig::Single(v) => format!("  {name}: {v}\n"),
+			UlimitConfig::Pair { soft, hard } => {
+				format!("  {name}:\n    soft: {soft}\n    hard: {hard}\n")
+			}
+		})
+		.collect::<String>();
+	serde_yaml::from_str(&format!("context: .\nulimits:\n{yaml}")).expect("build config parses")
 }

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -25,6 +25,7 @@ use futures_util::StreamExt;
 use tracing::{info, warn};
 
 use crate::compose::types::{BuildConfig, Service};
+use crate::engine::container_config::resources::is_known_ulimit;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::BuildOutput;
 use crate::libpod::urlencoded;
@@ -118,6 +119,37 @@ impl BuildOptions {
 		self.quiet = quiet;
 		self
 	}
+}
+
+/// Render `build.ulimits` into the `name=soft:hard` strings the libpod build
+/// endpoint takes.
+///
+/// podup used to report this field as having no libpod mapping. It does.
+/// Measured on podman 5.7.0 by building the same Containerfile twice through
+/// the API, with a `RUN` that prints `ulimit -n`: without the parameter the
+/// build saw 524288, with `ulimits=["nofile=1234:1234"]` it saw 1234.
+///
+/// An unrecognised name is dropped rather than forwarded. The value reaches a
+/// query string, so an unknown name is either a typo or an injection attempt —
+/// the same reasoning the container-side `build_ulimits` applies.
+fn render_build_ulimits(build: &BuildConfig) -> Vec<String> {
+	build
+		.ulimits()
+		.iter()
+		.filter_map(|(name, cfg)| {
+			if !is_known_ulimit(name) {
+				tracing::warn!(
+					"build.ulimits '{name}' is not a recognized resource name and is ignored"
+				);
+				return None;
+			}
+			let (soft, hard) = (cfg.soft(), cfg.hard());
+			// Podman rejects a soft limit above the hard one; the container
+			// path clamps rather than failing the build, so match it.
+			let soft = soft.min(hard);
+			Some(format!("{name}={soft}:{hard}"))
+		})
+		.collect()
 }
 
 impl Engine {
@@ -358,6 +390,12 @@ impl Engine {
 		} else {
 			Some(super::to_query_json("build.labels", &labels)?)
 		};
+		let build_ulimits = render_build_ulimits(build);
+		let ulimits_json = if build_ulimits.is_empty() {
+			None
+		} else {
+			Some(super::to_query_json("build.ulimits", &build_ulimits)?)
+		};
 
 		let mut qs = format!(
 			"t={}&rm=true&nocache={}",
@@ -388,6 +426,9 @@ impl Engine {
 		}
 		if let Some(l) = &labels_json {
 			qs.push_str(&format!("&labels={}", urlencoded(l)));
+		}
+		if let Some(u) = &ulimits_json {
+			qs.push_str(&format!("&ulimits={}", urlencoded(u)));
 		}
 		if let Some(target) = build.target() {
 			qs.push_str(&format!("&target={}", urlencoded(target)));

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -58,7 +58,14 @@ enum BodyPlan {
 /// `docker compose build`-style CLI overrides. Each augments (never weakens)
 /// the per-service `build:` config: a flag forces the behaviour on even when
 /// the compose file leaves it off.
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`BuildOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Default, Clone)]
+#[non_exhaustive]
 pub struct BuildOptions {
 	/// Force a cache-less build (`--no-cache`).
 	pub no_cache: bool,
@@ -68,6 +75,49 @@ pub struct BuildOptions {
 	pub build_args: Vec<String>,
 	/// Suppress build output (`-q/--quiet`).
 	pub quiet: bool,
+}
+
+impl BuildOptions {
+	/// Every `docker compose build` flag, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	pub fn new(no_cache: bool, pull: bool, build_args: Vec<String>, quiet: bool) -> Self {
+		Self {
+			no_cache,
+			pull,
+			build_args,
+			quiet,
+		}
+	}
+
+	/// Force a cache-less build (`--no-cache`). Builder-style.
+	#[must_use]
+	pub fn with_no_cache(mut self, no_cache: bool) -> Self {
+		self.no_cache = no_cache;
+		self
+	}
+
+	/// Always attempt to pull a newer base image (`--pull`). Builder-style.
+	#[must_use]
+	pub fn with_pull(mut self, pull: bool) -> Self {
+		self.pull = pull;
+		self
+	}
+
+	/// Extra build args (`KEY=VAL`); override the compose `build.args` on
+	/// conflict. Builder-style.
+	#[must_use]
+	pub fn with_build_args(mut self, build_args: Vec<String>) -> Self {
+		self.build_args = build_args;
+		self
+	}
+
+	/// Suppress build output (`-q/--quiet`). Builder-style.
+	#[must_use]
+	pub fn with_quiet(mut self, quiet: bool) -> Self {
+		self.quiet = quiet;
+		self
+	}
 }
 
 impl Engine {
@@ -512,107 +562,5 @@ impl Engine {
 }
 
 #[cfg(test)]
-mod tests {
-	use super::Engine;
-	use crate::libpod::Client;
-
-	fn engine(base: std::path::PathBuf) -> Engine {
-		Engine::with_base_dir(Client::new("/nonexistent.sock"), "p".into(), base)
-	}
-
-	fn build_of(file: &crate::compose::types::ComposeFile) -> &crate::compose::types::BuildConfig {
-		file.services["app"].build.as_ref().unwrap()
-	}
-
-	#[test]
-	fn build_secret_from_file_shipped_in_tar() {
-		let dir = tempfile::tempdir().unwrap();
-		std::fs::write(dir.path().join("token.txt"), b"s3cr3t").unwrap();
-		let yaml = "services:\n  app:\n    build:\n      context: .\n      secrets:\n        - tok\nsecrets:\n  tok:\n    file: token.txt\n";
-		let file = crate::compose::parse_str(yaml).unwrap();
-		let e = engine(dir.path().to_path_buf());
-		let (files, specs) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
-		assert_eq!(
-			specs,
-			vec!["id=tok,src=.podup-build-secret-tok".to_string()]
-		);
-		assert_eq!(files.len(), 1);
-		assert_eq!(files[0].0, ".podup-build-secret-tok");
-		assert_eq!(files[0].1, b"s3cr3t");
-	}
-
-	#[test]
-	fn build_secret_content_inlined() {
-		let yaml = "services:\n  app:\n    build:\n      context: .\n      secrets:\n        - c\nsecrets:\n  c:\n    content: inline-value\n";
-		let file = crate::compose::parse_str(yaml).unwrap();
-		let e = engine(std::env::temp_dir());
-		let (files, _) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
-		assert_eq!(files[0].1, b"inline-value");
-	}
-
-	#[test]
-	fn build_secret_external_is_skipped() {
-		let yaml = "services:\n  app:\n    build:\n      context: .\n      secrets:\n        - ext\nsecrets:\n  ext:\n    external: true\n";
-		let file = crate::compose::parse_str(yaml).unwrap();
-		let e = engine(std::env::temp_dir());
-		let (files, specs) = e.resolve_build_secrets(build_of(&file), &file).unwrap();
-		assert!(files.is_empty());
-		assert!(specs.is_empty());
-	}
-
-	#[tokio::test]
-	async fn empty_build_arg_key_is_rejected() {
-		// `--build-arg =value` is a user typo Podman would silently ignore; we
-		// reject it before contacting the daemon.
-		let dir = tempfile::tempdir().unwrap();
-		std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
-		let yaml = "services:\n  app:\n    build:\n      context: .\n";
-		let file = crate::compose::parse_str(yaml).unwrap();
-		let e = engine(dir.path().to_path_buf());
-		let opts = super::BuildOptions {
-			build_args: vec!["=orphan".to_string()],
-			..Default::default()
-		};
-		let err = e
-			.build_service("app", &file.services["app"], &file, &opts)
-			.await
-			.expect_err("empty build-arg key must be rejected");
-		assert!(
-			err.to_string().contains("build-arg"),
-			"unexpected error: {err}"
-		);
-	}
-
-	#[tokio::test]
-	async fn invalid_shm_size_is_rejected() {
-		// A malformed `build.shm_size` must error rather than silently fall back to
-		// the default shm size.
-		let dir = tempfile::tempdir().unwrap();
-		std::fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
-		let yaml = "services:\n  app:\n    build:\n      context: .\n      shm_size: \"64mb!\"\n";
-		let file = crate::compose::parse_str(yaml).unwrap();
-		let e = engine(dir.path().to_path_buf());
-		let err = e
-			.build_service(
-				"app",
-				&file.services["app"],
-				&file,
-				&super::BuildOptions::default(),
-			)
-			.await
-			.expect_err("malformed shm_size must be rejected");
-		assert!(
-			err.to_string().contains("shm_size"),
-			"unexpected error: {err}"
-		);
-	}
-
-	#[test]
-	fn build_secret_undefined_errors() {
-		let yaml =
-			"services:\n  app:\n    build:\n      context: .\n      secrets:\n        - missing\n";
-		let file = crate::compose::parse_str(yaml).unwrap();
-		let e = engine(std::env::temp_dir());
-		assert!(e.resolve_build_secrets(build_of(&file), &file).is_err());
-	}
-}
+#[path = "build_tests.rs"]
+mod tests;

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -15,13 +15,48 @@ use super::super::Engine;
 /// Options for [`Engine::pull_services_with_options`], mirroring `docker
 /// compose pull` flags. The `--policy` override is carried on the engine (see
 /// [`Engine::with_up_overrides`]), not here.
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`PullOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct PullOptions {
 	/// Warn and continue instead of aborting on the first failure,
 	/// `--ignore-pull-failures`.
 	pub ignore_failures: bool,
 	/// Also pull each named service's transitive `depends_on`, `--include-deps`.
 	pub include_deps: bool,
+}
+
+impl PullOptions {
+	/// Every `docker compose pull` flag, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	pub fn new(ignore_failures: bool, include_deps: bool) -> Self {
+		Self {
+			ignore_failures,
+			include_deps,
+		}
+	}
+
+	/// Warn and continue instead of aborting on the first failure,
+	/// `--ignore-pull-failures`. Builder-style.
+	#[must_use]
+	pub fn with_ignore_failures(mut self, ignore_failures: bool) -> Self {
+		self.ignore_failures = ignore_failures;
+		self
+	}
+
+	/// Also pull each named service's transitive `depends_on`, `--include-deps`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_include_deps(mut self, include_deps: bool) -> Self {
+		self.include_deps = include_deps;
+		self
+	}
 }
 
 /// Upper bound on how many distinct images a standalone `pull` fetches
@@ -403,330 +438,8 @@ pub(in crate::engine) fn pull_policy_checked(
 }
 
 #[cfg(test)]
-mod tests {
-	use super::{libpod_pull_policy, pull_dep_closure};
-
-	#[test]
-	fn dep_closure_includes_transitive_dependencies() {
-		let file = crate::parse_str(
-			"services:\n  web:\n    image: a\n    depends_on:\n      - api\n  api:\n    image: b\n    depends_on:\n      - db\n  db:\n    image: c\n  lone:\n    image: d\n",
-		)
-		.unwrap();
-		let mut got: Vec<String> = pull_dep_closure(&file, &["web".to_string()])
-			.into_iter()
-			.collect();
-		got.sort();
-		assert_eq!(got, vec!["api", "db", "web"]);
-	}
-
-	#[test]
-	fn dep_closure_of_leaf_is_just_itself() {
-		let file = crate::parse_str("services:\n  db:\n    image: c\n").unwrap();
-		let got: Vec<String> = pull_dep_closure(&file, &["db".to_string()])
-			.into_iter()
-			.collect();
-		assert_eq!(got, vec!["db"]);
-	}
-
-	#[tokio::test]
-	async fn pull_unknown_service_is_rejected() {
-		// `pull bogus` must error on the unknown name instead of silently exiting 0.
-		let file = crate::parse_str("services:\n  web:\n    image: a\n").unwrap();
-		let e = crate::engine::Engine::new(
-			crate::libpod::Client::new("/nonexistent.sock"),
-			"proj".into(),
-		);
-		let err = e
-			.pull_services(&file, &["nope".to_string()])
-			.await
-			.expect_err("unknown service must be rejected");
-		assert!(
-			matches!(err, crate::error::ComposeError::ServiceNotFound(_)),
-			"unexpected error: {err:?}"
-		);
-	}
-
-	// `pull_rejects_an_unknown_pull_policy_without_panicking` lives in the
-	// sibling `pull_typo_tests.rs` to keep this file below the source-line
-	// limit (#1450).
-
-	#[test]
-	fn pull_policy_maps_every_spec_value() {
-		assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
-		assert_eq!(libpod_pull_policy(Some("newer")), Some("newer"));
-		assert_eq!(libpod_pull_policy(Some("never")), Some("never"));
-		assert_eq!(libpod_pull_policy(Some("missing")), Some("missing"));
-		// `if_not_present` is the spec alias for `missing`.
-		assert_eq!(libpod_pull_policy(Some("if_not_present")), Some("missing"));
-		assert_eq!(libpod_pull_policy(Some("build")), Some("missing"));
-		assert_eq!(libpod_pull_policy(None), Some("missing"));
-		// Unknown values are reported (None) so the caller fails loud (#1369).
-		assert_eq!(libpod_pull_policy(Some("bogus")), None);
-	}
-
-	/// A typo'd `pull_policy:` must surface as a hard error (#1369): the
-	/// previous warn-and-default-to-missing path silently turned `alaways`
-	/// into the opposite of what the user wrote, and a `never` typo pulled
-	/// fresh images on every `up` without telling the operator.
-	#[test]
-	fn resolved_pull_policy_rejects_an_unknown_value() {
-		let e = crate::engine::Engine::new(
-			crate::libpod::Client::new("/nonexistent.sock"),
-			"proj".into(),
-		);
-		let svc = crate::compose::types::Service {
-			image: Some("nginx:1.27".to_string()),
-			pull_policy: Some("alaways".to_string()),
-			..crate::compose::types::Service::default()
-		};
-		let err = e.resolved_pull_policy("web", &svc).unwrap_err();
-		let msg = err.to_string();
-		assert!(msg.contains("alaways"), "got {msg}");
-		assert!(msg.contains("always"), "got {msg}");
-		assert!(
-			matches!(
-				err,
-				crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
-					ref service,
-					ref field,
-					..
-				}) if service == "web" && field == "pull_policy"
-			),
-			"unknown pull policy must surface as a Field error carrying the service and field name, got {err:?}"
-		);
-	}
-
-	#[cfg(unix)]
-	use crate::engine::fake_podman;
-
-	/// #8: `pull_services_with_options` used to build one future per service,
-	/// so two services sharing an image pulled it twice. They must now
-	/// dedupe down to a single pull request, with both services still
-	/// reported as successful.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn pull_dedupes_a_shared_image_into_a_single_pull() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "POST" && target.contains("/images/pull") {
-				(200, String::new())
-			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
-				(200, "{}".to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = crate::engine::Engine::new(fake.client(), "proj".into());
-		let file =
-			crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n")
-				.unwrap();
-
-		e.pull_services(&file, &[])
-			.await
-			.expect("pulling two services that share an image must succeed");
-
-		let seen = fake.requests.lock().unwrap();
-		let pulls = seen
-			.iter()
-			.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
-			.count();
-		assert_eq!(
-			pulls, 1,
-			"two services sharing one image must issue a single pull: {seen:?}"
-		);
-	}
-
-	/// Two services sharing an image but with *different* resolved pull
-	/// policies (no `--pull` override) must each get their own pull request,
-	/// not collapse into one — the dedup key must include the resolved
-	/// policy, not just the image reference.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn pull_issues_separate_requests_for_same_image_different_policy() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "POST" && target.contains("/images/pull") {
-				(200, String::new())
-			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
-				(200, "{}".to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = crate::engine::Engine::new(fake.client(), "proj".into());
-		let file = crate::parse_str(
-			"services:\n  a:\n    image: shared\n    pull_policy: never\n  b:\n    image: shared\n    pull_policy: always\n",
-		)
-		.unwrap();
-
-		e.pull_services(&file, &[])
-			.await
-			.expect("differing per-service pull_policy must not fail the pull");
-
-		let seen = fake.requests.lock().unwrap();
-		let pulls: Vec<&String> = seen
-			.iter()
-			.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
-			.collect();
-		assert_eq!(
-			pulls.len(),
-			2,
-			"same image with different resolved policies must issue two pulls, not one: {seen:?}"
-		);
-		assert!(
-			pulls.iter().any(|r| r.contains("policy=never")),
-			"missing the never-policy pull: {seen:?}"
-		);
-		assert!(
-			pulls.iter().any(|r| r.contains("policy=always")),
-			"missing the always-policy pull: {seen:?}"
-		);
-	}
-
-	/// A shared image that fails to pull must still be reported for *every*
-	/// service that names it — derived from the one shared outcome, not from
-	/// a redundant pull per service. `ignore_failures` lets both warnings
-	/// through instead of aborting on the first.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn pull_failure_on_a_shared_image_is_still_only_pulled_once() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "POST" && target.contains("/images/pull") {
-				(500, r#"{"message":"registry unreachable"}"#.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = crate::engine::Engine::new(fake.client(), "proj".into());
-		let file =
-			crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n")
-				.unwrap();
-
-		let opts = super::PullOptions {
-			ignore_failures: true,
-			include_deps: false,
-		};
-		e.pull_services_with_options(&file, &[], opts)
-			.await
-			.expect("ignore_failures must not error even though the shared pull failed");
-
-		let seen = fake.requests.lock().unwrap();
-		let pulls = seen
-			.iter()
-			.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
-			.count();
-		assert_eq!(
-			pulls, 1,
-			"a failing shared image must still be pulled once, not once per service: {seen:?}"
-		);
-	}
-
-	/// Without `ignore_failures`, a shared image that never lands must still
-	/// abort the whole pull — the per-service error report is derived from
-	/// the image's single shared outcome, so the failure is not silently
-	/// dropped for services 2..N once service 1 already reported it.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn pull_failure_on_a_shared_image_aborts_without_ignore_failures() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "POST" && target.contains("/images/pull") {
-				(500, r#"{"message":"registry unreachable"}"#.to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = crate::engine::Engine::new(fake.client(), "proj".into());
-		let file =
-			crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n")
-				.unwrap();
-
-		let err = e
-			.pull_services(&file, &[])
-			.await
-			.expect_err("a shared image that fails to pull must abort the pull");
-		assert!(
-			matches!(err, crate::error::ComposeError::Build(ref msg) if msg.contains("shared")),
-			"unexpected error: {err:?}"
-		);
-	}
-
-	// Bounding the standalone pull's concurrency (`MAX_PULL_CONCURRENCY`) is
-	// exercised structurally rather than by asserting a live in-flight count:
-	// `bounded_join_all` runs every future through the same
-	// `buffer_unordered(MAX_PULL_CONCURRENCY)` dispatcher the lifecycle
-	// fan-out's `join_bounded` uses (see `parallel::tests::
-	// join_bounded_preserves_input_order`), and a synchronous fake responder
-	// cannot observe real concurrency without a multi-thread runtime and a
-	// blocking rendezvous — exactly the flakiness the testing standard rules
-	// out. The dedup tests above already pin the dispatch contract (every
-	// unique image is attempted, exactly once).
-
-	/// #1076: libpod reports a failed pull as an in-band `error` line on a 200
-	/// response. That line used to be warned about and dropped, so every caller
-	/// believed the pull had succeeded.
-	///
-	/// The image is present here — a stale copy from an earlier pull — which is
-	/// exactly the case a presence probe cannot catch: it passes while the pull
-	/// failed. `up --pull always` against an unreachable registry therefore
-	/// started yesterday's image and exited 0.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn a_failed_pull_is_reported_even_when_a_stale_image_is_present() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "POST" && target.contains("/images/pull") {
-				// 200 with an in-band error, the way libpod reports it.
-				(
-					200,
-					r#"{"error":"initializing source: pinging container registry: connection refused"}"#
-						.to_string(),
-				)
-			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
-				// The stale image is in local storage.
-				(200, "{}".to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = crate::engine::Engine::new(fake.client(), "proj".into());
-		let file = crate::parse_str("services:\n  a:\n    image: stale:v1\n").unwrap();
-
-		let err = e
-			.pull_services(&file, &[])
-			.await
-			.expect_err("a pull that libpod reported as failed must not be reported as success");
-		assert!(
-			format!("{err}").contains("connection refused"),
-			"the underlying cause must survive: {err}"
-		);
-	}
-
-	/// The escape hatch still works: `--ignore-pull-failures` is deliberately
-	/// exit-0, and that must not change just because the failure is now visible.
-	#[tokio::test]
-	#[cfg(unix)]
-	async fn ignore_pull_failures_still_exits_zero_on_an_in_band_error() {
-		let fake = fake_podman::start(|method, target| {
-			if method == "POST" && target.contains("/images/pull") {
-				(200, r#"{"error":"connection refused"}"#.to_string())
-			} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
-				(200, "{}".to_string())
-			} else {
-				(404, r#"{"message":"not found"}"#.to_string())
-			}
-		});
-		let e = crate::engine::Engine::new(fake.client(), "proj".into());
-		let file = crate::parse_str("services:\n  a:\n    image: stale:v1\n").unwrap();
-
-		e.pull_services_with_options(
-			&file,
-			&[],
-			crate::engine::PullOptions {
-				ignore_failures: true,
-				..Default::default()
-			},
-		)
-		.await
-		.expect("--ignore-pull-failures must stay exit 0");
-	}
-}
+#[path = "pull_tests.rs"]
+mod tests;
 
 #[cfg(test)]
 #[path = "pull_typo_tests.rs"]

--- a/internal/engine/build/pull_tests.rs
+++ b/internal/engine/build/pull_tests.rs
@@ -1,0 +1,326 @@
+//! Unit and engine-level tests for the `pull` path: dependency-closure
+//! expansion, `pull_policy` resolution, and the de-duplication that collapses
+//! a shared image into a single request.
+//!
+//! Split out of `build/pull.rs` so the production code stays under the
+//! source-line limit, the same way `pull_typo_tests.rs` already is.
+
+use super::{libpod_pull_policy, pull_dep_closure};
+
+#[test]
+fn dep_closure_includes_transitive_dependencies() {
+	let file = crate::parse_str(
+		"services:\n  web:\n    image: a\n    depends_on:\n      - api\n  api:\n    image: b\n    depends_on:\n      - db\n  db:\n    image: c\n  lone:\n    image: d\n",
+	)
+	.unwrap();
+	let mut got: Vec<String> = pull_dep_closure(&file, &["web".to_string()])
+		.into_iter()
+		.collect();
+	got.sort();
+	assert_eq!(got, vec!["api", "db", "web"]);
+}
+
+#[test]
+fn dep_closure_of_leaf_is_just_itself() {
+	let file = crate::parse_str("services:\n  db:\n    image: c\n").unwrap();
+	let got: Vec<String> = pull_dep_closure(&file, &["db".to_string()])
+		.into_iter()
+		.collect();
+	assert_eq!(got, vec!["db"]);
+}
+
+#[tokio::test]
+async fn pull_unknown_service_is_rejected() {
+	// `pull bogus` must error on the unknown name instead of silently exiting 0.
+	let file = crate::parse_str("services:\n  web:\n    image: a\n").unwrap();
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	);
+	let err = e
+		.pull_services(&file, &["nope".to_string()])
+		.await
+		.expect_err("unknown service must be rejected");
+	assert!(
+		matches!(err, crate::error::ComposeError::ServiceNotFound(_)),
+		"unexpected error: {err:?}"
+	);
+}
+
+// `pull_rejects_an_unknown_pull_policy_without_panicking` lives in the
+// sibling `pull_typo_tests.rs` to keep this file below the source-line
+// limit (#1450).
+
+#[test]
+fn pull_policy_maps_every_spec_value() {
+	assert_eq!(libpod_pull_policy(Some("always")), Some("always"));
+	assert_eq!(libpod_pull_policy(Some("newer")), Some("newer"));
+	assert_eq!(libpod_pull_policy(Some("never")), Some("never"));
+	assert_eq!(libpod_pull_policy(Some("missing")), Some("missing"));
+	// `if_not_present` is the spec alias for `missing`.
+	assert_eq!(libpod_pull_policy(Some("if_not_present")), Some("missing"));
+	assert_eq!(libpod_pull_policy(Some("build")), Some("missing"));
+	assert_eq!(libpod_pull_policy(None), Some("missing"));
+	// Unknown values are reported (None) so the caller fails loud (#1369).
+	assert_eq!(libpod_pull_policy(Some("bogus")), None);
+}
+
+/// A typo'd `pull_policy:` must surface as a hard error (#1369): the
+/// previous warn-and-default-to-missing path silently turned `alaways`
+/// into the opposite of what the user wrote, and a `never` typo pulled
+/// fresh images on every `up` without telling the operator.
+#[test]
+fn resolved_pull_policy_rejects_an_unknown_value() {
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	);
+	let svc = crate::compose::types::Service {
+		image: Some("nginx:1.27".to_string()),
+		pull_policy: Some("alaways".to_string()),
+		..crate::compose::types::Service::default()
+	};
+	let err = e.resolved_pull_policy("web", &svc).unwrap_err();
+	let msg = err.to_string();
+	assert!(msg.contains("alaways"), "got {msg}");
+	assert!(msg.contains("always"), "got {msg}");
+	assert!(
+		matches!(
+			err,
+			crate::error::ComposeError::Podman(crate::libpod::PodmanError::Field {
+				ref service,
+				ref field,
+				..
+			}) if service == "web" && field == "pull_policy"
+		),
+		"unknown pull policy must surface as a Field error carrying the service and field name, got {err:?}"
+	);
+}
+
+#[cfg(unix)]
+use crate::engine::fake_podman;
+
+/// #8: `pull_services_with_options` used to build one future per service,
+/// so two services sharing an image pulled it twice. They must now
+/// dedupe down to a single pull request, with both services still
+/// reported as successful.
+#[tokio::test]
+#[cfg(unix)]
+async fn pull_dedupes_a_shared_image_into_a_single_pull() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+			(200, "{}".to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file =
+		crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n").unwrap();
+
+	e.pull_services(&file, &[])
+		.await
+		.expect("pulling two services that share an image must succeed");
+
+	let seen = fake.requests.lock().unwrap();
+	let pulls = seen
+		.iter()
+		.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
+		.count();
+	assert_eq!(
+		pulls, 1,
+		"two services sharing one image must issue a single pull: {seen:?}"
+	);
+}
+
+/// Two services sharing an image but with *different* resolved pull
+/// policies (no `--pull` override) must each get their own pull request,
+/// not collapse into one — the dedup key must include the resolved
+/// policy, not just the image reference.
+#[tokio::test]
+#[cfg(unix)]
+async fn pull_issues_separate_requests_for_same_image_different_policy() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+			(200, "{}".to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file = crate::parse_str(
+		"services:\n  a:\n    image: shared\n    pull_policy: never\n  b:\n    image: shared\n    pull_policy: always\n",
+	)
+	.unwrap();
+
+	e.pull_services(&file, &[])
+		.await
+		.expect("differing per-service pull_policy must not fail the pull");
+
+	let seen = fake.requests.lock().unwrap();
+	let pulls: Vec<&String> = seen
+		.iter()
+		.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
+		.collect();
+	assert_eq!(
+		pulls.len(),
+		2,
+		"same image with different resolved policies must issue two pulls, not one: {seen:?}"
+	);
+	assert!(
+		pulls.iter().any(|r| r.contains("policy=never")),
+		"missing the never-policy pull: {seen:?}"
+	);
+	assert!(
+		pulls.iter().any(|r| r.contains("policy=always")),
+		"missing the always-policy pull: {seen:?}"
+	);
+}
+
+/// A shared image that fails to pull must still be reported for *every*
+/// service that names it — derived from the one shared outcome, not from
+/// a redundant pull per service. `ignore_failures` lets both warnings
+/// through instead of aborting on the first.
+#[tokio::test]
+#[cfg(unix)]
+async fn pull_failure_on_a_shared_image_is_still_only_pulled_once() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			(500, r#"{"message":"registry unreachable"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file =
+		crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n").unwrap();
+
+	let opts = super::PullOptions {
+		ignore_failures: true,
+		include_deps: false,
+	};
+	e.pull_services_with_options(&file, &[], opts)
+		.await
+		.expect("ignore_failures must not error even though the shared pull failed");
+
+	let seen = fake.requests.lock().unwrap();
+	let pulls = seen
+		.iter()
+		.filter(|r| r.contains("/images/pull") && r.contains("reference=shared"))
+		.count();
+	assert_eq!(
+		pulls, 1,
+		"a failing shared image must still be pulled once, not once per service: {seen:?}"
+	);
+}
+
+/// Without `ignore_failures`, a shared image that never lands must still
+/// abort the whole pull — the per-service error report is derived from
+/// the image's single shared outcome, so the failure is not silently
+/// dropped for services 2..N once service 1 already reported it.
+#[tokio::test]
+#[cfg(unix)]
+async fn pull_failure_on_a_shared_image_aborts_without_ignore_failures() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			(500, r#"{"message":"registry unreachable"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file =
+		crate::parse_str("services:\n  a:\n    image: shared\n  b:\n    image: shared\n").unwrap();
+
+	let err = e
+		.pull_services(&file, &[])
+		.await
+		.expect_err("a shared image that fails to pull must abort the pull");
+	assert!(
+		matches!(err, crate::error::ComposeError::Build(ref msg) if msg.contains("shared")),
+		"unexpected error: {err:?}"
+	);
+}
+
+// Bounding the standalone pull's concurrency (`MAX_PULL_CONCURRENCY`) is
+// exercised structurally rather than by asserting a live in-flight count:
+// `bounded_join_all` runs every future through the same
+// `buffer_unordered(MAX_PULL_CONCURRENCY)` dispatcher the lifecycle
+// fan-out's `join_bounded` uses (see `parallel::tests::
+// join_bounded_preserves_input_order`), and a synchronous fake responder
+// cannot observe real concurrency without a multi-thread runtime and a
+// blocking rendezvous — exactly the flakiness the testing standard rules
+// out. The dedup tests above already pin the dispatch contract (every
+// unique image is attempted, exactly once).
+
+/// #1076: libpod reports a failed pull as an in-band `error` line on a 200
+/// response. That line used to be warned about and dropped, so every caller
+/// believed the pull had succeeded.
+///
+/// The image is present here — a stale copy from an earlier pull — which is
+/// exactly the case a presence probe cannot catch: it passes while the pull
+/// failed. `up --pull always` against an unreachable registry therefore
+/// started yesterday's image and exited 0.
+#[tokio::test]
+#[cfg(unix)]
+async fn a_failed_pull_is_reported_even_when_a_stale_image_is_present() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			// 200 with an in-band error, the way libpod reports it.
+			(
+				200,
+				r#"{"error":"initializing source: pinging container registry: connection refused"}"#
+					.to_string(),
+			)
+		} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+			// The stale image is in local storage.
+			(200, "{}".to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file = crate::parse_str("services:\n  a:\n    image: stale:v1\n").unwrap();
+
+	let err = e
+		.pull_services(&file, &[])
+		.await
+		.expect_err("a pull that libpod reported as failed must not be reported as success");
+	assert!(
+		format!("{err}").contains("connection refused"),
+		"the underlying cause must survive: {err}"
+	);
+}
+
+/// The escape hatch still works: `--ignore-pull-failures` is deliberately
+/// exit-0, and that must not change just because the failure is now visible.
+#[tokio::test]
+#[cfg(unix)]
+async fn ignore_pull_failures_still_exits_zero_on_an_in_band_error() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			(200, r#"{"error":"connection refused"}"#.to_string())
+		} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+			(200, "{}".to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file = crate::parse_str("services:\n  a:\n    image: stale:v1\n").unwrap();
+
+	e.pull_services_with_options(
+		&file,
+		&[],
+		crate::engine::PullOptions {
+			ignore_failures: true,
+			..Default::default()
+		},
+	)
+	.await
+	.expect("--ignore-pull-failures must stay exit 0");
+}

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -72,13 +72,49 @@ where
 
 /// Options for [`Engine::push`], mirroring `docker compose push` (plus a Podman
 /// `--tls-verify` escape hatch for insecure/local registries).
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`PushOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct PushOptions {
 	/// Continue with the remaining services after a push fails.
 	pub ignore_failures: bool,
 	/// Override TLS verification of the registry. `None` leaves Podman's default
 	/// (verify on); `Some(false)` allows an insecure/HTTP registry.
 	pub tls_verify: Option<bool>,
+}
+
+impl PushOptions {
+	/// Every `docker compose push` flag, in CLI order. A constructor rather than
+	/// a struct literal because the type is `#[non_exhaustive]`, so the next
+	/// flag to land is not a breaking change for anyone building one.
+	pub fn new(ignore_failures: bool, tls_verify: Option<bool>) -> Self {
+		Self {
+			ignore_failures,
+			tls_verify,
+		}
+	}
+
+	/// Continue with the remaining services after a push fails,
+	/// `--ignore-push-failures`. Builder-style.
+	#[must_use]
+	pub fn with_ignore_failures(mut self, ignore_failures: bool) -> Self {
+		self.ignore_failures = ignore_failures;
+		self
+	}
+
+	/// Override TLS verification of the registry, `--tls-verify` /
+	/// `--tls-verify=false`. `None` leaves Podman's default (verify on).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_tls_verify(mut self, tls_verify: Option<bool>) -> Self {
+		self.tls_verify = tls_verify;
+		self
+	}
 }
 
 impl Engine {

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -12,7 +12,7 @@ use crate::error::ComposeError;
 use crate::libpod::types::container::{HealthConfig, LogConfig};
 use crate::size;
 
-mod resources;
+pub(crate) mod resources;
 pub(super) use resources::{build_resource_limits, build_ulimits, cdi_devices};
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -155,7 +155,7 @@ pub(crate) fn build_ulimits(service: &Service) -> Vec<Ulimit> {
 /// The Linux rlimit resource names Podman accepts (without the `RLIMIT_`
 /// prefix). A name outside this set is a typo or an injection attempt and is
 /// rejected rather than forwarded verbatim to the API.
-fn is_known_ulimit(name: &str) -> bool {
+pub(crate) fn is_known_ulimit(name: &str) -> bool {
 	const KNOWN: [&str; 16] = [
 		"core",
 		"cpu",

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -23,7 +23,14 @@ use archive::{extract_archive, pack_path};
 const MAX_CP_ARCHIVE_BYTES: usize = 1024 * 1024 * 1024;
 
 /// Options for [`Engine::cp_with_options`], mirroring `docker compose cp` flags.
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new field can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`CpOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct CpOptions {
 	/// 1-based replica index for a scaled service, `--index` (default: first).
 	pub index: Option<u32>,
@@ -34,6 +41,46 @@ pub struct CpOptions {
 	/// container→host extraction always applies podup's security-hardened mode
 	/// sanitization, so this flag has no effect on the copied bytes.
 	pub archive: bool,
+}
+
+impl CpOptions {
+	/// Every `docker compose cp` flag, in CLI order. A constructor rather than
+	/// a struct literal because the type is `#[non_exhaustive]`, so the next
+	/// flag to land is not a breaking change for anyone building one.
+	pub fn new(index: Option<u32>, follow_link: bool, archive: bool) -> Self {
+		Self {
+			index,
+			follow_link,
+			archive,
+		}
+	}
+
+	/// 1-based replica index for a scaled service, `--index` (default: first).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_index(mut self, index: Option<u32>) -> Self {
+		self.index = index;
+		self
+	}
+
+	/// Follow symlinks in the host source before packing, `-L/--follow-link`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_follow_link(mut self, follow_link: bool) -> Self {
+		self.follow_link = follow_link;
+		self
+	}
+
+	/// Archive mode, `-a/--archive`. Accepted for command-line compatibility:
+	/// under rootless Podman the original uid/gid cannot be restored, and
+	/// container→host extraction always applies podup's security-hardened mode
+	/// sanitization, so this flag has no effect on the copied bytes.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_archive(mut self, archive: bool) -> Self {
+		self.archive = archive;
+		self
+	}
 }
 
 impl Engine {

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -11,7 +11,14 @@ use super::Engine;
 
 /// Options for [`Engine::stream_events`], mirroring `docker compose events`
 /// (`--since`, `--until`, `--filter`).
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`EventsOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct EventsOptions {
 	/// Only events at or after this timestamp/relative time (`--since`).
 	pub since: Option<String>,
@@ -19,6 +26,43 @@ pub struct EventsOptions {
 	pub until: Option<String>,
 	/// Extra `KEY=VALUE` event filters (`--filter`, e.g. `event=start`).
 	pub filters: Vec<String>,
+}
+
+impl EventsOptions {
+	/// Every `docker compose events` flag, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	pub fn new(since: Option<String>, until: Option<String>, filters: Vec<String>) -> Self {
+		Self {
+			since,
+			until,
+			filters,
+		}
+	}
+
+	/// Only events at or after this timestamp/relative time (`--since`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_since(mut self, since: Option<String>) -> Self {
+		self.since = since;
+		self
+	}
+
+	/// Only events up to this timestamp/relative time (`--until`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_until(mut self, until: Option<String>) -> Self {
+		self.until = until;
+		self
+	}
+
+	/// Extra `KEY=VALUE` event filters (`--filter`, e.g. `event=start`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_filters(mut self, filters: Vec<String>) -> Self {
+		self.filters = filters;
+		self
+	}
 }
 
 impl Engine {

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -13,9 +13,15 @@ use crate::libpod::{urlencoded, API_PREFIX};
 use super::super::Engine;
 
 /// Options for [`Engine::commit_with_options`], mirroring `docker compose commit`
-/// (`-m/--message`, `-a/--author`, `-p/--pause`, `-c/--change`). Kept off the
-/// frozen `commit` signature so the published library API stays stable across minors.
+/// (`-m/--message`, `-a/--author`, `-p/--pause`, `-c/--change`).
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new field can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`CommitOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct CommitOptions {
 	/// Commit message recorded on the new image (`-m/--message`).
 	pub message: Option<String>,
@@ -26,6 +32,56 @@ pub struct CommitOptions {
 	pub pause: Option<bool>,
 	/// Dockerfile instructions to apply to the committed image (`-c/--change`).
 	pub changes: Vec<String>,
+}
+
+impl CommitOptions {
+	/// Every `docker compose commit` field, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next field to land is not a breaking change for anyone building one.
+	pub fn new(
+		message: Option<String>,
+		author: Option<String>,
+		pause: Option<bool>,
+		changes: Vec<String>,
+	) -> Self {
+		Self {
+			message,
+			author,
+			pause,
+			changes,
+		}
+	}
+
+	/// Commit message recorded on the new image (`-m/--message`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_message(mut self, message: Option<String>) -> Self {
+		self.message = message;
+		self
+	}
+
+	/// Author recorded on the new image (`-a/--author`). Builder-style.
+	#[must_use]
+	pub fn with_author(mut self, author: Option<String>) -> Self {
+		self.author = author;
+		self
+	}
+
+	/// Pause the container during the commit (`-p/--pause`); `None` leaves
+	/// Podman's default (pause on). Builder-style.
+	#[must_use]
+	pub fn with_pause(mut self, pause: Option<bool>) -> Self {
+		self.pause = pause;
+		self
+	}
+
+	/// Dockerfile instructions to apply to the committed image
+	/// (`-c/--change`). Builder-style.
+	#[must_use]
+	pub fn with_changes(mut self, changes: Vec<String>) -> Self {
+		self.changes = changes;
+		self
+	}
 }
 
 /// Split a `commit` image reference into `(repo, tag)`, defaulting the tag to

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -8,6 +8,7 @@ mod images;
 // (#1219) fans out against the same `MAX_LIFECYCLE_CONCURRENCY` ceiling rather
 // than growing a second concurrency limit that could silently drift from this
 // one.
+mod options;
 pub(in crate::engine) mod parallel;
 mod prefetch;
 mod readiness;
@@ -18,6 +19,7 @@ mod schedule;
 mod seed;
 mod signal;
 mod targets;
+mod teardown;
 
 use std::collections::{HashMap, HashSet};
 
@@ -27,55 +29,14 @@ use crate::libpod::API_PREFIX;
 
 use readiness::SharedReady;
 
+pub use options::{RunOptions, RunOverrides};
 pub use targets::validate_stop_timeout;
 use targets::{expand_targets, filter_services, in_started_set, validate_targets};
 
 use super::container::config_hash;
 
-use super::network::resolve_network_name;
 use super::profiles::{active_profiles_set, enabled_profile_services};
 use super::Engine;
-
-/// Options for [`Engine::run`].
-#[derive(Default)]
-pub struct RunOptions {
-	/// Override the default service command.
-	pub cmd: Vec<String>,
-	/// Remove the container after it exits.
-	pub rm: bool,
-	/// Start the container in the background without streaming logs.
-	pub detach: bool,
-	/// Additional environment variables (`KEY=VAL` strings, override service env).
-	pub env_overrides: Vec<String>,
-	/// Override the generated container name.
-	pub name_override: Option<String>,
-	/// Publish the service's declared `ports:` (compose `run --service-ports`).
-	/// When false, `run` leaves ports unpublished to avoid host-port collisions.
-	pub service_ports: bool,
-}
-
-/// Extra `docker compose run` flag overrides threaded through the engine
-/// builder ([`Engine::with_run_overrides`]). These are CLI-only refinements of
-/// a `run` invocation; they live here rather than on the frozen [`RunOptions`]
-/// public struct so the published library API stays stable across minors, mirroring how the `up`
-/// image-acquisition overrides are carried on the engine.
-#[derive(Default, Clone)]
-pub struct RunOverrides {
-	/// Run the command as this user (`-u/--user`, `name or UID[:GID]`).
-	pub user: Option<String>,
-	/// Working directory inside the container (`-w/--workdir`).
-	pub workdir: Option<String>,
-	/// Override the image entrypoint (`--entrypoint`).
-	pub entrypoint: Option<String>,
-	/// Extra ad-hoc volume mounts in compose short form (`-v/--volume`).
-	pub volumes: Vec<String>,
-	/// Extra published ports in compose short form (`-p/--publish`).
-	pub publish: Vec<String>,
-	/// Keep STDIN open on the container (`-i/--interactive`).
-	pub interactive: bool,
-	/// Do not start `depends_on` services before the run (`--no-deps`).
-	pub no_deps: bool,
-}
 
 impl Engine {
 	/// Start all services defined in the compose file, creating containers that do not exist.
@@ -543,237 +504,6 @@ impl Engine {
 		}
 
 		Ok(())
-	}
-
-	/// Stop and remove all containers for the project. Does not remove volumes unless `remove_volumes` is set.
-	pub async fn down(&self, file: &ComposeFile) -> Result<()> {
-		self.down_with_options(file, false).await
-	}
-
-	/// Stop and remove services in reverse dependency order. Optionally removes named volumes and orphaned containers.
-	pub async fn down_with_options(&self, file: &ComposeFile, remove_volumes: bool) -> Result<()> {
-		let mut levels = crate::compose::resolve_levels(file)?;
-		// Teardown inverts startup: a dependent must stop before the service it
-		// depends on, so the dependency levels `up` would walk front-to-back are
-		// walked back-to-front here (the same inversion the other lifecycle
-		// commands' level walk uses, see `parallel.rs`).
-		levels.reverse();
-
-		// Prefetch every project container once and group by service, instead of
-		// one container-list round-trip per service (S+1 → 1 for the level walk).
-		let live_by_service = self.live_project_replicas().await?;
-
-		// Seed from the containers Podman actually has, walked in the same
-		// reversed level order the teardown below uses, so the board predicts
-		// what will happen rather than what the file describes. A service in the
-		// file that was never created must not sit on the board as a row that
-		// never moves.
-		let live_order: Vec<String> = levels
-			.iter()
-			.flatten()
-			.filter_map(|svc| live_by_service.get(svc))
-			.flatten()
-			.cloned()
-			.collect();
-		crate::ui::progress::begin(self.down_resources(file, &live_order, remove_volumes));
-
-		// Best-effort across every level/container/network/volume so one failure
-		// never leaves the rest of the teardown undone, but the first real
-		// REMOVAL failure is remembered and returned at the end instead of being
-		// swallowed into a warning — a `down` whose container/network/volume
-		// removal genuinely fails (storage error, active exec session) must exit
-		// non-zero, not print a warning and exit 0 (#598). A stalled or failed
-		// `stop` does NOT count towards this: the force-remove below SIGKILLs the
-		// container regardless (see `container_rm_path`), so only the removal
-		// outcome is aggregated. A 404 (already gone) stays an idempotent no-op
-		// throughout.
-		//
-		// Levels are walked strictly in order — every container in one level is
-		// attempted before the next level starts, preserving the dependency
-		// inversion above — but the containers *within* one level tear down
-		// concurrently via `join_bounded`, which returns results in input
-		// (service, then container) order rather than completion order. That
-		// keeps "the first error" deterministic regardless of which container
-		// happens to finish first: `first_error` picks the earliest in that
-		// fixed order, and since levels themselves are visited in a fixed
-		// sequence, only the first level with any failure can ever set
-		// `first_err` — a later level's failure is never mistaken for "first".
-		let mut first_err: Option<crate::error::ComposeError> = None;
-
-		for level in &levels {
-			let futs = level.iter().flat_map(|name| {
-				let service = &file.services[name];
-				let grace = self.grace_period_secs(service);
-				// Act only on containers Podman actually has. A defined-but-never-
-				// created service (or one already torn down) has no live
-				// containers, so it contributes nothing here rather than
-				// synthesizing predicted names and POSTing stop/rm to them —
-				// those 404 and, pre-fix, leaked warnings. docker compose
-				// enumerates by label and treats "nothing there" as a quiet
-				// idempotent no-op (#758).
-				live_by_service
-					.get(name)
-					.filter(|live| !live.is_empty())
-					.into_iter()
-					.flatten()
-					.map(move |container_name| {
-						self.teardown_one_container(
-							container_name,
-							grace,
-							&service.pre_stop,
-							remove_volumes,
-						)
-					})
-			});
-			if let Some(e) = parallel::first_error(parallel::join_bounded(futs).await) {
-				first_err.get_or_insert(e);
-			}
-		}
-
-		// Scaled replicas (`up --scale`/`scale`) carry the `podup.service` label
-		// of a service still in the file, so the level walk above already swept
-		// them via `live_by_service`. Orphan containers of services *removed* from
-		// the file are deliberately NOT touched here: docker compose only reaps
-		// them under `--remove-orphans`, which the dispatch layer handles via
-		// `remove_orphans` before teardown. Removing them unconditionally here
-		// made that flag a no-op.
-
-		for (key, config) in &file.networks {
-			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
-			if external {
-				continue;
-			}
-			let network_name = resolve_network_name(key, file, &self.project);
-			let net_path = format!(
-				"{API_PREFIX}/networks/{}",
-				crate::libpod::urlencoded(&network_name),
-			);
-			// `delete_existed`, not `delete_ok`: this loop walks the networks the
-			// compose file *declares*, which is not the same set as the networks
-			// that exist. `delete_ok` throws away the boolean that tells the two
-			// apart, so every 404 arrived here as `Ok(())` and was announced as a
-			// removal — measured on a project that had never been created,
-			// `down -v` reported removing two networks and a volume, none of
-			// which had ever existed. The `Err(404)` arm below was unreachable
-			// for the same reason: the layer underneath had already turned the
-			// 404 into a success.
-			crate::ui::progress::start("Network", &network_name, "Removing");
-			match self.client.delete_existed(&net_path).await {
-				Ok(true) => crate::ui::progress_line("Network", &network_name, "Removed"),
-				// The network was already gone (404) — nothing to do, but the row
-				// has to close, or the live board leaves it spinning on
-				// `Removing` forever (#1347).
-				Ok(false) => crate::ui::progress_line("Network", &network_name, "Absent"),
-				Err(e) => {
-					tracing::warn!("could not remove network {network_name}: {e}");
-					// Close the row visibly — a `down` whose removal genuinely
-					// failed previously hid the failure behind a spinner (#1347).
-					crate::ui::progress_line("Network", &network_name, "Failed");
-					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
-				}
-			}
-		}
-
-		// Sweep any remaining project networks by label — the implicit
-		// `<project>_default` (present only when the file was normalized), or a
-		// network whose compose key changed — mirroring the container sweep so
-		// teardown is complete regardless of how the file was parsed. Only
-		// podup-labelled networks match, so external networks are never touched.
-		// This is a supplementary catch-all on top of the file-driven network
-		// loop above (which already aggregates its own failures into
-		// `first_err`), so a failure here is intentionally swallowed rather than
-		// folded in again.
-		let _ = self.remove_project_networks_by_label().await;
-
-		if remove_volumes {
-			for (key, config) in &file.volumes {
-				let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
-				if external {
-					continue;
-				}
-				let volume_name = config
-					.as_ref()
-					.and_then(|c| c.name.as_deref())
-					.map(|s| s.to_string())
-					.unwrap_or_else(|| format!("{}_{}", self.project, key));
-				let vol_path = format!(
-					"{API_PREFIX}/volumes/{}",
-					crate::libpod::urlencoded(&volume_name),
-				);
-				// See the network loop above: only a delete that found something
-				// may be reported, and a volume is the object where a false
-				// "Removed" is worst — it names data the operator believes is
-				// gone.
-				crate::ui::progress::start("Volume", &volume_name, "Removing");
-				match self.client.delete_existed(&vol_path).await {
-					Ok(true) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
-					// The volume was already gone (404) — nothing to do, but the
-					// row has to close, or the live board leaves it spinning on
-					// `Removing` forever (#1347).
-					Ok(false) => crate::ui::progress_line("Volume", &volume_name, "Absent"),
-					Err(e) => {
-						tracing::warn!("could not remove volume {volume_name}: {e}");
-						// A `down -v` whose volume removal genuinely failed
-						// previously hid the failure behind a spinner (#1347).
-						crate::ui::progress_line("Volume", &volume_name, "Failed");
-						first_err.get_or_insert(crate::error::ComposeError::Podman(e));
-					}
-				}
-			}
-		}
-
-		// Internal native secrets are podup-owned (not user data), so remove
-		// them unconditionally — independent of `remove_volumes`.
-		let secrets = self.remove_internal_secrets(file).await;
-
-		// Close the board before returning, on every path: the region hides the
-		// cursor and an early `?` would leave the terminal without one.
-		crate::ui::progress::end();
-		secrets?;
-
-		if let Some(e) = first_err {
-			return Err(e);
-		}
-		Ok(())
-	}
-
-	/// Remove the images used by the project's services (`down --rmi`). With
-	/// `local_only`, only images of services that build locally (a `build:`
-	/// section) are removed — matching `docker compose down --rmi local`.
-	pub async fn remove_service_images(&self, file: &ComposeFile, local_only: bool) -> Result<()> {
-		// Aggregate like every sibling loop in this teardown: complete the sweep,
-		// then report the first real failure. Warning and returning Ok meant
-		// `down --rmi` exited 0 having left images behind.
-		let mut first_err: Option<crate::error::ComposeError> = None;
-		for (name, service) in &file.services {
-			let builds_locally = service.build.is_some();
-			if local_only && !builds_locally {
-				continue;
-			}
-			let image = match &service.image {
-				Some(img) => img.clone(),
-				None if builds_locally => self.service_image_tag(name, service),
-				None => continue,
-			};
-			// Do NOT force: a force-removal cascades to every container using the
-			// image — including ones owned by other compose projects that share it
-			// (e.g. two stacks both on `nginx:latest`). docker compose leaves an
-			// in-use image in place, so an "in use" conflict is a skip, not a
-			// failure.
-			let path = format!("{API_PREFIX}/images/{}", crate::libpod::urlencoded(&image),);
-			match self.client.delete_ok(&path).await {
-				Ok(_) => crate::ui::progress_line("Image", &image, "Removed"),
-				Err(e) if e.is_status(404) => {}
-				Err(e) if e.is_image_in_use() => {
-					tracing::debug!("image {image} is still in use — skipping removal")
-				}
-				Err(e) => {
-					tracing::warn!("could not remove image {image}: {e}");
-					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
-				}
-			}
-		}
-		first_err.map_or(Ok(()), Err)
 	}
 }
 

--- a/internal/engine/lifecycle/options.rs
+++ b/internal/engine/lifecycle/options.rs
@@ -1,0 +1,207 @@
+//! The public option structs for `run`, and the per-field builders that
+//! construct them.
+//!
+//! They live apart from the engine methods in `mod.rs` because they are
+//! surface, not behaviour: every field here is something an external caller
+//! sets, and every `with_*` is part of the published API. Keeping them
+//! together makes the whole `run` contract readable in one file.
+
+/// Options for [`crate::Engine::run`].
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new field can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`RunOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
+#[derive(Default)]
+#[non_exhaustive]
+pub struct RunOptions {
+	/// Override the default service command.
+	pub cmd: Vec<String>,
+	/// Remove the container after it exits.
+	pub rm: bool,
+	/// Start the container in the background without streaming logs.
+	pub detach: bool,
+	/// Additional environment variables (`KEY=VAL` strings, override service env).
+	pub env_overrides: Vec<String>,
+	/// Override the generated container name.
+	pub name_override: Option<String>,
+	/// Publish the service's declared `ports:` (compose `run --service-ports`).
+	/// When false, `run` leaves ports unpublished to avoid host-port collisions.
+	pub service_ports: bool,
+}
+
+impl RunOptions {
+	/// Every `docker compose run` option that lives on the published struct,
+	/// in CLI order. A constructor rather than a struct literal because the
+	/// type is `#[non_exhaustive]`, so the next field to land is not a
+	/// breaking change for anyone building one.
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		cmd: Vec<String>,
+		rm: bool,
+		detach: bool,
+		env_overrides: Vec<String>,
+		name_override: Option<String>,
+		service_ports: bool,
+	) -> Self {
+		Self {
+			cmd,
+			rm,
+			detach,
+			env_overrides,
+			name_override,
+			service_ports,
+		}
+	}
+
+	/// Override the default service command. Builder-style.
+	#[must_use]
+	pub fn with_cmd(mut self, cmd: Vec<String>) -> Self {
+		self.cmd = cmd;
+		self
+	}
+
+	/// Remove the container after it exits, `--rm`. Builder-style.
+	#[must_use]
+	pub fn with_rm(mut self, rm: bool) -> Self {
+		self.rm = rm;
+		self
+	}
+
+	/// Start the container in the background without streaming logs, `-d/--detach`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_detach(mut self, detach: bool) -> Self {
+		self.detach = detach;
+		self
+	}
+
+	/// Additional environment variables (`KEY=VAL` strings, override service env).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_env_overrides(mut self, env_overrides: Vec<String>) -> Self {
+		self.env_overrides = env_overrides;
+		self
+	}
+
+	/// Override the generated container name. Builder-style.
+	#[must_use]
+	pub fn with_name_override(mut self, name_override: Option<String>) -> Self {
+		self.name_override = name_override;
+		self
+	}
+
+	/// Publish the service's declared `ports:` (compose `run --service-ports`).
+	/// When false, `run` leaves ports unpublished to avoid host-port collisions.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_service_ports(mut self, service_ports: bool) -> Self {
+		self.service_ports = service_ports;
+		self
+	}
+}
+
+/// Extra `docker compose run` flag overrides threaded through the engine
+/// builder ([`crate::Engine::with_run_overrides`]).
+///
+/// `#[non_exhaustive]` since 4.0.0, same rationale as [`RunOptions`]: the
+/// next flag to land is not a breaking change for anyone building one with a
+/// builder or constructor.
+#[derive(Default, Clone)]
+#[non_exhaustive]
+pub struct RunOverrides {
+	/// Run the command as this user (`-u/--user`, `name or UID[:GID]`).
+	pub user: Option<String>,
+	/// Working directory inside the container (`-w/--workdir`).
+	pub workdir: Option<String>,
+	/// Override the image entrypoint (`--entrypoint`).
+	pub entrypoint: Option<String>,
+	/// Extra ad-hoc volume mounts in compose short form (`-v/--volume`).
+	pub volumes: Vec<String>,
+	/// Extra published ports in compose short form (`-p/--publish`).
+	pub publish: Vec<String>,
+	/// Keep STDIN open on the container (`-i/--interactive`).
+	pub interactive: bool,
+	/// Do not start `depends_on` services before the run (`--no-deps`).
+	pub no_deps: bool,
+}
+
+impl RunOverrides {
+	/// Every `docker compose run` override, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		user: Option<String>,
+		workdir: Option<String>,
+		entrypoint: Option<String>,
+		volumes: Vec<String>,
+		publish: Vec<String>,
+		interactive: bool,
+		no_deps: bool,
+	) -> Self {
+		Self {
+			user,
+			workdir,
+			entrypoint,
+			volumes,
+			publish,
+			interactive,
+			no_deps,
+		}
+	}
+
+	/// Run the command as this user (`-u/--user`, `name or UID[:GID]`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_user(mut self, user: Option<String>) -> Self {
+		self.user = user;
+		self
+	}
+
+	/// Working directory inside the container (`-w/--workdir`). Builder-style.
+	#[must_use]
+	pub fn with_workdir(mut self, workdir: Option<String>) -> Self {
+		self.workdir = workdir;
+		self
+	}
+
+	/// Override the image entrypoint (`--entrypoint`). Builder-style.
+	#[must_use]
+	pub fn with_entrypoint(mut self, entrypoint: Option<String>) -> Self {
+		self.entrypoint = entrypoint;
+		self
+	}
+
+	/// Extra ad-hoc volume mounts in compose short form (`-v/--volume`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_volumes(mut self, volumes: Vec<String>) -> Self {
+		self.volumes = volumes;
+		self
+	}
+
+	/// Extra published ports in compose short form (`-p/--publish`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_publish(mut self, publish: Vec<String>) -> Self {
+		self.publish = publish;
+		self
+	}
+
+	/// Keep STDIN open on the container (`-i/--interactive`). Builder-style.
+	#[must_use]
+	pub fn with_interactive(mut self, interactive: bool) -> Self {
+		self.interactive = interactive;
+		self
+	}
+
+	/// Do not start `depends_on` services before the run (`--no-deps`).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_no_deps(mut self, no_deps: bool) -> Self {
+		self.no_deps = no_deps;
+		self
+	}
+}

--- a/internal/engine/lifecycle/teardown.rs
+++ b/internal/engine/lifecycle/teardown.rs
@@ -1,0 +1,246 @@
+//! Teardown: `down`, and the image removal that `down --rmi` performs.
+//!
+//! Split from `mod.rs`, which keeps the startup half. The two directions do
+//! not share code beyond the level resolution they each invert, and holding
+//! them apart keeps either one readable on its own.
+
+use crate::compose::types::ComposeFile;
+use crate::engine::network::resolve_network_name;
+use crate::engine::Engine;
+use crate::error::Result;
+use crate::libpod::API_PREFIX;
+
+use super::parallel;
+
+impl Engine {
+	/// Stop and remove all containers for the project. Does not remove volumes unless `remove_volumes` is set.
+	pub async fn down(&self, file: &ComposeFile) -> Result<()> {
+		self.down_with_options(file, false).await
+	}
+
+	/// Stop and remove services in reverse dependency order. Optionally removes named volumes and orphaned containers.
+	pub async fn down_with_options(&self, file: &ComposeFile, remove_volumes: bool) -> Result<()> {
+		let mut levels = crate::compose::resolve_levels(file)?;
+		// Teardown inverts startup: a dependent must stop before the service it
+		// depends on, so the dependency levels `up` would walk front-to-back are
+		// walked back-to-front here (the same inversion the other lifecycle
+		// commands' level walk uses, see `parallel.rs`).
+		levels.reverse();
+
+		// Prefetch every project container once and group by service, instead of
+		// one container-list round-trip per service (S+1 → 1 for the level walk).
+		let live_by_service = self.live_project_replicas().await?;
+
+		// Seed from the containers Podman actually has, walked in the same
+		// reversed level order the teardown below uses, so the board predicts
+		// what will happen rather than what the file describes. A service in the
+		// file that was never created must not sit on the board as a row that
+		// never moves.
+		let live_order: Vec<String> = levels
+			.iter()
+			.flatten()
+			.filter_map(|svc| live_by_service.get(svc))
+			.flatten()
+			.cloned()
+			.collect();
+		crate::ui::progress::begin(self.down_resources(file, &live_order, remove_volumes));
+
+		// Best-effort across every level/container/network/volume so one failure
+		// never leaves the rest of the teardown undone, but the first real
+		// REMOVAL failure is remembered and returned at the end instead of being
+		// swallowed into a warning — a `down` whose container/network/volume
+		// removal genuinely fails (storage error, active exec session) must exit
+		// non-zero, not print a warning and exit 0 (#598). A stalled or failed
+		// `stop` does NOT count towards this: the force-remove below SIGKILLs the
+		// container regardless (see `container_rm_path`), so only the removal
+		// outcome is aggregated. A 404 (already gone) stays an idempotent no-op
+		// throughout.
+		//
+		// Levels are walked strictly in order — every container in one level is
+		// attempted before the next level starts, preserving the dependency
+		// inversion above — but the containers *within* one level tear down
+		// concurrently via `join_bounded`, which returns results in input
+		// (service, then container) order rather than completion order. That
+		// keeps "the first error" deterministic regardless of which container
+		// happens to finish first: `first_error` picks the earliest in that
+		// fixed order, and since levels themselves are visited in a fixed
+		// sequence, only the first level with any failure can ever set
+		// `first_err` — a later level's failure is never mistaken for "first".
+		let mut first_err: Option<crate::error::ComposeError> = None;
+
+		for level in &levels {
+			let futs = level.iter().flat_map(|name| {
+				let service = &file.services[name];
+				let grace = self.grace_period_secs(service);
+				// Act only on containers Podman actually has. A defined-but-never-
+				// created service (or one already torn down) has no live
+				// containers, so it contributes nothing here rather than
+				// synthesizing predicted names and POSTing stop/rm to them —
+				// those 404 and, pre-fix, leaked warnings. docker compose
+				// enumerates by label and treats "nothing there" as a quiet
+				// idempotent no-op (#758).
+				live_by_service
+					.get(name)
+					.filter(|live| !live.is_empty())
+					.into_iter()
+					.flatten()
+					.map(move |container_name| {
+						self.teardown_one_container(
+							container_name,
+							grace,
+							&service.pre_stop,
+							remove_volumes,
+						)
+					})
+			});
+			if let Some(e) = parallel::first_error(parallel::join_bounded(futs).await) {
+				first_err.get_or_insert(e);
+			}
+		}
+
+		// Scaled replicas (`up --scale`/`scale`) carry the `podup.service` label
+		// of a service still in the file, so the level walk above already swept
+		// them via `live_by_service`. Orphan containers of services *removed* from
+		// the file are deliberately NOT touched here: docker compose only reaps
+		// them under `--remove-orphans`, which the dispatch layer handles via
+		// `remove_orphans` before teardown. Removing them unconditionally here
+		// made that flag a no-op.
+
+		for (key, config) in &file.networks {
+			let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
+			if external {
+				continue;
+			}
+			let network_name = resolve_network_name(key, file, &self.project);
+			let net_path = format!(
+				"{API_PREFIX}/networks/{}",
+				crate::libpod::urlencoded(&network_name),
+			);
+			// `delete_existed`, not `delete_ok`: this loop walks the networks the
+			// compose file *declares*, which is not the same set as the networks
+			// that exist. `delete_ok` throws away the boolean that tells the two
+			// apart, so every 404 arrived here as `Ok(())` and was announced as a
+			// removal — measured on a project that had never been created,
+			// `down -v` reported removing two networks and a volume, none of
+			// which had ever existed. The `Err(404)` arm below was unreachable
+			// for the same reason: the layer underneath had already turned the
+			// 404 into a success.
+			crate::ui::progress::start("Network", &network_name, "Removing");
+			match self.client.delete_existed(&net_path).await {
+				Ok(true) => crate::ui::progress_line("Network", &network_name, "Removed"),
+				// The network was already gone (404) — nothing to do, but the row
+				// has to close, or the live board leaves it spinning on
+				// `Removing` forever (#1347).
+				Ok(false) => crate::ui::progress_line("Network", &network_name, "Absent"),
+				Err(e) => {
+					tracing::warn!("could not remove network {network_name}: {e}");
+					// Close the row visibly — a `down` whose removal genuinely
+					// failed previously hid the failure behind a spinner (#1347).
+					crate::ui::progress_line("Network", &network_name, "Failed");
+					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+				}
+			}
+		}
+
+		// Sweep any remaining project networks by label — the implicit
+		// `<project>_default` (present only when the file was normalized), or a
+		// network whose compose key changed — mirroring the container sweep so
+		// teardown is complete regardless of how the file was parsed. Only
+		// podup-labelled networks match, so external networks are never touched.
+		// This is a supplementary catch-all on top of the file-driven network
+		// loop above (which already aggregates its own failures into
+		// `first_err`), so a failure here is intentionally swallowed rather than
+		// folded in again.
+		let _ = self.remove_project_networks_by_label().await;
+
+		if remove_volumes {
+			for (key, config) in &file.volumes {
+				let external = config.as_ref().and_then(|c| c.external).unwrap_or(false);
+				if external {
+					continue;
+				}
+				let volume_name = config
+					.as_ref()
+					.and_then(|c| c.name.as_deref())
+					.map(|s| s.to_string())
+					.unwrap_or_else(|| format!("{}_{}", self.project, key));
+				let vol_path = format!(
+					"{API_PREFIX}/volumes/{}",
+					crate::libpod::urlencoded(&volume_name),
+				);
+				// See the network loop above: only a delete that found something
+				// may be reported, and a volume is the object where a false
+				// "Removed" is worst — it names data the operator believes is
+				// gone.
+				crate::ui::progress::start("Volume", &volume_name, "Removing");
+				match self.client.delete_existed(&vol_path).await {
+					Ok(true) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
+					// The volume was already gone (404) — nothing to do, but the
+					// row has to close, or the live board leaves it spinning on
+					// `Removing` forever (#1347).
+					Ok(false) => crate::ui::progress_line("Volume", &volume_name, "Absent"),
+					Err(e) => {
+						tracing::warn!("could not remove volume {volume_name}: {e}");
+						// A `down -v` whose volume removal genuinely failed
+						// previously hid the failure behind a spinner (#1347).
+						crate::ui::progress_line("Volume", &volume_name, "Failed");
+						first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+					}
+				}
+			}
+		}
+
+		// Internal native secrets are podup-owned (not user data), so remove
+		// them unconditionally — independent of `remove_volumes`.
+		let secrets = self.remove_internal_secrets(file).await;
+
+		// Close the board before returning, on every path: the region hides the
+		// cursor and an early `?` would leave the terminal without one.
+		crate::ui::progress::end();
+		secrets?;
+
+		if let Some(e) = first_err {
+			return Err(e);
+		}
+		Ok(())
+	}
+
+	/// Remove the images used by the project's services (`down --rmi`). With
+	/// `local_only`, only images of services that build locally (a `build:`
+	/// section) are removed — matching `docker compose down --rmi local`.
+	pub async fn remove_service_images(&self, file: &ComposeFile, local_only: bool) -> Result<()> {
+		// Aggregate like every sibling loop in this teardown: complete the sweep,
+		// then report the first real failure. Warning and returning Ok meant
+		// `down --rmi` exited 0 having left images behind.
+		let mut first_err: Option<crate::error::ComposeError> = None;
+		for (name, service) in &file.services {
+			let builds_locally = service.build.is_some();
+			if local_only && !builds_locally {
+				continue;
+			}
+			let image = match &service.image {
+				Some(img) => img.clone(),
+				None if builds_locally => self.service_image_tag(name, service),
+				None => continue,
+			};
+			// Do NOT force: a force-removal cascades to every container using the
+			// image — including ones owned by other compose projects that share it
+			// (e.g. two stacks both on `nginx:latest`). docker compose leaves an
+			// in-use image in place, so an "in use" conflict is a skip, not a
+			// failure.
+			let path = format!("{API_PREFIX}/images/{}", crate::libpod::urlencoded(&image),);
+			match self.client.delete_ok(&path).await {
+				Ok(_) => crate::ui::progress_line("Image", &image, "Removed"),
+				Err(e) if e.is_status(404) => {}
+				Err(e) if e.is_image_in_use() => {
+					tracing::debug!("image {image} is still in use — skipping removal")
+				}
+				Err(e) => {
+					tracing::warn!("could not remove image {image}: {e}");
+					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
+				}
+			}
+		}
+		first_err.map_or(Ok(()), Err)
+	}
+}

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -45,10 +45,11 @@ impl Engine {
 				.unwrap_or_default();
 			labels.insert("podup.project".to_string(), self.project.clone());
 
-			let driver_opts: HashMap<String, String> = config
+			let mut driver_opts: HashMap<String, String> = config
 				.as_ref()
 				.map(|c| c.driver_opts.clone())
 				.unwrap_or_default();
+			apply_default_isolation(&driver, &mut driver_opts);
 
 			let ipam = config.as_ref().and_then(|c| c.ipam.as_ref());
 			let subnets = ipam.map(build_subnets).unwrap_or_default();
@@ -153,6 +154,51 @@ pub(super) fn build_per_network_options(
 	}
 
 	opts
+}
+
+/// The netavark option that stops a bridge network from reaching another one.
+const ISOLATE_OPT: &str = "isolate";
+
+/// Ask netavark to isolate a bridge network unless the compose file said
+/// otherwise.
+///
+/// Docker isolates its bridge networks from each other and podman does not, so
+/// without this a service reaches ports on a neighbouring network that were
+/// never published. Measured on 2026-08-20 with the same experiment on both
+/// engines — a listener on an unpublished port in network B, and a container in
+/// network A dialling its address:
+///
+/// | engine | result |
+/// |---|---|
+/// | docker 29.6.2 | refused |
+/// | podman 5.7.0 | connected |
+///
+/// The control matters: inside the *same* network docker connects, so the
+/// refusal is isolation rather than a broken dial.
+///
+/// Also measured on podman 5.7.0 with the option set: traffic within one
+/// network still flows (compose keeps working) and outbound internet still
+/// works.
+///
+/// **The option only bites when both networks carry it.** Measured three ways:
+/// isolated → isolated is refused, isolated → plain connects, and plain →
+/// isolated connects. So this does not harden a network against the world; it
+/// makes networks that share the default stop seeing each other. Since podup
+/// now sets it on every bridge network it creates, the effect is that two
+/// podup projects no longer reach each other's unpublished ports — verified
+/// end to end with two projects — while a network created outside podup
+/// without the option still can. Being a default rather than opt-in is the
+/// whole point: one project opting in would protect nobody.
+///
+/// A compose file that sets `isolate` in `driver_opts` wins, including setting
+/// it to `false`, which is the escape hatch for a project that deliberately
+/// spans networks.
+fn apply_default_isolation(driver: &str, opts: &mut HashMap<String, String>) {
+	if driver != "bridge" {
+		return;
+	}
+	opts.entry(ISOLATE_OPT.to_string())
+		.or_insert_with(|| "true".to_string());
 }
 
 /// Resolve a service's networking into a netns `Namespace` and per-network

--- a/internal/engine/network/tests.rs
+++ b/internal/engine/network/tests.rs
@@ -356,3 +356,46 @@ fn lease_range_ipv6_zero_prefix_spans_whole_space() {
 fn lease_range_ipv6_rejects_oversized_prefix() {
 	assert!(lease_range_from_cidr("2001:db8::/129").is_none());
 }
+
+/// Docker isolates bridge networks from each other and podman does not, so a
+/// podup project used to let one service reach unpublished ports on another
+/// network. Measured on both engines; see `apply_default_isolation`.
+#[test]
+fn a_bridge_network_is_isolated_by_default() {
+	let mut opts = HashMap::new();
+	apply_default_isolation("bridge", &mut opts);
+	assert_eq!(opts.get("isolate").map(String::as_str), Some("true"));
+}
+
+/// The option is netavark's bridge plugin. Setting it on a driver that does
+/// not read it would be noise at best and a create failure at worst.
+#[test]
+fn only_bridge_networks_get_the_option() {
+	for driver in ["macvlan", "ipvlan", "host"] {
+		let mut opts = HashMap::new();
+		apply_default_isolation(driver, &mut opts);
+		assert!(opts.is_empty(), "{driver} should not be given isolate");
+	}
+}
+
+/// The escape hatch for a project that deliberately spans networks. A default
+/// that cannot be turned off is not a default, it is a policy.
+#[test]
+fn an_explicit_driver_opt_wins_in_both_directions() {
+	let mut off = HashMap::from([("isolate".to_string(), "false".to_string())]);
+	apply_default_isolation("bridge", &mut off);
+	assert_eq!(off.get("isolate").map(String::as_str), Some("false"));
+
+	let mut strict = HashMap::from([("isolate".to_string(), "strict".to_string())]);
+	apply_default_isolation("bridge", &mut strict);
+	assert_eq!(strict.get("isolate").map(String::as_str), Some("strict"));
+}
+
+/// Whatever else the compose file asked for has to survive.
+#[test]
+fn other_driver_opts_are_left_alone() {
+	let mut opts = HashMap::from([("mtu".to_string(), "9000".to_string())]);
+	apply_default_isolation("bridge", &mut opts);
+	assert_eq!(opts.get("mtu").map(String::as_str), Some("9000"));
+	assert_eq!(opts.get("isolate").map(String::as_str), Some("true"));
+}

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -11,7 +11,14 @@ use crate::libpod::types::container::ContainerListEntry;
 use crate::libpod::{urlencoded, Client, API_PREFIX};
 
 /// Options for [`list_projects`] (`docker compose ls`).
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`LsOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct LsOptions {
 	/// Include projects whose containers are all stopped.
 	pub all: bool,
@@ -19,6 +26,37 @@ pub struct LsOptions {
 	pub quiet: bool,
 	/// Emit a JSON array instead of a table.
 	pub json: bool,
+}
+
+impl LsOptions {
+	/// Every `docker compose ls` flag, in CLI order. A constructor rather than
+	/// a struct literal because the type is `#[non_exhaustive]`, so the next
+	/// flag to land is not a breaking change for anyone building one.
+	pub fn new(all: bool, quiet: bool, json: bool) -> Self {
+		Self { all, quiet, json }
+	}
+
+	/// Include projects whose containers are all stopped, `-a/--all`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_all(mut self, all: bool) -> Self {
+		self.all = all;
+		self
+	}
+
+	/// Print only project names, `-q/--quiet`. Builder-style.
+	#[must_use]
+	pub fn with_quiet(mut self, quiet: bool) -> Self {
+		self.quiet = quiet;
+		self
+	}
+
+	/// Emit a JSON array instead of a table, `--format json`. Builder-style.
+	#[must_use]
+	pub fn with_json(mut self, json: bool) -> Self {
+		self.json = json;
+		self
+	}
 }
 
 /// Split `ls --filter KEY=VALUE` predicates into name, status, and unknown

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -14,6 +14,7 @@ mod images;
 mod inspect;
 mod inspect_util;
 mod log_prefix;
+mod options;
 mod ps;
 pub(crate) mod terminal;
 
@@ -22,51 +23,9 @@ pub use ps::{PsDisplayOptions, PsFilterOptions, PsOptions};
 pub use exec::ExecOptions;
 #[allow(unused_imports)]
 use log_prefix::LinePrefixer;
+pub use options::{ImagesOptions, LogsDisplay, LogsOptions, DEFAULT_LOG_TAIL};
 
 pub use inspect::AttachOutcome;
-
-/// Options for [`Engine::images_with_options`].
-#[derive(Default)]
-pub struct ImagesOptions {
-	/// Print only image IDs, `-q/--quiet`.
-	pub quiet: bool,
-	/// Emit JSON instead of the table, `--format json`.
-	pub json: bool,
-}
-
-/// Default for `podup logs` when the user does not pass `--tail`: show the last
-/// 100 lines. `docker compose logs` defaults to "all"; podup's bounded default
-/// keeps the inspection case ("what just happened?") from flooding the
-/// terminal and stops CI scripts that capture `podup logs` from silently
-/// missing errors that landed before the window. Pass `--tail all` to opt
-/// back into the previous behaviour.
-pub const DEFAULT_LOG_TAIL: &str = "100";
-
-/// Options for [`Engine::logs_with_options`], mirroring `docker compose logs`.
-#[derive(Default)]
-pub struct LogsOptions {
-	/// Follow log output, `-f/--follow`.
-	pub follow: bool,
-	/// Number of lines to show from the end, `-n/--tail` (`None` = all).
-	pub tail: Option<String>,
-	/// Show logs since a timestamp/relative time, `--since`.
-	pub since: Option<String>,
-	/// Show logs until a timestamp/relative time, `--until`.
-	pub until: Option<String>,
-	/// Prefix each line with an RFC3339 timestamp, `-t/--timestamps`.
-	pub timestamps: bool,
-}
-
-/// Prefix-display options for [`Engine::logs_with_display`] (`docker compose
-/// logs --no-color` / `--no-log-prefix`). Kept off the frozen [`LogsOptions`]
-/// struct so the published library API stays stable across minors.
-#[derive(Default)]
-pub struct LogsDisplay {
-	/// Produce monochrome output (no colour in the prefix), `--no-color`.
-	pub no_color: bool,
-	/// Do not print the `{service} | ` prefix, `--no-log-prefix`.
-	pub no_log_prefix: bool,
-}
 
 /// Validate the `--tail`/`--since`/`--until` values client-side so a typo is
 /// rejected with a clear local message instead of a raw podman HTTP 400. `tail`

--- a/internal/engine/query/options.rs
+++ b/internal/engine/query/options.rs
@@ -1,0 +1,176 @@
+//! The public option structs for `images` and `logs`, and the per-field
+//! builders that construct them.
+//!
+//! Held apart from `mod.rs` because they are published surface rather than
+//! behaviour: every field is something an external caller sets, and every
+//! `with_*` is part of the API the crate promises not to break.
+
+/// Options for [`crate::Engine::images_with_options`].
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`ImagesOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
+#[derive(Default)]
+#[non_exhaustive]
+pub struct ImagesOptions {
+	/// Print only image IDs, `-q/--quiet`.
+	pub quiet: bool,
+	/// Emit JSON instead of the table, `--format json`.
+	pub json: bool,
+}
+
+impl ImagesOptions {
+	/// Every `docker compose images` flag, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	pub fn new(quiet: bool, json: bool) -> Self {
+		Self { quiet, json }
+	}
+
+	/// Print only image IDs, `-q/--quiet`. Builder-style.
+	#[must_use]
+	pub fn with_quiet(mut self, quiet: bool) -> Self {
+		self.quiet = quiet;
+		self
+	}
+
+	/// Emit JSON instead of the table, `--format json`. Builder-style.
+	#[must_use]
+	pub fn with_json(mut self, json: bool) -> Self {
+		self.json = json;
+		self
+	}
+}
+
+/// Default for `podup logs` when the user does not pass `--tail`: show the last
+/// 100 lines. `docker compose logs` defaults to "all"; podup's bounded default
+/// keeps the inspection case ("what just happened?") from flooding the
+/// terminal and stops CI scripts that capture `podup logs` from silently
+/// missing errors that landed before the window. Pass `--tail all` to opt
+/// back into the previous behaviour.
+pub const DEFAULT_LOG_TAIL: &str = "100";
+
+/// Options for [`crate::Engine::logs_with_options`], mirroring `docker compose logs`.
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`LogsOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
+#[derive(Default)]
+#[non_exhaustive]
+pub struct LogsOptions {
+	/// Follow log output, `-f/--follow`.
+	pub follow: bool,
+	/// Number of lines to show from the end, `-n/--tail` (`None` = all).
+	pub tail: Option<String>,
+	/// Show logs since a timestamp/relative time, `--since`.
+	pub since: Option<String>,
+	/// Show logs until a timestamp/relative time, `--until`.
+	pub until: Option<String>,
+	/// Prefix each line with an RFC3339 timestamp, `-t/--timestamps`.
+	pub timestamps: bool,
+}
+
+impl LogsOptions {
+	/// Every `docker compose logs` flag, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		follow: bool,
+		tail: Option<String>,
+		since: Option<String>,
+		until: Option<String>,
+		timestamps: bool,
+	) -> Self {
+		Self {
+			follow,
+			tail,
+			since,
+			until,
+			timestamps,
+		}
+	}
+
+	/// Follow log output, `-f/--follow`. Builder-style.
+	#[must_use]
+	pub fn with_follow(mut self, follow: bool) -> Self {
+		self.follow = follow;
+		self
+	}
+
+	/// Number of lines to show from the end, `-n/--tail` (`None` = all).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_tail(mut self, tail: Option<String>) -> Self {
+		self.tail = tail;
+		self
+	}
+
+	/// Show logs since a timestamp/relative time, `--since`. Builder-style.
+	#[must_use]
+	pub fn with_since(mut self, since: Option<String>) -> Self {
+		self.since = since;
+		self
+	}
+
+	/// Show logs until a timestamp/relative time, `--until`. Builder-style.
+	#[must_use]
+	pub fn with_until(mut self, until: Option<String>) -> Self {
+		self.until = until;
+		self
+	}
+
+	/// Prefix each line with an RFC3339 timestamp, `-t/--timestamps`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_timestamps(mut self, timestamps: bool) -> Self {
+		self.timestamps = timestamps;
+		self
+	}
+}
+
+/// Prefix-display options for [`crate::Engine::logs_with_display`] (`docker compose
+/// logs --no-color` / `--no-log-prefix`).
+///
+/// `#[non_exhaustive]` since 4.0.0, same rationale as [`LogsOptions`].
+#[derive(Default)]
+#[non_exhaustive]
+pub struct LogsDisplay {
+	/// Produce monochrome output (no colour in the prefix), `--no-color`.
+	pub no_color: bool,
+	/// Do not print the `{service} | ` prefix, `--no-log-prefix`.
+	pub no_log_prefix: bool,
+}
+
+impl LogsDisplay {
+	/// Both `docker compose logs` prefix flags, in CLI order. A constructor
+	/// rather than a struct literal because the type is `#[non_exhaustive]`,
+	/// so the next flag to land is not a breaking change for anyone building
+	/// one.
+	pub fn new(no_color: bool, no_log_prefix: bool) -> Self {
+		Self {
+			no_color,
+			no_log_prefix,
+		}
+	}
+
+	/// Produce monochrome output (no colour in the prefix), `--no-color`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_no_color(mut self, no_color: bool) -> Self {
+		self.no_color = no_color;
+		self
+	}
+
+	/// Do not print the `{service} | ` prefix, `--no-log-prefix`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_no_log_prefix(mut self, no_log_prefix: bool) -> Self {
+		self.no_log_prefix = no_log_prefix;
+		self
+	}
+}

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -10,7 +10,14 @@ use super::Engine;
 use crate::units::{format_bytes, format_duration, DurationFormat, SizeFormat};
 
 /// Options for [`Engine::ps_with_options`], mirroring `docker compose ps`.
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`PsOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct PsOptions {
 	/// Include stopped containers, `-a/--all` (default: running only).
 	pub all: bool,
@@ -18,6 +25,37 @@ pub struct PsOptions {
 	pub quiet: bool,
 	/// Emit JSON instead of the table, `--format json`.
 	pub json: bool,
+}
+
+impl PsOptions {
+	/// Every `docker compose ps` flag, in CLI order. A constructor rather than
+	/// a struct literal because the type is `#[non_exhaustive]`, so the next
+	/// flag to land is not a breaking change for anyone building one.
+	pub fn new(all: bool, quiet: bool, json: bool) -> Self {
+		Self { all, quiet, json }
+	}
+
+	/// Include stopped containers, `-a/--all` (default: running only).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_all(mut self, all: bool) -> Self {
+		self.all = all;
+		self
+	}
+
+	/// Print only container IDs, `-q/--quiet`. Builder-style.
+	#[must_use]
+	pub fn with_quiet(mut self, quiet: bool) -> Self {
+		self.quiet = quiet;
+		self
+	}
+
+	/// Emit JSON instead of the table, `--format json`. Builder-style.
+	#[must_use]
+	pub fn with_json(mut self, json: bool) -> Self {
+		self.json = json;
+		self
+	}
 }
 
 /// Options for `ps` added after the crate's API froze.
@@ -45,18 +83,30 @@ pub struct PsDisplayOptions {
 }
 
 impl PsDisplayOptions {
-	/// Ask for the SIZE column.
+	/// Ask for the SIZE column, `-s/--size`. Builder-style.
 	#[must_use]
 	pub fn with_size(mut self, size: bool) -> Self {
 		self.size = size;
 		self
 	}
+
+	/// The single `ps` display flag, in CLI order. A constructor rather than
+	/// a struct literal because the type is `#[non_exhaustive]`, so the next
+	/// flag to land is not a breaking change for anyone building one.
+	pub fn new(size: bool) -> Self {
+		Self { size }
+	}
 }
 
 /// Service/status/name filters for [`Engine::ps_filtered`] (`docker compose ps`
-/// `--services`, `[SERVICE...]`, `--status`, `--filter`). Kept off the frozen
-/// [`PsOptions`] struct so the published library API stays stable across minors.
+/// `--services`, `[SERVICE...]`, `--status`, `--filter`).
+///
+/// `#[non_exhaustive]` since 4.0.0, same rationale as [`PsOptions`]: a new
+/// filter kind can be added in a minor release without breaking external
+/// callers. Construct it via [`PsFilterOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct PsFilterOptions {
 	/// Print the service names instead of the container table, `--services`.
 	pub services_only: bool,
@@ -66,6 +116,58 @@ pub struct PsFilterOptions {
 	pub status: Vec<String>,
 	/// Generic `KEY=VALUE` predicates, `--filter` (supports status= and name=).
 	pub filters: Vec<String>,
+}
+
+impl PsFilterOptions {
+	/// Every `ps` filter flag, in CLI order. A constructor rather than a struct
+	/// literal because the type is `#[non_exhaustive]`, so the next flag to
+	/// land is not a breaking change for anyone building one.
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		services_only: bool,
+		services: Vec<String>,
+		status: Vec<String>,
+		filters: Vec<String>,
+	) -> Self {
+		Self {
+			services_only,
+			services,
+			status,
+			filters,
+		}
+	}
+
+	/// Print the service names instead of the container table, `--services`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_services_only(mut self, services_only: bool) -> Self {
+		self.services_only = services_only;
+		self
+	}
+
+	/// Restrict to these services' containers (positional `SERVICE` filter).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_services(mut self, services: Vec<String>) -> Self {
+		self.services = services;
+		self
+	}
+
+	/// Status filters, `--status` (e.g. running, exited); OR-combined.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_status(mut self, status: Vec<String>) -> Self {
+		self.status = status;
+		self
+	}
+
+	/// Generic `KEY=VALUE` predicates, `--filter` (supports status= and name=).
+	/// Builder-style.
+	#[must_use]
+	pub fn with_filters(mut self, filters: Vec<String>) -> Self {
+		self.filters = filters;
+		self
+	}
 }
 
 /// Human-readable status for `ps`. Podman's libpod list endpoint leaves

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -14,9 +14,15 @@ use crate::units::SizeFormat;
 use super::Engine;
 
 /// Options for [`Engine::stats_with_options`], mirroring `docker compose stats`
-/// and the table-shaping flags the other list commands expose. Kept off the
-/// frozen [`Engine::stats`] signature so the published library API stays stable across minors.
+/// and the table-shaping flags the other list commands expose.
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`StatsOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct StatsOptions {
 	/// Disable streaming; print a single snapshot and exit, `--no-stream`.
 	pub no_stream: bool,
@@ -40,6 +46,36 @@ impl StatsOptions {
 			no_trunc,
 			json,
 		}
+	}
+
+	/// Disable streaming; print a single snapshot and exit, `--no-stream`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_no_stream(mut self, no_stream: bool) -> Self {
+		self.no_stream = no_stream;
+		self
+	}
+
+	/// Include non-running containers as zeroed rows, `-a/--all`. Builder-style.
+	#[must_use]
+	pub fn with_all(mut self, all: bool) -> Self {
+		self.all = all;
+		self
+	}
+
+	/// Emit JSON instead of the table, `--format json`. Builder-style.
+	#[must_use]
+	pub fn with_json(mut self, json: bool) -> Self {
+		self.json = json;
+		self
+	}
+
+	/// Disable container-name truncation in the table, `--no-trunc`.
+	/// Builder-style.
+	#[must_use]
+	pub fn with_no_trunc(mut self, no_trunc: bool) -> Self {
+		self.no_trunc = no_trunc;
+		self
 	}
 }
 

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -42,21 +42,58 @@ pub struct VolumesDisplayOptions {
 }
 
 impl VolumesDisplayOptions {
-	/// Ask for the size columns.
+	/// Ask for the size columns, `-s/--size`. Builder-style.
 	#[must_use]
 	pub fn with_size(mut self, size: bool) -> Self {
 		self.size = size;
 		self
 	}
+
+	/// The single `volumes` display flag, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	pub fn new(size: bool) -> Self {
+		Self { size }
+	}
 }
 
 /// Options for [`Engine::list_volumes`], mirroring `docker compose volumes`.
+///
+/// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
+/// release without breaking every external caller that built the struct with
+/// a literal. Construct it via [`VolumesOptions::new`] or the `with_*` builders
+/// below; a struct literal is refused outside this crate, which is what buys
+/// the room to grow.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct VolumesOptions {
 	/// Print only volume names, `-q/--quiet`.
 	pub quiet: bool,
 	/// Emit a JSON array instead of the table, `--format json`.
 	pub json: bool,
+}
+
+impl VolumesOptions {
+	/// Every `docker compose volumes` flag, in CLI order. A constructor rather
+	/// than a struct literal because the type is `#[non_exhaustive]`, so the
+	/// next flag to land is not a breaking change for anyone building one.
+	pub fn new(quiet: bool, json: bool) -> Self {
+		Self { quiet, json }
+	}
+
+	/// Print only volume names, `-q/--quiet`. Builder-style.
+	#[must_use]
+	pub fn with_quiet(mut self, quiet: bool) -> Self {
+		self.quiet = quiet;
+		self
+	}
+
+	/// Emit a JSON array instead of the table, `--format json`. Builder-style.
+	#[must_use]
+	pub fn with_json(mut self, json: bool) -> Self {
+		self.json = json;
+		self
+	}
 }
 
 impl Engine {

--- a/internal/libpod/validate.rs
+++ b/internal/libpod/validate.rs
@@ -30,14 +30,27 @@ const UTS_FIELD: &str = "uts";
 const USERNS_FIELD: &str = "userns_mode";
 const CGROUP_FIELD: &str = "cgroup";
 
-/// The namespace modes libpod's `ParseNamespace` accepts (in the form a
-/// compose-side string would be in).
+/// The namespace modes every slot accepts, in the form a compose-side string
+/// would be in.
 ///
-/// `host`, `private`, `pod`, and `none` are the simple modes. `container:<id>`
-/// joins another container's namespace (compose's `container:NAME` and
-/// `service:NAME` forms; podup rewrites service→container before this list
-/// sees it). The `ns:<path>` form joins a namespace by an absolute filesystem
-/// path — directly user-facing on the compose side, so it has to be allowed.
+/// This list used to be the whole allow-list, shared by all five slots, and
+/// that made it wrong for four of them. Measured against podman 5.7.0, only
+/// `host`, `private` and `pod` are universal: `none` and `shareable` parse for
+/// `ipc` alone, and `keep-id`/`auto`/`nomap` for `userns_mode` alone. The
+/// per-slot extras live in [`IPC_EXTRA_MODES`] and [`USERNS_EXTRA_MODES`].
+///
+/// The measurement distinguishes a mode podman refuses to *parse* — it says
+/// "unrecognized namespace mode" — from one that parses and then fails to
+/// apply. On a rootless host `--userns=auto` reports "not enough unused IDs in
+/// user namespace" and `--userns=private` wants a UID mapping; both are valid
+/// modes that this host cannot satisfy, and neither belongs in a syntax
+/// allow-list.
+///
+/// `container:<id>` joins another container's namespace (compose's
+/// `container:NAME` and `service:NAME` forms; podup rewrites service→container
+/// before this list sees it). The `ns:<path>` form joins a namespace by an
+/// absolute filesystem path — directly user-facing on the compose side, so it
+/// has to be allowed.
 ///
 /// `network_mode` is intentionally **not** validated here: the engine
 /// translates `service:NAME` to `container:<cname>` and accepts `bridge`,
@@ -47,12 +60,27 @@ const CGROUP_FIELD: &str = "cgroup";
 /// translation post-hoc; a rejected value still surfaces through the
 /// `netns` field of the rendered error, just via the libpod message rather
 /// than the pre-validator.
-const NS_MODES: &[&str] = &["host", "private", "pod", "none"];
+const NS_MODES: &[&str] = &["host", "private", "pod"];
+
+/// `ipc` takes two modes the other slots reject. `shareable` is the one
+/// compose files actually reach for — it is what lets a second container join
+/// this one's IPC namespace later, and podup used to refuse it outright.
+const IPC_EXTRA_MODES: &[&str] = &["none", "shareable"];
+
+/// `userns_mode` has its own vocabulary, and it is the reason this list had to
+/// stop being shared. `keep-id` maps the calling user into the container and
+/// is the standard rootless answer to a file-ownership mismatch; `nomap` maps
+/// nothing; `auto` lets podman pick a free range.
+const USERNS_EXTRA_MODES: &[&str] = &["keep-id", "auto", "nomap"];
 
 /// `container:` is not a value in the allow-list; it must carry an id.
 /// `ns:` is not a value either — it must carry a path. The presence of the
 /// prefix is the test; the suffix is whatever the user typed.
 const NS_PREFIX_MODES: &[&str] = &["container:", "ns:"];
+
+/// `keep-id` and `auto` also take options, as `keep-id:uid=1000,gid=1000` or
+/// `auto:size=65536`. Only `userns_mode` accepts these.
+const USERNS_PREFIX_MODES: &[&str] = &["keep-id:", "auto:"];
 
 /// Per-namespace validator entry: the compose-side field name and the mode
 /// value to validate. `None` means the namespace slot was unset (skip).
@@ -65,44 +93,66 @@ type NsSlot<'a> = (&'a str, Option<&'a str>);
 pub(crate) fn first_invalid_namespace(slots: &[NsSlot<'_>]) -> Option<(String, String, String)> {
 	for (field, value) in slots {
 		let Some(mode) = value else { continue };
-		if is_valid_namespace_mode(mode) {
+		if is_valid_namespace_mode(field, mode) {
 			continue;
 		}
 		return Some((
 			(*field).to_string(),
 			(*mode).to_string(),
-			allowed_namespace_modes(),
+			allowed_namespace_modes(field),
 		));
 	}
 	None
 }
 
-fn is_valid_namespace_mode(mode: &str) -> bool {
-	if NS_MODES.contains(&mode) {
+/// The plain modes this slot accepts on top of [`NS_MODES`].
+fn extra_modes(field: &str) -> &'static [&'static str] {
+	match field {
+		IPC_FIELD => IPC_EXTRA_MODES,
+		USERNS_FIELD => USERNS_EXTRA_MODES,
+		_ => &[],
+	}
+}
+
+/// The `prefix:suffix` forms this slot accepts on top of [`NS_PREFIX_MODES`].
+fn extra_prefixes(field: &str) -> &'static [&'static str] {
+	if field == USERNS_FIELD {
+		USERNS_PREFIX_MODES
+	} else {
+		&[]
+	}
+}
+
+fn is_valid_namespace_mode(field: &str, mode: &str) -> bool {
+	if NS_MODES.contains(&mode) || extra_modes(field).contains(&mode) {
 		return true;
 	}
-	if NS_PREFIX_MODES.iter().any(|p| mode.starts_with(p)) {
-		// `container:` and `ns:` both require a non-empty suffix.
-		return mode.len() > "container:".len();
+	// Measure the suffix against the prefix that actually matched. The old
+	// code compared every prefix against `"container:".len()`, which would
+	// have rejected a short but legal `ns:/x`.
+	for p in NS_PREFIX_MODES.iter().chain(extra_prefixes(field)) {
+		if mode.starts_with(p) {
+			return mode.len() > p.len();
+		}
 	}
 	false
 }
 
-fn allowed_namespace_modes() -> String {
+fn allowed_namespace_modes(field: &str) -> String {
 	let mut s = String::from("one of ");
 	let mut first = true;
-	for m in NS_MODES {
-		if !first {
+	let sep = |s: &mut String, first: &mut bool| {
+		if !*first {
 			s.push_str(", ");
 		}
-		first = false;
+		*first = false;
+	};
+	for m in NS_MODES.iter().chain(extra_modes(field)) {
+		sep(&mut s, &mut first);
 		write!(&mut s, "`{m}`").expect("writing to String never fails");
 	}
-	for p in NS_PREFIX_MODES {
-		if !first {
-			s.push_str(", ");
-		}
-		first = false;
+	for p in NS_PREFIX_MODES.iter().chain(extra_prefixes(field)) {
+		sep(&mut s, &mut first);
 		write!(&mut s, "`{p}<id-or-path>`").expect("writing to String never fails");
 	}
 	s
@@ -314,23 +364,92 @@ mod tests {
 	use super::*;
 	use std::collections::HashMap;
 
+	/// The modes every slot shares.
 	#[test]
 	fn namespace_modes_accept_allow_list() {
-		assert!(is_valid_namespace_mode("host"));
-		assert!(is_valid_namespace_mode("private"));
-		assert!(is_valid_namespace_mode("pod"));
-		assert!(is_valid_namespace_mode("none"));
-		assert!(is_valid_namespace_mode("container:abc"));
-		assert!(is_valid_namespace_mode("ns:/run/netns/foo"));
+		for field in [PID_FIELD, IPC_FIELD, UTS_FIELD, USERNS_FIELD, CGROUP_FIELD] {
+			assert!(is_valid_namespace_mode(field, "host"), "{field}");
+			assert!(is_valid_namespace_mode(field, "private"), "{field}");
+			assert!(is_valid_namespace_mode(field, "pod"), "{field}");
+			assert!(is_valid_namespace_mode(field, "container:abc"), "{field}");
+			assert!(
+				is_valid_namespace_mode(field, "ns:/run/netns/foo"),
+				"{field}"
+			);
+		}
 	}
 
 	#[test]
 	fn namespace_modes_reject_unknown() {
-		assert!(!is_valid_namespace_mode("evil"));
-		assert!(!is_valid_namespace_mode(""));
-		assert!(!is_valid_namespace_mode("HOST"));
-		assert!(!is_valid_namespace_mode("container:"));
-		assert!(!is_valid_namespace_mode("ns:"));
+		assert!(!is_valid_namespace_mode(PID_FIELD, "evil"));
+		assert!(!is_valid_namespace_mode(PID_FIELD, ""));
+		assert!(!is_valid_namespace_mode(PID_FIELD, "HOST"));
+		assert!(!is_valid_namespace_mode(PID_FIELD, "container:"));
+		assert!(!is_valid_namespace_mode(PID_FIELD, "ns:"));
+	}
+
+	/// A one-character path is still a path. The old check measured every
+	/// prefix against `"container:".len()`, so `ns:/x` failed for being short
+	/// rather than for being wrong.
+	#[test]
+	fn a_short_ns_path_is_accepted() {
+		assert!(is_valid_namespace_mode(PID_FIELD, "ns:/x"));
+	}
+
+	/// Measured against podman 5.7.0: `shareable` and `none` parse for `ipc`
+	/// and are rejected by every other slot with "unrecognized namespace
+	/// mode". `shareable` is the one compose files reach for, and podup used
+	/// to refuse it.
+	#[test]
+	fn ipc_takes_shareable_and_none_but_no_other_slot_does() {
+		assert!(is_valid_namespace_mode(IPC_FIELD, "shareable"));
+		assert!(is_valid_namespace_mode(IPC_FIELD, "none"));
+		for field in [PID_FIELD, UTS_FIELD, USERNS_FIELD, CGROUP_FIELD] {
+			assert!(!is_valid_namespace_mode(field, "shareable"), "{field}");
+			assert!(!is_valid_namespace_mode(field, "none"), "{field}");
+		}
+	}
+
+	/// Measured against podman 5.7.0. `keep-id` is the standard rootless
+	/// answer to a file-ownership mismatch, and podup rejected it outright
+	/// (#1463). The option-carrying forms parse too.
+	#[test]
+	fn userns_takes_its_own_vocabulary() {
+		for mode in [
+			"keep-id",
+			"auto",
+			"nomap",
+			"keep-id:uid=1000,gid=1000",
+			"auto:size=65536",
+		] {
+			assert!(is_valid_namespace_mode(USERNS_FIELD, mode), "{mode}");
+		}
+		// And nowhere else.
+		for field in [PID_FIELD, IPC_FIELD, UTS_FIELD, CGROUP_FIELD] {
+			assert!(!is_valid_namespace_mode(field, "keep-id"), "{field}");
+			assert!(!is_valid_namespace_mode(field, "auto"), "{field}");
+			assert!(!is_valid_namespace_mode(field, "nomap"), "{field}");
+		}
+		// The option form still needs an option after the colon.
+		assert!(!is_valid_namespace_mode(USERNS_FIELD, "keep-id:"));
+		assert!(!is_valid_namespace_mode(USERNS_FIELD, "auto:"));
+	}
+
+	/// The error text has to name the modes the slot in hand accepts, not a
+	/// union that would send the reader after a value their slot rejects.
+	#[test]
+	fn the_error_lists_the_modes_for_that_slot() {
+		let userns = allowed_namespace_modes(USERNS_FIELD);
+		assert!(userns.contains("keep-id"), "{userns}");
+		assert!(!userns.contains("shareable"), "{userns}");
+
+		let ipc = allowed_namespace_modes(IPC_FIELD);
+		assert!(ipc.contains("shareable"), "{ipc}");
+		assert!(!ipc.contains("keep-id"), "{ipc}");
+
+		let pid = allowed_namespace_modes(PID_FIELD);
+		assert!(!pid.contains("keep-id"), "{pid}");
+		assert!(!pid.contains("shareable"), "{pid}");
 	}
 
 	#[test]

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -281,11 +281,7 @@ async fn run() -> podup::Result<()> {
 		)?;
 		return podup::list_projects_filtered(
 			&client,
-			podup::LsOptions {
-				all: *all,
-				quiet: *quiet,
-				json: *format == OutputFormat::Json,
-			},
+			podup::LsOptions::new(*all, *quiet, *format == OutputFormat::Json),
 			filter,
 		)
 		.await;
@@ -348,17 +344,13 @@ async fn run() -> podup::Result<()> {
 		return engine
 			.ps_filtered_with_display(
 				&file,
-				podup::PsOptions {
-					all: *all,
-					quiet: *quiet,
-					json: *format == OutputFormat::Json,
-				},
-				podup::PsFilterOptions {
-					services_only: *services_only,
-					services: services.clone(),
-					status: status.clone(),
-					filters: filter.clone(),
-				},
+				podup::PsOptions::new(*all, *quiet, *format == OutputFormat::Json),
+				podup::PsFilterOptions::new(
+					*services_only,
+					services.clone(),
+					status.clone(),
+					filter.clone(),
+				),
 				podup::PsDisplayOptions::default().with_size(*size),
 			)
 			.await;

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -267,6 +267,7 @@ pub fn generate_at(file: &ComposeFile, project: &str, base_dir: &std::path::Path
 		declared_networks: &declared_networks,
 		secrets: &file.secrets,
 		base_dir,
+		services: &file.services,
 	};
 	for (name, service) in &file.services {
 		// Emit a `.build` unit first so the systemd generator builds the image

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -32,6 +32,9 @@ pub(crate) struct UnitContext<'a> {
 	/// Directory compose resolves relative paths against — the compose file's
 	/// own directory, not the unit's. See [`abs_against`].
 	pub base_dir: &'a std::path::Path,
+	/// Every service in the file, so a `depends_on` condition can be judged
+	/// against the service it names rather than in the abstract.
+	pub services: &'a IndexMap<String, Service>,
 }
 
 /// Build the `.container` unit for one compose `service`.
@@ -52,6 +55,7 @@ pub(crate) fn container_unit(
 		declared_networks,
 		secrets,
 		base_dir,
+		services,
 	} = ctx;
 	let mut unit = Section::new("Unit");
 	unit.add("Description", format!("{name} (podup)"));
@@ -460,7 +464,7 @@ pub(crate) fn container_unit(
 		}
 	}
 
-	collect_warnings(name, service, warnings);
+	collect_warnings(name, service, services, warnings);
 
 	// The unforgeable ownership marker comes first, as its own comment line;
 	// see `owner_marker` for why it must stay separate from the `Label=` line.

--- a/internal/quadlet/unit/health.rs
+++ b/internal/quadlet/unit/health.rs
@@ -35,6 +35,24 @@ pub(super) fn render_healthcheck(
 		};
 		if !cmd.is_empty() {
 			container.add("HealthCmd", cmd);
+			// Tell systemd the unit is not up until the healthcheck passes.
+			// Quadlet renders this as `--sdnotify=healthy`, and without it
+			// systemd calls the service started the moment the container is
+			// created — so `After=`/`Requires=` order the *creation*, not the
+			// readiness, and a dependant starts against a service that is not
+			// serving yet.
+			//
+			// Measured on podman 5.7.0 with a probe that takes ten seconds to
+			// pass: `systemctl start` on the unit itself returned after 11s
+			// rather than immediately, and a second unit with
+			// `After=`/`Requires=` on it started 10s in. That second number is
+			// the one that matters — it is `depends_on: service_healthy`
+			// actually being honoured.
+			//
+			// Only emitted alongside a command. `--sdnotify=healthy` with
+			// nothing to probe would leave the unit starting until
+			// `TimeoutStartSec` expires.
+			container.add("Notify", "healthy".to_string());
 		}
 	}
 	if let Some(v) = &hc.interval {
@@ -140,5 +158,37 @@ mod tests {
 		// No key is emitted for start_interval, but the user is warned.
 		assert_eq!(warnings.len(), 1);
 		assert!(warnings[0].contains("start_interval"));
+	}
+
+	/// Without this systemd calls the unit started as soon as the container is
+	/// created, so `After=`/`Requires=` order creation rather than readiness.
+	/// Measured on podman 5.7.0: a dependant started 10s into a dependency
+	/// whose probe took 10s, instead of immediately.
+	#[test]
+	fn a_healthcheck_brings_notify_healthy() {
+		let (body, _) = render("image: x\nhealthcheck:\n  test: [\"CMD\", \"true\"]\n");
+		assert!(body.contains("Notify=healthy"), "{body}");
+	}
+
+	/// `--sdnotify=healthy` with nothing to probe would leave the unit starting
+	/// until `TimeoutStartSec` expires, so it must never be emitted alone.
+	#[test]
+	fn no_healthcheck_means_no_notify() {
+		let (body, _) = render("image: x\n");
+		assert!(!body.contains("Notify"), "{body}");
+	}
+
+	#[test]
+	fn a_disabled_healthcheck_means_no_notify() {
+		let (body, _) = render("image: x\nhealthcheck:\n  disable: true\n");
+		assert!(!body.contains("Notify"), "{body}");
+	}
+
+	/// An empty command emits no `HealthCmd`, so there is nothing for systemd
+	/// to wait on and `Notify` must not appear either.
+	#[test]
+	fn an_empty_test_means_no_notify() {
+		let (body, _) = render("image: x\nhealthcheck:\n  test: []\n");
+		assert!(!body.contains("Notify"), "{body}");
 	}
 }

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -1,11 +1,18 @@
 //! Report compose fields that are set but have no Quadlet mapping.
 
-use crate::compose::types::{DependsOn, Service, ServiceCondition};
+use indexmap::IndexMap;
+
+use crate::compose::types::{DependsOn, HealthCheck, Service, ServiceCondition};
 
 /// Warn for fields that are set but have no Quadlet mapping, so the operator
 /// knows the generated unit is incomplete rather than discovering it at run
 /// time.
-pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec<String>) {
+pub(super) fn collect_warnings(
+	name: &str,
+	service: &Service,
+	services: &IndexMap<String, Service>,
+	warnings: &mut Vec<String>,
+) {
 	let mut warn = |field: &str, detail: &str| {
 		warnings.push(format!("{name}: {field} {detail}"));
 	};
@@ -50,16 +57,35 @@ pub(super) fn collect_warnings(name: &str, service: &Service, warnings: &mut Vec
 			"hooks have no Quadlet equivalent and are skipped",
 		);
 	}
-	// systemd `After=`/`Requires=` order startup but cannot gate it on a
-	// dependency becoming healthy or completing; those conditions are dropped.
+	// `service_healthy` IS enforceable, as long as the service it names has a
+	// healthcheck: that service's unit carries `Notify=healthy`, so systemd
+	// does not call it started until the probe passes, and `After=`/`Requires=`
+	// then order against readiness rather than creation. Measured on podman
+	// 5.7.0 — a dependant started 10s into a dependency whose probe took 10s.
+	//
+	// So the warning is now about the cases that really cannot work: a
+	// `service_healthy` naming a service with no healthcheck to wait on, and
+	// `service_completed_successfully`, which would need the dependency to be a
+	// `Type=oneshot` unit that exits.
 	if let DependsOn::Map(deps) = &service.depends_on {
-		if deps
-			.values()
-			.any(|c| c.condition != ServiceCondition::ServiceStarted)
-		{
+		let unwaitable: Vec<&str> = deps
+			.iter()
+			.filter(|(dep_name, c)| match c.condition {
+				ServiceCondition::ServiceStarted => false,
+				ServiceCondition::ServiceHealthy => services
+					.get(dep_name.as_str())
+					.is_none_or(|d| d.healthcheck.as_ref().is_none_or(HealthCheck::is_disabled)),
+				_ => true,
+			})
+			.map(|(dep_name, _)| dep_name.as_str())
+			.collect();
+		if !unwaitable.is_empty() {
 			warn(
 				"depends_on",
-				"condition service_healthy/service_completed_successfully is not enforceable in Quadlet; only start ordering is emitted",
+				&format!(
+					"condition on {} is not enforceable in Quadlet and only start ordering is emitted; service_healthy needs the named service to declare a healthcheck, and service_completed_successfully has no equivalent",
+					unwaitable.join(", ")
+				),
 			);
 		}
 	}

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -179,15 +179,15 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 			interactive,
 			no_deps,
 			..
-		} => podup::RunOverrides {
-			user: user.clone(),
-			workdir: workdir.clone(),
-			entrypoint: entrypoint.clone(),
-			volumes: volume.clone(),
-			publish: publish.clone(),
-			interactive: *interactive,
-			no_deps: *no_deps,
-		},
+		} => podup::RunOverrides::new(
+			user.clone(),
+			workdir.clone(),
+			entrypoint.clone(),
+			volume.clone(),
+			publish.clone(),
+			*interactive,
+			*no_deps,
+		),
 		_ => podup::RunOverrides::default(),
 	}
 }

--- a/tests/engine_integration/build_images.rs
+++ b/tests/engine_integration/build_images.rs
@@ -127,11 +127,7 @@ async fn build_with_cli_no_cache_and_build_arg() {
 		.build_all_with_options(
 			&file,
 			&[],
-			&podup::BuildOptions {
-				no_cache: true,
-				build_args: vec!["VERSION=2.0".to_string()],
-				..Default::default()
-			},
+			&podup::BuildOptions::new(true, false, vec!["VERSION=2.0".to_string()], false),
 		)
 		.await
 		.unwrap();
@@ -569,10 +565,7 @@ async fn up_keeps_the_image_a_no_cache_build_produced() {
 		.build_all_with_options(
 			&file,
 			&[],
-			&podup::BuildOptions {
-				no_cache: true,
-				..Default::default()
-			},
+			&podup::BuildOptions::new(true, false, Vec::new(), false),
 		)
 		.await
 		.unwrap();

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -63,11 +63,14 @@ async fn engine_run_command_succeeds() {
 		.run(
 			&file,
 			"job",
-			podup::RunOptions {
-				cmd: vec!["echo".to_string(), "hello".to_string()],
-				rm: true,
-				..Default::default()
-			},
+			podup::RunOptions::new(
+				vec!["echo".to_string(), "hello".to_string()],
+				true,
+				false,
+				Vec::new(),
+				None,
+				false,
+			),
 		)
 		.await;
 	assert!(result.is_ok(), "run failed: {result:?}");
@@ -87,11 +90,14 @@ async fn engine_run_nonzero_exit_returns_run_exited() {
 		.run(
 			&file,
 			"job",
-			podup::RunOptions {
-				cmd: vec!["false".to_string()],
-				rm: true,
-				..Default::default()
-			},
+			podup::RunOptions::new(
+				vec!["false".to_string()],
+				true,
+				false,
+				Vec::new(),
+				None,
+				false,
+			),
 		)
 		.await;
 	assert!(

--- a/tests/engine_integration/cp_flags.rs
+++ b/tests/engine_integration/cp_flags.rs
@@ -25,10 +25,7 @@ async fn engine_cp_index_out_of_range_errors() {
 			&file,
 			local.to_str().unwrap(),
 			"web:/tmp",
-			podup::CpOptions {
-				index: Some(9),
-				..Default::default()
-			},
+			podup::CpOptions::new(Some(9), false, false),
 		)
 		.await;
 	assert!(
@@ -69,10 +66,7 @@ async fn engine_cp_follow_link_uploads_target_contents() {
 			&file,
 			link.to_str().unwrap(),
 			"web:/tmp",
-			podup::CpOptions {
-				follow_link: true,
-				..Default::default()
-			},
+			podup::CpOptions::new(None, true, false),
 		)
 		.await;
 	let out = engine

--- a/tests/engine_integration/lifecycle_query.rs
+++ b/tests/engine_integration/lifecycle_query.rs
@@ -311,14 +311,7 @@ async fn pull_ignore_failures_continues_past_bad_image() {
 
 	// With --ignore-pull-failures the failure is logged and pull returns Ok.
 	let lenient = engine
-		.pull_services_with_options(
-			&file,
-			&[],
-			podup::PullOptions {
-				ignore_failures: true,
-				include_deps: false,
-			},
-		)
+		.pull_services_with_options(&file, &[], podup::PullOptions::new(true, false))
 		.await;
 	assert!(
 		lenient.is_ok(),

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -124,15 +124,18 @@ async fn file_secret_bound() {
 		.run(
 			&file,
 			"web",
-			podup::RunOptions {
-				cmd: vec![
+			podup::RunOptions::new(
+				vec![
 					"sh".to_string(),
 					"-c".to_string(),
 					"test \"$(cat /run/secrets/filesecret)\" = file-secret-content".to_string(),
 				],
-				rm: true,
-				..Default::default()
-			},
+				true,
+				false,
+				Vec::new(),
+				None,
+				false,
+			),
 		)
 		.await;
 	engine.down(&file).await.unwrap();

--- a/tests/engine_integration/run_flags.rs
+++ b/tests/engine_integration/run_flags.rs
@@ -12,12 +12,15 @@ async fn engine_run_applies_user_workdir_env_and_entrypoint() {
 		None => return,
 	};
 	let proj = proj("ruwe");
-	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides {
-		entrypoint: Some("sh".to_string()),
-		user: Some("0".to_string()),
-		workdir: Some("/tmp".to_string()),
-		..Default::default()
-	});
+	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides::new(
+		Some("0".to_string()),
+		Some("/tmp".to_string()),
+		Some("sh".to_string()),
+		Vec::new(),
+		Vec::new(),
+		false,
+		false,
+	));
 	let file = parse_str("services:\n  job:\n    image: alpine:latest\n").unwrap();
 
 	// --entrypoint sh, cmd is its args; -u root, -w /tmp, -e MARK=ok. The command
@@ -26,16 +29,18 @@ async fn engine_run_applies_user_workdir_env_and_entrypoint() {
 		.run(
 			&file,
 			"job",
-			podup::RunOptions {
-				cmd: vec![
+			podup::RunOptions::new(
+				vec![
 					"-c".to_string(),
 					"test \"$(pwd)\" = /tmp && test \"$(id -u)\" = 0 && test \"$MARK\" = ok"
 						.to_string(),
 				],
-				rm: true,
-				env_overrides: vec!["MARK=ok".to_string()],
-				..Default::default()
-			},
+				true,
+				false,
+				vec!["MARK=ok".to_string()],
+				None,
+				false,
+			),
 		)
 		.await;
 	assert!(
@@ -62,12 +67,15 @@ async fn engine_run_applies_volume_publish_and_interactive() {
 	let mount = format!("{}:/mnt/in:ro,z", dir.path().to_str().unwrap());
 
 	let proj = proj("rvp");
-	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides {
-		volumes: vec![mount],
-		publish: vec!["127.0.0.1:0:9".to_string()],
-		interactive: true,
-		..Default::default()
-	});
+	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides::new(
+		None,
+		None,
+		None,
+		vec![mount],
+		vec!["127.0.0.1:0:9".to_string()],
+		true,
+		false,
+	));
 	let file = parse_str("services:\n  job:\n    image: alpine:latest\n").unwrap();
 
 	// -v bind-mounts the host dir, -i keeps stdin open, -p publishes an ad-hoc
@@ -76,15 +84,18 @@ async fn engine_run_applies_volume_publish_and_interactive() {
 		.run(
 			&file,
 			"job",
-			podup::RunOptions {
-				cmd: vec![
+			podup::RunOptions::new(
+				vec![
 					"sh".to_string(),
 					"-c".to_string(),
 					"test \"$(cat /mnt/in/marker.txt)\" = present".to_string(),
 				],
-				rm: true,
-				..Default::default()
-			},
+				true,
+				false,
+				Vec::new(),
+				None,
+				false,
+			),
 		)
 		.await;
 	assert!(
@@ -101,10 +112,15 @@ async fn engine_run_no_deps_skips_dependency_startup() {
 		None => return,
 	};
 	let proj = proj("rnd");
-	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides {
-		no_deps: true,
-		..Default::default()
-	});
+	let engine = Engine::new(client, proj.clone()).with_run_overrides(podup::RunOverrides::new(
+		None,
+		None,
+		None,
+		Vec::new(),
+		Vec::new(),
+		false,
+		true,
+	));
 	let file = parse_str(
 		"services:\n  job:\n    image: alpine:latest\n    depends_on:\n      - dep\n  dep:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
 	)
@@ -115,11 +131,14 @@ async fn engine_run_no_deps_skips_dependency_startup() {
 		.run(
 			&file,
 			"job",
-			podup::RunOptions {
-				cmd: vec!["true".to_string()],
-				rm: true,
-				..Default::default()
-			},
+			podup::RunOptions::new(
+				vec!["true".to_string()],
+				true,
+				false,
+				Vec::new(),
+				None,
+				false,
+			),
 		)
 		.await;
 	let names = engine
@@ -153,11 +172,14 @@ async fn engine_run_starts_dependencies_by_default() {
 		.run(
 			&file,
 			"job",
-			podup::RunOptions {
-				cmd: vec!["true".to_string()],
-				rm: true,
-				..Default::default()
-			},
+			podup::RunOptions::new(
+				vec!["true".to_string()],
+				true,
+				false,
+				Vec::new(),
+				None,
+				false,
+			),
 		)
 		.await;
 	let names = engine

--- a/tests/semver_constructible_structs.rs
+++ b/tests/semver_constructible_structs.rs
@@ -1,0 +1,197 @@
+//! Compilation contract for every public `*Options` struct.
+//!
+//! `podup` is committed to a 1.0.0 semver contract: adding a field to a
+//! `pub struct` that an external consumer can construct with a struct literal
+//! is a MAJOR bump. The crate therefore marks every external `*Options`
+//! `#[non_exhaustive]` and gives each a `new(...)` constructor plus per-field
+//! `with_*` builders, mirroring the pattern `ExecOptions` already uses.
+//!
+//! This file is the gate that keeps that promise. It is **not a runtime
+//! test**: it only needs to compile. If somebody adds a new field to one of
+//! these structs without the attribute, or breaks a builder, this binary
+//! stops compiling and the gate turns the PR red before the change ever
+//! reaches a downstream consumer. If somebody adds a new public
+//! `*Options`/`*Display`/`*Overrides` struct without going through the same
+//! `new` + `with_*` convention, the new entry simply has to be added here.
+//!
+//! Each block exercises the same surface an embedder would: `::default()`,
+//! `::new(...)` with every field, and one chain of `with_*` calls. None of
+//! the constructed values are used; the assignment to a `let _ =` is enough
+//! for the type-checker to walk every constructor and method.
+//!
+//! The contract applies to every public options struct re-exported at the
+//! crate root. The autostart option structs (`ServiceUnitOpts`,
+//! `InstallOptions`) learned the same lesson earlier (#1093) and predate
+//! this file; they are covered by their own integration tests.
+//!
+//! # Adding a new options struct
+//!
+//! 1. Mark it `#[non_exhaustive]`.
+//! 2. Give it a `pub fn new(...)` taking every field, and one
+//!    `#[must_use] pub fn with_<field>(mut self, ...) -> Self` per field.
+//! 3. Add a block here that builds it through the public API.
+
+#![allow(dead_code, unused_variables)]
+
+use podup::{
+	BuildOptions, Client, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions,
+	ImagesOptions, LogsDisplay, LogsOptions, LsOptions, PsDisplayOptions, PsFilterOptions,
+	PsOptions, PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions,
+	VolumesDisplayOptions, VolumesOptions,
+};
+
+#[test]
+fn every_public_options_struct_stays_constructible() {
+	// --- already non-exhaustive pre-#1475 (ExecOptions, PsDisplayOptions,
+	// VolumesDisplayOptions, plus InstallOptions/ServiceUnitOpts which predate
+	// this file): keep their existing pattern exercised so a future field
+	// addition has to come with a builder.
+
+	let _ = ExecOptions::default();
+	let _ = ExecOptions::new(Vec::new(), None, None, false, false, None, false);
+	let _ = ExecOptions::default()
+		.with_user(None)
+		.with_workdir(None)
+		.with_index(None)
+		.with_env(Vec::new());
+
+	let _ = PsDisplayOptions::default();
+	let _ = PsDisplayOptions::new(false);
+	let _ = PsDisplayOptions::default().with_size(true);
+
+	let _ = VolumesDisplayOptions::default();
+	let _ = VolumesDisplayOptions::new(false);
+	let _ = VolumesDisplayOptions::default().with_size(true);
+
+	// --- the nineteen structs touched by #1475.
+
+	let _ = LsOptions::default();
+	let _ = LsOptions::new(false, false, false);
+	let _ = LsOptions::default()
+		.with_all(true)
+		.with_quiet(true)
+		.with_json(true);
+
+	let _ = BuildOptions::default();
+	let _ = BuildOptions::new(false, false, Vec::new(), false);
+	let _ = BuildOptions::default()
+		.with_no_cache(true)
+		.with_pull(true)
+		.with_build_args(Vec::new())
+		.with_quiet(true);
+
+	let _ = PullOptions::default();
+	let _ = PullOptions::new(false, false);
+	let _ = PullOptions::default()
+		.with_ignore_failures(true)
+		.with_include_deps(true);
+
+	let _ = PushOptions::default();
+	let _ = PushOptions::new(false, None);
+	let _ = PushOptions::default()
+		.with_ignore_failures(true)
+		.with_tls_verify(Some(false));
+
+	let _ = ImagesOptions::default();
+	let _ = ImagesOptions::new(false, false);
+	let _ = ImagesOptions::default().with_quiet(true).with_json(true);
+
+	let _ = LogsOptions::default();
+	let _ = LogsOptions::new(false, None, None, None, false);
+	let _ = LogsOptions::default()
+		.with_follow(true)
+		.with_tail(None)
+		.with_since(None)
+		.with_until(None)
+		.with_timestamps(true);
+
+	let _ = LogsDisplay::default();
+	let _ = LogsDisplay::new(false, false);
+	let _ = LogsDisplay::default()
+		.with_no_color(true)
+		.with_no_log_prefix(true);
+
+	let _ = PsOptions::default();
+	let _ = PsOptions::new(false, false, false);
+	let _ = PsOptions::default()
+		.with_all(true)
+		.with_quiet(true)
+		.with_json(true);
+
+	let _ = PsFilterOptions::default();
+	let _ = PsFilterOptions::new(false, Vec::new(), Vec::new(), Vec::new());
+	let _ = PsFilterOptions::default()
+		.with_services_only(true)
+		.with_services(Vec::new())
+		.with_status(Vec::new())
+		.with_filters(Vec::new());
+
+	let _ = RunOptions::default();
+	let _ = RunOptions::new(Vec::new(), false, false, Vec::new(), None, false);
+	let _ = RunOptions::default()
+		.with_cmd(Vec::new())
+		.with_rm(true)
+		.with_detach(true)
+		.with_env_overrides(Vec::new())
+		.with_name_override(None)
+		.with_service_ports(true);
+
+	let _ = RunOverrides::default();
+	let _ = RunOverrides::new(None, None, None, Vec::new(), Vec::new(), false, false);
+	let _ = RunOverrides::default()
+		.with_user(None)
+		.with_workdir(None)
+		.with_entrypoint(None)
+		.with_volumes(Vec::new())
+		.with_publish(Vec::new())
+		.with_interactive(true)
+		.with_no_deps(true);
+
+	let _ = CommitOptions::default();
+	let _ = CommitOptions::new(None, None, None, Vec::new());
+	let _ = CommitOptions::default()
+		.with_message(None)
+		.with_author(None)
+		.with_pause(None)
+		.with_changes(Vec::new());
+
+	let _ = StatsOptions::default();
+	let _ = StatsOptions::new(false, false, false, false);
+	let _ = StatsOptions::default()
+		.with_no_stream(true)
+		.with_all(true)
+		.with_json(true)
+		.with_no_trunc(true);
+
+	let _ = VolumesOptions::default();
+	let _ = VolumesOptions::new(false, false);
+	let _ = VolumesOptions::default().with_quiet(true).with_json(true);
+
+	let _ = CpOptions::default();
+	let _ = CpOptions::new(None, false, false);
+	let _ = CpOptions::default()
+		.with_index(None)
+		.with_follow_link(true)
+		.with_archive(true);
+
+	let _ = EventsOptions::default();
+	let _ = EventsOptions::new(None, None, Vec::new());
+	let _ = EventsOptions::default()
+		.with_since(None)
+		.with_until(None)
+		.with_filters(Vec::new());
+}
+
+#[test]
+fn no_struct_literal_escapes_into_the_published_api() {
+	// Belt-and-braces: the same structs, but built without any helper so a
+	// future `#[non_exhaustive]` removal cannot sneak back in unnoticed. The
+	// `Default` bound is what every public options struct already has, so the
+	// only way for this block to compile is `SomeOpts::default()`. If a struct
+	// loses its `#[non_exhaustive]` and a downstream consumer starts using a
+	// struct literal, they would still build; this block would still build;
+	// the only signal would be the missing `#[non_exhaustive]` on the type
+	// itself, which `cargo public-api` / `cargo semver-checks` already catches
+	// at the API surface.
+	let _: Engine = Engine::new(Client::new("/dev/null"), "contract".to_string());
+}


### PR DESCRIPTION
The first major since 3.0.0. Six commits.

## Breaking

**Bridge networks are isolated from each other.** Docker does this and podman does not, so a podup service could reach ports on a neighbouring network that were never published. Measured with the same experiment on both engines — a listener on an unpublished port in network B, a container in network A dialling its address:

| engine | result |
|---|---|
| docker 29.6.2 | refused |
| podman 5.7.0 | connected |

Inside a single network docker connects, which is what makes that a measurement of isolation rather than of a broken dial.

podup now passes netavark's `isolate` on every bridge network it creates. Traffic within a network still flows and outbound internet still works, both checked against a plain network as control. The option only bites when *both* networks carry it, so it is a default rather than an opt-in — one project opting in would protect nobody. Two podup projects no longer reach each other's unpublished ports; a network created outside podup without the option still can.

A project that deliberately spans networks sets `driver_opts.isolate: false`.

**Nineteen public option structs are `#[non_exhaustive]`** (sixteen newly so), each with a `new(...)` and per-field `with_*` builders. A struct literal no longer compiles outside the crate. Marking them without a construction path would have made them unconstructible, so the builders are part of the same change, and `tests/semver_constructible_structs.rs` walks every one through the public API at compile time.

## Added

* **`Notify=healthy` in Quadlet units**, so `depends_on: condition: service_healthy` is honoured. podup used to warn that the condition "is not enforceable in Quadlet"; measured on podman 5.7.0 with a probe taking ten seconds to pass, a dependant now starts ten seconds in rather than immediately. The warning is scoped to what genuinely cannot work and names the service at fault.
* **`build.ulimits` reaches the build.** It was reported as unmapped; the libpod endpoint takes it. Measured by posting the same context twice with a `RUN` printing `ulimit -n`: 524288 without the parameter, 1234 with it.

## Fixed

* **Per-slot namespace validation.** One allow-list served `pid`, `ipc`, `uts`, `cgroup` and `userns_mode`, making it wrong for four of them — it refused `ipc: shareable` and every `userns_mode` value podman offers, while accepting `none` on four slots that reject it. Errors now list the modes the slot in hand accepts.

## Version

`Cargo.toml`, `Cargo.lock` and `debian/changelog` all read 4.0.0.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>