### PR TITLE
ci(podman-lane): record why plain actionlint does not return on this file

### DIFF
--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -1,4 +1,9 @@
 name: podman-lane
+# Running `actionlint` on this file without arguments does not return: it hands
+# the ~250-line cloud-init `user-data` heredoc below to shellcheck, which does
+# not finish. Use `actionlint -shellcheck= -pyflakes= .github/workflows/podman-lane.yml`
+# when checking this workflow by hand. Measured 2026-08-24; the repository's own
+# workflow-lint job is unaffected because it runs actionlint with its own flags.
 # Live-Podman integration for podup, validated against the FULL supported window.
 # Support policy: the latest Podman major + the one below it — today Podman 5 and 6.
 # Every engine PR runs the integration suite on BOTH majors (matrix), each inside a


### PR DESCRIPTION
`actionlint .github/workflows/podman-lane.yml` with no other arguments does not return. It hands the ~250-line cloud-init `user-data` heredoc to shellcheck, which does not finish — so the command looks like it is working and never comes back, which is worse than an error.

I hit this twice while working on #1552. The note at the top of the file says which invocation to use instead:

```
actionlint -shellcheck= -pyflakes= .github/workflows/podman-lane.yml
```

The repository's own `workflow-lint` job is unaffected — it runs actionlint with its own flags — so this is only about checking the file by hand.

Doubling as the first pull request through the migrated rulesets from #1552: both `protect-develop` and `protect-main` now require `rust / MSRV`, `rust / Extra platforms` and `Supported Podman majors` instead of the five names that carried a value. If the migration created a phantom, this is where it shows.