### PR TITLE
ci: bound every job, ten times its measured worst case

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -52,6 +52,9 @@ jobs:
   # pin the L7 error class on Linux.
   shell-signing-fixture:
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 16s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -120,6 +123,9 @@ jobs:
   # same L7 error class.
   powershell-signing-fixture:
     runs-on: windows-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 40s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -155,6 +161,9 @@ jobs:
   # the strict-equality-with-optional-v comparison fails here.
   shell-version-self-test:
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 6s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -167,6 +176,9 @@ jobs:
   # comparison or in the staged-file-removal on failure fails here.
   powershell-version-self-test:
     runs-on: windows-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 35s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -182,6 +194,9 @@ jobs:
   # release.yml sets up the release build.
   rust-self-test-reference:
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 88s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,9 @@ permissions: {}
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 17s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -70,6 +73,9 @@ jobs:
 
   benchmark:
     runs-on: [self-hosted, bench]
+    # Bound: no successful scheduled run in the last three to measure; bounded generously and to be tightened from the first. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 90
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read

--- a/.github/workflows/binary-budget.yml
+++ b/.github/workflows/binary-budget.yml
@@ -39,6 +39,9 @@ jobs:
   size:
     name: Release binary fits its budget
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 174s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -31,6 +31,9 @@ permissions:
 jobs:
   watch:
     runs-on: ubuntu-24.04
+    # Bound: worst of the last three successful runs on 2026-09-02 was 9s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -58,6 +58,9 @@ jobs:
   decide:
     name: Decide whether the VM has anything to look at
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 8s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     outputs:
       engine: ${{ steps.files.outputs.engine }}
     steps:
@@ -554,6 +557,9 @@ jobs:
     # check does not block a merge — the exact failure this job exists to prevent.
     if: always()
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 4s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - name: Reflect the matrix result
         env:

--- a/.github/workflows/podman-watch.yml
+++ b/.github/workflows/podman-watch.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   watch:
     runs-on: ubuntu-24.04
+    # Bound: worst of the last three successful runs on 2026-09-02 was 7s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
   verify:
     name: Verify tag matches crate version
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 189s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -128,6 +131,9 @@ jobs:
     name: Build ${{ matrix.asset }}
     needs: verify
     runs-on: ${{ matrix.runner }}
+    # Bound: worst of the last three successful runs on 2026-09-02 was 347s; the slowest leg is Windows arm64. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
@@ -250,6 +256,9 @@ jobs:
     name: Build Debian package (${{ matrix.arch }})
     needs: verify
     runs-on: ${{ matrix.runner }}
+    # Bound: worst of the last three successful runs on 2026-09-02 was 438s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 60
     # debian:trixie, digest-pinned. Sid was a moving tag:
     # two releases built from identical source could land in different
     # environments with nothing in history recording which, and Dependabot's
@@ -368,6 +377,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 216s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -454,6 +466,9 @@ jobs:
     name: Publish release
     needs: [build, build-deb, sbom]
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 33s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     permissions:
       contents: write
 

--- a/.github/workflows/reusable-dco.yml
+++ b/.github/workflows/reusable-dco.yml
@@ -18,6 +18,9 @@ jobs:
   dco:
     name: Signed-off-by present on every commit
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 7s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/reusable-dependabot-freshness.yml
+++ b/.github/workflows/reusable-dependabot-freshness.yml
@@ -80,6 +80,9 @@ jobs:
   freshness:
     name: dependabot freshness
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 7s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/reusable-installer-contract.yml
+++ b/.github/workflows/reusable-installer-contract.yml
@@ -51,6 +51,9 @@ jobs:
   check:
     name: install.sh ↔ release asset names
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 10s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/reusable-line-limit.yml
+++ b/.github/workflows/reusable-line-limit.yml
@@ -38,6 +38,9 @@ jobs:
   line-limit:
     name: line limit
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 8s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/reusable-main-guard.yml
+++ b/.github/workflows/reusable-main-guard.yml
@@ -16,6 +16,9 @@ jobs:
   develop-only:
     name: develop-only
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 4s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
     steps:
       - name: Require develop as source branch

--- a/.github/workflows/reusable-powershell-ci.yml
+++ b/.github/workflows/reusable-powershell-ci.yml
@@ -62,6 +62,9 @@ jobs:
   pssa:
     name: pssa
     runs-on: windows-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 41s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/reusable-rust-audit.yml
+++ b/.github/workflows/reusable-rust-audit.yml
@@ -37,6 +37,9 @@ jobs:
   audit:
     name: cargo audit
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 194s; cargo install of the auditor dominates. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -80,6 +83,9 @@ jobs:
   deny:
     name: cargo deny
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 137s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-rust-ci.yml
+++ b/.github/workflows/reusable-rust-ci.yml
@@ -74,6 +74,9 @@ jobs:
   lint:
     name: Format & lint
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 49s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -108,6 +111,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 106s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -140,6 +146,9 @@ jobs:
     name: Test (${{ matrix.os }})
     if: inputs.extra-test-os != '[]'
     runs-on: ${{ matrix.os }}
+    # Bound: worst of the last three successful runs on 2026-09-02 was 205s; the slowest leg is windows-latest. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -192,6 +201,9 @@ jobs:
     # it a gate rather than a decoration.
     if: always()
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 4s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - name: Reflect the extra-platform test result
         env:
@@ -209,6 +221,9 @@ jobs:
     name: Coverage
     if: inputs.coverage-threshold > 0
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 166s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -271,6 +286,9 @@ jobs:
     name: MSRV (${{ inputs.msrv }})
     if: inputs.msrv != ''
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 62s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -308,6 +326,9 @@ jobs:
     needs: msrv
     if: always()
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 4s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     steps:
       - name: Reflect the MSRV result
         env:
@@ -324,6 +345,9 @@ jobs:
     name: Package check
     if: inputs.package-check
     runs-on: ubuntu-latest
+    # Bound: skipped here since publish = false; bounded for the caller that does publish. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -346,6 +370,9 @@ jobs:
     name: Semver checks
     if: inputs.semver-check
     runs-on: ubuntu-latest
+    # Bound: skipped here since publish = false; bounded for the caller that does publish. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -373,6 +400,9 @@ jobs:
     name: Doc warnings
     if: inputs.doc-warnings
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 56s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-rust-debian.yml
+++ b/.github/workflows/reusable-rust-debian.yml
@@ -94,6 +94,9 @@ jobs:
   build:
     name: dpkg-buildpackage
     runs-on: ${{ inputs.runner }}
+    # Bound: worst of the last three successful runs on 2026-09-02 was 432s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 60
     container:
       image: ${{ inputs.debian-image }}
     defaults:
@@ -222,6 +225,9 @@ jobs:
     name: build (vendored / offline)
     if: ${{ inputs.check-vendored }}
     runs-on: ${{ inputs.runner }}
+    # Bound: worst of the last three successful runs on 2026-09-02 was 171s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 30
     container:
       image: ${{ inputs.debian-image }}
     defaults:

--- a/.github/workflows/reusable-rust-fuzz.yml
+++ b/.github/workflows/reusable-rust-fuzz.yml
@@ -53,6 +53,9 @@ jobs:
   fuzz:
     name: cargo fuzz
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 243s; the smoke pass; a longer scheduled pass passes its own seconds and this bound assumes it stays under a quarter of an hour of fuzzing. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-rust-supply-chain.yml
+++ b/.github/workflows/reusable-rust-supply-chain.yml
@@ -49,6 +49,9 @@ jobs:
   sbom-and-licenses:
     name: SBOM and license attribution
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 216s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 40
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-schedule-freshness.yml
+++ b/.github/workflows/reusable-schedule-freshness.yml
@@ -52,6 +52,9 @@ jobs:
   freshness:
     name: schedule freshness
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 10s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     permissions:
       actions: read # reading this repository's workflow-run history
     steps:

--- a/.github/workflows/reusable-shell-ci.yml
+++ b/.github/workflows/reusable-shell-ci.yml
@@ -47,6 +47,9 @@ jobs:
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 8s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -168,6 +171,9 @@ jobs:
     name: test
     if: inputs.test-command != ''
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 7s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -44,6 +44,9 @@ jobs:
   workflow-lint:
     name: workflow-lint
     runs-on: ubuntu-latest
+    # Bound: worst of the last three successful runs on 2026-09-02 was 32s. Ten times that, rounded up, never under ten
+    # minutes; the six-hour default is what a hang would otherwise cost.
+    timeout-minutes: 10
     env:
       ACTIONLINT_VERSION: v1.7.12
     steps:


### PR DESCRIPTION
## Problem

Forty-three jobs across twenty-one workflows had no `timeout-minutes`, so a hang cost GitHub's six-hour default. The three distribution channels got their bounds on 2026-09-01 (`standards/ci`, "Every job carries a `timeout-minutes` tuned from its measured duration"); this repository had two, both on the Podman lane.

## Measured

The worst of the last three successful runs per job, 2026-09-02, read off `gh run view --json jobs`. A few that decide the shape:

| job | worst | bound |
|---|---|---|
| `release` build (Windows arm64 leg) | 347s | 60 min |
| `release` build-deb | 438s | 60 min |
| `debian / dpkg-buildpackage` | 432s | 60 min |
| `rust / Test (windows-latest)` | 205s | 35 min |
| `cargo fuzz` smoke legs | 243s | 40 min |
| `audit / cargo audit` | 194s | 30 min |
| `rust / Coverage` | 166s | 30 min |
| the ten-second watchers and gates | 4 to 32s | 10 min |

Every bound is ten times its measurement rounded up, never under ten minutes, and the measurement is written beside the number in the workflow. Two jobs had nothing to measure and say so: `package` and `semver` (skipped while `publish = false`) and the scheduled `benchmark`.

## Change

`timeout-minutes` on every job that declares `runs-on`. A caller job that `uses:` a reusable cannot carry one, so the bound lives in the reusable's own jobs, where the work runs.

## Test plan

Every workflow parses; `workflow_audit_strictness`, `workflow_toolchain_pin` and `workflow_debian_image` pass; no trailing whitespace. This pull request touches workflow files, so the lane boots both legs.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>