### PR TITLE
chore(publish): stop shipping the benchmark harness in the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,24 @@ documentation = "https://docs.rs/podup"
 readme = "README.md"
 keywords = ["podman", "compose", "quadlet", "docker-compose", "rootless"]
 categories = ["command-line-utilities", "virtualization", "development-tools"]
-exclude = ["/.github", "/debian", "/deny.toml", "/docs", "/install.ps1", "/install.sh", "/tests"]
+# What `cargo package` ships. Not to be confused with `[workspace] exclude`
+# further down, which only decides workspace membership: that one names
+# `bench/timeit` and `fuzz`, which reads as though packaging is handled and
+# is a different question entirely. Measured before this line changed,
+# `cargo package --list` carried 30 files from `bench/` and both licence
+# report templates.
+exclude = [
+	"/.github",
+	"/about.hbs",
+	"/about.toml",
+	"/bench",
+	"/debian",
+	"/deny.toml",
+	"/docs",
+	"/install.ps1",
+	"/install.sh",
+	"/tests",
+]
 
 [[bin]]
 name = "podup"

--- a/tests/package_excludes.rs
+++ b/tests/package_excludes.rs
@@ -1,0 +1,144 @@
+//! Every top-level directory is either published or named in `exclude`.
+//!
+//! `cargo package` publishes the whole tree minus `[package] exclude`, so a new
+//! top-level directory ships the day it is added and nobody is told. That is how
+//! `bench/` came to be in the crate: `Cargo.toml` carries a second `exclude`
+//! under `[workspace]` which names `bench/timeit` and `fuzz`, and reading it
+//! answers a different question than the one it looks like it answers.
+//!
+//! This asserts the decision was taken, not that it went a particular way. A new
+//! directory has to be added to one of the two lists below, which is a line in a
+//! pull request rather than a surprise in a published crate.
+//!
+//! It reads the manifest instead of running `cargo package`, so it costs
+//! milliseconds and needs no network.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Top-level directories whose contents belong in the published crate.
+const PUBLISHED: &[&str] = &["internal"];
+
+/// Top-level directories that carry their own manifest at the top level.
+/// `cargo package` does not descend into a nested package, so these are absent
+/// from the crate whether or not `exclude` names them — which is why adding
+/// `fuzz` to `exclude` closed nothing when it was tried.
+///
+/// `bench` is deliberately NOT here. Its manifest is one level down, at
+/// `bench/timeit/Cargo.toml`, so `cargo package` descends into `bench/` and
+/// publishes everything beside that nested package: 30 files, measured. Listing
+/// it here was the first version of this file, and deleting `/bench` from the
+/// manifest left the test green — a control that can be removed without the
+/// test noticing is not a control.
+const NESTED_PACKAGES: &[&str] = &["fuzz"];
+
+/// Read the `exclude` array that belongs to `[package]`, stopping at the next
+/// table header so a later `[workspace] exclude` cannot be mistaken for it.
+fn package_excludes(manifest: &str) -> BTreeSet<String> {
+	let mut out = BTreeSet::new();
+	let mut in_package = true;
+	let mut in_exclude = false;
+	for line in manifest.lines() {
+		let trimmed = line.trim();
+		if trimmed.starts_with('[') {
+			in_package = trimmed == "[package]";
+			in_exclude = false;
+			continue;
+		}
+		if !in_package {
+			continue;
+		}
+		if let Some(rest) = trimmed.strip_prefix("exclude") {
+			let rest = rest.trim_start_matches([' ', '=']).trim();
+			if rest == "[" {
+				in_exclude = true;
+			} else {
+				for entry in rest.trim_matches(['[', ']']).split(',') {
+					let entry = entry.trim().trim_matches('"');
+					if !entry.is_empty() {
+						out.insert(entry.trim_start_matches('/').to_string());
+					}
+				}
+			}
+			continue;
+		}
+		if in_exclude {
+			if trimmed.starts_with(']') {
+				in_exclude = false;
+				continue;
+			}
+			let entry = trimmed.trim_end_matches(',').trim().trim_matches('"');
+			if !entry.is_empty() {
+				out.insert(entry.trim_start_matches('/').to_string());
+			}
+		}
+	}
+	out
+}
+
+#[test]
+fn every_top_level_directory_is_a_decision() {
+	let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+	let excluded = package_excludes(&fs::read_to_string(root.join("Cargo.toml")).unwrap());
+
+	// Ask git, not the filesystem. Inside a checkout `cargo package` takes its
+	// file list from git, so an untracked build directory in the working tree is
+	// never published — and reading `read_dir` here would fail the test on every
+	// machine that has one, which is the instrument measuring something other
+	// than the question.
+	let listing = Command::new("git")
+		.args(["ls-tree", "-d", "--name-only", "HEAD"])
+		.current_dir(root)
+		.output();
+	let Ok(listing) = listing else {
+		eprintln!("git is unavailable, so there is no file list to check");
+		return;
+	};
+	assert!(
+		listing.status.success(),
+		"git ls-tree failed: {}",
+		String::from_utf8_lossy(&listing.stderr)
+	);
+
+	let mut undecided = Vec::new();
+	for name in String::from_utf8_lossy(&listing.stdout).lines() {
+		let name = name.trim().to_string();
+		if name.is_empty() || name.starts_with('.') {
+			continue;
+		}
+		if PUBLISHED.contains(&name.as_str())
+			|| NESTED_PACKAGES.contains(&name.as_str())
+			|| excluded.contains(&name)
+		{
+			continue;
+		}
+		undecided.push(name);
+	}
+
+	assert!(
+		undecided.is_empty(),
+		"these top-level directories are neither published, a nested package, nor in \
+		 the [package] exclude list, so `cargo package` ships them: {undecided:?}. \
+		 Add each to Cargo.toml's [package] exclude, or to PUBLISHED in this file."
+	);
+}
+
+#[test]
+fn the_manifest_reader_stops_at_the_next_table() {
+	// The bug this file exists for: two `exclude` keys, and the wrong one is
+	// the easier one to read. A reader that ran to the end of the file would
+	// report `bench/timeit` as excluded from the package, which it is not.
+	let manifest =
+		"[package]\nexclude = [\"/docs\"]\n\n[workspace]\nexclude = [\"bench/timeit\", \"fuzz\"]\n";
+	let excluded = package_excludes(manifest);
+	assert!(
+		excluded.contains("docs"),
+		"the [package] entry must be read"
+	);
+	assert!(
+		!excluded.contains("bench/timeit"),
+		"the [workspace] entry must not be read as a packaging decision"
+	);
+}


### PR DESCRIPTION
`cargo package --list` on `develop` carried **30 files from `bench/`**, plus `about.toml` and
`about.hbs`:

```
    221 internal
     30 bench
      1 about.toml
      1 about.hbs
```

Among them `bench/scenarios/secrets/secret1.txt` through `secret6.txt`. Those are fixture
values committed in a public repository, so **nothing is leaked**. What is wrong is that
anyone depending on `podup` as a library downloads a benchmark harness, its Python
aggregation scripts, its Dockerfiles and its compose fixtures.

## Why it was missed

`Cargo.toml` has two `exclude` keys doing different jobs:

| key | decides | contents before this |
|---|---|---|
| `[package] exclude` | what `cargo package` ships | `.github`, `debian`, `deny.toml`, `docs`, `install.ps1`, `install.sh`, `tests` |
| `[workspace] exclude` | what is a workspace member | `bench/timeit`, `fuzz` |

`bench` and `fuzz` are sitting right there under a key named `exclude`, so the file reads as
though packaging is handled.

The asymmetry between those two is the part worth knowing. `fuzz/` needed nothing: it carries
its own manifest at the top level and `cargo package` does not descend into a nested package,
so it already shipped zero files — an earlier change adding `/fuzz` to the package exclude
was measured and dropped for closing nothing. `bench/` is the opposite: its manifest is one
level down at `bench/timeit/`, so cargo descends into `bench/` and publishes everything
beside that nested package.

## Changes

- `[package] exclude` gains `/bench`, `/about.toml`, `/about.hbs`, and becomes one entry per
  line with a comment naming the other key, since confusing them is what caused this.
- `tests/package_excludes.rs` holds it open: it asks git for the top-level directories and
  asserts each one is published, a nested package, or excluded. A new directory now has to be
  named in a pull request rather than turn up in a published crate. It reads the manifest
  rather than running `cargo package`, so it costs milliseconds and needs no network, and it
  stops parsing at the next table header so the `[workspace]` key cannot be read as a
  packaging decision.

## Test plan

- `cargo package --list` after the change: `internal` plus nine root files. No `bench`, no
  `about.*`.
- `cargo test --test package_excludes`: 2 passed.
- **Delete-the-control check, which is the only thing that says the test works.** I removed
  `/bench` from the manifest and re-ran.
  - **First version: still green.** It listed `bench` as a nested package, so the assertion
    could not see the deletion. A control that can be removed without the test noticing is
    not a control, and reading the test would never have told me.
  - Corrected `NESTED_PACKAGES` to `fuzz` alone. Re-ran without `/bench`: red, naming
    `["bench"]`. Restored it: green.
- The second test pins the parser against the exact confusion behind the bug — a `[package]`
  block followed by a `[workspace]` block, asserting `docs` is read and `bench/timeit` is not.

## Not in this pull request

`rustfmt.toml`, `.editorconfig` and `.gitignore` still ship. They are one file each and
harmless, and I would rather leave a deliberate decision than sweep them in unasked.

Closes #1509

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
