### PR TITLE
feat: podup audit, one row per service naming the hardening it did not ask for

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -620,6 +620,64 @@ still wins over an earlier one, and a bare `KEY` stays valueless because it mean
 | `--no-interpolate` | Leave `${VAR}` placeholders literal. | off |
 | `--resolve-image-digests` | Rewrite each service `image:` to its registry digest (`repo@sha256:...`). | off |
 
+### `audit`
+
+Print one row per service listing every hardening gap the compose file leaves
+open. The `audit` command is read-only and never contacts Podman; no check
+changes what `up` does. The same loading path as `config` is used, so
+`--profile`, `--env-file` and `-f` resolve identically, and `audit` reports
+what `up` would actually start.
+
+The default output is a table:
+
+```
+$ podup audit
+SERVICE  FINDINGS
+api      writable_root no_new_privileges_off secret_in_environment
+db       -
+  api: writable_root: read_only is not true: the container's root filesystem is writable
+  api: no_new_privileges_off: security_opt is missing no-new-privileges:true: setuid binaries may regain privileges
+  api: secret_in_environment: environment: DB_PASSWORD carries a hard-coded value; move it to secrets:
+```
+
+A service with no findings shows `-` in the `FINDINGS` column; a project
+with no findings at all prints `no findings` and nothing else.
+
+`--format json` emits a single machine-readable object so CI can pin the
+shape and grep the `check` ids:
+
+```
+{"findings":[{"service":"api","check":"writable_root","reason":"..."}, ...]}
+```
+
+The keys are alphabetically ordered; an empty list is `{"findings":[]}`,
+never `null`.
+
+`--strict` exits 1 when at least one finding is present (otherwise exits
+0), so a CI job can gate on `podup audit --strict` and fail when hardening
+gaps are introduced.
+
+The eleven checks and what they look for:
+
+| Check id | Fires when | Notes |
+|---|---|---|
+| `privileged` | `privileged: true` | Grants extended host privileges; under rootless Podman reduced but never incidental. |
+| `host_namespace` | `network_mode: host`, or `pid`/`ipc`/`uts`/`cgroup`/`userns_mode: host` | One finding per active mode. |
+| `dangerous_capability` | `cap_add` contains `SYS_ADMIN` or `ALL` | Effectively grants root inside the container. |
+| `writable_root` | `read_only` is not `true` | Compose's default is writable. |
+| `no_cap_drop_all` | `cap_drop` does not contain `ALL` | Without it the runtime's default capability set stays. |
+| `no_new_privileges_off` | `security_opt` lacks `no-new-privileges:true` | Both spellings (`no-new-privileges:true` and `no-new-privileges` alone, the Podman form) are accepted. |
+| `no_pids_limit` | `pids_limit` unset | A fork bomb can exhaust the host's process table. |
+| `no_memory_limit` | Neither `mem_limit` nor `deploy.resources.limits.memory` set | A leak can OOM the host. |
+| `no_userns` | `userns_mode` unset | Without it Podman's `auto` applies; the reason links to `docs/docker-migration.md`. |
+| `secret_in_environment` | `environment:` key matching `PASSWORD`/`SECRET`/`TOKEN`/`KEY` (case-insensitive) with a non-empty literal value | Bare keys (host inheritance) and `${VAR}` placeholders are not flagged. |
+| `unpinned_image` | `image:` with no tag, with tag `latest`, or `latest` without a digest | An `@sha256:` digest counts as pinning regardless of the tag. |
+
+| Flag | Description | Default |
+|---|---|---|
+| `--format <FMT>` | `table` (default) or `json`. | `table` |
+| `--strict` | Exit 1 when any finding is present, 0 otherwise. | off |
+
 ### `completions <SHELL>`
 Print a shell completion script to stdout for `bash`, `zsh`, `fish`,
 `powershell`, or `elvish`. The Debian package installs the bash/zsh/fish files

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -58,6 +58,16 @@ The compose keys that constrain a container are translated onto Podman's
 dropped. Everything below remains bounded by the rootless ceiling: a key can
 only tighten, never widen, what the launching user already has.
 
+A `podup audit [-f ...] [--strict]` subcommand reads the project the same way
+`config` does and prints, for each service, which of those keys the file did
+not set: host-binding namespacing modes, missing `read_only: true`, missing
+`cap_drop: [ALL]`, missing `security_opt: [no-new-privileges:true]`,
+missing `pids_limit`, missing memory limit, missing `userns_mode`, secrets in
+`environment:` instead of `secrets:`, and unpinned `:latest` images. The
+check list and exit codes are documented in
+[commands.md](commands.md#audit); `audit` never changes what `up` does, so it
+can be added to a CI gate without altering runtime behaviour.
+
 - `security_opt` is parsed into the matching SpecGenerator fields:
   - `no-new-privileges` → `no_new_privileges`
   - `seccomp=<profile.json>` (and `seccomp=unconfined`) → `seccomp_profile_path`

--- a/internal/audit/audit_tests.rs
+++ b/internal/audit/audit_tests.rs
@@ -1,0 +1,225 @@
+use podup::parse_str;
+
+use crate::audit;
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+// Pull the names this test file reaches for into scope so the body reads as
+// straight assertions rather than naming the path every line.
+#[allow(unused_imports)]
+use super::{
+	audit_file, ordered_services, render_json, render_table, AuditReport, Finding as _, Finding,
+};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+/// Parse `yaml` and return the only service. Panics if zero or >1, every
+/// check test targets a single-service file. Kept private to the module so
+/// no other file grows a dependency on this shape.
+fn single_service(yaml: &str) -> (String, podup::compose::types::Service) {
+	let file = parse_str(yaml).expect("compose parses");
+	let mut iter = file.services.into_iter();
+	let (name, svc) = iter.next().expect("at least one service");
+	assert!(iter.next().is_none(), "test should target one service");
+	(name, svc)
+}
+
+/// Find a finding for `service` whose check id equals `check`. Returns `None`
+/// when no such finding exists. Many tests use this as a list
+/// non-membership test (the early return they wanted was "no finding", the
+/// absence is the assertion).
+fn has_check(report: &AuditReport, service: &str, check: &str) -> bool {
+	report
+		.findings
+		.iter()
+		.any(|f| f.service == service && f.check == check)
+}
+
+// ---------------------------------------------------------------------------
+// Top-level run sanity: a fully hardened service has no findings.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_fully_hardened_service_has_no_findings() {
+	// The issue spells the list of keys a hardened service needs; this
+	// combines every one of them so a single regression in any check flips
+	// this test red.
+	let yaml = r#"
+services:
+  web:
+    image: nginx:1.27@sha256:0e7bb5afc7e5e22ee46c4f2cd4a8b3fa63ad3f5d5e5e5e5e5e5e5e5e5e5e5e5e
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    pids_limit: 200
+    mem_limit: 512m
+    userns_mode: auto
+    environment:
+      - LEVEL=info
+      - HOSTNAME
+"#;
+	let (name, svc) = single_service(yaml);
+	let file = parse_str(yaml).unwrap();
+	let report = audit::audit_file(&file);
+	let findings_for_web: Vec<&Finding> = report
+		.findings
+		.iter()
+		.filter(|f| f.service == name)
+		.collect();
+	assert!(
+		findings_for_web.is_empty(),
+		"hardened service produced findings: {findings_for_web:#?}"
+	);
+	// Sanity: the service really did carry every key we wanted to test, so
+	// the empty finding list reflects the check passing each one rather than
+	// the checks having nothing to look at. The cap_drop presence in
+	// particular guards the most-frequently-regressed check.
+	assert!(
+		svc.read_only == Some(true),
+		"sanity: read_only must be true"
+	);
+	assert!(
+		svc.cap_drop.iter().any(|c| c == "ALL"),
+		"sanity: cap_drop must contain ALL"
+	);
+	assert!(
+		!svc.security_opt.is_empty(),
+		"sanity: security_opt must be set"
+	);
+	assert!(svc.pids_limit.is_some(), "sanity: pids_limit must be set");
+	assert!(svc.mem_limit.is_some(), "sanity: mem_limit must be set");
+	assert!(svc.userns_mode.is_some(), "sanity: userns_mode must be set");
+}
+
+// ---------------------------------------------------------------------------
+// secret_in_environment: bare keys and ${VAR} placeholders must NOT fire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_secret_in_environment_ignores_bare_keys_and_placeholders() {
+	// Three environment entries that *look* like secrets by name but carry
+	// no value at all. The check deliberately leaves these alone, a bare
+	// key inherits from the host and a ${VAR} placeholder is still
+	// unresolved, neither of which is a published secret.
+	let yaml = r#"
+services:
+  app:
+    image: alpine:3.20
+    environment:
+      - DB_PASSWORD
+      - API_TOKEN=${TOKEN_FROM_ENV}
+"#;
+	let file = parse_str(yaml).expect("parses");
+	let report = audit::audit_file(&file);
+	assert!(
+		!has_check(&report, "app", "secret_in_environment"),
+		"bare / placeholder secrets must not fire: {:#?}",
+		report.findings
+	);
+	// And the same shape via the map form, so a regression in the List arm
+	// doesn't pass this test silently. `null` is what compose / podman read
+	// as "inherit from the host", the parser turns it into a `None` value
+	// in the `to_map()` view.
+	let yaml_map = r#"
+services:
+  app:
+    image: alpine:3.20
+    environment:
+      DB_PASSWORD: null
+      API_TOKEN: ${TOKEN_FROM_ENV}
+"#;
+	let file = parse_str(yaml_map).expect("parses");
+	let report = audit::audit_file(&file);
+	assert!(
+		!has_check(&report, "app", "secret_in_environment"),
+		"map-form bare / placeholder secrets must not fire: {:#?}",
+		report.findings
+	);
+}
+
+// ---------------------------------------------------------------------------
+// unpinned_image: a digest always counts as pinned.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_unpinned_image_accepts_a_digest() {
+	// The image reference carries an explicit tag *and* a digest. The
+	// digest is the actual pin; the tag is a convenience. A regression
+	// that ignores `@sha256:` and looks at the tag would flag this
+	// reference (the tag is `latest`, no less) and the test flips red.
+	let yaml = r#"
+services:
+  app:
+    image: nginx:latest@sha256:0e7bb5afc7e5e22ee46c4f2cd4a8b3fa63ad3f5d5e5e5e5e5e5e5e5e5e5e5e5e
+"#;
+	let file = parse_str(yaml).expect("parses");
+	let report = audit::audit_file(&file);
+	assert!(
+		!has_check(&report, "app", "unpinned_image"),
+		"digest-pinned image must not be flagged: {:#?}",
+		report.findings
+	);
+	// Also cover the no-tag case with a digest, so an `rfind` regression
+	// on the colon/slash boundary gets caught too.
+	let yaml_notag = r#"
+services:
+  app:
+    image: nginx@sha256:0e7bb5afc7e5e22ee46c4f2cd4a8b3fa63ad3f5d5e5e5e5e5e5e5e5e5e5e5e5e
+"#;
+	let report = audit::audit_file(&parse_str(yaml_notag).unwrap());
+	assert!(
+		!has_check(&report, "app", "unpinned_image"),
+		"digest-only image must not be flagged"
+	);
+}
+
+/// `has_findings` is what `--strict` reads; a mutation sweep replaced it with
+/// a constant and only the binary tests noticed.
+#[test]
+fn audit_report_has_findings_follows_the_list() {
+	let clean = report_for_file("services:\n  web:\n    image: alpine:3.20\n    read_only: true\n    cap_drop: [ALL]\n    security_opt: [no-new-privileges:true]\n    pids_limit: 64\n    mem_limit: 64m\n    userns_mode: auto\n");
+	assert!(!clean.has_findings());
+	let dirty = report_for_file("services:\n  web:\n    image: alpine\n");
+	assert!(dirty.has_findings());
+}
+
+/// `by_service` hands each service exactly its own findings, in file order,
+/// including a service with none.
+#[test]
+fn audit_report_by_service_keeps_file_order_and_ownership() {
+	let file = parse_str(
+		"services:\n  zeta:\n    image: alpine:3.20\n    privileged: true\n  alpha:\n    image: alpine:3.20\n    read_only: true\n    cap_drop: [ALL]\n    security_opt: [no-new-privileges:true]\n    pids_limit: 64\n    mem_limit: 64m\n    userns_mode: auto\n",
+	)
+	.unwrap();
+	let report = audit_file(&file);
+	let services = ordered_services(&file);
+	assert_eq!(
+		services.iter().map(|(n, _)| *n).collect::<Vec<_>>(),
+		vec!["zeta", "alpha"]
+	);
+	let grouped = report.by_service(&services);
+	assert_eq!(grouped.len(), 2);
+	assert_eq!(grouped[0].0, "zeta");
+	assert!(grouped[0].1.iter().all(|f| f.service == "zeta"));
+	assert!(grouped[0].1.iter().any(|f| f.check == "privileged"));
+	assert_eq!(grouped[1].0, "alpha");
+	assert!(grouped[1].1.is_empty());
+}
+
+/// A value that merely ends in `}` is not a `${VAR}` placeholder.
+#[test]
+fn audit_secret_in_environment_flags_a_value_that_only_ends_in_a_brace() {
+	let report = report_for_file("services:\n  web:\n    image: alpine:3.20\n    environment:\n      DB_PASSWORD: \"abc}\"\n");
+	assert!(report
+		.findings
+		.iter()
+		.any(|f| f.check == "secret_in_environment"));
+}
+
+fn report_for_file(yaml: &str) -> AuditReport {
+	audit_file(&parse_str(yaml).unwrap())
+}

--- a/internal/audit/checks.rs
+++ b/internal/audit/checks.rs
@@ -1,0 +1,332 @@
+//! Hardening checks: one pure function per audit check id, each returning
+//! every [`Finding`] a service raises under that check. Empty list = passed.
+//!
+//! Every check id is a stable snake_case string emitted into the JSON output
+//! and into the `FINDINGS` column. Renaming one is a breaking change for
+//! consumers; add new ids instead. `run_checks` is the single dispatch site
+//! that turns the eleven named checks into a flat `Vec<Finding>`.
+
+use podup::compose::types::{ComposeFile, Service};
+
+use super::Finding;
+
+/// Every check has the same shape: take the service name and the parsed
+/// service plus the whole file (for cross-service context), return the
+/// findings the service raises under this check. Pinned here so the
+/// `run_checks` array stays trivial and a new check is one line plus one
+/// function.
+type CheckFn = fn(&str, &Service, &ComposeFile) -> Vec<Finding>;
+
+/// Apply every registered check to one service, returning the union of all
+/// findings. Kept as one function so a new check is a single edit: extend
+/// the `check_*` vector at the bottom and the report picks it up.
+///
+/// `service_name` is the compose key; it is folded into each finding so the
+/// renderer can group by service.
+pub(super) fn run_checks(
+	service_name: &str,
+	service: &Service,
+	file: &ComposeFile,
+) -> Vec<Finding> {
+	const CHECKS: [CheckFn; 11] = [
+		check_privileged,
+		check_host_namespace,
+		check_dangerous_capability,
+		check_writable_root,
+		check_no_cap_drop_all,
+		check_no_new_privileges_off,
+		check_no_pids_limit,
+		check_no_memory_limit,
+		check_no_userns,
+		check_secret_in_environment,
+		check_unpinned_image,
+	];
+	let mut out = Vec::new();
+	for check in CHECKS {
+		out.extend(check(service_name, service, file));
+	}
+	out
+}
+
+/// Field-name substring matching for the `secret_in_environment` check:
+/// `PASSWORD`, `SECRET`, `TOKEN`, `KEY`. Case-insensitive. The list is the
+/// issue, so it lives in one place.
+const SECRET_NAME_SUBSTRINGS: &[&str] = &["PASSWORD", "SECRET", "TOKEN", "KEY"];
+
+/// `privileged: true`, grants extended host privileges that bypass the
+/// default capability set. Under rootless Podman the effect is reduced but
+/// the flag still means "give me more than the baseline"; it's never
+/// incidental.
+fn check_privileged(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	if service.privileged == Some(true) {
+		vec![finding(
+			name,
+			"privileged",
+			"privileged: true grants extended host privileges",
+		)]
+	} else {
+		Vec::new()
+	}
+}
+
+/// Host-binding namespacing modes: `pid`, `ipc`, `uts`, `cgroup`, `userns_mode`
+/// set to `host`, or `network_mode: host`. One finding per active mode.
+fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	let mut out = Vec::new();
+	if let Some(mode) = service.network_mode.as_deref() {
+		if mode == "host" {
+			out.push(finding(
+				name,
+				"host_namespace",
+				"network_mode: host shares the host's network namespace",
+			));
+		}
+	}
+	for field in ["pid", "ipc", "uts", "cgroup", "userns_mode"] {
+		let value = match field {
+			"pid" => &service.pid,
+			"ipc" => &service.ipc,
+			"uts" => &service.uts,
+			"cgroup" => &service.cgroup,
+			"userns_mode" => &service.userns_mode,
+			_ => unreachable!("checked field list"),
+		};
+		if let Some(mode) = value.as_deref() {
+			if mode == "host" {
+				out.push(finding(
+					name,
+					"host_namespace",
+					&format!("{field}: host shares the host's {field} namespace"),
+				));
+			}
+		}
+	}
+	out
+}
+
+/// `cap_add: [SYS_ADMIN]` or `cap_add: [ALL]`, Linux capabilities that
+/// effectively grant root inside the container.
+fn check_dangerous_capability(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	let mut out = Vec::new();
+	for cap in &service.cap_add {
+		let cap = normalized_capability(cap);
+		if cap == "SYS_ADMIN" || cap == "ALL" {
+			out.push(finding(
+				name,
+				"dangerous_capability",
+				&format!("cap_add: {cap} grants root-equivalent capability"),
+			));
+		}
+	}
+	out
+}
+
+/// `read_only` not set to `true`, the container's rootfs is writable.
+/// Compose's default is `false`; an absent key and an explicit `false` both
+/// keep the filesystem writable, so the check fires unless the service
+/// opted into read-only.
+fn check_writable_root(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	if service.read_only != Some(true) {
+		vec![finding(
+			name,
+			"writable_root",
+			"read_only is not true: the container's root filesystem is writable",
+		)]
+	} else {
+		Vec::new()
+	}
+}
+
+/// `cap_drop` without `ALL`, the service can inherit a broader capability
+/// set than it asked to drop. Spec asks for `ALL` (so the service starts
+/// from nothing and opts back in via `cap_add:`).
+fn check_no_cap_drop_all(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	if !service
+		.cap_drop
+		.iter()
+		.any(|c| normalized_capability(c) == "ALL")
+	{
+		vec![finding(
+			name,
+			"no_cap_drop_all",
+			"cap_drop does not contain ALL: the service keeps the runtime's default capability set",
+		)]
+	} else {
+		Vec::new()
+	}
+}
+
+/// `security_opt` without `no-new-privileges:true`. Podman spells it
+/// `no-new-privileges` (no `:true`); both spellings are accepted. The check
+/// iterates each entry and looks for a prefix match on either spelling; a
+/// bare `no-new-privileges` (no value) also passes.
+fn check_no_new_privileges_off(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	// Podman spells it `no-new-privileges` alone or `no-new-privileges:true`;
+	// `no-new-privileges:false` is the option being switched off, not on.
+	let has = service.security_opt.iter().any(|opt| {
+		let mut parts = opt.splitn(2, ':');
+		let head = parts.next().unwrap_or(opt);
+		let value = parts.next().unwrap_or("true");
+		head == "no-new-privileges" && value == "true"
+	});
+	if has {
+		Vec::new()
+	} else {
+		vec![finding(
+			name,
+			"no_new_privileges_off",
+			"security_opt is missing no-new-privileges:true: setuid binaries may regain privileges",
+		)]
+	}
+}
+
+/// `pids_limit` unset, no ceiling on the number of processes the container
+/// can fork, so a runaway loop can starve the host out of PIDs.
+fn check_no_pids_limit(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	if service.pids_limit.is_none() {
+		vec![finding(
+			name,
+			"no_pids_limit",
+			"pids_limit is not set: a fork bomb can exhaust the host's process table",
+		)]
+	} else {
+		Vec::new()
+	}
+}
+
+/// Neither `mem_limit` nor `deploy.resources.limits.memory` set, no upper
+/// bound on memory. A misbehaving service can OOM the host.
+fn check_no_memory_limit(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	let deploy_limit = service
+		.deploy
+		.as_ref()
+		.and_then(|d| d.resources.as_ref())
+		.and_then(|r| r.limits.as_ref())
+		.and_then(|l| l.memory.as_ref());
+	if service.mem_limit.is_none() && deploy_limit.is_none() {
+		vec![finding(
+			name,
+			"no_memory_limit",
+			"neither mem_limit nor deploy.resources.limits.memory is set: a leak can OOM the host",
+		)]
+	} else {
+		Vec::new()
+	}
+}
+
+/// `userns_mode` unset, Podman's `auto` (the default behaviour when the
+/// field is absent) gives each container its own UID range; an explicit
+/// keep-id/host is rare and is what we want the operator to confirm.
+fn check_no_userns(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	if service.userns_mode.is_none() {
+		vec![finding(
+			name,
+			"no_userns",
+			"userns_mode is not set: with `auto` Podman gives each container its own range of subordinate UIDs; see docs/docker-migration.md",
+		)]
+	} else {
+		Vec::new()
+	}
+}
+
+/// `environment:` key whose name contains `PASSWORD|SECRET|TOKEN|KEY`
+/// (case-insensitive) with a literal non-empty value. Bare keys (host
+/// inheritance) and unresolved `${VAR}` placeholders are not secrets.
+///
+/// Service-local: the check is a positional grep on the `environment:` map
+/// of this service. These are surfaced so the operator can
+/// move them to `secrets:`; the wider question of whether the project
+/// declares `secrets:` is not in scope.
+fn check_secret_in_environment(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	let mut out = Vec::new();
+	for (key, value) in service.environment.to_map() {
+		let upper = key.to_ascii_uppercase();
+		if !SECRET_NAME_SUBSTRINGS.iter().any(|s| upper.contains(s)) {
+			continue;
+		}
+		let Some(value) = value else {
+			// Bare key: inherited from the host. Not a published secret.
+			continue;
+		};
+		if value.is_empty() {
+			// Empty literal: probably a placeholder; `docker compose` does
+			// not raise this either.
+			continue;
+		}
+		if value.starts_with("${") && value.ends_with('}') {
+			// Unresolved ${VAR} placeholder: not a published secret either.
+			continue;
+		}
+		out.push(finding(
+			name,
+			"secret_in_environment",
+			&format!("environment: {key} carries a hard-coded value; move it to secrets:"),
+		));
+	}
+	// The `to_map` for the `Empty` enum yields nothing, so the unused
+	// `match arms` below are defensive: future variants of `EnvVars` ought
+	// to keep the same shape.
+	out
+}
+
+/// `image:` is unpinned: no tag (defaults to `latest`), tag is `latest`,
+/// or `latest` is not pinned by a digest. An `@sha256:` digest counts as
+/// pinned even when a tag is also present.
+fn check_unpinned_image(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	let Some(reference) = service.image.as_deref() else {
+		// A `build:` service without an `image:` is built from source and
+		// has no registry reference to pin; out of scope for this check.
+		return Vec::new();
+	};
+	if reference.contains('@') {
+		// Any digest (sha256: or otherwise) anchors the tag, so the service
+		// is pinned regardless of the tag's value.
+		return Vec::new();
+	}
+	let last_colon = reference.rfind(':').unwrap_or(0);
+	let last_slash = reference.rfind('/').unwrap_or(0);
+	// The tag/separator sits after the last colon not preceded by a slash;
+	// an image with no tag stops there.
+	let has_tag = last_colon > last_slash;
+	if !has_tag {
+		return vec![finding(
+			name,
+			"unpinned_image",
+			&format!("image: {reference} has no tag; defaults to :latest"),
+		)];
+	}
+	let tag = &reference[last_colon + 1..];
+	if tag == "latest" {
+		return vec![finding(
+			name,
+			"unpinned_image",
+			&format!("image: {reference} pins to :latest, which moves under you"),
+		)];
+	}
+	Vec::new()
+}
+
+/// Construct one [`Finding`]. Private to this module so callers always go
+/// through `run_checks`, and so the field-name ordering (service, check,
+/// reason) is consistent across all checks.
+/// `CAP_SYS_ADMIN`, `sys_admin` and `SYS_ADMIN` name the same capability;
+/// compose files carry all three spellings.
+fn normalized_capability(cap: &str) -> String {
+	let upper = cap.trim().to_ascii_uppercase();
+	upper.strip_prefix("CAP_").unwrap_or(&upper).to_string()
+}
+
+fn finding(name: &str, check: &'static str, reason: &str) -> Finding {
+	Finding {
+		service: name.to_string(),
+		check,
+		reason: reason.to_string(),
+	}
+}
+
+#[cfg(test)]
+#[path = "checks_more_tests.rs"]
+mod more_tests;
+#[cfg(test)]
+#[path = "checks_tests.rs"]
+mod tests;

--- a/internal/audit/checks_more_tests.rs
+++ b/internal/audit/checks_more_tests.rs
@@ -1,0 +1,302 @@
+//! The second half of the per-check matrix, split from `checks_tests.rs` to
+//! keep both files under the repository line limit. Same shape: one test
+//! for the bad shape and one for the good shape of each check.
+
+use super::tests::report_for;
+
+#[test]
+fn audit_no_new_privileges_off_passes_in_both_spellings() {
+	// Podman spells it `no-new-privileges` (no `:true`); the docker form
+	// carries `:true`. Both must count.
+	for entry in ["no-new-privileges", "no-new-privileges:true"] {
+		let yaml = format!(
+			"services:\n  web:\n    image: alpine:3.20\n    security_opt:\n      - {entry}\n"
+		);
+		let findings = report_for(&yaml);
+		assert!(
+			!findings.iter().any(|f| f.check == "no_new_privileges_off"),
+			"`{entry}` must pass the no-new-privileges-off check: {findings:#?}"
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// no_pids_limit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_no_pids_limit_flags_when_unset() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "no_pids_limit"),
+		"unset pids_limit must fire: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_no_pids_limit_passes_when_set() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    pids_limit: 200
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "no_pids_limit"),
+		"pids_limit: 200 must pass: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// no_memory_limit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_no_memory_limit_flags_when_unset() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "no_memory_limit"),
+		"unset memory limit must fire: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_no_memory_limit_passes_when_set_on_mem_limit() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    mem_limit: 512m
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "no_memory_limit"),
+		"mem_limit must pass: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_no_memory_limit_passes_when_set_on_deploy_resources() {
+	// The check accepts either location; `deploy.resources.limits.memory`
+	// covers the swarm-style shape that some compose files adopted as
+	// rootless Podman grew up.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "no_memory_limit"),
+		"deploy.resources.limits.memory must pass: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// no_userns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_no_userns_flags_when_unset() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "no_userns"),
+		"unset userns_mode must fire: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_no_userns_passes_when_set() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    userns_mode: keep-id
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "no_userns"),
+		"userns_mode: keep-id must pass: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// secret_in_environment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_secret_in_environment_flags_literal_secret_keys() {
+	// One per keyword so a regression that misses one is caught by its own
+	// test rather than masked by the others passing.
+	for (key, _hint) in [
+		("DB_PASSWORD", "PASSWORD"),
+		("AUTH_SECRET", "SECRET"),
+		("API_TOKEN", "TOKEN"),
+		("SIGNING_KEY", "KEY"),
+	] {
+		let yaml = format!(
+			"services:\n  app:\n    image: alpine:3.20\n    environment:\n      - {key}=literal\n"
+		);
+		let findings = report_for(&yaml);
+		assert!(
+			findings.iter().any(|f| f.check == "secret_in_environment"),
+			"environment: {key}=literal must fire secret_in_environment; got {findings:#?}"
+		);
+		// The reason must name the key without echoing the value back ,
+		// the literal value would defeat the whole point of the audit.
+		let f = findings
+			.iter()
+			.find(|f| f.check == "secret_in_environment")
+			.expect("finding");
+		assert!(
+			!f.reason.contains("literal"),
+			"reason must not echo the value: {f:?}"
+		);
+		assert!(
+			f.reason.contains(key),
+			"reason must name the key {key}: {f:?}"
+		);
+	}
+}
+
+#[test]
+fn audit_secret_in_environment_passes_for_unrelated_keys() {
+	let yaml = r#"
+services:
+  app:
+    image: alpine:3.20
+    environment:
+      - LOG_LEVEL=info
+      - HOSTNAME=host-1
+      - PORT=8080
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "secret_in_environment"),
+		"unrelated env keys must not fire secret_in_environment: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// unpinned_image
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_unpinned_image_flags_when_no_tag() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "unpinned_image"),
+		"untagged image must fire: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_unpinned_image_flags_when_tag_is_latest() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx:latest
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "unpinned_image"),
+		"`:latest` must fire: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_unpinned_image_passes_when_tagged_not_latest() {
+	// A non-default tag is the canonical "pinned to a version" case the
+	// check is supposed to recognise. The tag value is irrelevant beyond
+	// "is it the literal `latest`".
+	let yaml = r#"
+services:
+  web:
+    image: nginx:1.27.3
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "unpinned_image"),
+		"explicit non-latest tag must pass: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_unpinned_image_ignores_services_without_image() {
+	// A `build:` service has no registry reference: there is no tag to
+	// pin. Out of scope for this check; the report must be empty (or
+	// carry only unrelated findings).
+	let yaml = r#"
+services:
+  web:
+    build: .
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "unpinned_image"),
+		"build-only services are out of scope for unpinned_image: {findings:#?}"
+	);
+}
+
+/// `CAP_SYS_ADMIN`, `sys_admin` and `SYS_ADMIN` are the same capability, and
+/// compose files carry all three spellings; the check has to read them alike.
+#[test]
+fn audit_dangerous_capability_reads_every_spelling() {
+	for spelling in ["CAP_SYS_ADMIN", "sys_admin", "cap_all", "ALL"] {
+		let report = report_for(&format!(
+			"services:\n  web:\n    image: alpine:3.20\n    cap_add: [{spelling}]\n"
+		));
+		assert!(
+			report.iter().any(|f| f.check == "dangerous_capability"),
+			"{spelling} was not read as dangerous"
+		);
+	}
+}
+
+/// `cap_drop: [all]` and `cap_drop: [CAP_ALL]` satisfy the check like `ALL`.
+#[test]
+fn audit_no_cap_drop_all_accepts_every_spelling() {
+	for spelling in ["all", "CAP_ALL", "ALL"] {
+		let report = report_for(&format!(
+			"services:\n  web:\n    image: alpine:3.20\n    cap_drop: [{spelling}]\n"
+		));
+		assert!(
+			!report.iter().any(|f| f.check == "no_cap_drop_all"),
+			"{spelling} was not read as ALL"
+		);
+	}
+}
+
+/// `no-new-privileges:false` is the option switched off, not on.
+#[test]
+fn audit_no_new_privileges_off_flags_an_explicit_false() {
+	let report = report_for(
+		"services:\n  web:\n    image: alpine:3.20\n    security_opt: [\"no-new-privileges:false\"]\n",
+	);
+	assert!(report.iter().any(|f| f.check == "no_new_privileges_off"));
+}

--- a/internal/audit/checks_tests.rs
+++ b/internal/audit/checks_tests.rs
@@ -1,0 +1,272 @@
+//! Per-check positive/negative tests. Each check is covered by exactly two
+//! names, `<check>_flags_when_bad` and `<check>_passes_when_good`, so the
+//! matrix mirrors the contract verbatim: a service with the bad shape raises
+//! exactly the named finding; a service with the good shape raises nothing
+//! under that check.
+
+use podup::parse_str;
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// shared helpers
+// ---------------------------------------------------------------------------
+
+/// Run every check against `yaml` and return the flat list of findings.
+/// The checks today are all per-service, so callers only need this entry.
+pub(super) fn report_for(yaml: &str) -> Vec<Finding> {
+	let file = parse_str(yaml).expect("compose parses");
+	crate::audit::audit_file(&file).findings
+}
+
+// ---------------------------------------------------------------------------
+// privileged
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_privileged_flags_when_true() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    privileged: true
+"#;
+	let findings = report_for(yaml);
+	let privileged: Vec<&Finding> = findings
+		.iter()
+		.filter(|f| f.check == "privileged")
+		.collect();
+	assert_eq!(
+		privileged.len(),
+		1,
+		"exactly one privileged finding expected: {findings:#?}"
+	);
+	assert_eq!(privileged[0].check, "privileged");
+	assert_eq!(privileged[0].service, "web");
+}
+
+#[test]
+fn audit_privileged_passes_when_false_or_absent() {
+	// Explicit false: still fine. Absent: also fine. The check only fires on
+	// the literal `true`.
+	for yaml in [
+		r#"services:
+  web:
+    image: alpine:3.20
+    privileged: false
+"#,
+		r#"services:
+  web:
+    image: alpine:3.20
+"#,
+	] {
+		let findings = report_for(yaml);
+		assert!(
+			!findings.iter().any(|f| f.check == "privileged"),
+			"privileged check must not fire on the good shape: {findings:#?}"
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// host_namespace
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_host_namespace_flags_network_mode_host() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    network_mode: host
+"#;
+	let findings = report_for(yaml);
+	let kinds: Vec<&'static str> = findings.iter().map(|f| f.check).collect();
+	assert!(kinds.contains(&"host_namespace"), "got {kinds:?}");
+}
+
+#[test]
+fn audit_host_namespace_flags_pid_ipc_uts_cgroup_userns_host() {
+	// One service per bad field, so each test pins a specific field rather
+	// than asserting the whole shape at once.
+	for (yaml_field, expected) in [
+		("pid: host", "pid"),
+		("ipc: host", "ipc"),
+		("uts: host", "uts"),
+		("cgroup: host", "cgroup"),
+		("userns_mode: host", "userns_mode"),
+	] {
+		let yaml = format!("services:\n  web:\n    image: alpine:3.20\n    {yaml_field}\n");
+		let findings = report_for(&yaml);
+		assert!(
+			findings
+				.iter()
+				.any(|f| f.check == "host_namespace" && f.reason.contains(expected)),
+			"expected host_namespace finding mentioning `{expected}`; got {findings:#?}"
+		);
+	}
+}
+
+#[test]
+fn audit_host_namespace_passes_when_clean() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "host_namespace"),
+		"baseline must not flag host_namespace: {findings:#?}"
+	);
+	// And a service that names a non-host namespace value is also clean.
+	let yaml_service = r#"
+services:
+  web:
+    image: alpine:3.20
+    pid: service:sidecar
+"#;
+	let findings = report_for(yaml_service);
+	assert!(
+		!findings.iter().any(|f| f.check == "host_namespace"),
+		"service:<name> share must not flag host_namespace: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// dangerous_capability
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_dangerous_capability_flags_sys_admin_and_all() {
+	for cap in ["SYS_ADMIN", "ALL"] {
+		let yaml =
+			format!("services:\n  web:\n    image: alpine:3.20\n    cap_add:\n      - {cap}\n");
+		let findings = report_for(&yaml);
+		assert!(
+			findings.iter().any(|f| f.check == "dangerous_capability"),
+			"`cap_add: [{cap}]` should flag dangerous_capability; got {findings:#?}"
+		);
+	}
+}
+
+#[test]
+fn audit_dangerous_capability_passes_when_empty() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    cap_add: [NET_ADMIN]
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "dangerous_capability"),
+		"non-dangerous cap_add must not fire: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// writable_root
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_writable_root_flags_when_read_only_false_or_absent() {
+	for yaml in [
+		// absent entirely.
+		r#"services:
+  web:
+    image: alpine:3.20
+"#,
+		// explicit false (the compose default).
+		r#"services:
+  web:
+    image: alpine:3.20
+    read_only: false
+"#,
+	] {
+		let findings = report_for(yaml);
+		assert!(
+			findings.iter().any(|f| f.check == "writable_root"),
+			"the writable_root check must fire here: {findings:#?}"
+		);
+	}
+}
+
+#[test]
+fn audit_writable_root_passes_when_read_only_true() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    read_only: true
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "writable_root"),
+		"read_only: true must pass the writable_root check: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// no_cap_drop_all
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_no_cap_drop_all_flags_when_absent() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "no_cap_drop_all"),
+		"absent cap_drop must fire: {findings:#?}"
+	);
+	// cap_drop without ALL is still bad, only the literal `ALL` zeroes
+	// the baseline.
+	let yaml_other = r#"
+services:
+  web:
+    image: alpine:3.20
+    cap_drop: [NET_RAW, MKNOD]
+"#;
+	let findings = report_for(yaml_other);
+	assert!(
+		findings.iter().any(|f| f.check == "no_cap_drop_all"),
+		"cap_drop without ALL must fire: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_no_cap_drop_all_passes_when_all_present() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    cap_drop: [ALL]
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "no_cap_drop_all"),
+		"cap_drop: [ALL] must pass: {findings:#?}"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// no_new_privileges_off
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_no_new_privileges_off_flags_when_missing() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "no_new_privileges_off"),
+		"absent security_opt must fire: {findings:#?}"
+	);
+}

--- a/internal/audit/mod.rs
+++ b/internal/audit/mod.rs
@@ -1,0 +1,147 @@
+//! `podup audit`: render hardening findings for every service in a parsed
+//! compose file. The command is a read-only view; it never contacts Podman
+//! and never changes what `up` does.
+//!
+//! Checks live as a flat list of pure functions over the parsed
+//! [`podup::compose::types::Service`]. Each check returns the list of
+//! [`Finding`]s it raised; [`audit_file`] walks the file and the
+//! [`render_table`]/[`render_json`] functions translate the result into the
+//! `--format table|json` output the CLI asked for.
+
+use podup::compose::types::{ComposeFile, Service};
+
+mod checks;
+
+/// One detected hardening finding: a service that did something the spec
+/// asked us to flag, identified by a stable snake_case id the caller can grep
+/// (`podup audit --format json` is machine-readable specifically so this id
+/// is stable across releases).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+	/// Service name (the compose key, not the container name). Stable
+	/// across reloads; the audit table sorts by this.
+	pub service: String,
+	/// Stable snake_case check id (`privileged`, `host_namespace`, …).
+	pub check: &'static str,
+	/// One-line human-readable explanation. Printed after the table row and
+	/// emitted as the `reason` field in `--format json`.
+	pub reason: String,
+}
+
+/// What the audit walked: the file's services sorted by service name, and
+/// the findings keyed by the (service, check) pairs they belong to.
+#[derive(Debug, Default)]
+pub struct AuditReport {
+	/// Findings, in the order the checks produced them.
+	pub findings: Vec<Finding>,
+}
+
+impl AuditReport {
+	/// Whether at least one finding was produced.
+	pub fn has_findings(&self) -> bool {
+		!self.findings.is_empty()
+	}
+
+	/// Group every finding by service name, preserving the service order
+	/// ([`audit_file`] visits the services in YAML order). The findings
+	/// inside each group stay as refs into `self` so the renderer can pull
+	/// the check id and reason without cloning.
+	fn by_service<'a, 'b>(
+		&'a self,
+		services: &'b [(&str, &Service)],
+	) -> Vec<(&'b str, Vec<&'a Finding>)> {
+		let mut out = Vec::with_capacity(services.len());
+		for (name, _) in services {
+			let mine: Vec<&'a Finding> = self
+				.findings
+				.iter()
+				.filter(|f| f.service == *name)
+				.collect();
+			out.push((*name, mine));
+		}
+		out
+	}
+}
+
+/// Run every check against every service in `file`, returning the
+/// accumulated findings. Services are visited in the order they appear in
+/// [`ComposeFile::services`] (insertion order, which the parser preserves from
+/// the YAML). A service with no findings contributes nothing to the report.
+///
+/// Pure: no I/O, no logging, no global state. The callers wire the result
+/// into whichever renderer matches `--format`.
+pub fn audit_file(file: &ComposeFile) -> AuditReport {
+	let mut report = AuditReport::default();
+	for (name, service) in &file.services {
+		let findings = checks::run_checks(name, service, file);
+		report.findings.extend(findings);
+	}
+	report
+}
+
+/// Snapshot of `file.services` as an ordered slice of `(name, &service)`
+/// pairs in YAML order. Used by the table renderer so every row is in the
+/// same order the YAML declared (insertion order in the underlying
+/// `IndexMap`); `IndexMap::iter` already gives that, the slice form just
+/// keeps the borrow checker happy at the call site.
+pub fn ordered_services(file: &ComposeFile) -> Vec<(&str, &Service)> {
+	file.services.iter().map(|(k, v)| (k.as_str(), v)).collect()
+}
+
+/// Render `report` for `services` in `table` form to stdout.
+///
+/// Layout: header `SERVICE FINDINGS`, one row per service with the check ids
+/// joined by single spaces (or `-` when there are none), then one line per
+/// finding with `  <service>: <check>: <reason>` indented two spaces. When
+/// nothing was found, only the line `no findings` is printed, the table is
+/// suppressed so a CI log without any findings is minimal.
+pub fn render_table(services: &[(&str, &Service)], report: &AuditReport) {
+	let mut table = podup::ui::Table::new(&["SERVICE", "FINDINGS"]);
+	for (name, mine) in report.by_service(services) {
+		let findings = if mine.is_empty() {
+			"-".to_string()
+		} else {
+			mine.iter().map(|f| f.check).collect::<Vec<_>>().join(" ")
+		};
+		table.push(vec![(*name).to_string(), findings]);
+	}
+	if report.findings.is_empty() {
+		println!("no findings");
+		return;
+	}
+	table.print();
+	for finding in &report.findings {
+		println!(
+			"  {service}: {check}: {reason}",
+			service = finding.service,
+			check = finding.check,
+			reason = finding.reason,
+		);
+	}
+}
+
+/// Render `report` as a single JSON line to stdout. `serde_json` orders the
+/// object keys alphabetically (`findings`, then per-finding `check`, `reason`,
+/// `service`), which gives the stable shape CI scripts can rely on.
+///
+/// Empty finding lists emit `{"findings":[]}`, never `null`, so an empty
+/// body is still valid JSON without the consumer having to special-case it.
+pub fn render_json(report: &AuditReport) {
+	let findings: Vec<serde_json::Value> = report
+		.findings
+		.iter()
+		.map(|f| {
+			serde_json::json!({
+				"check": f.check,
+				"reason": f.reason,
+				"service": f.service,
+			})
+		})
+		.collect();
+	let out = serde_json::json!({ "findings": findings });
+	println!("{out}");
+}
+
+#[cfg(test)]
+#[path = "audit_tests.rs"]
+mod tests;

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -9,7 +9,8 @@ use clap_complete::Shell;
 
 use super::parse::{parse_progress, parse_pull_policy, parse_scale_pair, parse_timeout};
 use super::types::{
-	AutostartCommands, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat, RmiScope,
+	AuditFormat, AutostartCommands, ConfigFormat, EventsFormat, GenerateCommands, OutputFormat,
+	RmiScope,
 };
 
 #[derive(Subcommand)]
@@ -653,6 +654,19 @@ pub(crate) enum Commands {
 		/// Rewrite each service image to its registry digest (repo@sha256:...).
 		#[arg(long)]
 		resolve_image_digests: bool,
+	},
+	/// Audit the compose file for hardening gaps (read-only rootfs, dropped
+	/// capabilities, memory/PID limits, host-binding modes, secret-shaped env
+	/// vars, unpinned images, …) and print a row per service. No check changes
+	/// what `up` does; this is a view, not a gate. `--strict` exits 1 when any
+	/// finding is present, so it can fail CI.
+	Audit {
+		/// Exit 1 when any finding is present.
+		#[arg(long)]
+		strict: bool,
+		/// Output format.
+		#[arg(long, value_enum, default_value_t = AuditFormat::Table)]
+		format: AuditFormat,
 	},
 	/// Generate declarative artifacts from the compose file.
 	#[command(

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -9,8 +9,8 @@ mod parse;
 mod types;
 pub(crate) use commands::Commands;
 pub(crate) use types::{
-	AnsiMode, AutostartCommands, AutostartMode, ConfigFormat, EventsFormat, GenerateCommands,
-	OutputFormat, RmiScope,
+	AnsiMode, AuditFormat, AutostartCommands, AutostartMode, ConfigFormat, EventsFormat,
+	GenerateCommands, OutputFormat, RmiScope,
 };
 
 /// Help-screen colours.

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -66,6 +66,17 @@ pub(crate) enum ConfigFormat {
 	Json,
 }
 
+/// Output rendering for `audit`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum AuditFormat {
+	/// Aligned columns (`SERVICE` / `FINDINGS`) followed by per-finding lines.
+	#[default]
+	Table,
+	/// One JSON object per finding, with stable keys, or `{"findings": []}`
+	/// when nothing matched.
+	Json,
+}
+
 /// Which autostart backend `autostart install` sets up.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum AutostartMode {

--- a/internal/dispatch/rest.rs
+++ b/internal/dispatch/rest.rs
@@ -301,6 +301,7 @@ pub(super) async fn dispatch_rest(
 		Commands::Pause { .. } => unreachable!("handled in dispatch"),
 		Commands::Unpause { .. } => unreachable!("handled in dispatch"),
 		Commands::Config { .. } => unreachable!("handled above"),
+		Commands::Audit { .. } => unreachable!("handled above"),
 		Commands::Generate { .. } => unreachable!("handled above"),
 		Commands::Autostart { .. } => unreachable!("handled above"),
 		Commands::Watch => engine.watch(file).await?,

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -8,6 +8,7 @@ use std::process;
 #[cfg(feature = "completions")]
 use clap::CommandFactory;
 
+mod audit;
 mod autostart_cmd;
 mod cli;
 mod dispatch;
@@ -493,6 +494,31 @@ async fn run() -> podup::Result<()> {
 			&project,
 			&base_dir,
 		);
+	}
+
+	// `audit` is the read-only hardening view. It reuses the `config`
+	// loading path verbatim: same parsed file, same active-profile filter,
+	// same `env_file:` fold. It does not contact Podman. Honor active
+	// profiles so a service left out by `--profile` does not get audited;
+	// `audit` reports what `up` would start.
+	if let Commands::Audit { strict, format } = &cli.command {
+		let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);
+		let project = resolve_project_name(cli.project.clone(), file.name.as_deref(), &base_dir);
+		startup::validate_project_name(&project)?;
+		podup::ui::set_project(&project);
+		podup::ui::set_services(&file.services.keys().cloned().collect::<Vec<_>>());
+		let mut resolved = file.clone();
+		podup::retain_active_profiles(&mut resolved, &cli.profile);
+		podup::env_file::materialize_env_files(&mut resolved, &base_dir)?;
+		let report = audit::audit_file(&resolved);
+		match format {
+			AuditFormat::Table => audit::render_table(&audit::ordered_services(&resolved), &report),
+			AuditFormat::Json => audit::render_json(&report),
+		}
+		if *strict && report.has_findings() {
+			process::exit(1);
+		}
+		return Ok(());
 	}
 
 	let base_dir = resolve_base_dir(cli.project_directory.as_deref(), &compose_files[0]);

--- a/tests/audit_exit_codes.rs
+++ b/tests/audit_exit_codes.rs
@@ -1,0 +1,208 @@
+//! End-to-end checks for the `podup audit` subcommand's exit codes and JSON
+//! shape. Drives the compiled `podup` binary against a tiny compose file on
+//! disk so the parsing, profile honouring, and emit path are exercised the
+//! same way an operator would; the unit suite already covers the checks
+//! themselves in isolation.
+//!
+//! Names state the contract: `--strict` flips the exit code from 0
+//! to 1 when any finding is present, and `--format json` is the
+//! machine-readable surface CI consumes.
+
+use std::fs;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn bin() -> &'static str {
+	env!("CARGO_BIN_EXE_podup")
+}
+
+/// Render `body` to a unique tempfile under the system tempdir and return
+/// its path. The audit command is invoked with `-f <path>` so the compose
+/// file lives exactly where the operator would point `-f`. Every call gets
+/// a freshly-numbered subdirectory; the counter is atomic so two threads
+/// running the same test in parallel never share a directory.
+fn write_compose(body: &str) -> std::path::PathBuf {
+	static COUNTER: AtomicU64 = AtomicU64::new(0);
+	let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+	let dir = std::env::temp_dir().join(format!("podup-audit-{}-{n}", std::process::id()));
+	let _ = fs::remove_dir_all(&dir);
+	fs::create_dir_all(&dir).unwrap();
+	let path = dir.join("compose.yaml");
+	fs::write(&path, body).unwrap();
+	path
+}
+
+fn run(args: &[&str]) -> Output {
+	let mut cmd = Command::new(bin());
+	cmd.args(args);
+	// The integration tests share the developer's shell environment, so any
+	// pre-set `PODUP_*` / `COMPOSE_*` would leak into the spawned binary and
+	// break parsing or change the resolved project. Strip the env vars podup
+	// treats as global configuration; `PATH` and the locale stay so the
+	// process can locate shared libraries and render messages.
+	for key in [
+		"PODUP_LIBCOD_POOL",
+		"PODMAN_SOCKET",
+		"DOCKER_HOST",
+		"COMPOSE_PROJECT_NAME",
+		"COMPOSE_PROFILES",
+		"COMPOSE_FILE",
+		"NO_COLOR",
+	] {
+		cmd.env_remove(key);
+	}
+	cmd.output().expect("run podup audit")
+}
+
+// ---------------------------------------------------------------------------
+// exit codes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_exits_zero_with_findings_by_default() {
+	// A trivially unhardened service: every check that fires on a bare
+	// `image: nginx` will surface. Without `--strict` the exit code must
+	// stay 0, the same way `ps` exits 0 on a stopped project, so a CI
+	// pipeline that has not opted in sees the report without breaking.
+	let path = write_compose("services:\n  web:\n    image: nginx\n    privileged: true\n");
+	let p = path.to_str().unwrap();
+	let out = run(&["-f", p, "audit"]);
+	assert!(
+		out.status.success(),
+		"`audit` must default to exit 0; got {:?}\nstderr: {}\nstdout: {}",
+		out.status.code(),
+		String::from_utf8_lossy(&out.stderr),
+		String::from_utf8_lossy(&out.stdout),
+	);
+	// The table is the whole point of the default run; a sweep that emptied
+	// the renderer left this test green, so the output is read too.
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	assert!(
+		stdout.contains("SERVICE") && stdout.contains("FINDINGS"),
+		"no table header:\n{stdout}"
+	);
+	assert!(
+		stdout.contains("writable_root"),
+		"no finding named in the table:\n{stdout}"
+	);
+	assert!(
+		stdout.contains(": writable_root: "),
+		"no reason line under the table:\n{stdout}"
+	);
+}
+
+#[test]
+fn audit_strict_exits_one_with_findings() {
+	// Same compose file, `--strict` enabled: the same findings should now
+	// flip the exit to 1. CI scripts pipe `--strict` into a job's success
+	// gate, so this is the property they care about.
+	let path = write_compose("services:\n  web:\n    image: nginx\n    privileged: true\n");
+	let p = path.to_str().unwrap();
+	let out = run(&["-f", p, "audit", "--strict"]);
+	assert_eq!(
+		out.status.code(),
+		Some(1),
+		"`--strict` with findings must exit 1; got {:?}\nstderr: {}\nstdout: {}",
+		out.status.code(),
+		String::from_utf8_lossy(&out.stderr),
+		String::from_utf8_lossy(&out.stdout),
+	);
+}
+
+#[test]
+fn audit_strict_exits_zero_when_clean() {
+	// A fully hardened service must exit 0 even with `--strict`, otherwise
+	// the CI-gate promise is "fail forever" rather than "fail when there
+	// is something to fix". The unit suite already pins per-check
+	// pass/warn behaviour; this is the CLI-level sum of that.
+	let path = write_compose(
+		r#"services:
+  web:
+    image: nginx:1.27@sha256:0e7bb5afc7e5e22ee46c4f2cd4a8b3fa63ad3f5d5e5e5e5e5e5e5e5e5e5e5e5e
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    pids_limit: 200
+    mem_limit: 512m
+    userns_mode: auto
+    environment:
+      - LOG_LEVEL=info
+"#,
+	);
+	let p = path.to_str().unwrap();
+	let out = run(&["-f", p, "audit", "--strict"]);
+	assert!(
+		out.status.success(),
+		"`--strict` with no findings must exit 0; got {:?}\nstderr: {}\nstdout: {}",
+		out.status.code(),
+		String::from_utf8_lossy(&out.stderr),
+		String::from_utf8_lossy(&out.stdout),
+	);
+}
+
+// ---------------------------------------------------------------------------
+// JSON shape: every finding listed, stable schema, no escapes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_json_lists_every_finding() {
+	// Three services, each deliberately failing a different check. The
+	// JSON output must carry every one of them: a regression where a check
+	// silently no-ops in JSON (while still appearing in the table) would
+	// pass the unit tests and break CI consumers in production.
+	let path = write_compose(
+		r#"services:
+  pr:
+    image: nginx
+  caps:
+    image: nginx:1.27
+    cap_add: [SYS_ADMIN]
+  secret:
+    image: nginx:1.27
+    environment:
+      - DB_PASSWORD=hunter2
+"#,
+	);
+	let p = path.to_str().unwrap();
+	let out = run(&["-f", p, "audit", "--format", "json"]);
+	assert!(out.status.success(), "audit must succeed");
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	// Machine output never carries colour, even when
+	// forced. A regression that leaks an escape into `--format json`
+	// would corrupt every CI consumer parsing the output; verify the
+	// unforced (no `--ansi always`) path first, then assert the data.
+	assert!(
+		!stdout.contains('\u{1b}'),
+		"JSON output must not carry escapes: {stdout:?}"
+	);
+	let v: serde_json::Value = serde_json::from_str(&stdout).expect("JSON parses");
+	let arr = v
+		.get("findings")
+		.and_then(|f| f.as_array())
+		.expect("`findings` array");
+	// Each service is expected to fire at least one finding; json-list
+	// must reflect them all.
+	assert!(arr.len() >= 3, "expected at least 3 findings, got {arr:?}");
+	let services: Vec<&str> = arr
+		.iter()
+		.map(|f| f.get("service").and_then(|s| s.as_str()).unwrap_or("?"))
+		.collect();
+	for needed in ["pr", "caps", "secret"] {
+		assert!(
+			services.contains(&needed),
+			"missing finding for `{needed}` in {arr:?}"
+		);
+	}
+	// Per-object shape: every entry must carry all three keys, with
+	// non-empty strings. A consumer reading `reason: ""` as "no finding"
+	// would mis-classify an empty row, so we pin the absence.
+	for entry in arr {
+		for key in ["service", "check", "reason"] {
+			let s = entry.get(key).and_then(|v| v.as_str()).unwrap_or("");
+			assert!(
+				!s.is_empty(),
+				"every finding must carry non-empty `{key}`: {entry:?}"
+			);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1657.

## What

`podup audit [-f ...] [--strict] [--format table|json]`: the project loads the way `config` loads it, and one row per service lists the check ids of what it left open, with a reason line per finding under the table. Eleven checks: `privileged`, `host_namespace`, `dangerous_capability`, `writable_root`, `no_cap_drop_all`, `no_new_privileges_off`, `no_pids_limit`, `no_memory_limit`, `no_userns`, `secret_in_environment`, `unpinned_image`. Exit 0 by default; `--strict` exits 1 with any finding, for CI. No check changes what `up` does. Documented in `docs/commands.md` after `config`, and pointed at from the hardening section of the security model.

Capabilities are read in every spelling compose files carry (`CAP_SYS_ADMIN`, `sys_admin`, `all`), and `no-new-privileges:false` counts as off; both have tests.

## Verified

- Unit: 35 tests in the module, one positive and one negative per check plus the hardened-service, placeholder and digest cases; 4 binary tests on exit codes and output shape.
- `cargo mutants` over the module with the binary tests as the command: 53 caught, 15 unviable, 0 missed after two rounds (the first round left `has_findings`, `by_service`, `ordered_services`, one `&&` and the table renderer untested; each got a test).

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>