### PR TITLE
test(update): make https_only fail when it is deleted

### DIFF
--- a/internal/update/github.rs
+++ b/internal/update/github.rs
@@ -238,22 +238,78 @@ mod tests {
 
 	#[test]
 	fn latest_version_maps_transport_error() {
-		// Port 1 is closed → connection refused, offline and deterministic. The
-		// transport failure must map to the friendly "cannot reach" error.
+		// https so the request reaches a socket. Port 1 is closed, so the failure
+		// is a connection refusal: offline, deterministic, and genuinely the
+		// transport path this test is named for. An http base would never get
+		// that far — the agent rejects the scheme first, which is what this test
+		// used to measure while claiming to measure the socket.
 		use crate::update::ReleaseSource;
-		let src = GitHubSource::with_bases(REPO, "http://127.0.0.1:1", "http://127.0.0.1:1");
+		let src = GitHubSource::with_bases(REPO, "https://127.0.0.1:1", "https://127.0.0.1:1");
 		let err = src.latest_version().unwrap_err();
 		assert!(
 			err.to_string().contains("cannot reach GitHub releases API"),
 			"got: {err}"
+		);
+		assert!(
+			err.to_string().contains("Connection refused"),
+			"the transport path must be the one that failed, got: {err}"
 		);
 	}
 
 	#[test]
 	fn fetch_maps_transport_error() {
 		use crate::update::ReleaseSource;
-		let src = GitHubSource::with_bases(REPO, "http://127.0.0.1:1", "http://127.0.0.1:1");
+		let src = GitHubSource::with_bases(REPO, "https://127.0.0.1:1", "https://127.0.0.1:1");
 		let err = src.fetch("podup-linux-x86_64").unwrap_err();
 		assert!(err.to_string().contains("download failed"), "got: {err}");
+		assert!(
+			err.to_string().contains("Connection refused"),
+			"the transport path must be the one that failed, got: {err}"
+		);
+	}
+
+	/// A plaintext base must be refused for being plaintext, not for anything
+	/// else. `https_only(true)` is the only thing standing between a hostile
+	/// redirect and a downgraded download, and until this test existed the line
+	/// could be deleted with the whole suite staying green.
+	///
+	/// The assertion names the agent's own wording rather than the friendly
+	/// prefix: every failure on this path carries the prefix, so asserting it
+	/// proves only that something went wrong.
+	#[test]
+	fn plaintext_base_is_refused_for_being_plaintext() {
+		use crate::update::ReleaseSource;
+		let src = GitHubSource::with_bases(REPO, "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+		let err = src.latest_version().unwrap_err();
+		assert!(
+			err.to_string().contains("configured for https only"),
+			"the metadata read must be refused on the scheme, got: {err}"
+		);
+
+		let err = src.fetch("podup-linux-x86_64").unwrap_err();
+		assert!(
+			err.to_string().contains("configured for https only"),
+			"the download must be refused on the scheme, got: {err}"
+		);
+	}
+
+	/// The acceptance half of the pair above, one step inside the limit: the
+	/// same closed port over https gets past the scheme check and fails on the
+	/// socket instead. Without it, a plaintext URL rejected for some unrelated
+	/// reason would satisfy the rejection test and prove nothing.
+	#[test]
+	fn https_base_passes_the_scheme_check() {
+		use crate::update::ReleaseSource;
+		let src = GitHubSource::with_bases(REPO, "https://127.0.0.1:1", "https://127.0.0.1:1");
+		let err = src.latest_version().unwrap_err();
+		assert!(
+			!err.to_string().contains("configured for https only"),
+			"https must not be refused on the scheme, got: {err}"
+		);
+		assert!(
+			err.to_string().contains("Connection refused"),
+			"it must fail on the socket instead, got: {err}"
+		);
 	}
 }


### PR DESCRIPTION
`.https_only(true)` (`internal/update/github.rs:59`) is what stops GitHub's release-download
redirect to a CDN — or a hostile one — from being downgraded to plaintext. Its comment says
so.

**Deleting the line left the whole suite green.** By this project's own definition that is a
dead control, and it sits in the self-update download path.

## The two tests that looked like coverage could not discriminate

`latest_version_maps_transport_error` and `fetch_maps_transport_error` both pointed at
`http://127.0.0.1:1` and asserted a message prefix. Every failure on that path carries the
prefix, whether the request was refused on the scheme or on the closed port, so neither
assertion could tell them apart.

## And they were not testing what they are named for

Their comment read *"Port 1 is closed → connection refused, offline and deterministic."* That
is not what happened. With `https_only` active, ureq rejects the `http://` URL **before
opening a socket**, so nothing ever reached port 1. The tests named for the transport path
had been exercising the scheme check, and the comment described a mechanism that does not run.

Same shape as the three build tests that used `$VAR` inside `dockerfile_inline`: not weak
tests — tests verifying a different mechanism than the one they name, unable to notice.

## Measured before writing anything

| base URL | real error |
|---|---|
| `http://127.0.0.1:1` | `cannot reach GitHub releases API: configured for https only: http://127.0.0.1:1/...` |
| `https://127.0.0.1:1` | `cannot reach GitHub releases API: io: Connection refused` |

A clean discriminating pair, and neither test was using it.

## Changes

- The two transport tests move to `https://127.0.0.1:1` and additionally assert
  `Connection refused`, so they reach the socket and test the path they are named for. Comment
  corrected.
- `plaintext_base_is_refused_for_being_plaintext` asserts the `configured for https only`
  fragment, on both the metadata read and the download.
- `https_base_passes_the_scheme_check` is the acceptance half one step inside the limit: the
  same closed port over https gets past the scheme check and fails on the socket. Without it,
  a plaintext URL refused for an unrelated reason would satisfy the rejection test.

## Test plan

- `cargo test --lib update::github`: 12 passed.
- **Delete-the-control check**, which is the only thing that says these work. Commented out
  `.https_only(true)` and re-ran:
  ```
  test update::github::tests::plaintext_base_is_refused_for_being_plaintext ... FAILED
  the metadata read must be refused on the scheme, got: update error:
  cannot reach GitHub releases API: io: Connection refused
  ```
  Restored: 12 passed.

## One thing the plan asked for that turned out unnecessary

The item this comes from specified a test with a real TLS listener. Measuring showed the
scheme check runs before any connection, so a closed port discriminates perfectly — the tests
stay offline and deterministic, which the testing standard requires, and no listener is
needed.

Closes #1513

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
