### PR TITLE
ci: page the Dependabot window instead of reading twenty pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,11 @@ jobs:
   # re-registered, and like a dead cron it reports nothing at all. This fails
   # when no pull request has been opened recently enough.
   #
-  # Pinned at an untagged commit on purpose, for as long as this pull request is
-  # open. v1.16.0 read a single page of twenty pull requests and filtered it for
-  # the bot, which measures total activity rather than Dependabot's: run
-  # 32435521566 reported "no Dependabot pull request on record" while ten sat
-  # open. The CI standard asks for a reusable to be proven on a real consumer
-  # before its tag is cut, and this repository is the one that can do it — it
-  # runs no pin-policy caller, so an untagged SHA costs nothing here. The
-  # comment becomes # v1.16.1 before this merges.
+  # v1.16.0 read one page of twenty pull requests and filtered it for the bot,
+  # which measures how busy the repository is rather than whether Dependabot is
+  # running: run 32435521566 reported "no Dependabot pull request on record"
+  # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@e9cbd47344fcb03b1bb2400f8b15ab5289ff497f
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@e9cbd47344fcb03b1bb2400f8b15ab5289ff497f # v1.16.1
     with:
       max-age-days: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,16 @@ jobs:
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
   # when no pull request has been opened recently enough.
+  #
+  # Pinned at an untagged commit on purpose, for as long as this pull request is
+  # open. v1.16.0 read a single page of twenty pull requests and filtered it for
+  # the bot, which measures total activity rather than Dependabot's: run
+  # 32435521566 reported "no Dependabot pull request on record" while ten sat
+  # open. The CI standard asks for a reusable to be proven on a real consumer
+  # before its tag is cut, and this repository is the one that can do it — it
+  # runs no pin-policy caller, so an untagged SHA costs nothing here. The
+  # comment becomes # v1.16.1 before this merges.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@e9cbd47344fcb03b1bb2400f8b15ab5289ff497f
     with:
       max-age-days: 15


### PR DESCRIPTION
`dependabot-freshness` has been red on every pull request since it was adopted, and it is
measuring the wrong thing. Dependabot is not silent here: it opened ten pull requests on
20 August (#1464 through #1473) and every one of them is still open.

## What it measures today

`v1.16.0` reads a single page — `pulls?state=all&per_page=20` — then filters client-side for
`dependabot[bot]`. That is a window on **total** pull request activity, not on Dependabot's.
This repository has opened more than twenty pull requests since #1473, so the bot's newest
falls off the end of the page.

Measured on run [32435521566](https://github.com/Glyndor/podup/actions/runs/32435521566):

```
##[error]No Dependabot pull request on record for Glyndor/podup.
```

Ten of them sit within the newest forty. So the gate is not detecting a dead Dependabot, it
is detecting a busy repository — the one condition it must never confuse with silence. And
a guard that cries wolf on every pull request is worse than no guard: it trains the reviewer
to skip it, so the real silence goes through.

## Changes

The reusable pin moves to `e9cbd47`, which pages three times at 100 and stops at the first
page that yields a hit, so the common case still costs one request.

**The pin is deliberately at an untagged commit while this is open.** The CI standard asks
for a reusable to be proven on a real consumer before its tag is cut, because `.github`'s own
CI never exercises a caller — that rule exists because v1.9.0 was tagged straight after merge
and broke every Windows consumer. podup is the consumer that can do the proving: it runs no
`pin-policy` caller, so an untagged SHA costs nothing here, where it would turn `pin-policy`
red in `apt`, `homebrew-tap` and `scoop-bucket`.

Once this run is green for the right reason, I tag `Glyndor/.github` `v1.16.1` at that
commit and set the comment to `# v1.16.1` on this branch before merging. The other three
consumers pick it up through their own Dependabot bump.

## Test plan

- The gate itself is the test. Before: run 32435521566, red with "no Dependabot pull request
  on record". After: this branch's `dependabot-freshness` job must go green and print the
  newest Dependabot pull request with an age in days.
- It has to pass for the right reason, not by being skipped. I read the emitted line, not
  only the colour.
- Nothing else in the workflow changes, so the rest of CI is a regression check.

Closes #1504

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
