### PR TITLE
fix(update): detect Homebrew and Scoop, not only apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ cargo build --release
 
 ### Self-update
 
-Only for installs that did not come from a package manager — the apt build omits
-it, since apt owns upgrades there.
+Only for installs that did not come from a package manager. The apt build omits
+the subcommand entirely, and an apt, Homebrew or Scoop install is refused before
+anything is downloaded and pointed at that manager's own upgrade command.
 
 ```sh
 podup update            # download and install the latest signed release

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -29,12 +29,28 @@ relied on for integrity.
    the current build is already newest (unless `--force`), and `--check` returns
    here without downloading anything.
 2. **Refuse a package-manager-managed binary.** If the running executable is
-   owned by a system package manager (e.g. installed from the `.deb`, detected
-   via `dpkg-query`), `podup update` refuses **before downloading anything** and
-   redirects you to the package manager (e.g. `apt upgrade podup`); overwriting
-   the file in place would desync the manager's records. This applies even with
-   `--force`. cargo-install / manual layouts (`~/.cargo/bin`, `/usr/local/bin`)
-   are not package-owned and update normally.
+   owned by a package manager, `podup update` refuses **before downloading
+   anything** and names that manager's own command instead — overwriting the
+   file in place would desync its records. This applies even with `--force`.
+   Three are recognised:
+
+   | manager | how | told to run |
+   | --- | --- | --- |
+   | apt | `dpkg-query -S` on the resolved path | `apt upgrade podup` |
+   | Homebrew | the path resolves inside a `Cellar` | `brew upgrade podup` |
+   | Scoop | the path is under a Scoop root's `apps` or `shims` | `scoop update podup` |
+
+   apt is asked because `dpkg-query` is an authoritative database lookup. The
+   other two are read off the path: `brew` would cost a process spawn on every
+   update to learn a prefix already visible in the path, and Scoop is a
+   PowerShell function rather than an executable, so there is nothing to spawn.
+   Both path checks are shaped to fail one way only — a layout that merely looks
+   like theirs refuses an update that would have worked, which is visible and
+   recoverable, rather than missing one and rewriting a file its manager still
+   believes it knows.
+
+   cargo-install and manual layouts (`~/.cargo/bin`, `/usr/local/bin`) belong to
+   none of them and update normally.
 3. Fetch `SHA256SUMS` and `SHA256SUMS.sig` and **verify the Ed25519 signature**
    of `SHA256SUMS` against the embedded public key — *before* the binary is
    downloaded, so a tampered or unsigned release is rejected without first

--- a/internal/update/pkg.rs
+++ b/internal/update/pkg.rs
@@ -4,21 +4,91 @@
 //! manager's record of the installed file. When the running binary is tracked by
 //! such a manager the caller refuses and redirects the user to it.
 
-#[cfg(target_os = "linux")]
 use std::path::Path;
 
 use crate::ComposeError;
 
-/// Name of the system package manager that owns the running binary, if any.
+/// Name of the package manager that owns the running binary, if any.
 ///
-/// Only `dpkg`/`apt` is detected, on Linux. cargo-install layouts
-/// (`~/.cargo/bin`, `/usr/local/bin`) are not owned by `dpkg` and update
-/// normally. A path no package owns returns `None`.
-#[cfg(target_os = "linux")]
+/// Three are detected: apt on Linux, Homebrew on macOS and Linux, and Scoop on
+/// Windows. cargo-install layouts (`~/.cargo/bin`, `/usr/local/bin`) belong to
+/// none of them and update normally, and a path no manager owns returns `None`.
+///
+/// apt is asked; the other two are read off the path. That asymmetry is not
+/// laziness. `dpkg-query` is a real database lookup with an authoritative
+/// answer, while `brew` costs a process spawn on every `podup update` to learn
+/// a prefix that is already visible in the path, and Scoop is a PowerShell
+/// function rather than an executable, so there is nothing to spawn at all.
+///
+/// Both path checks can be wrong in one direction only, which is the direction
+/// that matters. A layout that merely looks like Homebrew's or Scoop's makes
+/// podup refuse to self-update and send the user to a package manager that does
+/// not own it — wrong, visible, and recoverable by hand. The opposite mistake,
+/// missing a managed install, silently rewrites a file whose manager still
+/// believes it knows the contents. These heuristics are shaped to fail the
+/// first way.
 pub fn managing_package_manager() -> Option<&'static str> {
 	let exe = std::env::current_exe().ok()?;
 	let path = std::fs::canonicalize(&exe).unwrap_or(exe);
-	dpkg_owns(&path).then_some("apt")
+
+	#[cfg(target_os = "linux")]
+	if dpkg_owns(&path) {
+		return Some("apt");
+	}
+	if homebrew_owns(&path) {
+		return Some("Homebrew");
+	}
+	if scoop_owns(&path) {
+		return Some("Scoop");
+	}
+	None
+}
+
+/// Whether `path` sits inside a Homebrew Cellar.
+///
+/// Homebrew installs every formula under `<prefix>/Cellar/<name>/<version>/`
+/// and links a symlink into `<prefix>/bin`, so the caller's `canonicalize`
+/// resolves into the Cellar whichever of the two the user invoked. The prefix
+/// itself moves — `/opt/homebrew` on Apple silicon, `/usr/local` on Intel,
+/// `/home/linuxbrew/.linuxbrew` on Linux, anywhere at all for a custom install
+/// — but the `Cellar` component does not, which is what makes it the thing to
+/// match rather than any of the prefixes.
+fn homebrew_owns(path: &Path) -> bool {
+	path.components()
+		.any(|c| c.as_os_str().eq_ignore_ascii_case("Cellar"))
+}
+
+/// Whether `path` sits inside a Scoop installation.
+///
+/// Scoop puts apps in `<root>/apps/<name>/<version>/` with shims in
+/// `<root>/shims`. The shim is a launcher that starts the real executable, so
+/// `current_exe` is the one under `apps` either way. The root defaults to
+/// `%USERPROFILE%\scoop` and is moved with the `SCOOP` environment variable,
+/// so that is consulted first; the `scoop`-then-`apps` pair is the fallback for
+/// a root the variable does not name, such as a machine-wide `SCOOP_GLOBAL`
+/// install another user configured.
+fn scoop_owns(path: &Path) -> bool {
+	scoop_owns_under(path, std::env::var_os("SCOOP").as_deref().map(Path::new))
+}
+
+/// The body of [`scoop_owns`] with the root passed in rather than read from the
+/// environment, so the configured-root branch can be tested without mutating
+/// `SCOOP` — which in a parallel test binary is a race against every other test
+/// in the process rather than a fixture.
+fn scoop_owns_under(path: &Path, root: Option<&Path>) -> bool {
+	if let Some(root) = root {
+		if path.starts_with(root.join("apps")) || path.starts_with(root.join("shims")) {
+			return true;
+		}
+	}
+	let parts: Vec<_> = path
+		.components()
+		.map(|c| c.as_os_str().to_owned())
+		.collect();
+	parts.windows(2).any(|w| {
+		w[0].eq_ignore_ascii_case("scoop")
+			&& (w[1].eq_ignore_ascii_case("apps") || w[1].eq_ignore_ascii_case("shims"))
+	})
 }
 
 /// Whether dpkg's database records `path` as belonging to an installed package.
@@ -57,24 +127,123 @@ fn dpkg_owns(path: &Path) -> bool {
 	}
 }
 
-/// Non-Linux platforms have no supported package-manager-managed install yet.
-#[cfg(not(target_os = "linux"))]
-pub fn managing_package_manager() -> Option<&'static str> {
-	None
-}
-
 /// Error returned when the running binary is managed by package manager `pm`.
 pub fn package_managed_error(pm: &str) -> ComposeError {
+	// The example command used to be `apt upgrade podup` unconditionally, which
+	// was correct while apt was the only manager detected and is a wrong
+	// instruction the moment it is not.
+	let how = match pm {
+		"Homebrew" => "brew upgrade podup",
+		"Scoop" => "scoop update podup",
+		_ => "apt upgrade podup",
+	};
 	ComposeError::Update(format!(
 		"this podup was installed by {pm}; update it with your package manager \
-		 (e.g. `apt upgrade podup`) rather than `podup update`, which would break \
-		 the package's record of the file"
+		 (`{how}`) rather than `podup update`, which would break the package's \
+		 record of the file"
 	))
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// Paths here use `/` even for the Windows layouts. `Path::components` splits
+	/// on `\\` as well when it runs on Windows, so the component sequence these
+	/// assert on is the one the real code sees there; a fixture written with
+	/// `\\` would simply not parse into components on Linux and the tests would
+	/// pass by asserting nothing.
+	#[test]
+	fn homebrew_layouts_are_recognised_on_every_prefix() {
+		for p in [
+			"/opt/homebrew/Cellar/podup/5.4.0/bin/podup",
+			"/usr/local/Cellar/podup/5.4.0/bin/podup",
+			"/home/linuxbrew/.linuxbrew/Cellar/podup/5.4.0/bin/podup",
+			"/somewhere/entirely/custom/Cellar/podup/5.4.0/bin/podup",
+		] {
+			assert!(homebrew_owns(Path::new(p)), "not detected as Homebrew: {p}");
+		}
+	}
+
+	#[test]
+	fn ordinary_layouts_are_not_mistaken_for_homebrew() {
+		for p in [
+			"/usr/local/bin/podup",
+			"/home/me/.cargo/bin/podup",
+			"/usr/bin/podup",
+			"/home/me/podup/target/release/podup",
+		] {
+			assert!(
+				!homebrew_owns(Path::new(p)),
+				"falsely detected as Homebrew: {p}"
+			);
+		}
+	}
+
+	#[test]
+	fn scoop_layouts_are_recognised_without_the_variable() {
+		for p in [
+			"/c/Users/me/scoop/apps/podup/5.4.0/podup.exe",
+			"/c/Users/me/scoop/shims/podup.exe",
+			"/c/ProgramData/scoop/apps/podup/current/podup.exe",
+		] {
+			assert!(
+				scoop_owns_under(Path::new(p), None),
+				"not detected as Scoop: {p}"
+			);
+		}
+	}
+
+	#[test]
+	fn a_relocated_scoop_root_is_recognised_through_the_variable() {
+		// The fallback cannot see this one: no component is named `scoop`.
+		let exe = Path::new("/d/tools/apps/podup/5.4.0/podup.exe");
+		assert!(
+			!scoop_owns_under(exe, None),
+			"the fallback should not match a root with no `scoop` component"
+		);
+		assert!(
+			scoop_owns_under(exe, Some(Path::new("/d/tools"))),
+			"a root named by SCOOP must be honoured"
+		);
+	}
+
+	#[test]
+	fn ordinary_layouts_are_not_mistaken_for_scoop() {
+		for p in [
+			"/c/Program Files/podup/podup.exe",
+			"/home/me/.cargo/bin/podup",
+			// `scoop` present but not followed by apps or shims: a checkout of
+			// the bucket repository, not an install.
+			"/home/me/src/scoop/bucket/podup.json",
+		] {
+			assert!(
+				!scoop_owns_under(Path::new(p), None),
+				"falsely detected as Scoop: {p}"
+			);
+		}
+	}
+
+	#[test]
+	fn the_error_tells_each_manager_its_own_command() {
+		for (pm, cmd) in [
+			("apt", "apt upgrade podup"),
+			("Homebrew", "brew upgrade podup"),
+			("Scoop", "scoop update podup"),
+		] {
+			let ComposeError::Update(msg) = package_managed_error(pm) else {
+				panic!("expected an Update error");
+			};
+			assert!(
+				msg.contains(pm),
+				"{pm} is not named in its own error: {msg}"
+			);
+			assert!(
+				msg.contains(cmd),
+				"{pm} is told to run something other than {cmd}: {msg}"
+			);
+		}
+	}
 
 	#[test]
 	fn package_managed_error_names_the_manager() {


### PR DESCRIPTION
## Summary

`podup update` replaces the running executable in place, and refuses when a package manager owns it, because doing so would desync that manager's record of the file. **It only ever recognised one manager.** `pkg.rs` said so plainly — *"Only `dpkg`/`apt` is detected, on Linux"* — and off Linux it did not look at all:

```rust
#[cfg(not(target_os = "linux"))]
pub fn managing_package_manager() -> Option<&'static str> { None }
```

So a Homebrew or Scoop install running `podup update` had its binary rewritten underneath a manifest that still claimed to know the contents.

That is true today and has been. **It matters more now** because the plan is to retire podup's own `install.sh` and `install.ps1` and leave apt, Homebrew and Scoop as the channels — which makes the undetected case the ordinary one rather than the exception. This is the step that has to land before that retirement, not after.

## What is detected, and why differently

| manager | how | told to run |
| --- | --- | --- |
| apt | `dpkg-query -S` on the resolved path | `apt upgrade podup` |
| Homebrew | the path resolves inside a `Cellar` | `brew upgrade podup` |
| Scoop | under a Scoop root's `apps` or `shims` | `scoop update podup` |

apt is **asked**, because `dpkg-query -S` is an authoritative database lookup. The other two are **read off the path**, and the asymmetry is deliberate: `brew` costs a process spawn on every update to learn a prefix the path already shows, and Scoop is a PowerShell function rather than an executable, so there is nothing to spawn.

**Homebrew.** Every formula lives under `<prefix>/Cellar/<name>/<version>/`, linked into `<prefix>/bin`, so the existing `canonicalize` resolves into the Cellar whichever the user invoked. The prefix moves — `/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`, anywhere for a custom install — and the `Cellar` component does not. That invariance is why it is what gets matched rather than any list of prefixes.

**Scoop.** Apps go in `<root>/apps/<name>/<version>/` with shims in `<root>/shims`, and the shim launches the real executable, so `current_exe` is the one under `apps` either way. `SCOOP` is consulted first for a relocated root, with the `scoop`-then-`apps` pair as the fallback.

## Wrong in one direction only, and it is the safe one

A layout that merely *looks* like Homebrew's or Scoop's makes podup refuse an update that would have worked — visible, and recoverable by hand. The opposite mistake rewrites a file whose manager still believes it knows the contents. Both heuristics are shaped to fail the first way, and the module documents that rather than leaving it to be inferred.

## A refactor that is not indirection for its own sake

`scoop_owns` reads `SCOOP` and delegates to `scoop_owns_under`, which takes the root as an argument. Setting an environment variable inside a parallel test binary is a race against every other test in the process rather than a fixture, so without this the configured-root branch would have gone untested — and it is the branch that handles the case the fallback provably cannot see.

## Test plan

- [x] `cargo fmt --all --check` and `cargo clippy --locked --all-targets --all-features -- -D warnings`, both clean
- [x] `cargo test --locked --all-features --lib --tests` exits **0**: 2395 passed, 0 failed
- [x] Six new tests, all driven red

A blind `homebrew_owns` reports the layout it failed to recognise, by path. One that matches everything reports the ordinary layout it falsely claimed. Putting `apt upgrade podup` back as the instruction for Homebrew reports that it was told to run something other than `brew upgrade podup`. Each sabotage was diffed against a copy taken beforehand and restored.

**The Windows fixtures are written with `/` on purpose.** `Path::components` splits on `\` as well when it runs on Windows, so the component sequence these assert on is the one the real code sees there — while a `\`-separated fixture would not parse into components on Linux at all, and the test would pass by asserting nothing. The comment above them says so, because that is exactly the shape of a test that looks thorough and checks nothing.

## Two things that had gone wrong in prose

**The error message hardcoded `apt upgrade podup`** as its example. Correct while apt was the only manager detected; a wrong instruction the moment it is not. It now names each manager's own command, and a test asserts each of the three gets its own.

**`docs/self-update.md`** said the check was `dpkg-query` and the redirect was apt. It now carries the table above and the reasoning for why two of the three are path-based.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` versions untouched
- [x] Docs updated: `docs/self-update.md` and the README's Self-update section

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>