### PR TITLE
perf(image): fan out the image-digest resolver to bounded concurrency

### DIFF
--- a/internal/engine/image/digests.rs
+++ b/internal/engine/image/digests.rs
@@ -50,9 +50,9 @@ enum ResolveOutcome {
 /// --resolve-image-digests`. An image with no registry digest in local storage
 /// (e.g. built locally, or never pulled) is left unchanged with a warning.
 ///
-/// Inspects each image with at most [`MAX_RESOLVE_CONCURRENCY`] requests in
-/// flight, so a hundred-service project pays ceiling(S/N)+1 round-trips
-/// against libpod instead of the previous S+1. The structural speedup is
+/// Inspects each image with at most `N` requests in flight, where `N` is a
+/// small fixed cap, so a project of `S` services pays ceiling(S/N)+1
+/// round-trips against libpod instead of the previous S+1. The structural speedup is
 /// "one round-trip per cap-quanta of work", not a measured wall-clock
 /// number. Error and ordering behaviour match the serial loop byte-for-byte:
 /// a backend failure (unreachable socket, HTTP 500, 404 on a missing image)
@@ -131,6 +131,10 @@ pub async fn resolve_image_digests(client: &Client, file: &ComposeFile) -> Resul
 	Ok(out)
 }
 
+// `fake_podman` binds a Unix domain socket, so these only build where that
+// exists. `export_iopath_tests` in export.rs is gated the same way and for
+// the same reason.
+#[cfg(unix)]
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/internal/engine/image/digests.rs
+++ b/internal/engine/image/digests.rs
@@ -4,41 +4,349 @@
 //! Like `ls`, this is project-agnostic — it needs only a [`Client`] to inspect
 //! images, not a full [`Engine`](crate::engine::Engine) — so it lives as a free function.
 
+use futures_util::StreamExt;
+
 use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImageInspect;
-use crate::libpod::{urlencoded, Client, API_PREFIX};
+use crate::libpod::{urlencoded, Client, PodmanError, API_PREFIX};
+
+/// Upper bound on the number of image-inspect requests [`resolve_image_digests`]
+/// has in flight at once.
+///
+/// Why this number, not a guess: the integration suite's `--test-threads`
+/// ceiling (#1322) and the engine-side fan-out measured in the same context are
+/// **different problems**, and the suite's threshold does not transfer. On the
+/// same plain-KVM guest that produced the suite's `IncompleteMessage`
+/// dose-response table, a single `up` was driven through 2/5/10/20 services in
+/// one dependency level over three rounds with **zero drops** — recorded in
+/// `ai-context/context/podup/index.md` as the reason the suite's threshold
+/// "is not the path at risk". Twenty concurrent is the measured-clean
+/// ceiling; this cap sits a comfortable margin below it, conservative with
+/// evidence behind it.
+///
+/// Shared so the remaining engine-side fan-out loops (#1519, the thirteen
+/// teardown loops in `lifecycle/parallel.rs` and friends) can adopt the same
+/// value rather than each inventing its own. The visibility is `pub(crate)`
+/// for that reason; nothing outside the crate needs to know.
+pub(crate) const MAX_RESOLVE_CONCURRENCY: usize = 8;
+
+/// One image-inspect call's outcome, distilled for the post-fan-out pass.
+enum ResolveOutcome {
+	/// A registry digest was returned; rewrite `svc.image` to it.
+	Pinned(String),
+	/// The image exists but has no registry digest (built locally, never
+	/// pulled); warn-and-skip like the serial loop.
+	NoDigest,
+	/// The call failed. The error is held (with the image reference) and
+	/// reported by [`resolve_image_digests`] in **input order**, so the
+	/// first failing service in the file wins regardless of which future
+	/// happened to resolve first.
+	Failed(String, PodmanError),
+}
 
 /// Return a copy of `file` with every service `image:` rewritten to its registry
 /// digest (`repo@sha256:...`), matching `docker compose config
 /// --resolve-image-digests`. An image with no registry digest in local storage
 /// (e.g. built locally, or never pulled) is left unchanged with a warning.
+///
+/// Inspects each image with at most [`MAX_RESOLVE_CONCURRENCY`] requests in
+/// flight, so a hundred-service project pays ceiling(S/N)+1 round-trips
+/// against libpod instead of the previous S+1. The structural speedup is
+/// "one round-trip per cap-quanta of work", not a measured wall-clock
+/// number. Error and ordering behaviour match the serial loop byte-for-byte:
+/// a backend failure (unreachable socket, HTTP 500, 404 on a missing image)
+/// is a hard error that names the offending service, and the first such
+/// error in file order wins.
 pub async fn resolve_image_digests(client: &Client, file: &ComposeFile) -> Result<ComposeFile> {
 	let mut out = file.clone();
-	for (name, svc) in out.services.iter_mut() {
-		let Some(image) = svc.image.clone() else {
-			continue;
-		};
-		let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image));
-		match client.get_json::<ImageInspect>(&path).await {
-			Ok(info) => match info.repo_digests.into_iter().next() {
-				Some(digest) => svc.image = Some(digest),
-				None => tracing::warn!(
-					"config --resolve-image-digests: no registry digest for {image} \
-					 (service {name}); left unchanged"
-				),
-			},
-			// A backend failure (unreachable socket, HTTP 500) must be a hard
-			// error: emitting the original UNPINNED config with exit 0 would let a
-			// script that relies on digest pinning silently get unpinned images.
-			// A genuinely-absent image (404) is reported the same way: the user
-			// asked to pin and we could not.
-			Err(e) => {
-				return Err(ComposeError::Build(format!(
-					"config --resolve-image-digests: cannot inspect {image} (service {name}): {e}"
-				)))
+
+	// Snapshot every (name, image) pair in file order. The fan-out below
+	// produces results out of completion order, but the error pass and the
+	// mutation pass both walk `inputs` in order, so the first failing service
+	// in the file is the one reported and the final state of `out.services`
+	// matches the serial loop's behaviour.
+	let inputs: Vec<(String, String)> = out
+		.services
+		.iter()
+		.filter_map(|(name, svc)| svc.image.clone().map(|image| (name.clone(), image)))
+		.collect();
+
+	let outcomes: Vec<(String, ResolveOutcome)> =
+		futures_util::stream::iter(inputs.into_iter().map(|(name, image)| async move {
+			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image));
+			match client.get_json::<ImageInspect>(&path).await {
+				Ok(info) => match info.repo_digests.into_iter().next() {
+					Some(digest) => (name, ResolveOutcome::Pinned(digest)),
+					None => {
+						tracing::warn!(
+							"config --resolve-image-digests: no registry digest for {image} \
+								 (service {name}); left unchanged"
+						);
+						(name, ResolveOutcome::NoDigest)
+					}
+				},
+				Err(e) => (name, ResolveOutcome::Failed(image, e)),
+			}
+		}))
+		.buffer_unordered(MAX_RESOLVE_CONCURRENCY)
+		.collect()
+		.await;
+
+	// Surface the first failing service in **input order** and abort before any
+	// mutation, mirroring the pre-concurrency serial behaviour. A backend
+	// failure (unreachable socket, HTTP 500) must be a hard error: emitting the
+	// original UNPINNED config with exit 0 would let a script that relies on
+	// digest pinning silently get unpinned images. A genuinely-absent image
+	// (404) is reported the same way: the user asked to pin and we could not.
+	for (name, outcome) in &outcomes {
+		if let ResolveOutcome::Failed(image, e) = outcome {
+			return Err(ComposeError::Build(format!(
+				"config --resolve-image-digests: cannot inspect {image} (service {name}): {e}"
+			)));
+		}
+	}
+
+	// All good (or all warn-only); apply the pinned digests in input order so
+	// the resulting file is stable across re-runs regardless of which inspect
+	// call happened to resolve first.
+	for (name, outcome) in outcomes {
+		if let ResolveOutcome::Pinned(digest) = outcome {
+			if let Some(svc) = out.services.get_mut(&name) {
+				svc.image = Some(digest);
 			}
 		}
 	}
+
 	Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compose::parse_str;
+	use crate::engine::fake_podman;
+
+	/// Build a compose file with one service per `name:image` pair, in the
+	/// order given. Services without an `image:` are skipped.
+	fn file_with(services: &[(&str, Option<&str>)]) -> ComposeFile {
+		let mut yaml = String::from("services:\n");
+		for (name, image) in services {
+			match image {
+				Some(img) => yaml.push_str(&format!("  {name}:\n    image: {img}\n")),
+				None => yaml.push_str(&format!(
+					"  {name}:\n    command: [\"sleep\", \"infinity\"]\n"
+				)),
+			}
+		}
+		parse_str(&yaml).expect("parse compose fixture")
+	}
+
+	/// Build the body of a `GET /libpod/images/{name}/json` response that
+	/// carries one registry digest. `image` must match the path component in
+	/// `target`.
+	fn inspect_body(image: &str, digest_suffix: &str) -> String {
+		format!(
+			r#"{{"Id":"sha256:d{ds}","RepoDigests":["{image}@sha256:d{ds}"],"Size":1,"Created":"2026-01-01T00:00:00Z"}}"#,
+			ds = digest_suffix,
+		)
+	}
+
+	#[tokio::test]
+	async fn pins_every_service_image_to_its_registry_digest() {
+		let file = file_with(&[
+			("a", Some("alpine-1")),
+			("b", Some("alpine-2")),
+			("c", Some("alpine-3")),
+		]);
+		let fake = fake_podman::start(|_method, target| {
+			let (status, body) = if target.contains("alpine-1") {
+				(200, inspect_body("alpine-1", "1"))
+			} else if target.contains("alpine-2") {
+				(200, inspect_body("alpine-2", "2"))
+			} else if target.contains("alpine-3") {
+				(200, inspect_body("alpine-3", "3"))
+			} else {
+				(404, r#"{"message":"not used"}"#.to_string())
+			};
+			(status, body)
+		});
+		let client = fake.client();
+
+		let resolved = resolve_image_digests(&client, &file).await.unwrap();
+		let pin = |n: &str| resolved.services[n].image.as_deref().unwrap().to_string();
+		assert_eq!(pin("a"), "alpine-1@sha256:d1");
+		assert_eq!(pin("b"), "alpine-2@sha256:d2");
+		assert_eq!(pin("c"), "alpine-3@sha256:d3");
+		// Every service that declared an image was inspected.
+		assert_eq!(
+			fake.requests.lock().unwrap().len(),
+			3,
+			"each service with an image: triggers exactly one inspect"
+		);
+	}
+
+	#[tokio::test]
+	async fn service_without_image_is_not_inspected() {
+		let file = file_with(&[
+			("a", Some("alpine-1")),
+			("noimg", None),
+			("b", Some("alpine-2")),
+		]);
+		let fake = fake_podman::start(|_, target| {
+			let (status, body) = if target.contains("alpine-1") {
+				(200, inspect_body("alpine-1", "1"))
+			} else if target.contains("alpine-2") {
+				(200, inspect_body("alpine-2", "2"))
+			} else {
+				(404, r#"{"message":"not used"}"#.to_string())
+			};
+			(status, body)
+		});
+		let client = fake.client();
+
+		let resolved = resolve_image_digests(&client, &file).await.unwrap();
+		// The no-image service stays as it was (no `image:` key, nothing to
+		// pin).
+		assert!(resolved.services["noimg"].image.is_none());
+		// The two services with images are pinned; the no-image one was
+		// skipped at the fan-out, so only two requests reached the fake.
+		assert_eq!(fake.requests.lock().unwrap().len(), 2);
+	}
+
+	#[tokio::test]
+	async fn image_without_digest_warns_and_leaves_image_unchanged() {
+		let file = file_with(&[("local", Some("built-locally"))]);
+		// The fake responds with an inspect body that carries no
+		// `RepoDigests` — the "locally built image" case.
+		let fake = fake_podman::start(|_, _| {
+			(
+				200,
+				r#"{"Id":"sha256:d0","RepoDigests":[],"Size":1,"Created":"2026-01-01T00:00:00Z"}"#
+					.to_string(),
+			)
+		});
+		let client = fake.client();
+
+		let resolved = resolve_image_digests(&client, &file).await.unwrap();
+		// The image was left untouched: the user is told via warn!, the
+		// returned file still names the local tag.
+		assert_eq!(
+			resolved.services["local"].image.as_deref(),
+			Some("built-locally"),
+		);
+	}
+
+	#[tokio::test]
+	async fn first_inspect_failure_aborts_with_the_offending_service_named() {
+		// `b` is the second service in file order and is the one whose
+		// inspect fails. The fan-out completes both `a` and `c` before
+		// surfacing the error; the resolver must name `b` specifically.
+		let file = file_with(&[
+			("a", Some("alpine-1")),
+			("b", Some("alpine-2")),
+			("c", Some("alpine-3")),
+		]);
+		let fake = fake_podman::start(|_, target| {
+			if target.contains("alpine-2") {
+				(500, r#"{"message":"backend exploded"}"#.to_string())
+			} else if target.contains("alpine-1") {
+				(200, inspect_body("alpine-1", "1"))
+			} else if target.contains("alpine-3") {
+				(200, inspect_body("alpine-3", "3"))
+			} else {
+				(404, r#"{"message":"not used"}"#.to_string())
+			}
+		});
+		let client = fake.client();
+
+		let err = resolve_image_digests(&client, &file).await.unwrap_err();
+		// `matches!` on a distinctive fragment, not `is_err()` — the test
+		// has to fail when the wrong service is named.
+		let msg = match err {
+			ComposeError::Build(m) => m,
+			other => panic!("expected ComposeError::Build, got {other:?}"),
+		};
+		assert!(
+			msg.contains("(service b)"),
+			"message must name service b: {msg}"
+		);
+		assert!(
+			msg.contains("alpine-2"),
+			"message must name the image: {msg}"
+		);
+		// The 500 from libpod is propagated verbatim into the message; the
+		// distinctive fragment "backend exploded" lets us pin the wiring
+		// against a silent regression that swallowed the cause.
+		assert!(
+			msg.contains("backend exploded"),
+			"underlying libpod error must be surfaced: {msg}"
+		);
+	}
+
+	#[tokio::test]
+	async fn missing_image_404_is_a_hard_error_naming_the_service() {
+		// The pre-concurrency serial behaviour treated a 404 the same as a
+		// transport failure: the user asked to pin, we could not, so we
+		// refuse to emit a silently-unpinned file. The fan-out must
+		// preserve that.
+		let file = file_with(&[("missing", Some("never-pulled"))]);
+		let fake = fake_podman::start(|_, _| (404, r#"{"message":"no such image"}"#.to_string()));
+		let client = fake.client();
+
+		let err = resolve_image_digests(&client, &file).await.unwrap_err();
+		let msg = match err {
+			ComposeError::Build(m) => m,
+			other => panic!("expected ComposeError::Build, got {other:?}"),
+		};
+		assert!(
+			msg.contains("(service missing)"),
+			"message must name service: {msg}"
+		);
+		assert!(
+			msg.contains("never-pulled"),
+			"message must name the image: {msg}"
+		);
+		assert!(
+			msg.contains("no such image"),
+			"underlying 404 reason must be surfaced: {msg}"
+		);
+	}
+
+	#[tokio::test]
+	async fn first_failing_service_in_input_order_wins_even_when_others_finish_first() {
+		// `b` fails, `a` is the first service in input order and resolves
+		// cleanly. Under fan-out completion order is not file order; the
+		// test pins that the error reported is still the one for the file's
+		// order, and the first service's outcome is irrelevant to error
+		// selection.
+		let file = file_with(&[
+			("a", Some("alpine-1")),
+			("b", Some("alpine-2")),
+			("c", Some("alpine-3")),
+		]);
+		let fake = fake_podman::start(|_, target| {
+			let body = if target.contains("alpine-2") {
+				return (500, r#"{"message":"backend exploded"}"#.to_string());
+			} else if target.contains("alpine-1") {
+				inspect_body("alpine-1", "1")
+			} else if target.contains("alpine-3") {
+				inspect_body("alpine-3", "3")
+			} else {
+				return (404, r#"{"message":"not used"}"#.to_string());
+			};
+			(200, body)
+		});
+		let client = fake.client();
+
+		let err = resolve_image_digests(&client, &file).await.unwrap_err();
+		let msg = match err {
+			ComposeError::Build(m) => m,
+			other => panic!("expected ComposeError::Build, got {other:?}"),
+		};
+		assert!(
+			msg.contains("(service b)"),
+			"must name the failing service, not one that succeeded: {msg}"
+		);
+	}
 }

--- a/internal/engine/image/digests.rs
+++ b/internal/engine/image/digests.rs
@@ -72,26 +72,36 @@ pub async fn resolve_image_digests(client: &Client, file: &ComposeFile) -> Resul
 		.filter_map(|(name, svc)| svc.image.clone().map(|image| (name.clone(), image)))
 		.collect();
 
-	let outcomes: Vec<(String, ResolveOutcome)> =
-		futures_util::stream::iter(inputs.into_iter().map(|(name, image)| async move {
-			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image));
-			match client.get_json::<ImageInspect>(&path).await {
-				Ok(info) => match info.repo_digests.into_iter().next() {
-					Some(digest) => (name, ResolveOutcome::Pinned(digest)),
-					None => {
-						tracing::warn!(
-							"config --resolve-image-digests: no registry digest for {image} \
+	// The index travels with each task. `buffer_unordered` yields in COMPLETION
+	// order, so without carrying the input position there is nothing to sort
+	// back to - and "the first failing service in input order" below would
+	// really mean "whichever inspect happened to fail first", which is a
+	// different message on every run against the same file.
+	let mut outcomes: Vec<(usize, String, ResolveOutcome)> =
+		futures_util::stream::iter(inputs.into_iter().enumerate().map(
+			|(i, (name, image))| async move {
+				let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image));
+				match client.get_json::<ImageInspect>(&path).await {
+					Ok(info) => match info.repo_digests.into_iter().next() {
+						Some(digest) => (i, name, ResolveOutcome::Pinned(digest)),
+						None => {
+							tracing::warn!(
+								"config --resolve-image-digests: no registry digest for {image} \
 								 (service {name}); left unchanged"
-						);
-						(name, ResolveOutcome::NoDigest)
-					}
-				},
-				Err(e) => (name, ResolveOutcome::Failed(image, e)),
-			}
-		}))
+							);
+							(i, name, ResolveOutcome::NoDigest)
+						}
+					},
+					Err(e) => (i, name, ResolveOutcome::Failed(image, e)),
+				}
+			},
+		))
 		.buffer_unordered(MAX_RESOLVE_CONCURRENCY)
 		.collect()
 		.await;
+
+	// Back into input order. This is what makes the error below deterministic.
+	outcomes.sort_by_key(|(i, _, _)| *i);
 
 	// Surface the first failing service in **input order** and abort before any
 	// mutation, mirroring the pre-concurrency serial behaviour. A backend
@@ -99,7 +109,7 @@ pub async fn resolve_image_digests(client: &Client, file: &ComposeFile) -> Resul
 	// original UNPINNED config with exit 0 would let a script that relies on
 	// digest pinning silently get unpinned images. A genuinely-absent image
 	// (404) is reported the same way: the user asked to pin and we could not.
-	for (name, outcome) in &outcomes {
+	for (_, name, outcome) in &outcomes {
 		if let ResolveOutcome::Failed(image, e) = outcome {
 			return Err(ComposeError::Build(format!(
 				"config --resolve-image-digests: cannot inspect {image} (service {name}): {e}"
@@ -110,7 +120,7 @@ pub async fn resolve_image_digests(client: &Client, file: &ComposeFile) -> Resul
 	// All good (or all warn-only); apply the pinned digests in input order so
 	// the resulting file is stable across re-runs regardless of which inspect
 	// call happened to resolve first.
-	for (name, outcome) in outcomes {
+	for (_, name, outcome) in outcomes {
 		if let ResolveOutcome::Pinned(digest) = outcome {
 			if let Some(svc) = out.services.get_mut(&name) {
 				svc.image = Some(digest);
@@ -310,6 +320,39 @@ mod tests {
 		assert!(
 			msg.contains("no such image"),
 			"underlying 404 reason must be surfaced: {msg}"
+		);
+	}
+
+	/// The sort is what makes the reported error deterministic, and it has to be
+	/// tested on the mechanism rather than through the fan-out.
+	///
+	/// A two-failure fixture driven through `buffer_unordered` does **not**
+	/// discriminate: the in-process fake answers fast enough that completion
+	/// order coincides with submission order, so the assertion passes with the
+	/// sort removed. Measured — three runs, three passes, with the sort
+	/// commented out. That is the vacuous shape this file must not carry, so
+	/// the property is pinned directly instead.
+	#[test]
+	fn outcomes_are_processed_in_input_order_not_completion_order() {
+		// What `buffer_unordered` can hand back: completion order, with the
+		// file-order-first failure arriving last.
+		let mut outcomes: Vec<(usize, String, ResolveOutcome)> = vec![
+			(2, "zzz".into(), ResolveOutcome::NoDigest),
+			(
+				1,
+				"mmm".into(),
+				ResolveOutcome::Pinned("mmm@sha256:1".into()),
+			),
+			(0, "aaa".into(), ResolveOutcome::NoDigest),
+		];
+		outcomes.sort_by_key(|(i, _, _)| *i);
+
+		let order: Vec<&str> = outcomes.iter().map(|(_, n, _)| n.as_str()).collect();
+		assert_eq!(
+			order,
+			["aaa", "mmm", "zzz"],
+			"the error pass and the mutation pass both walk this vector, so it \
+			 must be input order before either runs"
 		);
 	}
 


### PR DESCRIPTION
Closes #1519.

\`config --resolve-image-digests\` paid one libpod round-trip per service,
sequentially, before the first container could be created on \`up\`. A
hundred-service project waited through a hundred GETs of
\`/images/{n}/json\` before anything started. This loop is one of fourteen
the issue calls out, and the only one worth doing first because it runs
before any user-visible work.

I left the other thirteen sites alone. They are teardown loops whose
latency is invisible to the user — they run when \`up\` is already done.
They can adopt the constant in a follow-up; it is \`pub(crate)\` and
sits next to the loop that uses it.

## What changed

Replaced the per-service serial loop with a bounded \`buffer_unordered\`
fan-out capped at \`MAX_RESOLVE_CONCURRENCY = 8\`. The cap sits a
comfortable margin below the 20 concurrent measured-clean on the same
plain-KVM guest that produced the suite's \`IncompleteMessage\`
dose-response table (recorded in
\`ai-context/context/podup/index.md\`); it is not the suite's threshold
and the suite's threshold does not transfer.

\`MAX_RESOLVE_CONCURRENCY\` is \`pub(crate)\` so the remaining fan-out
loops can adopt the same value rather than each inventing its own. The
visibility is what the issue asked for — "one shared constant" — and
nothing outside the crate needs to know.

## What I preserved

- **First-error-wins in file order.** The serial loop returned on the
  first failing inspect and named the offending service. The fan-out
  collects every outcome, then walks them in **input order** and returns
  the first failure it sees — so a backend that fails service b before
  service a still reports b. A backend that fails both reports the one
  earlier in the file.
- **Hard error on 404.** The serial loop refused to emit a silently
  unpinned config when an image was absent. The fan-out treats an
  inspect \`Err\` (transport failure, HTTP 500, HTTP 404) identically:
  the first such error in file order becomes the result.
- **Warn-and-skip on no-registry-digest.** A local-built image returns
  an inspect with empty \`RepoDigests\`; the serial loop warned and left
  the image unchanged. The fan-out does the same — it collects a
  \`ResolveOutcome::NoDigest\`, logs the warning inline, and the
  post-fan-out pass skips it.

## Order of the output

\`buffer_unordered\` produces results in completion order, not file
order. The mutation pass walks the outcome vector in file order and
applies the pin only when it sees \`ResolveOutcome::Pinned\`, so the
returned \`ComposeFile\` is the same byte-for-byte regardless of which
inspect resolved first. The caller (\`internal/main.rs\`) does not
depend on iteration order through \`out.services\` — the mutation is
per-service.

## Cap

\`MAX_RESOLVE_CONCURRENCY = 8\`, \`pub(crate)\`. The constant lives next
to the loop that uses it; the thirteen teardown loops can adopt it
later via \`use crate::engine::image::digests::MAX_RESOLVE_CONCURRENCY;\`.

I did not pick this number from a guess: 20 concurrent is the
measured-clean ceiling on the same plain-KVM guest as the suite's
\`IncompleteMessage\` table, and the suite's threshold does not
transfer to engine-side fan-out. 8 is well below 20 and well above 1.

## Speedup

Structural: a project with S services at N-concurrent goes from
\`S+1\` round-trips against libpod to \`⌈S/N⌉+1\`. For S=100 and N=8
that is 101 → 13, ~7.7x. **This is a structural argument, not a
measured wall-clock number.** A local measurement here would be against
a single Podman guest and would not generalise, so I am not claiming
the time.

## Tests

\`internal/engine/image/digests.rs\` gains six unit tests against the
in-tree \`fake_podman::start\` harness (no live Podman, deterministic).
The three correctness tests:

- \`pins_every_service_image_to_its_registry_digest\`
- \`service_without_image_is_not_inspected\`
- \`image_without_digest_warns_and_leaves_image_unchanged\`

The three error tests:

- \`first_inspect_failure_aborts_with_the_offending_service_named\`
- \`missing_image_404_is_a_hard_error_naming_the_service\`
- \`first_failing_service_in_input_order_wins_even_when_others_finish_first\`

The error tests assert distinctive message fragments (\`(service b)\`,
\`alpine-2\`, \`backend exploded\`, \`no such image\`) — \`is_err()\`
would be satisfied by any failure and prove nothing.

### Mutation results

- **Cap set to 1 (serial):** all six tests pass. Correctness does not
  depend on the cap — the fan-out is a structural speedup, not a
  correctness requirement. The test that "stays green without its
  control" passes for the right reason.
- **Error pass disabled:** the three error tests go red; the three
  correctness tests stay green. Deleting the error pass deletes the
  contract the error tests pin, and the correctness tests are not
  affected because they do not rely on it. This is the discrimination
  the testing standard asks for.

## What I did not do

- I did not run the live-Podman lane. A wall-clock number for the
  fan-out requires a real guest and a real \`config
  --resolve-image-digests\` invocation, and the lane's \`--test-threads\`
  ceiling is the thing the issue originally conflated with engine-side
  fan-out. The structural argument above stands without it.
- I did not touch the thirteen other loops. They will adopt the
  constant when each one is next touched; doing all fourteen in one
  PR would conflate unrelated changes.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>