### PR TITLE
ci: own the CodeQL configuration instead of GitHub's default setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,81 @@
+name: CodeQL
+# Replaces GitHub's default setup, which analysed this repository from a
+# server-side configuration nothing here could see or change.
+#
+# Two reasons, and the second is the one that pays for the first.
+#
+# Default setup only analyses the DEFAULT branch. Every pull request landed on
+# `develop` unscanned, and its alerts appeared later attributed to whichever
+# commit promoted `develop` to `main` — so a finding was never attached to the
+# change that introduced it, and a promotion presented a batch of them at once.
+# Scanning pull requests is what puts the alert next to the diff that caused it.
+#
+# And default setup cannot load a model pack. `rust/cleartext-logging` treats the
+# return value of any function whose NAME matches a sensitive-data heuristic as
+# sensitive — `create_project_secrets` matches on `secret` — so seven assertions
+# formatting a `Result<()>` are reported as logging a secret. The query provides
+# `ModelsAsDataBarrier` for exactly this, and a barrier model needs a config this
+# repository owns. Glyndor/podup#1593 is unrelated; the alerts are #3 to #9.
+#
+# The job names `Analyze (rust)` and the rest carry a matrix value, so editing
+# the language list moves them. Nothing requires them today. Promoting one to
+# required needs a stable gate first, the way `Supported Podman majors` wraps the
+# Podman matrix. See #1552 before adding one.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  # So the first run after switching the repository over does not have to wait
+  # for a push, and so a re-scan can be asked for when only the queries changed.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Uploading the SARIF results is what needs this; everything else is read.
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # The three languages default setup analysed, kept identical on purpose:
+        # this workflow is meant to change WHERE the analysis runs, not what it
+        # covers, so a difference in the alert count after the switch means the
+        # migration is wrong rather than that the theory was.
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            # `none` rather than `manual`: the Rust extractor reads the source
+            # without a cargo build, which is what default setup did. Building
+            # would need the toolchain pinned here as a sixteenth site, and
+            # pin-watch already calls fifteen too many.
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Step one of two. This replaces GitHub's CodeQL default setup with a workflow this repository owns. It deliberately does **not** fix the seven `rust/cleartext-logging` alerts; that is step two, and separating them is what makes either one measurable.

## Why own it

**Default setup only analyses the default branch.** Every pull request lands on `develop` unscanned, and its alerts surface later attributed to whichever commit promoted `develop` to `main`. A finding is never attached to the change that introduced it, and a promotion presents a batch at once. It is also why measuring whether a fix worked has needed a promotion rather than a pull request — which is exactly what happened with #1599 earlier today.

**And it cannot load a model pack**, which is what step two needs.

## What the seven alerts actually are

Worth writing down, because the first attempt at them was aimed at the wrong thing. `rust/cleartext-logging` takes its sources from `SensitiveDataCall`:

```ql
HeuristicNames::nameIndicatesSensitiveData(name, classification)
```

The source is the **name of the called function**. `create_project_secrets` matches on "secret", so its return value is treated as sensitive regardless of the fact that the return type is `Result<()>` and cannot carry a payload. Taint then follows the `?` into `Engine::run`'s error and reaches seven assertions that format it.

Two measurements that pin this down:

- `resources_health.rs` calls `engine.up(&file).await.unwrap()` **eighteen times** on the same tainted value and not one is flagged. Only `assert!` interpolating `{result:?}` is a sink.
- `resources_health.rs:209` already asserts on the same tainted result with a plain message and no interpolation, and is not flagged.

So the fix belongs at the source, not at the seven sinks, and the query supplies `ModelsAsDataBarrier` for correcting a model. Rust has the extensible predicate:

```
extensible predicate barrierModel(path, output, kind, provenance, madId)
```

That is step two.

## What this pull request changes, and what it must not

Where the analysis runs, not what it covers. The matrix is the same three languages default setup ran — `rust`, `python`, `actions` — at the same `build-mode: none`, on `ubuntu-latest`, with the same job names.

**The control is that the alert count does not move.** Seven open, one closed as fixed, measured on `main` at `88f6c36`. If it moves after the switch, the migration is wrong, not the reasoning about the alerts.

## Test plan

- [x] `actionlint` clean on the new file, and the YAML parses
- [x] 42 code lines, under the 300 soft limit
- [x] Baseline captured before writing anything: run 33285480496 on `88f6c36` ran `Analyze (python)`, `Analyze (rust)` and `Analyze (actions)`, all success, event `dynamic`
- [x] The action is pinned to a full SHA with a version comment, matching every other third-party action here, and `github-actions` is already a daily Dependabot ecosystem targeting `develop`
- [ ] **The workflow cannot run yet.** While default setup is enabled, GitHub does not run a repository's own CodeQL workflow. It starts working when the repository is switched over in Settings, which is why `workflow_dispatch` is here.

## Order of operations

1. Merge this to `develop`.
2. Promote to `main`, so the workflow exists on the default branch.
3. Switch **Settings → Advanced Security → CodeQL analysis** from default to advanced. That disables default setup.
4. `workflow_dispatch` on `main`, and check three languages analysed and the alert count unchanged.
5. Only then, step two: the barrier model, verified by removing it and watching the seven come back. A `barrierModel` whose canonical path does not match fails silently and looks exactly like one that works, so "the alerts went away" is not evidence on its own.

## Known gap, not fixed here

If somebody re-enables default setup in Settings, this workflow silently stops running and nothing in the repository would say so. A test cannot read repository settings without the API, so this is recorded rather than gated.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` untouched
- [ ] Docs updated if behaviour changed. No product behaviour changed

Refs #3, #4, #5, #6, #7, #8, #9.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
