### PR TITLE
chore: silence the two dead_code warnings of a default-features build

### DIFF
--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -204,6 +204,9 @@ pub struct NetworkSettings {
 	/// registration is the part podup owns. Whether a lookup for it then
 	/// *answers* is the container runtime's DNS, which is a different layer and
 	/// fails for its own reasons (#1330).
+	// Read only by the `test-helpers` inspection path (`test_container_aliases`),
+	// so a default-features build would warn that nothing reads it.
+	#[cfg_attr(not(feature = "test-helpers"), allow(dead_code))]
 	#[serde(rename = "Networks", default)]
 	pub networks: HashMap<String, NetworkAttachment>,
 }
@@ -212,6 +215,7 @@ pub struct NetworkSettings {
 #[derive(Deserialize, Default, Clone)]
 pub struct NetworkAttachment {
 	/// Names this container answers to on the network, when DNS is working.
+	#[cfg_attr(not(feature = "test-helpers"), allow(dead_code))]
 	#[serde(rename = "Aliases", default, deserialize_with = "null_default")]
 	pub aliases: Vec<String>,
 }


### PR DESCRIPTION
Fixes #1651. `cargo build` with default features, and with the Debian feature set, now prints no warnings; `--all-features` clippy unchanged.

This pull request is also the probe for CodeQL on `develop`: the classic branch protection rule for `develop` was created tonight, and default setup scans "main and protected branches". If a CodeQL check appears here, `develop` counts.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>