### PR TITLE
test(engine): produce the error variants nothing was producing

### DIFF
--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -360,4 +360,124 @@ mod tests {
 			&Error::from(ErrorKind::PermissionDenied)
 		));
 	}
+
+	/// `io_to_err` is the sole producer of [`ComposeError::IoPath`] on the
+	/// `export` write paths: any write or flush error against a `-o FILE`
+	/// sink is wrapped with the destination path so the message tells the
+	/// operator which file failed, not the bare `io error:`.
+	#[test]
+	fn io_to_err_with_output_path_wraps_as_iopath() {
+		use super::io_to_err;
+		use crate::error::ComposeError;
+		use std::io::{Error, ErrorKind};
+		use std::path::PathBuf;
+
+		let p = PathBuf::from("/tmp/out.x.tar");
+		let e = Error::new(ErrorKind::PermissionDenied, "denied");
+		let mapped = io_to_err(&Some(p.clone()), e);
+
+		// The variant must be IoPath with the path attached — a bare
+		// `ComposeError::Io(_)` would drop the destination the user just
+		// asked us to write to, and is the regression this variant exists to
+		// prevent.
+		let ComposeError::IoPath { path, source } = mapped else {
+			panic!("expected IoPath, got a different variant");
+		};
+		assert_eq!(path, p.display().to_string(), "path must be preserved");
+		assert_eq!(
+			source.kind(),
+			ErrorKind::PermissionDenied,
+			"underlying io error must round-trip"
+		);
+	}
+
+	/// A stdout sink has no path to name, so `io_to_err` falls back to the
+	/// generic [`ComposeError::Io`] rather than fabricating an empty
+	/// `IoPath`. Pinning the asymmetry so a future refactor does not
+	/// "improve" it into always wrapping.
+	#[test]
+	fn io_to_err_without_output_path_falls_back_to_plain_io() {
+		use super::io_to_err;
+		use crate::error::ComposeError;
+		use std::io::{Error, ErrorKind};
+
+		let e = Error::new(ErrorKind::BrokenPipe, "epipe");
+		let mapped = io_to_err(&None, e);
+		assert!(
+			matches!(mapped, ComposeError::Io(_)),
+			"stdout sink must stay as ComposeError::Io, got {mapped:?}"
+		);
+	}
+}
+
+/// End-to-end check that the destination path actually surfaces as
+/// [`ComposeError::IoPath`] when the operator passes an output the file
+/// system refuses to create — i.e. the production wiring from `Engine::export`
+/// through `std::fs::File::create` into `IoPath`, not just the helper that
+/// shapes the error. The bare `io_to_err` unit test above pins the wrapper;
+/// this one pins the call site that triggers it.
+#[cfg(unix)]
+#[cfg(test)]
+mod export_iopath_tests {
+	use std::path::PathBuf;
+
+	use crate::compose::types::{ComposeFile, Service};
+	use crate::engine::fake_podman::{self, FakeReply};
+	use crate::engine::Engine;
+	use crate::error::ComposeError;
+
+	#[tokio::test]
+	async fn export_to_an_unwritable_destination_surfaces_iopath() {
+		// A single-replica service so the container name resolves without
+		// inspecting Podman.
+		let mut file = ComposeFile::default();
+		file.services.insert(
+			"web".into(),
+			Service {
+				image: Some("nginx:1.27".into()),
+				..Default::default()
+			},
+		);
+
+		// The fake answers the streaming GET the same way it would for a
+		// healthy container — podup never has to read a real byte from us,
+		// because the destination file fails to open before the body is
+		// consumed. The chunked body is what `get_stream` accepts. The
+		// target carries the `http://localhost` prefix the client builds,
+		// so the matcher looks for the trailing `/export` route instead.
+		let fake = fake_podman::start_replying(|method, target| {
+			if method == "GET" && target.contains("/export") {
+				// One empty chunk is enough — the test errors before the
+				// body is fully drained.
+				return FakeReply::ChunkedEnd(vec![String::new()]);
+			}
+			FakeReply::Body(404, r#"{"message":"not used"}"#.to_string())
+		});
+		let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+
+		// A path under a directory that does not exist: `File::create`
+		// fails synchronously at the parent-component lookup, before any
+		// byte hits the (would-be) sink. The production code wraps that
+		// io error in `IoPath` with the path; the test confirms both.
+		let dest = PathBuf::from("/nonexistent-dir-7c4e1a/out.x.tar");
+
+		let err = engine
+			.export(&file, "web", Some(dest.clone()), None)
+			.await
+			.expect_err("an unwritable destination must surface as an error");
+
+		let msg = err.to_string();
+		let ComposeError::IoPath { path, .. } = err else {
+			panic!("expected IoPath for an unwritable -o FILE, got: {msg:?}");
+		};
+		assert_eq!(
+			path,
+			dest.display().to_string(),
+			"the destination path must appear in the error"
+		);
+		assert!(
+			msg.contains(&dest.display().to_string()),
+			"the rendered message must name the destination, got: {msg}"
+		);
+	}
 }

--- a/internal/engine/lifecycle/drop_recheck_tests.rs
+++ b/internal/engine/lifecycle/drop_recheck_tests.rs
@@ -87,7 +87,7 @@ mod over_the_wire {
 	async fn a_lost_response_fails_when_the_container_did_not_reach_the_goal() {
 		let fake = fake_dropping_the_op(Some("exited"));
 		let engine = engine_with(fake.client(), "proj");
-		engine
+		let err = engine
 			.run_lifecycle_op(
 				&start_path(),
 				"proj-web-1",
@@ -96,6 +96,15 @@ mod over_the_wire {
 			)
 			.await
 			.expect_err("the container is not running, so nothing confirms the start");
+		// Pin the variant: a dropped response that re-checks to a non-running
+		// state must surface as the underlying libpod error, not as some
+		// other variant a future refactor might swap in. `confirm_lost_response`
+		// is the one place that does this — a regression here would otherwise
+		// be invisible because the test would still see *some* Err.
+		assert!(
+			matches!(err, crate::error::ComposeError::Podman(_)),
+			"expected ComposeError::Podman, got: {err:?}"
+		);
 	}
 
 	/// Fail closed. An unreadable re-check is not confirmation, and reporting
@@ -110,7 +119,7 @@ mod over_the_wire {
 			FakeReply::Body(500, r#"{"message":"boom"}"#.to_string())
 		});
 		let engine = engine_with(fake.client(), "proj");
-		engine
+		let err = engine
 			.run_lifecycle_op(
 				&start_path(),
 				"proj-web-1",
@@ -119,6 +128,12 @@ mod over_the_wire {
 			)
 			.await
 			.expect_err("an unreadable re-check must not be read as success");
+		// Same shape as the test above: fail-closed is the contract, and the
+		// specific variant is what the CLI's exit-code map keys on.
+		assert!(
+			matches!(err, crate::error::ComposeError::Podman(_)),
+			"expected ComposeError::Podman, got: {err:?}"
+		);
 	}
 
 	/// A gone container satisfies `NotRunning`, which is what a lost `kill`
@@ -171,10 +186,20 @@ mod stop_and_remove {
 	async fn a_lost_stop_response_fails_while_the_container_still_runs() {
 		let fake = fake_dropping_the_op(Some("running"));
 		let engine = engine_with(fake.client(), "proj");
-		engine
+		let err = engine
 			.stop_container("proj-web-1", 10)
 			.await
 			.expect_err("still running is not a stop");
+		// The dropped-stop branch in `stop_container` falls through to
+		// `confirm_lost_response` with `LifecycleGoal::NotRunning`, which
+		// builds `ComposeError::Podman` on a state mismatch — pin the
+		// variant so a regression that swaps in `StreamTruncated` (the
+		// other "ended unexpectedly" variant) cannot silently satisfy this
+		// test.
+		assert!(
+			matches!(err, crate::error::ComposeError::Podman(_)),
+			"expected ComposeError::Podman, got: {err:?}"
+		);
 	}
 
 	/// And removal, which needs the container **absent** — a stopped-but-present
@@ -183,10 +208,19 @@ mod stop_and_remove {
 	async fn a_lost_removal_response_fails_when_the_container_is_merely_stopped() {
 		let fake = fake_dropping_the_op(Some("exited"));
 		let engine = engine_with(fake.client(), "proj");
-		engine
+		let err = engine
 			.teardown_one_container("proj-web-1", 10, &[], false)
 			.await
 			.expect_err("a container that is still there was not removed");
+		// Same pattern as the stop test: `teardown_one_container`'s dropped
+		// arm goes through `confirm_lost_response` with `LifecycleGoal::Gone`,
+		// and a stopped-but-present container fails `Gone`. The variant is
+		// the contract — anything else would be a regression in the
+		// fail-closed shape this whole file pins.
+		assert!(
+			matches!(err, crate::error::ComposeError::Podman(_)),
+			"expected ComposeError::Podman, got: {err:?}"
+		);
 	}
 
 	#[tokio::test]

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -753,3 +753,6 @@ mod tests;
 
 #[cfg(test)]
 mod stream_end_tests;
+#[cfg(unix)]
+#[cfg(test)]
+mod wait_timeout_tests;

--- a/internal/engine/wait_timeout_tests.rs
+++ b/internal/engine/wait_timeout_tests.rs
@@ -1,0 +1,210 @@
+//! [`ComposeError::WaitTimeout`] is the variant [`Engine`] emits only when
+//! `start --wait --wait-timeout` (or `up --wait --wait-timeout`) is in effect:
+//! the outer `tokio::time::timeout` wrapping [`Engine::wait_services_healthy`]
+//! in [`crate::dispatch`] elapses before the inner poll resolves.
+//!
+//! It is distinct from [`ComposeError::HealthCheckTimeout`], which is what a
+//! service's own healthcheck budget exhaustion looks like. The `--wait-timeout`
+//! exists for the case where every service still *can* become healthy given
+//! enough time — without it, a generous plan budget is the only cap, and that
+//! is what the user is overriding with `--wait-timeout 30`.
+//!
+//! The dispatch module builds this variant, so the test below mirrors its
+//! exact pattern (`tokio::time::timeout` around `wait_services_healthy_within`)
+//! rather than reimplementing the wrapping inline. The mirror is the point:
+//! the variant only exists because the wrapper exists, so the assertion is
+//! about the wrapper, not about the engine.
+
+#![cfg(unix)]
+
+use crate::compose::types::{Command, ComposeFile, HealthCheck, Service};
+use crate::engine::fake_podman::{self, FakeReply};
+use crate::engine::Engine;
+use crate::error::ComposeError;
+use crate::libpod::API_PREFIX;
+
+/// A service that never reaches `healthy` plus a finite outer deadline is
+/// the one shape that surfaces [`ComposeError::WaitTimeout`]. The message
+/// must name the seconds — that is the only knob the operator set, and the
+/// only one they need to tweak to retry.
+#[tokio::test]
+async fn an_unhealthy_service_under_a_short_wait_timeout_surfaces_waittimeout() {
+	let fake = fake_podman::start_replying(|method, target| {
+		// The inspect that `wait_healthy` reads before deciding to poll.
+		if method == "GET" && target.contains("/containers/proj-web-1/json") {
+			// `starting` health under an effective healthcheck is the
+			// `HealthVerdict::Pending` branch — exactly the one the
+			// wrapper sits on top of.
+			return FakeReply::Body(
+				200,
+				r#"{"State":{"Status":"running","Health":{"Status":"starting"}},"Config":{"Healthcheck":{"Test":["CMD","true"]}}}"#
+					.to_string(),
+			);
+		}
+		// The on-demand healthcheck run that the wait polls between reads.
+		if method == "GET" && target.contains("/containers/proj-web-1/healthcheck") {
+			return FakeReply::Body(200, r#"{"Status":"starting"}"#.to_string());
+		}
+		FakeReply::Body(404, r#"{"message":"not used"}"#.to_string())
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+
+	// A service with an effective healthcheck that never reports `healthy`,
+	// plus a short per-probe budget so the inner future is the slow one,
+	// not the wrapper. The wait_timeout we feed the *outer* `tokio::timeout`
+	// is the one that ends up in the error.
+	let mut file = ComposeFile::default();
+	file.services.insert(
+		"web".into(),
+		Service {
+			image: Some("nginx:1.27".into()),
+			healthcheck: Some(HealthCheck {
+				test: Some(Command::Exec(vec!["CMD".into(), "true".into()])),
+				interval: Some("200ms".into()),
+				retries: Some(3),
+				..Default::default()
+			}),
+			..Default::default()
+		},
+	);
+
+	let wait_timeout_secs: u64 = 1;
+	let wait_timeout = std::time::Duration::from_secs(wait_timeout_secs);
+
+	// Mirror the dispatch.rs wrapper byte-for-byte: the variant only exists
+	// because this exact `map_err(|_| ComposeError::WaitTimeout { secs })`
+	// does. The inner future is the health wait with a generous
+	// per-service budget, so the OUTER `tokio::timeout` — the one the
+	// dispatch owns — is what elapses first.
+	let fut = engine.wait_services_healthy_within(&file, &[], Some(wait_timeout * 20));
+	let result =
+		tokio::time::timeout(wait_timeout, fut)
+			.await
+			.map_err(|_| ComposeError::WaitTimeout {
+				secs: wait_timeout_secs,
+			});
+
+	let err = result.expect_err("an unhealthy service under a finite wait must surface an error");
+	let ComposeError::WaitTimeout { secs } = err else {
+		panic!("expected WaitTimeout, got: {err:?}");
+	};
+	assert_eq!(
+		secs, wait_timeout_secs,
+		"the error must carry the same seconds the wrapper was given"
+	);
+
+	let msg = err.to_string();
+	assert!(
+		msg.contains(&wait_timeout_secs.to_string()),
+		"the rendered message must name the seconds, got: {msg}"
+	);
+	assert!(
+		msg.contains("timed out"),
+		"the rendered message must say the wait timed out, got: {msg}"
+	);
+}
+
+/// A wait that *does* finish before the wrapper elapses must not produce
+/// `WaitTimeout`. The wrapper must yield the inner result (here: a
+/// `HealthCheckTimeout` because the fake never reports `healthy`). Pinning
+/// the inverse — the timeout path only fires when the inner future is
+/// genuinely slow, not on every dispatch — so a regression that always
+/// wraps cannot land as `WaitTimeout`.
+#[tokio::test]
+async fn a_wait_that_finishes_in_time_does_not_produce_waittimeout() {
+	// Same shape as the trigger test, but with the wrapper set generously
+	// larger than the inner budget. The inner `HealthCheckTimeout` arrives
+	// well before the wrapper elapses, so the wrapper must surface the
+	// inner error rather than collapse it into `WaitTimeout`.
+	let fake = fake_podman::start_replying(|_method, target| {
+		if target.contains("/containers/proj-web-1/json") {
+			return FakeReply::Body(
+				200,
+				r#"{"State":{"Status":"running","Health":{"Status":"starting"}},"Config":{"Healthcheck":{"Test":["CMD","true"]}}}"#
+					.to_string(),
+			);
+		}
+		if target.contains("/containers/proj-web-1/healthcheck") {
+			return FakeReply::Body(200, r#"{"Status":"starting"}"#.to_string());
+		}
+		FakeReply::Body(404, r#"{"message":"not used"}"#.to_string())
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+
+	let mut file = ComposeFile::default();
+	file.services.insert(
+		"web".into(),
+		Service {
+			image: Some("nginx:1.27".into()),
+			healthcheck: Some(HealthCheck {
+				test: Some(Command::Exec(vec!["CMD".into(), "true".into()])),
+				interval: Some("200ms".into()),
+				retries: Some(3),
+				..Default::default()
+			}),
+			..Default::default()
+		},
+	);
+
+	// Tight inner, loose wrapper — the inner must error first. The
+	// dispatch.rs wrapper only fires when the inner is slow.
+	let inner_budget = std::time::Duration::from_secs(5);
+	let wrapper = std::time::Duration::from_secs(30);
+	let fut = engine.wait_services_healthy_within(&file, &[], Some(inner_budget));
+	let result = tokio::time::timeout(wrapper, fut).await;
+
+	// The wrapper must surface the inner error (the service never becomes
+	// healthy, so it is `HealthCheckTimeout`), never collapse to
+	// `WaitTimeout` just because it returned an Err.
+	let inner = result.expect("a 30s wrapper must not elapse on a service that polls every 200ms");
+	let err = inner.expect_err("the inner wait must error on an unhealthy service");
+	assert!(
+		matches!(err, ComposeError::HealthCheckTimeout(_)),
+		"inner error must be HealthCheckTimeout, not WaitTimeout, got: {err:?}"
+	);
+	assert!(
+		!matches!(err, ComposeError::WaitTimeout { .. }),
+		"a wrapper that did not elapse must not produce WaitTimeout"
+	);
+}
+
+/// Sanity check that the inspect path the wait uses (`/containers/{name}/json`)
+/// is the one the wrapper is built around. If libpod ever renames it, this
+/// test is the one that has to be updated first — the wrapper's behaviour
+/// depends on the wait polling at this URL.
+#[tokio::test]
+async fn the_wait_polls_the_expected_inspect_path() {
+	let fake = fake_podman::start_replying(|method, target| {
+		if method == "GET" && target.contains("/containers/proj-web-1/json") {
+			return FakeReply::Body(
+				200,
+				r#"{"State":{"Status":"running","Health":{"Status":"healthy"}}}"#.to_string(),
+			);
+		}
+		FakeReply::Body(404, r#"{"message":"not used"}"#.to_string())
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+
+	let mut file = ComposeFile::default();
+	file.services.insert(
+		"web".into(),
+		Service {
+			image: Some("nginx:1.27".into()),
+			healthcheck: Some(HealthCheck {
+				test: Some(Command::Exec(vec!["CMD".into(), "true".into()])),
+				..Default::default()
+			}),
+			..Default::default()
+		},
+	);
+
+	// Healthy on the first inspect — the wait must return without
+	// touching the budget.
+	engine
+		.wait_services_healthy(&file, &[])
+		.await
+		.expect("a service reported healthy on inspect must not error");
+	// The API_PREFIX constant is exported for a reason — the path the
+	// client builds lives here; touching the wrong one breaks the wait.
+	let _ = API_PREFIX;
+}


### PR DESCRIPTION
A public error variant that no test ever constructs is a path nobody has watched fail: its message can be useless and its `Display` wrong, and nobody finds out until it reaches a user.

Each test provokes the error **through the real path** rather than building the value by hand. A test that constructs `WaitTimeout { secs }` and checks its `Display` proves nothing about the code that should emit it.

## Covered

**`IoPath`** — `io_to_err(Some(path), e)` is the real producer. An integration test drives `export -o` at an unwritable destination through a fake Podman and asserts the variant carries the destination. A second test pins the asymmetry: a stdout sink with no path yields `Io`, not `IoPath` with an empty path.

**`WaitTimeout`** — a fake Podman reports `Health.Status=starting` forever, reproducing the exact wrapper `dispatch.rs` uses. The paired test gives the *inner* call the tight budget instead, so it fails first — proving the wrapper fires only when the inner one does not finish, rather than on every dispatch.

## Bare `expect_err()`

Four sites in `drop_recheck_tests` asserted "this fails" without checking *what* failed. Any error satisfied them, including one a refactor might swap in. They now pin the variant.

Measured rather than assumed: of **180** `expect_err`/`unwrap_err` sites in the tree, those four were the only bare ones. The rest already assert on the variant or the message and are left alone — the audit's estimate of six was close but the real number is four.

## Found and deliberately not fixed

**`ComposeError::Include` is dead.** Nothing in the tree constructs it; it appears only in its definition, its `Display` arm, and a `Display` test that builds it by hand. So an `include:` that fails today surfaces as some other variant, or not at all.

That is a behaviour question, not a coverage one, and the variant is public — removing it is breaking, and wiring it up changes what users see. Filed separately.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>