### PR TITLE
fix(packaging): require podman rather than recommending it

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ installs podup with apt — so upgrades and signing-key renewals arrive through
 packages. It leaves nothing of its own behind: the download is removed, and so
 is anything it had to install just to check the key.
 
-podup needs **Podman ≥ 5.0** (rootless) with its API socket listening. Podman is
-daemonless, but podup speaks the libpod API:
+podup needs **Podman ≥ 5.0** (rootless). The package depends on it, so apt
+installs it alongside podup, and refuses the install on a distribution whose
+Podman is older than that. Podman is daemonless, but podup speaks the libpod
+API, so the socket still has to be listening:
 
 ```sh
 systemctl --user enable --now podman.socket
@@ -105,9 +107,16 @@ it for its whole supported life.
 | Fedora 42 and newer           | 5.x+   | yes        |
 
 Ubuntu 24.04 LTS is not supported: it ships Podman 4.9.3 and will keep shipping
-that for its whole supported life. On any row marked "no", the engine has to
-come from somewhere other than the distribution:
+that for its whole supported life. On any row marked "no", `apt install podup`
+refuses rather than installing a podup that cannot reach an engine, and the
+engine has to come from somewhere other than the distribution:
 <https://podman.io/docs/installation>.
+
+Driving a **remote** Podman, or a `podman machine`, is the case apt cannot
+express: a package relationship only sees the local machine. Use the release
+binary there. `install.sh` warns instead of refusing when no local Podman is
+present, and takes `--skip-podman-check` when a local one is present but is not
+the engine podup will use.
 
 ### Platforms
 

--- a/debian/control
+++ b/debian/control
@@ -23,8 +23,26 @@ Rules-Requires-Root: no
 
 Package: podup
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Recommends: podman (>= 5.0)
+# podman is a Depends, not a Recommends. podup is a translator: it turns a
+# compose file into calls on Podman's libpod API and does nothing else, so a
+# podup without an engine is not a degraded install, it is an install that
+# cannot do the one thing it is for.
+#
+# The floor is the same one MIN_LIBPOD_API_MAJOR enforces at run time and
+# PODMAN_MIN_MAJOR checks in install.sh. Three copies of one number, tied by
+# tests/podman_floor.rs, because as a Depends this one decides whether the
+# package installs at all rather than merely what apt suggests alongside it.
+#
+# The consequence, stated rather than discovered: on a distribution whose
+# podman is below the floor, `apt install podup` now FAILS instead of leaving
+# a podup that cannot reach an engine. Ubuntu 24.04 LTS ships 4.9.3 and is
+# already documented as unsupported, so apt now refuses what the README
+# already said would not work. The cost is the operator driving a REMOTE
+# socket or a `podman machine`, who has no local engine to satisfy this and
+# must now install one; install.sh serves that case with
+# --skip-podman-check, and apt has no equivalent because a package
+# relationship cannot ask where the socket is.
+Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 5.0)
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -97,7 +97,7 @@ is published and `apt upgrade` installs it — nothing for users to re-run.
 
 ## What the skeleton covers
 
-- `debian/control` — source/binary stanzas, build dependencies, `Recommends: podman`
+- `debian/control` — source/binary stanzas, build dependencies, `Depends: podman (>= 5.0)`
 - `debian/rules` — debhelper with cargo overrides, `--locked` release build, tests run during the build
 - `debian/podup.1` + `debian/podup.manpages` — the man page, installed by `dh_installman`
 - `debian/copyright` — DEP-5, MIT

--- a/tests/podman_floor.rs
+++ b/tests/podman_floor.rs
@@ -1,0 +1,164 @@
+//! The Podman floor is written in three places and nothing derives one from
+//! another.
+//!
+//! - `internal/libpod/client/mod.rs` — `MIN_LIBPOD_API_MAJOR`, the gate the
+//!   running binary applies to the major the engine reports.
+//! - `install.sh` — `PODMAN_MIN_MAJOR`, the precheck that refuses to install
+//!   over a local engine below the floor.
+//! - `debian/control` — the `podman (>= N.0)` relationship.
+//!
+//! The third one used to be a `Recommends`, where a wrong number cost a
+//! suggestion. As a `Depends` it decides whether the package installs at all,
+//! so a copy that drifts low lets apt install podup onto an engine the binary
+//! will then refuse, and a copy that drifts high refuses an install that
+//! would have worked. Neither shows up until a user hits it, on a machine
+//! nobody here owns.
+//!
+//! `install.ps1` carries no floor and needs none: there is no Windows package
+//! relationship to satisfy, and the engine lives in a `podman machine` VM
+//! whose version the installer cannot read from the host.
+
+use std::fs;
+use std::path::Path;
+
+fn read(rel: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} is readable: {e}"))
+}
+
+/// `const MIN_LIBPOD_API_MAJOR: u64 = 5;`
+fn floor_from_source() -> u64 {
+	let src = read("internal/libpod/client/mod.rs");
+	src.lines()
+		.map(str::trim_start)
+		.filter(|l| !l.starts_with("//"))
+		.find_map(|l| l.split_once("MIN_LIBPOD_API_MAJOR: u64 = "))
+		.and_then(|(_, rest)| rest.trim_end_matches(';').trim().parse().ok())
+		.expect("MIN_LIBPOD_API_MAJOR is declared as a u64 literal")
+}
+
+/// `PODMAN_MIN_MAJOR=5`
+fn floor_from_installer() -> u64 {
+	let src = read("install.sh");
+	src.lines()
+		.map(str::trim_start)
+		.filter(|l| !l.starts_with('#'))
+		.find_map(|l| l.strip_prefix("PODMAN_MIN_MAJOR="))
+		.and_then(|v| v.trim().trim_matches('"').parse().ok())
+		.expect("install.sh assigns PODMAN_MIN_MAJOR")
+}
+
+/// The major out of `Depends: …, podman (>= 5.0)`.
+///
+/// Read off the `Depends:` line specifically, not from anywhere the string
+/// appears: this file exists because the same number in several places went
+/// out of step, and a comment quoting the relationship would satisfy a looser
+/// search. The comment above that field quotes it more than once.
+fn floor_from_control() -> u64 {
+	let src = read("debian/control");
+	let depends = src
+		.lines()
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.find(|l| l.starts_with("Depends:"))
+		.expect("debian/control's binary stanza declares Depends");
+	let (_, rest) = depends
+		.split_once("podman (>= ")
+		.unwrap_or_else(|| panic!("Depends does not require podman at all: {depends:?}"));
+	let version = rest
+		.split(')')
+		.next()
+		.expect("the podman relationship closes its parenthesis");
+	version
+		.split('.')
+		.next()
+		.and_then(|major| major.parse().ok())
+		.unwrap_or_else(|| panic!("cannot read a major out of {version:?}"))
+}
+
+#[test]
+fn the_package_requires_podman_rather_than_suggesting_it() {
+	let src = read("debian/control");
+	let binary = src
+		.split_once("\nPackage: podup\n")
+		.expect("debian/control has a binary stanza")
+		.1;
+	let relationships: Vec<&str> = binary
+		.lines()
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.filter(|l| l.starts_with("Depends:") || l.starts_with("Recommends:"))
+		.collect();
+
+	assert!(
+		relationships
+			.iter()
+			.any(|l| l.starts_with("Depends:") && l.contains("podman")),
+		"podman must be a Depends. podup translates a compose file into libpod \
+		 calls and does nothing else, so an install without an engine cannot do \
+		 the one thing it is for. Relationships found: {relationships:?}"
+	);
+	assert!(
+		!relationships
+			.iter()
+			.any(|l| l.starts_with("Recommends:") && l.contains("podman")),
+		"podman is declared as a Recommends as well as a Depends, which is \
+		 apt telling the user two different things about the same package"
+	);
+}
+
+#[test]
+fn every_podman_floor_agrees() {
+	let source = floor_from_source();
+	let installer = floor_from_installer();
+	let control = floor_from_control();
+
+	assert_eq!(
+		source, installer,
+		"MIN_LIBPOD_API_MAJOR is {source} and install.sh's PODMAN_MIN_MAJOR is \
+		 {installer}. The installer would admit an engine the binary refuses, \
+		 or refuse one it accepts."
+	);
+	assert_eq!(
+		source, control,
+		"MIN_LIBPOD_API_MAJOR is {source} and debian/control requires podman \
+		 >= {control}.0. Since podman is a Depends, this number decides whether \
+		 apt installs podup at all: too low and apt installs it onto an engine \
+		 the binary will refuse, too high and apt refuses an install that would \
+		 have worked."
+	);
+}
+
+/// The parsers are what the assertions above trust, so pin them on input that
+/// differs from today's files. A parser that always returned 5 would satisfy
+/// every equality and prove nothing.
+#[test]
+fn the_floor_parsers_read_the_values_rather_than_guessing_them() {
+	// Each helper reads a real file, so the shapes are exercised here through
+	// the same string handling rather than through the filesystem.
+	let control = "\
+# Depends: …, podman (>= 99.0) quoted in a comment
+Package: podup
+Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 7.0)
+";
+	let depends = control
+		.lines()
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.find(|l| l.starts_with("Depends:"))
+		.unwrap();
+	assert!(
+		depends.contains("podman (>= 7.0)"),
+		"the comment quoting a different floor must not be the line that is read"
+	);
+
+	// The real files still have to parse, and to a plausible major rather than
+	// to whatever `unwrap_or_default` would hand back.
+	for (name, got) in [
+		("MIN_LIBPOD_API_MAJOR", floor_from_source()),
+		("PODMAN_MIN_MAJOR", floor_from_installer()),
+		("debian/control", floor_from_control()),
+	] {
+		assert!(
+			(1..=99).contains(&got),
+			"{name} parsed as {got}, which is not a plausible Podman major"
+		);
+	}
+}

--- a/tests/podman_floor.rs
+++ b/tests/podman_floor.rs
@@ -32,7 +32,10 @@ fn floor_from_source(src: &str) -> u64 {
 		.map(str::trim_start)
 		.filter(|l| !l.starts_with("//"))
 		.find_map(|l| l.split_once("MIN_LIBPOD_API_MAJOR: u64 = "))
-		.and_then(|(_, rest)| rest.trim_end_matches(';').trim().parse().ok())
+		// `trim()` first. Trimming the semicolon before the whitespace leaves
+		// a trailing carriage return in front of it, so the `;` is never the
+		// last character and never removed, and the parse fails on `5;`.
+		.and_then(|(_, rest)| rest.trim().trim_end_matches(';').trim().parse().ok())
 		.expect("MIN_LIBPOD_API_MAJOR is declared as a u64 literal")
 }
 
@@ -200,27 +203,33 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 7.0)
 /// the longest round trip. Feeding the parsers CRLF here says it in a second.
 #[test]
 fn the_parsers_do_not_care_about_line_endings() {
-	let crlf = |rel: &str| read(rel).replace('\n', "\r\n");
+	// Normalise to LF first. On a Windows checkout the file already holds
+	// CRLF, so converting without normalising produces `\r\r\n`, which is
+	// not a shape any checkout delivers. This test asserted over it and went
+	// red on windows-latest for a defect of its own fixture rather than of
+	// the parsers it exists to cover.
+	let crlf = |rel: &str| read(rel).replace("\r\n", "\n").replace('\n', "\r\n");
+	let lf = |rel: &str| read(rel).replace("\r\n", "\n");
 
 	assert_eq!(
 		floor_from_source(&crlf("internal/libpod/client/mod.rs")),
-		floor_from_source(&read("internal/libpod/client/mod.rs")),
+		floor_from_source(&lf("internal/libpod/client/mod.rs")),
 		"MIN_LIBPOD_API_MAJOR reads differently under CRLF"
 	);
 	assert_eq!(
 		floor_from_installer(&crlf("install.sh")),
-		floor_from_installer(&read("install.sh")),
+		floor_from_installer(&lf("install.sh")),
 		"PODMAN_MIN_MAJOR reads differently under CRLF"
 	);
 	assert_eq!(
 		floor_from_control(&crlf("debian/control")),
-		floor_from_control(&read("debian/control")),
+		floor_from_control(&lf("debian/control")),
 		"the podman relationship reads differently under CRLF"
 	);
 
 	let crlf_control = crlf("debian/control");
 	let under_crlf = binary_stanza_relationships(&crlf_control);
-	let control = read("debian/control");
+	let control = lf("debian/control");
 	let under_lf = binary_stanza_relationships(&control);
 	assert_eq!(
 		under_crlf.len(),

--- a/tests/podman_floor.rs
+++ b/tests/podman_floor.rs
@@ -27,8 +27,7 @@ fn read(rel: &str) -> String {
 }
 
 /// `const MIN_LIBPOD_API_MAJOR: u64 = 5;`
-fn floor_from_source() -> u64 {
-	let src = read("internal/libpod/client/mod.rs");
+fn floor_from_source(src: &str) -> u64 {
 	src.lines()
 		.map(str::trim_start)
 		.filter(|l| !l.starts_with("//"))
@@ -38,8 +37,7 @@ fn floor_from_source() -> u64 {
 }
 
 /// `PODMAN_MIN_MAJOR=5`
-fn floor_from_installer() -> u64 {
-	let src = read("install.sh");
+fn floor_from_installer(src: &str) -> u64 {
 	src.lines()
 		.map(str::trim_start)
 		.filter(|l| !l.starts_with('#'))
@@ -54,8 +52,7 @@ fn floor_from_installer() -> u64 {
 /// appears: this file exists because the same number in several places went
 /// out of step, and a comment quoting the relationship would satisfy a looser
 /// search. The comment above that field quotes it more than once.
-fn floor_from_control() -> u64 {
-	let src = read("debian/control");
+fn floor_from_control(src: &str) -> u64 {
 	let depends = src
 		.lines()
 		.filter(|l| !l.trim_start().starts_with('#'))
@@ -75,18 +72,32 @@ fn floor_from_control() -> u64 {
 		.unwrap_or_else(|| panic!("cannot read a major out of {version:?}"))
 }
 
+/// The relationship lines of the binary stanza, in order.
+///
+/// Split with `lines()` rather than by searching for an embedded
+/// `"\nPackage: podup\n"`. That search is exact on bytes, so on a checkout
+/// with CRLF endings the newline after `podup` is `\r\n` and the needle is
+/// never found: the test panicked on Windows and nowhere else, over a file
+/// this change did not make platform-specific. `lines()` strips the carriage
+/// return for us.
+fn binary_stanza_relationships(control: &str) -> Vec<&str> {
+	control
+		.lines()
+		.skip_while(|l| l.trim_end() != "Package: podup")
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.filter(|l| l.starts_with("Depends:") || l.starts_with("Recommends:"))
+		.collect()
+}
+
 #[test]
 fn the_package_requires_podman_rather_than_suggesting_it() {
 	let src = read("debian/control");
-	let binary = src
-		.split_once("\nPackage: podup\n")
-		.expect("debian/control has a binary stanza")
-		.1;
-	let relationships: Vec<&str> = binary
-		.lines()
-		.filter(|l| !l.trim_start().starts_with('#'))
-		.filter(|l| l.starts_with("Depends:") || l.starts_with("Recommends:"))
-		.collect();
+	let relationships = binary_stanza_relationships(&src);
+	assert!(
+		!relationships.is_empty(),
+		"no Depends or Recommends line found after the `Package: podup` stanza \
+		 header; the parser has stopped seeing the file it is asserting about"
+	);
 
 	assert!(
 		relationships
@@ -107,9 +118,9 @@ fn the_package_requires_podman_rather_than_suggesting_it() {
 
 #[test]
 fn every_podman_floor_agrees() {
-	let source = floor_from_source();
-	let installer = floor_from_installer();
-	let control = floor_from_control();
+	let source = floor_from_source(&read("internal/libpod/client/mod.rs"));
+	let installer = floor_from_installer(&read("install.sh"));
+	let control = floor_from_control(&read("debian/control"));
 
 	assert_eq!(
 		source, installer,
@@ -152,13 +163,77 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 7.0)
 	// The real files still have to parse, and to a plausible major rather than
 	// to whatever `unwrap_or_default` would hand back.
 	for (name, got) in [
-		("MIN_LIBPOD_API_MAJOR", floor_from_source()),
-		("PODMAN_MIN_MAJOR", floor_from_installer()),
-		("debian/control", floor_from_control()),
+		(
+			"MIN_LIBPOD_API_MAJOR",
+			floor_from_source(&read("internal/libpod/client/mod.rs")),
+		),
+		(
+			"PODMAN_MIN_MAJOR",
+			floor_from_installer(&read("install.sh")),
+		),
+		(
+			"debian/control",
+			floor_from_control(&read("debian/control")),
+		),
 	] {
 		assert!(
 			(1..=99).contains(&got),
 			"{name} parsed as {got}, which is not a plausible Podman major"
 		);
 	}
+}
+
+/// Every parser here reads a file that a Windows checkout delivers with CRLF
+/// endings, and none of them should care.
+///
+/// This is a regression test with a date on it. The first version of
+/// `the_package_requires_podman_rather_than_suggesting_it` located the binary
+/// stanza with `split_once("\nPackage: podup\n")`, which is an exact byte
+/// match, so on CRLF the newline after `podup` is `\r\n` and the needle was
+/// never found. It passed on Linux and macOS and panicked on
+/// `rust / Test (windows-latest)` alone, over a file the change had not made
+/// platform-specific.
+///
+/// The point is not that one function. It is that a parser reading a
+/// repository file is reading a file whose line endings depend on who checked
+/// it out, and the only leg of the matrix that says so is the one that costs
+/// the longest round trip. Feeding the parsers CRLF here says it in a second.
+#[test]
+fn the_parsers_do_not_care_about_line_endings() {
+	let crlf = |rel: &str| read(rel).replace('\n', "\r\n");
+
+	assert_eq!(
+		floor_from_source(&crlf("internal/libpod/client/mod.rs")),
+		floor_from_source(&read("internal/libpod/client/mod.rs")),
+		"MIN_LIBPOD_API_MAJOR reads differently under CRLF"
+	);
+	assert_eq!(
+		floor_from_installer(&crlf("install.sh")),
+		floor_from_installer(&read("install.sh")),
+		"PODMAN_MIN_MAJOR reads differently under CRLF"
+	);
+	assert_eq!(
+		floor_from_control(&crlf("debian/control")),
+		floor_from_control(&read("debian/control")),
+		"the podman relationship reads differently under CRLF"
+	);
+
+	let crlf_control = crlf("debian/control");
+	let under_crlf = binary_stanza_relationships(&crlf_control);
+	let control = read("debian/control");
+	let under_lf = binary_stanza_relationships(&control);
+	assert_eq!(
+		under_crlf.len(),
+		under_lf.len(),
+		"the binary stanza yields {} relationship line(s) under CRLF and {} \
+		 under LF. This is the exact defect that reddened windows-latest and \
+		 nothing else.",
+		under_crlf.len(),
+		under_lf.len()
+	);
+	assert!(
+		!under_crlf.is_empty(),
+		"no relationship line found under CRLF; the comparison above would be \
+		 satisfied by both sides finding nothing"
+	);
 }


### PR DESCRIPTION
## Summary

- `podman (>= 5.0)` moves from `Recommends` to `Depends`. podup translates a compose file into libpod calls and does nothing else, so an install without an engine cannot do the thing it is for.
- A test ties the three places the Podman floor is written, because as a `Depends` that number decides whether the package installs at all.

## Changes

**The relationship.** `Recommends: podman (>= 5.0)` becomes part of `Depends`. The line arrived in the packaging skeleton in #36, when the goal was still the official Debian archive, and it is the only decision in `debian/control` with no reasoning beside it; the `Build-Depends` one carries a paragraph. It has one now.

**What changes for a user, stated rather than left to be discovered:**

| system | before | after |
|---|---|---|
| Debian trixie (Podman 5.4.2) | podman installed, because apt installs Recommends by default | podman installed, now as a requirement |
| Anything with `APT::Install-Recommends "false"` (minimal images, containers) | **neither engine nor warning** | podman installed |
| Ubuntu 24.04 LTS (Podman 4.9.3) | podup installs and cannot reach an engine | `apt install podup` **fails** |

The third row is the visible one. It is also the row the README has documented as unsupported since #1555, so apt now refuses what the documentation already said would not work, at install time instead of at first use.

**The case apt cannot express** is the operator driving a remote socket or a `podman machine`: a package relationship only sees the local machine, and there is no local engine to satisfy this. That case belongs to the release binary and `install.sh`, which warns rather than refusing when no local podman is present and takes `--skip-podman-check` when the local one is not the engine podup will use. The README says so beside the table now.

**`tests/podman_floor.rs`.** The floor is written in three places and derived from none of them:

- `internal/libpod/client/mod.rs` — `MIN_LIBPOD_API_MAJOR`, the gate the running binary applies
- `install.sh` — `PODMAN_MIN_MAJOR`, the installer precheck
- `debian/control` — the relationship

As a `Recommends` a wrong copy cost a suggestion. As a `Depends` a copy that drifts low lets apt install podup onto an engine the binary refuses, and one that drifts high refuses an install that would have worked. Neither surfaces until a user hits it, on a machine nobody here owns. The test also asserts the relationship is a `Depends` and not a `Recommends`, so putting it back is a red rather than a quiet regression.

`install.ps1` carries no floor and needs none: there is no Windows package relationship, and the engine lives in a `podman machine` VM whose version the installer cannot read from the host. That is written in the test rather than left as an absence.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally
- [x] `./tests/shell/*.test.sh` pass locally
- [x] shellcheck is clean over every tracked `*.sh`, at 0.10.0; CI pins 0.11.0
- [ ] Podman lane ran. No `internal/` change.
- [x] Asset-contract fixtures ran. `install.sh` is unchanged here, but `debian/**` puts this in the debian lane's filter, which is the one that builds the package this changes.
- [x] New or changed checks were verified by deleting the control and watching them fail

Three sabotages, each diffed against a copy taken beforehand, and the restoration confirmed by reading `Depends:` and `PODMAN_MIN_MAJOR` back rather than by the test going green:

- the `debian/control` floor moved to `6.0`: `every_podman_floor_agrees` red, naming both values and what each direction costs;
- `PODMAN_MIN_MAJOR` moved to `4`: same test red, naming the installer;
- the relationship put back to `Recommends`: all three tests red, including the parser test, which is the shape that says the file no longer looks like what the parsers were written for.

**`dpkg-parsechangelog` and a hand parse both read the new stanza**, and the binary stanza carries exactly one relationship line mentioning podman.

One thing found on the way and **not** fixed here, because it is a different defect: the pre-push shellcheck command in `CONTRIBUTING.md` uses `find` over the working tree, so on a tree where a local `.deb` build has run it walks `debian/cargo-home/`, a gitignored vendored registry, and reports findings in third-party crates that CI never sees. `git ls-files -z '*.sh' '*.bash' | xargs -0` is clean on the same tree. Worth its own change.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] Every new file in `tests/shell/` is named in some workflow's `test-command`. The new test is Rust, which cargo discovers.
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] Docs updated if behaviour changed. `README.md` and `docs/debian-packaging.md`, both of which described it as a recommendation.
- [x] `Cargo.toml` and `debian/changelog` are at the same version. Both 5.2.1, untouched; this is a packaging-relationship change and the next release carries it.
- [ ] Binary budget. No production code changed.

## Related issues

Refs #1553 and #1555, which established that Ubuntu 24.04 LTS is unsupported and that the product should say so before it breaks anything. This makes apt say it too.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
