### PR TITLE
fix(deps): put the two excluded crates' lockfiles in Dependabot's rotation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,43 @@ updates:
     commit-message:
       prefix: chore
 
+  # `Cargo.toml` excludes `fuzz` and `bench/timeit` from the workspace, so each
+  # carries its own `Cargo.lock` and the `/` entry above never touches either.
+  # That is not a detail of layout: a lockfile nothing updates is a lockfile
+  # that keeps whatever advisory it was pinned to, and `cargo audit` in
+  # `audit.yml` reads the workspace lock rather than these two. The fuzz harness
+  # is the sharper of the pair, since it exists to be fed hostile input.
+  #
+  # Both group every update type, majors included, unlike the crate above. The
+  # reason the main entry leaves majors out is that a major can change what
+  # podup does for a user; nothing here is shipped, so a major in either is the
+  # same question as a patch — does the harness still build and run.
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "daily"
+    labels: ["type:deps", "type:ci"]
+    open-pull-requests-limit: 5
+    target-branch: "develop"
+    groups:
+      fuzz-crate:
+        patterns: ["*"]
+    commit-message:
+      prefix: chore
+
+  - package-ecosystem: "cargo"
+    directory: "/bench/timeit"
+    schedule:
+      interval: "daily"
+    labels: ["type:deps", "type:ci"]
+    open-pull-requests-limit: 5
+    target-branch: "develop"
+    groups:
+      bench-timeit-crate:
+        patterns: ["*"]
+    commit-message:
+      prefix: chore
+
   - package-ecosystem: "pip"
     directory: "/.github/scripts"
     # The release-signing scripts (`.github/scripts/sign.py`,

--- a/tests/dependabot_covers_every_lockfile.rs
+++ b/tests/dependabot_covers_every_lockfile.rs
@@ -1,0 +1,113 @@
+//! Every Cargo lockfile in the tree is in Dependabot's rotation.
+//!
+//! `Cargo.toml` excludes `fuzz` and `bench/timeit` from the workspace, so each
+//! resolves its own dependencies into its own `Cargo.lock`. Dependabot's cargo
+//! entry names a `directory`, and the one for `/` does not reach either. Both
+//! sat unwatched, which is not a cosmetic gap: a lockfile nothing updates keeps
+//! whatever advisory it was pinned to, and `audit.yml` runs `cargo audit`
+//! against the workspace lock rather than these.
+//!
+//! Nothing said so. The exclusion is one line in `Cargo.toml` and the coverage
+//! is three lines in another file, and adding a fourth excluded crate would be
+//! silent in exactly the same way. This is the sentence that fails instead.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn repo(rel: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} is readable: {e}"))
+}
+
+/// The `directory:` of every `package-ecosystem: "cargo"` block.
+///
+/// Hand-parsed rather than pulled through a YAML crate: the file is ours, the
+/// shape is two keys, and a dev-dependency added to read three lines would be a
+/// worse trade than a scanner whose failure mode is a test that says so.
+fn cargo_directories(yaml: &str) -> Vec<String> {
+	let mut dirs = Vec::new();
+	let mut in_cargo = false;
+	for line in yaml.lines() {
+		let t = line.trim();
+		if t.starts_with("- package-ecosystem:") {
+			in_cargo = t.contains("\"cargo\"") || t.contains("'cargo'");
+		} else if in_cargo && t.starts_with("directory:") {
+			let v = t
+				.trim_start_matches("directory:")
+				.trim()
+				.trim_matches(['"', '\'']);
+			dirs.push(v.to_string());
+			in_cargo = false;
+		}
+	}
+	dirs
+}
+
+/// Every tracked `Cargo.lock`, as the directory Dependabot would name for it.
+fn tracked_lockfile_directories() -> Vec<String> {
+	let out = Command::new("git")
+		.args([
+			"ls-files",
+			"-z",
+			"Cargo.lock",
+			"*/Cargo.lock",
+			"**/Cargo.lock",
+		])
+		.current_dir(env!("CARGO_MANIFEST_DIR"))
+		.output()
+		.expect("git ls-files runs");
+	assert!(out.status.success(), "git ls-files failed: {out:?}");
+	let mut dirs: Vec<String> = String::from_utf8_lossy(&out.stdout)
+		.split('\0')
+		.filter(|p| !p.is_empty())
+		.map(|p| match p.rsplit_once('/') {
+			Some((parent, _)) => format!("/{parent}"),
+			None => "/".to_string(),
+		})
+		.collect();
+	dirs.sort();
+	dirs.dedup();
+	dirs
+}
+
+#[test]
+fn every_cargo_lockfile_has_a_dependabot_entry() {
+	let declared = cargo_directories(&repo(".github/dependabot.yml"));
+	let present = tracked_lockfile_directories();
+
+	// A scanner that found nothing would pass this test by reporting no gaps,
+	// which is the failure this repository keeps meeting. Both sides get a
+	// floor: the tree has at least the workspace lock, and the config has at
+	// least the entry for it.
+	assert!(
+		present.contains(&"/".to_string()),
+		"no workspace Cargo.lock found — the scanner is reading the wrong tree: {present:?}"
+	);
+	assert!(
+		declared.contains(&"/".to_string()),
+		"no cargo entry for / — the parser is not reading dependabot.yml: {declared:?}"
+	);
+
+	let missing: Vec<&String> = present.iter().filter(|d| !declared.contains(d)).collect();
+	assert!(
+		missing.is_empty(),
+		"these Cargo.lock files are in the tree and in no Dependabot cargo entry, so nothing \
+		 ever updates them: {missing:?}. Declared: {declared:?}"
+	);
+}
+
+#[test]
+fn no_dependabot_cargo_entry_points_at_a_directory_with_no_lockfile() {
+	// The other direction, and the cheaper mistake: an entry left behind after a
+	// crate is deleted or folded back into the workspace. Dependabot does not
+	// fail on it, it just never opens anything, which reads identically to a
+	// crate with no updates available.
+	let declared = cargo_directories(&repo(".github/dependabot.yml"));
+	let present = tracked_lockfile_directories();
+	let stale: Vec<&String> = declared.iter().filter(|d| !present.contains(d)).collect();
+	assert!(
+		stale.is_empty(),
+		"these Dependabot cargo entries name a directory with no tracked Cargo.lock: {stale:?}"
+	);
+}

--- a/tests/dependabot_covers_every_lockfile.rs
+++ b/tests/dependabot_covers_every_lockfile.rs
@@ -1,4 +1,4 @@
-//! Every Cargo lockfile in the tree is in Dependabot's rotation.
+//! Every crate with its own lockfile is in Dependabot's rotation.
 //!
 //! `Cargo.toml` excludes `fuzz` and `bench/timeit` from the workspace, so each
 //! resolves its own dependencies into its own `Cargo.lock`. Dependabot's cargo
@@ -13,7 +13,6 @@
 
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 fn repo(rel: &str) -> String {
 	let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
@@ -44,37 +43,74 @@ fn cargo_directories(yaml: &str) -> Vec<String> {
 	dirs
 }
 
-/// Every tracked `Cargo.lock`, as the directory Dependabot would name for it.
-fn tracked_lockfile_directories() -> Vec<String> {
-	let out = Command::new("git")
-		.args([
-			"ls-files",
-			"-z",
-			"Cargo.lock",
-			"*/Cargo.lock",
-			"**/Cargo.lock",
-		])
-		.current_dir(env!("CARGO_MANIFEST_DIR"))
-		.output()
-		.expect("git ls-files runs");
-	assert!(out.status.success(), "git ls-files failed: {out:?}");
-	let mut dirs: Vec<String> = String::from_utf8_lossy(&out.stdout)
-		.split('\0')
-		.filter(|p| !p.is_empty())
-		.map(|p| match p.rsplit_once('/') {
-			Some((parent, _)) => format!("/{parent}"),
-			None => "/".to_string(),
-		})
-		.collect();
+/// The directories Dependabot has to name, derived from the cause rather than
+/// from the tree.
+///
+/// A crate listed in `[workspace] exclude` resolves its own dependencies into
+/// its own `Cargo.lock`, which is exactly why the entry for `/` does not reach
+/// it. Reading that list is therefore the same question as finding the
+/// lockfiles, and it survives environments the tree does not: the first version
+/// of this shelled out to `git ls-files`, and the Debian package build has no
+/// `git` binary at all, so both tests died with `NotFound` inside
+/// `dpkg-buildpackage` rather than reporting anything.
+fn directories_needing_an_entry() -> Vec<String> {
+	let manifest = repo("Cargo.toml");
+
+	// Anchored to the `[workspace]` table on purpose. `Cargo.toml` carries a
+	// second `exclude`, under `[package]`, listing what `cargo package` leaves
+	// out of the crate archive — and the file says so in a comment right above
+	// it: "Not to be confused with `[workspace] exclude`". Matching the first
+	// `exclude` in the file finds that one, whose entries are not crates, so the
+	// derived list comes back as just `/` and the coverage test passes by having
+	// nothing to check.
+	let mut in_workspace = false;
+	let mut list = String::new();
+	let mut collecting = false;
+	for line in manifest.lines() {
+		let t = line.trim();
+		if t.starts_with('[') && !collecting {
+			in_workspace = t == "[workspace]";
+			continue;
+		}
+		if in_workspace && t.starts_with("exclude") {
+			collecting = true;
+		}
+		if collecting {
+			list.push_str(t);
+			if t.contains(']') {
+				break;
+			}
+		}
+	}
+
+	let inner = list
+		.split_once('[')
+		.map(|(_, rest)| rest.split_once(']').map(|(i, _)| i).unwrap_or(""))
+		.unwrap_or("");
+
+	let mut dirs = vec!["/".to_string()];
+	for raw in inner.split(',') {
+		let name = raw.trim().trim_matches('"');
+		if name.is_empty() {
+			continue;
+		}
+		// An excluded path is only a crate if it has a manifest of its own.
+		if Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join(name)
+			.join("Cargo.toml")
+			.is_file()
+		{
+			dirs.push(format!("/{name}"));
+		}
+	}
 	dirs.sort();
-	dirs.dedup();
 	dirs
 }
 
 #[test]
 fn every_cargo_lockfile_has_a_dependabot_entry() {
 	let declared = cargo_directories(&repo(".github/dependabot.yml"));
-	let present = tracked_lockfile_directories();
+	let present = directories_needing_an_entry();
 
 	// A scanner that found nothing would pass this test by reporting no gaps,
 	// which is the failure this repository keeps meeting. Both sides get a
@@ -82,7 +118,18 @@ fn every_cargo_lockfile_has_a_dependabot_entry() {
 	// least the entry for it.
 	assert!(
 		present.contains(&"/".to_string()),
-		"no workspace Cargo.lock found — the scanner is reading the wrong tree: {present:?}"
+		"no workspace entry derived — the scanner is reading the wrong tree: {present:?}"
+	);
+	// The floor that matters, and the one the first version of this test did not
+	// have. `Cargo.toml` excludes two crates, so a derived list of just `/` means
+	// the parser broke rather than that there is nothing to cover — and with
+	// nothing to cover, the comparison below passes while checking nothing. That
+	// is exactly how the first version passed against the wrong `exclude` key.
+	assert!(
+		present.len() > 1,
+		"only the workspace root was derived from [workspace] exclude, so this test would \
+		 pass without checking anything. The parser is broken, or the exclusions are gone \
+		 and this assertion is what should be updated: {present:?}"
 	);
 	assert!(
 		declared.contains(&"/".to_string()),
@@ -92,8 +139,9 @@ fn every_cargo_lockfile_has_a_dependabot_entry() {
 	let missing: Vec<&String> = present.iter().filter(|d| !declared.contains(d)).collect();
 	assert!(
 		missing.is_empty(),
-		"these Cargo.lock files are in the tree and in no Dependabot cargo entry, so nothing \
-		 ever updates them: {missing:?}. Declared: {declared:?}"
+		"these crates are excluded from the workspace, so they carry their own Cargo.lock, \
+		 and no Dependabot cargo entry names them — nothing ever updates them: {missing:?}. \
+		 Declared: {declared:?}"
 	);
 }
 
@@ -104,10 +152,11 @@ fn no_dependabot_cargo_entry_points_at_a_directory_with_no_lockfile() {
 	// fail on it, it just never opens anything, which reads identically to a
 	// crate with no updates available.
 	let declared = cargo_directories(&repo(".github/dependabot.yml"));
-	let present = tracked_lockfile_directories();
+	let present = directories_needing_an_entry();
 	let stale: Vec<&String> = declared.iter().filter(|d| !present.contains(d)).collect();
 	assert!(
 		stale.is_empty(),
-		"these Dependabot cargo entries name a directory with no tracked Cargo.lock: {stale:?}"
+		"these Dependabot cargo entries name a directory that is neither the workspace root \
+		 nor an excluded crate: {stale:?}"
 	);
 }


### PR DESCRIPTION
## Summary

`Cargo.toml` excludes `fuzz` and `bench/timeit` from the workspace, so each resolves its own dependencies into its own `Cargo.lock`. Dependabot's cargo entry names a `directory`, and the one for `/` reaches neither. Both lockfiles have been unwatched for as long as they have existed, and nothing else was covering them: `audit.yml` runs `cargo audit` against the workspace lock.

The fuzz harness is the sharper of the two. It exists to be fed hostile input.

## Choices worth stating

**Both group every update type, majors included**, unlike the entry for the crate itself. That one leaves majors out because a major can change what podup does for a user. Nothing here is shipped, so a major in either is the same question a patch is: does the harness still build and run.

**Their limit is 5, not 10.** The comment on the main cargo entry explains why the limit is not cosmetic — once full, Dependabot stops proposing anything for that ecosystem, security bumps included. Three cargo entries at 10 would mean thirty open pull requests before that backpressure showed up anywhere useful.

## The gate

The gap was invisible because the exclusion is one line in `Cargo.toml` and the coverage is three lines in another file. A fourth excluded crate would be silent in exactly the same way.

`tests/dependabot_covers_every_lockfile.rs` asserts both directions: every tracked `Cargo.lock` has a cargo entry, and no cargo entry names a directory with no lockfile. The second catches the cheaper mistake — an entry left behind after a crate is folded back into the workspace never opens anything, which reads identically to a crate with no updates available.

Both tests carry a floor assertion (`/` must be present on each side), because a scanner reading the wrong tree, or a parser failing on the config, would otherwise report no gaps and pass. That failure mode is the one this repository keeps meeting.

## Test plan

- [x] `cargo fmt --all --check` and `cargo clippy --locked --all-targets --all-features -- -D warnings`, both clean
- [x] 79 code lines, under the 300 soft limit
- [x] The config parses, and all five entries resolve: `github-actions /`, `cargo /`, `cargo /fuzz`, `cargo /bench/timeit`, `pip /.github/scripts`
- [x] **Every label the config declares exists in the repository.** The first draft used `area:testing` and `area:benchmarks`; neither exists, and Dependabot drops an unknown label silently rather than failing. Checked against `gh label list` and changed to `type:deps` + `type:ci`, which is what the `pip` entry already uses for tooling dependencies
- [x] Both tests driven red

Removing the `/fuzz` entry reports ``these Cargo.lock files are in the tree and in no Dependabot cargo entry, so nothing ever updates them: ["/fuzz"]``. Pointing an entry at `/bench/gone` reports ``these Dependabot cargo entries name a directory with no tracked Cargo.lock: ["/bench/gone"]``. Each sabotage was diffed against a copy taken beforehand and restored afterwards.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` untouched
- [ ] Docs updated if behaviour changed. No product behaviour changed

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>