### PR TITLE
release: 5.2.0

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Signing requirements must parse as separate pinned entries
         # A trailing backslash is a line continuation: if the last hash of a
         # block keeps one, pip folds the next package name into the previous
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install pinned cryptography
         # See the shell fixture for the rationale on --require-hashes.
         run: |

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -24,4 +24,4 @@ jobs:
     with:
       # A test no workflow runs is indistinguishable from one that passes --
       # the lesson debian-build.yml carries from #1295, applied here.
-      test-command: ./tests/shell/locale-pinned.test.sh
+      test-command: ./tests/shell/locale-pinned.test.sh && ./tests/shell/ci-runs-every-test.test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
     # and matches the suite CI validates against, so the release that ships
     # to users was produced by the same image the suite exercises. Bump the
     # digest here when rust-debian.yml's default moves; the two should agree.
-    container: debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4
+    container: debian:trixie@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/reusable-schedule-freshness.yml
+++ b/.github/workflows/reusable-schedule-freshness.yml
@@ -55,10 +55,10 @@ jobs:
     permissions:
       actions: read # reading this repository's workflow-run history
     steps:
-      # `gh api` is banned for the maintainer's own credentials — the org
-      # account has been suspended over raw API traffic before. A workflow is a
-      # different actor: GITHUB_TOKEN is a scoped job token on its own rate
-      # limit, which is the documented exception.
+      # This step runs as GITHUB_TOKEN, a job-scoped token on its own rate
+      # limit, and reads nothing beyond this repository's own run history. No
+      # personal credential is ever used here, and the `actions: read` grant
+      # above is the whole of what it can reach.
       - name: Check the newest successful scheduled run
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.1.0"
+version = "5.2.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+podup (5.2.0) unstable; urgency=medium
+
+  * push: --ignore-push-failures no longer exits 0 when every push failed.
+  * stats: --format json propagates serialisation failures instead of
+    printing an empty line and exiting 0.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Fri, 28 Aug 2026 04:55:41 -0500
+
 podup (5.1.0) unstable; urgency=medium
 
   New

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -147,6 +147,14 @@ impl Engine {
 			}
 		}
 
+		// Counted so "some pushes failed" and "every push failed" can be told
+		// apart. --ignore-push-failures used to give both an exit code of 0, so
+		// a gate written as `podup push --ignore-push-failures && deploy.sh`
+		// deployed against a registry that had received nothing at all. The flag
+		// means "do not stop at the first failure", not "never report failure".
+		let mut attempted = 0usize;
+		let mut failed = 0usize;
+
 		for (name, service) in &file.services {
 			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
 				continue;
@@ -155,7 +163,10 @@ impl Engine {
 				tracing::debug!("{name}: no image to push, skipping");
 				continue;
 			};
-			self.try_push(image, &opts, quiet).await?;
+			attempted += 1;
+			if !self.try_push(image, &opts, quiet).await? {
+				failed += 1;
+			}
 			// `build.tags` is locally retagged by `apply_extra_tags` after the
 			// build. Push each one too — the registry would otherwise end up
 			// with only the primary `image`, and the other refs a user expects
@@ -165,9 +176,20 @@ impl Engine {
 					if extra == image {
 						continue;
 					}
-					self.try_push(extra, &opts, quiet).await?;
+					attempted += 1;
+					if !self.try_push(extra, &opts, quiet).await? {
+						failed += 1;
+					}
 				}
 			}
+		}
+
+		// Only when every attempt failed. One survivor means the flag did its
+		// job and the run continued, which is exactly what it is for.
+		if attempted > 0 && failed == attempted {
+			return Err(ComposeError::Build(format!(
+				"every push failed ({failed} of {attempted}); --ignore-push-failures does not make that a success"
+			)));
 		}
 		Ok(())
 	}
@@ -177,12 +199,15 @@ impl Engine {
 	/// the caller aborts the whole push. Shared by the primary and the extra
 	/// `build.tags` loop in [`Engine::push_with_quiet`] so the two cannot drift
 	/// on how a per-image failure is treated.
-	async fn try_push(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<()> {
+	/// `Ok(true)` when the image reached the registry, `Ok(false)` when a
+	/// failure was ignored. The caller counts, because "some failed" and "all
+	/// failed" are different answers and this used to give both as exit 0.
+	async fn try_push(&self, image: &str, opts: &PushOptions, quiet: bool) -> Result<bool> {
 		match self.push_image(image, opts, quiet).await {
-			Ok(()) => Ok(()),
+			Ok(()) => Ok(true),
 			Err(e) if opts.ignore_failures => {
 				warn!("push {image} failed (ignored): {e}");
-				Ok(())
+				Ok(false)
 			}
 			Err(e) => Err(e),
 		}
@@ -269,3 +294,7 @@ mod tests {
 		assert!(matches!(err, ComposeError::Build(m) if m.contains("no progress")));
 	}
 }
+
+#[cfg(test)]
+#[path = "push_exit_tests.rs"]
+mod exit_tests;

--- a/internal/engine/build/push_exit_tests.rs
+++ b/internal/engine/build/push_exit_tests.rs
@@ -1,0 +1,72 @@
+//! `--ignore-push-failures` must not turn "every push failed" into a success.
+//!
+//! The flag means "do not stop at the first failure". It used to also mean
+//! "never report failure": each error was logged as a warning, `try_push`
+//! returned `Ok(())`, and the loop finished `Ok(())` however many failed. A
+//! gate written as `podup push --ignore-push-failures && deploy.sh` therefore
+//! deployed against a registry that had received nothing at all.
+//!
+//! The two cases below are the whole distinction. One survivor is the flag
+//! working; no survivors is a failed push wearing a zero.
+
+use super::PushOptions;
+// Gated the way pull_tests.rs gates it: fake_podman binds a unix socket, so the
+// import itself does not resolve on Windows. The #[cfg(unix)] on each test is
+// not enough -- a module-level use is compiled everywhere.
+#[cfg(unix)]
+use crate::engine::fake_podman;
+
+fn opts() -> PushOptions {
+	PushOptions {
+		ignore_failures: true,
+		tls_verify: None,
+	}
+}
+
+/// Every image fails. The flag must not hide that from the exit code.
+#[tokio::test]
+#[cfg(unix)]
+async fn every_push_failing_is_an_error_even_when_failures_are_ignored() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/push") {
+			(500, r#"{"message":"registry unreachable"}"#.to_string())
+		} else {
+			(200, "{}".to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file = crate::parse_str("services:\n  a:\n    image: one\n  b:\n    image: two\n").unwrap();
+
+	let err = e
+		.push_with_quiet(&file, &[], opts(), false)
+		.await
+		.expect_err("all pushes failed, so the run must not report success");
+
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("every push failed"),
+		"the error must say every push failed, not name one image: {msg}"
+	);
+}
+
+/// One image fails, one succeeds. That is what the flag is for, and it stays
+/// a success -- otherwise the fix would have replaced one wrong answer with
+/// another.
+#[tokio::test]
+#[cfg(unix)]
+async fn one_survivor_keeps_the_run_successful() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/push") && target.contains("bad") {
+			(500, r#"{"message":"registry unreachable"}"#.to_string())
+		} else {
+			(200, "{}".to_string())
+		}
+	});
+	let e = crate::engine::Engine::new(fake.client(), "proj".into());
+	let file =
+		crate::parse_str("services:\n  a:\n    image: bad\n  b:\n    image: good\n").unwrap();
+
+	e.push_with_quiet(&file, &[], opts(), false)
+		.await
+		.expect("one image failed and one succeeded: --ignore-push-failures must absorb that");
+}

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -426,7 +426,7 @@ impl Engine {
 					.await
 					.map_err(ComposeError::Podman)?
 			};
-			print_frame(&report, &running, &stopped, &opts, None);
+			print_frame(&report, &running, &stopped, &opts, None)?;
 			return Ok(());
 		}
 
@@ -448,7 +448,7 @@ impl Engine {
 
 		while let Some(frame) = frames.next().await {
 			match frame {
-				Ok(report) => print_frame(&report, &running, &stopped, &opts, region.as_mut()),
+				Ok(report) => print_frame(&report, &running, &stopped, &opts, region.as_mut())?,
 				Err(e) => {
 					// A `stats --stream` stream lives as long as any sampled
 					// container is running, and ends once none remain. libpod
@@ -624,7 +624,7 @@ fn print_frame(
 	stopped: &[String],
 	opts: &StatsOptions,
 	region: Option<&mut crate::ui::progress::Region>,
-) {
+) -> Result<()> {
 	let rows = frame_rows(report, running, stopped);
 
 	if opts.json {
@@ -635,13 +635,21 @@ fn print_frame(
 		// `stats --format json` was unreadable by anything for as long as it
 		// streamed. `--no-stream` prints one frame and exits, so it stays a
 		// single pretty document, which is valid JSON and nicer to read.
+		// Propagated, not swallowed. `unwrap_or_default()` printed an empty line
+		// on a serialisation failure and carried on, so `stats --format json`
+		// emitted a blank where a frame should be and still exited zero -- a
+		// consumer piping into `jq` sees a gap and no reason for it. The other
+		// five list commands route through `to_pretty_json`, whose contract says
+		// a failure "must propagate as an error and exit non-zero"; stats was
+		// the one that did not. Same error variant, so the message reads alike.
 		let text = if opts.no_stream {
 			serde_json::to_string_pretty(&json)
 		} else {
 			serde_json::to_string(&json)
-		};
-		println!("{}", text.unwrap_or_default());
-		return;
+		}
+		.map_err(|e| ComposeError::Build(format!("invalid stats frame: {e}")))?;
+		println!("{text}");
+		return Ok(());
 	}
 
 	let colour = crate::ui::stdout_colored();
@@ -656,12 +664,14 @@ fn print_frame(
 	// the cursor for no reason.
 	if let Some(region) = region {
 		region.show(&[], &lines);
-		return;
+		return Ok(());
 	}
 	for line in lines {
 		println!("{line}");
 	}
 	println!();
+
+	Ok(())
 }
 
 #[cfg(test)]

--- a/tests/shell/ci-runs-every-test.test.sh
+++ b/tests/shell/ci-runs-every-test.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Every shell test must be invoked by a workflow, and every shell test a
+# workflow invokes must exist. Both directions.
+#
+# This does NOT watch the Rust tests, and that is the point of writing it now
+# rather than copying it from the distribution repositories earlier. cargo
+# discovers its own tests and CI runs them with --all-features, so a Rust test
+# cannot sit unregistered -- the analysis in the independence plan said exactly
+# that, and it was right at the time, because this repository had no shell tests
+# at all.
+#
+# Then tests/shell/locale-pinned.test.sh was added, and with it the one file
+# type that only runs when a workflow names it. The conclusion did not survive
+# the change that followed it. A second shell test added tomorrow would sit
+# here, pass when anyone ran it by hand, and never execute in CI.
+#
+# In apt that happened for real: a guard against unpinned collation lived in
+# tests/ for a day, passed locally, and no workflow called it.
+#
+# Comments do not count as wiring. The first version of this check in apt
+# matched any mention of the path, so a test named only in prose read as
+# invoked. Strip comment lines before looking.
+#
+# Requires: nothing beyond coreutils, grep and git.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+pass=0; fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# What the workflows actually run, with comment lines removed first.
+invoked() {
+	grep -rh -v '^[[:space:]]*#' .github/workflows/ 2>/dev/null \
+		| grep -oE '\./tests/[A-Za-z0-9_./-]+\.test\.sh' \
+		| sed 's|^\./||' | LC_ALL=C sort -u
+}
+
+# What exists, from git rather than the working tree, so an untracked scratch
+# file does not fail the run for someone mid-edit.
+present() {
+	git ls-files 'tests/**/*.test.sh' 'tests/*.test.sh' | LC_ALL=C sort -u
+}
+
+inv="$(invoked)"
+pres="$(present)"
+
+check "there is at least one shell test to account for" "1" \
+	"$([ -n "$pres" ] && echo 1 || echo 0)"
+
+check "every shell test is invoked by a workflow" "" \
+	"$(comm -13 <(printf '%s\n' "$inv") <(printf '%s\n' "$pres"))"
+
+check "every test a workflow invokes exists" "" \
+	"$(comm -23 <(printf '%s\n' "$inv") <(printf '%s\n' "$pres"))"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Two behavioural fixes reach users with this release.

`push --ignore-push-failures` returned 0 when every push failed, so a gate
written as `podup push --ignore-push-failures && deploy.sh` deployed against a
registry that had received nothing. Only every-attempt-failed is an error now;
one survivor still succeeds, which is what the flag is for.

`stats --format json` swallowed serialisation failures, printing an empty line
and exiting 0 where the other five list commands propagate.

Minor rather than patch: both change observable exit codes, and a script that
depended on the old zero will notice. Not major -- neither is a deliberate API
change, they are corrections of behaviour that was wrong.

Also in this range, none of it touching the binary:

- a watcher that fails when a shell test exists but no workflow invokes it
- the two pins the drift watcher reported (#1563)
- fourteen reusables brought in from Glyndor/.github, the callers repointed, and
  the asset verifier owned locally, so this repository now calls nothing from
  that one