### PR TITLE
fix: two exit codes that reported success without it

### DIFF
--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -147,6 +147,14 @@ impl Engine {
 			}
 		}
 
+		// Counted so "some pushes failed" and "every push failed" can be told
+		// apart. --ignore-push-failures used to give both an exit code of 0, so
+		// a gate written as `podup push --ignore-push-failures && deploy.sh`
+		// deployed against a registry that had received nothing at all. The flag
+		// means "do not stop at the first failure", not "never report failure".
+		let mut attempted = 0usize;
+		let mut failed = 0usize;
+
 		for (name, service) in &file.services {
 			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
 				continue;
@@ -155,7 +163,10 @@ impl Engine {
 				tracing::debug!("{name}: no image to push, skipping");
 				continue;
 			};
-			self.try_push(image, &opts, quiet).await?;
+			attempted += 1;
+			if !self.try_push(image, &opts, quiet).await? {
+				failed += 1;
+			}
 			// `build.tags` is locally retagged by `apply_extra_tags` after the
 			// build. Push each one too — the registry would otherwise end up
 			// with only the primary `image`, and the other refs a user expects
@@ -165,9 +176,20 @@ impl Engine {
 					if extra == image {
 						continue;
 					}
-					self.try_push(extra, &opts, quiet).await?;
+					attempted += 1;
+					if !self.try_push(extra, &opts, quiet).await? {
+						failed += 1;
+					}
 				}
 			}
+		}
+
+		// Only when every attempt failed. One survivor means the flag did its
+		// job and the run continued, which is exactly what it is for.
+		if attempted > 0 && failed == attempted {
+			return Err(ComposeError::Build(format!(
+				"every push failed ({failed} of {attempted}); --ignore-push-failures does not make that a success"
+			)));
 		}
 		Ok(())
 	}
@@ -177,12 +199,15 @@ impl Engine {
 	/// the caller aborts the whole push. Shared by the primary and the extra
 	/// `build.tags` loop in [`Engine::push_with_quiet`] so the two cannot drift
 	/// on how a per-image failure is treated.
-	async fn try_push(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<()> {
+	/// `Ok(true)` when the image reached the registry, `Ok(false)` when a
+	/// failure was ignored. The caller counts, because "some failed" and "all
+	/// failed" are different answers and this used to give both as exit 0.
+	async fn try_push(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<bool> {
 		match self.push_image(image, opts, quiet).await {
-			Ok(()) => Ok(()),
+			Ok(()) => Ok(true),
 			Err(e) if opts.ignore_failures => {
 				warn!("push {image} failed (ignored): {e}");
-				Ok(())
+				Ok(false)
 			}
 			Err(e) => Err(e),
 		}
@@ -269,3 +294,7 @@ mod tests {
 		assert!(matches!(err, ComposeError::Build(m) if m.contains("no progress")));
 	}
 }
+
+#[cfg(test)]
+#[path = "push_exit_tests.rs"]
+mod exit_tests;

--- a/internal/engine/build/push_exit_tests.rs
+++ b/internal/engine/build/push_exit_tests.rs
@@ -10,6 +10,10 @@
 //! working; no survivors is a failed push wearing a zero.
 
 use super::PushOptions;
+// Gated the way pull_tests.rs gates it: fake_podman binds a unix socket, so the
+// import itself does not resolve on Windows. The #[cfg(unix)] on each test is
+// not enough -- a module-level use is compiled everywhere.
+#[cfg(unix)]
 use crate::engine::fake_podman;
 
 fn opts() -> PushOptions {

--- a/internal/engine/build/push_exit_tests.rs
+++ b/internal/engine/build/push_exit_tests.rs
@@ -1,0 +1,68 @@
+//! `--ignore-push-failures` must not turn "every push failed" into a success.
+//!
+//! The flag means "do not stop at the first failure". It used to also mean
+//! "never report failure": each error was logged as a warning, `try_push`
+//! returned `Ok(())`, and the loop finished `Ok(())` however many failed. A
+//! gate written as `podup push --ignore-push-failures && deploy.sh` therefore
+//! deployed against a registry that had received nothing at all.
+//!
+//! The two cases below are the whole distinction. One survivor is the flag
+//! working; no survivors is a failed push wearing a zero.
+
+use super::PushOptions;
+use crate::engine::fake_podman;
+
+fn opts() -> PushOptions {
+	PushOptions {
+		ignore_failures: true,
+		tls_verify: None,
+	}
+}
+
+/// Every image fails. The flag must not hide that from the exit code.
+#[tokio::test]
+#[cfg(unix)]
+async fn every_push_failing_is_an_error_even_when_failures_are_ignored() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/push") {
+			(500, r#"{"message":"registry unreachable"}"#.to_string())
+		} else {
+			(200, "{}".to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file = crate::parse_str("services:\n  a:\n    image: one\n  b:\n    image: two\n").unwrap();
+
+	let err = e
+		.push_with_quiet(&file, &[], opts(), false)
+		.await
+		.expect_err("all pushes failed, so the run must not report success");
+
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("every push failed"),
+		"the error must say every push failed, not name one image: {msg}"
+	);
+}
+
+/// One image fails, one succeeds. That is what the flag is for, and it stays
+/// a success -- otherwise the fix would have replaced one wrong answer with
+/// another.
+#[tokio::test]
+#[cfg(unix)]
+async fn one_survivor_keeps_the_run_successful() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/push") && target.contains("bad") {
+			(500, r#"{"message":"registry unreachable"}"#.to_string())
+		} else {
+			(200, "{}".to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file =
+		crate::parse_str("services:\n  a:\n    image: bad\n  b:\n    image: good\n").unwrap();
+
+	e.push_with_quiet(&file, &[], opts(), false)
+		.await
+		.expect("one image failed and one succeeded: --ignore-push-failures must absorb that");
+}

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -426,7 +426,7 @@ impl Engine {
 					.await
 					.map_err(ComposeError::Podman)?
 			};
-			print_frame(&report, &running, &stopped, &opts, None);
+			print_frame(&report, &running, &stopped, &opts, None)?;
 			return Ok(());
 		}
 
@@ -448,7 +448,7 @@ impl Engine {
 
 		while let Some(frame) = frames.next().await {
 			match frame {
-				Ok(report) => print_frame(&report, &running, &stopped, &opts, region.as_mut()),
+				Ok(report) => print_frame(&report, &running, &stopped, &opts, region.as_mut())?,
 				Err(e) => {
 					// A `stats --stream` stream lives as long as any sampled
 					// container is running, and ends once none remain. libpod
@@ -624,7 +624,7 @@ fn print_frame(
 	stopped: &[String],
 	opts: &StatsOptions,
 	region: Option<&mut crate::ui::progress::Region>,
-) {
+) -> Result<()> {
 	let rows = frame_rows(report, running, stopped);
 
 	if opts.json {
@@ -635,13 +635,21 @@ fn print_frame(
 		// `stats --format json` was unreadable by anything for as long as it
 		// streamed. `--no-stream` prints one frame and exits, so it stays a
 		// single pretty document, which is valid JSON and nicer to read.
+		// Propagated, not swallowed. `unwrap_or_default()` printed an empty line
+		// on a serialisation failure and carried on, so `stats --format json`
+		// emitted a blank where a frame should be and still exited zero -- a
+		// consumer piping into `jq` sees a gap and no reason for it. The other
+		// five list commands route through `to_pretty_json`, whose contract says
+		// a failure "must propagate as an error and exit non-zero"; stats was
+		// the one that did not. Same error variant, so the message reads alike.
 		let text = if opts.no_stream {
 			serde_json::to_string_pretty(&json)
 		} else {
 			serde_json::to_string(&json)
-		};
-		println!("{}", text.unwrap_or_default());
-		return;
+		}
+		.map_err(|e| ComposeError::Build(format!("invalid stats frame: {e}")))?;
+		println!("{text}");
+		return Ok(());
 	}
 
 	let colour = crate::ui::stdout_colored();
@@ -656,12 +664,14 @@ fn print_frame(
 	// the cursor for no reason.
 	if let Some(region) = region {
 		region.show(&[], &lines);
-		return;
+		return Ok(());
 	}
 	for line in lines {
 		println!("{line}");
 	}
 	println!();
+
+	Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Both are the same shape: a command that did not do what it was asked and said
zero anyway. Found auditing the CLI surface, and both confirmed in the code
before touching anything.

**push --ignore-push-failures returned 0 when every push failed.** Each failure
was logged as a warning and `try_push` returned Ok, so the loop finished Ok
however many failed. A gate written as
`podup push --ignore-push-failures && deploy.sh` deployed against a registry
that had received nothing at all.

The flag means "do not stop at the first failure". It should not also mean
"never report failure". `try_push` now reports whether the image reached the
registry, the caller counts, and only every-attempt-failed is an error. One
survivor keeps the run successful, which is the case the flag exists for -- and
there is a test for that too, so the fix cannot drift into refusing what it was
meant to allow.

This diverges from docker compose, which exits 0 regardless. Deliberate: the
difference between "some failed" and "all failed" is the difference between a
partial publish and no publish, and a gate cannot tell them apart from an exit
code that is 0 for both.

**stats --format json swallowed serialisation failures.** print_frame used
`unwrap_or_default()`, so a frame that failed to serialise printed an empty
line and the run carried on at exit 0 -- a consumer piping into jq sees a gap
and no reason for it. The other five list commands route through
`to_pretty_json`, whose own contract says a failure "must propagate as an error
and exit non-zero". stats was the one that did not. Same error variant now, so
the message reads like the others.

Mutation-tested: removing the every-push-failed check fails the first test and
leaves the second passing, which is the split the two are there to hold.