### PR TITLE
test(ui): pin that a second project evicts the first project's colours

### DIFF
--- a/internal/ui/mod_tests.rs
+++ b/internal/ui/mod_tests.rs
@@ -3,6 +3,7 @@
 //! libpod client and `stats` already use.
 
 use super::*;
+use std::collections::HashMap;
 
 /// The bug this exists to stop: `ls` reports `running(1), exited(1)`, and
 /// styling it as one string let the first matching substring win — `exit`
@@ -169,12 +170,30 @@ fn an_unprefixed_label_is_keyed_on_itself() {
 	);
 }
 
+/// Serialises the tests that write the process-wide colour registry.
+///
+/// `SERVICES` is one static for the whole process, so two tests calling
+/// `set_services` on different threads race and each can read the other's
+/// registration. That would make both flaky, and a flaky test is a defect
+/// rather than noise — so every test that writes the registry takes this
+/// first. Tests that only build a local `HashMap` do not need it.
+///
+/// The lock is poison-tolerant on purpose: a panic in one of these tests must
+/// fail that test, not cascade into every other one as a poisoned-lock panic
+/// that hides which assertion actually broke.
+static COLOUR_REGISTRY: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn registry_guard() -> std::sync::MutexGuard<'static, ()> {
+	COLOUR_REGISTRY.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// `set_services` is what makes `service_style` disagree with the plain hash:
 /// once a project's names are registered, sequential assignment guarantees
 /// they spread across the palette, rather than each colliding independently
 /// under the hash the way `palette_index` used to.
 #[test]
 fn set_services_makes_registered_names_distinct() {
+	let _guard = registry_guard();
 	set_services(&[
 		"colourreg-alpha".to_string(),
 		"colourreg-beta".to_string(),
@@ -207,4 +226,54 @@ fn every_wide_palette_slot_indexes_the_narrow_palette_safely() {
 		let _ = slot_to_style(slot, false);
 		let _ = slot_to_style(slot, true);
 	}
+}
+
+/// Registering a second project evicts the first project's colours.
+///
+/// **This pins a defect, not a guarantee — see #1517.** `SERVICES` is a single
+/// process-wide static and `set_services` replaces it rather than merging, so
+/// with two `Engine` values alive in one process (helmly-agent's shape, a fleet
+/// of projects) the second registration drops the first project's names. They
+/// fall through to `colour_for`'s hash fallback and their colours change
+/// underneath a run that is still going, silently.
+///
+/// The assertion is written the way the code behaves today so the eviction
+/// cannot change without something going red. **When #1517 lands, this test
+/// must be inverted, not deleted** — the fix is exactly the case where the
+/// first project's slot survives the second registration.
+///
+/// The two name sets are chosen so the registered slot and the hash fallback
+/// disagree; `colour_for_prefers_the_registered_slot_over_the_hash` is what
+/// establishes that they can. Without that the test would pass whether or not
+/// the eviction happened, which is the vacuous shape this file already carries
+/// a warning about elsewhere.
+#[test]
+fn a_second_project_evicts_the_first_projects_colours() {
+	let _guard = registry_guard();
+
+	let first = ["evict-one".to_string(), "evict-two".to_string()];
+	set_services(&first);
+	let registered = service_slot("evict-one");
+
+	// A second Engine registers its own project. Nothing merges.
+	set_services(&[
+		"evict-other-alpha".to_string(),
+		"evict-other-beta".to_string(),
+	]);
+	let after = service_slot("evict-one");
+
+	// What the first project would get with no registry at all: the hash.
+	let unregistered = crate::ui::palette::colour_for("evict-one", &HashMap::new());
+
+	assert_eq!(
+		after, unregistered,
+		"today the first project falls back to the hash after a second registration \
+		 (#1517). If this now differs, the registry stopped being shared - invert \
+		 this test rather than deleting it."
+	);
+	assert_ne!(
+		registered, unregistered,
+		"the fixture cannot discriminate: pick names whose registered slot and hash \
+		 slot differ, or the assertion above holds whether or not eviction happened"
+	);
 }

--- a/tests/api_surface.rs
+++ b/tests/api_surface.rs
@@ -26,7 +26,7 @@ fn public_types_are_nameable() {
 /// because the retry simply stops happening.
 #[test]
 fn retry_predicates_are_callable_from_outside() {
-	fn _probe(e: &PodmanError) -> (bool, bool, bool, bool, bool, bool, &'static str) {
+	fn _probe(e: &PodmanError) -> (bool, bool, bool, bool, bool, bool, bool, &'static str) {
 		(
 			e.is_timeout(),
 			e.is_incomplete_message(),
@@ -34,6 +34,12 @@ fn retry_predicates_are_callable_from_outside() {
 			e.is_already_exists(),
 			e.is_image_in_use(),
 			e.is_state_conflict(),
+			// The only predicate that takes an argument, and the only one this
+			// file did not name until #1502. A daemon deciding whether to retry
+			// asks about a specific status - 409 is worth another try after a
+			// backoff, 404 never is - so it belongs in the contract as much as
+			// the nullary ones.
+			e.is_status(409),
 			e.stream_end_kind(),
 		)
 	}


### PR DESCRIPTION
Two `Engine` values alive in one process share one colour registry, and nothing tested it.

## What is actually shared

```rust
// internal/ui/mod.rs:112
static SERVICES: RwLock<Option<HashMap<String, usize>>> = RwLock::new(None);

pub fn set_services(names: &[String]) {
    if let Ok(mut slot) = SERVICES.write() {
        *slot = Some(palette::assign(names));   // replaces, never merges
    }
}
```

One static for the process, and `set_services` replaces the map. Its doc comment says *"Call
once per invocation"* — true for the CLI, false for the thing this crate also is. With two
engines alive, the second registration drops the first project's names, they fall through to
`colour_for`'s hash fallback, and their colours change underneath a run that is still going.
Nothing errors. That is helmly-agent's shape: a fleet of projects in one process.

Filed as **#1517**. This pull request is the test half only — #1502 was about the missing
test, and the fix is a per-`Engine` registry that touches the signature of everything that
colours a label.

## Changes

**`a_second_project_evicts_the_first_projects_colours`** asserts the eviction as it behaves
today, so the behaviour cannot change silently, and its failure message tells the next reader
to **invert it rather than delete it** when #1517 lands.

**A module-level mutex around the two tests that write the registry.** They were racing —
one static, two tests writing it on different threads, each able to read the other's
registration. That is a flaky test waiting to happen, and this repository treats a flaky test
as a defect rather than noise. The guard is poison-tolerant so a panic in one of them fails
that test instead of cascading as a poisoned-lock panic that hides which assertion broke.

**`is_status` named in `tests/api_surface.rs`.** It was the only retry predicate nothing
called anywhere in the tree. It takes an argument, which is likely why it was left out of a
probe whose other calls are nullary.

## Test plan

- `cargo test --lib ui::`: 75 passed.
- `cargo check --tests`: clean.
- **Verified the new test can detect the fix**, which is the only thing that makes it worth
  having. I simulated #1517 by making `set_services` merge instead of replace, and re-ran:
  ```
  test ui::tests::a_second_project_evicts_the_first_projects_colours ... FAILED
  assertion `left == right` failed: today the first project falls back to the hash
  after a second registration (#1517). If this now differs, the registry stopped
  being shared - invert this test rather than deleting it.
  ```
  Restored: 75 passed.
- The fixture is chosen so the registered slot and the hash slot disagree, and a second
  assertion checks exactly that — without it the first assertion would hold whether or not
  the eviction happened.

## Correction to the issue

#1502 originally also asked for a new `tests/api_surface_rs_use.rs`. `tests/api_surface.rs`
already landed with #1478 and is that contract; a new file would have duplicated it. The
issue was retitled and this is why only `is_status` remains of that half.

Closes #1502
Refs #1517

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
