### PR TITLE
fix(autostart): report when the network ordering is not loadable

### DIFF
--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -130,9 +130,29 @@ at start time.
 Measured 2026-08-30: the shim first ships in Podman 5.3.0, while `podup`'s floor
 is 5.0. On 5.0 through 5.2 systemd finds no such unit, drops the `Wants=` and
 `After=` with `LoadState=not-found`, and starts the unit clean with
-`Result=success` and nothing in the journal. Those versions behave exactly as they
-did before, so nothing regresses on them; they simply get no ordering, which is
-what they had.
+`Result=success` and nothing in the journal. Nothing regresses on those versions;
+they simply get no ordering, which is what they had.
+
+That silence is the problem with leaving it there. The unit file *reads* as
+though it waits for the network, and on those versions it does not, with nothing
+anywhere to say so. `podup autostart status` therefore asks:
+
+```
+network wait  podman-user-wait-network-online.service is loaded
+```
+
+or, when it is not:
+
+```
+network wait  podman-user-wait-network-online.service is not loadable, so the
+              unit's network ordering is dropped silently (Podman ships it from 5.3.0)
+```
+
+Note for anyone changing that check: `systemctl show <unit> -p LoadState` exits
+**0 whether or not the unit exists**, and reports the answer only in the
+`LoadState=` string. That is the opposite of `is-active` and `is-enabled`, which
+both exit 4 for an unknown unit. A guard written against the exit code reports
+the shim as present in exactly the case it is missing.
 
 ## Running `systemctl --user` for a login-less account
 

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -413,6 +413,25 @@ pub fn installed_mode(project: &str) -> InstalledMode {
 	}
 }
 
+/// Whether the network-ordering the generated units declare is real.
+///
+/// `Wants=`/`After=` naming a unit systemd cannot load is dropped silently:
+/// `LoadState` reads `not-found`, the dependent starts clean, and nothing
+/// reaches the journal. So a unit file can say it waits for the network while
+/// waiting for nothing, and the only way to tell is to ask.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkWait {
+	/// systemd loaded the shim, so the ordering the unit declares takes effect.
+	Loaded,
+	/// No such unit. Podman ships it from 5.3.0; below that the ordering in
+	/// every autostart unit is inert.
+	NotFound,
+	/// `systemctl` could not be asked, or answered something unrecognised.
+	/// Carried rather than collapsed into `NotFound`: "we could not tell" and
+	/// "it is not there" are different answers and only one is a problem.
+	Unknown(String),
+}
+
 /// A snapshot of the autostart unit's state, gathered for `status`.
 pub struct StatusReport {
 	/// Absolute path to where the unit file would live.
@@ -429,6 +448,8 @@ pub struct StatusReport {
 	pub linger: bool,
 	/// Whether `XDG_RUNTIME_DIR` is set (a user session is present).
 	pub runtime_dir: bool,
+	/// Whether the network shim the generated units order against is loadable.
+	pub network_wait: NetworkWait,
 }
 
 /// Read the unit file's permission bits, on Unix. Other platforms have no POSIX
@@ -461,6 +482,41 @@ fn query<S: SystemCtl>(sc: &S, arg: &str, unit_name: &str) -> String {
 	}
 }
 
+/// The unit every autostart mode orders against, so the name lives in one place.
+pub(crate) const NETWORK_SHIM: &str = "podman-user-wait-network-online.service";
+
+/// Ask systemd whether the network shim is loadable.
+///
+/// **The exit code is not the signal, and must not be used as one.** Measured
+/// 2026-08-30 on Podman 5.7.0, rootless: `systemctl --user show <unit> -p
+/// LoadState` exits **0 for a unit that does not exist** just as it does for one
+/// that does, printing `LoadState=not-found` in the first case and
+/// `LoadState=loaded` in the second. A guard branching on the status would
+/// report the shim as fine while it is missing, which is the same vacuous check
+/// this function exists to replace.
+///
+/// That differs from the two verbs the rest of this status uses: `is-active`
+/// and `is-enabled` both exit **4** for an unknown unit. Two conventions, one
+/// module, so the difference is stated here rather than left to be rediscovered.
+fn network_wait_state<S: SystemCtl>(sc: &S) -> NetworkWait {
+	let out = match sc.systemctl(&["show", NETWORK_SHIM, "-p", "LoadState"]) {
+		Ok(out) => out,
+		Err(e) => return NetworkWait::Unknown(format!("systemctl show failed: {e}")),
+	};
+	let text = String::from_utf8_lossy(&out.stdout);
+	let Some(state) = text
+		.lines()
+		.find_map(|l| l.trim().strip_prefix("LoadState="))
+	else {
+		return NetworkWait::Unknown("systemctl show printed no LoadState".to_string());
+	};
+	match state.trim() {
+		"loaded" => NetworkWait::Loaded,
+		"not-found" => NetworkWait::NotFound,
+		other => NetworkWait::Unknown(other.to_string()),
+	}
+}
+
 /// Gather the autostart status for a project, going through the [`SystemCtl`] seam
 /// so it is testable without a live systemd.
 pub fn collect_status<S: SystemCtl>(sc: &S, project: &str) -> StatusReport {
@@ -475,6 +531,7 @@ pub fn collect_status<S: SystemCtl>(sc: &S, project: &str) -> StatusReport {
 		is_enabled: query(sc, "is-enabled", &unit_name),
 		linger: current_user().is_some_and(|u| linger_enabled(sc, &u)),
 		runtime_dir: std::env::var_os("XDG_RUNTIME_DIR").is_some_and(|s| !s.is_empty()),
+		network_wait: network_wait_state(sc),
 	}
 }
 
@@ -509,6 +566,27 @@ pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 		crate::ui::print_labelled_neutral("enabled", &r.is_enabled);
 	}
 	row("linger", if r.linger { "enabled" } else { "disabled" });
+	// Prose for the same reason the session line is prose: "not-found" alone
+	// would read as a broken install rather than as the ordering being inert,
+	// and the operator needs to be told what it costs and what fixes it.
+	match &r.network_wait {
+		NetworkWait::Loaded => crate::ui::print_labelled_with(
+			"network wait",
+			&format!("{NETWORK_SHIM} is loaded"),
+			Some(true),
+		),
+		NetworkWait::NotFound => crate::ui::print_labelled_with(
+			"network wait",
+			&format!(
+				"{NETWORK_SHIM} is not loadable, so the unit's network ordering \
+				 is dropped silently (Podman ships it from 5.3.0)"
+			),
+			Some(false),
+		),
+		NetworkWait::Unknown(why) => {
+			crate::ui::print_labelled_neutral("network wait", &format!("unknown ({why})"))
+		}
+	}
 	// Prose, not a state word, so the meaning is stated rather than inferred.
 	crate::ui::print_labelled_with(
 		"session",

--- a/internal/autostart/tests.rs
+++ b/internal/autostart/tests.rs
@@ -413,14 +413,25 @@ fn the_status_asks_about_the_unit_the_units_actually_name() {
 		"{:?}",
 		sc.systemctl_log()
 	);
-	assert!(
-		super::render_service_unit(&super::ServiceUnitOpts::new(
-			std::path::PathBuf::from("/usr/bin/podup"),
-			vec![std::path::PathBuf::from("/srv/app/compose.yml")],
-			"app".to_string(),
-			std::path::PathBuf::from("/srv/app"),
-		))
-		.contains(NETWORK_SHIM),
-		"the unit must order against the same name the status checks"
-	);
+	// Every renderer that emits the ordering, not just the one that had it
+	// first. Checking only service mode would leave start mode free to name a
+	// different unit than the status reports on, which is the same silent
+	// mismatch this whole check exists to surface.
+	let service = super::render_service_unit(&super::ServiceUnitOpts::new(
+		std::path::PathBuf::from("/usr/bin/podup"),
+		vec![std::path::PathBuf::from("/srv/app/compose.yml")],
+		"app".to_string(),
+		std::path::PathBuf::from("/srv/app"),
+	));
+	let start = super::render_start_unit(&super::StartUnitOpts::new(
+		std::path::PathBuf::from("/usr/bin/podman"),
+		"app".to_string(),
+		"app-web-1".to_string(),
+	));
+	for (mode, unit) in [("service", &service), ("start", &start)] {
+		assert!(
+			unit.contains(NETWORK_SHIM),
+			"{mode} mode must order against the same name the status checks:\n{unit}"
+		);
+	}
 }

--- a/internal/autostart/tests.rs
+++ b/internal/autostart/tests.rs
@@ -20,6 +20,11 @@ struct FakeCtl {
 	/// default; `4 << 8` is systemd's "no such unit", the only value
 	/// `unit_is_known` treats as "there is nothing here".
 	is_active_code: i32,
+	/// What `systemctl --user show <shim> -p LoadState` prints. Real systemd
+	/// exits 0 whether or not the unit exists, so this fake always does too:
+	/// a fake that signalled absence through the exit code would let a guard
+	/// that reads the code pass here and fail in production.
+	show_load_state: String,
 	fail: bool,
 }
 
@@ -32,6 +37,7 @@ impl FakeCtl {
 			is_active: "active".to_string(),
 			is_enabled: "enabled".to_string(),
 			is_active_code: 0,
+			show_load_state: "LoadState=loaded\n".to_string(),
 			fail: false,
 		}
 	}
@@ -58,6 +64,7 @@ impl SystemCtl for FakeCtl {
 		let stdout = match args.first().copied() {
 			Some("is-active") => self.is_active.as_str(),
 			Some("is-enabled") => self.is_enabled.as_str(),
+			Some("show") => self.show_load_state.as_str(),
 			_ => "",
 		};
 		// `is-enabled` is read through stdout only, so its status stays
@@ -66,7 +73,10 @@ impl SystemCtl for FakeCtl {
 		// blanket `fail` flag.
 		let code = match args.first().copied() {
 			Some("is-active") => self.is_active_code,
-			Some("is-enabled") => 0,
+			// Both 0, deliberately. Measured on real systemd: `show` reports a
+			// missing unit through `LoadState=not-found` in stdout and still
+			// exits 0, unlike `is-enabled`, which exits 4 for the same unit.
+			Some("is-enabled") | Some("show") => 0,
 			_ => code,
 		};
 		Ok(out(code, stdout))
@@ -339,4 +349,78 @@ fn max_stop_grace_skips_an_unparseable_value() {
 	)
 	.unwrap();
 	assert_eq!(super::max_stop_grace_secs(&file), Some(30));
+}
+
+// --- the network shim (#1616's ordering is only real if the unit loads) ---
+
+/// The trap, pinned. Real `systemctl show` exits **0** for a unit that does not
+/// exist, printing `LoadState=not-found`. A guard reading the exit code would
+/// call the shim present here and be wrong in exactly the case it exists to
+/// catch, which is the same vacuous shape as the assertion #1616 replaced.
+#[test]
+fn a_missing_shim_is_read_from_load_state_not_from_the_exit_code() {
+	let mut sc = FakeCtl::new();
+	sc.show_load_state = "LoadState=not-found\n".to_string();
+	let r = collect_status(&sc, "app");
+	assert_eq!(r.network_wait, NetworkWait::NotFound);
+	// The call really did succeed, so nothing about the status distinguished
+	// these two cases except the string.
+	assert_eq!(
+		sc.systemctl(&["show", NETWORK_SHIM, "-p", "LoadState"])
+			.unwrap()
+			.status
+			.code(),
+		Some(0)
+	);
+}
+
+#[test]
+fn a_loaded_shim_reads_as_loaded() {
+	let sc = FakeCtl::new();
+	assert_eq!(collect_status(&sc, "app").network_wait, NetworkWait::Loaded);
+}
+
+/// "We could not tell" is not "it is not there". Collapsing the two would report
+/// a broken ordering on every machine whose systemctl answered oddly.
+#[test]
+fn an_unrecognised_answer_is_unknown_rather_than_missing() {
+	let mut sc = FakeCtl::new();
+	sc.show_load_state = "LoadState=masked\n".to_string();
+	assert!(matches!(
+		collect_status(&sc, "app").network_wait,
+		NetworkWait::Unknown(s) if s == "masked"
+	));
+
+	let mut sc = FakeCtl::new();
+	sc.show_load_state = String::new();
+	assert!(matches!(
+		collect_status(&sc, "app").network_wait,
+		NetworkWait::Unknown(_)
+	));
+}
+
+/// The status asks about the shim by the same name the units order against, so
+/// a rename cannot leave the guard checking a unit nothing depends on.
+#[test]
+fn the_status_asks_about_the_unit_the_units_actually_name() {
+	let sc = FakeCtl::new();
+	let _ = collect_status(&sc, "app");
+	assert!(
+		sc.systemctl_log()
+			.iter()
+			.any(|c| c.first().map(String::as_str) == Some("show")
+				&& c.contains(&NETWORK_SHIM.to_string())),
+		"{:?}",
+		sc.systemctl_log()
+	);
+	assert!(
+		super::render_service_unit(&super::ServiceUnitOpts::new(
+			std::path::PathBuf::from("/usr/bin/podup"),
+			vec![std::path::PathBuf::from("/srv/app/compose.yml")],
+			"app".to_string(),
+			std::path::PathBuf::from("/srv/app"),
+		))
+		.contains(NETWORK_SHIM),
+		"the unit must order against the same name the status checks"
+	);
 }


### PR DESCRIPTION
Closes #1623.

#1618 made every autostart unit order against `podman-user-wait-network-online.service` and nothing checked the unit exists. The shim ships in Podman 5.3.0, podup's floor is 5.0, so on 5.0 through 5.2 systemd drops the dependency with `LoadState=not-found` and starts the unit clean with nothing in the journal.

I wrote that up as harmless in #1618, and as an *error* it is. As a *guarantee* it is not: the unit file reads as though it waits for the network, on those versions it does not, and no signal exists anywhere. That is the trap the ordering was added to escape, one layer along — #1616 existed because naming `network-online.target` from user scope does nothing quietly, and this is naming a unit that does not exist and having it do nothing quietly, with podup writing the line instead of an operator.

## What changed

`autostart status` gains a line:

```
network wait  podman-user-wait-network-online.service is loaded
```

```
network wait  podman-user-wait-network-online.service is not loadable, so the
              unit's network ordering is dropped silently (Podman ships it from 5.3.0)
```

## The exit code is not the signal

Measured on this machine, Podman 5.7.0, rootless, 2026-08-30:

```
$ systemctl --user show podman-user-wait-network-online.service -p LoadState
LoadState=loaded
exit=0

$ systemctl --user show podup-no-such-shim.service -p LoadState
LoadState=not-found
exit=0
```

`show` exits 0 for a unit that does not exist. The answer lives only in the string.

That is the opposite convention from the two verbs the rest of this module uses:

```
$ systemctl --user is-enabled podup-no-such-shim.service
not-found
exit=4
```

So the obvious implementation, matching the surrounding style, reports the shim as present in exactly the case it is missing. The reason is written at the call site rather than left implicit, because the next person to touch it will reach for `status.success()`.

## The fake exits 0 too, and that is the load-bearing part

`FakeCtl` returns a configurable `LoadState` string and always exits 0 for `show`.

A test double that signalled absence through the exit code would let an implementation reading the status pass its tests and fail in production. That is a worse failure than a vacuous assertion: a vacuous assertion fails to catch a bug, a vacuous fake **certifies** one, and it does it one level below where anybody looks.

Verified the tests discriminate rather than assuming it. I wrote the wrong implementation on purpose — `if out.status.success() { return NetworkWait::Loaded; }` before the parse, which is what matching the surrounding style produces:

```
test autostart::tests::an_unrecognised_answer_is_unknown_rather_than_missing ... FAILED
test autostart::tests::a_missing_shim_is_read_from_load_state_not_from_the_exit_code ... FAILED
```

Both red, then reverted. So the tests catch that specific wrong implementation, not merely some implementation.

## `Unknown` is a third state on purpose

Not folded into `NotFound`. "Could not tell" reported as "not there" is a false alarm, and a guard that cries wolf on odd-but-fine machines is a guard that gets ignored on the machine where it matters. A masked shim reads as `Unknown("masked")`; so does a `systemctl` that prints no `LoadState` at all.

## Not hypothetical

A hand-written boot unit elsewhere carried `After=network-online.target` for months before someone read `LoadState` and found the wait had never been there. podup's service mode had the same shape independently, which is what #1616 fixed. Two instances of one mistake inside a month is a trap rather than an oversight, and that is the case for spending a status line on it.

## Out of scope

`install` does not warn. The answer goes stale the moment Podman moves past 5.3.0 in either direction, and `status` is where an operator goes to ask whether autostart is set up correctly.

## Merge order

This touches `internal/autostart/mod.rs`, and so does #1622. This branch is cut from `develop`, not from #1622, so whichever lands second needs a local rebase — `gh pr update-branch` produces unsigned commits and leaves the merge BLOCKED without saying why.
