### PR TITLE
chore(debian): bump Standards-Version to 4.7.4.1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper-compat (= 13)
 # target has to be present first. That is acceptable here because the releases
 # standard rules out submitting to the Debian archive - this package is built
 # by one workflow, for one self-hosted archive.
-Standards-Version: 4.7.0
+Standards-Version: 4.7.4.1
 Homepage: https://github.com/Glyndor/podup
 Vcs-Git: https://github.com/Glyndor/podup.git
 Vcs-Browser: https://github.com/Glyndor/podup


### PR DESCRIPTION
The current Debian Policy is 4.7.4.1, released 2026-03-31. Issue #1526 called for a bump to 4.7.4; I checked the policy site and the live release is one patch ahead, so the version in debian/control must reflect that.

I walked the upgrading checklist from 4.7.0 through 4.7.4.1. The intervening revisions (4.7.1, 4.7.2, 4.7.3, 4.7.4) add no requirement that binds this package:

- 4.7.1 (Feb 2025): /bin, /lib, /sbin are symlinks to /usr; no requirement on /usr/share/locale, man, or info. The package ships a single binary into /usr/bin; it does not touch /lib or /sbin and does not depend on locale, man, or info being present.
- 4.7.2 (Feb 2025): relaxes the /usr/games collision rule. Not applicable.
- 4.7.3 (Dec 2025): Priority in the source stanza is no longer recommended; Git-Tag-Tagger and Git-Tag-Info are new optional fields. podup declares Priority on both stanzas, which remains valid; the new fields are optional and there is no requirement to add them.
- 4.7.4 (Mar 2026): *.so linker scripts in -dev packages; non-free-firmware copyright explanation. podup ships no -dev package and is MIT, not non-free-firmware.

The bump is therefore a number-only update with no accompanying change needed elsewhere in debian/. Verified locally with `dpkg-checkbuilddeps` (parses cleanly; the only unmet is `debhelper-compat (= 13)`, which is expected on a host without that package) and `cargo test --test workflow_toolchain_pin` (3 passed).

Part of #1526.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>