### PR TITLE
ci: stop persisting the job token in checkouts

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -54,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
@@ -120,6 +122,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
         with:
@@ -153,6 +157,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run the version-self-test shell fixture
         run: bash tests/fixtures/releases/version-self-test.sh
   # Same fixture on Windows so install.ps1's Test-StagedVersion is
@@ -163,6 +169,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run the version-self-test PowerShell fixture
         shell: pwsh
         run: pwsh -NoProfile -File tests/fixtures/releases/version-self-test.ps1
@@ -176,6 +184,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         env:
           RUST_TOOLCHAIN: "1.85"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,6 +42,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Check the harness shell syntax
         run: bash -n bench/run.sh
       - name: Check the harness Python syntax
@@ -73,6 +75,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build podup
         run: cargo build --release --all-features --locked
       - name: Pre-pull pinned images

--- a/.github/workflows/binary-budget.yml
+++ b/.github/workflows/binary-budget.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build the release binary
         # The same profile the release ships, including the strip setting: a

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Detect drift in pinned tool versions
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/podman-lane-develop-nightly.yml
+++ b/.github/workflows/podman-lane-develop-nightly.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: develop
       - name: Install qemu + cloud tools
         run: sudo apt-get update -qq && sudo apt-get install -y -qq qemu-system-x86 qemu-utils cloud-image-utils

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -56,6 +56,8 @@ jobs:
         podman: ["5", "6"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install qemu + cloud tools
         run: sudo apt-get update -qq && sudo apt-get install -y -qq qemu-system-x86 qemu-utils cloud-image-utils
       - name: Fetch Fedora cloud image (Podman 6 = rawhide, 5 = Fedora 44)

--- a/.github/workflows/podman-watch.yml
+++ b/.github/workflows/podman-watch.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Detect newer packaged Podman
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # The only checkout in this repository that keeps the token: the step
+        # below runs `git fetch origin main` to prove the tag is reachable from
+        # main, and this is the release path, which runs once, at the tag, on
+        # a release that is immutable. The repository is public, so an
+        # anonymous fetch would work today; it is not worth learning otherwise
+        # at release time. This job holds no signing key.
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
@@ -166,6 +172,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
       - name: Install build target
@@ -309,6 +316,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
       - name: Build the package
@@ -363,6 +371,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
       - name: Install Rust toolchain
@@ -451,6 +460,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
       - name: Install Rust toolchain


### PR DESCRIPTION
## Problem

`actions/checkout` writes the job token into `.git/config` unless told not to. Measured by reading every `uses: actions/checkout@` in `.github/workflows/` and the lines after it: 17 checkouts across eight workflows persisted it. The reusables in this repository already pass `persist-credentials: false`; the callers did not. The release workflow's `build`, `build-deb`, `sbom` and `release` jobs are the ones that matter: they hold `GLYNDOR_RELEASE_ED25519_KEY`, and the job token sat beside it in the workspace for the whole job.

## Change

`persist-credentials: false` on every checkout except one: the `verify` job of `release.yml`, which runs `git fetch origin main` to prove the tag is reachable from `main`. That job holds no key, and the release path runs once, at the tag, on an immutable release; an anonymous fetch of a public repository would work, but release time is not where to learn otherwise. The exception says so beside the checkout.

No workflow here runs `git push`; releases are created with `gh release` through `GH_TOKEN`.

## Test plan

The five workflow-shape suites (`workflow_audit_strictness`, `workflow_debian_image`, `workflow_toolchain_pin`, `dependabot_covers_every_lockfile`, `keyring_bootstrap_order`) pass. The same change landed on the three distribution channels (`Glyndor/apt#200`, `Glyndor/homebrew-tap#141`, `Glyndor/scoop-bucket#128`).

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>