### PR TITLE
perf(cp): stream the container archive into the extractor

### DIFF
--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -16,6 +16,7 @@ use super::Engine;
 /// Crate-private so the fuzz harness behind the `test-helpers` feature can
 /// reach `extract_tar_guarded` without widening the published API surface.
 pub(crate) mod archive;
+mod stream;
 
 use archive::{extract_archive, pack_path};
 
@@ -156,17 +157,31 @@ impl Engine {
 			.get_stream(&path)
 			.await
 			.map_err(ComposeError::Podman)?;
-		// Cap the buffered archive so a huge/hostile container path cannot OOM the
-		// CLI (the streaming `get_stream` path bypasses the client's own cap).
+		let dst = dst.to_path_buf();
+
+		// Two destination shapes, and only one of them can be streamed.
 		//
-		// Kept as `Bytes` rather than `.to_vec()`. The extractor takes `&[u8]`,
-		// which `Bytes` derefs to, and `Bytes` is `Send + 'static` so it moves
-		// into `spawn_blocking` unchanged. The `.to_vec()` that used to be here
-		// allocated a second buffer and copied every byte into it while the
-		// first was still alive, which put the peak at twice the archive size.
+		// An existing directory goes straight to `extract_tar_guarded`, which
+		// walks the archive once — so the body can be piped into it and nothing
+		// accumulates. That is also the shape that moves bulk data (`cp
+		// svc:/var/lib/data ./backup/`), which is why it is the one worth
+		// streaming.
 		//
-		// This still buffers the whole archive; #1515 carries the streaming
-		// rewrite that stops it doing so at all.
+		// Any other destination goes through `extract_archive`, which reads the
+		// archive twice: `archive_contains_dir` decides whether the destination
+		// names a file or a directory to create, and only then does it extract.
+		// A stream cannot be rewound, so that path still buffers. Making it
+		// single-pass means changing what `cp` does with an ambiguous
+		// destination, which is a behaviour decision rather than a memory one.
+		if dst.is_dir() {
+			return stream::extract_streamed(resp, dst, MAX_CP_ARCHIVE_BYTES as u64).await;
+		}
+
+		// Cap the buffered archive so a huge/hostile container path cannot OOM
+		// the CLI (the streaming `get_stream` path bypasses the client's own
+		// cap). Kept as `Bytes` rather than `.to_vec()`: the extractor takes
+		// `&[u8]`, which `Bytes` derefs to, and a `.to_vec()` here would hold a
+		// second copy alive beside the first.
 		let tar_bytes: Bytes = Limited::new(resp.into_body(), MAX_CP_ARCHIVE_BYTES)
 			.collect()
 			.await
@@ -178,7 +193,6 @@ impl Engine {
 			})?
 			.to_bytes();
 
-		let dst = dst.to_path_buf();
 		tokio::task::spawn_blocking(move || extract_archive(&tar_bytes, &dst))
 			.await
 			.map_err(|e| ComposeError::Build(e.to_string()))??;

--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -201,9 +201,8 @@ fn unpacked_path(dst_dir: &Path, rel: &Path) -> Option<std::path::PathBuf> {
 /// `engine` (which is `pub(crate)`) keeps the function off the public API, and
 /// the fuzz harness behind the `test-helpers` feature reaches it through
 /// `crate::fuzz_api`.
-pub fn extract_tar_guarded(tar_bytes: &[u8], dst_dir: &Path) -> Result<()> {
-	let cursor = std::io::Cursor::new(tar_bytes);
-	let mut archive = tar::Archive::new(cursor);
+pub fn extract_tar_guarded<R: std::io::Read>(src: R, dst_dir: &Path) -> Result<()> {
+	let mut archive = tar::Archive::new(src);
 	for entry in archive.entries().map_err(ComposeError::Io)? {
 		let mut entry = entry.map_err(ComposeError::Io)?;
 		let rel = entry.path().map(|p| p.into_owned()).ok();
@@ -360,7 +359,7 @@ mod tests {
 	fn extract_tar_guarded_writes_benign_entry() {
 		let dir = tempfile::tempdir().expect("tempdir");
 		let bytes = tar_bytes_with("hello.txt", b"hi");
-		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
+		super::extract_tar_guarded(&bytes[..], dir.path()).expect("extract");
 		assert_eq!(
 			std::fs::read(dir.path().join("hello.txt")).expect("read"),
 			b"hi"
@@ -467,7 +466,7 @@ mod tests {
 		let mut builder = tar::Builder::new(Vec::new());
 		builder.append(&h, &b"hi"[..]).expect("append");
 		let bytes = builder.into_inner().expect("finish");
-		super::extract_tar_guarded(&bytes, dir.path()).expect("extract");
+		super::extract_tar_guarded(&bytes[..], dir.path()).expect("extract");
 		let mode = std::fs::metadata(dir.path().join("f"))
 			.expect("meta")
 			.permissions()
@@ -484,7 +483,7 @@ mod tests {
 		let dst = dir.path().join("dest");
 		std::fs::create_dir(&dst).expect("mkdir");
 		let bytes = tar_bytes_with("../evil.txt", b"pwned");
-		let err = super::extract_tar_guarded(&bytes, &dst).unwrap_err();
+		let err = super::extract_tar_guarded(&bytes[..], &dst).unwrap_err();
 		assert!(
 			format!("{err}").contains("escapes destination"),
 			"expected a zip-slip refusal, got: {err}"
@@ -632,7 +631,7 @@ mod tests {
 		builder.append(&header, &b"evil"[..]).expect("append");
 		let bytes = builder.into_inner().expect("tar");
 
-		super::extract_tar_guarded(&bytes, &dst).expect("extraction should succeed");
+		super::extract_tar_guarded(&bytes[..], &dst).expect("extraction should succeed");
 
 		let mode = std::fs::metadata(&victim)
 			.expect("stat")

--- a/internal/engine/copy/stream.rs
+++ b/internal/engine/copy/stream.rs
@@ -1,0 +1,145 @@
+//! Bridge the container→host `cp` response body into a blocking tar reader
+//! without buffering the whole archive.
+//!
+//! The mirror of `build/stream.rs`, which runs a blocking tar *writer* on a
+//! `spawn_blocking` thread feeding a bounded channel that an async body drains.
+//! Here the flow reverses: an async task drains the response body into the same
+//! kind of bounded channel, and a blocking [`Read`] implementation pulls from
+//! it so the tar extractor can work entry by entry.
+//!
+//! Peak memory is about `CHANNEL_CAP` chunks regardless of archive size, in
+//! place of the whole archive.
+
+use std::io::{self, Read};
+
+use http_body_util::BodyExt;
+
+use bytes::Bytes;
+use tokio::sync::mpsc;
+
+use super::archive::extract_tar_guarded;
+use crate::error::{ComposeError, Result};
+
+/// How many chunks the channel holds. Same reasoning as the build side: enough
+/// to keep the socket and the extractor both busy, small enough that the bound
+/// is the point.
+pub(super) const CHANNEL_CAP: usize = 8;
+
+/// A chunk of archive bytes, or the transport failure that ended the stream.
+pub(super) type ChunkItem = io::Result<Bytes>;
+
+/// Serves the bytes an async producer sends over a bounded channel to a
+/// blocking consumer, refusing to serve more than `cap` in total.
+///
+/// The cap is no longer a memory bound — nothing accumulates — but it stays
+/// meaningful: a compromised container can stream without end, and the bytes
+/// land on the host's disk as they arrive. What it protects changed from RAM to
+/// disk, so it is not redundant.
+pub(super) struct ChannelReader {
+	rx: mpsc::Receiver<ChunkItem>,
+	/// The chunk currently being handed out, consumed from the front.
+	current: Bytes,
+	/// Bytes served so far, compared against `cap` on every read.
+	served: u64,
+	cap: u64,
+}
+
+impl ChannelReader {
+	pub(super) fn new(rx: mpsc::Receiver<ChunkItem>, cap: u64) -> Self {
+		Self {
+			rx,
+			current: Bytes::new(),
+			served: 0,
+			cap,
+		}
+	}
+}
+
+impl Read for ChannelReader {
+	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+		if buf.is_empty() {
+			return Ok(0);
+		}
+		// A producer may send an empty frame; skip those rather than reporting
+		// end of stream, which would truncate the archive silently.
+		while self.current.is_empty() {
+			match self.rx.blocking_recv() {
+				// Channel closed: the producer finished or was dropped. Either
+				// way there are no more bytes, which is a clean end of file —
+				// a truncated archive surfaces as a tar error, not here.
+				None => return Ok(0),
+				Some(Err(e)) => return Err(e),
+				Some(Ok(chunk)) => self.current = chunk,
+			}
+		}
+
+		let n = buf.len().min(self.current.len());
+		self.served += n as u64;
+		if self.served > self.cap {
+			return Err(io::Error::other(format!(
+				"cp: container archive exceeds {} bytes",
+				self.cap
+			)));
+		}
+		buf[..n].copy_from_slice(&self.current[..n]);
+		self.current = self.current.slice(n..);
+		Ok(n)
+	}
+}
+
+/// Pipe the archive body straight into the guarded extractor.
+///
+/// An async task drains the response body into a bounded channel; a
+/// `spawn_blocking` task drives the tar extractor from the other end
+/// through [`ChannelReader`]. Peak memory is the channel's depth rather
+/// than the archive's size.
+///
+/// The pump is spawned before the extractor is awaited, and the extractor
+/// is what the caller waits on. Awaiting the pump first would deadlock: it
+/// blocks once the bounded channel fills, and only the extractor drains it.
+/// This is the same ordering `build/stream.rs` documents in the other
+/// direction.
+pub(super) async fn extract_streamed(
+	resp: hyper::Response<hyper::body::Incoming>,
+	dst: std::path::PathBuf,
+	cap: u64,
+) -> Result<()> {
+	let (tx, rx) = tokio::sync::mpsc::channel::<ChunkItem>(CHANNEL_CAP);
+
+	let pump = tokio::spawn(async move {
+		let mut body = resp.into_body();
+		while let Some(frame) = body.frame().await {
+			let item = match frame {
+				Ok(f) => match f.into_data() {
+					Ok(data) => Ok(data),
+					// A trailers frame carries no payload and is not an
+					// error; skip it rather than ending the archive.
+					Err(_) => continue,
+				},
+				Err(e) => Err(std::io::Error::other(e.to_string())),
+			};
+			let fatal = item.is_err();
+			// A send failure means the extractor is gone, which it does on
+			// its own error. Stop rather than reporting a second fault over
+			// the first.
+			if tx.send(item).await.is_err() || fatal {
+				break;
+			}
+		}
+	});
+
+	let reader = ChannelReader::new(rx, cap);
+	let extracted = tokio::task::spawn_blocking(move || extract_tar_guarded(reader, &dst))
+		.await
+		.map_err(|e| ComposeError::Build(e.to_string()))?;
+
+	// The extractor's verdict is the one that matters; the pump only
+	// carries bytes. Abort it so a body still arriving after a refused
+	// entry does not outlive the command.
+	pump.abort();
+	extracted
+}
+
+#[cfg(test)]
+#[path = "stream_tests.rs"]
+mod tests;

--- a/internal/engine/copy/stream_tests.rs
+++ b/internal/engine/copy/stream_tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+/// Feed a reader from a list of chunks, as the body pump would.
+fn reader_over(chunks: Vec<ChunkItem>, cap: u64) -> ChannelReader {
+	let (tx, rx) = mpsc::channel(CHANNEL_CAP);
+	for c in chunks {
+		tx.try_send(c)
+			.expect("test channel must accept the fixture");
+	}
+	drop(tx);
+	ChannelReader::new(rx, cap)
+}
+
+#[test]
+fn chunks_are_reassembled_in_order() {
+	let mut r = reader_over(
+		vec![
+			Ok(Bytes::from_static(b"hello ")),
+			Ok(Bytes::from_static(b"world")),
+		],
+		1024,
+	);
+	let mut out = String::new();
+	r.read_to_string(&mut out).expect("read");
+	assert_eq!(out, "hello world");
+}
+
+/// The reader must survive a producer that sends an empty frame. Reporting
+/// end-of-stream there would truncate the archive with no error anywhere —
+/// exactly the silent-data-loss shape this file exists to avoid.
+#[test]
+fn an_empty_frame_is_not_end_of_stream() {
+	let mut r = reader_over(
+		vec![
+			Ok(Bytes::from_static(b"a")),
+			Ok(Bytes::new()),
+			Ok(Bytes::from_static(b"b")),
+		],
+		1024,
+	);
+	let mut out = Vec::new();
+	r.read_to_end(&mut out).expect("read");
+	assert_eq!(out, b"ab", "the empty frame must be skipped, not terminate");
+}
+
+/// A short buffer must not lose the rest of the chunk.
+#[test]
+fn a_chunk_larger_than_the_buffer_is_served_across_reads() {
+	let mut r = reader_over(vec![Ok(Bytes::from_static(b"abcdef"))], 1024);
+	let mut buf = [0u8; 2];
+	let mut seen = Vec::new();
+	loop {
+		let n = r.read(&mut buf).expect("read");
+		if n == 0 {
+			break;
+		}
+		seen.extend_from_slice(&buf[..n]);
+	}
+	assert_eq!(seen, b"abcdef");
+}
+
+/// The cap is what stops a compromised container streaming without end onto the
+/// host's disk. Assert the specific refusal rather than any error: a bare
+/// `is_err` would be satisfied by a channel fault too.
+#[test]
+fn past_the_cap_the_read_is_refused_for_being_over_the_cap() {
+	let mut r = reader_over(vec![Ok(Bytes::from_static(b"0123456789"))], 4);
+	let mut out = Vec::new();
+	let err = r.read_to_end(&mut out).expect_err("must refuse");
+	assert!(
+		err.to_string().contains("exceeds 4 bytes"),
+		"must name the cap it exceeded, got: {err}"
+	);
+}
+
+/// The acceptance half of the pair above, one byte inside the limit. Without
+/// it, an archive refused for an unrelated reason would satisfy the rejection
+/// test and prove nothing about the cap.
+#[test]
+fn exactly_at_the_cap_is_served() {
+	let mut r = reader_over(vec![Ok(Bytes::from_static(b"0123"))], 4);
+	let mut out = Vec::new();
+	r.read_to_end(&mut out)
+		.expect("four bytes under a cap of four must pass");
+	assert_eq!(out, b"0123");
+}
+
+/// A transport failure mid-stream must reach the extractor as an error, not as
+/// a clean end of file. The distinction is the whole point: a truncated archive
+/// that ends cleanly is silent data loss.
+#[test]
+fn a_transport_error_is_not_a_clean_end() {
+	let mut r = reader_over(
+		vec![
+			Ok(Bytes::from_static(b"partial")),
+			Err(io::Error::other("connection reset")),
+		],
+		1024,
+	);
+	let mut buf = [0u8; 64];
+	assert_eq!(r.read(&mut buf).expect("first chunk"), 7);
+	let err = r.read(&mut buf).expect_err("the fault must surface");
+	assert!(
+		err.to_string().contains("connection reset"),
+		"the transport cause must survive, got: {err}"
+	);
+}


### PR DESCRIPTION
`cp_from_container` buffered the whole container archive before extracting it, bounded at
1 GiB. A 900 MB copy cost 900 MB resident, and anything larger was refused with a message
telling the user to run `podman cp` instead.

## What it does now

`internal/engine/copy/stream.rs` mirrors `build/stream.rs` in the other direction. There, a
blocking tar **writer** runs on `spawn_blocking` feeding a bounded channel that an async body
drains — the change that took a 512 MiB build context from ~533 MiB peak RSS to ~20 MiB
(#1058). Here the flow reverses: an async task drains the response body into the same kind of
bounded channel, and `ChannelReader` serves it to the tar extractor on a `spawn_blocking`
thread. Peak memory becomes the channel's depth rather than the archive's size.

`extract_tar_guarded` is generic over `Read` now. `&[u8]` implements it, so the fuzz target
and every existing test call are unchanged apart from `&bytes[..]`.

## Only one destination shape is streamed, and that is a limit not an oversight

The brief for this was "mirror `build`". Reading the consumer showed the mirror is not
symmetric, which is the part worth knowing:

- **An existing directory** goes straight to `extract_tar_guarded`, which walks the archive
  **once**. A stream can drive that, and it is the shape that moves bulk data
  (`cp svc:/var/lib/data ./backup/`). Streamed.
- **Anything else** goes through `extract_archive`, which reads the archive **twice**:
  `archive_contains_dir` decides whether the destination names a file or a directory to
  create, and only then does it extract. A stream cannot be rewound.

Making the second path single-pass means changing what `cp` does with an ambiguous
destination — a behaviour decision about a command with a history (#1097, #1270), not a
memory one. It still buffers, and the comment in `copy.rs` says why so the next reader does
not take it for an omission.

## The cap stays, and what it protects changed

`MAX_CP_ARCHIVE_BYTES` was a memory bound. Nothing accumulates now, so it is a **disk** bound:
a compromised container can stream without end, and on the streaming path those bytes land on
the host as they arrive. Removing it because "streaming makes it unnecessary" would have been
the wrong read.

## Two details that would each be silent data loss

- **An empty frame must not read as end of stream.** The reader loops past empty chunks; a
  bare `if` there truncates the archive with no error anywhere.
- **A transport fault must reach the extractor as an error, not a clean EOF** — same reason.
  A truncated archive that ends cleanly is the worst outcome available.

## Test plan

- `cargo test --lib`: **1709 passed**, 0 failed.
- `cargo test --lib engine::copy`: 38 passed.
- `cargo check --tests --all-features`: clean.
- `cargo +nightly fuzz build extract_tar`: still builds after the signature change.
- **Delete-the-control on both new controls**, since reading a test cannot say whether it
  works:
  - empty-frame loop → `if`: `an_empty_frame_is_not_end_of_stream` FAILED.
  - cap check removed: `past_the_cap_the_read_is_refused_for_being_over_the_cap` FAILED.
  - Restored: 6 passed.
- The cap tests are a rejection/acceptance pair one byte apart (4 bytes under a cap of 4
  passes; 10 under a cap of 4 is refused **naming the cap**), so a failure for an unrelated
  reason cannot satisfy the rejection.

## What is unverified, stated plainly

**I did not put a large copy through a real container and watch RSS.** The tests are
in-process over synthetic tar bytes, which proves the reader's contract and not the end-to-end
memory figure. No number in this description is a measured peak — the argument is structural:
nothing holds the archive.

The real gate is `podman-vm (5)` and `podman-vm (6)`, which run the integration suite against
a real Podman on this pull request. That is the layer this repository's testing standard says
has to be green before a runtime change like this counts, and it is the one I cannot run
locally.

## Also

`extract_streamed` lives in `stream.rs` rather than `copy.rs`. `copy.rs` was at 460 code lines
after the first draft, past the 300-line soft limit the structure standard asks you to look
for a split at; it is 430 now and the streaming logic sits with the reader it drives.

Closes #1515

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
