### PR TITLE
fix(pod): the user namespace is the pod's, and every service declares it alike

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -885,7 +885,9 @@ What changes inside the pod:
 - `ports:` are published by the pod, as the union of every service's list.
   A container inside a pod cannot publish its own.
 - Only the network namespace is shared. UTS and IPC stay per container, so
-  `hostname:` keeps working.
+  `hostname:` keeps working. The user namespace is the pod's: a `userns_mode`
+  every service declares alike (`auto`, say) is applied to the pod, and a
+  member cannot carry its own.
 - The pod carries the project's networks, the same set the containers would
   have joined.
 - `up` creates the pod before the first container, prints `Creating`/`Created`
@@ -909,7 +911,9 @@ the message:
 - `network_mode` on any service;
 - a service whose `networks:` set differs from another service's (every
   service declares the same set, or none and gets the project default);
-- two services publishing the same host port, whichever host IPs they bind.
+- two services publishing the same host port, whichever host IPs they bind;
+- services that disagree on `userns_mode` (one sets it and another does not,
+  or they set different values).
 
 What it costs and what it saves, measured on 2026-09-03 with the `wide-level`
 benchmark scenario (42 services), 10 measured runs after 2 warm-up, twice,

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -171,7 +171,14 @@ impl Engine {
 		let ipcns = service.ipc.as_deref().map(Namespace::parse);
 		let utsns = service.uts.as_deref().map(Namespace::parse);
 		let cgroupns = service.cgroup.as_deref().map(Namespace::parse);
-		let userns = service.userns_mode.as_deref().map(Namespace::parse);
+		// In pod mode the user namespace is the pod's; a member must not set
+		// its own (Podman's CLI refuses the pair, and the API would give the
+		// member a namespace the pod does not share).
+		let userns = if in_pod {
+			None
+		} else {
+			service.userns_mode.as_deref().map(Namespace::parse)
+		};
 		let (image_os, image_arch) = service
 			.platform
 			.as_deref()

--- a/internal/engine/pod/engine_more_tests.rs
+++ b/internal/engine/pod/engine_more_tests.rs
@@ -1,0 +1,206 @@
+//! The second half of the pod engine tests, split from `engine_tests.rs`
+//! to keep both under the repository line limit: the stale container list
+//! after a recreate, the infra container, inspect failures, the label
+//! sweep and the pod's user namespace.
+
+use crate::compose::parse_str;
+use crate::engine::fake_podman;
+
+use super::engine_tests::{engine_for, pod_up_fake, route};
+
+/// A pod recreate removes its member containers with it. The container list
+/// `up` fetched before that is stale afterwards; without forgetting it, `up`
+/// reads the listed container as unchanged and only starts it, which is a
+/// start on a container that no longer exists.
+#[tokio::test]
+#[cfg(unix)]
+async fn a_recreated_pod_forgets_the_containers_it_removed() {
+	let yaml = r#"
+x-podman-pod: true
+services:
+  web:
+    image: nginx
+"#;
+	let file = parse_str(yaml).unwrap();
+	// The listed container carries the hash and image ID `up` will compute, so
+	// with a stale list it reads as unchanged.
+	let hash = crate::engine::container::config_hash(&file.services["web"], &file).unwrap();
+	let listing = format!(
+		r#"[{{"Id":"aaa","Names":["/proj-web-1"],"Image":"nginx","ImageID":"sha256:0000000000000000000000000000000000000000000000000000000000000000","Status":"","State":"running","Ports":[],"Labels":{{"podup.project":"proj","podup.service":"web","podup.config-hash":"{hash}"}}}}]"#
+	);
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			return (200, listing.clone());
+		}
+		route(method, target, Some("wrong-hash"))
+	});
+	let engine = engine_for(&fake, "proj");
+	engine.up(&file).await.expect("up must succeed");
+
+	let requests = fake.requests.lock().unwrap().clone();
+	let recreated_pod = requests
+		.iter()
+		.any(|r| r.starts_with("DELETE") && r.contains("/pods/proj") && r.contains("force=true"));
+	let created_container = requests
+		.iter()
+		.any(|r| r.starts_with("POST") && r.contains("/containers/create"));
+	assert!(
+		recreated_pod,
+		"the mismatching pod must be recreated; requests: {requests:?}"
+	);
+	assert!(
+		created_container,
+		"the service must be created afresh, not started as if it survived the pod; requests: {requests:?}"
+	);
+}
+
+/// The infra container carries the project label and belongs to no service.
+/// On the first real run it was reported, and would have been removed, as an
+/// orphan; it lives and dies with the pod.
+#[tokio::test]
+#[cfg(unix)]
+async fn the_infra_container_is_not_an_orphan() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			return (
+				200,
+				r#"[{"Id":"iii","Names":["/abc-infra"],"Image":"localhost/podman-pause:5","ImageID":"sha256:pause","Status":"","State":"running","Ports":[],"IsInfra":true,"Labels":{"podup.project":"proj"}},{"Id":"sss","Names":["/proj-old-1"],"Image":"nginx","ImageID":"sha256:web","Status":"","State":"running","Ports":[],"Labels":{"podup.project":"proj","podup.service":"old"}}]"#.to_string(),
+			);
+		}
+		route(method, target, None)
+	});
+	let engine = engine_for(&fake, "proj");
+	let file = parse_str("x-podman-pod: true\nservices:\n  web:\n    image: nginx\n").unwrap();
+	engine
+		.remove_orphans(&file)
+		.await
+		.expect("remove_orphans must succeed");
+
+	let requests = fake.requests.lock().unwrap().clone();
+	assert!(
+		requests
+			.iter()
+			.any(|r| r.starts_with("DELETE") && r.contains("/containers/proj-old-1")),
+		"a container of a service no longer in the file is an orphan; requests: {requests:?}"
+	);
+	assert!(
+		!requests
+			.iter()
+			.any(|r| r.starts_with("DELETE") && r.contains("infra")),
+		"the infra container must never be removed as an orphan; requests: {requests:?}"
+	);
+}
+
+/// Only a 404 on the pod inspect means "no pod yet". Any other failure must
+/// surface, not be read as absence and answered with a create.
+#[tokio::test]
+#[cfg(unix)]
+async fn a_failing_pod_inspect_is_an_error_not_an_absence() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/pods/") && target.contains("/json") {
+			return (500, r#"{"message":"boom"}"#.to_string());
+		}
+		route(method, target, None)
+	});
+	let engine = engine_for(&fake, "proj");
+	let file = parse_str("x-podman-pod: true\nservices:\n  web:\n    image: nginx\n").unwrap();
+	let err = engine
+		.up(&file)
+		.await
+		.expect_err("a 500 on inspect must fail up");
+	assert!(
+		format!("{err}").contains("boom"),
+		"the engine's message must reach the user: {err}"
+	);
+	let requests = fake.requests.lock().unwrap().clone();
+	assert!(
+		!requests.iter().any(|r| r.contains("/pods/create")),
+		"no pod may be created on top of an unreadable one; requests: {requests:?}"
+	);
+}
+
+/// `down --remove-orphans` sweeps pods under the project's label that are
+/// not the project's own pod, and leaves that one to `remove_pod`.
+#[tokio::test]
+#[cfg(unix)]
+async fn the_label_sweep_removes_stale_pods_and_keeps_the_projects_own() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/pods/json") {
+			return (200, r#"[{"Name":"proj"},{"Name":"proj-old"}]"#.to_string());
+		}
+		if method == "DELETE" && target.contains("/pods/") {
+			return (200, r#"{"Id":"x"}"#.to_string());
+		}
+		route(method, target, None)
+	});
+	let engine = engine_for(&fake, "proj");
+	engine.remove_project_pods_by_label().await;
+	let requests = fake.requests.lock().unwrap().clone();
+	assert!(
+		requests
+			.iter()
+			.any(|r| r.starts_with("DELETE") && r.contains("/pods/proj-old")),
+		"the stale pod under the label must be removed; requests: {requests:?}"
+	);
+	assert!(
+		!requests
+			.iter()
+			.any(|r| r.starts_with("DELETE") && r.contains("/pods/proj?")),
+		"the project's own pod is not the sweep's to remove; requests: {requests:?}"
+	);
+}
+
+/// A common `userns_mode` lands on the pod, not on the members, and it is
+/// part of the hash that decides a recreate.
+#[tokio::test]
+#[cfg(unix)]
+async fn a_common_userns_mode_is_the_pods_and_not_the_members() {
+	let fake = pod_up_fake();
+	let engine = engine_for(&fake, "proj");
+	let yaml = r#"
+x-podman-pod: true
+services:
+  web:
+    image: nginx
+    userns_mode: auto
+  db:
+    image: postgres
+    userns_mode: auto
+"#;
+	let file = parse_str(yaml).unwrap();
+	engine.up(&file).await.expect("up must succeed");
+	let requests = fake.requests.lock().unwrap().clone();
+	let bodies = fake.bodies.lock().unwrap().clone();
+	let mut pod_body = None;
+	let mut container_bodies = Vec::new();
+	for (r, b) in requests.iter().zip(bodies.iter()) {
+		if r.contains("/pods/create") {
+			pod_body = Some(serde_json::from_slice::<serde_json::Value>(b).unwrap());
+		} else if r.contains("/containers/create") {
+			container_bodies.push(serde_json::from_slice::<serde_json::Value>(b).unwrap());
+		}
+	}
+	let pod_body = pod_body.expect("a pod must be created");
+	assert_eq!(
+		pod_body["userns"],
+		serde_json::json!({"nsmode": "auto"}),
+		"{pod_body}"
+	);
+	assert_eq!(container_bodies.len(), 2);
+	for c in &container_bodies {
+		assert!(
+			c.get("userns").is_none() || c["userns"].is_null(),
+			"a member must not carry its own userns: {c}"
+		);
+	}
+	let without = parse_str(
+		"x-podman-pod: true\nservices:\n  web:\n    image: nginx\n  db:\n    image: postgres\n",
+	)
+	.unwrap();
+	let ports: Vec<Vec<crate::ports::ParsedPort>> = vec![Vec::new(), Vec::new()];
+	assert_ne!(
+		crate::engine::pod::pod_config_hash(&ports, &file),
+		crate::engine::pod::pod_config_hash(&ports, &without),
+		"the user namespace is part of the pod hash"
+	);
+}

--- a/internal/engine/pod/engine_tests.rs
+++ b/internal/engine/pod/engine_tests.rs
@@ -12,14 +12,14 @@ use crate::engine::Engine;
 /// pod-enabled project. Every request gets a 200 with the smallest body the
 /// daemon would return; the test then inspects `fake.requests` and
 /// `fake.bodies` to assert what the engine actually did.
-fn pod_up_fake() -> fake_podman::FakePodman {
+pub(super) fn pod_up_fake() -> fake_podman::FakePodman {
 	fake_podman::start(|method, target| route(method, target, None))
 }
 
 /// As [`pod_up_fake`] but reports the pod as already existing with a given
 /// hash label. The engine will inspect it, compare against the new hash,
 /// and either reuse or recreate.
-fn pod_up_fake_with_existing(existing_hash: Option<&str>) -> fake_podman::FakePodman {
+pub(super) fn pod_up_fake_with_existing(existing_hash: Option<&str>) -> fake_podman::FakePodman {
 	let hash_label = existing_hash.unwrap_or("wrong-hash").to_string();
 	fake_podman::start(move |method, target| route(method, target, Some(&hash_label)))
 }
@@ -27,7 +27,7 @@ fn pod_up_fake_with_existing(existing_hash: Option<&str>) -> fake_podman::FakePo
 /// One fake routing table, parameterised by the recorded `podup.pod-config-hash`.
 /// `existing_hash == None` means the pod does not yet exist (the engine
 /// creates it); `Some(hash)` means the pod exists with that recorded hash.
-fn route(method: &str, target: &str, existing_hash: Option<&str>) -> (u16, String) {
+pub(super) fn route(method: &str, target: &str, existing_hash: Option<&str>) -> (u16, String) {
 	if method == "GET" && target.contains("/containers/json") {
 		(200, "[]".to_string())
 	} else if method == "POST"
@@ -111,7 +111,7 @@ fn decode_body(bodies: &[Vec<u8>], needle: &str) -> serde_json::Value {
 	panic!("no body matching {needle} in {} bodies", bodies.len())
 }
 
-fn engine_for(fake: &fake_podman::FakePodman, project: &str) -> Engine {
+pub(super) fn engine_for(fake: &fake_podman::FakePodman, project: &str) -> Engine {
 	Engine::with_base_dir(fake.client(), project.to_string(), std::env::temp_dir())
 }
 
@@ -417,202 +417,5 @@ async fn ps_hides_the_infra_container() {
 	assert!(
 		!names.iter().any(|n| n.contains("infra")),
 		"infra container must be hidden from ps; got: {names:?}"
-	);
-}
-
-/// A pod recreate removes its member containers with it. The container list
-/// `up` fetched before that is stale afterwards; without forgetting it, `up`
-/// reads the listed container as unchanged and only starts it, which is a
-/// start on a container that no longer exists.
-#[tokio::test]
-#[cfg(unix)]
-async fn a_recreated_pod_forgets_the_containers_it_removed() {
-	let yaml = r#"
-x-podman-pod: true
-services:
-  web:
-    image: nginx
-"#;
-	let file = parse_str(yaml).unwrap();
-	// The listed container carries the hash and image ID `up` will compute, so
-	// with a stale list it reads as unchanged.
-	let hash = crate::engine::container::config_hash(&file.services["web"], &file).unwrap();
-	let listing = format!(
-		r#"[{{"Id":"aaa","Names":["/proj-web-1"],"Image":"nginx","ImageID":"sha256:0000000000000000000000000000000000000000000000000000000000000000","Status":"","State":"running","Ports":[],"Labels":{{"podup.project":"proj","podup.service":"web","podup.config-hash":"{hash}"}}}}]"#
-	);
-	let fake = fake_podman::start(move |method, target| {
-		if method == "GET" && target.contains("/containers/json") {
-			return (200, listing.clone());
-		}
-		route(method, target, Some("wrong-hash"))
-	});
-	let engine = engine_for(&fake, "proj");
-	engine.up(&file).await.expect("up must succeed");
-
-	let requests = fake.requests.lock().unwrap().clone();
-	let recreated_pod = requests
-		.iter()
-		.any(|r| r.starts_with("DELETE") && r.contains("/pods/proj") && r.contains("force=true"));
-	let created_container = requests
-		.iter()
-		.any(|r| r.starts_with("POST") && r.contains("/containers/create"));
-	assert!(
-		recreated_pod,
-		"the mismatching pod must be recreated; requests: {requests:?}"
-	);
-	assert!(
-		created_container,
-		"the service must be created afresh, not started as if it survived the pod; requests: {requests:?}"
-	);
-}
-
-/// The infra container carries the project label and belongs to no service.
-/// On the first real run it was reported, and would have been removed, as an
-/// orphan; it lives and dies with the pod.
-#[tokio::test]
-#[cfg(unix)]
-async fn the_infra_container_is_not_an_orphan() {
-	let fake = fake_podman::start(|method, target| {
-		if method == "GET" && target.contains("/containers/json") {
-			return (
-				200,
-				r#"[{"Id":"iii","Names":["/abc-infra"],"Image":"localhost/podman-pause:5","ImageID":"sha256:pause","Status":"","State":"running","Ports":[],"IsInfra":true,"Labels":{"podup.project":"proj"}},{"Id":"sss","Names":["/proj-old-1"],"Image":"nginx","ImageID":"sha256:web","Status":"","State":"running","Ports":[],"Labels":{"podup.project":"proj","podup.service":"old"}}]"#.to_string(),
-			);
-		}
-		route(method, target, None)
-	});
-	let engine = engine_for(&fake, "proj");
-	let file = parse_str("x-podman-pod: true\nservices:\n  web:\n    image: nginx\n").unwrap();
-	engine
-		.remove_orphans(&file)
-		.await
-		.expect("remove_orphans must succeed");
-
-	let requests = fake.requests.lock().unwrap().clone();
-	assert!(
-		requests
-			.iter()
-			.any(|r| r.starts_with("DELETE") && r.contains("/containers/proj-old-1")),
-		"a container of a service no longer in the file is an orphan; requests: {requests:?}"
-	);
-	assert!(
-		!requests
-			.iter()
-			.any(|r| r.starts_with("DELETE") && r.contains("infra")),
-		"the infra container must never be removed as an orphan; requests: {requests:?}"
-	);
-}
-
-/// Only a 404 on the pod inspect means "no pod yet". Any other failure must
-/// surface, not be read as absence and answered with a create.
-#[tokio::test]
-#[cfg(unix)]
-async fn a_failing_pod_inspect_is_an_error_not_an_absence() {
-	let fake = fake_podman::start(|method, target| {
-		if method == "GET" && target.contains("/pods/") && target.contains("/json") {
-			return (500, r#"{"message":"boom"}"#.to_string());
-		}
-		route(method, target, None)
-	});
-	let engine = engine_for(&fake, "proj");
-	let file = parse_str("x-podman-pod: true\nservices:\n  web:\n    image: nginx\n").unwrap();
-	let err = engine
-		.up(&file)
-		.await
-		.expect_err("a 500 on inspect must fail up");
-	assert!(
-		format!("{err}").contains("boom"),
-		"the engine's message must reach the user: {err}"
-	);
-	let requests = fake.requests.lock().unwrap().clone();
-	assert!(
-		!requests.iter().any(|r| r.contains("/pods/create")),
-		"no pod may be created on top of an unreadable one; requests: {requests:?}"
-	);
-}
-
-/// `down --remove-orphans` sweeps pods under the project's label that are
-/// not the project's own pod, and leaves that one to `remove_pod`.
-#[tokio::test]
-#[cfg(unix)]
-async fn the_label_sweep_removes_stale_pods_and_keeps_the_projects_own() {
-	let fake = fake_podman::start(|method, target| {
-		if method == "GET" && target.contains("/pods/json") {
-			return (200, r#"[{"Name":"proj"},{"Name":"proj-old"}]"#.to_string());
-		}
-		if method == "DELETE" && target.contains("/pods/") {
-			return (200, r#"{"Id":"x"}"#.to_string());
-		}
-		route(method, target, None)
-	});
-	let engine = engine_for(&fake, "proj");
-	engine.remove_project_pods_by_label().await;
-	let requests = fake.requests.lock().unwrap().clone();
-	assert!(
-		requests
-			.iter()
-			.any(|r| r.starts_with("DELETE") && r.contains("/pods/proj-old")),
-		"the stale pod under the label must be removed; requests: {requests:?}"
-	);
-	assert!(
-		!requests
-			.iter()
-			.any(|r| r.starts_with("DELETE") && r.contains("/pods/proj?")),
-		"the project's own pod is not the sweep's to remove; requests: {requests:?}"
-	);
-}
-
-/// A common `userns_mode` lands on the pod, not on the members, and it is
-/// part of the hash that decides a recreate.
-#[tokio::test]
-#[cfg(unix)]
-async fn a_common_userns_mode_is_the_pods_and_not_the_members() {
-	let fake = pod_up_fake();
-	let engine = engine_for(&fake, "proj");
-	let yaml = r#"
-x-podman-pod: true
-services:
-  web:
-    image: nginx
-    userns_mode: auto
-  db:
-    image: postgres
-    userns_mode: auto
-"#;
-	let file = parse_str(yaml).unwrap();
-	engine.up(&file).await.expect("up must succeed");
-	let requests = fake.requests.lock().unwrap().clone();
-	let bodies = fake.bodies.lock().unwrap().clone();
-	let mut pod_body = None;
-	let mut container_bodies = Vec::new();
-	for (r, b) in requests.iter().zip(bodies.iter()) {
-		if r.contains("/pods/create") {
-			pod_body = Some(serde_json::from_slice::<serde_json::Value>(b).unwrap());
-		} else if r.contains("/containers/create") {
-			container_bodies.push(serde_json::from_slice::<serde_json::Value>(b).unwrap());
-		}
-	}
-	let pod_body = pod_body.expect("a pod must be created");
-	assert_eq!(
-		pod_body["userns"],
-		serde_json::json!({"nsmode": "auto"}),
-		"{pod_body}"
-	);
-	assert_eq!(container_bodies.len(), 2);
-	for c in &container_bodies {
-		assert!(
-			c.get("userns").is_none() || c["userns"].is_null(),
-			"a member must not carry its own userns: {c}"
-		);
-	}
-	let without = parse_str(
-		"x-podman-pod: true\nservices:\n  web:\n    image: nginx\n  db:\n    image: postgres\n",
-	)
-	.unwrap();
-	let ports: Vec<Vec<crate::ports::ParsedPort>> = vec![Vec::new(), Vec::new()];
-	assert_ne!(
-		crate::engine::pod::pod_config_hash(&ports, &file),
-		crate::engine::pod::pod_config_hash(&ports, &without),
-		"the user namespace is part of the pod hash"
 	);
 }

--- a/internal/engine/pod/engine_tests.rs
+++ b/internal/engine/pod/engine_tests.rs
@@ -561,3 +561,58 @@ async fn the_label_sweep_removes_stale_pods_and_keeps_the_projects_own() {
 		"the project's own pod is not the sweep's to remove; requests: {requests:?}"
 	);
 }
+
+/// A common `userns_mode` lands on the pod, not on the members, and it is
+/// part of the hash that decides a recreate.
+#[tokio::test]
+#[cfg(unix)]
+async fn a_common_userns_mode_is_the_pods_and_not_the_members() {
+	let fake = pod_up_fake();
+	let engine = engine_for(&fake, "proj");
+	let yaml = r#"
+x-podman-pod: true
+services:
+  web:
+    image: nginx
+    userns_mode: auto
+  db:
+    image: postgres
+    userns_mode: auto
+"#;
+	let file = parse_str(yaml).unwrap();
+	engine.up(&file).await.expect("up must succeed");
+	let requests = fake.requests.lock().unwrap().clone();
+	let bodies = fake.bodies.lock().unwrap().clone();
+	let mut pod_body = None;
+	let mut container_bodies = Vec::new();
+	for (r, b) in requests.iter().zip(bodies.iter()) {
+		if r.contains("/pods/create") {
+			pod_body = Some(serde_json::from_slice::<serde_json::Value>(b).unwrap());
+		} else if r.contains("/containers/create") {
+			container_bodies.push(serde_json::from_slice::<serde_json::Value>(b).unwrap());
+		}
+	}
+	let pod_body = pod_body.expect("a pod must be created");
+	assert_eq!(
+		pod_body["userns"],
+		serde_json::json!({"nsmode": "auto"}),
+		"{pod_body}"
+	);
+	assert_eq!(container_bodies.len(), 2);
+	for c in &container_bodies {
+		assert!(
+			c.get("userns").is_none() || c["userns"].is_null(),
+			"a member must not carry its own userns: {c}"
+		);
+	}
+	let without = parse_str(
+		"x-podman-pod: true\nservices:\n  web:\n    image: nginx\n  db:\n    image: postgres\n",
+	)
+	.unwrap();
+	let ports: Vec<Vec<crate::ports::ParsedPort>> = vec![Vec::new(), Vec::new()];
+	assert_ne!(
+		crate::engine::pod::pod_config_hash(&ports, &file),
+		crate::engine::pod::pod_config_hash(&ports, &without),
+		"the user namespace is part of the pod hash"
+	);
+}

--- a/internal/engine/pod/hash.rs
+++ b/internal/engine/pod/hash.rs
@@ -70,6 +70,11 @@ pub(crate) fn pod_config_hash(parsed_ports: &[Vec<ParsedPort>], file: &ComposeFi
 	let hosts_value = serde_json::to_value(&hosts).expect("hosts serialise");
 	hasher.update(b"hosts");
 	hash_canon(&mut hasher, &hosts_value);
+	// The pod's user namespace is fixed at create time, so a change to it is
+	// a recreate.
+	let userns_value = serde_json::to_value(super::pod_userns(file)).expect("userns serialises");
+	hasher.update(b"userns");
+	hash_canon(&mut hasher, &userns_value);
 
 	hasher
 		.finalize()

--- a/internal/engine/pod/mod.rs
+++ b/internal/engine/pod/mod.rs
@@ -14,6 +14,9 @@ mod validate;
 mod validate_tests;
 
 #[cfg(all(test, unix))]
+#[path = "engine_more_tests.rs"]
+mod engine_more_tests;
+#[cfg(all(test, unix))]
 #[path = "engine_tests.rs"]
 mod engine_tests;
 

--- a/internal/engine/pod/mod.rs
+++ b/internal/engine/pod/mod.rs
@@ -79,6 +79,15 @@ where
 /// infra container carries the same attachment list as every joined
 /// service would, so a service that pinned `aliases:` would still see its
 /// name on the network.
+/// The `userns_mode` every service agrees on, applied to the pod. Validation
+/// refused the project before this runs when the services disagree, so the
+/// first service's value is the project's.
+pub(super) fn pod_userns(file: &crate::compose::types::ComposeFile) -> Option<&str> {
+	file.services
+		.values()
+		.find_map(|s| s.userns_mode.as_deref())
+}
+
 pub(super) fn pod_networks(
 	file: &crate::compose::types::ComposeFile,
 	project: &str,
@@ -126,5 +135,6 @@ pub(super) fn build_pod_spec_with_hash(
 		},
 		networks,
 		hostadd: hostadd_for_services(file.services.keys()),
+		userns: pod_userns(file).map(crate::libpod::types::container::Namespace::parse),
 	}
 }

--- a/internal/engine/pod/validate.rs
+++ b/internal/engine/pod/validate.rs
@@ -75,6 +75,26 @@ pub(crate) fn validate_pod_or_refuse(file: &ComposeFile) -> Result<(), String> {
 	//    the same host_port bound to two different host IPs. Tracked by
 	//    (host_port, protocol) so a TCP and UDP on the same host port do
 	//    not falsely collide.
+	// A pod has one user namespace and Podman refuses a member with its own,
+	// so every service declares the same `userns_mode`, or none.
+	let mut userns: Option<(&str, Option<&str>)> = None;
+	for (name, service) in &services {
+		let mode = service.userns_mode.as_deref();
+		match userns {
+			None => userns = Some((name, mode)),
+			Some((first, first_mode)) if first_mode != mode => {
+				return Err(format!(
+					"service \"{name}\": userns_mode {} does not match service \"{first}\"'s {}; \
+					 x-podman-pod gives the pod one user namespace, so every service declares \
+					 the same userns_mode (or none)",
+					mode.map_or("(unset)".to_string(), |m| format!("{m:?}")),
+					first_mode.map_or("(unset)".to_string(), |m| format!("{m:?}")),
+				));
+			}
+			_ => {}
+		}
+	}
+
 	let mut host_port_owner: std::collections::HashMap<(u16, String), String> =
 		std::collections::HashMap::new();
 	for (name, service) in &services {

--- a/internal/engine/pod/validate_tests.rs
+++ b/internal/engine/pod/validate_tests.rs
@@ -160,3 +160,36 @@ services:
 "#;
 	check(yaml).expect("the same port on the same IP for two protocols must be accepted");
 }
+
+/// One user namespace per pod: services that disagree on `userns_mode` are
+/// refused, naming both, and the unset case counts as a value.
+#[test]
+fn pod_refuses_services_that_disagree_on_userns_mode() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+    userns_mode: auto
+  db:
+    image: postgres
+"#;
+	let err = check(yaml).expect_err("a userns_mode on one service only must be refused");
+	assert!(
+		err.contains("userns_mode") && err.contains("web") && err.contains("db"),
+		"{err}"
+	);
+}
+
+#[test]
+fn pod_accepts_services_that_agree_on_userns_mode() {
+	let yaml = r#"
+services:
+  web:
+    image: nginx
+    userns_mode: auto
+  db:
+    image: postgres
+    userns_mode: auto
+"#;
+	check(yaml).expect("the same userns_mode on every service must be accepted");
+}

--- a/internal/libpod/types/pod.rs
+++ b/internal/libpod/types/pod.rs
@@ -65,6 +65,12 @@ pub struct PodSpecGenerator {
 	/// container spec's `hostadd` uses (a `Vec<String>` of `<host>:<ip>`).
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	pub hostadd: Vec<String>,
+
+	/// User namespace of the pod, shared by every member. Podman's CLI
+	/// refuses `--userns` on a container inside a pod; the namespace is the
+	/// pod's, so a project's common `userns_mode` lands here.
+	#[serde(skip_serializing_if = "Option::is_none", default)]
+	pub userns: Option<Namespace>,
 }
 
 /// Response from `GET /libpod/pods/{name}/json`. Only the fields the engine

--- a/internal/libpod/types/pod_tests.rs
+++ b/internal/libpod/types/pod_tests.rs
@@ -13,6 +13,7 @@ fn pod_spec_serialises_with_known_field_names() {
 	labels.insert("podup.pod-config-hash".to_string(), "abc".to_string());
 	let spec = PodSpecGenerator {
 		netns: None,
+		userns: None,
 		name: "demo".to_string(),
 		labels,
 		shared_namespaces: vec!["net".to_string()],

--- a/tests/engine_integration/x_podman_pod.rs
+++ b/tests/engine_integration/x_podman_pod.rs
@@ -230,3 +230,48 @@ async fn down_removes_the_pod() {
 	);
 	assert!(gone, "down must remove the pod");
 }
+
+/// A `userns_mode` every service declares is applied to the pod, so a member
+/// runs in that user namespace without carrying the key itself.
+#[tokio::test]
+async fn a_pod_takes_the_services_user_namespace() {
+	if podman().await.is_none() {
+		return;
+	}
+	let dir = tempfile::tempdir().unwrap();
+	let proj = proj("pod-userns");
+	let yaml = "x-podman-pod: true\nservices:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    userns_mode: auto\n  db:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    userns_mode: auto\n";
+	let path = dir.path().join("docker-compose.yml");
+	fs::write(&path, yaml).unwrap();
+	let compose = path.to_str().unwrap().to_string();
+	let up = Command::new(bin())
+		.args(["-f", &compose, "-p", &proj, "up", "-d"])
+		.output()
+		.unwrap();
+	let in_pod = Command::new("podman")
+		.args([
+			"exec",
+			&format!("{proj}-web-1"),
+			"cat",
+			"/proc/self/uid_map",
+		])
+		.output()
+		.unwrap();
+	let plain = Command::new("podman")
+		.args(["run", "--rm", "alpine:latest", "cat", "/proc/self/uid_map"])
+		.output()
+		.unwrap();
+	down(&compose, &proj);
+	assert!(
+		up.status.success(),
+		"up failed: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+	let in_pod = String::from_utf8_lossy(&in_pod.stdout).to_string();
+	let plain = String::from_utf8_lossy(&plain.stdout).to_string();
+	assert_ne!(
+		in_pod.trim(),
+		plain.trim(),
+		"a member of a pod created with userns auto must not run in the default rootless mapping"
+	);
+}


### PR DESCRIPTION
Fixes #1668.

Under `x-podman-pod: true`, a `userns_mode` every service declares alike is applied to the pod and to no member; services that disagree (one sets it and another does not, or different values) are refused before anything is created; the value is part of the pod hash. `docs/commands.md` says so.

## Verified

- Unit: 1815 pass; the pod create body carries `userns: {nsmode: auto}` and no member does; the hash differs with and without it; the refusal names both services.
- Integration on Podman 5.7.0: a member of a project with `userns_mode: auto` on every service reads a `/proc/self/uid_map` different from a plain rootless container's; the other four pod tests still pass.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>