### PR TITLE
fix(compose): wire up ComposeError::Include for include resolution failures

### DIFF
--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -4,7 +4,46 @@
 //! secrets, configs, and models from the included file are added only if the
 //! key does not already exist in the parent (parent wins on conflict).
 
+use std::path::Path;
+
 use super::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+
+/// Read and parse a file referenced by `include:`, wrapping every failure in
+/// [`ComposeError::Include`] so a consumer matching on the variant can tell the
+/// failure originated from an included file rather than the top-level compose
+/// file. A missing included file is not the same as a missing main file, and
+/// an invalid-YAML included file is not the same as a malformed main file —
+/// the variant lets a handler branch on the difference, and the message names
+/// the included path so the operator can find it.
+pub(super) fn parse_included_file(
+	path: &Path,
+	dir: &Path,
+	env_files: &[String],
+	interpolate: bool,
+) -> Result<ComposeFile> {
+	let display = path.display().to_string();
+	super::parse_file_inner_with_env(path, dir, env_files, interpolate).map_err(|e| match e {
+		ComposeError::FileNotFound(p) => {
+			ComposeError::Include(format!("included compose file not found: {p}"))
+		}
+		ComposeError::Parse(yaml_err) => {
+			let msg = match yaml_err.location() {
+				Some(loc) => format!(
+					"failed to parse included compose file '{display}' at line {}, column {}",
+					loc.line(),
+					loc.column()
+				),
+				None => format!("failed to parse included compose file '{display}'"),
+			};
+			ComposeError::Include(msg)
+		}
+		ComposeError::Io(io_err) => ComposeError::Include(format!(
+			"io error reading included compose file '{display}': {io_err}"
+		)),
+		other => ComposeError::Include(format!("included compose file '{display}': {other}")),
+	})
+}
 
 /// Merge `other` into `target`.
 ///
@@ -40,6 +79,7 @@ pub(super) fn merge_compose_file(target: &mut ComposeFile, other: ComposeFile) {
 mod tests {
 	use super::super::types::Service;
 	use super::*;
+	use std::path::Path;
 
 	fn svc(image: &str) -> Service {
 		Service {
@@ -161,5 +201,132 @@ mod tests {
 		let other = ComposeFile::default();
 		merge_compose_file(&mut target, other);
 		assert_eq!(target.services.len(), 1);
+	}
+
+	// parse_included_file — wraps every failure in ComposeError::Include (#1500).
+	//
+	// Each rejection test asserts the variant with `matches!` so the assertion
+	// cannot be satisfied by a different failure mode. Every rejection is paired
+	// with an acceptance test of the same shape, because a fixture that fails for
+	// the wrong reason still satisfies `expect_err` and proves nothing.
+
+	fn write_file(path: &Path, body: &str) {
+		std::fs::write(path, body).expect("write fixture");
+	}
+
+	fn parse_main(main: &Path) -> crate::error::Result<ComposeFile> {
+		crate::compose::parse_file(main)
+	}
+
+	#[test]
+	fn included_file_missing_becomes_include_variant() {
+		// The `include:` points at a path that does not exist. Before the fix
+		// this surfaced as `ComposeError::FileNotFound`; it must now surface as
+		// `ComposeError::Include` so the consumer can tell a missing include from
+		// a missing main file.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let main = dir.path().join("docker-compose.yml");
+		write_file(
+			&main,
+			"include:\n  - ./missing.yml\nservices:\n  app:\n    image: nginx\n",
+		);
+		let err = parse_main(&main).expect_err("missing include must error");
+		assert!(
+			matches!(err, ComposeError::Include(_)),
+			"expected Include, got {err:?}"
+		);
+		// The path of the missing include is named in the message.
+		assert!(
+			err.to_string().contains("missing.yml"),
+			"message should name the include path, got: {err}"
+		);
+		// Acceptance shape: the same compose succeeds when the include is present,
+		// so a rejection above is the include path firing and not something else.
+		let present = dir.path().join("present.yml");
+		write_file(&present, "services:\n  helper:\n    image: alpine\n");
+		let main_ok = dir.path().join("ok.yml");
+		write_file(
+			&main_ok,
+			"include:\n  - ./present.yml\nservices:\n  app:\n    image: nginx\n",
+		);
+		let ok = parse_main(&main_ok).expect("present include must succeed");
+		assert!(ok.services.contains_key("helper"));
+	}
+
+	#[test]
+	fn included_file_invalid_yaml_becomes_include_variant() {
+		// The included file has valid YAML semantics *except* it contains a
+		// type error. Before the fix this surfaced as `ComposeError::Parse`
+		// with no hint that the failure was in the included file; it must now
+		// surface as `ComposeError::Include`.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let bad = dir.path().join("bad.yml");
+		// `services` must be a mapping; a sequence is a type error.
+		write_file(&bad, "services:\n  - not\n  - a\n  - mapping\n");
+		let main = dir.path().join("docker-compose.yml");
+		write_file(
+			&main,
+			"include:\n  - ./bad.yml\nservices:\n  app:\n    image: nginx\n",
+		);
+		let err = parse_main(&main).expect_err("malformed include must error");
+		assert!(
+			matches!(err, ComposeError::Include(_)),
+			"expected Include, got {err:?}"
+		);
+		// The message names the included file so the operator can find it.
+		assert!(
+			err.to_string().contains("bad.yml"),
+			"message should name the include path, got: {err}"
+		);
+		// Acceptance shape: the same main file with a well-formed include
+		// succeeds, so the rejection above is the malformed-include path
+		// firing — not a YAML error in the main file itself.
+		let good = dir.path().join("good.yml");
+		write_file(&good, "services:\n  helper:\n    image: alpine\n");
+		let main_ok = dir.path().join("ok.yml");
+		write_file(
+			&main_ok,
+			"include:\n  - ./good.yml\nservices:\n  app:\n    image: nginx\n",
+		);
+		assert!(parse_main(&main_ok).is_ok());
+	}
+
+	#[test]
+	fn valid_include_does_not_surface_include_variant() {
+		// The acceptance shape for the rejection tests above. A well-formed
+		// include must succeed and must NOT emit Include; if it did, the
+		// rejection tests would pass for the wrong reason.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let included = dir.path().join("included.yml");
+		write_file(&included, "services:\n  helper:\n    image: alpine\n");
+		let main = dir.path().join("docker-compose.yml");
+		write_file(
+			&main,
+			"include:\n  - ./included.yml\nservices:\n  app:\n    image: nginx\n",
+		);
+		let file = parse_main(&main).expect("valid include must succeed");
+		assert!(file.services.contains_key("app"));
+		assert!(file.services.contains_key("helper"));
+	}
+
+	#[test]
+	fn included_path_is_directory_becomes_include_variant() {
+		// Pointing `include:` at a directory provokes a non-NotFound io error
+		// from the file reader (open-fails with IsADirectory on Unix, an
+		// access error on Windows). The wrapping must convert it to
+		// `Include`, not let `Io` leak out — that's the catch-all arm.
+		let dir = tempfile::tempdir().expect("tempdir");
+		let not_a_file = dir.path().join("a-directory");
+		std::fs::create_dir(&not_a_file).expect("mkdir");
+		let main = dir.path().join("docker-compose.yml");
+		write_file(
+			&main,
+			"include:\n  - ./a-directory\nservices:\n  app:\n    image: nginx\n",
+		);
+		let err = parse_main(&main).expect_err("directory include must error");
+		assert!(
+			matches!(err, ComposeError::Include(_)),
+			"expected Include, got {err:?}"
+		);
 	}
 }

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -100,8 +100,12 @@ pub fn parse_file_with_env_files_interp(
 			});
 			let mut combined_env_files = env_files.to_vec();
 			combined_env_files.extend(extra_env_files.iter().cloned());
-			let mut included =
-				parse_file_inner_with_env(&inc_path, &inc_dir, &combined_env_files, interpolate)?;
+			let mut included = include::parse_included_file(
+				&inc_path,
+				&inc_dir,
+				&combined_env_files,
+				interpolate,
+			)?;
 			anchor::anchor_compose_file(&mut included, &inc_dir);
 			include::merge_compose_file(&mut file, included);
 		}

--- a/tests/parse/include.rs
+++ b/tests/parse/include.rs
@@ -1,4 +1,4 @@
-use podup::parse_file;
+use podup::{parse_file, ComposeError};
 use std::io::Write;
 
 #[test]
@@ -227,4 +227,83 @@ fn multiple_files_merge_with_override() {
 	let env = file.services["web"].environment.to_map();
 	assert!(env.contains_key("A"));
 	assert!(env.contains_key("B"));
+}
+
+// `include:` failure surfaces as `ComposeError::Include` (#1500).
+//
+// Before the fix the same failure surfaced as `ComposeError::FileNotFound`,
+// `ComposeError::Parse`, or nothing distinguishable at all. Each rejection
+// test asserts the variant with `matches!`, so the assertion cannot be
+// satisfied by a different failure mode. Every rejection is paired with an
+// acceptance test of the same shape, because a fixture that fails for the
+// wrong reason still satisfies `expect_err` and proves nothing.
+
+#[test]
+fn include_missing_path_surfaces_as_include_variant() {
+	let dir = tempfile::tempdir().unwrap();
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		"include:\n  - ./not-here.yml\nservices:\n  app:\n    image: alpine\n"
+	)
+	.unwrap();
+	let err = parse_file(&main).expect_err("missing include must error");
+	assert!(
+		matches!(err, ComposeError::Include(_)),
+		"expected Include, got {err:?}"
+	);
+	// Acceptance shape: a present include succeeds, so the rejection above is
+	// the missing-include path firing and not the parse path.
+	let present = dir.path().join("present.yml");
+	writeln!(
+		std::fs::File::create(&present).unwrap(),
+		"services:\n  helper:\n    image: alpine\n"
+	)
+	.unwrap();
+	let main_ok = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main_ok).unwrap(),
+		"include:\n  - ./present.yml\nservices:\n  app:\n    image: alpine\n"
+	)
+	.unwrap();
+	let ok = parse_file(&main_ok).expect("present include must succeed");
+	assert!(ok.services.contains_key("helper"));
+}
+
+#[test]
+fn include_invalid_yaml_surfaces_as_include_variant() {
+	let dir = tempfile::tempdir().unwrap();
+	// `services` must be a mapping; a sequence is a YAML type error.
+	let bad = dir.path().join("bad.yml");
+	writeln!(
+		std::fs::File::create(&bad).unwrap(),
+		"services:\n  - not\n  - a\n  - mapping\n"
+	)
+	.unwrap();
+	let main = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main).unwrap(),
+		"include:\n  - ./bad.yml\nservices:\n  app:\n    image: alpine\n"
+	)
+	.unwrap();
+	let err = parse_file(&main).expect_err("malformed include must error");
+	assert!(
+		matches!(err, ComposeError::Include(_)),
+		"expected Include, got {err:?}"
+	);
+	// Acceptance shape: a well-formed include succeeds, so the rejection above
+	// is the malformed-include path firing and not a YAML error in the main file.
+	let good = dir.path().join("good.yml");
+	writeln!(
+		std::fs::File::create(&good).unwrap(),
+		"services:\n  helper:\n    image: alpine\n"
+	)
+	.unwrap();
+	let main_ok = dir.path().join("docker-compose.yml");
+	writeln!(
+		std::fs::File::create(&main_ok).unwrap(),
+		"include:\n  - ./good.yml\nservices:\n  app:\n    image: alpine\n"
+	)
+	.unwrap();
+	assert!(parse_file(&main_ok).is_ok());
 }


### PR DESCRIPTION
Closes #1500.

## What

`ComposeError::Include(String)` is public API that no production path was producing — a `match` arm on the type compiled but never ran. This wires it up: any failure that occurs while resolving an `include:` is now mapped to `Include(...)` with the included path in the message.

The wrap lives in a new helper `internal/compose/include.rs::parse_included_file`. It is the only call site that parses an included file (the loop in `parse_file_with_env_files_interp`), so every entry point is covered by one change.

## Before / after

Every sub-failure that an included file can produce:

| failure                                  | before                       | after                                                    |
|------------------------------------------|------------------------------|----------------------------------------------------------|
| include path missing                     | `FileNotFound(p)`            | `Include("included compose file not found: {p}")`        |
| include file invalid YAML                | `Parse(serde_yaml)`          | `Include("failed to parse included compose file '...' at line L, column C")` |
| include file unreadable (permission, …)  | `Io(io_err)`                 | `Include("io error reading included compose file '...': {io_err}")` |
| include file unsupported YAML (flow/aliases) | `Unsupported(...)`        | `Include("included compose file '...': {msg}")`          |
| well-formed include                      | `Ok(ComposeFile)`            | `Ok(ComposeFile)` (unchanged)                            |

A consumer matching on `FileNotFound`/`Parse`/`Io` specifically to handle a failing `include:` will need to switch to the `Include` arm — that is the behaviour change. The variant itself was already public and `#[non_exhaustive]`, so the public type did not change.

## Breaking?

Yes. Marked `breaking` on this PR.

The public type (`ComposeError::Include(String)`) is unchanged. The variant is reachable now where it was unreachable before, and three existing variants stop firing for the include case. A consumer that branched on `FileNotFound` for a missing include, on `Parse` for an invalid include, or on `Io` for an unreadable include now needs the `Include` arm to fire at all. A consumer that did not branch on those specifically for the include case sees no change.

I weighed this against leaving the failure mode surfaced as `FileNotFound`/`Parse`/`Io` with no message indicating `include:` was involved — and decided the downstream update is the smaller cost, especially given that the `Include` arm was the intended surface all along (the variant was public and had a working `Display`).

## Test plan

- **Unit tests in `internal/compose/include.rs`** (`compose::include::tests::included_*`):
  - `included_file_missing_becomes_include_variant` — missing include → `Include`, message names the path.
  - `included_file_invalid_yaml_becomes_include_variant` — included YAML type error → `Include`, message names the path.
  - `included_path_is_directory_becomes_include_variant` — include points at a directory → `Include` (catches the `Io` arm via the catch-all).
  - `valid_include_does_not_surface_include_variant` — the acceptance shape that the rejection tests rely on (a fixture rejected for the wrong reason still satisfies `expect_err`).
  - Every rejection is paired with an acceptance test of the same shape.
- **Integration tests in `tests/parse/include.rs`** repeat the `FileNotFound` and `Parse` cases through the public `parse_file` library entry point, so the end-to-end behaviour as a library consumer sees it is also pinned.

## Delete-the-control check

I reverted the wrap in `internal/compose/mod.rs` (changed the call back to `parse_file_inner_with_env`), ran the new tests, and confirmed all five go red with exactly the variants the issue named:

```
expected Include, got FileNotFound("/tmp/..././missing.yml")
expected Include, got Parse(Error("invalid type: sequence, expected a map"))
expected Include, got Io(Os { code: 21, kind: IsADirectory, message: "Is a directory" })
```

Same check against the integration tests produced:

```
expected Include, got FileNotFound("/tmp/..././not-here.yml")
expected Include, got Parse(Error("invalid type: sequence, expected a map"))
```

I restored the wrap and re-ran: all five green, plus the existing 307 `compose` unit tests and 183 `parse` integration tests still pass.


## The cost this carries, stated rather than left to be discovered

`Include` holds a `String`, so wiring it up flattens whatever the inner parse returned. A
consumer that wants to know *why* an include failed — missing file, invalid YAML, unreadable
path, an unsupported construct — can no longer branch on it. The only route back is
`err.to_string().contains(..)`, which is the exact pattern #1478 existed to remove for
`PodmanError`.

That loss is inherent to the variant's shape, not something this pull request introduces: the
alternative is `Include { path: PathBuf, source: Box<ComposeError> }`, and changing a public
variant's shape is a MAJOR. podup is on 4.0.0 and there is no 5.0.0 in view, so the trade
today is a reachable-but-flat `Include` against an unreachable structured one, and reachable
wins — a consumer can at least tell "the include failed" from "the main file failed", which
was impossible before.

Recorded here rather than filed, because it is not actionable until a major is on the table.
Whoever opens that major should take it then.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
