### PR TITLE
fix(secrets): make a secret payload unprintable rather than merely unprinted

### DIFF
--- a/internal/engine/secrets/create.rs
+++ b/internal/engine/secrets/create.rs
@@ -377,3 +377,90 @@ mod tests {
 		);
 	}
 }
+
+/// The payload of a secret must never reach an error message.
+///
+/// CodeQL raised seven `rust/cleartext-logging` alerts against
+/// `tests/engine_integration/`, all with the same source:
+/// `self.create_project_secrets(...)` flowing into an `assert!` message. The
+/// claim is worth answering rather than dismissing, because the answer is a
+/// property of this file and nothing was checking it.
+///
+/// It holds today. `create_project_secrets` returns `Result<()>`, so the bytes
+/// are not in the type a caller can print, and the one error it builds itself
+/// carries `path.display()` and the underlying I/O error rather than the
+/// payload. What was missing is anything that keeps it true: every variant of
+/// `ComposeError` on this path carries a `String`, and a future edit that
+/// formats the payload into one would leak it into a public CI log, where the
+/// integration tests print the error on failure.
+///
+/// The marker is deliberately long and unlike anything else in the tree, so a
+/// substring match cannot pass by coincidence.
+#[cfg(test)]
+#[cfg(unix)]
+mod payload_never_reaches_an_error {
+	use crate::compose::types::ComposeFile;
+	use crate::engine::fake_podman;
+	use crate::engine::secrets::tests_support::engine_on;
+
+	const MARKER: &str = "podup-secret-payload-marker-must-never-be-logged";
+
+	fn file_with_marker() -> ComposeFile {
+		crate::compose::parse_str(&format!(
+			"services:\n  app:\n    image: alpine\n    secrets:\n      - s1\nsecrets:\n  s1: {{content: \"{MARKER}\"}}\n"
+		))
+		.expect("fixture compose file should parse")
+	}
+
+	/// The engine talks to a Podman that refuses every write. The error that
+	/// comes back is the one an integration test would print.
+	#[tokio::test]
+	async fn a_failing_secret_create_does_not_put_the_payload_in_the_error() {
+		let fake = fake_podman::start(|method, target| {
+			if method == "POST" && target.contains("/secrets/create") {
+				(
+					500,
+					r#"{"message":"secret store is unavailable"}"#.to_string(),
+				)
+			} else if method == "GET" && target.contains("/secrets/") {
+				(404, r#"{"message":"no such secret"}"#.to_string())
+			} else {
+				(201, r#"{"ID":"abc"}"#.to_string())
+			}
+		});
+		let e = engine_on(&fake);
+
+		let err = e
+			.create_project_secrets(&file_with_marker())
+			.await
+			.expect_err("a 500 from the secret store must surface as an error");
+
+		// Both renderings, because a test prints `{err:?}` and a user sees
+		// `{err}`, and only one of them being clean is not a guarantee.
+		let display = format!("{err}");
+		let debug = format!("{err:?}");
+		assert!(
+			!display.contains(MARKER),
+			"the secret payload reached the error's Display: {display}"
+		);
+		assert!(
+			!debug.contains(MARKER),
+			"the secret payload reached the error's Debug: {debug}"
+		);
+	}
+
+	/// The control that makes the assertion above mean something. A test that
+	/// searches for a marker proves nothing unless the marker was in play: if
+	/// the fixture stopped carrying it, both assertions above would pass over
+	/// a compose file with no secret in it at all.
+	#[test]
+	fn the_fixture_actually_carries_the_marker() {
+		let file = file_with_marker();
+		let rendered = format!("{file:?}");
+		assert!(
+			rendered.contains(MARKER),
+			"the fixture no longer carries the marker, so the assertions that \
+			 look for it are searching for something that was never there"
+		);
+	}
+}

--- a/internal/engine/secrets/create.rs
+++ b/internal/engine/secrets/create.rs
@@ -11,6 +11,7 @@ use crate::error::{ComposeError, Result};
 use crate::libpod::{urlencoded, API_PREFIX};
 
 use super::plan::{check_secret_size, Payload};
+use super::secret_bytes::SecretBytes;
 use super::{collect_payload_union, Engine};
 
 impl Engine {
@@ -27,7 +28,7 @@ impl Engine {
 	/// secret carries the `podup.project=<proj>` label so the label-guarded
 	/// teardown on `down` still only removes secrets podup owns.
 	pub(in crate::engine) async fn create_project_secrets(&self, file: &ComposeFile) -> Result<()> {
-		let mut work: Vec<(String, Vec<u8>)> = Vec::new();
+		let mut work: Vec<(String, SecretBytes)> = Vec::new();
 		for (name, payload) in collect_payload_union(&self.project, file, &self.base_dir)? {
 			let bytes = match payload {
 				Payload::Inline(bytes) => bytes,
@@ -35,12 +36,14 @@ impl Engine {
 				// the compose→plan mapping remains unit-testable. The cap is the
 				// same bounded read the compose-adjacent files get; Podman's own
 				// 512 kB secret limit is enforced right after, in `create_secret`.
-				Payload::File(path) => crate::filesystem::read_capped(&path).map_err(|e| {
-					ComposeError::Unsupported(format!(
-						"secret/config source {} could not be read: {e}",
-						path.display()
-					))
-				})?,
+				Payload::File(path) => {
+					SecretBytes::new(crate::filesystem::read_capped(&path).map_err(|e| {
+						ComposeError::Unsupported(format!(
+							"secret/config source {} could not be read: {e}",
+							path.display()
+						))
+					})?)
+				}
 			};
 			work.push((name, bytes));
 		}
@@ -127,8 +130,8 @@ impl Engine {
 	/// recognises and rewraps into a legible "something else created a secret
 	/// of that name in between" message — the operator can act on it without
 	/// having to read the libpod error verbatim.
-	async fn create_secret(&self, name: &str, payload: &[u8]) -> Result<()> {
-		check_secret_size(name, payload.len())?;
+	async fn create_secret(&self, name: &str, payload: &SecretBytes) -> Result<()> {
+		check_secret_size(name, payload.byte_len())?;
 		// Guard the delete-then-create: if a secret of this name already exists and
 		// is not labelled as ours, refuse rather than clobber a foreign secret.
 		// Our own secret (or a 404) is replaced fresh, keeping re-`up` idempotent.
@@ -174,7 +177,7 @@ impl Engine {
 		self.client
 			.post_bytes_json::<serde_json::Value>(
 				&path,
-				bytes::Bytes::copy_from_slice(payload),
+				bytes::Bytes::copy_from_slice(payload.expose_secret()),
 				"application/octet-stream",
 			)
 			.await

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -34,6 +34,7 @@
 mod create;
 mod plan;
 mod remove;
+mod secret_bytes;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -201,7 +202,7 @@ mod tests {
 		assert_eq!(union.len(), 1);
 		assert!(matches!(
 			union.get("proj_secret_tok"),
-			Some(Payload::Inline(b)) if b == b"shared"
+			Some(Payload::Inline(b)) if b.expose_secret() == b"shared"
 		));
 	}
 

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -8,6 +8,7 @@ use crate::compose::types::{ComposeFile, Service, ServiceConfigRef, ServiceSecre
 use crate::error::{ComposeError, Result};
 
 use super::super::staging;
+use super::secret_bytes::SecretBytes;
 
 /// Podman's hard limit on secret payload size (from `containers/common`): the
 /// payload must be larger than 0 and strictly smaller than this many bytes.
@@ -21,7 +22,7 @@ pub(super) const MAX_SECRET_BYTES: usize = 512_000;
 /// the secret.
 pub(super) enum Payload {
 	/// Inline `content:`/`environment:` — the bytes, already resolved.
-	Inline(Vec<u8>),
+	Inline(SecretBytes),
 	/// `file:` — the resolved host path to read at creation time.
 	File(PathBuf),
 }
@@ -53,7 +54,7 @@ struct SourceDef<'a> {
 /// Where a secret/config's bytes come from once the compose def is resolved.
 enum Source {
 	/// Inline `content:`/`environment:` — `(scoped podman name, payload bytes)`.
-	Inline(String, Vec<u8>),
+	Inline(String, SecretBytes),
 	/// `file:` — `(scoped podman name, resolved host path)`.
 	File(String, PathBuf),
 	/// `external: true` — name of the pre-existing podman secret.
@@ -166,7 +167,7 @@ fn resolve_source(
 	if let Some(content) = content {
 		return Ok(Some(Source::Inline(
 			scoped_name(project, kind, name),
-			content.as_bytes().to_vec(),
+			SecretBytes::new(content.as_bytes().to_vec()),
 		)));
 	}
 	if let Some(env_var) = environment {
@@ -177,7 +178,7 @@ fn resolve_source(
 		})?;
 		return Ok(Some(Source::Inline(
 			scoped_name(project, kind, name),
-			value.into_bytes(),
+			SecretBytes::new(value.into_bytes()),
 		)));
 	}
 	if let Some(host_path) = file_source {
@@ -363,7 +364,7 @@ mod tests {
 	/// The inline bytes of a plan's payload, or `None` for an external/file source.
 	fn inline_bytes(p: &NativePlan) -> Option<&[u8]> {
 		match &p.payload {
-			Some(Payload::Inline(b)) => Some(b),
+			Some(Payload::Inline(b)) => Some(b.expose_secret()),
 			_ => None,
 		}
 	}

--- a/internal/engine/secrets/secret_bytes.rs
+++ b/internal/engine/secrets/secret_bytes.rs
@@ -1,0 +1,118 @@
+//! The wrapper that keeps a secret's bytes out of every message podup writes.
+//!
+//! Its own file rather than a corner of [`super::plan`] because the point of the
+//! type is that its audit is short: what it allows, and who is allowed to unwrap
+//! it, should read in one screen without the compose-to-plan mapping around it.
+
+use std::fmt;
+
+/// The bytes of a secret podup creates, in a wrapper that cannot be printed.
+///
+/// The leak this prevents is not hypothetical shape: every variant of
+/// [`ComposeError`] carries a `String`, so any error built on this path is one
+/// `format!` away from putting a secret into a public CI log. Keeping that from
+/// happening was, until this type existed, a property of nobody having written
+/// it — not of anything stopping them.
+///
+/// So the guarantee is moved into the type. `SecretBytes` implements neither
+/// `Display` nor a derived `Debug`: `format!("{payload}")` does not compile at
+/// all, and `format!("{payload:?}")` prints the length instead of the contents.
+/// Those two are how every message in this module is built, which leaves exactly
+/// one way for the bytes to get out — [`SecretBytes::expose_secret`], named after
+/// the `secrecy` crate's convention so that grepping for it enumerates the
+/// audit surface. It has one caller: the body of the `secrets/create` request.
+pub(super) struct SecretBytes(Vec<u8>);
+
+impl SecretBytes {
+	pub(super) fn new(bytes: Vec<u8>) -> Self {
+		Self(bytes)
+	}
+
+	/// Deliberately not called `len`: `clippy::len_without_is_empty` would then
+	/// want an `is_empty` this type has no use for, and "byte length" is the more
+	/// honest name for the one measurement callers are allowed to take.
+	pub(super) fn byte_len(&self) -> usize {
+		self.0.len()
+	}
+
+	/// The bytes themselves, for the single place they have to leave: the body of
+	/// the `secrets/create` request. Any other caller is a leak, which is the
+	/// point of it being greppable rather than implicit.
+	pub(super) fn expose_secret(&self) -> &[u8] {
+		&self.0
+	}
+}
+
+impl fmt::Debug for SecretBytes {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "<{} bytes of secret redacted>", self.0.len())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The redaction is the whole point of [`SecretBytes`], so it is asserted
+	/// rather than assumed. Without this, someone deriving `Debug` on the type —
+	/// the obvious thing to reach for — would silently undo it.
+	#[test]
+	fn secret_bytes_debug_redacts_the_contents_and_keeps_the_length() {
+		let payload = SecretBytes::new(b"a-secret-that-must-not-be-printed".to_vec());
+		let shown = format!("{payload:?}");
+		assert!(
+			!shown.contains("a-secret-that-must-not-be-printed"),
+			"the Debug of SecretBytes printed the secret: {shown}"
+		);
+		// Absence of the secret is not enough on its own: a `Debug` that wrote
+		// nothing at all would satisfy it while making every error that mentions a
+		// payload useless. The length is the diagnostic the redaction keeps.
+		assert_eq!(shown, "<33 bytes of secret redacted>");
+	}
+
+	/// The leak this type replaces is not only the readable one. `Debug` on a
+	/// bare `&[u8]` prints decimal, so a guard that merely looked for the secret
+	/// as text would pass over a real disclosure. Recording that here is what
+	/// keeps the reason for the newtype from being re-litigated as paranoia.
+	#[test]
+	fn the_bare_byte_form_this_replaces_leaks_in_decimal() {
+		let payload = SecretBytes::new(b"secret".to_vec());
+		let bare = format!("{:?}", payload.expose_secret());
+		assert_eq!(bare, "[115, 101, 99, 114, 101, 116]");
+		assert!(!bare.contains("secret"), "the decimal form is the point");
+	}
+
+	/// [`SecretBytes::expose_secret`] is the only way the bytes get out, so
+	/// grepping for it is the audit — and an audit surface nothing measures is one
+	/// that grows. Test code may call it freely; production may not.
+	#[test]
+	fn the_escape_hatch_has_exactly_one_production_caller() {
+		let sources = [
+			("secret_bytes.rs", include_str!("secret_bytes.rs")),
+			("plan.rs", include_str!("plan.rs")),
+			("create.rs", include_str!("create.rs")),
+			("mod.rs", include_str!("mod.rs")),
+		];
+		let mut callers = Vec::new();
+		for (name, src) in sources {
+			// Everything from the first `#[cfg(test)]` on is test code.
+			let production = src.split("#[cfg(test)]").next().unwrap();
+			for line in production.lines() {
+				if line.contains("expose_secret()") && !line.contains("fn expose_secret") {
+					callers.push(format!("{name}: {}", line.trim()));
+				}
+			}
+		}
+		assert_eq!(
+			callers.len(),
+			1,
+			"the secret bytes may leave SecretBytes in exactly one place: the body \
+			 of the secrets/create request. Found {callers:#?}"
+		);
+		assert!(
+			callers[0].contains("copy_from_slice"),
+			"the one caller moved: {}",
+			callers[0]
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Seven `rust/cleartext-logging` alerts point at assertions in the secrets tests that format a `Result` returned from `create_project_secrets`. The property they are worried about held: that function returns `Result<()>`, so no payload is in the printable type, and its only self-built error carries `path.display()` rather than the bytes.

It held because nobody had written the line that would break it. Every variant of `ComposeError` carries a `String`, so any error on this path was one `format!` away from putting a secret into a public Actions log. I first added a test asserting it, then replaced the assertion with a type that makes the mistake unavailable.

## Changes

**`SecretBytes` wraps the payload and cannot be printed.** It implements neither `Display` nor a derived `Debug`: `format!("{payload}")` does not compile, and `format!("{payload:?}")` prints `<48 bytes of secret redacted>`. Those two are how every message in the module is built, which leaves one way out — `expose_secret`, named after the `secrecy` crate's convention so that grepping for it *is* the audit. It has one production caller, the body of the `secrets/create` request, and a test asserts that count rather than trusting it, because an audit surface nothing measures is one that grows.

The type is a hand-rolled 40 lines instead of the `secrecy` dependency. The dependency surface was audited a week ago and the argument for keeping it small applies here; `secrecy` would also bring `zeroize`, which is a different guarantee than the one this closes (see below).

**It closes a hole in my own first attempt, which is what sent me looking.** `Debug` on a bare `&[u8]` prints decimal, so a real disclosure renders as `[112, 111, 100, ...]` and a guard asserting only that the marker string is absent would pass straight over it. `SecretBytes` redacts both forms. `the_bare_byte_form_this_replaces_leaks_in_decimal` records the decimal shape so the reason for the newtype is not re-read later as paranoia.

**The type is in its own file.** Partly so the audit — what it allows, who may unwrap it — reads in one screen. Partly because `plan.rs` was at 472 code lines against the 500-line hard limit, and adding it there would have failed `line-limit`.

## Test plan

- [x] `cargo fmt --all --check`, and `cargo clippy --locked --all-targets --all-features -- -D warnings`, both clean
- [x] `cargo test --locked --all-features --workspace`: 2056 passed. One integration failure, `build_images::build_with_args_and_extra_tags`, on `Build("checking if cached image exists from a previous build: getting top layer info: layer not known")` — a Podman layer-cache race under full parallelism. It passes run on its own, an earlier full run on the same commit came back 188/188, and this change touches no build path. That is #1322, not this.
- [x] Every new check was driven red by deleting the control

Each sabotage was diffed against a copy taken beforehand and reported inert if it had not altered the file, and each was restored and re-run green.

`{payload}` interpolated into `create_secret`'s error: `error[E0277]: SecretBytes doesn't implement std::fmt::Display`. `{payload:?}` interpolated into the same error compiles and renders `secret 'proj_secret_s1' [<48 bytes of secret redacted>] did not exist when podup checked…` — which is the check that matters, because green alone would also be what an unreached branch looks like. I probed the rendered message rather than trusting the pass.

`secret_bytes_debug_redacts_the_contents_and_keeps_the_length`: replacing the hand-written `Debug` with a derive reports the decimal leak in full. It asserts the exact redacted string, not merely the absence of the secret — a `Debug` that printed nothing would satisfy absence while making every error that mentions a payload useless.

`the_escape_hatch_has_exactly_one_production_caller`: routing `check_secret_size` through `expose_secret().len()` instead of `byte_len()` reports both callers by their source line. Re-run after the file split, since the test reads its siblings by name and a move could have made it vacuous.

## What this does not do

**It does not dismiss the seven alerts, and they may well survive the next scan.** The flow they describe still exists; what changed is that its sink is now demonstrably inert. Dismissing them citing `payload_never_reaches_an_error` and `SecretBytes` is a call for the repository owner, not for this pull request.

**I did not weaken the seven `{result:?}` assertions.** Dropping the formatted result would clear the alerts and make the tests worse: those messages are what identify which of five `run` shapes broke, and `standards/testing` asks an assertion to say which failure it caught. With the payload unprintable, printing those errors is safe.

**It does not zeroize.** Secret bytes still linger in freed memory, and the wire path copies them into a `bytes::Bytes` this type does not own, so zeroizing only our copy would be half a mitigation described as a whole one. Worth doing deliberately or not at all.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures. The test marker is a literal chosen to be distinctive, not a real value
- [x] `Cargo.toml` and `debian/changelog` untouched
- [ ] Docs updated if behaviour changed. No user-facing behaviour changed; the guarantee is documented on the type

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
