### PR TITLE
ci: gate on check names that cannot move

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,13 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
+      # Each entry here becomes its own check name: `rust / Test (macos-latest)`
+      # and `rust / Test (windows-latest)`. Editing this list changes the names
+      # emitted while the ruleset still requires the old ones, so the PR
+      # carrying the edit blocks itself. A ruleset should require the stable
+      # gate `rust / Extra platforms` instead, which names no platform. #1552.
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%
       # while a `coverage-ignore-regex` hid 36% of the code — 14,432 of 39,681
@@ -47,6 +52,11 @@ jobs:
       # The 90 gate belongs where the tests can actually run — the `podman-vm`
       # lane — and that is tracked separately rather than papered over here.
       coverage-threshold: 79
+      # This number is inside the check name `rust / MSRV (1.85)`. Bumping it
+      # emits `rust / MSRV (<new>)` while the ruleset still requires the old
+      # string, so the PR carrying the bump blocks itself. A ruleset should
+      # require the stable gate `rust / MSRV` instead, which carries no
+      # version. See #1552.
       msrv: "1.85"
       package-check: true
       semver-check: true
@@ -64,7 +74,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: audit.yml
       max-age-days: 15
@@ -73,7 +83,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: fuzz.yml
       max-age-days: 15
@@ -82,7 +92,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: podman-lane.yml
       max-age-days: 3
@@ -91,7 +101,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: podman-watch.yml
       max-age-days: 3
@@ -102,7 +112,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: benchmark.yml
       max-age-days: 65
@@ -121,7 +131,7 @@ jobs:
   # on a Dependabot-authored pull request - the condition that forced
   # `Analyze (actions)` out of apt.
   pin-policy:
-    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
 
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
@@ -132,6 +142,6 @@ jobs:
   # running: run 32435521566 reported "no Dependabot pull request on record"
   # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       max-age-days: 15

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -36,6 +36,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # This list appears in the required check names `podman-vm (5)` /
+        # `podman-vm (6)`. Editing it changes the emitted names while the
+        # ruleset still requires the old ones, so the PR carrying the edit
+        # blocks itself. The stable gate a ruleset should require is
+        # `Supported Podman majors`. See #1552.
         podman: ["5", "6"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -442,3 +447,30 @@ jobs:
             echo "::warning::Podman $VER: $FAIL failures, $FLAKY match a connection-drop signature — the rest are the known nested-virt-unstable subset (see the failures section). Not gated until that flakiness is reduced."
           fi
           echo "GREEN: podup core PASSED on Podman $VER ($PASS tests >= baseline $BASELINE; $FAIL in the nested-virt-noisy subset)."
+
+  podman-majors:
+    name: Supported Podman majors
+    # A required status check is matched by name, and `podman-vm (5)` / `podman-vm (6)`
+    # carry the matrix values. The support policy moves that matrix — when Podman 7
+    # ships, `["5", "6"]` becomes `["6", "7"]` — and on that pull request the required
+    # name `podman-vm (5)` stops being emitted while the ruleset still requires it, so
+    # the pull request that carries the change blocks itself. This name does not move.
+    # See #1552.
+    needs: podman-vm
+    # `needs` on its own SKIPS this job when the matrix fails, and a skipped required
+    # check does not block a merge — the exact failure this job exists to prevent.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reflect the matrix result
+        env:
+          RESULT: ${{ needs.podman-vm.result }}
+        run: |
+          set -euo pipefail
+          # Unlike the gates in the shared rust-ci reusable, `skipped` is NOT a pass
+          # here: podman-vm carries no `if:` and runs on every pull request, so a
+          # skipped matrix means something went wrong rather than a caller opting out.
+          case "$RESULT" in
+            success) echo "every supported Podman major passed" ;;
+            *) echo "::error::the Podman matrix did not pass (result: $RESULT)"; exit 1 ;;
+          esac

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0


### PR DESCRIPTION
Second step of #1552. Adopts the stable gate names from Glyndor/.github v1.20.0 and adds the equivalent for this repository's own matrix.

**Nothing is removed here, and the ruleset is not touched.** The new names have to be emitting before anything can require them, and they only start emitting once this lands. Migrating the two rulesets is the next step, separately.

## What changed

**Every reusable pin moves to v1.20.0** (`76f8bc6d`), across 12 workflow files. That release added two jobs whose names carry no value. This repository's caller job is `rust`, so they arrive as `rust / MSRV` and `rust / Extra platforms`.

**`podman-lane` gains `Supported Podman majors`**, the same shape over its own matrix. One deliberate difference from the two above: `skipped` is **not** a pass here. `msrv` and `test-extra` are conditional on caller inputs, so a caller that asks for neither has nothing to fail — but `podman-vm` carries no `if:` and runs on every pull request, so a skipped matrix means something went wrong rather than a caller opting out. That reasoning is a comment in the job, so nobody unifies the two later.

Note the emitted name has no prefix. `rust / …` appears because `ci.yml` calls a *reusable* from a job named `rust`; `podman-lane.yml` defines its jobs directly, which is why the current ruleset reads `podman-vm (5)` and not `podman-lane / podman-vm (5)`.

**A comment above each of the three values that feed a required name** — `extra-test-os`, `msrv`, and the `podman:` matrix — saying which check name it is inside today, that editing it blocks the very pull request making the edit, and which stable gate to require instead.

## Verification

The gate logic was executed against all four values `needs.podman-vm.result` can take, rather than reasoned about:

| `needs.result` | exit | output |
|---|---|---|
| `success` | 0 | `every supported Podman major passed` |
| `skipped` | **1** | `::error::the Podman matrix did not pass (result: skipped)` |
| `failure` | 1 | `::error::the Podman matrix did not pass (result: failure)` |
| `cancelled` | 1 | `::error::the Podman matrix did not pass (result: cancelled)` |

`actionlint` clean on both changed workflows. Worth recording for whoever runs it next: plain `actionlint` does not return on `podman-lane.yml` — it hands the ~250-line cloud-init `user-data` heredoc to shellcheck, which does not finish. `actionlint -shellcheck= -pyflakes=` exits 0.

No occurrence of the old pin `8ae47ccd` remains anywhere under `.github/`.

## After this

The two rulesets — `protect-develop` (17287557) and `protect-main` (17287556) — get the three stable names **added first**, and only then lose the five value-carrying ones. Doing it in the other order blocks every pull request here in the gap.
