### PR TITLE
perf(cp): stop copying the container archive a second time

### DIFF
--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -156,7 +156,16 @@ impl Engine {
 			.map_err(ComposeError::Podman)?;
 		// Cap the buffered archive so a huge/hostile container path cannot OOM the
 		// CLI (the streaming `get_stream` path bypasses the client's own cap).
-		let tar_bytes = Limited::new(resp.into_body(), MAX_CP_ARCHIVE_BYTES)
+		//
+		// Kept as `Bytes` rather than `.to_vec()`. The extractor takes `&[u8]`,
+		// which `Bytes` derefs to, and `Bytes` is `Send + 'static` so it moves
+		// into `spawn_blocking` unchanged. The `.to_vec()` that used to be here
+		// allocated a second buffer and copied every byte into it while the
+		// first was still alive, which put the peak at twice the archive size.
+		//
+		// This still buffers the whole archive; #1515 carries the streaming
+		// rewrite that stops it doing so at all.
+		let tar_bytes: Bytes = Limited::new(resp.into_body(), MAX_CP_ARCHIVE_BYTES)
 			.collect()
 			.await
 			.map_err(|_| {
@@ -165,8 +174,7 @@ impl Engine {
 					 copy fewer files or use `podman cp` for very large transfers"
 				))
 			})?
-			.to_bytes()
-			.to_vec();
+			.to_bytes();
 
 		let dst = dst.to_path_buf();
 		tokio::task::spawn_blocking(move || extract_archive(&tar_bytes, &dst))


### PR DESCRIPTION
`cp_from_container` collected the response body into a `Bytes` and then called `.to_vec()`
on it. That allocates a second buffer and copies every byte across while the first is still
alive, so the peak sat at roughly **twice the archive size** — a 900 MB copy peaking near
1.8 GB.

Nothing needed the `Vec`. `extract_archive` takes `&[u8]`, which `Bytes` derefs to, and
`Bytes` is `Send + 'static` so it moves into `spawn_blocking` unchanged.

## Scope, stated so the commit is not read as more than it is

This removes the duplication, not the buffering. The whole archive is still resident, bounded
by `MAX_CP_ARCHIVE_BYTES` at 1 GiB, and a copy larger than that is still refused with the
message pointing at `podman cp`.

#1515 carries the streaming rewrite that removes the buffering itself. The shape already
exists in this repository, in the other direction: `build` writes its context tar from a
`spawn_blocking` walker into a bounded channel feeding the request body, which took a 512 MiB
context from ~533 MiB peak RSS to ~20 MiB (#1058). This one wants the mirror — a bounded
channel fed by the async body and drained by a blocking reader the tar extractor pulls from.

That is worth its own review, which is why it is not here.

## Test plan

- `cargo check --lib`: clean (the two warnings are pre-existing dead-code notes about
  `NetworkAttachment`, untouched here).
- `cargo test --lib engine::copy`: 32 passed.
- **Not measured:** I did not put a real multi-hundred-megabyte copy through a container and
  watch RSS. The change is a type-level one — the second allocation is gone because the
  `Vec` is gone — but the peak-memory figures above are read off the code, not off a run.
  Calling that measured would be the mistake this repository keeps a standard about.

Refs #1515

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
