### PR TITLE
chore(release): bump to 5.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+podup (5.2.1) unstable; urgency=medium
+
+  * No user-visible change. CI only: the Rust toolchain pin is watched
+    here now, in all nine places it is written, and a path-filtered
+    workflow is failed when it does not name the reusable it calls.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sat, 29 Aug 2026 03:20:00 -0500
+
 podup (5.2.0) unstable; urgency=medium
 
   * push: --ignore-push-failures no longer exits 0 when every push failed.


### PR DESCRIPTION
## Summary

- Version bump only, ahead of the `develop` to `main` release pull request.
- `5.2.1` rather than `5.3.0`: the four commits since 5.2.0 are CI and documentation, and nothing a user runs behaves differently.

## Changes

`Cargo.toml`, `Cargo.lock` and `debian/changelog`, which are the three files that stamp a version onto a shipped artifact. The release workflow's verify job compares them before building, and 1.9.0 is the release that taught us why: it shipped `podup_1.8.0_*.deb`, so `apt upgrade` reported nothing to do and Debian users never received it.

**Why publish CI-only work at all.** One of the four commits is inert until it is on the default branch. GitHub reads a `schedule:` trigger from the default branch and runs *that branch's* version of the file, so Monday's `pin-watch` run is `main`'s four-pin copy, with the line saying Rust is watched by `Glyndor/.github`. The five-pin version that closes #1582's gap is on `develop` and does nothing there. This release is what moves it.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally. The three suites a version bump can move are green: `package_excludes`, `workflow_toolchain_pin` and `api_surface`.
- [x] `./tests/shell/*.test.sh` pass locally
- [x] shellcheck is clean. At 0.10.0 locally; CI pins 0.11.0.
- [ ] Podman lane ran. No `internal/` change.
- [ ] Asset-contract fixtures ran. No installer or fixture change.
- [x] New or changed checks were verified by deleting the control and watching them fail. No check changes here.

`dpkg-parsechangelog` reads the new stanza as `Version: 5.2.1`, `Distribution: unstable`, `Urgency: medium`, which is what `dpkg-buildpackage` will stamp on the `.deb`. The weekday in the timestamp was checked against the date rather than typed from memory; a wrong one is the kind of thing that only fails inside the packaging container.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] Every new file in `tests/shell/` is named in some workflow's `test-command`. No new files.
- [x] No secrets, keys or credentials in code, logs or fixtures
- [ ] Docs updated if behaviour changed. No behaviour changed.
- [x] `Cargo.toml` and `debian/changelog` are at the same version. Both read 5.2.1, and so does `Cargo.lock`.
- [ ] Binary budget. No production code changed.

## Related issues

Refs #1582, whose fix this release is what activates.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
