### PR TITLE
feat(cli): tell the user how to fix an unsupported Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,23 @@ Podman 5.x and 6.x**. It talks to Podman's native libpod API, requesting the
 `/v5.0.0/libpod` path that Podman 6 still serves; the gate is the major version
 the engine reports, so it needs **Podman ≥ 5.0**. Both supported majors run the
 integration suite in CI on every engine change (Fedora 44 for the latest 5.x,
-rawhide for 6.x). Many distributions still ship 4.x, so check `podman --version`
-and upgrade if needed. Fedora, Debian trixie/sid and recent Ubuntu releases carry
-5.x; on an older release, follow the official guide:
+rawhide for 6.x). Many distributions still ship 4.x, so `podman --version` is
+worth checking before installing — and a distribution never changes its Podman
+major version mid-release, so an LTS that shipped below the floor stays below
+it for its whole supported life.
+
+| distribution                  | Podman | podup runs |
+|-------------------------------|--------|------------|
+| Debian 12 bookworm            | 4.3.1  | no         |
+| Debian 13 trixie              | 5.4.2  | yes        |
+| Ubuntu 22.04 LTS              | 3.4.4  | no         |
+| Ubuntu 24.04 LTS              | 4.9.3  | no         |
+| Ubuntu 26.04 LTS              | 5.7.0  | yes        |
+| Fedora 42 and newer           | 5.x+   | yes        |
+
+Ubuntu 24.04 LTS is not supported: it ships Podman 4.9.3 and will keep shipping
+that for its whole supported life. On any row marked "no", the engine has to
+come from somewhere other than the distribution:
 <https://podman.io/docs/installation>.
 
 ### Platforms

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,10 @@
 #
 #   curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
 #
+# --skip-podman-check: bypass the local-Podman-version precheck. Use this when
+# the engine podup will use is on a different host than the local podman
+# binary (e.g. a `podman machine` VM, or a remote socket).
+#
 # Environment:
 #   PODUP_VERSION      Release tag to install (e.g. v0.3.0). Default: latest.
 #   PODUP_INSTALL_DIR  Installation directory (binary mode). Default: /usr/local/bin.
@@ -22,6 +26,8 @@ REPO="Glyndor/podup"
 INSTALL_DIR="${PODUP_INSTALL_DIR:-/usr/local/bin}"
 VERSION="${PODUP_VERSION:-latest}"
 MODE="binary"
+PODMAN_MIN_MAJOR=5
+SKIP_PODMAN_CHECK=""
 
 log_info()  { printf '\033[1;34m[info]\033[0m %s\n' "$1"; }
 log_ok()    { printf '\033[1;32m[ ok ]\033[0m %s\n' "$1"; }
@@ -33,7 +39,7 @@ fail() {
 }
 
 usage() {
-	sed -n '3,17p' "$0" | sed 's/^# \{0,1\}//'
+	sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
 	exit 0
 }
 
@@ -41,9 +47,10 @@ usage() {
 
 for arg in "$@"; do
 	case "$arg" in
-		--apt)      MODE="apt" ;;
-		-h|--help)  usage ;;
-		*)          fail "Unknown argument: ${arg} (try --help)" ;;
+		--apt)                MODE="apt" ;;
+		--skip-podman-check)  SKIP_PODMAN_CHECK=1 ;;
+		-h|--help)            usage ;;
+		*)                    fail "Unknown argument: ${arg} (try --help)" ;;
 	esac
 done
 
@@ -441,7 +448,60 @@ or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, the
 	log_ok "podup installed: $("${target}" --version)"
 }
 
+# --- Podman precheck ---------------------------------------------------------
+
+# Verify the local Podman engine meets podup's floor. Local podman is NOT
+# required: podup can drive a remote socket, and on macOS it talks to a
+# `podman machine` VM. So absence is a WARN, not a failure. A present local
+# podman whose major version is below PODMAN_MIN_MAJOR is the Ubuntu 24.04
+# case and is refused, since installing podup against it would leave the user
+# with a binary that cannot talk to their engine.
+check_podman() {
+	if ! command -v podman >/dev/null 2>&1; then
+		log_info "No local 'podman' binary found. podup needs Podman >= 5.0 to run; \
+this is fine if the engine podup will use is remote or a 'podman machine' VM."
+		return 0
+	fi
+
+	local version_output
+	# `set -e` would abort on a failing command substitution. podman can fail
+	# (e.g. a broken install, missing runtime files); treat that as an
+	# unparseable version, not a hard failure.
+	if ! version_output="$(podman --version 2>/dev/null)"; then
+		log_info "Local 'podman --version' could not be read; skipping the Podman \
+precheck. podup needs Podman >= 5.0 to run."
+		return 0
+	fi
+
+	# Output is `podman version 5.7.0`; field 3 is the version, then
+	# everything before the first '.' is the major.
+	local raw_version major
+	read -r _ _ raw_version _ <<< "$version_output" || raw_version=""
+	major="${raw_version%%.*}"
+
+	if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+		log_info "Could not parse the local Podman version ('${version_output}'); \
+skipping the Podman precheck. podup needs Podman >= 5.0 to run."
+		return 0
+	fi
+
+	if [[ "$major" -lt "$PODMAN_MIN_MAJOR" ]]; then
+		if [[ -n "$SKIP_PODMAN_CHECK" ]]; then
+			log_info "Podman precheck skipped by request (--skip-podman-check)"
+			return 0
+		fi
+		fail "Local Podman ${raw_version} is below the >= 5.0 floor podup requires. \
+podup will install, but will not be able to talk to this engine. Upgrade Podman \
+or point podup at a different, newer host (see https://podman.io/docs/installation). \
+If the engine podup will use is on a different host, re-run with --skip-podman-check."
+	fi
+
+	log_ok "Local Podman version meets the >= 5.0 requirement"
+}
+
 # --- Dispatch ----------------------------------------------------------------
+
+check_podman
 
 if [[ "$MODE" == "apt" ]]; then
 	install_apt

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -95,7 +95,9 @@ impl fmt::Display for PodmanError {
 				};
 				write!(
 					f,
-					"podup requires Podman >= 5.0; this server reports libpod API version {reported}"
+					"podup requires Podman >= 5.0; this server reports libpod API version {reported}. \
+					 Upgrade Podman, or point podup at a host running 5.0 or newer: \
+					 https://podman.io/docs/installation"
 				)
 			}
 		}

--- a/internal/libpod/error/tests.rs
+++ b/internal/libpod/error/tests.rs
@@ -277,6 +277,32 @@ fn display_incompatible_api_version_reports_version() {
 }
 
 #[test]
+fn display_incompatible_api_version_offers_a_remedy() {
+	let e = PodmanError::IncompatibleApiVersion {
+		reported: "4.9.3".into(),
+	};
+	let msg = e.to_string();
+	assert!(msg.contains("podman.io/docs/installation"), "got {msg:?}");
+	assert!(msg.contains("Upgrade Podman"), "got {msg:?}");
+}
+
+#[test]
+fn display_incompatible_api_version_keeps_diagnosis_before_remedy() {
+	let e = PodmanError::IncompatibleApiVersion {
+		reported: "4.9.3".into(),
+	};
+	let msg = e.to_string();
+	let diagnosis = msg.find("4.9.3").expect("diagnosis should be present");
+	let remedy = msg
+		.find("Upgrade Podman")
+		.expect("remedy should be present");
+	assert!(
+		diagnosis < remedy,
+		"remedy must follow the diagnosis it explains: {msg:?}"
+	);
+}
+
+#[test]
 fn display_incompatible_api_version_handles_missing_header() {
 	// An empty reported version (no `Libpod-API-Version` header) renders a
 	// readable placeholder rather than a blank.


### PR DESCRIPTION
Closes the actionable half of #1553: Ubuntu 24.04 LTS is not supported, and the product now says so before it breaks anything instead of after.

## Why

podup requires Podman >= 5.0. Ubuntu 24.04 LTS ships 4.9.3, no distribution changes Podman major version mid-release, and there is no backports pocket — so it stays below the floor until it leaves standard support in 2029. `apt install podup` succeeds, because the `.deb` is musl-static and has no unmet dependency, and only then does the tool find it cannot talk to the engine.

Three independent changes, all in this repository. The apt repository is deliberately not touched: its installer template is shared by every product and rendered with a plain `sed s/@PRODUCT@/…/g`, so an engine check there would ship in epistle's, helmly's, klyradb's and unitpm's installers too.

## What changed

**`internal/libpod/error.rs`** — the `IncompatibleApiVersion` `Display` arm keeps its diagnosis byte-identical and appends a remedy:

```
podup requires Podman >= 5.0; this server reports libpod API version 4.9.3. Upgrade Podman, or point podup at a host running 5.0 or newer: https://podman.io/docs/installation
```

It names no distribution on purpose. A string compiled into a binary cannot be updated for someone who already installed it, and every release in the README table has an expiry date — Debian 12 in 2028, Ubuntu 24.04 in 2029. The URL and the README carry the detail that ages.

**`install.sh`** — a `check_podman` precheck runs before both install paths. The rule that is easy to get backwards, and is why this is a precheck rather than a hard requirement: podup does not need a *local* Podman. It can drive a remote socket, and on macOS it talks to a `podman machine` VM.

| local podman | verdict |
|---|---|
| present, major < 5 | refuse, install nothing |
| absent | warn, continue — proves nothing |
| present, unparseable version | warn, continue — never guess |
| present, major >= 5 | confirm, continue |

`--skip-podman-check` bypasses the refusal for someone whose engine is a different, newer host.

**`README.md`** — names the releases instead of "recent Ubuntu releases", which was true and still led readers to the wrong conclusion: the recent ones are the non-LTS ones, and LTS is what the reader of that sentence is running.

No third-party package repository is recommended, in the installer or the docs.

## Verification

Not just read — run.

`check_podman` was extracted from the real `install.sh` and exercised in eight scenarios: this machine's actual Podman 5.7.0 (passes), fakes at 6.1.0 (passes), 4.9.3 and 3.4.4 (both refuse, exit 1), 4.9.3 with the bypass (passes), a `podman` that exits non-zero (warns, continues), unparseable output (warns, continues), and genuine absence with `PATH` emptied and bash invoked by absolute path (warns, continues).

Two defects were found and fixed this way, neither visible in the diff:

- `usage()` printed a truncated help. Its `sed -n '3,17p'` had been widened to `'3,20p'` for three new documentation lines, but four lines had shifted, so `--help` ended mid-way through the Environment block. Now `'3,21p'`.
- The refusal message read `Local Podman podman version 4.9.3 is below …` because it interpolated the whole `podman --version` output rather than the parsed version.

For the Rust side, the deletion test from `standards/testing`: reverting the `Display` change turns exactly the two new tests red and leaves the two pre-existing ones green, which also confirms the diagnosis clause stayed byte-identical.

Gates: `cargo fmt --all --check` clean, `cargo clippy --locked --all-targets --all-features -- -D warnings` clean, `cargo test --locked --features test-helpers --lib` 1724 passed / 0 failed, `bash -n` and `shellcheck install.sh` clean.

## Still open on #1553

Nothing here decides the wording of a per-distribution remedy page, and #1554 tracks the separate problem that the two-major support window collides with LTS lifetimes once Podman 7 ships.
