### PR TITLE
docs: state when a Podman major is dropped, in terms that can be met

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ release's Ed25519 signature and SHA-256 checksum, failing closed otherwise. See
 podup tracks the **latest stable Podman** and supports its **last two majors,
 Podman 5.x and 6.x**. It talks to Podman's native libpod API, requesting the
 `/v5.0.0/libpod` path that Podman 6 still serves; the gate is the major version
-the engine reports, so it needs **Podman ≥ 5.0**. Both supported majors run the
+the engine reports, so it needs **Podman ≥ 5.0**. When a new major ships, it is
+added and the oldest is dropped — but only once the **newest LTS of each
+distribution family carries the new one or better**, so nobody on a current
+release is stranded. Both supported majors run the
 integration suite in CI on every engine change (Fedora 44 for the latest 5.x,
 rawhide for 6.x). Many distributions still ship 4.x, so `podman --version` is
 worth checking before installing — and a distribution never changes its Podman


### PR DESCRIPTION
The user-facing half of #1554. The policy half is Glyndor/ai-context#125, and the two must not drift.

## What was wrong

The README said podup supports the last two Podman majors and left the drop condition entirely in `ai-context`, where it read: drop N−1 "once stable distros have moved off N−1".

**That condition can never be satisfied.** A distribution never changes its Podman major mid-release — the README says so two sentences later — so "moved off" only becomes true when the release dies.

| release | Podman | supported until |
|---|---|---|
| Ubuntu 26.04 LTS | 5.7.0 | 2031-04-30 (ESM 2036) |
| Debian 13 trixie | 5.4.2 | 2028-08-09 (LTS 2030) |

Podman 7 is due around 2027. The old wording therefore committed podup to three majors for roughly four years, with a 5.x that upstream freezes after 6.0.

## What it says now

The condition anchors on the **newest LTS of each distribution family** carrying the new major. Same intent — do not strand someone on a current release — without tying the window to a twelve-year ESM tail.

It belongs in the README and not only in `ai-context` because this is the copy a user reads when deciding whether their distribution will keep working. The paragraph already tells them a distribution never changes major mid-release; leaving out what that implies for support is the half that was missing.