### PR TITLE
ci: name the tag now that v1.17.0 carries the toolchain inputs

### DIFF
--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -40,11 +40,12 @@ permissions:
 
 jobs:
   debian:
-    # Pinned at an untagged commit while the reusable is proven on a real
-    # consumer, which is what the CI standard asks for before a tag is cut -
-    # .github's own CI never exercises a caller. The comment becomes
-    # # v1.17.0 before this merges.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e70ff47fd8aefa0f054846815f19b98768d61122
+    # v1.17.0 added rust-toolchain and rust-target. It was pinned here at the
+    # untagged commit first, because the CI standard asks for a reusable to be
+    # proven on a real consumer before its tag is cut - .github's own CI never
+    # exercises a caller. This repository's dpkg-buildpackage job was that
+    # proof, going from red to green in 6m36s on #1525.
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e70ff47fd8aefa0f054846815f19b98768d61122 # v1.17.0
     with:
       package-name: podup
       check-vendored: true


### PR DESCRIPTION
The `rust-debian` pin sat at an untagged commit while the reusable was proven on this repository — the order the CI standard asks for, because `.github`'s own CI never exercises a caller.

`Glyndor/.github` **v1.17.0** is that commit, cut after `debian / dpkg-buildpackage` went from red (33s, `the x86_64-unknown-linux-musl target may not be installed`) to green (6m36s, building `podup_4.0.0_amd64.deb`) on #1525.

So the comment names the tag.

This also clears `pin-policy`, which was **correctly red** on #1525 — a pin whose comment names no tag is exactly what that guard exists to catch. It was advisory there, which is why #1525 could merge with it red; leaving it red would have been the wrong lesson.

## Test plan

- `pin-policy / pin policy` must go green and report every pin at the latest surface.
- Nothing else changes: the SHA is untouched, only the trailing comment.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>