### PR TITLE
ci: adopt the pin-policy guard, which this repo alone was missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,22 @@ jobs:
       workflow: benchmark.yml
       max-age-days: 65
 
+  # This repository pins thirteen reusables, more than twice any other in the
+  # org, and was the only one of the five without this guard. On 2026-08-21 ten
+  # Dependabot pull requests proposed 1.15.0 to 1.16.0 across ten caller files;
+  # comparing the surfaces by hand showed all thirteen byte-identical to
+  # v1.16.1, so every one was a no-op and all ten were closed. Nothing here was
+  # going to say that, and the alternative to the hand comparison is merging
+  # no-ops until open-pull-requests-limit fills and Dependabot stops proposing
+  # anything at all, security bumps included.
+  #
+  # Advisory. Promotion to required needs the check seen failing for its own
+  # reason, its emitted name read off a real run, and confirmation that it runs
+  # on a Dependabot-authored pull request - the condition that forced
+  # `Analyze (actions)` out of apt.
+  pin-policy:
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@8517d94fde00466f59b95c5d1bd838e2ad24a8bf # v1.15.2
+
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
   # when no pull request has been opened recently enough.


### PR DESCRIPTION
`apt`, `homebrew-tap` and `scoop-bucket` all call `pin-policy`. podup did not — and it pins
**thirteen** reusables against their five.

## What that cost, today

Ten Dependabot pull requests (#1464–#1473) sat open proposing `1.15.0 → 1.16.0` across ten
caller files. I compared the surfaces by hand and found **thirteen of thirteen byte-identical
to `v1.16.1`**, so every one was a no-op, and all ten were closed under the pin policy.

Nothing in this repository was going to say that. Without the hand comparison the choice is
between merging ten no-ops — which burns `open-pull-requests-limit`, and once that fills
Dependabot stops proposing anything at all, security bumps included — or leaving them open,
which fills it anyway.

The one pin that *did* carry a real change (`dependabot-freshness`, fixed in #1505) was found
because the gate it powers had been red on every pull request for days. Not because anything
compared it.

## Advisory, deliberately

The CI standard promotes a check to required only after three things: it has been seen failing
for its intended reason with a link to the run, its emitted name has been read off a real run
and matches the ruleset string, and it is confirmed to run for **every** actor that opens pull
requests here. That last one is what forced `Analyze (actions)` out of `apt`, where CodeQL
default setup silently skipped Dependabot-authored events and left every Dependabot pull
request unmergeable with all five real gates green.

None of the three is satisfied yet, so this goes in as a plain caller.

## Test plan, and what I could not do

- The workflow parses (`yaml.safe_load`).
- **I could not run the guard locally.** `scripts/pin-policy.py` calls `gh api`, which is
  legitimate for a workflow's own `GITHUB_TOKEN` — a scoped bot token on its own rate limit —
  and banned for the owner's identity, which is what I would be running as. So this pull
  request's own CI run is the first real execution, and the check's green is the evidence
  rather than anything I can show here.
- Expected outcome from the by-hand comparison above: `DIFF: 0`, all thirteen at the
  `v1.16.1` surface, and every `# vX.Y.Z` comment naming a tag that exists (`v1.13.0`,
  `v1.15.0`, `v1.16.0`, `v1.16.1` all do). If it comes back red, the comparison was wrong and
  that is worth more than the guard.

Closes #1523

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
