### PR TITLE
ci: own the asset verifier, and clear what the move left behind

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,12 +33,15 @@ updates:
     # is the wrong word here: it implies an external maintainer I need to
     # audit, when in fact this group is GitHub's own primitives. The name
     # should describe what it matches.
+    #
+    # That split has nothing left to separate. #1566 through #1568 made this
+    # repository self-contained: every reusable it calls now lives here, so no
+    # `Glyndor/.github` reference survives for the pattern to match. The group
+    # matched nothing and its companion exclusion excluded nothing -- a config
+    # claiming coverage it does not have. apt reached the same state at #125.
     groups:
-      glyndor-reusables:
-        patterns: ["Glyndor/.github*"]
       github-owned:
         patterns: ["*"]
-        exclude-patterns: ["Glyndor/.github*"]
     # Dependabot infers a prefix from the commit history when this is absent,
     # and the inference has been unstable across repositories (build(deps):
     # Bump ... in some, chore(deps): bump ... in others). Set it so the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,30 +527,6 @@ jobs:
             "$venv_py" .github/scripts/verify-signing-key.py "$base" "$sig"
           done
 
-      # Cloned by hand under RUNNER_TEMP rather than with actions/checkout:
-      # `cargo publish` refuses a dirty tree, and this helper's 83 files are
-      # untracked as far as podup's git is concerned. v3.7.1 published its
-      # release and then failed at the publish step for exactly that reason
-      # (#1462). actions/checkout cannot be the tool here — it rejects any
-      # `path:` outside the workspace ("is not under /home/runner/work/..."),
-      # which is what broke v3.8.0.
-      #
-      # The pin is still the commit SHA, not the tag: the tag is a moving
-      # label and the SHA is the boundary. `git fetch` of one SHA at depth 1
-      # is what keeps that guarantee without a full clone.
-      - name: Check out Glyndor/.github for the asset-existence script
-        env:
-          UPSTREAM_SHA: 118244b8d758bdec6d2c5115d815dbc2e5c4f4e9 # v1.16.0
-        run: |
-          set -euo pipefail
-          git init -q "$RUNNER_TEMP/upstream"
-          git -C "$RUNNER_TEMP/upstream" remote add origin \
-            https://github.com/Glyndor/.github.git
-          git -C "$RUNNER_TEMP/upstream" fetch -q --depth 1 origin "$UPSTREAM_SHA"
-          git -C "$RUNNER_TEMP/upstream" checkout -q FETCH_HEAD
-          # Fail loudly rather than run a script that silently is not there.
-          test -f "$RUNNER_TEMP/upstream/scripts/verify-release-assets.py"
-
       - name: Verify every file the installers fetch is staged
         run: |
           set -euo pipefail
@@ -563,7 +539,7 @@ jobs:
           # from install.sh's own ${BASE_URL} fetches, so it covers
           # SHA256SUMS.sig too — install.sh aborts without it, and nothing
           # upstream of here ever checked it was produced.
-          python3 "$RUNNER_TEMP/upstream/scripts/verify-release-assets.py" \
+          python3 scripts/verify-release-assets.py \
             --workdir . \
             --install-script install.sh \
             --install-ps1 install.ps1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ exclude = [
 	"/docs",
 	"/install.ps1",
 	"/install.sh",
+	"/scripts",
 	"/tests",
 ]
 

--- a/scripts/verify-release-assets.py
+++ b/scripts/verify-release-assets.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Assert that every file the install scripts fetch from a release exists on
+disk, in the staging directory, immediately before the release is published.
+
+This is the substance half of the installer contract. `installer-contract.yml`
+answers a different question — "do `install.sh` and `release.yml` agree on the
+asset *names*?" — by reading both files. That is a cross-reference between two
+declarations, and reading YAML is the right way to answer it. It cannot answer
+"does the release actually produce these files", because nothing in a workflow
+file is evidence that a step ran.
+
+That distinction was not academic. Between v1.14.1 and this change the gate
+carried a third check that tried to answer the substance question from the same
+parsed set:
+
+    published = set(re.findall(r"^\\s*-?\\s*asset:\\s*(\\S+)\\s*$", release_yml, re.M))
+    if "SHA256SUMS" not in published: fail
+
+`published` is the build matrix. `SHA256SUMS` is a manifest computed *from* the
+matrix outputs in a later step and passed to `gh release create` as an argument,
+so it can never appear as a matrix entry. The check was therefore unpassable by
+construction: failing it was the normal state of a correct release workflow, and
+the only way to pass was to declare a matrix entry named `SHA256SUMS` without
+producing one — the exact lie the check existed to prevent. Measured on
+2026-08-17: no repository in the org declared that asset, podup was the gate's
+only consumer and was still pinned to a tag from before the clause, so the check
+had never run green anywhere. Its first contact with a real repository (the pin
+bump in podup#1425) failed a workflow that does produce and sign the manifest.
+
+The fix is not a better regex over the same file. It is to ask the question at
+the only moment it can be answered honestly: after the assets are built, signed
+and checksummed, while they are sitting in the runner's working directory, and
+before `gh release create` makes them immutable. At that point existence is a
+stat call, not an inference.
+
+What it checks is derived from the install script rather than hardcoded. A
+release-fetching line looks like
+
+    download "${BASE_URL}/SHA256SUMS" "${TMP_DIR}/SHA256SUMS"
+
+so the set of names is read straight out of the contract the installer will
+execute. Hardcoding `SHA256SUMS` here would have repeated the original mistake
+one layer down: the old clause never checked `SHA256SUMS.sig`, which
+`install.sh` also downloads and without which it aborts, so a release missing
+only the signature would have passed a gate whose stated purpose was making
+downloads verifiable.
+
+Conscious non-goals: this does not verify signatures (release.yml already
+re-verifies every `.sig` against the keys consumers embed), does not check file
+contents, and does not talk to GitHub. It answers one question — are the files
+the installer will ask for present — and fails closed on anything it cannot
+parse, because an unparsed installer is not evidence of a good release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# `download "${BASE_URL}/<name>" "<dest>"` — the only shape the install scripts
+# use to pull a file out of the release. Anything fetched from another host
+# (the apt keyring, for example) does not go through BASE_URL and is correctly
+# invisible here.
+DOWNLOAD_RE = re.compile(r'\$\{BASE_URL\}/([^"\']+)')
+
+ARTIFACT_RE = re.compile(r'ARTIFACT="([^"]+)"')
+ARTIFACT_TEMPLATE_RE = re.compile(r"([A-Za-z0-9_.-]+)-\$\{OS\}-\$\{ARCH\}")
+OS_RE = re.compile(r'OS="([a-z0-9_]+)"')
+ARCH_RE = re.compile(r'ARCH="([a-z0-9_]+)"')
+
+PS_ARTIFACT_RE = re.compile(r'\$Artifact\s*=\s*"([^"]+)"')
+PS_ARTIFACT_TEMPLATE_RE = re.compile(
+    r"([A-Za-z0-9_.-]+)-(\$\{?OS\}?|[a-z0-9_]+)-\$\{?Arch\}?(\.[A-Za-z0-9]+)?"
+)
+PS_OS_RE = re.compile(r"\$OS\s*=\s*['\"]([a-z0-9_]+)['\"]")
+PS_ARCH_RE = re.compile(r"\$Arch\s*=\s*['\"]([a-z0-9_]+)['\"]")
+
+
+def fail(message: str) -> "NoReturn":  # noqa: F821
+    sys.exit(f"verify-release-assets: {message}")
+
+
+def artifact_names_sh(text: str, path: Path) -> set[str]:
+    """Expand install.sh's ARTIFACT template over every OS/ARCH arm it handles."""
+    template = ARTIFACT_RE.search(text)
+    if not template:
+        fail(f'no ARTIFACT="..." in {path}.')
+    matched = ARTIFACT_TEMPLATE_RE.fullmatch(template.group(1))
+    if not matched:
+        fail(
+            'ARTIFACT template must be "<name>-${OS}-${ARCH}"; got ' + template.group(1)
+        )
+    oses = set(OS_RE.findall(text))
+    arches = set(ARCH_RE.findall(text))
+    if not oses or not arches:
+        fail(f"could not parse OS/ARCH arms from {path}.")
+    return {f"{matched.group(1)}-{o}-{a}" for o in oses for a in arches}
+
+
+def artifact_names_ps1(text: str, path: Path) -> set[str]:
+    """Expand install.ps1's $Artifact template. The OS is usually a literal —
+    there being only one Windows — but an interpolation is accepted too."""
+    template = PS_ARTIFACT_RE.search(text)
+    if not template:
+        fail(f'no $Artifact = "..." in {path}.')
+    matched = PS_ARTIFACT_TEMPLATE_RE.fullmatch(template.group(1))
+    if not matched:
+        fail(
+            'the $Artifact template must be "<name>-<os>-$Arch[.ext]"; got '
+            + template.group(1)
+        )
+    prefix, os_token, suffix = (
+        matched.group(1),
+        matched.group(2),
+        matched.group(3) or "",
+    )
+    oses = (
+        {os_token} if os_token not in ("$OS", "${OS}") else set(PS_OS_RE.findall(text))
+    )
+    arches = set(PS_ARCH_RE.findall(text))
+    if not oses or not arches:
+        fail(f"could not parse OS/ARCH arms from {path}.")
+    return {f"{prefix}-{o}-{a}{suffix}" for o in oses for a in arches}
+
+
+def release_fetches(text: str, path: Path) -> set[str]:
+    """Every name install.sh pulls from the release, with the artifact
+    placeholder left in for the caller to expand.
+
+    Only the shell installer is parsed for this. install.ps1 expresses the same
+    downloads through a helper (`Get-ReleaseFile 'SHA256SUMS'`) rather than an
+    interpolated URL, and teaching this script a second shape keyed on a
+    PowerShell function name would be exactly the brittle name-matching the
+    gate is being fixed to stop doing. It is also unnecessary: the manifest and
+    its signature are properties of the release, not of the installer that
+    fetches them, so both installers must find the same ones. What genuinely
+    differs between the two is the per-platform artifact, and that is read from
+    each script separately below.
+    """
+    names = set(DOWNLOAD_RE.findall(text))
+    if not names:
+        fail(
+            f"{path} fetches nothing from the release. Either the installer no "
+            "longer downloads release assets, in which case this gate should be "
+            "removed from the caller, or the ${BASE_URL}/... form changed and "
+            "this script must be taught the new one."
+        )
+    return names
+
+
+def expand(names: set[str], artifacts: set[str]) -> set[str]:
+    """Replace the ARTIFACT placeholder with every concrete name it stands for."""
+    expanded: set[str] = set()
+    for name in names:
+        if "${ARTIFACT}" in name:
+            head, _, tail = name.partition("${ARTIFACT}")
+            expanded.update(f"{head}{a}{tail}" for a in artifacts)
+        else:
+            expanded.add(name)
+    return expanded
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workdir",
+        required=True,
+        type=Path,
+        help="directory holding the staged release assets",
+    )
+    parser.add_argument(
+        "--install-script", required=True, type=Path, help="path to install.sh"
+    )
+    parser.add_argument(
+        "--install-ps1",
+        type=Path,
+        default=None,
+        help="path to install.ps1; skipped when absent",
+    )
+    args = parser.parse_args()
+
+    if not args.workdir.is_dir():
+        fail(f"{args.workdir} is not a directory.")
+    if not args.install_script.is_file():
+        fail(f"{args.install_script} not found.")
+
+    sh_text = args.install_script.read_text()
+    fetches = release_fetches(sh_text, args.install_script)
+    artifacts = artifact_names_sh(sh_text, args.install_script)
+
+    if args.install_ps1 and args.install_ps1.is_file():
+        artifacts |= artifact_names_ps1(args.install_ps1.read_text(), args.install_ps1)
+    elif args.install_ps1:
+        print(
+            f"::notice::verify-release-assets: {args.install_ps1} not found, skipped."
+        )
+
+    required = expand(fetches, artifacts)
+
+    missing = sorted(n for n in required if not (args.workdir / n).is_file())
+    if missing:
+        listed = "\n".join(f"  - {n}" for n in missing)
+        fail(
+            "the install scripts fetch files this release does not stage:\n"
+            f"{listed}\n"
+            f"staged in {args.workdir}: {sorted(p.name for p in args.workdir.iterdir())}\n"
+            "Add them to the step that builds the release, not to the workflow's "
+            "asset declarations — this check reads the directory, not the YAML."
+        )
+
+    print(f"OK: all {len(required)} files the install scripts fetch are staged.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workflow_toolchain_pin.rs
+++ b/tests/workflow_toolchain_pin.rs
@@ -209,7 +209,7 @@ jobs:
 	let deb_yml = "\
 jobs:
   debian:
-    uses: Glyndor/.github/.github/workflows/rust-debian.yml@e70ff47fd8aefa0f054846815f19b98768d61122
+    uses: ./.github/workflows/reusable-rust-debian.yml
     with:
       package-name: podup
       check-vendored: true


### PR DESCRIPTION
Three residues from #1566-#1568. The first was a real dependency; the other two
are configuration and a fixture that described a repository that no longer
exists.

release.yml cloned Glyndor/.github at run time to use
scripts/verify-release-assets.py. Every reusable had moved but this had not, so a
release still needed that repository present, at a SHA pinned to v1.16.0 while
everything else sat at v1.21.0. The script is now in scripts/, byte-identical to
the SHA it was pinned at -- and identical to that repository's main too, so
there was no version to choose between.

The clone existed for a reason its own comment gives: `cargo publish` refuses a
dirty tree and the helper's 83 files are untracked, which is why it went under
RUNNER_TEMP by hand rather than through actions/checkout. Bringing one tracked
file in removes the condition instead of working around it. v3.7.1 published its
release and then failed at publish for exactly that dirty-tree reason (#1462),
and v3.8.0 broke on actions/checkout rejecting a path outside the workspace.
Neither can recur through this path.

dependabot.yml kept a `glyndor-reusables` group matching `Glyndor/.github*`, and
a companion `exclude-patterns` on the group beside it. Nothing matches either
now. apt hit the same state at #125 and its comment names it exactly: a config
claiming coverage it does not have. Same removal, same reasoning.

tests/workflow_toolchain_pin.rs used a `uses: Glyndor/.github/...@e70ff47` line
as fixture YAML. The test passes either way -- it exercises a parser, and the
parser does not care -- but the fixture no longer resembles any file in the
repository, so it would keep passing against a shape nobody writes.

What stays is prose: two "keep this in step with" comments in release.yml, one
note in pin-watch.yml about which watcher covers what, and the link to
SECURITY.md in docs/security-model.md -- which is one of the four
community-health files this repository inherits from .github deliberately, and
that is unchanged.