### PR TITLE
chore(release): bump to 5.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.6.0"
+version = "5.7.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.6.0"
+version = "5.7.0"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+podup (5.7.0) unstable; urgency=medium
+
+  * `up` reports a container it replaced as `Recreating`/`Recreated`, and
+    keeps `Starting`/`Started` for one that did not exist and `Running` for
+    one it left alone. Recreation destroys the writable layer, so the word is
+    the operator's signal at the moment it happens, and `--force-recreate` and
+    `--no-recreate` can be read off the output.
+  * `up` keeps an existing container when its config hash and the image it is
+    bound to both still match, and replaces it when either changed. A `build:`
+    service used to be replaced on every run whether or not its image had
+    changed, which cost a stop, remove, create and start for nothing and the
+    writable layer each time, including on every reboot under
+    `autostart --mode service`. A rebuilt or re-pulled image, or a tag moved by
+    `podman tag`, still replaces the container, for every service.
+  * The README names the Podman floor before the install one-liner for readers
+    on Debian 12 or Ubuntu 24.04.
+
+ -- Jose <75870284+Jaro-c@users.noreply.github.com>  Tue, 02 Sep 2026 07:20:00 -0500
+
 podup (5.6.0) unstable; urgency=medium
 
   * `podup autostart` gains a third mode. `--mode start` writes a unit whose


### PR DESCRIPTION
Minor rather than patch: `up`'s keep-or-replace rule changed for every service (#1630), which a user can observe, and the progress vocabulary gained `Recreating`/`Recreated` (#1629).

Everything `develop` carries over `main`, for the release notes:

- #1629 — `up` says `Recreating`/`Recreated` when it replaces a container, `Starting`/`Started` for one that did not exist, `Running` for one left alone. Closes #1619.
- #1630 — `up` keeps a container when its config hash and image ID both match and replaces it when either changed; the `build:` exemption that recreated on every run is gone. Closes #1620.
- #1628 — README names the Podman floor before the install one-liner. Closes #1608.
- #1637 — the `up` reference says what decides keep or replace (docs).
- #1639 — `docs/threat-model.md`: assets, adversaries, one row per threat with its control and evidence, residual risks (docs).
- #1631, #1635, #1636, #1634 — CI only: no persisted job token in checkouts, the Dependabot freshness tie-breaker, the lane boots nothing on a docs-only pull request, unit tests moved to sibling files with the coverage threshold read honestly.
- #1627, #1613 — dependency bumps (flate2, hyper, indexmap, miniz_oxide; fuzz: bytes).

## The three files, and how I found them

`Cargo.toml`, `Cargo.lock`, `debian/changelog`, derived by searching the tree for `5.6.0`, not by copying the last bump's diff. The releases standard warns against the latter for a measured reason: 1.8.1 dropped `debian/changelog`, 1.9.0 inherited the gap and shipped `podup_1.8.0_*.deb`.

## Verified against the gate, with a control

Ran `release.yml`'s three version comparisons locally:

```
tag=5.7.0 crate=5.7.0 deb=5.7.0 lock=5.7.0
GATE OK
```

then desynced `debian/changelog` to 5.6.0 to confirm the comparison fails rather than comparing nothing: `GATE FAIL`. Restored, `GATE OK` again. `cargo build --locked` clean.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
