### PR TITLE
release: 5.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.5.0"
+version = "5.6.0"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,29 @@
+podup (5.6.0) unstable; urgency=medium
+
+  * `podup autostart` gains a third mode. `--mode start` writes a unit whose
+    ExecStart is `podman start`, so the boot resumes the container Podman
+    already holds instead of reconciling it against the compose file. Podman's
+    store survives a reboot, so nothing on that path needs the compose file,
+    the environment, a registry or a build. A container missing at boot means
+    a deploy went wrong, and this mode says so in the journal rather than
+    rebuilding it silently. Single-service projects only: `podman start` waits
+    for nothing, so anything with depends_on needs quadlet mode, and the
+    refusal says so.
+  * Both service mode and start mode now order their unit against
+    podman-user-wait-network-online.service. Quadlet mode already inherited
+    that from Podman's generator and service mode did not, so the two modes
+    differed in a guarantee and nothing said which. Rootless Podman builds the
+    container network at start time, so an early boot could land on a network
+    that was not ready.
+  * `podup autostart status` reports whether that ordering is real. The unit
+    ships in Podman 5.3.0 and podup supports 5.0, so below 5.3.0 systemd drops
+    the dependency silently: the unit file reads as though it waits for the
+    network while waiting for nothing. The status now says which of the two it
+    is.
+  * No change to any existing command's flags or output.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Sun, 30 Aug 2026 23:17:02 -0500
+
 podup (5.5.0) unstable; urgency=medium
 
   * `podup update` no longer overwrites a Homebrew or Scoop install. It

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -24,21 +24,57 @@ because the unit it writes will not start at boot until you enable it.
 
 ## Picking a mode
 
-`--mode` selects the backend. Both are rootless and user-scope; they differ in
-who owns the containers.
+`--mode` selects the backend. All three are rootless and user-scope; they differ
+in who owns the containers, and in whether the boot path reconciles.
 
 | Mode | What it installs | Choose it when |
 |---|---|---|
 | `service` (default) | One `Type=oneshot` unit that runs `podup up -d` at boot and `podup stop` on shutdown. | You want the whole stack managed as a unit, the simplest option — one thing to enable, one to remove. |
 | `quadlet` | One native Podman Quadlet unit per service (`.container`/`.build`/`.volume`/`.network`), which systemd owns directly. | You want per-container supervision — systemd restarts, ordering and status for each service independently. |
+| `start` | One `Type=oneshot` unit whose `ExecStart` is `podman start`. Single-service projects only. | You want the boot to resume the container that already exists, with nothing else on the path. |
 
-Service mode keeps the compose front-end (`.env`, interpolation, profiles) on the
-runtime path; systemd starts `podup`, and `podup` reads the compose file. Quadlet
-mode renders the stack to systemd units once, at install time, and hands them over
-— after that systemd runs the containers with no `podup` process in the loop.
+### Reconcile or restore
 
-The two cannot coexist for one project: each install refuses if the other is
-present, since both would bring the same stack up at boot.
+This is the axis that actually separates them, and it is worth being explicit
+because two of the three sit on the same side of it.
+
+`service` and `quadlet` both make the world match the file at boot. Service mode
+keeps the compose front-end (`.env`, interpolation, profiles) on the runtime path:
+systemd starts `podup`, and `podup` reads the compose file. Quadlet mode renders
+the stack to systemd units once, at install time, and hands them over, after which
+systemd runs the containers with no `podup` process in the loop, though Podman
+still reconciles each `.container` against its unit.
+
+`start` does neither. Podman is daemonless and its store survives a reboot, so
+every setting was baked into the container definition when it was created.
+`podman start` restores the lot with no compose file, no `.env`, no registry and
+no build on the path.
+
+The failure semantics are the reason to choose it rather than a side effect. A
+container missing at boot means a deploy went wrong, and booting cannot fix a
+broken deploy: `start` fails loudly in the journal, where `up -d` would rebuild it
+silently. Deploy reconciles; boot restores.
+
+### What `start` costs
+
+**Single-service projects only.** `podman start` waits for nothing, so a project
+with `depends_on` (and especially `condition: service_healthy`) needs ordering
+between units, which is exactly what quadlet mode derives from the compose file.
+Rather than reimplement that, `start` refuses a project with more than one service,
+or one scaled past a single replica, and the error names the mode to use instead.
+
+**Drift is caught at install, not at boot.** If `compose.yaml` changes after the
+container was created, a boot would resume the old configuration. `podup` compares
+the container's `podup.config-hash` label against what the file renders and refuses
+to install over a mismatch, or over a container that does not exist yet.
+
+That check runs when you install, because there is no `podup` at boot to run it —
+which is the point of the mode, and therefore also its limit. Editing the compose
+file after installing leaves the unit starting the old container silently. Run
+`podup up -d` after any change to the file, exactly as you would to deploy it.
+
+The three cannot coexist for one project: each install refuses if another is
+present, since they would all bring the same stack up at boot.
 
 ## Commands
 

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -67,10 +67,36 @@ builds at deploy time, whenever you run `podup up`.
 The unit is a `--user` unit wired into `default.target`, not the system
 `multi-user.target`. `multi-user.target` is a system-manager concept and is inert
 in the user instance, so ordering against it would imply a boot gate that never
-fires. Under lingering the user manager starts after the system network is already
-up, and `podup` reaches Podman over a socket on demand, so no explicit network
-ordering is needed. The generated units carry no `network-online.target` ordering
-for the same reason.
+fires. The same is true of `network-online.target`, which is why neither mode
+names it.
+
+Waiting for the network still has to happen somewhere, and Podman ships the piece
+that makes it possible from a user unit:
+`podman-user-wait-network-online.service`, a `Type=oneshot` unit that polls
+`systemctl is-active network-online.target` until the system target comes up.
+Both modes order against that shim. Quadlet mode gets it from Podman's generator
+(`man podman-systemd.unit`, under *Implicit network dependencies*), which adds
+`Wants=` and `After=` to every `.container` unit it converts. Service mode writes
+its final unit itself, so `podup` puts the same two lines in directly:
+
+```ini
+[Unit]
+Description=podup <project>
+Wants=podman-user-wait-network-online.service
+After=podman-user-wait-network-online.service
+```
+
+The wait earns its place in service mode more than it does under Quadlet, not
+less. Quadlet's `ExecStart` starts a container; this one is `podup up -d`, which
+may pull an image, and under rootless Podman pasta builds the container network
+at start time.
+
+Measured 2026-08-30: the shim first ships in Podman 5.3.0, while `podup`'s floor
+is 5.0. On 5.0 through 5.2 systemd finds no such unit, drops the `Wants=` and
+`After=` with `LoadState=not-found`, and starts the unit clean with
+`Result=success` and nothing in the journal. Those versions behave exactly as they
+did before, so nothing regresses on them; they simply get no ordering, which is
+what they had.
 
 ## Running `systemctl --user` for a login-less account
 

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -130,9 +130,29 @@ at start time.
 Measured 2026-08-30: the shim first ships in Podman 5.3.0, while `podup`'s floor
 is 5.0. On 5.0 through 5.2 systemd finds no such unit, drops the `Wants=` and
 `After=` with `LoadState=not-found`, and starts the unit clean with
-`Result=success` and nothing in the journal. Those versions behave exactly as they
-did before, so nothing regresses on them; they simply get no ordering, which is
-what they had.
+`Result=success` and nothing in the journal. Nothing regresses on those versions;
+they simply get no ordering, which is what they had.
+
+That silence is the problem with leaving it there. The unit file *reads* as
+though it waits for the network, and on those versions it does not, with nothing
+anywhere to say so. `podup autostart status` therefore asks:
+
+```
+network wait  podman-user-wait-network-online.service is loaded
+```
+
+or, when it is not:
+
+```
+network wait  podman-user-wait-network-online.service is not loadable, so the
+              unit's network ordering is dropped silently (Podman ships it from 5.3.0)
+```
+
+Note for anyone changing that check: `systemctl show <unit> -p LoadState` exits
+**0 whether or not the unit exists**, and reports the answer only in the
+`LoadState=` string. That is the opposite of `is-active` and `is-enabled`, which
+both exit 4 for an unknown unit. A guard written against the exit code reports
+the shim as present in exactly the case it is missing.
 
 ## Running `systemctl --user` for a login-less account
 

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -9,9 +9,17 @@
 
 mod quadlet;
 mod service;
+mod start;
+
+#[cfg(test)]
+#[path = "start_tests.rs"]
+mod start_tests;
 
 pub use quadlet::{install_quadlet, rebuild_quadlet, uninstall_quadlet};
 pub use service::{render_service_unit, ServiceUnitOpts};
+pub use start::{
+	render_start_unit, sole_container, validate_start_unit_opts, StartModeRefusal, StartUnitOpts,
+};
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -229,39 +237,73 @@ fn checked(res: io::Result<Output>, what: &str) -> crate::Result<()> {
 	)))
 }
 
+/// Refuse to stack a single-unit mode on top of an existing Quadlet autostart
+/// install for the same project: both would start the stack at boot.
+fn refuse_if_quadlet_present(project: &str) -> crate::Result<()> {
+	let quadlet = quadlet_units_present(project);
+	if quadlet.is_empty() {
+		return Ok(());
+	}
+	let names: Vec<String> = quadlet.iter().map(|p| p.display().to_string()).collect();
+	Err(ComposeError::Autostart(format!(
+		"quadlet autostart units for project '{project}' already exist:\n    {}\n\
+		 remove them before installing another mode (quadlet autostart is tracked by #993).",
+		names.join("\n    ")
+	)))
+}
+
 /// Install (and, unless `no_start`, enable + start) the service-mode autostart
 /// unit. Writes only under `${XDG_CONFIG_HOME:-~/.config}/systemd/user/`.
 pub fn install<S: SystemCtl>(sc: &S, opts: &InstallOptions) -> crate::Result<()> {
 	let project = &opts.unit.project;
-	let path = unit_path(project);
-
-	// Refuse to stack service mode on top of an existing Quadlet autostart install
-	// for the same project — both would start the stack at boot.
-	let quadlet = quadlet_units_present(project);
-	if !quadlet.is_empty() {
-		let names: Vec<String> = quadlet.iter().map(|p| p.display().to_string()).collect();
-		return Err(ComposeError::Autostart(format!(
-			"quadlet autostart units for project '{project}' already exist:\n    {}\n\
-			 remove them before installing service mode (quadlet autostart is tracked by #993).",
-			names.join("\n    ")
-		)));
-	}
+	refuse_if_quadlet_present(project)?;
 
 	// Fail closed on values a unit line cannot represent (control characters
 	// would inject directives via the literal `WorkingDirectory=` line).
 	service::validate_unit_opts(&opts.unit).map_err(ComposeError::Autostart)?;
 
 	let unit_text = render_service_unit(&opts.unit);
+	place_unit(sc, project, &unit_text, opts.dry_run, opts.no_start)
+}
+
+/// Install the start-mode unit: `ExecStart=podman start <container>`, so the
+/// boot path resumes what Podman already holds instead of reconciling it
+/// against the compose file. Single-service projects only; `sole_container`
+/// is what refuses the rest, and its refusal names the mode to use instead.
+pub fn install_start<S: SystemCtl>(
+	sc: &S,
+	opts: &StartUnitOpts,
+	dry_run: bool,
+	no_start: bool,
+) -> crate::Result<()> {
+	let project = &opts.project;
+	refuse_if_quadlet_present(project)?;
+	validate_start_unit_opts(opts).map_err(ComposeError::Autostart)?;
+	let unit_text = render_start_unit(opts);
+	place_unit(sc, project, &unit_text, dry_run, no_start)
+}
+
+/// Write the unit, reload systemd and (unless `no_start`) enable it. Shared by
+/// every mode that writes one final `.service` file, so the two do not drift on
+/// where the file lands or which systemctl calls follow it.
+fn place_unit<S: SystemCtl>(
+	sc: &S,
+	project: &str,
+	unit_text: &str,
+	dry_run: bool,
+	no_start: bool,
+) -> crate::Result<()> {
+	let path = unit_path(project);
 	let unit_name = unit_file_name(project);
 
 	// Surface the linger / session guards before acting (or previewing).
 	emit_guards(sc);
 
-	if opts.dry_run {
+	if dry_run {
 		print!("{unit_text}");
 		println!("\n# would write {}", path.display());
 		println!("# would run: systemctl --user daemon-reload");
-		if opts.no_start {
+		if no_start {
 			println!("# (--no-start) would not enable or start the unit");
 		} else {
 			println!("# would run: systemctl --user enable --now {unit_name}");
@@ -277,7 +319,7 @@ pub fn install<S: SystemCtl>(sc: &S, opts: &InstallOptions) -> crate::Result<()>
 	eprintln!("podup: wrote {}", path.display());
 
 	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
-	if opts.no_start {
+	if no_start {
 		eprintln!("podup: installed {unit_name} (not enabled; --no-start)");
 	} else {
 		checked(

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -413,6 +413,25 @@ pub fn installed_mode(project: &str) -> InstalledMode {
 	}
 }
 
+/// Whether the network-ordering the generated units declare is real.
+///
+/// `Wants=`/`After=` naming a unit systemd cannot load is dropped silently:
+/// `LoadState` reads `not-found`, the dependent starts clean, and nothing
+/// reaches the journal. So a unit file can say it waits for the network while
+/// waiting for nothing, and the only way to tell is to ask.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkWait {
+	/// systemd loaded the shim, so the ordering the unit declares takes effect.
+	Loaded,
+	/// No such unit. Podman ships it from 5.3.0; below that the ordering in
+	/// every autostart unit is inert.
+	NotFound,
+	/// `systemctl` could not be asked, or answered something unrecognised.
+	/// Carried rather than collapsed into `NotFound`: "we could not tell" and
+	/// "it is not there" are different answers and only one is a problem.
+	Unknown(String),
+}
+
 /// A snapshot of the autostart unit's state, gathered for `status`.
 pub struct StatusReport {
 	/// Absolute path to where the unit file would live.
@@ -429,6 +448,8 @@ pub struct StatusReport {
 	pub linger: bool,
 	/// Whether `XDG_RUNTIME_DIR` is set (a user session is present).
 	pub runtime_dir: bool,
+	/// Whether the network shim the generated units order against is loadable.
+	pub network_wait: NetworkWait,
 }
 
 /// Read the unit file's permission bits, on Unix. Other platforms have no POSIX
@@ -461,6 +482,41 @@ fn query<S: SystemCtl>(sc: &S, arg: &str, unit_name: &str) -> String {
 	}
 }
 
+/// The unit every autostart mode orders against, so the name lives in one place.
+pub(crate) const NETWORK_SHIM: &str = "podman-user-wait-network-online.service";
+
+/// Ask systemd whether the network shim is loadable.
+///
+/// **The exit code is not the signal, and must not be used as one.** Measured
+/// 2026-08-30 on Podman 5.7.0, rootless: `systemctl --user show <unit> -p
+/// LoadState` exits **0 for a unit that does not exist** just as it does for one
+/// that does, printing `LoadState=not-found` in the first case and
+/// `LoadState=loaded` in the second. A guard branching on the status would
+/// report the shim as fine while it is missing, which is the same vacuous check
+/// this function exists to replace.
+///
+/// That differs from the two verbs the rest of this status uses: `is-active`
+/// and `is-enabled` both exit **4** for an unknown unit. Two conventions, one
+/// module, so the difference is stated here rather than left to be rediscovered.
+fn network_wait_state<S: SystemCtl>(sc: &S) -> NetworkWait {
+	let out = match sc.systemctl(&["show", NETWORK_SHIM, "-p", "LoadState"]) {
+		Ok(out) => out,
+		Err(e) => return NetworkWait::Unknown(format!("systemctl show failed: {e}")),
+	};
+	let text = String::from_utf8_lossy(&out.stdout);
+	let Some(state) = text
+		.lines()
+		.find_map(|l| l.trim().strip_prefix("LoadState="))
+	else {
+		return NetworkWait::Unknown("systemctl show printed no LoadState".to_string());
+	};
+	match state.trim() {
+		"loaded" => NetworkWait::Loaded,
+		"not-found" => NetworkWait::NotFound,
+		other => NetworkWait::Unknown(other.to_string()),
+	}
+}
+
 /// Gather the autostart status for a project, going through the [`SystemCtl`] seam
 /// so it is testable without a live systemd.
 pub fn collect_status<S: SystemCtl>(sc: &S, project: &str) -> StatusReport {
@@ -475,6 +531,7 @@ pub fn collect_status<S: SystemCtl>(sc: &S, project: &str) -> StatusReport {
 		is_enabled: query(sc, "is-enabled", &unit_name),
 		linger: current_user().is_some_and(|u| linger_enabled(sc, &u)),
 		runtime_dir: std::env::var_os("XDG_RUNTIME_DIR").is_some_and(|s| !s.is_empty()),
+		network_wait: network_wait_state(sc),
 	}
 }
 
@@ -509,6 +566,27 @@ pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 		crate::ui::print_labelled_neutral("enabled", &r.is_enabled);
 	}
 	row("linger", if r.linger { "enabled" } else { "disabled" });
+	// Prose for the same reason the session line is prose: "not-found" alone
+	// would read as a broken install rather than as the ordering being inert,
+	// and the operator needs to be told what it costs and what fixes it.
+	match &r.network_wait {
+		NetworkWait::Loaded => crate::ui::print_labelled_with(
+			"network wait",
+			&format!("{NETWORK_SHIM} is loaded"),
+			Some(true),
+		),
+		NetworkWait::NotFound => crate::ui::print_labelled_with(
+			"network wait",
+			&format!(
+				"{NETWORK_SHIM} is not loadable, so the unit's network ordering \
+				 is dropped silently (Podman ships it from 5.3.0)"
+			),
+			Some(false),
+		),
+		NetworkWait::Unknown(why) => {
+			crate::ui::print_labelled_neutral("network wait", &format!("unknown ({why})"))
+		}
+	}
 	// Prose, not a state word, so the meaning is stated rather than inferred.
 	crate::ui::print_labelled_with(
 		"session",

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -107,6 +107,10 @@ fn is_bare_safe(token: &str) -> bool {
 /// quoted path — but doubling it up front (rather than only inside the quoted
 /// branch) means the escape holds even if that allowed set ever changes, and a
 /// bare-looking token like `50%off` still comes out as `50%%off`.
+pub(super) fn quote_arg_for_exec(token: &str) -> String {
+	quote_arg(token)
+}
+
 fn quote_arg(token: &str) -> String {
 	let token = token.replace('%', "%%");
 	if is_bare_safe(&token) {

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -209,11 +209,29 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// leaves them on disk, which is exactly what ExecStart expects to find, and
 	// honours each container's own stop_signal / stop_grace_period.
 	let stop = exec_line(opts, &["stop"]);
-	// No `network-online.target` ordering: that target is a system-manager
-	// concept and stays inert in the `--user` instance, so depending on it would
-	// imply a network-readiness gate that never fires. Under linger the user
-	// manager starts after the system network is already up, and podup reaches
-	// Podman over a socket on demand, so no explicit network ordering is needed.
+	// Network ordering goes through Podman's user-scope shim, never through
+	// `network-online.target` directly. That target is a system-manager concept
+	// and stays inert in the `--user` instance, so naming it here would read as a
+	// readiness gate and fire as nothing. Podman ships
+	// `podman-user-wait-network-online.service` for exactly that gap
+	// (containers/podman#22197): a `Type=oneshot` unit that polls
+	// `systemctl is-active network-online.target` until the system target comes
+	// up, which is the one thing a user unit can actually wait on.
+	//
+	// Quadlet mode gets this for free. `man podman-systemd.unit`, under *Implicit
+	// network dependencies*, says the generator adds `Wants=`/`After=` on the
+	// same shim to every `.container` unit it converts, so the files
+	// `autostart/quadlet.rs` emits pick it up at boot. Service mode writes the
+	// final unit itself and inherits nothing, and the reason applies here with
+	// more force rather than less: Quadlet's `ExecStart` starts a container,
+	// ours is `podup up -d`, which may pull an image, and rootless pasta builds
+	// the container network at start time.
+	//
+	// Measured 2026-08-30: the shim first ships in Podman 5.3.0, and podup's
+	// floor is 5.0. On 5.0 through 5.2 systemd finds no such unit, drops the
+	// `Wants=`/`After=` with `LoadState=not-found`, and starts this unit clean
+	// with `Result=success` and nothing in the journal, which is the behaviour
+	// those versions already had.
 	//
 	// `WorkingDirectory=` takes the rest of its line literally — unlike an
 	// exec-line token, it understands none of the C-style backslash escapes
@@ -247,6 +265,8 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	format!(
 		"[Unit]\n\
 		 Description=podup {project}\n\
+		 Wants=podman-user-wait-network-online.service\n\
+		 After=podman-user-wait-network-online.service\n\
 		 \n\
 		 [Service]\n\
 		 Type=oneshot\n\
@@ -287,9 +307,6 @@ mod tests {
 	fn renders_single_file_unit() {
 		let s = render_service_unit(&opts_single());
 		assert!(s.contains("Description=podup app"));
-		// A `--user` unit must NOT order against the system `network-online.target`
-		// (it is inert in the user manager); assert it is absent.
-		assert!(!s.contains("network-online.target"));
 		assert!(s.contains("Type=oneshot"));
 		assert!(s.contains("RemainAfterExit=yes"));
 		assert!(s.contains("WorkingDirectory=/srv/app"));
@@ -349,6 +366,37 @@ mod tests {
 			!s.contains(" down"),
 			"ExecStop must stop, not remove the containers:\n{s}"
 		);
+	}
+
+	/// #1616: service mode writes the final unit, so it inherits none of the
+	/// ordering Quadlet's generator adds on its own. What has to hold is that the
+	/// unit waits for the network, and that it waits through Podman's user-scope
+	/// shim rather than through `network-online.target`, which is inert in the
+	/// `--user` instance.
+	///
+	/// The assertion this replaced only forbade the string `network-online.target`,
+	/// which a unit carrying no ordering at all also satisfies. That is the state
+	/// this test exists to rule out, so it asserts the keys that must be present
+	/// first and the spelling that must not appear second.
+	#[test]
+	fn orders_against_the_user_scope_network_shim() {
+		let s = render_service_unit(&opts_single());
+		assert!(
+			s.contains("Wants=podman-user-wait-network-online.service"),
+			"the unit must pull in the network shim:\n{s}"
+		);
+		assert!(
+			s.contains("After=podman-user-wait-network-online.service"),
+			"wanting the shim without ordering after it starts both at once, \
+			 which is the same as not waiting:\n{s}"
+		);
+		for key in ["Wants=", "After=", "Requires=", "BindsTo=", "PartOf="] {
+			assert!(
+				!s.contains(&format!("{key}network-online.target")),
+				"a `--user` unit must not depend on the system target directly, \
+				 since it never activates there:\n{s}"
+			);
+		}
 	}
 
 	#[test]

--- a/internal/autostart/start.rs
+++ b/internal/autostart/start.rs
@@ -1,0 +1,198 @@
+//! Pure rendering and validation for start mode: a unit whose `ExecStart` is
+//! `podman start`, so the boot path resumes the container Podman already holds
+//! rather than reconciling it against the compose file.
+//!
+//! The other two modes make the world match the file at boot. Service mode
+//! parses the compose file, interpolates the environment and may build; quadlet
+//! mode hands systemd a description Podman reconciles. Both are the right shape
+//! for a deploy. Podman is daemonless and its store survives a reboot, so every
+//! setting is already baked into the container definition when it is created,
+//! and `podman start` restores the lot with no compose file, no `.env`, no
+//! registry and no build on the path.
+//!
+//! The failure semantics are the point rather than a side effect. A container
+//! missing at boot means a deploy went wrong, and booting cannot fix a broken
+//! deploy: failing loudly in the journal is correct there, and rebuilding it
+//! silently is not. Deploy reconciles, boot restores.
+
+use std::path::PathBuf;
+
+use crate::compose::types::{ComposeFile, Service};
+
+/// Inputs to render a start-mode autostart unit. Both paths must be absolute:
+/// systemd resolves an exec line with no working directory of its own.
+#[non_exhaustive]
+#[derive(Default)]
+pub struct StartUnitOpts {
+	/// Absolute path to the `podman` executable.
+	pub podman: PathBuf,
+	/// Project name (already validated as a safe path component).
+	pub project: String,
+	/// The one container this project resolves to.
+	pub container: String,
+	/// The service's `stop_grace_period`, in seconds, when it set one.
+	pub stop_grace_secs: Option<u64>,
+}
+
+impl StartUnitOpts {
+	/// The three values a unit cannot be rendered without.
+	pub fn new(podman: PathBuf, project: String, container: String) -> Self {
+		Self {
+			podman,
+			project,
+			container,
+			stop_grace_secs: None,
+		}
+	}
+
+	/// The service's `stop_grace_period`, so the unit can bound `ExecStop` above
+	/// it rather than letting systemd's 90s default cut a slower container off
+	/// mid-shutdown. Builder-style.
+	pub fn with_stop_grace_secs(mut self, secs: Option<u64>) -> Self {
+		self.stop_grace_secs = secs;
+		self
+	}
+}
+
+/// Reject any unit-embedded value carrying ASCII control characters, for the
+/// same reason `service::validate_unit_opts` does: a value with an
+/// embedded newline would terminate its directive and inject arbitrary unit
+/// lines. No legitimate path or container name contains control bytes.
+pub fn validate_start_unit_opts(opts: &StartUnitOpts) -> Result<(), String> {
+	fn check(field: &str, value: &str) -> Result<(), String> {
+		if value.chars().any(|c| c.is_ascii_control()) {
+			return Err(format!(
+				"{field} contains a control character and cannot be embedded in a systemd unit: {value:?}"
+			));
+		}
+		Ok(())
+	}
+	check("podman path", &opts.podman.to_string_lossy())?;
+	check("project name", &opts.project)?;
+	check("container name", &opts.container)
+}
+
+/// Why a project cannot use start mode. Carried as a distinct type so the
+/// caller renders one message and the tests assert the reason rather than the
+/// wording.
+#[derive(Debug, PartialEq, Eq)]
+pub enum StartModeRefusal {
+	/// The compose file defines no services at all.
+	NoServices,
+	/// More than one service. `podman start` waits for nothing, so a project
+	/// with `depends_on` (and especially `condition: service_healthy`) needs
+	/// ordering between units, which is what quadlet mode already derives.
+	MultipleServices(Vec<String>),
+	/// One service, but scaled past a single replica.
+	MultipleReplicas {
+		/// The one service the file defines.
+		service: String,
+		/// How many replicas it declares.
+		replicas: usize,
+	},
+}
+
+impl std::fmt::Display for StartModeRefusal {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::NoServices => write!(
+				f,
+				"start mode needs exactly one service and this project defines none"
+			),
+			Self::MultipleServices(names) => write!(
+				f,
+				"start mode supports single-service projects only, and this one defines {}: {}.\n\
+				 `podman start` waits for nothing, so a project with `depends_on` needs ordering \
+				 between units. Use `--mode quadlet`, which derives that ordering from the \
+				 compose file, or `--mode service`.",
+				names.len(),
+				names.join(", ")
+			),
+			Self::MultipleReplicas { service, replicas } => write!(
+				f,
+				"start mode supports a single container and service '{service}' resolves to \
+				 {replicas} replicas. Use `--mode quadlet` or `--mode service`."
+			),
+		}
+	}
+}
+
+/// The one container a project resolves to, or why it does not resolve to one.
+///
+/// The name must agree with what the engine created, so it comes from
+/// `engine::sole_replica_name` rather than being spelled out again
+/// here: a second copy of the naming rule would drift from the first one
+/// silently, and the unit would name a container that does not exist.
+pub fn sole_container(file: &ComposeFile, project: &str) -> Result<String, StartModeRefusal> {
+	let mut names: Vec<&String> = file.services.keys().collect();
+	names.sort();
+	let (name, service): (&String, &Service) = match names.as_slice() {
+		[] => return Err(StartModeRefusal::NoServices),
+		[only] => (*only, &file.services[*only]),
+		many => {
+			return Err(StartModeRefusal::MultipleServices(
+				many.iter().map(|s| (*s).clone()).collect(),
+			))
+		}
+	};
+	let replicas = crate::engine::declared_replicas(service);
+	if replicas != 1 {
+		return Err(StartModeRefusal::MultipleReplicas {
+			service: name.clone(),
+			replicas,
+		});
+	}
+	Ok(crate::engine::sole_replica_name(project, name, service))
+}
+
+/// Render the full `.service` unit for start mode.
+pub fn render_start_unit(opts: &StartUnitOpts) -> String {
+	// Both exec lines take the container name, never the compose file: that is
+	// the whole mode. `podman start` restores the container definition from
+	// Podman's store, which survives a reboot, so nothing here needs the file,
+	// the environment, a registry or a build.
+	//
+	// `stop`, not `rm`: the container must still be there for the next boot's
+	// ExecStart to find, exactly as service mode uses `stop` rather than `down`.
+	//
+	// Network ordering matches service mode and is there for the same reason
+	// (#1616), though it costs less here: `podman start` pulls nothing, so the
+	// wait guards the container's own networking rather than an image fetch.
+	//
+	// A literal `%` is doubled in every interpolated value. systemd's specifier
+	// expansion runs over unit-file values before anything else interprets them,
+	// so an undoubled `%h`/`%o` in a container name or path would expand.
+	let podman = quote_arg(&opts.podman.to_string_lossy());
+	let container = quote_arg(&opts.container);
+	let project = opts.project.replace('%', "%%");
+	// systemd bounds ExecStop at DefaultTimeoutStopUSec (90s) regardless of what
+	// `podman stop` honours inside it. Give it headroom over the container's own
+	// grace period rather than the exact value, matching service mode.
+	let stop_timeout = match opts.stop_grace_secs {
+		Some(secs) => format!("TimeoutStopSec={}\n", secs.saturating_add(30)),
+		None => String::new(),
+	};
+	format!(
+		"[Unit]\n\
+		 Description=podup {project}\n\
+		 Wants=podman-user-wait-network-online.service\n\
+		 After=podman-user-wait-network-online.service\n\
+		 \n\
+		 [Service]\n\
+		 Type=oneshot\n\
+		 RemainAfterExit=yes\n\
+		 ExecStart={podman} start {container}\n\
+		 ExecStop={podman} stop {container}\n\
+		 {stop_timeout}\
+		 \n\
+		 [Install]\n\
+		 WantedBy=default.target\n",
+	)
+}
+
+/// Quote one exec-line token, doubling a literal `%` first. Same rules as
+/// [`super::service`]; kept as its own copy of the call rather than sharing the
+/// private helper, since only these two tokens need it here.
+fn quote_arg(token: &str) -> String {
+	super::service::quote_arg_for_exec(token)
+}

--- a/internal/autostart/start_tests.rs
+++ b/internal/autostart/start_tests.rs
@@ -1,0 +1,167 @@
+//! Tests for start mode's renderer and its refusals.
+
+use super::start::*;
+use crate::compose::parse_str;
+use std::path::PathBuf;
+
+fn opts() -> StartUnitOpts {
+	StartUnitOpts::new(
+		PathBuf::from("/usr/bin/podman"),
+		"app".to_string(),
+		"app-web-1".to_string(),
+	)
+}
+
+#[test]
+fn the_boot_path_carries_no_compose_file() {
+	// The whole mode. `podman start` restores the container definition from
+	// Podman's store, so nothing here may reach for the file, the environment,
+	// a registry or a build. Asserted as the positive fact first, then as the
+	// absences, so a unit that rendered nothing at all cannot pass.
+	let s = render_start_unit(&opts());
+	assert!(
+		s.contains("ExecStart=/usr/bin/podman start app-web-1"),
+		"{s}"
+	);
+	assert!(s.contains("ExecStop=/usr/bin/podman stop app-web-1"), "{s}");
+	// Scoped to the exec lines: `Description=podup <project>` legitimately
+	// names podup, and asserting over the whole unit would fail on the label
+	// rather than on the boot path, which is the thing under test.
+	let execs: String = s
+		.lines()
+		.filter(|l| l.starts_with("ExecStart=") || l.starts_with("ExecStop="))
+		.collect::<Vec<_>>()
+		.join("\n");
+	assert_eq!(execs.lines().count(), 2, "{s}");
+	for absent in ["podup", "-f ", "--env-file", "up -d", "--build"] {
+		assert!(
+			!execs.contains(absent),
+			"the boot path must not carry `{absent}`:\n{execs}"
+		);
+	}
+}
+
+#[test]
+fn execstop_stops_rather_than_removes() {
+	// `rm` would delete the container the next boot's ExecStart expects to
+	// find, turning every reboot into a broken start. Same contract service
+	// mode pins with `down`.
+	let s = render_start_unit(&opts());
+	assert!(s.contains(" stop app-web-1"), "{s}");
+	assert!(!s.contains(" rm "), "ExecStop must not remove:\n{s}");
+}
+
+#[test]
+fn orders_against_the_user_scope_network_shim() {
+	let s = render_start_unit(&opts());
+	assert!(
+		s.contains("Wants=podman-user-wait-network-online.service"),
+		"{s}"
+	);
+	assert!(
+		s.contains("After=podman-user-wait-network-online.service"),
+		"{s}"
+	);
+	for key in ["Wants=", "After=", "Requires=", "BindsTo=", "PartOf="] {
+		assert!(
+			!s.contains(&format!("{key}network-online.target")),
+			"a `--user` unit must not depend on the system target directly:\n{s}"
+		);
+	}
+}
+
+#[test]
+fn stop_timeout_leaves_headroom_and_is_omitted_when_unset() {
+	let s = render_start_unit(&opts().with_stop_grace_secs(Some(10)));
+	assert!(s.contains("TimeoutStopSec=40"), "{s}");
+	let s = render_start_unit(&opts());
+	assert!(!s.contains("TimeoutStopSec"), "{s}");
+}
+
+#[test]
+fn percent_is_doubled_in_every_interpolated_value() {
+	let mut o = opts();
+	o.container = "50%off".to_string();
+	o.project = "50%h".to_string();
+	let s = render_start_unit(&o);
+	assert!(s.contains("Description=podup 50%%h"), "{s}");
+	assert!(s.contains("\"50%%off\""), "{s}");
+	assert!(!s.contains("start 50%off"), "{s}");
+}
+
+#[test]
+fn a_path_with_spaces_stays_one_argument() {
+	let mut o = opts();
+	o.podman = PathBuf::from("/opt/my tools/podman");
+	let s = render_start_unit(&o);
+	assert!(
+		s.contains("ExecStart=\"/opt/my tools/podman\" start"),
+		"{s}"
+	);
+}
+
+#[test]
+fn validate_rejects_control_characters() {
+	let mut o = opts();
+	o.container = "web\nExecStartPre=/bin/evil".to_string();
+	assert!(validate_start_unit_opts(&o).is_err());
+	assert!(validate_start_unit_opts(&opts()).is_ok());
+}
+
+#[test]
+fn one_service_resolves_to_the_engine_name() {
+	let f = parse_str("services:\n  web:\n    image: x\n").unwrap();
+	assert_eq!(sole_container(&f, "app").unwrap(), "app-web-1");
+}
+
+#[test]
+fn an_explicit_container_name_is_honoured() {
+	let f =
+		parse_str("services:\n  web:\n    image: x\n    container_name: alanalarana\n").unwrap();
+	assert_eq!(sole_container(&f, "app").unwrap(), "alanalarana");
+}
+
+#[test]
+fn two_services_are_refused_and_the_message_names_quadlet() {
+	let f = parse_str("services:\n  web:\n    image: x\n  db:\n    image: y\n").unwrap();
+	let why = sole_container(&f, "app").unwrap_err();
+	assert!(
+		matches!(&why, StartModeRefusal::MultipleServices(n) if n.len() == 2),
+		"{why:?}"
+	);
+	// The refusal has to say where to go, or it is a dead end rather than a
+	// boundary.
+	let msg = why.to_string();
+	assert!(msg.contains("--mode quadlet"), "{msg}");
+	assert!(msg.contains("depends_on"), "{msg}");
+}
+
+#[test]
+fn a_scaled_service_is_refused() {
+	let f = parse_str("services:\n  web:\n    image: x\n    scale: 3\n").unwrap();
+	assert_eq!(
+		sole_container(&f, "app").unwrap_err(),
+		StartModeRefusal::MultipleReplicas {
+			service: "web".to_string(),
+			replicas: 3,
+		}
+	);
+}
+
+#[test]
+fn deploy_replicas_counts_the_same_as_scale() {
+	let f = parse_str("services:\n  web:\n    image: x\n    deploy:\n      replicas: 2\n").unwrap();
+	assert!(matches!(
+		sole_container(&f, "app").unwrap_err(),
+		StartModeRefusal::MultipleReplicas { replicas: 2, .. }
+	));
+}
+
+#[test]
+fn a_file_with_no_services_is_refused() {
+	let f = parse_str("services: {}\n").unwrap();
+	assert_eq!(
+		sole_container(&f, "app").unwrap_err(),
+		StartModeRefusal::NoServices
+	);
+}

--- a/internal/autostart/tests.rs
+++ b/internal/autostart/tests.rs
@@ -20,6 +20,11 @@ struct FakeCtl {
 	/// default; `4 << 8` is systemd's "no such unit", the only value
 	/// `unit_is_known` treats as "there is nothing here".
 	is_active_code: i32,
+	/// What `systemctl --user show <shim> -p LoadState` prints. Real systemd
+	/// exits 0 whether or not the unit exists, so this fake always does too:
+	/// a fake that signalled absence through the exit code would let a guard
+	/// that reads the code pass here and fail in production.
+	show_load_state: String,
 	fail: bool,
 }
 
@@ -32,6 +37,7 @@ impl FakeCtl {
 			is_active: "active".to_string(),
 			is_enabled: "enabled".to_string(),
 			is_active_code: 0,
+			show_load_state: "LoadState=loaded\n".to_string(),
 			fail: false,
 		}
 	}
@@ -58,6 +64,7 @@ impl SystemCtl for FakeCtl {
 		let stdout = match args.first().copied() {
 			Some("is-active") => self.is_active.as_str(),
 			Some("is-enabled") => self.is_enabled.as_str(),
+			Some("show") => self.show_load_state.as_str(),
 			_ => "",
 		};
 		// `is-enabled` is read through stdout only, so its status stays
@@ -66,7 +73,10 @@ impl SystemCtl for FakeCtl {
 		// blanket `fail` flag.
 		let code = match args.first().copied() {
 			Some("is-active") => self.is_active_code,
-			Some("is-enabled") => 0,
+			// Both 0, deliberately. Measured on real systemd: `show` reports a
+			// missing unit through `LoadState=not-found` in stdout and still
+			// exits 0, unlike `is-enabled`, which exits 4 for the same unit.
+			Some("is-enabled") | Some("show") => 0,
 			_ => code,
 		};
 		Ok(out(code, stdout))
@@ -339,4 +349,89 @@ fn max_stop_grace_skips_an_unparseable_value() {
 	)
 	.unwrap();
 	assert_eq!(super::max_stop_grace_secs(&file), Some(30));
+}
+
+// --- the network shim (#1616's ordering is only real if the unit loads) ---
+
+/// The trap, pinned. Real `systemctl show` exits **0** for a unit that does not
+/// exist, printing `LoadState=not-found`. A guard reading the exit code would
+/// call the shim present here and be wrong in exactly the case it exists to
+/// catch, which is the same vacuous shape as the assertion #1616 replaced.
+#[test]
+fn a_missing_shim_is_read_from_load_state_not_from_the_exit_code() {
+	let mut sc = FakeCtl::new();
+	sc.show_load_state = "LoadState=not-found\n".to_string();
+	let r = collect_status(&sc, "app");
+	assert_eq!(r.network_wait, NetworkWait::NotFound);
+	// The call really did succeed, so nothing about the status distinguished
+	// these two cases except the string.
+	assert_eq!(
+		sc.systemctl(&["show", NETWORK_SHIM, "-p", "LoadState"])
+			.unwrap()
+			.status
+			.code(),
+		Some(0)
+	);
+}
+
+#[test]
+fn a_loaded_shim_reads_as_loaded() {
+	let sc = FakeCtl::new();
+	assert_eq!(collect_status(&sc, "app").network_wait, NetworkWait::Loaded);
+}
+
+/// "We could not tell" is not "it is not there". Collapsing the two would report
+/// a broken ordering on every machine whose systemctl answered oddly.
+#[test]
+fn an_unrecognised_answer_is_unknown_rather_than_missing() {
+	let mut sc = FakeCtl::new();
+	sc.show_load_state = "LoadState=masked\n".to_string();
+	assert!(matches!(
+		collect_status(&sc, "app").network_wait,
+		NetworkWait::Unknown(s) if s == "masked"
+	));
+
+	let mut sc = FakeCtl::new();
+	sc.show_load_state = String::new();
+	assert!(matches!(
+		collect_status(&sc, "app").network_wait,
+		NetworkWait::Unknown(_)
+	));
+}
+
+/// The status asks about the shim by the same name the units order against, so
+/// a rename cannot leave the guard checking a unit nothing depends on.
+#[test]
+fn the_status_asks_about_the_unit_the_units_actually_name() {
+	let sc = FakeCtl::new();
+	let _ = collect_status(&sc, "app");
+	assert!(
+		sc.systemctl_log()
+			.iter()
+			.any(|c| c.first().map(String::as_str) == Some("show")
+				&& c.contains(&NETWORK_SHIM.to_string())),
+		"{:?}",
+		sc.systemctl_log()
+	);
+	// Every renderer that emits the ordering, not just the one that had it
+	// first. Checking only service mode would leave start mode free to name a
+	// different unit than the status reports on, which is the same silent
+	// mismatch this whole check exists to surface.
+	let service = super::render_service_unit(&super::ServiceUnitOpts::new(
+		std::path::PathBuf::from("/usr/bin/podup"),
+		vec![std::path::PathBuf::from("/srv/app/compose.yml")],
+		"app".to_string(),
+		std::path::PathBuf::from("/srv/app"),
+	));
+	let start = super::render_start_unit(&super::StartUnitOpts::new(
+		std::path::PathBuf::from("/usr/bin/podman"),
+		"app".to_string(),
+		"app-web-1".to_string(),
+	));
+	for (mode, unit) in [("service", &service), ("start", &start)] {
+		assert!(
+			unit.contains(NETWORK_SHIM),
+			"{mode} mode must order against the same name the status checks:\n{unit}"
+		);
+	}
 }

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -89,6 +89,51 @@ pub(crate) async fn dispatch(
 				.with_dry_run(*dry_run);
 			podup::autostart::install(&podup::autostart::RealSystemCtl, &opts)
 		}
+		AutostartCommands::Install {
+			mode: AutostartMode::Start,
+			no_start,
+			dry_run,
+		} => {
+			// Start mode's whole point is that the boot path holds no compose
+			// file, so the container name has to be resolved here, once, and
+			// baked into the unit. `sole_container` is also the refusal: it is
+			// what rejects a multi-service or scaled project and names the mode
+			// to use instead.
+			let container = podup::autostart::sole_container(file, &project)
+				.map_err(|why| ComposeError::Autostart(why.to_string()))?;
+			// systemd resolves an exec line with no PATH of its own, so the unit
+			// needs podman by absolute path rather than by name.
+			let podman = resolve_podman()?;
+			let opts = podup::autostart::StartUnitOpts::new(podman, project.clone(), container)
+				.with_stop_grace_secs(podup::autostart::max_stop_grace_secs(file));
+
+			// The one check that needs a live Podman. Start mode restores what
+			// the store holds and deliberately does not reconcile, so a
+			// container that is absent, or present but no longer matching the
+			// file, must be refused HERE — at install, where a human is
+			// watching. At boot there is no podup to notice: that is the cost of
+			// keeping it off the boot path, not an oversight.
+			//
+			// Skipped under --dry-run, which exists to show the unit without
+			// touching anything, including the socket.
+			if !*dry_run {
+				let client = podup::podman::connect_with_pool_size(
+					env.socket.as_deref(),
+					env.connection_pool_size
+						.unwrap_or(podup::Client::DEFAULT_POOL_SIZE),
+				)?;
+				let engine =
+					podup::Engine::with_base_dir(client, project.clone(), base_dir.clone());
+				precheck_start_mode(&engine, file, &opts.container).await?;
+			}
+
+			podup::autostart::install_start(
+				&podup::autostart::RealSystemCtl,
+				&opts,
+				*dry_run,
+				*no_start,
+			)
+		}
 		AutostartCommands::Uninstall { purge } => {
 			// Remove whichever mode is installed — the two never coexist, and asking
 			// the user to name the mode only risks a no-op against the wrong one.
@@ -128,5 +173,63 @@ pub(crate) async fn dispatch(
 			&project,
 			service.as_deref(),
 		),
+	}
+}
+
+/// The absolute path to `podman`, looked up on `PATH`. A systemd exec line has
+/// no `PATH` of its own, so a bare name in the unit would fail at boot with
+/// nothing to point at.
+fn resolve_podman() -> podup::Result<PathBuf> {
+	let path = std::env::var_os("PATH").ok_or_else(|| {
+		ComposeError::Autostart("PATH is not set, so podman cannot be located".to_string())
+	})?;
+	for dir in std::env::split_paths(&path) {
+		let candidate = dir.join("podman");
+		if candidate.is_file() {
+			return Ok(std::fs::canonicalize(&candidate).unwrap_or(candidate));
+		}
+	}
+	Err(ComposeError::Autostart(
+		"cannot find `podman` on PATH; start mode's unit runs it directly, so it needs an \
+		 absolute path at install time"
+			.to_string(),
+	))
+}
+
+/// Refuse to install start mode over a container that is absent or has drifted
+/// from the compose file.
+///
+/// Both refusals are the mode stating its own contract. It restores what Podman
+/// holds rather than reconciling, so a missing container means a deploy that
+/// never completed, and a hash mismatch means the file has moved on since the
+/// container was created. Booting would silently resume the old configuration
+/// in the second case, which is the mirror of the `up -d` hazard and worse,
+/// because `up -d` at least converges.
+async fn precheck_start_mode(
+	engine: &podup::Engine,
+	file: &ComposeFile,
+	container: &str,
+) -> podup::Result<()> {
+	let (name, service) = file
+		.services
+		.iter()
+		.next()
+		.expect("sole_container already established exactly one service");
+	let expected = engine.expected_config_hash(service, file)?;
+	match engine.container_config_hash(container).await? {
+		None => Err(ComposeError::Autostart(format!(
+			"start mode needs the container to exist already: no container named \
+			 '{container}' for service '{name}'.\n\
+			 Start mode resumes what Podman holds and never creates anything, so run \
+			 `podup up -d` first, then install."
+		))),
+		Some(found) if found != expected => Err(ComposeError::Autostart(format!(
+			"container '{container}' no longer matches the compose file: it was created from \
+			 config {found}, the file now renders {expected}.\n\
+			 Start mode restores rather than reconciles, so installing now would boot the old \
+			 configuration silently. Run `podup up -d` to bring the container up to date, then \
+			 install."
+		))),
+		Some(_) => Ok(()),
 	}
 }

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -77,6 +77,11 @@ pub(crate) enum AutostartMode {
 	/// `.container`/`.build`/`.volume`/`.network` units, so systemd owns boot,
 	/// restart and dependency ordering directly.
 	Quadlet,
+	/// A single `Type=oneshot` `systemctl --user` service whose `ExecStart` is
+	/// `podman start`, so the boot path resumes the container Podman already
+	/// holds instead of reconciling it against the compose file. Single-service
+	/// projects only.
+	Start,
 }
 
 /// Subcommands of `autostart`.
@@ -85,8 +90,9 @@ pub(crate) enum AutostartCommands {
 	/// Install (and, by default, enable + start) the autostart unit for this
 	/// project. User-scope only: writes under `${XDG_CONFIG_HOME:-~/.config}`.
 	Install {
-		/// Autostart backend: `service` (one unit that runs `podup up`) or
-		/// `quadlet` (native systemd units, one per service).
+		/// Autostart backend: `service` (one unit that runs `podup up`),
+		/// `quadlet` (native systemd units, one per service), or `start`
+		/// (resume the existing container; single-service projects only).
 		#[arg(long, value_enum, default_value_t)]
 		mode: AutostartMode,
 		/// Install the unit but do not enable or start it immediately.

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -307,10 +307,7 @@ impl Engine {
 		if let Some(&n) = self.scale_overrides.get(service_name) {
 			return n as usize;
 		}
-		service
-			.scale
-			.or(service.deploy.as_ref().and_then(|d| d.replicas))
-			.unwrap_or(1) as usize
+		declared_replicas(service)
 	}
 
 	/// The cached URL-encoded `{"label":["podup.project=…"]}` JSON for the
@@ -747,6 +744,34 @@ mod to_query_json_tests {
 		assert!(err.to_string().contains("build.cache_to"), "got {err}");
 	}
 }
+
+/// How many replicas a service declares in the file, before any `--scale` on
+/// the current invocation. Split out of [`Engine::resolve_replicas`] so a
+/// caller with no `Engine` (autostart's start mode) reads the same rule rather
+/// than restating it.
+pub(crate) fn declared_replicas(service: &Service) -> usize {
+	service
+		.scale
+		.or(service.deploy.as_ref().and_then(|d| d.replicas))
+		.unwrap_or(1) as usize
+}
+
+/// The container name a service resolves to at exactly one replica.
+///
+/// This is [`Engine::replica_names_for`] at `count == 1`, extracted so
+/// autostart's start mode names the container the engine actually created
+/// instead of spelling the rule out a second time. The two are pinned together
+/// by `naming_agrees_with_the_engine_at_one_replica`; without that test this
+/// would be a copy that drifts silently, and the unit would name a container
+/// that does not exist.
+pub(crate) fn sole_replica_name(project: &str, service_name: &str, service: &Service) -> String {
+	match &service.container_name {
+		Some(explicit) => explicit.clone(),
+		None => format!("{project}-{service_name}-1"),
+	}
+}
+
+mod start_mode;
 
 #[cfg(test)]
 #[path = "to_pretty_json_tests.rs"]

--- a/internal/engine/start_mode.rs
+++ b/internal/engine/start_mode.rs
@@ -1,0 +1,51 @@
+//! The two readings `autostart --mode start` needs from a live Podman before it
+//! will write a unit: whether the container exists, and whether what exists
+//! still matches the compose file.
+//!
+//! The policy lives in `autostart`; this file only answers. Keeping the two
+//! apart means the engine has no opinion about what a mismatch should cost.
+
+use super::container::config_hash;
+use super::Engine;
+use crate::compose::types::{ComposeFile, Service};
+use crate::error::ComposeError;
+use crate::libpod::types::container::ContainerListEntry;
+use crate::Result;
+
+impl Engine {
+	/// The `podup.config-hash` label Podman holds for `container`, or `None`
+	/// when no container by that name exists.
+	///
+	/// `Some(None)` cannot happen: podup writes the label on every container it
+	/// creates (`engine::container`), so a container that exists without one was
+	/// created by something else, and that is reported as a missing hash rather
+	/// than as a match.
+	pub async fn container_config_hash(&self, container: &str) -> Result<Option<String>> {
+		let path = format!(
+			"{}/containers/json?all=true&filters={}",
+			crate::libpod::API_PREFIX,
+			self.project_label_filter_encoded(),
+		);
+		let entries = self
+			.client
+			.get_json::<Vec<ContainerListEntry>>(&path)
+			.await
+			.map_err(ComposeError::Podman)?;
+		for entry in entries {
+			if entry
+				.names
+				.iter()
+				.any(|n| n.trim_start_matches('/') == container)
+			{
+				return Ok(entry.labels.get("podup.config-hash").cloned());
+			}
+		}
+		Ok(None)
+	}
+
+	/// The config hash `service` renders to right now, which is what a container
+	/// created from the current file would carry.
+	pub fn expected_config_hash(&self, service: &Service, file: &ComposeFile) -> Result<String> {
+		config_hash(service, file)
+	}
+}

--- a/internal/engine/tests.rs
+++ b/internal/engine/tests.rs
@@ -175,3 +175,43 @@ fn project_label_filter_with_splices_project_once() {
 	);
 	assert_eq!(with, expected);
 }
+
+/// `sole_replica_name` is a second spelling of the rule in `replica_names_for`,
+/// extracted so autostart's start mode can name a container without an
+/// `Engine`. Two spellings of one rule drift silently, and the failure would be
+/// a boot unit naming a container that does not exist, so pin them together.
+#[test]
+fn naming_agrees_with_the_engine_at_one_replica() {
+	let eng = engine("app");
+	let cases: [(&str, Option<&str>); 3] =
+		[("web", None), ("db", None), ("web", Some("alanalarana"))];
+	for (svc, explicit) in cases {
+		let service = Service {
+			image: Some("x".to_string()),
+			container_name: explicit.map(str::to_string),
+			..Default::default()
+		};
+		assert_eq!(
+			super::sole_replica_name("app", svc, &service),
+			eng.replica_names_for(svc, &service, 1)[0],
+			"service {svc} with container_name {explicit:?}"
+		);
+	}
+}
+
+/// The other half of the same coupling: start mode refuses anything that is not
+/// one replica, and `declared_replicas` is what it asks. It must read the file
+/// the same way the engine does when no `--scale` is in play.
+#[test]
+fn declared_replicas_matches_the_engine_without_an_override() {
+	let eng = engine("app");
+	let mut service = Service {
+		image: Some("x".to_string()),
+		..Default::default()
+	};
+	assert_eq!(super::declared_replicas(&service), 1);
+	assert_eq!(eng.resolve_replicas("web", &service), 1);
+	service.scale = Some(4);
+	assert_eq!(super::declared_replicas(&service), 4);
+	assert_eq!(eng.resolve_replicas("web", &service), 4);
+}

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -233,5 +233,7 @@ fn free_port() -> u16 {
 mod push_registry;
 #[path = "engine_integration/scale.rs"]
 mod scale;
+#[path = "engine_integration/start_restores_config.rs"]
+mod start_restores_config;
 #[path = "engine_integration/stats_flags.rs"]
 mod stats_flags;

--- a/tests/engine_integration/start_restores_config.rs
+++ b/tests/engine_integration/start_restores_config.rs
@@ -1,0 +1,142 @@
+//! The premise `autostart --mode start` rests on: Podman's store survives a
+//! stop, so starting a container restores the configuration it was created
+//! with, and the boot path needs no compose file to put it back.
+//!
+//! That claim was believed rather than measured. It is asserted here instead of
+//! written down because the podman lane runs this file against Podman 5 and 6
+//! (`podman-lane.yml`, `podman: ["5", "6"]`), so it is re-answered on both
+//! majors on every pull request. A reading taken once on one machine is a note
+//! that rots; this is a control.
+//!
+//! The field list is not invented. It comes from diffing a real deployment's
+//! `HostConfig` against a bare `podman run` container, so every key below is
+//! measured as non-default rather than remembered as interesting. Four of them
+//! would not have been guessed: `MemorySwappiness` is written by Podman when a
+//! memory limit is present and never appears in the compose file, `NetworkMode`
+//! flips to `bridge` merely because a network is declared, `Init` is *absent*
+//! from a default container rather than false (so a diff visiting only shared
+//! keys would skip it), and `Ulimits` carries a host default alongside the
+//! declared one, which is why the assertion below looks up the named limit
+//! instead of comparing the array.
+use super::*;
+
+/// Every `HostConfig` key the reference deployment sets away from the default.
+/// A container that comes back with all of these intact has kept the settings
+/// an operator would notice losing.
+const HOST_CONFIG_KEYS: &[&str] = &[
+	"Binds",
+	"CapDrop",
+	"Init",
+	"LogConfig",
+	"Memory",
+	"MemorySwap",
+	"MemorySwappiness",
+	"NetworkMode",
+	"PidsLimit",
+	"PortBindings",
+	"ReadonlyRootfs",
+	"RestartPolicy",
+	"SecurityOpt",
+	"ShmSize",
+	"Tmpfs",
+];
+
+async fn host_config(client: &Client, name: &str) -> serde_json::Value {
+	let path = format!("/v5.0.0/libpod/containers/{name}/json");
+	let v: serde_json::Value = client.get_json(&path).await.expect("inspect");
+	v.get("HostConfig").cloned().expect("HostConfig present")
+}
+
+/// The soft limit of a named ulimit, or `None`. Looked up by name because the
+/// array also carries the host's own `RLIMIT_NPROC`, whose value is
+/// machine-specific: comparing the whole array would assert the runner's
+/// configuration rather than the container's.
+fn ulimit(host_config: &serde_json::Value, name: &str) -> Option<i64> {
+	host_config
+		.get("Ulimits")?
+		.as_array()?
+		.iter()
+		.find(|u| u.get("Name").and_then(|n| n.as_str()) == Some(name))?
+		.get("Soft")?
+		.as_i64()
+}
+
+#[tokio::test]
+async fn a_stopped_container_starts_back_with_its_configuration() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	// A second connection for the raw inspects: `Client` is not `Clone`, and the
+	// engine takes ownership of the first.
+	let inspector = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("startcfg");
+	let engine = Engine::new(client, proj.clone());
+	// Exercises what the reference deployment exercises: memory and swap, pids,
+	// shm, a named ulimit, read-only rootfs, dropped capabilities, security_opt,
+	// a port bound to an explicit host IP, a named volume, tmpfs with options,
+	// restart policy, a sized log driver, and init.
+	let file = parse_str(&format!(
+		"services:\n  \
+		 web:\n    \
+		 image: alpine:latest\n    \
+		 command: [\"sleep\", \"infinity\"]\n    \
+		 init: true\n    \
+		 read_only: true\n    \
+		 mem_limit: 512m\n    \
+		 pids_limit: 256\n    \
+		 shm_size: 16m\n    \
+		 restart: unless-stopped\n    \
+		 cap_drop: [CHOWN, SETUID]\n    \
+		 security_opt: [\"no-new-privileges\"]\n    \
+		 ulimits:\n      \
+		 nofile:\n        soft: 4096\n        hard: 8192\n    \
+		 ports:\n      - \"127.0.0.1:0:8080\"\n    \
+		 tmpfs:\n      - /run:size=8m,mode=755\n    \
+		 logging:\n      driver: json-file\n      options:\n        max-size: 10m\n    \
+		 volumes:\n      - {proj}-cache:/cache\nvolumes:\n  {proj}-cache:\n"
+	))
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web-1");
+	let before = host_config(&inspector, &cname).await;
+
+	// Guard the guard. If the compose keys above stopped reaching Podman, every
+	// key would read the same trivially on both sides and the test would pass
+	// having compared nothing. Assert the settings arrived at all first.
+	assert_eq!(
+		before.get("Memory").and_then(|v| v.as_i64()),
+		Some(536870912)
+	);
+	assert_eq!(before.get("PidsLimit").and_then(|v| v.as_i64()), Some(256));
+	assert_eq!(
+		before.get("ReadonlyRootfs").and_then(|v| v.as_bool()),
+		Some(true)
+	);
+	assert_eq!(ulimit(&before, "RLIMIT_NOFILE"), Some(4096));
+
+	engine.stop(&file, &[]).await.unwrap();
+	engine.start(&file, &[]).await.unwrap();
+	let after = host_config(&inspector, &cname).await;
+
+	for key in HOST_CONFIG_KEYS {
+		assert_eq!(
+			before.get(*key),
+			after.get(*key),
+			"HostConfig.{key} changed across stop/start:\n  before {:?}\n  after  {:?}",
+			before.get(*key),
+			after.get(*key)
+		);
+	}
+	assert_eq!(
+		ulimit(&before, "RLIMIT_NOFILE"),
+		ulimit(&after, "RLIMIT_NOFILE"),
+		"the declared ulimit must survive"
+	);
+
+	engine.down_with_options(&file, true).await.unwrap();
+}


### PR DESCRIPTION
Release `develop` → `main` for **5.6.0**. Merge commit, not squash: `main` is the released state.

## What ships

**`autostart --mode start`** (#1621, PR #1622). A third mode whose `ExecStart` is `podman start`, so the boot resumes the container Podman already holds instead of reconciling it against the compose file. Podman's store survives a reboot, so nothing on that path needs the compose file, the environment, a registry or a build. A container missing at boot means a deploy went wrong, and this mode says so in the journal rather than rebuilding it silently.

Single-service projects only, and the refusal is part of the design: `podman start` waits for nothing, so anything with `depends_on` needs quadlet mode, and the error says which mode to use.

**Network ordering in service mode** (#1616, PR #1618). Quadlet mode inherited `Wants=`/`After=` on `podman-user-wait-network-online.service` from Podman's generator; service mode wrote its own unit and inherited nothing, so the two modes differed in a guarantee and nothing said which. Rootless Podman builds the container network at start time, so an early boot could land on a network that was not ready.

**`autostart status` reports whether that ordering is real** (#1623, PR #1624). The shim ships in Podman 5.3.0 and podup supports 5.0, so below 5.3.0 systemd drops the dependency in silence: the unit file reads as though it waits for the network while waiting for nothing. The status now distinguishes the two.

No change to any existing command's flags or output.

## Measured rather than asserted

The premise start mode rests on — that `podman start` restores a container's configuration — is now an integration test rather than a note. It ran on both majors in this branch's CI:

```
podman-vm (5)  podman version 5.8.1
  test start_restores_config::a_stopped_container_starts_back_with_its_configuration ... ok
podman-vm (6)  podman version 6.1.0
  test start_restores_config::a_stopped_container_starts_back_with_its_configuration ... ok
```

Its field list came from diffing a real deployment's `HostConfig` against a bare `podman run`, which is why it covers `MemorySwappiness` (written by Podman, never in the compose file), `NetworkMode` (flips on declaring a network), `Init` (absent rather than false in the baseline, so a shared-key diff would skip it) and a named ulimit rather than the array (which also carries the host's own `RLIMIT_NPROC`).

## Version gate

`Cargo.toml`, `Cargo.lock` and `debian/changelog` all read 5.6.0, verified by reading `develop` after the bump merged. `release.yml`'s three comparisons were also run locally with a negative control before the bump was committed.