### PR TITLE
ci(codeowners): name the workflows directory explicitly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,18 @@
 # Default owner for everything in this repository.
-* @Jaro-c
+*                       @Jaro-c
+
+# Listed again, after the catch-all, because GitHub applies the LAST matching
+# rule: any more specific pattern added below `*` later would leave this path
+# uncovered, and nothing reports that. Naming it explicitly fixes it here.
+#
+# This path is the one that matters. A pull request that edits a workflow can
+# change what the gates do in the same run that the gates evaluate it, so
+# review of this directory is the mitigation for gate spoofing.
+#
+# require_code_owner_review is `false` in both rulesets today, which is correct
+# while there is a single maintainer -- a review requirement nobody else can
+# satisfy blocks the only person who can merge. The mitigation needs this file
+# to already say the right thing on the day it is switched on, which is why the
+# line is here now rather than written in a hurry then. Recorded in the closeout
+# plan of 2026-07-19 and unapplied until today.
+.github/workflows/      @Jaro-c


### PR DESCRIPTION
The file had only the catch-all. GitHub applies the last matching rule, so any
more specific pattern added below `*` later would leave .github/workflows/
uncovered, silently.

That directory is the one that matters: a pull request editing a workflow can
change what the gates do in the run that evaluates it, so review of this path is
the gate-spoofing mitigation. require_code_owner_review stays false in both
rulesets, which is right with one maintainer -- this makes the file say the
correct thing on the day it is switched on rather than being written that day.

Noted in the 2026-07-19 closeout plan and unapplied until now. epistle#759 did
it first and this follows its shape; the trio has it open as apt#149,
homebrew-tap#98 and scoop-bucket#89.