### PR TITLE
ci(release): pin build-deb container to trixie digest

### DIFF
--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -17,6 +17,13 @@ on:
       # all-features and compiles the same code fine.
       - "tests/**"
       - ".github/workflows/debian-build.yml"
+      # The release job builds the .deb too, in its own container, and until
+      # this line a change to it triggered nothing. That is the shape of #1295:
+      # the filter left tests/** out, and a broken develop rode twenty pull
+      # requests because the one lane that compiles with debian/rules' feature
+      # set never ran. A gate that does not run is indistinguishable from one
+      # that passes.
+      - ".github/workflows/release.yml"
   pull_request:
     branches:
       - main
@@ -34,6 +41,13 @@ on:
       # all-features and compiles the same code fine.
       - "tests/**"
       - ".github/workflows/debian-build.yml"
+      # The release job builds the .deb too, in its own container, and until
+      # this line a change to it triggered nothing. That is the shape of #1295:
+      # the filter left tests/** out, and a broken develop rode twenty pull
+      # requests because the one lane that compiles with debian/rules' feature
+      # set never ran. A gate that does not run is indistinguishable from one
+      # that passes.
+      - ".github/workflows/release.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,16 @@ jobs:
     name: Build Debian package (${{ matrix.arch }})
     needs: verify
     runs-on: ${{ matrix.runner }}
-    container: debian:sid
+    # debian:trixie, digest-pinned at the same snapshot Glyndor/.github's
+    # rust-debian.yml uses (default for the CI image). Sid was a moving tag:
+    # two releases built from identical source could land in different
+    # environments with nothing in history recording which, and Dependabot's
+    # github-actions ecosystem does not bump a workflow's `container:` image,
+    # so a digest of sid would have no bump path and freeze. Trixie is stable
+    # and matches the suite CI validates against, so the release that ships
+    # to users was produced by the same image the suite exercises. Bump the
+    # digest here when rust-debian.yml's default moves; the two should agree.
+    container: debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Closes #1487.

#1525 closed the toolchain half of #1487 (the .deb no longer ships from Debian's `rustc`; it is built by the rustup toolchain pinned to the same version rust-ci.yml defaults to). This PR closes the **container** half: `release.yml`'s `build-deb` job was running in `container: debian:sid`, a moving tag, so two releases built from identical source could land in different environments with nothing in history recording which.

## Why not pin a digest of sid

Dependabot's `github-actions` ecosystem does not update a workflow's `container:` image. I checked this against the dependabot-core source rather than taking it on faith: `github_actions/lib/dependabot/github_actions/file_parser.rb` calls `deep_fetch_uses(json.fetch("jobs", json.fetch("runs", nil)))` and only collects `uses:` strings — the parser never visits the `container:` key at any level, and `update_checker.rb` only mutates `source.ref` for the dependencies the parser built. So a digest of sid would freeze with no bump path, and a frozen `sid` digest eventually stops resolving `apt-get install` altogether as the rolling suite moves past it.

## Why trixie

Trixie is the suite `Glyndor/.github`'s `rust-debian.yml` defaults its `debian-image` input to. I re-checked the digest before pinning to it: `rust-debian.yml` on `main` is still on `debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4` (the 2026-07-17 snapshot), and that digest still resolves against `registry-1.docker.io` (HTTP 200, OCI image index).

Aligning the release job with the CI image closes a second defect that was sitting on the same line of YAML: CI was validating the package against trixie while the release was building it on sid, so the binary users installed was never exercised by the suite that gated it. After this change, both sides build in the same snapshot.

## What I verified vs reasoned

- **Verified directly:** the digest resolves (`curl` against `registry-1.docker.io/v2/library/debian/manifests/<digest>` returns 200 with `application/vnd.oci.image.index.v1+json`); `musl-tools` (1.2.5-3.1) and `debhelper` (13.24.2, satisfying `debhelper-compat (= 13)`) are present in trixie; `actionlint` is clean; `cargo fmt --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings` are clean.
- **Reasoned:** trixie's own age does not matter for the build — the toolchain comes from rustup, pinned to `1.97`, and the only thing the container provides that affects compilation is `build-essential`, `dpkg-dev`, `debhelper` and `musl-tools`, all of which are standard trixie packages (verified above).
- **Verified by analogy:** the release job's own path cannot be exercised without cutting a release. The `debian / dpkg-buildpackage` CI lane is the proof and it builds in the same image (`rust-debian.yml`'s default), the same rustup toolchain (`1.97`), and the same `debian/rules` flags — so a working `debian-build.yml` run on this repo implies the release job's path works. The lane's path filter does not include `.github/workflows/release.yml`, so this PR does not itself trigger it; the most recent green run on `develop` (after #1525 merged) is the evidence.

## Bump policy

The digest bumps when `rust-debian.yml`'s default moves, not on its own. Both should agree; a one-line edit to `release.yml` keeps them in sync.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>