### PR TITLE
fix(packaging): require unattended-upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ is anything it had to install just to check the key.
 
 podup needs **Podman ≥ 5.0** (rootless). The package depends on it, so apt
 installs it alongside podup, and refuses the install on a distribution whose
-Podman is older than that. Podman is daemonless, but podup speaks the libpod
-API, so the socket still has to be listening:
+Podman is older than that. It also depends on `unattended-upgrades`: an
+apt-installed podup updates through apt and nothing else, since `podup update`
+refuses to replace a dpkg-owned binary, and only the latest release is
+supported. Podman is daemonless, but podup speaks the libpod API, so the
+socket still has to be listening:
 
 ```sh
 systemctl --user enable --now podman.socket

--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,30 @@ Architecture: any
 # must now install one; install.sh serves that case with
 # --skip-podman-check, and apt has no equivalent because a package
 # relationship cannot ask where the socket is.
-Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 5.0)
+# unattended-upgrades is a Depends for a different reason than podman, and the
+# difference is worth stating because the two look alike in this field.
+#
+# podman is here because podup cannot work without it. unattended-upgrades is
+# here because of what happens when podup is NOT updated: only the latest
+# release is supported org-wide, nothing is back-ported, and `podup update`
+# refuses on a dpkg-owned binary and redirects to `apt upgrade`. So for an apt
+# install, the package manager is the ONLY update path, and a machine that
+# never runs it sits on a release that will not receive a fix. Secure by
+# default means the operator opts out of that, not into it.
+#
+# What this does and does not buy, so nobody reads more into it than it does.
+# It guarantees the package is PRESENT. It does not guarantee it RUNS: Debian
+# ships no `/etc/apt/apt.conf.d/20auto-upgrades`, which is the switch, and
+# podup ships no maintainer scripts to write one. Ubuntu server ships both.
+# The bootstrap installer at apt.glyndor.net/install/podup writes that file
+# when it is the thing that installed the package, and deliberately leaves an
+# existing configuration alone.
+#
+# The cost, stated rather than discovered: `apt remove unattended-upgrades`
+# now takes podup with it. An operator who schedules upgrades by hand, which
+# the releases standard permits, has to keep the package installed and switch
+# it off through its own configuration instead.
+Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 5.0), unattended-upgrades
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -97,7 +97,7 @@ is published and `apt upgrade` installs it — nothing for users to re-run.
 
 ## What the skeleton covers
 
-- `debian/control` — source/binary stanzas, build dependencies, `Depends: podman (>= 5.0)`
+- `debian/control` — source/binary stanzas, build dependencies, `Depends: podman (>= 5.0), unattended-upgrades`
 - `debian/rules` — debhelper with cargo overrides, `--locked` release build, tests run during the build
 - `debian/podup.1` + `debian/podup.manpages` — the man page, installed by `dh_installman`
 - `debian/copyright` — DEP-5, MIT

--- a/tests/podman_floor.rs
+++ b/tests/podman_floor.rs
@@ -1,3 +1,13 @@
+//! The binary stanza's relationships, and the Podman floor that one of them
+//! carries.
+//!
+//! Two packages are required, for different reasons that look alike in the
+//! `Depends` field. podman because podup cannot work without it.
+//! unattended-upgrades because of what happens when podup is not updated:
+//! only the latest release is supported, and `podup update` refuses on a
+//! dpkg-owned binary, so for an apt install the package manager is the only
+//! update path.
+//!
 //! The Podman floor is written in three places and nothing derives one from
 //! another.
 //!
@@ -116,6 +126,35 @@ fn the_package_requires_podman_rather_than_suggesting_it() {
 			.any(|l| l.starts_with("Recommends:") && l.contains("podman")),
 		"podman is declared as a Recommends as well as a Depends, which is \
 		 apt telling the user two different things about the same package"
+	);
+}
+
+/// The second required package, and the one whose absence is silent.
+///
+/// A missing engine fails loudly the first time podup runs. A machine that
+/// never upgrades fails by staying on a release nobody is fixing, which
+/// nothing reports, so the relationship is the only thing holding it.
+#[test]
+fn the_package_requires_unattended_upgrades() {
+	let src = read("debian/control");
+	let relationships = binary_stanza_relationships(&src);
+
+	assert!(
+		relationships
+			.iter()
+			.any(|l| l.starts_with("Depends:") && l.contains("unattended-upgrades")),
+		"unattended-upgrades must be a Depends. For an apt install the package \
+		 manager is the only update path: `podup update` refuses on a \
+		 dpkg-owned binary and redirects to `apt upgrade`, nothing is \
+		 back-ported, and a machine that never upgrades sits on a release that \
+		 will not receive a fix. Relationships found: {relationships:?}"
+	);
+	assert!(
+		!relationships
+			.iter()
+			.any(|l| l.starts_with("Recommends:") && l.contains("unattended-upgrades")),
+		"unattended-upgrades is declared as a Recommends as well as a Depends, \
+		 which is apt being told two different things about one package"
 	);
 }
 


### PR DESCRIPTION
## Summary

- `unattended-upgrades` joins `podman` in `Depends`. Owner decision, on the secure-by-default rule: the operator opts out of automatic updates, never into them.
- A test asserts it, because a machine that stops updating reports nothing.

## Changes

**Why this one is a `Depends` when it is not a functional need.** The two required packages are here for different reasons that look identical in the field. podman because podup cannot work without it. `unattended-upgrades` because of what happens when podup is *not* updated: only the latest release is supported org-wide, nothing is back-ported, and `podup update` refuses to replace a dpkg-owned binary and redirects to `apt upgrade`. For an apt install the package manager is the only update path. A machine that never runs it sits on a release that will not receive a fix.

The asymmetry that decides it: a missing engine fails loudly on the first command. A machine that has stopped updating fails by staying quiet, and no check anywhere reports it. The relationship is the only thing holding that.

**What it buys and what it does not.** It guarantees the package is **present**. It does not guarantee it **runs**:

| system | package | `20auto-upgrades` switch |
|---|---|---|
| Debian | not shipped, now pulled by this Depends | **not shipped, and nothing here writes it** |
| Ubuntu server | shipped | shipped |

podup ships no maintainer scripts. The bootstrap installer at `apt.glyndor.net/install/podup` writes `20auto-upgrades` when it is the thing that installed the package, and deliberately leaves an existing configuration alone (`apt/scripts/install-template.sh:195-215`, and its comment says why: *"Whether the machine runs unattended upgrades at all is the operator's"*).

So on the documented install path, Debian gets both. On `apt install podup` with the archive already registered, Debian now gets the package and not the switch. That gap is real and is **not** closed here; closing it means podup shipping a `postinst` that writes system-wide apt policy, which is a bigger decision than a relationship and deserves its own change.

**The cost, stated rather than discovered.** `apt remove unattended-upgrades` now takes podup with it. An operator who schedules upgrades by hand, which the releases standard explicitly permits, keeps the package installed and switches it off through its own configuration instead.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally
- [x] `./tests/shell/*.test.sh` pass locally
- [x] shellcheck is clean over every tracked `*.sh`, at 0.10.0; CI pins 0.11.0
- [ ] Podman lane ran. No `internal/` change.
- [x] Asset-contract fixtures ran. `debian/**` puts this in the debian lane's filter.
- [x] New or changed checks were verified by deleting the control and watching them fail

Two sabotages, each diffed against a copy taken beforehand and the `Depends:` line read back afterwards rather than trusting the test going green:

- `unattended-upgrades` dropped from `Depends`: `the_package_requires_unattended_upgrades` red, naming what an apt install loses;
- degraded to a `Recommends`: same test red on the second assertion, which exists because a package declared in both fields is apt being told two different things about one package.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] Every new file in `tests/shell/` is named in some workflow's `test-command`. No new files.
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] Docs updated if behaviour changed. `README.md` and `docs/debian-packaging.md`.
- [x] `Cargo.toml` and `debian/changelog` are at the same version. Both 5.3.0, untouched; the next release carries this.
- [ ] Binary budget. No production code changed.

## Related issues

Follows #1588, which made podman a requirement. Same field, different reason, and the file now says which is which.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
