### PR TITLE
ci: group cargo bumps by answer, and count workflow YAML against the line limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,26 @@ updates:
     labels: ["type:deps"]
     open-pull-requests-limit: 10
     target-branch: "develop"
+    # Grouped by the ANSWER the pull request needs, which is the split the CI
+    # standard asks for, not by convenience. A patch or minor bump of a crate
+    # this repository already depends on is one question with one answer: does
+    # CI still pass. Nineteen of them arrived one per pull request before this,
+    # each carrying the same answer and the same review.
+    #
+    # A major is left OUT of the group deliberately, so it arrives alone. It is
+    # the one that can change behaviour, and the reason to split is the same
+    # reason the org splits its reusable bumps: a pull request that mixes a
+    # question needing thought with several that do not is answered by the
+    # cheap ones.
+    #
+    # The limit is what makes this more than tidiness. It is 10, and once it is
+    # full Dependabot stops proposing anything at all, including the security
+    # bump the queue exists to deliver. Twenty-three direct dependencies and a
+    # 164-crate lockfile can reach that on an ordinary week.
+    groups:
+      cargo-patch-and-minor:
+        patterns: ["*"]
+        update-types: ["patch", "minor"]
     commit-message:
       prefix: chore
 

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -9,7 +9,24 @@ name: Line limit
 # both rulesets require a pull request, so no content reaches develop or main
 # without one. If a direct-push path is ever opened, this scoping stops covering
 # the tree and a push trigger becomes the correct one.
+# On pushes as well as pull requests, and the reason is what this check reads.
+#
+# It diffs nothing. The reusable ends `done < <(git ls-files -z)` and counts
+# code lines in every tracked file matching its extension list, so it is a
+# property of the TREE and evaluates identically either way. A check about the
+# tree that runs only on pull requests cannot see content that arrives by
+# direct merge, which on `main` is every release.
+#
+# This workflow was pull-request-only and nothing here said why. The org's CI
+# standard names that omission by name: "podup restricts it to pull_request,
+# and that is the scoping nobody has justified". It is justified now, in the
+# other direction, and the file says so where the trigger is rather than in a
+# commit message nobody reads twice.
 on:
+  push:
+    branches:
+      - main
+      - develop
   pull_request:
     branches:
       - main
@@ -21,3 +38,22 @@ permissions:
 jobs:
   line-limit:
     uses: ./.github/workflows/reusable-line-limit.yml
+    with:
+      # `yml yaml` on top of the reusable's default list. The limit is a
+      # maintainability rule and workflow YAML is maintained by the same people
+      # under the same constraint: release.yml is 419 code lines and
+      # reusable-rust-ci.yml 321, both past the soft limit, and neither was
+      # being counted. Measured before adopting: of 54 tracked YAML files three
+      # warn and NONE fails, so this arrives amber rather than red, which is
+      # the condition for landing a widened gate at all.
+      extensions: "rs go ts tsx js jsx mjs cjs py sh astro vue svelte yml yaml"
+      # bench/scenarios holds compose files whose size IS the fixture: the
+      # config-heavy scenario is 321 lines because the benchmark measures what
+      # a large project costs. A maintainability warning there is noise, and
+      # noise on a warning teaches people to stop reading warnings.
+      #
+      # The condition, so this expires on its own rather than ageing: it holds
+      # while bench/scenarios contains only generated or deliberately-oversized
+      # fixtures. The day something maintained by hand lands there, the
+      # exclusion is wrong and this sentence is where it says so.
+      exclude-pattern: "^bench/scenarios/"


### PR DESCRIPTION
## Summary

- Cargo bumps are grouped by the answer they need, so nineteen pull requests carrying one question stop being nineteen reviews.
- The line limit counts workflow YAML now, and runs on pushes as well as pull requests.

## Changes

### Dependabot: grouped by answer, not by convenience

Nineteen cargo pull requests have arrived one per crate, each a patch or minor bump of a dependency this repository already has, each with the same question and the same answer: does CI still pass.

A major is **left out** of the group deliberately, so it arrives alone. It is the one that can change behaviour, and a pull request mixing a question that needs thought with several that do not is answered by the cheap ones.

**The limit is what makes this more than tidiness.** It is 10, and the CI standard records what happens when it fills: Dependabot stops proposing anything at all, including the security bump the queue exists to deliver. Twenty-three direct dependencies over a 164-crate lockfile can reach that on an ordinary week, and this repository has already been on the wrong side of it once, when eight reusable-pin bumps landed on the same day.

`pip` is left ungrouped: one requirements file, nothing ever proposed for it.

### Line limit: it was not counting the files that grew

`yml` was not in the extension list, so the files that grew most this month were the ones nothing measured:

| file | code lines |
| --- | ---: |
| `.github/workflows/release.yml` | 419 |
| `.github/workflows/reusable-rust-ci.yml` | 321 |

**Measured before adopting rather than after.** Of 54 tracked YAML files, three exceed the soft limit and **none** exceeds the hard one, so the widened gate arrives amber. A gate that arrives red is a gate somebody turns off, and turning it off looks exactly like tidying up.

`bench/scenarios` is excluded: the config-heavy compose file is 321 lines on purpose, because the benchmark measures what a large project costs. A maintainability warning on a fixture is noise, and noise on a warning teaches people to stop reading warnings. The exclusion **names its condition** instead of carrying a date, so it invalidates itself the day something hand-maintained lands there.

### Line limit: it ran on pull requests only

It diffs nothing. The reusable ends `done < <(git ls-files -z)` and counts every tracked file matching its extensions, so it is a property of the tree and evaluates identically on a push. A tree check that skips pushes cannot see content arriving by direct merge, which on `main` is every release.

The org's CI standard names this repository's scoping by name: *"podup restricts it to `pull_request`, and that is the scoping nobody has justified."* It is justified now, in the file, next to the trigger, rather than in a commit message nobody reads twice.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally
- [x] `./tests/shell/*.test.sh` pass locally
- [x] `actionlint` clean on `line-limit.yml`, at v1.7.12
- [x] `dependabot.yml` parses; three ecosystems, groups as intended
- [ ] Podman lane ran. No `internal/` change.
- [x] New or changed checks were verified

The widened limit was simulated against the tree before landing, with the same counting rule the reusable uses (blank and comment lines dropped): two warnings, zero failures, and the excluded fixture confirmed to be the only thing the exclusion removes.

`line-limit / line limit` is a required check on both rulesets. Adding a `push` trigger does not change that: required checks are evaluated on pull requests, and the push run is additional coverage rather than a new gate.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [ ] Docs updated if behaviour changed. No user-visible behaviour changed.
- [x] `Cargo.toml` and `debian/changelog` at the same version. Both 5.3.0, untouched.

## Related issues

From the audit pass over the thirteen questions.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
