### PR TITLE
chore(release): bump to 5.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.4.0"
+version = "5.5.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.4.0"
+version = "5.5.0"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+podup (5.5.0) unstable; urgency=medium
+
+  * `podup update` no longer overwrites a Homebrew or Scoop install. It
+    refused only for dpkg, and off Linux did not look at all, so on those
+    two it rewrote the binary underneath a manifest that still claimed to
+    know the contents. It now names each manager's own upgrade command.
+  * On an apt install, the refusal also says when apt will never do it
+    either. unattended-upgrades installs only from origins its own
+    configuration permits, and a machine without that rule is never
+    upgraded and never finds out; the refusal now reads apt's merged
+    configuration and gives the reason and the remedy.
+  * The package now also requires glyndor-archive-keyring. It ships the
+    rule that points unattended-upgrades at Glyndor, so without it the
+    daemon runs, the logs look healthy, and podup is never upgraded.
+  * podup is no longer published to crates.io. The library target stays and
+    the tests build against it; 5.4.0 remains on crates.io because a
+    published version cannot be deleted, only yanked.
+  * No change to any command's flags or output.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 30 Aug 2026 16:04:17 -0500
+
 podup (5.4.0) unstable; urgency=medium
 
   * The package now requires unattended-upgrades as well as podman. An


### PR DESCRIPTION
## Summary

Bumps to **5.5.0**, MINOR. Everything in it is already on `main`; this is the version stamp so the tag can be cut.

## What 5.5.0 contains

**User-facing**

- `podup update` no longer overwrites a Homebrew or Scoop install (#1609). It refused only for dpkg, and off Linux did not look at all, so on those two it rewrote the binary underneath a manifest that still claimed to know the contents.
- On an apt install, the refusal also says when apt will never do it either (#1612).
- The package now also requires `glyndor-archive-keyring` (#1607), which ships the rule pointing unattended-upgrades at Glyndor.
- podup is no longer published to crates.io (#1606).

**Not user-facing**: the seven `rust/cleartext-logging` alerts, all now `closed as fixed` (#1611); Dependabot covering the two excluded lockfiles (#1604); two files split off the line-limit cap (#1605); README corrections (#1601).

## MINOR, and why not MAJOR

No pull request in this release carries the `breaking` label, which `standards/releases` makes the marker, and no command's flags or output changed.

The one arguable case is `podup update` now refusing on Homebrew and Scoop where it previously overwrote. What it did before corrupted the manager's record of the file, so this is a fix rather than a withdrawal of function — and the refusal names that manager's own upgrade command.

## Three manifests, not two

`Cargo.lock` stamps the version too, and `--locked` refuses to update it during a build. A bump touching only `Cargo.toml` and `debian/changelog` leaves the lock claiming 5.4.0, and the release build then fails at the gate rather than at review. Caught here rather than at tag time:

```
error: cannot update the lock file … because --locked was passed
```

## Test plan

- [x] All three manifests agree at 5.5.0: `Cargo.toml`, `Cargo.lock`, `debian/changelog`
- [x] `dpkg-parsechangelog` reads the new entry: Source podup, Version 5.5.0
- [x] `cargo fmt --all --check` and `cargo clippy --locked --all-targets --all-features -- -D warnings`, both clean
- [x] `cargo test --locked --all-features --lib --tests` exits 0: 2400 passed, 0 failed
- [x] `cargo build --locked` succeeds, which is what proves the lock was updated rather than assumed

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`) and signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] `Cargo.toml` and `debian/changelog` are at the same version — the release gate compares them
- [ ] Docs updated if behaviour changed. The behaviour changes shipped with their own pull requests

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>