### PR TITLE
test(fuzz): add extract_tar target for the container tar extractor

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,7 +13,7 @@ jobs:
     name: cargo fuzz (smoke)
     uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
     with:
-      targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson"]'
+      targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"
       timeout: "10"
       rss-limit-mb: "2048"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -86,6 +86,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +155,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -665,15 +670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,14 +705,16 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "0.15.1"
+version = "4.0.0"
 dependencies = [
+ "anstream",
+ "anstyle",
+ "base64 0.23.1",
  "bytes",
  "clap",
  "clap_complete",
  "ed25519-dalek",
  "flate2",
- "futures-core",
  "futures-util",
  "http-body-util",
  "hyper",
@@ -733,12 +731,14 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "podup-fuzz"
 version = "0.0.0"
 dependencies = [
+ "bytes",
  "libfuzzer-sys",
  "podup",
 ]
@@ -1012,12 +1012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1053,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -1117,7 +1112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
@@ -1162,7 +1156,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "log",
  "percent-encoding",
  "rustls",
@@ -1178,7 +1172,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -56,3 +56,10 @@ path = "fuzz_targets/stream_ndjson.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "extract_tar"
+path = "fuzz_targets/extract_tar.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/extract_tar.rs
+++ b/fuzz/fuzz_targets/extract_tar.rs
@@ -1,0 +1,49 @@
+#![no_main]
+
+//! Fuzz the container→host tar extractor (`extract_tar_guarded`) on
+//! attacker-controlled bytes. The function parses a tar that came out of a
+//! (possibly compromised) container during `cp`, refusing any entry whose
+//! path would escape the destination or whose mode carries group/other-write
+//! or setuid/setgid/sticky bits. The unit test
+//! `extract_tar_guarded_rejects_parent_traversal` covers the obvious `..`
+//! escape; this target exercises every header field the fuzzer can mutate.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use libfuzzer_sys::fuzz_target;
+
+/// Per-iteration scratch directory under `std::env::temp_dir()`, removed on
+/// drop so the fuzz target never accumulates state between inputs.
+struct ScratchDir {
+	path: PathBuf,
+}
+
+impl ScratchDir {
+	fn new() -> std::io::Result<Self> {
+		static COUNTER: AtomicU64 = AtomicU64::new(0);
+		let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+		let path = std::env::temp_dir().join(format!(
+			"podup-fuzz-extract-tar-{}-{n}",
+			std::process::id(),
+		));
+		std::fs::create_dir_all(&path)?;
+		Ok(Self { path })
+	}
+}
+
+impl Drop for ScratchDir {
+	fn drop(&mut self) {
+		let _ = std::fs::remove_dir_all(&self.path);
+	}
+}
+
+fuzz_target!(|data: &[u8]| {
+	let Ok(scratch) = ScratchDir::new() else {
+		return;
+	};
+	// `extract_tar_guarded` returns `Result<()>`. Any `Err` is the documented
+	// outcome for a hostile header (zip-slip, unreadable mode, …) and not a
+	// finding — only a panic (caught by libFuzzer as a crash) would be.
+	let _ = podup::fuzz_api::extract_tar_guarded(data, &scratch.path);
+});

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -13,7 +13,9 @@ use crate::libpod::API_PREFIX;
 
 use super::Engine;
 
-mod archive;
+/// Crate-private so the fuzz harness behind the `test-helpers` feature can
+/// reach `extract_tar_guarded` without widening the published API surface.
+pub(crate) mod archive;
 
 use archive::{extract_archive, pack_path};
 

--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -196,7 +196,12 @@ fn unpacked_path(dst_dir: &Path, rel: &Path) -> Option<std::path::PathBuf> {
 /// such entries, returning `Ok(false)`; we turn that into a hard error so the
 /// copy fails loudly instead of silently skipping data. Pure and synchronous so
 /// the guard can be unit-tested without a container.
-fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
+///
+/// `pub fn` inside the crate-private `archive` module: the path through
+/// `engine` (which is `pub(crate)`) keeps the function off the public API, and
+/// the fuzz harness behind the `test-helpers` feature reaches it through
+/// `crate::fuzz_api`.
+pub fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
 	let cursor = std::io::Cursor::new(tar_bytes);
 	let mut archive = tar::Archive::new(cursor);
 	for entry in archive.entries().map_err(ComposeError::Io)? {

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -4,7 +4,11 @@
 
 mod build;
 mod container;
-mod copy;
+/// `pub(crate)` so the fuzz harness behind the `test-helpers` feature can
+/// reach `archive::extract_tar_guarded` without widening the published API:
+/// the chain stays `engine → copy → archive` all `pub(crate)` (or stricter),
+/// which a third-party crate cannot see.
+pub(crate) mod copy;
 pub(crate) mod events;
 mod terminal_pump;
 pub use events::EventsOptions;

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -80,10 +80,12 @@ pub use libpod::{parse_json_lines, parse_multiplexed, parse_raw, LogOutput};
 ///
 /// These are not part of the public API (the feature is off by default, so the
 /// published crate does not expose them); they let the fuzz harness reach the
-/// crate-private dotenv parser and the libpod stream framer.
+/// crate-private dotenv parser, the libpod stream framer, and the
+/// container→host tar extractor.
 #[cfg(feature = "test-helpers")]
 pub mod fuzz_api {
 	pub use crate::dotenv::parse as dotenv_parse;
+	pub use crate::engine::copy::archive::extract_tar_guarded;
 	pub use crate::libpod::types::stream::{
 		parse_frame, record_stream_bytes, take_json_line, MAX_STREAM_BUF,
 	};


### PR DESCRIPTION
Four of the six fuzz targets spend CI time on input this project treats as trusted (compose
files and their environment). `extract_tar_guarded` parses the tar that comes out of a
container during `cp`, which is attacker-controlled the moment that container is compromised,
and had no target.

The function is not undefended. It carries traversal checks and a parent-traversal unit test.
What it lacked was fuzzing — a hand-written case tests the escape someone thought of; a
fuzzer tests the header field nobody did.

## Visibility option taken

Option 1 from the issue: a `pub(crate)` seam through the existing `test-helpers` feature,
rather than fuzzing the public `Engine::cp` entry point and accepting the intervening layers.

The chain `engine → copy → archive` is `pub(crate)` at every boundary and the function itself
is `pub fn`, so `podup::engine::copy::archive::extract_tar_guarded` stays crate-only. The
public re-export through `podup::fuzz_api` is gated by `test-helpers`, like every other
internal parser the harness already reaches. `dotenv::parse` is the template, applied
identically.

## What ran locally

- `cargo +nightly fuzz build extract_tar` finished in 46s, no errors.
- `cargo +nightly fuzz run extract_tar -- -max_total_time=60` reached 1,042,189 iterations,
  no crash, no panic.

## What is unverified, stated plainly

- **The lane was not re-run on this branch.** `fuzz.yml` now lists `extract_tar` alongside
  the six, but nothing here proves the lane picks it up. The next scheduled run is the proof.
- The local seed corpus lives in `fuzz/corpus/extract_tar/`, which is gitignored — same as
  the other six — so it is a convenience on one machine and **does not reach CI**. The
  reusable's own header calls itself "a smoke run, not a corpus-building soak", so the 60
  second window starts cold for every target. That is a property of the lane, not of this
  target, and I am not changing an org-wide reusable to fix it here.
- `cargo test` was not run: the task excluded it because the owner's host slows to a crawl
  under the integration suite. The unit-test suite on this branch is unverified locally and
  CI is what covers it.

## Dropped from this branch, with the measurement that killed it

The first version carried a `chore(publish): exclude fuzz/ from the published crate` commit.
I measured it and removed it: `cargo package --list` on `develop` ships **zero** files from
`fuzz/` already, because `fuzz/` is a separate package with its own manifest. The commit
fixed nothing while its message claimed a hole was closed.

Measuring that turned up a real one next to it, which is **not** in this pull request:
`cargo package` still ships **30 files from `bench/`**, including
`bench/scenarios/secrets/secret1.txt` through `secret6.txt`, plus `about.toml` and
`about.hbs`. The two `exclude` keys in `Cargo.toml` are easy to confuse — the `[workspace]`
one lists `fuzz` and `bench/timeit` and only decides workspace membership, while the
`[package]` one is what `cargo package` reads and lists neither. Filed separately.

## Acceptance

- `fuzz/fuzz_targets/extract_tar.rs`, with a per-iteration scratch directory removed on drop
- `fuzz/Cargo.toml` gains the `[[bin]]` entry
- the seam: `engine → copy → archive` `pub(crate)`, re-export through `fuzz_api`
- `extract_tar` added to the `fuzz.yml` target list

Closes #1503

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
