### PR TITLE
chore(release): 5.1.0

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       # Each entry here becomes its own check name: `rust / Test (macos-latest)`
       # and `rust / Test (windows-latest)`. Editing this list changes the names
@@ -74,7 +74,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: audit.yml
       max-age-days: 15
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: fuzz.yml
       max-age-days: 15
@@ -92,7 +92,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: podman-lane.yml
       max-age-days: 3
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: podman-watch.yml
       max-age-days: 3
@@ -120,7 +120,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: benchmark.yml
       max-age-days: 65
@@ -139,7 +139,7 @@ jobs:
   # on a Dependabot-authored pull request - the condition that forced
   # `Analyze (actions)` out of apt.
   pin-policy:
-    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
 
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
@@ -150,6 +150,6 @@ jobs:
   # running: run 32435521566 reported "no Dependabot pull request on record"
   # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       max-age-days: 15

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,36 @@
+podup (5.1.0) unstable; urgency=medium
+
+  New
+
+  * An unsupported Podman now says what to do about it. podup requires
+    Podman >= 5.0 and Ubuntu 24.04 LTS ships 4.9.3 for its whole supported
+    life, so `apt install podup` succeeded and the tool then could not reach
+    the engine. The error carries a remedy, `install.sh` refuses before
+    installing when a local podman is below the floor, and the README names
+    the releases instead of saying "recent Ubuntu releases" -- which was true
+    and still led readers to the wrong conclusion, since the recent ones are
+    the non-LTS ones.
+
+  * The Podman support policy states when a major is dropped in terms that
+    can be met: once the newest LTS of each distribution family carries the
+    new one. The previous wording waited for stable distributions to "move
+    off" the old major, which never becomes true, because an LTS does not
+    change Podman major mid-release.
+
+  Packaging and CI
+
+  * SBOMs are generated in a job that holds no secrets. `cargo install` runs
+    a build script for every crate it resolves, and that was happening in the
+    job that signs the release.
+
+  * Required status checks no longer carry a value in their name, so the pull
+    request that changes an MSRV or a Podman matrix no longer blocks itself.
+
+  * A weekly watcher reports pinned tool versions that have drifted from
+    upstream; four of this repository's pins had no watcher at all.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 24 Aug 2026 23:40:00 -0500
+
 podup (5.0.0) unstable; urgency=medium
 
   Breaking


### PR DESCRIPTION
Version bump for the 5.1.0 release. Lands on `develop`; the release pull request to `main` follows.

Ten commits since 5.0.0, one of them user-facing and the reason this ships now: an unsupported Podman used to fail silently. Ubuntu 24.04 LTS carries Podman 4.9.3 for its whole supported life, so `apt install podup` succeeded and the tool then could not reach the engine. That fix has been on `develop` since this morning.

MINOR, not PATCH: #1555 added behaviour — a remedy in the error, a precheck in the installer.

`Cargo.toml`, `Cargo.lock` and `debian/changelog` move together. The verify job fails when the first and the last disagree, because a release once carried a `.deb` built from a stale changelog.

Verified: `cargo fmt --all --check` clean, `cargo test --locked --features test-helpers --lib` 1724 passed / 0 failed. The `--locked` matters here — it is what caught that `Cargo.lock` still said 5.0.0 after the manifest had moved.