### PR TITLE
docs: own the contributing guide and the issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,103 @@
+name: Bug report
+description: Report a bug or unexpected behaviour in podup
+title: "[bug]: "
+labels: ["type:bug", "status:triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting, please search existing issues to avoid duplicates.
+        **Security issue? Do NOT file it here**: use the Security tab, "Report a vulnerability" instead.
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      description: Which part of podup is affected (e.g. engine, compose parser, update / self-update, quadlet export, ports, env_file, cli, install.sh, install.ps1, debian package).
+      placeholder: engine
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: podup-version
+    attributes:
+      label: podup version
+      description: The output of `podup --version`, or the version string from the package metadata.
+      placeholder: v5.1.0
+    validations:
+      required: true
+  - type: input
+    id: install-method
+    attributes:
+      label: How did you install podup?
+      description: "Source matters for self-update, signing and packaging issues: only the install.sh / install.ps1 / cargo install paths carry the `update` feature; apt, Homebrew and Scoop own upgrades."
+      placeholder: 'apt · brew · scoop · cargo install · install.sh · install.ps1'
+    validations:
+      required: true
+  - type: input
+    id: podman-version
+    attributes:
+      label: Podman version and major
+      description: "The output of `podman --version`. The major is what gates support: podup requires Podman 5 or 6."
+      placeholder: '5.4.2 (Podman 5)'
+    validations:
+      required: true
+  - type: input
+    id: podman-socket
+    attributes:
+      label: Podman socket
+      description: Where the libpod socket lives (e.g. `unix:///run/user/1000/podman/podman.sock`, `unix://$HOME/.local/share/containers/podman/machine/qemu/podman.sock` on macOS, `npipe:////./pipe/podman-machine-default` on Windows).
+      placeholder: 'unix:///run/user/1000/podman/podman.sock'
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: 'Debian 13 trixie · Ubuntu 24.04 LTS · Fedora 42 · macOS 15 · Windows 11'
+    validations:
+      required: true
+  - type: input
+    id: arch
+    attributes:
+      label: Architecture
+      placeholder: 'x86_64 · aarch64'
+  - type: dropdown
+    id: rootless
+    attributes:
+      label: Is this a rootless install?
+      description: "Podman reports `rootless: true` in `podman info` when the user namespace is unprivileged."
+      options:
+        - label: 'Yes, rootless'
+          value: rootless
+        - label: 'No, rootful'
+          value: rootful
+        - label: 'Not sure'
+          value: unknown
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste relevant output. Redact secrets, IPs, hostnames and emails. Set `RUST_LOG=podup=debug` for a verbose trace.
+      render: shell
+  - type: input
+    id: compose
+    attributes:
+      label: docker-compose.yml (or a minimal reproducer)
+      description: Paste the file or a link to it. Strip comments and replace image tags with placeholders if the file is large.
+      placeholder: 'see https://gist.example/... or paste inline'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Glyndor/podup/security/policy
+    about: "Do not open a public issue. Use the Security tab of this repository and click 'Report a vulnerability'."
+  - name: Discussions
+    url: https://github.com/Glyndor/podup/discussions
+    about: "Questions, ideas and 'is this supposed to work this way?' go here, not in an issue."
+  - name: Podman compatibility
+    url: https://github.com/containers/podman/issues
+    about: "If the problem reproduces with plain `podman` against the libpod REST API, it belongs upstream, not here."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature request
+description: Propose a new feature or improvement to podup
+title: "[feat]: "
+labels: ["type:feature", "status:triage"]
+body:
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      description: Which part of podup this affects (e.g. engine, compose parser, update / self-update, quadlet export, ports, env_file, cli, install.sh, install.ps1, debian package, docs).
+      placeholder: engine
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, including "do nothing".
+  - type: dropdown
+    id: podman-scope
+    attributes:
+      label: Podman majors this should work with
+      description: podup supports Podman 5 and Podman 6; the latest stable and the one below it. A change that needs Podman 7 is an API break, not a feature.
+      options:
+        - label: 'Both 5 and 6 (default support window)'
+          value: both
+        - label: 'Podman 6 only (newest)'
+          value: 6
+        - label: 'Podman 5 only (older)'
+          value: 5
+        - label: 'Engine-agnostic (no Podman API change)'
+          value: agnostic
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Platforms this affects
+      description: podup ships on Linux, macOS and Windows (x86_64 and aarch64). Mark all that apply.
+      multiple: true
+      options:
+        - label: 'Linux (x86_64)'
+          value: linux-amd64
+        - label: 'Linux (aarch64)'
+          value: linux-arm64
+        - label: 'macOS (x86_64 and arm64)'
+          value: macos
+        - label: 'Windows (x86_64 and arm64)'
+          value: windows
+  - type: textarea
+    id: install-impact
+    attributes:
+      label: Impact on installation and packaging
+      description: Does this need changes to install.sh, install.ps1, debian/rules, the Homebrew formula or the Scoop manifest? Which paths carry the `update` feature, and which do not?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+## Changes
+
+<!-- List the main changes made. -->
+
+## Test plan
+
+<!-- How was this tested? Check all that apply. -->
+
+- [ ] `cargo fmt --all --check` is clean
+- [ ] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
+- [ ] `cargo test --locked --all-features --workspace` passes locally
+- [ ] `./tests/shell/*.test.sh` pass locally (every tracked test, including `ci-runs-every-test.test.sh`)
+- [ ] shellcheck is clean on every tracked `*.sh` and every extensionless script with a shell shebang
+- [ ] Podman lane ran (live Podman 5 and Podman 6, in the PR's own check run) for changes to `internal/`, the engine integration, or the libpod REST adapter
+- [ ] Asset-contract fixtures ran for changes to `install.sh`, `install.ps1`, `internal/update/install.rs`, the signing scripts or the release fixtures
+
+<!--
+A test that was not watched fail is not a test. If this PR adds or changes
+a check, say which control you removed to make it go red, and what it
+reported. See standards/testing, "Three ways a sabotage lies to you".
+-->
+
+- [ ] New or changed checks were verified by deleting the control and watching them fail
+
+## Checklist
+
+- [ ] Targets `develop` (the release pull request that targets `main` is the one exception, gated by `reusable-main-guard.yml`)
+- [ ] Commits are signed off (DCO, `git commit -s`)
+- [ ] Commits are signed (`required_signatures` is enforced on `develop` and `main`)
+- [ ] Labels applied (`type:`, `prio:`, `effort:`, `area:` where applicable)
+- [ ] Every new file in `tests/shell/` is named in some workflow's `test-command` (`ci-runs-every-test.test.sh` enforces this on every pull request)
+- [ ] No secrets, keys or credentials in code, logs or fixtures
+- [ ] Docs updated if behaviour changed (`docs/commands.md`, `docs/security-model.md`, `docs/self-update.md` as relevant)
+- [ ] `Cargo.toml` and `debian/changelog` are at the same version (the release gate compares them, but a mismatched pair during development is a hidden cost)
+- [ ] `cargo build --release --locked --bin podup` fits `bench/binary-budget-mib` for changes that can move the binary size
+
+## Related issues
+
+<!-- Closes #123, refs #456 -->
+
+The `Closes #N` trailer does not auto-close on pull requests into
+`develop`, because the default branch is `main` and GitHub only closes
+from there. Mention the issue in this body and update the issue's
+labels; closing happens when the release pull request merges into
+`main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contributing to Glyndor/podup
+
+This repository has its own guide because the organisation's shared one
+describes a `topic → develop → main` flow that names branch flow and
+checklists that do not match what the workflows actually do here.
+Following it would tell you to push to a branch that is not where work
+lands.
+
+Contributions are invitation-only. Bug reports and ideas through issues
+are welcome; unsolicited pull requests are not accepted.
+
+## What this repository is
+
+It builds and ships **podup**, a docker-compose translator and runner for
+rootless Podman. A single static Rust binary, with no daemon and no
+Python runtime. The Rust library crate is consumed by
+`helmly-agent`; the `podup` binary is what end users install.
+
+Nothing automated writes to this repository's git. `release.yml` builds
+binaries and attaches them to a GitHub Release; it never commits back.
+
+## Branch flow
+
+```
+topic branch ──squash──▶ develop ──merge commit──▶ main
+```
+
+- **Branch from `develop`.** Pull requests target `develop`, not `main`.
+  The exception is the release pull request, which targets `main` and is
+  the only path that crosses the `develop → main` boundary. A reusable
+  (`reusable-main-guard.yml`) enforces that: any other pull request into
+  `main` fails the `develop-only` check before it can merge.
+- **Squash-merge into `develop.** The pull request title is the squashed
+  commit message, written in Conventional Commit form.
+- **Merge-commit into `main.** The release pull request is a real merge
+  commit, so `develop` keeps the history of every fix until the release
+  is cut. Tags come off `main` only; `release.yml` refuses a tag that is
+  not reachable from `origin/main`.
+
+`Closes #N` in a pull request that lands on `develop` does not auto-close
+the issue, because the default branch is `main` and GitHub only closes
+from there. Mention the issue in the pull request body and add the label
+that marks the work done; closing happens when the release pull request
+merges.
+
+## Before you open a pull request
+
+- **An issue first.** Labels are the tracking system here; there is no
+  board. Apply `type:`, `prio:`, `effort:`, `status:` and `area:` where
+  they fit.
+- **Sign every commit off**, with `git commit -s`. The `dco` check is
+  required and is the only thing standing behind that attestation.
+- **Commits are signed**, GPG or SSH. `required_signatures` is enforced
+  on `develop` and on `main`, and rebase-merge is disabled because GitHub
+  re-creates rebased commits without signatures.
+- **Conventional Commit title** on the pull request. It becomes the
+  squashed commit message.
+
+## Tests
+
+Run the suite before pushing:
+
+```sh
+cargo fmt --all --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-features --workspace
+for t in tests/shell/*.test.sh; do bash "$t" || echo "FAILED: $t"; done
+# shellcheck covers every tracked *.sh and every extensionless script with
+# a shell shebang; the workflow runs the same find + xargs pipeline.
+find . -type f \( -name '*.sh' -o -name '*.bash' \) -not -path './.git/*' \
+  -print0 | xargs -0 -r shellcheck --severity=style
+```
+
+The Rust toolchain is pinned at `1.98` by `reusable-rust-ci.yml`. The
+declared MSRV is `1.85`; the MSRV gate uses that and only that.
+
+Two rules matter more than coverage:
+
+**A shell test no workflow runs is indistinguishable from one that
+passes.** `./tests/shell/ci-runs-every-test.test.sh` fails when a file in
+`tests/shell/` is not named in any workflow's `test-command`, and when a
+workflow names one that does not exist. Both directions. cargo discovers
+its own Rust tests and CI runs them with `--all-features`, so the same
+watcher is unnecessary for the Rust suite and was deliberately not
+copied from the distribution repositories.
+
+**A test you have not watched fail is not a test.** Before claiming a
+check works, delete or invert the control it covers, run it, and confirm
+it goes red for the reason it names. Three ways that goes wrong are
+written up in `standards/testing`, "Three ways a sabotage lies to you":
+a sabotage that changes nothing, one that changes something the test
+does not look at, and one where the red comes from somewhere else
+entirely. All three were hit here in a single day.
+
+Assert **which** failure fired, never that some failure did. Every
+shell script runs under `set -euo pipefail`, so almost any mistake
+exits non-zero and a bare non-zero assertion is satisfied by the failure
+you did not mean.
+
+## Workflows
+
+CI is split by responsibility rather than gathered in one file:
+
+| file | what fails there |
+|---|---|
+| `ci.yml` | the rustfmt / clippy / test / coverage / MSRV / package / semver gates, plus freshness audits on the scheduled workflows |
+| `lint-shell.yml` | shellcheck and the shell test suite |
+| `lint-powershell.yml` | PSScriptAnalyzer on `install.ps1` |
+| `debian-build.yml` | the .deb builds under `debian/rules`' narrower feature set, on every change that can shift it |
+| `binary-budget.yml` | the release binary fits `bench/binary-budget-mib` |
+| `asset-contract.yml` | the release asset names, signing-key rotation, install self-test, and shell/PowerShell signing fixtures |
+| `podman-lane.yml` | the integration suite against live Podman 5 and Podman 6 in a Fedora qemu VM, on every pull request |
+| `podman-lane-develop-nightly.yml` | the same lane, instrumented for coverage, fired nightly from `develop` |
+| `dco.yml`, `line-limit.yml`, `workflow-lint.yml` | one rule each |
+| `main-guard.yml` | `develop-only`: only the release pull request can target `main` |
+| `release.yml` | tag validity, Cargo.toml / debian/changelog / Cargo.lock agreement, `cargo audit`, signed binaries, GitHub Release |
+
+Every reusable this repository calls lives in
+`.github/workflows/reusable-*.yml` as a copy taken from a named
+`Glyndor/.github` tag. Nothing is pulled remotely.
+
+**Job ids are load-bearing.** A required status check is named
+`<caller job id> / <inner job name>`, so renaming a job renames its check
+and creates a phantom the ruleset still requires, which blocks every pull
+request with no explanation. Move jobs between files freely; renaming one
+is a ruleset change.
+
+## Security
+
+Never open a public issue for a vulnerability. Use the Security tab,
+**Report a vulnerability**. The organisation's `SECURITY.md` applies here
+and is deliberately not duplicated in this repository.


### PR DESCRIPTION
## The problem

This repository inherits five community health files from `Glyndor/.github`. The workflow
standard says exactly four are inherited org-wide, because one answer has to hold everywhere for
them: code of conduct, security policy, support and funding. `CONTRIBUTING.md` and the issue and
pull request templates are per repository and never inherited, because they describe a branch
flow and checklists that name branches, test commands and components.

The inherited ones here are not false, they are generic, which is the quieter failure. "Tested on
a real VM/VPS" is not what this repository needs checked, and a checkbox nobody can tick
meaningfully is not a weaker gate than a wrong one. It is the same gate, read as present.

There is a second reason this went unnoticed for so long: **the inheritance is invisible**.
Nothing in this repository expresses it. No line, no reference, no configuration. The files do
not appear in the file browser, the history, a clone, or a `grep`. They exist only in GitHub's
interface. That is the opposite of how a reusable workflow couples, which is an explicit `uses:`
line you can find.

## What I added

Five files of this repository's own, adapted from the sibling channel repositories rather than
copied from them. The differences that matter:

- **Branch flow.** The model was written for a main-only repository. This one runs the full
  model, so the checklist asks that a pull request targets `develop`, and names the one exception,
  the release pull request into `main` gated by `reusable-main-guard.yml`.
- **`Closes #N` does not auto-close here**, because the fix lands on `develop` and GitHub only
  closes on merges into the default branch. The template says so, rather than leaving people to
  wonder why their issue stayed open.
- **The test plan lists what CI actually runs**, read off the workflows: `cargo fmt --all
  --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test
  --locked --all-features --workspace`, the shell suite under `tests/shell/`, shellcheck, the
  Podman lane against live Podman 5 and 6, and the asset-contract fixtures.
- **`check-test-coverage.sh` is deliberately absent from the checklist**, because it is
  deliberately absent from this repository. What is referenced instead is the watcher that does
  exist, which asserts every shell test is invoked by some workflow.
- **The version-pair line** asks that `Cargo.toml` and `debian/changelog` agree. The release gate
  compares them, and a mismatched pair during development is a cost that only surfaces at tag
  time, when it is immutable.
- **The bug report asks what actually diagnoses a bug here**: the podup version, how it was
  installed (apt, Homebrew, Scoop, crates.io or the installer), the Podman version and major, the
  socket, rootless or not, the OS and the architecture, plus a minimal compose reproducer.

## How I checked

Every command in the test plan was verified to appear in a real workflow file rather than taken
on trust. All three issue templates parse as YAML. No file outside `CONTRIBUTING.md` and
`.github/` is touched, and nothing under `internal/`, `Cargo.toml` or any workflow is modified.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
