### PR TITLE
release: 5.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.4.0"
+version = "5.5.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.4.0"
+version = "5.5.0"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+podup (5.5.0) unstable; urgency=medium
+
+  * `podup update` no longer overwrites a Homebrew or Scoop install. It
+    refused only for dpkg, and off Linux did not look at all, so on those
+    two it rewrote the binary underneath a manifest that still claimed to
+    know the contents. It now names each manager's own upgrade command.
+  * On an apt install, the refusal also says when apt will never do it
+    either. unattended-upgrades installs only from origins its own
+    configuration permits, and a machine without that rule is never
+    upgraded and never finds out; the refusal now reads apt's merged
+    configuration and gives the reason and the remedy.
+  * The package now also requires glyndor-archive-keyring. It ships the
+    rule that points unattended-upgrades at Glyndor, so without it the
+    daemon runs, the logs look healthy, and podup is never upgraded.
+  * podup is no longer published to crates.io. The library target stays and
+    the tests build against it; 5.4.0 remains on crates.io because a
+    published version cannot be deleted, only yanked.
+  * No change to any command's flags or output.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 30 Aug 2026 16:04:17 -0500
+
 podup (5.4.0) unstable; urgency=medium
 
   * The package now requires unattended-upgrades as well as podman. An


### PR DESCRIPTION
## Summary

The release pull request for **5.5.0**. Everything else in it was already promoted; this carries the version stamp so `v5.5.0` can be tagged on `main`.

## What 5.5.0 changes for a user

- **`podup update` no longer overwrites a Homebrew or Scoop install** (#1609). It refused only for dpkg, and off Linux did not look at all, so on those two it rewrote the binary underneath a manifest that still claimed to know the contents. It now names each manager's own upgrade command.
- **On an apt install, the refusal also says when apt will never do it either** (#1612). unattended-upgrades installs only from origins its configuration permits, and a machine without that rule is never upgraded and never finds out.
- **The package now also requires `glyndor-archive-keyring`** (#1607), which ships that rule.
- **podup is no longer published to crates.io** (#1606). The library target stays and the tests build against it; 5.4.0 remains on crates.io, because a published version cannot be deleted, only yanked, and leaving it reserves the name.

No command's flags or output changed.

## MINOR

No pull request in this release carries the `breaking` label, which `standards/releases` makes the marker. The one arguable case is `podup update` refusing where it previously overwrote — and what it did before corrupted the manager's record of the file, so it is a fix rather than a withdrawal.

## Test plan

- [x] All three manifests agree at 5.5.0: `Cargo.toml`, `Cargo.lock`, `debian/changelog`. The lock is the one a two-file bump misses, and `--locked` refuses to fix it during a build, so it would have failed at tag time rather than at review
- [x] `dpkg-parsechangelog` reads the entry: Source podup, Version 5.5.0
- [x] #1614 merged green on `develop`: 27 checks, 0 failures
- [x] The seven `rust/cleartext-logging` alerts are `closed as fixed` on `main`, and code scanning reports **0 open**

## After this

Tag `v5.5.0` on `main`, which is what `release.yml` fires on. Releases are immutable org-wide, so that is the step with no undo.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>