### PR TITLE
fix(up): say Recreating when a container is replaced

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -717,6 +717,14 @@ were never created reports no removal. A command that acted on nothing says so â
 `no containers to stop`, `no containers to start (project not created)` â€” rather
 than exiting silently, which is indistinguishable from success.
 
+A container that is replaced reads differently from one that is created:
+`Recreating`/`Recreated` for a container `up` or `create` removed and built
+again (a changed config, `--force-recreate`), `Starting`/`Started` or
+`Creating`/`Created` for one that did not exist, and `Running` or `Exists` for
+one left alone. Recreation destroys the container's writable layer, so the word
+is the operator's only signal at the moment it happens, and it is what makes
+`--force-recreate` and `--no-recreate` verifiable from the output.
+
 The live region needs stderr to be a terminal, colour to be on, and the terminal
 size to be readable. If any of those is missing it falls back to the plain
 lines, which is also what `--ansi never` and `NO_COLOR` select.

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -158,9 +158,14 @@ impl Engine {
 			// Prefetch the project's containers once (instead of one API call per
 			// replica): which names already exist, and each one's config-hash
 			// label so we can decide whether a container needs recreation.
+			//
+			// Fetched on the `--force-recreate` path too. The hash is unused
+			// there, but `present` is what tells the progress stream that a
+			// container was replaced rather than created (#1619), and a forced
+			// recreate is exactly the case where that word matters.
 			let mut present: HashSet<String> = HashSet::new();
 			let mut existing_hash: HashMap<String, String> = HashMap::new();
-			if !force_recreate {
+			{
 				let path = format!(
 					"{API_PREFIX}/containers/json?all=true&filters={}",
 					self.project_label_filter_encoded(),
@@ -483,18 +488,24 @@ impl Engine {
 				return Ok(());
 			}
 		}
-		crate::ui::progress::start(
-			"Container",
-			&container_name,
-			if start { "Starting" } else { "Creating" },
-		);
+		// Replacing a container destroys its writable layer, and creating one
+		// does not, so the two get different words. Before #1619 both printed
+		// `Starting`/`Started`, and the only way to learn that a container had
+		// been removed was to compare IDs by hand; `--force-recreate` and
+		// `--no-recreate` were unverifiable from the output for the same reason.
+		// `Recreating`/`Recreated` is docker compose's word for it too
+		// (`Recreate`/`Recreated`, measured on v5.3.1), so a reader of either
+		// tool's log reads the same event the same way.
+		let existed = present.contains(&container_name);
+		let (doing, done) = match (existed, start) {
+			(true, _) => ("Recreating", "Recreated"),
+			(false, true) => ("Starting", "Started"),
+			(false, false) => ("Creating", "Created"),
+		};
+		crate::ui::progress::start("Container", &container_name, doing);
 		self.create_and_start(&container_name, name, service, file, start)
 			.await?;
-		crate::ui::progress_line(
-			"Container",
-			&container_name,
-			if start { "Started" } else { "Created" },
-		);
+		crate::ui::progress_line("Container", &container_name, done);
 
 		// `post_start` hooks run inside a running container, so only on `up`.
 		if start {

--- a/tests/recreate_vocabulary.rs
+++ b/tests/recreate_vocabulary.rs
@@ -1,0 +1,158 @@
+//! A replaced container says so.
+//!
+//! Recreating a container destroys its writable layer. Until #1619 the
+//! progress stream reported that with the same `Starting`/`Started` pair it
+//! uses for a container that did not exist, so the only way to learn that
+//! anything had been removed was to compare container IDs by hand, and
+//! `--force-recreate` / `--no-recreate` could not be told apart from a plain
+//! `up` in the output. These tests pin the vocabulary per outcome, on a real
+//! Podman, by reading the stderr stream the way a CI log would.
+//!
+//! Each assertion names the container, not just the verb: a looser check
+//! passed once with the container's own event deleted because the network's
+//! `Creating` satisfied it (see `reporting_contract.rs`).
+
+mod harness;
+
+use harness::{podman_up, Project};
+use std::fs;
+use tempfile::tempdir;
+
+fn compose(command: &str) -> String {
+	format!(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"{command}\"]\n"
+	)
+}
+
+fn project(tag: &str) -> Project {
+	let dir = tempdir().unwrap();
+	let path = dir.path().join("compose.yaml");
+	fs::write(&path, compose("infinity")).unwrap();
+	Project {
+		compose: path.to_string_lossy().into_owned(),
+		name: format!("t{}-{tag}", std::process::id()),
+		_dir: dir,
+	}
+}
+
+/// `true` when some line of `stderr` names both the container and one of the
+/// verbs. Per resource, deliberately.
+fn says(stderr: &str, container: &str, verbs: &[&str]) -> bool {
+	stderr
+		.lines()
+		.any(|l| l.contains(container) && verbs.iter().any(|v| l.contains(v)))
+}
+
+/// A container that did not exist is `Starting`/`Started`, never `Recreating`.
+/// This is the control for the tests below: without it a stream that said
+/// `Recreating` on every run would pass them all.
+#[tokio::test]
+async fn a_first_up_creates_and_never_says_recreating() {
+	if !podman_up().await {
+		return;
+	}
+	let p = project("rcv-first");
+	let container = format!("{}-web-1", p.name);
+	let first = p.progress(&["up", "-d"]);
+	assert!(
+		says(&first, &container, &["Starting"]) && says(&first, &container, &["Started"]),
+		"a new container is Starting/Started; got:\n{first}"
+	);
+	assert!(
+		!first.contains("Recreat"),
+		"nothing existed, so nothing can have been recreated; got:\n{first}"
+	);
+}
+
+/// An unchanged `up` leaves the container alone and says `Running`, so the
+/// skip path and the recreate path cannot share a word either.
+#[tokio::test]
+async fn an_unchanged_up_says_running_not_recreating() {
+	if !podman_up().await {
+		return;
+	}
+	let p = project("rcv-same");
+	let container = format!("{}-web-1", p.name);
+	p.progress(&["up", "-d"]);
+	let again = p.progress(&["up", "-d"]);
+	assert!(
+		says(&again, &container, &["Running"]),
+		"an unchanged container reports Running; got:\n{again}"
+	);
+	assert!(
+		!again.contains("Recreat") && !says(&again, &container, &["Starting", "Started"]),
+		"an unchanged container was reported as replaced or created; got:\n{again}"
+	);
+}
+
+/// A changed config replaces the container, and the stream says so with a
+/// word that only the recreate branch emits.
+#[tokio::test]
+async fn a_changed_config_says_recreating_and_recreated() {
+	if !podman_up().await {
+		return;
+	}
+	let p = project("rcv-change");
+	let container = format!("{}-web-1", p.name);
+	p.progress(&["up", "-d"]);
+	fs::write(&p.compose, compose("120")).unwrap();
+	let changed = p.progress(&["up", "-d"]);
+	assert!(
+		says(&changed, &container, &["Recreating"]),
+		"a replaced container needs its own transition; got:\n{changed}"
+	);
+	assert!(
+		says(&changed, &container, &["Recreated"]),
+		"and its own ending; got:\n{changed}"
+	);
+	assert!(
+		!says(&changed, &container, &["Starting", "Started"]),
+		"Starting/Started is the word for a container that did not exist; got:\n{changed}"
+	);
+}
+
+/// `--force-recreate` is verifiable from the output: it replaces a container
+/// whose config did not change, and the stream says `Recreating`, not
+/// `Running`. This is the case a `present` set fetched only on the
+/// non-forced path would get wrong.
+#[tokio::test]
+async fn force_recreate_says_recreating_on_an_unchanged_config() {
+	if !podman_up().await {
+		return;
+	}
+	let p = project("rcv-force");
+	let container = format!("{}-web-1", p.name);
+	p.progress(&["up", "-d"]);
+	let forced = p.progress(&["up", "-d", "--force-recreate"]);
+	assert!(
+		says(&forced, &container, &["Recreating"]) && says(&forced, &container, &["Recreated"]),
+		"--force-recreate replaced the container and must say so; got:\n{forced}"
+	);
+	assert!(
+		!says(&forced, &container, &["Running", "Starting", "Started"]),
+		"a forced recreate must not read as a skip or a first start; got:\n{forced}"
+	);
+}
+
+/// `create` over an existing container replaces it too, and the stopped
+/// outcome keeps the same pair: the word is about what happened to the old
+/// container, not about whether the new one was started.
+#[tokio::test]
+async fn create_over_an_existing_container_says_recreating() {
+	if !podman_up().await {
+		return;
+	}
+	let p = project("rcv-create");
+	let container = format!("{}-web-1", p.name);
+	let first = p.progress(&["create"]);
+	assert!(
+		says(&first, &container, &["Creating"]) && says(&first, &container, &["Created"]),
+		"a first create is Creating/Created; got:\n{first}"
+	);
+	fs::write(&p.compose, compose("120")).unwrap();
+	let again = p.progress(&["create"]);
+	assert!(
+		says(&again, &container, &["Recreating"]) && says(&again, &container, &["Recreated"]),
+		"create over a changed container replaces it and must say so; got:\n{again}"
+	);
+}


### PR DESCRIPTION
## What

`up` and `create` now report a container they removed and built again as `Recreating`/`Recreated`. A container that did not exist keeps `Starting`/`Started` (or `Creating`/`Created`), and one left alone keeps `Running`/`Exists`.

## Why

Recreation destroys the container's writable layer, and the stream said `Starting` for it, the same word as a first start. Measured in #1619: four consecutive recreates, four identical outputs, container IDs the only tell. `--force-recreate` and `--no-recreate` could not be verified from the output either, because both change what `up` does and neither changed what it printed.

`Recreate`/`Recreated` is what docker compose v5.3.1 prints for the same event (measured on a real dockerd this session), so the pair fits both podup's `-ing`/`-ed` convention and the reference.

One structural change came with it: the container list was only fetched when not forcing, so `present` was empty on `--force-recreate` and the branch could not know the container had existed. It is fetched on both paths now, one call either way.

## Test plan

- New `tests/recreate_vocabulary.rs`, five cases against a real Podman (5.7.0 locally): first `up` says `Starting`/`Started` and never `Recreat`; unchanged `up` says `Running`; changed config, `--force-recreate`, and `create` over an existing container all say `Recreating`/`Recreated` and not `Starting`.
- Sabotage: with the fix reverted and the tests kept, exactly the three recreate cases fail and the two controls stay green (`2 passed; 3 failed`).
- `cargo fmt --check`, `cargo clippy --all-targets --features test-helpers -D warnings` clean.

Closes #1619

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>