### PR TITLE
ci(reusable): adopt Glyndor/.github at v1.18.0 and Rust 1.98

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@11d87e7e4d6320d1cf89eb403a50d03613a18e30 # v1.18.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@11d87e7e4d6320d1cf89eb403a50d03613a18e30 # v1.18.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@11d87e7e4d6320d1cf89eb403a50d03613a18e30 # v1.18.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@bc27850b34b0cc8de17bd7a98d492b95dae0e6b5 # TEMP: branch of Glyndor/.github#142
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@11d87e7e4d6320d1cf89eb403a50d03613a18e30 # v1.18.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@bc27850b34b0cc8de17bd7a98d492b95dae0e6b5 # TEMP: branch of Glyndor/.github#142
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Install Rust toolchain
         env:
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
         run: |
           set -euo pipefail
           rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@11d87e7e4d6320d1cf89eb403a50d03613a18e30 # v1.18.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e70ff47fd8aefa0f054846815f19b98768d61122 # v1.17.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@11d87e7e4d6320d1cf89eb403a50d03613a18e30 # v1.18.0
     with:
       package-name: podup
       check-vendored: true
@@ -68,5 +68,5 @@ jobs:
       # Debian's toolchain ships no musl standard library. Keep this in step
       # with rust-ci.yml's default: the whole point is that the packaged binary
       # comes from the compiler CI validates with.
-      rust-toolchain: "1.97"
+      rust-toolchain: "1.98"
       rust-target: x86_64-unknown-linux-musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           # this version and defeat the MSRV gate. A release still must not float
           # on whatever Rust the runner ships, so pin it here, in the release path
           # only.
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt-get update -qq
@@ -265,7 +265,7 @@ jobs:
           # defaults to. Before this the package was compiled by Debian's rustc
           # while CI validated with 1.97, so the binary users installed came
           # from a compiler the suite had never run against.
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
           ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
@@ -336,7 +336,7 @@ jobs:
         # that day. Keep in step with rust-ci.yml's toolchain default (see the
         # build job for why this is not a repo-root rust-toolchain.toml).
         env:
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
         run: rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Adopts the reusables at v1.18.0, which brings Rust 1.98, the `rust-toolchain-watch` workflow, and the `.deb` dependency gate. Part of #1526.

## Three pins move, twelve stay

I compared every pinned reusable's surface against v1.18.0 rather than bumping on sight. Twelve of the fifteen are byte-identical and are untouched — the pin policy is to bump only when the surface differs, and bumping identical pins is how this org came to close thirteen no-op Dependabot pull requests in one afternoon.

    rust-ci.yml      v1.15.0 -> v1.18.0    12059 B -> 12059 B
    rust-audit.yml   v1.15.0 -> v1.18.0     4161 B ->  4161 B
    rust-debian.yml  v1.17.0 -> v1.18.0     8201 B -> 10501 B

The first two are worth pausing on: **identical sizes, different content.** v1.18.0 raised the toolchain from `1.97` to `1.98`, and those two strings are the same length. A pin check that compared byte counts would have called this a match and left the repository on the older compiler while reporting itself current. `pin-policy` compares content, which is why it caught it.

## The toolchain moves with them, in five places

`rust-ci` at v1.18.0 builds with 1.98. Leaving this repo's own pins at 1.97 would mean the packaged binary came from a compiler CI never ran — which is #1487, already fixed once and not worth re-earning.

`tests/workflow_toolchain_pin.rs` asserts the two pins agree and both satisfy `rust-version`, but it only reads two of the five places `1.97` appears:

    debian-build.yml:71     rust-toolchain: "1.97"     tested
    release.yml:165         RUST_TOOLCHAIN: "1.97"     tested
    release.yml:268         RUST_TOOLCHAIN: "1.97"
    release.yml:339         RUST_TOOLCHAIN: "1.97"
    crates-publish.yml:84   RUST_TOOLCHAIN: "1.97"

All five move. A green `workflow_toolchain_pin` would have proved nothing about the other three, so they were found by searching rather than by trusting the test — worth noting as a gap in the test rather than a gap here.

`Cargo.toml` keeps `rust-version = "1.85"`. That is the crate's floor, not the CI toolchain, and raising it is a user-visible change this is not.

The only `1.97` left in `.github/` is the comment in `release.yml:266` that records the history of #1487. It is correct as written.

## 1.98 was tested with 1.98

An unpinned toolchain upgraded itself in July and turned every open pull request in this org red on a clippy lint nobody had introduced, so "it should be fine" is not good enough here. I installed 1.98 locally and ran against it:

    cargo +1.98 clippy --all-targets --all-features -- -D warnings   exit 0
    cargo +1.98 fmt --all --check                                    exit 0
    cargo +1.98 test --lib                                           1722 passed, 0 failed

The first run finished in 0.08s off a warm cache and told me nothing; the numbers above are from a forced re-analysis after touching every source file. A green run that did no work is not a result.

## rust-debian v1.18.0 adds a gate

It now fails a musl build whose package declares any shared-library dependency, so #1512's `libc6 (>= 2.39)` floor cannot come back unnoticed. That gate was proved against this repository before it was tagged — #1535 watched it fail on a deliberately-broken build and pass on the same pin without it — so `debian / dpkg-buildpackage` passing here is the expected outcome rather than a new claim.

The v1.18.0 SHA was re-resolved against upstream, not read from a local clone: `git ls-remote refs/tags/v1.18.0` on `Glyndor/.github` returns `11d87e7`, which is what is written in all three files.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
