### PR TITLE
feat(ui): every command with verbs draws the live board

### DIFF
--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -79,6 +79,11 @@ where
 		.await
 }
 
+/// What determines one actual pull request: the image reference, the resolved
+/// pull policy (the `--pull` override applied ahead of the service's own
+/// `pull_policy:`), and the platform. The dedup key of a standalone pull.
+type PullKey<'a> = (&'a str, &'static str, Option<&'a str>);
+
 impl Engine {
 	/// Pull images for all services that declare an `image:` key, concurrently.
 	pub async fn pull(&self, file: &ComposeFile) -> Result<()> {
@@ -139,7 +144,6 @@ impl Engine {
 		// the dedup step below and the final reporting loop agree on exactly
 		// the same value instead of recomputing it (and re-warning on an
 		// unrecognized policy) twice.
-		type PullKey<'a> = (&'a str, &'static str, Option<&'a str>);
 		let candidates: Vec<(&str, &Service, PullKey)> = file
 			.services
 			.iter()
@@ -167,13 +171,45 @@ impl Engine {
 			})
 			.collect::<Result<Vec<_>>>()?;
 
+		// Seed the board with every distinct image this pass will fetch, before
+		// the first `Pulling` line. The set is knowable exactly here: it is the
+		// same `candidates` the dedup below works from, and every progress event
+		// on this path fires once its own pull is over. Two services naming the
+		// same image share one row, since the row is the image.
+		let mut images: Vec<String> = Vec::new();
+		for (_, _, key) in &candidates {
+			if !images.iter().any(|seen| seen == key.0) {
+				images.push(key.0.to_string());
+			}
+		}
+		crate::ui::progress::begin(
+			images
+				.into_iter()
+				.map(|image| (crate::ui::progress::Kind::Image, image)),
+		);
+		let outcome = self.pull_candidates(&candidates, opts).await;
+		// Close the board on every exit, the way `run_up` does: the live region
+		// hides the cursor, so an early return through it would leave the
+		// terminal without a caret. `end` is idempotent.
+		crate::ui::progress::end();
+		outcome
+	}
+
+	/// Issue the deduplicated pulls for `candidates` and report each service's
+	/// outcome. Split out of [`Self::pull_services_with_options`] so the board
+	/// opened over the image set has exactly one exit to close on.
+	async fn pull_candidates<'a>(
+		&self,
+		candidates: &[(&'a str, &'a Service, PullKey<'a>)],
+		opts: PullOptions,
+	) -> Result<()> {
 		// Dedup by that key: 50 services agreeing on image, resolved policy
 		// and platform must issue one pull, not 50. Two services naming the
 		// same image with a different resolved policy or platform get their
 		// own key, and so their own pull — one representative service per
 		// unique key is enough to issue it.
-		let mut representative: HashMap<PullKey, &Service> = HashMap::new();
-		for (_, service, key) in &candidates {
+		let mut representative: HashMap<PullKey<'a>, &'a Service> = HashMap::new();
+		for (_, service, key) in candidates {
 			representative.entry(*key).or_insert(service);
 		}
 
@@ -207,7 +243,7 @@ impl Engine {
 
 		for (name, _service, key) in candidates {
 			let image = key.0;
-			let (present, pull_err) = outcomes.get(&key).cloned().unwrap_or((false, None));
+			let (present, pull_err) = outcomes.get(key).cloned().unwrap_or((false, None));
 			// Presence alone is not success. A stale copy of the image already in
 			// local storage makes the probe pass while the pull actually failed,
 			// so `pull` against an unreachable registry exited 0 and reported
@@ -476,3 +512,7 @@ mod tests;
 #[cfg(test)]
 #[path = "pull_typo_tests.rs"]
 mod typo_tests;
+
+#[cfg(all(test, unix))]
+#[path = "pull_board_tests.rs"]
+mod board_tests;

--- a/internal/engine/build/pull_board_tests.rs
+++ b/internal/engine/build/pull_board_tests.rs
@@ -1,0 +1,111 @@
+//! The board a standalone `pull` opens.
+//!
+//! `pull` printed plain append lines with no spinner, no elapsed column and no
+//! marker while `up` over the same images drew a board (#1671). What is
+//! asserted here is what a unit test can see: the board is seeded with the
+//! image set before the first `Pulling`, one row per distinct image, and it is
+//! closed on the way out, including the way out of a failure.
+
+use crate::engine::fake_podman;
+use crate::engine::Engine;
+use crate::ui::progress::capture::Capture;
+use crate::ui::progress::Kind;
+
+/// Three services over two distinct images: the shared one is one row, because
+/// the row is the image and not the service.
+const FILE: &str = "\
+services:
+  one:
+    image: img-a
+  two:
+    image: img-b
+  three:
+    image: img-a
+";
+
+/// A fake that accepts every pull and reports the image present afterwards, so
+/// the pass succeeds.
+fn engine() -> (fake_podman::FakePodman, Engine) {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			(200, String::new())
+		} else if method == "GET" && target.contains("/images/") {
+			(200, "{}".to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+	(fake, engine)
+}
+
+#[tokio::test]
+async fn pull_draws_the_board_for_every_image() {
+	let (_fake, engine) = engine();
+	let file = crate::parse_str(FILE).expect("the fixture parses");
+
+	let capture = Capture::start();
+	engine
+		.pull(&file)
+		.await
+		.expect("a pull the fake accepts succeeds");
+	let mut names = capture.names();
+	names.sort();
+	assert_eq!(
+		names,
+		vec!["img-a", "img-b"],
+		"one row per distinct image, not per service"
+	);
+	assert!(
+		capture.rows().iter().all(|(kind, _)| *kind == Kind::Image),
+		"every row is an image: {:?}",
+		capture.rows()
+	);
+	assert!(
+		capture.every_board_ended(),
+		"the board must be closed, or a terminal is left without a cursor"
+	);
+}
+
+/// A pull that fails still closes its board. The live region hides the cursor,
+/// so an early return through an open one leaves the terminal without a caret.
+#[tokio::test]
+async fn a_failed_pull_still_closes_the_board() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			(200, r#"{"error":"registry unreachable"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+	let file = crate::parse_str("services:\n  one:\n    image: img-a\n").expect("parses");
+
+	let capture = Capture::start();
+	engine
+		.pull(&file)
+		.await
+		.expect_err("an in-band pull error must fail the pass");
+	assert_eq!(capture.names(), vec!["img-a"]);
+	assert!(capture.every_board_ended());
+}
+
+/// Off a terminal, the board opens no live region: no cursor hiding, no
+/// repaint, and every event goes out as the plain line it always was (the
+/// plain sink writes it through `write_progress_line`, the one line format both
+/// renderers share). `cargo test` redirects stderr, which is the same
+/// condition a pipe puts podup in; the end-to-end version of this, with the
+/// real binary and its stderr piped, is
+/// `a_piped_pull_keeps_the_plain_lines` in `tests/reporting_contract.rs`.
+#[tokio::test]
+async fn a_pull_off_a_terminal_opens_no_live_region() {
+	let (_fake, engine) = engine();
+	let file = crate::parse_str(FILE).expect("the fixture parses");
+
+	let capture = Capture::start();
+	engine.pull(&file).await.expect("the pull succeeds");
+	assert!(
+		!capture.any_live(),
+		"a redirected stderr must not get a repainted region"
+	);
+}

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -61,6 +61,22 @@ fn note_if_idle(acted: &std::sync::atomic::AtomicBool, verb: &str) {
 	}
 }
 
+/// The verb a row shows while the engine is still working, from the verb it
+/// will show when done. The board keeps a spinner and a clock on the row
+/// between the two; a plain sink prints only the final one.
+pub(super) fn working_verb(done: &str) -> &'static str {
+	match done {
+		"Started" => "Starting",
+		"Stopped" => "Stopping",
+		"Restarted" => "Restarting",
+		"Killed" => "Killing",
+		"Paused" => "Pausing",
+		"Unpaused" => "Unpausing",
+		"Removed" => "Removing",
+		_ => "Working",
+	}
+}
+
 impl Engine {
 	/// Run a lifecycle POST against one container with a consistent outcome:
 	/// success prints a `Container {container}  {done}` progress line; "already
@@ -86,6 +102,7 @@ impl Engine {
 		done: &str,
 		goal: LifecycleGoal,
 	) -> Result<bool> {
+		crate::ui::progress::start("Container", container, working_verb(done));
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				crate::ui::progress_line("Container", container, done);
@@ -93,6 +110,7 @@ impl Engine {
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_kill_of_stopped() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
+				crate::ui::progress_line("Container", container, "Skipped");
 				Ok(false)
 			}
 			// The server closed before completing the response. That is not an
@@ -125,6 +143,7 @@ impl Engine {
 		container: &str,
 		done: &str,
 	) -> Result<bool> {
+		crate::ui::progress::start("Container", container, working_verb(done));
 		match self.client.post_empty_ok(path).await {
 			Ok(()) => {
 				crate::ui::progress_line("Container", container, done);
@@ -132,6 +151,7 @@ impl Engine {
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) || e.is_state_conflict() => {
 				tracing::debug!("{container}: {done} skipped ({e})");
+				crate::ui::progress_line("Container", container, "Skipped");
 				Ok(false)
 			}
 			Err(e) => Err(ComposeError::Podman(e)),
@@ -162,6 +182,7 @@ impl Engine {
 			crate::libpod::urlencoded(container),
 			stop_timeout_param(grace),
 		);
+		crate::ui::progress::start("Container", container, "Stopping");
 		match self
 			.client
 			.post_empty_ok_within(&path, stop_deadline(grace))
@@ -173,6 +194,7 @@ impl Engine {
 			}
 			Err(e) if e.is_status(304) || e.is_status(404) => {
 				tracing::debug!("{container}: stop skipped ({e})");
+				crate::ui::progress_line("Container", container, "Skipped");
 				Ok(false)
 			}
 			// `stop` is one of the four state-changing calls the drops were
@@ -251,27 +273,43 @@ impl Engine {
 		// the end rather than aborting mid-batch and leaving later services
 		// unrestarted.
 		let acted = std::sync::atomic::AtomicBool::new(false);
-		let mut first_err: Option<ComposeError> = None;
-		for level in &levels {
-			let futs = level.iter().map(|name| {
-				let service = &file.services[name];
-				let grace = self.grace_period_secs(service);
-				let done = if targets.contains(name) {
-					"Restarted"
-				} else {
-					"Restarted (dependency)"
-				};
-				let names = live_by_service.get(name).cloned().unwrap_or_default();
-				self.restart_one_service(names, grace, done, &acted)
-			});
-			if let Some(e) = first_error(join_bounded(futs).await) {
-				first_err.get_or_insert(e);
+		// Seed the board with the containers this restart will walk, in the level
+		// order it walks them, before the first `Restarted` line. The set is
+		// knowable here and nowhere later: every progress event on this path
+		// fires once its own container is already done.
+		crate::ui::progress::begin(super::seed::level_container_resources(
+			&levels,
+			&live_by_service,
+		));
+		let outcome = async {
+			let mut first_err: Option<ComposeError> = None;
+			for level in &levels {
+				let futs = level.iter().map(|name| {
+					let service = &file.services[name];
+					let grace = self.grace_period_secs(service);
+					let done = if targets.contains(name) {
+						"Restarted"
+					} else {
+						"Restarted (dependency)"
+					};
+					let names = live_by_service.get(name).cloned().unwrap_or_default();
+					self.restart_one_service(names, grace, done, &acted)
+				});
+				if let Some(e) = first_error(join_bounded(futs).await) {
+					first_err.get_or_insert(e);
+				}
+			}
+			match first_err {
+				Some(e) => Err(e),
+				None => Ok(()),
 			}
 		}
-
-		if let Some(e) = first_err {
-			return Err(e);
-		}
+		.await;
+		// Close the board on every exit, the way `run_up` does: the region hides
+		// the cursor, so an early return through it would leave the terminal
+		// without a caret. `end` is idempotent.
+		crate::ui::progress::end();
+		outcome?;
 		note_if_idle(&acted, "restart");
 		Ok(())
 	}
@@ -406,16 +444,28 @@ impl Engine {
 		// `Ok(false)` for libpod's 304/404 idempotent no-ops, which is how this
 		// flag stays accurate with the bulk listing.
 		let acted = std::sync::atomic::AtomicBool::new(false);
-		for level in &levels {
-			let futs = level.iter().map(|name| {
-				let grace = self.grace_period_secs(&file.services[name]);
-				let names = live_by_service.get(name).cloned().unwrap_or_default();
-				self.stop_one_service(names, grace, &acted)
-			});
-			if let Some(e) = first_error(join_bounded(futs).await) {
-				return Err(e);
+		// The board over the containers this stop will walk, seeded in the
+		// reversed level order the walk below uses.
+		crate::ui::progress::begin(super::seed::level_container_resources(
+			&levels,
+			&live_by_service,
+		));
+		let outcome = async {
+			for level in &levels {
+				let futs = level.iter().map(|name| {
+					let grace = self.grace_period_secs(&file.services[name]);
+					let names = live_by_service.get(name).cloned().unwrap_or_default();
+					self.stop_one_service(names, grace, &acted)
+				});
+				if let Some(e) = first_error(join_bounded(futs).await) {
+					return Err(e);
+				}
 			}
+			Ok(())
 		}
+		.await;
+		crate::ui::progress::end();
+		outcome?;
 		note_if_idle(&acted, "stop");
 		Ok(())
 	}
@@ -440,20 +490,31 @@ impl Engine {
 		let live_by_service = self.live_project_replicas().await?;
 
 		let any_live = std::sync::atomic::AtomicBool::new(false);
-		let mut first_err: Option<ComposeError> = None;
-		for level in &levels {
-			let futs = level.iter().map(|name| {
-				let names = live_by_service.get(name).cloned().unwrap_or_default();
-				self.start_one_service(names, &any_live)
-			});
-			if let Some(e) = first_error(join_bounded(futs).await) {
-				first_err.get_or_insert(e);
+		// The board over the containers Podman actually has, in the dependency
+		// order the walk below starts them in.
+		crate::ui::progress::begin(super::seed::level_container_resources(
+			&levels,
+			&live_by_service,
+		));
+		let outcome = async {
+			let mut first_err: Option<ComposeError> = None;
+			for level in &levels {
+				let futs = level.iter().map(|name| {
+					let names = live_by_service.get(name).cloned().unwrap_or_default();
+					self.start_one_service(names, &any_live)
+				});
+				if let Some(e) = first_error(join_bounded(futs).await) {
+					first_err.get_or_insert(e);
+				}
+			}
+			match first_err {
+				Some(e) => Err(e),
+				None => Ok(()),
 			}
 		}
-
-		if let Some(e) = first_err {
-			return Err(e);
-		}
+		.await;
+		crate::ui::progress::end();
+		outcome?;
 		// `start`'s flag answers a narrower question than the others' — whether any
 		// container existed at all, not whether anything changed — so it can name
 		// the cause, and the extra clause rides in the verb.
@@ -481,15 +542,26 @@ impl Engine {
 		let live_by_service = self.live_project_replicas().await?;
 
 		let acted = std::sync::atomic::AtomicBool::new(false);
-		for level in &levels {
-			let futs = level.iter().map(|name| {
-				let names = live_by_service.get(name).cloned().unwrap_or_default();
-				self.kill_one_service(names, signal, &acted)
-			});
-			if let Some(e) = first_error(join_bounded(futs).await) {
-				return Err(e);
+		// The board over the containers this signal will reach.
+		crate::ui::progress::begin(super::seed::level_container_resources(
+			&levels,
+			&live_by_service,
+		));
+		let outcome = async {
+			for level in &levels {
+				let futs = level.iter().map(|name| {
+					let names = live_by_service.get(name).cloned().unwrap_or_default();
+					self.kill_one_service(names, signal, &acted)
+				});
+				if let Some(e) = first_error(join_bounded(futs).await) {
+					return Err(e);
+				}
 			}
+			Ok(())
 		}
+		.await;
+		crate::ui::progress::end();
+		outcome?;
 		note_if_idle(&acted, "signal");
 		Ok(())
 	}
@@ -527,19 +599,31 @@ impl Engine {
 		let live_by_service = self.live_project_replicas().await?;
 
 		let acted = std::sync::atomic::AtomicBool::new(false);
-		let mut first_err: Option<ComposeError> = None;
-		for level in &levels {
-			let futs = level.iter().map(|name| {
-				let names = live_by_service.get(name).cloned().unwrap_or_default();
-				self.rm_one_service(names, force, remove_volumes, &acted)
-			});
-			if let Some(e) = first_error(join_bounded(futs).await) {
-				first_err.get_or_insert(e);
+		// The board over the containers this removal will walk, in the reversed
+		// level order it walks them.
+		crate::ui::progress::begin(super::seed::level_container_resources(
+			&levels,
+			&live_by_service,
+		));
+		let outcome = async {
+			let mut first_err: Option<ComposeError> = None;
+			for level in &levels {
+				let futs = level.iter().map(|name| {
+					let names = live_by_service.get(name).cloned().unwrap_or_default();
+					self.rm_one_service(names, force, remove_volumes, &acted)
+				});
+				if let Some(e) = first_error(join_bounded(futs).await) {
+					first_err.get_or_insert(e);
+				}
+			}
+			match first_err {
+				Some(e) => Err(e),
+				None => Ok(()),
 			}
 		}
-		if let Some(e) = first_err {
-			return Err(e);
-		}
+		.await;
+		crate::ui::progress::end();
+		outcome?;
 		note_if_idle(&acted, "remove");
 		Ok(())
 	}
@@ -559,19 +643,30 @@ impl Engine {
 		// batch and leave the rest in an inconsistent partial state. Services in a
 		// level are paused concurrently (#757).
 		let acted = std::sync::atomic::AtomicBool::new(false);
-		let mut first_err: Option<ComposeError> = None;
-		for level in &levels {
-			let futs = level.iter().map(|name| {
-				let names = live_by_service.get(name).cloned().unwrap_or_default();
-				self.idempotent_state_service(names, "pause", "Paused", &acted)
-			});
-			if let Some(e) = first_error(join_bounded(futs).await) {
-				first_err.get_or_insert(e);
+		// The board over the containers this pause will reach.
+		crate::ui::progress::begin(super::seed::level_container_resources(
+			&levels,
+			&live_by_service,
+		));
+		let outcome = async {
+			let mut first_err: Option<ComposeError> = None;
+			for level in &levels {
+				let futs = level.iter().map(|name| {
+					let names = live_by_service.get(name).cloned().unwrap_or_default();
+					self.idempotent_state_service(names, "pause", "Paused", &acted)
+				});
+				if let Some(e) = first_error(join_bounded(futs).await) {
+					first_err.get_or_insert(e);
+				}
+			}
+			match first_err {
+				Some(e) => Err(e),
+				None => Ok(()),
 			}
 		}
-		if let Some(e) = first_err {
-			return Err(e);
-		}
+		.await;
+		crate::ui::progress::end();
+		outcome?;
 		note_if_idle(&acted, "pause");
 		Ok(())
 	}
@@ -590,19 +685,30 @@ impl Engine {
 		// container is a no-op, and a single mismatch must not abort the batch.
 		// Services in a level are unpaused concurrently (#757).
 		let acted = std::sync::atomic::AtomicBool::new(false);
-		let mut first_err: Option<ComposeError> = None;
-		for level in &levels {
-			let futs = level.iter().map(|name| {
-				let names = live_by_service.get(name).cloned().unwrap_or_default();
-				self.idempotent_state_service(names, "unpause", "Unpaused", &acted)
-			});
-			if let Some(e) = first_error(join_bounded(futs).await) {
-				first_err.get_or_insert(e);
+		// The board over the containers this unpause will reach.
+		crate::ui::progress::begin(super::seed::level_container_resources(
+			&levels,
+			&live_by_service,
+		));
+		let outcome = async {
+			let mut first_err: Option<ComposeError> = None;
+			for level in &levels {
+				let futs = level.iter().map(|name| {
+					let names = live_by_service.get(name).cloned().unwrap_or_default();
+					self.idempotent_state_service(names, "unpause", "Unpaused", &acted)
+				});
+				if let Some(e) = first_error(join_bounded(futs).await) {
+					first_err.get_or_insert(e);
+				}
+			}
+			match first_err {
+				Some(e) => Err(e),
+				None => Ok(()),
 			}
 		}
-		if let Some(e) = first_err {
-			return Err(e);
-		}
+		.await;
+		crate::ui::progress::end();
+		outcome?;
 		note_if_idle(&acted, "unpause");
 		Ok(())
 	}
@@ -625,3 +731,7 @@ impl Engine {
 #[cfg(test)]
 #[path = "commands_wait_output_tests.rs"]
 mod wait_output_tests;
+
+#[cfg(all(test, unix))]
+#[path = "commands_board_tests.rs"]
+mod board_tests;

--- a/internal/engine/lifecycle/commands_board_tests.rs
+++ b/internal/engine/lifecycle/commands_board_tests.rs
@@ -1,0 +1,168 @@
+//! The board the level-walking lifecycle commands open.
+//!
+//! Every one of `restart`, `stop`, `start`, `kill`, `pause`, `unpause` and `rm`
+//! used to print plain append lines with no spinner, no elapsed column and no
+//! marker, so the feel changed from one command to the next (#1671). What is
+//! asserted here is the part a unit test can see: the board is opened over the
+//! containers Podman actually has, in the order the command walks them, and it
+//! is closed again on the way out.
+
+use crate::engine::fake_podman;
+use crate::engine::Engine;
+use crate::ui::progress::capture::Capture;
+use crate::ui::progress::Kind;
+
+/// Two services, `two` after `one`, so the level order is `one` then `two` and
+/// the reversed order (`stop`, `rm`) is `two` then `one`.
+const FILE: &str = "\
+services:
+  one:
+    image: alpine
+  two:
+    image: alpine
+    depends_on:
+      - one
+";
+
+/// The project listing every command below prefetches: one live replica per
+/// service, handed back in the shuffled order a real libpod is free to use.
+const LIVE: &str = r#"[
+	{"Names":["/proj-two-1"],"State":"running","Labels":{"podup.service":"two"}},
+	{"Names":["/proj-one-1"],"State":"running","Labels":{"podup.service":"one"}}
+]"#;
+
+/// A fake that answers the project listing and accepts every state change.
+fn engine() -> (fake_podman::FakePodman, Engine) {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, LIVE.to_string())
+		} else {
+			(200, String::new())
+		}
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+	(fake, engine)
+}
+
+fn file() -> crate::compose::types::ComposeFile {
+	crate::parse_str(FILE).expect("the fixture parses")
+}
+
+/// Every row is a container, which is what these commands act on.
+fn all_containers(rows: &[(Kind, String)]) -> bool {
+	rows.iter().all(|(kind, _)| *kind == Kind::Container)
+}
+
+#[tokio::test]
+async fn restart_stop_start_draw_the_board_for_every_container() {
+	let (_fake, engine) = engine();
+	let file = file();
+
+	let capture = Capture::start();
+	engine
+		.restart_with_options(&file, &[], false)
+		.await
+		.expect("restart against the fake succeeds");
+	assert!(all_containers(&capture.rows()), "{:?}", capture.rows());
+	assert_eq!(
+		capture.names(),
+		vec!["proj-one-1", "proj-two-1"],
+		"restart walks the dependency order, so the board is seeded in it"
+	);
+	assert!(capture.every_board_ended(), "the board must be closed");
+	drop(capture);
+
+	let capture = Capture::start();
+	engine.stop(&file, &[]).await.expect("stop succeeds");
+	assert_eq!(
+		capture.names(),
+		vec!["proj-two-1", "proj-one-1"],
+		"stop inverts the levels, and the board is seeded in the inverted order"
+	);
+	assert!(capture.every_board_ended());
+	drop(capture);
+
+	let capture = Capture::start();
+	engine.start(&file, &[]).await.expect("start succeeds");
+	assert_eq!(capture.names(), vec!["proj-one-1", "proj-two-1"]);
+	assert!(capture.every_board_ended());
+}
+
+#[tokio::test]
+async fn kill_pause_unpause_rm_draw_the_board_for_every_container() {
+	let (_fake, engine) = engine();
+	let file = file();
+
+	let capture = Capture::start();
+	engine
+		.kill(&file, &[], "SIGTERM")
+		.await
+		.expect("kill succeeds");
+	assert_eq!(capture.names(), vec!["proj-one-1", "proj-two-1"]);
+	assert!(capture.every_board_ended());
+	drop(capture);
+
+	let capture = Capture::start();
+	engine.pause(&file, &[]).await.expect("pause succeeds");
+	assert_eq!(capture.names(), vec!["proj-one-1", "proj-two-1"]);
+	assert!(capture.every_board_ended());
+	drop(capture);
+
+	let capture = Capture::start();
+	engine.unpause(&file, &[]).await.expect("unpause succeeds");
+	assert_eq!(capture.names(), vec!["proj-one-1", "proj-two-1"]);
+	assert!(capture.every_board_ended());
+	drop(capture);
+
+	let capture = Capture::start();
+	engine
+		.rm_with_options(&file, &[], true, false)
+		.await
+		.expect("rm succeeds");
+	assert!(all_containers(&capture.rows()));
+	assert_eq!(
+		capture.names(),
+		vec!["proj-two-1", "proj-one-1"],
+		"rm inverts the levels like stop does"
+	);
+	assert!(capture.every_board_ended());
+}
+
+/// A service the file defines but that Podman has never created contributes no
+/// row: a row that never moves reads as something hung, which is the rule
+/// `down_resources` already follows.
+#[tokio::test]
+async fn a_never_created_service_gets_no_row() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(
+				200,
+				r#"[{"Names":["/proj-one-1"],"Labels":{"podup.service":"one"}}]"#.to_string(),
+			)
+		} else {
+			(200, String::new())
+		}
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+	let capture = Capture::start();
+	engine.stop(&file(), &[]).await.expect("stop succeeds");
+	assert_eq!(capture.names(), vec!["proj-one-1"]);
+}
+
+/// Every final verb has a working verb the row shows while the engine acts,
+/// so a ten-second stop is a turning spinner and a clock, not a frozen
+/// `Pending`.
+#[test]
+fn every_final_verb_has_a_working_verb() {
+	for (done, doing) in [
+		("Started", "Starting"),
+		("Stopped", "Stopping"),
+		("Restarted", "Restarting"),
+		("Killed", "Killing"),
+		("Paused", "Pausing"),
+		("Unpaused", "Unpausing"),
+		("Removed", "Removing"),
+	] {
+		assert_eq!(super::working_verb(done), doing);
+	}
+}

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -176,35 +176,55 @@ impl Engine {
 		// framing a TTY produces. So the two are consistent, not contradictory.
 		run_service.tty = want_tty.then_some(true);
 
-		// Ensure the project networks exist (compose `run` brings them up like
-		// `up` does); the service may reference the synthesized `default`
-		// network, which is created here as `{project}_default`.
-		self.create_networks(file).await?;
-		// Inline secrets/configs are created up front (no longer in the
-		// per-container build path), so materialise them here too before the run
-		// container is created.
-		self.create_project_secrets(file).await?;
-		// `x-podman-pod`: ensure the pod exists with the current hash. A run
-		// container joins the same pod as the project's `up` would.
-		if file.podman_pod().map_err(ComposeError::Unsupported)? {
-			let pod_ports: Vec<Vec<crate::ports::ParsedPort>> = file
-				.services
-				.values()
-				.map(|s| crate::ports::parse_ports(&s.ports))
-				.collect::<crate::error::Result<Vec<_>>>()?;
-			// `run` creates one fresh container, so a recreated pod changes nothing here.
-			self.ensure_pod(file, &pod_ports).await?;
-		}
+		// Seed the board with the rows `run` reports before the container's own
+		// output takes over: the project networks, and the image when it still
+		// has to be acquired. Asked here rather than derived from the compose
+		// file alone, because whether the image is present is the one part of
+		// that list the file cannot answer.
+		let image_missing = match run_service.image.as_deref() {
+			Some(image) => !self.image_present(image).await,
+			None => false,
+		};
+		crate::ui::progress::begin(self.run_resources(file, &run_service, image_missing));
+		let prepared = async {
+			// Ensure the project networks exist (compose `run` brings them up like
+			// `up` does); the service may reference the synthesized `default`
+			// network, which is created here as `{project}_default`.
+			self.create_networks(file).await?;
+			// Inline secrets/configs are created up front (no longer in the
+			// per-container build path), so materialise them here too before the run
+			// container is created.
+			self.create_project_secrets(file).await?;
+			// `x-podman-pod`: ensure the pod exists with the current hash. A run
+			// container joins the same pod as the project's `up` would.
+			if file.podman_pod().map_err(ComposeError::Unsupported)? {
+				let pod_ports: Vec<Vec<crate::ports::ParsedPort>> = file
+					.services
+					.values()
+					.map(|s| crate::ports::parse_ports(&s.ports))
+					.collect::<crate::error::Result<Vec<_>>>()?;
+				// `run` creates one fresh container, so a recreated pod changes nothing here.
+				self.ensure_pod(file, &pod_ports).await?;
+			}
 
-		// Refuse to clobber a pre-existing container of the same name (data-loss
-		// footgun): `create_and_start` would force-remove it. Only the verbatim
-		// user-supplied name can collide with something we don't own.
-		if user_named && self.container_exists(&run_name).await? {
-			return Err(ComposeError::Unsupported(format!(
-				"the container name \"{run_name}\" is already in use; remove the existing \
-				 container or choose a different --name"
-			)));
+			// Refuse to clobber a pre-existing container of the same name (data-loss
+			// footgun): `create_and_start` would force-remove it. Only the verbatim
+			// user-supplied name can collide with something we don't own.
+			if user_named && self.container_exists(&run_name).await? {
+				return Err(ComposeError::Unsupported(format!(
+					"the container name \"{run_name}\" is already in use; remove the existing \
+					 container or choose a different --name"
+				)));
+			}
+			Ok(())
 		}
+		.await;
+		// Close the board before the container's own output starts: it is the
+		// container that owns the terminal from here on, and a region left open
+		// would repaint over its output. `end` is idempotent, so the error path
+		// below leaves no hidden cursor either.
+		crate::ui::progress::end();
+		prepared?;
 
 		let rm_path = format!(
 			"{API_PREFIX}/containers/{}?force=true",
@@ -383,3 +403,9 @@ mod tests;
 #[cfg(unix)]
 #[path = "run_stream_end_tests.rs"]
 mod stream_end_tests;
+
+/// The board `run` opens over the networks and image it reports before the
+/// container's own output takes over (#1671).
+#[cfg(all(test, unix))]
+#[path = "run_board_tests.rs"]
+mod board_tests;

--- a/internal/engine/lifecycle/run_board_tests.rs
+++ b/internal/engine/lifecycle/run_board_tests.rs
@@ -1,0 +1,100 @@
+//! The board a one-off `run` opens over what it does before the container's
+//! own output takes over.
+//!
+//! `run` printed plain append lines for the networks it ensures while `up` over
+//! the same networks drew a board (#1671). The image row joins them when the
+//! image still has to be acquired; an image already in local storage produces
+//! no verb on this path, so seeding a row for it would leave a line reading
+//! `Pending` behind every successful run.
+
+use crate::engine::fake_podman;
+use crate::engine::Engine;
+use crate::ui::progress::capture::Capture;
+use crate::ui::progress::Kind;
+
+const FILE: &str = "\
+services:
+  app:
+    image: img
+networks:
+  extra:
+";
+
+fn options() -> crate::engine::RunOptions {
+	crate::engine::RunOptions {
+		cmd: vec![],
+		rm: false,
+		// Detached, so the run returns as soon as the container is started and
+		// the test never has to model a log stream.
+		detach: true,
+		env_overrides: vec![],
+		name_override: None,
+		service_ports: false,
+	}
+}
+
+/// A fake with no image in local storage, no network yet, and a container
+/// create/start that succeeds.
+fn engine(image_present: bool) -> (fake_podman::FakePodman, Engine) {
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/images/") {
+			if image_present {
+				(200, "{}".to_string())
+			} else {
+				(404, r#"{"message":"no such image"}"#.to_string())
+			}
+		} else if method == "POST" {
+			(200, r#"{"Id":"cafe"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+	(fake, engine)
+}
+
+#[tokio::test]
+async fn run_draws_the_board_for_its_network_and_image_rows() {
+	let (_fake, engine) = engine(false);
+	let file = crate::parse_str(FILE).expect("the fixture parses");
+
+	let capture = Capture::start();
+	engine
+		.run(&file, "app", options())
+		.await
+		.expect("a detached run against the fake succeeds");
+	let rows = capture.rows();
+	assert!(
+		rows.iter()
+			.any(|(kind, name)| *kind == Kind::Network && name == "proj_extra"),
+		"the project network is a row: {rows:?}"
+	);
+	assert_eq!(
+		rows.last(),
+		Some(&(Kind::Image, "img".to_string())),
+		"the image the run has to acquire is the last row before the container: {rows:?}"
+	);
+	assert!(
+		capture.every_board_ended(),
+		"the board closes before the container's own output starts"
+	);
+}
+
+/// An image already in local storage gets no row, because nothing on this path
+/// reports it and a row that never moves reads as something hung.
+#[tokio::test]
+async fn a_present_image_gets_no_row() {
+	let (_fake, engine) = engine(true);
+	let file = crate::parse_str(FILE).expect("the fixture parses");
+
+	let capture = Capture::start();
+	engine
+		.run(&file, "app", options())
+		.await
+		.expect("a detached run against the fake succeeds");
+	assert!(
+		!capture.rows().iter().any(|(kind, _)| *kind == Kind::Image),
+		"{:?}",
+		capture.rows()
+	);
+}

--- a/internal/engine/lifecycle/seed.rs
+++ b/internal/engine/lifecycle/seed.rs
@@ -14,15 +14,74 @@
 //! is appended by the board when its event arrives. Being approximately right
 //! before the work starts beats being exactly right after it finished.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use crate::compose::types::ComposeFile;
+use crate::compose::types::{ComposeFile, Service};
 use crate::ui::progress::Kind;
 
 use super::super::network::resolve_network_name;
 use super::super::Engine;
 
+/// Every container a level-walking lifecycle command will act on, in the order
+/// it will act on them: the levels as that command walks them (already
+/// reversed for the ones that tear down), and within a level the replicas the
+/// prefetched listing found.
+///
+/// Built from what Podman actually has, like [`Engine::down_resources`]: a
+/// service the file defines but that was never created contributes no row,
+/// because a row that never moves reads as something hung. Shared by `stop`,
+/// `start`, `restart`, `kill`, `pause`, `unpause` and `rm`, which all walk
+/// levels over the same prefetched listing.
+pub(super) fn level_container_resources(
+	levels: &[Vec<String>],
+	live_by_service: &HashMap<String, Vec<String>>,
+) -> Vec<(Kind, String)> {
+	levels
+		.iter()
+		.flatten()
+		.filter_map(|service| live_by_service.get(service))
+		.flatten()
+		.map(|name| (Kind::Container, name.clone()))
+		.collect()
+}
+
 impl Engine {
+	/// The project networks a command will create or remove: every declared
+	/// network that is not `external`, under the name Podman will show it by.
+	///
+	/// External networks are never created or removed by podup, so they are not
+	/// work any command will do and must not appear as rows waiting to happen.
+	fn network_resources(&self, file: &ComposeFile) -> Vec<(Kind, String)> {
+		file.networks
+			.iter()
+			.filter(|(_, cfg)| !cfg.as_ref().and_then(|c| c.external).unwrap_or(false))
+			.map(|(key, _)| {
+				(
+					Kind::Network,
+					resolve_network_name(key, file, &self.project),
+				)
+			})
+			.collect()
+	}
+
+	/// The project volumes a command will create or remove, under the names
+	/// Podman will show them by. External volumes are left out for the same
+	/// reason external networks are.
+	fn volume_resources(&self, file: &ComposeFile) -> Vec<(Kind, String)> {
+		file.volumes
+			.iter()
+			.filter(|(_, cfg)| !cfg.as_ref().and_then(|c| c.external).unwrap_or(false))
+			.map(|(key, cfg)| {
+				let name = cfg
+					.as_ref()
+					.and_then(|c| c.name.as_deref())
+					.map(str::to_string)
+					.unwrap_or_else(|| format!("{}_{key}", self.project));
+				(Kind::Volume, name)
+			})
+			.collect()
+	}
+
 	/// Every resource an `up`/`create` pass will touch, in the order it will
 	/// touch them: networks, then volumes, then containers by dependency level.
 	///
@@ -35,31 +94,8 @@ impl Engine {
 		enabled: &HashSet<String>,
 		target_set: &Option<HashSet<String>>,
 	) -> Vec<(Kind, String)> {
-		let mut out = Vec::new();
-
-		// External networks and volumes are never created by podup, so they are
-		// not work this command will do and must not appear as rows waiting to
-		// happen.
-		for (key, cfg) in &file.networks {
-			if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
-				continue;
-			}
-			out.push((
-				Kind::Network,
-				resolve_network_name(key, file, &self.project),
-			));
-		}
-		for (key, cfg) in &file.volumes {
-			let cfg = cfg.as_ref();
-			if cfg.and_then(|c| c.external).unwrap_or(false) {
-				continue;
-			}
-			let name = cfg
-				.and_then(|c| c.name.as_deref())
-				.map(str::to_string)
-				.unwrap_or_else(|| format!("{}_{}", self.project, key));
-			out.push((Kind::Volume, name));
-		}
+		let mut out = self.network_resources(file);
+		out.extend(self.volume_resources(file));
 
 		// Containers in dependency order, which is the order they will start.
 		// Falls back to the file's own order if the graph cannot be resolved —
@@ -107,29 +143,33 @@ impl Engine {
 			.iter()
 			.map(|name| (Kind::Container, name.clone()))
 			.collect();
-		for (key, cfg) in &file.networks {
-			if cfg.as_ref().and_then(|c| c.external).unwrap_or(false) {
-				continue;
-			}
-			out.push((
-				Kind::Network,
-				resolve_network_name(key, file, &self.project),
-			));
-		}
+		out.extend(self.network_resources(file));
 		// Volumes survive a `down` without `-v`, so they are not work this pass
 		// will do.
 		if remove_volumes {
-			for (key, cfg) in &file.volumes {
-				let cfg = cfg.as_ref();
-				if cfg.and_then(|c| c.external).unwrap_or(false) {
-					continue;
-				}
-				let name = cfg
-					.and_then(|c| c.name.as_deref())
-					.map(str::to_string)
-					.unwrap_or_else(|| format!("{}_{}", self.project, key));
-				out.push((Kind::Volume, name));
-			}
+			out.extend(self.volume_resources(file));
+		}
+		out
+	}
+
+	/// What a one-off `run` reports before the container's own output takes
+	/// over: the project networks it ensures, then the service's image when
+	/// that image still has to be acquired.
+	///
+	/// `image_missing` is the caller's answer to "is the image absent from
+	/// local storage", which is the only part of this list that a compose file
+	/// cannot tell. An image already in storage produces no verb on this path,
+	/// so seeding a row for it would leave a line reading `Pending` after the
+	/// board closed.
+	pub(super) fn run_resources(
+		&self,
+		file: &ComposeFile,
+		service: &Service,
+		image_missing: bool,
+	) -> Vec<(Kind, String)> {
+		let mut out = self.network_resources(file);
+		if let Some(image) = service.image.as_deref().filter(|_| image_missing) {
+			out.push((Kind::Image, image.to_string()));
 		}
 		out
 	}

--- a/internal/ui/progress/capture.rs
+++ b/internal/ui/progress/capture.rs
@@ -1,0 +1,131 @@
+//! Test-only record of the boards a command opens.
+//!
+//! `begin` and `end` are the whole of "this command draws the board", and
+//! neither leaves anything behind that a test could read afterwards: `end`
+//! takes the session. Recording the two calls is what lets a command be
+//! checked against a fake Podman with no terminal in sight, which is the only
+//! place the nine lifecycle commands can be driven in a unit test.
+//!
+//! Per thread, not process-global, and independent of whether progress output
+//! is on. Both follow from the suite: 1800-odd tests run in parallel over one
+//! process, so a shared record would mix one test's `begin` with another's, and
+//! switching the process-wide progress flag on to observe a board would make
+//! every *other* test's lifecycle call start recording one.
+
+use std::cell::{Cell, RefCell};
+
+use super::Kind;
+
+/// One recorded call.
+#[derive(Debug, Clone)]
+pub(crate) enum Event {
+	/// A [`super::begin`], with the rows it seeded and whether a live region
+	/// would be opened for them. `live` is false under `cargo test`, where
+	/// stderr is redirected, which is the same condition a pipe puts podup in.
+	Begin {
+		rows: Vec<(Kind, String)>,
+		live: bool,
+	},
+	/// An [`super::end`].
+	End,
+}
+
+thread_local! {
+	/// Whether this thread is inside a [`Capture`]. Without it every test in
+	/// the suite would accumulate events nobody reads.
+	static RECORDING: Cell<bool> = const { Cell::new(false) };
+	static EVENTS: RefCell<Vec<Event>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(super) fn record_begin(rows: &[(Kind, String)], live: bool) {
+	if !RECORDING.get() {
+		return;
+	}
+	EVENTS.with_borrow_mut(|events| {
+		events.push(Event::Begin {
+			rows: rows.to_vec(),
+			live,
+		})
+	});
+}
+
+pub(super) fn record_end() {
+	if !RECORDING.get() {
+		return;
+	}
+	EVENTS.with_borrow_mut(|events| events.push(Event::End));
+}
+
+/// A recording session, cleared when it drops, including the drop that runs
+/// while a failing test is unwinding.
+pub(crate) struct Capture {
+	/// Not constructible from outside, so the recording flag cannot be left on
+	/// by a caller that builds one itself.
+	_private: (),
+}
+
+impl Capture {
+	/// Begin recording the calls made on this thread.
+	pub(crate) fn start() -> Self {
+		EVENTS.with_borrow_mut(|events| events.clear());
+		RECORDING.set(true);
+		Self { _private: () }
+	}
+
+	/// The rows of every board opened so far, in order.
+	pub(crate) fn boards(&self) -> Vec<Vec<(Kind, String)>> {
+		EVENTS.with_borrow(|events| {
+			events
+				.iter()
+				.filter_map(|e| match e {
+					Event::Begin { rows, .. } => Some(rows.clone()),
+					Event::End => None,
+				})
+				.collect()
+		})
+	}
+
+	/// The rows of the one board a test that opens exactly one is about.
+	pub(crate) fn rows(&self) -> Vec<(Kind, String)> {
+		let boards = self.boards();
+		assert_eq!(boards.len(), 1, "expected exactly one board: {boards:?}");
+		boards.into_iter().next().unwrap_or_default()
+	}
+
+	/// The names on that one board, which is what most assertions are about.
+	pub(crate) fn names(&self) -> Vec<String> {
+		self.rows().into_iter().map(|(_, name)| name).collect()
+	}
+
+	/// Whether every board that was opened was also closed. An unclosed board
+	/// on a terminal leaves the cursor hidden, so this is not a detail.
+	pub(crate) fn every_board_ended(&self) -> bool {
+		EVENTS.with_borrow(|events| {
+			let begins = events
+				.iter()
+				.filter(|e| matches!(e, Event::Begin { .. }))
+				.count();
+			let ends = events.iter().filter(|e| matches!(e, Event::End)).count();
+			begins > 0 && begins == ends
+		})
+	}
+
+	/// Whether any board would have opened a live region. False with stderr
+	/// redirected, which is how a test reads the plain-line half of the
+	/// contract.
+	pub(crate) fn any_live(&self) -> bool {
+		EVENTS.with_borrow(|events| {
+			events.iter().any(|e| match e {
+				Event::Begin { live, .. } => *live,
+				Event::End => false,
+			})
+		})
+	}
+}
+
+impl Drop for Capture {
+	fn drop(&mut self) {
+		RECORDING.set(false);
+		EVENTS.with_borrow_mut(|events| events.clear());
+	}
+}

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -15,6 +15,8 @@ use std::sync::Mutex;
 use std::time::Instant;
 
 mod board;
+#[cfg(test)]
+pub(crate) mod capture;
 mod live;
 mod row;
 
@@ -96,9 +98,21 @@ fn width_from(size: Option<(u16, u16)>) -> Option<usize> {
 /// A no-op when progress output is off, so an embedding crate never gets a
 /// board it did not ask for.
 pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
+	// Recorded before the gate, so a test can read which rows a command asked
+	// for without switching the process-wide progress flag on for every other
+	// test in the suite. Compiled out of a release build entirely.
+	#[cfg(test)]
+	let resources: Vec<(Kind, String)> = resources.into_iter().collect();
+	#[cfg(test)]
+	capture::record_begin(&resources, live_terminal_colored());
 	if !super::progress_enabled() {
 		return;
 	}
+	// Cache the terminal+colour decision here (it cannot change mid-command)
+	// and only re-read the width per repaint, so a resize mid-command is
+	// still honoured. `live_allowed` previously re-ran both halves ten times a
+	// second for the lifetime of the board (#1364).
+	let live = live_terminal_colored();
 	let board = Board::new(resources);
 	let name_width = board
 		.live_rows()
@@ -107,11 +121,6 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 		.max()
 		.unwrap_or(0)
 		.clamp(12, 40);
-	// Cache the terminal+colour decision here (it cannot change mid-command)
-	// and only re-read the width per repaint, so a resize mid-command is
-	// still honoured. `live_allowed` previously re-ran both halves ten times a
-	// second for the lifetime of the board (#1364).
-	let live = live_terminal_colored();
 	let region = live.then(|| live::Region::new(live::Target::Stderr));
 	if let Ok(mut slot) = SESSION.lock() {
 		*slot = Some(Session {
@@ -237,6 +246,8 @@ pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 ///
 /// Idempotent, because the commands that open a board have several exits.
 pub fn end() {
+	#[cfg(test)]
+	capture::record_end();
 	if !SESSION_OPEN.swap(false, std::sync::atomic::Ordering::AcqRel) {
 		// No board was ever opened — the flag is the single source of truth
 		// for that. Drop it first so a racing `finish` doesn't take the lock

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -545,3 +545,47 @@ async fn up_pulls_an_image_once() {
 		"one image must produce at most one Pulling on up; got {pulls} in:\n{stderr}"
 	);
 }
+
+/// A `pull` whose stderr is a pipe keeps the plain lines it always printed.
+///
+/// `pull` now opens the same board `up` does (#1671), and the board owns the
+/// rendering once it is open. Off a terminal that must change nothing: the
+/// events go out as ` Image <ref>  Pulling` / ` Pulled`, one line each, with no
+/// cursor hiding, no cursor moves and no spinner. Animation in a CI log is a
+/// defect, and so is a log that says less than it used to.
+///
+/// `Command::output` gives the child a pipe for stderr, which is exactly the
+/// condition being asserted.
+#[tokio::test]
+async fn a_piped_pull_keeps_the_plain_lines() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(&compose, "services:\n  x:\n    image: alpine:latest\n").unwrap();
+	let p = Project {
+		compose: compose.to_string_lossy().into_owned(),
+		name: format!("t{}-pipe", std::process::id()),
+		_dir: dir,
+	};
+	let stderr = p.progress(&["pull"]);
+	assert!(
+		stderr.contains(" Image alpine:latest  Pulling"),
+		"the plain line is unchanged in a pipe; got:\n{stderr}"
+	);
+	assert!(
+		stderr.contains(" Image alpine:latest  Pulled"),
+		"and so is its closing line; got:\n{stderr}"
+	);
+	assert!(
+		!stderr.contains('\x1b'),
+		"a pipe gets no escape sequence at all, board or otherwise; got:\n{stderr:?}"
+	);
+	for marker in ["⠿", "✔", "[+] Running"] {
+		assert!(
+			!stderr.contains(marker),
+			"a pipe gets no board furniture ({marker}); got:\n{stderr}"
+		);
+	}
+}


### PR DESCRIPTION
Fixes #1671.

## What

`pull`, `restart`, `stop`, `start`, `kill`, `pause`, `unpause`, `rm` and `run` open the live board over the resources they will touch and close it on every exit, the way `up` does; in a pipe the plain lines stay. Each container action gets a working verb before the call (`Stopping`, `Restarting`, `Killing`, `Pausing`, `Unpausing`, `Removing`), so the row carries the spinner and the clock while Podman works, and a skipped container ends its row with `Skipped` instead of silence.

## Measured (pseudo-terminal, `script`, local Podman 5.7.0)

| command | board before | board after | last row |
|---|---|---|---|
| pull | 0 | 1 | `✔ Image alpine:3.20 Pulled 0.0s` |
| restart, stop, start, pause, unpause, kill, rm | 0 | 1 | `✔ Container ux-web-1 Restarted` and so on |
| run --rm | 0 | 1 | network rows, then the command's output on stdout |
| stop with `stop_grace_period: 3s` on a container that ignores SIGTERM | frozen `Pending` | `⠋ Stopping 0.0s` for 35 frames, then `✔ Stopped 3.2s` |

Piped `pull` prints `Pulling` and `Pulled` as before (test `a_piped_pull_keeps_the_plain_lines`).

## How it was built

MiniMax wrote the wiring and nine tests under a brief; I added the working verbs, the `Skipped` final and its test after the captures showed rows jumping from `Pending` to the final verb with no activity in between. Unit: 1824 pass. Clippy and fmt clean.

Note for the merge order: #1672/#1673/#1675 (in review next) make the plain sink print only final verbs; whichever lands second adapts the piped-pull expectation.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>