### PR TITLE
ci(release): generate SBOMs in a job that holds no secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,13 +318,23 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  release:
-    name: Publish release
+  # SBOM generation runs here, in its own job, so a third-party build script
+  # executed by `cargo install` cannot reach the signing step. cargo install
+  # builds every crate in the dependency tree of cargo-cyclonedx and
+  # cargo-about (427 crates across the two, several under live RustSec
+  # advisories), and `build.rs` has full filesystem access on the runner that
+  # runs it. The release job holds GLYNDOR_RELEASE_ED25519_KEY on its signing
+  # step; if SBOM generation lived in the same job, a malicious build script
+  # could persist in the workspace and rewrite `.github/scripts/sign.py` or
+  # `.github/scripts/sign-requirements.txt` before the signing step ran them
+  # with the key in its environment. This job holds `contents: read` and no
+  # secrets, so persistence here has nothing to land on. See Glyndor/apt#121.
+  sbom:
+    name: Generate SBOM and license attribution
     needs: [build, build-deb]
-    runs-on: ubuntu-latest
     permissions:
-      contents: write
-
+      contents: read
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -342,15 +352,6 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
-
-      - name: Verify both Debian packages are present
-        run: |
-          for arch in amd64 arm64; do
-            if ! ls podup_*_${arch}.deb >/dev/null 2>&1; then
-              echo "::error::Debian package artifact for ${arch} is missing"
-              exit 1
-            fi
-          done
 
       - name: Generate per-target SBOMs and license attribution
         # Government/enterprise consumers require a machine-readable SBOM
@@ -403,6 +404,51 @@ jobs:
           done
 
           cargo about generate about.hbs > NOTICES.html
+
+      - name: Upload SBOM and NOTICE artifacts
+        # if-no-files-found: error matters: a silent empty upload would let the
+        # release job sign nothing and still succeed, defeating the SBOM gate.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: |
+            *.cdx.json
+            NOTICES.html
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: [build, build-deb, sbom]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Install Rust toolchain
+        # Pin rather than `stable`: a release runs once at tag time and is
+        # immutable, so it must not be built by whatever Rust the runner ships
+        # that day. Keep in step with rust-ci.yml's toolchain default (see the
+        # build job for why this is not a repo-root rust-toolchain.toml).
+        env:
+          RUST_TOOLCHAIN: "1.98"
+        run: rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+
+      - name: Verify both Debian packages are present
+        run: |
+          for arch in amd64 arm64; do
+            if ! ls podup_*_${arch}.deb >/dev/null 2>&1; then
+              echo "::error::Debian package artifact for ${arch} is missing"
+              exit 1
+            fi
+          done
 
       - name: Generate checksums
         run: |


### PR DESCRIPTION
Acts on Glyndor/apt#121, direction A, after measuring the tooling trees.

## What was wrong

`cargo install` executes `build.rs` for every crate it resolves. That is arbitrary code execution by design, not a flaw in any of those crates. Generating the SBOMs pulled **427 crates** across `cargo-cyclonedx` 0.5.9 and `cargo-about` 0.9.0 into the job that signs the release.

Audited against RustSec today:

| tool | crates | vulnerabilities | other |
|---|---|---|---|
| `cargo-cyclonedx` 0.5.9 | 179 | 1 (`RUSTSEC-2026-0009`, `time`, CVSS 6.8) | 2 unsound, **`xml-rs` 0.8.19 yanked** |
| `cargo-about` 0.9.0 | 248 | 1 (`RUSTSEC-2026-0204`, `crossbeam-epoch`) | 1 unsound |

The yank deserves a note: `cargo install --locked` installs a yanked crate without complaint, because `--locked` does no resolution. Verified — `cargo fetch --locked` on that tree exits 0. A yank is the author saying "do not use this version", and it was resolving into the signing runner regardless.

## What the risk actually is

Not what I first thought, and worth stating precisely because it changes the fix.

Secrets here are declared **per step**, not per job. The `release` job has no `env:` block; `GLYNDOR_RELEASE_ED25519_KEY` appears only on the signing step and `CARGO_REGISTRY_TOKEN` only on the publish step. A build script at the SBOM step could not read the key — it is not in any environment yet.

The exposure is **persistence**. A build script can alter `.github/scripts/sign.py` or `.github/scripts/sign-requirements.txt` in the workspace, and the signing step then executes those with the key in its environment, on the same runner, a few steps later.

## What changed

A new `sbom` job with `contents: read` **and nothing else** — no `id-token: write`, no `attestations: write`. A build script running there can read a public repository and publish an artifact; that is the whole blast radius.

It needs `[build, build-deb]` because the step names each package's SBOM after the `.deb` it describes (`deb="$(ls podup_*_"${arch}".deb)"`), so the packages must be present.

The SBOMs reach the release job as an artifact rather than through a shared workspace, with `if-no-files-found: error` — without it an empty upload would make the release job sign nothing and still report success.

The signing step is untouched.

## Verified

```
verify    contents:read   no secrets   installs cargo-audit
sbom      contents:read   no secrets   installs cyclonedx + about   ← moved here
release   contents:write  KEY + TOKEN  installs nothing
```

Every `cargo install` line in the file was enumerated per job: no third-party tool is installed in a job that holds a secret any more. The SBOM step exists exactly once — moved, not copied, so the install does not also still run beside the key. `actionlint` clean.

## What I could not verify

`release.yml` runs only on a release, so **no pull-request CI exercises this**. Syntax, permissions, the `needs` graph and the artifact wiring are checked; the run itself is not. A defect here surfaces during the next podup release, with the release half-done.

## Not addressed here

- `verify` still installs `cargo-audit` 0.22.2, whose own tree carries `RUSTSEC-2026-0185` (`quinn-proto`, CVSS 7.5). It holds no secrets, so the same reasoning says it is fine where it is — but the highest-severity finding of the sweep is in the auditing tool, and nothing audits the auditor.
- Nothing yet audits these trees on an ongoing basis. That is the rest of apt#121.