### PR TITLE
test: cover the five controls a mutation sweep found green without them

### DIFF
--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -32,7 +32,7 @@ const MAX_CP_ARCHIVE_BYTES: usize = 1024 * 1024 * 1024;
 /// a literal. Construct it via [`CpOptions::new`] or the `with_*` builders
 /// below; a struct literal is refused outside this crate, which is what buys
 /// the room to grow.
-#[derive(Default)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct CpOptions {
 	/// 1-based replica index for a scaled service, `--index` (default: first).

--- a/internal/engine/copy_tests.rs
+++ b/internal/engine/copy_tests.rs
@@ -177,3 +177,22 @@ fn check_endpoint_allows_normal_forms() {
 	assert!(super::check_endpoint("web:/app/data").is_ok());
 	assert!(super::check_endpoint("./local").is_ok());
 }
+
+/// The builders set the field they are named for and nothing else. Nothing
+/// in the tree calls them (the CLI goes through `CpOptions::new`), so a
+/// mutation sweep on 2026-09-02 replaced each with `Default::default()` and
+/// every suite stayed green; this is the only thing that reads them.
+#[test]
+fn the_cp_option_builders_set_their_field() {
+	use super::CpOptions;
+	let base = CpOptions::new(None, false, false);
+	assert_eq!(
+		CpOptions::new(Some(3), false, false),
+		base.clone().with_index(Some(3))
+	);
+	assert_eq!(
+		CpOptions::new(None, true, false),
+		base.clone().with_follow_link(true)
+	);
+	assert_eq!(CpOptions::new(None, false, true), base.with_archive(true));
+}

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -169,6 +169,10 @@ mod name_tests;
 mod staging_tests;
 
 #[cfg(all(test, unix))]
+#[path = "staging_base_tests.rs"]
+mod base_tests;
+
+#[cfg(all(test, unix))]
 #[path = "staging_ensure_dir_tests.rs"]
 mod ensure_dir_tests;
 

--- a/internal/engine/staging_base_tests.rs
+++ b/internal/engine/staging_base_tests.rs
@@ -1,0 +1,135 @@
+//! `staging_base` decides where secret material is staged, and the decision
+//! rests on `XDG_RUNTIME_DIR`: an absolute, private, own-user directory is used
+//! (under `podup/`), anything else falls back to a per-uid directory under the
+//! system temp dir. No test exercised that decision; a mutation sweep on
+//! 2026-09-02 replaced the absolute-path guard with `true` and with `false`,
+//! and the whole function with `Ok(Default::default())`, and every suite
+//! stayed green.
+//!
+//! The environment is process-wide, so the cases take one lock and restore
+//! the variable on every exit, including a panic.
+
+use super::staging_base;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+static ENV: Mutex<()> = Mutex::new(());
+
+/// Sets `XDG_RUNTIME_DIR` for the scope of the guard and puts the previous
+/// value back on drop.
+struct Xdg {
+	_lock: MutexGuard<'static, ()>,
+	previous: Option<std::ffi::OsString>,
+}
+
+impl Xdg {
+	fn set(value: Option<&Path>) -> Self {
+		let lock = ENV.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+		let previous = std::env::var_os("XDG_RUNTIME_DIR");
+		// The process-wide environment is written under the lock above, which
+		// every test in this module takes; nothing else in the unit suite reads
+		// XDG_RUNTIME_DIR concurrently.
+		match value {
+			Some(p) => std::env::set_var("XDG_RUNTIME_DIR", p),
+			None => std::env::remove_var("XDG_RUNTIME_DIR"),
+		}
+		Xdg {
+			_lock: lock,
+			previous,
+		}
+	}
+}
+
+impl Drop for Xdg {
+	fn drop(&mut self) {
+		match &self.previous {
+			Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+			None => std::env::remove_var("XDG_RUNTIME_DIR"),
+		}
+	}
+}
+
+fn euid() -> u32 {
+	// Read the owner of a directory this process just created rather than
+	// calling geteuid here: the crate denies unsafe code outside the few
+	// audited sites, and the effect is the same.
+	use std::os::unix::fs::MetadataExt;
+	let tmp = tempfile::tempdir().expect("tempdir");
+	std::fs::metadata(tmp.path()).expect("metadata").uid()
+}
+
+fn private_dir(root: &Path, name: &str) -> PathBuf {
+	use std::os::unix::fs::DirBuilderExt;
+	let dir = root.join(name);
+	std::fs::DirBuilder::new()
+		.mode(0o700)
+		.create(&dir)
+		.expect("create private dir");
+	dir
+}
+
+/// An absolute, private runtime dir is used, and the staging base is a
+/// private directory inside it.
+#[test]
+fn an_absolute_private_xdg_runtime_dir_is_used() {
+	use std::os::unix::fs::MetadataExt;
+	let tmp = tempfile::tempdir().expect("tempdir");
+	let xdg = private_dir(tmp.path(), "runtime");
+	let _env = Xdg::set(Some(&xdg));
+
+	let base = staging_base().expect("staging base");
+	assert_eq!(base, xdg.join("podup"), "the base is XDG_RUNTIME_DIR/podup");
+	let meta = std::fs::symlink_metadata(&base).expect("base exists");
+	assert!(meta.is_dir());
+	assert_eq!(meta.mode() & 0o777, 0o700, "created private");
+	assert_eq!(meta.uid(), euid());
+}
+
+/// A relative `XDG_RUNTIME_DIR` is not a runtime dir; the fallback is the
+/// per-uid directory under the temp dir, never something relative to the
+/// working directory.
+#[test]
+fn a_relative_xdg_runtime_dir_falls_back_to_the_temp_dir() {
+	let _env = Xdg::set(Some(Path::new("relative/runtime")));
+
+	let base = staging_base().expect("staging base");
+	assert_eq!(
+		base,
+		std::env::temp_dir().join(format!("podup-{}", euid())),
+		"a relative value must not be honoured"
+	);
+	assert!(base.is_absolute());
+}
+
+/// Unset behaves like relative: the temp-dir fallback.
+#[test]
+fn an_unset_xdg_runtime_dir_falls_back_to_the_temp_dir() {
+	let _env = Xdg::set(None);
+
+	let base = staging_base().expect("staging base");
+	assert_eq!(base, std::env::temp_dir().join(format!("podup-{}", euid())));
+}
+
+/// A runtime dir another user could write to is refused outright, with the
+/// reason: secret staging under a world-writable path would be staging under
+/// someone else's control.
+#[test]
+fn a_group_or_world_accessible_xdg_runtime_dir_is_refused() {
+	use std::os::unix::fs::PermissionsExt;
+	let tmp = tempfile::tempdir().expect("tempdir");
+	let xdg = tmp.path().join("shared");
+	std::fs::create_dir(&xdg).expect("create dir");
+	std::fs::set_permissions(&xdg, std::fs::Permissions::from_mode(0o777)).expect("chmod");
+	let _env = Xdg::set(Some(&xdg));
+
+	let err = staging_base().expect_err("a shared runtime dir must be refused");
+	let msg = err.to_string();
+	assert!(
+		msg.contains("not a private directory owned by the current user"),
+		"refused for the right reason, not something else: {msg}"
+	);
+	assert!(
+		!xdg.join("podup").exists(),
+		"nothing is created under a directory that was refused"
+	);
+}

--- a/internal/engine/staging_name_tests.rs
+++ b/internal/engine/staging_name_tests.rs
@@ -9,6 +9,22 @@ fn safe_project_names_accepted() {
 	}
 }
 
+/// The acceptance half of the length bound. `unsafe_project_names_rejected`
+/// refuses 129; without this case a bound that slipped to `>= 128` would
+/// still pass every test, because nothing asked for the longest legal name.
+#[test]
+fn a_name_of_exactly_128_characters_is_accepted() {
+	let longest = "a".repeat(128);
+	assert!(
+		is_safe_project_name(&longest),
+		"128 is the bound, inclusive"
+	);
+	assert!(
+		!is_safe_project_name(&format!("{longest}a")),
+		"129 is over it"
+	);
+}
+
 #[test]
 fn unsafe_project_names_rejected() {
 	let long = "a".repeat(129);

--- a/internal/libpod/validate_tests.rs
+++ b/internal/libpod/validate_tests.rs
@@ -87,6 +87,22 @@ fn the_error_lists_the_modes_for_that_slot() {
 	let pid = allowed_namespace_modes(PID_FIELD);
 	assert!(!pid.contains("keep-id"), "{pid}");
 	assert!(!pid.contains("shareable"), "{pid}");
+
+	// The list reads as a list: a separator between items and none before
+	// the first. A separator emitted on the wrong side survived every
+	// `contains` above, since the words were all still there.
+	for list in [&userns, &ipc, &pid] {
+		assert!(list.starts_with("one of "), "{list}");
+		assert!(
+			!list.starts_with("one of ,"),
+			"separator before the first item: {list}"
+		);
+		assert!(
+			!list.contains(",,") && !list.contains(", ,"),
+			"doubled separator: {list}"
+		);
+		assert!(list.contains(", "), "no separator between items: {list}");
+	}
 }
 
 #[test]

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -572,3 +572,42 @@ async fn engine_attach_logs_timestamps_returns_when_container_exits() {
 	);
 	res.unwrap().unwrap();
 }
+
+/// The container-to-host archive is buffered in memory under a cap of one
+/// gibibyte. A file of two mebibytes is far under it and must arrive whole;
+/// a cap that shrank by an arithmetic slip (a mutation sweep on 2026-09-02
+/// turned the `*` in the constant into `+` and nothing noticed, because every
+/// copy in the suite was a few bytes) refuses this one.
+#[tokio::test]
+async fn engine_cp_from_container_carries_a_file_of_two_mebibytes() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let proj = proj("cpbig");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	engine.up(&file).await.unwrap();
+	engine
+		.test_exec_capture(
+			&format!("{proj}-web-1"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"head -c 2097152 /dev/zero > /tmp/big.bin".into(),
+			],
+		)
+		.await
+		.unwrap();
+
+	let dir = tempfile::tempdir().unwrap();
+	let dst = dir.path().to_str().unwrap().to_string();
+	let result = engine.cp(&file, "web:/tmp/big.bin", &dst).await;
+	engine.down(&file).await.unwrap();
+	result.unwrap();
+	let size = fs::metadata(dir.path().join("big.bin")).unwrap().len();
+	assert_eq!(size, 2 * 1024 * 1024, "the whole file must arrive");
+}


### PR DESCRIPTION
## What I measured

`cargo mutants` (27.1.0) over the security-relevant modules: `internal/update`, `internal/libpod/validate.rs`, `internal/engine/{secrets,copy,copy.rs,names.rs,staging.rs,container/security.rs}`, `internal/quadlet/unit`. Test command: the unit and binary suites plus `secret_safety`, `project_name_safety`, `quadlet`, `keyring_bootstrap_order`, `cli_flags`.

| | mutants |
|---|---|
| tested | 154 |
| caught | 117 |
| unviable | 4 |
| survived | 33 |

The 33, read one by one: 21 in `copy.rs`, whose behaviour the integration suite exercises against a real Podman (a second pass with that suite is running); 3 on Windows-only lines of `staging_base` that Linux never compiles; 2 equivalent mutants (`|` to `^` over the disjoint setuid/setgid/sticky bits); 2 `Engine` wrappers reachable only through a live engine (`Engine::validate_object_names`, `pre_validate_spec`); and **5 gaps**.

## The five, and the tests that close them

- `is_safe_project_name`: the suite refused 129 characters and never accepted 128, so `> 128` could become `>= 128` with every test green. One case asserts 128 in and 129 out.
- `staging_base` (three mutants: the absolute-path guard forced to `true`, forced to `false`, and the function returning a default path): no test set `XDG_RUNTIME_DIR`. `staging_base_tests.rs` pins the decision: an absolute private runtime dir is used and the base is created `0700` under it; a relative value and an unset value fall back to the per-uid temp dir; a group- or world-accessible runtime dir is refused for that reason and nothing is created under it. The environment is process-wide, so the cases take one lock and restore the variable on drop.
- `allowed_namespace_modes`: deleting the `!` in the separator logic emitted `, ` before the first item and every `contains` stayed green. The list is now asserted to start with `one of ` and not with `one of ,`, and to carry a separator between items.

## `copy.rs`, second pass

A second pass ran the six cp integration tests against a real Podman 5.7.0 over `copy.rs` (40 mutants, 17 caught by those alone). Intersected with the unit pass, ten mutants were reached by no local test: three in `put_archive_verified`'s verification path, which only runs when libpod closes the archive PUT without a response, the Podman 6 behaviour the lane's Podman 6 leg exercises and a Podman 5 host cannot; four on `cfg(windows)` lines Linux never compiles (`rust / Test (windows-latest)` is where those run); and the three `CpOptions` builders, which nothing in the tree called. Two more, the `*` in the one-gibibyte archive cap, survived both passes because every copy in the suite was a few bytes.

The second commit covers the last five: a unit test reads each builder's field (the type derives `Clone`, `Debug` and `PartialEq` for it, additive), and an integration test copies a two-mebibyte file out of a container and asserts the size, which a cap shrunk to about one mebibyte refuses.

## Test plan

- `cargo test --lib staging` 17 passed (4 new), `--lib validate` 66 passed; `cargo clippy --all-targets --features test-helpers -D warnings` and `cargo fmt --check` clean.
- Re-run of `cargo mutants` on `staging.rs`, `validate.rs`, `names.rs` with the new tests: 106 mutants, 97 caught, 2 unviable, 7 survived, and each of the seven is one of the four kinds above (three Windows-only, two equivalent, two wrappers).

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
