### PR TITLE
ci: podup owns its reusables

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   check:
-    uses: Glyndor/.github/.github/workflows/installer-contract.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-installer-contract.yml
   # Per-asset .sig loop, three-slot regex, and ed25519 error classification
   # regression (issue #1359). The fixture carries a release with three
   # populated rotation slots; the test verifies every .sig against the

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/rust-audit.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-rust-audit.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   rust:
-    uses: Glyndor/.github/.github/workflows/rust-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-rust-ci.yml
     with:
       # Each entry here becomes its own check name: `rust / Test (macos-latest)`
       # and `rust / Test (windows-latest)`. Editing this list changes the names
@@ -74,7 +74,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-schedule-freshness.yml
     with:
       workflow: audit.yml
       max-age-days: 15
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-schedule-freshness.yml
     with:
       workflow: fuzz.yml
       max-age-days: 15
@@ -92,7 +92,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-schedule-freshness.yml
     with:
       workflow: podman-lane.yml
       max-age-days: 3
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-schedule-freshness.yml
     with:
       workflow: podman-watch.yml
       max-age-days: 3
@@ -120,26 +120,10 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-schedule-freshness.yml
     with:
       workflow: benchmark.yml
       max-age-days: 65
-
-  # This repository pins thirteen reusables, more than twice any other in the
-  # org, and was the only one of the five without this guard. On 2026-08-21 ten
-  # Dependabot pull requests proposed 1.15.0 to 1.16.0 across ten caller files;
-  # comparing the surfaces by hand showed all thirteen byte-identical to
-  # v1.16.1, so every one was a no-op and all ten were closed. Nothing here was
-  # going to say that, and the alternative to the hand comparison is merging
-  # no-ops until open-pull-requests-limit fills and Dependabot stops proposing
-  # anything at all, security bumps included.
-  #
-  # Advisory. Promotion to required needs the check seen failing for its own
-  # reason, its emitted name read off a real run, and confirmation that it runs
-  # on a Dependabot-authored pull request - the condition that forced
-  # `Analyze (actions)` out of apt.
-  pin-policy:
-    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
 
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
@@ -150,6 +134,6 @@ jobs:
   # running: run 32435521566 reported "no Dependabot pull request on record"
   # while ten sat open. v1.16.1 pages the window.
   dependabot-freshness:
-    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-dependabot-freshness.yml
     with:
       max-age-days: 15

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-dco.yml

--- a/.github/workflows/debian-build.yml
+++ b/.github/workflows/debian-build.yml
@@ -59,7 +59,7 @@ jobs:
     # proven on a real consumer before its tag is cut - .github's own CI never
     # exercises a caller. This repository's dpkg-buildpackage job was that
     # proof, going from red to green in 6m36s on #1525.
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-rust-debian.yml
     with:
       package-name: podup
       check-vendored: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fuzz:
     name: cargo fuzz (smoke)
-    uses: Glyndor/.github/.github/workflows/rust-fuzz.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-rust-fuzz.yml
     with:
       targets: '["parse_compose", "substitute", "size", "dotenv", "stream_frame", "stream_ndjson", "extract_tar"]'
       max-total-time: "60"

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-line-limit.yml

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   psscriptanalyzer:
     name: PSScriptAnalyzer
-    uses: Glyndor/.github/.github/workflows/powershell-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-powershell-ci.yml
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   shellcheck:
-    uses: Glyndor/.github/.github/workflows/shell-ci.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-shell-ci.yml

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -21,3 +21,7 @@ permissions:
 jobs:
   shellcheck:
     uses: ./.github/workflows/reusable-shell-ci.yml
+    with:
+      # A test no workflow runs is indistinguishable from one that passes --
+      # the lesson debian-build.yml carries from #1295, applied here.
+      test-command: ./tests/shell/locale-pinned.test.sh

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-main-guard.yml

--- a/.github/workflows/reusable-dco.yml
+++ b/.github/workflows/reusable-dco.yml
@@ -1,0 +1,119 @@
+name: DCO (reusable)
+
+# Enforce the Developer Certificate of Origin: every commit on a pull request
+# must carry a `Signed-off-by:` trailer. Machine-checked attestation gate rather
+# than a convention, which government and enterprise audits expect.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dco-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dco:
+    name: Signed-off-by present on every commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify Signed-off-by trailers
+        env:
+          # BASE_SHA/HEAD_SHA are the PR's real base and head commits from the
+          # event payload, not refs/pull/N/merge (the synthetic merge commit
+          # actions/checkout builds when it checks out a PR ref). That
+          # synthetic commit is never in this BASE_SHA..HEAD_SHA range to
+          # begin with — it isn't an ancestor of HEAD_SHA — so `--no-merges`
+          # below has nothing to do with excluding it; it skips real merge
+          # commits that may exist on the PR branch itself. Those are covered
+          # separately by "Detect evil merges" below, which checks
+          # merge-commit tree integrity rather than sign-off trailers.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for sha in $(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}"); do
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            if ! git show -s --format='%(trailers:key=Signed-off-by)' "$sha" \
+              | grep -qi 'Signed-off-by:'; then
+              echo "::error::commit $sha ($author) is missing a Signed-off-by trailer"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Add a sign-off with: git commit -s (or git rebase --signoff)."
+            exit 1
+          fi
+          echo "All commits carry a Signed-off-by trailer."
+
+      - name: Detect evil merges
+        # A merge commit's tree should always equal the clean, conflict-free
+        # merge of its two parents. If it doesn't, the merge was hand-edited
+        # to smuggle in a change that exists in neither parent and therefore
+        # never went through review or DCO sign-off on its own commit. This
+        # check is independent of the Signed-off-by scope above: merge
+        # commits are still exempt from carrying their own trailer, but their
+        # tree must not silently diverge from what a real merge would produce.
+        #
+        # Policy for edge cases:
+        #   - Octopus merges (more than two parents) are rejected outright:
+        #     `git merge-tree --write-tree` only compares two parents, so a
+        #     three-way-or-more merge can't be verified this way and is not
+        #     assumed safe.
+        #   - A merge whose parents conflict, or whose tree otherwise can't
+        #     be recomputed, fails closed rather than being waved through:
+        #     `git merge-tree --write-tree` exiting non-zero means we cannot
+        #     recompute what the merge should have produced, and a
+        #     hand-resolved conflict is unverifiable by construction — there
+        #     is no way to distinguish a faithful resolution from one that
+        #     also smuggled in an unrelated change. This org's flow is
+        #     squash-only, so merge commits inside a PR range are rare and
+        #     always avoidable (rebase onto the base branch instead of
+        #     merging, or re-merge without conflicts), which is what makes
+        #     failing closed here acceptable friction rather than a
+        #     false-positive machine.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          bad=0
+          stderr_file="$(mktemp)"
+          merges="$(git rev-list --merges "${BASE_SHA}..${HEAD_SHA}")" || {
+            echo "::error::could not enumerate merge commits between ${BASE_SHA} and ${HEAD_SHA} — history may be corrupted or incomplete; this check fails closed"
+            exit 1
+          }
+          for m in $merges; do
+            read -r -a parents <<< "$(git show -s --format='%P' "$m")"
+            if [ "${#parents[@]}" -ne 2 ]; then
+              echo "::error::merge commit $m has ${#parents[@]} parents — evil-merge detection only supports ordinary two-parent merges; an octopus merge is rejected rather than assumed safe"
+              bad=1
+              continue
+            fi
+            actual_tree="$(git rev-parse "${m}^{tree}")"
+            if ! clean_tree="$(git merge-tree --write-tree "${parents[0]}" "${parents[1]}" 2>"$stderr_file")"; then
+              echo "::error::merge commit $m cannot be automatically verified (conflicted or merge-tree error); this check fails closed because a hand-resolved merge can carry content that exists in no parent. Rebase the branch onto its base (producing no merge commit) or re-merge without conflicts, then push again."
+              echo "git merge-tree stderr for $m:"
+              cat "$stderr_file"
+              bad=1
+              continue
+            fi
+            if [ "$clean_tree" != "$actual_tree" ]; then
+              echo "::error::merge commit $m's tree does not match the clean merge of its parents ${parents[0]} and ${parents[1]} — it introduces changes present in neither parent"
+              bad=1
+            fi
+          done
+          rm -f "$stderr_file"
+          if [ "$bad" -ne 0 ]; then
+            echo "One or more merge commits smuggle unreviewed changes, use an unsupported merge shape, or could not be automatically verified. See the errors above."
+            exit 1
+          fi
+          echo "No evil merges found."

--- a/.github/workflows/reusable-dependabot-freshness.yml
+++ b/.github/workflows/reusable-dependabot-freshness.yml
@@ -1,0 +1,133 @@
+name: Dependabot freshness (reusable)
+
+# Fails when Dependabot has not opened a pull request recently enough in the
+# calling repository.
+#
+# The companion guard `schedule-freshness.yml` fails when a *workflow* stops
+# firing. Dependabot is not a workflow — it is an integration with its own
+# schedule, and a silent Dependabot emits nothing. "All up to date" and
+# "Dependabot is dead" produce the same signal: silence. This job converts
+# that silence into a red check on ordinary work, by treating the newest
+# dependabot-authored PR as the last time Dependabot spoke.
+#
+# Two differences from `schedule-freshness.yml`, both forced by Dependabot:
+#
+# 1. The signal is a pull request, not a workflow run. We cannot ask for the
+#    newest *scheduled* run of a Dependabot job because there is no such job;
+#    Dependabot runs as a GitHub integration. We list recent PRs across all
+#    states and pick the newest whose author is Dependabot.
+#
+# 2. The age threshold is higher than the schedule-freshness default. The
+#    "2× the period" rule is for workflows that fire on schedule; Dependabot
+#    only opens a PR when there is an upstream update, so a healthy but idle
+#    Dependabot is expected to be silent for stretches. 15 days is well above
+#    one missed run for a daily Dependabot, but still inside the window that
+#    catches a dead Dependabot (template-repository went the lifetime of the
+#    repo without one before this gate landed).
+#
+# The caller is responsible for granting `contents: read`; a called workflow
+# cannot elevate beyond the permissions of the workflow that calls it, and
+# reading public PR history through the API needs that scope.
+#
+# Add the check only once Dependabot has opened at least one PR in the repo
+# — with nothing on record the job reports that as a failure, which for a
+# live Dependabot is exactly right (it means we cannot even prove Dependabot
+# is alive here).
+#
+# Default shell is pinned to bash: `date -u -d "$latest" +%s` is GNU-date
+# syntax, and a future Windows caller would otherwise silently mis-parse the
+# date and fail the arithmetic on an empty string.
+#
+# `concurrency:` cancels an in-flight run when a newer one starts. The group
+# key uses `github.workflow` so an unrelated caller triggering the same
+# reusable does not collide, and `github.ref` to distinguish per-ref runs.
+
+on:
+  workflow_call:
+    inputs:
+      max-age-days:
+        description: >-
+          Fail when the newest Dependabot pull request is older than this.
+          Allow well above one missed run, since Dependabot only opens a PR
+          when there is an upstream update; 15 covers daily cadence.
+        type: number
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: dependabot-freshness-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  freshness:
+    name: dependabot freshness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check the newest Dependabot pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          MAX_AGE_DAYS: ${{ inputs.max-age-days }}
+        run: |
+          set -euo pipefail
+
+          # List recent PRs (any state), filter client-side for
+          # dependabot[bot], and pick the newest. Doing the filter and sort in
+          # jq avoids the GitHub API's known wrinkle where
+          # `state=all&sort=created&per_page=1` does not always include
+          # closed/merged PRs in the sort order one would expect, and depends
+          # on the bot author being a queryable user login (it is —
+          # dependabot[bot] — not the app slug `app/dependabot`).
+          #
+          # The window has to be paged, not fixed. A single page of 20 is a
+          # window on *total* PR activity, not on Dependabot's: in a busy
+          # repository the bot's newest pull request falls off the end and the
+          # check reports it as never having run. Measured on Glyndor/podup,
+          # where the twenty newest PRs contained none from Dependabot while
+          # ten sat within the newest forty — the gate failed on a repository
+          # where Dependabot had opened ten pull requests that same day.
+          #
+          # Three pages of 100 is a 300-PR window, and the loop stops at the
+          # first page that yields a hit, so the common case still costs one
+          # request.
+          latest=""
+          pages_read=0
+          for page in 1 2 3; do
+            pages_read="$page"
+            latest=$(gh api \
+              "repos/${REPO}/pulls?state=all&per_page=100&page=${page}" \
+              --jq '[.[] | select(.user.login == "dependabot[bot]")] | sort_by(.created_at) | reverse | .[0].created_at // empty')
+            [ -n "$latest" ] && break
+          done
+
+          if [ -z "$latest" ]; then
+            echo "::error::No Dependabot pull request in the newest $((pages_read * 100)) for ${REPO}."
+            echo "Either Dependabot has never run here, or its schedule was dropped." >&2
+            echo "Check that dependabot.yml is on the default branch and touches the package ecosystem you expect," >&2
+            echo "then disable and re-enable Dependabot to re-register it." >&2
+            exit 1
+          fi
+
+          age_seconds=$(( $(date -u +%s) - $(date -u -d "$latest" +%s) ))
+          age_days=$(( age_seconds / 86400 ))
+
+          echo "Newest Dependabot pull request in ${REPO}: ${latest} (${age_days}d ago)."
+
+          if [ "$age_days" -gt "$MAX_AGE_DAYS" ]; then
+            echo "::error::Dependabot last opened a pull request ${age_days} days ago in ${REPO}, over the ${MAX_AGE_DAYS}-day limit."
+            echo "A silent Dependabot reports nothing, so treat this as the alert it never sent." >&2
+            echo "GitHub runs Dependabot on its own schedule, hours late; a small overrun right at the boundary" >&2
+            echo "is not the problem — a multiple of the period is. Check dependabot.yml is still on the default" >&2
+            echo "branch and that the package ecosystem is configured, then disable/enable Dependabot to" >&2
+            echo "re-register it, and check the next scheduled scan rather than the next few minutes." >&2
+            exit 1
+          fi
+
+          echo "Within the ${MAX_AGE_DAYS}-day limit."

--- a/.github/workflows/reusable-installer-contract.yml
+++ b/.github/workflows/reusable-installer-contract.yml
@@ -1,0 +1,148 @@
+name: Installer contract (reusable)
+
+# Assert install.sh and the release workflow agree on release asset names.
+# Releases are immutable: once a tag ships, its asset names can never change.
+# install.sh downloads `<name>-${OS}-${ARCH}` for the platform it runs on, and
+# the release workflow publishes a fixed list of assets. If the two drift, the
+# installer breaks for users. This catches the drift on the PR, before any tag.
+#
+# Scope — this gate reads declarations, and only declarations. It compares two
+# files and answers "do install.sh and release.yml agree on the asset names?".
+# That is a cross-reference between two statements of intent, and parsing YAML
+# is the right way to answer it.
+#
+# It deliberately does NOT answer "does the release produce these files". Until
+# 2026-08-17 it tried to, with a third check that required `SHA256SUMS` to
+# appear among the parsed `asset:` keys. Those keys are the build matrix, and
+# the manifest is computed FROM the matrix outputs in a later step, so it can
+# never be one of them: the check was unpassable by construction, and the only
+# way to satisfy it was to declare a matrix entry that produced nothing — the
+# exact defect it existed to catch. It had never run green in any repository.
+# Existence is answered where it can be answered honestly, against the staged
+# files at release time, by `scripts/verify-release-assets.py`.
+
+on:
+  workflow_call:
+    inputs:
+      install-script:
+        description: Path to the install script
+        type: string
+        default: "install.sh"
+      release-workflow:
+        description: Path to the release workflow that publishes assets
+        type: string
+        default: ".github/workflows/release.yml"
+      install-ps1-path:
+        description: Path to the PowerShell install script (skipped if absent)
+        type: string
+        default: "install.ps1"
+
+permissions:
+  contents: read
+
+concurrency:
+  # install-script distinguishes two contract checks in the same repo/ref
+  # (e.g. a repo with more than one installer), which would otherwise cancel
+  # each other's in-flight run.
+  group: installer-contract-${{ github.workflow }}-${{ github.ref }}-${{ inputs.install-script }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: install.sh ↔ release asset names
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify asset names are in sync
+        env:
+          INSTALL_SH: ${{ inputs.install-script }}
+          RELEASE_YML: ${{ inputs.release-workflow }}
+          INSTALL_PS1: ${{ inputs.install-ps1-path }}
+        run: |
+          python3 - <<'PY'
+          import os, re, sys
+          from pathlib import Path
+
+          install_sh = Path(os.environ["INSTALL_SH"])
+          release_yml = Path(os.environ["RELEASE_YML"])
+
+          text = install_sh.read_text()
+          template = re.search(r'ARTIFACT="([^"]+)"', text)
+          if not template:
+              sys.exit(f"installer-contract: no ARTIFACT=\"...\" in {install_sh}.")
+          m = re.fullmatch(r'([A-Za-z0-9_.-]+)-\$\{OS\}-\$\{ARCH\}', template.group(1))
+          if not m:
+              sys.exit(
+                  "installer-contract: ARTIFACT template must be "
+                  '"<name>-${OS}-${ARCH}"; got ' + template.group(1)
+              )
+          prefix = m.group(1)
+          oses = set(re.findall(r'OS="([a-z0-9_]+)"', text))
+          arches = set(re.findall(r'ARCH="([a-z0-9_]+)"', text))
+          if not oses or not arches:
+              sys.exit(f"installer-contract: could not parse OS/ARCH arms from {install_sh}.")
+          requestable = {f"{prefix}-{o}-{a}" for o in oses for a in arches}
+
+          published = set(re.findall(r"^\s*-?\s*asset:\s*(\S+)\s*$",
+                                     release_yml.read_text(), re.MULTILINE))
+          if not published:
+              sys.exit(f"installer-contract: could not parse asset names from {release_yml}.")
+
+          missing = sorted(requestable - published)
+          if missing:
+              lines = "\n".join(f"  - {n}" for n in missing)
+              sys.exit(
+                  "installer-contract: install.sh can request assets the release "
+                  f"workflow does not declare:\n{lines}\n"
+                  f"declared: {sorted(published)}\n"
+                  "This gate reads the workflow's asset declarations only. It "
+                  "does not check that the release produces them — "
+                  "scripts/verify-release-assets.py does that against the "
+                  "staging directory at release time."
+              )
+          print(f"OK: all {len(requestable)} installer-requestable assets are published.")
+
+          install_ps1 = Path(os.environ["INSTALL_PS1"])
+          if not install_ps1.is_file():
+              print(f"::notice::installer-contract: {install_ps1} not found, skipping install.ps1 check.")
+          else:
+              ps_text = install_ps1.read_text()
+              ps_template = re.search(r'\$Artifact\s*=\s*"([^"]+)"', ps_text)
+              if not ps_template:
+                  sys.exit(f'installer-contract: no $Artifact = "..." in {install_ps1}.')
+              # The Windows installer builds one artifact per architecture; the OS
+              # is usually a fixed literal in the template (there being only one
+              # Windows), but a $OS/${OS} interpolation is also accepted for a
+              # ps1 that targets more than one OS.
+              ps_m = re.fullmatch(
+                  r'([A-Za-z0-9_.-]+)-(\$\{?OS\}?|[a-z0-9_]+)-\$\{?Arch\}?(\.[A-Za-z0-9]+)?',
+                  ps_template.group(1),
+              )
+              if not ps_m:
+                  sys.exit(
+                      "installer-contract: $Artifact template must be "
+                      '"<name>-<os>-$Arch[.ext]"; got ' + ps_template.group(1)
+                  )
+              ps_prefix, ps_os_token, ps_suffix = ps_m.group(1), ps_m.group(2), ps_m.group(3) or ""
+              if ps_os_token in ("$OS", "${OS}"):
+                  ps_oses = set(re.findall(r"\$OS\s*=\s*['\"]([a-z0-9_]+)['\"]", ps_text))
+              else:
+                  ps_oses = {ps_os_token}
+              ps_arches = set(re.findall(r"\$Arch\s*=\s*['\"]([a-z0-9_]+)['\"]", ps_text))
+              if not ps_oses or not ps_arches:
+                  sys.exit(f"installer-contract: could not parse OS/ARCH arms from {install_ps1}.")
+              ps_requestable = {f"{ps_prefix}-{o}-{a}{ps_suffix}" for o in ps_oses for a in ps_arches}
+
+              ps_missing = sorted(ps_requestable - published)
+              if ps_missing:
+                  lines = "\n".join(f"  - {n}" for n in ps_missing)
+                  sys.exit(
+                      "installer-contract: install.ps1 can request assets the release "
+                      f"workflow does not declare:\n{lines}\n"
+                      f"declared: {sorted(published)}"
+                  )
+              print(f"OK: all {len(ps_requestable)} install.ps1-requestable assets are published.")
+          PY

--- a/.github/workflows/reusable-line-limit.yml
+++ b/.github/workflows/reusable-line-limit.yml
@@ -1,0 +1,90 @@
+name: Line limit (reusable)
+
+# Enforce the file-size standard: warn past the soft limit, fail past the hard
+# limit. Language-agnostic — scans tracked source files by extension. Counts
+# CODE lines only: blank lines and comment-only lines (including the required
+# doc comments) do not count, so documenting a public API never pushes a file
+# over the limit. The comment detection is a pragmatic heuristic (lines whose
+# first non-space character starts a line/block/doc/template comment).
+
+on:
+  workflow_call:
+    inputs:
+      hard-limit:
+        description: Files with more lines than this fail the build
+        type: number
+        default: 500
+      soft-limit:
+        description: Files with more lines than this emit a warning
+        type: number
+        default: 300
+      extensions:
+        description: Space-separated source file extensions to check
+        type: string
+        default: "rs go ts tsx js jsx mjs cjs py sh astro vue svelte"
+      exclude-pattern:
+        description: Optional extended regex; matching paths are skipped
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: line-limit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  line-limit:
+    name: line limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check file lengths
+        env:
+          HARD: ${{ inputs.hard-limit }}
+          SOFT: ${{ inputs.soft-limit }}
+          EXTS: ${{ inputs.extensions }}
+          EXCLUDE: ${{ inputs.exclude-pattern }}
+        run: |
+          set -euo pipefail
+          ext_re="$(echo "$EXTS" | tr ' ' '|')"
+          ext_pattern="\.(${ext_re})\$"
+          fail=0
+          while IFS= read -r -d '' f; do
+            [[ "$f" =~ $ext_pattern ]] || continue
+            [ -f "$f" ] || continue
+            case "$f" in
+              vendor/*|*/vendor/*|*.min.*) continue ;;
+            esac
+            if [ -n "$EXCLUDE" ] && echo "$f" | grep -qE "$EXCLUDE"; then
+              continue
+            fi
+            # `#` starts a comment only in hash-comment languages; in Rust it
+            # begins an attribute (#[...]/#![...]), so don't drop those lines.
+            case "$f" in
+              *.sh|*.bash|*.py|*.rb|*.pl|*.yml|*.yaml|*.toml) hash_comment=1 ;;
+              *) hash_comment=0 ;;
+            esac
+            n="$(awk -v hc="$hash_comment" '
+              { line = $0; sub(/^[[:space:]]+/, "", line)
+                if (line == "") next
+                if (line ~ /^(\/\/|\*|\/\*|\*\/|<!--)/) next
+                if (hc == 1 && line ~ /^#/) next
+                code++ }
+              END { print code + 0 }' "$f")"
+            if [ "$n" -gt "$HARD" ]; then
+              echo "::error file=$f::$f has $n code lines (hard limit $HARD — split required)"
+              fail=1
+            elif [ "$n" -gt "$SOFT" ]; then
+              echo "::warning file=$f::$f has $n code lines (soft limit $SOFT — look for a split point)"
+            fi
+          done < <(git ls-files -z)
+          if [ "$fail" -ne 0 ]; then
+            echo "Some files exceed the ${HARD}-line hard limit."
+            exit 1
+          fi
+          echo "All checked files are within the ${HARD}-line hard limit."

--- a/.github/workflows/reusable-main-guard.yml
+++ b/.github/workflows/reusable-main-guard.yml
@@ -1,0 +1,37 @@
+name: Main guard (reusable)
+
+# Enforce that pull requests into `main` come from `develop`, keeping the
+# topic -> develop -> main flow that product repositories follow.
+
+on:
+  workflow_call:
+
+permissions: {}
+
+concurrency:
+  group: main-guard-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  develop-only:
+    name: develop-only
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    steps:
+      - name: Require develop as source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          # The branch name alone is forgeable: a fork can name any branch
+          # `develop`. Require the head to live in this repository too.
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::Pull requests into main must come from this repository's develop branch (got $HEAD_REPO)."
+            exit 1
+          fi
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::Pull requests into main must come from develop (got $HEAD_REF)."
+            exit 1
+          fi
+          echo "Source branch is develop."

--- a/.github/workflows/reusable-powershell-ci.yml
+++ b/.github/workflows/reusable-powershell-ci.yml
@@ -1,0 +1,115 @@
+name: PowerShell CI (reusable)
+
+# PSScriptAnalyzer lint for repositories shipping .ps1 scripts (podup's
+# install.ps1 today; unitpm and klyradb are expected to gain their own
+# PowerShell installers later). Replaces podup's inline
+# .github/workflows/lint-powershell.yml with one reviewed implementation —
+# the swap itself is Phase 4.2, not part of this change.
+#
+# Runner is windows-latest and `defaults: run: shell: pwsh` is deliberate, not
+# an oversight: the CI standard's rule that a reusable job must default to
+# bash on a non-Linux runner exists because `$VAR` under PowerShell reads a
+# PowerShell variable, not the environment, so env-passed values silently
+# become empty strings. That trap only bites a job whose *content* is meant to
+# be POSIX shell running on Windows. This job's content IS PowerShell, so pwsh
+# is the correct shell, not the thing being guarded against — and every input
+# below is still read via `$env:VAR` (pwsh's real environment-variable syntax)
+# rather than a bare `$VAR`, for the same reason the standard calls out.
+#
+# pssa-version's default was checked against the live PowerShell Gallery
+# (podup's own lint-powershell.yml has no pin at all — floats on whatever
+# `Install-Module PSScriptAnalyzer -Force` resolves to that day); 1.25.0 was
+# the current non-prerelease release at the time this default was set.
+#
+# `paths` is a "<dir>/**/<pattern>"-shaped glob (default "**/*.ps1"), but the
+# **-segment is stripped rather than handed to Get-ChildItem: its own docs
+# warn against combining -Path with -Recurse for wildcard matching and confirm
+# there is no "**" arbitrary-depth token at all — the documented way to match
+# a pattern at every depth is -LiteralPath (a plain directory) + -Recurse +
+# -Include, which is what the step below builds from this input.
+
+on:
+  workflow_call:
+    inputs:
+      pssa-version:
+        description: Exact PSScriptAnalyzer version to install from the PowerShell Gallery; bumped via .github releases
+        type: string
+        default: "1.25.0"
+      paths:
+        description: >-
+          "<dir>/**/<pattern>"-shaped glob (relative to the repository root)
+          matching the PowerShell scripts to analyze at any depth under <dir>;
+          default scans the whole repository for *.ps1 files
+        type: string
+        default: "**/*.ps1"
+      exclude-rules:
+        description: >-
+          Comma-separated PSScriptAnalyzer rule names to exclude from the
+          gate (passed to -ExcludeRule), for rules a script violates on
+          purpose — e.g. PSAvoidUsingWriteHost in an installer that talks to
+          a human over stdout. Empty excludes nothing.
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: powershell-ci-${{ github.workflow }}-${{ github.ref }}-${{ inputs.paths }}
+  cancel-in-progress: true
+
+jobs:
+  pssa:
+    name: pssa
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install PSScriptAnalyzer
+        env:
+          PSSA_VERSION: ${{ inputs.pssa-version }}
+        run: Install-Module PSScriptAnalyzer -RequiredVersion $env:PSSA_VERSION -Force -Scope CurrentUser
+
+      - name: Run PSScriptAnalyzer
+        env:
+          SCRIPT_PATHS: ${{ inputs.paths }}
+          EXCLUDE_RULES: ${{ inputs.exclude-rules }}
+        run: |
+          # Get-ChildItem has no "**" recursion token and its own docs warn
+          # against -Path + -Recurse for wildcard matching; split the glob
+          # into a literal base directory and an -Include pattern instead,
+          # dropping any "**" segment since -Recurse already covers any depth.
+          $leaf = Split-Path -Path $env:SCRIPT_PATHS -Leaf
+          $dirPart = Split-Path -Path $env:SCRIPT_PATHS -Parent
+          $dirSegments = $dirPart -split '[\\/]' | Where-Object { $_ -and $_ -ne '**' }
+          $baseDir = if ($dirSegments) { $dirSegments -join [IO.Path]::DirectorySeparatorChar } else { '.' }
+
+          if (-not (Test-Path -LiteralPath $baseDir)) {
+            Write-Host "Base directory '$baseDir' (from paths '$env:SCRIPT_PATHS') does not exist; nothing to check."
+            exit 0
+          }
+
+          $files = Get-ChildItem -LiteralPath $baseDir -Recurse -Include $leaf -File
+          if (-not $files) {
+            Write-Host "No PowerShell scripts matched '$env:SCRIPT_PATHS'; nothing to check."
+            exit 0
+          }
+
+          $analyzerArgs = @{ Path = $files.FullName; Severity = "Error", "Warning" }
+          if ($env:EXCLUDE_RULES) {
+            $analyzerArgs.ExcludeRule = $env:EXCLUDE_RULES -split "," | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+          }
+          $findings = Invoke-ScriptAnalyzer @analyzerArgs
+
+          if ($findings) {
+            $findings | Format-Table -AutoSize | Out-String -Width 4096 | Write-Host
+            Write-Error "PSScriptAnalyzer reported $($findings.Count) Error/Warning finding(s)."
+            exit 1
+          }
+
+          Write-Host "PSScriptAnalyzer: no Error or Warning findings."

--- a/.github/workflows/reusable-rust-audit.yml
+++ b/.github/workflows/reusable-rust-audit.yml
@@ -1,0 +1,115 @@
+name: Rust audit (reusable)
+
+# Scheduled supply-chain audit for Rust crates: cargo-audit flags RUSTSEC
+# advisories, cargo-deny enforces the license/ban/source policy in deny.toml.
+# Callers wire the schedule (e.g. weekly cron) in their own workflow.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Directory containing the Cargo workspace
+        type: string
+        default: "."
+      # Pinned, not the runner's floating preinstalled Rust — see rust-ci.yml's
+      # toolchain input for why an unpinned toolchain is a problem.
+      toolchain:
+        description: Rust toolchain to pin the audit and deny jobs to
+        type: string
+        default: "1.98"
+      cargo-audit-version:
+        description: Exact version of cargo-audit to install; bumped via .github releases
+        type: string
+        default: "0.22.2"
+      cargo-deny-version:
+        description: Exact version of cargo-deny to install; bumped via .github releases
+        type: string
+        default: "0.20.2"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-audit-${{ github.workflow }}-${{ github.ref }}-${{ inputs.working-directory }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    env:
+      TOOL_VERSION: ${{ inputs.cargo-audit-version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+          # The toolchain is part of the key: a cache built under an older
+          # pin must not survive a bump via the `command -v ... ||`
+          # short-circuit below, or the pin would be silently ignored.
+          key: cargo-audit-${{ runner.os }}-${{ inputs.toolchain }}-${{ inputs.cargo-audit-version }}
+
+      - name: Install cargo-audit
+        # A bare "X.Y.Z" passed to `cargo install --version` already installs
+        # that exact release — caret ("^") matching is a Cargo.toml dependency
+        # rule, not a `cargo install` one. The leading "=" here is redundant,
+        # kept only to make the exact pin explicit at a glance.
+        run: command -v cargo-audit >/dev/null || cargo install cargo-audit --version "=$TOOL_VERSION" --locked
+
+      - name: Run cargo audit
+        # --deny warnings so unmaintained/unsound/yanked advisories also fail,
+        # not just vulnerabilities.
+        run: cargo audit --deny warnings
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    env:
+      TOOL_VERSION: ${{ inputs.cargo-deny-version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+          # Same reasoning as cargo-audit's cache key above.
+          key: cargo-deny-${{ runner.os }}-${{ inputs.toolchain }}-${{ inputs.cargo-deny-version }}
+
+      - name: Install cargo-deny
+        # Same exact-pin reasoning as cargo-audit above: the bare version is
+        # already exact, not caret-matched.
+        run: command -v cargo-deny >/dev/null || cargo install cargo-deny --version "=$TOOL_VERSION" --locked
+
+      - name: Run cargo deny
+        run: cargo deny check

--- a/.github/workflows/reusable-rust-ci.yml
+++ b/.github/workflows/reusable-rust-ci.yml
@@ -1,0 +1,390 @@
+name: Rust CI (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Directory containing the Cargo workspace
+        type: string
+        default: "."
+      # Pinned, not `stable`: an unpinned toolchain moves on its own the day
+      # upstream ships a release, and every consumer's pull requests go red at
+      # once for a change nobody made. That is not hypothetical — Rust 1.97.0
+      # landed on 2026-07-07, widened a clippy lint, and reddened every open PR
+      # in podup until the lint was fixed. Bump this pin via a new `.github`
+      # release so each repo adopts the new toolchain deliberately, sees which
+      # lints it gained, and fixes them on its own schedule.
+      toolchain:
+        description: Rust toolchain to pin the build, lint and test jobs to
+        type: string
+        default: "1.98"
+      coverage-threshold:
+        description: Minimum line coverage percentage (0 disables the gate)
+        type: number
+        default: 0
+      coverage-ignore-regex:
+        description: Regex of file paths to exclude from coverage (e.g. code covered only by a separate DB integration job)
+        type: string
+        default: ""
+      llvm-cov-version:
+        description: Exact version of the tool; bumped via .github releases
+        type: string
+        default: "0.8.7"
+      extra-test-os:
+        description: JSON array of extra runner images to also run tests on (e.g. '["macos-latest"]')
+        type: string
+        default: "[]"
+      podman:
+        description: Start rootless Podman socket before running the coverage job (ubuntu-latest only)
+        type: boolean
+        default: false
+      msrv:
+        description: Minimum supported Rust version to verify a --locked build against (empty disables the check)
+        type: string
+        default: ""
+      package-check:
+        description: Run cargo publish --dry-run on PRs to catch packaging breakage before tagging
+        type: boolean
+        default: false
+      semver-check:
+        description: Run cargo-semver-checks to flag public API breaks against the last published release
+        type: boolean
+        default: false
+      semver-checks-version:
+        description: Exact version of the tool; bumped via .github releases
+        type: string
+        default: "0.50.0"
+      doc-warnings:
+        description: Build the docs with -D warnings so broken doc links fail the build
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-ci-${{ github.workflow }}-${{ github.ref }}-${{ inputs.working-directory }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Format & lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal --component rustfmt,clippy
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ inputs.working-directory }}/target
+          key: rust-lint-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-lint-${{ runner.os }}-
+
+      - name: rustfmt
+        run: cargo fmt --all --check
+
+      - name: clippy
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ inputs.working-directory }}/target
+          key: rust-test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-test-${{ runner.os }}-
+
+      - name: Tests
+        run: cargo test --locked --all-features --workspace
+
+  test-extra:
+    name: Test (${{ matrix.os }})
+    if: inputs.extra-test-os != '[]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.extra-test-os) }}
+    defaults:
+      run:
+        # This is the only job that can land on a Windows runner, where the
+        # default shell is PowerShell — and there `$VAR` reads a PowerShell
+        # variable, not the environment, so every `env:` value silently becomes
+        # an empty string. Pin the shell so steps behave the same on all three
+        # OSes, as release.yml's cross-OS matrix already does.
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ inputs.working-directory }}/target
+          key: rust-test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-test-${{ runner.os }}-
+
+      - name: Tests
+        run: cargo test --locked --all-features --workspace
+
+  extra-platforms-gate:
+    name: Extra platforms
+    # A required status check is matched by name, so a name carrying a value makes
+    # the pull request that changes the value block itself: the job emits a new
+    # name, the ruleset still requires the old one, and nothing emits it. This job
+    # carries a name that cannot move, so a ruleset gates on "the extra-platform
+    # tests passed" without naming which platforms those are. Glyndor/podup#1552.
+    needs: test-extra
+    # `needs` on its own SKIPS this job when the dependency fails, and a skipped
+    # required check does not block a merge - which is the exact failure this job
+    # exists to prevent. `if: always()` plus an explicit result check is what makes
+    # it a gate rather than a decoration.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reflect the extra-platform test result
+        env:
+          RESULT: ${{ needs.test-extra.result }}
+        run: |
+          set -euo pipefail
+          # `skipped` is a pass: test-extra is gated on `extra-test-os != '[]'`, so a
+          # caller that asks for no extra platforms has nothing to fail.
+          case "$RESULT" in
+            success | skipped) echo "extra-platform tests: $RESULT" ;;
+            *) echo "::error::extra-platform tests did not pass (result: $RESULT)"; exit 1 ;;
+          esac
+
+  coverage:
+    name: Coverage
+    if: inputs.coverage-threshold > 0
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal --component llvm-tools
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ~/.cargo/bin
+            ${{ inputs.working-directory }}/target
+          # The tool version is part of the key: a cache built under an older
+          # pin must not survive a version bump via the `command -v ... ||`
+          # short-circuit below, or the pin would be silently ignored.
+          key: rust-cov-${{ runner.os }}-${{ inputs.llvm-cov-version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-cov-${{ runner.os }}-${{ inputs.llvm-cov-version }}-
+
+      - name: Install cargo-llvm-cov
+        env:
+          LLVM_COV_VERSION: ${{ inputs.llvm-cov-version }}
+        run: command -v cargo-llvm-cov >/dev/null || cargo install cargo-llvm-cov --locked --version "$LLVM_COV_VERSION"
+
+      - name: Start Podman socket
+        if: inputs.podman
+        id: podman-socket
+        run: |
+          systemctl --user start podman.socket
+          until [ -S "/run/user/$(id -u)/podman/podman.sock" ]; do sleep 0.1; done
+          echo "path=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_OUTPUT"
+
+      - name: Coverage gate
+        env:
+          PODMAN_SOCKET: ${{ steps.podman-socket.outputs.path }}
+          COVERAGE_IGNORE_REGEX: ${{ inputs.coverage-ignore-regex }}
+          COVERAGE_THRESHOLD: ${{ inputs.coverage-threshold }}
+        run: |
+          cargo llvm-cov --locked --workspace --all-features --summary-only --json --output-path coverage.json \
+            ${COVERAGE_IGNORE_REGEX:+--ignore-filename-regex "$COVERAGE_IGNORE_REGEX"}
+          PCT=$(python3 -c "import json; print(json.load(open('coverage.json'))['data'][0]['totals']['lines']['percent'])")
+          echo "### Coverage: ${PCT}% (threshold: ${COVERAGE_THRESHOLD}%)" >> "$GITHUB_STEP_SUMMARY"
+          python3 - "$PCT" "$COVERAGE_THRESHOLD" <<'EOF'
+          import sys
+          pct, threshold = float(sys.argv[1]), float(sys.argv[2])
+          sys.exit(0 if pct >= threshold else 1)
+          EOF
+
+  msrv:
+    name: MSRV (${{ inputs.msrv }})
+    if: inputs.msrv != ''
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install MSRV toolchain
+        env:
+          MSRV: ${{ inputs.msrv }}
+        run: |
+          rustup toolchain install "$MSRV" --profile minimal
+          rustup default "$MSRV"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ inputs.working-directory }}/target
+          key: rust-msrv-${{ inputs.msrv }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-msrv-${{ inputs.msrv }}-
+
+      - name: Build on the declared MSRV
+        run: cargo build --locked --all-features
+
+  msrv-gate:
+    name: MSRV
+    # Same reason as extra-platforms-gate: `MSRV (1.85)` moves the day the MSRV
+    # moves, and takes the gate with it. MSRV is the worse of the two because it is
+    # not a matrix - a single job interpolating an input into its own name. The
+    # number stays visible in the job log and in the `MSRV (x.y)` job itself.
+    needs: msrv
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reflect the MSRV result
+        env:
+          RESULT: ${{ needs.msrv.result }}
+        run: |
+          set -euo pipefail
+          # `skipped` is a pass: msrv is gated on `inputs.msrv != ''`.
+          case "$RESULT" in
+            success | skipped) echo "MSRV: $RESULT" ;;
+            *) echo "::error::MSRV job did not pass (result: $RESULT)"; exit 1 ;;
+          esac
+
+  package:
+    name: Package check
+    if: inputs.package-check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - name: cargo publish --dry-run
+        run: cargo publish --dry-run --locked
+
+  semver:
+    name: Semver checks
+    if: inputs.semver-check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - name: Install cargo-semver-checks
+        env:
+          SEMVER_CHECKS_VERSION: ${{ inputs.semver-checks-version }}
+        run: command -v cargo-semver-checks >/dev/null || cargo install cargo-semver-checks --locked --version "$SEMVER_CHECKS_VERSION"
+
+      - name: Check for public API breaks
+        run: cargo semver-checks check-release
+
+  doc:
+    name: Doc warnings
+    if: inputs.doc-warnings
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - name: Build docs with warnings denied
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --all-features

--- a/.github/workflows/reusable-rust-debian.yml
+++ b/.github/workflows/reusable-rust-debian.yml
@@ -1,0 +1,272 @@
+name: Rust Debian package (reusable)
+
+# Build a .deb with dpkg-buildpackage, and (optionally) prove an air-gapped
+# build works from vendored crates with no crates.io access. Optionally upload
+# the produced package as an artifact for a release pipeline to consume.
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: Debian package name (the .deb is <package-name>_*.deb)
+        type: string
+        required: true
+      runner:
+        description: Runner to build on
+        type: string
+        default: "ubuntu-latest"
+      debian-image:
+        description: Container image to build in (a stable suite is reproducible)
+        type: string
+        # debian:trixie as of 2026-07-17. Digest-pinned so a retag of the
+        # trixie tag can't silently change the build environment; bump this
+        # via a new .github release when a newer trixie snapshot is needed.
+        default: "debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4"
+      arch:
+        description: Architecture to verify/stage (empty matches any)
+        type: string
+        default: ""
+      upload-artifact:
+        description: Upload the produced .deb as an artifact
+        type: boolean
+        default: false
+      artifact-name:
+        description: Artifact name when upload-artifact is true
+        type: string
+        default: ""
+      check-vendored:
+        description: Also run an offline build from vendored crates
+        type: boolean
+        default: false
+      offline-cargo-args:
+        description: Extra cargo args for the offline build (e.g. feature flags)
+        type: string
+        default: ""
+      rust-toolchain:
+        # Empty keeps the distribution's cargo/rustc, which is what every
+        # caller had before this input existed. Set it when the package must
+        # be built by a specific compiler - typically the one the repository's
+        # CI validates with, so the shipped binary is not produced by a
+        # toolchain the test suite never ran against.
+        description: rustup toolchain to install instead of the distro cargo/rustc (empty keeps the distro toolchain)
+        type: string
+        default: ""
+      apt-packages:
+        # The job installs a fixed list of Debian build tooling and does not
+        # read Build-Depends, so a package needing another build-time tool has
+        # no way to ask for it. unitpm is the case: `ring` compiles C, and
+        # cross-compiling it to musl needs musl-tools, which is not a Rust
+        # dependency and so has no business in Cargo.toml.
+        description: Space-separated apt packages the build needs on top of the fixed tooling
+        type: string
+        default: ""
+
+      rust-target:
+        # Requires rust-toolchain: a distribution toolchain carries only its
+        # own target's standard library, so `--target` cannot resolve against
+        # it. rustup targets are per-toolchain, so this installs against the
+        # pinned one rather than whatever is default.
+        description: Extra rustup target to install (needs rust-toolchain; e.g. x86_64-unknown-linux-musl)
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  # package-name distinguishes two packages built from the same repo/ref, which
+  # would otherwise cancel each other's in-flight run.
+  group: rust-debian-${{ github.workflow }}-${{ github.ref }}-${{ inputs.arch }}-${{ inputs.package-name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: dpkg-buildpackage
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.debian-image }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PKG: ${{ inputs.package-name }}
+      ARCH: ${{ inputs.arch }}
+      # Job-wide because the confirm step reads it too, to decide whether the
+      # package is allowed to declare a shared-library dependency.
+      RUST_TARGET: ${{ inputs.rust-target }}
+    steps:
+      - name: Install build tooling
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          RUST_TOOLCHAIN: ${{ inputs.rust-toolchain }}
+          APT_PACKAGES: ${{ inputs.apt-packages }}
+        run: |
+          apt-get update -qq
+          if [ -n "$RUST_TOOLCHAIN" ]; then
+            apt-get install -y --no-install-recommends \
+              ca-certificates build-essential dpkg-dev debhelper curl
+          else
+            apt-get install -y --no-install-recommends \
+              ca-certificates build-essential dpkg-dev debhelper cargo rustc
+          fi
+          if [ -n "$APT_PACKAGES" ]; then
+            # shellcheck disable=SC2086 # intentional word-splitting of the list
+            apt-get install -y --no-install-recommends $APT_PACKAGES
+          fi
+
+      - name: Install the pinned Rust toolchain
+        # Only when the caller asked for one. rustup goes on PATH for every
+        # later step, and the target is added against the pinned toolchain
+        # rather than the default, because rustup targets are per-toolchain.
+        if: inputs.rust-toolchain != ''
+        env:
+          RUST_TOOLCHAIN: ${{ inputs.rust-toolchain }}
+          RUST_TARGET: ${{ inputs.rust-target }}
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain "$RUST_TOOLCHAIN"
+          . "$HOME/.cargo/env"
+          if [ -n "$RUST_TARGET" ]; then
+            rustup target add "$RUST_TARGET" --toolchain "$RUST_TOOLCHAIN"
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Confirm build dependencies are satisfiable
+        run: dpkg-checkbuilddeps
+
+      - name: Build the package
+        run: dpkg-buildpackage -us -uc -b
+
+      - name: Confirm the .deb was produced
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          if [ -n "$ARCH" ]; then
+            debs=( ../"${PKG}"_*_"${ARCH}".deb )
+          else
+            debs=( ../"${PKG}"_*.deb )
+          fi
+          if [ ${#debs[@]} -eq 0 ]; then
+            echo "::error::no .deb artifact was produced"
+            exit 1
+          fi
+          deb="${debs[0]}"
+          echo "Built $deb"
+          dpkg-deb --contents "$deb"
+
+          # What the package DECLARES, not just what it contains. Depends is
+          # generated from ${shlibs:Depends}, so it is derived at build time
+          # from the binary's shared-library needs and cannot be read off any
+          # file in the repository - the built package is the only place it
+          # exists.
+          #
+          # Glyndor/podup#1512 is why this is here. Every published .deb
+          # declared `libc6 (>= 2.39)`, so apt install failed on Debian 12
+          # (2.36) and Ubuntu 22.04 (2.35). The fix builds against musl so the
+          # substitution comes out empty - and the lane could confirm the
+          # package builds while saying nothing about the line that was the
+          # whole point. Printing it turns that claim into something a run
+          # settles instead of something a person re-measures by hand.
+          echo "--- control fields ---"
+          dpkg-deb -f "$deb"
+
+          # And fail when the declaration is wrong, not just print it. A musl
+          # target is a static binary, so ${shlibs:Depends} must substitute to
+          # nothing and Depends must name no shared library. That property is
+          # the whole fix for Glyndor/podup#1512, and until now nothing
+          # defended it: if the build ever links dynamically again, the
+          # dpkg-shlibdeps warnings simply stop appearing and a libc6 floor
+          # comes back with every check still green. A regression here is
+          # invisible at build time and only shows up as apt refusing to
+          # install on an older release, which is the expensive place to find
+          # it.
+          case "$RUST_TARGET" in
+            *musl*)
+              depends="$(dpkg-deb -f "$deb" Depends || true)"
+              if printf '%s' "$depends" | grep -qE '(^|[[:space:],])lib[a-z0-9]'; then
+                echo "::error::built for $RUST_TARGET but the package declares a shared-library dependency: $depends"
+                exit 1
+              fi
+              echo "Depends declares no shared library, as a $RUST_TARGET build must."
+              ;;
+          esac
+
+          cp "$deb" "$(basename "$deb")"
+
+      - name: Upload artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.package-name }}_*.deb
+          retention-days: 1
+          if-no-files-found: error
+
+  vendored:
+    name: build (vendored / offline)
+    if: ${{ inputs.check-vendored }}
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.debian-image }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PKG: ${{ inputs.package-name }}
+      OFFLINE_ARGS: ${{ inputs.offline-cargo-args }}
+    steps:
+      - name: Install build tooling
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          RUST_TOOLCHAIN: ${{ inputs.rust-toolchain }}
+        run: |
+          apt-get update -qq
+          if [ -n "$RUST_TOOLCHAIN" ]; then
+            apt-get install -y --no-install-recommends \
+              ca-certificates build-essential curl
+          else
+            apt-get install -y --no-install-recommends \
+              ca-certificates build-essential cargo rustc
+          fi
+
+      - name: Install the pinned Rust toolchain
+        # Only when the caller asked for one. rustup goes on PATH for every
+        # later step, and the target is added against the pinned toolchain
+        # rather than the default, because rustup targets are per-toolchain.
+        if: inputs.rust-toolchain != ''
+        env:
+          RUST_TOOLCHAIN: ${{ inputs.rust-toolchain }}
+          RUST_TARGET: ${{ inputs.rust-target }}
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain "$RUST_TOOLCHAIN"
+          . "$HOME/.cargo/env"
+          if [ -n "$RUST_TARGET" ]; then
+            rustup target add "$RUST_TARGET" --toolchain "$RUST_TOOLCHAIN"
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Vendor dependencies (the only step allowed network access)
+        run: |
+          cargo vendor vendor
+          mkdir -p .cargo
+          printf '[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "vendor"\n' > .cargo/config.toml
+
+      - name: Build offline from the vendored tree
+        env:
+          CARGO_NET_OFFLINE: "true"
+        run: |
+          read -ra offline_args <<< "$OFFLINE_ARGS"
+          cargo build --release --locked --offline "${offline_args[@]}"
+          test -x "target/release/${PKG}"
+          echo "Built target/release/${PKG} offline from vendored sources"

--- a/.github/workflows/reusable-rust-fuzz.yml
+++ b/.github/workflows/reusable-rust-fuzz.yml
@@ -1,0 +1,103 @@
+name: Rust fuzz (reusable)
+
+# Scheduled fuzzing for Rust crates: runs `cargo fuzz run` (cargo-fuzz +
+# libfuzzer, nightly) against each declared target for a short, bounded time to
+# surface parser panics and edge cases on a fixed tree. Callers wire the schedule
+# (e.g. nightly cron) and pass the target list in their own workflow. This is a
+# smoke run, not a corpus-building soak.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Directory containing the crate (the one holding the fuzz/ dir)
+        type: string
+        default: "."
+      targets:
+        description: >-
+          JSON array of cargo-fuzz target names, e.g.
+          ["smtp_command","smtp_line","smtp_address"]
+        type: string
+        required: true
+      max-total-time:
+        description: Seconds to fuzz each target (libfuzzer -max_total_time)
+        type: string
+        default: "60"
+      timeout:
+        description: Per-input timeout in seconds (libfuzzer -timeout)
+        type: string
+        default: "10"
+      toolchain:
+        description: Rust toolchain to use (cargo-fuzz requires nightly)
+        type: string
+        default: "nightly-2026-07-16"
+      cargo-fuzz-version:
+        description: Exact version of the tool; bumped via .github releases
+        type: string
+        default: "0.13.2"
+      rss-limit-mb:
+        description: >-
+          libfuzzer -rss_limit_mb value in MiB; empty (the default) omits the
+          flag entirely, leaving libfuzzer's own default in effect
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-fuzz-${{ github.workflow }}-${{ github.ref }}-${{ inputs.working-directory }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: cargo fuzz
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(inputs.targets) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    env:
+      TOOLCHAIN: ${{ inputs.toolchain }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ${{ inputs.working-directory }}/fuzz/target
+          # The tool version is part of the key: fuzz/Cargo.toml's hash alone
+          # doesn't change when the pin is bumped, so a stale cargo-fuzz
+          # binary could otherwise survive the command -v short-circuit below.
+          key: cargo-fuzz-${{ runner.os }}-${{ inputs.cargo-fuzz-version }}-${{ hashFiles(format('{0}/fuzz/Cargo.toml', inputs.working-directory)) }}
+
+      - name: Install cargo-fuzz
+        env:
+          CARGO_FUZZ_VERSION: ${{ inputs.cargo-fuzz-version }}
+        run: command -v cargo-fuzz >/dev/null || cargo install cargo-fuzz --locked --version "$CARGO_FUZZ_VERSION"
+
+      - name: Fuzz ${{ matrix.target }}
+        env:
+          TARGET: ${{ matrix.target }}
+          MAX_TOTAL_TIME: ${{ inputs.max-total-time }}
+          FUZZ_TIMEOUT: ${{ inputs.timeout }}
+          RSS_LIMIT_MB: ${{ inputs.rss-limit-mb }}
+        run: |
+          libfuzzer_args=(-max_total_time="$MAX_TOTAL_TIME" -timeout="$FUZZ_TIMEOUT")
+          if [ -n "$RSS_LIMIT_MB" ]; then
+            libfuzzer_args+=(-rss_limit_mb="$RSS_LIMIT_MB")
+          fi
+          cargo fuzz run "$TARGET" -- "${libfuzzer_args[@]}"

--- a/.github/workflows/reusable-rust-supply-chain.yml
+++ b/.github/workflows/reusable-rust-supply-chain.yml
@@ -1,0 +1,125 @@
+name: Rust supply chain (reusable)
+
+# Generate the supply-chain artifacts government and enterprise consumers expect:
+# a machine-readable SBOM (CycloneDX, per US EO 14028) and a third-party license
+# attribution (NOTICES). Run on every PR to keep the generators honest; the
+# release workflow attaches the same artifacts to each published release.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Directory containing the Cargo workspace
+        type: string
+        default: "."
+      # Pinned, not the runner's floating preinstalled Rust — see rust-ci.yml's
+      # toolchain input for why an unpinned toolchain is a problem.
+      #
+      # Keep this equal to rust-ci.yml's `toolchain`. It was 1.97 while rust-ci
+      # was already on 1.98, because the bump raised one and not the other and
+      # nothing compared them. A repository whose SBOM is produced by a compiler
+      # its test suite never ran is the defect podup#1487 recorded, and podup
+      # now has a test asserting its own two pins agree — nothing asserts it
+      # across these two reusables, so it is written here instead.
+      toolchain:
+        description: Rust toolchain to pin the SBOM and license job to
+        type: string
+        default: "1.98"
+      about-template:
+        description: cargo-about handlebars template
+        type: string
+        default: "about.hbs"
+      cyclonedx-version:
+        description: Exact version of cargo-cyclonedx to install; bumped via .github releases
+        type: string
+        default: "0.5.9"
+      cargo-about-version:
+        description: Exact version of cargo-about to install; bumped via .github releases
+        type: string
+        default: "0.9.2"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-supply-chain-${{ github.workflow }}-${{ github.ref }}-${{ inputs.working-directory }}
+  cancel-in-progress: true
+
+jobs:
+  sbom-and-licenses:
+    name: SBOM and license attribution
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    env:
+      ABOUT_TEMPLATE: ${{ inputs.about-template }}
+      CYCLONEDX_VERSION: ${{ inputs.cyclonedx-version }}
+      ABOUT_VERSION: ${{ inputs.cargo-about-version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        env:
+          TOOLCHAIN: ${{ inputs.toolchain }}
+        run: |
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+          # The toolchain is part of the key: a cache built under an older
+          # pin must not survive a bump via the `command -v ... ||`
+          # short-circuits below, or the pin would be silently ignored.
+          key: rust-supply-chain-${{ runner.os }}-${{ inputs.toolchain }}-${{ inputs.cyclonedx-version }}-${{ inputs.cargo-about-version }}
+
+      - name: Install generators
+        # `cargo install --version X.Y.Z` already installs that exact release;
+        # the leading "=" below is redundant, kept only for readability —
+        # caret ("^") matching is a Cargo.toml dependency rule, not this one.
+        run: |
+          command -v cargo-cyclonedx >/dev/null || cargo install --locked cargo-cyclonedx --version "=$CYCLONEDX_VERSION"
+          command -v cargo-about >/dev/null || cargo install --locked --features cli cargo-about --version "=$ABOUT_VERSION"
+
+      - name: Generate CycloneDX SBOM
+        run: cargo cyclonedx --format json --all-features
+
+      - name: Generate third-party license attribution (NOTICES)
+        run: cargo about generate "$ABOUT_TEMPLATE" > NOTICES.html
+
+      - name: Compute artifact name suffix
+        # Two same-run calls of this reusable with different working-directory
+        # inputs (e.g. two crates in one repo) must not collide on the fixed
+        # artifact name upload-artifact used to have; qualify it by
+        # working-directory instead. Artifact names reject "/" and other
+        # separator characters, so the raw input can't be interpolated as-is.
+        id: artifact-suffix
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: |
+          suffix="$WORKING_DIRECTORY"
+          suffix="${suffix#./}"
+          # "." and "./" both strip down to the same "root" case; so does an
+          # empty input ("") — none of them denote a real subdirectory name,
+          # and left alone they'd produce a trailing-hyphen artifact name
+          # ("sbom-and-notices-") instead of one qualified by directory.
+          if [ "$suffix" = "." ] || [ -z "$suffix" ]; then
+            suffix="root"
+          fi
+          suffix="$(printf '%s' "$suffix" | tr '/:<>|*?\\"' '-' | tr -s '-')"
+          suffix="$(printf '%s' "$suffix" | sed 's/^-*//; s/-*$//')"
+          echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-and-notices-${{ steps.artifact-suffix.outputs.suffix }}
+          path: |
+            ${{ inputs.working-directory }}/**/*.cdx.json
+            ${{ inputs.working-directory }}/NOTICES.html
+          if-no-files-found: error

--- a/.github/workflows/reusable-schedule-freshness.yml
+++ b/.github/workflows/reusable-schedule-freshness.yml
@@ -1,0 +1,97 @@
+name: Schedule freshness (reusable)
+
+# Fails when a scheduled workflow has not succeeded recently enough.
+#
+# Every other guard in this organisation is an assertion that fails loudly. A
+# cron that stops firing is the exception: it emits nothing at all, and "no
+# alert" is indistinguishable from "all clear". On 2026-06-29 every scheduled
+# workflow in the org stopped. podup and apt recovered on 07-15 because they
+# happened to get activity and a disable/enable cycle; authcore, epistle, unitpm
+# and glyndor.net stayed dark for four more weeks, all of them reporting
+# `active` the whole time. It cost a real finding — authcore's GO-2026-5856 was
+# caught by a hand-run of govulncheck, not by the weekly audit that exists for
+# exactly that.
+#
+# Call this from a workflow that already runs often (normal CI) so the absence
+# of a scheduled run becomes a red check on ordinary work. It is the same idea
+# as apt's `ValidFor: 14d`, which expires the archive rather than letting it
+# serve a frozen snapshot when the pipeline stalls.
+#
+# The caller must grant `actions: read` alongside `contents: read`: a called
+# workflow cannot elevate beyond the permissions of the workflow that calls it,
+# and reading run history needs that scope. Without it the run does not start.
+#
+# Add the check only once the schedule has fired successfully at least once —
+# with no successful run on record there is nothing to measure and the job
+# reports that as a failure, which for an established workflow is exactly right.
+
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        description: >-
+          File name of the scheduled workflow to check, e.g. "audit.yml".
+        type: string
+        required: true
+      max-age-days:
+        description: >-
+          Fail when the newest successful scheduled run is older than this.
+          Allow about two periods, so a weekly job tolerates one miss: 15 for a
+          weekly schedule, 3 for a daily one.
+        type: number
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: schedule-freshness-${{ github.workflow }}-${{ github.ref }}-${{ inputs.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  freshness:
+    name: schedule freshness
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # reading this repository's workflow-run history
+    steps:
+      # `gh api` is banned for the maintainer's own credentials — the org
+      # account has been suspended over raw API traffic before. A workflow is a
+      # different actor: GITHUB_TOKEN is a scoped job token on its own rate
+      # limit, which is the documented exception.
+      - name: Check the newest successful scheduled run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ inputs.workflow }}
+          MAX_AGE_DAYS: ${{ inputs.max-age-days }}
+        run: |
+          set -euo pipefail
+
+          latest=$(gh api \
+            "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?event=schedule&status=success&per_page=1" \
+            --jq '.workflow_runs[0].created_at // empty')
+
+          if [ -z "$latest" ]; then
+            echo "::error::No successful scheduled run on record for ${WORKFLOW}."
+            echo "Either its cron has never fired, or the schedule was dropped." >&2
+            echo "Check that the workflow still exists on the default branch, then" >&2
+            echo "toggle it: gh workflow disable ${WORKFLOW} && gh workflow enable ${WORKFLOW}" >&2
+            exit 1
+          fi
+
+          age_seconds=$(( $(date -u +%s) - $(date -u -d "$latest" +%s) ))
+          age_days=$(( age_seconds / 86400 ))
+
+          echo "Newest successful scheduled run of ${WORKFLOW}: ${latest} (${age_days}d ago)."
+
+          if [ "$age_days" -gt "$MAX_AGE_DAYS" ]; then
+            echo "::error::${WORKFLOW} last succeeded on a schedule ${age_days} days ago, over the ${MAX_AGE_DAYS}-day limit."
+            echo "A schedule that stops firing reports nothing, so treat this as the alert it never sent." >&2
+            echo "GitHub runs crons hours late, so a small overrun right at the boundary is not the problem;" >&2
+            echo "a multiple of the period is. Toggle the workflow off and on to re-register it, then check" >&2
+            echo "the next scheduled fire rather than the next few minutes." >&2
+            exit 1
+          fi
+
+          echo "Within the ${MAX_AGE_DAYS}-day limit."

--- a/.github/workflows/reusable-shell-ci.yml
+++ b/.github/workflows/reusable-shell-ci.yml
@@ -1,0 +1,192 @@
+name: Shell CI (reusable)
+
+# Lint every shell script in the repository: bash -n catches syntax errors,
+# shellcheck catches quoting, unset-variable and other correctness bugs.
+# Optionally runs the repository's shell test suite (`test-command`).
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Directory to scan for shell scripts
+        type: string
+        default: "."
+      severity:
+        description: Minimum shellcheck severity to report (style|info|warning|error)
+        type: string
+        default: "style"
+      shellcheck-version:
+        description: Exact shellcheck release tag to install from koalaman/shellcheck; bumped via .github releases
+        type: string
+        default: "v0.11.0"
+      shellcheck-sha256:
+        description: sha256 of that release's linux.x86_64 tarball; travels with shellcheck-version, so overriding one without the other fails the install
+        type: string
+        default: "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+      test-command:
+        description: Command running the repository's shell test suite (skipped when empty)
+        type: string
+        default: ""
+      apt-packages:
+        description: Space-separated apt packages the test suite needs
+        type: string
+        default: ""
+      check-exec-bit:
+        description: Fail when a script the workflows invoke as ./path is not executable in git
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shell-ci-${{ github.workflow }}-${{ github.ref }}-${{ inputs.working-directory }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    env:
+      SEVERITY: ${{ inputs.severity }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Collect shell scripts
+        run: |
+          set -euo pipefail
+          list="$RUNNER_TEMP/shell-files"
+          : > "$list"
+          # By extension.
+          find . -type f \( -name '*.sh' -o -name '*.bash' \) \
+            -not -path './.git/*' -print0 >> "$list"
+          # Extensionless scripts whose shebang names a shell (hooks, bin/ tools).
+          # Restricted to sh/bash/dash: shellcheck cannot lint ksh or zsh, and
+          # running it against them anyway produces false reds rather than
+          # real findings.
+          while IFS= read -r -d '' f; do
+            if head -n1 "$f" | grep -qE '^#!.*(/| )(sh|bash|dash)([[:space:]]|$)'; then
+              printf '%s\0' "$f" >> "$list"
+            fi
+          done < <(find . -type f ! -name '*.*' -not -path './.git/*' -print0)
+
+      - name: Install shellcheck
+        env:
+          SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
+          SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
+        run: |
+          set -euo pipefail
+          # Pinned by version and by content. Every other tool here arrives
+          # through a registry that verifies what it hands over (Go's sumdb,
+          # crates.io, PyPI); this is a plain download, so the checksum is the
+          # only thing standing between us and whatever the transport returns.
+          # It has to land in a file first: piping curl into tar extracts the
+          # bytes before anything can check them.
+          dir="$RUNNER_TEMP/shellcheck-bin"
+          tarball="$RUNNER_TEMP/shellcheck.tar.xz"
+          mkdir -p "$dir"
+          curl -sSfL -o "$tarball" \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          printf '%s  %s\n' "$SHELLCHECK_SHA256" "$tarball" | sha256sum -c -
+          tar -xJ -f "$tarball" -C "$dir" --strip-components=1 "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+          chmod +x "$dir/shellcheck"
+          echo "$dir" >> "$GITHUB_PATH"
+
+      - name: Syntax check
+        run: |
+          set -euo pipefail
+          list="$RUNNER_TEMP/shell-files"
+          [ -s "$list" ] || { echo "No shell scripts found; nothing to check."; exit 0; }
+          while IFS= read -r -d '' f; do
+            bash -n "$f"
+          done < "$list"
+
+      - name: Run shellcheck
+        run: |
+          set -euo pipefail
+          xargs -0 -r shellcheck --severity="$SEVERITY" < "$RUNNER_TEMP/shell-files"
+
+      # A script invoked as `./path` needs the executable bit recorded IN GIT.
+      # `chmod +x` in a working tree is local state; the mode git stores is what
+      # reaches the runner, and when it disagrees the job dies with exit 126 and
+      # "Permission denied" — a message about the file, not about the mode, which
+      # is why it costs a round trip to diagnose every time.
+      #
+      # This happened twice in one day in Glyndor/apt (2026-08-23): once on
+      # scripts/build-installers.sh, once on tests/build-installers.test.sh.
+      #
+      # Deliberately narrow. It does NOT assert that every `.sh` is 0755 — that
+      # would be wrong. `apt/scripts/install-template.sh` is a template that is
+      # read and substituted, never executed, and is correctly 0644; and repos
+      # that invoke their scripts as `bash path` (podup, helmly, unitpm — 21
+      # non-executable scripts between them) have nothing to fix. The check is
+      # derived from how the workflows actually call each script, so a repo that
+      # never uses `./path` finds nothing and passes.
+      #
+      # Default is on rather than opt-in: the SHA pin is the buffer, so no
+      # consumer sees this until it deliberately bumps its pin, which is the
+      # moment to look at a new red.
+      - name: Scripts invoked by path must be executable in git
+        if: ${{ inputs.check-exec-bit }}
+        run: |
+          set -euo pipefail
+          # Every `./something.sh` mentioned anywhere in the calling repo's
+          # workflows. Paths are relative to the repo root, which is where the
+          # runner starts, so that is what the mode is checked against.
+          refs="$(grep -rhoE '\./[A-Za-z0-9_./-]+\.(sh|bash)' .github/workflows/ 2>/dev/null \
+                  | sed 's|^\./||' | sort -u || true)"
+          if [ -z "$refs" ]; then
+            echo "No script is invoked as ./path by any workflow; nothing to check."
+            exit 0
+          fi
+          rc=0
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            mode="$(git ls-files --stage -- "$f" | awk '{print $1}')"
+            if [ -z "$mode" ]; then
+              echo "note: $f is invoked as ./$f but is not tracked; skipping."
+              continue
+            fi
+            if [ "$mode" != "100755" ]; then
+              echo "::error file=$f::$f is invoked as ./$f but git records mode $mode; the job will fail with exit 126 (Permission denied). Fix with: git update-index --chmod=+x $f"
+              rc=1
+            fi
+          done <<EOF
+          $refs
+          EOF
+          [ "$rc" -eq 0 ] && echo "Every script invoked by path is executable in git."
+          exit "$rc"
+
+  test:
+    name: test
+    if: inputs.test-command != ''
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    env:
+      TEST_COMMAND: ${{ inputs.test-command }}
+      APT_PACKAGES: ${{ inputs.apt-packages }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install test dependencies
+        run: |
+          set -euo pipefail
+          if [ -n "$APT_PACKAGES" ]; then
+            sudo apt-get update -qq
+            # shellcheck disable=SC2086 # intentional word-splitting of the package list
+            sudo apt-get install -y -qq $APT_PACKAGES
+          fi
+
+      - name: Run tests
+        run: |
+          set -euo pipefail
+          bash -c "$TEST_COMMAND"

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -1,0 +1,213 @@
+name: Workflow lint (reusable)
+
+# Lint the CALLING repository's own workflow YAML with actionlint — the release
+# workflows and other per-repo callers that live outside this repository and
+# are today validated by nobody. This is where the phantom-required-check
+# naming mismatches and the PowerShell $VAR-under-pwsh trap have actually
+# shipped, because nothing caught them before a consumer's CI ran for real.
+# Contrast with actionlint.yml in this repository: that one is this repo's own
+# self-CI over ITS reusables; this one runs actionlint over the CALLER's
+# checkout, wherever the calling job invokes it from.
+#
+# actionlint's embedded shellcheck pass otherwise falls back to whatever
+# shellcheck the runner image ships, which floats independently of the org's
+# pinned version (shell-ci.yml). Installing the same pinned shellcheck here
+# and pointing actionlint at it with -shellcheck keeps that pass reproducible
+# too.
+
+on:
+  workflow_call:
+    inputs:
+      shellcheck-version:
+        description: Exact shellcheck release tag to install from koalaman/shellcheck for actionlint's embedded shellcheck pass; bumped via .github releases
+        type: string
+        default: "v0.11.0"
+      shellcheck-sha256:
+        description: sha256 of that release's linux.x86_64 tarball; travels with shellcheck-version, so overriding one without the other fails the install
+        type: string
+        default: "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+      tooling-isolation:
+        description: Fail when a job that holds a secret also installs third-party tooling
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workflow-lint:
+    name: workflow-lint
+    runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_VERSION: v1.7.12
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: actionlint-cache
+        with:
+          path: ~/go/bin/actionlint
+          key: actionlint-${{ runner.os }}-${{ env.ACTIONLINT_VERSION }}
+
+      - name: Install actionlint
+        if: steps.actionlint-cache.outputs.cache-hit != 'true'
+        run: go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+
+      - name: Install shellcheck
+        env:
+          SHELLCHECK_VERSION: ${{ inputs.shellcheck-version }}
+          SHELLCHECK_SHA256: ${{ inputs.shellcheck-sha256 }}
+        run: |
+          set -euo pipefail
+          # Same verified-download idiom as shell-ci.yml: pinned by tag rather
+          # than whatever the runner image preinstalls, and checked against the
+          # release's sha256 before extraction, since a plain HTTPS fetch has no
+          # registry behind it vouching for what came back.
+          dir="$RUNNER_TEMP/shellcheck-bin"
+          tarball="$RUNNER_TEMP/shellcheck.tar.xz"
+          mkdir -p "$dir"
+          curl -sSfL -o "$tarball" \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          printf '%s  %s\n' "$SHELLCHECK_SHA256" "$tarball" | sha256sum -c -
+          tar -xJ -f "$tarball" -C "$dir" --strip-components=1 "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+          chmod +x "$dir/shellcheck"
+          echo "SHELLCHECK_BIN=$dir/shellcheck" >> "$GITHUB_ENV"
+
+      - name: Run actionlint over the caller's workflows
+        env:
+          SHELLCHECK_BIN: ${{ env.SHELLCHECK_BIN }}
+        run: actionlint -color "-shellcheck=${SHELLCHECK_BIN}"
+
+      # A job that installs third-party tooling is running code we did not
+      # write: `cargo install` (and the other installers) executes build
+      # scripts over the whole dependency tree, so the secrets a job holds
+      # are reachable from code outside this organisation. Keeping the
+      # install out of any job that holds a secret bounds that reach to
+      # nothing. `pip install --require-hashes` is the exception because a
+      # hash-pinned install resolves nothing — the artifacts are fixed by
+      # the lockfile, so no surprise tree appears.
+      - name: A job holding a secret must not install third-party tooling
+        if: ${{ inputs.tooling-isolation }}
+        run: |
+          python3 - <<'PY'
+          import glob
+          import re
+          import sys
+
+          import yaml
+
+          # `secrets.<id>` is how every GitHub Actions expression reaches a
+          # secret. `secrets: inherit` and `secrets:` declarations on
+          # reusable calls don't match — those are declaration blocks, not
+          # references, and `secrets:` does not contain a `.`.
+          SECRET_RE = re.compile(r"(?<!\w)secrets\.[A-Za-z_]\w*")
+
+          # (`pattern`, `opt-out marker on the same line`). The marker, when
+          # present on the line, exempts that install: the only case where
+          # the resolved tree is fixed is pip with --require-hashes, which
+          # reads the lockfile verbatim and installs exactly what it lists.
+          INSTALL_PATTERNS = (
+              ("cargo install",   None),
+              ("go install",      None),
+              ("gem install",     None),
+              ("npm install -g",  None),
+              ("npm i -g",        None),
+              ("pip install",     "--require-hashes"),
+          )
+
+
+          def normalize_run(value):
+              # `run:` is either a single string or a list of strings. Split
+              # each into lines so the install scan is per-line: a
+              # `--require-hashes` marker on one line only exempts that line.
+              if isinstance(value, list):
+                  out = []
+                  for v in value:
+                      if isinstance(v, str):
+                          out.extend(v.splitlines())
+                  return out
+              if isinstance(value, str):
+                  return value.splitlines()
+              return []
+
+
+          def find_violations(spec_path):
+              violations = []
+              try:
+                  with open(spec_path) as fh:
+                      spec = yaml.safe_load(fh)
+              except yaml.YAMLError as e:
+                  # Silent skip would hide a misconfigured workflow that the
+                  # caller is going to learn about elsewhere in CI for the
+                  # wrong reason. Warning annotation instead.
+                  print(f"::warning file={spec_path}::skipped: YAML parse error: {e}")
+                  return violations
+              if not isinstance(spec, dict):
+                  return violations
+              jobs = spec.get("jobs") or {}
+              for job_id, job in jobs.items():
+                  if not isinstance(job, dict):
+                      continue
+                  # Re-serialize the job so `with:`, `env:`, `if:` and
+                  # `run:` strings are all scanned for a secret reference.
+                  # Comments are stripped by safe_load, so they cannot
+                  # produce a false positive.
+                  job_text = yaml.safe_dump(job)
+                  if not SECRET_RE.search(job_text):
+                      continue
+                  for step in (job.get("steps") or []):
+                      if not isinstance(step, dict):
+                          continue
+                      run = step.get("run")
+                      if run is None:
+                          continue
+                      for line in normalize_run(run):
+                          stripped = line.lstrip()
+                          if not stripped or stripped.startswith("#"):
+                              continue
+                          for pattern, except_marker in INSTALL_PATTERNS:
+                              if pattern in line and not (
+                                  except_marker and except_marker in line
+                              ):
+                                  violations.append((spec_path, job_id, line))
+                                  break
+              return violations
+
+
+          def main():
+              files = sorted(set(
+                  glob.glob(".github/workflows/*.yml")
+                  + glob.glob(".github/workflows/*.yaml")
+              ))
+              violations = []
+              for path in files:
+                  violations.extend(find_violations(path))
+              if violations:
+                  for path, job_id, line in violations:
+                      msg = (
+                          f"job `{job_id}` installs third-party tooling while holding a secret: "
+                          f"`{line.strip()}` — see Glyndor/apt#121. Fix by moving the install "
+                          f"into a job that holds no secrets, or pin it by hash "
+                          f"(e.g. `pip install --require-hashes`)."
+                      )
+                      print(f"::error file={path}::{msg}")
+                  sys.exit(1)
+              print(
+                  "tooling-isolation: no job holding a secret installs third-party tooling."
+              )
+              sys.exit(0)
+
+
+          if __name__ == "__main__":
+              sys.exit(main())
+          PY

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: Glyndor/.github/.github/workflows/rust-supply-chain.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-rust-supply-chain.yml

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   workflow-lint:
-    uses: Glyndor/.github/.github/workflows/workflow-lint.yml@d5041b038b7d4935e75400dff612962e6fa14893 # v1.21.0
+    uses: ./.github/workflows/reusable-workflow-lint.yml

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -155,8 +155,14 @@ timed() { # tool, compose-file, project, op-args...
 teardown() { run "$1" "$2" "$3" down -v >/dev/null 2>&1; }
 
 # Pre-pull the digest-pinned bases so image download is never on the timed path.
+#
+# LC_ALL=C on the sort: UTF-8 collations ignore punctuation at the primary
+# level, so `sort -u` treats two image references that differ only in a hyphen
+# as equal and drops one. That image is then pulled during the run instead of
+# before it, and the benchmark times a network download rather than a start --
+# silently, as a number that is simply larger.
 echo ">>> pre-pulling pinned images"
-grep -rhoE 'docker\.io/[^ "]+@sha256:[a-f0-9]+' "$SCEN_DIR" | sort -u | while read -r img; do
+grep -rhoE 'docker\.io/[^ "]+@sha256:[a-f0-9]+' "$SCEN_DIR" | LC_ALL=C sort -u | while read -r img; do
 	podman pull -q "$img" >/dev/null 2>&1 || echo "  warning: could not pre-pull $img" >&2
 done
 

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -68,14 +68,23 @@ the signing key and source list), then runs `apt install podup`.
 
 ```bash
 curl -fsSLO https://apt.glyndor.net/glyndor-archive-keyring.deb
-sudo dpkg -i glyndor-archive-keyring.deb
-gpg --show-keys /usr/share/keyrings/glyndor.gpg   # compare the fingerprint
-sudo apt update && sudo apt install podup
+dpkg-deb -x glyndor-archive-keyring.deb keyring-check
+gpg --show-keys keyring-check/usr/share/keyrings/glyndor.gpg
 ```
 
 Check the printed fingerprint against the one published in the
 [apt repository README](https://github.com/Glyndor/apt#verify-the-signing-key)
-— a channel independent of `apt.glyndor.net`.
+— a channel independent of `apt.glyndor.net`. Only once it matches:
+
+```bash
+sudo dpkg -i glyndor-archive-keyring.deb
+sudo apt update && sudo apt install podup
+```
+
+`dpkg -i` runs the package's maintainer scripts as root, which is why the
+fingerprint is read from a copy unpacked with `dpkg-deb -x` rather than from
+the installed keyring: `dpkg-deb -x` runs nothing from the package, so the
+check happens before anything in it can execute.
 
 ### Why key renewal is automatic
 

--- a/tests/keyring_bootstrap_order.rs
+++ b/tests/keyring_bootstrap_order.rs
@@ -1,0 +1,94 @@
+//! `docs/debian-packaging.md` must check the archive key before installing it.
+//!
+//! The bootstrap this document publishes used to read `dpkg -i` first and
+//! `gpg --show-keys /usr/share/keyrings/glyndor.gpg` second. `dpkg -i` runs the
+//! package's maintainer scripts as root, so that order verified a keyring after
+//! giving the package that wrote it full privileges — the check ran on its own
+//! subject. `dpkg-deb -x` unpacks the data archive and runs nothing, which is
+//! why the fingerprint has to come from an extracted copy.
+//!
+//! The same inversion was live in four places at once: this file, the apt
+//! repository's README, the index page apt publishes, and the installer script
+//! it generates. Fixing prose resets the clock; this test is what makes the
+//! order a property rather than a habit.
+//!
+//! What it does NOT check, and deliberately: whether the fingerprint printed by
+//! the documented command is the right one, and whether the anchor it links to
+//! still exists in the apt repository. Both live in another repository, so this
+//! test cannot see them change. apt's own tests/readme-bootstrap.test.sh covers
+//! that side.
+
+use std::path::Path;
+
+const DOC: &str = "docs/debian-packaging.md";
+
+fn doc() -> String {
+	let p = Path::new(env!("CARGO_MANIFEST_DIR")).join(DOC);
+	std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("cannot read {}: {e}", p.display()))
+}
+
+/// Line index of the first line containing `needle`, or a failure naming what
+/// was being looked for — an `Option` that silently becomes `None` would let a
+/// renamed command turn this test green.
+fn line_of(text: &str, needle: &str) -> usize {
+	text.lines()
+		.position(|l| l.contains(needle))
+		.unwrap_or_else(|| panic!("{DOC} no longer contains {needle:?}"))
+}
+
+#[test]
+fn the_keyring_is_unpacked_before_it_is_installed() {
+	let text = doc();
+	let extract = line_of(&text, "dpkg-deb -x glyndor-archive-keyring.deb");
+	let install = line_of(&text, "sudo dpkg -i glyndor-archive-keyring.deb");
+	assert!(
+		extract < install,
+		"{DOC} tells the reader to run `sudo dpkg -i` (line {}) before \
+		 unpacking with `dpkg-deb -x` (line {}). `dpkg -i` runs maintainer \
+		 scripts as root, so nothing from the package may run before its key \
+		 has been checked.",
+		install + 1,
+		extract + 1,
+	);
+}
+
+#[test]
+fn the_fingerprint_is_read_before_the_install() {
+	let text = doc();
+	let show = line_of(&text, "gpg --show-keys");
+	let install = line_of(&text, "sudo dpkg -i glyndor-archive-keyring.deb");
+	assert!(
+		show < install,
+		"{DOC} reads the fingerprint at line {} but installs at line {}. A \
+		 check that runs after the thing it gates proves nothing.",
+		show + 1,
+		install + 1,
+	);
+}
+
+#[test]
+fn the_fingerprint_comes_from_the_unpacked_copy() {
+	let text = doc();
+	let show = text
+		.lines()
+		.find(|l| l.contains("gpg --show-keys"))
+		.expect("no `gpg --show-keys` line");
+	assert!(
+		show.contains("keyring-check/"),
+		"{DOC} reads the fingerprint from {show:?}. Before the package is \
+		 installed there is no /usr/share/keyrings copy to read, and after it \
+		 is installed the file belongs to the package being checked; read the \
+		 copy `dpkg-deb -x` unpacked instead.",
+	);
+}
+
+#[test]
+fn the_fingerprint_is_still_compared_against_another_host() {
+	let text = doc();
+	assert!(
+		text.contains("github.com/Glyndor/apt#verify-the-signing-key"),
+		"{DOC} no longer points at the apt README for the fingerprint. \
+		 Comparing a key against the archive that served it is \
+		 self-attestation; the second channel is the whole point.",
+	);
+}

--- a/tests/shell/locale-pinned.test.sh
+++ b/tests/shell/locale-pinned.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Every `sort` in a shell script must run under a fixed collation.
+#
+# UTF-8 collations ignore punctuation at the primary level, so `sort -u`
+# considers `pod-up` and `podup` EQUAL and drops one of them. Both are legal
+# names -- for a Debian package, for a container image, for anything a script
+# collects and deduplicates. The runner's locale is not the developer's, so a
+# script that passes on one machine can silently drop an entry on another, and
+# the output looks like a shorter list rather than an error.
+#
+# Measured in Glyndor/apt on 2026-08-24: under en_US.UTF-8 a two-entry list
+# came back with one entry and nothing said so.
+#
+# This is the one meta-test from the distribution trio that transfers here.
+# `ci-runs-every-test` does not: cargo discovers the Rust tests and CI runs them
+# with --all-features, so a test cannot sit unregistered the way a shell file
+# can. Its real analogue -- code compiled only under debian/rules' narrower
+# feature set -- is already covered by debian-build.yml's path filters, which
+# carry the #1295 lesson in their own comments.
+#
+# Requires: nothing beyond coreutils and grep.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+pass=0; fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Every tracked shell script, so a new one is covered the day it lands rather
+# than when someone remembers to add it here. Comments do not count: a `sort`
+# inside one is not executed, and matching them would make the check unfixable
+# by explaining the rule next to the code that follows it.
+scripts="$(git ls-files '*.sh' | grep -v '^tests/shell/')"
+check "there are shell scripts to check" "1" \
+	"$([ -n "$scripts" ] && echo 1 || echo 0)"
+
+unpinned=""
+for f in $scripts; do
+	hits="$(grep -nE '(^|[|;&(]|\$\()[[:space:]]*sort\b' "$f" 2>/dev/null \
+		| grep -v '^[0-9]*:[[:space:]]*#' \
+		| grep -v 'LC_ALL' || true)"
+	[ -n "$hits" ] && unpinned="$unpinned$f: $hits"$'\n'
+done
+
+check "every sort runs under a pinned collation" "" "${unpinned%$'\n'}"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Brings develop to main. Five commits, none of which change the product binary:
four are CI and tests, one is documentation.

- #1566 the 14 reusables, byte-identical to Glyndor/.github v1.21.0
- #1567 the eleven single-call workflows repointed at them
- #1568 ci.yml repointed, pin-policy dropped, zero calls to .github left
- #1569 a meta-test pinning every sort's collation, and the one in bench/run.sh
  that was not — it collected digest-pinned images with a bare `sort -u`, so a
  reference differing only in a hyphen would be dropped and that image pulled
  during the timed run instead of before it
- #1565 the README's keyring bootstrap

No version bump and no tag: nothing here changes what the binary does, and a
release number is inmutable once published. This merge exists so main stops
calling Glyndor/.github, not to publish anything.