### PR TITLE
fix(up): recreate when the image moved, not when the service has a build key

### DIFF
--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -372,6 +372,29 @@ impl Engine {
 			.await
 			.is_ok()
 	}
+
+	/// The 64-hex ID the image reference resolves to in local storage right
+	/// now, or `None` when no such image is present.
+	///
+	/// A name is a pointer and this is what it points at. `up` uses it to tell
+	/// whether an existing container is still bound to the image its service
+	/// resolves to, which the config hash cannot say: a rebuild, a pull or a
+	/// `podman tag` moves the name and leaves the hash alone (#1620). A
+	/// transport error is returned rather than folded into `None`, because the
+	/// caller's fallback for "unknown" is to recreate, and a flaky socket must
+	/// not silently turn every skip into a rebuild.
+	pub(in crate::engine) async fn image_id(&self, image: &str) -> Result<Option<String>> {
+		let path = format!("{API_PREFIX}/images/{}/json", urlencoded(image));
+		match self
+			.client
+			.get_json::<crate::libpod::types::image::ImageInspect>(&path)
+			.await
+		{
+			Ok(inspect) => Ok(Some(inspect.id)),
+			Err(e) if e.is_status(404) => Ok(None),
+			Err(e) => Err(ComposeError::Podman(e)),
+		}
+	}
 }
 
 /// The transitive `depends_on` closure of `services` (including the services

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -38,6 +38,29 @@ use super::container::config_hash;
 use super::profiles::{active_profiles_set, enabled_profile_services};
 use super::Engine;
 
+/// What `up` knows about a container the project already has, read once from
+/// the container list before any work starts.
+///
+/// Two facts decide whether the container is left alone or replaced, and they
+/// answer different questions. The config hash says whether the compose
+/// definition changed. The image ID says whether the image the container is
+/// bound to is still the one its service resolves to, which the hash cannot:
+/// a rebuild, a `pull`, or a `podman tag` moves the name and leaves the hash
+/// untouched. docker compose recreates on either (measured on v5.3.1: an
+/// unchanged `build:` service stays `Running`; retagging its image, or
+/// rebuilding it out of band, gets `Recreate`). Before #1620 podup approximated
+/// the second question with "does the service have a `build:` key", which
+/// recreated every build service on every `up` and never noticed a retagged
+/// `image:` one.
+pub(super) struct ExistingContainer {
+	/// The `podup.config-hash` label, absent on a container podup did not
+	/// create or one from before the label existed. Absent never matches, so
+	/// such a container is recreated.
+	config_hash: Option<String>,
+	/// The 64-hex ID of the image the container was created from.
+	image_id: String,
+}
+
 impl Engine {
 	/// Start all services defined in the compose file, creating containers that do not exist.
 	pub async fn up(&self, file: &ComposeFile) -> Result<()> {
@@ -63,6 +86,43 @@ impl Engine {
 			}
 			Err(e) => Err(crate::error::ComposeError::Podman(e)),
 		}
+	}
+
+	/// Whether the existing container named `container_name` can be left in
+	/// place: its recorded config hash equals `new_hash`, and the image it is
+	/// bound to is still the one `service` resolves to now.
+	///
+	/// The second half is what the hash cannot see, and it applies to every
+	/// service rather than only to `build:` ones. A `build:` service is the
+	/// common case (a rebuild moves the tag), but `up --pull always` and a
+	/// `podman tag` move an `image:` service's tag exactly the same way, and
+	/// docker compose recreates on both (measured on v5.3.1). One image inspect
+	/// per unchanged replica is the cost; the alternative was the pre-#1620
+	/// rule of recreating every `build:` service on every `up`, which destroyed
+	/// the writable layer for nothing.
+	///
+	/// A tag that resolves to nothing, or a container without a recorded image,
+	/// counts as changed: the fail-closed answer is the recreate, which is what
+	/// the old rule did unconditionally.
+	async fn unchanged(
+		&self,
+		container_name: &str,
+		name: &str,
+		service: &Service,
+		existing: &HashMap<String, ExistingContainer>,
+		new_hash: &str,
+	) -> Result<bool> {
+		let Some(container) = existing.get(container_name) else {
+			return Ok(false);
+		};
+		if container.config_hash.as_deref() != Some(new_hash) {
+			return Ok(false);
+		}
+		if container.image_id.is_empty() {
+			return Ok(false);
+		}
+		let tag = self.service_image_tag(name, service);
+		Ok(self.image_id(&tag).await?.as_deref() == Some(container.image_id.as_str()))
 	}
 
 	/// Start services with explicit options. When `no_recreate` is true, running containers are left untouched. On partial failure, staging directories are cleaned up.
@@ -156,15 +216,15 @@ impl Engine {
 			let target_set = expand_targets(file, target_services, no_deps);
 
 			// Prefetch the project's containers once (instead of one API call per
-			// replica): which names already exist, and each one's config-hash
-			// label so we can decide whether a container needs recreation.
+			// replica): which names already exist, and for each the two facts
+			// that decide whether it is kept or replaced (see
+			// [`ExistingContainer`]).
 			//
-			// Fetched on the `--force-recreate` path too. The hash is unused
-			// there, but `present` is what tells the progress stream that a
-			// container was replaced rather than created (#1619), and a forced
-			// recreate is exactly the case where that word matters.
-			let mut present: HashSet<String> = HashSet::new();
-			let mut existing_hash: HashMap<String, String> = HashMap::new();
+			// Fetched on the `--force-recreate` path too. Neither fact is
+			// consulted there, but membership is what tells the progress stream
+			// that a container was replaced rather than created (#1619), and a
+			// forced recreate is exactly the case where that word matters.
+			let mut existing: HashMap<String, ExistingContainer> = HashMap::new();
 			{
 				let path = format!(
 					"{API_PREFIX}/containers/json?all=true&filters={}",
@@ -176,14 +236,15 @@ impl Engine {
 					.await
 					.map_err(crate::error::ComposeError::Podman)?;
 				for entry in entries {
-					if let Some(hash) = entry.labels.get("podup.config-hash") {
-						for raw in &entry.names {
-							existing_hash
-								.insert(raw.trim_start_matches('/').to_string(), hash.clone());
-						}
-					}
+					let config_hash = entry.labels.get("podup.config-hash").cloned();
 					for raw in entry.names {
-						present.insert(raw.trim_start_matches('/').to_string());
+						existing.insert(
+							raw.trim_start_matches('/').to_string(),
+							ExistingContainer {
+								config_hash: config_hash.clone(),
+								image_id: entry.image_id.clone(),
+							},
+						);
 					}
 				}
 			}
@@ -227,8 +288,7 @@ impl Engine {
 				file,
 				&enabled,
 				&target_set,
-				&present,
-				&existing_hash,
+				&existing,
 				no_recreate,
 				force_recreate,
 				start,
@@ -282,8 +342,7 @@ impl Engine {
 		file: &ComposeFile,
 		enabled: &HashSet<String>,
 		target_set: &Option<HashSet<String>>,
-		present: &HashSet<String>,
-		existing_hash: &HashMap<String, String>,
+		existing: &HashMap<String, ExistingContainer>,
 		no_recreate: bool,
 		force_recreate: bool,
 		start: bool,
@@ -413,8 +472,7 @@ impl Engine {
 					name,
 					service,
 					file,
-					present,
-					existing_hash,
+					existing,
 					&new_hash,
 					no_recreate,
 					force_recreate,
@@ -442,15 +500,15 @@ impl Engine {
 		name: &str,
 		service: &Service,
 		file: &ComposeFile,
-		present: &HashSet<String>,
-		existing_hash: &HashMap<String, String>,
+		existing: &HashMap<String, ExistingContainer>,
 		new_hash: &str,
 		no_recreate: bool,
 		force_recreate: bool,
 		start: bool,
 	) -> Result<()> {
+		let present = existing.contains_key(&container_name);
 		if !force_recreate {
-			if no_recreate && present.contains(&container_name) {
+			if no_recreate && present {
 				tracing::debug!("{container_name} already exists — skipping recreate");
 				// `create` leaves an existing container as-is; `up` ensures it runs.
 				if start {
@@ -463,18 +521,9 @@ impl Engine {
 				);
 				return Ok(());
 			}
-			// A service with a `build:` section is recreated even when its hash
-			// matches: the compose-config hash compared below does not cover
-			// the build context's source files, so the existing container may
-			// still hold an image built from an older tree. Recreating forces
-			// the new container to bind whatever image is current.
-			//
-			// `up` stopped rebuilding these unconditionally in #1094 — it now
-			// builds only when the image is missing — so the fresh-image
-			// guarantee this recreate used to inherit from that rebuild no
-			// longer comes for free.
-			if service.build.is_none()
-				&& existing_hash.get(&container_name).map(String::as_str) == Some(new_hash)
+			if self
+				.unchanged(&container_name, name, service, existing, new_hash)
+				.await?
 			{
 				tracing::debug!("{container_name} is up to date — skipping recreate");
 				if start {
@@ -496,8 +545,7 @@ impl Engine {
 		// `Recreating`/`Recreated` is docker compose's word for it too
 		// (`Recreate`/`Recreated`, measured on v5.3.1), so a reader of either
 		// tool's log reads the same event the same way.
-		let existed = present.contains(&container_name);
-		let (doing, done) = match (existed, start) {
+		let (doing, done) = match (present, start) {
 			(true, _) => ("Recreating", "Recreated"),
 			(false, true) => ("Starting", "Started"),
 			(false, false) => ("Creating", "Created"),

--- a/internal/engine/lifecycle/schedule.rs
+++ b/internal/engine/lifecycle/schedule.rs
@@ -11,7 +11,7 @@ use crate::compose::types::ComposeFile;
 use crate::error::Result;
 
 use super::readiness::SharedReady;
-use super::Engine;
+use super::{Engine, ExistingContainer};
 
 impl Engine {
 	/// Start every scheduled service, each as soon as its own dependencies are
@@ -24,8 +24,7 @@ impl Engine {
 		file: &ComposeFile,
 		enabled: &HashSet<String>,
 		target_set: &Option<HashSet<String>>,
-		present: &HashSet<String>,
-		existing_hash: &HashMap<String, String>,
+		existing: &HashMap<String, ExistingContainer>,
 		no_recreate: bool,
 		force_recreate: bool,
 		start: bool,
@@ -71,8 +70,7 @@ impl Engine {
 		// rather than trying to move them per service.
 		let enabled = &enabled;
 		let target_set = &target_set;
-		let present = &present;
-		let existing_hash = &existing_hash;
+		let existing = &existing;
 		let readiness = &readiness;
 		let started = scheduled.iter().map(|name| {
 			let permits = permits.clone();
@@ -108,8 +106,7 @@ impl Engine {
 						file,
 						enabled,
 						target_set,
-						present,
-						existing_hash,
+						existing,
 						no_recreate,
 						force_recreate,
 						start,

--- a/internal/engine/query/ps/tests.rs
+++ b/internal/engine/query/ps/tests.rs
@@ -11,6 +11,7 @@ fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 
 fn entry(status: &str, state: &str) -> ContainerListEntry {
 	ContainerListEntry {
+		image_id: String::new(),
 		id: "abc123".into(),
 		names: vec!["/web".into()],
 		image: "alpine".into(),
@@ -76,6 +77,7 @@ fn display_status_prefers_status_when_present() {
 
 fn entry_exit(state: &str, code: Option<i32>) -> ContainerListEntry {
 	ContainerListEntry {
+		image_id: String::new(),
 		exit_code: code,
 		..entry("", state)
 	}
@@ -111,6 +113,7 @@ fn table_status_keeps_running_and_rich_status_text() {
 	assert_eq!(table_status(&entry("", "running"), NOW), "running");
 	// A Docker-style status that already carries the code is left untouched.
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		exit_code: Some(7),
 		..entry("Exited (7) 4 seconds ago", "exited")
 	};
@@ -240,6 +243,7 @@ fn health_is_derived_from_status_text() {
 #[test]
 fn a_running_container_reports_how_long_it_has_been_up() {
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		started_at: NOW - (2 * 3600 + 5 * 60 + 3),
 		..entry("", "running")
 	};
@@ -253,14 +257,17 @@ fn a_running_container_reports_how_long_it_has_been_up() {
 fn the_health_suffix_appears_only_when_there_is_a_healthcheck() {
 	let started = NOW - 13 * 3600;
 	let healthy = ContainerListEntry {
+		image_id: String::new(),
 		started_at: started,
 		..entry("healthy", "running")
 	};
 	let unhealthy = ContainerListEntry {
+		image_id: String::new(),
 		started_at: started,
 		..entry("unhealthy", "running")
 	};
 	let plain = ContainerListEntry {
+		image_id: String::new(),
 		started_at: started,
 		..entry("", "running")
 	};
@@ -275,6 +282,7 @@ fn the_health_suffix_appears_only_when_there_is_a_healthcheck() {
 #[test]
 fn an_absent_start_time_does_not_become_an_age() {
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		started_at: 0,
 		..entry("", "running")
 	};
@@ -287,6 +295,7 @@ fn an_absent_start_time_does_not_become_an_age() {
 #[test]
 fn a_start_time_in_the_future_clamps_to_zero() {
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		started_at: NOW + 3,
 		..entry("", "running")
 	};
@@ -305,18 +314,21 @@ fn a_start_time_in_the_future_clamps_to_zero() {
 #[test]
 fn only_a_running_container_reports_an_age() {
 	let exited = ContainerListEntry {
+		image_id: String::new(),
 		started_at: NOW - 3600,
 		..entry_exit("exited", Some(7))
 	};
 	assert_eq!(table_status(&exited, NOW), "Exited (7)");
 
 	let paused = ContainerListEntry {
+		image_id: String::new(),
 		started_at: NOW - 3600,
 		..entry("paused", "paused")
 	};
 	assert_eq!(table_status(&paused, NOW), "paused");
 
 	let created = ContainerListEntry {
+		image_id: String::new(),
 		started_at: NOW - 3600,
 		..entry("", "created")
 	};
@@ -328,6 +340,7 @@ fn only_a_running_container_reports_an_age() {
 #[test]
 fn the_created_cell_reports_the_age_of_the_container() {
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		// 2026-08-02 22:34:41 at -05:00 is 2026-08-03 03:34:41Z, which is two
 		// hours and change after NOW... so use a value comfortably before it.
 		created: "2026-08-01T00:58:45Z".into(),
@@ -342,6 +355,7 @@ fn the_created_cell_reports_the_age_of_the_container() {
 fn an_unparseable_created_leaves_the_cell_blank() {
 	for bad in ["", "not a timestamp", "2026-13-01T00:00:00Z"] {
 		let c = ContainerListEntry {
+			image_id: String::new(),
 			created: bad.into(),
 			..entry("", "running")
 		};
@@ -387,6 +401,7 @@ fn the_size_cell_matches_what_podman_prints() {
 	];
 	for (rw, root_fs, expected) in cases {
 		let c = ContainerListEntry {
+			image_id: String::new(),
 			size: Some(crate::libpod::types::container::ContainerSize { rw, root_fs }),
 			..entry("", "running")
 		};
@@ -404,6 +419,7 @@ fn virtual_is_the_image_size_and_not_the_total() {
 	let rw = 577_461_099;
 	let root_fs = 2_082_961_972;
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		size: Some(crate::libpod::types::container::ContainerSize { rw, root_fs }),
 		..entry("", "running")
 	};
@@ -431,6 +447,7 @@ fn a_size_that_was_not_requested_leaves_the_cell_empty() {
 #[test]
 fn a_zero_byte_writable_layer_still_renders() {
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		size: Some(crate::libpod::types::container::ContainerSize {
 			rw: 0,
 			root_fs: 1_000_000,
@@ -449,6 +466,7 @@ fn the_json_row_distinguishes_an_absent_size_from_a_zero() {
 	assert!(absent["Size"].is_null(), "{}", absent["Size"]);
 
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		size: Some(crate::libpod::types::container::ContainerSize {
 			rw: 143_362,
 			root_fs: 224_997_461,
@@ -466,6 +484,7 @@ fn the_json_row_distinguishes_an_absent_size_from_a_zero() {
 #[test]
 fn the_json_row_carries_the_raw_instants() {
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		started_at: 1_785_728_082,
 		created: "2026-08-02T22:34:41.982670-05:00".into(),
 		..entry("", "running")
@@ -484,6 +503,7 @@ fn ps_json_row_surfaces_state_exitcode_and_publishers() {
 	labels.insert("podup.project".to_string(), "demo".to_string());
 	labels.insert("podup.service".to_string(), "web".to_string());
 	let c = ContainerListEntry {
+		image_id: String::new(),
 		id: "deadbeef".into(),
 		names: vec!["/demo-web-1".into()],
 		image: "nginx:1.25".into(),

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -32,6 +32,16 @@ pub struct ContainerListEntry {
 	#[serde(rename = "Image", default)]
 	pub image: String,
 
+	/// Full 64-hex ID of the image the container is bound to. This is the
+	/// image's identity; `image` above is the name it was asked for, which a
+	/// later pull, build or `podman tag` can point at a different image without
+	/// touching the container. `up` compares it against what the service's tag
+	/// resolves to now, which is how a container built from an older image gets
+	/// recreated (#1620). Measured on Podman 5.7.0: `ImageID` on the list
+	/// endpoint equals `Id` on `GET /libpod/images/{name}/json`.
+	#[serde(rename = "ImageID", default)]
+	pub image_id: String,
+
 	/// Human-readable status string for `ps` display (e.g. `Up 3 minutes`,
 	/// `Exited (0) 5 seconds ago`). Empty on libpod, which reports `State`.
 	#[serde(rename = "Status", default)]

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -188,6 +188,8 @@ mod lifecycle;
 mod lifecycle_query;
 #[path = "engine_integration/niche.rs"]
 mod niche;
+#[path = "engine_integration/recreate_on_image.rs"]
+mod recreate_on_image;
 #[path = "engine_integration/resources_health.rs"]
 mod resources_health;
 #[path = "engine_integration/run_flags.rs"]

--- a/tests/engine_integration/recreate_on_image.rs
+++ b/tests/engine_integration/recreate_on_image.rs
@@ -1,0 +1,173 @@
+//! `up` keeps or replaces a container by two facts: the config hash, and the
+//! image the container is bound to against the image its service resolves to
+//! now (#1620). These tests pin the second fact on a real Podman.
+//!
+//! The marker technique is the one `up_skips_recreate_when_config_unchanged`
+//! uses: a file written into the running container survives a skip and is
+//! gone after a recreate, so the three outcomes read from inside rather than
+//! from a container ID compared by hand. Every service here has no `image:`,
+//! so the tag the engine inspects is the derived `{project}-{service}:latest`
+//! one, which is the path #1620 measured.
+
+use super::*;
+
+const V1: &[u8] = b"FROM alpine:latest\nRUN echo v1 > /version\n";
+const V2: &[u8] = b"FROM alpine:latest\nRUN echo v2 > /version\n";
+const YAML: &str = "services:\n  web:\n    build: .\n    command: [\"sleep\", \"infinity\"]\n";
+
+fn write_marker() -> Vec<String> {
+	vec!["sh".into(), "-c".into(), "echo marked > /marker".into()]
+}
+
+fn read_marker() -> Vec<String> {
+	vec!["cat".into(), "/marker".into()]
+}
+
+fn rmi(project: &str) {
+	let _ = std::process::Command::new("podman")
+		.args(["rmi", "-f", &format!("{project}-web:latest")])
+		.output();
+}
+
+/// The case #1620 measured: an unchanged `build:` service is left alone. Before
+/// the fix it was stopped, removed, created and started on every `up`, bound
+/// to exactly the image it already had, and its writable layer went with it.
+#[tokio::test]
+async fn an_unchanged_build_service_is_left_in_place() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), V1).unwrap();
+	let proj = proj("rci-same");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let file = parse_str(YAML).unwrap();
+	let cname = format!("{proj}-web-1");
+
+	engine.up(&file).await.unwrap();
+	engine
+		.test_exec_capture(&cname, write_marker())
+		.await
+		.unwrap();
+	engine.up(&file).await.unwrap();
+	let after = engine
+		.test_exec_capture(&cname, read_marker())
+		.await
+		.unwrap_or_default();
+	engine.down(&file).await.unwrap();
+	rmi(&proj);
+
+	assert_eq!(
+		after.trim(),
+		"marked",
+		"an unchanged build: service was recreated instead of kept"
+	);
+}
+
+/// The reason the old rule existed, done properly: when the image behind the
+/// tag changes and the compose config does not, the container is replaced.
+/// The rebuild here is out of band (`build`, then `up`), which is the shape a
+/// `build --no-cache` followed by `up` takes. docker compose v5.3.1 recreates
+/// on this too.
+#[tokio::test]
+async fn a_rebuilt_image_recreates_the_container() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), V1).unwrap();
+	let proj = proj("rci-rebuild");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let file = parse_str(YAML).unwrap();
+	let cname = format!("{proj}-web-1");
+
+	engine.up(&file).await.unwrap();
+	engine
+		.test_exec_capture(&cname, write_marker())
+		.await
+		.unwrap();
+	fs::write(dir.path().join("Dockerfile"), V2).unwrap();
+	engine.build_all(&file, &[]).await.unwrap();
+	engine.up(&file).await.unwrap();
+	let version = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/version".into()])
+		.await
+		.unwrap_or_default();
+	let marker = engine
+		.test_exec_capture(&cname, read_marker())
+		.await
+		.unwrap_or_default();
+	engine.down(&file).await.unwrap();
+	rmi(&proj);
+
+	assert_eq!(
+		version.trim(),
+		"v2",
+		"the container is still bound to the old image after a rebuild"
+	);
+	assert_ne!(
+		marker.trim(),
+		"marked",
+		"a rebuilt image must replace the container, and the old writable layer with it"
+	);
+}
+
+/// The same fact from the other direction: an `image:` service is not exempt.
+/// A `podman tag` that moves the name to a different image leaves the config
+/// hash alone and must still recreate, which is what `up --pull always` on a
+/// moved upstream tag looks like. Both images are built locally so the test
+/// needs nothing but `alpine:latest`.
+#[tokio::test]
+async fn a_retagged_image_recreates_an_image_service() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("rci-retag");
+	let tag = format!("localhost/{proj}-pinned:latest");
+	let build = |contents: &[u8]| {
+		fs::write(dir.path().join("Dockerfile"), contents).unwrap();
+		let out = std::process::Command::new("podman")
+			.args(["build", "-q", "-t", &tag, "-f", "Dockerfile", "."])
+			.current_dir(dir.path())
+			.output()
+			.expect("podman build");
+		assert!(
+			out.status.success(),
+			"podman build failed: {}",
+			String::from_utf8_lossy(&out.stderr)
+		);
+	};
+	build(V1);
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let yaml =
+		format!("services:\n  web:\n    image: {tag}\n    command: [\"sleep\", \"infinity\"]\n");
+	let file = parse_str(&yaml).unwrap();
+	let cname = format!("{proj}-web-1");
+
+	engine.up(&file).await.unwrap();
+	engine
+		.test_exec_capture(&cname, write_marker())
+		.await
+		.unwrap();
+	// Same tag, different image underneath: the hash is identical, the ID is not.
+	build(V2);
+	engine.up(&file).await.unwrap();
+	let version = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/version".into()])
+		.await
+		.unwrap_or_default();
+	engine.down(&file).await.unwrap();
+	let _ = std::process::Command::new("podman")
+		.args(["rmi", "-f", &tag])
+		.output();
+
+	assert_eq!(
+		version.trim(),
+		"v2",
+		"an image: service whose tag moved to a new image kept the old container"
+	);
+}


### PR DESCRIPTION
## What

`up` decides whether to keep an existing container by two facts instead of one: the config hash it already compared, and the ID of the image the container is bound to against what the service's tag resolves to now. An unchanged `build:` service is left in place; a rebuilt image, or an `image:` tag moved by a pull or a `podman tag`, recreates. The `service.build.is_none()` exemption is gone.

## Why

#1620 measured it: after #1094, `up` builds only when the image is missing, so on the default path the container the exemption destroyed was bound to exactly the image its replacement got. A stop, remove, create and start for nothing, the writable layer gone each time, and on every reboot under `autostart --mode service`.

This is option 2 from the issue, and it is what docker compose does. Measured this session on a real dockerd (compose v5.3.1): an unchanged `build:` service stays `Running`; retagging an `image:` service's tag to a different image gets `Recreate`; rebuilding the `build:` service out of band and running `up` gets `Recreate`. Podup now matches all three.

The comparison applies to every service, not only `build:` ones, because the moved-tag case is the same defect for `image:` services and the old rule never noticed it. Cost: one `GET /images/{tag}/json` per unchanged replica. A tag that resolves to nothing, or a container without a recorded image ID, counts as changed, which is the old fail-closed answer.

`present` and `existing_hash` collapse into one `HashMap<String, ExistingContainer>` so the two facts travel together; `ContainerListEntry` gains `image_id` (`ImageID` on the list endpoint, measured on Podman 5.7.0 to equal `Id` on the image inspect).

## Test plan

- `tests/engine_integration/recreate_on_image.rs`, three cases on a real Podman (5.7.0 locally): an unchanged `build:` service keeps its marker; a rebuilt image recreates (the container reads `v2` and the marker is gone); an `image:` service whose tag was rebuilt to a new image recreates. The existing `up_skips_recreate_when_config_unchanged` and `watch_rebuild_recreates_the_container_from_the_new_image` still pass.
- Sabotage: with the image comparison replaced by `Ok(true)`, the rebuilt and retagged cases fail and the unchanged case stays green (`1 passed; 2 failed`).
- `cargo test --lib lifecycle` and `--lib ps` (the `ContainerListEntry` fixtures gained the field) green; `cargo clippy --all-targets --features test-helpers -D warnings` and `cargo fmt --check` clean.

Closes #1620

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>