### PR TITLE
fix(autostart): order the service-mode unit after the user network shim

### DIFF
--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -67,10 +67,36 @@ builds at deploy time, whenever you run `podup up`.
 The unit is a `--user` unit wired into `default.target`, not the system
 `multi-user.target`. `multi-user.target` is a system-manager concept and is inert
 in the user instance, so ordering against it would imply a boot gate that never
-fires. Under lingering the user manager starts after the system network is already
-up, and `podup` reaches Podman over a socket on demand, so no explicit network
-ordering is needed. The generated units carry no `network-online.target` ordering
-for the same reason.
+fires. The same is true of `network-online.target`, which is why neither mode
+names it.
+
+Waiting for the network still has to happen somewhere, and Podman ships the piece
+that makes it possible from a user unit:
+`podman-user-wait-network-online.service`, a `Type=oneshot` unit that polls
+`systemctl is-active network-online.target` until the system target comes up.
+Both modes order against that shim. Quadlet mode gets it from Podman's generator
+(`man podman-systemd.unit`, under *Implicit network dependencies*), which adds
+`Wants=` and `After=` to every `.container` unit it converts. Service mode writes
+its final unit itself, so `podup` puts the same two lines in directly:
+
+```ini
+[Unit]
+Description=podup <project>
+Wants=podman-user-wait-network-online.service
+After=podman-user-wait-network-online.service
+```
+
+The wait earns its place in service mode more than it does under Quadlet, not
+less. Quadlet's `ExecStart` starts a container; this one is `podup up -d`, which
+may pull an image, and under rootless Podman pasta builds the container network
+at start time.
+
+Measured 2026-08-30: the shim first ships in Podman 5.3.0, while `podup`'s floor
+is 5.0. On 5.0 through 5.2 systemd finds no such unit, drops the `Wants=` and
+`After=` with `LoadState=not-found`, and starts the unit clean with
+`Result=success` and nothing in the journal. Those versions behave exactly as they
+did before, so nothing regresses on them; they simply get no ordering, which is
+what they had.
 
 ## Running `systemctl --user` for a login-less account
 

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -209,11 +209,29 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// leaves them on disk, which is exactly what ExecStart expects to find, and
 	// honours each container's own stop_signal / stop_grace_period.
 	let stop = exec_line(opts, &["stop"]);
-	// No `network-online.target` ordering: that target is a system-manager
-	// concept and stays inert in the `--user` instance, so depending on it would
-	// imply a network-readiness gate that never fires. Under linger the user
-	// manager starts after the system network is already up, and podup reaches
-	// Podman over a socket on demand, so no explicit network ordering is needed.
+	// Network ordering goes through Podman's user-scope shim, never through
+	// `network-online.target` directly. That target is a system-manager concept
+	// and stays inert in the `--user` instance, so naming it here would read as a
+	// readiness gate and fire as nothing. Podman ships
+	// `podman-user-wait-network-online.service` for exactly that gap
+	// (containers/podman#22197): a `Type=oneshot` unit that polls
+	// `systemctl is-active network-online.target` until the system target comes
+	// up, which is the one thing a user unit can actually wait on.
+	//
+	// Quadlet mode gets this for free. `man podman-systemd.unit`, under *Implicit
+	// network dependencies*, says the generator adds `Wants=`/`After=` on the
+	// same shim to every `.container` unit it converts, so the files
+	// `autostart/quadlet.rs` emits pick it up at boot. Service mode writes the
+	// final unit itself and inherits nothing, and the reason applies here with
+	// more force rather than less: Quadlet's `ExecStart` starts a container,
+	// ours is `podup up -d`, which may pull an image, and rootless pasta builds
+	// the container network at start time.
+	//
+	// Measured 2026-08-30: the shim first ships in Podman 5.3.0, and podup's
+	// floor is 5.0. On 5.0 through 5.2 systemd finds no such unit, drops the
+	// `Wants=`/`After=` with `LoadState=not-found`, and starts this unit clean
+	// with `Result=success` and nothing in the journal, which is the behaviour
+	// those versions already had.
 	//
 	// `WorkingDirectory=` takes the rest of its line literally — unlike an
 	// exec-line token, it understands none of the C-style backslash escapes
@@ -247,6 +265,8 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	format!(
 		"[Unit]\n\
 		 Description=podup {project}\n\
+		 Wants=podman-user-wait-network-online.service\n\
+		 After=podman-user-wait-network-online.service\n\
 		 \n\
 		 [Service]\n\
 		 Type=oneshot\n\
@@ -287,9 +307,6 @@ mod tests {
 	fn renders_single_file_unit() {
 		let s = render_service_unit(&opts_single());
 		assert!(s.contains("Description=podup app"));
-		// A `--user` unit must NOT order against the system `network-online.target`
-		// (it is inert in the user manager); assert it is absent.
-		assert!(!s.contains("network-online.target"));
 		assert!(s.contains("Type=oneshot"));
 		assert!(s.contains("RemainAfterExit=yes"));
 		assert!(s.contains("WorkingDirectory=/srv/app"));
@@ -349,6 +366,37 @@ mod tests {
 			!s.contains(" down"),
 			"ExecStop must stop, not remove the containers:\n{s}"
 		);
+	}
+
+	/// #1616: service mode writes the final unit, so it inherits none of the
+	/// ordering Quadlet's generator adds on its own. What has to hold is that the
+	/// unit waits for the network, and that it waits through Podman's user-scope
+	/// shim rather than through `network-online.target`, which is inert in the
+	/// `--user` instance.
+	///
+	/// The assertion this replaced only forbade the string `network-online.target`,
+	/// which a unit carrying no ordering at all also satisfies. That is the state
+	/// this test exists to rule out, so it asserts the keys that must be present
+	/// first and the spelling that must not appear second.
+	#[test]
+	fn orders_against_the_user_scope_network_shim() {
+		let s = render_service_unit(&opts_single());
+		assert!(
+			s.contains("Wants=podman-user-wait-network-online.service"),
+			"the unit must pull in the network shim:\n{s}"
+		);
+		assert!(
+			s.contains("After=podman-user-wait-network-online.service"),
+			"wanting the shim without ordering after it starts both at once, \
+			 which is the same as not waiting:\n{s}"
+		);
+		for key in ["Wants=", "After=", "Requires=", "BindsTo=", "PartOf="] {
+			assert!(
+				!s.contains(&format!("{key}network-online.target")),
+				"a `--user` unit must not depend on the system target directly, \
+				 since it never activates there:\n{s}"
+			);
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #1616.

`autostart --mode quadlet` inherits network ordering that `--mode service` does not, and nothing said so. Podman's Quadlet generator adds `Wants=`/`After=` on `podman-user-wait-network-online.service` to every `.container` unit it converts (`man podman-systemd.unit`, *Implicit network dependencies*). Service mode writes its final `.service` itself, so it inherited nothing: the whole `[Unit]` section was a `Description=`.

The reason applies here with more force rather than less. Quadlet's `ExecStart` starts a container; ours is `podup up -d`, which may pull an image, and under rootless Podman pasta builds the container network at start time. An early boot lands on a network that is not ready and the failure surfaces whenever someone next reads the journal.

## What changed

`render_service_unit` now emits the two lines directly:

```ini
[Unit]
Description=podup <project>
Wants=podman-user-wait-network-online.service
After=podman-user-wait-network-online.service
```

Not `network-online.target`. That target is a system-manager concept and stays inert in the `--user` instance, so naming it would read as a readiness gate and fire as nothing. The shim is what Podman built for that gap, and its own header says so:

```
Documentation=https://github.com/containers/podman/issues/22197
ExecStart=/bin/sh -c 'until systemctl is-active network-online.target; do sleep 0.5; done'
```

## The old test would not have caught this

`service.rs` asserted the absence of a spelling:

```rust
assert!(!s.contains("network-online.target"));
```

`podman-user-wait-network-online.service` does not contain that substring, so the assertion passes with the fix in and passes with it out. A unit carrying no ordering at all also satisfies it, which is precisely the state it looked like it was guarding.

Replaced with `orders_against_the_user_scope_network_shim`, which asserts the keys that must be present first and the spelling that must not appear second. Verified by reverting the render change and putting the old assertion back:

```
test orders_against_the_user_scope_network_shim ... FAILED
test renders_single_file_unit ... ok
```

Red for the right reason, and the old assertion green beside it.

## Podman 5.0 through 5.2

Measured 2026-08-30 against the podman tags, path `contrib/systemd/user/podman-user-wait-network-online.service`:

```
v5.0.0 404   v5.1.0 404   v5.2.0 404
v5.3.0 200   v5.4.0 200   v5.5.0 200   v5.6.0 200   v5.7.0 200
```

podup's floor is 5.0 (`internal/libpod/error.rs:98`), so on 5.0 through 5.2 the unit does not exist. systemd drops a `Wants=`/`After=` naming a unit it cannot load, records `LoadState=not-found`, and starts the dependent clean with `Result=success` and nothing in the journal. Those versions behave exactly as they did before this change. The caveat is recorded in the code comment and in the docs, because it also qualifies the "Quadlet gets it free" half of the argument: on 5.0 through 5.2 the generator has no shim to name either.

## No opt-out

Quadlet has `DefaultDependencies=false` because Quadlet imposes the dependency on you. Here you would be asking for it. Nothing else in the service-mode unit is configurable and I do not want to start with this one.

## Docs

`docs/autostart.md` claimed "The generated units carry no `network-online.target` ordering", plural, covering both modes. That was already false for quadlet before this change. Rewritten to say where each mode gets its ordering from, and to carry the 5.0-through-5.2 note with its date.

## Local test run

`cargo fmt --check` and `clippy --all-targets --all-features -D warnings` clean. `cargo test --all-features` is green except for `engine_integration::build_images`, which fails against this machine's Podman storage with `getting top layer info: layer not known`.

That is pre-existing and not from this change. Control: with `internal/autostart/service.rs` and `docs/autostart.md` reverted to `develop`, so the tree is byte-identical to the base, `build_images` still fails. The failing set also moves between runs (three tests on one pass, a different single test on the next), which is the flakiness rather than a behaviour this branch introduced.
