### PR TITLE
docs(ci): say why these workflows trigger where they do

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,10 @@
 #                the `bench` label exists.
 name: benchmark
 
+# Three triggers, three questions:
+# pull_request (with paths): did this PR break the harness code itself?
+# workflow_dispatch: starts the engine job on the self-hosted runner.
+# monthly schedule: keeps the engine job ticking so a missed dispatch is visible.
 on:
   # The harness checks only guard anything if they run when the harness changes.
   # Until #1227 they fired on dispatch and the monthly cron alone, so a PR could

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -13,6 +13,8 @@ name: Publish to crates.io
 # crates.io. It never touches the release, the assets, the tag, or the signing
 # key. crates.io rejects a duplicate version, so a second run is a no-op rather
 # than a hazard.
+# Trigger is workflow_dispatch only: manual recovery for a publish step that
+# already failed in release.yml, never a check that runs on every change.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -1,5 +1,14 @@
 name: Line limit
 
+# Pull request only, and this one is worth saying because it looks like dco's
+# twin and is not. dco reads the commit range off the pull request event, so a
+# push is not a range it can walk. line-limit reads no base ref at all: the
+# reusable ends `done < <(git ls-files -z)` and counts code lines in tracked
+# files, so it is a property of the tree and would evaluate identically on a
+# push. What makes pull_request sufficient here is not its shape, it is that
+# both rulesets require a pull request, so no content reaches develop or main
+# without one. If a direct-push path is ever opened, this scoping stops covering
+# the tree and a push trigger becomes the correct one.
 on:
   pull_request:
     branches:

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -1,5 +1,10 @@
 name: guard
 
+# Pull request into main only. The reusable's `if:` already restricts to base
+# == main, and I mirrored it here because the rulesets require this check on
+# main and not on develop. A skipped required check reports Success, so the
+# asymmetry is what stops develop merges being blocked by an unanswerable
+# check.
 on:
   pull_request:
     branches: ["main"]

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -10,6 +10,13 @@ name: podman-lane
 # Fedora qemu VM booted in the runner (nested-virt — the ubuntu-24.04 runner exposes
 # /dev/kvm) with full systemd, as a rootless user. Podman 6 = Fedora rawhide;
 # Podman 5 = Fedora 44.
+
+# Three triggers, three questions:
+# workflow_dispatch: starts the lane on demand.
+# pull_request (no paths): must report on every PR; runtime behaviour is the
+# whole point, so this is the gate the merge hangs on.
+# schedule: GitHub only reads this from the default branch, so the cron
+# works because this workflow lives on main.
 on:
   workflow_dispatch:
   # Nightly safety net on the default branch: catches a runtime regression that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: release
 
+# Trigger is push on a v* tag, plus workflow_dispatch with a tag input. A tag
+# push is the only natural release event (a release is a tag), and I added
+# dispatch so a release that started from a tag push but failed partway can be
+# retried against the same tag, without bumping the version.
 on:
   push:
     tags:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,5 +1,8 @@
 name: Supply chain
 
+# Pull request runs with a Cargo path filter (only supply-chain-touching PRs
+# pay the cost); push to develop runs unfiltered (every develop commit must
+# validate the supply chain, so the branch never sits with a stale audit).
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## The problem

The org CI standard asks that a workflow whose trigger list differs from its siblings' says why in
the file, on the grounds that an undocumented scoping decision cannot be told apart from an
oversight. It also records, about this repository specifically, that its split "may be sound, but
it is reconstructed here from the shape, not quoted from anywhere". This closes that.

## What I added

Comments only, directly above each `on:` block that differs. Nothing else is touched: no trigger,
job, step, `env:`, `permissions:` block or input, and every file still parses as YAML.

Two of the reasons are worth pulling out of the diff, because they were not obvious to me before
I measured them.

**A workflow carrying a cron works because it is on `main`, not because the cron is written
correctly.** GitHub reads `schedule:` triggers only from the default branch, so a scheduled
workflow living on `develop` alone is inert with nothing reporting it: it runs on whatever other
triggers it declares, reports green, and its cron never fires. `helmly-agent` found this in its
own repository, where the weekly `cargo audit` had been silent for eleven days. I verified every
scheduled workflow here exists on `main` **with its `schedule:` block intact**, checking both
separately, because a file present on the default branch without the block would produce the same
defect and an existence check would miss it.

**`line-limit` looks like `dco`'s twin and is not** (podup only). `dco` reads the commit range off
the pull request event, so a push is not a range it can walk. `line-limit` reads no base ref at
all: the reusable ends `done < <(git ls-files -z)` and counts code lines in tracked files, so it
is a property of the tree and would evaluate identically on a push. What makes `pull_request`
sufficient is not its shape, it is that both rulesets require a pull request, so no content
reaches `develop` or `main` without one. I read both rulesets to confirm that rather than assume
it. If a direct-push path is ever opened, this scoping stops covering the tree.

## How this was written

The comments were drafted by a model given the measured facts up front with an instruction not to
re-derive them, and one rule that mattered: if a trigger list differs and the reason is not
determinable from the repository, say the scoping is undocumented and leave the choice to the
maintainer, because an invented rationale is worse than the gap. I reviewed every claim against
the repository before committing, and wrote the `line-limit` comment myself after finding my own
brief had a contradiction the model resolved the other way.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
