### PR TITLE
chore(release): 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,52 @@
+podup (5.0.0) unstable; urgency=medium
+
+  Breaking
+
+  * A failure while resolving an `include:` now surfaces as
+    `ComposeError::Include` instead of letting `ComposeError::Io` leak out.
+    A consumer matching on `Io` to detect a missing included file no longer
+    enters that arm. The variant already existed and nothing ever produced
+    it, so the error a caller saw did not say which file the parser had been
+    reading. Every include failure is wrapped now, including the catch-all.
+
+  New
+
+  * `up --abort-on-container-exit` stops the remaining containers as soon as
+    any one exits, and `--exit-code-from SERVICE` propagates that service's
+    exit code as podup's own. The propagation rule was measured against the
+    reference tool rather than assumed: the named service's code may be 137
+    when it was still running and got SIGKILLed during the teardown.
+  * `config` warns when a port is published on every interface, which is the
+    difference between a service reachable from the host and one reachable
+    from the network the host sits on.
+
+  Packaging
+
+  * The package is built against musl and linked statically, so it declares
+    no libc floor and installs on Debian 12 and Ubuntu 22.04 again. Every
+    4.x package declared `libc6 (>= 2.39)`, which excluded both. The reusable
+    workflow now fails a musl build whose package declares any shared-library
+    dependency, so the property is enforced rather than observed.
+  * The package is compiled by the toolchain CI runs, pinned with rustup
+    against a digest-pinned container, instead of whatever the build image
+    happened to ship.
+  * `debian/rules` is executable, as policy requires.
+
+  Performance
+
+  * Image digests resolve with up to eight requests in flight. A project of
+    S services pays ceiling(S/8)+1 round-trips before `up` can start,
+    instead of S+1.
+  * `cp` streams the container archive into the extractor instead of copying
+    it a second time.
+
+  Fixes
+
+  * The identity-colour registry is keyed by project, so a second project in
+    one process no longer evicts the first project's service colours.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sat, 22 Aug 2026 01:34:53 -0500
+
 podup (4.0.0) unstable; urgency=medium
 
   Breaking

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anstream",
  "anstyle",


### PR DESCRIPTION
Bumps the version to 5.0.0 ahead of the release pull request into `main`.

## Why MAJOR

#1511 is on `develop` carrying the `breaking` label, and the break is real rather than a label somebody typed. A failure resolving an `include:` used to let `ComposeError::Io` leak out; it now surfaces as `ComposeError::Include`. A consumer matching on `Io` to detect a missing included file no longer enters that arm, and helmly-agent consumes podup as a dependency, so that is a real caller rather than a hypothetical one.

`cargo semver-checks check-release --baseline-version 4.0.0` reports `223 pass, 0 fail — no semver update required`, and that is not a contradiction: it compares structure, and this break is behavioural. It is worth stating plainly, because the tool being green is exactly how this could have shipped as a minor by accident.

#1532 originally added three structural breaks on top of that. Those were removed rather than released — the abort feature is additive now, so the only thing forcing MAJOR is the one break that genuinely is one.

## Four files stamp the version, not three

The release workflow compares `Cargo.toml`, `debian/changelog` and `Cargo.lock`. `fuzz/Cargo.lock` also records `podup`'s version and nothing checks it. All four are at 5.0.0.

I found them by searching rather than by copying the shape of the last bump. The releases standard warns about exactly that: a previous bump that missed a file reproduces the miss, which is how 1.8.1 dropped `debian/changelog` and 1.9.0 inherited the gap.

The `4.0.0` strings still in `internal/**.rs` are deliberate — they read `#[non_exhaustive] since 4.0.0` and are correct as history. Rewriting them would make them false.

## Checked before opening this

- `dpkg-parsechangelog` parses the new entry: `Version: 5.0.0`
- changelog, `Cargo.toml`, `Cargo.lock` and the `v5.0.0` tag name all agree, run the same way the release workflow runs it
- `cargo check --all-features` builds at 5.0.0
- `cargo fmt --all --check` clean
- library suite: 1722 passed, 0 failed

Labels: `type:chore`, `prio:P1`, `effort:S`, `breaking`.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>