### PR TITLE
ci(asset-contract): watch the signer, not only the verifier

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/asset-contract.yml"
       - ".github/scripts/verify-signing-key.py"
+      - ".github/scripts/sign.py"
       - "internal/update/install.rs"
       - "tests/fixtures/releases/**"
   pull_request:
@@ -22,6 +23,7 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/asset-contract.yml"
       - ".github/scripts/verify-signing-key.py"
+      - ".github/scripts/sign.py"
       - "internal/update/install.rs"
       - "tests/fixtures/releases/**"
 


### PR DESCRIPTION
`asset-contract.yml` guards the release asset contract and the signing-key handling. Its
path filter watched `.github/scripts/verify-signing-key.py` — the script that **checks** a
signature — and not `.github/scripts/sign.py`, the one that **produces** them.

`release.yml` calls `sign.py` eight times (lines 205, 415, 417, 422, 424, 427, 428): every
binary, every `.deb`, every SBOM, `NOTICES.html` and both installers. A change to the format
it emits did not trigger the gate that exists to catch exactly that.

## Changes

One line added to each of the two `paths:` blocks, on the `push` and the `pull_request`
trigger.

## Test plan, and what it does not prove

- This pull request edits `asset-contract.yml`, which was already in the filter, so the
  workflow runs here and shows it still parses and passes. That is the regression check.
- **It does not prove a `sign.py`-only change fires the gate**, because this diff also
  touches the workflow, so the trigger cannot be attributed to the new entry. A path filter
  that never fires is indistinguishable from a gate that passes, and I would rather say so
  than claim the green here settles it. The next change that touches only `sign.py` is the
  real proof, and it costs nothing to wait for one rather than manufacture it.

## Not in this pull request

The audit also proposed adding `paths:` to the `push:` trigger of `supply-chain.yml`, for
symmetry with its filtered `pull_request` trigger. I measured it and left it alone: today
that job runs on **every** push to `develop`, and adding the filter would make it run less
often. Narrowing a supply-chain gate so two blocks match is a trade of coverage for
tidiness. The reasoning is written up in #1506.

Closes #1506

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
