### PR TITLE
ci: raise the two pins the watcher reported

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Signing requirements must parse as separate pinned entries
         # A trailing backslash is a line continuation: if the last hash of a
         # block keeps one, pip folds the next package name into the previous
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install pinned cryptography
         # See the shell fixture for the rationale on --require-hashes.
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
     # and matches the suite CI validates against, so the release that ships
     # to users was produced by the same image the suite exercises. Bump the
     # digest here when rust-debian.yml's default moves; the two should agree.
-    container: debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4
+    container: debian:trixie@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Closes #1563 — which `pin-watch` opened on its first real run. The first thing that workflow did after merging was find two drifts nobody was tracking.

## The container digest

`debian:trixie` moves from `fac46bff` to `f324c7ff`. It was pinned in #1530 and has drifted **twice in two days** — `34cd9e9f` yesterday, `f324c7ff` today. Debian rebuilds that tag for security updates, so staying pinned means building releases against an image missing them.

This is exactly what `release.yml`'s own comment predicts: Dependabot's `github-actions` ecosystem does not update a workflow's `container:` image, so a digest pin has no bump path. Only a watcher closes that, and now one does.

**No pull request verifies this**, because `release.yml` runs on a tag and never on a PR. So I verified it by hand rather than trusting it:

- the digest is what the registry serves for `trixie` right now, read from `Docker-Content-Digest`
- the container was pulled and checked for everything `build-deb` installs:

| package | in the new image |
|---|---|
| ca-certificates | 20250419 |
| build-essential | 12.12 |
| dpkg-dev | 1.22.22 |
| debhelper | 13.24.2 |
| curl | 8.14.1-2+deb13u4 |
| musl-tools | 1.2.5-3.1~deb13u1 |

`debhelper 13.24.2` matters beyond being present: it matches the `debhelper-compat 13` that `debian/control` declares, so the constraint keeping compat at 13 — compat 14 is sid-only — still holds in the new image.

## python-version

3.13 to 3.14, both occurrences in `asset-contract.yml`. That workflow runs on `pull_request`, so this PR's own CI is the verification rather than a hand check.

## The loop closes

Running `pin-watch`'s script against the tree afterwards:

    No drift in any pinned tool version.

The watcher opened the issue, the issue named the two pins, and the watcher now reports the tree clean.