### PR TITLE
docs: say what depending on unattended-upgrades does not buy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,21 @@ is anything it had to install just to check the key.
 
 podup needs **Podman ≥ 5.0** (rootless). The package depends on it, so apt
 installs it alongside podup, and refuses the install on a distribution whose
-Podman is older than that. It also depends on `unattended-upgrades`: an
-apt-installed podup updates through apt and nothing else, since `podup update`
-refuses to replace a dpkg-owned binary, and only the latest release is
-supported. Podman is daemonless, but podup speaks the libpod API, so the
+Podman is older than that. It also depends on `unattended-upgrades`, because an
+apt-installed podup updates through apt and nothing else: `podup update` refuses
+to replace a dpkg-owned binary, and only the latest release is supported.
+
+That dependency guarantees `unattended-upgrades` is installed, not that it is
+running. What switches it on is `/etc/apt/apt.conf.d/20auto-upgrades`, which is
+system-wide policy for every package on the machine rather than podup's to set,
+so no podup maintainer script writes it. The one-line installer above writes it
+when it is absent, and Ubuntu normally has it already. If you registered the
+archive yourself and then ran `apt install podup` on Debian, podup is installed
+and the Glyndor archive is allowlisted, but nothing upgrades it until you run
+`apt upgrade`. `systemctl status unattended-upgrades` says which of the two you
+have.
+
+Podman is daemonless, but podup speaks the libpod API, so the
 socket still has to be listening:
 
 ```sh

--- a/tests/no_system_wide_apt_policy.rs
+++ b/tests/no_system_wide_apt_policy.rs
@@ -1,0 +1,122 @@
+//! podup does not decide the machine's update policy.
+//!
+//! `unattended-upgrades` is a hard `Depends`, so podup can be sure the package
+//! is installed. Whether it *runs* is a different file:
+//! `/etc/apt/apt.conf.d/20auto-upgrades`, which switches automatic upgrades on
+//! for every package on the machine rather than for Glyndor's. That is the
+//! operator's call, or a fleet manager's. A container runtime is not the thing
+//! that should make it, and #1593 settled it that way: leave the one uncovered
+//! row (a Debian where somebody registered the archive by hand and ran
+//! `apt install podup`) rather than close it from a `postinst`.
+//!
+//! The consequence is that the README owes the reader a sentence, because the
+//! dependency looks like it delivers the outcome and does not. Both halves of
+//! that live in prose, and prose stops being true without anything failing.
+//! These are the gate.
+
+use std::fs;
+use std::path::Path;
+
+fn read(rel: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} is readable: {e}"))
+}
+
+/// Every file dpkg would install or run, not only the maintainer scripts: a
+/// conffile shipped under `debian/` reaches `/etc` just as effectively as a
+/// `postinst` that writes one.
+#[test]
+fn nothing_podup_packages_writes_the_machine_wide_upgrade_switch() {
+	let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("debian");
+	let mut offenders = Vec::new();
+	for entry in fs::read_dir(&dir).expect("debian/ is readable") {
+		let path = entry.expect("debian/ entry is readable").path();
+		if !path.is_file() {
+			continue;
+		}
+		let name = path.file_name().unwrap().to_string_lossy().into_owned();
+		// `debian/changelog` describes releases and may well mention the switch
+		// by name when explaining that podup does not write it.
+		if name == "changelog" || name == "copyright" {
+			continue;
+		}
+		let Ok(text) = fs::read_to_string(&path) else {
+			continue; // a binary artefact under debian/ writes no apt policy
+		};
+		// Comments are stripped, and finding that out is the reason this comment
+		// exists: `debian/control` names the switch in the paragraph explaining
+		// that podup does not write it, so matching raw text reported the
+		// documentation of the rule as a breach of it. `#` opens a comment in
+		// every format under `debian/` this test reads, control and rules and
+		// shell alike. A line that emits the switch from a heredoc is still a
+		// line, so it survives the strip and is still caught.
+		let effective: String = text
+			.lines()
+			.filter(|l| !l.trim_start().starts_with('#'))
+			.collect::<Vec<_>>()
+			.join("\n");
+		for needle in ["20auto-upgrades", "APT::Periodic", "Unattended-Upgrade::"] {
+			if effective.contains(needle) {
+				offenders.push(format!("debian/{name} contains {needle}"));
+			}
+		}
+	}
+	assert!(
+		offenders.is_empty(),
+		"podup would be setting update policy for every package on the machine, \
+		 which #1593 decided it must not. The Glyndor archive's own allowlist \
+		 belongs to glyndor-archive-keyring, not here. Found: {offenders:#?}"
+	);
+}
+
+/// A tripwire rather than a rule. A maintainer script is not forbidden, but the
+/// reason podup has none is the decision above, so adding the first one should
+/// cost a deliberate look rather than passing as routine packaging.
+#[test]
+fn adding_a_maintainer_script_asks_you_to_re_read_the_decision() {
+	let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("debian");
+	let mut scripts = Vec::new();
+	for entry in fs::read_dir(&dir).expect("debian/ is readable") {
+		let name = entry
+			.expect("debian/ entry is readable")
+			.file_name()
+			.to_string_lossy()
+			.into_owned();
+		// dpkg accepts both `podup.postinst` and a bare `postinst` in a
+		// single-binary source package, so match the suffix rather than the name.
+		if ["postinst", "preinst", "postrm", "prerm"]
+			.iter()
+			.any(|s| name == *s || name.ends_with(&format!(".{s}")))
+		{
+			scripts.push(name);
+		}
+	}
+	assert!(
+		scripts.is_empty(),
+		"podup ships no maintainer scripts, and #1593 is why: the one thing a \
+		 postinst was proposed for was writing /etc/apt/apt.conf.d/20auto-upgrades, \
+		 which is the machine's policy and not podup's. If this script is for \
+		 something else, say so and delete this test rather than widening it. \
+		 Found: {scripts:#?}"
+	);
+}
+
+/// The dependency reads like a promise that podup keeps itself up to date. On
+/// one install path it does not, so the README has to say so; a user who never
+/// runs `apt upgrade` is otherwise running whatever they installed months ago
+/// while believing the opposite.
+#[test]
+fn the_readme_says_what_the_dependency_does_not_guarantee() {
+	let readme = read("README.md");
+	for needle in [
+		"is installed, not that it is\nrunning",
+		"20auto-upgrades",
+		"apt install podup",
+	] {
+		assert!(
+			readme.contains(needle),
+			"README.md no longer tells the reader that depending on \
+			 unattended-upgrades does not switch it on. Missing: {needle:?}"
+		);
+	}
+}

--- a/tests/no_system_wide_apt_policy.rs
+++ b/tests/no_system_wide_apt_policy.rs
@@ -101,15 +101,25 @@ fn adding_a_maintainer_script_asks_you_to_re_read_the_decision() {
 	);
 }
 
+/// Neither the line endings nor the wrap points are the claim, and both broke
+/// this test before they were flattened away. The Windows checkout is CRLF, so a
+/// needle spanning a line break cannot match there at all; and reflowing the
+/// paragraph moves where the breaks fall, which would fail the test while the
+/// README still said exactly the right thing. Collapsing every run of whitespace
+/// to a single space leaves only the words, which are what is being asserted.
+fn flattened(text: &str) -> String {
+	text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// The dependency reads like a promise that podup keeps itself up to date. On
 /// one install path it does not, so the README has to say so; a user who never
 /// runs `apt upgrade` is otherwise running whatever they installed months ago
 /// while believing the opposite.
 #[test]
 fn the_readme_says_what_the_dependency_does_not_guarantee() {
-	let readme = read("README.md");
+	let readme = flattened(&read("README.md"));
 	for needle in [
-		"is installed, not that it is\nrunning",
+		"is installed, not that it is running",
 		"20auto-upgrades",
 		"apt install podup",
 	] {


### PR DESCRIPTION
## Summary

Answers #1593. podup does **not** ship a `postinst` writing `/etc/apt/apt.conf.d/20auto-upgrades`. That file switches automatic upgrades on for every package on the machine, and podup only answers for Glyndor's. Whether a whole machine updates itself is the operator's decision, or a fleet manager's; a container runtime is not the thing that should make it on their behalf.

That is the "leave it" option from the issue, and it is a real choice rather than a deferral, so this closes the issue rather than parking it.

## What the decision costs, and where it is now written

Choosing to leave the gap made the README wrong, which is the substance of this pull request. It said an apt-installed podup "updates through apt and nothing else", which reads as a promise that it stays current. The dependency guarantees the package is **installed**, not that it **runs**:

| how it was installed | does podup upgrade itself? |
| --- | --- |
| `curl … apt.glyndor.net/install/podup \| sudo sh` | yes, the installer writes the switch when it is absent |
| Ubuntu, any path | yes, the switch is normally already on |
| **`apt install podup` on Debian with the archive registered by hand** | **no** |

The README now names that third row and gives `systemctl status unattended-upgrades` as the way to tell which one you are on. A user who never runs `apt upgrade` was otherwise running whatever they installed months ago while believing the opposite.

`debian/control` already recorded this correctly, in a comment written when `unattended-upgrades` became a hard `Depends`. Nothing enforced it.

## The gate

`tests/no_system_wide_apt_policy.rs`, three tests:

- **no file podup packages writes the switch.** Every file under `debian/`, not only maintainer scripts, because a conffile reaches `/etc` just as effectively.
- **adding a first maintainer script asks you to re-read the decision.** A tripwire, not a rule: a `postinst` is not forbidden, but the reason podup has none is this decision, and the failure message says to delete the test deliberately rather than widen it.
- **the README keeps the sentence.**

## Test plan

- [x] `cargo fmt --all --check` and `cargo clippy --locked --all-targets --all-features -- -D warnings`, both clean
- [x] `cargo test --locked --all-features --lib --tests` exits 0, 27 binaries green
- [x] The new file is 81 code lines, under the 300 soft limit
- [x] Each of the three was driven red

Each sabotage was checked to have altered the file before the result was read, and restored afterwards.

Adding `debian/podup.postinst` that writes the switch from a heredoc fails **both** the content test and the tripwire, which is the check that matters: the matcher drops comment lines, and I needed to know that a line emitting the file still survives that. Rewriting the README's "is installed, not that it is running" fails the third by name.

**One thing the first version got wrong, and it is the reason the strip exists.** The matcher reported `debian/control` as a breach, because the paragraph explaining that podup does not write the switch names the switch. A pattern that reads prose about a rule as a violation of it is measuring the documentation, not the package.

**And one correction to the issue's own wording.** It says "Ubuntu server ships both". On Ubuntu 26.04 the switch is present and enabled, but `dpkg -S` finds no owner and it is not among `unattended-upgrades`' conffiles, so that is true about the outcome and wrong about the mechanism. The README says Ubuntu normally has it and points at `systemctl status` instead of claiming why. This was measured on one Ubuntu box, which is evidence about Ubuntu and none at all about Debian; the Debian row is the issue's measurement, not a fresh one.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` untouched. No behaviour changed, so no changelog entry is owed
- [x] Docs updated: that is what this is

## Related issues

Closes #1593. Refs `Glyndor/apt#177`, which fixed the installer branch that the hard `Depends` had killed.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
