### PR TITLE
fix(packaging): require glyndor-archive-keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,19 @@ podup needs **Podman ≥ 5.0** (rootless). The package depends on it, so apt
 installs it alongside podup, and refuses the install on a distribution whose
 Podman is older than that. It also depends on `unattended-upgrades`, because an
 apt-installed podup updates through apt and nothing else: `podup update` refuses
-to replace a dpkg-owned binary, and only the latest release is supported.
+to replace a dpkg-owned binary, and only the latest release is supported. And on
+`glyndor-archive-keyring`, which is what points that engine at Glyndor rather
+than only at Debian's own security suite: it ships the `.sources` file and the
+`Allowed-Origins` entry, and the entry is appended to whatever the machine
+already allows rather than replacing it.
 
 That dependency guarantees `unattended-upgrades` is installed, not that it is
 running. What switches it on is `/etc/apt/apt.conf.d/20auto-upgrades`, which is
 system-wide policy for every package on the machine rather than podup's to set,
 so no podup maintainer script writes it. The one-line installer above writes it
 when it is absent, and Ubuntu normally has it already. If you registered the
-archive yourself and then ran `apt install podup` on Debian, podup is installed
-and the Glyndor archive is allowlisted, but nothing upgrades it until you run
-`apt upgrade`. `systemctl status unattended-upgrades` says which of the two you
+archive yourself and then ran `apt install podup` on Debian, podup and the
+allowlist are both installed but nothing upgrades it until you run `apt upgrade`. `systemctl status unattended-upgrades` says which of the two you
 have.
 
 Podman is daemonless, but podup speaks the libpod API, so the

--- a/debian/control
+++ b/debian/control
@@ -56,7 +56,10 @@ Architecture: any
 # What this does and does not buy, so nobody reads more into it than it does.
 # It guarantees the package is PRESENT. It does not guarantee it RUNS: Debian
 # ships no `/etc/apt/apt.conf.d/20auto-upgrades`, which is the switch, and
-# podup ships no maintainer scripts to write one. Ubuntu server ships both.
+# podup ships no maintainer scripts to write one. An Ubuntu install normally
+# has the switch already, though measured on 26.04 no package owns the file and
+# it is not one of unattended-upgrades' conffiles, so that is true about the
+# outcome and wrong about the mechanism.
 # The bootstrap installer at apt.glyndor.net/install/podup writes that file
 # when it is the thing that installed the package, and deliberately leaves an
 # existing configuration alone.
@@ -65,7 +68,30 @@ Architecture: any
 # now takes podup with it. An operator who schedules upgrades by hand, which
 # the releases standard permits, has to keep the package installed and switch
 # it off through its own configuration instead.
-Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 5.0), unattended-upgrades
+#
+# glyndor-archive-keyring is the third, and it is what makes the second mean
+# anything. unattended-upgrades is the engine; the keyring is what points it at
+# Glyndor. It ships two files and nothing else:
+#
+#   /etc/apt/sources.list.d/glyndor.sources            the archive
+#   /etc/apt/apt.conf.d/51glyndor-unattended-upgrades  the Allowed-Origins entry
+#
+# Without it the daemon runs, the logs look healthy, and podup is never upgraded
+# — which is the exact outcome the unattended-upgrades dependency was added to
+# prevent. Two install paths reached that state: `dpkg -i` of the .deb from a
+# GitHub release, and adding the repository by hand rather than through the
+# bootstrap installer. #1602.
+#
+# No bootstrap problem, measured rather than reasoned: the keyring is in the
+# archive index and `apt-cache policy` resolves it from apt.glyndor.net, so a
+# machine that already reaches the repository can install it. A standalone
+# `dpkg -i` with no repository at all fails on the unmet dependency, which is
+# the intended answer rather than a gap.
+#
+# A fork publishing its own archive — which install-template.sh supports through
+# KEYRING_URL and GLYNDOR_APT_FPR — must declare `Provides: glyndor-archive-keyring`
+# on its own keyring package, or this relationship cannot be satisfied by it.
+Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 5.0), unattended-upgrades, glyndor-archive-keyring
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -97,7 +97,12 @@ is published and `apt upgrade` installs it — nothing for users to re-run.
 
 ## What the skeleton covers
 
-- `debian/control` — source/binary stanzas, build dependencies, `Depends: podman (>= 5.0), unattended-upgrades`
+- `debian/control` — source/binary stanzas, build dependencies, `Depends: podman
+  (>= 5.0), unattended-upgrades, glyndor-archive-keyring`. The third is what aims
+  the second: it ships the `.sources` file and the `Allowed-Origins` entry, so
+  without it unattended-upgrades runs and never looks at Glyndor. A fork
+  publishing its own archive must declare `Provides: glyndor-archive-keyring` on
+  its own keyring package, or this relationship cannot be satisfied by it.
 - `debian/rules` — debhelper with cargo overrides, `--locked` release build, tests run during the build
 - `debian/podup.1` + `debian/podup.manpages` — the man page, installed by `dh_installman`
 - `debian/copyright` — DEP-5, MIT

--- a/tests/podman_floor.rs
+++ b/tests/podman_floor.rs
@@ -1,12 +1,15 @@
 //! The binary stanza's relationships, and the Podman floor that one of them
 //! carries.
 //!
-//! Two packages are required, for different reasons that look alike in the
+//! Three packages are required, for different reasons that look alike in the
 //! `Depends` field. podman because podup cannot work without it.
 //! unattended-upgrades because of what happens when podup is not updated:
 //! only the latest release is supported, and `podup update` refuses on a
 //! dpkg-owned binary, so for an apt install the package manager is the only
-//! update path.
+//! update path. glyndor-archive-keyring because it is what points that engine
+//! at Glyndor: it ships the `.sources` file and the `Allowed-Origins` entry,
+//! and without it unattended-upgrades runs, the logs look healthy, and podup is
+//! never upgraded.
 //!
 //! The Podman floor is written in three places and nothing derives one from
 //! another.
@@ -155,6 +158,37 @@ fn the_package_requires_unattended_upgrades() {
 			.any(|l| l.starts_with("Recommends:") && l.contains("unattended-upgrades")),
 		"unattended-upgrades is declared as a Recommends as well as a Depends, \
 		 which is apt being told two different things about one package"
+	);
+}
+
+/// The third relationship, and the one that makes the second do anything.
+///
+/// `unattended-upgrades` is the engine; this is what aims it. The keyring
+/// package ships `/etc/apt/sources.list.d/glyndor.sources` and
+/// `/etc/apt/apt.conf.d/51glyndor-unattended-upgrades`, and with neither of
+/// them the daemon runs against Debian's own security suite and nothing else.
+/// Two paths reached that state — `dpkg -i` of a release `.deb`, and adding the
+/// repository by hand — and on both, podup installed and never updated again.
+/// #1602.
+#[test]
+fn the_package_requires_the_archive_keyring() {
+	let control = read("debian/control");
+	let lines = binary_stanza_relationships(&control);
+	assert!(
+		lines
+			.iter()
+			.any(|l| l.starts_with("Depends:") && l.contains("glyndor-archive-keyring")),
+		"glyndor-archive-keyring must be a Depends rather than a Recommends. As a \
+		 Recommends, `--no-install-recommends` and every `dpkg -i` skip it, and what \
+		 they skip is the file that tells unattended-upgrades the Glyndor archive is \
+		 allowed at all. Found: {lines:?}"
+	);
+	assert!(
+		!lines
+			.iter()
+			.any(|l| l.starts_with("Recommends:") && l.contains("glyndor-archive-keyring")),
+		"glyndor-archive-keyring is declared as a Recommends as well as a Depends, \
+		 which is contradictory: {lines:?}"
 	);
 }
 


### PR DESCRIPTION
## Summary

`unattended-upgrades` has been a hard dependency since 5.4.0, and on its own it guarantees **an engine with nothing aimed at Glyndor**. `glyndor-archive-keyring` is what aims it. It ships exactly two files and nothing else:

```
/etc/apt/sources.list.d/glyndor.sources            the archive
/etc/apt/apt.conf.d/51glyndor-unattended-upgrades  the Allowed-Origins entry
```

Without them the daemon runs against Debian's own security suite, the logs look healthy, and podup is never upgraded — the exact outcome the `unattended-upgrades` dependency was added to prevent. Two install paths reached it: `dpkg -i` of the `.deb` a GitHub release links, and adding the repository by hand rather than through the bootstrap installer.

Closes #1602.

## No bootstrap problem, measured

The obvious worry is a circle: the keyring configures the source apt would download the keyring from. It is not circular.

```
$ apt-cache policy glyndor-archive-keyring
  Candidato: 1.0.0+pkg20260820150821
    500 https://apt.glyndor.net stable/main amd64 Packages
```

A machine that already reaches the archive installs it like any other dependency. A standalone `dpkg -i` with no repository fails on the unmet dependency, which is the intended answer rather than a gap. And the one-line installer was never affected: it `dpkg -i`s the keyring **before** it runs `apt-get install`.

## One line, deliberately

The field stays on a single line. A continuation line is valid in `debian/control` and dpkg reads it — but `tests/podman_floor.rs` finds the field with `starts_with("Depends:")`, so a wrapped field would have been **invisible to the very checks that exist to read it**. I wrote it wrapped first, noticed, and unwrapped it. Not worth the hazard for the formatting.

## The gate

`the_package_requires_the_archive_keyring`, in the file that already ties the other two relationships. Driven red twice:

- **Demoted to `Recommends`** — reports why that is not enough: `--no-install-recommends` and every `dpkg -i` skip it, and what they skip is the file that tells unattended-upgrades the Glyndor archive is allowed at all.
- **Removed entirely** — reports that.

Each sabotage was diffed against a copy taken beforehand and restored afterwards.

## Two things corrected while here

**`debian/control` claimed "Ubuntu server ships both".** Measured on Ubuntu 26.04: the switch is present and enabled, but no package owns the file and it is not one of `unattended-upgrades`' conffiles. True about the outcome, wrong about the mechanism, and the comment now says which.

**The README no longer has to hedge.** The sentence about the `apt install podup` row said "podup is installed and the Glyndor archive is allowlisted", which held only when the keyring happened to be there. Now it always is, so the hedge is gone rather than papered over.

## The escape hatch this closes off

`docs/debian-packaging.md` records it: a fork publishing its own archive through `install-template.sh`'s `KEYRING_URL` and `GLYNDOR_APT_FPR` must declare `Provides: glyndor-archive-keyring` on its own keyring package, or it cannot satisfy this relationship. Undocumented, that path would have stopped working without a word.

## Scope, stated rather than discovered

**podup alone, by the owner's decision.** Measured on `origin/develop`: epistle declares neither `unattended-upgrades` nor the keyring, so two products of the same archive now answer this question differently. That is known and chosen, not overlooked.

## Test plan

- [x] `cargo fmt --all --check` and `cargo clippy --locked --all-targets --all-features -- -D warnings`, both clean
- [x] `cargo test --locked --all-features --lib --tests` exits **0**: 2389 passed, 0 failed
- [x] The five pre-existing `podman_floor` tests still parse the field after the edit
- [x] The new check driven red by demoting to `Recommends` and by removing it
- [x] Bootstrap resolution verified with `apt-cache policy` against the live archive, not reasoned about

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` versions untouched. This changes a package relationship, which ships with the next release rather than needing one of its own
- [x] Docs updated: README and `docs/debian-packaging.md`

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>