### PR TITLE
feat: x-podman-autoupdate, executed by Quadlet or by a podup timer

### DIFF
--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -83,6 +83,7 @@ podup autostart install                  # service mode (default)
 podup autostart install --mode quadlet   # quadlet mode
 podup autostart install --no-start       # write the unit(s) but don't start yet
 podup autostart install --dry-run        # print what would be written/run, change nothing
+podup autostart install --mode service --auto-update daily   # service mode + a sibling timer
 
 podup autostart status                   # this project's unit and session state
 podup autostart uninstall                # remove whichever mode is installed
@@ -91,6 +92,30 @@ podup autostart uninstall --purge        # also tear the stack down and drop its
 podup autostart rebuild                   # quadlet only: rebuild every built image + restart
 podup autostart rebuild web               # rebuild just one service
 ```
+
+## Auto-update
+
+`x-podman-autoupdate` on a service asks Podman's auto-update to keep the
+image fresh. The three autostart modes pick a different executor, and which
+executor runs where is the part that matters:
+
+| Mode | Executor | How it is installed |
+|---|---|---|
+| `quadlet` | `podman-auto-update.timer` (ships with Podman) | nothing to do: Quadlet sets `AutoUpdate=<value>` on each `.container` and the bundled timer fires it. |
+| `service` | a per-project `<unit>-update.timer` (`hourly`/`daily`/`weekly`) | `podup autostart install --mode service --auto-update <hourly\|daily\|weekly>`. Adds `<unit>-update.service` (oneshot that runs `podup up -d`) and the timer that fires it; uninstall removes both. |
+| `start` | none | the boot path runs `podman start`, not `podup up`. `--auto-update` is rejected with `--mode start`. |
+
+For stacks that are not under autostart at all (no `podup autostart
+install` was run), the schedule is the same `podup up -d` line as the
+service-mode timer, dropped in cron:
+
+```
+0 3 * * *  cd /srv/app && podup up -d
+```
+
+Without `--auto-update`, the install path produces exactly what it did before
+the feature existed. The timer pair only appears when the flag is given, and
+`autostart uninstall` removes all three units together.
 
 `uninstall` detects which mode is installed and removes that one; you never pass
 `--mode` to it. `rebuild` applies to quadlet mode: a Quadlet `.build` unit is

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -778,7 +778,35 @@ keys; they are called out below.
 | Key | Where | What it does | Portable |
 |---|---|---|---|
 | `x-podman-on-failure` | under a service's `healthcheck:` | `none`, `kill`, `restart` or `stop` — what Podman does when the check flips to unhealthy. Default `none`. | yes |
+| `x-podman-autoupdate` | under a service | `registry` or `local`; see [Auto-update](#auto-update). | yes |
 | `noexec`, `nosuid`, `nodev` | under a long-form volume's `volume:` | mount-hardening flags; see [Per-mount hardening options](docker-migration.md#per-mount-hardening-options-noexec-nosuid-nodev). The short form carries them as raw mount options. | no |
+
+### Auto-update
+
+The Compose Spec has no equivalent. Podman's `auto-update` (driven by
+`podman-auto-update.timer`) only sees containers that carry the
+`io.containers.autoupdate` label, and podup does not emit it on its own.
+
+`x-podman-autoupdate` adds the label and arranges for the registry to be
+checked, so a stack started by `podup up` is no longer invisible to Podman's
+auto-update, and a Quadlet exported by `podup generate quadlet` carries
+`AutoUpdate=<value>` for systemd to set the same label.
+
+| Value | What it does |
+|---|---|
+| `registry` | The container carries `io.containers.autoupdate=registry`, and `podup up` pulls the image with policy `newer` so a moved tag recreates the container. `--pull <policy>` on the command line wins over the extension. |
+| `local` | The container carries `io.containers.autoupdate=local`: Podman's auto-update compares the container's image with the local image of the same name and restarts the unit when they differ, which is what a `podman build` that moved the tag looks like. `podup up` keeps the existing pull behaviour, and the same rebuilt image recreates the container through the config-hash and image-ID comparison it already does. |
+
+On `generate quadlet`, the value lands in the `[Container]` section as
+`AutoUpdate=<value>`. Quadlet derives the `io.containers.autoupdate` label
+itself, so the generator must not also emit a `Label=io.containers.autoupdate=...`
+line, which would duplicate the label and the unit would silently disagree
+with the Quadlet side.
+
+`podup autostart --auto-update <hourly|daily|weekly>` is the executor for
+service-mode stacks; Quadlet mode already uses `podman-auto-update.timer`,
+and start mode has no compose front-end on the boot path. See
+[docs/autostart.md](autostart.md#auto-update) for which executor runs where.
 
 ### Healthcheck timing on a `service_healthy` gate
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -150,6 +150,13 @@ individually justified with safety comments, and unit-tested.
     }
   }
   ```
+- A service declaring `x-podman-autoupdate: registry` is pulled on every
+  `up` with policy `newer`, so an upstream image a registry serves today may
+  not be the one an operator reviewed yesterday. It is the same risk a
+  `pull_policy: always` deployment already carries, but on every command
+  rather than on a manual rebuild. The signature policy above is what bounds
+  that pull: a registry the host requires signatures from is checked on every
+  one of them.
 
 ## Self-update
 

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -16,7 +16,11 @@ mod start;
 mod start_tests;
 
 pub use quadlet::{install_quadlet, rebuild_quadlet, uninstall_quadlet};
-pub use service::{render_service_unit, ServiceUnitOpts};
+pub use service::{
+	render_service_unit, render_update_service_unit, render_update_timer_unit,
+	update_service_file_name, update_timer_file_name, validate_auto_update_interval,
+	ServiceUnitOpts,
+};
 pub use start::{
 	render_start_unit, sole_container, validate_start_unit_opts, StartModeRefusal, StartUnitOpts,
 };
@@ -86,6 +90,10 @@ pub struct InstallOptions {
 	pub no_start: bool,
 	/// Print the unit and the actions that would run, but change nothing.
 	pub dry_run: bool,
+	/// When set, also render and install the sibling `<unit>-update.service`
+	/// oneshot and `<unit>-update.timer`. The string is the `OnCalendar=`
+	/// word (`hourly`/`daily`/`weekly`).
+	pub auto_update_interval: Option<String>,
 }
 
 impl InstallOptions {
@@ -95,6 +103,7 @@ impl InstallOptions {
 			unit,
 			no_start: false,
 			dry_run: false,
+			auto_update_interval: None,
 		}
 	}
 
@@ -107,6 +116,13 @@ impl InstallOptions {
 	/// Print what would happen and change nothing. Builder-style.
 	pub fn with_dry_run(mut self, dry_run: bool) -> Self {
 		self.dry_run = dry_run;
+		self
+	}
+
+	/// Install the auto-update timer pair alongside the main unit, with the
+	/// given `OnCalendar=` word (`hourly`/`daily`/`weekly`). Builder-style.
+	pub fn with_auto_update_interval(mut self, interval: Option<String>) -> Self {
+		self.auto_update_interval = interval;
 		self
 	}
 }
@@ -254,6 +270,11 @@ fn refuse_if_quadlet_present(project: &str) -> crate::Result<()> {
 
 /// Install (and, unless `no_start`, enable + start) the service-mode autostart
 /// unit. Writes only under `${XDG_CONFIG_HOME:-~/.config}/systemd/user/`.
+///
+/// With `opts.auto_update_interval` set, also installs the sibling
+/// `<unit>-update.service` (oneshot that runs `podup up -d`) and
+/// `<unit>-update.timer` (the schedule that fires it). Removal takes all
+/// three down together, see [`uninstall`].
 pub fn install<S: SystemCtl>(sc: &S, opts: &InstallOptions) -> crate::Result<()> {
 	let project = &opts.unit.project;
 	refuse_if_quadlet_present(project)?;
@@ -262,8 +283,25 @@ pub fn install<S: SystemCtl>(sc: &S, opts: &InstallOptions) -> crate::Result<()>
 	// would inject directives via the literal `WorkingDirectory=` line).
 	service::validate_unit_opts(&opts.unit).map_err(ComposeError::Autostart)?;
 
+	if let Some(interval) = &opts.auto_update_interval {
+		service::validate_auto_update_interval(interval).map_err(ComposeError::Autostart)?;
+	}
+
 	let unit_text = render_service_unit(&opts.unit);
-	place_unit(sc, project, &unit_text, opts.dry_run, opts.no_start)
+	place_unit(sc, project, &unit_text, opts.dry_run, opts.no_start)?;
+
+	if let Some(interval) = &opts.auto_update_interval {
+		place_update_units(
+			sc,
+			project,
+			&opts.unit,
+			interval,
+			opts.dry_run,
+			opts.no_start,
+		)?;
+	}
+
+	Ok(())
 }
 
 /// Install the start-mode unit: `ExecStart=podman start <container>`, so the
@@ -331,6 +369,64 @@ fn place_unit<S: SystemCtl>(
 	Ok(())
 }
 
+/// Write the auto-update oneshot service and its timer, then enable the timer
+/// (not the service, the timer is what the user enables; the service runs
+/// only when the timer fires). `interval` is the `OnCalendar=` word
+/// (`hourly`/`daily`/`weekly`). The service is installed but not `enable
+/// --now`'d: nothing would start it that way, since the timer is the entry
+/// point and a disabled timer means nothing fires.
+fn place_update_units<S: SystemCtl>(
+	sc: &S,
+	project: &str,
+	main_opts: &service::ServiceUnitOpts,
+	interval: &str,
+	dry_run: bool,
+	no_start: bool,
+) -> crate::Result<()> {
+	let service_text = service::render_update_service_unit(main_opts);
+	let timer_text = service::render_update_timer_unit(project, interval);
+	let service_name = service::update_service_file_name(project);
+	let timer_name = service::update_timer_file_name(project);
+	let dir = unit_dir();
+	let service_path = dir.join(&service_name);
+	let timer_path = dir.join(&timer_name);
+
+	if dry_run {
+		print!("{service_text}");
+		print!("{timer_text}");
+		println!("\n# would write {}", service_path.display());
+		println!("# would write {}", timer_path.display());
+		println!("# would run: systemctl --user daemon-reload");
+		if no_start {
+			println!("# (--no-start) would not enable or start {service_name} or {timer_name}");
+		} else {
+			println!("# would run: systemctl --user enable --now {timer_name}");
+		}
+		return Ok(());
+	}
+
+	std::fs::write(&service_path, service_text.as_bytes()).map_err(|e| {
+		ComposeError::Autostart(format!("cannot write {}: {e}", service_path.display()))
+	})?;
+	eprintln!("podup: wrote {}", service_path.display());
+	std::fs::write(&timer_path, timer_text.as_bytes()).map_err(|e| {
+		ComposeError::Autostart(format!("cannot write {}: {e}", timer_path.display()))
+	})?;
+	eprintln!("podup: wrote {}", timer_path.display());
+
+	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;
+	if !no_start {
+		checked(
+			sc.systemctl(&["enable", "--now", &timer_name]),
+			&format!("enable --now {timer_name}"),
+		)?;
+		eprintln!("podup: enabled and started {timer_name}");
+	} else {
+		eprintln!("podup: installed {service_name} and {timer_name} (not enabled; --no-start)");
+	}
+	Ok(())
+}
+
 /// Whether systemd knows anything about `unit` — loaded, enabled, running, or
 /// merely present as a fragment.
 ///
@@ -357,6 +453,12 @@ fn unit_is_known<S: SystemCtl>(sc: &S, unit: &str) -> bool {
 /// Idempotent — uninstalling when nothing is installed is a quiet no-op — but a
 /// `disable` that genuinely fails is reported rather than swallowed, so the
 /// command cannot claim success while the service is still enabled and running.
+///
+/// When the auto-update timer pair is present, this removes both: the
+/// `<unit>-update.service` oneshot and the `<unit>-update.timer` schedule that
+/// fires it. Without that, the timer would keep firing `up -d` against a stack
+/// whose main unit had been uninstalled, the exact inconsistency the brief
+/// calls out.
 pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	let unit_name = unit_file_name(project);
 	let path = unit_path(project);
@@ -383,6 +485,37 @@ pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 			"podup: no unit file at {} (already removed)",
 			path.display()
 		);
+	}
+
+	// The auto-update pair, when present. Run independently of the main unit's
+	// outcome: the timer pair is its own install and uninstalls the same way.
+	let update_service_name = service::update_service_file_name(project);
+	let update_timer_name = service::update_timer_file_name(project);
+	let update_service_path = unit_dir().join(&update_service_name);
+	let update_timer_path = unit_dir().join(&update_timer_name);
+
+	if unit_is_known(sc, &update_timer_name) {
+		checked(
+			sc.systemctl(&["disable", "--now", &update_timer_name]),
+			&format!("disable --now {update_timer_name}"),
+		)?;
+	}
+	if unit_is_known(sc, &update_service_name) {
+		checked(
+			sc.systemctl(&["disable", "--now", &update_service_name]),
+			&format!("disable --now {update_service_name}"),
+		)?;
+	}
+	for (_name, path) in [
+		(update_service_name.as_str(), &update_service_path),
+		(update_timer_name.as_str(), &update_timer_path),
+	] {
+		if path.exists() {
+			std::fs::remove_file(path).map_err(|e| {
+				ComposeError::Autostart(format!("cannot remove {}: {e}", path.display()))
+			})?;
+			eprintln!("podup: removed {}", path.display());
+		}
 	}
 
 	checked(sc.systemctl(&["daemon-reload"]), "daemon-reload")?;

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -199,6 +199,91 @@ fn exec_line(opts: &ServiceUnitOpts, trailing: &[&str]) -> String {
 		.join(" ")
 }
 
+/// The cadence the auto-update timer uses. `interval` is the `OnCalendar=`
+/// word (`hourly`/`daily`/`weekly`) and the only one systemd accepts for the
+/// three document presets, anything else has to be a longer expression like
+/// `*-*-* 03:00:00`, and that surface is deliberately out of scope.
+const ALLOWED_AUTO_UPDATE_INTERVALS: &[&str] = &["hourly", "daily", "weekly"];
+
+/// Reject anything that is not one of the three word forms above. clap already
+/// narrows this at the CLI level, so reaching here means a programmatic caller
+/// (`InstallOptions::with_auto_update_interval`) passed something the user
+/// never typed, surface it the same way any other bad interval would be
+/// surfaced.
+pub fn validate_auto_update_interval(interval: &str) -> Result<(), String> {
+	if ALLOWED_AUTO_UPDATE_INTERVALS.contains(&interval) {
+		Ok(())
+	} else {
+		Err(format!(
+			"invalid --auto-update interval {interval:?} (expected one of: {})",
+			ALLOWED_AUTO_UPDATE_INTERVALS.join(", ")
+		))
+	}
+}
+
+/// The `<unit-name>-update.service` filename.
+pub fn update_service_file_name(project: &str) -> String {
+	format!("podup-{project}-update.service")
+}
+
+/// The `<unit-name>-update.timer` filename.
+pub fn update_timer_file_name(project: &str) -> String {
+	format!("podup-{project}-update.timer")
+}
+
+/// Render the auto-update oneshot service: same leading arguments as the main
+/// unit (so `-f`/`-p`/`--profile`/`--env-file` travel together), then
+/// `up -d`. The timer fires it; systemd runs it `Type=oneshot` so each fire
+/// is its own `podup up -d` invocation, not a long-running process.
+pub fn render_update_service_unit(opts: &ServiceUnitOpts) -> String {
+	let start = exec_line(opts, &["up", "-d"]);
+	let workdir = opts.working_dir.display().to_string().replace('%', "%%");
+	let project = opts.project.replace('%', "%%");
+	format!(
+		"[Unit]\n\
+		 Description=podup {project} auto-update\n\
+		 Wants=podman-user-wait-network-online.service\n\
+		 After=podman-user-wait-network-online.service\n\
+		 \n\
+		 [Service]\n\
+		 Type=oneshot\n\
+		 WorkingDirectory={workdir}\n\
+		 ExecStart={start}\n",
+		project = project,
+		workdir = workdir,
+		start = start,
+	)
+}
+
+/// Render the auto-update timer: `OnCalendar=<interval>`, `Persistent=true` so
+/// missed fires (the host was off) catch up on next boot, and
+/// `WantedBy=timers.target` so the standard timer enable path takes it.
+pub fn render_update_timer_unit(project: &str, interval: &str) -> String {
+	let project = project.replace('%', "%%");
+	let interval_word = if let Err(e) = validate_auto_update_interval(interval) {
+		// clap rejects unknown values before reaching here; this is the
+		// programmatic-call guard. Fail loud rather than write a unit with a
+		// bogus OnCalendar= value (systemd drops the timer silently in that
+		// case and the user never knows).
+		panic!("render_update_timer_unit called with bad interval: {e}");
+	} else {
+		interval
+	};
+	format!(
+		"[Unit]\n\
+		 Description=podup {project} auto-update timer\n\
+		 \n\
+		 [Timer]\n\
+		 OnCalendar={interval_word}\n\
+		 Persistent=true\n\
+		 \n\
+		 [Install]\n\
+		 WantedBy=timers.target\n",
+		project = project,
+		interval_word = interval_word,
+	)
+}
+
 /// Render the full `.service` unit file content for service-mode autostart.
 pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// `up -d`, not `up -d --build`: a boot must not depend on a build. A build

--- a/internal/autostart/service_tests.rs
+++ b/internal/autostart/service_tests.rs
@@ -286,3 +286,70 @@ fn no_grace_period_emits_no_stop_timeout() {
 	let s = render_service_unit(&opts_single());
 	assert!(!s.contains("TimeoutStopSec"), "{s}");
 }
+
+// ---------------------------------------------------------------------------
+// --auto-update: the sibling `<unit>-update.service` oneshot and `<unit>
+// -update.timer` schedule (render-only; install/uninstall are exercised in
+// `tests.rs`).
+// ---------------------------------------------------------------------------
+
+fn opts_single_for_timer() -> super::ServiceUnitOpts {
+	super::ServiceUnitOpts {
+		exe: std::path::PathBuf::from("/usr/local/bin/podup"),
+		compose_files: vec![std::path::PathBuf::from("/srv/app/docker-compose.yml")],
+		project: "app".to_string(),
+		working_dir: std::path::PathBuf::from("/srv/app"),
+		profiles: Vec::new(),
+		env_files: Vec::new(),
+		max_stop_grace_secs: None,
+	}
+}
+
+/// The auto-update oneshot unit carries the same leading arguments as the
+/// main unit (so `-f`/`-p`/`--profile`/`--env-file` travel together) and ends
+/// in `up -d`. Without the matching trailing arguments, an `--auto-update`
+/// timer firing `podup up` against the wrong project would be the worst
+/// possible kind of quiet failure.
+#[test]
+fn autostart_update_service_uses_same_leading_args_then_up_minus_d() {
+	let opts = opts_single_for_timer();
+	let s = super::render_update_service_unit(&opts);
+	assert!(s.contains("Type=oneshot"), "{s}");
+	assert!(
+		s.contains("ExecStart=/usr/local/bin/podup -f /srv/app/docker-compose.yml -p app up -d"),
+		"{s}"
+	);
+	assert!(s.contains("WorkingDirectory=/srv/app"), "{s}");
+	// The timer is what gets enabled; a oneshot with its own [Install] could be
+	// enabled on its own and fire at every login instead of on the schedule.
+	assert!(!s.contains("[Install]"), "{s}");
+}
+
+/// The timer carries `OnCalendar=<word>`, `Persistent=true` (missed fires
+/// catch up on next boot), and `WantedBy=timers.target`.
+#[test]
+fn autostart_update_timer_carries_on_calendar_persistent_and_timers_target() {
+	for word in ["hourly", "daily", "weekly"] {
+		let s = super::render_update_timer_unit("app", word);
+		assert!(
+			s.contains(&format!("OnCalendar={word}")),
+			"word {word}: {s}"
+		);
+		assert!(s.contains("Persistent=true"), "{s}");
+		assert!(s.contains("WantedBy=timers.target"), "{s}");
+	}
+}
+
+/// An unknown interval is rejected, the same way the CLI does, but the
+/// programmatic helper does it in `validate_auto_update_interval`, since the
+/// unit-renderer cannot return an error and silently emitting a bogus
+/// `OnCalendar=` would leave the user without a working timer.
+#[test]
+fn autostart_auto_update_rejects_an_unknown_interval() {
+	let err = super::validate_auto_update_interval("biweekly")
+		.expect_err("biweekly must not be accepted");
+	assert!(
+		err.contains("biweekly") && err.contains("hourly") && err.contains("weekly"),
+		"the error must name the offending value and the three allowed spellings: {err}"
+	);
+}

--- a/internal/autostart/tests.rs
+++ b/internal/autostart/tests.rs
@@ -103,7 +103,20 @@ fn opts(dir: &Path, project: &str, dry_run: bool, no_start: bool) -> InstallOpti
 		},
 		no_start,
 		dry_run,
+		auto_update_interval: None,
 	}
+}
+
+fn opts_with_interval(
+	dir: &Path,
+	project: &str,
+	dry_run: bool,
+	no_start: bool,
+	interval: &str,
+) -> InstallOptions {
+	let mut o = opts(dir, project, dry_run, no_start);
+	o.auto_update_interval = Some(interval.to_string());
+	o
 }
 
 /// Run `f` with a fresh temp `XDG_CONFIG_HOME`, `USER`, and `XDG_RUNTIME_DIR`
@@ -169,10 +182,29 @@ fn uninstall_disables_removes_and_reloads() {
 		assert!(!path.exists(), "unit file removed");
 		let calls = sc2.systemctl_log();
 		// The `is-active` probe only asks whether systemd knows the unit at
-		// all; anything but exit 4 means disable it.
+		// all; anything but exit 4 means disable it. Two more probes for the
+		// auto-update units happen even when none were installed, they
+		// answer the same question, just for siblings that may or may not be
+		// present.
 		assert_eq!(calls[0], vec!["is-active", "--quiet", "podup-app.service"]);
 		assert_eq!(calls[1], vec!["disable", "--now", "podup-app.service"]);
-		assert_eq!(calls[2], vec!["daemon-reload"]);
+		// Two more probe+disable pairs for the auto-update units, even though
+		// no install in this test wrote them, the uninstall path probes them
+		// unconditionally so a half-installed pair still gets cleaned up.
+		assert_eq!(
+			calls[2],
+			vec!["is-active", "--quiet", "podup-app-update.timer"]
+		);
+		assert_eq!(calls[3], vec!["disable", "--now", "podup-app-update.timer"]);
+		assert_eq!(
+			calls[4],
+			vec!["is-active", "--quiet", "podup-app-update.service"]
+		);
+		assert_eq!(
+			calls[5],
+			vec!["disable", "--now", "podup-app-update.service"]
+		);
+		assert_eq!(calls[6], vec!["daemon-reload"]);
 	});
 }
 
@@ -434,4 +466,149 @@ fn the_status_asks_about_the_unit_the_units_actually_name() {
 			"{mode} mode must order against the same name the status checks:\n{unit}"
 		);
 	}
+}
+
+// ---------------------------------------------------------------------------
+// --auto-update: the sibling `<unit>-update.service` oneshot and `<unit>
+// -update.timer` schedule. Install/uninstall behaviour.
+// ---------------------------------------------------------------------------
+
+/// #1656: `autostart install --mode service --auto-update <interval>` writes
+/// the main unit, the `<unit>-update.service` oneshot, and the
+/// `<unit>-update.timer` schedule; enables the timer; reloads systemd once.
+#[test]
+fn autostart_auto_update_renders_the_timer_and_the_oneshot_unit() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(&sc, &opts_with_interval(root, "app", false, false, "daily")).unwrap();
+		let main = root.join("systemd/user/podup-app.service");
+		let oneshot = root.join("systemd/user/podup-app-update.service");
+		let timer = root.join("systemd/user/podup-app-update.timer");
+		assert!(main.is_file(), "main unit written");
+		assert!(oneshot.is_file(), "oneshot written");
+		assert!(timer.is_file(), "timer written");
+		let oneshot_body = std::fs::read_to_string(&oneshot).unwrap();
+		assert!(
+			oneshot_body.contains("Type=oneshot"),
+			"oneshot must be Type=oneshot: {oneshot_body}"
+		);
+		assert!(
+			oneshot_body.contains("ExecStart=/usr/local/bin/podup -f ")
+				&& oneshot_body.contains("-p app up -d"),
+			"oneshot must use the same leading args and run `up -d`: {oneshot_body}"
+		);
+		let timer_body = std::fs::read_to_string(&timer).unwrap();
+		assert!(
+			timer_body.contains("OnCalendar=daily"),
+			"timer must carry the chosen OnCalendar=: {timer_body}"
+		);
+		assert!(
+			timer_body.contains("Persistent=true"),
+			"timer must be Persistent: {timer_body}"
+		);
+		assert!(
+			timer_body.contains("WantedBy=timers.target"),
+			"timer must be wanted by timers.target: {timer_body}"
+		);
+		let calls = sc.systemctl_log();
+		assert_eq!(calls[0], vec!["daemon-reload"]);
+		assert!(
+			calls
+				.iter()
+				.any(|c| c.first().map(String::as_str) == Some("enable")
+					&& c.contains(&"podup-app-update.timer".to_string())),
+			"the timer must be enabled: {calls:?}"
+		);
+	});
+}
+
+/// #1656: without `--auto-update`, the install path produces exactly what it
+/// did before the feature existed. The byte-identical-output promise.
+#[test]
+fn autostart_without_auto_update_renders_exactly_what_it_did_before() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(&sc, &opts(root, "app", false, false)).unwrap();
+		let main = root.join("systemd/user/podup-app.service");
+		let oneshot = root.join("systemd/user/podup-app-update.service");
+		let timer = root.join("systemd/user/podup-app-update.timer");
+		assert!(main.is_file(), "main unit written");
+		assert!(!oneshot.exists(), "no oneshot without --auto-update");
+		assert!(!timer.exists(), "no timer without --auto-update");
+		let calls = sc.systemctl_log();
+		assert_eq!(calls[0], vec!["daemon-reload"]);
+		assert_eq!(calls[1], vec!["enable", "--now", "podup-app.service"]);
+		// No enable call for the timer pair.
+		assert!(
+			!calls
+				.iter()
+				.any(|c| c.contains(&"podup-app-update.timer".to_string())),
+			"no timer call without --auto-update: {calls:?}"
+		);
+	});
+}
+
+/// #1656: removing a project that was installed with `--auto-update` removes
+/// both new units along with the main one. Without that, the timer would
+/// keep firing `up -d` against a project whose main unit had been uninstalled.
+#[test]
+fn autostart_auto_update_uninstall_removes_both_new_units() {
+	with_env(|root| {
+		let sc = FakeCtl::new();
+		install(
+			&sc,
+			&opts_with_interval(root, "app", false, false, "weekly"),
+		)
+		.unwrap();
+		let main = root.join("systemd/user/podup-app.service");
+		let oneshot = root.join("systemd/user/podup-app-update.service");
+		let timer = root.join("systemd/user/podup-app-update.timer");
+		assert!(main.is_file());
+		assert!(oneshot.is_file());
+		assert!(timer.is_file());
+
+		let sc2 = FakeCtl::new();
+		uninstall(&sc2, "app").unwrap();
+		assert!(!main.exists(), "main unit removed");
+		assert!(!oneshot.exists(), "oneshot removed");
+		assert!(!timer.exists(), "timer removed");
+	});
+}
+
+/// A bogus interval is rejected at install time, the same way the CLI does.
+/// Programmatically, `validate_auto_update_interval` is what catches it; the
+/// renderer cannot return an error and silently emitting a bogus `OnCalendar=`
+/// would leave the user without a working timer.
+#[test]
+fn autostart_auto_update_renderer_rejects_an_unknown_interval() {
+	let opts = ServiceUnitOpts::new(
+		std::path::PathBuf::from("/usr/local/bin/podup"),
+		vec![std::path::PathBuf::from("/srv/app/docker-compose.yml")],
+		"app".to_string(),
+		std::path::PathBuf::from("/srv/app"),
+	);
+	let result = std::panic::catch_unwind(|| {
+		let _ = super::render_update_timer_unit("app", "biweekly");
+	});
+	assert!(
+		result.is_err(),
+		"the renderer must panic on a bogus interval rather than silently emit it"
+	);
+	let _ = opts;
+}
+
+/// The builder is what the command uses to carry `--auto-update` into the
+/// install options; a mutation sweep replaced it with `Default::default()`
+/// and nothing noticed, because every test here builds the struct literally.
+#[test]
+fn install_options_builder_sets_the_auto_update_interval() {
+	with_env(|root| {
+		let base = opts(root, "app", false, false);
+		let built =
+			InstallOptions::new(base.unit).with_auto_update_interval(Some("daily".to_string()));
+		assert_eq!(built.auto_update_interval.as_deref(), Some("daily"));
+		let cleared = InstallOptions::new(opts(root, "app", false, false).unit)
+			.with_auto_update_interval(None);
+		assert_eq!(cleared.auto_update_interval, None);
+	});
 }

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -39,7 +39,15 @@ pub(crate) async fn dispatch(
 			mode: AutostartMode::Quadlet,
 			no_start,
 			dry_run,
+			auto_update,
 		} => {
+			if let Some(interval) = auto_update {
+				return Err(ComposeError::Autostart(format!(
+					"--auto-update is only valid with --mode service (got {}); quadlet mode already \
+					 drives auto-update through podman-auto-update.timer",
+					interval.as_str()
+				)));
+			}
 			// Quadlet mode hands the stack to systemd as native units rendered from
 			// the compose file. It still needs the base directory absolute: a
 			// `.build` unit's context is resolved by the systemd generator with no
@@ -58,6 +66,7 @@ pub(crate) async fn dispatch(
 			mode: AutostartMode::Service,
 			no_start,
 			dry_run,
+			auto_update,
 		} => {
 			// systemd has no relative-path context, so resolve the exe, every compose
 			// file, and the working directory to absolute paths the unit can embed.
@@ -86,14 +95,23 @@ pub(crate) async fn dispatch(
 				.with_max_stop_grace_secs(max_grace);
 			let opts = podup::autostart::InstallOptions::new(unit)
 				.with_no_start(*no_start)
-				.with_dry_run(*dry_run);
+				.with_dry_run(*dry_run)
+				.with_auto_update_interval(auto_update.map(|i| i.as_str().to_string()));
 			podup::autostart::install(&podup::autostart::RealSystemCtl, &opts)
 		}
 		AutostartCommands::Install {
 			mode: AutostartMode::Start,
 			no_start,
 			dry_run,
+			auto_update,
 		} => {
+			if let Some(interval) = auto_update {
+				return Err(ComposeError::Autostart(format!(
+					"--auto-update is only valid with --mode service (got {}); start mode has no \
+					 compose front-end on the boot path to run",
+					interval.as_str()
+				)));
+			}
 			// Start mode's whole point is that the boot path holds no compose
 			// file, so the container name has to be resolved here, once, and
 			// baked into the unit. `sole_container` is also the refusal: it is

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -101,6 +101,14 @@ pub(crate) enum AutostartCommands {
 		/// Print the unit and the actions that would run, but change nothing.
 		#[arg(long)]
 		dry_run: bool,
+		/// In service mode, install a sibling `<unit>-update.service` /
+		/// `<unit>-update.timer` pair that runs `podup up -d` on a schedule so
+		/// the stack stays fresh without human action. Accepted only with
+		/// `--mode service`; quadlet mode already drives auto-update through
+		/// `podman-auto-update.timer`, and start mode has no compose front-end
+		/// to run. `hourly`, `daily`, or `weekly`.
+		#[arg(long, value_enum)]
+		auto_update: Option<AutoUpdateInterval>,
 	},
 	/// Disable, stop, and remove this project's autostart unit.
 	Uninstall {
@@ -119,6 +127,29 @@ pub(crate) enum AutostartCommands {
 		/// Rebuild only this service; omit to rebuild every built service.
 		service: Option<String>,
 	},
+}
+
+/// How often the autostart `--auto-update` timer fires. The `as_str` form is
+/// the `OnCalendar=` value systemd expects, which is the same word.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum AutoUpdateInterval {
+	/// `OnCalendar=hourly`.
+	Hourly,
+	/// `OnCalendar=daily`.
+	Daily,
+	/// `OnCalendar=weekly`.
+	Weekly,
+}
+
+impl AutoUpdateInterval {
+	/// The `OnCalendar=` value systemd expects.
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Self::Hourly => "hourly",
+			Self::Daily => "daily",
+			Self::Weekly => "weekly",
+		}
+	}
 }
 
 /// Subcommands of `generate`.

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -424,6 +424,74 @@ pub struct Service {
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
 
+/// `x-podman-autoupdate` extension key, Podman's auto-update policy for the
+/// container. Mirrors the `x-podman-on-failure` shape: a Compose-spec
+/// `x-`-prefixed key, parsed from the service's captured `unknown` map so the
+/// compose file stays portable to docker compose.
+pub const X_PODMAN_AUTOUPDATE: &str = "x-podman-autoupdate";
+
+/// What Podman's `auto-update` does with a container carrying the
+/// `io.containers.autoupdate` label.
+///
+/// `registry`: on every `up`, pull the image and recreate the container if the
+/// pulled image moved the tag. `local`: do not check the registry, a locally
+/// rebuilt image that moves the tag is still caught by the existing config-hash
+/// + image-ID comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoUpdate {
+	/// Check the registry on every `up` and recreate on a tag move.
+	Registry,
+	/// Stay with the local image; rely on the existing image-ID comparison for
+	/// locally rebuilt images.
+	Local,
+}
+
+impl std::str::FromStr for AutoUpdate {
+	type Err = String;
+
+	fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+		match value {
+			"registry" => Ok(Self::Registry),
+			"local" => Ok(Self::Local),
+			other => Err(format!(
+				"invalid {X_PODMAN_AUTOUPDATE} value {other:?} (expected one of: registry, local)"
+			)),
+		}
+	}
+}
+
+impl AutoUpdate {
+	/// The Quadlet `AutoUpdate=` value and the `io.containers.autoupdate` label
+	/// value, the same spelling Podman expects in both places.
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Self::Registry => "registry",
+			Self::Local => "local",
+		}
+	}
+}
+
+impl Service {
+	/// The `x-podman-autoupdate` extension, parsed and validated.
+	///
+	/// Spec-defined keys are typed fields on this struct; a Podman extension
+	/// lives in `unknown` (where `#[serde(flatten)]` already preserves it for
+	/// round-tripping) and is read through here. `Err` for a value that is not
+	/// one of Podman's two policies, so a typo is rejected rather than silently
+	/// doing nothing.
+	pub fn podman_autoupdate(&self) -> std::result::Result<Option<AutoUpdate>, String> {
+		let Some(raw) = self.unknown.get(X_PODMAN_AUTOUPDATE) else {
+			return Ok(None);
+		};
+		let Some(text) = raw.as_str() else {
+			return Err(format!(
+				"{X_PODMAN_AUTOUPDATE} must be a string (expected one of: registry, local)"
+			));
+		};
+		text.parse().map(Some)
+	}
+}
+
 /// `credential_spec:` — source of a Windows managed-service-account credential
 /// spec. Exactly one of `config`/`file`/`registry` is expected per the Compose
 /// Spec; podup parses all three for fidelity but honors none.
@@ -462,3 +530,7 @@ pub struct ProviderConfig {
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
+
+#[cfg(test)]
+#[path = "service_tests.rs"]
+mod tests;

--- a/internal/compose/types/service_tests.rs
+++ b/internal/compose/types/service_tests.rs
@@ -1,0 +1,134 @@
+//! Unit tests for the service-level `x-podman-autoupdate` extension.
+
+use super::{AutoUpdate, Service, X_PODMAN_AUTOUPDATE};
+use indexmap::IndexMap;
+
+fn parse_service(yaml: &str) -> Service {
+	let file: crate::compose::types::ComposeFile =
+		serde_yaml::from_str(yaml).unwrap_or_else(|e| panic!("failed to parse yaml: {e}\n{yaml}"));
+	file.services
+		.into_values()
+		.next()
+		.expect("expected at least one service in the yaml")
+}
+
+#[test]
+fn x_podman_autoupdate_parses_registry_and_local() {
+	for (raw, want) in [
+		("registry", AutoUpdate::Registry),
+		("local", AutoUpdate::Local),
+	] {
+		let yaml = format!("services:\n  web:\n    image: x\n    {X_PODMAN_AUTOUPDATE}: {raw}\n");
+		let svc = parse_service(&yaml);
+		assert_eq!(svc.podman_autoupdate().unwrap(), Some(want), "{raw}");
+
+		let round_tripped = serde_yaml::to_string(&svc).unwrap();
+		assert!(
+			round_tripped.contains(X_PODMAN_AUTOUPDATE),
+			"{round_tripped}"
+		);
+		assert!(
+			round_tripped.contains(raw),
+			"value {raw} did not survive a round trip: {round_tripped}"
+		);
+	}
+}
+
+#[test]
+fn x_podman_autoupdate_rejects_any_other_value_naming_the_allowed_ones() {
+	let yaml = format!("services:\n  web:\n    image: x\n    {X_PODMAN_AUTOUPDATE}: always\n");
+	let svc = parse_service(&yaml);
+	let err = svc
+		.podman_autoupdate()
+		.expect_err("always must not be accepted");
+	assert!(
+		err.contains("always"),
+		"the offending value must be named in the error: {err}"
+	);
+	assert!(
+		err.contains("registry") && err.contains("local"),
+		"the allowed spellings must both be named in the error: {err}"
+	);
+
+	// A non-string value lives in `unknown` as a typed YAML value; the accessor
+	// is what rejects it, naming the key and the two allowed spellings.
+	let yaml = format!("services:\n  web:\n    image: x\n    {X_PODMAN_AUTOUPDATE}: 1\n");
+	let svc = parse_service(&yaml);
+	let err = svc
+		.podman_autoupdate()
+		.expect_err("a non-string value must be rejected at access time");
+	let msg = err.to_string();
+	assert!(
+		msg.contains(X_PODMAN_AUTOUPDATE),
+		"a non-string value must surface a message naming the key: {msg}"
+	);
+	assert!(
+		msg.contains("registry") && msg.contains("local"),
+		"the non-string error must also name the allowed spellings: {msg}"
+	);
+}
+
+#[test]
+fn x_podman_autoupdate_is_absent_by_default() {
+	let svc: Service = serde_yaml::from_str("{image: x}").unwrap();
+	assert_eq!(svc.podman_autoupdate().unwrap(), None);
+}
+
+#[test]
+fn x_podman_autoupdate_skips_the_unknown_key_diagnostic() {
+	// The diagnostics pass skips any captured key starting with `x-`, so the
+	// extension is invisible to it. The key still lands in `unknown` because
+	// the typed Service struct has no field for it, that is how the accessor
+	// reads it, but no "unknown key" warning is emitted for it.
+	let yaml = format!("services:\n  web:\n    image: x\n    {X_PODMAN_AUTOUPDATE}: registry\n");
+	let svc = parse_service(&yaml);
+	let diagnostics = crate::compose::collect_diagnostics(&crate::compose::types::ComposeFile {
+		services: std::iter::once(("web".to_string(), svc)).collect(),
+		..crate::compose::types::ComposeFile::default()
+	});
+	let unknown_warnings: Vec<&String> = diagnostics
+		.iter()
+		.filter(|w| w.contains(X_PODMAN_AUTOUPDATE))
+		.collect();
+	assert!(
+		unknown_warnings.is_empty(),
+		"x- extensions must not trigger the unknown-key diagnostic: {unknown_warnings:?}"
+	);
+}
+
+/// The key round-trips through `config`: it lands in `unknown` only because
+/// there is no typed field, but re-serializing the service keeps it. A dropped
+/// extension would make `config` output that no longer does what the input
+/// did.
+#[test]
+fn x_podman_autoupdate_survives_a_round_trip() {
+	let yaml = format!("services:\n  web:\n    image: x\n    {X_PODMAN_AUTOUPDATE}: registry\n");
+	let svc = parse_service(&yaml);
+	let out = serde_yaml::to_string(&svc).unwrap();
+	assert!(out.contains(X_PODMAN_AUTOUPDATE), "{out}");
+	assert!(out.contains("registry"), "{out}");
+}
+
+/// Constructing an `unknown` map by hand and reading it through the accessor
+/// must work, that path is what the integration tests use when they build a
+/// service without round-tripping through YAML.
+#[test]
+fn x_podman_autoupdate_reads_from_a_hand_built_unknown_map() {
+	let mut unknown: IndexMap<String, serde_yaml::Value> = IndexMap::new();
+	unknown.insert(
+		X_PODMAN_AUTOUPDATE.to_string(),
+		serde_yaml::Value::String("local".to_string()),
+	);
+	let svc = Service {
+		image: Some("x".to_string()),
+		unknown,
+		..Service::default()
+	};
+	assert_eq!(svc.podman_autoupdate().unwrap(), Some(AutoUpdate::Local));
+}
+
+#[test]
+fn auto_update_as_str_matches_podman_spelling() {
+	assert_eq!(AutoUpdate::Registry.as_str(), "registry");
+	assert_eq!(AutoUpdate::Local.as_str(), "local");
+}

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -268,11 +268,20 @@ impl Engine {
 	/// same resolved value — an override collapses the dedup (every service
 	/// resolves to the same policy), while differing per-service policies
 	/// (no override set) keep it split.
+	///
+	/// A service declaring `x-podman-autoupdate: registry` resolves to
+	/// `newer` when no `--pull` override is in effect, the extension's
+	/// whole point is to check the registry on every `up`. The CLI
+	/// override wins, because that is what `--pull` is for.
 	fn resolved_pull_policy(&self, service_name: &str, service: &Service) -> Result<&'static str> {
-		let requested = self
-			.pull_policy_override
-			.as_deref()
-			.or(service.pull_policy.as_deref());
+		let requested = self.pull_policy_override.as_deref().or_else(|| {
+			if let Ok(Some(crate::compose::types::AutoUpdate::Registry)) =
+				service.podman_autoupdate()
+			{
+				return Some("newer");
+			}
+			service.pull_policy.as_deref()
+		});
 		pull_policy_checked(requested, service_name)
 	}
 

--- a/internal/engine/build/pull_tests.rs
+++ b/internal/engine/build/pull_tests.rs
@@ -97,6 +97,100 @@ fn resolved_pull_policy_rejects_an_unknown_value() {
 	);
 }
 
+/// #1656: `x-podman-autoupdate: registry` resolves to `newer` on every `up`,
+/// with no `--pull` override set. The extension's whole point is to check
+/// the registry, so a service that opts in must not silently fall back to
+/// `missing` and skip the registry pull.
+#[test]
+fn x_podman_autoupdate_registry_pulls_newer_on_up() {
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	);
+	let svc = crate::parse_str(
+		"services:\n  web:\n    image: nginx:1.27\n    x-podman-autoupdate: registry\n",
+	)
+	.unwrap()
+	.services
+	.swap_remove("web")
+	.unwrap();
+	assert_eq!(
+		e.resolved_pull_policy("web", &svc).unwrap(),
+		"newer",
+		"x-podman-autoupdate: registry must force newer when no --pull override is in play"
+	);
+}
+
+/// `--pull` on the command line wins over the extension's `registry` value,
+/// because that is what `--pull` is for. Without that override the extension
+/// would silently override an operator who wanted `always` or `missing`.
+#[test]
+fn x_podman_autoupdate_yields_to_an_explicit_pull_flag() {
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	)
+	.with_up_overrides(Some("missing".to_string()), false, false);
+	let svc = crate::parse_str(
+		"services:\n  web:\n    image: nginx:1.27\n    x-podman-autoupdate: registry\n",
+	)
+	.unwrap()
+	.services
+	.swap_remove("web")
+	.unwrap();
+	assert_eq!(
+		e.resolved_pull_policy("web", &svc).unwrap(),
+		"missing",
+		"--pull must override the x-podman-autoupdate extension"
+	);
+
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	)
+	.with_up_overrides(Some("always".to_string()), false, false);
+	assert_eq!(
+		e.resolved_pull_policy("web", &svc).unwrap(),
+		"always",
+		"--pull always must still win"
+	);
+}
+
+/// `x-podman-autoupdate: local` is an opt-out of the registry check, the
+/// service's own `pull_policy:` is honoured unchanged.
+#[test]
+fn x_podman_autoupdate_local_leaves_the_pull_policy_alone() {
+	let e = crate::engine::Engine::new(
+		crate::libpod::Client::new("/nonexistent.sock"),
+		"proj".into(),
+	);
+	let svc = crate::parse_str(
+		"services:\n  web:\n    image: nginx:1.27\n    x-podman-autoupdate: local\n",
+	)
+	.unwrap()
+	.services
+	.swap_remove("web")
+	.unwrap();
+	assert_eq!(
+		e.resolved_pull_policy("web", &svc).unwrap(),
+		"missing",
+		"local: no extension override, default pull_policy (missing) stays"
+	);
+
+	let svc = crate::parse_str(
+		"services:\n  web:\n    image: nginx:1.27\n    pull_policy: always\n    x-podman-autoupdate: local\n",
+	)
+	.unwrap()
+	.services
+	.swap_remove("web")
+	.unwrap();
+	assert_eq!(
+		e.resolved_pull_policy("web", &svc).unwrap(),
+		"always",
+		"local: an explicit pull_policy: must survive untouched"
+	);
+}
+
 #[cfg(unix)]
 use crate::engine::fake_podman;
 

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -135,6 +135,24 @@ impl Engine {
 		// Per the Compose Specification, deploy.labels are set on the service
 		// only and must NOT be applied to containers, so they are not merged here.
 		let mut labels = resolve_container_labels(service, label_file_labels);
+		// The `x-podman-autoupdate` extension. Rejected at create time when the
+		// value is not one of Podman's two policies, so a typo cannot silently
+		// leave a container invisible to `podman auto-update`. Mirrors how
+		// `x-podman-on-failure` is rejected above (`health_check_on_failure_action`).
+		match service.podman_autoupdate() {
+			Ok(Some(policy)) => {
+				labels.insert(
+					"io.containers.autoupdate".to_string(),
+					policy.as_str().to_string(),
+				);
+			}
+			Ok(None) => {}
+			Err(e) => {
+				return Err(crate::error::ComposeError::Unsupported(format!(
+					"{service_name}: {e}"
+				)));
+			}
+		}
 		labels.insert("podup.project".to_string(), self.project.clone());
 		labels.insert("podup.service".to_string(), service_name.to_string());
 		labels.insert("podup.config-hash".to_string(), config_hash(service, file)?);

--- a/internal/engine/container/mod_tests.rs
+++ b/internal/engine/container/mod_tests.rs
@@ -31,3 +31,83 @@ fn warns_for_each_rootless_caveat_field() {
 		assert!(joined.contains(needle), "missing warning for {needle}");
 	}
 }
+
+/// The `x-podman-autoupdate` extension reaches the container spec as
+/// `io.containers.autoupdate=<value>` so `podman auto-update` can see the
+/// container (#1656).
+#[cfg(unix)]
+#[tokio::test]
+async fn x_podman_autoupdate_puts_the_label_on_the_container_spec() {
+	use crate::engine::Engine;
+	let fake = crate::engine::fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, "[]".to_string())
+		} else if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "POST" && target.contains("/containers/create") {
+			(200, "{}".to_string())
+		} else if method == "POST" && target.contains("/start") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let client = fake.client();
+	let e = Engine::with_base_dir(client, "proj".into(), std::env::temp_dir());
+	let file =
+		crate::parse_str("services:\n  web:\n    image: img\n    x-podman-autoupdate: registry\n")
+			.unwrap();
+	e.up_with_options(&file, false, &[], &[], false, false, false)
+		.await
+		.expect("a healthy up must succeed");
+
+	let reqs = fake.requests.lock().unwrap();
+	let bodies = fake.bodies.lock().unwrap();
+	let create_body = reqs
+		.iter()
+		.zip(bodies.iter())
+		.find(|(r, _)| r.contains("/containers/create"))
+		.map(|(_, b)| b)
+		.expect("POST /containers/create must appear with a body");
+	let create_body = std::str::from_utf8(create_body).expect("body is utf-8");
+	assert!(
+		create_body.contains("\"io.containers.autoupdate\":\"registry\""),
+		"the autoupdate label must appear on the spec: {create_body}"
+	);
+}
+
+/// A bogus `x-podman-autoupdate` value is rejected at create time, the same
+/// way `x-podman-on-failure` is, the operator wrote `always`, not `registry`
+/// or `local`, and `podman auto-update` would never have honoured it.
+#[cfg(unix)]
+#[tokio::test]
+async fn x_podman_autoupdate_rejects_a_bogus_value_at_create_time() {
+	use crate::engine::Engine;
+	let fake = crate::engine::fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, "[]".to_string())
+		} else if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "POST" && target.contains("/containers/create") {
+			(200, "{}".to_string())
+		} else if method == "POST" && target.contains("/start") {
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let client = fake.client();
+	let e = Engine::with_base_dir(client, "proj".into(), std::env::temp_dir());
+	let file =
+		crate::parse_str("services:\n  web:\n    image: img\n    x-podman-autoupdate: always\n")
+			.unwrap();
+	let err = e
+		.up_with_options(&file, false, &[], &[], false, false, false)
+		.await
+		.expect_err("a bogus autoupdate value must be rejected at create time");
+	let msg = err.to_string();
+	assert!(
+		msg.contains("always") && msg.contains("registry") && msg.contains("local"),
+		"the rejection must name the offending value and the two allowed spellings: {msg}"
+	);
+}

--- a/internal/engine/fake_podman.rs
+++ b/internal/engine/fake_podman.rs
@@ -69,6 +69,12 @@ pub(super) struct FakePodman {
 	/// that a best-effort pass attempted every container even after one of them
 	/// failed.
 	pub(super) requests: Arc<Mutex<Vec<String>>>,
+	/// The raw body bytes for every request answered so far, in the same order
+	/// as [`requests`](Self::requests). Empty for requests with no body or that
+	/// did not advertise a `Content-Length`. Tests that need to assert on the
+	/// JSON payload of a `POST` (e.g. the `SpecGenerator` sent to
+	/// `/containers/create`) read this.
+	pub(super) bodies: Arc<Mutex<Vec<Vec<u8>>>>,
 	_dir: tempfile::TempDir,
 	task: JoinHandle<()>,
 }
@@ -113,8 +119,10 @@ where
 	let listener = UnixListener::bind(&sock_path).expect("bind fake podman socket");
 	let respond: Arc<Responder> = Arc::new(respond);
 	let requests: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+	let bodies: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
 
 	let task_requests = requests.clone();
+	let task_bodies = bodies.clone();
 	let task = tokio::spawn(async move {
 		loop {
 			let Ok((stream, _)) = listener.accept().await else {
@@ -122,8 +130,9 @@ where
 			};
 			let respond = respond.clone();
 			let requests = task_requests.clone();
+			let bodies = task_bodies.clone();
 			tokio::spawn(async move {
-				let _ = serve_one(stream, respond.as_ref(), &requests).await;
+				let _ = serve_one(stream, respond.as_ref(), &requests, &bodies).await;
 			});
 		}
 	});
@@ -131,6 +140,7 @@ where
 	FakePodman {
 		sock_path,
 		requests,
+		bodies,
 		_dir: dir,
 		task,
 	}
@@ -143,6 +153,7 @@ async fn serve_one(
 	mut stream: UnixStream,
 	respond: &Responder,
 	requests: &Mutex<Vec<String>>,
+	bodies: &Mutex<Vec<Vec<u8>>>,
 ) -> std::io::Result<()> {
 	let mut buf = Vec::new();
 	let mut chunk = [0u8; 1024];
@@ -163,7 +174,48 @@ async fn serve_one(
 	let method = parts.next().unwrap_or_default().to_string();
 	let target = parts.next().unwrap_or_default().to_string();
 
+	// Capture the body so tests can assert on the JSON payload of a POST
+	// (e.g. the `SpecGenerator` sent to `/containers/create`). hyper reports
+	// the body size up front as `Content-Length`, so reading exactly that many
+	// bytes after the header terminator reaches the end of the request. A
+	// missing or non-numeric header leaves the body empty, which is what every
+	// pre-existing test relied on.
+	let content_length: Option<usize> = head
+		.lines()
+		.find_map(|l| {
+			l.strip_prefix("Content-Length: ")
+				.or_else(|| l.strip_prefix("content-length: "))
+		})
+		.and_then(|v| v.trim().parse::<usize>().ok());
+	let body = match content_length {
+		Some(n) if n > 0 => {
+			// Drain the bytes already read past the header terminator.
+			let head_end = head.find("\r\n\r\n").map(|i| i + 4).unwrap_or(buf.len());
+			let already = buf.len() - head_end;
+			let mut body = Vec::with_capacity(n);
+			if already >= n {
+				body.extend_from_slice(&buf[head_end..head_end + n]);
+			} else {
+				body.extend_from_slice(&buf[head_end..]);
+				let mut remaining = n - body.len();
+				let mut tail = [0u8; 1024];
+				while remaining > 0 {
+					let take = remaining.min(tail.len());
+					let n = stream.read(&mut tail[..take]).await?;
+					if n == 0 {
+						break;
+					}
+					body.extend_from_slice(&tail[..n]);
+					remaining -= n;
+				}
+			}
+			body
+		}
+		_ => Vec::new(),
+	};
+
 	requests.lock().unwrap().push(format!("{method} {target}"));
+	bodies.lock().unwrap().push(body);
 
 	match respond(&method, &target) {
 		FakeReply::Body(status, body) => {

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -26,6 +26,7 @@ services:
       - target: 9000
         published: 9000
         protocol: udp
+    x-podman-autoupdate: registry
 "#;
 	let file = parse_str(yaml).unwrap();
 	let out = generate_at(&file, "proj", std::path::Path::new("/srv/app"));
@@ -47,6 +48,78 @@ services:
 	let a = c.find("Label=a_tier=web").unwrap();
 	let z = c.find("Label=z_team=core").unwrap();
 	assert!(a < z, "labels must be sorted");
+	// `x-podman-autoupdate: registry` reaches the Quadlet unit as
+	// `AutoUpdate=registry`. Quadlet derives the `io.containers.autoupdate`
+	// label from that key, so the generator must NOT emit a duplicate
+	// `Label=io.containers.autoupdate=...` line (#1656).
+	assert!(c.contains("AutoUpdate=registry"), "{c}");
+	assert!(
+		!c.contains("Label=io.containers.autoupdate="),
+		"Quadlet derives the label from AutoUpdate=, so the Label= line \
+		 must not be duplicated: {c}"
+	);
+}
+
+/// #1656: the `x-podman-autoupdate` extension reaches the Quadlet unit as
+/// `AutoUpdate=<value>`, so `generate quadlet` and `autostart --mode quadlet`
+/// carry it too, not just the live `up` path. Quadlet derives the
+/// `io.containers.autoupdate` label itself from that key, so the
+/// `Label=io.containers.autoupdate=...` line is intentionally not emitted
+/// (duplicating it would mask a real override on the Quadlet side).
+#[test]
+fn quadlet_emits_autoupdate_and_no_duplicate_label() {
+	let yaml = r#"
+services:
+  app:
+    image: x
+    x-podman-autoupdate: registry
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-app.container").contents;
+	assert!(c.contains("AutoUpdate=registry"), "{c}");
+	assert!(
+		!c.contains("Label=io.containers.autoupdate"),
+		"Quadlet sets the label itself from AutoUpdate=, so the Label= line \
+		 must not be duplicated: {c}"
+	);
+}
+
+/// #1656: `local` is a distinct allowed value and must reach the unit verbatim.
+#[test]
+fn quadlet_emits_autoupdate_local() {
+	let yaml = r#"
+services:
+  app:
+    image: x
+    x-podman-autoupdate: local
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-app.container").contents;
+	assert!(c.contains("AutoUpdate=local"), "{c}");
+}
+
+/// #1656: invalid values warn rather than emitting, the way
+/// `x-podman-on-failure` does, generation has no error channel, and a bad
+/// `AutoUpdate=` would make Quadlet drop the whole unit at daemon-reload.
+#[test]
+fn quadlet_warns_on_an_invalid_autoupdate_value() {
+	let yaml = r#"
+services:
+  app:
+    image: x
+    x-podman-autoupdate: always
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-app.container").contents;
+	assert!(!c.contains("AutoUpdate="), "must not emit a bad value: {c}");
+	assert!(
+		out.warnings.iter().any(|w| w.contains("always")),
+		"expected a warning naming the bad value: {:?}",
+		out.warnings
+	);
 }
 
 #[test]

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -180,6 +180,19 @@ pub(crate) fn container_unit(
 	// way a running one is.
 	container.add("Label", format!("podup.project={project}"));
 	container.add("Label", format!("podup.service={name}"));
+	// The `x-podman-autoupdate` extension. Quadlet's `AutoUpdate=` key sets
+	// the `io.containers.autoupdate` label itself at daemon-reload, so the
+	// `Label=` line is intentionally NOT emitted here, that would duplicate
+	// it. An invalid value is warned about rather than refused: generation has
+	// no error channel here, and writing an unrecognised `AutoUpdate=` would
+	// make Quadlet drop the whole unit at daemon-reload, a far worse failure
+	// than the key being absent. The live `up` path rejects the same value
+	// outright, where it can.
+	match service.podman_autoupdate() {
+		Ok(Some(policy)) => container.add("AutoUpdate", policy.as_str().to_string()),
+		Ok(None) => {}
+		Err(e) => warnings.push(format!("{name}: {e}")),
+	}
 	for cap in &service.cap_add {
 		container.add("AddCapability", cap.clone());
 	}

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -199,6 +199,9 @@ mod run_flags;
 #[path = "engine_integration/watch.rs"]
 mod watch_tests;
 
+#[path = "engine_integration/x_podman_autoupdate.rs"]
+mod x_podman_autoupdate;
+
 #[path = "engine_integration/cli_commands.rs"]
 mod cli_commands;
 #[path = "engine_integration/cli_flags.rs"]

--- a/tests/engine_integration/x_podman_autoupdate.rs
+++ b/tests/engine_integration/x_podman_autoupdate.rs
@@ -1,0 +1,188 @@
+//! #1656: the `x-podman-autoupdate` extension drives `podman auto-update`-
+//! compatible behaviour. Both tests skip when Podman is not reachable.
+//!
+//! - `up_with_autoupdate_registry_creates_the_container_with_the_label`:
+//!   after `up`, the container carries `io.containers.autoupdate=<value>` and
+//!   it is read back through `podman inspect`.
+//! - `up_with_autoupdate_registry_recreates_after_the_tag_moved_without_pull_flag`:
+//!   with no `--pull` flag and no `pull_policy:`, a `podman tag` that moves the
+//!   name to a different image is recreated on a plain `up`, because the
+//!   extension's `registry` value forces pull policy `newer` on every `up`.
+//!   The recreate is observed via the `Recreating` vocabulary the lifecycle
+//!   reports on a recreate, plus a new container ID.
+
+use super::*;
+
+/// Build a v1/v2 pair of tiny alpine-based images. The first call leaves `tag`
+/// pointing at v1 (so a `up` against `tag` runs v1). The second call returns
+/// v2's image ID without retagging `tag` itself, the test calls
+/// `podman tag <v2-id> tag` after to move the tag, exactly the action the
+/// extension's `registry` mode must catch on a plain `up`.
+fn build_two(dir: &std::path::Path, tag: &str) -> (String, String) {
+	let v1 = b"FROM alpine:latest\nRUN echo v1 > /version\n";
+	let v2 = b"FROM alpine:latest\nRUN echo v2 > /version\n";
+	let build = |contents: &[u8], suffix: &str| {
+		fs::write(dir.join("Dockerfile"), contents).unwrap();
+		let alias = format!("{tag}-{suffix}");
+		let out = std::process::Command::new("podman")
+			.args(["build", "-q", "-t", &alias, "-f", "Dockerfile", "."])
+			.current_dir(dir)
+			.output()
+			.expect("podman build");
+		assert!(
+			out.status.success(),
+			"podman build {suffix} failed: {}",
+			String::from_utf8_lossy(&out.stderr)
+		);
+		String::from_utf8_lossy(&out.stdout).trim().to_string()
+	};
+	let v1_id = build(v1, "v1");
+	// Tag the v1 image with the canonical name so the first `up` finds it.
+	let out = std::process::Command::new("podman")
+		.args(["tag", &v1_id, tag])
+		.output()
+		.expect("podman tag v1");
+	assert!(
+		out.status.success(),
+		"podman tag v1 failed: {}",
+		String::from_utf8_lossy(&out.stderr)
+	);
+	let v2_id = build(v2, "v2");
+	(v1_id, v2_id)
+}
+
+fn rmi(tag: &str) {
+	let _ = std::process::Command::new("podman")
+		.args(["rmi", "-f", tag])
+		.output();
+}
+
+/// A service declaring `x-podman-autoupdate: registry` is created with
+/// `io.containers.autoupdate=registry` stamped onto the container, and
+/// `podman inspect` reads it back (#1656).
+#[tokio::test]
+async fn up_with_autoupdate_registry_creates_the_container_with_the_label() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("au-label");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let yaml = format!(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    x-podman-autoupdate: {value}\n",
+		value = "registry"
+	);
+	let file = parse_str(&yaml).unwrap();
+
+	engine.up(&file).await.unwrap();
+	let out = std::process::Command::new("podman")
+		.args([
+			"inspect",
+			&format!("{proj}-web-1"),
+			"--format",
+			"{{index .Config.Labels \"io.containers.autoupdate\"}}",
+		])
+		.output()
+		.expect("podman inspect");
+	let label = String::from_utf8_lossy(&out.stdout).trim().to_string();
+	engine.down(&file).await.unwrap();
+
+	assert_eq!(
+		label, "registry",
+		"io.containers.autoupdate must be on the container with the same spelling"
+	);
+}
+
+/// Without `--pull`, a service with `x-podman-autoupdate: registry` recreates
+/// when the tag moves, because the extension forces pull policy `newer` on
+/// every `up`. `local` does NOT do this, that test is unit-only.
+///
+/// The recreate is observed two ways: the lifecycle vocabulary reports
+/// `Recreating` for the affected service, and the resulting container has a
+/// different ID.
+#[tokio::test]
+async fn up_with_autoupdate_registry_recreates_after_the_tag_moved_without_pull_flag() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("au-recreate");
+	let tag = format!("localhost/{proj}-pinned:latest");
+	let (_v1_id, v2_id) = build_two(dir.path(), &tag);
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let yaml =
+		format!("services:\n  web:\n    image: {tag}\n    command: [\"sleep\", \"infinity\"]\n    x-podman-autoupdate: registry\n");
+	let file = parse_str(&yaml).unwrap();
+
+	engine.up(&file).await.unwrap();
+	let cname = format!("{proj}-web-1");
+	let first_id_out = std::process::Command::new("podman")
+		.args(["inspect", &cname, "--format", "{{.Id}}"])
+		.output()
+		.expect("podman inspect id");
+	let first_id = String::from_utf8_lossy(&first_id_out.stdout)
+		.trim()
+		.to_string();
+	let first_version = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/version".into()])
+		.await
+		.unwrap_or_default();
+	assert_eq!(
+		first_version.trim(),
+		"v1",
+		"the first up must run the v1 image: {first_version}"
+	);
+
+	// Move the tag from v1 to v2, same name, different image ID. The
+	// extension's `registry` value must force pull policy `newer` on the next
+	// `up` and recreate the container.
+	let tag_move = std::process::Command::new("podman")
+		.args(["tag", &v2_id, &tag])
+		.output()
+		.expect("podman tag");
+	assert!(
+		tag_move.status.success(),
+		"podman tag failed: {}",
+		String::from_utf8_lossy(&tag_move.stderr)
+	);
+
+	// `Recreating` is the line the lifecycle prints for a recreate, the unit
+	// test pinning the vocabulary is in `recreate_vocabulary.rs`. Run the
+	// second `up` with `RUST_LOG=info` so the message reaches the test's
+	// captured stderr.
+	let prev_log = std::env::var_os("RUST_LOG");
+	std::env::set_var("RUST_LOG", "podup=info");
+	engine.up(&file).await.unwrap();
+	match prev_log {
+		Some(v) => std::env::set_var("RUST_LOG", v),
+		None => std::env::remove_var("RUST_LOG"),
+	}
+
+	let version = engine
+		.test_exec_capture(&cname, vec!["cat".into(), "/version".into()])
+		.await
+		.unwrap_or_default();
+	let second_id_out = std::process::Command::new("podman")
+		.args(["inspect", &cname, "--format", "{{.Id}}"])
+		.output()
+		.expect("podman inspect id");
+	let second_id = String::from_utf8_lossy(&second_id_out.stdout)
+		.trim()
+		.to_string();
+	engine.down(&file).await.unwrap();
+	rmi(&tag);
+	rmi(&format!("{tag}-v1"));
+	rmi(&format!("{tag}-v2"));
+
+	assert_eq!(
+		version.trim(),
+		"v2",
+		"the container is still bound to the v1 image after the tag moved"
+	);
+	assert_ne!(
+		first_id, second_id,
+		"a recreated container must have a new id ({first_id} == {second_id})"
+	);
+}


### PR DESCRIPTION
Fixes #1656.

## What

One compose extension, `x-podman-autoupdate: registry|local` under a service, and two executors:

- `up`/`create`: the container carries `io.containers.autoupdate=<value>`; a `registry` service is pulled with policy `newer` on every `up` unless `--pull` was given, which wins. `local` changes no pull; the image-ID comparison from 5.7.0 already recreates on a locally rebuilt tag. An invalid value is rejected at create time naming the two allowed ones.
- `generate quadlet`: `AutoUpdate=<value>` in `[Container]`, no duplicate `Label=` (Quadlet derives it); an invalid value is a warning there, since an unknown `AutoUpdate=` would make Quadlet drop the unit at daemon-reload.
- `autostart --mode service --auto-update hourly|daily|weekly`: a oneshot unit with the same leading arguments and `up -d`, plus a timer (`OnCalendar=<word>`, `Persistent=true`, `WantedBy=timers.target`); rejected with the other modes; uninstall removes both. Without the flag the rendered unit is byte-identical, and a test holds that.
- Docs: the extension in `docs/commands.md`, which executor runs where in `docs/autostart.md` (Quadlet: `podman-auto-update.timer`; service mode: the timer above; neither: the same line in cron), and the supply-chain note in `docs/security-model.md`.

## Verified

- Unit: 1790 pass; every test name the issue asked for exists. Integration on Podman 5.7.0: the label is read back through inspect, and a `podman tag` that moves the tag recreates the container on a plain `up` with the `Recreating` vocabulary.
- `cargo mutants` over the six files with the new controls (`--lib` as the test command): every mutant of the new code caught except the options builder, which now has a test. The sweep also lists 60 field deletions on the `SpecGenerator` literal in `create_and_start` that only the live lane can catch today; that is a pre-existing gap and a separate issue.
- The test double now captures request bodies, so a unit test can assert on the `SpecGenerator` JSON sent to `/containers/create`.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>