### PR TITLE
ci: adopt Glyndor/.github v1.19.0

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%
@@ -64,7 +64,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: audit.yml
       max-age-days: 15
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: fuzz.yml
       max-age-days: 15
@@ -82,7 +82,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: podman-lane.yml
       max-age-days: 3
@@ -91,7 +91,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: podman-watch.yml
       max-age-days: 3
@@ -102,7 +102,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: benchmark.yml
       max-age-days: 65
@@ -121,7 +121,7 @@ jobs:
   # on a Dependabot-authored pull request - the condition that forced
   # `Analyze (actions)` out of apt.
   pin-policy:
-    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@8517d94fde00466f59b95c5d1bd838e2ad24a8bf # v1.15.2
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
 
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
@@ -132,6 +132,6 @@ jobs:
   # running: run 32435521566 reported "no Dependabot pull request on record"
   # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@e9cbd47344fcb03b1bb2400f8b15ab5289ff497f # v1.16.1
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       max-age-days: 15

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0


### PR DESCRIPTION
Two reusables changed surface since `v1.18.1`, both additive:

- **`shell-ci`** gained the `check-exec-bit` step — fails when a script the workflows invoke as `./path` is not executable in git. `chmod +x` is local state; the mode git records is what reaches the runner, and when they disagree the job dies with exit 126 and `Permission denied`. It happened twice in one day in `apt`.
- **`rust-debian`** gained an `apt-packages` input.

Every pin in this repository moves to the same SHA, so it sits on one release rather than a spread across several.

**The release was proved before the tag was cut**, per `standards/ci`: `Glyndor/apt#120` pinned this exact SHA, ran `shell-ci` on a real runner with `check-exec-bit: true`, and `shell / shellcheck` and `shell / test` both passed. This adoption is not the first time the code runs anywhere.

`v1.19.0` points at `8ae47cc`, the same commit `apt` proved.