### PR TITLE
ci: fail when a scheduled workflow stops firing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,66 @@ jobs:
       package-check: true
       semver-check: true
       doc-warnings: true
+
+  # A cron that stops firing emits nothing, and "no alert" is indistinguishable
+  # from "all clear". Every scheduled workflow in this org went dark on
+  # 2026-06-29; four repos stayed dark for another four weeks while reporting
+  # `active` the whole time, and it cost a real finding. These turn the absence
+  # of a scheduled run into a red check on ordinary work.
+  #
+  # max-age-days allows about two periods, so one miss is tolerated:
+  # 15 for weekly, 3 for daily, 65 for the monthly benchmark.
+  freshness-audit:
+    permissions:
+      contents: read
+      actions: read
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    with:
+      workflow: audit.yml
+      max-age-days: 15
+
+  freshness-fuzz:
+    permissions:
+      contents: read
+      actions: read
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    with:
+      workflow: fuzz.yml
+      max-age-days: 15
+
+  freshness-podman-lane:
+    permissions:
+      contents: read
+      actions: read
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    with:
+      workflow: podman-lane.yml
+      max-age-days: 3
+
+  freshness-podman-watch:
+    permissions:
+      contents: read
+      actions: read
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    with:
+      workflow: podman-watch.yml
+      max-age-days: 3
+
+  # Monthly (`0 4 1 * *`), so seventeen days without a run is normal and a
+  # weekly threshold here would fail on ordinary work for most of the month.
+  freshness-benchmark:
+    permissions:
+      contents: read
+      actions: read
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    with:
+      workflow: benchmark.yml
+      max-age-days: 65
+
+  # Dependabot silently stops proposing updates when its config is not
+  # re-registered, and like a dead cron it reports nothing at all. This fails
+  # when no pull request has been opened recently enough.
+  dependabot-freshness:
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    with:
+      max-age-days: 15


### PR DESCRIPTION
The `schedule-freshness` reusable exists and had **zero callers anywhere** — measured with `uses:`, not by grepping for mentions, which counts the reusable definitions themselves and reads as coverage that is not there.

Every other guard in this org is an assertion that fails loudly. A cron that stops firing is the exception: it emits nothing, and *no alert* is indistinguishable from *all clear*.

That is not hypothetical. Every scheduled workflow in the org went dark on 2026-06-29. podup and apt recovered on 07-15 only because they happened to get activity and a disable/enable cycle; four other repos stayed dark four more weeks, all reporting `active` throughout. It cost a real finding.

## Cadence read, not assumed

`max-age-days` allows about two periods, so one miss is tolerated. Each value comes from the actual cron expression.

Every workflow gated here has a **successful run on record**, which the reusable requires — with nothing to measure it reports failure, correctly.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>

## This repo

| workflow | cron | max-age-days |
|---|---|---|
| `audit.yml` | `0 6 * * 1` weekly | 15 |
| `fuzz.yml` | `0 7 * * 1` weekly | 15 |
| `podman-lane.yml` | `0 9 * * *` daily | 3 |
| `podman-watch.yml` | `0 8 * * *` daily | 3 |
| `benchmark.yml` | `0 4 1 * *` **monthly** | 65 |

`benchmark` is worth calling out: its last success was seventeen days ago, which looks alarming until you read the cron and find it is monthly. A weekly threshold there would have failed ordinary work for most of every month.

Also adds the missing `dependabot-freshness` caller — apt, the tap and the bucket already had one; this repo did not.