### PR TITLE
ci: watch the pinned tool versions nothing else watches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,14 +106,13 @@ jobs:
       workflow: podman-watch.yml
       max-age-days: 3
 
-  freshness-pin-watch:
-    permissions:
-      contents: read
-      actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
-    with:
-      workflow: pin-watch.yml
-      max-age-days: 15
+  # A newly added scheduled workflow cannot be registered here in the same pull
+  # request that adds it. The guard passes only on a run with `event=schedule`
+  # and `status=success`; GitHub fires crons solely from the default branch, and
+  # `workflow_dispatch` does not count. So a fresh entry fails with "No
+  # successful scheduled run on record" until the workflow has reached `main`
+  # and its cron has fired once. `pin-watch.yml` (#1526) is waiting for exactly
+  # that and gets its entry afterwards.
 
   # Monthly (`0 4 1 * *`), so seventeen days without a run is normal and a
   # weekly threshold here would fail on ordinary work for most of the month.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,15 @@ jobs:
       workflow: podman-watch.yml
       max-age-days: 3
 
+  freshness-pin-watch:
+    permissions:
+      contents: read
+      actions: read
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    with:
+      workflow: pin-watch.yml
+      max-age-days: 15
+
   # Monthly (`0 4 1 * *`), so seventeen days without a run is normal and a
   # weekly threshold here would fail on ordinary work for most of the month.
   freshness-benchmark:

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -1,0 +1,139 @@
+name: pin-watch
+# Notifies (opens an issue) when a tool version pinned in this repository has
+# drifted from upstream. Four pins are owned here and watched nowhere else:
+#   - the `debian:trixie` container digest in release.yml
+#   - `python-version` in asset-contract.yml (it appears more than once; the
+#     entries must agree, and disagreement is itself a drift)
+#   - `Standards-Version` in debian/control
+#   - `debhelper-compat` in debian/control
+# Rust is watched by Glyndor/.github's rust-toolchain-watch.yml and Podman by
+# this repository's podman-watch.yml, so neither is repeated here.
+#
+# Weekly, not daily: these move on the scale of months, and a daily run would
+# be noise. 05:00 Monday keeps it off audit.yml's 06:00 and fuzz.yml's 07:00 —
+# stacking crons on the same minute only invites GitHub's scheduling delays.
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  watch:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Detect drift in pinned tool versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Every `python3 -c` below is ONE line, deliberately. Automatic dedent
+          # of `-c` source arrived in CPython 3.13 and this runner ships 3.12,
+          # where indented source is an IndentationError — measured against a
+          # real 3.12, not assumed. Un-indenting to column 0 is not the way out
+          # either: inside a YAML `run: |` block a line at column 0 ends the
+          # block. One line sidesteps both traps.
+          DRIFTS=$(mktemp); BODY=$(mktemp)
+          trap 'rm -f "$DRIFTS" "$BODY"' EXIT
+          add_drift() { printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$DRIFTS"; }
+
+          # ---- 1. debian:trixie container digest ------------------------------
+          # Read the pinned value FROM THE FILE, so the watcher cannot silently
+          # disagree with what the workflow actually uses.
+          PINNED_DIGEST=$(grep -oE 'container: debian:trixie@sha256:[a-f0-9]{64}' \
+            .github/workflows/release.yml | head -n1 | sed 's/.*@//')
+          [[ "$PINNED_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] \
+            || { echo "::error::could not parse the pinned debian:trixie digest from release.yml"; exit 1; }
+          TOKEN=$(curl -fsSL 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/debian:pull' \
+            | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+          [[ -n "$TOKEN" ]] || { echo "::error::empty token from auth.docker.io"; exit 1; }
+          # The Accept header must offer the manifest-list types or the registry
+          # answers 406 for a multi-arch tag.
+          LATEST_DIGEST=$(curl -fsSL -I -H "Authorization: Bearer $TOKEN" \
+            -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' \
+            'https://registry-1.docker.io/v2/library/debian/manifests/trixie' \
+            | tr -d '\r' | awk -F': ' 'tolower($1) == "docker-content-digest" { print $2; exit }')
+          [[ "$LATEST_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] \
+            || { echo "::error::registry returned an unexpected digest: '$LATEST_DIGEST'"; exit 1; }
+          [ "$PINNED_DIGEST" = "$LATEST_DIGEST" ] \
+            || add_drift "debian:trixie container digest" ".github/workflows/release.yml" "$PINNED_DIGEST" "$LATEST_DIGEST"
+
+          # ---- 2. python-version ----------------------------------------------
+          # Plain shell does this; no interpreter needed.
+          PY_DISTINCT=$(grep -oE '^[[:space:]]+python-version:[[:space:]]*"?[0-9]+\.[0-9]+' \
+            .github/workflows/asset-contract.yml | grep -oE '[0-9]+\.[0-9]+$' | sort -u)
+          PY_COUNT=$(printf '%s\n' "$PY_DISTINCT" | grep -c . || true)
+          [ "${PY_COUNT:-0}" -gt 0 ] \
+            || { echo "::error::no python-version line found in asset-contract.yml"; exit 1; }
+          if [ "$PY_COUNT" -gt 1 ]; then
+            add_drift "python-version (entries disagree)" ".github/workflows/asset-contract.yml" \
+              "$(printf '%s' "$PY_DISTINCT" | paste -sd ', ' -)" "(they must agree)"
+          else
+            LATEST_PY=$(curl -fsSL https://endoflife.date/api/python.json \
+              | python3 -c 'import sys,json; print(json.load(sys.stdin)[0]["cycle"])')
+            [[ "$LATEST_PY" =~ ^[0-9]+\.[0-9]+$ ]] \
+              || { echo "::error::endoflife.date returned an unexpected cycle: '$LATEST_PY'"; exit 1; }
+            [ "$PY_DISTINCT" = "$LATEST_PY" ] \
+              || add_drift "python-version" ".github/workflows/asset-contract.yml" "$PY_DISTINCT" "$LATEST_PY"
+          fi
+
+          # ---- 3. Standards-Version -------------------------------------------
+          # The regex MUST admit FOUR components. A three-component one silently
+          # truncates 4.7.4.1 to 4.7.4 and reports a false match — that exact
+          # mistake was already made once on #1526.
+          PINNED_STD=$(grep -oE '^Standards-Version:[[:space:]]+[0-9]+(\.[0-9]+){2,3}' debian/control \
+            | head -n1 | awk '{print $2}')
+          [[ -n "$PINNED_STD" ]] \
+            || { echo "::error::could not parse Standards-Version from debian/control"; exit 1; }
+          LATEST_STD=$(curl -fsSL https://www.debian.org/doc/debian-policy/ \
+            | grep -oE 'version [0-9]+(\.[0-9]+){2,3}' | head -n1 | awk '{print $2}')
+          [[ -n "$LATEST_STD" ]] \
+            || { echo "::error::could not read the current Debian Policy version"; exit 1; }
+          [ "$PINNED_STD" = "$LATEST_STD" ] \
+            || add_drift "Standards-Version" "debian/control" "$PINNED_STD" "$LATEST_STD"
+
+          # ---- 4. debhelper-compat ---------------------------------------------
+          # Compared against what **trixie** ships, NOT sid and NOT unstable. CI
+          # builds in trixie; compat 14 exists only in sid/forky today, so raising
+          # it would break the build. A watcher that reads sid and says "bump to
+          # 14" every Monday is worse than no watcher at all.
+          PINNED_COMPAT=$(grep -oE 'debhelper-compat[[:space:]]*\([[:space:]]*=[[:space:]]*[0-9]+' debian/control \
+            | head -n1 | grep -oE '[0-9]+$')
+          [[ "$PINNED_COMPAT" =~ ^[0-9]+$ ]] \
+            || { echo "::error::could not parse debhelper-compat from debian/control"; exit 1; }
+          DEBHELPER_VER=$(curl -fsSL https://sources.debian.org/api/src/debhelper/ \
+            | python3 -c 'import sys,json; m=[v["version"] for v in json.load(sys.stdin)["versions"] if "trixie" in v.get("suites",[])]; print(m[0].split("~")[0].split("+")[0] if m else "")')
+          [[ "$DEBHELPER_VER" =~ ^[0-9]+(\.[0-9]+)*$ ]] \
+            || { echo "::error::no debhelper version found for trixie (got '$DEBHELPER_VER')"; exit 1; }
+          [ "$PINNED_COMPAT" = "${DEBHELPER_VER%%.*}" ] \
+            || add_drift "debhelper-compat" "debian/control" "$PINNED_COMPAT" "${DEBHELPER_VER%%.*} (debhelper $DEBHELPER_VER in trixie)"
+
+          # ---- Report ----------------------------------------------------------
+          if [ ! -s "$DRIFTS" ]; then echo "No drift in any pinned tool version."; exit 0; fi
+          TITLE="Pinned tool versions have drifted"
+          # Idempotent: the title never changes, so a week that finds the same
+          # drift again does not open a second issue.
+          if gh issue list --state open --search "in:title $TITLE" --json title --jq '.[].title' | grep -qxF "$TITLE"; then
+            echo "Drift found, but the issue is already open — nothing to do."; exit 0
+          fi
+          {
+            echo "| Pin | Pinned at | Pinned | Upstream |"
+            echo "| --- | --- | --- | --- |"
+            while IFS=$'\t' read -r name path pinned upstream; do
+              # shellcheck disable=SC2016  # the backticks are literal markdown for
+              # the issue body, not command substitution waiting to expand.
+              printf '| %s | `%s` | `%s` | `%s` |\n' "$name" "$path" "$pinned" "$upstream"
+            done < "$DRIFTS"
+            echo
+            echo "The container digest has no bump path through Dependabot: the \`github-actions\` ecosystem does not update a workflow's \`container:\` image, so it has to be raised by hand."
+          } > "$BODY"
+          # Label on creation. An unlabelled issue is a process bug, and one filed
+          # by a bot is no exception — podman-watch carries the same note because
+          # #673 and #1016 both landed bare.
+          gh issue create --title "$TITLE" \
+            --label "type:ci" --label "prio:P2" --label "status:ready" \
+            --label "area:ci" --label "effort:S" \
+            --body-file "$BODY"
+          echo "Opened the drift report."


### PR DESCRIPTION
Closes the watcher half of #1526.

## Why now

The issue asked for this — "the watcher, because otherwise this recurs" — and one pin has already recurred. The `debian:trixie` digest was pinned in #1530 and has drifted since, exactly as `release.yml`'s own comment predicts: Dependabot's `github-actions` ecosystem does not update a workflow's `container:` image, so a digest pin has no bump path.

## What it covers

The four pins this repository owns that nothing else watches. Rust is covered by `rust-toolchain-watch` in Glyndor/.github and Podman by `podman-watch`, so neither is repeated.

Weekly at 05:00 Monday — off `audit.yml`'s 06:00 and `fuzz.yml`'s 07:00, since stacking crons on one minute only invites scheduling delays. One issue listing every drift, not one per pin, deduplicated on a title that never changes. Registered with `schedule-freshness` at 15 days so a cron that stops firing is itself reported.

## Verified by running it, not by reading it

The step's script was extracted from the workflow and executed against the real repository files with a stubbed `gh`:

```
| Pin                            | Pinned          | Upstream        |
| debian:trixie container digest | sha256:fac46bff… | sha256:34cd9e9f… |
| python-version                 | 3.13            | 3.14            |
```

Both match what I measured by hand beforehand. Just as important is what it did **not** report: `Standards-Version` (4.7.4.1, current) and `debhelper-compat` (13, which is trixie's major) stayed silent. The debhelper check reading sid instead of trixie was the trap most likely to be built in, and it would have filed "bump to 14" every Monday — a demand that breaks the build if followed.

The deduplication path was exercised too: with the issue already open, the run reports `Drift found, but the issue is already open — nothing to do.` and creates nothing.

`actionlint` is clean **with shellcheck enabled**. That matters here: an earlier draft passed `actionlint -shellcheck=` while containing a heredoc whose terminator was indented, so it never closed. Running the script is what found it, along with two more:

- a `python3 -c` block written across several indented lines. It works on this machine (Python 3.14) and fails on the runner (3.12, `IndentationError`) — confirmed against a real 3.12 container, not assumed from the changelog.
- the cron I first specified collided with `fuzz.yml`'s.

## Not fixing the digest here

I measured that it is stale but am not bumping it blind. `release.yml` only runs on a release, so no pull-request CI would exercise the new image. The watcher will file it, and it should be raised where a build can prove it.