### PR TITLE
chore(release): bump to 5.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.3.0"
+version = "5.4.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.3.0"
+version = "5.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Translate and run docker-compose files on rootless Podman"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+podup (5.4.0) unstable; urgency=medium
+
+  * The package now requires unattended-upgrades as well as podman. An
+    apt-installed podup updates through apt and nothing else, since
+    `podup update` refuses to replace a dpkg-owned binary and only the
+    latest release is supported, so a machine that never upgrades sits on
+    a release that will not receive a fix. Removing unattended-upgrades
+    now removes podup with it; an operator who schedules upgrades by hand
+    keeps the package and switches it off in its own configuration.
+  * No change to any command. The rest of this release is CI and tests.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sat, 29 Aug 2026 16:35:00 -0500
+
 podup (5.3.0) unstable; urgency=medium
 
   * The package now requires podman (>= 5.0) instead of recommending it.


### PR DESCRIPTION
## Summary

- Version bump only, ahead of the `develop` to `main` release pull request.
- `5.4.0` rather than `5.3.1`: apt now installs a package it did not before.

## Changes

`Cargo.toml`, `Cargo.lock` and `debian/changelog`, the three files that stamp a version onto a shipped artifact. The release workflow's verify job compares them before building, and 1.9.0 is the release that taught us why.

**Why MINOR.** Nothing a user runs behaves differently and the library API is untouched. But `unattended-upgrades` joined `podman` in `Depends`, so `apt install podup` pulls a package it did not before, and `apt remove unattended-upgrades` now removes podup with it. A provisioning script notices that.

What this release carries:

- **#1591** — `unattended-upgrades` becomes a requirement. For an apt install the package manager is the only update path: `podup update` refuses to replace a dpkg-owned binary and only the latest release is supported, so a machine that never upgrades sits on a release that will not receive a fix.
- **#1592** — the release audit stops being the weaker gate (`--deny warnings` on both), and `cargo audit` runs at pull-request time scoped to the manifest, so an upstream advisory cannot block work that did not cause it.
- **#1594** — cargo bumps grouped by the answer they need, and the line limit counts workflow YAML.
- **#1595** — `sign.py`, which signs every release, gets its first tests, and `ci-runs-every-test` stops being blind to the fixtures that cover the signing path.

## The ordering that made this safe to release today

`#1591` killed a branch in `Glyndor/apt`'s bootstrap installer: it decided whether to write `/etc/apt/apt.conf.d/20auto-upgrades` by testing whether the package was installed, twelve lines after installing podup, which now pulls it. Fixed in `apt#177` — the condition tests the switch file instead — merged at 21:18 UTC.

The fixed installer is **not yet served**: `apt.glyndor.net/install/podup` still carries `if dpkg -s unattended-upgrades` because apt publishes at 06:00.

That does not open a window, and the reason is that one publish run regenerates both. `publish.yml` calls `build-repo.sh` at line 249 and `build-installers.sh` at line 271, so tomorrow's run serves 5.4.0 and the fixed installer together. Until then the archive serves 5.3.0, whose `Depends` is `podman (>= 5.0)` alone, which the old installer handles correctly.

Read from the published artifact rather than the source:

```
$ dpkg-deb -f podup_5.3.0_amd64.deb Version Depends
Version: 5.3.0
Depends: podman (>= 5.0)
```

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally; the six suites a version bump or packaging change can move are green
- [x] `./tests/shell/*.test.sh` pass locally
- [ ] Podman lane ran. No `internal/` change.
- [x] Asset-contract fixtures ran. `debian/**` puts this in the debian lane's filter.

`dpkg-parsechangelog` reads the stanza as `Version: 5.4.0`, `Date: Sat, 29 Aug 2026 16:35:00 -0500`. The timestamp is generated under `LC_ALL=C`, because a Debian changelog needs English day and month names and this machine's locale is Spanish.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` at the same version, and so is `Cargo.lock`

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
