### PR TITLE
ci: audit the lockfile that changed, and stop the release being the weaker gate

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,9 +1,42 @@
 name: Security audit
 
+# Two triggers answering two different questions, and the split is the whole
+# point rather than a convenience.
+#
+# The weekly cron audits the WHOLE tree against an advisory database that moves
+# on somebody else's schedule. A finding there belongs to a third party: RustSec
+# published something today about a crate nobody here touched. That must not be
+# able to block a pull request, which is why this workflow was cron-only, and
+# `standards/testing` says so in as many words: "a finding that belongs to a
+# third party must NOT fail the run, or someone else's disclosure timing blocks
+# every pull request in the organisation".
+#
+# The pull-request trigger asks the other question: does THIS change introduce a
+# dependency with a known advisory? That finding belongs to the pull request, and
+# blocking is the right answer. Scoping it to the manifest and the lockfile is
+# what keeps the two apart: a pull request that touches neither cannot introduce
+# a dependency, so upstream's timing reaches it through the cron and not through
+# a red check it did not cause.
+#
+# The residue, stated rather than discovered: a pull request that does change the
+# lockfile on the day an unrelated advisory lands is blocked by that advisory.
+# That is the narrow case where the two questions overlap, and it lands on the
+# pull request that is changing dependencies, which is where someone is already
+# looking at them.
 on:
   schedule:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/audit.yml"
+      - ".github/workflows/reusable-rust-audit.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,9 +102,21 @@ jobs:
       - name: Audit dependencies for known advisories
         # Gate the release on `cargo audit`: a RUSTSEC advisory in a pinned
         # dependency must block publishing, not wait for the weekly cron scan.
+        #
+        # `--deny warnings`, matching reusable-rust-audit.yml. Without it this
+        # step was the WEAKER of the two gates: the weekly cron failed on a
+        # warning-level advisory and the release did not, so the check standing
+        # in front of the immutable artifact was the more permissive one. An
+        # unmaintained or yanked crate is a warning, and a release is the one
+        # place a warning cannot be looked at again later.
+        #
+        # The third-party-timing rule that keeps this off ordinary pull requests
+        # does not apply here and the asymmetry is deliberate: a blocked release
+        # is fixed by releasing again, and a published one cannot be fixed at
+        # all.
         run: |
           cargo install cargo-audit --version "=0.22.2" --locked
-          cargo audit
+          cargo audit --deny warnings
 
   build:
     name: Build ${{ matrix.asset }}

--- a/tests/workflow_audit_strictness.rs
+++ b/tests/workflow_audit_strictness.rs
@@ -1,0 +1,113 @@
+//! The release's dependency audit must be at least as strict as the weekly one.
+//!
+//! Two workflows run `cargo audit` and the strictness flag is written in both,
+//! derived from neither. Before #1592 they disagreed: `reusable-rust-audit.yml`
+//! ran `--deny warnings` and `release.yml` did not, so the gate standing in
+//! front of an immutable artifact was the more permissive of the two. An
+//! unmaintained or yanked crate is a warning, and a release is the one place a
+//! warning cannot be looked at again later.
+//!
+//! The asymmetry with pull requests is deliberate and is not what this file
+//! asserts: an upstream advisory must not block an unrelated pull request, so
+//! `audit.yml`'s pull-request trigger is scoped to the manifest and the
+//! lockfile. A blocked release is fixed by releasing again. A published one
+//! cannot be fixed at all.
+
+use std::fs;
+use std::path::Path;
+
+fn read(name: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join(".github/workflows")
+		.join(name);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{name} is readable: {e}"))
+}
+
+/// Every line that INVOKES `cargo audit`, with its flags.
+///
+/// Two shapes are excluded and both are real. A comment line: both files
+/// explain the flag in prose directly above the line that carries it, so a
+/// search for the string finds it whether or not the command has it. And a
+/// YAML key: `reusable-rust-audit.yml` names its job `cargo audit`, which is a
+/// label, not a command. The first draft of this parser counted that label and
+/// the test went red against a file that was already correct.
+///
+/// So the rule is positional: the trimmed line must BEGIN the command, either
+/// on its own inside a `run: |` block or immediately after `run:`.
+fn audit_invocations(workflow: &str) -> Vec<&str> {
+	workflow
+		.lines()
+		.map(str::trim)
+		.filter(|l| !l.starts_with('#'))
+		.filter(|l| l.starts_with("cargo audit") || l.starts_with("run: cargo audit"))
+		.collect()
+}
+
+#[test]
+fn every_cargo_audit_denies_warnings() {
+	for name in ["release.yml", "reusable-rust-audit.yml"] {
+		let body = read(name);
+		let calls = audit_invocations(&body);
+		assert!(
+			!calls.is_empty(),
+			"{name} runs no cargo audit; either the step moved and this test is \
+			 reading the wrong file, or the gate is gone"
+		);
+		for call in calls {
+			assert!(
+				call.contains("--deny warnings"),
+				"{name} runs {call:?} without --deny warnings. The two gates \
+				 must agree on strictness: whichever is weaker is the one that \
+				 decides, and for the release that decision is immutable."
+			);
+		}
+	}
+}
+
+#[test]
+fn the_pull_request_audit_is_scoped_to_the_manifest() {
+	let body = read("audit.yml");
+	assert!(
+		body.contains("pull_request:"),
+		"audit.yml no longer runs on pull requests, so a change that introduces \
+		 a vulnerable dependency waits up to a week for the Monday cron"
+	);
+	for path in ["\"Cargo.lock\"", "\"Cargo.toml\""] {
+		assert!(
+			body.contains(path),
+			"audit.yml's pull-request trigger does not name {path}. Without the \
+			 manifest in its paths filter it either misses the change that \
+			 introduces a dependency, or runs on every pull request and lets \
+			 somebody else's disclosure timing block work that did not cause it."
+		);
+	}
+	assert!(
+		body.contains("paths:"),
+		"audit.yml runs on every pull request with no paths filter. An upstream \
+		 advisory published today would then block every open pull request, \
+		 which is the case standards/testing rules out by name."
+	);
+}
+
+/// The parser is what both tests trust. Pin it on input that differs from the
+/// real files, including the shape it must not count.
+#[test]
+fn the_parser_ignores_the_prose_that_explains_the_flag() {
+	let yml = "\
+  audit:
+    name: cargo audit
+    steps:
+      - name: Audit
+        # cargo audit --deny warnings, explained here and not run
+        run: |
+          cargo audit --deny warnings
+";
+	let calls = audit_invocations(yml);
+	assert_eq!(
+		calls,
+		vec!["cargo audit --deny warnings"],
+		"exactly one line invokes it. The other two name it: a job label \
+		 `name: cargo audit`, which is what the first draft of this parser \
+		 counted, and a comment explaining the flag."
+	);
+}


### PR DESCRIPTION
## Summary

- The release ran `cargo audit` while the weekly cron ran `cargo audit --deny warnings`, so the gate in front of the immutable artifact was the more permissive of the two.
- `cargo audit` ran on a Monday cron and nowhere else, so a pull request introducing a vulnerable dependency could sit for up to a week.

## Changes

**The release stops being the weaker gate.** An unmaintained or yanked crate is a warning-level advisory. The weekly cron failed on one; the release did not. A release is the one place a warning cannot be looked at again later, so both invocations carry `--deny warnings` now.

**The obvious fix for the second one is wrong, and `standards/testing` says why:**

> A finding that belongs to a third party — an upstream advisory, a new release — must NOT fail the run, or someone else's disclosure timing blocks every pull request in the organisation.

A flat `pull_request` trigger does exactly that: RustSec publishes something about one of 164 crates and every open pull request goes red over a change none of them made. So the trigger is scoped to `Cargo.toml`, `Cargo.lock`, `deny.toml` and the two audit workflows. A pull request touching none of them cannot introduce a dependency, and meets upstream's timing through the cron instead.

The residue is written into the file rather than left to be discovered: a pull request that *does* change the lockfile on the day an unrelated advisory lands is blocked by it. That is the one case where the two questions overlap, and it lands on the pull request that is changing dependencies, where somebody is already looking at them.

The asymmetry with the release is deliberate and the file says so: a blocked release is fixed by releasing again, a published one cannot be fixed at all.

**Neither gate arrives red.** `cargo audit --deny warnings` against the tree exits 0 and reports `Scanning Cargo.lock for vulnerabilities (164 crate dependencies)`, which matches the lockfile's own count, so it read the tree rather than nothing.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally
- [x] `./tests/shell/*.test.sh` pass locally
- [x] shellcheck clean over every tracked `*.sh`, at 0.10.0; CI pins 0.11.0
- [x] `actionlint` clean on both edited workflows, at v1.7.12, the version the reusable pins
- [ ] Podman lane ran. No `internal/` change.
- [x] Asset-contract fixtures ran. `release.yml` is in that workflow's filter.
- [x] New or changed checks were verified by deleting the control and watching them fail

Three sabotages, each diffed against a copy taken beforehand and the lines read back afterwards rather than trusting the colour: the release flag removed, `Cargo.lock` dropped from the paths filter, and the `pull_request` trigger removed. Each turns exactly the test that names it red.

**The new test's parser was wrong on its first run, and the test is what said so.** It counted `name: cargo audit`, which is `reusable-rust-audit.yml`'s job label rather than a command, so it failed against a file that was already correct. It matches position now, and the parser test carries that exact shape alongside a comment that names the flag without running it.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] Every new file in `tests/shell/` is named in some workflow's `test-command`. The new test is Rust, which cargo discovers.
- [x] No secrets, keys or credentials in code, logs or fixtures
- [ ] Docs updated if behaviour changed. No user-visible behaviour changed.
- [x] `Cargo.toml` and `debian/changelog` at the same version. Both 5.3.0, untouched.
- [ ] Binary budget. No production code changed.

## Related issues

Found in the audit pass over the thirteen questions. The second-opinion run raised both; the scoping that keeps the pull-request trigger from blocking unrelated work is not what it recommended.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
