### PR TITLE
test(up): the object-name preflight runs before anything is created

### DIFF
--- a/tests/engine_integration/error_surfacing.rs
+++ b/tests/engine_integration/error_surfacing.rs
@@ -276,3 +276,47 @@ fn parse_compose_passes_with_bogus_fields_unchanged() {
 		vec!["db:127.0.0.1,github.com:127.0.0.1".to_string()]
 	);
 }
+
+/// `up` validates every object name client-side before it issues a single
+/// create, so a name Podman's regex would refuse surfaces as podup's own
+/// error and nothing is created. The validator is unit-tested; this is the
+/// wiring. A mutation sweep on 2026-09-02 replaced the `Engine` wrapper that
+/// calls it with `Ok(())` and every test stayed green: nothing had asked
+/// whether `up` calls it. A volume is the object to use here, since a
+/// container name is checked a second time at create and would pass with the
+/// preflight gone.
+#[tokio::test]
+async fn up_refuses_an_invalid_volume_name_before_creating_anything() {
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("badvol");
+	let yaml = "services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    volumes:\n      - data:/data\nvolumes:\n  data:\n    name: \"bad name\"\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let c = path.to_str().unwrap();
+
+	let out = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	// Whatever was created is removed before asserting, so a failure here
+	// leaves nothing behind.
+	let _ = Command::new(bin())
+		.args(["-f", c, "-p", &proj, "down", "-v"])
+		.output();
+	assert!(
+		!out.status.success(),
+		"a volume name with a space must be refused"
+	);
+	assert!(
+		stderr.contains("invalid volume name \"bad name\""),
+		"refused by podup's own preflight, not by libpod; got:\n{stderr}"
+	);
+	assert!(
+		!stderr.contains("500") && !stderr.contains("Internal Server Error"),
+		"the refusal must happen before any libpod call; got:\n{stderr}"
+	);
+}


### PR DESCRIPTION
## What

One integration case: `up -d` with a volume whose `name:` is `"bad name"` is refused by podup's own preflight (`invalid volume name "bad name"`), with no HTTP 500 in the output.

## Why

The validator is unit-tested; the wiring was not. The mutation sweep behind #1642 replaced `Engine::validate_object_names` with `Ok(())` and every suite stayed green, including the integration suite: nothing had asked whether `up` calls it. The comment on the call site says the preflight exists so a bad name surfaces as a clear client-side error with nothing created; this case holds `up` to that.

A volume, not a container. My first draft used `container_name: "bad name"` and the mutants survived it: container names are checked a second time at create (`container/mod.rs`, for the `run --name` path), so a bad container name is refused with the preflight gone. Volumes and networks are checked only by the preflight.

## Test plan

Green against Podman 5.7.0. `cargo mutants` on `names.rs` with this case as the test command: both `validate_object_names` mutants caught (the run before it reported both missed).

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>