### PR TITLE
chore(release): 5.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,43 @@ updates:
     labels: ["type:deps", "type:ci"]
     open-pull-requests-limit: 10
     target-branch: "develop"
+    # Sixteen Glyndor reusables and five `actions/*` references across the
+    # workflows, all SHA-pinned. Without grouping, one upstream release day
+    # means near-identical pull requests and full CI runs per action. One pull
+    # request per day is enough to review the same information.
+    # Grouped into two, not one. The Glyndor reusables and the actions/* get
+    # opposite answers from the same review, and a single group forces one
+    # answer for both.
+    #
+    # A .github release usually changes nothing this repository calls. The
+    # reusables come back byte-identical and I close the bump as a no-op. A
+    # third-party bump is the opposite: actions/checkout moving is the one
+    # thing here worth reading line by line.
+    #
+    # Under patterns: ["*"] both arrive in the same pull request, so closing
+    # the no-op closes the bump that mattered. That is the whole reason for
+    # the split: one pull request, one answer.
+    #
+    # The second group is named `github-owned`, not `third-party` as in apt.
+    # apt's comment calls it "third-party" but in this repository every
+    # non-Glyndor `uses:` is in the `actions/*` namespace (checkout, setup-python,
+    # upload-artifact, download-artifact, attest-build-provenance) -- all
+    # GitHub-owned, all runner primitives per the org CI standard. `third-party`
+    # is the wrong word here: it implies an external maintainer I need to
+    # audit, when in fact this group is GitHub's own primitives. The name
+    # should describe what it matches.
+    groups:
+      glyndor-reusables:
+        patterns: ["Glyndor/.github*"]
+      github-owned:
+        patterns: ["*"]
+        exclude-patterns: ["Glyndor/.github*"]
+    # Dependabot infers a prefix from the commit history when this is absent,
+    # and the inference has been unstable across repositories (build(deps):
+    # Bump ... in some, chore(deps): bump ... in others). Set it so the
+    # generated title is predictable and matches homebrew-tap and scoop-bucket.
+    commit-message:
+      prefix: chore
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -16,6 +53,8 @@ updates:
     labels: ["type:deps"]
     open-pull-requests-limit: 10
     target-branch: "develop"
+    commit-message:
+      prefix: chore
 
   - package-ecosystem: "pip"
     directory: "/.github/scripts"
@@ -31,3 +70,5 @@ updates:
     labels: ["type:deps", "type:ci"]
     open-pull-requests-limit: 10
     target-branch: "develop"
+    commit-message:
+      prefix: chore

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/installer-contract.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-audit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,14 @@ jobs:
       workflow: podman-watch.yml
       max-age-days: 3
 
+  # A newly added scheduled workflow cannot be registered here in the same pull
+  # request that adds it. The guard passes only on a run with `event=schedule`
+  # and `status=success`; GitHub fires crons solely from the default branch, and
+  # `workflow_dispatch` does not count. So a fresh entry fails with "No
+  # successful scheduled run on record" until the workflow has reached `main`
+  # and its cron has fired once. `pin-watch.yml` (#1526) is waiting for exactly
+  # that and gets its entry afterwards.
+
   # Monthly (`0 4 1 * *`), so seventeen days without a run is normal and a
   # weekly threshold here would fail on ordinary work for most of the month.
   freshness-benchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%
@@ -64,7 +64,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: audit.yml
       max-age-days: 15
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: fuzz.yml
       max-age-days: 15
@@ -82,7 +82,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: podman-lane.yml
       max-age-days: 3
@@ -91,7 +91,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: podman-watch.yml
       max-age-days: 3
@@ -102,7 +102,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       workflow: benchmark.yml
       max-age-days: 65
@@ -121,7 +121,7 @@ jobs:
   # on a Dependabot-authored pull request - the condition that forced
   # `Analyze (actions)` out of apt.
   pin-policy:
-    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@8517d94fde00466f59b95c5d1bd838e2ad24a8bf # v1.15.2
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
 
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
@@ -132,6 +132,6 @@ jobs:
   # running: run 32435521566 reported "no Dependabot pull request on record"
   # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@e9cbd47344fcb03b1bb2400f8b15ab5289ff497f # v1.16.1
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       max-age-days: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       # Each entry here becomes its own check name: `rust / Test (macos-latest)`
       # and `rust / Test (windows-latest)`. Editing this list changes the names
@@ -74,7 +74,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: audit.yml
       max-age-days: 15
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: fuzz.yml
       max-age-days: 15
@@ -92,7 +92,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: podman-lane.yml
       max-age-days: 3
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: podman-watch.yml
       max-age-days: 3
@@ -120,7 +120,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       workflow: benchmark.yml
       max-age-days: 65
@@ -139,7 +139,7 @@ jobs:
   # on a Dependabot-authored pull request - the condition that forced
   # `Analyze (actions)` out of apt.
   pin-policy:
-    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
 
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
@@ -150,6 +150,6 @@ jobs:
   # running: run 32435521566 reported "no Dependabot pull request on record"
   # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       max-age-days: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,13 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
+      # Each entry here becomes its own check name: `rust / Test (macos-latest)`
+      # and `rust / Test (windows-latest)`. Editing this list changes the names
+      # emitted while the ruleset still requires the old ones, so the PR
+      # carrying the edit blocks itself. A ruleset should require the stable
+      # gate `rust / Extra platforms` instead, which names no platform. #1552.
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%
       # while a `coverage-ignore-regex` hid 36% of the code — 14,432 of 39,681
@@ -47,6 +52,11 @@ jobs:
       # The 90 gate belongs where the tests can actually run — the `podman-vm`
       # lane — and that is tracked separately rather than papered over here.
       coverage-threshold: 79
+      # This number is inside the check name `rust / MSRV (1.85)`. Bumping it
+      # emits `rust / MSRV (<new>)` while the ruleset still requires the old
+      # string, so the PR carrying the bump blocks itself. A ruleset should
+      # require the stable gate `rust / MSRV` instead, which carries no
+      # version. See #1552.
       msrv: "1.85"
       package-check: true
       semver-check: true
@@ -64,7 +74,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: audit.yml
       max-age-days: 15
@@ -73,7 +83,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: fuzz.yml
       max-age-days: 15
@@ -82,7 +92,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: podman-lane.yml
       max-age-days: 3
@@ -91,7 +101,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: podman-watch.yml
       max-age-days: 3
@@ -102,7 +112,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       workflow: benchmark.yml
       max-age-days: 65
@@ -121,7 +131,7 @@ jobs:
   # on a Dependabot-authored pull request - the condition that forced
   # `Analyze (actions)` out of apt.
   pin-policy:
-    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
 
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
@@ -132,6 +142,6 @@ jobs:
   # running: run 32435521566 reported "no Dependabot pull request on record"
   # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       max-age-days: 15

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Install Rust toolchain
         env:
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
         run: |
           set -euo pipefail
           rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e70ff47fd8aefa0f054846815f19b98768d61122 # v1.17.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       package-name: podup
       check-vendored: true
@@ -68,5 +68,5 @@ jobs:
       # Debian's toolchain ships no musl standard library. Keep this in step
       # with rust-ci.yml's default: the whole point is that the packaged binary
       # comes from the compiler CI validates with.
-      rust-toolchain: "1.97"
+      rust-toolchain: "1.98"
       rust-target: x86_64-unknown-linux-musl

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-debian.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@e61aaf0e920345b3dbb82cacd3bd36a499951a92 # v1.13.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/shell-ci.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -1,0 +1,139 @@
+name: pin-watch
+# Notifies (opens an issue) when a tool version pinned in this repository has
+# drifted from upstream. Four pins are owned here and watched nowhere else:
+#   - the `debian:trixie` container digest in release.yml
+#   - `python-version` in asset-contract.yml (it appears more than once; the
+#     entries must agree, and disagreement is itself a drift)
+#   - `Standards-Version` in debian/control
+#   - `debhelper-compat` in debian/control
+# Rust is watched by Glyndor/.github's rust-toolchain-watch.yml and Podman by
+# this repository's podman-watch.yml, so neither is repeated here.
+#
+# Weekly, not daily: these move on the scale of months, and a daily run would
+# be noise. 05:00 Monday keeps it off audit.yml's 06:00 and fuzz.yml's 07:00 —
+# stacking crons on the same minute only invites GitHub's scheduling delays.
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  watch:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Detect drift in pinned tool versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Every `python3 -c` below is ONE line, deliberately. Automatic dedent
+          # of `-c` source arrived in CPython 3.13 and this runner ships 3.12,
+          # where indented source is an IndentationError — measured against a
+          # real 3.12, not assumed. Un-indenting to column 0 is not the way out
+          # either: inside a YAML `run: |` block a line at column 0 ends the
+          # block. One line sidesteps both traps.
+          DRIFTS=$(mktemp); BODY=$(mktemp)
+          trap 'rm -f "$DRIFTS" "$BODY"' EXIT
+          add_drift() { printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$DRIFTS"; }
+
+          # ---- 1. debian:trixie container digest ------------------------------
+          # Read the pinned value FROM THE FILE, so the watcher cannot silently
+          # disagree with what the workflow actually uses.
+          PINNED_DIGEST=$(grep -oE 'container: debian:trixie@sha256:[a-f0-9]{64}' \
+            .github/workflows/release.yml | head -n1 | sed 's/.*@//')
+          [[ "$PINNED_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] \
+            || { echo "::error::could not parse the pinned debian:trixie digest from release.yml"; exit 1; }
+          TOKEN=$(curl -fsSL 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/debian:pull' \
+            | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+          [[ -n "$TOKEN" ]] || { echo "::error::empty token from auth.docker.io"; exit 1; }
+          # The Accept header must offer the manifest-list types or the registry
+          # answers 406 for a multi-arch tag.
+          LATEST_DIGEST=$(curl -fsSL -I -H "Authorization: Bearer $TOKEN" \
+            -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' \
+            'https://registry-1.docker.io/v2/library/debian/manifests/trixie' \
+            | tr -d '\r' | awk -F': ' 'tolower($1) == "docker-content-digest" { print $2; exit }')
+          [[ "$LATEST_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] \
+            || { echo "::error::registry returned an unexpected digest: '$LATEST_DIGEST'"; exit 1; }
+          [ "$PINNED_DIGEST" = "$LATEST_DIGEST" ] \
+            || add_drift "debian:trixie container digest" ".github/workflows/release.yml" "$PINNED_DIGEST" "$LATEST_DIGEST"
+
+          # ---- 2. python-version ----------------------------------------------
+          # Plain shell does this; no interpreter needed.
+          PY_DISTINCT=$(grep -oE '^[[:space:]]+python-version:[[:space:]]*"?[0-9]+\.[0-9]+' \
+            .github/workflows/asset-contract.yml | grep -oE '[0-9]+\.[0-9]+$' | sort -u)
+          PY_COUNT=$(printf '%s\n' "$PY_DISTINCT" | grep -c . || true)
+          [ "${PY_COUNT:-0}" -gt 0 ] \
+            || { echo "::error::no python-version line found in asset-contract.yml"; exit 1; }
+          if [ "$PY_COUNT" -gt 1 ]; then
+            add_drift "python-version (entries disagree)" ".github/workflows/asset-contract.yml" \
+              "$(printf '%s' "$PY_DISTINCT" | paste -sd ', ' -)" "(they must agree)"
+          else
+            LATEST_PY=$(curl -fsSL https://endoflife.date/api/python.json \
+              | python3 -c 'import sys,json; print(json.load(sys.stdin)[0]["cycle"])')
+            [[ "$LATEST_PY" =~ ^[0-9]+\.[0-9]+$ ]] \
+              || { echo "::error::endoflife.date returned an unexpected cycle: '$LATEST_PY'"; exit 1; }
+            [ "$PY_DISTINCT" = "$LATEST_PY" ] \
+              || add_drift "python-version" ".github/workflows/asset-contract.yml" "$PY_DISTINCT" "$LATEST_PY"
+          fi
+
+          # ---- 3. Standards-Version -------------------------------------------
+          # The regex MUST admit FOUR components. A three-component one silently
+          # truncates 4.7.4.1 to 4.7.4 and reports a false match — that exact
+          # mistake was already made once on #1526.
+          PINNED_STD=$(grep -oE '^Standards-Version:[[:space:]]+[0-9]+(\.[0-9]+){2,3}' debian/control \
+            | head -n1 | awk '{print $2}')
+          [[ -n "$PINNED_STD" ]] \
+            || { echo "::error::could not parse Standards-Version from debian/control"; exit 1; }
+          LATEST_STD=$(curl -fsSL https://www.debian.org/doc/debian-policy/ \
+            | grep -oE 'version [0-9]+(\.[0-9]+){2,3}' | head -n1 | awk '{print $2}')
+          [[ -n "$LATEST_STD" ]] \
+            || { echo "::error::could not read the current Debian Policy version"; exit 1; }
+          [ "$PINNED_STD" = "$LATEST_STD" ] \
+            || add_drift "Standards-Version" "debian/control" "$PINNED_STD" "$LATEST_STD"
+
+          # ---- 4. debhelper-compat ---------------------------------------------
+          # Compared against what **trixie** ships, NOT sid and NOT unstable. CI
+          # builds in trixie; compat 14 exists only in sid/forky today, so raising
+          # it would break the build. A watcher that reads sid and says "bump to
+          # 14" every Monday is worse than no watcher at all.
+          PINNED_COMPAT=$(grep -oE 'debhelper-compat[[:space:]]*\([[:space:]]*=[[:space:]]*[0-9]+' debian/control \
+            | head -n1 | grep -oE '[0-9]+$')
+          [[ "$PINNED_COMPAT" =~ ^[0-9]+$ ]] \
+            || { echo "::error::could not parse debhelper-compat from debian/control"; exit 1; }
+          DEBHELPER_VER=$(curl -fsSL https://sources.debian.org/api/src/debhelper/ \
+            | python3 -c 'import sys,json; m=[v["version"] for v in json.load(sys.stdin)["versions"] if "trixie" in v.get("suites",[])]; print(m[0].split("~")[0].split("+")[0] if m else "")')
+          [[ "$DEBHELPER_VER" =~ ^[0-9]+(\.[0-9]+)*$ ]] \
+            || { echo "::error::no debhelper version found for trixie (got '$DEBHELPER_VER')"; exit 1; }
+          [ "$PINNED_COMPAT" = "${DEBHELPER_VER%%.*}" ] \
+            || add_drift "debhelper-compat" "debian/control" "$PINNED_COMPAT" "${DEBHELPER_VER%%.*} (debhelper $DEBHELPER_VER in trixie)"
+
+          # ---- Report ----------------------------------------------------------
+          if [ ! -s "$DRIFTS" ]; then echo "No drift in any pinned tool version."; exit 0; fi
+          TITLE="Pinned tool versions have drifted"
+          # Idempotent: the title never changes, so a week that finds the same
+          # drift again does not open a second issue.
+          if gh issue list --state open --search "in:title $TITLE" --json title --jq '.[].title' | grep -qxF "$TITLE"; then
+            echo "Drift found, but the issue is already open — nothing to do."; exit 0
+          fi
+          {
+            echo "| Pin | Pinned at | Pinned | Upstream |"
+            echo "| --- | --- | --- | --- |"
+            while IFS=$'\t' read -r name path pinned upstream; do
+              # shellcheck disable=SC2016  # the backticks are literal markdown for
+              # the issue body, not command substitution waiting to expand.
+              printf '| %s | `%s` | `%s` | `%s` |\n' "$name" "$path" "$pinned" "$upstream"
+            done < "$DRIFTS"
+            echo
+            echo "The container digest has no bump path through Dependabot: the \`github-actions\` ecosystem does not update a workflow's \`container:\` image, so it has to be raised by hand."
+          } > "$BODY"
+          # Label on creation. An unlabelled issue is a process bug, and one filed
+          # by a bot is no exception — podman-watch carries the same note because
+          # #673 and #1016 both landed bare.
+          gh issue create --title "$TITLE" \
+            --label "type:ci" --label "prio:P2" --label "status:ready" \
+            --label "area:ci" --label "effort:S" \
+            --body-file "$BODY"
+          echo "Opened the drift report."

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -36,6 +36,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # This list appears in the required check names `podman-vm (5)` /
+        # `podman-vm (6)`. Editing it changes the emitted names while the
+        # ruleset still requires the old ones, so the PR carrying the edit
+        # blocks itself. The stable gate a ruleset should require is
+        # `Supported Podman majors`. See #1552.
         podman: ["5", "6"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -442,3 +447,30 @@ jobs:
             echo "::warning::Podman $VER: $FAIL failures, $FLAKY match a connection-drop signature — the rest are the known nested-virt-unstable subset (see the failures section). Not gated until that flakiness is reduced."
           fi
           echo "GREEN: podup core PASSED on Podman $VER ($PASS tests >= baseline $BASELINE; $FAIL in the nested-virt-noisy subset)."
+
+  podman-majors:
+    name: Supported Podman majors
+    # A required status check is matched by name, and `podman-vm (5)` / `podman-vm (6)`
+    # carry the matrix values. The support policy moves that matrix — when Podman 7
+    # ships, `["5", "6"]` becomes `["6", "7"]` — and on that pull request the required
+    # name `podman-vm (5)` stops being emitted while the ruleset still requires it, so
+    # the pull request that carries the change blocks itself. This name does not move.
+    # See #1552.
+    needs: podman-vm
+    # `needs` on its own SKIPS this job when the matrix fails, and a skipped required
+    # check does not block a merge — the exact failure this job exists to prevent.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reflect the matrix result
+        env:
+          RESULT: ${{ needs.podman-vm.result }}
+        run: |
+          set -euo pipefail
+          # Unlike the gates in the shared rust-ci reusable, `skipped` is NOT a pass
+          # here: podman-vm carries no `if:` and runs on every pull request, so a
+          # skipped matrix means something went wrong rather than a caller opting out.
+          case "$RESULT" in
+            success) echo "every supported Podman major passed" ;;
+            *) echo "::error::the Podman matrix did not pass (result: $RESULT)"; exit 1 ;;
+          esac

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -1,4 +1,9 @@
 name: podman-lane
+# Running `actionlint` on this file without arguments does not return: it hands
+# the ~250-line cloud-init `user-data` heredoc below to shellcheck, which does
+# not finish. Use `actionlint -shellcheck= -pyflakes= .github/workflows/podman-lane.yml`
+# when checking this workflow by hand. Measured 2026-08-24; the repository's own
+# workflow-lint job is unaffected because it runs actionlint with its own flags.
 # Live-Podman integration for podup, validated against the FULL supported window.
 # Support policy: the latest Podman major + the one below it — today Podman 5 and 6.
 # Every engine PR runs the integration suite on BOTH majors (matrix), each inside a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,13 +318,23 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  release:
-    name: Publish release
+  # SBOM generation runs here, in its own job, so a third-party build script
+  # executed by `cargo install` cannot reach the signing step. cargo install
+  # builds every crate in the dependency tree of cargo-cyclonedx and
+  # cargo-about (427 crates across the two, several under live RustSec
+  # advisories), and `build.rs` has full filesystem access on the runner that
+  # runs it. The release job holds GLYNDOR_RELEASE_ED25519_KEY on its signing
+  # step; if SBOM generation lived in the same job, a malicious build script
+  # could persist in the workspace and rewrite `.github/scripts/sign.py` or
+  # `.github/scripts/sign-requirements.txt` before the signing step ran them
+  # with the key in its environment. This job holds `contents: read` and no
+  # secrets, so persistence here has nothing to land on. See Glyndor/apt#121.
+  sbom:
+    name: Generate SBOM and license attribution
     needs: [build, build-deb]
-    runs-on: ubuntu-latest
     permissions:
-      contents: write
-
+      contents: read
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -342,15 +352,6 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
-
-      - name: Verify both Debian packages are present
-        run: |
-          for arch in amd64 arm64; do
-            if ! ls podup_*_${arch}.deb >/dev/null 2>&1; then
-              echo "::error::Debian package artifact for ${arch} is missing"
-              exit 1
-            fi
-          done
 
       - name: Generate per-target SBOMs and license attribution
         # Government/enterprise consumers require a machine-readable SBOM
@@ -403,6 +404,51 @@ jobs:
           done
 
           cargo about generate about.hbs > NOTICES.html
+
+      - name: Upload SBOM and NOTICE artifacts
+        # if-no-files-found: error matters: a silent empty upload would let the
+        # release job sign nothing and still succeed, defeating the SBOM gate.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: |
+            *.cdx.json
+            NOTICES.html
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: [build, build-deb, sbom]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Install Rust toolchain
+        # Pin rather than `stable`: a release runs once at tag time and is
+        # immutable, so it must not be built by whatever Rust the runner ships
+        # that day. Keep in step with rust-ci.yml's toolchain default (see the
+        # build job for why this is not a repo-root rust-toolchain.toml).
+        env:
+          RUST_TOOLCHAIN: "1.98"
+        run: rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+
+      - name: Verify both Debian packages are present
+        run: |
+          for arch in amd64 arm64; do
+            if ! ls podup_*_${arch}.deb >/dev/null 2>&1; then
+              echo "::error::Debian package artifact for ${arch} is missing"
+              exit 1
+            fi
+          done
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           # this version and defeat the MSRV gate. A release still must not float
           # on whatever Rust the runner ships, so pin it here, in the release path
           # only.
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt-get update -qq
@@ -265,7 +265,7 @@ jobs:
           # defaults to. Before this the package was compiled by Debian's rustc
           # while CI validated with 1.97, so the binary users installed came
           # from a compiler the suite had never run against.
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
           ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
@@ -336,7 +336,7 @@ jobs:
         # that day. Keep in step with rust-ci.yml's toolchain default (see the
         # build job for why this is not a repo-root rust-toolchain.toml).
         env:
-          RUST_TOOLCHAIN: "1.97"
+          RUST_TOOLCHAIN: "1.98"
         run: rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@fadfbebc989a58a2292438fecbd5a616ffa0bdf3 # v1.15.0
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@8ae47ccd49ffdbf59d1acf7e6f9c18165bfba959 # v1.19.0
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@76f8bc6dd79baa995d5bfa347c4b985433cb0ce1 # v1.20.0
+    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -13,72 +13,65 @@ Package: [crates.io/crates/podup](https://crates.io/crates/podup) · MSRV 1.85 �
 
 ## Install
 
-### Debian / Ubuntu (apt), recommended
-
-Register the signed Glyndor repository and install. Copy-paste:
-
-```bash
-curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
+```sh
+curl -fsSL https://apt.glyndor.net/install/podup | sudo sh
 ```
 
-The installer verifies the keyring package's Ed25519 signature against its
-pinned release key before anything is installed (fail-closed). The keyring
-package registers `https://apt.glyndor.net` and ships the signing key, so podup
-updates (and key renewals) arrive through `apt upgrade`. The apt build omits
-self-update, since apt owns upgrades. Requires **Podman ≥ 5.0** (rootless) with
-its **API socket listening** — `podman` itself is daemonless, but podup speaks
-the libpod API:
+That is the whole install on Debian and Ubuntu. It registers the signed Glyndor
+apt repository, verifies the archive key's fingerprint before trusting it, and
+installs podup with apt — so upgrades and signing-key renewals arrive through
+`apt upgrade` like any other package. Root is needed because it installs
+packages. It leaves nothing of its own behind: the download is removed, and so
+is anything it had to install just to check the key.
 
-```bash
+podup needs **Podman ≥ 5.0** (rootless) with its API socket listening. Podman is
+daemonless, but podup speaks the libpod API:
+
+```sh
 systemctl --user enable --now podman.socket
 ```
 
-To register the repository by hand instead, fetch the keyring and check the
-key's fingerprint against the one published in the
-[apt repository README](https://github.com/Glyndor/apt#verify-the-signing-key):
+### Optional — macOS
 
-```bash
-curl -fsSLO https://apt.glyndor.net/glyndor-archive-keyring.deb
-sudo dpkg -i glyndor-archive-keyring.deb
-gpg --show-keys /usr/share/keyrings/glyndor.gpg   # compare the fingerprint
-sudo apt update && sudo apt install podup
+```sh
+brew install glyndor/tap/podup
 ```
 
-<details>
-<summary><b>Other methods: Linux/macOS script · Windows · build from source · self-update · Podman version · platforms</b></summary>
+### Optional — Windows
 
-### apt, one-liner (script)
-
-Same as above via the install script (registers the repo, then installs):
-
-```bash
-curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
+```powershell
+scoop bucket add glyndor https://github.com/Glyndor/scoop-bucket
+scoop install podup
 ```
 
-### Linux / macOS (install script)
+Scoop clones the bucket with git, so git has to be installed first — Scoop's own
+installer does not bring it.
 
-```bash
+### Optional — Linux without apt
+
+```sh
 curl -fsSL https://glyndor.net/podup/install/unix | bash
 ```
 
-### Windows (PowerShell)
+Installs the release binary rather than a package. Use it on a distribution apt
+does not serve; on Debian and Ubuntu the line at the top is better, because apt
+keeps podup current and this does not.
 
-```powershell
-irm https://glyndor.net/podup/install/windows | iex
-```
-
-Both installers verify the Ed25519 signature over `SHA256SUMS` and fail closed
-otherwise.
+<details>
+<summary><b>Build from source · self-update · Podman versions · platforms</b></summary>
 
 ### Build from source
 
-```bash
+```sh
 cargo build --release
 ```
 
 ### Self-update
 
-```bash
+Only for installs that did not come from a package manager — the apt build omits
+it, since apt owns upgrades there.
+
+```sh
 podup update            # download and install the latest signed release
 podup update --check    # report whether a newer release exists, install nothing
 ```
@@ -92,12 +85,12 @@ release's Ed25519 signature and SHA-256 checksum, failing closed otherwise. See
 podup tracks the **latest stable Podman** and supports its **last two majors,
 Podman 5.x and 6.x**. It talks to Podman's native libpod API, requesting the
 `/v5.0.0/libpod` path that Podman 6 still serves; the gate is the major version
-the engine reports, so it needs **Podman ≥ 5.0**. Both supported majors
-run the integration suite in CI on every engine change (Fedora 44 for the
-latest 5.x, rawhide for 6.x). Many distributions still ship 4.x, so check
-`podman --version` and upgrade if needed. Fedora, Debian trixie/sid and recent
-Ubuntu releases carry 5.x; on an older release, install or upgrade Podman
-following the official guide: <https://podman.io/docs/installation>.
+the engine reports, so it needs **Podman ≥ 5.0**. Both supported majors run the
+integration suite in CI on every engine change (Fedora 44 for the latest 5.x,
+rawhide for 6.x). Many distributions still ship 4.x, so check `podman --version`
+and upgrade if needed. Fedora, Debian trixie/sid and recent Ubuntu releases carry
+5.x; on an older release, follow the official guide:
+<https://podman.io/docs/installation>.
 
 ### Platforms
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ release's Ed25519 signature and SHA-256 checksum, failing closed otherwise. See
 podup tracks the **latest stable Podman** and supports its **last two majors,
 Podman 5.x and 6.x**. It talks to Podman's native libpod API, requesting the
 `/v5.0.0/libpod` path that Podman 6 still serves; the gate is the major version
-the engine reports, so it needs **Podman ≥ 5.0**. Both supported majors run the
+the engine reports, so it needs **Podman ≥ 5.0**. When a new major ships, it is
+added and the oldest is dropped — but only once the **newest LTS of each
+distribution family carries the new one or better**, so nobody on a current
+release is stranded. Both supported majors run the
 integration suite in CI on every engine change (Fedora 44 for the latest 5.x,
 rawhide for 6.x). Many distributions still ship 4.x, so `podman --version` is
 worth checking before installing — and a distribution never changes its Podman

--- a/README.md
+++ b/README.md
@@ -87,9 +87,23 @@ Podman 5.x and 6.x**. It talks to Podman's native libpod API, requesting the
 `/v5.0.0/libpod` path that Podman 6 still serves; the gate is the major version
 the engine reports, so it needs **Podman ≥ 5.0**. Both supported majors run the
 integration suite in CI on every engine change (Fedora 44 for the latest 5.x,
-rawhide for 6.x). Many distributions still ship 4.x, so check `podman --version`
-and upgrade if needed. Fedora, Debian trixie/sid and recent Ubuntu releases carry
-5.x; on an older release, follow the official guide:
+rawhide for 6.x). Many distributions still ship 4.x, so `podman --version` is
+worth checking before installing — and a distribution never changes its Podman
+major version mid-release, so an LTS that shipped below the floor stays below
+it for its whole supported life.
+
+| distribution                  | Podman | podup runs |
+|-------------------------------|--------|------------|
+| Debian 12 bookworm            | 4.3.1  | no         |
+| Debian 13 trixie              | 5.4.2  | yes        |
+| Ubuntu 22.04 LTS              | 3.4.4  | no         |
+| Ubuntu 24.04 LTS              | 4.9.3  | no         |
+| Ubuntu 26.04 LTS              | 5.7.0  | yes        |
+| Fedora 42 and newer           | 5.x+   | yes        |
+
+Ubuntu 24.04 LTS is not supported: it ships Podman 4.9.3 and will keep shipping
+that for its whole supported life. On any row marked "no", the engine has to
+come from somewhere other than the distribution:
 <https://podman.io/docs/installation>.
 
 ### Platforms

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,36 @@
+podup (5.1.0) unstable; urgency=medium
+
+  New
+
+  * An unsupported Podman now says what to do about it. podup requires
+    Podman >= 5.0 and Ubuntu 24.04 LTS ships 4.9.3 for its whole supported
+    life, so `apt install podup` succeeded and the tool then could not reach
+    the engine. The error carries a remedy, `install.sh` refuses before
+    installing when a local podman is below the floor, and the README names
+    the releases instead of saying "recent Ubuntu releases" -- which was true
+    and still led readers to the wrong conclusion, since the recent ones are
+    the non-LTS ones.
+
+  * The Podman support policy states when a major is dropped in terms that
+    can be met: once the newest LTS of each distribution family carries the
+    new one. The previous wording waited for stable distributions to "move
+    off" the old major, which never becomes true, because an LTS does not
+    change Podman major mid-release.
+
+  Packaging and CI
+
+  * SBOMs are generated in a job that holds no secrets. `cargo install` runs
+    a build script for every crate it resolves, and that was happening in the
+    job that signs the release.
+
+  * Required status checks no longer carry a value in their name, so the pull
+    request that changes an MSRV or a Podman matrix no longer blocks itself.
+
+  * A weekly watcher reports pinned tool versions that have drifted from
+    upstream; four of this repository's pins had no watcher at all.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 24 Aug 2026 23:40:00 -0500
+
 podup (5.0.0) unstable; urgency=medium
 
   Breaking

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,10 @@
 #
 #   curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
 #
+# --skip-podman-check: bypass the local-Podman-version precheck. Use this when
+# the engine podup will use is on a different host than the local podman
+# binary (e.g. a `podman machine` VM, or a remote socket).
+#
 # Environment:
 #   PODUP_VERSION      Release tag to install (e.g. v0.3.0). Default: latest.
 #   PODUP_INSTALL_DIR  Installation directory (binary mode). Default: /usr/local/bin.
@@ -22,6 +26,8 @@ REPO="Glyndor/podup"
 INSTALL_DIR="${PODUP_INSTALL_DIR:-/usr/local/bin}"
 VERSION="${PODUP_VERSION:-latest}"
 MODE="binary"
+PODMAN_MIN_MAJOR=5
+SKIP_PODMAN_CHECK=""
 
 log_info()  { printf '\033[1;34m[info]\033[0m %s\n' "$1"; }
 log_ok()    { printf '\033[1;32m[ ok ]\033[0m %s\n' "$1"; }
@@ -33,7 +39,7 @@ fail() {
 }
 
 usage() {
-	sed -n '3,17p' "$0" | sed 's/^# \{0,1\}//'
+	sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
 	exit 0
 }
 
@@ -41,9 +47,10 @@ usage() {
 
 for arg in "$@"; do
 	case "$arg" in
-		--apt)      MODE="apt" ;;
-		-h|--help)  usage ;;
-		*)          fail "Unknown argument: ${arg} (try --help)" ;;
+		--apt)                MODE="apt" ;;
+		--skip-podman-check)  SKIP_PODMAN_CHECK=1 ;;
+		-h|--help)            usage ;;
+		*)                    fail "Unknown argument: ${arg} (try --help)" ;;
 	esac
 done
 
@@ -441,7 +448,60 @@ or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, the
 	log_ok "podup installed: $("${target}" --version)"
 }
 
+# --- Podman precheck ---------------------------------------------------------
+
+# Verify the local Podman engine meets podup's floor. Local podman is NOT
+# required: podup can drive a remote socket, and on macOS it talks to a
+# `podman machine` VM. So absence is a WARN, not a failure. A present local
+# podman whose major version is below PODMAN_MIN_MAJOR is the Ubuntu 24.04
+# case and is refused, since installing podup against it would leave the user
+# with a binary that cannot talk to their engine.
+check_podman() {
+	if ! command -v podman >/dev/null 2>&1; then
+		log_info "No local 'podman' binary found. podup needs Podman >= 5.0 to run; \
+this is fine if the engine podup will use is remote or a 'podman machine' VM."
+		return 0
+	fi
+
+	local version_output
+	# `set -e` would abort on a failing command substitution. podman can fail
+	# (e.g. a broken install, missing runtime files); treat that as an
+	# unparseable version, not a hard failure.
+	if ! version_output="$(podman --version 2>/dev/null)"; then
+		log_info "Local 'podman --version' could not be read; skipping the Podman \
+precheck. podup needs Podman >= 5.0 to run."
+		return 0
+	fi
+
+	# Output is `podman version 5.7.0`; field 3 is the version, then
+	# everything before the first '.' is the major.
+	local raw_version major
+	read -r _ _ raw_version _ <<< "$version_output" || raw_version=""
+	major="${raw_version%%.*}"
+
+	if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+		log_info "Could not parse the local Podman version ('${version_output}'); \
+skipping the Podman precheck. podup needs Podman >= 5.0 to run."
+		return 0
+	fi
+
+	if [[ "$major" -lt "$PODMAN_MIN_MAJOR" ]]; then
+		if [[ -n "$SKIP_PODMAN_CHECK" ]]; then
+			log_info "Podman precheck skipped by request (--skip-podman-check)"
+			return 0
+		fi
+		fail "Local Podman ${raw_version} is below the >= 5.0 floor podup requires. \
+podup will install, but will not be able to talk to this engine. Upgrade Podman \
+or point podup at a different, newer host (see https://podman.io/docs/installation). \
+If the engine podup will use is on a different host, re-run with --skip-podman-check."
+	fi
+
+	log_ok "Local Podman version meets the >= 5.0 requirement"
+}
+
 # --- Dispatch ----------------------------------------------------------------
+
+check_podman
 
 if [[ "$MODE" == "apt" ]]; then
 	install_apt

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -95,7 +95,9 @@ impl fmt::Display for PodmanError {
 				};
 				write!(
 					f,
-					"podup requires Podman >= 5.0; this server reports libpod API version {reported}"
+					"podup requires Podman >= 5.0; this server reports libpod API version {reported}. \
+					 Upgrade Podman, or point podup at a host running 5.0 or newer: \
+					 https://podman.io/docs/installation"
 				)
 			}
 		}

--- a/internal/libpod/error/tests.rs
+++ b/internal/libpod/error/tests.rs
@@ -277,6 +277,32 @@ fn display_incompatible_api_version_reports_version() {
 }
 
 #[test]
+fn display_incompatible_api_version_offers_a_remedy() {
+	let e = PodmanError::IncompatibleApiVersion {
+		reported: "4.9.3".into(),
+	};
+	let msg = e.to_string();
+	assert!(msg.contains("podman.io/docs/installation"), "got {msg:?}");
+	assert!(msg.contains("Upgrade Podman"), "got {msg:?}");
+}
+
+#[test]
+fn display_incompatible_api_version_keeps_diagnosis_before_remedy() {
+	let e = PodmanError::IncompatibleApiVersion {
+		reported: "4.9.3".into(),
+	};
+	let msg = e.to_string();
+	let diagnosis = msg.find("4.9.3").expect("diagnosis should be present");
+	let remedy = msg
+		.find("Upgrade Podman")
+		.expect("remedy should be present");
+	assert!(
+		diagnosis < remedy,
+		"remedy must follow the diagnosis it explains: {msg:?}"
+	);
+}
+
+#[test]
 fn display_incompatible_api_version_handles_missing_header() {
 	// An empty reported version (no `Libpod-API-Version` header) renders a
 	// readable placeholder rather than a blank.


### PR DESCRIPTION
Release pull request for **5.1.0**. Eleven commits since 5.0.0.

## Why this ships now

One change is user-facing and it is the reason. podup requires Podman >= 5.0, and **Ubuntu 24.04 LTS ships 4.9.3 for its whole supported life** — until 2029, with ESM to 2036, and no LTS changes Podman major mid-release. So `apt install podup` succeeded, and the tool then could not reach the engine. The failure was real, silent, and had no remedy attached.

That fix (#1555) has been sitting on `develop` all day. Everything else here is packaging and CI.

## What is in it

**User-facing**

- The `IncompatibleApiVersion` message keeps its diagnosis and appends what to do about it. It names no distribution on purpose: a string compiled into a binary cannot be updated for someone who already installed it, and every release in the README table has an expiry date.
- `install.sh` refuses before installing when a **local** podman is present and below the floor. Absence is a warning, not a refusal — podup can drive a remote socket or a `podman machine` VM, so a missing local binary proves nothing. `--skip-podman-check` bypasses it.
- The README names each release instead of saying "recent Ubuntu releases", which was true and still led readers to the wrong conclusion, since the recent ones are the non-LTS ones.
- The support policy now states when a Podman major is dropped in terms that can be met: once the newest LTS of each distribution family carries the new one. The old wording waited for stable distributions to "move off" the old major, which never becomes true.

**Supply chain and CI**

- SBOM generation moved out of the job that signs releases (#1559). `cargo install` runs a build script for every crate it resolves — 427 across cargo-cyclonedx and cargo-about, five under a live advisory and one yanked — and that was happening on the runner that signs.
- Required status check names no longer carry a value (#1556), so the pull request that changes an MSRV or the Podman matrix no longer blocks itself. Both rulesets were migrated to the stable names.
- A weekly watcher reports pinned tool versions that have drifted (#1558). Four of this repository's pins had none.
- Reusables adopt Glyndor/.github v1.21.0, which brings the `tooling-isolation` check and raises `rust-supply-chain`'s toolchain from 1.97 to 1.98 — matching `rust-ci`, so the SBOM is no longer produced by a compiler the suite never ran.

## Notes for the merge

**Merge commit, not squash** — this is the release path, per the workflow standard.

This is also the **first pull request to `main` since both rulesets were migrated** to check names that carry no value. `rust / MSRV`, `rust / Extra platforms` and `Supported Podman majors` are required here now, in place of the five that embedded a version or a matrix value. If the migration created a phantom, this is where it shows.

`Cargo.toml`, `Cargo.lock` and `debian/changelog` all read 5.1.0. The verify job fails when the first and the last disagree, because a release once carried a `.deb` built from a stale changelog. The lockfile is worth calling out separately: it still said 5.0.0 after the manifest moved, and only `cargo test --locked` caught it.

MINOR rather than PATCH: #1555 added behaviour, not only a message.
