### PR TITLE
docs(commands): say when up keeps a container and when it replaces it

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,6 +80,16 @@ each with the compose-spec field shown.
 Create and start all services (or only the named ones, plus their transitive
 `depends_on`). Accepts a trailing service list.
 
+A container that already exists is left in place when two facts both hold:
+its recorded config hash equals what the compose file renders now, and the
+image it is bound to is still the image its service resolves to. Either
+changing replaces it: an edited service definition, a rebuilt or re-pulled
+image, or a tag moved by `podman tag`. The image comparison is what a
+`build:` service relies on, since the config hash does not cover the build
+context, and it is the same rule docker compose applies. `--no-recreate`
+keeps an existing container regardless; `--force-recreate` replaces it
+regardless.
+
 | Flag | Description | Default |
 |---|---|---|
 | `-d, --detach` | Run containers in the background. | off |
@@ -719,7 +729,7 @@ than exiting silently, which is indistinguishable from success.
 
 A container that is replaced reads differently from one that is created:
 `Recreating`/`Recreated` for a container `up` or `create` removed and built
-again (a changed config, `--force-recreate`), `Starting`/`Started` or
+again (a changed config or image, `--force-recreate`), `Starting`/`Started` or
 `Creating`/`Created` for one that did not exist, and `Running` or `Exists` for
 one left alone. Recreation destroys the container's writable layer, so the word
 is the operator's only signal at the moment it happens, and it is what makes


### PR DESCRIPTION
## What

The `up` reference gains the rule that decides whether an existing container is kept or replaced: the config hash and the image the container is bound to must both match, and either changing recreates it. The progress paragraph named a changed config as the only cause of a recreate; a changed image is the other.

## Why

#1630 changed the rule (image ID compared for every service, the `build:` exemption gone) and nothing in `docs/` said what `up` decides on. A reader who saw `Recreating` after a `podman tag` had no sentence to find.

## Test plan

Docs only. This is also the first pull request since #1636 whose diff the VM cannot observe: the `decide` job should answer `engine=false`, both `podman-vm` legs should finish in seconds on the `Nothing to boot` step, and `Supported Podman majors` should stay green. If either leg boots, #1636 did not do what it says.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>