### PR TITLE
chore(release): bump to 5.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.7.0"
+version = "5.7.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.7.0"
+version = "5.7.1"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+podup (5.7.1) unstable; urgency=medium
+
+  * The arm64 Linux binary and the arm64 Debian package are now static
+    position-independent executables, like the x86_64 ones have been. Until
+    5.7.0 they were static executables at a fixed address, so the kernel could
+    not randomise where the program sat in memory. The release now reads that
+    property, full RELRO, a non-executable stack and a stripped symbol table
+    off every Linux binary before signing anything, and runs each binary once
+    on the architecture it was built for.
+
+ -- Jose <75870284+Jaro-c@users.noreply.github.com>  Wed, 02 Sep 2026 18:57:13 -0500
+
 podup (5.7.0) unstable; urgency=medium
 
   * `up` reports a container it replaced as `Recreating`/`Recreated`, and


### PR DESCRIPTION
Bump for the patch release carrying #1645: the arm64 Linux binary and the arm64 `.deb` become static PIE, and the release verifies the hardening of every Linux binary before signing.

## Verified

`release.yml`'s three version comparisons run locally: `crate=5.7.1 lock=5.7.1 deb=5.7.1`, GATE OK; `cargo metadata --locked` accepts the lockfile.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>