### PR TITLE
docs: document the 35 undocumented public items and deny the 36th

### DIFF
--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 /// `develop:` service key — holds file-watch rules for the `watch` command.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DevelopConfig {
+	/// The rules in declaration order. `watch` evaluates them in order and the
+	/// first matching path wins, so order is meaningful rather than cosmetic.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub watch: Vec<WatchRule>,
 }
@@ -36,6 +38,9 @@ pub struct WatchRule {
 	/// Command run inside the container for the `sync+exec` action.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub exec: Option<WatchExec>,
+	/// Keys under this rule that podup does not recognise, kept so `config`
+	/// round-trips a compose file without silently dropping them. Insertion
+	/// order is preserved.
 	#[serde(flatten, default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
 	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -27,7 +27,14 @@ pub enum ComposeError {
 	/// A service has neither an `image:` nor a `build:` section.
 	NoImageOrBuild(String),
 	/// A `${VAR}` with the `?err` modifier was required but unset.
-	RequiredVarNotSet { var: String, msg: String },
+	RequiredVarNotSet {
+		/// The variable name as it appeared in the compose file, without the
+		/// `${}` or the `:?` suffix.
+		var: String,
+		/// The author's own explanation, taken verbatim from the text after
+		/// `:?` in the interpolation. Empty when the form was bare `${VAR?}`.
+		msg: String,
+	},
 	/// A `${…}` interpolation reference is malformed (e.g. an invalid character
 	/// in the variable name, as in `${FOO BAR}` or `${FOO.BAR}`).
 	InvalidSubstitution(String),
@@ -73,39 +80,73 @@ pub enum ComposeError {
 	/// A service is scaled to more than one replica but publishes a fixed host
 	/// port, which only one container can bind.
 	ScalePortConflict {
+		/// The compose key of the service, not a container name.
 		service: String,
+		/// The replica count that made the binding impossible; always above one.
 		replicas: usize,
+		/// The host ports the service pins, in the order compose declared them.
+		/// Only fixed ports appear — a range or an unspecified host port cannot
+		/// collide this way.
 		ports: Vec<u16>,
 	},
 	/// A container being waited on (`up`/`start --wait`, or a `service_healthy`
 	/// dependency) exited non-zero before becoming ready.
-	WaitServiceExited { container: String, code: i64 },
+	WaitServiceExited {
+		/// The container name Podman reported, replica suffix included, rather
+		/// than the compose service key.
+		container: String,
+		/// The container's exit status. Non-zero by construction: a zero exit is
+		/// not this error.
+		code: i64,
+	},
 	/// A service requests more replicas than the configured ceiling, which would
 	/// let an untrusted `deploy.replicas`/`scale:` drive unbounded container
 	/// creation (host DoS).
 	ReplicaLimitExceeded {
+		/// The compose key of the service that asked for too many.
 		service: String,
+		/// The count requested, from `deploy.replicas` or `scale:`.
 		replicas: usize,
+		/// The ceiling in force when the request was refused.
 		max: u32,
 	},
 	/// `start --wait --wait-timeout` elapsed before services became healthy.
-	WaitTimeout { secs: u64 },
+	WaitTimeout {
+		/// The budget that elapsed, in whole seconds, as `--wait-timeout`
+		/// received it. Not the time actually spent waiting.
+		secs: u64,
+	},
 	/// A replica index (`--index`) does not name a replica of the service (zero,
 	/// or beyond the replica count). Kept distinct from [`Self::ServiceNotFound`]
 	/// so the index hint renders outside the quoted service name.
-	ReplicaIndex { service: String, index: u32 },
+	ReplicaIndex {
+		/// The compose key of the service the index was meant to address.
+		service: String,
+		/// The index as given. Either zero, which is never valid because
+		/// replicas are numbered from one, or past the service's replica count.
+		index: u32,
+	},
 	/// A filesystem operation failed against a known path; carries the path so the
 	/// message can name the offending file (Rust's `File::create`/`open` errors
 	/// drop it).
 	IoPath {
+		/// The path the operation was attempted against, as resolved rather than
+		/// as written in the compose file.
 		path: String,
+		/// The underlying failure. Carried separately because Rust's own
+		/// `File::create`/`open` errors drop the path.
 		source: std::io::Error,
 	},
 	/// A service's build context could not be accessed; names the service and the
 	/// resolved context path instead of a bare `io error`.
 	BuildContext {
+		/// The compose key of the service whose build context could not be read.
 		service: String,
+		/// The resolved context directory, anchored against the project
+		/// directory rather than the current one.
 		path: String,
+		/// The underlying failure, kept so the message can name both the service
+		/// and the file rather than reporting a bare io error.
 		source: std::io::Error,
 	},
 	/// A targeted service container is not running (e.g. `exec`/`attach` against a

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -8,6 +8,11 @@
 // locally with `#![allow(unsafe_code)]` and a soundness comment per block, so a
 // new `unsafe` block elsewhere fails the build.
 #![deny(unsafe_code)]
+// Documentation is part of the public surface for a crate two other products
+// consume as a library, so a missing doc comment fails the build rather than
+// being noticed a year later. Turned on at 35 outstanding items; it is cheap to
+// adopt at that size and expensive at three hundred.
+#![deny(missing_docs)]
 
 /// `podup autostart`: render and manage a rootless `systemctl --user` unit that
 /// brings a compose stack up at boot (service mode).

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -16,7 +16,14 @@ pub enum PodmanError {
 	/// A newline-delimited stream ended with an unterminated record.
 	StreamEndedEarly,
 	/// Podman API returned an error response (4xx/5xx).
-	Api { status: u16, message: String },
+	Api {
+		/// The HTTP status the daemon returned. Compare it with
+		/// [`PodmanError::is_status`] rather than by hand.
+		status: u16,
+		/// The daemon's own message, preserved verbatim. podup never rewrites
+		/// it, so a caller matching on wording is matching on libpod's.
+		message: String,
+	},
 	/// A libpod field-level rejection that podup identified and attributed to a
 	/// specific field of the request it sent.
 	///
@@ -49,7 +56,11 @@ pub enum PodmanError {
 	/// The reachable Podman server speaks a libpod API version below the minimum
 	/// podup supports. Carries the version string the server reported (empty when
 	/// the server sent no `Libpod-API-Version` header).
-	IncompatibleApiVersion { reported: String },
+	IncompatibleApiVersion {
+		/// The version string from the server's `Libpod-API-Version` header, or
+		/// empty when the server sent no such header.
+		reported: String,
+	},
 }
 
 impl fmt::Display for PodmanError {

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -16,9 +16,17 @@ use crate::libpod::error::PodmanError;
 #[derive(Debug)]
 pub enum LogOutput {
 	/// Payload demuxed from the stdout stream (frame stream type 1).
-	StdOut { message: Bytes },
+	StdOut {
+		/// The payload bytes, with the frame header already stripped. Not
+		/// guaranteed to end on a line boundary — one frame may split a line.
+		message: Bytes,
+	},
 	/// Payload demuxed from the stderr stream (frame stream type 2).
-	StdErr { message: Bytes },
+	StdErr {
+		/// The payload bytes, header stripped. Same framing caveat as
+		/// [`Self::StdOut`]: a frame boundary is not a line boundary.
+		message: Bytes,
+	},
 }
 
 /// Boxed stream alias used for parse_multiplexed and parse_json_lines return types.

--- a/internal/ui/progress/board.rs
+++ b/internal/ui/progress/board.rs
@@ -13,10 +13,16 @@ use std::time::{Duration, Instant};
 /// the same vocabulary `progress_line` has always used.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Kind {
+	/// A compose network, project-scoped unless declared `external`.
 	Network,
+	/// A compose volume, project-scoped unless declared `external`.
 	Volume,
+	/// A Podman-native secret, which is what every compose `secrets:` and
+	/// `configs:` entry becomes.
 	Secret,
+	/// A container image, whether pulled or built.
 	Image,
+	/// A container, one per replica rather than one per service.
 	Container,
 }
 
@@ -60,8 +66,13 @@ pub enum State {
 /// One resource's row.
 #[derive(Debug, Clone)]
 pub struct Row {
+	/// Which noun this row is about; also the first column.
 	pub kind: Kind,
+	/// The resource's name as Podman knows it, project prefix included, so it
+	/// matches what `podman ps` or `podman network ls` would show.
 	pub name: String,
+	/// Where the row is in its lifecycle. Ordering is `Pending`, `Working`,
+	/// `Done`, and a row never goes backwards.
 	pub state: State,
 	/// When this row last entered `Working`, for the elapsed column. `None`
 	/// while `Pending`, since nothing has taken any time yet.

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -36,7 +36,11 @@ fn cursor_up(n: usize) -> String {
 /// one stream and the content in the other.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Target {
+	/// For a region whose content *is* the command's output, so a redirect
+	/// captures it. `stats` is the case this exists for.
 	Stdout,
+	/// For a region that decorates another stream's output. The lifecycle board
+	/// goes here so stdout stays a clean pipe.
 	Stderr,
 }
 


### PR DESCRIPTION
The style standard says every public item carries a doc comment addressed to a third-party
reader. Nothing enforced it, and `rustdoc` is the surface helmly-agent and epistle read.

Turning the lint on counted the gap exactly: **35 items**, 28 struct fields and 7 variants,
across six files.

| file | items |
|---|---|
| `internal/error.rs` | 16 — `ComposeError`'s fields |
| `internal/ui/progress/board.rs` | 8 — `Kind`'s variants, `Row`'s fields |
| `internal/libpod/error.rs` | 4 |
| `internal/libpod/types/stream.rs` | 2 |
| `internal/ui/progress/live.rs` | 2 |
| `internal/compose/types/develop.rs` | 2 |

Sixteen of the thirty-five are `ComposeError`'s own fields — the type a library consumer
matches on, and the one #1478 and #1500 spent this cycle making reachable. A consumer who can
now name `ComposeError::Include` still could not read what is inside it without opening the
source.

## The comments state a contract, not the field name again

`path: String` documented as "the path" satisfies the lint and tells the reader less than the
field name already did. So each one says something the signature does not:

- which identifier a field carries — `WaitServiceExited::container` is the Podman container
  name with its replica suffix, `ScalePortConflict::service` is the compose key;
- what a value excludes — `ScalePortConflict::ports` lists only fixed host ports, because a
  range or an unspecified port cannot collide that way;
- what a reader must not assume — a `LogOutput` frame boundary is **not** a line boundary, so
  one frame can split a line;
- where the wording comes from — `Api::message` is libpod's own text, preserved verbatim, so
  a caller matching on it is matching on libpod's wording rather than ours;
- that `develop.watch` rules are order-sensitive, first match wins.

## The gate

`#![deny(missing_docs)]` goes in beside the existing `#![deny(unsafe_code)]`, with a comment
saying why now: cheap to adopt at 35, expensive at three hundred, and the count only rises.

## Test plan

- `cargo check --lib`, `cargo check --lib --all-features`, `cargo check --bins`: all clean.
- `cargo test --lib error::`: 32 passed.
- **Verified the gate fires rather than assuming it.** A lint nobody has watched fail is
  decoration, so I deleted one of the new comments and re-ran:
  ```
  error: missing documentation for a struct field
  error: could not compile `podup` (lib) due to 1 previous error
  ```
  Restored: clean.

Closes #1520

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
