### PR TITLE
docs(ci): explain the token, not the incident, in the gh api comment

### DIFF
--- a/.github/workflows/reusable-schedule-freshness.yml
+++ b/.github/workflows/reusable-schedule-freshness.yml
@@ -55,10 +55,10 @@ jobs:
     permissions:
       actions: read # reading this repository's workflow-run history
     steps:
-      # `gh api` is banned for the maintainer's own credentials — the org
-      # account has been suspended over raw API traffic before. A workflow is a
-      # different actor: GITHUB_TOKEN is a scoped job token on its own rate
-      # limit, which is the documented exception.
+      # This step runs as GITHUB_TOKEN, a job-scoped token on its own rate
+      # limit, and reads nothing beyond this repository's own run history. No
+      # personal credential is ever used here, and the `actions: read` grant
+      # above is the whole of what it can reach.
       - name: Check the newest successful scheduled run
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## The problem

`reusable-schedule-freshness.yml` justifies its `gh api` call by describing an enforcement
action against the organisation account:

```
# `gh api` is banned for the maintainer's own credentials — the org
# account has been suspended over raw API traffic before.
```

This repository is public, and my documentation standard keeps internal operations detail out of
anything a third party reads. It also does not help the reader it was written for: someone
auditing this file needs to know the call is correct because it runs as a job-scoped token. Why
I hold a rule about my own credentials is a different fact and not theirs to need.

The copy here came in with the reusables. I found it while cleaning the same text out of `apt`,
`homebrew-tap` and `scoop-bucket`; the source copy in `Glyndor/.github` is fixed separately.

## What I changed

The comment only. No `run:` line, `env:`, `permissions:` block, input or trigger is touched.
`origin/main` and `origin/develop` hold this file byte-identical today, so this lands cleanly
and carries forward on the next release merge.

## What I checked

No occurrence of "suspend", "banned", "ban" or "this machine" is left in the file, and it still
parses as YAML.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
