### PR TITLE
chore(release): bump to 5.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.2.1"
+version = "5.3.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.2.1"
+version = "5.3.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+podup (5.3.0) unstable; urgency=medium
+
+  * The package now requires podman (>= 5.0) instead of recommending it.
+    apt installs the engine alongside podup, and refuses the install on a
+    distribution whose podman is older than that. Ubuntu 24.04 LTS ships
+    4.9.3 and has been documented as unsupported since 5.1.0; apt now says
+    so at install time rather than leaving a podup that cannot reach an
+    engine. Driving a remote podman or a podman machine is the case a
+    package relationship cannot express: use the release binary and
+    install.sh there.
+  * The pull-request lane and the release now build the .deb in the same
+    debian:trixie snapshot. They had carried different digests, so the
+    package that shipped was built in an environment no pull request had
+    exercised.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sat, 29 Aug 2026 09:45:00 -0500
+
 podup (5.2.1) unstable; urgency=medium
 
   * No user-visible change. CI only: the Rust toolchain pin is watched


### PR DESCRIPTION
## Summary

- Version bump only, ahead of the `develop` to `main` release pull request.
- `5.3.0` rather than `5.2.2`, because the package now declines an install it used to accept.

## Changes

`Cargo.toml`, `Cargo.lock` and `debian/changelog`, the three files that stamp a version onto a shipped artifact. The release workflow's verify job compares them before building, and 1.9.0 is the release that taught us why: it shipped `podup_1.8.0_*.deb`, so `apt upgrade` reported nothing to do and Debian users never received it.

**Why MINOR and not PATCH.** The library API did not change and nothing a user runs behaves differently, which normally points at a patch. But #1588 moved podman from `Recommends` to `Depends`, so on a distribution below the Podman floor `apt install podup` now fails where it used to install a podup that could not reach an engine. The package declines where it used to accept. Nobody's binary changed, but a provisioning script notices, and that is what a MINOR is for: an observable behaviour change rather than a corrected defect users were already working around.

The two changes this release carries:

- **#1588** — podman becomes a hard dependency, with `tests/podman_floor.rs` tying the three places the floor is written. Ubuntu 24.04 LTS ships 4.9.3 and has been documented as unsupported since 5.1.0; apt now says so at install time.
- **#1587** — the pull-request lane and the release build the `.deb` in the same `debian:trixie` snapshot. They had carried different digests, six weeks apart, so the package that shipped was built in an environment no pull request had exercised.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally. The five suites a version bump or a packaging change can move are green: `package_excludes`, `workflow_toolchain_pin`, `api_surface`, `podman_floor` and `workflow_debian_image`.
- [x] `./tests/shell/*.test.sh` pass locally
- [x] shellcheck is clean over every tracked `*.sh`, at 0.10.0; CI pins 0.11.0
- [ ] Podman lane ran. No `internal/` change.
- [x] Asset-contract fixtures ran. `debian/**` puts this in the debian lane's filter.
- [x] New or changed checks were verified by deleting the control and watching them fail. No check changes here; the ones this release carries were driven red in #1587 and #1588.

`dpkg-parsechangelog` reads the new stanza as `Version: 5.3.0`, `Distribution: unstable`, `Urgency: medium`, `Date: Sat, 29 Aug 2026 09:45:00 -0500`.

**The timestamp is generated under `LC_ALL=C`.** A Debian changelog needs English day and month names, and this machine's locale is Spanish, so inheriting it would write a date `dpkg` cannot parse. The weekday was taken from the date rather than typed, for the same reason as last release: a wrong one only fails inside the packaging container.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] Every new file in `tests/shell/` is named in some workflow's `test-command`. No new files.
- [x] No secrets, keys or credentials in code, logs or fixtures
- [ ] Docs updated if behaviour changed. `README.md` and `docs/debian-packaging.md` were updated in #1588, where the behaviour changed.
- [x] `Cargo.toml` and `debian/changelog` are at the same version. Both read 5.3.0, and so does `Cargo.lock`.
- [ ] Binary budget. No production code changed.

## Related issues

Refs #1553 and #1555, which established that Ubuntu 24.04 LTS is unsupported; this release is where apt starts saying it.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
