### PR TITLE
test: pin the collation of every sort, and fix the one that was not

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -21,3 +21,7 @@ permissions:
 jobs:
   shellcheck:
     uses: ./.github/workflows/reusable-shell-ci.yml
+    with:
+      # A test no workflow runs is indistinguishable from one that passes --
+      # the lesson debian-build.yml carries from #1295, applied here.
+      test-command: ./tests/shell/locale-pinned.test.sh

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -155,8 +155,14 @@ timed() { # tool, compose-file, project, op-args...
 teardown() { run "$1" "$2" "$3" down -v >/dev/null 2>&1; }
 
 # Pre-pull the digest-pinned bases so image download is never on the timed path.
+#
+# LC_ALL=C on the sort: UTF-8 collations ignore punctuation at the primary
+# level, so `sort -u` treats two image references that differ only in a hyphen
+# as equal and drops one. That image is then pulled during the run instead of
+# before it, and the benchmark times a network download rather than a start --
+# silently, as a number that is simply larger.
 echo ">>> pre-pulling pinned images"
-grep -rhoE 'docker\.io/[^ "]+@sha256:[a-f0-9]+' "$SCEN_DIR" | sort -u | while read -r img; do
+grep -rhoE 'docker\.io/[^ "]+@sha256:[a-f0-9]+' "$SCEN_DIR" | LC_ALL=C sort -u | while read -r img; do
 	podman pull -q "$img" >/dev/null 2>&1 || echo "  warning: could not pre-pull $img" >&2
 done
 

--- a/tests/shell/locale-pinned.test.sh
+++ b/tests/shell/locale-pinned.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Every `sort` in a shell script must run under a fixed collation.
+#
+# UTF-8 collations ignore punctuation at the primary level, so `sort -u`
+# considers `pod-up` and `podup` EQUAL and drops one of them. Both are legal
+# names -- for a Debian package, for a container image, for anything a script
+# collects and deduplicates. The runner's locale is not the developer's, so a
+# script that passes on one machine can silently drop an entry on another, and
+# the output looks like a shorter list rather than an error.
+#
+# Measured in Glyndor/apt on 2026-08-24: under en_US.UTF-8 a two-entry list
+# came back with one entry and nothing said so.
+#
+# This is the one meta-test from the distribution trio that transfers here.
+# `ci-runs-every-test` does not: cargo discovers the Rust tests and CI runs them
+# with --all-features, so a test cannot sit unregistered the way a shell file
+# can. Its real analogue -- code compiled only under debian/rules' narrower
+# feature set -- is already covered by debian-build.yml's path filters, which
+# carry the #1295 lesson in their own comments.
+#
+# Requires: nothing beyond coreutils and grep.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+pass=0; fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Every tracked shell script, so a new one is covered the day it lands rather
+# than when someone remembers to add it here. Comments do not count: a `sort`
+# inside one is not executed, and matching them would make the check unfixable
+# by explaining the rule next to the code that follows it.
+scripts="$(git ls-files '*.sh' | grep -v '^tests/shell/')"
+check "there are shell scripts to check" "1" \
+	"$([ -n "$scripts" ] && echo 1 || echo 0)"
+
+unpinned=""
+for f in $scripts; do
+	hits="$(grep -nE '(^|[|;&(]|\$\()[[:space:]]*sort\b' "$f" 2>/dev/null \
+		| grep -v '^[0-9]*:[[:space:]]*#' \
+		| grep -v 'LC_ALL' || true)"
+	[ -n "$hits" ] && unpinned="$unpinned$f: $hits"$'\n'
+done
+
+check "every sort runs under a pinned collation" "" "${unpinned%$'\n'}"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Step 5 of plans/2026-08-27-podup-independence.md, and it is one meta-test rather
than the trio's three, because the other two do not transfer.

`ci-runs-every-test` guards a failure mode this repository does not have. In the
trio a workflow names each shell test, so a new one sits in tests/ passing
locally and never running. Here cargo discovers the Rust tests and CI runs them
with --all-features, so nothing can go unregistered that way. Its real analogue
is code compiled only under debian/rules' narrower feature set, and
debian-build.yml already covers that -- its path filters carry the #1295 lesson
in their own comments, where a develop broken under that feature set rode twenty
pull requests because the one lane that would have caught it never ran.

`check-test-coverage` finds nothing today: all three shell scripts are already
exercised by a workflow. Adding it would be a check that cannot fail.

`locale-pinned` does transfer, and it failed the moment it was written.
bench/run.sh:159 collected digest-pinned image references with a bare `sort -u`.
UTF-8 collations ignore punctuation at the primary level, so two references
differing only in a hyphen compare equal and one is dropped -- and that image is
then pulled during the run instead of before it. The script exists to keep image
downloads off the timed path; the failure would have shown up as a benchmark
number that was simply larger, with nothing to say why.

The check reads every tracked *.sh from git rather than a list, so a script added
tomorrow is covered the day it lands. It skips comments, because a `sort`
inside one does not execute and matching them would make the rule unfixable by
explaining it. Mutation-tested: removing the LC_ALL fails it.

Registered in lint-shell.yml through the reusable's test-command input, whose
path filter already matches **.sh. A test no workflow runs is indistinguishable
from one that passes.