### PR TITLE
test: stop printing the asserted Result in the seven flagged assertions

### DIFF
--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -1,6 +1,13 @@
 //! Engine integration tests (split for the source line limit).
 use super::*;
 
+// Seven assertions in this suite deliberately do not print the `Result` they
+// assert on, while others still do. `rust/cleartext-logging` takes its sources
+// from the NAME of the called function, so `create_project_secrets` is a taint
+// source and those seven were the sinks it reached through `?`. Nothing
+// syntactic separates them from the rest, so this note is what keeps the
+// inconsistency from reading as an oversight somebody tidies up. #1599.
+
 // ---------------------------------------------------------------------------
 // Pause / unpause
 // ---------------------------------------------------------------------------
@@ -73,7 +80,7 @@ async fn engine_run_command_succeeds() {
 			),
 		)
 		.await;
-	assert!(result.is_ok(), "run failed: {result:?}");
+	assert!(result.is_ok(), "run failed");
 }
 
 #[tokio::test]
@@ -100,9 +107,13 @@ async fn engine_run_nonzero_exit_returns_run_exited() {
 			),
 		)
 		.await;
+	// Split rather than flattened. Dropping the formatted value would otherwise
+	// lose the difference between "succeeded" and "failed with the wrong
+	// variant"; `expect_err` prints the `Ok` value, which here is `()`.
+	let err = result.expect_err("expected RunExited, got Ok");
 	assert!(
-		matches!(result, Err(podup::ComposeError::RunExited(_))),
-		"expected RunExited, got {result:?}"
+		matches!(err, podup::ComposeError::RunExited(_)),
+		"expected RunExited, got a different ComposeError variant"
 	);
 }
 

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -1,6 +1,13 @@
 //! Engine integration tests (split for the source line limit).
 use super::*;
 
+// Seven assertions in this suite deliberately do not print the `Result` they
+// assert on, while others still do. `rust/cleartext-logging` takes its sources
+// from the NAME of the called function, so `create_project_secrets` is a taint
+// source and those seven were the sinks it reached through `?`. Nothing
+// syntactic separates them from the rest, so this note is what keeps the
+// inconsistency from reading as an oversight somebody tidies up. #1599.
+
 // Volumes, secrets, configs
 // ---------------------------------------------------------------------------
 
@@ -141,7 +148,7 @@ async fn file_secret_bound() {
 	engine.down(&file).await.unwrap();
 	assert!(
 		read.is_ok(),
-		"the container could not read /run/secrets/filesecret: {read:?}"
+		"the container could not read /run/secrets/filesecret"
 	);
 }
 

--- a/tests/engine_integration/run_flags.rs
+++ b/tests/engine_integration/run_flags.rs
@@ -5,6 +5,13 @@
 //! engine carrying the overrides under test.
 use super::*;
 
+// Seven assertions in this suite deliberately do not print the `Result` they
+// assert on, while others still do. `rust/cleartext-logging` takes its sources
+// from the NAME of the called function, so `create_project_secrets` is a taint
+// source and those seven were the sinks it reached through `?`. Nothing
+// syntactic separates them from the rest, so this note is what keeps the
+// inconsistency from reading as an oversight somebody tidies up. #1599.
+
 #[tokio::test]
 async fn engine_run_applies_user_workdir_env_and_entrypoint() {
 	let client = match podman().await {
@@ -45,7 +52,7 @@ async fn engine_run_applies_user_workdir_env_and_entrypoint() {
 		.await;
 	assert!(
 		result.is_ok(),
-		"run with user/workdir/env/entrypoint failed: {result:?}"
+		"run with user/workdir/env/entrypoint failed"
 	);
 }
 
@@ -98,10 +105,7 @@ async fn engine_run_applies_volume_publish_and_interactive() {
 			),
 		)
 		.await;
-	assert!(
-		result.is_ok(),
-		"run with volume/publish/interactive failed: {result:?}"
-	);
+	assert!(result.is_ok(), "run with volume/publish/interactive failed");
 }
 
 #[cfg(feature = "test-helpers")]
@@ -147,7 +151,7 @@ async fn engine_run_no_deps_skips_dependency_startup() {
 		.unwrap_or_default();
 	let dep_present = names.iter().any(|n| n.contains("-dep"));
 	engine.down(&file).await.unwrap();
-	assert!(result.is_ok(), "run --no-deps failed: {result:?}");
+	assert!(result.is_ok(), "run --no-deps failed");
 	assert!(
 		!dep_present,
 		"dependency container created despite --no-deps: {names:?}"
@@ -188,7 +192,7 @@ async fn engine_run_starts_dependencies_by_default() {
 		.unwrap_or_default();
 	let dep_present = names.iter().any(|n| n.contains("-dep"));
 	engine.down(&file).await.unwrap();
-	assert!(result.is_ok(), "run with deps failed: {result:?}");
+	assert!(result.is_ok(), "run with deps failed");
 	assert!(
 		dep_present,
 		"dependency was not started by default: {names:?}"


### PR DESCRIPTION
## Summary

Seven `rust/cleartext-logging` alerts are open on `main`, all the same shape: an assertion in the integration suite formatting a `Result` that CodeQL traced back to `create_project_secrets`.

**The source is the function's name.** `SensitiveDataCall` matches on `HeuristicNames::nameIndicatesSensitiveData`, so `create_project_secrets` is a taint source because it contains "secret" — not because of anything its `Result<()>` can carry, and #1599 already made it impossible for a payload to reach one of those errors.

The fix that corrects the model rather than the sinks needs a `ModelsAsDataBarrier`, which needs a configuration this repository owns, which the organization's `Glyndor baseline` pins away. That was #1603 and it is closed. This is what is left.

## Why removing the value is certain to work

Not hoped — measured, twice, from the scan's own results:

- `resources_health.rs:209` already asserts on the same tainted result with a plain message and **is not flagged**.
- Eighteen `.unwrap()` calls on the same values across the suite are **not flagged** either.

Only `assert!` interpolating the value is a sink.

## Seven changed, eleven left alone

There are **eighteen** occurrences of the pattern in the suite. CodeQL flagged **seven**. The other eleven are on paths the query does not reach.

Nothing syntactic separates them, so each of the three files gains a note saying the inconsistency is deliberate. Without it the next reader tidies it up and the alerts come back — which is the failure this repository keeps meeting in prose form.

## The one that lost the most is split, not flattened

`commands_networking.rs`'s `matches!` assertion would have gone from naming what it got to saying nothing:

```rust
let err = result.expect_err("expected RunExited, got Ok");
assert!(
    matches!(err, podup::ComposeError::RunExited(_)),
    "expected RunExited, got a different ComposeError variant"
);
```

`expect_err` prints the `Ok` value, which here is `()`, so it is safe and it keeps the difference between *the run succeeded* and *it failed with the wrong variant*. A single flat message would have thrown that away.

## Test plan

- [x] `cargo fmt --all --check` and `cargo clippy --locked --all-targets --all-features -- -D warnings`, both clean
- [x] The affected tests pass against live Podman: `run_flags` and `commands_networking` all green, including the restructured one
- [x] The restructured assertion driven red by expecting `Unsupported` instead of `RunExited` — reports *"expected RunExited, got a different ComposeError variant"*
- [x] Exactly seven occurrences removed: 18 before, 11 after

## The cost, stated rather than discovered

These seven no longer say which error they got. And **nothing prevents an eighth**: a syntactic gate cannot tell the seven from the eleven, so there is no check to add that would not also ban the assertions that are fine.

Whether the alerts actually clear will not be visible until this reaches `main`, because code scanning runs on the default branch only.

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` untouched
- [ ] Docs updated if behaviour changed. Tests only

Refs #3, #4, #5, #6, #7, #8, #9.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>