### PR TITLE
ci(debian): prove the new Depends gate fires (do not merge)

### DIFF
--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e70ff47fd8aefa0f054846815f19b98768d61122 # v1.17.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@4b8df6cc119877ba55452b6fd7d9b5ef8eab09ef # TEMP: branch of Glyndor/.github#141
     with:
       package-name: podup
       check-vendored: true

--- a/debian/rules
+++ b/debian/rules
@@ -18,9 +18,7 @@ export CARGO_HOME = $(CURDIR)/debian/cargo-home
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 RUST_TARGET_amd64 = x86_64-unknown-linux-musl
 RUST_TARGET_arm64 = aarch64-unknown-linux-musl
-# TEMP MUTATION: must trip the new gate. No inline comment - make would
-# keep the space before the # inside the value.
-RUST_TARGET = x86_64-unknown-linux-gnu
+RUST_TARGET = $(RUST_TARGET_$(DEB_HOST_ARCH))
 
 # Fail here rather than silently building for the host. A package that quietly
 # went back to glibc would reintroduce the floor with nothing to notice it, and

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ export CARGO_HOME = $(CURDIR)/debian/cargo-home
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 RUST_TARGET_amd64 = x86_64-unknown-linux-musl
 RUST_TARGET_arm64 = aarch64-unknown-linux-musl
-RUST_TARGET = $(RUST_TARGET_$(DEB_HOST_ARCH))
+RUST_TARGET = x86_64-unknown-linux-gnu # TEMP MUTATION: must trip the new gate
 
 # Fail here rather than silently building for the host. A package that quietly
 # went back to glibc would reintroduce the floor with nothing to notice it, and

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,9 @@ export CARGO_HOME = $(CURDIR)/debian/cargo-home
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 RUST_TARGET_amd64 = x86_64-unknown-linux-musl
 RUST_TARGET_arm64 = aarch64-unknown-linux-musl
-RUST_TARGET = x86_64-unknown-linux-gnu # TEMP MUTATION: must trip the new gate
+# TEMP MUTATION: must trip the new gate. No inline comment - make would
+# keep the space before the # inside the value.
+RUST_TARGET = x86_64-unknown-linux-gnu
 
 # Fail here rather than silently building for the host. A package that quietly
 # went back to glibc would reintroduce the floor with nothing to notice it, and


### PR DESCRIPTION
Temporary proof branch for the gate added in Glyndor/.github#141. Not for merging — I will close it once both directions are on record.

The reusable now fails a musl build whose package declares a shared-library dependency. That predicate was checked in a shell against six inputs, but the integration was not: whether `RUST_TARGET` reaches the confirm step, whether `dpkg-deb -f` returns what the pattern expects, and whether the `case` matches at all.

So this branch pins `debian-build.yml` to the pull request's branch and changes one line of `debian/rules` to build `x86_64-unknown-linux-gnu` while the workflow input still says `x86_64-unknown-linux-musl`. That is the drift the gate exists to catch: the declared target and the built binary disagree, every other check stays green, and today nothing notices.

Expected: `debian / dpkg-buildpackage` fails, naming the `libc6` dependency. I will then revert only the `debian/rules` line and confirm the same pin goes green.

A gate nobody has watched fail is decoration.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>