### PR TITLE
ci: build the .deb in one trixie snapshot, and assert it stays that way

### DIFF
--- a/.github/workflows/reusable-rust-debian.yml
+++ b/.github/workflows/reusable-rust-debian.yml
@@ -18,12 +18,21 @@ on:
       debian-image:
         description: Container image to build in (a stable suite is reproducible)
         type: string
-        # debian:trixie as of 2026-07-17. Digest-pinned so a retag of the
-        # trixie tag can't silently change the build environment; bump this
-        # default when a newer trixie snapshot is needed. release.yml pins a
-        # digest of its own for the same suite and the two do not agree; see
-        # the note there.
-        default: "debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4"
+        # debian:trixie as the registry served it on 2026-08-29.
+        # Digest-pinned so a retag of the trixie tag can't silently change the
+        # build environment; bump this default when a newer trixie snapshot is
+        # needed.
+        #
+        # release.yml pins a digest of its own for the same suite, because a
+        # `container:` needs a literal and cannot read this default. The two
+        # must be the same value: this one is what every pull request builds
+        # the .deb in, that one is what the published .deb is built in, and a
+        # difference means the package that ships was never built in an
+        # environment any pull request exercised. They were different from
+        # before #1568 until #1583, by an image and six weeks. pin-watch.yml
+        # reads both and reports them disagreeing, and
+        # tests/workflow_debian_image.rs asserts it on every pull request.
+        default: "debian:trixie@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1"
       arch:
         description: Architecture to verify/stage (empty matches any)
         type: string

--- a/tests/workflow_debian_image.rs
+++ b/tests/workflow_debian_image.rs
@@ -1,0 +1,161 @@
+//! The two workflows that build the `.deb` must build it in the same image.
+//!
+//! `release.yml`'s `build-deb` job names a `container:`, and
+//! `reusable-rust-debian.yml` carries a `debian-image` default that the
+//! `debian-build` lane takes on every pull request. A `container:` needs a
+//! literal and cannot read the reusable's default, so the value exists twice
+//! and nothing derives one from the other.
+//!
+//! They were different from before #1568 until #1583, by an image and six
+//! weeks. The consequence is not cosmetic: the `.deb` that ships was built in
+//! an environment no pull request had exercised, and the release is immutable,
+//! so the first place a difference could surface was the one place it cannot
+//! be corrected.
+//!
+//! `pin-watch.yml` reads both and reports them disagreeing, and that is a
+//! weekly cron. This is the same assertion at pull-request time, which is
+//! while the fix is still a one-line edit in an open branch. The overlap is
+//! deliberate; both files say so.
+
+use std::fs;
+use std::path::Path;
+
+/// Pull the pinned image out of a workflow.
+///
+/// `scope` is the key whose block the value lives in, or `None` when the key
+/// is at the top level of a job (`container:`). Scoping matters: the first
+/// draft took the first `default:` in the file, which in
+/// `reusable-rust-debian.yml` belongs to a different input and reads
+/// `ubuntu-latest`. Both assertions below failed on the first run and said so
+/// by name, which is the argument for writing the test before trusting the
+/// parser under it.
+///
+/// Comment lines are dropped first. A comment quoting a digest would satisfy
+/// a bare search for the shape, and this file exists because a comment about
+/// these two values was wrong for six weeks.
+fn pinned_image(workflow: &str, scope: Option<&str>, key: &str) -> String {
+	let mut inside = scope.is_none();
+	let mut scope_indent = 0usize;
+
+	for line in workflow.lines() {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() || trimmed.starts_with('#') {
+			continue;
+		}
+		let indent = line.len() - trimmed.len();
+
+		if let Some(name) = scope {
+			if !inside {
+				if trimmed == name {
+					inside = true;
+					scope_indent = indent;
+				}
+				continue;
+			}
+			// A key at the same or lower indent closes the block, so a
+			// `default:` belonging to the next input is not attributed here.
+			if indent <= scope_indent {
+				break;
+			}
+		}
+
+		if let Some(rest) = trimmed.strip_prefix(key) {
+			return rest.trim().trim_matches('"').to_string();
+		}
+	}
+	panic!(
+		"no `{key}` line pinning an image{}",
+		match scope {
+			Some(name) => format!(" under `{name}`"),
+			None => String::new(),
+		}
+	)
+}
+
+fn read(name: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join(".github/workflows")
+		.join(name);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{name} is readable: {e}"))
+}
+
+#[test]
+fn both_deb_builds_pin_the_same_debian_image() {
+	let release = pinned_image(&read("release.yml"), None, "container:");
+	let lane = pinned_image(
+		&read("reusable-rust-debian.yml"),
+		Some("debian-image:"),
+		"default:",
+	);
+
+	assert_eq!(
+		release, lane,
+		"release.yml builds the published .deb in {release:?} while the \
+		 debian-build lane builds it in {lane:?}. A difference means the \
+		 package that ships was never built in an environment any pull \
+		 request exercised, and a published release cannot be corrected."
+	);
+}
+
+#[test]
+fn the_pinned_image_is_a_digest_and_not_a_moving_tag() {
+	for (name, scope, key) in [
+		("release.yml", None, "container:"),
+		(
+			"reusable-rust-debian.yml",
+			Some("debian-image:"),
+			"default:",
+		),
+	] {
+		let pinned = pinned_image(&read(name), scope, key);
+		let (image, digest) = pinned
+			.split_once("@sha256:")
+			.unwrap_or_else(|| panic!("{name} pins {pinned:?}, which carries no sha256 digest"));
+		assert_eq!(
+			image, "debian:trixie",
+			"{name} pins {image:?}. Sid was a moving tag: two releases built \
+			 from identical source could land in different environments with \
+			 nothing in history recording which."
+		);
+		assert!(
+			digest.len() == 64 && digest.bytes().all(|c| c.is_ascii_hexdigit()),
+			"{name} pins {digest:?}, which is not a 64-character hex digest"
+		);
+	}
+}
+
+/// The parser is what both tests trust, so pin it on input that differs from
+/// today's files. Otherwise a parser that always returned the same string
+/// would satisfy the equality above and prove nothing.
+#[test]
+fn the_parser_reads_the_value_rather_than_guessing_it() {
+	let yml = "\
+jobs:
+  build-deb:
+    # container: debian:trixie@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    container: debian:trixie@sha256:1111111111111111111111111111111111111111111111111111111111111111
+";
+	assert_eq!(
+		pinned_image(yml, None, "container:"),
+		"debian:trixie@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"a digest named only in a comment must not be returned"
+	);
+
+	// The case the first draft got wrong: another input defaults ahead of
+	// debian-image, and an unscoped search returns that one.
+	let reusable = "\
+      runner:
+        default: \"ubuntu-latest\"
+      debian-image:
+        description: Container image to build in
+        default: \"debian:trixie@sha256:2222222222222222222222222222222222222222222222222222222222222222\"
+      arch:
+        default: \"amd64\"
+";
+	assert_eq!(
+		pinned_image(reusable, Some("debian-image:"), "default:"),
+		"debian:trixie@sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		"the value must come from debian-image's own block, not from whichever \
+		 input defaults first"
+	);
+}


### PR DESCRIPTION
## Summary

- The two workflows that build the `.deb` now build it in the same image, and a test keeps them that way.
- The `debian-build` lane moves from `fac46b` to `f324c7`, which is what the registry serves for `debian:trixie` today.

## Changes

`release.yml` pinned `f324c7` and `reusable-rust-debian.yml` defaulted to `fac46b`, six weeks older. The lane every pull request runs takes the default, so the package that shipped was built in an environment no pull request had exercised. A published release cannot be corrected, so the first place a difference could surface was the one place it cannot be fixed.

**The image is not a guess.** `f324c7` is what the registry served when this was measured, and it is what `v5.2.1` was built in an hour ago: both `.deb`s came out of it without incident. The risk of this change is on the other side, in the lane, which is where you want it.

**Equal is not enough on its own.** A `container:` needs a literal and cannot read the reusable's default, so the value exists twice and nothing derives one from the other. That is how they drifted apart without anyone noticing. `pin-watch.yml` already reports them disagreeing, but it is a weekly cron, and a drift reported up to seven days later is no longer a one-line edit in a branch somebody still has open. `tests/workflow_debian_image.rs` asserts it on every pull request. The overlap is deliberate and both files say so.

The comment in each file is rewritten. The one in `release.yml` claimed the two were the same snapshot, which was false from before #1568 until now.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally
- [x] `./tests/shell/*.test.sh` pass locally
- [x] shellcheck is clean. At 0.10.0 locally; CI pins 0.11.0.
- [x] `actionlint` clean on both edited workflows, at v1.7.12, the version the reusable pins
- [ ] Podman lane ran. No `internal/` change.
- [x] Asset-contract fixtures ran. No installer change, but `release.yml` is in that workflow's filter.
- [x] New or changed checks were verified by deleting the control and watching them fail

Both sabotages were diffed against a copy taken beforehand:

- the two digests made different again: `both_deb_builds_pin_the_same_debian_image` red, naming both values;
- `release.yml` rewritten to the moving `debian:sid` tag that its own comment exists to warn about: `the_pinned_image_is_a_digest_and_not_a_moving_tag` red as well as the equality one.

**The parser was wrong on the first run and the test is what said so.** The first draft took the first `default:` line in the file, which in `reusable-rust-debian.yml` belongs to another input and reads `ubuntu-latest`. Both assertions failed and named that value, so the parser is scoped to `debian-image`'s own block now, and the parser test carries that exact case rather than a made-up one.

One thing worth recording because it cost a wrong reading. Restoring a sabotage with `git checkout -- <file>` restores from HEAD, not from the working tree, so on a branch whose fix is not committed yet it discards the fix rather than the sabotage. The restoration step went red for that reason and not for the test's, and the digest had to be reapplied. Commit first, or keep the copy taken beforehand and restore from it.

`pin-watch.yml` run against the tree afterwards reports no drift in any of its five pins.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] Every new file in `tests/shell/` is named in some workflow's `test-command`. The new test is Rust, which cargo discovers.
- [x] No secrets, keys or credentials in code, logs or fixtures
- [ ] Docs updated if behaviour changed. No user-visible behaviour changed.
- [x] `Cargo.toml` and `debian/changelog` are at the same version. Both 5.2.1, untouched.
- [ ] Binary budget. No production code changed.

## Related issues

Closes #1583.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
