### PR TITLE
release: 5.3.0

### DIFF
--- a/.github/workflows/reusable-rust-debian.yml
+++ b/.github/workflows/reusable-rust-debian.yml
@@ -18,12 +18,21 @@ on:
       debian-image:
         description: Container image to build in (a stable suite is reproducible)
         type: string
-        # debian:trixie as of 2026-07-17. Digest-pinned so a retag of the
-        # trixie tag can't silently change the build environment; bump this
-        # default when a newer trixie snapshot is needed. release.yml pins a
-        # digest of its own for the same suite and the two do not agree; see
-        # the note there.
-        default: "debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4"
+        # debian:trixie as the registry served it on 2026-08-29.
+        # Digest-pinned so a retag of the trixie tag can't silently change the
+        # build environment; bump this default when a newer trixie snapshot is
+        # needed.
+        #
+        # release.yml pins a digest of its own for the same suite, because a
+        # `container:` needs a literal and cannot read this default. The two
+        # must be the same value: this one is what every pull request builds
+        # the .deb in, that one is what the published .deb is built in, and a
+        # difference means the package that ships was never built in an
+        # environment any pull request exercised. They were different from
+        # before #1568 until #1583, by an image and six weeks. pin-watch.yml
+        # reads both and reports them disagreeing, and
+        # tests/workflow_debian_image.rs asserts it on every pull request.
+        default: "debian:trixie@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1"
       arch:
         description: Architecture to verify/stage (empty matches any)
         type: string

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.2.1"
+version = "5.3.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.2.1"
+version = "5.3.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ installs podup with apt — so upgrades and signing-key renewals arrive through
 packages. It leaves nothing of its own behind: the download is removed, and so
 is anything it had to install just to check the key.
 
-podup needs **Podman ≥ 5.0** (rootless) with its API socket listening. Podman is
-daemonless, but podup speaks the libpod API:
+podup needs **Podman ≥ 5.0** (rootless). The package depends on it, so apt
+installs it alongside podup, and refuses the install on a distribution whose
+Podman is older than that. Podman is daemonless, but podup speaks the libpod
+API, so the socket still has to be listening:
 
 ```sh
 systemctl --user enable --now podman.socket
@@ -105,9 +107,16 @@ it for its whole supported life.
 | Fedora 42 and newer           | 5.x+   | yes        |
 
 Ubuntu 24.04 LTS is not supported: it ships Podman 4.9.3 and will keep shipping
-that for its whole supported life. On any row marked "no", the engine has to
-come from somewhere other than the distribution:
+that for its whole supported life. On any row marked "no", `apt install podup`
+refuses rather than installing a podup that cannot reach an engine, and the
+engine has to come from somewhere other than the distribution:
 <https://podman.io/docs/installation>.
+
+Driving a **remote** Podman, or a `podman machine`, is the case apt cannot
+express: a package relationship only sees the local machine. Use the release
+binary there. `install.sh` warns instead of refusing when no local Podman is
+present, and takes `--skip-podman-check` when a local one is present but is not
+the engine podup will use.
 
 ### Platforms
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+podup (5.3.0) unstable; urgency=medium
+
+  * The package now requires podman (>= 5.0) instead of recommending it.
+    apt installs the engine alongside podup, and refuses the install on a
+    distribution whose podman is older than that. Ubuntu 24.04 LTS ships
+    4.9.3 and has been documented as unsupported since 5.1.0; apt now says
+    so at install time rather than leaving a podup that cannot reach an
+    engine. Driving a remote podman or a podman machine is the case a
+    package relationship cannot express: use the release binary and
+    install.sh there.
+  * The pull-request lane and the release now build the .deb in the same
+    debian:trixie snapshot. They had carried different digests, so the
+    package that shipped was built in an environment no pull request had
+    exercised.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sat, 29 Aug 2026 09:45:00 -0500
+
 podup (5.2.1) unstable; urgency=medium
 
   * No user-visible change. CI only: the Rust toolchain pin is watched

--- a/debian/control
+++ b/debian/control
@@ -23,8 +23,26 @@ Rules-Requires-Root: no
 
 Package: podup
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Recommends: podman (>= 5.0)
+# podman is a Depends, not a Recommends. podup is a translator: it turns a
+# compose file into calls on Podman's libpod API and does nothing else, so a
+# podup without an engine is not a degraded install, it is an install that
+# cannot do the one thing it is for.
+#
+# The floor is the same one MIN_LIBPOD_API_MAJOR enforces at run time and
+# PODMAN_MIN_MAJOR checks in install.sh. Three copies of one number, tied by
+# tests/podman_floor.rs, because as a Depends this one decides whether the
+# package installs at all rather than merely what apt suggests alongside it.
+#
+# The consequence, stated rather than discovered: on a distribution whose
+# podman is below the floor, `apt install podup` now FAILS instead of leaving
+# a podup that cannot reach an engine. Ubuntu 24.04 LTS ships 4.9.3 and is
+# already documented as unsupported, so apt now refuses what the README
+# already said would not work. The cost is the operator driving a REMOTE
+# socket or a `podman machine`, who has no local engine to satisfy this and
+# must now install one; install.sh serves that case with
+# --skip-podman-check, and apt has no equivalent because a package
+# relationship cannot ask where the socket is.
+Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 5.0)
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -97,7 +97,7 @@ is published and `apt upgrade` installs it — nothing for users to re-run.
 
 ## What the skeleton covers
 
-- `debian/control` — source/binary stanzas, build dependencies, `Recommends: podman`
+- `debian/control` — source/binary stanzas, build dependencies, `Depends: podman (>= 5.0)`
 - `debian/rules` — debhelper with cargo overrides, `--locked` release build, tests run during the build
 - `debian/podup.1` + `debian/podup.manpages` — the man page, installed by `dh_installman`
 - `debian/copyright` — DEP-5, MIT

--- a/tests/podman_floor.rs
+++ b/tests/podman_floor.rs
@@ -1,0 +1,248 @@
+//! The Podman floor is written in three places and nothing derives one from
+//! another.
+//!
+//! - `internal/libpod/client/mod.rs` — `MIN_LIBPOD_API_MAJOR`, the gate the
+//!   running binary applies to the major the engine reports.
+//! - `install.sh` — `PODMAN_MIN_MAJOR`, the precheck that refuses to install
+//!   over a local engine below the floor.
+//! - `debian/control` — the `podman (>= N.0)` relationship.
+//!
+//! The third one used to be a `Recommends`, where a wrong number cost a
+//! suggestion. As a `Depends` it decides whether the package installs at all,
+//! so a copy that drifts low lets apt install podup onto an engine the binary
+//! will then refuse, and a copy that drifts high refuses an install that
+//! would have worked. Neither shows up until a user hits it, on a machine
+//! nobody here owns.
+//!
+//! `install.ps1` carries no floor and needs none: there is no Windows package
+//! relationship to satisfy, and the engine lives in a `podman machine` VM
+//! whose version the installer cannot read from the host.
+
+use std::fs;
+use std::path::Path;
+
+fn read(rel: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} is readable: {e}"))
+}
+
+/// `const MIN_LIBPOD_API_MAJOR: u64 = 5;`
+fn floor_from_source(src: &str) -> u64 {
+	src.lines()
+		.map(str::trim_start)
+		.filter(|l| !l.starts_with("//"))
+		.find_map(|l| l.split_once("MIN_LIBPOD_API_MAJOR: u64 = "))
+		// `trim()` first. Trimming the semicolon before the whitespace leaves
+		// a trailing carriage return in front of it, so the `;` is never the
+		// last character and never removed, and the parse fails on `5;`.
+		.and_then(|(_, rest)| rest.trim().trim_end_matches(';').trim().parse().ok())
+		.expect("MIN_LIBPOD_API_MAJOR is declared as a u64 literal")
+}
+
+/// `PODMAN_MIN_MAJOR=5`
+fn floor_from_installer(src: &str) -> u64 {
+	src.lines()
+		.map(str::trim_start)
+		.filter(|l| !l.starts_with('#'))
+		.find_map(|l| l.strip_prefix("PODMAN_MIN_MAJOR="))
+		.and_then(|v| v.trim().trim_matches('"').parse().ok())
+		.expect("install.sh assigns PODMAN_MIN_MAJOR")
+}
+
+/// The major out of `Depends: …, podman (>= 5.0)`.
+///
+/// Read off the `Depends:` line specifically, not from anywhere the string
+/// appears: this file exists because the same number in several places went
+/// out of step, and a comment quoting the relationship would satisfy a looser
+/// search. The comment above that field quotes it more than once.
+fn floor_from_control(src: &str) -> u64 {
+	let depends = src
+		.lines()
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.find(|l| l.starts_with("Depends:"))
+		.expect("debian/control's binary stanza declares Depends");
+	let (_, rest) = depends
+		.split_once("podman (>= ")
+		.unwrap_or_else(|| panic!("Depends does not require podman at all: {depends:?}"));
+	let version = rest
+		.split(')')
+		.next()
+		.expect("the podman relationship closes its parenthesis");
+	version
+		.split('.')
+		.next()
+		.and_then(|major| major.parse().ok())
+		.unwrap_or_else(|| panic!("cannot read a major out of {version:?}"))
+}
+
+/// The relationship lines of the binary stanza, in order.
+///
+/// Split with `lines()` rather than by searching for an embedded
+/// `"\nPackage: podup\n"`. That search is exact on bytes, so on a checkout
+/// with CRLF endings the newline after `podup` is `\r\n` and the needle is
+/// never found: the test panicked on Windows and nowhere else, over a file
+/// this change did not make platform-specific. `lines()` strips the carriage
+/// return for us.
+fn binary_stanza_relationships(control: &str) -> Vec<&str> {
+	control
+		.lines()
+		.skip_while(|l| l.trim_end() != "Package: podup")
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.filter(|l| l.starts_with("Depends:") || l.starts_with("Recommends:"))
+		.collect()
+}
+
+#[test]
+fn the_package_requires_podman_rather_than_suggesting_it() {
+	let src = read("debian/control");
+	let relationships = binary_stanza_relationships(&src);
+	assert!(
+		!relationships.is_empty(),
+		"no Depends or Recommends line found after the `Package: podup` stanza \
+		 header; the parser has stopped seeing the file it is asserting about"
+	);
+
+	assert!(
+		relationships
+			.iter()
+			.any(|l| l.starts_with("Depends:") && l.contains("podman")),
+		"podman must be a Depends. podup translates a compose file into libpod \
+		 calls and does nothing else, so an install without an engine cannot do \
+		 the one thing it is for. Relationships found: {relationships:?}"
+	);
+	assert!(
+		!relationships
+			.iter()
+			.any(|l| l.starts_with("Recommends:") && l.contains("podman")),
+		"podman is declared as a Recommends as well as a Depends, which is \
+		 apt telling the user two different things about the same package"
+	);
+}
+
+#[test]
+fn every_podman_floor_agrees() {
+	let source = floor_from_source(&read("internal/libpod/client/mod.rs"));
+	let installer = floor_from_installer(&read("install.sh"));
+	let control = floor_from_control(&read("debian/control"));
+
+	assert_eq!(
+		source, installer,
+		"MIN_LIBPOD_API_MAJOR is {source} and install.sh's PODMAN_MIN_MAJOR is \
+		 {installer}. The installer would admit an engine the binary refuses, \
+		 or refuse one it accepts."
+	);
+	assert_eq!(
+		source, control,
+		"MIN_LIBPOD_API_MAJOR is {source} and debian/control requires podman \
+		 >= {control}.0. Since podman is a Depends, this number decides whether \
+		 apt installs podup at all: too low and apt installs it onto an engine \
+		 the binary will refuse, too high and apt refuses an install that would \
+		 have worked."
+	);
+}
+
+/// The parsers are what the assertions above trust, so pin them on input that
+/// differs from today's files. A parser that always returned 5 would satisfy
+/// every equality and prove nothing.
+#[test]
+fn the_floor_parsers_read_the_values_rather_than_guessing_them() {
+	// Each helper reads a real file, so the shapes are exercised here through
+	// the same string handling rather than through the filesystem.
+	let control = "\
+# Depends: …, podman (>= 99.0) quoted in a comment
+Package: podup
+Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 7.0)
+";
+	let depends = control
+		.lines()
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.find(|l| l.starts_with("Depends:"))
+		.unwrap();
+	assert!(
+		depends.contains("podman (>= 7.0)"),
+		"the comment quoting a different floor must not be the line that is read"
+	);
+
+	// The real files still have to parse, and to a plausible major rather than
+	// to whatever `unwrap_or_default` would hand back.
+	for (name, got) in [
+		(
+			"MIN_LIBPOD_API_MAJOR",
+			floor_from_source(&read("internal/libpod/client/mod.rs")),
+		),
+		(
+			"PODMAN_MIN_MAJOR",
+			floor_from_installer(&read("install.sh")),
+		),
+		(
+			"debian/control",
+			floor_from_control(&read("debian/control")),
+		),
+	] {
+		assert!(
+			(1..=99).contains(&got),
+			"{name} parsed as {got}, which is not a plausible Podman major"
+		);
+	}
+}
+
+/// Every parser here reads a file that a Windows checkout delivers with CRLF
+/// endings, and none of them should care.
+///
+/// This is a regression test with a date on it. The first version of
+/// `the_package_requires_podman_rather_than_suggesting_it` located the binary
+/// stanza with `split_once("\nPackage: podup\n")`, which is an exact byte
+/// match, so on CRLF the newline after `podup` is `\r\n` and the needle was
+/// never found. It passed on Linux and macOS and panicked on
+/// `rust / Test (windows-latest)` alone, over a file the change had not made
+/// platform-specific.
+///
+/// The point is not that one function. It is that a parser reading a
+/// repository file is reading a file whose line endings depend on who checked
+/// it out, and the only leg of the matrix that says so is the one that costs
+/// the longest round trip. Feeding the parsers CRLF here says it in a second.
+#[test]
+fn the_parsers_do_not_care_about_line_endings() {
+	// Normalise to LF first. On a Windows checkout the file already holds
+	// CRLF, so converting without normalising produces `\r\r\n`, which is
+	// not a shape any checkout delivers. This test asserted over it and went
+	// red on windows-latest for a defect of its own fixture rather than of
+	// the parsers it exists to cover.
+	let crlf = |rel: &str| read(rel).replace("\r\n", "\n").replace('\n', "\r\n");
+	let lf = |rel: &str| read(rel).replace("\r\n", "\n");
+
+	assert_eq!(
+		floor_from_source(&crlf("internal/libpod/client/mod.rs")),
+		floor_from_source(&lf("internal/libpod/client/mod.rs")),
+		"MIN_LIBPOD_API_MAJOR reads differently under CRLF"
+	);
+	assert_eq!(
+		floor_from_installer(&crlf("install.sh")),
+		floor_from_installer(&lf("install.sh")),
+		"PODMAN_MIN_MAJOR reads differently under CRLF"
+	);
+	assert_eq!(
+		floor_from_control(&crlf("debian/control")),
+		floor_from_control(&lf("debian/control")),
+		"the podman relationship reads differently under CRLF"
+	);
+
+	let crlf_control = crlf("debian/control");
+	let under_crlf = binary_stanza_relationships(&crlf_control);
+	let control = lf("debian/control");
+	let under_lf = binary_stanza_relationships(&control);
+	assert_eq!(
+		under_crlf.len(),
+		under_lf.len(),
+		"the binary stanza yields {} relationship line(s) under CRLF and {} \
+		 under LF. This is the exact defect that reddened windows-latest and \
+		 nothing else.",
+		under_crlf.len(),
+		under_lf.len()
+	);
+	assert!(
+		!under_crlf.is_empty(),
+		"no relationship line found under CRLF; the comparison above would be \
+		 satisfied by both sides finding nothing"
+	);
+}

--- a/tests/workflow_debian_image.rs
+++ b/tests/workflow_debian_image.rs
@@ -1,0 +1,161 @@
+//! The two workflows that build the `.deb` must build it in the same image.
+//!
+//! `release.yml`'s `build-deb` job names a `container:`, and
+//! `reusable-rust-debian.yml` carries a `debian-image` default that the
+//! `debian-build` lane takes on every pull request. A `container:` needs a
+//! literal and cannot read the reusable's default, so the value exists twice
+//! and nothing derives one from the other.
+//!
+//! They were different from before #1568 until #1583, by an image and six
+//! weeks. The consequence is not cosmetic: the `.deb` that ships was built in
+//! an environment no pull request had exercised, and the release is immutable,
+//! so the first place a difference could surface was the one place it cannot
+//! be corrected.
+//!
+//! `pin-watch.yml` reads both and reports them disagreeing, and that is a
+//! weekly cron. This is the same assertion at pull-request time, which is
+//! while the fix is still a one-line edit in an open branch. The overlap is
+//! deliberate; both files say so.
+
+use std::fs;
+use std::path::Path;
+
+/// Pull the pinned image out of a workflow.
+///
+/// `scope` is the key whose block the value lives in, or `None` when the key
+/// is at the top level of a job (`container:`). Scoping matters: the first
+/// draft took the first `default:` in the file, which in
+/// `reusable-rust-debian.yml` belongs to a different input and reads
+/// `ubuntu-latest`. Both assertions below failed on the first run and said so
+/// by name, which is the argument for writing the test before trusting the
+/// parser under it.
+///
+/// Comment lines are dropped first. A comment quoting a digest would satisfy
+/// a bare search for the shape, and this file exists because a comment about
+/// these two values was wrong for six weeks.
+fn pinned_image(workflow: &str, scope: Option<&str>, key: &str) -> String {
+	let mut inside = scope.is_none();
+	let mut scope_indent = 0usize;
+
+	for line in workflow.lines() {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() || trimmed.starts_with('#') {
+			continue;
+		}
+		let indent = line.len() - trimmed.len();
+
+		if let Some(name) = scope {
+			if !inside {
+				if trimmed == name {
+					inside = true;
+					scope_indent = indent;
+				}
+				continue;
+			}
+			// A key at the same or lower indent closes the block, so a
+			// `default:` belonging to the next input is not attributed here.
+			if indent <= scope_indent {
+				break;
+			}
+		}
+
+		if let Some(rest) = trimmed.strip_prefix(key) {
+			return rest.trim().trim_matches('"').to_string();
+		}
+	}
+	panic!(
+		"no `{key}` line pinning an image{}",
+		match scope {
+			Some(name) => format!(" under `{name}`"),
+			None => String::new(),
+		}
+	)
+}
+
+fn read(name: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join(".github/workflows")
+		.join(name);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{name} is readable: {e}"))
+}
+
+#[test]
+fn both_deb_builds_pin_the_same_debian_image() {
+	let release = pinned_image(&read("release.yml"), None, "container:");
+	let lane = pinned_image(
+		&read("reusable-rust-debian.yml"),
+		Some("debian-image:"),
+		"default:",
+	);
+
+	assert_eq!(
+		release, lane,
+		"release.yml builds the published .deb in {release:?} while the \
+		 debian-build lane builds it in {lane:?}. A difference means the \
+		 package that ships was never built in an environment any pull \
+		 request exercised, and a published release cannot be corrected."
+	);
+}
+
+#[test]
+fn the_pinned_image_is_a_digest_and_not_a_moving_tag() {
+	for (name, scope, key) in [
+		("release.yml", None, "container:"),
+		(
+			"reusable-rust-debian.yml",
+			Some("debian-image:"),
+			"default:",
+		),
+	] {
+		let pinned = pinned_image(&read(name), scope, key);
+		let (image, digest) = pinned
+			.split_once("@sha256:")
+			.unwrap_or_else(|| panic!("{name} pins {pinned:?}, which carries no sha256 digest"));
+		assert_eq!(
+			image, "debian:trixie",
+			"{name} pins {image:?}. Sid was a moving tag: two releases built \
+			 from identical source could land in different environments with \
+			 nothing in history recording which."
+		);
+		assert!(
+			digest.len() == 64 && digest.bytes().all(|c| c.is_ascii_hexdigit()),
+			"{name} pins {digest:?}, which is not a 64-character hex digest"
+		);
+	}
+}
+
+/// The parser is what both tests trust, so pin it on input that differs from
+/// today's files. Otherwise a parser that always returned the same string
+/// would satisfy the equality above and prove nothing.
+#[test]
+fn the_parser_reads_the_value_rather_than_guessing_it() {
+	let yml = "\
+jobs:
+  build-deb:
+    # container: debian:trixie@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    container: debian:trixie@sha256:1111111111111111111111111111111111111111111111111111111111111111
+";
+	assert_eq!(
+		pinned_image(yml, None, "container:"),
+		"debian:trixie@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"a digest named only in a comment must not be returned"
+	);
+
+	// The case the first draft got wrong: another input defaults ahead of
+	// debian-image, and an unscoped search returns that one.
+	let reusable = "\
+      runner:
+        default: \"ubuntu-latest\"
+      debian-image:
+        description: Container image to build in
+        default: \"debian:trixie@sha256:2222222222222222222222222222222222222222222222222222222222222222\"
+      arch:
+        default: \"amd64\"
+";
+	assert_eq!(
+		pinned_image(reusable, Some("debian-image:"), "default:"),
+		"debian:trixie@sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		"the value must come from debian-image's own block, not from whichever \
+		 input defaults first"
+	);
+}


### PR DESCRIPTION
One change in this release reaches users, and it changes what `apt` does rather than what the binary does.

**podman is a requirement now, not a recommendation.** podup translates a compose file into libpod calls and does nothing else, so an install without an engine is not a degraded install, it is one that cannot do the thing it is for. The relationship had been a `Recommends` since the packaging skeleton in #36, when the goal was still the official Debian archive, and it was the only decision in `debian/control` with no reasoning beside it.

What that means per system:

| system | before | now |
|---|---|---|
| Debian trixie, Podman 5.4.2 | podman installed, because apt installs Recommends by default | podman installed, as a requirement |
| Anything with `APT::Install-Recommends "false"` | neither engine nor warning | podman installed |
| Ubuntu 24.04 LTS, Podman 4.9.3 | podup installed and could not reach an engine | `apt install podup` fails |

The third row is the visible one, and it is the row the README has documented as unsupported since 5.1.0. apt now says it at install time rather than leaving something that breaks at first use.

**The case a package relationship cannot express** is the operator driving a remote Podman or a `podman machine`: apt only sees the local machine, and there is no local engine to satisfy this. That case belongs to the release binary and `install.sh`, which warns rather than refusing when no local podman is present and takes `--skip-podman-check` when the local one is not the engine podup will use. The README says so beside the support table.

Also in this range, and not user-visible:

- The pull-request lane and the release build the `.deb` in the same `debian:trixie` snapshot (#1587). They had carried different digests six weeks apart, so the package that shipped was built in an environment no pull request had exercised. A test keeps them equal, because a `container:` needs a literal and cannot read the reusable's default, so the value still exists twice.
- `tests/podman_floor.rs` ties the three places the Podman floor is written: `MIN_LIBPOD_API_MAJOR`, `install.sh`'s `PODMAN_MIN_MAJOR`, and the package relationship. As a `Recommends` a wrong copy cost a suggestion; as a `Depends` it decides whether the package installs at all.

MINOR rather than PATCH: nothing a user runs behaves differently and the library API is untouched, but the package declines an install it used to accept, and a provisioning script notices.

Refs #1553, #1555.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
