### PR TITLE
fix(ui): key the identity-colour registry by project (#1517)

### DIFF
--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -54,9 +54,16 @@ impl Engine {
 		// Without this every container here fell back to the per-label hash
 		// instead of the sequential identity colour `ps` and the compose-file
 		// `down` path use — the same class of defect fixed for `logs` (#1082).
+		//
+		// `set_services` registers under the project's name in the process-wide
+		// identity-colour registry. Two `Engine` values alive in one process
+		// (helmly-agent's fleet) key off their own `self.project`, so neither
+		// registration evicts the other (#1517). `set_project` must come
+		// first; without it the registration is a no-op.
 		let by_service = self.live_project_replicas().await?;
 		let mut service_names: Vec<String> = by_service.keys().cloned().collect();
 		service_names.sort();
+		crate::ui::set_project(&self.project);
 		crate::ui::set_services(&service_names);
 
 		let containers: Vec<String> = by_service.into_values().flatten().collect();

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -85,11 +85,18 @@ static PROJECT: std::sync::RwLock<String> = std::sync::RwLock::new(String::new()
 
 /// The pre-formatted `"{project}-"` prefix, cached so [`identity_slot`] does
 /// not reallocate it on every call. Set in tandem with [`PROJECT`] by
-/// [`set_project`]; read by [`identity_slot`] on every progress event, table
-/// row, and log-prefix row (~300 of those per 100-service `up`, #1364).
+/// [`set_project`]; read by [`identity_slot`]'s no-registration fallback path
+/// so `proj-web-1` and `web-1` still collapse to one hash slot when no
+/// project has called `set_services` yet. The main registered lookup iterates
+/// the per-project prefix entries in [`SERVICES`] directly, so this cache
+/// only matters when nothing has been registered.
 static PROJECT_PREFIX: std::sync::RwLock<String> = std::sync::RwLock::new(String::new());
 
-/// Record the project name for identity colouring. Set once per invocation.
+/// Record the project name for identity colouring. Set once per invocation
+/// per project: two `Engine` values alive in one process must each register
+/// their own project name, and the last `set_project` wins for the global
+/// `PROJECT` — but every project's services live under its own key in
+/// [`SERVICES`], so neither evicts the other.
 pub fn set_project(name: &str) {
 	if let Ok(mut slot) = PROJECT.write() {
 		name.clone_into(&mut slot);
@@ -106,20 +113,36 @@ pub fn set_project(name: &str) {
 	}
 }
 
-/// The service-to-colour map for this invocation, filled once the compose file
-/// has been resolved. Empty until then, which is why `colour_for` falls back to
-/// a hash rather than requiring registration.
-static SERVICES: std::sync::RwLock<Option<std::collections::HashMap<String, usize>>> =
-	std::sync::RwLock::new(None);
+/// The service-to-colour map, keyed by project name so two `Engine` values
+/// alive in one process (helmly-agent's fleet shape) coexist: a second
+/// `set_services` inserts under a different project key and the first
+/// project's slots survive (#1517).
+///
+/// Empty until [`set_services`] is called, which is why [`identity_slot`] and
+/// [`service_slot`] fall back to a hash rather than requiring registration.
+static SERVICES: std::sync::RwLock<
+	Option<std::collections::HashMap<String, std::collections::HashMap<String, usize>>>,
+> = std::sync::RwLock::new(None);
 
 /// Record this project's service names so each gets its own identity colour.
 ///
-/// Call once per invocation, after the compose file is parsed. Without it every
-/// label falls back to the hash, which still works — it just cannot promise two
+/// Call once per project per invocation, after the compose file is parsed
+/// (or, for the label-only teardown in
+/// `engine::lifecycle::down_label::Engine::down_by_label`, after the live
+/// container listing is fetched). Without a prior [`set_project`] for the
+/// same project this is a no-op: registration has no project key to live
+/// under. Every CLI command and the engine call site already calls
+/// [`set_project`] first. Without any registration every label falls back
+/// to the per-label hash, which still works — it just cannot promise two
 /// services differ.
 pub fn set_services(names: &[String]) {
+	let project = match PROJECT.read() {
+		Ok(p) if !p.is_empty() => p.clone(),
+		_ => return,
+	};
 	if let Ok(mut slot) = SERVICES.write() {
-		*slot = Some(palette::assign(names));
+		let map = slot.get_or_insert_with(std::collections::HashMap::new);
+		map.insert(project, palette::assign(names));
 	}
 }
 
@@ -135,21 +158,49 @@ pub fn identity_style(label: &str) -> Style {
 
 /// The palette slot backing [`identity_style`]. See [`service_slot`] for why
 /// this exists as its own, unrendered step.
+///
+/// First tries every project registered in [`SERVICES`], stripping each
+/// project's `"{name}-"` prefix in turn — a label from a project whose
+/// [`set_project`] was overwritten by another engine in the same process
+/// still resolves correctly (#1517). If no project matched, falls back to
+/// the legacy [`PROJECT_PREFIX`]-stripped lookup so `proj-web-1` and
+/// `web-1` collapse to one hash slot in the no-registration case
+/// (`every_spelling_of_one_container_gets_one_colour` pins that contract).
 pub(crate) fn identity_slot(label: &str) -> usize {
-	// Use the cached `"{project}-"` prefix instead of formatting one per call.
-	// `progress_line` and the table renderers fire this on every container
-	// name in every command, so the per-call `format!` was ~300 wasted
-	// allocations per 100-service `up` (#1364).
-	let key = PROJECT_PREFIX
+	if let Ok(slot) = SERVICES.read() {
+		if let Some(map) = slot.as_ref() {
+			for (project, services) in map.iter() {
+				if project.is_empty() {
+					continue;
+				}
+				let prefix = format!("{project}-");
+				if let Some(stripped) = label.strip_prefix(prefix.as_str()) {
+					let key = strip_replica_suffix(stripped);
+					if let Some(&slot) = services.get(key) {
+						return slot;
+					}
+				}
+			}
+		}
+	}
+	// No project's services matched. Strip the currently-set project prefix
+	// (cached in PROJECT_PREFIX so the per-call `format!` is not re-paid)
+	// and look up the bare key — the legacy single-engine behaviour that
+	// `every_spelling_of_one_container_gets_one_colour` pins (#1364).
+	let prefix = PROJECT_PREFIX
 		.read()
 		.ok()
-		.and_then(|p| {
-			(!p.is_empty())
-				.then(|| label.strip_prefix(p.as_str()).map(str::to_string))
-				.flatten()
-		})
-		.unwrap_or_else(|| label.to_string());
-	service_slot(strip_replica_suffix(&key))
+		.map(|p| p.clone())
+		.unwrap_or_default();
+	let stripped = if prefix.is_empty() {
+		label.to_string()
+	} else {
+		label
+			.strip_prefix(prefix.as_str())
+			.unwrap_or(label)
+			.to_string()
+	};
+	service_slot(strip_replica_suffix(&stripped))
 }
 
 /// Drop a trailing `-N` replica index, so every surface hashes the same key.
@@ -417,6 +468,12 @@ const SERVICE_PALETTE: [AnsiColor; 6] = [
 /// The palette slot backing [`service_style`], before it is rendered into a
 /// [`Style`] for whichever palette the terminal supports.
 ///
+/// Looks up `name` in every project's services registered in [`SERVICES`],
+/// first match wins. Two `Engine` values alive in one process own separate
+/// maps under separate project keys, so neither evicts the other (#1517).
+/// Falls back to the per-label hash when nothing is registered — the same
+/// fallback [`palette::colour_for`] has always used for an undeclared label.
+///
 /// Split out so a routing regression can be asserted on the slot itself: the
 /// narrow (6-colour) fallback wraps a slot index mod 6, so two different
 /// wide-palette slots can render as the same `Style` there. A test comparing
@@ -424,11 +481,16 @@ const SERVICE_PALETTE: [AnsiColor; 6] = [
 /// terminal that never announces the wide palette; the slot never wraps, so
 /// it stays a real comparison on both.
 pub(crate) fn service_slot(name: &str) -> usize {
-	SERVICES
-		.read()
-		.ok()
-		.and_then(|slot| slot.as_ref().map(|map| palette::colour_for(name, map)))
-		.unwrap_or_else(|| palette::colour_for(name, &std::collections::HashMap::new()))
+	if let Ok(slot) = SERVICES.read() {
+		if let Some(map) = slot.as_ref() {
+			for services in map.values() {
+				if let Some(&slot) = services.get(name) {
+					return slot;
+				}
+			}
+		}
+	}
+	palette::colour_for(name, &std::collections::HashMap::new())
 }
 
 /// The stable colour for a service's aggregated-log prefix.

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -95,8 +95,8 @@ static PROJECT_PREFIX: std::sync::RwLock<String> = std::sync::RwLock::new(String
 /// Record the project name for identity colouring. Set once per invocation
 /// per project: two `Engine` values alive in one process must each register
 /// their own project name, and the last `set_project` wins for the global
-/// `PROJECT` — but every project's services live under its own key in
-/// [`SERVICES`], so neither evicts the other.
+/// `PROJECT` — but every project's services live under its own key in the
+/// service registry, so neither evicts the other.
 pub fn set_project(name: &str) {
 	if let Ok(mut slot) = PROJECT.write() {
 		name.clone_into(&mut slot);

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -138,7 +138,18 @@ static SERVICES: std::sync::RwLock<
 pub fn set_services(names: &[String]) {
 	let project = match PROJECT.read() {
 		Ok(p) if !p.is_empty() => p.clone(),
-		_ => return,
+		_ => {
+			// Returning quietly would leave every label on the hash fallback
+			// with nothing to say why: colours would still appear, just not
+			// the assigned ones, which is the shape of failure nobody
+			// notices. The CLI always calls set_project first; a library
+			// consumer has no such habit, and this is the line that tells
+			// them.
+			tracing::warn!(
+				"identity colours not registered: set_project must be called before set_services"
+			);
+			return;
+		}
 	};
 	if let Ok(mut slot) = SERVICES.write() {
 		let map = slot.get_or_insert_with(std::collections::HashMap::new);

--- a/internal/ui/mod_tests.rs
+++ b/internal/ui/mod_tests.rs
@@ -251,7 +251,7 @@ fn every_wide_palette_slot_indexes_the_narrow_palette_safely() {
 /// the fix were in place, the vacuous shape this file already carries a
 /// warning about elsewhere.
 #[test]
-fn a_second_project_evicts_the_first_projects_colours() {
+fn a_second_project_leaves_the_first_projects_colours_alone() {
 	let _guard = registry_guard();
 
 	// `set_services` is project-keyed; each project's services live under its

--- a/internal/ui/mod_tests.rs
+++ b/internal/ui/mod_tests.rs
@@ -194,6 +194,10 @@ fn registry_guard() -> std::sync::MutexGuard<'static, ()> {
 #[test]
 fn set_services_makes_registered_names_distinct() {
 	let _guard = registry_guard();
+	// `set_services` is project-keyed; without a project name to register
+	// under, every name falls back to the hash and the test's `assert_ne!`
+	// chain no longer holds (#1517).
+	set_project("colourreg-distinct");
 	set_services(&[
 		"colourreg-alpha".to_string(),
 		"colourreg-beta".to_string(),
@@ -228,34 +232,38 @@ fn every_wide_palette_slot_indexes_the_narrow_palette_safely() {
 	}
 }
 
-/// Registering a second project evicts the first project's colours.
+/// Two projects in one process coexist: the first project's colours survive
+/// the second project's registration.
 ///
-/// **This pins a defect, not a guarantee — see #1517.** `SERVICES` is a single
-/// process-wide static and `set_services` replaces it rather than merging, so
-/// with two `Engine` values alive in one process (helmly-agent's shape, a fleet
-/// of projects) the second registration drops the first project's names. They
-/// fall through to `colour_for`'s hash fallback and their colours change
-/// underneath a run that is still going, silently.
+/// Inversion of the defect pinned in #1518 — `SERVICES` was a single
+/// process-wide static and `set_services` replaced it rather than merging,
+/// so with two `Engine` values alive in one process (helmly-agent's shape,
+/// a fleet of projects) the second registration dropped the first project's
+/// names. They fell through to `colour_for`'s hash fallback and their colours
+/// changed underneath a run that was still going, silently.
 ///
-/// The assertion is written the way the code behaves today so the eviction
-/// cannot change without something going red. **When #1517 lands, this test
-/// must be inverted, not deleted** — the fix is exactly the case where the
-/// first project's slot survives the second registration.
+/// The registry is now keyed by project name: a second registration inserts
+/// under a different project key, so the first project's slot stays put.
 ///
 /// The two name sets are chosen so the registered slot and the hash fallback
-/// disagree; `colour_for_prefers_the_registered_slot_over_the_hash` is what
-/// establishes that they can. Without that the test would pass whether or not
-/// the eviction happened, which is the vacuous shape this file already carries
-/// a warning about elsewhere.
+/// disagree; the second assertion guards that the fixture can actually
+/// discriminate — without it the first assertion would hold whether or not
+/// the fix were in place, the vacuous shape this file already carries a
+/// warning about elsewhere.
 #[test]
 fn a_second_project_evicts_the_first_projects_colours() {
 	let _guard = registry_guard();
 
+	// `set_services` is project-keyed; each project's services live under its
+	// own key (#1517). Register the first project's names under `evict-proj-a`.
+	set_project("evict-proj-a");
 	let first = ["evict-one".to_string(), "evict-two".to_string()];
 	set_services(&first);
 	let registered = service_slot("evict-one");
 
-	// A second Engine registers its own project. Nothing merges.
+	// A second Engine registers its own project under a different key. With
+	// project-keying, the first project's slot survives.
+	set_project("evict-proj-b");
 	set_services(&[
 		"evict-other-alpha".to_string(),
 		"evict-other-beta".to_string(),
@@ -266,10 +274,10 @@ fn a_second_project_evicts_the_first_projects_colours() {
 	let unregistered = crate::ui::palette::colour_for("evict-one", &HashMap::new());
 
 	assert_eq!(
-		after, unregistered,
-		"today the first project falls back to the hash after a second registration \
-		 (#1517). If this now differs, the registry stopped being shared - invert \
-		 this test rather than deleting it."
+		after, registered,
+		"the first project's slot must survive the second project's registration \
+		 (#1517). If this now differs, the registry stopped being project-keyed \
+		 - the first project's entries are being evicted again."
 	);
 	assert_ne!(
 		registered, unregistered,


### PR DESCRIPTION
Two `Engine` values alive in one process (helmly-agent's fleet shape)
saw the second `set_services` evict the first project's colours. The
engine itself writes the registry from `lifecycle/down_label.rs:60`, so
an embedder could not avoid it by discipline.

The registry is now keyed by project name. `set_services` reads the
project set by `set_project` and inserts under that key; `identity_slot`
and `service_slot` iterate every registered project before falling back
to the per-label hash. The engine call site in `down_by_label.rs` now
calls `set_project` before its `set_services`, so the label-only
teardown keys under its own project. `PROJECT_PREFIX` stays as a
fallback strip so `every_spelling_of_one_container_gets_one_colour`
still pins the no-registration collapse to one hash slot.

The seven other process-wide statics this audit looked at are correct
and say so in their own doc comments — the progress trio because
`begin` is inert without the CLI, the signal-handler latch because it
already names the embedding-crate case, `quadlet`'s `NO_WARN` because it
is a `thread_local!`, and `palette`'s `AVAILABLE` because it is a
property of the process's stdout.

## Design

The honest fix would be an `Engine`-owned registry threaded through
every renderer, but `service_slot` is read from deep inside — the log
prefixer, `progress_line`, the table renderers, `stats`, `events`,
`paint_status_cell` — so threading would cross several layer boundaries.
I rejected that option because the public API of `ui` cannot widen
(#1478, #1481 made that surface deliberate).

The third option, merging registrations rather than replacing, narrows
the window without closing it: two projects sharing a service name
(`web`, `db`, `api`) still collide. I rejected that because helmly-agent's
fleet would hit it on day one.

Keying the existing `SERVICES` map by project — option 2 — is the same
answer for the registry shape (one process, N slot tables) without
threading anything new. The only signature change is adding
`set_project` before `set_services` in the engine path; the public API
stays exactly the same.

The bare-key fallback (`identity_slot` and `service_slot`) iterates
every project's services in HashMap order, first match wins. In a
single-project process this is identical to the legacy behaviour. In
helmly-agent's fleet it is the linear-in-projects lookup the design
admits; the alternative would be a thread-local active engine, which
does not survive across the async boundaries the engine's own call
sites cross.

## Tests

Inverts `a_second_project_evicts_the_first_projects_colours` (#1518)
to assert `after == registered` (the first project's slot survives a
second registration), keeping the same fixture names and the
discriminating `assert_ne!(registered, unregistered)` guard. Adds a
`set_project` to `set_services_makes_registered_names_distinct` for
the same reason — `set_services` is now project-keyed, so a registration
without a project name is a no-op.

Mutation check: I temporarily changed `set_services` to clear the
project map on every call (the original eviction behaviour) and the
inverted test went red on the surviving-slot assertion. Restored;
all 1710 lib tests pass with `--all-features`.

## Breaking?

No. `set_project`, `set_services`, `identity_style`, and `service_style`
keep their signatures. The behaviour change is observable only across
the multi-engine boundary the issue pins. `set_services` is now a no-op
without a prior `set_project` for the same project; every existing
caller (CLI commands and the engine path, post-fix) already calls
`set_project` first.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>