### PR TITLE
chore(release): bump to 5.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.5.0"
+version = "5.6.0"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,29 @@
+podup (5.6.0) unstable; urgency=medium
+
+  * `podup autostart` gains a third mode. `--mode start` writes a unit whose
+    ExecStart is `podman start`, so the boot resumes the container Podman
+    already holds instead of reconciling it against the compose file. Podman's
+    store survives a reboot, so nothing on that path needs the compose file,
+    the environment, a registry or a build. A container missing at boot means
+    a deploy went wrong, and this mode says so in the journal rather than
+    rebuilding it silently. Single-service projects only: `podman start` waits
+    for nothing, so anything with depends_on needs quadlet mode, and the
+    refusal says so.
+  * Both service mode and start mode now order their unit against
+    podman-user-wait-network-online.service. Quadlet mode already inherited
+    that from Podman's generator and service mode did not, so the two modes
+    differed in a guarantee and nothing said which. Rootless Podman builds the
+    container network at start time, so an early boot could land on a network
+    that was not ready.
+  * `podup autostart status` reports whether that ordering is real. The unit
+    ships in Podman 5.3.0 and podup supports 5.0, so below 5.3.0 systemd drops
+    the dependency silently: the unit file reads as though it waits for the
+    network while waiting for nothing. The status now says which of the two it
+    is.
+  * No change to any existing command's flags or output.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 30 Aug 2026 23:17:02 -0500
+
 podup (5.5.0) unstable; urgency=medium
 
   * `podup update` no longer overwrites a Homebrew or Scoop install. It


### PR DESCRIPTION
Minor rather than patch: `autostart --mode start` is new behaviour.

Everything `develop` carries over `main`:

- #1618 — service mode now orders against `podman-user-wait-network-online.service`, which quadlet mode already inherited from Podman's generator. Closes #1616.
- #1622 — `autostart --mode start`, which resumes the existing container instead of reconciling it at boot. Closes #1621.
- #1624 — `autostart status` reports whether that network ordering is actually loadable, since below Podman 5.3.0 systemd drops it in silence. Closes #1623.

## The three files, and how I found them

`Cargo.toml`, `Cargo.lock`, `debian/changelog` — derived by searching the tree for `5.5.0`, not by copying the last bump's diff. The standard warns against the latter for a measured reason: 1.8.1 dropped `debian/changelog`, 1.9.0 inherited the gap and shipped `podup_1.8.0_*.deb`, so apt reported nothing to upgrade and Debian users were stranded on the one release that had also rotated the signing key.

## Verified against the gate, with a control

Ran `release.yml`'s three version comparisons locally:

```
tag=5.6.0 crate=5.6.0 deb=5.6.0 lock=5.6.0
GATE OK
```

and then desynced `debian/changelog` to 5.5.0 to confirm the comparison actually fails, rather than trusting a green that might have been comparing nothing:

```
control OK: detecta deb=5.5.0 vs crate=5.6.0
```

`cargo build --locked` clean, so the lockfile edit is consistent.