### PR TITLE
chore(release): bump to 5.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.1.0"
+version = "5.2.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+podup (5.2.0) unstable; urgency=medium
+
+  * push: --ignore-push-failures no longer exits 0 when every push failed.
+  * stats: --format json propagates serialisation failures instead of
+    printing an empty line and exiting 0.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Fri, 28 Aug 2026 04:55:41 -0500
+
 podup (5.1.0) unstable; urgency=medium
 
   New


### PR DESCRIPTION
Version bump only, ahead of the develop -> main release pull request.

All three files that stamp a version onto a shipped artifact: Cargo.toml,
Cargo.lock and debian/changelog. The release workflow's verify job compares them
before building.

5.2.0 rather than 5.1.1: #1574 changes observable exit codes in `push` and
`stats`, and a script that depended on the old zero will notice.