### PR TITLE
docs(readme): name the Podman floor before the install one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ MSRV 1.85 · License: MIT
 
 ## Install
 
+On Debian 12 or Ubuntu 24.04, read [Podman version](#podman-version) first:
+both ship Podman 4.x, below the floor podup needs, and the line below refuses
+to install there rather than leaving a podup that cannot reach an engine.
+
 ```sh
 curl -fsSL https://apt.glyndor.net/install/podup | sudo sh
 ```


### PR DESCRIPTION
## What

One sentence above the apt one-liner in the README, pointing a reader on Debian 12 or Ubuntu 24.04 at the Podman-version table before they run it.

## Why

Both distributions ship Podman 4.x, below the floor, so the line refuses. Since `Glyndor/apt#191` the operator sees apt's real diagnosis (`Depends: podman (>= 5.0) but it is not going to be installed`), which names the dependency and not the remedy. The table that says which distributions are below the floor was already in the README, one screen down: the reader met it after the failure rather than before.

Of the three options in #1608 this is the one that needs nobody else's repository. A per-product remedy hook in the shared apt template stays open as an idea there; it is not what this change decides.

## Test plan

Docs only. Rendered the section locally; the anchor `#podman-version` matches the existing `### Podman version` heading.

Closes #1608

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>